### PR TITLE
Appveyor: Updates for options - CURL_STATICLIB/BUILD_TESTING

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 7.47.0.{build}
+version: 7.50.0.{build}
 
 environment:
     matrix:
@@ -6,30 +6,60 @@ environment:
         BDIR: msvc2012
         PRJ_CFG: Release
         OPENSSL: OFF
+        TESTING: OFF
+        STATICLIB: OFF
       - PRJ_GEN: "Visual Studio 12 2013 Win64"
         BDIR: msvc2013
         PRJ_CFG: Release
         OPENSSL: OFF
+        TESTING: OFF
+        STATICLIB: OFF
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         BDIR: msvc2015
         PRJ_CFG: Release
         OPENSSL: OFF
+        TESTING: OFF
+        STATICLIB: OFF
       - PRJ_GEN: "Visual Studio 11 2012 Win64"
         BDIR: msvc2012
         PRJ_CFG: Release
         OPENSSL: ON
+        TESTING: OFF
+        STATICLIB: OFF
       - PRJ_GEN: "Visual Studio 12 2013 Win64"
         BDIR: msvc2013
         PRJ_CFG: Release
         OPENSSL: ON
+        TESTING: OFF
+        STATICLIB: OFF
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         BDIR: msvc2015
         PRJ_CFG: Release
         OPENSSL: ON
+        TESTING: OFF
+        STATICLIB: OFF
+      - PRJ_GEN: "Visual Studio 11 2012 Win64"
+        BDIR: msvc2012
+        PRJ_CFG: Release
+        OPENSSL: OFF
+        TESTING: ON
+        STATICLIB: ON
+      - PRJ_GEN: "Visual Studio 12 2013 Win64"
+        BDIR: msvc2013
+        PRJ_CFG: Release
+        OPENSSL: OFF
+        TESTING: ON
+        STATICLIB: ON
+      - PRJ_GEN: "Visual Studio 14 2015 Win64"
+        BDIR: msvc2015
+        PRJ_CFG: Release
+        OPENSSL: OFF
+        TESTING: ON
+        STATICLIB: ON
 
 
 build_script:
     - mkdir build.%BDIR%
     - cd build.%BDIR%
-    - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL%
+    - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL% -DCURL_STATICLIB=%STATICLIB% -DBUILD_TESTING=%TESTING%
     - cmake --build . --config %PRJ_CFG% --clean-first


### PR DESCRIPTION
Fix for Appveyor builds.

Unit Tests enabled in #882 required libcurl as static build, because Windows DLL does not export some internal functions like ```Curl_hash_....```