### PR TITLE
wolfSSL pinnedpubkey doesn't work for non-configure builds

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2032,7 +2032,7 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
     /*
      * Enable certificate status verifying.
      */
-    if(!Curl_ssl_cert_status_request()) {
+    if(!Curl_ssl_supports_cert_status_request()) {
       result = CURLE_NOT_BUILT_IN;
       break;
     }
@@ -2063,11 +2063,10 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
     /*
      * Enable TLS false start.
      */
-    if(!Curl_ssl_false_start()) {
+    if(!Curl_ssl_supports_false_start()) {
       result = CURLE_NOT_BUILT_IN;
       break;
     }
-
     data->set.ssl.falsestart = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
   case CURLOPT_CERTINFO:
@@ -2078,16 +2077,16 @@ CURLcode Curl_setopt(struct SessionHandle *data, CURLoption option,
 #endif
     break;
   case CURLOPT_PINNEDPUBLICKEY:
-#ifdef have_curlssl_pinnedpubkey /* only by supported backends */
     /*
      * Set pinned public key for SSL connection.
      * Specify file name of the public key in DER format.
      */
+    if(!Curl_ssl_supports_pinnedpubkey()) {
+      result = CURLE_NOT_BUILT_IN;
+      break;
+    }
     result = setstropt(&data->set.str[STRING_SSL_PINNEDPUBLICKEY],
                        va_arg(param, char *));
-#else
-    result = CURLE_NOT_BUILT_IN;
-#endif
     break;
   case CURLOPT_CAINFO:
     /*

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -101,6 +101,18 @@ and that's a problem since options.h hasn't been included yet. */
 #endif
 #endif
 
+/* KEEP_PEER_CERT is a product of the presence of build time symbol
+   OPENSSL_EXTRA without NO_CERTS, depending on the version. KEEP_PEER_CERT is
+   in wolfSSL's settings.h, and the latter two are build time symbols in
+   options.h. */
+#ifndef KEEP_PEER_CERT
+#if defined(HAVE_CYASSL_GET_PEER_CERTIFICATE) || \
+    defined(HAVE_WOLFSSL_GET_PEER_CERTIFICATE) || \
+    (defined(OPENSSL_EXTRA) && !defined(NO_CERTS))
+#define KEEP_PEER_CERT
+#endif
+#endif
+
 /* HAVE_SUPPORTED_CURVES is wolfSSL's build time symbol for enabling the ECC
    supported curve extension in options.h. Note ECC is enabled separately. */
 #ifndef HAVE_SUPPORTED_CURVES
@@ -903,6 +915,15 @@ void Curl_cyassl_sha256sum(const unsigned char *tmp, /* input */
   InitSha256(&SHA256pw);
   Sha256Update(&SHA256pw, tmp, (word32)tmplen);
   Sha256Final(&SHA256pw, sha256sum);
+}
+
+bool Curl_cyassl_supports_pinnedpubkey(void)
+{
+#ifdef KEEP_PEER_CERT
+  return TRUE;
+#else
+  return FALSE;
+#endif
 }
 
 #endif

--- a/lib/vtls/cyassl.h
+++ b/lib/vtls/cyassl.h
@@ -25,18 +25,6 @@
 
 #ifdef USE_CYASSL
 
-/* KEEP_PEER_CERT is a product of the presence of build time symbol
-   OPENSSL_EXTRA without NO_CERTS, depending on the version. KEEP_PEER_CERT is
-   in wolfSSL's settings.h, and the latter two are build time symbols in
-   options.h. */
-#ifndef KEEP_PEER_CERT
-#if defined(HAVE_CYASSL_GET_PEER_CERTIFICATE) || \
-    defined(HAVE_WOLFSSL_GET_PEER_CERTIFICATE) || \
-    (defined(OPENSSL_EXTRA) && !defined(NO_CERTS))
-#define KEEP_PEER_CERT
-#endif
-#endif
-
 CURLcode Curl_cyassl_connect(struct connectdata *conn, int sockindex);
 bool Curl_cyassl_data_pending(const struct connectdata* conn, int connindex);
 int Curl_cyassl_shutdown(struct connectdata* conn, int sockindex);
@@ -59,16 +47,17 @@ void Curl_cyassl_sha256sum(const unsigned char *tmp, /* input */
                      unsigned char *sha256sum, /* output */
                      size_t unused);
 
-/* Set the API backend definition to Schannel */
+bool Curl_cyassl_supports_pinnedpubkey(void);
+
+/* Set the API backend definition to CyaSSL */
 #define CURL_SSL_BACKEND CURLSSLBACKEND_CYASSL
 
 /* this backend supports CURLOPT_SSL_CTX_* */
 #define have_curlssl_ssl_ctx 1
 
-#ifdef KEEP_PEER_CERT
-/* this backend supports CURLOPT_PINNEDPUBLICKEY */
-#define have_curlssl_pinnedpubkey 1
-#endif
+/* this backend may support CURLOPT_PINNEDPUBLICKEY */
+#define curlssl_supports_pinnedpubkey() \
+  Curl_cyassl_supports_pinnedpubkey()
 
 /* API setup for CyaSSL */
 #define curlssl_init Curl_cyassl_init

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2377,7 +2377,7 @@ void Curl_darwinssl_md5sum(unsigned char *tmp, /* input */
   (void)CC_MD5(tmp, (CC_LONG)tmplen, md5sum);
 }
 
-bool Curl_darwinssl_false_start(void) {
+bool Curl_darwinssl_supports_false_start(void) {
 #if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
   if(SSLSetSessionOption != NULL)
     return TRUE;

--- a/lib/vtls/darwinssl.h
+++ b/lib/vtls/darwinssl.h
@@ -48,10 +48,13 @@ void Curl_darwinssl_md5sum(unsigned char *tmp, /* input */
                            size_t tmplen,
                            unsigned char *md5sum, /* output */
                            size_t md5len);
-bool Curl_darwinssl_false_start(void);
+bool Curl_darwinssl_supports_false_start(void);
 
 /* Set the API backend definition to SecureTransport */
 #define CURL_SSL_BACKEND CURLSSLBACKEND_DARWINSSL
+
+/* this backend may support CURLOPT_SSL_FALSESTART */
+#define curlssl_supports_false_start() Curl_darwinssl_supports_false_start()
 
 /* API setup for SecureTransport */
 #define curlssl_init() (1)
@@ -70,7 +73,6 @@ bool Curl_darwinssl_false_start(void);
 #define curlssl_data_pending(x,y) Curl_darwinssl_data_pending(x, y)
 #define curlssl_random(x,y,z) ((void)x, Curl_darwinssl_random(y,z))
 #define curlssl_md5sum(a,b,c,d) Curl_darwinssl_md5sum(a,b,c,d)
-#define curlssl_false_start() Curl_darwinssl_false_start()
 
 #endif /* USE_DARWINSSL */
 #endif /* HEADER_CURL_DARWINSSL_H */

--- a/lib/vtls/gskit.h
+++ b/lib/vtls/gskit.h
@@ -47,6 +47,9 @@ int Curl_gskit_check_cxn(struct connectdata *cxn);
 /* this backend supports CURLOPT_CERTINFO */
 #define have_curlssl_certinfo 1
 
+/* this backend supports CURLOPT_PINNEDPUBLICKEY */
+#define curlssl_supports_pinnedpubkey() (1)
+
 /* API setup for GSKit */
 #define curlssl_init Curl_gskit_init
 #define curlssl_cleanup Curl_gskit_cleanup

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1619,7 +1619,7 @@ void Curl_gtls_sha256sum(const unsigned char *tmp, /* input */
 #endif
 }
 
-bool Curl_gtls_cert_status_request(void)
+bool Curl_gtls_supports_cert_status_request(void)
 {
 #ifdef HAS_OCSP
   return TRUE;

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -53,7 +53,7 @@ void Curl_gtls_sha256sum(const unsigned char *tmp, /* input */
                       unsigned char *sha256sum, /* output */
                       size_t sha256len);
 
-bool Curl_gtls_cert_status_request(void);
+bool Curl_gtls_supports_cert_status_request(void);
 
 /* Set the API backend definition to GnuTLS */
 #define CURL_SSL_BACKEND CURLSSLBACKEND_GNUTLS
@@ -64,8 +64,12 @@ bool Curl_gtls_cert_status_request(void);
 /* this backend supports CURLOPT_CERTINFO */
 #define have_curlssl_certinfo 1
 
+/* this backend may support CURLOPT_SSL_VERIFYSTATUS */
+#define curlssl_supports_cert_status_request() \
+  Curl_gtls_supports_cert_status_request()
+
 /* this backend supports CURLOPT_PINNEDPUBLICKEY */
-#define have_curlssl_pinnedpubkey 1
+#define curlssl_supports_pinnedpubkey() (1)
 
 /* API setup for GnuTLS */
 #define curlssl_init Curl_gtls_init
@@ -85,7 +89,6 @@ bool Curl_gtls_cert_status_request(void);
 #define curlssl_random(x,y,z) Curl_gtls_random(x,y,z)
 #define curlssl_md5sum(a,b,c,d) Curl_gtls_md5sum(a,b,c,d)
 #define curlssl_sha256sum(a,b,c,d) Curl_gtls_sha256sum(a,b,c,d)
-#define curlssl_cert_status_request() Curl_gtls_cert_status_request()
 
 #endif /* USE_GNUTLS */
 #endif /* HEADER_CURL_GTLS_H */

--- a/lib/vtls/mbedtls.h
+++ b/lib/vtls/mbedtls.h
@@ -50,8 +50,8 @@ void Curl_mbedtls_session_free(void *ptr);
 size_t Curl_mbedtls_version(char *buffer, size_t size);
 int Curl_mbedtls_shutdown(struct connectdata *conn, int sockindex);
 
-/* this backends supports CURLOPT_PINNEDPUBLICKEY */
-#define have_curlssl_pinnedpubkey 1
+/* this backend supports CURLOPT_PINNEDPUBLICKEY */
+#define curlssl_supports_pinnedpubkey() (1)
 
 /* API setup for mbedTLS */
 #define curlssl_init() Curl_mbedtls_init()

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2061,7 +2061,7 @@ void Curl_nss_sha256sum(const unsigned char *tmp, /* input */
   PK11_DestroyContext(SHA256pw, PR_TRUE);
 }
 
-bool Curl_nss_cert_status_request(void)
+bool Curl_nss_supports_cert_status_request(void)
 {
 #ifdef SSL_ENABLE_OCSP_STAPLING
   return TRUE;
@@ -2070,7 +2070,7 @@ bool Curl_nss_cert_status_request(void)
 #endif
 }
 
-bool Curl_nss_false_start(void) {
+bool Curl_nss_supports_false_start(void) {
 #if NSSVERNUM >= 0x030f04 /* 3.15.4 */
   return TRUE;
 #else

--- a/lib/vtls/nssg.h
+++ b/lib/vtls/nssg.h
@@ -61,9 +61,8 @@ void Curl_nss_sha256sum(const unsigned char *tmp, /* input */
                      unsigned char *sha256sum, /* output */
                      size_t sha256len);
 
-bool Curl_nss_cert_status_request(void);
-
-bool Curl_nss_false_start(void);
+bool Curl_nss_supports_cert_status_request(void);
+bool Curl_nss_supports_false_start(void);
 
 /* Set the API backend definition to NSS */
 #define CURL_SSL_BACKEND CURLSSLBACKEND_NSS
@@ -74,8 +73,15 @@ bool Curl_nss_false_start(void);
 /* this backend supports CURLOPT_CERTINFO */
 #define have_curlssl_certinfo 1
 
-/* this backends supports CURLOPT_PINNEDPUBLICKEY */
-#define have_curlssl_pinnedpubkey 1
+/* this backend may support CURLOPT_SSL_VERIFYSTATUS */
+#define curlssl_supports_cert_status_request() \
+  Curl_nss_supports_cert_status_request()
+
+/* this backend may support CURLOPT_SSL_FALSESTART */
+#define curlssl_supports_false_start() Curl_nss_supports_false_start()
+
+/* this backend supports CURLOPT_PINNEDPUBLICKEY */
+#define curlssl_supports_pinnedpubkey() (1)
 
 /* API setup for NSS */
 #define curlssl_init Curl_nss_init
@@ -98,8 +104,6 @@ bool Curl_nss_false_start(void);
 #define curlssl_random(x,y,z) Curl_nss_random(x,y,z)
 #define curlssl_md5sum(a,b,c,d) Curl_nss_md5sum(a,b,c,d)
 #define curlssl_sha256sum(a,b,c,d) Curl_nss_sha256sum(a,b,c,d)
-#define curlssl_cert_status_request() Curl_nss_cert_status_request()
-#define curlssl_false_start() Curl_nss_false_start()
 
 #endif /* USE_NSS */
 #endif /* HEADER_CURL_NSSG_H */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3187,7 +3187,7 @@ void Curl_ossl_sha256sum(const unsigned char *tmp, /* input */
 }
 #endif
 
-bool Curl_ossl_cert_status_request(void)
+bool Curl_ossl_supports_cert_status_request(void)
 {
 #if (OPENSSL_VERSION_NUMBER >= 0x0090808fL) && !defined(OPENSSL_NO_TLSEXT) && \
     !defined(OPENSSL_NO_OCSP)

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -77,7 +77,7 @@ void Curl_ossl_sha256sum(const unsigned char *tmp, /* input */
                       unsigned char *sha256sum /* output */,
                       size_t unused);
 
-bool Curl_ossl_cert_status_request(void);
+bool Curl_ossl_supports_cert_status_request(void);
 
 /* Set the API backend definition to OpenSSL */
 #define CURL_SSL_BACKEND CURLSSLBACKEND_OPENSSL
@@ -91,8 +91,12 @@ bool Curl_ossl_cert_status_request(void);
 /* this backend supports CURLOPT_SSL_CTX_* */
 #define have_curlssl_ssl_ctx 1
 
+/* this backend may support CURLOPT_SSL_VERIFYSTATUS */
+#define curlssl_supports_cert_status_request() \
+  Curl_ossl_supports_cert_status_request()
+
 /* this backend supports CURLOPT_PINNEDPUBLICKEY */
-#define have_curlssl_pinnedpubkey 1
+#define curlssl_supports_pinnedpubkey() (1)
 
 /* API setup for OpenSSL */
 #define curlssl_init Curl_ossl_init
@@ -114,7 +118,6 @@ bool Curl_ossl_cert_status_request(void);
 #if (OPENSSL_VERSION_NUMBER >= 0x0090800fL) && !defined(OPENSSL_NO_SHA256)
 #define curlssl_sha256sum(a,b,c,d) Curl_ossl_sha256sum(a,b,c,d)
 #endif
-#define curlssl_cert_status_request() Curl_ossl_cert_status_request()
 
 #define DEFAULT_CIPHER_SELECTION \
   "ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH"

--- a/lib/vtls/polarssl.h
+++ b/lib/vtls/polarssl.h
@@ -52,8 +52,8 @@ int Curl_polarssl_shutdown(struct connectdata *conn, int sockindex);
 /* this backend supports the CAPATH option */
 #define have_curlssl_ca_path 1
 
-/* this backends supports CURLOPT_PINNEDPUBLICKEY */
-#define have_curlssl_pinnedpubkey 1
+/* this backend supports CURLOPT_PINNEDPUBLICKEY */
+#define curlssl_supports_pinnedpubkey() (1)
 
 /* API setup for PolarSSL */
 #define curlssl_init() Curl_polarssl_init()

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -971,10 +971,10 @@ CURLcode Curl_ssl_md5sum(unsigned char *tmp, /* input */
 /*
  * Check whether the SSL backend supports the status_request extension.
  */
-bool Curl_ssl_cert_status_request(void)
+bool Curl_ssl_supports_cert_status_request(void)
 {
-#ifdef curlssl_cert_status_request
-  return curlssl_cert_status_request();
+#ifdef curlssl_supports_cert_status_request
+  return curlssl_supports_cert_status_request();
 #else
   return FALSE;
 #endif
@@ -983,10 +983,22 @@ bool Curl_ssl_cert_status_request(void)
 /*
  * Check whether the SSL backend supports false start.
  */
-bool Curl_ssl_false_start(void)
+bool Curl_ssl_supports_false_start(void)
 {
-#ifdef curlssl_false_start
-  return curlssl_false_start();
+#ifdef curlssl_supports_false_start
+  return curlssl_supports_false_start();
+#else
+  return FALSE;
+#endif
+}
+
+/*
+ * Check whether the SSL backend supports pinned public keys.
+ */
+bool Curl_ssl_supports_pinnedpubkey(void)
+{
+#ifdef curlssl_supports_pinnedpubkey
+  return curlssl_supports_pinnedpubkey();
 #else
   return FALSE;
 #endif

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -153,9 +153,9 @@ CURLcode Curl_pin_peer_pubkey(struct SessionHandle *data,
                               const char *pinnedpubkey,
                               const unsigned char *pubkey, size_t pubkeylen);
 
-bool Curl_ssl_cert_status_request(void);
-
-bool Curl_ssl_false_start(void);
+bool Curl_ssl_supports_cert_status_request(void);
+bool Curl_ssl_supports_false_start(void);
+bool Curl_ssl_supports_pinnedpubkey(void);
 
 #define SSL_SHUTDOWN_TIMEOUT 10000 /* ms */
 
@@ -183,8 +183,9 @@ bool Curl_ssl_false_start(void);
 #define Curl_ssl_connect_nonblocking(x,y,z) CURLE_NOT_BUILT_IN
 #define Curl_ssl_kill_session(x) Curl_nop_stmt
 #define Curl_ssl_random(x,y,z) ((void)x, CURLE_NOT_BUILT_IN)
-#define Curl_ssl_cert_status_request() FALSE
-#define Curl_ssl_false_start() FALSE
+#define Curl_ssl_supports_cert_status_request() FALSE
+#define Curl_ssl_supports_false_start() FALSE
+#define Curl_ssl_supports_pinnedpubkey() FALSE
 #endif
 
 #endif /* HEADER_CURL_VTLS_H */


### PR DESCRIPTION
### I did this

Built curl 7.49.1 release with wolfSSL 3.9.0 using Visual Studio projects. pinnedpubkey doesn't work:

```
>curld --pinnedpubkey "sha256//xmvvalwaPni4IBbhPzFPPMX6JbHlKqua257FmJsWWto=" https://example.com
curl: (4) A requested feature, protocol or option was not found built-in in this libcurl due to a build-time decision.
```
### I expected the following

I expected it would connect since my wolfSSL has `KEEP_PEER_CERT`, which is what is needed by pinnedpubkey at build time. It looks like commit 283babf broke this, since it moved the KEEP_PEER_CERT check from cyassl.c to cyassl.h. Since the latter doesn't include cyassl's options.h KEEP_PEER_CERT isn't enabled.

options.h isn't always available and the includes must be in a certain order for compatibility (see [here](https://github.com/curl/curl/blob/curl-7_49_1/lib/vtls/cyassl.c#L33-L45)) so I don't think it will be as simple as including options.h in cyassl.h.
### curl/libcurl version

```
curl 7.49.1 (i386-pc-win32) libcurl/7.49.1 wolfSSL/3.9.0 nghttp2/1.11.1
Protocols: dict file ftp ftps gopher http https imap imaps ldap pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS Debug Largefile NTLM SSL HTTP2
```
### operating system

Windows 7 x64 Enterprise
