### PR TITLE
configure: resolve conflict with AC_CHECK_HEADERS

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1158,7 +1158,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETNAMEINFO], [
       #
       AC_DEFINE_UNQUOTED(HAVE_GETNAMEINFO, 1,
         [Define to 1 if you have the getnameinfo function.])
-      ac_cv_func_getnameinfo="yes"
+      curl_cv_func_getnameinfo="yes"
     fi
   fi
 ])
@@ -1427,7 +1427,7 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
       #
       AC_DEFINE_UNQUOTED(HAVE_RECV, 1,
         [Define to 1 if you have the recv function.])
-      ac_cv_func_recv="yes"
+      curl_cv_func_recv="yes"
     fi
   else
     AC_MSG_ERROR([Unable to link function recv])
@@ -1594,7 +1594,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
       #
       AC_DEFINE_UNQUOTED(HAVE_SEND, 1,
         [Define to 1 if you have the send function.])
-      ac_cv_func_send="yes"
+      curl_cv_func_send="yes"
     fi
   else
     AC_MSG_ERROR([Unable to link function send])
@@ -2453,7 +2453,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
       #
       AC_DEFINE_UNQUOTED(HAVE_SELECT, 1,
         [Define to 1 if you have the select function.])
-      ac_cv_func_select="yes"
+      curl_cv_func_select="yes"
     fi
   fi
 ])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1740,13 +1740,13 @@ AC_DEFUN([TYPE_SIG_ATOMIC_T], [
         ]])
       ],[
         AC_MSG_RESULT([no])
-        ac_cv_sig_atomic_t_volatile="no"
+        curl_cv_sig_atomic_t_volatile="no"
       ],[
         AC_MSG_RESULT([yes])
-        ac_cv_sig_atomic_t_volatile="yes"
+        curl_cv_sig_atomic_t_volatile="yes"
       ])
       #
-      if test "$ac_cv_sig_atomic_t_volatile" = "yes"; then
+      if test "$curl_cv_sig_atomic_t_volatile" = "yes"; then
         AC_DEFINE(HAVE_SIG_ATOMIC_T_VOLATILE, 1,
           [Define to 1 if sig_atomic_t is already defined as volatile.])
       fi

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1878,10 +1878,10 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC], [
       ]])
     ],[
       AC_MSG_RESULT([yes])
-      ac_cv_func_clock_gettime="yes"
+      curl_func_clock_gettime="yes"
     ],[
       AC_MSG_RESULT([no])
-      ac_cv_func_clock_gettime="no"
+      curl_func_clock_gettime="no"
     ])
   fi
   dnl Definition of HAVE_CLOCK_GETTIME_MONOTONIC is intentionally postponed
@@ -1897,7 +1897,7 @@ dnl check and prepended to LIBS any needed libraries.
 AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
   AC_REQUIRE([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC])dnl
   #
-  if test "$ac_cv_func_clock_gettime" = "yes"; then
+  if test "$curl_func_clock_gettime" = "yes"; then
     #
     AC_MSG_CHECKING([for clock_gettime in libraries])
     #
@@ -1942,11 +1942,11 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
       X-unknown)
         AC_MSG_RESULT([cannot find clock_gettime])
         AC_MSG_WARN([HAVE_CLOCK_GETTIME_MONOTONIC will not be defined])
-        ac_cv_func_clock_gettime="no"
+        curl_func_clock_gettime="no"
         ;;
       X-)
         AC_MSG_RESULT([no additional lib required])
-        ac_cv_func_clock_gettime="yes"
+        curl_func_clock_gettime="yes"
         ;;
       *)
         if test -z "$curl_cv_save_LIBS"; then
@@ -1955,13 +1955,13 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
           LIBS="$curl_cv_gclk_LIBS $curl_cv_save_LIBS"
         fi
         AC_MSG_RESULT([$curl_cv_gclk_LIBS])
-        ac_cv_func_clock_gettime="yes"
+        curl_func_clock_gettime="yes"
         ;;
     esac
     #
     dnl only do runtime verification when not cross-compiling
     if test "x$cross_compiling" != "xyes" &&
-      test "$ac_cv_func_clock_gettime" = "yes"; then
+      test "$curl_func_clock_gettime" = "yes"; then
       AC_MSG_CHECKING([if monotonic clock_gettime works])
       AC_RUN_IFELSE([
         AC_LANG_PROGRAM([[
@@ -1993,12 +1993,12 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
       ],[
         AC_MSG_RESULT([no])
         AC_MSG_WARN([HAVE_CLOCK_GETTIME_MONOTONIC will not be defined])
-        ac_cv_func_clock_gettime="no"
+        curl_func_clock_gettime="no"
         LIBS="$curl_cv_save_LIBS"
       ])
     fi
     #
-    case "$ac_cv_func_clock_gettime" in
+    case "$curl_func_clock_gettime" in
       yes)
         AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME_MONOTONIC, 1,
           [Define to 1 if you have the clock_gettime function and monotonic timer.])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -174,7 +174,7 @@ dnl -------------------------------------------------
 dnl Check for compilable and valid windows.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_WINDOWS], [
-  AC_CACHE_CHECK([for windows.h], [ac_cv_header_windows_h], [
+  AC_CACHE_CHECK([for windows.h], [curl_cv_header_windows_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -190,12 +190,12 @@ AC_DEFUN([CURL_CHECK_HEADER_WINDOWS], [
 #endif
       ]])
     ],[
-      ac_cv_header_windows_h="yes"
+      curl_cv_header_windows_h="yes"
     ],[
-      ac_cv_header_windows_h="no"
+      curl_cv_header_windows_h="no"
     ])
   ])
-  case "$ac_cv_header_windows_h" in
+  case "$curl_cv_header_windows_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WINDOWS_H, 1,
         [Define to 1 if you have the windows.h header file.])
@@ -212,9 +212,9 @@ dnl Check if building a native Windows target
 
 AC_DEFUN([CURL_CHECK_NATIVE_WINDOWS], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([whether build target is a native Windows one], [ac_cv_native_windows], [
-    if test "$ac_cv_header_windows_h" = "no"; then
-      ac_cv_native_windows="no"
+  AC_CACHE_CHECK([whether build target is a native Windows one], [curl_cv_native_windows], [
+    if test "$curl_cv_header_windows_h" = "no"; then
+      curl_cv_native_windows="no"
     else
       AC_COMPILE_IFELSE([
         AC_LANG_PROGRAM([[
@@ -227,13 +227,13 @@ AC_DEFUN([CURL_CHECK_NATIVE_WINDOWS], [
 #endif
         ]])
       ],[
-        ac_cv_native_windows="yes"
+        curl_cv_native_windows="yes"
       ],[
-        ac_cv_native_windows="no"
+        curl_cv_native_windows="no"
       ])
     fi
   ])
-  AM_CONDITIONAL(DOING_NATIVE_WINDOWS, test "x$ac_cv_native_windows" = xyes)
+  AM_CONDITIONAL(DOING_NATIVE_WINDOWS, test "x$curl_cv_native_windows" = xyes)
 ])
 
 
@@ -243,7 +243,7 @@ dnl Check for compilable and valid winsock.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_WINSOCK], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([for winsock.h], [ac_cv_header_winsock_h], [
+  AC_CACHE_CHECK([for winsock.h], [curl_cv_header_winsock_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -260,12 +260,12 @@ AC_DEFUN([CURL_CHECK_HEADER_WINSOCK], [
 #endif
       ]])
     ],[
-      ac_cv_header_winsock_h="yes"
+      curl_cv_header_winsock_h="yes"
     ],[
-      ac_cv_header_winsock_h="no"
+      curl_cv_header_winsock_h="no"
     ])
   ])
-  case "$ac_cv_header_winsock_h" in
+  case "$curl_cv_header_winsock_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WINSOCK_H, 1,
         [Define to 1 if you have the winsock.h header file.])
