### PR TITLE
Proposed fix for bug #1327: don't remove DNS entries that are in use

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -237,7 +237,7 @@ hostcache_timestamp_remove(void *datap, void *hc)
     (struct hostcache_prune_data *) datap;
   struct Curl_dns_entry *c = (struct Curl_dns_entry *) hc;
 
-  return (data->now - c->timestamp >= data->cache_timeout);
+  return !c->inuse && (data->now - c->timestamp >= data->cache_timeout);
 }
 
 /*


### PR DESCRIPTION
Bug report: https://sourceforge.net/p/curl/bugs/1327/

hostcache_timestamp_remove() should remove old _unused_ entries from the host cache, but it never checked whether the entry was actually in use. This complements commit 030a2b8cb.
