### PR TITLE
The error variable has to be reset before verifying each socket

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -749,8 +749,8 @@ CURLcode Curl_is_connected(struct connectdata *conn,
   }
 
   for(i=0; i<2; i++) {
-    error = 0;
     const int other = i ^ 1;
+    error = 0;
     if(conn->tempsock[i] == CURL_SOCKET_BAD)
       continue;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -749,6 +749,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
   }
 
   for(i=0; i<2; i++) {
+    error = 0;
     const int other = i ^ 1;
     if(conn->tempsock[i] == CURL_SOCKET_BAD)
       continue;


### PR DESCRIPTION
The error variable has to be reset before verifying each socket connection.
In other case, an error in the first socket might make Curl_is_connected
think the second socket in conn->tempsock has an error too and fail with
a "Network is unreachable" error in perfectly valid situations.

This fixes intermittent network errors from happening when ipv6 is not
available and the second choice is a valid ipv4 connection.