### PR TITLE
Issue #627: Checks for doomed connections when selecting a connection.

### DIFF
--- a/CHANGES.0
+++ b/CHANGES.0
@@ -16359,7 +16359,7 @@ Daniel (17 January 2000):
    progress deal better with larger files and added a "Time" field which shows
    the time spent on the download so far.
  - I'm now using the CVS repository on sourceforge.net, which also allows web
-   browsing. See https://curl.haxx.nu.
+   browsing.
 
 Daniel (10 January 2000):
  - Renumbered some enums in curl/curl.h since tag number 35 was used twice!
@@ -16748,7 +16748,7 @@ Version 5.10
  - I corrected a few minor things that made the compiler complain when
    -Wall -pedantic was used.
 
- - I'm moving the official curl web page to https://curl.haxx.nu. I think it
+ - I'm moving the official curl web page to curl.haxx.nu. I think it
    will make it easier to remember as it is a lot shorter and less cryptic.
    The old one still works and shows the same info.
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3209,10 +3209,11 @@ ConnectionExists(struct SessionHandle *data,
       pipeLen = check->send_pipe->size + check->recv_pipe->size;
 
       if(canPipeline) {
-        /* We can not use this connection if the connection can not be reused,
-         * or is marked for closure due to an error (ie. a timeout)
+        /*
+         * We can not use this connection if the connection is marked for
+         * closure due to an error (ie. a timeout)
          */
-        if (check->bits.close)
+        if(check->bits.close)
             continue;
 
         if(!check->bits.multiplex) {


### PR DESCRIPTION
Checks for doomed connections when selecting a connection for pipelining.  Restores lost checks by Carlo Wood in url.c for old issue 1420.