@@ -280,7 +280,7 @@ dnl Check for compilable and valid winsock2.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_WINSOCK2], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([for winsock2.h], [ac_cv_header_winsock2_h], [
+  AC_CACHE_CHECK([for winsock2.h], [curl_cv_header_winsock2_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -297,12 +297,12 @@ AC_DEFUN([CURL_CHECK_HEADER_WINSOCK2], [
 #endif
       ]])
     ],[
-      ac_cv_header_winsock2_h="yes"
+      curl_cv_header_winsock2_h="yes"
     ],[
-      ac_cv_header_winsock2_h="no"
+      curl_cv_header_winsock2_h="no"
     ])
   ])
-  case "$ac_cv_header_winsock2_h" in
+  case "$curl_cv_header_winsock2_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WINSOCK2_H, 1,
         [Define to 1 if you have the winsock2.h header file.])
@@ -317,7 +317,7 @@ dnl Check for compilable and valid ws2tcpip.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_WS2TCPIP], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
-  AC_CACHE_CHECK([for ws2tcpip.h], [ac_cv_header_ws2tcpip_h], [
+  AC_CACHE_CHECK([for ws2tcpip.h], [curl_cv_header_ws2tcpip_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -335,12 +335,12 @@ AC_DEFUN([CURL_CHECK_HEADER_WS2TCPIP], [
 #endif
       ]])
     ],[
-      ac_cv_header_ws2tcpip_h="yes"
+      curl_cv_header_ws2tcpip_h="yes"
     ],[
-      ac_cv_header_ws2tcpip_h="no"
+      curl_cv_header_ws2tcpip_h="no"
     ])
   ])
-  case "$ac_cv_header_ws2tcpip_h" in
+  case "$curl_cv_header_ws2tcpip_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WS2TCPIP_H, 1,
         [Define to 1 if you have the ws2tcpip.h header file.])
@@ -355,7 +355,7 @@ dnl Check for compilable and valid winldap.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_WINLDAP], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([for winldap.h], [ac_cv_header_winldap_h], [
+  AC_CACHE_CHECK([for winldap.h], [curl_cv_header_winldap_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -375,12 +375,12 @@ AC_DEFUN([CURL_CHECK_HEADER_WINLDAP], [
 #endif
       ]])
     ],[
-      ac_cv_header_winldap_h="yes"
+      curl_cv_header_winldap_h="yes"
     ],[
-      ac_cv_header_winldap_h="no"
+      curl_cv_header_winldap_h="no"
     ])
   ])
-  case "$ac_cv_header_winldap_h" in
+  case "$curl_cv_header_winldap_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WINLDAP_H, 1,
         [Define to 1 if you have the winldap.h header file.])
@@ -395,7 +395,7 @@ dnl Check for compilable and valid winber.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_WINBER], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINLDAP])dnl
-  AC_CACHE_CHECK([for winber.h], [ac_cv_header_winber_h], [
+  AC_CACHE_CHECK([for winber.h], [curl_cv_header_winber_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -417,12 +417,12 @@ AC_DEFUN([CURL_CHECK_HEADER_WINBER], [
 #endif
       ]])
     ],[
-      ac_cv_header_winber_h="yes"
+      curl_cv_header_winber_h="yes"
     ],[
-      ac_cv_header_winber_h="no"
+      curl_cv_header_winber_h="no"
     ])
   ])
-  case "$ac_cv_header_winber_h" in
+  case "$curl_cv_header_winber_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WINBER_H, 1,
         [Define to 1 if you have the winber.h header file.])
@@ -438,7 +438,7 @@ dnl and check if it is needed even with ldap.h
 
 AC_DEFUN([CURL_CHECK_HEADER_LBER], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([for lber.h], [ac_cv_header_lber_h], [
+  AC_CACHE_CHECK([for lber.h], [curl_cv_header_lber_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -462,12 +462,12 @@ AC_DEFUN([CURL_CHECK_HEADER_LBER], [
         ber_free(bep, 1);
       ]])
     ],[
-      ac_cv_header_lber_h="yes"
+      curl_cv_header_lber_h="yes"
     ],[
-      ac_cv_header_lber_h="no"
+      curl_cv_header_lber_h="no"
     ])
   ])
-  if test "$ac_cv_header_lber_h" = "yes"; then
+  if test "$curl_cv_header_lber_h" = "yes"; then
     AC_DEFINE_UNQUOTED(HAVE_LBER_H, 1,
       [Define to 1 if you have the lber.h header file.])
     #
@@ -518,7 +518,7 @@ dnl Check for compilable and valid ldap.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_LDAP], [
   AC_REQUIRE([CURL_CHECK_HEADER_LBER])dnl
-  AC_CACHE_CHECK([for ldap.h], [ac_cv_header_ldap_h], [
+  AC_CACHE_CHECK([for ldap.h], [curl_cv_header_ldap_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -544,12 +544,12 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAP], [
         int res = ldap_unbind(ldp);
       ]])
     ],[
-      ac_cv_header_ldap_h="yes"
+      curl_cv_header_ldap_h="yes"
     ],[
-      ac_cv_header_ldap_h="no"
+      curl_cv_header_ldap_h="no"
     ])
   ])
-  case "$ac_cv_header_ldap_h" in
+  case "$curl_cv_header_ldap_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_LDAP_H, 1,
         [Define to 1 if you have the ldap.h header file.])
@@ -564,7 +564,7 @@ dnl Check for compilable and valid ldap_ssl.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_LDAP_SSL], [
   AC_REQUIRE([CURL_CHECK_HEADER_LDAP])dnl
-  AC_CACHE_CHECK([for ldap_ssl.h], [ac_cv_header_ldap_ssl_h], [
+  AC_CACHE_CHECK([for ldap_ssl.h], [curl_cv_header_ldap_ssl_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -592,12 +592,12 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAP_SSL], [
         LDAP *ldp = ldapssl_init("dummy", LDAPS_PORT, 1);
       ]])
     ],[
-      ac_cv_header_ldap_ssl_h="yes"
+      curl_cv_header_ldap_ssl_h="yes"
     ],[
-      ac_cv_header_ldap_ssl_h="no"
+      curl_cv_header_ldap_ssl_h="no"
     ])
   ])
-  case "$ac_cv_header_ldap_ssl_h" in
+  case "$curl_cv_header_ldap_ssl_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_LDAP_SSL_H, 1,
         [Define to 1 if you have the ldap_ssl.h header file.])
