### PR TITLE
Use Curl_ssl_connect for non-blocking connect fallback

### DIFF
--- a/lib/sslgen.c
+++ b/lib/sslgen.c
@@ -215,8 +215,7 @@ Curl_ssl_connect_nonblocking(struct connectdata *conn, int sockindex,
   return res;
 #else
   *done = TRUE; /* fallback to BLOCKING */
-  conn->ssl[sockindex].use = TRUE;
-  return curlssl_connect(conn, sockindex);
+  return Curl_ssl_connect(conn, sockindex);
 #endif /* non-blocking connect support */
 }
 


### PR DESCRIPTION
This gets the appconnect time right for ssl backends, which don't
support non-blocking connects.

Signed-off-by: Sven Wegener sven.wegener@stealer.net

This is an old patch that I wrote when the GnuTLS backend did not support non-blocking commits, but I think it's still a good change.
