### PR TITLE
libcurl/Curl_resolv_timeout: curl_jmpenv should be set before alarm() call

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -596,10 +596,6 @@ int Curl_resolv_timeout(struct connectdata *conn,
 #endif
 #endif /* HAVE_SIGACTION */
 
-  /* alarm() makes a signal get sent when the timeout fires off, and that
-     will abort system calls */
-  prev_alarm = alarm(curlx_sltoui(timeout/1000L));
-
   /* This allows us to time-out from the name resolver, as the timeout
      will generate a signal and we will siglongjmp() from that here.
      This technique has problems (see alarmfunc).
@@ -612,6 +608,10 @@ int Curl_resolv_timeout(struct connectdata *conn,
     rc = CURLRESOLV_ERROR;
     goto clean_up;
   }
+
+  /* alarm() makes a signal get sent when the timeout fires off, and that
+     will abort system calls */
+  prev_alarm = alarm(curlx_sltoui(timeout/1000L));
 
 #else
 #ifndef CURLRES_ASYNCH


### PR DESCRIPTION
Hello,
while debugging an issue in a PHP extension, i experienced some
segfaults caused by libcurl.
I found out the cause was at hostip.c:506:

siglongjmp(curl_jmpenv, 1);

curl_jmpenv was 0x0.
That happens when SIGALRM is sent _before_ sigsetjmp is called at
hostip.c:609. This could happens, for example, while debugging or when
process is descheduled for a time greater than SIGALRM timeout.
This patch simply moves sigsetjmp() before alarm().
