### PR TITLE
ask user for password for PKCS12 files

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -465,7 +465,8 @@ int cert_stuff(struct connectdata *conn,
 
       if(!data->set.str[STRING_KEY_PASSWD]) {
         /* See if an empty password will do */
-        if(!(PKCS12_verify_mac(p12, "", 0) || PKCS12_verify_mac(p12, NULL, 0))) {
+        if(!(PKCS12_verify_mac(p12, "", 0) ||
+             PKCS12_verify_mac(p12, NULL, 0))) {
           /* ??? EVP_set_pw_prompt("Enter PKCS12 pass phrase:"); */
           PEM_def_callback(pass, PEM_BUFSIZE, 0, NULL);
         }


### PR DESCRIPTION
Signed-off-by: Dmitry Bakshaev dab1818@gmail.com

only option to specify pkcs12 password is CURLOPT_SSLCERTPASSWD.
or from command-line: ... --cert-type P12 --cert my.p12:secret.
if "secret" is not specified, curl not asks password and throws error
"could not parse PKCS12 file, check password, OpenSSL error error:23076071:PKCS12 routines:PKCS12_parse:mac verify failure".
