### PR TITLE
polarssl: fix compilation

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -306,8 +306,8 @@ struct ssl_connect_data {
   ssl_context ssl;
   ssl_session ssn;
   int server_fd;
-  x509_cert cacert;
-  x509_cert clicert;
+  x509_crt cacert;
+  x509_crt clicert;
   x509_crl crl;
   rsa_context rsa;
   ssl_connect_state connecting_state;

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -31,6 +31,7 @@
 
 #ifdef USE_POLARSSL
 
+#include <polarssl/compat-1.2.h>
 #include <polarssl/net.h>
 #include <polarssl/ssl.h>
 #include <polarssl/certs.h>
@@ -192,7 +193,7 @@ polarssl_connect_step1(struct connectdata *conn,
 #endif /* POLARSSL_VERSION_NUMBER<0x01010000 */
 
   /* Load the trusted CA */
-  memset(&connssl->cacert, 0, sizeof(x509_cert));
+  memset(&connssl->cacert, 0, sizeof(x509_crt));
 
   if(data->set.str[STRING_SSL_CAFILE]) {
     ret = x509parse_crtfile(&connssl->cacert,
@@ -211,7 +212,7 @@ polarssl_connect_step1(struct connectdata *conn,
   }
 
   /* Load the client certificate */
-  memset(&connssl->clicert, 0, sizeof(x509_cert));
+  memset(&connssl->clicert, 0, sizeof(x509_crt));
 
   if(data->set.str[STRING_CERT]) {
     ret = x509parse_crtfile(&connssl->clicert,


### PR DESCRIPTION
Rename x509_cert to x509_crt and add "compat-1.2.h"
include.
This would still need some more thorough conversion
in order to drop "compat-1.2.h" include.

Tested with openssl and polarssl build-path.

Also see https://bugs.gentoo.org/show_bug.cgi?id=503558
