### PR TITLE
Add support for setting options on easy handles through primitives

### DIFF
--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -31,12 +31,12 @@ CURL_EXTERN CURLcode curl_easy_setopt_bool(CURL *curl, CURLoption option, int va
 CURL_EXTERN CURLcode curl_easy_setopt_headers(CURL *curl, struct curl_slist *headers);
 CURL_EXTERN CURLcode curl_easy_setopt_int(CURL *curl, CURLoption option, long data);
 CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char *data);
-  CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
-                                                      size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
-                                                                         void *userdata));
+CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
+    size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
+      void *userdata));
 CURL_EXTERN CURLcode curl_easy_setopt_write_function(CURL *curl, void *userData,
-                                                     size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
-                                                                         void *userdata));
+    size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
+      void *userdata));
 
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -31,6 +31,13 @@ CURL_EXTERN CURLcode curl_easy_setopt_bool(CURL *curl, CURLoption option, int va
 CURL_EXTERN CURLcode curl_easy_setopt_headers(CURL *curl, struct curl_slist *headers);
 CURL_EXTERN CURLcode curl_easy_setopt_int(CURL *curl, CURLoption option, long data);
 CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char *data);
+CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
+                                                    size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
+                                                    void *userdata));
+CURL_EXTERN CURLcode curl_easy_setopt_write_function(CURL *curl, void *userData,
+                                                     size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
+                                                     void *userdata));
+
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);
 
@@ -48,8 +55,9 @@ CURL_EXTERN void curl_easy_cleanup(CURL *curl);
  * transfer is completed.
  */
 CURL_EXTERN CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ...);
