### PR TITLE
Fix invalid "Network is unreachable" errors

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -764,6 +764,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
     rc = Curl_socket_ready(CURL_SOCKET_BAD, conn->tempsock[i], 0);
 
     if(rc == 0) { /* no connection yet */
+      error = 0;
       if(curlx_tvdiff(now, conn->connecttime) >= conn->timeoutms_per_addr) {
         infof(data, "After %ldms connect time, move on!\n",
               conn->timeoutms_per_addr);


### PR DESCRIPTION
Sometimes, in systems with both ipv4 and ipv6 addresses but where the
network doesn't support ipv6, Curl_is_connected returns an error
(intermittently) even if the ipv4 socket connects successfully.

This happens because there's a for-loop that iterates on the sockets
but the error variable is not resetted when the ipv4 is checked and
is ok.

This patch fixes this problem by setting error to 0 when checking the
second socket and not having a result yet.