### PR TITLE
Curl_connecthost: friendlier "couldn't connect" message

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1101,7 +1101,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,  /* context */
 
   if(sockfd == CURL_SOCKET_BAD) {
     /* no good connect was made */
-    failf(data, "couldn't connect to host");
+    failf(data, "couldn't connect to %s:%d", conn->host.name, conn->port);
     return CURLE_COULDNT_CONNECT;
   }
 


### PR DESCRIPTION
`connect` errors now reproduce the relevant host and port number in the error message. I found this useful in scripts that do a lot of curl commands.
