### PR TITLE
openssl: Fix MSVC warnings

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2322,7 +2322,7 @@ static CURLcode get_cert_chain(struct connectdata *conn,
     EVP_PKEY *pubkey=NULL;
     int j;
     char *ptr;
-    ASN1_BIT_STRING *psig;
+    ASN1_BIT_STRING *psig = NULL;
 
     X509_NAME_print_ex(mem, X509_get_subject_name(x), 0, XN_FLAG_ONELINE);
     push_certinfo("Subject", i);
@@ -2342,7 +2342,7 @@ static CURLcode get_cert_chain(struct connectdata *conn,
 
 #if defined(HAVE_X509_GET0_SIGNATURE) && defined(HAVE_X509_GET0_EXTENSIONS)
     {
-      X509_ALGOR *palg;
+      X509_ALGOR *palg = NULL;
       ASN1_STRING *a = ASN1_STRING_new();
       if(a) {
         X509_get0_signature(&psig, &palg, x);


### PR DESCRIPTION
When compiling with OpenSSL 1.1.0 (so that the
`HAVE_X509_GET0_SIGNATURE && HAVE_X509_GET0_EXTENSIONS `
preprocessor block is active), Visual C++ 14 complains:

> openssl.c(2352): warning C4701: potentially uninitialized local variable 'palg' used
> openssl.c(2450): warning C4701: potentially uninitialized local variable 'psig' used