### PR TITLE
opts: Warn CURLOPT_TIMEOUT overrides when set after CURLOPT_TIMEOUT_MS

### DIFF
--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.3
@@ -37,6 +37,9 @@ libcurl to use the SIGALRM signal to timeout system calls.
 In unix-like systems, this might cause signals to be used unless
 \fICURLOPT_NOSIGNAL(3)\fP is set.
 
+If both \fICURLOPT_TIMEOUT(3)\fP and \fICURLOPT_TIMEOUT_MS(3)\fP are set, the
+value set last will be used.
+
 Since this puts a hard limit for how long time a request is allowed to take,
 it has limited use in dynamic use cases with varying transfer times. You are
 then advised to explore \fICURLOPT_LOW_SPEED_LIMIT(3)\fP,


### PR DESCRIPTION
Change CURLOPT_TIMEOUT doc to warn that if CURLOPT_TIMEOUT and
CURLOPT_TIMEOUT_MS are both set whichever one is set last is the one
that will be used.

Prior to this change that behavior was only noted in the
CURLOPT_TIMEOUT_MS doc.
