### PR TITLE
url.c: fixed DEBUGASSERT() for WinSock workaround

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2701,7 +2701,9 @@ static void conn_reset_postponed_data(struct connectdata *conn, int num)
   if(psnd->buffer) {
     DEBUGASSERT(psnd->allocated_size > 0);
     DEBUGASSERT(psnd->recv_size <= psnd->allocated_size);
-    DEBUGASSERT(psnd->recv_processed < psnd->recv_size);
+    DEBUGASSERT(psnd->recv_size ?
+                (psnd->recv_processed < psnd->recv_size) :
+                (psnd->recv_processed == 0));
     DEBUGASSERT(psnd->bindsock != CURL_SOCKET_BAD);
     free(psnd->buffer);
     psnd->buffer = NULL;


### PR DESCRIPTION
If buffer is allocated, but nothing is received during prereceive
stage, than number of processed bytes must be zero.

Fixed assert from #668.