### PR TITLE
examples: Get pedantic about initialization and cleanup

### DIFF
--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -20,6 +20,7 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #ifdef WIN32
 #  include <io.h>
@@ -57,6 +58,13 @@
 #ifndef intptr_t
 #define intptr_t long
 #endif
+#endif
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
 #endif
 
 /*
@@ -120,6 +128,24 @@ int main(int argc, char **argv)
   char *file;
   char *url;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   if(argc < 3)
     return 1;
 
@@ -129,9 +155,6 @@ int main(int argc, char **argv)
   /* get the file size of the local file */
   hd = open(file, O_RDONLY) ;
   fstat(hd, &file_info);
-
-  /* In windows, this will init the winsock stuff */
-  curl_global_init(CURL_GLOBAL_ALL);
 
   /* get a curl handle */
   curl = curl_easy_init();
@@ -180,6 +203,5 @@ int main(int argc, char **argv)
   }
   close(hd); /* close the local file */
 
-  curl_global_cleanup();
   return 0;
 }

--- a/docs/examples/asiohiper.cpp
+++ b/docs/examples/asiohiper.cpp
@@ -45,9 +45,17 @@
  */
 
 
+#include <stdlib.h>
 #include <curl/curl.h>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 #define MSG_OUT stdout /* Send info to stdout, change to stderr if you want */
 
@@ -433,6 +441,24 @@ int main(int argc, char **argv)
   CURLMcode rc;
   (void)argc;
   (void)argv;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   memset(&g, 0, sizeof(GlobalInfo));
   g.multi = curl_multi_init();

--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -33,6 +33,14 @@
 #include <openssl/ssl.h>
 #include <curl/curl.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 size_t writefunction( void *ptr, size_t size, size_t nmemb, void *stream)
 {
@@ -116,7 +124,24 @@ int main(void)
   CURL * ch;
   CURLcode rv;
 
-  rv=curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   ch=curl_easy_init();
   rv=curl_easy_setopt(ch,CURLOPT_VERBOSE, 0L);
   rv=curl_easy_setopt(ch,CURLOPT_HEADER, 0L);
@@ -150,6 +175,5 @@ int main(void)
     printf("*** transfer failed ***\n");
 
   curl_easy_cleanup(ch);
-  curl_global_cleanup();
   return rv;
 }

