### PR TITLE
Improve the documentation for CURLOPT_CONNECT_TO

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
@@ -75,6 +75,11 @@ port, the HTTP proxy is automatically switched to tunnel mode for this
 specific request. This is necessary because it is not possible to connect to a
 specific host or port in normal (non-tunnel) mode.
 
+When this option is passed to \fIcurl_easy_setopt(3)\fP, libcurl will not copy
+the entire list so you \fBmust\fP keep it around until you no longer use this
+\fIhandle\fP for a transfer before you call \fIcurl_slist_free_all(3)\fP on
+the list.
+
 .SH DEFAULT
 NULL
 .SH PROTOCOLS


### PR DESCRIPTION
The application must keep the list until the transfer is complete.

I have copied the paragraph from the documentation of CURLOPT_HTTPHEADER.