### PR TITLE
Make building successful

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,8 +31,8 @@ XC_OVR_ZZ60
 CURL_OVERRIDE_AUTOCONF
 
 dnl configure script copyright
-AC_COPYRIGHT([Copyright (c) 1998 - 2016 Daniel Stenberg, <daniel@haxx.se>
-This configure script may be copied, distributed and modified under the
+AC_COPYRIGHT([Copyright (c) 1998 - 2016 Daniel Stenberg, <daniel@haxx.se> \
+This configure script may be copied, distributed and modified under the \
 terms of the curl license; see COPYING for more details])
 
 AC_CONFIG_SRCDIR([lib/urldata.h])


### PR DESCRIPTION
avoid  "Makefile:299: *** missing separator.  Stop."