### PR TITLE
Response headers added by proxy servers missing in CURLINFO_HEADER_SIZE

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -356,6 +356,10 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
 
                   result = Curl_client_write(conn, writetype, line_start,
                                              perline);
+
+                  data->info.header_size += (long)perline;
+                  data->req.headerbytecount += (long)perline;
+
                   if(result)
                     return result;
 


### PR DESCRIPTION
Often times proxy servers add their own headers (like `HTTP/1.0 200 Connection established`) to responses on their way back to the client. The size of these headers was not taken into account when calculating `CURLINFO_HEADER_SIZE` before the change from this pull request.

The problem can be reproduced quite easily using the test program from https://gist.github.com/mj/5102778. In our case the proxy server at `proxy:8080` was the default Squid that ships with Debian stable.
