### PR TITLE
Fixed some blind casting to int

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -67,7 +67,7 @@ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
   curl_ntlm_msgs.h curl_sasl.h curl_multibyte.h hostcheck.h             \
   conncache.h curl_setup_once.h multihandle.h setup-vms.h pipeline.h    \
   dotdot.h x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h  \
-  curl_printf.h
+  curl_printf.h curl_limits.h
 
 LIB_RCFILES = libcurl.rc
 

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -22,9 +22,6 @@
 
 #include "curl_setup.h"
 
-#ifdef HAVE_LIMITS_H
-#include <limits.h>
-#endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
@@ -69,6 +66,7 @@
 #include "select.h"
 #include "progress.h"
 #include "curl_printf.h"
+#include "curl_limits.h"
 
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) && \
      (defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__))

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -127,7 +127,7 @@ tcpkeepalive(struct SessionHandle *data,
     if(WSAIoctl(sockfd, SIO_KEEPALIVE_VALS, (LPVOID) &vals, sizeof(vals),
                 NULL, 0, &dummy, NULL, NULL) != 0) {
       infof(data, "Failed to set SIO_KEEPALIVE_VALS on fd %d: %d\n",
-            (int)sockfd, WSAGetLastError());
+            curlx_sktosi(sockfd), WSAGetLastError());
     }
 #else
 #ifdef TCP_KEEPIDLE

--- a/lib/curl_limits.h
+++ b/lib/curl_limits.h
@@ -1,0 +1,44 @@
+#ifndef HEADER_CURL_LIMITS_H
+#define HEADER_CURL_LIMITS_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2016, Karlson2k (Evgeny Grin).
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
+
+#ifndef USHORT_MAX
+#define USHORT_MAX ((unsigned short)~((unsigned short)0)))
+#endif /* USHORT_MAX */
+
+#ifndef INT_MAX
+#define INT_MAX ((int)((~((int)0))>>1))
+#endif /* INT_MAX */
+
+#ifndef UINT_MAX
+#define UINT_MAX ((unsigned int)~((unsigned int)0)))
+#endif /* UINT_MAX */
+
+
+#endif /* HEADER_CURL_LIMITS_H */

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -199,7 +199,7 @@ static CURLcode rtmp_connect(struct connectdata *conn, bool *done)
   RTMP *r = conn->proto.generic;
   SET_RCVTIMEO(tv, 10);
 
