### PR TITLE
openssl: remove most BoringSSL #ifdefs.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1631,8 +1631,6 @@ if test "$curl_ssl_msg" = "$init_ssl_msg" && test X"$OPT_SSL" != Xno; then
     dnl Older versions of Cyassl (some time before 2.9.4) don't have
     dnl SSL_get_shutdown (but this check won't actually detect it there
     dnl as it's a macro that needs the header files be included)
-    dnl BoringSSL didn't have DES_set_odd_parity for a while but now it is
-    dnl back again.
 
     AC_CHECK_FUNCS( RAND_status \
                     RAND_screen \
@@ -1640,8 +1638,7 @@ if test "$curl_ssl_msg" = "$init_ssl_msg" && test X"$OPT_SSL" != Xno; then
                     ENGINE_cleanup \
                     CRYPTO_cleanup_all_ex_data \
                     SSL_get_shutdown \
-                    SSLv2_client_method \
-                    DES_set_odd_parity )
+                    SSLv2_client_method )
 
     AC_MSG_CHECKING([for BoringSSL])
     AC_COMPILE_IFELSE([

--- a/docs/THANKS
+++ b/docs/THANKS
@@ -457,6 +457,7 @@ Glen A Johnson Jr.
 Glen Nakamura
 Glen Scott
 Glenn Sheridan
+Google Inc.
 Gordon Marler
 Gorilla Maguila
 Grant Erickson

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -228,12 +228,6 @@
    This is present in OpenSSL versions after 0.9.6b */
 #define HAVE_CRYPTO_CLEANUP_ALL_EX_DATA 1
 
-/* Define if you have the 'DES_set_odd_parity' function when using OpenSSL/
-   BoringSSL */
-#if defined(USE_OPENSSL) || defined(HAVE_BORINGSSL)
-#define HAVE_DES_SET_ODD_PARITY 1
-#endif
-
 /* Define if you have the select function. */
 #define HAVE_SELECT 1
 

--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -22,7 +22,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NTLM) && !defined(HAVE_DES_SET_ODD_PARITY)
+#if defined(USE_NTLM) && !defined(USE_OPENSSL)
 
 #include "curl_des.h"
 
@@ -60,4 +60,4 @@ void Curl_des_set_odd_parity(unsigned char *bytes, size_t len)
   }
 }
 
-#endif /* USE_NTLM && !HAVE_DES_SET_ODD_PARITY */
+#endif /* USE_NTLM && !USE_OPENSSL */

--- a/lib/curl_des.h
+++ b/lib/curl_des.h
@@ -24,11 +24,11 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NTLM) && !defined(HAVE_DES_SET_ODD_PARITY)
+#if defined(USE_NTLM) && !defined(USE_OPENSSL)
 
 /* Applies odd parity to the given byte array */
 void Curl_des_set_odd_parity(unsigned char *bytes, size_t length);
 
-#endif /* USE_NTLM && !HAVE_DES_SET_ODD_PARITY */
+#endif /* USE_NTLM && !USE_OPENSSL */
 
 #endif /* HEADER_CURL_DES_H */

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -143,14 +143,10 @@ static void setup_des_key(const unsigned char *key_56,
   DES_cblock key;
 
   /* Expand the 56-bit key to 64-bits */
-  extend_key_56_to_64(key_56, (char *) key);
+  extend_key_56_to_64(key_56, (char *) &key);
 
   /* Set the key parity to odd */
-#ifndef HAVE_DES_SET_ODD_PARITY /* older boringssl */
-  Curl_des_set_odd_parity((unsigned char *) &key, sizeof(key));
-#else
   DES_set_odd_parity(&key);
-#endif
 
   /* Set the key */
   DES_set_key(&key, ks);

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -628,11 +628,7 @@ int netware_init(void);
     defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_DARWINSSL) || \
     defined(USE_OS400CRYPTO) || defined(USE_WIN32_CRYPTO)
 
-#ifdef HAVE_BORINGSSL /* BoringSSL is not NTLM capable */
-#undef USE_NTLM
-#else
 #define USE_NTLM
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
I've tested this against BoringSSL and OpenSSL 1.0.2. `make test` passes against both on my machine. I'm happy to be more or less aggressive in removing the #ifdefs as you prefer.

Notably, I can see an argument to keep the RAND seeding code out. See https://commondatastorage.googleapis.com/chromium-boringssl-docs/rand.h.html#Deprecated-functions for the various ridiculous tricks we do to no-op everyone's RAND seeding logic. :-) Your call.

----

As of https://boringssl-review.googlesource.com/#/c/6980/, almost all of BoringSSL #ifdefs in cURL should be unnecessary:

- BoringSSL provides no-op stubs for compatibility which replaces most #ifdefs.

- DES_set_odd_parity has been in BoringSSL for nearly a year now. Remove the compatibility codepath.

- With a small tweak to an extend_key_56_to_64 call, the NTLM code builds fine.

- Switch OCSP-related #ifdefs to the more generally useful OPENSSL_NO_OCSP.

The only #ifdefs which remain are Curl_ossl_version and the #undefs to work around OpenSSL and wincrypt.h name conflicts. (BoringSSL leaves that to the consumer. The in-header workaround makes things sensitive to include order.)

This change errs on the side of removing conditionals despite many of the restored codepaths being no-ops. (BoringSSL generally adds no-op compatibility stubs when possible. OPENSSL_VERSION_NUMBER #ifdefs are bad enough!)