### PR TITLE
Fixed build on ARM systems without configure scripts.

### DIFF
--- a/include/curl/curlbuild.h.dist
+++ b/include/curl/curlbuild.h.dist
@@ -527,7 +527,7 @@
 /* ===================================== */
 
 #elif defined(__GNUC__)
-#  if defined(__i386__) || defined(__ppc__)
+#  if defined(__i386__) || defined(__ppc__) || defined(__arm__)
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"


### PR DESCRIPTION
Numerous projects have cropped up with compile issues traced to this file.
An example test case:

include <stdio.h>
include "include/curl/curlbuild.h.dist"
int main() {    printf("%s\n", CURL_FORMAT_CURL_OFF_T);}

This file will fail to compile on a Raspberry pi due to running GCC,
on neither i386, ppc or x64.
Whilst the correctly using the ./configure script resolves this issue, multiple products without configure scripts have simply included this file.
