### PR TITLE
examples: Wait recommended 100ms when no file descriptors are ready

### DIFF
--- a/docs/examples/imap-multi.c
+++ b/docs/examples/imap-multi.c
@@ -120,20 +120,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -109,20 +109,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 

--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -183,20 +183,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 

--- a/docs/examples/multi-double.c
+++ b/docs/examples/multi-double.c
@@ -98,20 +98,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 

--- a/docs/examples/multi-post.c
+++ b/docs/examples/multi-post.c
@@ -119,20 +119,24 @@ int main(void)
       }
 
       /* On success the value of maxfd is guaranteed to be >= -1. We call
-         select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-         select(0, ...), which is basically equal to sleeping the timeout. On
-         Windows we can't sleep via select without a dummy socket and instead
-         we Sleep() for 100ms which is the minimum suggested value in the
+         select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+         no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+         to sleep 100ms, which is the minimum suggested value in the
          curl_multi_fdset() doc. */
 
-#ifdef _WIN32
       if(maxfd == -1) {
+#ifdef _WIN32
         Sleep(100);
         rc = 0;
-      }
-      else
+#else
+        /* Portable sleep for platforms other than Windows. */
+        struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+        rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-      {
+      }
+      else {
+        /* Note that on some platforms 'timeout' may be modified by select().
+           If you need access to the original value save a copy beforehand. */
         rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
       }
 

--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -96,20 +96,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 

--- a/docs/examples/pop3-multi.c
+++ b/docs/examples/pop3-multi.c
@@ -120,20 +120,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 

--- a/docs/examples/smtp-multi.c
+++ b/docs/examples/smtp-multi.c
@@ -187,20 +187,24 @@ int main(void)
     }
 
     /* On success the value of maxfd is guaranteed to be >= -1. We call
-       select(maxfd + 1, ...); specially in case of (maxfd == -1) we call
-       select(0, ...), which is basically equal to sleeping the timeout. On
-       Windows we can't sleep via select without a dummy socket and instead
-       we Sleep() for 100ms which is the minimum suggested value in the
+       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
+       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
+       to sleep 100ms, which is the minimum suggested value in the
        curl_multi_fdset() doc. */
 
-#ifdef _WIN32
     if(maxfd == -1) {
+#ifdef _WIN32
       Sleep(100);
       rc = 0;
-    }
-    else
+#else
+      /* Portable sleep for platforms other than Windows. */
+      struct timeval wait = { 0, 100 * 1000 }; /* 100ms */
+      rc = select(0, NULL, NULL, NULL, &wait);
 #endif
-    {
+    }
+    else {
+      /* Note that on some platforms 'timeout' may be modified by select().
+         If you need access to the original value save a copy beforehand. */
       rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
     }
 


### PR DESCRIPTION
As discussed on the [mailing list](http://curl.haxx.se/mail/lib-2014-11/0264.html):

Prior to this change when no file descriptors were ready on platforms
other than Windows the multi examples would sleep whatever was in
timeout, which may or may not have been less than the minimum
recommended value [1](http://curl.haxx.se/libcurl/c/curl_multi_fdset.html) of 100ms.
