### PR TITLE
Display short usage when no arguments given

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -41,8 +41,16 @@
  *  curl --help | cut -c5- | grep "^-" | sort
  */
 
+static const char usage[] = "Usage: curl [options...] <url>";
+
+static const char *const helptext_short[] = {
+  usage,
+  "  Transfers data at <url> to standard output.",
+  NULL
+};
+
 static const char *const helptext[] = {
-  "Usage: curl [options...] <url>",
+  usage,
   "Options: (H) means HTTP/HTTPS only, (F) means FTP only",
   "     --anyauth       Pick \"any\" authentication method (H)",
   " -a, --append        Append to target file when uploading (F/SFTP)",
@@ -244,3 +252,15 @@ void tool_help(void)
   }
 }
 
+/*
+ * Print usage summary (for argc<2) on fp.
+ */
+void tool_help_short(FILE *fp)
+{
+  const char *line;
+  int i;
+  for(i = 0; (line = helptext_short[i]) != NULL; i++) {
+    fputs(line, fp);
+    putc('\n', fp);
+  }
+}

--- a/src/tool_help.h
+++ b/src/tool_help.h
@@ -24,6 +24,7 @@
 #include "tool_setup.h"
 
 void tool_help(void);
+void tool_help_short(FILE *);
 
 #endif /* HEADER_CURL_TOOL_HELP_H */
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -57,6 +57,7 @@
 #include "tool_doswin.h"
 #include "tool_easysrc.h"
 #include "tool_getparam.h"
+#include "tool_help.h"
 #include "tool_helpers.h"
 #include "tool_homedir.h"
 #include "tool_libinfo.h"
@@ -211,8 +212,10 @@ int operate(struct Configurable *config, int argc, argv_item_t argv[])
     parseconfig(NULL, config); /* ignore possible failure */
   }
 
-  if((argc < 2)  && !config->url_list) {
-    helpf(config->errors, NULL);
+  if((argc < 2) && !config->url_list) {
+    FILE *err = config->errors;
+    tool_help_short(err);
+    helpf(err, NULL);
     res = CURLE_FAILED_INIT;
     goto quit_curl;
   }


### PR DESCRIPTION
This patch adds a usage message to the help for `argc<2`:

```
Usage: curl [options...] <url>
  Transfers data at <url> to standard output.
curl: try 'curl --help' or 'curl --manual' for more information
```

The second line makes it clear that curl != wget, so novice users get a hint that they can expect a lot of garbage on their terminals :)
