### PR TITLE
update vc6curltool.dsp to add SOURCE warnless.c

### DIFF
--- a/vs/vc6/src/vc6curltool.dsp
+++ b/vs/vc6/src/vc6curltool.dsp
@@ -151,6 +151,10 @@ SOURCE=..\..\..\lib\strtoofft.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\..\lib\warnless.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\..\src\tool_binmode.c
 # End Source File
 # Begin Source File


### PR DESCRIPTION
fixed issue #1373 unresolved symbol _curlx_read referenced in function _tool_read_cberror when build curl using Visual Studio 2013

I tried compiling libCurl and Curl in Visual Studio 2013 using the project file included in the ./vs/vc6 folder (vc6curl.dsw).
I am using the latest curl 7.36.0 from the offical website.
I compiled libCurl without any error.But When I tried to build curl,I got 
2>dll-debug/curl.exe : fatal error LNK1120: 1 unresolved externals
here is the full log,I omit some unimportant logs with ...
1>------ Build started: Project: libcurl, Configuration: DLL Debug Win32 ------
1> amigaos.c
1> asyn-ares.c
1> asyn-thread.c
1> base64.c
...
1> Generating Code...
1> Compiling...
1> hostip6.c
1> hostip.c
...
1> md5.c
1> Generating Code...
1> Compiling...
1> memdebug.c
...
1> smtp.c
1> Generating Code...
1> Compiling...
1> socks.c
...
1> curl_darwinssl.c
1> curl_schannel.c
1> Generating Code...
1> Compiling...
1> cyassl.c
1> gskit.c
...
1> x509asn1.c
1> Generating Code...
1> Creating library dll-debug/libcurld_imp.lib and object dll-debug/libcurld_imp.exp
1> vc6libcurl.vcxproj -> I:\lib\curl-7.36.0\vs\vc6\lib.\dll-debug\libcurl.dll
2>------ Build started: Project: curl, Configuration: using libcurl DLL Debug Win32 ------
2>C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppBuild.targets(381,5): warning MSB8028: The intermediate directory (.\dll-debug/obj) contains files shared from another project (curltool.vcxproj). This can lead to incorrect clean and rebuild behavior.
2> nonblock.c
2> rawstr.c
2> strtoofft.c
2> tool_binmode.c
...
2> tool_writeout.c
2> Generating Code...
2> Compiling...
2> tool_xattr.c
2> Generating Code...
2>tool_cb_rea.obj : error LNK2019: unresolved external symbol _curlx_read referenced in function _tool_read_cb
2>dll-debug/curl.exe : fatal error LNK1120: 1 unresolved externals
========== Build: 1 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
I found the problem is that curl using curlx_read function which is not an offical libCurl API,
but the visual studio curl project didn`t add the warnless.c,when I add warnless.c to curl project,the problem fixed.
so I made  a patch by adding warnless.c to curl project，tested under Visual Studio 2008 and Visual Studio 2013