--- a/docs/examples/certinfo.c
+++ b/docs/examples/certinfo.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 static size_t wrfu(void *ptr,  size_t  size,  size_t  nmemb,  void *stream)
 {
@@ -35,7 +43,23 @@ int main(void)
   CURL *curl;
   CURLcode res;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {
@@ -79,8 +103,6 @@ int main(void)
 
     curl_easy_cleanup(curl);
   }
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -36,6 +36,13 @@
 
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 #define URL_BASE "http://speedtest.your.domain/"
 #define URL_1M   URL_BASE "file_1M.bin"
 #define URL_2M   URL_BASE "file_2M.bin"
@@ -63,6 +70,24 @@ int main(int argc, char *argv[])
   int prtall = 0, prtsep = 0, prttime = 0;
   const char *url = URL_1M;
   char *appname = argv[0];
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   if (argc > 1) {
     /* parse input parameters */
@@ -125,9 +150,6 @@ int main(int argc, char *argv[])
     printf("Localtime: %s", ctime(&t));
   }
 
-  /* init libcurl */
-  curl_global_init(CURL_GLOBAL_ALL);
-
   /* init the curl session */
   curl_handle = curl_easy_init();
 
@@ -182,9 +204,6 @@ int main(int argc, char *argv[])
 
   /* cleanup curl stuff */
   curl_easy_cleanup(curl_handle);
-
-  /* we're done with libcurl, so clean it up */
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -29,6 +29,13 @@
 
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 static void
 print_cookies(CURL *curl)
 {
@@ -61,7 +68,24 @@ main(void)
   CURL *curl;
   CURLcode res;
 
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   curl = curl_easy_init();
   if (curl) {
     char nline[256];
@@ -119,6 +143,7 @@ main(void)
     return 1;
   }
 
-  curl_global_cleanup();
+  curl_easy_cleanup(curl);
+
   return 0;
 }

--- a/docs/examples/curlgtk.c
+++ b/docs/examples/curlgtk.c
@@ -10,9 +10,17 @@
 /* an attempt to use the curl library in concert with a gtk-threaded application */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <gtk/gtk.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 GtkWidget *Bar;
 
@@ -74,8 +82,23 @@ int main(int argc, char **argv)
   GtkWidget *Window, *Frame, *Frame2;
   GtkAdjustment *adj;
 
-  /* Must initialize libcurl before any threads are started */
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* Init thread */
   g_thread_init(NULL);

--- a/docs/examples/debug.c
+++ b/docs/examples/debug.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 struct data {
   char trace_ascii; /* 1 or 0 */
@@ -119,6 +127,24 @@ int main(void)
   CURL *curl;
   CURLcode res;
   struct data config;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   config.trace_ascii = 1; /* enable ascii tracing */
 

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -69,6 +69,13 @@ callback.
 #include <sys/stat.h>
 #include <errno.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 #define DPRINT(x...) printf(x)
 
 #define MSG_OUT stdout /* Send info to stdout, change to stderr if you want */
@@ -417,6 +424,24 @@ int main(int argc, char **argv)
   CURLMcode rc;
   (void)argc;
   (void)argv;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   memset(&g, 0, sizeof(GlobalInfo));
   g.loop = ev_default_loop(0);

--- a/docs/examples/ftp-wildcard.c
+++ b/docs/examples/ftp-wildcard.c
@@ -21,6 +21,14 @@
  ***************************************************************************/
 #include <curl/curl.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 struct callback_data {
   FILE *output;
@@ -45,15 +53,27 @@ int main(int argc, char **argv)
   /* help data */
   struct callback_data data = { 0 };
 
-  /* global initialization */
-  rc = curl_global_init(CURL_GLOBAL_ALL);
-  if(rc)
-    return rc;
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* initialization of easy handle */
   handle = curl_easy_init();
   if(!handle) {
-    curl_global_cleanup();
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -85,7 +105,6 @@ int main(int argc, char **argv)
   rc = curl_easy_perform(handle);
 
   curl_easy_cleanup(handle);
-  curl_global_cleanup();
   return rc;
 }
 

--- a/docs/examples/ftpget.c
+++ b/docs/examples/ftpget.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /*
  * This is an example showing how to get a single file from an FTP server.
@@ -57,7 +65,23 @@ int main(void)
     NULL
   };
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {
@@ -87,8 +111,6 @@ int main(void)
 
   if(ftpfile.stream)
     fclose(ftpfile.stream); /* close the local file */
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/ftpgetresp.c
+++ b/docs/examples/ftpgetresp.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /*
  * Similar to ftpget.c but this also stores the received response-lines
@@ -43,6 +51,24 @@ int main(void)
   CURLcode res;
   FILE *ftpfile;
   FILE *respfile;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* local file name to store the file as */
   ftpfile = fopen("ftp-list", "wb"); /* b is binary, needed on win32 */

--- a/docs/examples/ftpsget.c
+++ b/docs/examples/ftpsget.c
@@ -21,8 +21,16 @@
  ***************************************************************************/
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /*
  * This is an example showing how to get a single file from an FTPS server.
@@ -59,7 +67,23 @@ int main(void)
     NULL
   };
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {
@@ -94,8 +118,6 @@ int main(void)
 
   if(ftpfile.stream)
     fclose(ftpfile.stream); /* close the local file */
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/getinfo.c
+++ b/docs/examples/getinfo.c
@@ -20,12 +20,38 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* http://curl.haxx.se/libcurl/c/curl_easy_init.html */
   curl = curl_easy_init();

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -29,6 +29,13 @@
 
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 struct MemoryStruct {
   char *memory;
   size_t size;
@@ -63,10 +70,26 @@ int main(void)
 
   struct MemoryStruct chunk;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   chunk.memory = malloc(1);  /* will be grown as needed by the realloc above */
   chunk.size = 0;    /* no data at this point */
-
-  curl_global_init(CURL_GLOBAL_ALL);
 
   /* init the curl session */
   curl_handle = curl_easy_init();
@@ -108,9 +131,6 @@ int main(void)
 
   if(chunk.memory)
     free(chunk.memory);
-
-  /* we're done with libcurl, so clean it up */
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -66,6 +66,13 @@ callback.
 #include <sys/stat.h>
 #include <errno.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 
 #define MSG_OUT stdout /* Send info to stdout, change to stderr if you want */
 
@@ -407,6 +414,24 @@ int main(int argc, char **argv)
   GlobalInfo g;
   (void)argc;
   (void)argv;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   memset(&g, 0, sizeof(GlobalInfo));
   g.evbase = event_base_new();

--- a/docs/examples/href_extractor.c
+++ b/docs/examples/href_extractor.c
@@ -30,8 +30,16 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
 #include <htmlstreamparser.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 
 static size_t write_callback(void *buffer, size_t size, size_t nmemb,
@@ -55,6 +63,24 @@ int main(int argc, char *argv[])
   char tag[1], attr[4], val[128];
   CURL *curl;
   HTMLSTREAMPARSER *hsp;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   if (argc != 2) {
     printf("Usage: %s URL\n", argv[0]);

--- a/docs/examples/htmltidy.c
+++ b/docs/examples/htmltidy.c
@@ -29,9 +29,17 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <tidy/tidy.h>
 #include <tidy/buffio.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* curl write callback, to fill tidy's input buffer...  */
 uint write_cb(char *in, uint size, uint nmemb, TidyBuffer *out)
@@ -83,6 +91,25 @@ int main(int argc, char **argv )
   TidyBuffer docbuf = {0};
   TidyBuffer tidy_errbuf = {0};
   int err;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   if ( argc == 2) {
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);

--- a/docs/examples/htmltitle.cpp
+++ b/docs/examples/htmltitle.cpp
@@ -35,6 +35,13 @@
 #include <curl/curl.h>
 #include <libxml/HTMLparser.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 //
 //  Case-insensitive string comparison
 //
@@ -269,6 +276,24 @@ int main(int argc, char *argv[])
   CURLcode code;
   std::string title;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   // Ensure one argument is given
 
   if (argc != 2)
@@ -277,8 +302,6 @@ int main(int argc, char *argv[])
 
     exit(EXIT_FAILURE);
   }
-
-  curl_global_init(CURL_GLOBAL_DEFAULT);
 
   // Initialize CURL connection
 

--- a/docs/examples/http-post.c
+++ b/docs/examples/http-post.c
@@ -20,15 +20,38 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res;
 
-  /* In windows, this will init the winsock stuff */
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* get a curl handle */
   curl = curl_easy_init();
@@ -50,6 +73,5 @@ int main(void)
     /* always cleanup */
     curl_easy_cleanup(curl);
   }
-  curl_global_cleanup();
   return 0;
 }

--- a/docs/examples/httpcustomheader.c
+++ b/docs/examples/httpcustomheader.c
@@ -20,12 +20,38 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/https.c
+++ b/docs/examples/https.c
@@ -20,14 +20,38 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {
@@ -67,8 +91,6 @@ int main(void)
     /* always cleanup */
     curl_easy_cleanup(curl);
   }
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/imap-append.c
+++ b/docs/examples/imap-append.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to send mail using libcurl's IMAP
  * capabilities.
@@ -79,6 +87,24 @@ int main(void)
   CURL *curl;
   CURLcode res = CURLE_OK;
   struct upload_status upload_ctx;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   upload_ctx.lines_read = 0;
 

--- a/docs/examples/imap-copy.c
+++ b/docs/examples/imap-copy.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to copy a mail from one mailbox folder
  * to another using libcurl's IMAP capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-create.c
+++ b/docs/examples/imap-create.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to create a new mailbox folder using
  * libcurl's IMAP capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-delete.c
+++ b/docs/examples/imap-delete.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to delete an existing mailbox folder
  * using libcurl's IMAP capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-examine.c
+++ b/docs/examples/imap-examine.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to obtain information about a mailbox
  * folder using libcurl's IMAP capabilities via the EXAMINE command.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-fetch.c
+++ b/docs/examples/imap-fetch.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to fetch mail using libcurl's IMAP
  * capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-list.c
+++ b/docs/examples/imap-list.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to list the folders within an IMAP
  * mailbox.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-lsub.c
+++ b/docs/examples/imap-lsub.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to list the subscribed folders within
  * an IMAP mailbox.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-multi.c
+++ b/docs/examples/imap-multi.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to fetch mail using libcurl's IMAP
  * capabilities. It builds on the imap-fetch.c example to demonstrate how to
@@ -55,7 +63,23 @@ int main(void)
   int still_running = 1;
   struct timeval mp_start;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(!curl)
@@ -159,9 +183,8 @@ int main(void)
 
   /* Always cleanup */
   curl_multi_remove_handle(mcurl, curl);
-  curl_multi_cleanup(mcurl);
   curl_easy_cleanup(curl);
-  curl_global_cleanup();
+  curl_multi_cleanup(mcurl);
 
   return 0;
 }

--- a/docs/examples/imap-noop.c
+++ b/docs/examples/imap-noop.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to perform a noop using libcurl's IMAP
  * capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-search.c
+++ b/docs/examples/imap-search.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to search for new messages using
  * libcurl's IMAP capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-ssl.c
+++ b/docs/examples/imap-ssl.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to fetch mail using libcurl's IMAP
  * capabilities. It builds on the imap-fetch.c example adding transport
@@ -33,6 +41,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-store.c
+++ b/docs/examples/imap-store.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to modify an existing mail using
  * libcurl's IMAP capabilities with the STORE command.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/imap-tls.c
+++ b/docs/examples/imap-tls.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to fetch mail using libcurl's IMAP
  * capabilities. It builds on the imap-fetch.c example adding transport
@@ -33,6 +41,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -22,6 +22,7 @@
 /* This is an example application source code using the multi interface. */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* somewhat unix-specific */
@@ -30,6 +31,13 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /*
  * Download a HTTP file and upload an FTP file simultaneously.
@@ -49,6 +57,24 @@ int main(void)
 
   CURLMsg *msg; /* for picking up messages with the transfer status */
   int msgs_left; /* how many messages are left */
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* Allocate one CURL handle per transfer */
   for (i=0; i<HANDLECOUNT; i++)
@@ -164,11 +190,13 @@ int main(void)
     }
   }
 
