### PR TITLE
Fix Curl_client_chop_write for max documented header length

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1030,20 +1030,8 @@ CURLcode curl_easy_pause(CURL *curl, int action)
   /* put it back in the keepon */
   k->keepon = newstate;
 
-  if(!(newstate & KEEP_RECV_PAUSE) && data->state.tempwrite) {
-    /* we have a buffer for sending that we now seem to be able to deliver
-       since the receive pausing is lifted! */
-
-    /* get the pointer in local copy since the function may return PAUSE
-       again and then we'll get a new copy allocted and stored in
-       the tempwrite variables */
-    char *tempwrite = data->state.tempwrite;
-
-    data->state.tempwrite = NULL;
-    result = Curl_client_chop_write(data->easy_conn, data->state.tempwritetype,
-                                    tempwrite, data->state.tempwritesize);
-    free(tempwrite);
-  }
+  if(!(newstate & KEEP_RECV_PAUSE))
+    result = Curl_client_chop_write(data->easy_conn, 0, NULL, 0);
 
   /* if there's no error and we're not pausing both directions, we want
      to have this handle checked soon */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1030,8 +1030,11 @@ CURLcode curl_easy_pause(CURL *curl, int action)
   /* put it back in the keepon */
   k->keepon = newstate;
 
+  /* write any saved write data to the user callbacks. this may pause again. */
   if(!(newstate & KEEP_RECV_PAUSE))
     result = Curl_client_chop_write(data->easy_conn, 0, NULL, 0);
+
+  /* FIXME: What to do if it pauses again? */
 
   /* if there's no error and we're not pausing both directions, we want
      to have this handle checked soon */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -591,8 +591,8 @@ static CURLcode multi_done(struct connectdata **connp,
 
   /* if the transfer was completed in a paused state there can be buffered
      data left to write and then kill */
-  free(data->state.tempwrite);
-  data->state.tempwrite = NULL;
+  Curl_llist_destroy(data->state.tmp_writebuf_list, NULL);
+  data->state.tmp_writebuf_list = NULL;
 
   /* if data->set.reuse_forbid is TRUE, it means the libcurl client has
      forced us to close this connection. This is ignored for requests taking

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1231,6 +1231,15 @@ struct auth {
                    be RFC compliant */
 };
 
+
+struct tmp_writebuf {
+  char *buf;        /* buffer to store data when the connection is paused */
+  size_t memsize;   /* the allocated size of buf */
+  size_t offset;    /* the offset into buf where the unwritten data starts */
+  size_t len;       /* the length of the unwritten data starting from offset */
+  int type;         /* CLIENTWRITE_ bitmask */
+};
+
 struct UrlState {
 
   /* Points to the connection cache */
@@ -1264,11 +1273,8 @@ struct UrlState {
   int first_remote_port; /* remote port of the first (not followed) request */
   struct curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
   long sessionage;                  /* number of the most recent session */
-  char *tempwrite;      /* allocated buffer to keep data in when a write
-                           callback returns to make the connection paused */
-  size_t tempwritesize; /* size of the 'tempwrite' allocated buffer */
-  int tempwritetype;    /* type of the 'tempwrite' buffer as a bitmask that is
-                           used with Curl_client_write() */
+  struct curl_llist *tmp_writebuf_list; /* a chronological list of tmp_writebuf
+                                           that stores data when paused */
   char *scratch; /* huge buffer[BUFSIZE*2] when doing upload CRLF replacing */
   bool errorbuf; /* Set to TRUE if the error buffer is already filled in.
                     This must be set to FALSE every time _easy_perform() is

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1233,7 +1233,8 @@ struct auth {
 
 
 struct tmp_writebuf {
-  char *buf;        /* buffer to store data when the connection is paused */
+  char *buf;        /* buffer to store data when the connection is paused.
+                       data is not terminated and may contain null chars. */
   size_t memsize;   /* the allocated size of buf */
   size_t offset;    /* the offset into buf where the unwritten data starts */
   size_t len;       /* the length of the unwritten data starting from offset */


### PR DESCRIPTION
_Work in progress, will bump thread when done._

It is [documented](https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html) that "The header callback will be called once for each header and only complete header lines are passed on to the callback" but at the moment that's [not true](https://github.com/curl/curl/blob/curl-7_48_0/lib/sendf.c#L431). The header function will receive a header line in chunks if that line+CRLF is larger than `CURL_MAX_WRITE_SIZE`.

This fix changes the max header length for user callback from CURL_MAX_WRITE_SIZE
to CURL_MAX_HTTP_HEADER. Because the chunk sizes for header and body are different, a part of one can be written and then paused before the other. In order to address this I'm switching the temporary buffer format to a linked list of buffers to separate the two when necessary, and I've tried to do it in a way that requires a minimum amount of extra memory when paused.

This is just to show where I'm at. It does not build yet.
