### PR TITLE
Make Curl_gss_log_error more verbose

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -76,6 +76,32 @@ OM_uint32 Curl_gss_init_sec_context(
                               NULL /* time_rec */);
 }
 
+#define GSS_LOG_BUFFER_LEN 1024
+static size_t display_gss_error(OM_uint32 status, int type,
+                                char *buf, size_t len) {
+  OM_uint32 maj_stat;
+  OM_uint32 min_stat;
+  OM_uint32 msg_ctx = 0;
+  gss_buffer_desc status_string;
+
+  do {
+    maj_stat = gss_display_status(&min_stat,
+                                  status,
+                                  type,
+                                  GSS_C_NO_OID,
+                                  &msg_ctx,
+                                  &status_string);
+    if(GSS_LOG_BUFFER_LEN > len + status_string.length + 3) {
+       len += snprintf(buf + len, GSS_LOG_BUFFER_LEN - len,
+                       "%.*s. ", (int)status_string.length,
+                       (char*)status_string.value);
+    }
+    gss_release_buffer(&min_stat, &status_string);
+  } while(!GSS_ERROR(maj_stat) && msg_ctx != 0);
+
+  return len;
+}
+
 /*
  * Curl_gss_log_error()
  *
@@ -84,37 +110,22 @@ OM_uint32 Curl_gss_init_sec_context(
  * Parameters:
  *
  * data    [in] - The session handle.
- * status  [in] - The status code.
  * prefix  [in] - The prefix of the log message.
+ * status  [in] - The major status code.
+ * status  [in] - The minor status code.
  */
-void Curl_gss_log_error(struct SessionHandle *data, OM_uint32 status,
-                        const char *prefix)
+void Curl_gss_log_error(struct SessionHandle *data, const char *prefix,
+                        OM_uint32 major, OM_uint32 minor)
 {
-  OM_uint32 maj_stat;
-  OM_uint32 min_stat;
-  OM_uint32 msg_ctx = 0;
-  gss_buffer_desc status_string;
-  char buf[1024];
-  size_t len;
+  char buf[GSS_LOG_BUFFER_LEN];
+  size_t len = 0;
 
-  snprintf(buf, sizeof(buf), "%s", prefix);
-  len = strlen(buf);
-  do {
-    maj_stat = gss_display_status(&min_stat,
-                                  status,
-                                  GSS_C_MECH_CODE,
-                                  GSS_C_NO_OID,
-                                  &msg_ctx,
-                                  &status_string);
-    if(sizeof(buf) > len + status_string.length + 1) {
-      snprintf(buf + len, sizeof(buf) - len,
-        ": %s", (char*)status_string.value);
-      len += status_string.length;
-    }
-    gss_release_buffer(&min_stat, &status_string);
-  } while(!GSS_ERROR(maj_stat) && msg_ctx != 0);
+  if(major != GSS_S_FAILURE)
+    len = display_gss_error(major, GSS_C_GSS_CODE, buf, len);
 
-  infof(data, "%s\n", buf);
+  display_gss_error(minor, GSS_C_MECH_CODE, buf, len);
+
+  infof(data, "%s%s\n", prefix, buf);
 }
 
 #endif /* HAVE_GSSAPI */

--- a/lib/curl_gssapi.h
+++ b/lib/curl_gssapi.h
@@ -56,8 +56,8 @@ OM_uint32 Curl_gss_init_sec_context(
     OM_uint32 *ret_flags);
 
 /* Helper to log a GSS-API error status */
-void Curl_gss_log_error(struct SessionHandle *data, OM_uint32 status,
-                        const char *prefix);
+void Curl_gss_log_error(struct SessionHandle *data, const char *prefix,
+                        OM_uint32 major, OM_uint32 minor);
 
 /* Provide some definitions missing in old headers */
 #ifdef HAVE_OLD_GSSMIT

