### PR TITLE
multi: inform multi about closed sockets before they are closed

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1244,11 +1244,12 @@ int Curl_closesocket(struct connectdata *conn,
     else
       return conn->fclosesocket(conn->closesocket_client, sock);
   }
-  sclose(sock);
 
   if(conn)
     /* tell the multi-socket code about this */
     Curl_multi_closed(conn, sock);
+
+  sclose(sock);
 
   return 0;
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2113,7 +2113,7 @@ static void singlesocket(struct Curl_multi *multi,
  * Curl_multi_closed()
  *
  * Used by the connect code to tell the multi_socket code that one of the
- * sockets we were using have just been closed.  This function will then
+ * sockets we were using is about to be closed.  This function will then
  * remove it from the sockethash for this handle to make the multi_socket API
  * behave properly, especially for the case when libcurl will create another
  * socket again and it gets the same file descriptor number.

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -82,7 +82,7 @@ size_t Curl_multi_max_total_connections(struct Curl_multi *multi);
  * Curl_multi_closed()
  *
  * Used by the connect code to tell the multi_socket code that one of the
- * sockets we were using have just been closed.  This function will then
+ * sockets we were using is about to be closed.  This function will then
  * remove it from the sockethash for this handle to make the multi_socket API
  * behave properly, especially for the case when libcurl will create another
  * socket again and it gets the same file descriptor number.


### PR DESCRIPTION
When the connection code decides to close a socket it informs
the multi system via the Curl_multi_closed function. The multi
system may, in turn, invoke the CURLMOPT_SOCKETFUNCTION function
with CURL_POLL_REMOVE. This happens after the socket has already
been closed. Reorder the code so that CURL_POLL_REMOVE is called
before the socket is closed.
