### PR TITLE
SFTP/SCP: allow quote commands to fail if they're prefixed with '*'

### DIFF
--- a/lib/ssh.h
+++ b/lib/ssh.h
@@ -115,6 +115,7 @@ struct ssh_conn {
   char *quote_path1;          /* two generic pointers for the QUOTE stuff */
   char *quote_path2;
   LIBSSH2_SFTP_ATTRIBUTES quote_attrs; /* used by the SFTP_QUOTE state */
+  bool acceptfail;            /* accept file in SFTP_QUOTE state */
   char *homedir;              /* when doing SFTP we figure out home dir in the
                                  connect phase */
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -53,8 +53,9 @@ test600 test601 test602 test603 test604	\
 test605 test606 test607 test608 test609 test610 test611 test612 test613	\
 test614 test615 test616 test617 test618 test619 test620 test621 test622	\
 test623 test624 test625 test626 test627 test628 test629 test630 test631	\
-test632 test633 test634 test635 test636 test637 test700 test701 test702	\
-test703 test704 test705 test706 test707 test708 test709 test710 \
+test632 test633 test634 test635 test636 test637 test638 test639 \
+test700 test701 test702	test703 test704 test705 test706 test707 test708 \
+test709 test710 \
 test800 test801 test802	\
 test803 test804 test805 test806 test807 test808 test809 test810 test811	\
 test812 test813 test814 \

--- a/tests/data/test638
+++ b/tests/data/test638
@@ -1,0 +1,49 @@
+<testcase>
+<info>
+<keywords>
+SFTP
+post-quote
+acceptfail
+asterisk
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+Dummy test file for rename test
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+sftp
+</server>
+<precheck>
+perl %SRCDIR/libtest/test610.pl mkdir %PWD/log/test638.dir
+</precheck>
+ <name>
+SFTP post-quote rename * asterisk accept-fail
+ </name>
+ <command>
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/log/test638.dir %PWD/log/test638.new" sftp://%HOSTIP:%SSHPORT%PWD/log/file638.txt --insecure
+</command>
+<postcheck>
+perl %SRCDIR/libtest/test610.pl rmdir %PWD/log/test638.new
+</postcheck>
+<file name="log/file638.txt">
+Dummy test file for rename test
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<valgrind>
+disable
+</valgrind>
+</verify>
+</testcase>

--- a/tests/data/test639
+++ b/tests/data/test639
@@ -1,0 +1,49 @@
+<testcase>
+<info>
+<keywords>
+SFTP
+post-quote
+acceptfail
+asterisk
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+Dummy test file for rename test
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+sftp
+</server>
+<precheck>
+perl %SRCDIR/libtest/test610.pl mkdir %PWD/log/test639.dir
+</precheck>
+ <name>
+SFTP post-quote rename * asterisk accept-fail
+ </name>
+ <command>
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/log/test639-not-exists-dir %PWD/log/test639.new" sftp://%HOSTIP:%SSHPORT%PWD/log/file639.txt --insecure
+</command>
+<postcheck>
+perl %SRCDIR/libtest/test610.pl rmdir %PWD/log/test639.dir
+</postcheck>
+<file name="log/file639.txt">
+Dummy test file for rename test
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<valgrind>
+disable
+</valgrind>
+</verify>
+</testcase>


### PR DESCRIPTION
Hi Daniel

Here is my patch for the \* (asterisk) accept-fail sftp quote commands.
Because it's my first curl patch, it would be great if someone can review it.
## Thanks

Jonas
