### PR TITLE
makefile.m32: add missing libs for -winssl option

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -215,6 +215,11 @@ ifdef SSH2
   INCLUDES += -I"$(LIBSSH2_PATH)/include" -I"$(LIBSSH2_PATH)/win32"
   CFLAGS += -DUSE_LIBSSH2 -DHAVE_LIBSSH2_H
   DLL_LIBS += -L"$(LIBSSH2_PATH)/win32" -lssh2
+  ifdef WINSSL
+    ifndef DYN
+      DLL_LIBS += -lbcrypt -lcrypt32
+    endif
+  endif
 endif
 ifdef SSL
   ifndef OPENSSL_INCLUDE

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -236,6 +236,11 @@ endif
 ifdef SSH2
   CFLAGS += -DUSE_LIBSSH2 -DHAVE_LIBSSH2_H
   curl_LDADD += -L"$(LIBSSH2_PATH)/win32" -lssh2
+  ifdef WINSSL
+    ifndef DYN
+      curl_LDADD += -lbcrypt -lcrypt32
+    endif
+  endif
 endif
 ifdef SSL
   ifndef OPENSSL_INCLUDE


### PR DESCRIPTION
Required for a successful link. Similar logic is already [present in `libssh2`](https://github.com/libssh2/libssh2/blob/master/win32/GNUmakefile#L157).