### PR TITLE
Copy the darwinssl SSLContext peer trust into the PureInfo struct

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1947,6 +1947,7 @@ struct curl_certinfo {
 #define CURLINFO_LONG     0x200000
 #define CURLINFO_DOUBLE   0x300000
 #define CURLINFO_SLIST    0x400000
+#define CURLINFO_PTR      0x500000
 #define CURLINFO_MASK     0x0fffff
 #define CURLINFO_TYPEMASK 0xf00000
 
@@ -1995,8 +1996,9 @@ typedef enum {
   CURLINFO_LOCAL_IP         = CURLINFO_STRING + 41,
   CURLINFO_LOCAL_PORT       = CURLINFO_LONG   + 42,
   /* Fill in new entries below here! */
+  CURLINFO_SSL_TRUST        = CURLINFO_PTR    + 43,
 
-  CURLINFO_LASTONE          = 42
+  CURLINFO_LASTONE          = 43
 } CURLINFO;
 
 /* CURLINFO_RESPONSE_CODE is the new name for the option previously known as

--- a/lib/url.c
+++ b/lib/url.c
@@ -437,6 +437,11 @@ CURLcode Curl_close(struct SessionHandle *data)
 
   Curl_safefree(data->info.contenttype);
   Curl_safefree(data->info.wouldredirect);
+  
+  if(data->info.ssl_trust != NULL) {
+    data->info.free_ssl_trust(data->info.ssl_trust);
+  }
+  data->info.ssl_trust = NULL;
 
   /* this destroys the channel and we cannot use it anymore after this */
   Curl_resolver_cleanup(data->state.resolver);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1062,6 +1062,9 @@ struct PureInfo {
   struct curl_certinfo certs; /* info about the certs, only populated in
                                  OpenSSL builds. Asked for with
                                  CURLOPT_CERTINFO / CURLINFO_CERTINFO */
+
+  void *ssl_trust;
+  void (*free_ssl_trust)(void *);
 };
 
 


### PR DESCRIPTION
When `CURLE_SSL_CACERT` is returned callers can extract `CURLINFO_SSL_TRUST` to get the `SecTrustRef` suitable for presenting to the user and modifying the keychain trust settings.

I saw Nick Ziztmann discuss adding a new info selector in http://curl.haxx.se/mail/lib-2012-06/0334.html but don’t think this code was ever published.
