### PR TITLE
idn_win32: Fall back to ANSI encoding if UTF-8 fails

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -35,18 +35,18 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-wchar_t *Curl_convert_UTF8_to_wchar(const char *str_utf8)
+wchar_t *Curl_convert_multibyte_to_wchar(const char *str_mb, unsigned codepage)
 {
   wchar_t *str_w = NULL;
 
-  if(str_utf8) {
-    int str_w_len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
-                                        str_utf8, -1, NULL, 0);
+  if(str_mb) {
+    int str_w_len = MultiByteToWideChar(codepage, MB_ERR_INVALID_CHARS,
+                                        str_mb, -1, NULL, 0);
     if(str_w_len > 0) {
       str_w = malloc(str_w_len * sizeof(wchar_t));
       if(str_w) {
-        if(MultiByteToWideChar(CP_UTF8, 0, str_utf8, -1, str_w,
-                               str_w_len) == 0) {
+        if(MultiByteToWideChar(codepage, 0, str_mb, -1,
+                               str_w, str_w_len) == 0) {
           free(str_w);
           return NULL;
         }
@@ -57,26 +57,26 @@ wchar_t *Curl_convert_UTF8_to_wchar(const char *str_utf8)
   return str_w;
 }
 
-char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w)
+char *Curl_convert_wchar_to_multibyte(const wchar_t *str_w, unsigned codepage)
 {
-  char *str_utf8 = NULL;
+  char *str_mb = NULL;
 
   if(str_w) {
-    int str_utf8_len = WideCharToMultiByte(CP_UTF8, 0, str_w, -1, NULL,
-                                           0, NULL, NULL);
-    if(str_utf8_len > 0) {
-      str_utf8 = malloc(str_utf8_len * sizeof(wchar_t));
-      if(str_utf8) {
-        if(WideCharToMultiByte(CP_UTF8, 0, str_w, -1, str_utf8, str_utf8_len,
-                               NULL, FALSE) == 0) {
-          free(str_utf8);
+    int str_mb_len = WideCharToMultiByte(codepage, 0, str_w, -1,
+                                         NULL, 0, NULL, NULL);
+    if(str_mb_len > 0) {
+      str_mb = malloc(str_mb_len * sizeof(wchar_t));
+      if(str_mb) {
+        if(WideCharToMultiByte(codepage, 0, str_w, -1,
+                               str_mb, str_mb_len, NULL, FALSE) == 0) {
+          free(str_mb);
           return NULL;
         }
       }
     }
   }
 
-  return str_utf8;
+  return str_mb;
 }
 
 #endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -35,7 +35,8 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-wchar_t *Curl_convert_multibyte_to_wchar(const char *str_mb, unsigned codepage)
+wchar_t *Curl_convert_multibyte_to_wchar(const char *str_mb,
+                                         unsigned int codepage)
 {
   wchar_t *str_w = NULL;
 
@@ -57,7 +58,8 @@ wchar_t *Curl_convert_multibyte_to_wchar(const char *str_mb, unsigned codepage)
   return str_w;
 }
 
-char *Curl_convert_wchar_to_multibyte(const wchar_t *str_w, unsigned codepage)
+char *Curl_convert_wchar_to_multibyte(const wchar_t *str_w,
+                                      unsigned int codepage)
 {
   char *str_mb = NULL;
 

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -30,8 +30,21 @@
   * MultiByte conversions using Windows kernel32 library.
   */
 
-wchar_t *Curl_convert_UTF8_to_wchar(const char *str_utf8);
-char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w);
+wchar_t *Curl_convert_multibyte_to_wchar(const char *str_mb,
+                                         unsigned codepage);
+char *Curl_convert_wchar_to_multibyte(const wchar_t *str_w, unsigned codepage);
+
+#define Curl_convert_UTF8_to_wchar(x) \
+  Curl_convert_multibyte_to_wchar((x), CP_UTF8)
+
+#define Curl_convert_wchar_to_UTF8(x) \
+  Curl_convert_wchar_to_multibyte((x), CP_UTF8)
+
+#define Curl_convert_ACP_to_wchar(x) \
+  Curl_convert_multibyte_to_wchar((x), CP_ACP)
+
+#define Curl_convert_wchar_to_ACP(x) \
+  Curl_convert_wchar_to_multibyte((x), CP_ACP)
 
 #endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */
 

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -31,20 +31,21 @@
   */
 
 wchar_t *Curl_convert_multibyte_to_wchar(const char *str_mb,
-                                         unsigned codepage);
-char *Curl_convert_wchar_to_multibyte(const wchar_t *str_w, unsigned codepage);
+                                         unsigned int codepage);
+char *Curl_convert_wchar_to_multibyte(const wchar_t *str_w,
+                                      unsigned int codepage);
 
 #define Curl_convert_UTF8_to_wchar(x) \
-  Curl_convert_multibyte_to_wchar((x), CP_UTF8)
+  Curl_convert_multibyte_to_wchar((x), 65001)
 
 #define Curl_convert_wchar_to_UTF8(x) \
-  Curl_convert_wchar_to_multibyte((x), CP_UTF8)
+  Curl_convert_wchar_to_multibyte((x), 65001)
 
 #define Curl_convert_ACP_to_wchar(x) \
-  Curl_convert_multibyte_to_wchar((x), CP_ACP)
+  Curl_convert_multibyte_to_wchar((x), 0)
 
 #define Curl_convert_wchar_to_ACP(x) \
-  Curl_convert_wchar_to_multibyte((x), CP_ACP)
+  Curl_convert_wchar_to_multibyte((x), 0)
 
 #endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */
 

--- a/lib/idn_win32.c
+++ b/lib/idn_win32.c
@@ -66,7 +66,7 @@ WINBASEAPI int WINAPI IdnToUnicode(DWORD dwFlags,
 #define IDN_MAX_LENGTH 255
 
 int curl_win32_idn_to_punycode(const char *in, char **out);
-int curl_win32_punycode_to_idn(const char *in, unsigned output_codepage,
+int curl_win32_punycode_to_idn(const char *in, unsigned int output_codepage,
                                char **out);
 
 /* IDN => punycode
@@ -105,7 +105,7 @@ int curl_win32_idn_to_punycode(const char *in, char **out)
 Success: (1) *out points to the IDN encoded in the output codepage.
 Failure: (!= 1) *out is NULL.
 */
-int curl_win32_punycode_to_idn(const char *in, unsigned output_codepage,
+int curl_win32_punycode_to_idn(const char *in, unsigned int output_codepage,
                                char **out)
 {
   int ret = 0;

--- a/lib/non-ascii.c
+++ b/lib/non-ascii.c
@@ -343,6 +343,15 @@ CURLcode Curl_convert_form(struct SessionHandle *data, struct FormData *form)
 
 #if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
                                 defined(USE_WIN32_LDAP)) && defined(UNICODE))
+#if (CURL_SIZEOF_CURL_OFF_T == 4)
+#  define CURL_OFF_T_MAX  CURL_OFF_T_C(0x7FFFFFFF)
+#elif (CURL_SIZEOF_CURL_OFF_T == 8)
+#  define CURL_OFF_T_MAX  CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
+#elif (CURL_SIZEOF_CURL_OFF_T == 16)
+#  define CURL_OFF_T_MAX  CURL_OFF_T_C(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+#else
+#  error "CURL_SIZEOF_CURL_OFF_T size unknown"
+#endif
 /* utf8_strict_codepoint_count:
 Count the number of Unicode codepoints encoded in a UTF-8 string.
 
@@ -370,6 +379,8 @@ curl_off_t utf8_strict_codepoint_count(const char *str)
 
   for(; *ch; ++ch, ++count) {
     unsigned char first = *ch; /* first byte */
+    if(count == CURL_OFF_T_MAX)
+      return error;
     if(*ch <= 0x7F)
       continue;
     if(*ch < 0xC2 || *ch > 0xF4)

--- a/lib/non-ascii.c
+++ b/lib/non-ascii.c
@@ -22,18 +22,22 @@
 
 #include "curl_setup.h"
 
-#ifdef CURL_DOES_CONVERSIONS
-
 #include <curl/curl.h>
 
 #include "non-ascii.h"
+
+#ifdef CURL_DOES_CONVERSIONS
 #include "formdata.h"
 #include "sendf.h"
 #include "urldata.h"
+#endif /* CURL_DOES_CONVERSIONS */
 
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"
+
+
+#ifdef CURL_DOES_CONVERSIONS
 
 #ifdef HAVE_ICONV
 #include <iconv.h>
@@ -336,3 +340,56 @@ CURLcode Curl_convert_form(struct SessionHandle *data, struct FormData *form)
 }
 
 #endif /* CURL_DOES_CONVERSIONS */
+
+#if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
+                                defined(USE_WIN32_LDAP)) && defined(UNICODE))
+/* utf8_strict_codepoint_count:
+Count the number of Unicode codepoints encoded in a UTF-8 string.
+
+Note that a UTF-8 BOM is a codepoint and is counted as such.
+
+This function also tests for valid UTF-8 in accordance with the Unicode
+Standard, Section Conformance 3.9, Table 3-7, Well-Formed UTF-8 Byte Sequences.
+http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G7404
+
+The UTF-8 conformance in this function must remain strict, its purpose is to
+test for exactly that. If we encounter any byte sequence that is not
+well-formed then we error.
+
+Success: (>= 0) The number of Unicode codepoints encoded in UTF-8 string 'str'.
+Failure: (-1) 'str' is NULL or points to invalid UTF-8.
+*/
+curl_off_t utf8_strict_codepoint_count(const char *str)
+{
+  const unsigned char *ch = (const unsigned char*)str;
+  const curl_off_t error = -1;
+  curl_off_t count = 0;
+
+  if(!ch)
+    return error;
+
+  for(; *ch; ++ch, ++count) {
+    unsigned char first = *ch; /* first byte */
+    if(*ch <= 0x7F)
+      continue;
+    if(*ch < 0xC2 || *ch > 0xF4)
+      return error;
+    ++ch; /* second byte */
+    if(*ch < (first == 0xE0 ? 0xA0 : (first == 0xF0 ? 0x90 : 0x80)) ||
+       *ch > (first == 0xED ? 0x9F : (first == 0xF4 ? 0x8F : 0xBF)))
+      return error;
+    if(first <= 0xDF)
+      continue;
+    ++ch; /* third byte */
+    if(*ch < 0x80 || *ch > 0xBF)
+      return error;
+    if(first <= 0xEF)
+      continue;
+    ++ch; /* fourth byte */
+    if(*ch < 0x80 || *ch > 0xBF)
+      return error;
+  }
+
+  return count;
+}
+#endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */

--- a/lib/non-ascii.h
+++ b/lib/non-ascii.h
@@ -60,4 +60,15 @@ CURLcode Curl_convert_form(struct SessionHandle *data, struct FormData *form);
 #define Curl_convert_form(a,b) CURLE_OK
 #endif
 
+#if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
+                                defined(USE_WIN32_LDAP)) && defined(UNICODE))
+/*
+ * utf8_strict_codepoint_count returns the Unicode codepoint count from a UTF-8
+ * string or -1 if invalid UTF-8 is encountered. Note that a UTF-8 BOM is a
+ * codepoint and is counted as such.
+ * Refer to comment block above this function's definition for more detail.
+ */
+curl_off_t utf8_strict_codepoint_count(const char *str);
+#endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */
+
 #endif /* HEADER_CURL_NON_ASCII_H */

--- a/lib/url.c
+++ b/lib/url.c
@@ -74,8 +74,8 @@ void idn_free (void *ptr);
 #define idn_free(x) (free)(x)
 #endif
 #elif defined(USE_WIN32_IDN)
-/* prototype for curl_win32_idn_to_ascii() */
-int curl_win32_idn_to_ascii(const char *in, char **out);
+/* prototype for curl_win32_idn_to_punycode() */
+int curl_win32_idn_to_punycode(const char *in, char **out);
 #endif  /* USE_LIBIDN */
 
 #include "urldata.h"
@@ -3789,7 +3789,7 @@ static void fix_hostname(struct SessionHandle *data,
    * Check name for non-ASCII and convert hostname to ACE form.
    *************************************************************/
     char *ace_hostname = NULL;
-    int rc = curl_win32_idn_to_ascii(host->name, &ace_hostname);
+    int rc = curl_win32_idn_to_punycode(host->name, &ace_hostname);
     if(rc == 0)
       infof(data, "Failed to convert %s to ACE;\n",
             host->name);
@@ -3816,8 +3816,7 @@ static void free_fixed_hostname(struct hostname *host)
     host->encalloc = NULL;
   }
 #elif defined(USE_WIN32_IDN)
-  free(host->encalloc); /* must be freed withidn_free() since this was
-                           allocated by curl_win32_idn_to_ascii */
+  free(host->encalloc);
   host->encalloc = NULL;
 #else
   (void)host;


### PR DESCRIPTION
~~~
When converting the hostname from IDN to punycode if the IDN is not
valid UTF-8, or if it is and fails to convert, fall back to converting
the IDN to punycode using the user's ANSI codepage.
~~~

@pierrejoye @mkauf @gvanem based on our discussion in #637.

This will bring the WinIDN code more in line with libidn. We try treating the IDN in UTF-8 encoding and if that doesn't work we use locale encoding.

This detection isn't 100% accurate since an ANSI encoded hostname could be determined to be valid UTF-8, though that seems unlikely. How unlikely? I don't know.

Another thing is a possible privacy issue where a server may be able to determine the user's codepage by sending a hostname for redirect with bad UTF-8 to force it to be converted using the user's codepage. This is already possible with libidn, afaics.

In terms of codepage conversion I went with CP_ACP which is the user's current ANSI codepage. I did not go with CP_OEMCP which may be more appropriate because it's the console codepage. I've never seen the latter used in any codebase I've worked on. Sometimes the OEM and ANSI codepages can differ, apparently. I would be curious how this affects those users but I don't know much about the differences. Microsoft's support [article](https://support.microsoft.com/en-us/kb/108450) on when to use ANSI and when to use OEM is lacking. I believe more people use ANSI simply because when you save a file for, say, running a script and you are not saving in Unicode then you're most likely saving in ANSI.
