### PR TITLE
Fix for disabling certificate validation on OS X 10.8 (Mountain Lion)

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1281,14 +1281,20 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
 #if CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS
   /* Snow Leopard introduced the SSLSetSessionOption() function, but due to
      a library bug with the way the kSSLSessionOptionBreakOnServerAuth flag
-     works, it doesn't work as expected under Snow Leopard or Lion.
+     works, it doesn't work as expected under Snow Leopard, Lion or Mountain Lion.
      So we need to call SSLSetEnableCertVerify() on those older cats in order
      to disable certificate validation if the user turned that off.
      (SecureTransport will always validate the certificate chain by
-     default.) */
-  /* (Note: Darwin 12.x.x is Mountain Lion.) */
+     default.)
+  Note: 
+  Darwin 11.x.x is Lion (10.7)
+  Darwin 12.x.x is Mountain Lion (10.8).
+  Darwin 13.x.x is Maverik (10.9)
+  Darwin 14.x.x is Yosemite (10.10) 
+  Darwin 15.x.x is El Capitan (10.11)
+  */
 #if CURL_BUILD_MAC
-  if(SSLSetSessionOption != NULL && darwinver_maj >= 12) {
+  if(SSLSetSessionOption != NULL && darwinver_maj >= 13) {
 #else
   if(SSLSetSessionOption != NULL) {
 #endif /* CURL_BUILD_MAC */

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1281,16 +1281,17 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
 #if CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS
   /* Snow Leopard introduced the SSLSetSessionOption() function, but due to
      a library bug with the way the kSSLSessionOptionBreakOnServerAuth flag
-     works, it doesn't work as expected under Snow Leopard, Lion or Mountain Lion.
+     works, it doesn't work as expected under Snow Leopard, Lion or 
+	 Mountain Lion.
      So we need to call SSLSetEnableCertVerify() on those older cats in order
      to disable certificate validation if the user turned that off.
      (SecureTransport will always validate the certificate chain by
      default.)
-  Note: 
+  Note:
   Darwin 11.x.x is Lion (10.7)
-  Darwin 12.x.x is Mountain Lion (10.8).
+  Darwin 12.x.x is Mountain Lion (10.8)
   Darwin 13.x.x is Maverik (10.9)
-  Darwin 14.x.x is Yosemite (10.10) 
+  Darwin 14.x.x is Yosemite (10.10)
   Darwin 15.x.x is El Capitan (10.11)
   */
 #if CURL_BUILD_MAC

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1281,8 +1281,8 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
 #if CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS
   /* Snow Leopard introduced the SSLSetSessionOption() function, but due to
      a library bug with the way the kSSLSessionOptionBreakOnServerAuth flag
-     works, it doesn't work as expected under Snow Leopard, Lion or 
-	 Mountain Lion.
+     works, it doesn't work as expected under Snow Leopard, Lion or
+     Mountain Lion.
      So we need to call SSLSetEnableCertVerify() on those older cats in order
      to disable certificate validation if the user turned that off.
      (SecureTransport will always validate the certificate chain by


### PR DESCRIPTION
This is pull request for the problem I asked about on the [mailing list](https://curl.haxx.se/mail/lib-2016-05/0041.html).

I stumbled on [this old patch](https://curl.haxx.se/mail/lib-2012-12/att-0218/0001-darwinssl-Fixed-inability-to-disable-peer-verificati.patch) from 2012 which is similar to my issue, but not quite the same. Some further digging and testing has reviled that the issue also exists on OS X 10.8. I've tested these changes on 10.7.5, 10.8, 10.9, 10.10.2 and 10.11 and am able to enable/disable CURLOPT_SSL_VERIFYPEER on all of these version with this change.

Cheers,

Per