### PR TITLE
Change example for the -F file uploading option

### DIFF
--- a/docs/curl.1
+++ b/docs/curl.1
@@ -634,11 +634,11 @@ the symbol <. The difference between @ and < is then that @ makes a file get
 attached in the post as a file upload, while the < makes a text field and just
 get the contents for that text field from a file.
 
-Example, to send your password file to the server, where
-\&'password' is the name of the form-field to which /etc/passwd will be the
+Example, to send your vimrc file to a server, where
+\&'vimrc' is the name of the form-field to which ~/.vimrc will be the
 input:
 
-\fBcurl\fP -F password=@/etc/passwd www.mypasswords.com
+\fBcurl\fP -F password=@~/.vimrc https://my.website/submit-vimrc.html
 
 To read content from stdin instead of a file, use - as the filename. This goes
 for both @ and < constructs. Unfortunately it does not support reading the


### PR DESCRIPTION
It's a very, very, very bad idea to upload your password file anywhere, especially over http. I know it's just an example, but we certainly don't want anyone copy-pasting it.