--- a/lib/vauth/krb5_gssapi.c
+++ b/lib/vauth/krb5_gssapi.c
@@ -101,7 +101,8 @@ CURLcode Curl_auth_create_gssapi_user_message(struct SessionHandle *data,
     gss_major_status = gss_import_name(&gss_minor_status, &spn_token,
                                        GSS_C_NT_HOSTBASED_SERVICE, &krb5->spn);
     if(GSS_ERROR(gss_major_status)) {
-      Curl_gss_log_error(data, gss_minor_status, "gss_import_name() failed: ");
+      Curl_gss_log_error(data, "gss_import_name() failed: ",
+                         gss_major_status, gss_minor_status);
 
       free(spn);
 
@@ -147,8 +148,8 @@ CURLcode Curl_auth_create_gssapi_user_message(struct SessionHandle *data,
     if(output_token.value)
       gss_release_buffer(&gss_status, &output_token);
 
-    Curl_gss_log_error(data, gss_minor_status,
-                       "gss_init_sec_context() failed: ");
+    Curl_gss_log_error(data, "gss_init_sec_context() failed: ",
+                       gss_major_status, gss_minor_status);
 
     return CURLE_RECV_ERROR;
   }
@@ -224,8 +225,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct SessionHandle *data,
                                          &username, NULL, NULL, NULL, NULL,
                                          NULL, NULL);
   if(GSS_ERROR(gss_major_status)) {
-    Curl_gss_log_error(data, gss_minor_status,
-                       "gss_inquire_context() failed: ");
+    Curl_gss_log_error(data, "gss_inquire_context() failed: ",
+                       gss_major_status, gss_minor_status);
 
     free(chlg);
 
@@ -236,7 +237,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct SessionHandle *data,
   gss_major_status = gss_display_name(&gss_minor_status, username,
                                       &username_token, NULL);
   if(GSS_ERROR(gss_major_status)) {
-    Curl_gss_log_error(data, gss_minor_status, "gss_display_name() failed: ");
+    Curl_gss_log_error(data, "gss_display_name() failed: ",
+                       gss_major_status, gss_minor_status);
 
     free(chlg);
 
@@ -251,7 +253,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct SessionHandle *data,
   gss_major_status = gss_unwrap(&gss_minor_status, krb5->context, &input_token,
                                 &output_token, NULL, &qop);
   if(GSS_ERROR(gss_major_status)) {
-    Curl_gss_log_error(data, gss_minor_status, "gss_unwrap() failed: ");
+    Curl_gss_log_error(data, "gss_unwrap() failed: ",
+                       gss_major_status, gss_minor_status);
 
     gss_release_buffer(&gss_status, &username_token);
     free(chlg);
@@ -325,7 +328,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct SessionHandle *data,
                               GSS_C_QOP_DEFAULT, &input_token, NULL,
                               &output_token);
   if(GSS_ERROR(gss_major_status)) {
-    Curl_gss_log_error(data, gss_minor_status, "gss_wrap() failed: ");
+    Curl_gss_log_error(data, "gss_wrap() failed: ",
+                       gss_major_status, gss_minor_status);
 
     free(message);
 

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -102,7 +102,8 @@ CURLcode Curl_auth_decode_spnego_message(struct SessionHandle *data,
                                    GSS_C_NT_HOSTBASED_SERVICE,
                                    &nego->server_name);
     if(GSS_ERROR(major_status)) {
-      Curl_gss_log_error(data, minor_status, "gss_import_name() failed: ");
+      Curl_gss_log_error(data, "gss_import_name() failed: ",
+                         major_status, minor_status);
 
       free(spn);
 
@@ -150,8 +151,8 @@ CURLcode Curl_auth_decode_spnego_message(struct SessionHandle *data,
     if(output_token.value)
       gss_release_buffer(&unused_status, &output_token);
 
-    Curl_gss_log_error(data, minor_status,
-                       "gss_init_sec_context() failed: ");
+    Curl_gss_log_error(data, "gss_init_sec_context() failed: ",
+                       major_status, minor_status);
 
     return CURLE_OUT_OF_MEMORY;
   }


### PR DESCRIPTION
Dispaly also the GSS_C_GSS_CODE (major code) when specified,
instead of only GSS_C_MECH_CODE (minor code).

In addition, the old code was printing twice a colon after the
prefix and also miscalculated the length of the buffer in between
calls to gss_display_status (the length of ": " was missing).

Also, gss_buffer is not guaranteed to be NULL terminated and
need to restrict reading by its length.

Discussed over #723