### PR TITLE
POP3 STARTTLS support

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -296,6 +296,7 @@ static CURLcode pop3_state_starttls_resp(struct connectdata *conn,
   if(pop3code != 'O') {
     failf(data, "STARTTLS denied. %c", pop3code);
     result = CURLE_LOGIN_DENIED;
+    state(conn, POP3_STOP);
   }
   else {
     /* Curl_ssl_connect is BLOCKING */
@@ -304,8 +305,10 @@ static CURLcode pop3_state_starttls_resp(struct connectdata *conn,
       pop3_to_pop3s(conn);
       result = pop3_state_user(conn);
     }
+    else {
+      state(conn, POP3_STOP);
+    }
   }
-  state(conn, POP3_STOP);
   return result;
 }
 


### PR DESCRIPTION
With the current master you get this:

```
$ src/curl -kv --ftp-ssl pop3://testuser:testuser@localhost/
* About to connect() to localhost port 110 (#0)
*   Trying ::1... Connection refused
*   Trying 127.0.0.1... connected
* Connected to localhost (127.0.0.1) port 110 (#0)
* POP3 0x15a5b38 state change from STOP to SERVERGREET
< +OK Dovecot ready.
> STARTTLS
* POP3 0x15a5b38 state change from SERVERGREET to STARTTLS
< -ERR Unknown command.
* STARTTLS denied. E
* POP3 0x15a5b38 state change from STARTTLS to STOP
> QUIT
* POP3 0x15a5b38 state change from STOP to QUIT
< +OK Logging out
* POP3 0x15a5b38 state change from QUIT to STOP
* Closing connection #0
curl: (67) STARTTLS denied. E
```

And that's because with POP3 the STARTTLS command is named 'STLS'. :-)

Okay, easy to patch but there are more bugs still. The response parser goes off the rails after the upgrade to TLS:

```
$ src/curl -kv --ftp-ssl pop3://testuser:testuser@localhost/
* About to connect() to localhost port 110 (#0)
*   Trying ::1... Connection refused
*   Trying 127.0.0.1... connected
* Connected to localhost (127.0.0.1) port 110 (#0)
* POP3 0x1bbdb38 state change from STOP to SERVERGREET
< +OK Dovecot ready.
> STLS
* POP3 0x1bbdb38 state change from SERVERGREET to STARTTLS
< +OK Begin TLS negotiation now.
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: none
* SSLv3, TLS handshake, Client hello (1):
* SSLv3, TLS handshake, Server hello (2):
* SSLv3, TLS handshake, CERT (11):
* SSLv3, TLS handshake, Server key exchange (12):
* SSLv3, TLS handshake, Server finished (14):
* SSLv3, TLS handshake, Client key exchange (16):
* SSLv3, TLS change cipher, Client hello (1):
* SSLv3, TLS handshake, Finished (20):
* SSLv3, TLS change cipher, Client hello (1):
* SSLv3, TLS handshake, Finished (20):
* SSL connection using DHE-RSA-AES256-SHA
* Server certificate:
*        subject: O=Dovecot mail server; OU=bender; CN=bender; emailAddress=root@bender
*        start date: 2011-03-17 13:32:31 GMT
*        expire date: 2012-03-16 13:32:31 GMT
*        common name: bender (does not match 'localhost')
*        issuer: O=Dovecot mail server; OU=bender; CN=bender; emailAddress=root@bender
*        SSL certificate verify result: self signed certificate (18), continuing anyway.
> USER testuser
* POP3 0x1bbdb38 state change from STARTTLS to USER
* POP3 0x1bbdb38 state change from USER to STOP
* DO phase starts
> LIST 
* POP3 0x1bbdb38 state change from STOP to LIST
< +OK
* POP3 0x1bbdb38 state change from LIST to STOP
* DO phase is complete
-ERR Unknown command.
```

I'll try to update this pull request with a fix for that too.
