### PR TITLE
Fixed usage of %PWD in testsuite on MinGW64

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2311,7 +2311,7 @@ sub checksystem {
             $curl =~ s/^(.*)(libcurl.*)/$1/g;
 
             $libcurl = $2;
-            if($curl =~ /mingw32/) {
+            if($curl =~ /mingw(32|64)/) {
                 # This is a windows minw32 build, we need to translate the
                 # given path to the "actual" windows path. The MSYS shell
                 # has a builtin 'pwd -W' command which converts the path.


### PR DESCRIPTION
Fixed usage of %PWD in testsuite on MinGW64.
This fixed tests number 200, 202, 203, 204, 231, 288, 502, 1016, 1017, 1018, 1019, 1020, 1063, 1220, 1340, 1341, 1422, 1423, 2000, 2001, 2002, 2003.