### PR TITLE
Fix memory leak in curl_sasl.c

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -782,6 +782,7 @@ CURLcode Curl_sasl_decode_digest_http_message(const char *chlg,
     /* Extract a value=content pair */
     if(!Curl_sasl_digest_get_pair(chlg, value, content, &chlg)) {
       if(Curl_raw_equal(value, "nonce")) {
+        free(digest->nonce);
         digest->nonce = strdup(content);
         if(!digest->nonce)
           return CURLE_OUT_OF_MEMORY;
@@ -793,11 +794,13 @@ CURLcode Curl_sasl_decode_digest_http_message(const char *chlg,
         }
       }
       else if(Curl_raw_equal(value, "realm")) {
+        free(digest->realm);
         digest->realm = strdup(content);
         if(!digest->realm)
           return CURLE_OUT_OF_MEMORY;
       }
       else if(Curl_raw_equal(value, "opaque")) {
+        free(digest->opaque);
         digest->opaque = strdup(content);
         if(!digest->opaque)
           return CURLE_OUT_OF_MEMORY;
@@ -825,17 +828,20 @@ CURLcode Curl_sasl_decode_digest_http_message(const char *chlg,
 
         /* Select only auth or auth-int. Otherwise, ignore */
         if(foundAuth) {
+          free(digest->qop);
           digest->qop = strdup(DIGEST_QOP_VALUE_STRING_AUTH);
           if(!digest->qop)
             return CURLE_OUT_OF_MEMORY;
         }
         else if(foundAuthInt) {
+          free(digest->qop);
           digest->qop = strdup(DIGEST_QOP_VALUE_STRING_AUTH_INT);
           if(!digest->qop)
             return CURLE_OUT_OF_MEMORY;
         }
       }
       else if(Curl_raw_equal(value, "algorithm")) {
+        free(digest->algorithm);
         digest->algorithm = strdup(content);
         if(!digest->algorithm)
           return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
If any parameter in a HTTP DIGEST challenge message is present multiple
times, memory allocated for all but the last entry should be freed.

Server answer to reproduce the leak is:
```
HTTP/1.1 401 hui
WWW-Authenticate: Digest algorithm=MD5, algorithm=MD5, nonce=1, nonce=2

```

Two blocks will be "definitely lost" in valgrind: one for the first algorithm and one for the first nonce.
