### PR TITLE
makefile.m32: add crypt32 for winssl builds

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -258,6 +258,10 @@ ifdef SSL
       CFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
     endif
   endif
+else
+ifdef WINSSL
+  DLL_LIBS += -lcrypt32
+endif
 endif
 ifdef ZLIB
   INCLUDES += -I"$(ZLIB_PATH)"

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -274,6 +274,10 @@ ifdef SSL
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
   CFLAGS += -DUSE_OPENSSL
   curl_LDADD += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
+else
+ifdef WINSSL
+  curl_LDADD += -lcrypt32
+endif
 endif
 ifdef ZLIB
   INCLUDES += -I"$(ZLIB_PATH)"


### PR DESCRIPTION
Following: https://github.com/curl/curl/commit/6cabd78531f80d5c6cd942ed1aa97eaa5ec080df
