### PR TITLE
fix memory leak on invalid algorithm in curl_sasl.c

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -844,8 +844,11 @@ CURLcode Curl_sasl_decode_digest_http_message(const char *chlg,
           digest->algo = CURLDIGESTALGO_MD5SESS;
         else if(Curl_raw_equal(content, "MD5"))
           digest->algo = CURLDIGESTALGO_MD5;
-        else
+        else {
+          free(digest->algorithm);
+          digest->algorithm = NULL;
           return CURLE_BAD_CONTENT_ENCODING;
+        }
       }
       else {
         /* unknown specifier, ignore it! */


### PR DESCRIPTION
If digest->algorithm is invalid, it should be free'd before returning CURLE_BAD_CONTENT_ENCODING .