### PR TITLE
Enclose CONNECT requests to IPv6 literals in brackets

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -139,7 +139,11 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
       if(!req_buffer)
         return CURLE_OUT_OF_MEMORY;
 
-      host_port = aprintf("%s:%hu", hostname, remote_port);
+      host_port = aprintf("%s%s%s:%hu",
+        conn->bits.ipv6_ip ? "[" : "",
+        hostname,
+        conn->bits.ipv6_ip ? "]" : "",
+        remote_port);
       if(!host_port) {
         free(req_buffer);
         return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
Summary:
- RFC2732 suggests enclosing IPv6 literals in URIs in brackets to make
  easier to parse. Since the argument to the CONNECT method is an
  authority clause (from the URI spec), this should be enclosed as well.

Test Plan:
- Verify that "curl -g -vvv -x fwdproxy:8080
  'https://[2a03:2880:2050:1f01:face:b00c:0:9]/'" sends a CONNECT with
  []-enclosed URL
- Verify that "curl -vvv -x fwdproxy:8080 https://www.facebook.com"
  does not []-enclose www.facebook.com when issuing a CONNECT
- Verify that "curl -vvv -x fwdproxy:8080
  'http://[2a03:2880:2050:1f01:face:b00c:0:9]/'" sends a GET with
  []-enclosed URL
