### PR TITLE
CMake 2.8's FindZLIB.cmake documents _DIRS*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,7 @@ if(CURL_ZLIB)
     set(HAVE_ZLIB ON)
     set(HAVE_LIBZ ON)
     list(APPEND CURL_LIBS ${ZLIB_LIBRARIES})
-    include_directories(${ZLIB_INCLUDE_DIR})
+    include_directories(${ZLIB_INCLUDE_DIRS})
   endif()
 endif()
 


### PR DESCRIPTION
CMake 2.8's FindZLIB.cmake documents
ZLIB_INCLUDE_DIRS http://www.cmake.org/cmake/help/v2.8.0/cmake.html#module:FindZLIB
