### PR TITLE
http: fix CONNECT_ONLY with Negotiate authentication

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1454,8 +1454,10 @@ CURLcode Curl_http_done(struct connectdata *conn,
      data->state.negotiate.state == GSS_AUTHSENT) {
     /* add forbid re-use if http-code != 401/407 as a WA only needed for
      * 401/407 that signal auth failure (empty) otherwise state will be RECV
-     * with current code */
-    if((data->req.httpcode != 401) && (data->req.httpcode != 407))
+     * with current code.
+     * Do not close CONNECT_ONLY connections. */
+    if((data->req.httpcode != 401) && (data->req.httpcode != 407) &&
+       !data->set.connect_only)
       connclose(conn, "Negotiate transfer completed");
     Curl_cleanup_negotiate(data);
   }


### PR DESCRIPTION
Since https://github.com/curl/curl/commit/79b9d5f1a42578f807a6c94914bc65cbaa304b6d, connections were closed immediately before the libcurl user had a chance to extract the socket if Negotiate authentication was used. If CURLOPT_CONNECT_ONLY is set, it is the user's responsibility to decide when to close the connection.

This pull request is the same as #520, but without the HTTP status code check.