### PR TITLE
Fix compile break with MSVC XP toolset

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -63,7 +63,7 @@
 
 /* ALPN requires version 8.1 of the  Windows SDK, which was
    shipped with Visual Studio 2013, aka _MSC_VER 1800*/
-#if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#if defined(_MSC_VER) && (_MSC_VER >= 1800) && !defined(_USING_V110_SDK71_)
 #  define HAS_ALPN 1
 #endif
 


### PR DESCRIPTION
For the Windows XP toolset of Visual C++ 2013/2015, the old Windows SDK 7.1
is used. In this case, `_USING_V110_SDK71_` is defined.