### PR TITLE
test 1140 fails in curl 7.49 release tarball (after dependencies fix)

### DIFF
--- a/docs/libcurl/Makefile.am
+++ b/docs/libcurl/Makefile.am
@@ -41,7 +41,7 @@ man_MANS = curl_easy_cleanup.3 curl_easy_getinfo.3 curl_easy_init.3	 \
  curl_multi_timeout.3 curl_formget.3 curl_multi_assign.3		 \
  curl_easy_pause.3 curl_easy_recv.3 curl_easy_send.3			 \
  curl_multi_socket_action.3 curl_multi_wait.3 libcurl-symbols.3 	 \
- libcurl-thread.3
+ libcurl-thread.3 curl_multi_socket_all.3
 
 HTMLPAGES = curl_easy_cleanup.html curl_easy_getinfo.html		\
  curl_easy_init.html curl_easy_perform.html curl_easy_setopt.html	\
@@ -62,7 +62,7 @@ HTMLPAGES = curl_easy_cleanup.html curl_easy_getinfo.html		\
  curl_multi_timeout.html curl_formget.html curl_multi_assign.html	\
  curl_easy_pause.html curl_easy_recv.html curl_easy_send.html		\
  curl_multi_socket_action.html curl_multi_wait.html			\
- libcurl-symbols.html libcurl-thread.html
+ libcurl-symbols.html libcurl-thread.html curl_multi_socket_all.html
 
 PDFPAGES = curl_easy_cleanup.pdf curl_easy_getinfo.pdf			 \
  curl_easy_init.pdf curl_easy_perform.pdf curl_easy_setopt.pdf		 \
@@ -82,7 +82,8 @@ PDFPAGES = curl_easy_cleanup.pdf curl_easy_getinfo.pdf			 \
  curl_multi_setopt.pdf curl_multi_socket.pdf curl_multi_timeout.pdf	 \
  curl_formget.pdf curl_multi_assign.pdf curl_easy_pause.pdf		 \
  curl_easy_recv.pdf curl_easy_send.pdf curl_multi_socket_action.pdf 	 \
- curl_multi_wait.pdf libcurl-symbols.pdf libcurl-thread.pdf
+ curl_multi_wait.pdf libcurl-symbols.pdf libcurl-thread.pdf		 \
+ curl_multi_socket_all.pdf
 
 m4macrodir = $(datadir)/aclocal
 dist_m4macro_DATA = libcurl.m4


### PR DESCRIPTION
~~~
$ cat log/stderr1140
error: ./../docs/libcurl/curl_easy_pause.3:82: refering to non-existing man page curl_multi_socket_all.3
error: ./../docs/libcurl/curl_multi_socket.3:66: refering to non-existing man page curl_multi_socket_all.3
~~~

~~~
$ git grep curl_multi_socket_all.3
curl_easy_pause.3:forcibly call for example \fIcurl_multi_socket_all(3)\fP - wit
curl_multi_socket.3:just a single one by calling \fIcurl_multi_socket_all(3)\fP.
~~~

Server says:
`The requested URL /libcurl/c/curl_multi_socket_all.html was not found on this server.`

Generating in roffit from repo version:
`See the man3/curl_multi_socket.3 man page.`


Both the references in the manpages appear valid. I think we should have a link in curl_multi_socket_all.3 to curl_multi_socket instead of just saying see it (roffit may already do this if curl_multi_socket.3 is generated to html, I didn't check).

If curl_multi_socket_all.pdf was an actual copy of curl_multi_socket.pdf I think that would make more sense though than saying see the other pdf. But I'm thinking something like this at least:
~~~diff
diff --git a/docs/libcurl/Makefile.am b/docs/libcurl/Makefile.am
index f32435a..49acd97 100644
--- a/docs/libcurl/Makefile.am
+++ b/docs/libcurl/Makefile.am
@@ -41,7 +41,7 @@ man_MANS = curl_easy_cleanup.3 curl_easy_getinfo.3 curl_easy_i
  curl_multi_timeout.3 curl_formget.3 curl_multi_assign.3                \
  curl_easy_pause.3 curl_easy_recv.3 curl_easy_send.3                    \
  curl_multi_socket_action.3 curl_multi_wait.3 libcurl-symbols.3         \
- libcurl-thread.3
+ libcurl-thread.3 curl_multi_socket_all.3

 HTMLPAGES = curl_easy_cleanup.html curl_easy_getinfo.html              \
  curl_easy_init.html curl_easy_perform.html curl_easy_setopt.html      \
@@ -62,7 +62,7 @@ HTMLPAGES = curl_easy_cleanup.html curl_easy_getinfo.html
  curl_multi_timeout.html curl_formget.html curl_multi_assign.html      \
  curl_easy_pause.html curl_easy_recv.html curl_easy_send.html          \
  curl_multi_socket_action.html curl_multi_wait.html                    \
- libcurl-symbols.html libcurl-thread.html
+ libcurl-symbols.html libcurl-thread.html curl_multi_socket_all.html

 PDFPAGES = curl_easy_cleanup.pdf curl_easy_getinfo.pdf                  \
  curl_easy_init.pdf curl_easy_perform.pdf curl_easy_setopt.pdf          \
@@ -82,7 +82,8 @@ PDFPAGES = curl_easy_cleanup.pdf curl_easy_getinfo.pdf
  curl_multi_setopt.pdf curl_multi_socket.pdf curl_multi_timeout.pdf     \
  curl_formget.pdf curl_multi_assign.pdf curl_easy_pause.pdf             \
  curl_easy_recv.pdf curl_easy_send.pdf curl_multi_socket_action.pdf     \
- curl_multi_wait.pdf libcurl-symbols.pdf libcurl-thread.pdf
+ curl_multi_wait.pdf libcurl-symbols.pdf libcurl-thread.pdf             \
+ curl_multi_socket_all.pdf

 m4macrodir = $(datadir)/aclocal
 dist_m4macro_DATA = libcurl.m4
~~~