### PR TITLE
mbedtls: fix memory leak when destroying SSL connection data

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -211,7 +211,7 @@ mbedtls_connect_step1(struct connectdata *conn,
 #endif /* THREADING_SUPPORT */
 
   /* Load the trusted CA */
-  memset(&connssl->cacert, 0, sizeof(mbedtls_x509_crt));
+  mbedtls_x509_crt_init(&connssl->cacert);
 
   if(data->set.str[STRING_SSL_CAFILE]) {
     ret = mbedtls_x509_crt_parse_file(&connssl->cacert,
@@ -246,7 +246,7 @@ mbedtls_connect_step1(struct connectdata *conn,
   }
 
   /* Load the client certificate */
-  memset(&connssl->clicert, 0, sizeof(mbedtls_x509_crt));
+  mbedtls_x509_crt_init(&connssl->clicert);
 
   if(data->set.str[STRING_CERT]) {
     ret = mbedtls_x509_crt_parse_file(&connssl->clicert,
@@ -264,8 +264,9 @@ mbedtls_connect_step1(struct connectdata *conn,
   }
 
   /* Load the client private key */
+  mbedtls_pk_init(&connssl->pk);
+
   if(data->set.str[STRING_KEY]) {
-    mbedtls_pk_init(&connssl->pk);
     ret = mbedtls_pk_parse_keyfile(&connssl->pk, data->set.str[STRING_KEY],
                                    data->set.str[STRING_KEY_PASSWD]);
     if(ret == 0 && !mbedtls_pk_can_do(&connssl->pk, MBEDTLS_PK_RSA))
@@ -283,7 +284,7 @@ mbedtls_connect_step1(struct connectdata *conn,
   }
 
   /* Load the CRL */
-  memset(&connssl->crl, 0, sizeof(mbedtls_x509_crl));
+  mbedtls_x509_crl_init(&connssl->crl);
 
   if(data->set.str[STRING_SSL_CRLFILE]) {
     ret = mbedtls_x509_crl_parse_file(&connssl->crl,
@@ -645,11 +646,16 @@ void Curl_mbedtls_close_all(struct SessionHandle *data)
 
 void Curl_mbedtls_close(struct connectdata *conn, int sockindex)
 {
-  /* mbedtls_rsa_free(&conn->ssl[sockindex].rsa); */
+  mbedtls_pk_free(&conn->ssl[sockindex].pk);
   mbedtls_x509_crt_free(&conn->ssl[sockindex].clicert);
   mbedtls_x509_crt_free(&conn->ssl[sockindex].cacert);
   mbedtls_x509_crl_free(&conn->ssl[sockindex].crl);
+  mbedtls_ssl_config_free(&conn->ssl[sockindex].config);
   mbedtls_ssl_free(&conn->ssl[sockindex].ssl);
+  mbedtls_ctr_drbg_free(&conn->ssl[sockindex].ctr_drbg);
+#ifndef THREADING_SUPPORT
+  mbedtls_entropy_free(&conn->ssl[sockindex].entropy);
+#endif /* THREADING_SUPPORT */
 }
 
 static ssize_t mbedtls_recv(struct connectdata *conn,


### PR DESCRIPTION
Using cURL 7.46 with mbedTLS 2.2.1 I've come across some memory leak according to Valgrind:
```
==93== 8,940 (1,080 direct, 7,860 indirect) bytes in 10 blocks are definitely lost in loss record 6 of 7
==93==    at 0x402B1E5: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
[...]
==93==    by 0x80C7856: rsa_alloc_wrap (pk_wrap.c:136)
==93==    by 0x80C7233: mbedtls_pk_setup (pk.c:106)
==93==    by 0x80C8CA6: mbedtls_pk_parse_key (pkparse.c:1087)
==93==    by 0x80C8F8D: mbedtls_pk_parse_keyfile (pkparse.c:134)
==93==    by 0x808AF31: mbedtls_connect_common
==93==    by 0x8089D0E: Curl_ssl_connect_nonblocking
==93==    by 0x808E16E: Curl_http_connect
```

To fix this, I've added some missing _mbedtls_xxx_free_ to _Curl_mbedtls_close_. I've also substituted some _memcpy_ with the proper _mbedtls_xxx_init_ function when available.