### PR TITLE
Allow forcing select over WSAPoll

### DIFF
--- a/lib/select.h
+++ b/lib/select.h
@@ -48,6 +48,16 @@
 #  endif
 #endif
 
+
+/*
+ * In some cases select may be preferred over poll/WSAPoll.
+ */
+
+#ifdef FORCE_SELECT
+#define HAVE_SELECT 1
+#undef HAVE_POLL_FINE
+#endif // FORCE_SELECT
+
 /*
  * Definition of pollfd struct and constants for platforms lacking them.
  */


### PR DESCRIPTION
By default libcurl prefers WSAPoll instead of select. I have a case where that's the wrong thing to do and so I _must_ use select. I thought forcing select would be a nice option (and requisite in my case) and this is the patch.
