### PR TITLE
HTTPS verify when retrieving CA file

### DIFF
--- a/lib/mk-ca-bundle.pl
+++ b/lib/mk-ca-bundle.pl
@@ -32,7 +32,7 @@
 #
 use Getopt::Std;
 use MIME::Base64;
-use LWP::UserAgent;
+use LWP::UserAgent 6;
 use strict;
 use vars qw($opt_b $opt_h $opt_i $opt_l $opt_n $opt_q $opt_t $opt_u $opt_v);
 


### PR DESCRIPTION
Here are some changes to retrieve the CA file in a more secure way.

See the commit messages for details.
