### PR TITLE
CMake // Fixed issue with static build for MSVC2010

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -94,6 +94,10 @@ add_library(
   ${HHEADERS} ${CSOURCES}
   )
 
+if(MSVC AND CURL_STATICLIB)
+  set_target_properties(${LIB_NAME} PROPERTIES STATIC_LIBRARY_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+endif()
+
 target_link_libraries(${LIB_NAME} ${CURL_LIBS})
 
 if(WIN32)
@@ -107,14 +111,6 @@ setup_curl_dependencies(${LIB_NAME})
 # Remove the "lib" prefix since the library is already named "libcurl".
 set_target_properties(${LIB_NAME} PROPERTIES PREFIX "")
 set_target_properties(${LIB_NAME} PROPERTIES IMPORT_PREFIX "")
-
-if(MSVC)
-  if(NOT BUILD_RELEASE_DEBUG_DIRS)
-    # Ugly workaround to remove the "/debug" or "/release" in each output
-    set_target_properties(${LIB_NAME} PROPERTIES PREFIX "../")
-    set_target_properties(${LIB_NAME} PROPERTIES IMPORT_PREFIX "../")
-  endif()
-endif()
 
 if(WIN32)
   if(NOT CURL_STATICLIB)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,13 +46,6 @@ target_link_libraries( ${EXE_NAME} libcurl )
 set_target_properties(${EXE_NAME} PROPERTIES
   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
-if(MSVC)
-  if(NOT BUILD_RELEASE_DEBUG_DIRS)
-    # Ugly workaround to remove the "/debug" or "/release" in each output
-    set_target_properties(${EXE_NAME} PROPERTIES PREFIX "../")
-  endif()
-endif()
-
 #INCLUDE(ModuleInstall OPTIONAL)
 
 install(TARGETS ${EXE_NAME} DESTINATION bin)

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -25,14 +25,6 @@ function(SETUP_TEST TEST_NAME)          # ARGN are the files in the test
   set_target_properties(${TEST_NAME}
     PROPERTIES DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
-  if(MSVC)
-    if(NOT BUILD_RELEASE_DEBUG_DIRS)
-      # Ugly workaround to remove the "/debug" or "/release" in each output
-      set_target_properties(${TEST_NAME} PROPERTIES PREFIX "../")
-      set_target_properties(${TEST_NAME} PROPERTIES IMPORT_PREFIX "../")
-    endif()
-  endif()
-
 endfunction()
 
 

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -33,14 +33,6 @@ function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
   set_target_properties(${TEST_NAME} PROPERTIES
     DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
-  if(MSVC)
-    if(NOT BUILD_RELEASE_DEBUG_DIRS)
-      # Ugly workaround to remove the "/debug" or "/release" in each output
-      set_target_properties(${TEST_NAME} PROPERTIES PREFIX "../")
-      set_target_properties(${TEST_NAME} PROPERTIES IMPORT_PREFIX "../")
-    endif()
-  endif()
-
 endfunction()
 
 


### PR DESCRIPTION
Fixed issue with static build for MSVC2010.
The issue was raised in following thread http://curl.haxx.se/mail/lib-2013-07/0046.html

After some investigation I've discovered known issue http://public.kitware.com/Bug/view.php?id=11240
When .rc file is linked to static lib it fails with following linker error

LINK : warning LNK4068: /MACHINE not specified; defaulting to X86
file.obj : fatal error LNK1112: module machine type 'x64' conflicts with target machine type 'X86'

Fix add target property  /MACHINE:<arch> for MSVC generation.

Also removed old workarounds - it caused errors during msvc build.
