### PR TITLE
resolve: add support for IPv6 DNS64/NAT64 Networks on Apple operating system

### DIFF
--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -563,3 +563,29 @@ curl_dogetaddrinfo(const char *hostname,
 }
 #endif /* defined(CURLDEBUG) && defined(HAVE_GETADDRINFO) */
 
+#if defined(HAVE_GETADDRINFO)
+void Curl_addrinfo_set_port(Curl_addrinfo *addrinfo,
+                            int port)
+{
+  Curl_addrinfo *ca;
+  struct sockaddr_in *addr;
+#ifdef ENABLE_IPV6
+  struct sockaddr_in6 *addr6;
+#endif
+  for(ca = addrinfo; ca != NULL; ca = ca->ai_next) {
+    switch (ca->ai_family) {
+    case AF_INET:
+      addr = (void *)ca->ai_addr; /* storage area for this info */
+      addr->sin_port = htons((unsigned short)port);
+      break;
+
+#ifdef ENABLE_IPV6
+    case AF_INET6:
+      addr6 = (void *)ca->ai_addr; /* storage area for this info */
+      addr6->sin6_port = htons((unsigned short)port);
+      break;
+#endif
+    }
+  }
+}
+#endif

--- a/lib/curl_addrinfo.h
+++ b/lib/curl_addrinfo.h
@@ -99,4 +99,9 @@ curl_dogetaddrinfo(const char *hostname,
                    int line, const char *source);
 #endif
 
+#ifdef HAVE_GETADDRINFO
+void Curl_addrinfo_set_port(Curl_addrinfo *addrinfo,
+                            int port);
+#endif
+
 #endif /* HEADER_CURL_ADDRINFO_H */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -222,6 +222,15 @@
 #endif
 
 /*
+ * Use getaddrinfo to resolve the IPv4 address literal. If the current network
+ * interface doesn’t support IPv4, but supports IPv6, NAT64, and DNS64,
+ * performing this task will result in a synthesized IPv6 address.
+ */
+#ifdef  __APPLE__
+#define USE_RESOLVE_ON_IPS 1
+#endif
+
+/*
  * Include header files for windows builds before redefining anything.
  * Use this preprocessor block only to include or exclude windows.h,
  * winsock2.h, ws2tcpip.h or winsock.h. Any other windows thing belongs

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -167,7 +167,9 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
   int error;
   char sbuf[12];
   char *sbufptr = NULL;
+#ifndef USE_RESOLVE_ON_IPS
   char addrbuf[128];
+#endif
   int pf;
 #if !defined(CURL_DISABLE_VERBOSE_STRINGS)
   struct SessionHandle *data = conn->data;
@@ -196,11 +198,17 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
   hints.ai_family = pf;
   hints.ai_socktype = conn->socktype;
 
+  /*
+   * The AI_NUMERICHOST must be removed to get synthesized IPv6 address from
+   * an IPv4 address on iOS and Mac OS X.
+   */
+#ifndef USE_RESOLVE_ON_IPS
   if((1 == Curl_inet_pton(AF_INET, hostname, addrbuf)) ||
      (1 == Curl_inet_pton(AF_INET6, hostname, addrbuf))) {
     /* the given address is numerical only, prevent a reverse lookup */
     hints.ai_flags = AI_NUMERICHOST;
   }
+#endif
 
   if(port) {
     snprintf(sbuf, sizeof(sbuf), "%d", port);
@@ -212,6 +220,15 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
     infof(data, "getaddrinfo(3) failed for %s:%d\n", hostname, port);
     return NULL;
   }
+
+#ifdef USE_RESOLVE_ON_IPS
+  /*
+   * Work-arounds the sin6_port is always zero bug on iOS 9.3.2 and
+   * Mac OS X(10.11.5).
+   */
+  if(port)
+    Curl_addrinfo_set_port(res, port);
+#endif
 
   dump_addrinfo(conn, res);
 


### PR DESCRIPTION
Use getaddrinfo to resolve the IPv4 address literal on iOS/Mac OS X.
If the current network interface doesn’t support IPv4, but supports
IPv6, NAT64, and DNS64.

Fixes bug #863