### PR TITLE
schannel: Add ALPN support

### DIFF
--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -7,7 +7,7 @@ HTTP/2 with curl
 Build prerequisites
 -------------------
   - nghttp2
-  - OpenSSL, NSS, GnutTLS or PolarSSL with a new enough version
+  - OpenSSL, NSS, GnutTLS, PolarSSL or SChannel with a new enough version
 
 [nghttp2](https://nghttp2.org/)
 -------------------------------
@@ -58,6 +58,7 @@ provide the necessary TLS features. Right now we support:
   - NSS:      ALPN and NPN
   - GnuTLS:   ALPN
   - PolarSSL: ALPN
+  - SChannel: ALPN
 
 Multiplexing
 ------------


### PR DESCRIPTION
Add ALPN support for schannel. This allows cURL to negotiate
HTTP/2.0 connections when built with schannel.

This requires Visual Studio 2013 or newer.