### PR TITLE
NTLM: Stick to a connection while negotiating

### DIFF
--- a/lib/curl_ntlm.c
+++ b/lib/curl_ntlm.c
@@ -81,6 +81,8 @@ CURLcode Curl_input_ntlm(struct connectdata *conn,
       if(result)
         return result;
 
+      conn->data->state.ntlm_conn = conn; /* Attach to this connection */
+
       ntlm->state = NTLMSTATE_TYPE2; /* We got a type-2 message */
     }
     else {

--- a/lib/url.c
+++ b/lib/url.c
@@ -3375,6 +3375,16 @@ ConnectionExists(struct SessionHandle *data,
            looking so that we can reuse NTLM connections if
            possible. (Especially we must not reuse the same connection if
            partway through a handshake!) */
+
+        /* If we are engaged to a connection, don't use another one */
+        if(data->state.ntlm_conn && (data->state.ntlm_conn != check))
+          continue;
+        /* Otherwise, don't use a connection that's negotiating */
+        if(!data->state.ntlm_conn &&
+           ((check->ntlm.state == NTLMSTATE_TYPE2) ||
+            (check->proxyntlm.state == NTLMSTATE_TYPE2)))
+          continue;
+
         if(wantNTLMhttp) {
           if(!strequal(needle->user, check->user) ||
              !strequal(needle->passwd, check->passwd))

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1326,6 +1326,8 @@ struct UrlState {
   struct SessionHandle *stream_depends_on;
   bool stream_depends_e; /* set or don't set the Exclusive bit */
   int stream_weight;
+
+  struct connectdata *ntlm_conn; /* Connection to use for NTLM negitiation */
 };
 
 


### PR DESCRIPTION
Currently NTLM auth is state-less, meaning a request may start
an NTLM connection and once it gets the challenge it may pick another
authenticated connection instead of answering the challenge (if,
for instance such connection got just freed).

With this fix, once we get NTLM challenge we stick to the
current connection and won't try to use any other one.