-  curl_multi_cleanup(multi_handle);
-
   /* Free the CURL handles */
-  for (i=0; i<HANDLECOUNT; i++)
-      curl_easy_cleanup(handles[i]);
+  for (i=0; i<HANDLECOUNT; i++) {
+    curl_multi_remove_handle(multi_handle, handles[i]);
+    curl_easy_cleanup(handles[i]);
+  }
+
+  curl_multi_cleanup(multi_handle);
 
   return 0;
 }

--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -22,6 +22,7 @@
 /* This is an example showing the multi interface and the debug callback. */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* somewhat unix-specific */
@@ -30,6 +31,13 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 typedef char bool;
 #define TRUE 1
@@ -127,6 +135,24 @@ int main(void)
 
   int still_running; /* keep number of running handles */
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   http_handle = curl_easy_init();
 
   /* set the options (I left out a few, you'll get the point anyway) */
@@ -218,9 +244,9 @@ int main(void)
     }
   } while(still_running);
 
-  curl_multi_cleanup(multi_handle);
-
+  curl_multi_remove_handle(multi_handle, http_handle);
   curl_easy_cleanup(http_handle);
+  curl_multi_cleanup(multi_handle);
 
   return 0;
 }

--- a/docs/examples/multi-double.c
+++ b/docs/examples/multi-double.c
@@ -20,6 +20,7 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* somewhat unix-specific */
@@ -28,6 +29,13 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /*
  * Simply download two HTTP files!
@@ -39,6 +47,24 @@ int main(void)
   CURLM *multi_handle;
 
   int still_running; /* keep number of running handles */
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   http_handle = curl_easy_init();
   http_handle2 = curl_easy_init();
