### PR TITLE
[win64] fix for broken hash fn on windows 64: ensure modulo performed on unsigned ints.

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -231,15 +231,15 @@ static size_t fd_key_compare(void *k1, size_t k1_len, void *k2, size_t k2_len)
 {
   (void) k1_len; (void) k2_len;
 
-  return (*((int *) k1)) == (*((int *) k2));
+  return (*((curl_socket_t *) k1)) == (*((curl_socket_t *) k2));
 }
 
 static size_t hash_fd(void *key, size_t key_length, size_t slots_num)
 {
-  int fd = *((int *) key);
+  curl_socket_t fd = *((curl_socket_t *) key);
   (void) key_length;
 
-  return (fd % (int)slots_num);
+  return (fd % slots_num);
 }
 
 /*


### PR DESCRIPTION
As discussed here: https://github.com/pycurl/pycurl/issues/395 there is an issue on 64 bit windows that will produce a segmentation fault due to bad indexing on the hash table due to a broken hash function `hash_fd():lib/multi.c:237` that would operate over a negative value as a product of casting to `int`. The negative value result of the function, when returned as `size_t` represents a very large number, that causes a segfault when indexing the hash table.

Because it's just a hash function, the impact of performing the hash function over a cast to `unsigned int`s should be none, and would incur in no performance penalty. Alternatively I can provide a fix that would ensure we always operate on positive via bitwise operations that would consume three additional cpu cycles. Let me know what's preferable. 