### PR TITLE
http2: Add space between colon and header value

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -862,7 +862,7 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
 
     Curl_add_buffer(stream->trailer_recvbuf, &n, sizeof(n));
     Curl_add_buffer(stream->trailer_recvbuf, name, namelen);
-    Curl_add_buffer(stream->trailer_recvbuf, ":", 1);
+    Curl_add_buffer(stream->trailer_recvbuf, ": ", 2);
     Curl_add_buffer(stream->trailer_recvbuf, value, valuelen);
     Curl_add_buffer(stream->trailer_recvbuf, "\r\n\0", 3);
 
@@ -894,7 +894,7 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
      received, and this is not pseudo-header field . */
   /* convert to a HTTP1-style header */
   Curl_add_buffer(stream->header_recvbuf, name, namelen);
-  Curl_add_buffer(stream->header_recvbuf, ":", 1);
+  Curl_add_buffer(stream->header_recvbuf, ": ", 2);
   Curl_add_buffer(stream->header_recvbuf, value, valuelen);
   Curl_add_buffer(stream->header_recvbuf, "\r\n", 2);
   /* if we receive data for another handle, wake that up */


### PR DESCRIPTION
Resolves #797.

curl's representation of HTTP/2 responses involves transforming the
response to a format that is similar to HTTP/1.1. Prior to this change,
curl would do this by separating header names and values with only a
colon, without introducing a space after the colon.

While this is technically a valid way to represent a HTTP/1.1 header
block, it is much more common to see a space following the colon. This
change introduces that space, to ensure that incautious tools are safely
able to parse the header block.

This also ensures that the difference between the HTTP/1.1 and HTTP/2
response layout is as minimal as possible.

Bug: https://github.com/curl/curl/issues/797