### PR TITLE
The static connection counter caused a race condition.

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -149,6 +149,7 @@ CURLcode Curl_conncache_add_conn(struct conncache *connc,
     return result;
   }
 
+  conn->connection_id = connc->next_connection_id++;
   connc->num_connections++;
 
   return CURLE_OK;

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -25,6 +25,7 @@
 struct conncache {
   struct curl_hash *hash;
   size_t num_connections;
+  size_t next_connection_id;
 };
 
 struct conncache *Curl_conncache_init(int size);

--- a/lib/url.c
+++ b/lib/url.c
@@ -3254,19 +3254,7 @@ ConnectionDone(struct SessionHandle *data, struct connectdata *conn)
 static CURLcode ConnectionStore(struct SessionHandle *data,
                                 struct connectdata *conn)
 {
-  static int connection_id_counter = 0;
-
-  CURLcode result;
-
-  /* Assign a number to the connection for easier tracking in the log
-     output */
-  conn->connection_id = connection_id_counter++;
-
-  result = Curl_conncache_add_conn(data->state.conn_cache, conn);
-  if(result != CURLE_OK)
-    conn->connection_id = -1;
-
-  return result;
+  return Curl_conncache_add_conn(data->state.conn_cache, conn);
 }
 
 /* after a TCP connection to the proxy has been verified, this function does


### PR DESCRIPTION
Moving the connection id counter into conncache solves it, as well as simplifying
the related logic.

This can be verified by testing under ThreadSanitizer in a multithreaded environment.
