### PR TITLE
use libssh2_scp_recv2 to support > 2GB files on windows over SFTP

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2368,19 +2368,30 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SCP_DOWNLOAD_INIT:
     {
+      curl_off_t bytecount;
+
       /*
        * We must check the remote file; if it is a directory no values will
        * be set in sb
        */
-      struct stat sb;
-      curl_off_t bytecount;
 
-      /* clear the struct scp recv will fill in */
-      memset(&sb, 0, sizeof(struct stat));
+       /*
+        * If support for >2GB files exists, use it.
+        */
 
       /* get a fresh new channel from the ssh layer */
+#if LIBSSH2_VERSION_NUM < 0x010700
+      struct stat sb;
+      memset(&sb, 0, sizeof(struct stat));
       sshc->ssh_channel = libssh2_scp_recv(sshc->ssh_session,
                                            sftp_scp->path, &sb);
+#else
+      libssh2_struct_stat sb;
+      memset(&sb, 0, sizeof(libssh2_struct_stat));
+      sshc->ssh_channel = libssh2_scp_recv2(sshc->ssh_session,
+                                            sftp_scp->path, &sb);
+#endif
+
       if(!sshc->ssh_channel) {
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {


### PR DESCRIPTION
Now that https://github.com/libssh2/libssh2/pull/31 is merged to master of libssh2, here is the little bit left to use it in curl.  I imagine we need to release a version of libssh2 that contains libssh2_scp_recv2 before it's safe to merge this, but I figured I'd get the ball rolling a bit.

Tested by receiving a > 2GB file on OS X 10.10.5 using a scp:// url.  I could use a hand testing this on windows as I'm still struggling to build curl against a hand-built libssh2 there.

Also, these results from make check on OS X 10.10.5:
```
TESTDONE: 864 tests out of 867 reported OK: 99%
TESTFAIL: These test cases failed: 20 507 534 
TESTDONE: 994 tests were considered during 409 seconds.
```
though note the same failures occurred on master.

I used this test config:
```
********* System characteristics ******** 
* curl 7.45.0-DEV (x86_64-apple-darwin14.5.0) 
* libcurl/7.45.0-DEV OpenSSL/0.9.8zd zlib/1.2.5 libssh2/1.6.1_DEV
* Features: Debug TrackMemory IPv6 Largefile NTLM NTLM_WB SSL libz UnixSockets 
* Host: David-Byrons-MacBook-Pro.local
* System: Darwin David-Byrons-MacBook-Pro.local 14.5.0 Darwin Kernel Version 14.5.0: Wed Jul 29 02:26:53 PDT 2015; root:xnu-2782.40.9~1/RELEASE_X86_64 x86_64
* Server SSL:        OFF  libcurl SSL:  ON 
* debug build:       ON   track memory: ON 
* valgrind:          OFF  HTTP IPv6     ON 
* HTTP Unix     ON 
* FTP IPv6           ON   Libtool lib:  OFF
* Shared build:      yes  Resolver:     stock
* SSL library:       OpenSSL
* Ports:
*   HTTP/8990 FTP/8992 FTP2/8995 RTSP/9007 
*   TFTP/8997 HTTP-IPv6/8994 RTSP-IPv6/9008 FTP-IPv6/8996 
*   GOPHER/9009 GOPHER-IPv6/9009
*   SSH/8999 SOCKS/9000 POP3/9001 IMAP/9003 SMTP/9005
*   POP3-IPv6/9002 IMAP-IPv6/9004 SMTP-IPv6/9006
*   HTTP-PIPE/9014 
* Unix socket paths:
*   HTTP-Unix:http.sock
***************************************** 
