### PR TITLE
GSSAPI: Add initial test infrastructure

### DIFF
--- a/tests/gssapi/httpd_negotiate.py
+++ b/tests/gssapi/httpd_negotiate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2016, Isaac Boukris <iboukris@gmail.com>
+# MIT licensed - see COPYING
+
+
+import sys
+import gssapi
+import base64
+import argparse
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='HTTP Negotiate Server (GSSAPI)')
+  parser.add_argument('--addr', default='127.0.0.1', help="The address to listen on")
+  parser.add_argument('--port', default='8040', help="The port to listen on")
+
+  return vars(parser.parse_args())
+
+
+class negotiateHandler(BaseHTTPRequestHandler):
+  protocol_version = 'HTTP/1.1'
+
+  def do_GET(self):
+    auth_header = self.headers.get("Authorization")
+
+    if auth_header and auth_header.find("Negotiate") == 0:
+      in_token = base64.b64decode(auth_header.split()[1])
+      ctx = gssapi.SecurityContext(usage='accept')
+      out_token = ctx.step(in_token)
+
+      if ctx.complete:
+        body = str(ctx.initiator_name)
+        self.send_response(200)
+
+        if out_token:
+          self.send_header('WWW-Authenticate',
+                           'Negotiate ' + base64.b64encode(out_token))
+
+        self.send_header('Content-Type', 'text/plain')
+        self.send_header('Content-Length', len(body))
+
+        self.end_headers()
+        self.wfile.write(body)
+
+        return
+
+    self.send_response(401)
+    self.send_header('WWW-Authenticate', 'Negotiate')
+    self.send_header('Content-Type', 'text/plain')
+    self.send_header('Content-Length', '7')
+    self.end_headers()
+    self.wfile.write('Go away')
+
+    return
+
+
+if __name__ == '__main__':
+  args = parse_args()
+  try:
+    server = HTTPServer((args['addr'], int(args['port'])), negotiateHandler)
+    sys.stderr.write('Serving at: %s:%s\n' % (args['addr'], args['port']))
+    sys.stdout.write('ready')
+    sys.stdout.flush()
+
+    server.serve_forever()
+
+  finally:
+    server.socket.close()
+

--- a/tests/gssapi/kdc.py
+++ b/tests/gssapi/kdc.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2016, Isaac Boukris <iboukris@gmail.com>
+# MIT licensed - see COPYING
+
+
+import os
+from string import Template
+import subprocess
+
+
+KRB5_CONF_TEMPLATE = '''
+[libdefaults]
+  default_realm = ${REALM}
+  dns_lookup_realm = false
+  dns_lookup_kdc = false
+  rdns = false
+  default_ccache_name = MEMORY:temp
+
+[realms]
+  ${REALM} = {
+    kdc = ${ADDR}:${PORT}
+
+    default_principal_flags = +preauth
+    key_stash_file = ${DIR}/kdc_stash.file
+  }
+
+[domain_realm]
+  .${LOWREALM} = ${REALM}
+  ${LOWREALM} = ${REALM}
+
+[dbmodules]
+  ${REALM} = {
+    database_name = ${DIR}/kdc_db.file
+  }
+
+[kdcdefaults]
+ kdc_ports = ${PORT}
+ kdc_tcp_ports = ${PORT}
+
+[logging]
+  kdc = FILE:${DIR}/kdc_log.file
+'''
+
+KEY_TYPE = "aes256-cts-hmac-sha1-96:normal"
+
+
+class KDC:
+
+  def __init__(self, realm, env, directory, addr, port):
+    krb5conf = os.path.join(directory, 'krb5.conf')
+
+    t = Template(KRB5_CONF_TEMPLATE)
+    conf = t.substitute({'REALM': realm,
+                         'DIR': directory,
+                         'ADDR': addr,
+                         'PORT': port,
+                         'LOWREALM': realm.lower()})
+    with open(krb5conf, 'w+') as f:
+      f.write(conf)
+
+    self.env = {}
+    self.env.update(env)
+
+    kdcenv = {'KRB5_CONFIG': krb5conf,
+              'KRB5_TRACE': os.path.join(directory, 'krbtrace.log')}
+    self.env.update(kdcenv)
+
+    self.log = os.path.join(directory, 'kdc.log')
+
+    with open(self.log, 'a') as logfile:
+      ksetup = subprocess.Popen(["kdb5_util", "create", "-W", "-s",
+                                 "-r", realm, "-P", "kdc-p@s$w0rd"],
+                                stdout=logfile, stderr=logfile,
+                                env=self.env, preexec_fn=os.setsid)
+    ksetup.wait()
+    if ksetup.returncode != 0:
+      raise ValueError('KDC Setup failed')
+
+
+  def run(self):
+    with open(self.log, 'a') as logfile:
+      kdcproc = subprocess.Popen(['krb5kdc', '-n'],
+                                 stdout=logfile, stderr=logfile,
+                                 env=self.env, preexec_fn=os.setsid)
+
+    return kdcproc
+
+
+  def kadmin_local(self, cmd):
+    with open(self.log, 'a') as logfile:
+      kadmin = subprocess.Popen(["kadmin.local", "-q", cmd],
+                              stdout=logfile, stderr=logfile,
+                              env=self.env, preexec_fn=os.setsid)
+    kadmin.wait()
+    if kadmin.returncode != 0:
+      raise ValueError('Kadmin local [%s] failed' % cmd)
+
+
+  def add_user_principal(self, username, password):
+    cmd = "addprinc -pw %s -e %s %s" % (password, KEY_TYPE, username)
+    self.kadmin_local(cmd)
+
+
+  def add_service_principal(self, service_name, keytab):
+    cmd = "addprinc -randkey -e %s %s" % (KEY_TYPE, service_name)
+    self.kadmin_local(cmd)
+
+    cmd = "ktadd -k %s -e %s %s" % (keytab, KEY_TYPE, service_name)
+    self.kadmin_local(cmd)
+

