### PR TITLE
Sanity check pipeline pointer before accessing it.

### DIFF
--- a/lib/pipeline.c
+++ b/lib/pipeline.c
@@ -323,10 +323,11 @@ CURLMcode Curl_pipeline_set_server_blacklist(char **servers,
 static bool pipe_head(struct SessionHandle *data,
                       struct curl_llist *pipeline)
 {
-  struct curl_llist_element *curr = pipeline->head;
-  if(curr)
-    return (curr->ptr == data) ? TRUE : FALSE;
-
+  if(pipeline) {
+    struct curl_llist_element *curr = pipeline->head;
+    if(curr)
+      return (curr->ptr == data) ? TRUE : FALSE;
+  }
   return FALSE;
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -2868,15 +2868,17 @@ static bool IsPipeliningPossible(const struct SessionHandle *handle,
 int Curl_removeHandleFromPipeline(struct SessionHandle *handle,
                                   struct curl_llist *pipeline)
 {
-  struct curl_llist_element *curr;
+  if(pipeline) {
+    struct curl_llist_element *curr;
 
-  curr = pipeline->head;
-  while(curr) {
-    if(curr->ptr == handle) {
-      Curl_llist_remove(pipeline, curr, NULL);
-      return 1; /* we removed a handle */
+    curr = pipeline->head;
+    while(curr) {
+      if(curr->ptr == handle) {
+        Curl_llist_remove(pipeline, curr, NULL);
+        return 1; /* we removed a handle */
+      }
+      curr = curr->next;
     }
-    curr = curr->next;
   }
 
   return 0;


### PR DESCRIPTION
I got a crash with this stack:

curl/lib/url.c:2873 (Curl_removeHandleFromPipeline)
curl/lib/url.c:2919 (Curl_getoff_all_pipelines)
curl/lib/multi.c:561 (curl_multi_remove_handle)
curl/lib/url.c:415 (Curl_close)
curl/lib/easy.c:859 (curl_easy_cleanup)