### PR TITLE
build-openssl.bat: Fix x64 release build

### DIFF
--- a/projects/build-openssl.bat
+++ b/projects/build-openssl.bat
@@ -156,7 +156,7 @@ rem ***************************************************************************
   set OUTDIR=build\Win64\%VC_DESC%
   if not exist %OUTDIR% md %OUTDIR%
 
-  if "%BUILD_CONFIG%" == "release" goto x86release
+  if "%BUILD_CONFIG%" == "release" goto x64release
 
 :x64debug
   rem Configuring 64-bit Debug Build


### PR DESCRIPTION
Prior to this change if x64 release was specified a failed attempt was
made to build x86 release instead.
