### PR TITLE
Change cnonce values more frequently

### DIFF
--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -344,7 +344,7 @@ CURLcode Curl_output_digest(struct connectdata *conn,
   if(!d->cnonce) {
     /* Generate a cnonce */
     now = Curl_tvnow();
-    snprintf(cnoncebuf, sizeof(cnoncebuf), "%06ld", (long)now.tv_sec);
+    snprintf(cnoncebuf, sizeof(cnoncebuf), "%06ld", (long)now.tv_sec + now.tv_usec);
 
     rc = Curl_base64_encode(data, cnoncebuf, strlen(cnoncebuf),
                             &cnonce, &cnonce_sz);


### PR DESCRIPTION
When using only 1 second precision, curl doesn't change cnonce values frequently enough for all uses.

For example, issuing the following command multiple times within a few seconds to a recent Tomcat causes authentication failures (after one success):

curl --digest -utest:test http://tomcat.test.com:8080/manager/list

This is because curl uses the same cnonce for several seconds, but doesn't increment the nonce counter.  Tomcat correctly interprets this as a replay attack and rejects the request.

When microsecond-precision is available, this commit causes curl to change cnonce values much more frequently.
