### PR TITLE
Added missing mbedTLS support with CMake

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -915,6 +915,9 @@
 /* if PolarSSL is enabled */
 #cmakedefine USE_POLARSSL 1
 
+/* if mbedTLS is enabled */
+#cmakedefine USE_MBEDTLS 1
+
 /* if libSSH2 is in use */
 #cmakedefine USE_LIBSSH2 1
 


### PR DESCRIPTION
Here is a trivial commit to be able to compile with mbedTLS while using the CMake build system.