@@ -612,7 +612,7 @@ dnl Check for compilable and valid ldapssl.h header
 
 AC_DEFUN([CURL_CHECK_HEADER_LDAPSSL], [
   AC_REQUIRE([CURL_CHECK_HEADER_LDAP])dnl
-  AC_CACHE_CHECK([for ldapssl.h], [ac_cv_header_ldapssl_h], [
+  AC_CACHE_CHECK([for ldapssl.h], [curl_cv_header_ldapssl_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -644,12 +644,12 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAPSSL], [
         LDAP *ldp = ldap_ssl_init("dummy", LDAPS_PORT, cert_label);
       ]])
     ],[
-      ac_cv_header_ldapssl_h="yes"
+      curl_cv_header_ldapssl_h="yes"
     ],[
-      ac_cv_header_ldapssl_h="no"
+      curl_cv_header_ldapssl_h="no"
     ])
   ])
-  case "$ac_cv_header_ldapssl_h" in
+  case "$curl_cv_header_ldapssl_h" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_LDAPSSL_H, 1,
         [Define to 1 if you have the ldapssl.h header file.])
@@ -866,7 +866,7 @@ dnl Check for compilable and valid malloc.h header,
 dnl and check if it is needed even with stdlib.h
 
 AC_DEFUN([CURL_CHECK_HEADER_MALLOC], [
-  AC_CACHE_CHECK([for malloc.h], [ac_cv_header_malloc_h], [
+  AC_CACHE_CHECK([for malloc.h], [curl_cv_header_malloc_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #include <malloc.h>
@@ -877,12 +877,12 @@ AC_DEFUN([CURL_CHECK_HEADER_MALLOC], [
         free(q);
       ]])
     ],[
-      ac_cv_header_malloc_h="yes"
+      curl_cv_header_malloc_h="yes"
     ],[
-      ac_cv_header_malloc_h="no"
+      curl_cv_header_malloc_h="no"
     ])
   ])
-  if test "$ac_cv_header_malloc_h" = "yes"; then
+  if test "$curl_cv_header_malloc_h" = "yes"; then
     AC_DEFINE_UNQUOTED(HAVE_MALLOC_H, 1,
       [Define to 1 if you have the malloc.h header file.])
     #
@@ -918,7 +918,7 @@ dnl and check if it is needed even with stdlib.h for
 dnl memory related functions.
 
 AC_DEFUN([CURL_CHECK_HEADER_MEMORY], [
-  AC_CACHE_CHECK([for memory.h], [ac_cv_header_memory_h], [
+  AC_CACHE_CHECK([for memory.h], [curl_cv_header_memory_h], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #include <memory.h>
@@ -929,12 +929,12 @@ AC_DEFUN([CURL_CHECK_HEADER_MEMORY], [
         free(q);
       ]])
     ],[
-      ac_cv_header_memory_h="yes"
+      curl_cv_header_memory_h="yes"
     ],[
-      ac_cv_header_memory_h="no"
+      curl_cv_header_memory_h="no"
     ])
   ])
-  if test "$ac_cv_header_memory_h" = "yes"; then
+  if test "$curl_cv_header_memory_h" = "yes"; then
     AC_DEFINE_UNQUOTED(HAVE_MEMORY_H, 1,
       [Define to 1 if you have the memory.h header file.])
     #
@@ -1213,7 +1213,7 @@ AC_DEFUN([CURL_CHECK_NI_WITHSCOPEID], [
                    netdb.h netinet/in.h arpa/inet.h)
   #
   AC_CACHE_CHECK([for working NI_WITHSCOPEID],
-    [ac_cv_working_ni_withscopeid], [
+    [curl_cv_working_ni_withscopeid], [
     AC_RUN_IFELSE([
       AC_LANG_PROGRAM([[
 #ifdef HAVE_STDLIB_H
@@ -1271,10 +1271,10 @@ AC_DEFUN([CURL_CHECK_NI_WITHSCOPEID], [
       ]]) # AC-LANG-PROGRAM
     ],[
       # Exit code == 0. Program worked.
-      ac_cv_working_ni_withscopeid="yes"
+      curl_cv_working_ni_withscopeid="yes"
     ],[
       # Exit code != 0. Program failed.
-      ac_cv_working_ni_withscopeid="no"
+      curl_cv_working_ni_withscopeid="no"
     ],[
       # Program is not run when cross-compiling. So we assume
       # NI_WITHSCOPEID will work if we are able to compile it.
@@ -1287,13 +1287,13 @@ AC_DEFUN([CURL_CHECK_NI_WITHSCOPEID], [
           unsigned int dummy= NI_NUMERICHOST | NI_NUMERICSERV | NI_WITHSCOPEID;
         ]])
       ],[
-        ac_cv_working_ni_withscopeid="yes"
+        curl_cv_working_ni_withscopeid="yes"
       ],[
-        ac_cv_working_ni_withscopeid="no"
+        curl_cv_working_ni_withscopeid="no"
       ]) # AC-COMPILE-IFELSE
     ]) # AC-RUN-IFELSE
   ]) # AC-CACHE-CHECK
-  case "$ac_cv_working_ni_withscopeid" in
+  case "$curl_cv_working_ni_withscopeid" in
     yes)
       AC_DEFINE(HAVE_NI_WITHSCOPEID, 1,
         [Define to 1 if NI_WITHSCOPEID exists and works.])
@@ -1607,7 +1607,7 @@ dnl Check for MSG_NOSIGNAL
 
 AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
   AC_CHECK_HEADERS(sys/types.h sys/socket.h)
-  AC_CACHE_CHECK([for MSG_NOSIGNAL], [ac_cv_msg_nosignal], [
+  AC_CACHE_CHECK([for MSG_NOSIGNAL], [curl_cv_msg_nosignal], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -1635,12 +1635,12 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
         int flag=MSG_NOSIGNAL;
       ]])
     ],[
-      ac_cv_msg_nosignal="yes"
+      curl_cv_msg_nosignal="yes"
     ],[
-      ac_cv_msg_nosignal="no"
+      curl_cv_msg_nosignal="no"
     ])
   ])
-  case "$ac_cv_msg_nosignal" in
+  case "$curl_cv_msg_nosignal" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_MSG_NOSIGNAL, 1,
         [Define to 1 if you have the MSG_NOSIGNAL flag.])
@@ -1658,7 +1658,7 @@ AC_DEFUN([CURL_CHECK_STRUCT_TIMEVAL], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK])dnl
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
   AC_CHECK_HEADERS(sys/types.h sys/time.h time.h sys/socket.h)
-  AC_CACHE_CHECK([for struct timeval], [ac_cv_struct_timeval], [
+  AC_CACHE_CHECK([for struct timeval], [curl_cv_struct_timeval], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
 #undef inline
@@ -1697,12 +1697,12 @@ AC_DEFUN([CURL_CHECK_STRUCT_TIMEVAL], [
         ts.tv_usec = 0;
       ]])
     ],[
-      ac_cv_struct_timeval="yes"
+      curl_cv_struct_timeval="yes"
     ],[
-      ac_cv_struct_timeval="no"
+      curl_cv_struct_timeval="no"
     ])
   ])
-  case "$ac_cv_struct_timeval" in
+  case "$curl_cv_struct_timeval" in
     yes)
       AC_DEFINE_UNQUOTED(HAVE_STRUCT_TIMEVAL, 1,
         [Define to 1 if you have the timeval struct.])
