### PR TITLE
[pop3 + ssl] connect and upgrade asynchronously in multi mode

### DIFF
--- a/lib/pop3.h
+++ b/lib/pop3.h
@@ -32,6 +32,7 @@ typedef enum {
   POP3_USER,
   POP3_PASS,
   POP3_STARTTLS,
+  POP3_UPGRADETLS, /* asynchronously upgrade the connection to SSL/TLS (multi mode only) */
   POP3_LIST,
   POP3_RETR,
   POP3_QUIT,


### PR DESCRIPTION
For the sake of POP3, IMAP and SMTP feature parity. The test case is [here](https://gist.github.com/828613#file_curl_pop3_ssl.c).

This changeset includes the patches from pull request #11 because that was the only way I could get the STARTTLS tests to pass.
