### PR TITLE
examples: remove sony.com from 10-at-a-time

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -62,7 +62,6 @@ static const char *urls[] = {
   "http://www.uefa.com",
   "http://www.ieee.org",
   "http://www.apple.com",
-  "http://www.sony.com",
   "http://www.symantec.com",
   "http://www.zdnet.com",
   "http://www.fujitsu.com",


### PR DESCRIPTION
Prior to this change the 10-at-a-time example showed CURLE_RECV_ERROR
for the sony website because its website proxy ends the connection when
the request is missing a user agent.
