### PR TITLE
Increase the timeout for test 1112 from 7s to 16s.

### DIFF
--- a/tests/data/test1112
+++ b/tests/data/test1112
@@ -89,7 +89,7 @@ ftps
 FTPS download with strict timeout and slow data transfer
  </name>
  <command timeout="1">
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/1112 -m 7
+-k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/1112 -m 16
 </command>
 </client>
 


### PR DESCRIPTION
As someone [reported on the mailing list a while back](http://curl.haxx.se/mail/lib-2010-02/0200.html), the hard-coded arbitrary timeout of 7s in test 1112 is not sufficient in some build environments.  At Arista Networks we build and test curl as part of our automated build system, and we've run into this timeout 170 times so far.  Our build servers are typically quite busy building and testing a lot of code in parallel, so despite being beefy machines with 32 cores and 128GB of RAM we still hit this 7s timeout regularly.
