### PR TITLE
Storing the URL alongside the downloaded file

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -15,11 +15,12 @@ CURLX_ONES = $(top_srcdir)/lib/strtoofft.c \
 	$(top_srcdir)/lib/nonblock.c
 
 CURL_CFILES = main.c hugehelp.c urlglob.c writeout.c writeenv.c \
-	getpass.c homedir.c curlutil.c os-specific.c
+	getpass.c homedir.c curlutil.c os-specific.c xattr_url.c
 
 CURL_HFILES = hugehelp.h setup.h config-win32.h config-mac.h \
 	config-riscos.h urlglob.h version.h os-specific.h \
-	writeout.h writeenv.h getpass.h homedir.h curlutil.h
+	writeout.h writeenv.h getpass.h homedir.h curlutil.h \
+	xattr_url.h
 
 curl_SOURCES = $(CURL_CFILES) $(CURLX_ONES) $(CURL_HFILES)
 

--- a/src/xattr_url.c
+++ b/src/xattr_url.c
@@ -1,0 +1,12 @@
+#include <sys/types.h>
+#include <attr/xattr.h>
+#include <string.h>
+#include <stdio.h>
+
+int set_xattr_url( const char *origin, const char *filename ) {
+  int err = setxattr( filename, "user.curl.origin", origin, strlen(origin), 0 );
+  if (err) {
+    fprintf(stderr, "setxattr: %s\n", strerror (errno));
+  }
+  return err;
+}

--- a/src/xattr_url.h
+++ b/src/xattr_url.h
@@ -1,0 +1,1 @@
+int set_xattr_url( const char *origin, const char *filename );


### PR DESCRIPTION
This patch stores the URL alongside the retrieved file using extended attributes; it makes it easy to track down the origin of once downloaded files.
