### PR TITLE
connect: treat an interface bindlocal() problem as a non-fatal error

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -310,41 +310,54 @@ static CURLcode bindlocal(struct connectdata *conn,
     }
 
     /* interface */
-    if(!is_host && (is_interface || Curl_if_is_interface_name(dev))) {
-      if(Curl_if2ip(af, dev, myhost, sizeof(myhost)) == NULL)
-        return CURLE_INTERFACE_FAILED;
-
-      /*
-       * We now have the numerical IP address in the 'myhost' buffer
-       */
-      infof(data, "Local Interface %s is ip %s using address family %i\n",
-            dev, myhost, af);
-      done = 1;
+    if(!is_host) {
+      switch(Curl_if2ip(af, conn->scope, dev, myhost, sizeof(myhost))) {
+        case IF2IP_NOT_FOUND:
+          if(is_interface) {
+            /* Do not fall back to treating it as a host name */
+            failf(data, "Couldn't bind to interface '%s'", dev);
+            return CURLE_INTERFACE_FAILED;
+          }
+          break;
+        case IF2IP_AF_NOT_SUPPORTED:
+          /* Signal the caller to try another address family if available */
+          return CURLE_UNSUPPORTED_PROTOCOL;
+        case IF2IP_FOUND:
+          is_interface = TRUE;
+          /*
+           * We now have the numerical IP address in the 'myhost' buffer
+           */
+          infof(data, "Local Interface %s is ip %s using address family %i\n",
+                dev, myhost, af);
+          done = 1;
 
 #ifdef SO_BINDTODEVICE
-      /* I am not sure any other OSs than Linux that provide this feature, and
-       * at the least I cannot test. --Ben
-       *
-       * This feature allows one to tightly bind the local socket to a
-       * particular interface.  This will force even requests to other local
-       * interfaces to go out the external interface.
-       *
-       *
-       * Only bind to the interface when specified as interface, not just as a
-       * hostname or ip address.
-       */
-      if(setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
-                    dev, (curl_socklen_t)strlen(dev)+1) != 0) {
-        error = SOCKERRNO;
-        infof(data, "SO_BINDTODEVICE %s failed with errno %d: %s;"
-              " will do regular bind\n",
-              dev, error, Curl_strerror(conn, error));
-        /* This is typically "errno 1, error: Operation not permitted" if
-           you're not running as root or another suitable privileged user */
-      }
+          /* I am not sure any other OSs than Linux that provide this feature,
+           * and at the least I cannot test. --Ben
+           *
+           * This feature allows one to tightly bind the local socket to a
+           * particular interface.  This will force even requests to other
+           * local interfaces to go out the external interface.
+           *
+           *
+           * Only bind to the interface when specified as interface, not just
+           * as a hostname or ip address.
+           */
+          if(setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
+                        dev, (curl_socklen_t)strlen(dev)+1) != 0) {
+            error = SOCKERRNO;
+            infof(data, "SO_BINDTODEVICE %s failed with errno %d: %s;"
+                  " will do regular bind\n",
+                  dev, error, Curl_strerror(conn, error));
+            /* This is typically "errno 1, error: Operation not permitted" if
+               you're not running as root or another suitable privileged
+               user */
+          }
 #endif
+          break;
+      }
     }
