### PR TITLE
Update proxy authentication documentation

### DIFF
--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -1307,7 +1307,7 @@ use. For some methods, this will induce an extra network round-trip. Set the
 actual name and password with the \fICURLOPT_PROXYUSERPWD\fP option. The
 bitmask can be constructed by or'ing together the bits listed above for the
 \fICURLOPT_HTTPAUTH\fP option. As of 7.17.1, only Basic, Digest, NTLM, and Negotiate
-work. (Added in 7.10.17)
+work. (Added in 7.10.7)
 .IP CURLOPT_SASL_IR
 Pass a long. If the value is 1, curl will send the initial response to the
 server in the first authentication packet in order to reduce the number of


### PR DESCRIPTION
This seems to have been added in 7.17.1.

http://curl.haxx.se/changes.html
