### PR TITLE
makefile.m32: allow to pass .dll/.exe-specific LDFLAGS

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -80,7 +80,7 @@ CC	= $(CROSSPREFIX)gcc
 CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
-LDFLAGS	= $(CURL_LDFLAG_EXTRAS) -s
+LDFLAGS	= $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL) -s
 AR	= $(CROSSPREFIX)ar
 RANLIB	= $(CROSSPREFIX)ranlib
 RC	= $(CROSSPREFIX)windres

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -92,7 +92,7 @@ CC	= $(CROSSPREFIX)gcc
 CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
-LDFLAGS	= $(CURL_LDFLAG_EXTRAS) -s
+LDFLAGS	= $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s
 AR	= $(CROSSPREFIX)ar
 RC	= $(CROSSPREFIX)windres
 RCFLAGS	= --include-dir=$(PROOT)/include -O COFF


### PR DESCRIPTION
using envvars `CURL_LDFLAG_EXTRAS_DLL` and `CURL_LDFLAG_EXTRAS_EXE`
respectively. This is useful f.e. to pass ASLR-related extra options,
that are required to make this feature work when using the mingw toolchain.

Ref: https://github.com/curl/curl/pull/670#issuecomment-190863985
