### PR TITLE
http2: Support trailer fields

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1478,6 +1478,8 @@ CURLcode Curl_http_done(struct connectdata *conn,
     DEBUGF(infof(data, "free header_recvbuf!!\n"));
     Curl_add_buffer_free(http->header_recvbuf);
     http->header_recvbuf = NULL; /* clear the pointer */
+    Curl_add_buffer_free(http->trailer_recvbuf);
+    http->trailer_recvbuf = NULL; /* clear the pointer */
     if(http->push_headers) {
       /* if they weren't used and then freed before */
       for(; http->push_headers_used > 0; --http->push_headers_used) {

--- a/lib/http.h
+++ b/lib/http.h
@@ -163,6 +163,7 @@ struct HTTP {
   Curl_send_buffer *header_recvbuf;
   size_t nread_header_recvbuf; /* number of bytes in header_recvbuf fed into
                                   upper layer */
+  Curl_send_buffer *trailer_recvbuf;
   int status_code; /* HTTP status code */
   const uint8_t *pausedata; /* pointer to data received in on_data_chunk */
   size_t pauselen; /* the number of bytes left in data */


### PR DESCRIPTION
This commit adds trailer support in HTTP/2.  In HTTP/1.1, chunked
encoding must be used to send trialer fields.  HTTP/2 deprecated any
trandfer-encoding, including chunked.  But trailer fields are now
always available.

Since trailer fields are relatively rare these days (gRPC uses them
extensively though), allocating buffer for trailer fields is done when
we detect that HEADERS frame containing trailer fields is started.  We
use Curl_add_buffer_* functions to buffer all trailers, just like we
do for regular header fields.  And then deliver them when stream is
closed.  We have to be careful here so that all data are delivered to
upper layer before sending trailers to the application.

We can deliver trailer field one by one using NGHTTP2_ERR_PAUSE
mechanism, but current method is far more simple.

Another possibility is use chunked encoding internally for HTTP/2
traffic.  I have not tested it, but it could add another overhead.