### PR TITLE
http: fix CONNECT_ONLY with Negotiate authentication

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1456,8 +1456,10 @@ CURLcode Curl_http_done(struct connectdata *conn,
      data->state.negotiate.state == GSS_AUTHSENT) {
     /* add forbid re-use if http-code != 401/407 as a WA only needed for
      * 401/407 that signal auth failure (empty) otherwise state will be RECV
-     * with current code */
-    if((data->req.httpcode != 401) && (data->req.httpcode != 407))
+     * with current code.
+     * Do NOT close successful CONNECT-only connections. */
+    if((data->req.httpcode != 401) && (data->req.httpcode != 407) &&
+       (!data->set.connect_only || data->req.httpcode != 200))
       connclose(conn, "Negotiate transfer completed");
     Curl_cleanup_negotiate(data);
   }


### PR DESCRIPTION
CONNECT-only connections were closed immediately before the
user had a change to extract the socket when the proxy required
Negotiate authentication.

This is probably a regression from 79b9d5f1a42578f807a6c94914bc65cbaa304b6d (CVE-2015-3148).