### PR TITLE
Fix wrong CURLINFO_CONTENT_LENGTH_DOWNLOAD result with redirect.

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3005,6 +3005,9 @@ CURLcode Curl_http_readwrite_headers(struct SessionHandle *data,
           Curl_pgrsSetDownloadSize(data, k->size);
           k->maxdownload = k->size;
         }
+        else if (data->state.this_is_a_follow)
+          /* We are redirected, clear previous content-length anyway */
+          Curl_pgrsSetDownloadSize(data, k->size);
 
         /* If max download size is *zero* (nothing) we already
            have nothing and can safely return ok now! */


### PR DESCRIPTION
when the target file redirected to a result url which has no content-length, call getinfo for CURLINFO_CONTENT_LENGTH_DOWNLOAD will get the previous 302 page's body content-length, this commit fixed it.

test link: http://mp3.live.tv-radio.com/francemusique/all/francemusiquehautdebit.mp3 
