### PR TITLE
docs/libcurl/libcurl.m4 bug

### DIFF
--- a/docs/libcurl/libcurl.m4
+++ b/docs/libcurl/libcurl.m4
@@ -76,10 +76,10 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
 	libcurl_with_prefix=`dirname $withval`
         LIBCURL_CPPFLAGS="-I$libcurl_with_prefix/include"
         _libcurl_ldflags="-L$withval"
-        AC_PATH_PROG([_libcurl_config],[curl-config],["$libcurl_with_prefix/bin"],
+        AC_PATH_PROG([_libcurl_config],[curl-config],[],
                      ["$libcurl_with_prefix/bin"])
      else
-        AC_PATH_PROG([_libcurl_config],[curl-config])
+        AC_PATH_PROG([_libcurl_config],[curl-config],[],[$PATH])
      fi
 
      if test x$_libcurl_config != "x" ; then


### PR DESCRIPTION
The LIBCURL_CHECK_CONFIG macro has a bug such that it uses the value passed in --with-libcurl= as a prefix instead of as a lib directory.  so the result of passing "/usr/lib" is searching for curl in /usr/lib/lib.  

The patch fixes that.

The second patch fixes some odd, perhaps obsolete uses of AC_PATH_PROG()

Let me know if it needs modification.
