### PR TITLE
[smtp + ssl] connect and upgrade asynchronously in multi mode

### DIFF
--- a/lib/smtp.h
+++ b/lib/smtp.h
@@ -34,6 +34,7 @@ typedef enum {
   SMTP_EHLO,
   SMTP_HELO,
   SMTP_STARTTLS,
+  SMTP_UPGRADETLS, /* asynchronously upgrade the connection to SSL/TLS (multi mode only) */
   SMTP_AUTHPLAIN,
   SMTP_AUTHLOGIN,
   SMTP_AUTHPASSWD,


### PR DESCRIPTION
Pretty much identical to [imap + ssl](https://github.com/bagder/curl/pull/7) but for SMTP.

I'll update with test cases once I get them to work (this patch passes the existing ones, by the way, same goes for IMAP) but here is an external one:

https://gist.github.com/828613#file_curl_smtp_ssl.c
