### PR TITLE
remove passwords example from docs

### DIFF
--- a/docs/curl.1
+++ b/docs/curl.1
@@ -638,7 +638,7 @@ Example, to send your password file to the server, where
 \&'password' is the name of the form-field to which /etc/passwd will be the
 input:
 
-\fBcurl\fP -F password=@/etc/passwd www.mypasswords.com
+\fBcurl\fP -F password=@/etc/hosts www.myhostfiles.com
 
 To read content from stdin instead of a file, use - as the filename. This goes
 for both @ and < constructs. Unfortunately it does not support reading the


### PR DESCRIPTION
Sending password file through a random site makes a bad example.

Based on a twitter discussion kicked off by this https://twitter.com/climagic/status/717451153076649984
-> https://twitter.com/bagder/status/717460215608786944

Sending your `/etc/passwd` to a random site, is a bad examples. man pages should be a safe place and in order to be beginner friendly using a example that should be less harmful might be the better options.

  