@@ -131,10 +157,11 @@ int main(void)
     }
   } while(still_running);
 
-  curl_multi_cleanup(multi_handle);
-
+  curl_multi_remove_handle(multi_handle, http_handle);
   curl_easy_cleanup(http_handle);
+  curl_multi_remove_handle(multi_handle, http_handle2);
   curl_easy_cleanup(http_handle2);
+  curl_multi_cleanup(multi_handle);
 
   return 0;
 }

--- a/docs/examples/multi-post.c
+++ b/docs/examples/multi-post.c
@@ -22,10 +22,18 @@
 /* This is an example application source code using the multi interface
  * to do a multipart formpost without "blocking". */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
@@ -38,6 +46,24 @@ int main(void)
   struct curl_httppost *lastptr=NULL;
   struct curl_slist *headerlist=NULL;
   static const char buf[] = "Expect:";
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* Fill in the file upload field. This makes libcurl load data from
      the given file name when curl_easy_perform() is called. */
@@ -154,10 +180,9 @@ int main(void)
       }
     } while(still_running);
 
-    curl_multi_cleanup(multi_handle);
-
-    /* always cleanup */
+    curl_multi_remove_handle(multi_handle, curl);
     curl_easy_cleanup(curl);
+    curl_multi_cleanup(multi_handle);
 
     /* then cleanup the formpost chain */
     curl_formfree(formpost);

