### PR TITLE
If Curl_done is called with premature == TRUE we can't pipeline

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -6157,7 +6157,8 @@ CURLcode Curl_done(struct connectdata **connp,
       result = CURLE_ABORTED_BY_CALLBACK;
   }
 
-  if((conn->send_pipe->size + conn->recv_pipe->size != 0 &&
+  if((!premature &&
+      conn->send_pipe->size + conn->recv_pipe->size != 0 &&
       !data->set.reuse_forbid &&
       !conn->bits.close)) {
     /* Stop if pipeline is not empty and we do not have to close


### PR DESCRIPTION
This prevents a crash in the following scenario:

2 (or more) requests are made to the same host and pipelining is enabled.

The first request times out. Curl_done will return early in this block
since conn->send_pipe->size == 1:

  if((conn->send_pipe->size + conn->recv_pipe->size != 0 &&
      !data->set.reuse_forbid &&
      !conn->bits.close)) {
    /* Stop if pipeline is not empty and we do not have to close
       connection. */
    DEBUGF(infof(data, "Connection still in use, no more Curl_done now!\n"));
    return CURLE_OK;
  }

When the second one fails it will not return early and will in fact
call Curl_disconnect which will free the connection.

When curl_easy_cleanup is called on the first request his easy_conn
pointer will be a dangling pointer and the app will crash.

ASAN output:
~~~
==7245==ERROR: AddressSanitizer: heap-use-after-free on address 0xda366d80 at pc 0x986d05b bp 0xd94b16d8 sp 0xd94b16c0
READ of size 4 at 0xda366d80 thread T16 (RESOURCE_HTTP)
    #0 0x986d05a in curl_multi_remove_handle
    #1 0x98a3e2b in Curl_close
    #2 0x985abb5 in curl_easy_cleanup
    #3 0x9777302 in <application frames>
    #4 0xf7b2a016 in __asan::AsanThread::ThreadStart(unsigned long)
    #5 0xf7b16f40 in asan_thread_start(void*)
    #6 0xf7a971a9 in start_thread
    #7 0xf681b02d in clone

0xda366d80 is located 0 bytes inside of 1100-byte region [0xda366d80,0xda3671cc)
freed by thread T16 (RESOURCE_HTTP) here:
    #0 0xf7b1fa5a in free
    #1 0x98b5948 in Curl_disconnect
    #2 0x98d067d in Curl_done
    #3 0x9875a61 in curl_multi_perform
    #4 0x9758a71 in <application frames>
    #5 0xf7b2a016 in __asan::AsanThread::ThreadStart(unsigned long)
    #6 0xf681b02d in clone
~~~