-  r->m_sb.sb_socket = conn->sock[FIRSTSOCKET];
+  r->m_sb.sb_socket = curlx_sktosi(conn->sock[FIRSTSOCKET]);
 
   /* We have to know if it's a write before we send the
    * connect request packet

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -75,6 +75,7 @@
 #include "sigpipe.h"
 #include "ssh.h"
 #include "curl_printf.h"
+#include "curl_limits.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -594,6 +595,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     int i;
     struct timeval before;
     struct timeval after;
+    int timeout_ms;
 
     /* populate the fds[] array */
     for(m = ev->list, f=&fds[0]; m; m = m->next) {
@@ -608,8 +610,10 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     /* get the time stamp to use to figure out how long poll takes */
     before = curlx_tvnow();
 
+    timeout_ms = (ev->ms > (long)INT_MAX) ? INT_MAX : ev->ms;
+
     /* wait for activity or timeout */
-    pollrc = Curl_poll(fds, numfds, (int)ev->ms);
+    pollrc = Curl_poll(fds, numfds, timeout_ms);
 
     after = curlx_tvnow();
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -78,6 +78,7 @@
 #include "http_proxy.h"
 #include "non-ascii.h"
 #include "curl_printf.h"
+#include "curl_limits.h"
 
 #include "curl_memory.h"
 /* The last #include file should be: */
@@ -3993,8 +3994,10 @@ static CURLcode wc_statemach(struct connectdata *conn)
 
     infof(conn->data, "Wildcard - START of \"%s\"\n", finfo->filename);
     if(conn->data->set.chunk_bgn) {
+      const int list_size = (wildcard->filelist->size > (size_t)INT_MAX) ?
+                            INT_MAX : (int)wildcard->filelist->size;
       long userresponse = conn->data->set.chunk_bgn(
-          finfo, wildcard->customptr, (int)wildcard->filelist->size);
+          finfo, wildcard->customptr, list_size);
       switch(userresponse) {
       case CURL_CHUNK_BGN_FUNC_SKIP:
         infof(conn->data, "Wildcard - \"%s\" skipped by user\n",

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -83,7 +83,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   char *sel;
   char *sel_org = NULL;
   ssize_t amount, k;
-  int len;
+  size_t len;
 
   *done = TRUE; /* unconditionally */
 
@@ -94,6 +94,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   }
   else {
     char *newp;
+    int len_int;
     size_t j, i;
 
     /* Otherwise, drop / and the first character (i.e., item type) ... */
@@ -107,10 +108,11 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
         newp[i] = '\x09';
 
     /* ... and finally unescape */
-    sel = curl_easy_unescape(data, newp, 0, &len);
+    sel = curl_easy_unescape(data, newp, 0, &len_int);
     if(!sel)
       return CURLE_OUT_OF_MEMORY;
     sel_org = sel;
+    len = (size_t)len_int;
   }
 
   /* We use Curl_write instead of Curl_sendf to make sure the entire buffer is

--- a/lib/http.c
+++ b/lib/http.c
@@ -2639,7 +2639,18 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
         else {
           if(postsize) {
             /* Append the POST data chunky-style */
-            result = Curl_add_bufferf(req_buffer, "%x\r\n", (int)postsize);
+            if(sizeof(curl_off_t) == sizeof(long))
+              result = Curl_add_bufferf(req_buffer, "%lx\r\n",
+                                        (long)postsize);
+#ifdef HAVE_LONGLONG
+            else if(sizeof (curl_off_t) == sizeof (long long))
+              result = Curl_add_bufferf(req_buffer, "%llx\r\n",
+                                        (long long)postsize);
+#endif /* HAVE_LONGLONG */
+            else
+              result = Curl_add_bufferf (req_buffer, "%x\r\n",
+                                         (int)postsize);
+
             if(!result) {
               result = Curl_add_buffer(req_buffer, data->set.postfields,
                                        (size_t)postsize);

--- a/lib/security.c
+++ b/lib/security.c
@@ -50,10 +50,6 @@
 #include <netdb.h>
 #endif
 
-#ifdef HAVE_LIMITS_H
-#include <limits.h>
-#endif
-
 #include "urldata.h"
 #include "curl_base64.h"
 #include "curl_memory.h"
@@ -62,6 +58,7 @@
 #include "sendf.h"
 #include "rawstr.h"
 #include "warnless.h"
+#include "curl_limits.h"
 
 /* The last #include file should be: */
 #include "memdebug.h"

--- a/lib/select.c
+++ b/lib/select.c
@@ -49,6 +49,7 @@
 #include "connect.h"
 #include "select.h"
 #include "warnless.h"
+#include "curl_limits.h"
 
 /* Convenience local macros */
 
@@ -164,6 +165,9 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   int error;
   int r;
   int ret;
+
+  if(timeout_ms > (long)INT_MAX)
+    timeout_ms = (long)INT_MAX; /* this is too long for real cases */
 
   if((readfd0 == CURL_SOCKET_BAD) && (readfd1 == CURL_SOCKET_BAD) &&
      (writefd == CURL_SOCKET_BAD)) {

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -94,6 +94,7 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, int bytes, int *nreadp)
   struct SessionHandle *data = conn->data;
   size_t buffersize = (size_t)bytes;
   int nread;
+  size_t res; /* temporal store for returned value */
 #ifdef CURL_DOES_CONVERSIONS
   bool sending_http_headers = FALSE;
 
@@ -113,17 +114,15 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, int bytes, int *nreadp)
     data->req.upload_fromhere += (8 + 2); /* 32bit hex + CRLF */
   }
 
-  /* this function returns a size_t, so we typecast to int to prevent warnings
-     with picky compilers */
-  nread = (int)data->state.fread_func(data->req.upload_fromhere, 1,
+  res = data->state.fread_func(data->req.upload_fromhere, 1,
                                       buffersize, data->state.in);
 
-  if(nread == CURL_READFUNC_ABORT) {
+  if(res == CURL_READFUNC_ABORT) {
     failf(data, "operation aborted by callback");
     *nreadp = 0;
     return CURLE_ABORTED_BY_CALLBACK;
   }
-  else if(nread == CURL_READFUNC_PAUSE) {
+  else if(res == CURL_READFUNC_PAUSE) {
 
     if(conn->handler->flags & PROTOPT_NONETWORK) {
       /* protocols that work without network cannot be paused. This is
@@ -144,12 +143,13 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, int bytes, int *nreadp)
     }
     return CURLE_OK; /* nothing was read */
   }
-  else if((size_t)nread > buffersize) {
+  else if(res > buffersize) {
     /* the read function returned a too large value */
     *nreadp = 0;
     failf(data, "read function returned funny value");
     return CURLE_READ_ERROR;
   }
+  nread = (int)res; /* already checked that data fits int */
 
   if(!data->req.forbidchunk && data->req.upload_chunky) {
     /* if chunked Transfer-Encoding

--- a/lib/vtls/axtls.c
+++ b/lib/vtls/axtls.c
@@ -42,6 +42,7 @@
 #include "curl_printf.h"
 #include "hostcheck.h"
 #include <unistd.h>
+#include "curl_limits.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -513,6 +514,9 @@ static ssize_t axtls_send(struct connectdata *conn,
                           size_t len,
                           CURLcode *err)
 {
+  if(len > (size_t)INT_MAX)
+    len = INT_MAX; /* trim to largest possible value */
+
   /* ssl_write() returns 'int' while write() and send() returns 'size_t' */
   int rc = ssl_write(conn->ssl[sockindex].ssl, mem, (int)len);
 

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -44,10 +44,6 @@ and that's a problem since options.h hasn't been included yet. */
 #include <cyassl/options.h>
 #endif
 
-#ifdef HAVE_LIMITS_H
-#include <limits.h>
-#endif
-
 #include "urldata.h"
 #include "sendf.h"
 #include "inet_pton.h"
@@ -59,6 +55,8 @@ and that's a problem since options.h hasn't been included yet. */
 #include "rawstr.h"
 #include "x509asn1.h"
 #include "curl_printf.h"
+#include "warnless.h"
+#include "curl_limits.h"
 
 #include <cyassl/ssl.h>
 #ifdef HAVE_CYASSL_ERROR_SSL_H
@@ -322,7 +320,7 @@ cyassl_connect_step1(struct connectdata *conn,
   }
 
   /* pass the raw socket into the SSL layer */
-  if(!SSL_set_fd(conssl->handle, (int)sockfd)) {
+  if(!SSL_set_fd(conssl->handle, curlx_sktosi(sockfd))) {
     failf(data, "SSL: SSL_set_fd failed");
     return CURLE_SSL_CONNECT_ERROR;
   }

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -61,10 +61,6 @@
 #endif
 
 
-#ifdef HAVE_LIMITS_H
-#  include <limits.h>
-#endif
-
 #include <curl/curl.h>
 #include "urldata.h"
 #include "sendf.h"
@@ -75,6 +71,7 @@
 #include "strequal.h"
 #include "x509asn1.h"
 #include "curl_printf.h"
+#include "curl_limits.h"
 
 #include "curl_memory.h"
 /* The last #include file should be: */
@@ -521,6 +518,8 @@ static ssize_t gskit_send(struct connectdata *conn, int sockindex,
   CURLcode cc;
   int written;
 
+  if(len > (size_t)INT_MAX)
+    len = (size_t)INT_MAX;
   cc = gskit_status(data,
                     gsk_secure_soc_write(conn->ssl[sockindex].handle,
                                          (char *) mem, (int) len, &written),

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -67,6 +67,7 @@
 #include "rawstr.h"
 #include "warnless.h"
 #include "x509asn1.h"
+#include "curl_limits.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -1951,6 +1952,9 @@ static ssize_t nss_send(struct connectdata *conn,  /* connection data */
                         size_t len,                /* amount to write */
                         CURLcode *curlcode)
 {
+  if(len > (size_t)INT_MAX)
+    len = (size_t)INT_MAX;
+
   ssize_t rc = PR_Send(conn->ssl[sockindex].handle, mem, (int)len, 0,
                        PR_INTERVAL_NO_WAIT);
   if(rc < 0) {
@@ -1982,6 +1986,9 @@ static ssize_t nss_recv(struct connectdata * conn, /* connection data */
                         size_t buffersize,         /* max amount to read */
                         CURLcode *curlcode)
 {
+  if(buffersize > (size_t)INT_MAX)
+    buffersize = (size_t)INT_MAX;
+
   ssize_t nread = PR_Recv(conn->ssl[num].handle, buf, (int)buffersize, 0,
                           PR_INTERVAL_NO_WAIT);
   if(nread < 0) {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -34,10 +34,6 @@
 
 #ifdef USE_OPENSSL
 
-#ifdef HAVE_LIMITS_H
-#include <limits.h>
-#endif
-
 #include "urldata.h"
 #include "sendf.h"
 #include "formdata.h" /* for the boundary function */
@@ -52,6 +48,8 @@
 #include "rawstr.h"
 #include "hostcheck.h"
 #include "curl_printf.h"
+#include "warnless.h"
+#include "curl_limits.h"
 
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
@@ -2030,7 +2028,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   }
 
   /* pass the raw socket into the SSL layers */
-  if(!SSL_set_fd(connssl->handle, (int)sockfd)) {
+  if(!SSL_set_fd(connssl->handle, curlx_sktosi(sockfd))) {
     failf(data, "SSL: SSL_set_fd failed: %s",
           ERR_error_string(ERR_get_error(), NULL));
     return CURLE_SSL_CONNECT_ERROR;
@@ -2172,8 +2170,10 @@ static int asn1_object_dump(ASN1_OBJECT *a, char *buf, size_t len)
 {
   int i, ilen;
 
-  if((ilen = (int)len) < 0)
+  if(len > (size_t)INT_MAX)
     return 1; /* buffer too big */
+
+  ilen = (int)len;
 
   i = i2t_ASN1_OBJECT(buf, ilen, a);
 

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -60,6 +60,12 @@ int curlx_sktosi(curl_socket_t s);
 
 curl_socket_t curlx_sitosk(int i);
 
+#else  /* USE_WINSOCK */
+
+#define curlx_sktosi(s) ((int)(s))
+
+#define  curlx_sitosk(i) ((curl_socket_t)(i))
+
 #endif /* USE_WINSOCK */
 
 #if defined(WIN32) || defined(_WIN32)


### PR DESCRIPTION
On 64-bit platforms blind casing `size_t` or `long` result of losing high bits and could produce negative values. This could lead to undesirable, unexpected effects, incorrect functioning and run time errors.
This PR fixed this by properly checking values **before** truncating.

As bonus - added ability to be compiled without `limits.h`