--- a/tests/gssapi/test_gssapi.py
+++ b/tests/gssapi/test_gssapi.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+#
+# Test Curl with GSSAPI authentication (KRB5)
+#
+# Copyright (C) 2016, Isaac Boukris <iboukris@gmail.com>
+# MIT licensed - see COPYING
+# Credit: Inspired by mod_auth_gssapi test suite by Simo Sorce <simo@redhat.com>
+#
+# Requires MIT krb5 packages, and python-gssapi.
+# To run, change to tests/gssapi directory and run ./test_gssapi.py --path tmp
+
+
+from kdc import KDC
+import argparse
+import os
+import shutil
+from string import Template
+import subprocess
+import sys
+
+
+REALM = 'CURL.DEV'
+ADDR = '127.0.0.1'
+KDC_PORT = 8844
+HTTP_PORT = 8040
+HTTP_HOST = 'www.curl.dev'
+USER_NAME = 'curluser'
+USER_PWD = 'curlpwd'
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Curl GSSAPI Tests Environment')
+  parser.add_argument('--path', default='%s/gssapi_tmp' % os.getcwd(),
+                      help="Directory in which tests are run")
+
+  return vars(parser.parse_args())
+
+
+def run_httpd(addr, port, env, log):
+  cmd = [os.path.join(os.getcwd(), 'httpd_negotiate.py'),
+         '--addr', '%s' % addr, '--port', '%s' % port]
+  with open(log, 'a') as logfile:
+    httpdproc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=logfile,
+                                 env=env, preexec_fn=os.setsid)
+
+  ack = httpdproc.stdout.read(len('ready'));
+  if ack != 'ready':
+    httpdproc.terminate()
+    raise Exception('Failed to start HTTPD server')
+
+  return httpdproc
+
+
+def kinit_user(user, pwd, env, log):
+  with open(log, 'a') as logfile:
+    kinit = subprocess.Popen(["kinit", '-V', user],
+                             stdin=subprocess.PIPE,
+                             stdout=logfile, stderr=logfile,
+                             env=env, preexec_fn=os.setsid)
+    kinit.communicate('%s\n' % pwd)
+    kinit.wait()
+    if kinit.returncode != 0:
+      raise ValueError('kinit failed for user %s' % user)
+
+
+def test_http_negotiate(kdc, testdir, log):
+  keytab = os.path.join(testdir, 'http_service.keytab')
+  kdc.add_service_principal('HTTP/%s' % HTTP_HOST, keytab)
+  httpdenv = {'KRB5_KTNAME': keytab}
+  httpdenv.update(kdc.env)
+  httpdlog = os.path.join(testdir, 'httpd.log')
+  httpdproc = run_httpd(ADDR, HTTP_PORT, httpdenv, httpdlog)
+
+  try:
+    kdc.add_user_principal(USER_NAME, USER_PWD)
+    ccache = os.path.join(testdir, '%s.ccache' % USER_NAME)
+    userenv = {'KRB5CCNAME': ccache}
+    userenv.update(kdc.env)
+    kinit_user(USER_NAME, USER_PWD, userenv, log)
+
+    cmd = ['curl', '-v', '-s', '-u:', '--negotiate',
+           '--resolve', '%s:%d:%s' % (HTTP_HOST, HTTP_PORT, ADDR),
+           'http://%s:%d' % (HTTP_HOST, HTTP_PORT)]
+    with open(log, 'a') as logfile:
+      curl = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=logfile,
+                              env=userenv, preexec_fn=os.setsid)
+      user = curl.communicate()[0]
+
+    if curl.returncode != 0:
+      raise Exception('Curl command failed with %d!' % curl.returncode)
+
+    if user != USER_NAME + '@' + REALM:
+      raise Exception('HTTP Negotiate failed: wrong username returned!')
+
+  finally:
+    httpdproc.terminate()
+
+
+if __name__ == '__main__':
+
+  args = parse_args()
+
+  testdir = args['path']
+  if os.path.exists(testdir):
+    shutil.rmtree(testdir)
+  os.makedirs(testdir)
+
+  testlog = os.path.join(testdir, 'tests.log')
+
+  env = {'PATH': '../../src/.libs:' + os.environ['PATH'],
+         'LD_LIBRARY_PATH': '../../lib/.libs'}
+
+  try:
+    kdc = KDC(REALM, env, testdir, ADDR, KDC_PORT)
+    kdcproc = kdc.run()
+
+    test_http_negotiate(kdc, testdir, testlog)
+    sys.stderr.write('Curl GSSAPI: HTTP Negotiate test OK\n')
+
+  finally:
+    kdcproc.terminate()
+


### PR DESCRIPTION
The test is to be run manually from the tests/gssapi directory
by running the ./test_gssapi.py script.

When run, it mounts a Kerberos KDC into which a user and a
service principals are added, and then it starts GSSAPI tests.
Currently only a simple Curl HTTP Negotiate test is provided.

Requires MIT krb5 packages, and python-gssapi.

Note, I've tried to wire this to Curl's test-suite but it got complicated for now.
However, I think it could still be useful when run manually.
