### PR TITLE
ftp: Fix EPSV-disable over SOCKS

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1743,7 +1743,7 @@ static CURLcode ftp_state_quote(struct connectdata *conn,
   /*
    * This state uses:
    * 'count1' to iterate over the commands to send
-   * 'count2' to store wether to allow commands to fail
+   * 'count2' to store whether to allow commands to fail
    */
 
   if(init)
@@ -3675,14 +3675,15 @@ static CURLcode ftp_do_more(struct connectdata *conn, int *completep)
         result = proxy_magic(conn, ftpc->newhost, ftpc->newport, &connected);
       }
     }
-    else {
-      if(result && (ftpc->count1 == 0)) {
-        *completep = -1; /* go back to DOING please */
-        /* this is a EPSV connect failing, try PASV instead */
-        return ftp_epsv_disable(conn);
-      }
-      return result;
+
+    if(result && (ftpc->count1 == 0)) {
+      *completep = -1; /* go back to DOING please */
+      /* this is a EPSV connect failing, try PASV instead */
+      return ftp_epsv_disable(conn);
     }
+
+    if(!connected)
+      return result;
   }
 
   if(ftpc->state) {


### PR DESCRIPTION
libcurl doesn't disable EPSV over SOCKS when it fails. The disable check doesn't take into account whether the proxy was successful in connecting to the final destination. The [code](https://github.com/bagder/curl/blob/curl-7_45_0/lib/ftp.c#L3656-L3674) is:

``` c
    result = Curl_is_connected(conn, SECONDARYSOCKET, &connected);

    /* Ready to do more? */
    if(connected) {
      DEBUGF(infof(data, "DO-MORE connected phase starts\n"));
      if(conn->bits.proxy) {
        infof(data, "Connection to proxy confirmed\n");
        result = proxy_magic(conn, ftpc->newhost, ftpc->newport, &connected);
      }
    }
    else {
      if(result && (ftpc->count1 == 0)) {
        *completep = -1; /* go back to DOING please */
        /* this is a EPSV connect failing, try PASV instead */
        return ftp_epsv_disable(conn);
      }
      return result;
    }
```

Looks like a regression: http://sourceforge.net/p/curl/bugs/1166/
Fixed in 076e1fa 2012-11-12 and according to bisect regressed in d44b014 2013-10-26.

This is a PR to associate my branch, it's not ready to go in I'm still in draft. This will need a test at least.

---

Repro case:
SOCKS5 server: ssocksd -vvvv
Client: curld -v --socks5-hostname host:1080 ftp://ftp.kernel.org/

Relevant client output:

```
* DO phase starts
> EPSV
* FTP 0xa389d8 (line 1381) state change from STOP to PASV
* Connect data stream passively
* ftp_perform ends with SECONDARY: 0
* STATE: DO => DOING handle 0xa21c68; line 1324 (connection #0)
< 229 Entering Extended Passive Mode (|||30324|).
* Hostname X.X.X.X was found in DNS cache
*   Trying X.X.X.X...
* Connecting to ftp.kernel.org (X.X.X.X) port 1080
* FTP 0xa389d8 (line 2100) state change from PASV to STOP
* DO phase is complete2
* STATE: DOING => DO_MORE handle 0xa21c68; line 1413 (connection #0)
* Connected to X.X.X.X (X.X.X.X) port 1080 (#0)
* DO-MORE connected phase starts
* Connection to proxy confirmed
* Can't complete SOCKS5 connection to X.X.X.X:23463. (1)
> TYPE A
* FTP 0xa389d8 (line 3540) state change from STOP to LIST_TYPE
< 200 Switching to ASCII mode.
> LIST
* FTP 0xa389d8 (line 1539) state change from LIST_TYPE to LIST
< 425 Failed to establish connection.
* RETR response: 425
* Curl_done
* Remembering we are in dir ""
* Connection #0 to host ftp.kernel.org left intact
curl: (19) Can't complete SOCKS5 connection to X.X.X.X:23463. (1)
```

Ignore the "Can't complete SOCKS5 connection to X.X.X.X" message detail, they're showing the bind address for some reason. I'll fix that separately.

The reason the EPSV fails in this case is because ftp.kernel.org resolves to multiple addresses and the control connection may have a different address than the data connection.

```
Name:    ftp.all.kernel.org
Addresses:  198.145.20.140
          149.20.4.69
          199.204.44.194
Aliases:  ftp.kernel.org
```

When I FTP to ftp.kernel.org via SOCKS5H (hostname resolved by server) in curl, ssocksd looked up ftp.kernel.org to 199.204.44.194. Then an EPSV was issued.

curl again issues SOCKS5H request for ftp.kernel.org to the EPSV port 30324. This time though ssocksd looks up ftp.kernel.org as 198.145.20.140 and tries to connect to that port (so says wireshark) and fails, likely because ftp.kernel.org expects us to connect to 199.204.44.194:30324 only.

```
curl 7.45.0-DEV (i386-pc-win32) libcurl/7.45.0-DEV OpenSSL/1.0.2d nghttp2/1.3.4
Protocols: dict file ftp ftps gopher http https imap imaps ldap pop3 pop3s rtsp
smb smbs smtp smtps telnet tftp
Features: AsynchDNS Debug Largefile NTLM SSL HTTP
```

```
ssockd - Server Socks5 v0.0.14
```

I'm not sure if this is all correct behavior on behalf of the server but regardless it appears we need a fix for EPSV-disable over SOCKS.

---

draft1 changes it so the EPSV-disable check is done regardless of the connected state because if `connected` then we're connected to SOCKS but not necessarily to the final destination so we have to wait for the proxy magic result.
