### PR TITLE
Fix FAILONERROR doc typo

### DIFF
--- a/CHANGES.0
+++ b/CHANGES.0
@@ -17851,7 +17851,7 @@ Version 2.7
    rewrite the former -l kludge in an external script that'll use urlget to
    fetch multipart files like that.
  - '-f' is introduced, it means Fail without output in case of HTTP server
-   errors (return code >=300).
+   errors (return code >=400).
  - Added support for -r, ranges. Specify which part of a document you
    want, and only that part is returned. Only with HTTP/1.1-servers.
  - Split up the source in 3 parts. Now all pure URL functions are in

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -989,7 +989,7 @@ typedef enum {
   CINIT(HEADER, LONG, 42),       /* throw the header out too */
   CINIT(NOPROGRESS, LONG, 43),   /* shut off the progress meter */
   CINIT(NOBODY, LONG, 44),       /* use HEAD to get http document */
-  CINIT(FAILONERROR, LONG, 45),  /* no output on http error codes >= 300 */
+  CINIT(FAILONERROR, LONG, 45),  /* no output on http error codes >= 400 */
   CINIT(UPLOAD, LONG, 46),       /* this is an upload */
   CINIT(POST, LONG, 47),         /* HTTP POST method */
   CINIT(DIRLISTONLY, LONG, 48),  /* bare names when listing directories */

--- a/lib/url.c
+++ b/lib/url.c
@@ -769,7 +769,7 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
     break;
   case CURLOPT_FAILONERROR:
     /*
-     * Don't output the >=300 error code HTML-page, but instead only
+     * Don't output the >=400 error code HTML-page, but instead only
      * return error.
      */
     data->set.http_fail_on_error = (0 != va_arg(param, long))?TRUE:FALSE;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1572,7 +1572,7 @@ struct UserDefined {
   bool ftp_list_only;    /* switch FTP command for listing directories */
   bool ftp_use_port;     /* use the FTP PORT command */
   bool hide_progress;    /* don't use the progress meter */
-  bool http_fail_on_error;  /* fail on HTTP error codes >= 300 */
+  bool http_fail_on_error;  /* fail on HTTP error codes >= 400 */
   bool http_follow_location; /* follow HTTP redirects */
   bool http_transfer_encoding; /* request compressed HTTP transfer-encoding */
   bool http_disable_hostname_check_before_authentication;


### PR DESCRIPTION
The typo has propagated to websites and print, e.g., Zak Greant's "PHP Functions Essential Reference" (ISBN 9780735709706).
