### PR TITLE
Improve the docs for curl_easy_pause

### DIFF
--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -38,8 +38,8 @@ that returns pause signals to the library that it couldn't take care of any
 data at all, and that data will then be delivered again to the callback when
 the writing is later unpaused.
 
-NOTE: while it may feel tempting, take care and notice that you cannot call
-this function from another thread.
+NOTE: While it may feel tempting, take care and notice that you cannot call
+this function from another thread. To unpause, you may call it from the progress callback (see \fICURLOPT_PROGRESSFUNCTION\fP), which gets called at least once per second, even if the connection is paused.
 
 When this function is called to unpause reading, the chance is high that you
 will get your write callback called before this function returns.


### PR DESCRIPTION
Several users seem to struggle with `curl_easy_pause`, I'd like to add a sentence to the docs, from where `curl_easy_pause` could be called to unpause a connection. I think, the progress callback is most suitable, because it should be called at least once per second even if idle or paused, right?
What do you think?
