### PR TITLE
Fix cppcheck reports:

### DIFF
--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -62,6 +62,7 @@ int main(void)
   bodyfile = fopen(bodyfilename,"wb");
   if (bodyfile == NULL) {
     curl_easy_cleanup(curl_handle);
+    fclose(headerfile);
     return -1;
   }
 

--- a/tests/libtest/lib1900.c
+++ b/tests/libtest/lib1900.c
@@ -179,7 +179,7 @@ int test(char *URL)
       now = tutil_tvnow();
       msnow = now.tv_sec * 1000 + now.tv_usec / 1000;
       mslast = last_handle_add.tv_sec * 1000 + last_handle_add.tv_usec / 1000;
-      if(msnow - mslast >= urltime[handlenum] && handlenum < num_handles) {
+      if(handlenum < num_handles && ((msnow - mslast) >= urltime[handlenum])) {
         fprintf(stdout, "Adding handle %d\n", handlenum);
         setup_handle(URL, m, handlenum);
         last_handle_add = now;


### PR DESCRIPTION
[tests/libtest/lib1900.c:182]: (style) Array index 'handlenum' is used before limits check.
[docs/examples/sepheaders.c:65]: (error) Resource leak: headerfile