-    else {
+    if(!is_interface) {
       /*
        * This was not an interface, resolve the name as a host name
        * or IP number
@@ -388,11 +401,26 @@ static CURLcode bindlocal(struct connectdata *conn,
     if(done > 0) {
 #ifdef ENABLE_IPV6
       /* ipv6 address */
-      if((af == AF_INET6) &&
-         (Curl_inet_pton(AF_INET6, myhost, &si6->sin6_addr) > 0)) {
-        si6->sin6_family = AF_INET6;
-        si6->sin6_port = htons(port);
-        sizeof_sa = sizeof(struct sockaddr_in6);
+      if(af == AF_INET6) {
+#ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+        char *scope_ptr = strchr(myhost, '%');
+
+        if(scope_ptr) *(scope_ptr++) = 0;
+#endif
+        if(Curl_inet_pton(AF_INET6, myhost, &si6->sin6_addr) > 0) {
+          si6->sin6_family = AF_INET6;
+          si6->sin6_port = htons(port);
+#ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+          if(scope_ptr) {
+            /* The "myhost" string either comes from Curl_if2ip or
+               from Curl_printable_address. The latter returns only
+               numeric scope IDs and the former returns none at all.
+               So the scope ID, if present, is known to be numeric */
+            si6->sin6_scope_id = atoi(scope_ptr);
+          }
+        }
+#endif
+          sizeof_sa = sizeof(struct sockaddr_in6);
       }
       else
 #endif
@@ -966,6 +994,11 @@ singleipconnect(struct connectdata *conn,
   res = bindlocal(conn, sockfd, addr.family);
   if(res) {
     Curl_closesocket(conn, sockfd); /* close socket and bail out */
+    if(res == CURLE_UNSUPPORTED_PROTOCOL) {
+      /* The address family is not supported on this interface.
+         We can continue trying addresses */
+      return CURLE_OK;
+    }
     return res;
   }
 

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -83,42 +83,59 @@ bool Curl_if_is_interface_name(const char *interf)
   return result;
 }
 
-char *Curl_if2ip(int af, const char *interf, char *buf, int buf_size)
+if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
+                          const char *interf, char *buf, int buf_size)
 {
   struct ifaddrs *iface, *head;
-  char *ip = NULL;
+  if2ip_result_t res = IF2IP_NOT_FOUND;
 
   if(getifaddrs(&head) >= 0) {
     for(iface=head; iface != NULL; iface=iface->ifa_next) {
-      if((iface->ifa_addr != NULL) &&
-         (iface->ifa_addr->sa_family == af) &&
-         curl_strequal(iface->ifa_name, interf)) {
-        void *addr;
-        char scope[12]="";
-        char ipstr[64];
+      if(iface->ifa_addr != NULL) {
+        if(iface->ifa_addr->sa_family == af) {
+          if(curl_strequal(iface->ifa_name, interf)) {
+            void *addr;
+            char *ip;
+            char scope[12]="";
+            char ipstr[64];
 #ifdef ENABLE_IPV6
-        if(af == AF_INET6) {
-          unsigned int scopeid = 0;
-          addr = &((struct sockaddr_in6 *)iface->ifa_addr)->sin6_addr;
+            if(af == AF_INET6) {
+              unsigned int scopeid = 0;
+              addr = &((struct sockaddr_in6 *)iface->ifa_addr)->sin6_addr;
 #ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
-          /* Include the scope of this interface as part of the address */
-          scopeid = ((struct sockaddr_in6 *)iface->ifa_addr)->sin6_scope_id;
+              /* Include the scope of this interface as part of the address */
+              scopeid =
+                ((struct sockaddr_in6 *)iface->ifa_addr)->sin6_scope_id;
 #endif
-          if(scopeid)
-            snprintf(scope, sizeof(scope), "%%%u", scopeid);
+              if(scopeid != remote_scope) {
+                /* We are interested only in interface addresses whose
+                   scope ID matches the remote address we want to
+                   connect to: global (0) for global, link-local for
+                   link-local, etc... */
+                if(res == IF2IP_NOT_FOUND) res = IF2IP_AF_NOT_SUPPORTED;
+                continue;
+              }
+              if(scopeid)
+                snprintf(scope, sizeof(scope), "%%%u", scopeid);
+            }
+            else
+#endif
+              addr = &((struct sockaddr_in *)iface->ifa_addr)->sin_addr;
+            res = IF2IP_FOUND;
+            ip = (char *) Curl_inet_ntop(af, addr, ipstr, sizeof(ipstr));
+            snprintf(buf, buf_size, "%s%s", ip, scope);
+            break;
+          }
         }
-        else
-#endif
-          addr = &((struct sockaddr_in *)iface->ifa_addr)->sin_addr;
-        ip = (char *) Curl_inet_ntop(af, addr, ipstr, sizeof(ipstr));
-        snprintf(buf, buf_size, "%s%s", ip, scope);
-        ip = buf;
-        break;
+        else if((res == IF2IP_NOT_FOUND) &&
+                curl_strequal(iface->ifa_name, interf)) {
+          res = IF2IP_AF_NOT_SUPPORTED;
+        }
       }
     }
     freeifaddrs(head);
   }
-  return ip;
+  return res;
 }
 
 #elif defined(HAVE_IOCTL_SIOCGIFADDR)
@@ -128,30 +145,29 @@ bool Curl_if_is_interface_name(const char *interf)
   /* This is here just to support the old interfaces */
   char buf[256];
 
-  char *ip = Curl_if2ip(AF_INET, interf, buf, sizeof(buf));
-
-  return (ip != NULL) ? TRUE : FALSE;
+  return (Curl_if2ip(AF_INET, 0, interf, buf, sizeof(buf)) == IF2IP_NOT_FOUND) ?
+         FALSE : TRUE;
 }
 
-char *Curl_if2ip(int af, const char *interf, char *buf, int buf_size)
+if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
+                          const char *interf, char *buf, int buf_size)
 {
   struct ifreq req;
   struct in_addr in;
   struct sockaddr_in *s;
   curl_socket_t dummy;
   size_t len;
-  char *ip;
 
   if(!interf || (af != AF_INET))
-    return NULL;
+    return IF2IP_NOT_FOUND;
 
   len = strlen(interf);
   if(len >= sizeof(req.ifr_name))
-    return NULL;
+    return IF2IP_NOT_FOUND;
 
   dummy = socket(AF_INET, SOCK_STREAM, 0);
   if(CURL_SOCKET_BAD == dummy)
-    return NULL;
+    return IF2IP_NOT_FOUND;
 
   memset(&req, 0, sizeof(req));
   memcpy(req.ifr_name, interf, len+1);
@@ -159,15 +175,18 @@ char *Curl_if2ip(int af, const char *interf, char *buf, int buf_size)
 
   if(ioctl(dummy, SIOCGIFADDR, &req) < 0) {
     sclose(dummy);
-    return NULL;
+    /* With SIOCGIFADDR, we cannot tell the difference between an interface
+       that does not exist and an interface that has no address of the
+       correct family. Assume the interface does not exist */
+    return IF2IP_NOT_FOUND;
   }
 
   s = (struct sockaddr_in *)&req.ifr_addr;
   memcpy(&in, &s->sin_addr, sizeof(in));
-  ip = (char *) Curl_inet_ntop(s->sin_family, &in, buf, buf_size);
+  Curl_inet_ntop(s->sin_family, &in, buf, buf_size);
 
   sclose(dummy);
-  return ip;
+  return IF2IP_FOUND;
 }
 
 #else
@@ -179,13 +198,14 @@ bool Curl_if_is_interface_name(const char *interf)
   return FALSE;
 }
 