@@ -2159,7 +2159,7 @@ AC_DEFUN([CURL_CONFIGURE_CURL_SOCKLEN_T], [
   AC_MSG_CHECKING([size of curl_socklen_t])
   curl_sizeof_curl_socklen_t="unknown"
   curl_pull_headers_socklen_t="unknown"
-  if test "$ac_cv_header_ws2tcpip_h" = "yes"; then
+  if test "$curl_cv_header_ws2tcpip_h" = "yes"; then
     tst_pull_header_checks='none ws2tcpip'
     tst_size_checks='4'
   else
@@ -3011,7 +3011,7 @@ AC_DEFUN([CURL_CHECK_WIN32_LARGEFILE], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
   AC_MSG_CHECKING([whether build target supports WIN32 file API])
   curl_win32_file_api="no"
-  if test "$ac_cv_header_windows_h" = "yes"; then
+  if test "$curl_cv_header_windows_h" = "yes"; then
     if test x"$enable_largefile" != "xno"; then
       AC_COMPILE_IFELSE([
         AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -3341,7 +3341,7 @@ dnl and get the types of five of its arguments.
 CURL_CHECK_FUNC_GETNAMEINFO
 
 if test "$ipv6" = "yes"; then
-  if test "$ac_cv_func_getaddrinfo" = "yes"; then
+  if test "$curl_cv_func_getaddrinfo" = "yes"; then
     AC_DEFINE(ENABLE_IPV6, 1, [Define if you want to enable IPv6 support])
     IPV6_ENABLED=1
     AC_SUBST(IPV6_ENABLED)

--- a/configure.ac
+++ b/configure.ac
@@ -339,7 +339,7 @@ dnl **********************************************************************
 
 CURL_CHECK_HEADER_WINDOWS
 CURL_CHECK_NATIVE_WINDOWS
-case X-"$ac_cv_native_windows" in
+case X-"$curl_cv_native_windows" in
   X-yes)
     CURL_CHECK_HEADER_WINSOCK
     CURL_CHECK_HEADER_WINSOCK2
@@ -348,11 +348,11 @@ case X-"$ac_cv_native_windows" in
     CURL_CHECK_HEADER_WINBER
     ;;
   *)
-    ac_cv_header_winsock_h="no"
-    ac_cv_header_winsock2_h="no"
-    ac_cv_header_ws2tcpip_h="no"
-    ac_cv_header_winldap_h="no"
-    ac_cv_header_winber_h="no"
+    curl_cv_header_winsock_h="no"
+    curl_cv_header_winsock2_h="no"
+    curl_cv_header_ws2tcpip_h="no"
+    curl_cv_header_winldap_h="no"
+    curl_cv_header_winber_h="no"
     ;;
 esac
 CURL_CHECK_WIN32_LARGEFILE
@@ -742,8 +742,8 @@ fi
 if test "$HAVE_GETHOSTBYNAME" != "1"
 then
   dnl This is for winsock systems
-  if test "$ac_cv_header_windows_h" = "yes"; then
-    if test "$ac_cv_header_winsock_h" = "yes"; then
+  if test "$curl_cv_header_windows_h" = "yes"; then
+    if test "$curl_cv_header_winsock_h" = "yes"; then
       case $host in
         *-*-mingw32ce*)
           winsock_LIB="-lwinsock"
@@ -753,7 +753,7 @@ then
           ;;
       esac
     fi
-    if test "$ac_cv_header_winsock2_h" = "yes"; then
+    if test "$curl_cv_header_winsock2_h" = "yes"; then
       winsock_LIB="-lws2_32"
     fi
     if test ! -z "$winsock_LIB"; then
@@ -999,7 +999,7 @@ if test x$CURL_DISABLE_LDAP != x1 ; then
   CURL_CHECK_HEADER_LDAP_SSL
 
   if test -z "$LDAPLIBNAME" ; then
-    if test "$ac_cv_native_windows" = "yes"; then
+    if test "$curl_cv_native_windows" = "yes"; then
       dnl Windows uses a single and unique LDAP library name
       LDAPLIBNAME="wldap32"
       LBERLIBNAME="no"
@@ -1349,7 +1349,7 @@ AC_HELP_STRING([--without-winssl], [disable Windows native SSL/TLS]),
 AC_MSG_CHECKING([whether to enable Windows native SSL/TLS (Windows native builds only)])
 if test "$curl_ssl_msg" = "$init_ssl_msg"; then
   if test "x$OPT_WINSSL" != "xno"  &&
-     test "x$ac_cv_native_windows" = "xyes"; then
+     test "x$curl_cv_native_windows" = "xyes"; then
     AC_MSG_RESULT(yes)
     AC_DEFINE(USE_SCHANNEL, 1, [to enable Windows native SSL/TLS support])
     AC_SUBST(USE_SCHANNEL, [1])
@@ -3173,7 +3173,7 @@ AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(off_t)
 
 soname_bump=no
-if test x"$ac_cv_native_windows" != "xyes" &&
+if test x"$curl_cv_native_windows" != "xyes" &&
    test $ac_cv_sizeof_off_t -ne $curl_sizeof_curl_off_t; then
   AC_MSG_WARN([This libcurl built is probably not ABI compatible with previous])
   AC_MSG_WARN([builds! You MUST read lib/README.curl_off_t to figure it out.])
@@ -3408,7 +3408,7 @@ AM_CONDITIONAL(USE_MANUAL, test x"$USE_MANUAL" = x1)
 CURL_CHECK_LIB_ARES
 AM_CONDITIONAL(USE_EMBEDDED_ARES, test x$embedded_ares = xyes)
 
-if test "x$ac_cv_native_windows" != "xyes" &&
+if test "x$curl_cv_native_windows" != "xyes" &&
    test "x$enable_shared" = "xyes"; then
   build_libhostname=yes
 else
@@ -3478,7 +3478,7 @@ AC_HELP_STRING([--enable-sspi],[Enable SSPI])
 AC_HELP_STRING([--disable-sspi],[Disable SSPI]),
 [ case "$enableval" in
   yes)
-       if test "$ac_cv_native_windows" = "yes"; then
+       if test "$curl_cv_native_windows" = "yes"; then
          AC_MSG_RESULT(yes)
          AC_DEFINE(USE_WINDOWS_SSPI, 1, [to enable SSPI support])
          AC_SUBST(USE_WINDOWS_SSPI, [1])

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -464,7 +464,7 @@ AC_DEFUN([CURL_CONFIGURE_SYMBOL_HIDING], [
   AC_MSG_CHECKING([whether hiding of library internal symbols will actually happen])
   CFLAG_CURL_SYMBOL_HIDING=""
   doing_symbol_hiding="no"
-  if test x"$ac_cv_native_windows" != "xyes" &&
+  if test x"$curl_cv_native_windows" != "xyes" &&
     test "$want_symbol_hiding" = "yes" &&
     test "$supports_symbol_hiding" = "yes"; then
     doing_symbol_hiding="yes"
@@ -611,7 +611,7 @@ AC_DEFUN([CURL_CHECK_NTLM_WB], [
   AC_REQUIRE([CURL_CHECK_OPTION_NTLM_WB])dnl
   AC_REQUIRE([CURL_CHECK_NATIVE_WINDOWS])dnl
   AC_MSG_CHECKING([whether to enable NTLM delegation to winbind's helper])
-  if test "$ac_cv_native_windows" = "yes" ||
+  if test "$curl_cv_native_windows" = "yes" ||
     test "x$SSL_ENABLED" = "x"; then
     want_ntlm_wb_file=""
     want_ntlm_wb="no"

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -433,15 +433,15 @@ AC_DEFUN([CURL_CHECK_NONBLOCKING_SOCKET], [
   tst_method="unknown"
 
   AC_MSG_CHECKING([how to set a socket into non-blocking mode])
-  if test "x$ac_cv_func_fcntl_o_nonblock" = "xyes"; then
+  if test "x$curl_cv_func_fcntl_o_nonblock" = "xyes"; then
     tst_method="fcntl O_NONBLOCK"
-  elif test "x$ac_cv_func_ioctl_fionbio" = "xyes"; then
+  elif test "x$curl_cv_func_ioctl_fionbio" = "xyes"; then
     tst_method="ioctl FIONBIO"
-  elif test "x$ac_cv_func_ioctlsocket_fionbio" = "xyes"; then
+  elif test "x$curl_cv_func_ioctlsocket_fionbio" = "xyes"; then
     tst_method="ioctlsocket FIONBIO"
-  elif test "x$ac_cv_func_ioctlsocket_camel_fionbio" = "xyes"; then
+  elif test "x$curl_cv_func_ioctlsocket_camel_fionbio" = "xyes"; then
     tst_method="IoctlSocket FIONBIO"
-  elif test "x$ac_cv_func_setsockopt_so_nonblock" = "xyes"; then
+  elif test "x$curl_cv_func_setsockopt_so_nonblock" = "xyes"; then
     tst_method="setsockopt SO_NONBLOCK"
   fi
   AC_MSG_RESULT([$tst_method])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -639,10 +639,10 @@ AC_DEFUN([CURL_CHECK_FUNC_ALARM], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_ALARM, 1,
       [Define to 1 if you have the alarm function.])
-    ac_cv_func_alarm="yes"
+    curl_cv_func_alarm="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_alarm="no"
+    curl_cv_func_alarm="no"
   fi
 ])
 
@@ -730,10 +730,10 @@ AC_DEFUN([CURL_CHECK_FUNC_BASENAME], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_BASENAME, 1,
       [Define to 1 if you have the basename function.])
-    ac_cv_func_basename="yes"
+    curl_cv_func_basename="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_basename="no"
+    curl_cv_func_basename="no"
   fi
 ])
 
@@ -824,10 +824,10 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_CLOSESOCKET, 1,
       [Define to 1 if you have the closesocket function.])
-    ac_cv_func_closesocket="yes"
+    curl_cv_func_closesocket="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_closesocket="no"
+    curl_cv_func_closesocket="no"
   fi
 ])
 
@@ -914,10 +914,10 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET_CAMEL], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_CLOSESOCKET_CAMEL, 1,
       [Define to 1 if you have the CloseSocket camel case function.])
-    ac_cv_func_closesocket_camel="yes"
+    curl_cv_func_closesocket_camel="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_closesocket_camel="no"
+    curl_cv_func_closesocket_camel="no"
   fi
 ])
 
