### PR TITLE
[pop3] remove extra space in LIST command

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -481,11 +481,14 @@ static CURLcode pop3_list(struct connectdata *conn)
   CURLcode result = CURLE_OK;
   struct pop3_conn *pop3c = &conn->proto.pop3c;
 
-  result = Curl_pp_sendf(&conn->proto.pop3c.pp, "LIST %s", pop3c->mailbox);
+  if(pop3c->mailbox[0] != '\0')
+    result = Curl_pp_sendf(&conn->proto.pop3c.pp, "LIST %s", pop3c->mailbox);
+  else
+    result = Curl_pp_sendf(&conn->proto.pop3c.pp, "LIST");
   if(result)
     return result;
 
-  if(strlen(pop3c->mailbox))
+  if(pop3c->mailbox[0] != '\0')
     state(conn, POP3_LIST_SINGLE);
   else
     state(conn, POP3_LIST);

--- a/tests/data/test810
+++ b/tests/data/test810
@@ -38,7 +38,7 @@ pop3://%HOSTIP:%POP3PORT/ -u user:secret
 <protocol>
 USER user
 PASS secret
-LIST 
+LIST
 QUIT
 </protocol>
 </verify>

--- a/tests/data/test811
+++ b/tests/data/test811
@@ -36,7 +36,7 @@ pop3://%HOSTIP:%POP3PORT/ -u user:secret
 <protocol>
 USER user
 PASS secret
-LIST 
+LIST
 QUIT
 </protocol>
 </verify>


### PR DESCRIPTION
Some servers, e.g. mail.bezeqint.net:110, consider it a syntax error
