### PR TITLE
docs: clarify returning values of read_callback and write_callback

### DIFF
--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.3
@@ -64,6 +64,9 @@ internal read function will be used. It is doing an fread() on the FILE *
 userdata set with \fICURLOPT_READDATA(3)\fP.
 .SH DEFAULT
 The default internal read callback is fread().
+
+\fBNote\fP: fread() returns the number of items it read but not the bytes, no
+worries, because the argument \fIsize\fP is always 1.
 .SH PROTOCOLS
 This is used for all protocols when doing uploads.
 .SH EXAMPLE

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -66,7 +66,10 @@ Set this option to NULL to get the internal default function used instead of
 your callback. The internal default function will write the data to the FILE *
 given with \fICURLOPT_WRITEDATA(3)\fP.
 .SH DEFAULT
-libcurl will use 'fwrite' as a callback by default.
+libcurl will use 'fwrite()' as a callback by default.
+
+\fBNote\fP: fwrite() returns the number of items it wrote but not the bytes,
+no worries, because the argument \fIsize\fP is always 1.
 .SH PROTOCOLS
 For all protocols
 .SH AVAILABILITY


### PR DESCRIPTION
read_callback() and write_callback() return the number of bytes, but fread() and fwrite() return the number of items, which might make users confused(like I was), this commit clarifies it.