@@ -1012,10 +1012,10 @@ AC_DEFUN([CURL_CHECK_FUNC_CONNECT], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_CONNECT, 1,
       [Define to 1 if you have the connect function.])
-    ac_cv_func_connect="yes"
+    curl_cv_func_connect="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_connect="no"
+    curl_cv_func_connect="no"
   fi
 ])
 
@@ -1246,10 +1246,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FDOPEN], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_FDOPEN, 1,
       [Define to 1 if you have the fdopen function.])
-    ac_cv_func_fdopen="yes"
+    curl_cv_func_fdopen="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_fdopen="no"
+    curl_cv_func_fdopen="no"
   fi
 ])
 
@@ -1368,10 +1368,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FGETXATTR], [
       AC_DEFINE(HAVE_FGETXATTR_6, 1, [fgetxattr() takes 6 args])
     fi
     #
-    ac_cv_func_fgetxattr="yes"
+    curl_cv_func_fgetxattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_fgetxattr="no"
+    curl_cv_func_fgetxattr="no"
   fi
 ])
 
@@ -1490,10 +1490,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FLISTXATTR], [
       AC_DEFINE(HAVE_FLISTXATTR_4, 1, [flistxattr() takes 4 args])
     fi
     #
-    ac_cv_func_flistxattr="yes"
+    curl_cv_func_flistxattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_flistxattr="no"
+    curl_cv_func_flistxattr="no"
   fi
 ])
 
@@ -1586,10 +1586,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FREEADDRINFO], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_FREEADDRINFO, 1,
       [Define to 1 if you have the freeaddrinfo function.])
-    ac_cv_func_freeaddrinfo="yes"
+    curl_cv_func_freeaddrinfo="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_freeaddrinfo="no"
+    curl_cv_func_freeaddrinfo="no"
   fi
 ])
 
@@ -1670,10 +1670,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FREEIFADDRS], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_FREEIFADDRS, 1,
       [Define to 1 if you have the freeifaddrs function.])
-    ac_cv_func_freeifaddrs="yes"
+    curl_cv_func_freeifaddrs="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_freeifaddrs="no"
+    curl_cv_func_freeifaddrs="no"
   fi
 ])
 
@@ -1792,10 +1792,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FREMOVEXATTR], [
       AC_DEFINE(HAVE_FREMOVEXATTR_3, 1, [fremovexattr() takes 3 args])
     fi
     #
-    ac_cv_func_fremovexattr="yes"
+    curl_cv_func_fremovexattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_fremovexattr="no"
+    curl_cv_func_fremovexattr="no"
   fi
 ])
 
@@ -1914,10 +1914,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FSETXATTR], [
       AC_DEFINE(HAVE_FSETXATTR_6, 1, [fsetxattr() takes 6 args])
     fi
     #
-    ac_cv_func_fsetxattr="yes"
+    curl_cv_func_fsetxattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_fsetxattr="no"
+    curl_cv_func_fsetxattr="no"
   fi
 ])
 
@@ -1999,10 +1999,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FTRUNCATE], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_FTRUNCATE, 1,
       [Define to 1 if you have the ftruncate function.])
-    ac_cv_func_ftruncate="yes"
+    curl_cv_func_ftruncate="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ftruncate="no"
+    curl_cv_func_ftruncate="no"
   fi
 ])
 
@@ -2151,8 +2151,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
     curl_cv_func_getaddrinfo="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_getaddrinfo_threadsafe="no"
     curl_cv_func_getaddrinfo="no"
+    curl_cv_func_getaddrinfo_threadsafe="no"
   fi
   #
   if test "$curl_cv_func_getaddrinfo" = "yes"; then
@@ -2263,9 +2263,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
     if test "$tst_tsafe_getaddrinfo" = "yes"; then
       AC_DEFINE_UNQUOTED(HAVE_GETADDRINFO_THREADSAFE, 1,
         [Define to 1 if the getaddrinfo function is threadsafe.])
-      ac_cv_func_getaddrinfo_threadsafe="yes"
+      curl_cv_func_getaddrinfo_threadsafe="yes"
     else
-      ac_cv_func_getaddrinfo_threadsafe="no"
+      curl_cv_func_getaddrinfo_threadsafe="no"
     fi
   fi
 ])
