### PR TITLE
Update CURLMOPT_SOCKETFUNCTION.3

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
@@ -54,7 +54,7 @@ Wait for incoming data. For the socket to become readable.
 .IP CURL_POLL_OUT
 Wait for outgoing data. For the socket to become writable.
 .IP CURL_POLL_INOUT
-Wait for incoming abd outgoing data. For the socket to become readable or
+Wait for incoming and outgoing data. For the socket to become readable or
 writable.
 .IP CURL_POLL_REMOVE
 The specified socket/file descriptor is no longer used by libcurl.


### PR DESCRIPTION
Documentation spelling correction:

-fixed abd to and