### PR TITLE
Fix potential overflow problem with timevals 

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3089,9 +3089,10 @@ static int call_disconnect_if_dead(struct connectdata *conn,
 static void prune_dead_connections(struct SessionHandle *data)
 {
   struct timeval now = Curl_tvnow();
-  long elapsed = Curl_tvdiff(now, data->state.conn_cache->last_cleanup);
 
-  if(elapsed >= 1000L) {
+  if((!data->state.conn_cache->last_cleanup.tv_sec
+      && !data->state.conn_cache->last_cleanup.tv_usec)
+     || Curl_tvdiff(now, data->state.conn_cache->last_cleanup) >= 1000L) {
     Curl_conncache_foreach(data->state.conn_cache, data,
                            call_disconnect_if_dead);
     data->state.conn_cache->last_cleanup = now;


### PR DESCRIPTION
When comparing a null timeval with a current timeval using curlx_tvdiff on a 32-bit linux system there's an overflow happening. 

Compiling with -fsanitize=undefined I get this warning on startup of our app using libcurl:

.../curl/lib/timeval.c:120:37: runtime error: signed integer overflow: 5873565 * 1000 cannot be represented in type 'long int'

The attached fix solves the problem by checking for a null timeval before comparing. Strictly speaking the function probably should return something that's guaranteed to be 64-bit but the majority of the usecases actually cast the result to an int and basically just compares two timevals that are close together so I decided against making a bigger change.