@@ -2357,10 +2357,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYADDR], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GETHOSTBYADDR, 1,
       [Define to 1 if you have the gethostbyaddr function.])
-    ac_cv_func_gethostbyaddr="yes"
+    curl_cv_func_gethostbyaddr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gethostbyaddr="no"
+    curl_cv_func_gethostbyaddr="no"
   fi
 ])
 
@@ -2450,10 +2450,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GAI_STRERROR], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GAI_STRERROR, 1,
       [Define to 1 if you have the gai_strerror function.])
-    ac_cv_func_gai_strerror="yes"
+    curl_cv_func_gai_strerror="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gai_strerror="no"
+    curl_cv_func_gai_strerror="no"
   fi
 ])
 
@@ -2592,10 +2592,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYADDR_R], [
       AC_DEFINE(HAVE_GETHOSTBYADDR_R_8, 1, [gethostbyaddr_r() takes 8 args])
     fi
     #
-    ac_cv_func_gethostbyaddr_r="yes"
+    curl_cv_func_gethostbyaddr_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gethostbyaddr_r="no"
+    curl_cv_func_gethostbyaddr_r="no"
   fi
 ])
 
@@ -2686,10 +2686,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GETHOSTBYNAME, 1,
       [Define to 1 if you have the gethostbyname function.])
-    ac_cv_func_gethostbyname="yes"
+    curl_cv_func_gethostbyname="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gethostbyname="no"
+    curl_cv_func_gethostbyname="no"
   fi
 ])
 
@@ -2828,10 +2828,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME_R], [
       AC_DEFINE(HAVE_GETHOSTBYNAME_R_6, 1, [gethostbyname_r() takes 6 args])
     fi
     #
-    ac_cv_func_gethostbyname_r="yes"
+    curl_cv_func_gethostbyname_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gethostbyname_r="no"
+    curl_cv_func_gethostbyname_r="no"
   fi
 ])
 
@@ -2952,10 +2952,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GETHOSTNAME, 1,
       [Define to 1 if you have the gethostname function.])
-    ac_cv_func_gethostname="yes"
+    curl_cv_func_gethostname="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gethostname="no"
+    curl_cv_func_gethostname="no"
   fi
 ])
 
@@ -3068,10 +3068,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETIFADDRS], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GETIFADDRS, 1,
       [Define to 1 if you have a working getifaddrs function.])
-    ac_cv_func_getifaddrs="yes"
+    curl_cv_func_getifaddrs="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_getifaddrs="no"
+    curl_cv_func_getifaddrs="no"
   fi
 ])
 
@@ -3208,10 +3208,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETSERVBYPORT_R], [
       AC_DEFINE(GETSERVBYPORT_R_BUFSIZE, 4096,
         [Specifies the size of the buffer to pass to getservbyport_r])
     fi
-    ac_cv_func_getservbyport_r="yes"
+    curl_cv_func_getservbyport_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_getservbyport_r="no"
+    curl_cv_func_getservbyport_r="no"
   fi
 ])
 
@@ -3330,10 +3330,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETXATTR], [
       AC_DEFINE(HAVE_GETXATTR_6, 1, [getxattr() takes 6 args])
     fi
     #
-    ac_cv_func_getxattr="yes"
+    curl_cv_func_getxattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_getxattr="no"
+    curl_cv_func_getxattr="no"
   fi
 ])
 
@@ -3446,10 +3446,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GMTIME_R], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GMTIME_R, 1,
       [Define to 1 if you have a working gmtime_r function.])
-    ac_cv_func_gmtime_r="yes"
+    curl_cv_func_gmtime_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_gmtime_r="no"
+    curl_cv_func_gmtime_r="no"
   fi
 ])
 
@@ -3570,10 +3570,10 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOA_R], [
       AC_DEFINE(HAVE_INET_NTOA_R_3, 1, [inet_ntoa_r() takes 3 args])
     fi
     #
-    ac_cv_func_inet_ntoa_r="yes"
+    curl_cv_func_inet_ntoa_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_inet_ntoa_r="no"
+    curl_cv_func_inet_ntoa_r="no"
   fi
 ])
 
@@ -3729,10 +3729,10 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_INET_NTOP, 1,
       [Define to 1 if you have a IPv6 capable working inet_ntop function.])
-    ac_cv_func_inet_ntop="yes"
+    curl_cv_func_inet_ntop="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_inet_ntop="no"
+    curl_cv_func_inet_ntop="no"
   fi
 ])
 
@@ -3881,10 +3881,10 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_INET_PTON, 1,
       [Define to 1 if you have a IPv6 capable working inet_pton function.])
-    ac_cv_func_inet_pton="yes"
+    curl_cv_func_inet_pton="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_inet_pton="no"
+    curl_cv_func_inet_pton="no"
   fi
 ])
 
@@ -4491,10 +4491,10 @@ AC_DEFUN([CURL_CHECK_FUNC_LISTXATTR], [
       AC_DEFINE(HAVE_LISTXATTR_4, 1, [listxattr() takes 4 args])
     fi
     #
-    ac_cv_func_listxattr="yes"
+    curl_cv_func_listxattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_listxattr="no"
+    curl_cv_func_listxattr="no"
   fi
 ])
 
@@ -4607,10 +4607,10 @@ AC_DEFUN([CURL_CHECK_FUNC_LOCALTIME_R], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_LOCALTIME_R, 1,
       [Define to 1 if you have a working localtime_r function.])
-    ac_cv_func_localtime_r="yes"
+    curl_cv_func_localtime_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_localtime_r="no"
+    curl_cv_func_localtime_r="no"
   fi
 ])
 
@@ -4712,10 +4712,10 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_MEMRCHR, 1,
       [Define to 1 if you have the memrchr function or macro.])
-    ac_cv_func_memrchr="yes"
+    curl_cv_func_memrchr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_memrchr="no"
+    curl_cv_func_memrchr="no"
   fi
 ])
 
@@ -4841,10 +4841,10 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
       [Define to 1 if you have a working poll function.])
     AC_DEFINE_UNQUOTED(HAVE_POLL_FINE, 1,
       [If you have a fine poll])
-    ac_cv_func_poll="yes"
+    curl_cv_func_poll="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_poll="no"
+    curl_cv_func_poll="no"
   fi
 ])
 
@@ -4963,10 +4963,10 @@ AC_DEFUN([CURL_CHECK_FUNC_REMOVEXATTR], [
       AC_DEFINE(HAVE_REMOVEXATTR_3, 1, [removexattr() takes 3 args])
     fi
     #
-    ac_cv_func_removexattr="yes"
+    curl_cv_func_removexattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_removexattr="no"
+    curl_cv_func_removexattr="no"
   fi
 ])
 
@@ -5236,10 +5236,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SETXATTR], [
       AC_DEFINE(HAVE_SETXATTR_6, 1, [setxattr() takes 6 args])
     fi
     #
-    ac_cv_func_setxattr="yes"
+    curl_cv_func_setxattr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_setxattr="no"
+    curl_cv_func_setxattr="no"
   fi
 ])
 
@@ -5321,10 +5321,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGACTION], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SIGACTION, 1,
       [Define to 1 if you have the sigaction function.])
-    ac_cv_func_sigaction="yes"
+    curl_cv_func_sigaction="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_sigaction="no"
+    curl_cv_func_sigaction="no"
   fi
 ])
 
