### PR TITLE
libcurl.m4: Avoid obsolete warning

### DIFF
--- a/docs/libcurl/libcurl.m4
+++ b/docs/libcurl/libcurl.m4
@@ -82,7 +82,7 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
   AH_TEMPLATE([LIBCURL_PROTOCOL_SMTP],[Defined if libcurl supports SMTP])
 
   AC_ARG_WITH(libcurl,
-     AC_HELP_STRING([--with-libcurl=PREFIX],[look for the curl library in PREFIX/lib and headers in PREFIX/include]),
+     AS_HELP_STRING([--with-libcurl=PREFIX],[look for the curl library in PREFIX/lib and headers in PREFIX/include]),
      [_libcurl_with=$withval],[_libcurl_with=ifelse([$1],,[yes],[$1])])
 
   if test "$_libcurl_with" != "no" ; then


### PR DESCRIPTION
`autoconf --warnings=all` [resulted](http://www.gnu.org/software/autoconf/manual/autoconf.html#Obsolete-Macros) in
``warning: The macro `AC_HELP_STRING' is obsolete.``