### PR TITLE
Add parameter to curl_multi_wait() to return number of active sockets

### DIFF
--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -29,7 +29,8 @@ curl_multi_select - polls on all easy handles in a multi handle
 CURLMcode curl_multi_wait(CURLM *multi_handle,
                           struct curl_waitfd extra_fds[],
                           unsigned int extra_nfds,
-                          int timeout_ms);
+                          int timeout_ms,
+                          int *ret);
 .ad
 .SH DESCRIPTION
 This function polls on all file descriptors used by the curl easy handles
@@ -38,6 +39,9 @@ detected on at least one of the handles or \fItimeout_ms\fP has passed.
 
 The calling application may pass additional curl_waitfd structures which are
 similar to \fIpoll(2)\fP's pollfd structure to be waited on in the same call.
+
+On completion, if \fIret\fI is supplied, it will be populated with the
+number of file descriptors on which interesting events occured.
 
 This function is encouraged to be used instead of select(3) when using the
 multi interface to allow applications to easier circumvent the common problem

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -157,7 +157,8 @@ CURL_EXTERN CURLMcode curl_multi_fdset(CURLM *multi_handle,
 CURL_EXTERN CURLMcode curl_multi_wait(CURLM *multi_handle,
                                       struct curl_waitfd extra_fds[],
                                       unsigned int extra_nfds,
-                                      int timeout_ms);
+                                      int timeout_ms,
+                                      int *ret);
 
  /*
   * Name:    curl_multi_perform()

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -944,7 +944,8 @@ CURLMcode curl_multi_fdset(CURLM *multi_handle,
 CURLMcode curl_multi_wait(CURLM *multi_handle,
                           struct curl_waitfd extra_fds[],
                           unsigned int extra_nfds,
-                          int timeout_ms)
+                          int timeout_ms,
+                          int *ret)
 {
   struct Curl_multi *multi=(struct Curl_multi *)multi_handle;
   struct Curl_one_easy *easy;
@@ -1023,8 +1024,11 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
   }
 
   /* wait... */
-  Curl_poll(ufds, nfds, timeout_ms);
+  i = Curl_poll(ufds, nfds, timeout_ms);
   free(ufds);
+  if (ret) {
+    *ret = i;
+  }
   return CURLM_OK;
 }
 

--- a/tests/libtest/lib1500.c
+++ b/tests/libtest/lib1500.c
@@ -54,9 +54,15 @@ int test(char *URL)
   abort_on_test_timeout();
 
   while(still_running) {
-    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT);
+    int num;
+    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
     if (res != CURLM_OK) {
       printf("curl_multi_wait() returned %d\n", res);
+      res = -1;
+      goto test_cleanup;
+    }
+    if (num != 1) {
+      printf("curl_multi_wait() returned on %d handle(s), expected 1\n", num);
       res = -1;
       goto test_cleanup;
     }


### PR DESCRIPTION
Minor change to recently introduced function.  BC breaking, but since
curl_multi_wait() doesn't exist in any releases that should be fine.