@@ -5406,10 +5406,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGINTERRUPT], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SIGINTERRUPT, 1,
       [Define to 1 if you have the siginterrupt function.])
-    ac_cv_func_siginterrupt="yes"
+    curl_cv_func_siginterrupt="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_siginterrupt="no"
+    curl_cv_func_siginterrupt="no"
   fi
 ])
 
@@ -5491,10 +5491,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGNAL], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SIGNAL, 1,
       [Define to 1 if you have the signal function.])
-    ac_cv_func_signal="yes"
+    curl_cv_func_signal="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_signal="no"
+    curl_cv_func_signal="no"
   fi
 ])
 
@@ -5598,10 +5598,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGSETJMP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SIGSETJMP, 1,
       [Define to 1 if you have the sigsetjmp function or macro.])
-    ac_cv_func_sigsetjmp="yes"
+    curl_cv_func_sigsetjmp="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_sigsetjmp="no"
+    curl_cv_func_sigsetjmp="no"
   fi
 ])
 
@@ -5696,10 +5696,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SOCKET, 1,
       [Define to 1 if you have the socket function.])
-    ac_cv_func_socket="yes"
+    curl_cv_func_socket="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_socket="no"
+    curl_cv_func_socket="no"
   fi
 ])
 
@@ -5785,10 +5785,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKETPAIR], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SOCKETPAIR, 1,
       [Define to 1 if you have the socketpair function.])
-    ac_cv_func_socketpair="yes"
+    curl_cv_func_socketpair="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_socketpair="no"
+    curl_cv_func_socketpair="no"
   fi
 ])
 
@@ -5870,10 +5870,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCASECMP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRCASECMP, 1,
       [Define to 1 if you have the strcasecmp function.])
-    ac_cv_func_strcasecmp="yes"
+    curl_cv_func_strcasecmp="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strcasecmp="no"
+    curl_cv_func_strcasecmp="no"
   fi
 ])
 
@@ -5954,10 +5954,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCMPI], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRCMPI, 1,
       [Define to 1 if you have the strcmpi function.])
-    ac_cv_func_strcmpi="yes"
+    curl_cv_func_strcmpi="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strcmpi="no"
+    curl_cv_func_strcmpi="no"
   fi
 ])
 
@@ -6039,10 +6039,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRDUP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRDUP, 1,
       [Define to 1 if you have the strdup function.])
-    ac_cv_func_strdup="yes"
+    curl_cv_func_strdup="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strdup="no"
+    curl_cv_func_strdup="no"
   fi
 ])
 
@@ -6298,10 +6298,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
       AC_DEFINE_UNQUOTED(STRERROR_R_TYPE_ARG3, $tst_posix_strerror_r_type_arg3,
         [Define to the type of arg 3 for strerror_r.])
     fi
-    ac_cv_func_strerror_r="yes"
+    curl_cv_func_strerror_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strerror_r="no"
+    curl_cv_func_strerror_r="no"
   fi
   #
   if test "$tst_compi_strerror_r" = "yes" &&
@@ -6389,10 +6389,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRICMP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRICMP, 1,
       [Define to 1 if you have the stricmp function.])
-    ac_cv_func_stricmp="yes"
+    curl_cv_func_stricmp="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_stricmp="no"
+    curl_cv_func_stricmp="no"
   fi
 ])
 
@@ -6473,10 +6473,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRNCASECMP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRNCASECMP, 1,
       [Define to 1 if you have the strncasecmp function.])
-    ac_cv_func_strncasecmp="yes"
+    curl_cv_func_strncasecmp="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strncasecmp="no"
+    curl_cv_func_strncasecmp="no"
   fi
 ])
 
@@ -6558,10 +6558,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRNCMPI], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRNCMPI, 1,
       [Define to 1 if you have the strncmpi function.])
-    ac_cv_func_strncmpi="yes"
+    curl_cv_func_strncmpi="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strncmpi="no"
+    curl_cv_func_strncmpi="no"
   fi
 ])
 
@@ -6643,10 +6643,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRNICMP], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRNICMP, 1,
       [Define to 1 if you have the strnicmp function.])
-    ac_cv_func_strnicmp="yes"
+    curl_cv_func_strnicmp="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strnicmp="no"
+    curl_cv_func_strnicmp="no"
   fi
 ])
 
@@ -6728,10 +6728,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRSTR], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRSTR, 1,
       [Define to 1 if you have the strstr function.])
-    ac_cv_func_strstr="yes"
+    curl_cv_func_strstr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strstr="no"
+    curl_cv_func_strstr="no"
   fi
 ])
 
@@ -6813,10 +6813,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOK_R], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRTOK_R, 1,
       [Define to 1 if you have the strtok_r function.])
-    ac_cv_func_strtok_r="yes"
+    curl_cv_func_strtok_r="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strtok_r="no"
+    curl_cv_func_strtok_r="no"
   fi
 ])
 
@@ -6898,10 +6898,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOLL], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_STRTOLL, 1,
       [Define to 1 if you have the strtoll function.])
-    ac_cv_func_strtoll="yes"
+    curl_cv_func_strtoll="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_strtoll="no"
+    curl_cv_func_strtoll="no"
   fi
 ])
 
@@ -6983,9 +6983,9 @@ AC_DEFUN([CURL_CHECK_FUNC_WRITEV], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_WRITEV, 1,
       [Define to 1 if you have the writev function.])
-    ac_cv_func_writev="yes"
+    curl_cv_func_writev="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_writev="no"
+    curl_cv_func_writev="no"
   fi
 ])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1097,11 +1097,11 @@ AC_DEFUN([CURL_CHECK_FUNC_FCNTL], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_FCNTL, 1,
       [Define to 1 if you have the fcntl function.])
-    ac_cv_func_fcntl="yes"
+    curl_cv_func_fcntl="yes"
     CURL_CHECK_FUNC_FCNTL_O_NONBLOCK
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_fcntl="no"
+    curl_cv_func_fcntl="no"
   fi
 ])
 
@@ -1125,7 +1125,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FCNTL_O_NONBLOCK], [
       ;;
   esac
   #
-  if test "$ac_cv_func_fcntl" = "yes"; then
+  if test "$curl_cv_func_fcntl" = "yes"; then
     AC_MSG_CHECKING([if fcntl O_NONBLOCK is compilable])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
@@ -1161,10 +1161,10 @@ AC_DEFUN([CURL_CHECK_FUNC_FCNTL_O_NONBLOCK], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_FCNTL_O_NONBLOCK, 1,
       [Define to 1 if you have a working fcntl O_NONBLOCK function.])
-    ac_cv_func_fcntl_o_nonblock="yes"
+    curl_cv_func_fcntl_o_nonblock="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_fcntl_o_nonblock="no"
+    curl_cv_func_fcntl_o_nonblock="no"
   fi
 ])
 
@@ -2148,14 +2148,14 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_GETADDRINFO, 1,
       [Define to 1 if you have a working getaddrinfo function.])
-    ac_cv_func_getaddrinfo="yes"
+    curl_cv_func_getaddrinfo="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_getaddrinfo="no"
     ac_cv_func_getaddrinfo_threadsafe="no"
+    curl_cv_func_getaddrinfo="no"
   fi
   #
