### PR TITLE
Curl_getconnectinfo: works on detached easy connection from a multi hand...

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1189,15 +1189,29 @@ curl_socket_t Curl_getconnectinfo(struct SessionHandle *data,
 
   DEBUGASSERT(data);
 
-  /* this only works for an easy handle that has been used for
-     curl_easy_perform()! */
-  if(data->state.lastconnect && data->multi_easy) {
-    struct connectdata *c = data->state.lastconnect;
+  /* this works for an easy handle:
+   * - that has been used for curl_easy_perform()
+   * - that is associated with a multi handle, and whose connection
+   *   was detached with pause/CURLOPT_FORBID_REUSE/CURLOPT_CONNECT_ONLY
+   */
+  if((data->state.lastconnect && data->multi_easy) ||
+     (data->easy_conn && data->multi)) {
+    struct connectdata *c;
     struct connfind find;
-    find.tofind = data->state.lastconnect;
+    struct Curl_multi *multi;
+    
+    if (data->multi) { /* connection from a multi handle */
+      c = data->easy_conn;
+      multi = data->multi;
+    } else { // use of a connect_only easy_socket
+      c = data->state.lastconnect;
+      multi = data->multi_easy;
+    }
+    
+    find.tofind = c;
     find.found = FALSE;
 
-    Curl_conncache_foreach(data->multi_easy->conn_cache, &find, conn_is_conn);
+    Curl_conncache_foreach(multi->conn_cache, &find, conn_is_conn);
 
     if(!find.found) {
       data->state.lastconnect = NULL;


### PR DESCRIPTION
...le

it can be used to implement websocket with curl and a custom websocket
parser:
1) add a easy handle wich represent your UPGRADE http request,
   with CURLOPT_HEADERFUNCTION set
2) on the last last header, do the following to detach the connection
     curl_easy_pause(easy_handle, CURLPAUSE_ALL);
     curl_easy_setopt(easy_handle, CURLOPT_FORBID_REUSE, 1);
     curl_easy_setopt(easy_handle, CURLOPT_CONNECT_ONLY, 1);
3) using the multi port you have, you can safely poll your socket
   for data, and use curl_easy_send/curl_easy_recv to exchange
   data with the connection
