### PR TITLE
[imap + ssl] connect and upgrade asynchronously in multi mode

### DIFF
--- a/lib/imap.h
+++ b/lib/imap.h
@@ -33,6 +33,7 @@ typedef enum {
                        a connect */
   IMAP_LOGIN,
   IMAP_STARTTLS,
+  IMAP_UPGRADETLS, /* asynchronously upgrade the connection to SSL/TLS (multi mode only) */
   IMAP_SELECT,
   IMAP_FETCH,
   IMAP_LOGOUT,


### PR DESCRIPTION
Hi bagder,

Could you review these patches? I'd like to know if this is an acceptable approach because I need to do it for SMTP and maybe POP3 too. :-)

Here is a test case that covers all modes (easy vs. multi, IMAP, IMAPS and IMAP + STARTTLS).

https://gist.github.com/828613

Thanks!
