### PR TITLE
docs/examples: correct return values of read_callback and write_callback

### DIFF
--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -311,7 +311,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
   ConnInfo *conn = (ConnInfo*) data;
   (void)ptr;
   (void)conn;
-  return realsize;
+  return nmemb;
 }
 
 

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -53,7 +53,7 @@ WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
   mem->size += realsize;
   mem->memory[mem->size] = 0;
 
-  return realsize;
+  return nmemb;
 }
 
 int main(void)

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -266,7 +266,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
   ConnInfo *conn = (ConnInfo*) data;
   (void)ptr;
   (void)conn;
-  return realsize;
+  return nmemb;
 }
 
 /* CURLOPT_PROGRESSFUNCTION */

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -294,7 +294,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
   ConnInfo *conn = (ConnInfo*) data;
   (void)ptr;
   (void)conn;
-  return realsize;
+  return nmemb;
 }
 
 

--- a/docs/examples/href_extractor.c
+++ b/docs/examples/href_extractor.c
@@ -47,7 +47,7 @@ static size_t write_callback(void *buffer, size_t size, size_t nmemb,
           printf("%s\n", html_parser_val(hsp));
         }
   }
-  return realsize;
+  return nmemb;
 }
 
 int main(int argc, char *argv[])

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -50,7 +50,7 @@ WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
   mem->size += realsize;
   mem->memory[mem->size] = 0;
 
-  return realsize;
+  return nmemb;
 }
 
 int main(void)


### PR DESCRIPTION
read_callback() and write_callback() should return the number of objects
read or written just like fread() and fwrite(), but not the bytes.

Seems libcurl always sets the size of every item to 1, makes returning
number of bytes also works. However, we should correct them, which are
*wrong examples*, might make users confused(like I was).