-  if test "$ac_cv_func_getaddrinfo" = "yes"; then
+  if test "$curl_cv_func_getaddrinfo" = "yes"; then
     AC_MSG_CHECKING([if getaddrinfo is threadsafe])
     case $host_os in
       aix[[1234]].* | aix5.[[01]].*)
@@ -3966,12 +3966,12 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTL, 1,
       [Define to 1 if you have the ioctl function.])
-    ac_cv_func_ioctl="yes"
+    curl_cv_func_ioctl="yes"
     CURL_CHECK_FUNC_IOCTL_FIONBIO
     CURL_CHECK_FUNC_IOCTL_SIOCGIFADDR
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctl="no"
+    curl_cv_func_ioctl="no"
   fi
 ])
 
@@ -3988,7 +3988,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL_FIONBIO], [
   tst_compi_ioctl_fionbio="unknown"
   tst_allow_ioctl_fionbio="unknown"
   #
-  if test "$ac_cv_func_ioctl" = "yes"; then
+  if test "$curl_cv_func_ioctl" = "yes"; then
     AC_MSG_CHECKING([if ioctl FIONBIO is compilable])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
@@ -4024,10 +4024,10 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL_FIONBIO], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTL_FIONBIO, 1,
       [Define to 1 if you have a working ioctl FIONBIO function.])
-    ac_cv_func_ioctl_fionbio="yes"
+    curl_cv_func_ioctl_fionbio="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctl_fionbio="no"
+    curl_cv_func_ioctl_fionbio="no"
   fi
 ])
 
@@ -4044,7 +4044,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL_SIOCGIFADDR], [
   tst_compi_ioctl_siocgifaddr="unknown"
   tst_allow_ioctl_siocgifaddr="unknown"
   #
-  if test "$ac_cv_func_ioctl" = "yes"; then
+  if test "$curl_cv_func_ioctl" = "yes"; then
     AC_MSG_CHECKING([if ioctl SIOCGIFADDR is compilable])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
@@ -4081,10 +4081,10 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL_SIOCGIFADDR], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTL_SIOCGIFADDR, 1,
       [Define to 1 if you have a working ioctl SIOCGIFADDR function.])
-    ac_cv_func_ioctl_siocgifaddr="yes"
+    curl_cv_func_ioctl_siocgifaddr="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctl_siocgifaddr="no"
+    curl_cv_func_ioctl_siocgifaddr="no"
   fi
 ])
 
@@ -4171,11 +4171,11 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTLSOCKET, 1,
       [Define to 1 if you have the ioctlsocket function.])
-    ac_cv_func_ioctlsocket="yes"
+    curl_cv_func_ioctlsocket="yes"
     CURL_CHECK_FUNC_IOCTLSOCKET_FIONBIO
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctlsocket="no"
+    curl_cv_func_ioctlsocket="no"
   fi
 ])
 
@@ -4192,7 +4192,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_FIONBIO], [
   tst_compi_ioctlsocket_fionbio="unknown"
   tst_allow_ioctlsocket_fionbio="unknown"
   #
-  if test "$ac_cv_func_ioctlsocket" = "yes"; then
+  if test "$curl_cv_func_ioctlsocket" = "yes"; then
     AC_MSG_CHECKING([if ioctlsocket FIONBIO is compilable])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
@@ -4228,10 +4228,10 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_FIONBIO], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTLSOCKET_FIONBIO, 1,
       [Define to 1 if you have a working ioctlsocket FIONBIO function.])
-    ac_cv_func_ioctlsocket_fionbio="yes"
+    curl_cv_func_ioctlsocket_fionbio="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctlsocket_fionbio="no"
+    curl_cv_func_ioctlsocket_fionbio="no"
   fi
 ])
 
@@ -4313,11 +4313,11 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTLSOCKET_CAMEL, 1,
       [Define to 1 if you have the IoctlSocket camel case function.])
-    ac_cv_func_ioctlsocket_camel="yes"
+    curl_cv_func_ioctlsocket_camel="yes"
     CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL_FIONBIO
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctlsocket_camel="no"
+    curl_cv_func_ioctlsocket_camel="no"
   fi
 ])
 
@@ -4333,7 +4333,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL_FIONBIO], [
   tst_compi_ioctlsocket_camel_fionbio="unknown"
   tst_allow_ioctlsocket_camel_fionbio="unknown"
   #
-  if test "$ac_cv_func_ioctlsocket_camel" = "yes"; then
+  if test "$curl_cv_func_ioctlsocket_camel" = "yes"; then
     AC_MSG_CHECKING([if IoctlSocket FIONBIO is compilable])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
@@ -4369,10 +4369,10 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL_FIONBIO], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTLSOCKET_CAMEL_FIONBIO, 1,
       [Define to 1 if you have a working IoctlSocket camel case FIONBIO function.])
-    ac_cv_func_ioctlsocket_camel_fionbio="yes"
+    curl_cv_func_ioctlsocket_camel_fionbio="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_ioctlsocket_camel_fionbio="no"
+    curl_cv_func_ioctlsocket_camel_fionbio="no"
   fi
 ])
 
@@ -5057,11 +5057,11 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SETSOCKOPT, 1,
       [Define to 1 if you have the setsockopt function.])
-    ac_cv_func_setsockopt="yes"
+    curl_cv_func_setsockopt="yes"
     CURL_CHECK_FUNC_SETSOCKOPT_SO_NONBLOCK
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_setsockopt="no"
+    curl_cv_func_setsockopt="no"
   fi
 ])
 
@@ -5078,7 +5078,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT_SO_NONBLOCK], [
   tst_compi_setsockopt_so_nonblock="unknown"
   tst_allow_setsockopt_so_nonblock="unknown"
   #
-  if test "$ac_cv_func_setsockopt" = "yes"; then
+  if test "$curl_cv_func_setsockopt" = "yes"; then
     AC_MSG_CHECKING([if setsockopt SO_NONBLOCK is compilable])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
@@ -5114,10 +5114,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT_SO_NONBLOCK], [
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_SETSOCKOPT_SO_NONBLOCK, 1,
       [Define to 1 if you have a working setsockopt SO_NONBLOCK function.])
-    ac_cv_func_setsockopt_so_nonblock="yes"
+    curl_cv_func_setsockopt_so_nonblock="yes"
   else
     AC_MSG_RESULT([no])
-    ac_cv_func_setsockopt_so_nonblock="no"
+    curl_cv_func_setsockopt_so_nonblock="no"
   fi
 ])
 

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2208,7 +2208,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         ;;
     esac
     if test "$tst_tsafe_getaddrinfo" = "unknown" &&
-       test "$ac_cv_native_windows" = "yes"; then
+       test "$curl_cv_native_windows" = "yes"; then
       tst_tsafe_getaddrinfo="yes"
     fi
     if test "$tst_tsafe_getaddrinfo" = "unknown"; then


### PR DESCRIPTION
AC_CHECK_HEADERS produces `ac_cv_header_*_h' cache variables, which
conflict with curl-specific header check for windows.h. By renaming the
variable used by curl, any conflict with other projects and shared
config.caches is resolved. The conflict occurs under CYGWIN, as
AC_CHECK_HEADERS (from a different project) will set
ac_cv_header_windows_h=1, while the expected value for curl is 0.