-
-
+CURL_EXTERN CURLcode curl_easy_getinfo_string(CURL *curl, CURLINFO info, char **data);
+CURL_EXTERN CURLcode curl_easy_getinfo_long(CURL *curl, CURLINFO info, long *data);
+    
 /*
  * NAME curl_easy_duphandle()
  *

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -27,6 +27,10 @@ extern "C" {
 
 CURL_EXTERN CURL *curl_easy_init(void);
 CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...);
+CURL_EXTERN CURLcode curl_easy_setopt_bool(CURL *curl, CURLoption option, int value);
+CURL_EXTERN CURLcode curl_easy_setopt_headers(CURL *curl, struct curl_slist *headers);
+CURL_EXTERN CURLcode curl_easy_setopt_int(CURL *curl, CURLoption option, long data);
+CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char *data);
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);
 

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -31,12 +31,12 @@ CURL_EXTERN CURLcode curl_easy_setopt_bool(CURL *curl, CURLoption option, int va
 CURL_EXTERN CURLcode curl_easy_setopt_headers(CURL *curl, struct curl_slist *headers);
 CURL_EXTERN CURLcode curl_easy_setopt_int(CURL *curl, CURLoption option, long data);
 CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char *data);
-CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
-                                                    size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
-                                                    void *userdata));
+  CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
+                                                      size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
+                                                                         void *userdata));
 CURL_EXTERN CURLcode curl_easy_setopt_write_function(CURL *curl, void *userData,
                                                      size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
-                                                     void *userdata));
+                                                                         void *userdata));
 
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);
@@ -57,7 +57,7 @@ CURL_EXTERN void curl_easy_cleanup(CURL *curl);
 CURL_EXTERN CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ...);
 CURL_EXTERN CURLcode curl_easy_getinfo_string(CURL *curl, CURLINFO info, char **data);
 CURL_EXTERN CURLcode curl_easy_getinfo_long(CURL *curl, CURLINFO info, long *data);
-    
+
 /*
  * NAME curl_easy_duphandle()
  *

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -411,6 +411,26 @@ CURLcode curl_easy_setopt(CURL *curl, CURLoption tag, ...)
   return result;
 }
 
+CURL_EXTERN CURLcode curl_easy_setopt_bool(CURL *curl, CURLoption option, int value)
+{
+  return curl_easy_setopt(curl, option, value == 1 ? 1L : 0L);
+}
+
+CURL_EXTERN CURLcode curl_easy_setopt_headers(CURL *curl, struct curl_slist *headers)
+{
+    return curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+}
+
+CURL_EXTERN CURLcode curl_easy_setopt_int(CURL *curl, CURLoption option, long data)
+{
+    return curl_easy_setopt(curl, option, data);
+}
+
+CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char *data)
+{
+    return curl_easy_setopt(curl, option, data);
+}
+
 #ifdef CURLDEBUG
 
 struct socketmonitor {

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -432,8 +432,9 @@ CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char
 }
 
 CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
-                                                    size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
-                                                                       void *userdata)) {
+    size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
+      void *userdata)) 
+{
   CURLcode rc = curl_easy_setopt(curl, CURLOPT_READDATA, userData);
   if  (rc == CURLE_OK) {
     rc = curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
@@ -442,8 +443,9 @@ CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
 }
 
 CURL_EXTERN CURLcode curl_easy_setopt_write_function(CURL *curl, void *userData,
-                                                     size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
-                                                                         void *userdata)) {
+    size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
+      void *userdata)) 
+{
   CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 1);
   if  (rc == CURLE_OK)  {
     rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -431,6 +431,30 @@ CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char
     return curl_easy_setopt(curl, option, data);
 }
 
+CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
+                                                    size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
+                                                                       void *userdata)) {
+                                                        
+                                                        CURLcode rc = curl_easy_setopt(curl, CURLOPT_READDATA, userData);
+                                                        if  (rc == CURLE_OK) {
+                                                            rc = curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
+                                                        }
+                                                        return rc;
+}
+
+CURL_EXTERN CURLcode curl_easy_setopt_write_function(CURL *curl, void *userData,
+                                                     size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
+                                                                         void *userdata)) {
+                                                         CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 1);
+                                                         if  (rc == CURLE_OK)  {
+                                                             rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);
+                                                             if  (rc == CURLE_OK) {
+                                                                 rc = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+                                                             }
+                                                         }
+                                                         return rc;
+}
+
 #ifdef CURLDEBUG
 
 struct socketmonitor {
@@ -899,6 +923,16 @@ CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ...)
 
   va_end(arg);
   return result;
+}
+
+CURLcode curl_easy_getinfo_string(CURL *curl, CURLINFO info, char **data)
+{
+  return curl_easy_getinfo(curl, info, data);
+}
+
+CURLcode curl_easy_getinfo_long(CURL *curl, CURLINFO info, long *data)
+{
+  return curl_easy_getinfo(curl, info, data);    
 }
 
 /*

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -434,25 +434,24 @@ CURL_EXTERN CURLcode curl_easy_setopt_string(CURL *curl, CURLoption option, char
 CURL_EXTERN CURLcode curl_easy_setopt_read_function(CURL *curl, void *userData,
                                                     size_t (*read_cb) (char *buffer, size_t size, size_t nitems,
                                                                        void *userdata)) {
-                                                        
-                                                        CURLcode rc = curl_easy_setopt(curl, CURLOPT_READDATA, userData);
-                                                        if  (rc == CURLE_OK) {
-                                                            rc = curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
-                                                        }
-                                                        return rc;
+  CURLcode rc = curl_easy_setopt(curl, CURLOPT_READDATA, userData);
+  if  (rc == CURLE_OK) {
+    rc = curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
+  }
+  return rc;
 }
 
 CURL_EXTERN CURLcode curl_easy_setopt_write_function(CURL *curl, void *userData,
                                                      size_t (*write_cb) (char *buffer, size_t size, size_t nitems,
                                                                          void *userdata)) {
-                                                         CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 1);
-                                                         if  (rc == CURLE_OK)  {
-                                                             rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);
-                                                             if  (rc == CURLE_OK) {
-                                                                 rc = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
-                                                             }
-                                                         }
-                                                         return rc;
+  CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 1);
+  if  (rc == CURLE_OK)  {
+    rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);
+    if  (rc == CURLE_OK) {
+      rc = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    }
+  }
+  return rc;
 }
 
 #ifdef CURLDEBUG


### PR DESCRIPTION
Many languages cannot bind to variadic C functions (for example Swift). Currently, many language bindings get around this problem by creating a shim wrapper which requires C-compilation. Yet, many Package Managers do not support C-compilation on installation or compilation.

This PR offers a solution by adding the following getters and setters for setting options on easy handles:

1. curl_easy_setopt_bool
2. curl_easy_setopt_headers
3. curl_easy_setopt_int
4. curl_easy_setopt_string
5. curl_easy_setopt_read_function
6. curl_easy_setopt_write_function
7. curl_easy_getinfo_string
8. curl_easy_getinfo_long

Let me know if this matches the philosophy behind libcurl and whether adding test cases could improve the chances of getting this PR accepted. Adding this functionality could enable applications using the Swift Package Manager to use libcurl. 