### PR TITLE
makefile.m32: fix to allow -ssh2-winssl combination

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -153,7 +153,9 @@ ZLIB = 1
 endif
 ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
 SSH2 = 1
+ifneq ($(findstring -winssl,$(CFG)),-winssl)
 SSL = 1
+endif
 ZLIB = 1
 endif
 ifeq ($(findstring -ssl,$(CFG)),-ssl)

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -168,7 +168,9 @@ ZLIB = 1
 endif
 ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
 SSH2 = 1
+ifneq ($(findstring -winssl,$(CFG)),-winssl)
 SSL = 1
+endif
 ZLIB = 1
 endif
 ifeq ($(findstring -ssl,$(CFG)),-ssl)


### PR DESCRIPTION
In makefile.m32, option -ssh2 (libssh2) automatically
implied -ssl (OpenSSL) option, with no way to override
it with -winssl. Since both libssh2 and curl support
using Windows's built-in SSL backend, modify the logic
to allow that combination.