### PR TITLE
CURLOPT_CONNECTTIMEOUT_MS.3: Fix doc example to use milliseconds option

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
@@ -47,7 +47,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
 
   /* complete connection within 10000 milliseconds */
-  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10000L);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 10000L);
 
   curl_easy_perform(curl);
 }


### PR DESCRIPTION
Change the example in the docs for CURLOPT_CONNECTTIMEOUT_MS to use
CURLOPT_CONNECTTIMEOUT_MS instead of CURLOPT_CONNECTTIMEOUT.
