### PR TITLE
acinclude.m4: improve autodetection of CA bundle on FreeBSD

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2565,8 +2565,8 @@ dnl regarding the paths this will scan:
 dnl /etc/ssl/certs/ca-certificates.crt Debian systems
 dnl /etc/pki/tls/certs/ca-bundle.crt Redhat and Mandriva
 dnl /usr/share/ssl/certs/ca-bundle.crt old(er) Redhat
-dnl /usr/local/share/certs/ca-root.crt FreeBSD
-dnl /etc/ssl/cert.pem OpenBSD
+dnl /usr/local/share/certs/ca-root-nss.crt FreeBSD
+dnl /etc/ssl/cert.pem OpenBSD, FreeBSD (symlink)
 dnl /etc/ssl/certs/ (ca path) SUSE
 
 AC_DEFUN([CURL_CHECK_CA_BUNDLE], [
@@ -2640,7 +2640,7 @@ AC_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
         for a in /etc/ssl/certs/ca-certificates.crt \
                  /etc/pki/tls/certs/ca-bundle.crt \
                  /usr/share/ssl/certs/ca-bundle.crt \
-                 /usr/local/share/certs/ca-root.crt \
+                 /usr/local/share/certs/ca-root-nss.crt \
                  /etc/ssl/cert.pem \
                  "$cac"; do
           if test -f "$a"; then


### PR DESCRIPTION
The FreeBSD Port security/ca_root_nss installs the Mozilla NSS CA bundle to
/usr/local/share/certs/ca-root-nss.crt. Use this bundle in the discovery process.

`configure` output:

    configure: Configured to build curl/libcurl:
    
      curl version:     7.50.0-DEV
      Host setup:       i386-unknown-freebsd9.3
      Install prefix:   /net/home/osipovmi/freebsd-ca-bundle
      Compiler:         gcc
      SSL support:      enabled (OpenSSL)
      SSH support:      enabled (libSSH2)
      zlib support:     enabled
      GSS-API support:  no      (--with-gssapi)
      TLS-SRP support:  enabled
      resolver:         default (--enable-ares / --enable-threaded-resolver)
      IPv6 support:     no      (--enable-ipv6)
      Unix sockets support: enabled
      IDN support:      enabled
      Build libcurl:    Shared=yes, Static=yes
      Built-in manual:  enabled
      --libcurl option: enabled (--disable-libcurl-option)
      Verbose errors:   enabled (--disable-verbose)
      SSPI support:     no      (--enable-sspi)
      ca cert bundle:   /usr/local/share/certs/ca-root-nss.crt
      ca cert path:     no
      ca fallback:      no
      LDAP support:     enabled (OpenLDAP)
      LDAPS support:    enabled
      RTSP support:     enabled
      RTMP support:     no      (--with-librtmp)
      metalink support: no      (--with-libmetalink)
      PSL support:      no      (libpsl not found)
      HTTP2 support:    disabled (--with-nghttp2)
      Protocols:        DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SCP SFTP SMB SMBS SMTP SMTPS TELNET TFTP

`curl-config` output:

    $ ~/freebsd-ca-bundle/bin/curl-config --ca
    /usr/local/share/certs/ca-root-nss.crt

Sample request:

    $ ~/freebsd-ca-bundle/bin/curl -I --verbose https://<server>
    *   Trying <IP>...
    * Connected to <server> (<IP>) port 443 (#0)
    * ALPN, offering http/1.1
    * Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
    * successfully set certificate verify locations:
    *   CAfile: /usr/local/share/certs/ca-root-nss.crt
      CApath: none
    * TLSv1.2 (OUT), TLS header, Certificate Status (22):
    * TLSv1.2 (OUT), TLS handshake, Client hello (1):
    * TLSv1.2 (IN), TLS handshake, Server hello (2):
    * TLSv1.2 (IN), TLS handshake, Certificate (11):
    * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
    * TLSv1.2 (IN), TLS handshake, Server finished (14):
    * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
    * TLSv1.2 (OUT), TLS change cipher, Client hello (1):
    * TLSv1.2 (OUT), TLS handshake, Finished (20):
    * TLSv1.2 (IN), TLS change cipher, Client hello (1):
    * TLSv1.2 (IN), TLS handshake, Finished (20):
    * SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
    * ALPN, server did not agree to a protocol
    * Server certificate:
    *  subject: OU=...; C=DE; CN=<server>
    *  SSL certificate verify ok.