-char *Curl_if2ip(int af, const char *interf, char *buf, int buf_size)
+if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
+                          const char *interf, char *buf, int buf_size)
 {
     (void) af;
     (void) interf;
     (void) buf;
     (void) buf_size;
-    return NULL;
+    return IF2IP_NOT_FOUND;
 }
 
 #endif

--- a/lib/if2ip.h
+++ b/lib/if2ip.h
@@ -24,7 +24,15 @@
 #include "curl_setup.h"
 
 bool Curl_if_is_interface_name(const char *interf);
-char *Curl_if2ip(int af, const char *interf, char *buf, int buf_size);
+
+typedef enum {
+  IF2IP_NOT_FOUND = 0, /* Interface not found */
+  IF2IP_AF_NOT_SUPPORTED = 1, /* Int. exists but has no address for this af */
+  IF2IP_FOUND = 2 /* The address has been stored in "buf" */
+} if2ip_result_t;
+
+if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
+                          const char *interf, char *buf, int buf_size);
 
 #ifdef __INTERIX
 


### PR DESCRIPTION
I am using curl_easy_setopt(CURLOPT_INTERFACE, "if!something") to force
transfers to use a particular interface but the transfer fails with
CURLE_INTERFACE_FAILED, "Failed binding local connection end" if the
interface I specify has no IPv6 address. The cause is as follows:

The remote hostname resolves successfully and has an IPv6 address and an
IPv4 address.

cURL attempts to connect to the IPv6 address first.

bindlocal (in lib/connect.c) fails because Curl_if2ip cannot find an
IPv6 address on the interface.

This is a fatal error in singleipconnect()

This change will make cURL try the next IP address in the list.

Also included are two changes related to IPv6 address scope:
- Filter the choice of address in Curl_if2ip to only consider addresses
  with the same scope ID as the connection address (mismatched scope for
  local and remote address does not result in a working connection).
- bindlocal was ignoring the scope ID of addresses returned by
  Curl_if2ip . Now it uses them.

Bug: http://curl.haxx.se/bug/view.cgi?id=1189
