### PR TITLE
Fix some syntax errors in example code fragments

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
@@ -83,13 +83,14 @@ All
 .nf
 CURL *curl;
 struct curl_slist *connect_to = NULL;
-host = curl_slist_append(NULL, "example.com::server1.example.com:");
+connect_to = curl_slist_append(NULL, "example.com::server1.example.com:");
 
 curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
-  res = curl_easy_perform(curl);
+
+  curl_easy_perform(curl);
 
   /* always cleanup */
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.3
@@ -100,7 +100,7 @@ were skipped on import are not exported.
 */
 curl_easy_setopt(curl, CURLOPT_COOKIEJAR, "cookies.txt");  /* export */
 
-res = curl_easy_perform(curl);  /* cookies imported from cookies.txt */
+curl_easy_perform(curl);  /* cookies imported from cookies.txt */
 
 curl_easy_cleanup(curl);  /* cookies exported to cookies.txt */
 .fi

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.3
@@ -67,7 +67,8 @@ curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_RESOLVE, host);
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
-  res = curl_easy_perform(curl);
+
+  curl_easy_perform(curl);
 
   /* always cleanup */
   curl_easy_cleanup(curl);


### PR DESCRIPTION
* Fix wrong variable name in `CURLOPT_CONNECT_TO.3`
* `res` is not declared -> remove assignment