--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -22,6 +22,7 @@
 /* This is a very simple example using the multi interface. */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* somewhat unix-specific */
@@ -30,6 +31,13 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /*
  * Simply download a HTTP file.
@@ -41,7 +49,23 @@ int main(void)
 
   int still_running; /* keep number of running handles */
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   http_handle = curl_easy_init();
 
@@ -136,8 +160,6 @@ int main(void)
   curl_easy_cleanup(http_handle);
 
   curl_multi_cleanup(multi_handle);
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -39,6 +39,13 @@
 #include <uv.h>
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 uv_loop_t *loop;
 CURLM *curl_handle;
 uv_timer_t timeout;
@@ -208,9 +215,22 @@ int main(int argc, char **argv)
   if(argc <= 1)
     return 0;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
   if(curl_global_init(CURL_GLOBAL_ALL)) {
-    fprintf(stderr, "Could not init cURL\n");
-    return 1;
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
   }
 
   uv_timer_init(loop, &timeout);

--- a/docs/examples/multithread.c
+++ b/docs/examples/multithread.c
@@ -23,8 +23,16 @@
  * X remote files at once */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <pthread.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 #define NUMT 4
 
@@ -69,8 +77,23 @@ int main(int argc, char **argv)
   int i;
   int error;
 
-  /* Must initialize libcurl before any threads are started */
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   for(i=0; i< NUMT; i++) {
     error = pthread_create(&tid[i],

--- a/docs/examples/persistant.c
+++ b/docs/examples/persistant.c
@@ -20,15 +20,39 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res;
 
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-dele.c
+++ b/docs/examples/pop3-dele.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to delete an existing mail using
  * libcurl's POP3 capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-list.c
+++ b/docs/examples/pop3-list.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example using libcurl's POP3 capabilities to list the
  * contents of a mailbox.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-multi.c
+++ b/docs/examples/pop3-multi.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to retrieve mail using libcurl's POP3
  * capabilities. It builds on the pop3-retr.c example to demonstrate how to use
@@ -55,7 +63,23 @@ int main(void)
   int still_running = 1;
   struct timeval mp_start;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(!curl)
@@ -159,9 +183,8 @@ int main(void)
 
   /* Always cleanup */
   curl_multi_remove_handle(mcurl, curl);
-  curl_multi_cleanup(mcurl);
   curl_easy_cleanup(curl);
-  curl_global_cleanup();
+  curl_multi_cleanup(mcurl);
 
   return 0;
 }

--- a/docs/examples/pop3-noop.c
+++ b/docs/examples/pop3-noop.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to perform a noop using libcurl's POP3
  * capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-retr.c
+++ b/docs/examples/pop3-retr.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to retrieve mail using libcurl's POP3
  * capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-ssl.c
+++ b/docs/examples/pop3-ssl.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to retrieve mail using libcurl's POP3
  * capabilities. It builds on the pop3-retr.c example adding transport
@@ -33,6 +41,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-stat.c
+++ b/docs/examples/pop3-stat.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to obtain message statistics using
  * libcurl's POP3 capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-tls.c
+++ b/docs/examples/pop3-tls.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to retrieve mail using libcurl's POP3
  * capabilities. It builds on the pop3-retr.c example adding transport
@@ -33,6 +41,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-top.c
+++ b/docs/examples/pop3-top.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to retrieve only the headers of a mail
  * using libcurl's POP3 capabilities.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/pop3-uidl.c
+++ b/docs/examples/pop3-uidl.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example using libcurl's POP3 capabilities to list the
  * contents of a mailbox by unique ID.
@@ -32,6 +40,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/post-callback.c
+++ b/docs/examples/post-callback.c
@@ -23,8 +23,16 @@
  * data through a read callback.
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 const char data[]="this is what we post to the silly web server";
 
@@ -57,17 +65,26 @@ int main(void)
 
   struct WriteThis pooh;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   pooh.readptr = data;
   pooh.sizeleft = (long)strlen(data);
-
-  /* In windows, this will init the winsock stuff */
-  res = curl_global_init(CURL_GLOBAL_DEFAULT);
-  /* Check for errors */
-  if(res != CURLE_OK) {
-    fprintf(stderr, "curl_global_init() failed: %s\n",
-            curl_easy_strerror(res));
-    return 1;
-  }
 
   /* get a curl handle */
   curl = curl_easy_init();
@@ -138,6 +155,5 @@ int main(void)
     /* always cleanup */
     curl_easy_cleanup(curl);
   }
