### PR TITLE
Adding support for IDLE command

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1099,10 +1099,7 @@ static CURLcode imap_state_select_resp(struct connectdata *conn, int imapcode,
       imapc->mailbox = strdup(imap->mailbox);
 
       if(imap->custom) {
-        if (!strcmp(imap->custom,"IDLE"))
-          result = imap_perform_idle(conn);
-        else
-          result = imap_perform_list(conn);
+        result = imap_perform_list(conn);
       }
       else if(imap->query)
         result = imap_perform_search(conn);
@@ -1624,6 +1621,8 @@ static CURLcode imap_perform(struct connectdata *conn, bool *connected,
   if(conn->data->set.upload)
     /* APPEND can be executed directly */
     result = imap_perform_append(conn);
+  else if(imap->custom && !strcmp(imap->custom, "IDLE"))
+    result = imap_perform_idle(conn);
   else if(imap->custom && (selected || !imap->mailbox))
     /* Custom command using the same mailbox or no mailbox */
     result = imap_perform_list(conn);

--- a/lib/imap.h
+++ b/lib/imap.h
@@ -46,6 +46,7 @@ typedef enum {
   IMAP_APPEND_FINAL,
   IMAP_SEARCH,
   IMAP_LOGOUT,
+  IMAP_IDLE,
   IMAP_LAST          /* never used */
 } imapstate;
 


### PR DESCRIPTION
I want to get some feedback on implementing IDLE command for IMAP.
This is just a simple proof of concept, I am missing:
 - Proper timeout handling: do not close connection on timeouts for IDLE command
 - Use IDLE/DONE sequences: Schedule a DONE+IDLE sequence every N seconds to keepalive TCP & IMAP connection (and other possible sources of disconnect such as NAT).
 - Proper reporting to the user: The idea is that the user will perform a custom IDLE command to avoid continuous fetches to the inbox.
 - Add/check support for aborting the transaction: If the user implements a progress callback we should be able to gracefully terminate the IDLE operation.

I'm waiting for your feedback :D 
Thanks!