### PR TITLE
try to fix CONNECT blocking

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1229,17 +1229,19 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /* this is HTTP-specific, but sending CONNECT to a proxy is HTTP... */
       result = Curl_http_connect(data->easy_conn, &protocol_connect);
 
-      rc = CURLM_CALL_MULTI_PERFORM;
       if(data->easy_conn->bits.proxy_connect_closed) {
+        rc = CURLM_CALL_MULTI_PERFORM;
         /* connect back to proxy again */
         result = CURLE_OK;
         Curl_done(&data->easy_conn, CURLE_OK, FALSE);
         multistate(data, CURLM_STATE_CONNECT);
       }
       else if(!result) {
-        if(data->easy_conn->tunnel_state[FIRSTSOCKET] == TUNNEL_COMPLETE)
+        if(data->easy_conn->tunnel_state[FIRSTSOCKET] == TUNNEL_COMPLETE) {
+          rc = CURLM_CALL_MULTI_PERFORM;
           /* initiate protocol connect phase */
           multistate(data, CURLM_STATE_SENDPROTOCONNECT);
+        }
       }
       break;
 #endif


### PR DESCRIPTION
Hello, guys!

I use curl multi-* API and as far as I understand it's supposed to be non-blocking. But I have an issue with HTTP proxy: during querying the proxy with CONNECT method (establishing a tunnel for an HTTPS session) libcurl blocks in curl_multi_socket_action until the proxy returns "200 Connection established". After some debugging I've found that actually libcurl blocks in multi_runsingle function. The code snippet below explains the details:

```c
do {
  switch( state ) {
    case CURLM_STATE_WAITPROXYCONNECT:
       // this unconditional statement causes that blocking
       rc = CURLM_CALL_MULTI_PERFORM;
    break;
  };
} while( rc == CURLM_CALL_MULTI_PERFORM );
```

It seems we can not to block in the loop but wait a callback from curl_multi_socket_action. 
Here is the patch. It's working for me but still it looks pretty naive :) Please review it and give me a hint how to solve the faced issue in a proper way.
I'm looking forward to hearing from you soon.

Regards