### PR TITLE
Fix rewording

### DIFF
--- a/docs/libcurl/curl_multi_socket_action.3
+++ b/docs/libcurl/curl_multi_socket_action.3
@@ -43,7 +43,7 @@ libcurl will test the descriptor internally. It is also permissible to pass
 CURL_SOCKET_TIMEOUT to the \fBsockfd\fP parameter in order to initiate the
 whole process or when a timeout occurs.
 
-At return, the integer \fBrunning_handles\fP points to will contain the number
+At return, the integer \fBrunning_handles\fP points to the number
 of running easy handles within the multi handle. When this number reaches
 zero, all transfers are complete/done. When you call
 \fIcurl_multi_socket_action(3)\fP on a specific socket and the counter


### PR DESCRIPTION
Seems like a phrase was about to be replaced with another one, but only the addition made it in, not the removal.