-  curl_global_cleanup();
   return 0;
 }

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -24,6 +24,13 @@
 #include <string.h>
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 struct MemoryStruct {
   char *memory;
   size_t size;
@@ -56,10 +63,27 @@ int main(void)
   struct MemoryStruct chunk;
   static const char *postthis="Field=1&Field=2&Field=3";
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   chunk.memory = malloc(1);  /* will be grown as needed by realloc above */
   chunk.size = 0;    /* no data at this point */
 
-  curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   if(curl) {
 
@@ -103,9 +127,6 @@ int main(void)
 
     if(chunk.memory)
       free(chunk.memory);
-
-    /* we're done with libcurl, so clean it up */
-    curl_global_cleanup();
   }
   return 0;
 }

--- a/docs/examples/postit2.c
+++ b/docs/examples/postit2.c
@@ -34,9 +34,17 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -48,7 +56,23 @@ int main(int argc, char *argv[])
   struct curl_slist *headerlist=NULL;
   static const char buf[] = "Expect:";
 
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* Fill in the file upload field */
   curl_formadd(&formpost,

--- a/docs/examples/progressfunc.c
+++ b/docs/examples/progressfunc.c
@@ -20,7 +20,15 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 #define STOP_DOWNLOAD_AFTER_THIS_MANY_BYTES         6000
 #define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL     3
@@ -77,6 +85,24 @@ int main(void)
   CURL *curl;
   CURLcode res = CURLE_OK;
   struct myprogress prog;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/resolve.c
+++ b/docs/examples/resolve.c
@@ -20,13 +20,39 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
   struct curl_slist *host = NULL;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* Each single name resolve string should be written using the format
      HOST:PORT:ADDRESS where HOST is the name libcurl will try to resolve,

--- a/docs/examples/sampleconv.c
+++ b/docs/examples/sampleconv.c
@@ -37,7 +37,15 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 CURLcode my_conv_from_ascii_to_ebcdic(char *buffer, size_t length)
 {
@@ -85,6 +93,24 @@ int main(void)
 {
   CURL *curl;
   CURLcode res;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/sendrecv.c
+++ b/docs/examples/sendrecv.c
@@ -22,8 +22,16 @@
 /* An example of curl_easy_send() and curl_easy_recv() usage. */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* Auxiliary function that waits on the socket. */
 static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
@@ -65,6 +73,24 @@ int main(void)
   long sockextr;
   size_t iolen;
   curl_off_t nread;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -25,6 +25,13 @@
 
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   int written = fwrite(ptr, size, nmemb, (FILE *)stream);
@@ -39,7 +46,23 @@ int main(void)
   static const char *bodyfilename = "body.out";
   FILE *bodyfile;
 
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* init the curl session */
   curl_handle = curl_easy_init();

--- a/docs/examples/sessioninfo.c
+++ b/docs/examples/sessioninfo.c
@@ -24,9 +24,17 @@
    GnuTLS (and this program must also be linked against -lgnutls). */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
 #include <gnutls/gnutls.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 static CURL *curl;
 
@@ -81,7 +89,23 @@ static size_t wrfu(void *ptr, size_t size, size_t nmemb, void *stream)
 
 int main(void)
 {
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {
@@ -98,8 +122,6 @@ int main(void)
 
     curl_easy_cleanup(curl);
   }
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -21,8 +21,16 @@
  ***************************************************************************/
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* define this to switch off the use of ssh-agent in this program */
 #undef DISABLE_SSH_AGENT
@@ -62,7 +70,23 @@ int main(void)
     NULL
   };
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {
@@ -99,8 +123,6 @@ int main(void)
 
   if(ftpfile.stream)
     fclose(ftpfile.stream); /* close the local file */
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/simple.c
+++ b/docs/examples/simple.c
@@ -20,12 +20,38 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
   CURL *curl;
   CURLcode res;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/simplepost.c
+++ b/docs/examples/simplepost.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 int main(void)
 {
@@ -29,6 +37,24 @@ int main(void)
   CURLcode res;
 
   static const char *postthis="moo mooo moo moo";
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/simplessl.c
+++ b/docs/examples/simplessl.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* some requirements for this to work:
    1.   set pCertFile to the file with the client certificate
@@ -57,6 +65,24 @@ int main(void)
 
   const char *pEngine;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
 #ifdef USE_ENGINE
   pKeyName  = "rsa_test";
   pKeyType  = "ENG";
@@ -68,8 +94,6 @@ int main(void)
 #endif
 
   headerfile = fopen("dumpit", "w");
-
-  curl_global_init(CURL_GLOBAL_DEFAULT);
 
   curl = curl_easy_init();
   if(curl) {
@@ -131,8 +155,6 @@ int main(void)
     /* always cleanup */
     curl_easy_cleanup(curl);
   }
-
-  curl_global_cleanup();
 
   return 0;
 }

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -31,12 +31,20 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <gtk/gtk.h>
 #include <glib.h>
 #include <unistd.h>
 #include <pthread.h>
 
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 #define NUMT 4
 
@@ -177,8 +185,23 @@ int main(int argc, char **argv)
 {
   GtkWidget *top_window, *outside_frame, *inside_frame, *progress_bar;
 
-  /* Must initialize libcurl before any threads are started */
-  curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   /* Init thread */
   g_thread_init(NULL);

--- a/docs/examples/smtp-expn.c
+++ b/docs/examples/smtp-expn.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to expand an email mailing list.
  *
@@ -36,6 +44,24 @@ int main(void)
   CURL *curl;
   CURLcode res;
   struct curl_slist *recipients = NULL;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/smtp-mail.c
+++ b/docs/examples/smtp-mail.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to send mail using libcurl's SMTP
  * capabilities. For an exmaple of using the multi interface please see
@@ -81,6 +89,24 @@ int main(void)
   CURLcode res = CURLE_OK;
   struct curl_slist *recipients = NULL;
   struct upload_status upload_ctx;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   upload_ctx.lines_read = 0;
 

--- a/docs/examples/smtp-ssl.c
+++ b/docs/examples/smtp-ssl.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to send mail using libcurl's SMTP
  * capabilities. It builds on the smtp-mail.c example to add authentication
@@ -82,6 +90,24 @@ int main(void)
   CURLcode res = CURLE_OK;
   struct curl_slist *recipients = NULL;
   struct upload_status upload_ctx;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   upload_ctx.lines_read = 0;
 

--- a/docs/examples/smtp-tls.c
+++ b/docs/examples/smtp-tls.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to send mail using libcurl's SMTP
  * capabilities. It builds on the smtp-mail.c example to add authentication
@@ -82,6 +90,24 @@ int main(void)
   CURLcode res = CURLE_OK;
   struct curl_slist *recipients = NULL;
   struct upload_status upload_ctx;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   upload_ctx.lines_read = 0;
 

--- a/docs/examples/smtp-vrfy.c
+++ b/docs/examples/smtp-vrfy.c
@@ -20,8 +20,16 @@
  *
  ***************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 /* This is a simple example showing how to verify an email address from an
  * SMTP server.
@@ -39,6 +47,24 @@ int main(void)
   CURL *curl;
   CURLcode res;
   struct curl_slist *recipients = NULL;
+
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -25,6 +25,13 @@
 
 #include <curl/curl.h>
 
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
 static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
@@ -37,12 +44,28 @@ int main(int argc, char *argv[])
   static const char *pagefilename = "page.out";
   FILE *pagefile;
 
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   if(argc < 2 ) {
     printf("Usage: %s <URL>\n", argv[0]);
     return 1;
   }
-
-  curl_global_init(CURL_GLOBAL_ALL);
 
   /* init the curl session */
   curl_handle = curl_easy_init();

--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -32,6 +32,14 @@
 #include <openssl/pem.h>
 #include <curl/curl.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#ifndef EXIT_SUCCESS
+#define EXIT_SUCCESS 0
+#endif
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
 
 static size_t writefunction(void *ptr, size_t size, size_t nmemb, void *stream)
 {
@@ -175,7 +183,24 @@ int main(void)
   CURL *ch;
   CURLcode rv;
 
-  rv = curl_global_init(CURL_GLOBAL_ALL);
+  /* Call curl_global_init immediately after the program starts, while it is
+  still only one thread and before it uses libcurl at all. If the function
+  returns non-zero, something went wrong and you cannot use the other curl
+  functions. */
+  if(curl_global_init(CURL_GLOBAL_ALL)) {
+    fprintf(stderr, "Fatal: The initialization of libcurl has failed.\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Call curl_global_cleanup immediately before the program exits, when the
+  program is again only one thread and after its last use of libcurl. For
+  example, you can use atexit to ensure the cleanup will be called at exit. */
+  if(atexit(curl_global_cleanup)) {
+    fprintf(stderr, "Fatal: atexit failed to register curl_global_cleanup.\n");
+    curl_global_cleanup();
+    return EXIT_FAILURE;
+  }
+
   ch = curl_easy_init();
   rv = curl_easy_setopt(ch,CURLOPT_VERBOSE, 0L);
   rv = curl_easy_setopt(ch,CURLOPT_HEADER, 0L);
@@ -219,6 +244,5 @@ int main(void)
   }
 
   curl_easy_cleanup(ch);
-  curl_global_cleanup();
   return rv;
 }


### PR DESCRIPTION
These changes make the examples reflect what is API documented regarding
initialization and cleanup.

All examples will now:
- Call curl_global_init immediately after the program starts.
- Call curl_global_cleanup immediately before the program exits.
- Call curl_easy_cleanup for each easy handle.
- Follow the cleanup call order for multi handles and the easy handles
  they contain. Specifically this order: curl_multi_remove_handle,
  curl_easy_cleanup, curl_multi_cleanup.

More can be done. To really get pedantic there needs to be logic to
check every curl function that can return an error. For example right
now in some cases curl_multi_init() isn't checked for NULL.
