### PR TITLE
curlbuild.h.dist: fix GCC build on SPARC64 for non-configure systems

### DIFF
--- a/include/curl/curlbuild.h.dist
+++ b/include/curl/curlbuild.h.dist
@@ -529,7 +529,7 @@
 #elif defined(__GNUC__)
 #  if defined(__ILP32__) || \
       defined(__i386__) || defined(__ppc__) || defined(__arm__) || \
-      defined(__sparc__) && !defined(__sparc64__) || defined(__mips__) || defined(__sh__)
+      (defined(__sparc__) && !defined(__sparc64__)) || defined(__mips__) || defined(__sh__)
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"

--- a/include/curl/curlbuild.h.dist
+++ b/include/curl/curlbuild.h.dist
@@ -529,7 +529,7 @@
 #elif defined(__GNUC__)
 #  if defined(__ILP32__) || \
       defined(__i386__) || defined(__ppc__) || defined(__arm__) || \
-      defined(__sparc__) || defined(__mips__) || defined(__sh__)
+      defined(__sparc__) && !defined(__sparc64__) || defined(__mips__) || defined(__sh__)
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"


### PR DESCRIPTION
sparc64 defines both __sparc__ and __sparc64__. This allows choosing the correct size / offsets