### PR TITLE
curl-config: --static-libs should not output static libraries when they are disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3350,6 +3350,11 @@ dnl yes or no
 ENABLE_SHARED="$enable_shared"
 AC_SUBST(ENABLE_SHARED)
 
+dnl to let curl-config output the static libraries correctly
+ENABLE_STATIC="$enable_static"
+AC_SUBST(ENABLE_STATIC)
+
+
 dnl
 dnl For keeping supported features and protocols also in pkg-config file
 dnl since it is more cross-compile friendly than curl-config

--- a/curl-config.in
+++ b/curl-config.in
@@ -155,7 +155,12 @@ while test $# -gt 0; do
         ;;
 
     --static-libs)
-        echo @libdir@/libcurl.@libext@ @LDFLAGS@ @LIBCURL_LIBS@
+	if test "X@ENABLE_STATIC@" != "Xno" ; then
+		echo @libdir@/libcurl.@libext@ @LDFLAGS@ @LIBCURL_LIBS@
+	else
+		echo "curl was built with static libraries disabled" >&2
+		exit 1
+	fi
         ;;
 
     --configure)


### PR DESCRIPTION
Curl-config outputs static libraries even when they are disabled in configure.
This causes problems with the build of pycurl.

Now it outputs the message "curl was built with static libraries disabled".
