### PR TITLE
Avoid warning on 32-bit platform.

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -387,7 +387,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     case CURLFORM_CONTENTLEN:
       current_form->flags |= CURL_HTTPPOST_LARGE;
       current_form->contentslength =
-        array_state?(curl_off_t)array_value:va_arg(params, curl_off_t);
+        array_state?(curl_off_t)((uintptr_t)array_value):va_arg(params, curl_off_t);
       break;
 
       /* Get contents from a given file name */


### PR DESCRIPTION
.../curl/lib/formdata.c:390:21: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]