### PR TITLE
Add mbedTLS support to nmake build system

### DIFF
--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -64,6 +64,7 @@ where <options> is one or many of:
                                  Libraries can be fetched at http://windows.php.net/downloads/php-sdk/deps/
                                  Uncompress them into the deps folder.
   WITH_SSL=<dll or static>     - Enable OpenSSL support, DLL or static
+  WITH_MBEDTLS=<dll or static> - Enable mbedTLS support, DLL or static
   WITH_CARES=<dll or static>   - Enable c-ares support, DLL or static
   WITH_ZLIB=<dll or static>    - Enable zlib support, DLL or static
   WITH_SSH2=<dll or static>    - Enable libSSH2 support, DLL or static

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -24,6 +24,7 @@ CFGSET=true
 !MESSAGE   WITH_CARES=<dll or static>   - Enable c-ares support, DLL or static
 !MESSAGE   WITH_ZLIB=<dll or static>    - Enable zlib support, DLL or static
 !MESSAGE   WITH_SSH2=<dll or static>    - Enable libSSH2 support, DLL or static
+!MESSAGE   WITH_MBEDTLS=<dll or static> - Enable mbedTLS support, DLL or static
 !MESSAGE   ENABLE_IDN=<yes or no>       - Enable use of Windows IDN APIs, defaults to yes
 !MESSAGE                                  Requires Windows Vista or later, or installation from:
 !MESSAGE                                  https://www.microsoft.com/en-us/download/details.aspx?id=734
@@ -35,6 +36,10 @@ CFGSET=true
 !MESSAGE   MACHINE=<x86 or x64>         - Target architecture (default x64 on AMD64, x86 on others)
 !ERROR please choose a valid mode
 
+!ENDIF
+
+!IF DEFINED(WITH_SSL) && DEFINED(ENABLE_WINSSL) || DEFINED(WITH_SSL) && DEFINED(WITH_MBEDTLS) || DEFINED(WITH_MBEDTLS) && DEFINED(ENABLE_WINSSL)
+!ERROR WITH_SSL, WITH_MBEDTLS and ENABLE_WINSSL are mutual exclusive options.
 !ENDIF
 
 !INCLUDE "../lib/Makefile.inc"
@@ -87,7 +92,7 @@ USE_SSPI = false
 !ENDIF
 
 !IFNDEF ENABLE_WINSSL
-!IFDEF WITH_SSL
+!IF DEFINED(WITH_SSL) || DEFINED(WITH_MBEDTLS)
 USE_WINSSL = false
 !ELSE
 USE_WINSSL = $(USE_SSPI)
@@ -106,6 +111,11 @@ SSL     = dll
 !ELSEIF "$(WITH_SSL)"=="static"
 USE_SSL = true
 SSL     = static
+!ENDIF
+
+!IF "$(WITH_MBEDTLS)"=="dll" || "$(WITH_MBEDTLS)"=="static"
+USE_MBEDTLS = true
+MBEDTLS     = $(WITH_MBEDTLS)
 !ENDIF
 
 !IF "$(WITH_CARES)"=="dll"
@@ -148,6 +158,10 @@ CONFIG_NAME_LIB = $(CONFIG_NAME_LIB)-static
 
 !IF "$(USE_SSL)"=="true"
 CONFIG_NAME_LIB = $(CONFIG_NAME_LIB)-ssl-$(SSL)
+!ENDIF
+
+!IF "$(USE_MBEDTLS)"=="true"
+CONFIG_NAME_LIB = $(CONFIG_NAME_LIB)-mbedtls-$(MBEDTLS)
 !ENDIF
 
 !IF "$(USE_CARES)"=="true"

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1999 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1999 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -120,6 +120,14 @@ SSL          = static
 !IFDEF USE_SSL
 SSL_CFLAGS   = /DUSE_OPENSSL /I"$(DEVEL_INCLUDE)/openssl"
 !ENDIF
+
+!IF "$(WITH_MBEDTLS)"=="dll" || "$(WITH_MBEDTLS)"=="static"
+USE_MBEDTLS    = true
+MBEDTLS        = $(WITH_MBEDTLS)
+MBEDTLS_CFLAGS = /DUSE_MBEDTLS
+MBEDTLS_LIBS   = mbedtls.lib mbedcrypto.lib mbedx509.lib
+!ENDIF
+
 
 !IF "$(WITH_CARES)"=="dll"
 !IF "$(DEBUG)"=="yes"
@@ -316,6 +324,11 @@ CC       = $(CC) $(CFLAGS_LIBCURL_STATIC)
 !IF "$(USE_SSL)"=="true"
 CFLAGS = $(CFLAGS) $(SSL_CFLAGS)
 LFLAGS = $(LFLAGS) $(SSL_LFLAGS) $(SSL_LIBS)
+!ENDIF
+
+!IF "$(USE_MBEDTLS)"=="true"
+CFLAGS = $(CFLAGS) $(MBEDTLS_CFLAGS)
+LFLAGS = $(LFLAGS) $(MBEDTLS_LFLAGS) $(MBEDTLS_LIBS)
 !ENDIF
 
 !IF "$(USE_CARES)"=="true"


### PR DESCRIPTION
I modified the nmake scripts to accept an additional WITH_MBEDTLS option which works almost exactly like the WITH_SSL option.
I used the autoconf script as a reference for this implementation and it works well with Visual Studio 2015. If I missed something important I'll fix it ASAP.

Cheers,
Henrik