### PR TITLE
Check if IPv6 works during global init.

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -105,6 +105,9 @@ int Curl_resolver_global_init(void)
     return CURLE_FAILED_INIT;
   }
 #endif
+#ifdef ENABLE_IPV6 /* CURLRES_IPV6 */
+  Curl_ipv6works();
+#endif
   return CURLE_OK;
 }
 

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -105,9 +105,6 @@ int Curl_resolver_global_init(void)
     return CURLE_FAILED_INIT;
   }
 #endif
-#ifdef ENABLE_IPV6 /* CURLRES_IPV6 */
-  Curl_ipv6works();
-#endif
   return CURLE_OK;
 }
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -271,6 +271,10 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     return CURLE_FAILED_INIT;
   }
 
+#ifdef ENABLE_IPV6
+  Curl_ipv6works();
+#endif
+
 #if defined(USE_LIBSSH2) && defined(HAVE_LIBSSH2_INIT)
   if(libssh2_init(0)) {
     DEBUGF(fprintf(stderr, "Error: libssh2_init failed\n"));


### PR DESCRIPTION
re #915.  I added it to the resolver init, since that's the only user of this.