### PR TITLE
Two memory leaks and one size check

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -227,15 +227,19 @@ static CURLcode file_connect(struct connectdata *conn, bool *done)
   for(i=0; i < real_path_len; ++i)
     if(actual_path[i] == '/')
       actual_path[i] = '\\';
-    else if(!actual_path[i]) /* binary zero */
+    else if(!actual_path[i]) {/* binary zero */
+      Curl_safefree(real_path);
       return CURLE_URL_MALFORMAT;
+    }
 
   fd = open_readonly(actual_path, O_RDONLY|O_BINARY);
   file->path = actual_path;
 #else
-  if(memchr(real_path, 0, real_path_len))
+  if(memchr(real_path, 0, real_path_len)) {
     /* binary zeroes indicate foul play */
+    Curl_safefree(real_path);
     return CURLE_URL_MALFORMAT;
+  }
 
   fd = open_readonly(real_path, O_RDONLY);
   file->path = real_path;

--- a/lib/pipeline.c
+++ b/lib/pipeline.c
@@ -299,11 +299,16 @@ CURLMcode Curl_pipeline_set_server_blacklist(char **servers,
       char *server_name;
 
       server_name = strdup(*servers);
-      if(!server_name)
+      if(!server_name) {
+        Curl_llist_destroy(new_list, NULL);
         return CURLM_OUT_OF_MEMORY;
+      }
 
-      if(!Curl_llist_insert_next(new_list, new_list->tail, server_name))
+      if(!Curl_llist_insert_next(new_list, new_list->tail, server_name)) {
+        Curl_llist_destroy(new_list, NULL);
+        Curl_safefree(server_name);
         return CURLM_OUT_OF_MEMORY;
+      }
 
       servers++;
     }

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -34,6 +34,7 @@
 #include "curl_sspi.h"
 #include "curl_multibyte.h"
 #include "warnless.h"
+#include "strdup.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -96,10 +97,9 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
 
   /* prepare service name */
   if(strchr(service, '/')) {
-    service_name = malloc(strlen(service));
+    service_name = strdup(service);
     if(!service_name)
       return CURLE_OUT_OF_MEMORY;
-    memcpy(service_name, service, strlen(service));
   }
   else {
     service_name = malloc(strlen(service) + strlen(conn->proxy.name) + 2);


### PR DESCRIPTION
My colleagues have run static analysis on curl code base.

Two memory leaks we found.   One in function lib/file.c:fileconnect where memory pointed to by variable real_path is never returned when returning CURLE_URL_MALFORMAT from the function.  The other is in function lib/pipeline.c:Curl_pipeline_set_server_blacklist where both new_list and server_name have potential of leaking memory in case CURLM_OUT_OF_MEMORY is returned from the function.

The second issue appears to be in function lib/sock_sspi.c:Curl_SOCKS5_gssapi_negotiate where service_name is allocated via malloc(strlen(service)) while I believe the resulting string should be null-terminated.
