### PR TITLE
Tests code updated for build with MS Visual Studio

### DIFF
--- a/tests/libtest/lib1501.c
+++ b/tests/libtest/lib1501.c
@@ -98,13 +98,13 @@ int test(char *URL)
     abort_on_test_timeout();
 
     fprintf(stderr, "ping\n");
-    gettimeofday(&before, 0);
+    before = tutil_tvnow();
 
     multi_perform(mhandle, &still_running);
 
     abort_on_test_timeout();
 
-    gettimeofday(&after, 0);
+    after = tutil_tvnow();
     e = elapsed(&before, &after);
     fprintf(stderr, "pong = %d\n", e);
 

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -133,7 +133,7 @@ static int curlTimerCallback(CURLM *multi, long timeout_ms, void *userp)
 
   (void)multi; /* unused */
   if (timeout_ms != -1) {
-    gettimeofday(timeout, 0);
+    *timeout = tutil_tvnow();
     timeout->tv_usec += timeout_ms * 1000;
   }
   else {
@@ -173,8 +173,7 @@ static int getMicroSecondTimeout(struct timeval* timeout)
 {
   struct timeval now;
   ssize_t result;
-
-  gettimeofday(&now, 0);
+  now = tutil_tvnow();
   result = (timeout->tv_sec - now.tv_sec) * 1000000 +
     timeout->tv_usec - now.tv_usec;
   if (result < 0)

--- a/tests/libtest/libauthretry.c
+++ b/tests/libtest/libauthretry.c
@@ -25,7 +25,7 @@
  */
 
 #include "test.h"
-
+#include "strequal.h"
 #include "memdebug.h"
 
 static int send_request(CURL *curl, const char *url, int seq,
@@ -72,11 +72,11 @@ static long parse_auth_name(const char *arg)
 {
   if (!arg)
     return CURLAUTH_NONE;
-  if (strcasecmp(arg, "basic") == 0)
+  if (strequal(arg, "basic") == 0)
     return CURLAUTH_BASIC;
-  if (strcasecmp(arg, "digest") == 0)
+  if (strequal(arg, "digest") == 0)
     return CURLAUTH_DIGEST;
-  if (strcasecmp(arg, "ntlm") == 0)
+  if (strequal(arg, "ntlm") == 0)
     return CURLAUTH_NTLM;
   return CURLAUTH_NONE;
 }

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -22,6 +22,9 @@
 
 #include "test.h"
 
+#define _MPRINTF_REPLACE /* use our functions only */
+#include <curl/mprintf.h>
+
 #include "testutil.h"
 #include "testtrace.h"
 #include "memdebug.h"


### PR DESCRIPTION
Fixes for missed API on windows for tests
- gettimeofday
- strcasecmp
- snprintf

Here the error without the fix:

Linking C executable ..\lib1501.exe
lib1501.c.obj : error LNK2019: unresolved external symbol _gettimeofday referenc
ed in function _test
..\lib1501.exe : fatal error LNK1120: 1 unresolved externals
LINK Pass 1 failed. with 2
NMAKE : fatal error U1077: '"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe"' :
return code '0xffffffff'
Stop.
NMAKE : fatal error U1077: '"c:\Program Files (x86)\Microsoft Visual Studio 10.0
\VC\BIN\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"c:\Program Files (x86)\Microsoft Visual Studio 10.0
\VC\BIN\nmake.exe"' : return code '0x2'
Stop.

C:\WORK\oss\b.curl>
