### PR TITLE
schannel: Disable ALPN on Windows < 8.1

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -65,6 +65,7 @@
    shipped with Visual Studio 2013, aka _MSC_VER 1800*/
 #if defined(_MSC_VER) && (_MSC_VER >= 1800) && !defined(_USING_V110_SDK71_)
 #  define HAS_ALPN 1
+#  include <VersionHelpers.h>
 #endif
 
 /* Uncomment to force verbose output
@@ -94,6 +95,15 @@ static void InitSecBufferDesc(SecBufferDesc *desc, SecBuffer *BufArr,
   desc->pBuffers = BufArr;
   desc->cBuffers = NumArrElem;
 }
+
+#ifdef HAS_ALPN
+static __inline bool alpn_supported()
+{
+  /* ALPN support has been added to schannel in Windows 8.1
+     https://technet.microsoft.com/en-us/library/hh831771%28v=ws.11%29.aspx */
+  return IsWindows8Point1OrGreater();
+}
+#endif
 
 static CURLcode
 schannel_connect_step1(struct connectdata *conn, int sockindex)
@@ -231,7 +241,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
   }
 
 #ifdef HAS_ALPN
-  if(conn->bits.tls_enable_alpn) {
+  if(conn->bits.tls_enable_alpn && alpn_supported()) {
     int cur = 0;
     int list_start_index = 0;
     unsigned int* extension_len = NULL;
@@ -630,7 +640,7 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
   }
 
 #ifdef HAS_ALPN
-  if(conn->bits.tls_enable_alpn) {
+  if(conn->bits.tls_enable_alpn && alpn_supported()) {
     sspi_status = s_pSecFn->QueryContextAttributes(&connssl->ctxt->ctxt_handle,
       SECPKG_ATTR_APPLICATION_PROTOCOL, &alpn_result);
 


### PR DESCRIPTION
Calling QueryContextAttributes with SECPKG_ATTR_APPLICATION_PROTOCOL fails on Windows < 8.1 (and < Server 2012 R2), so we need to disable ALPN on these OS versions.

Fixes #840

I built curl on Windows Server 2012 R2 with MSVS 2015 and the command line `nmake /f Makefile.vc MODE=dll VC=14 DEBUG=no`. I tested the result with `curl.exe -v https://google.com/` on both the build machine and a Windows 7 box.

TL;DR: The behavior on Windows Server 2012 R2 doesn't change, but on Windows 7, the patch fixes the TLS connection by disabling ALPN.

### Windows Server 2012 R2, master
```
*   Trying 216.58.214.110...
* Connected to google.com (216.58.214.110) port 443 (#0)
* schannel: SSL/TLS connection with google.com port 443 (step 1/3)
* schannel: checking server certificate revocation
* schannel: ALPN, offering http/1.1
* schannel: sending initial handshake data: sending 198 bytes...
[...]
* schannel: SSL/TLS connection with google.com port 443 (step 3/3)
* schannel: ALPN, server accepted to use http/1.1
* schannel: incremented credential handle refcount = 1
```

### Windows Server 2012 R2, patched
Same result as with master, as expected.

### Windows 7, master
```
*   Trying 216.58.201.238...
* Connected to google.com (216.58.201.238) port 443 (#0)
* schannel: SSL/TLS connection with google.com port 443 (step 1/3)
* schannel: checking server certificate revocation
* schannel: ALPN, offering http/1.1
* schannel: sending initial handshake data: sending 179 bytes...
[...]
* schannel: SSL/TLS connection with google.com port 443 (step 3/3)
* schannel: failed to retrieve ALPN result
* Closing connection 0
* schannel: shutting down SSL/TLS connection with google.com port 443
* schannel: clear security context handle
* schannel: clear credential handle
curl: (35) schannel: failed to retrieve ALPN result
```

### Windows 7, patched
```
*   Trying 216.58.201.238...
* Connected to google.com (216.58.201.238) port 443 (#0)
* schannel: SSL/TLS connection with google.com port 443 (step 1/3)
* schannel: checking server certificate revocation
* schannel: sending initial handshake data: sending 179 bytes...
[...]
* schannel: SSL/TLS connection with google.com port 443 (step 3/3)
* schannel: incremented credential handle refcount = 1
```