### PR TITLE
getpass: fix password parsing from console

### DIFF
--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -117,7 +117,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
       if(buffer[i] == '\b')
         /* remove this letter and if this is not the first key, remove the
            previous one as well */
-        i = i - (i >= 1) ? 2 : 1;
+        i = i - (i >= 1 ? 2 : 1);
   }
 #ifndef __SYMBIAN32__
   /* since echo is disabled, print a newline */


### PR DESCRIPTION
Incorrect password if use backspace while entered the password.

Regression from f7bfdbabf2d5398f4c266eabb0992a04af661f22

The '?:' operator has lower priority than the '-' operator
