### PR TITLE
vauth: add digest authentication support with SSPI when stale=true

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -314,9 +314,10 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 {
   size_t chlglen = strlen(chlg);
 
-  /* We had an input token before and we got another one now. This means we
-     provided bad credentials in the previous request. */
-  if(digest->input_token)
+  /* We had an input token before and we got another one now without
+     'stale=true'. This means we provided bad credentials in the previous
+     request. */
+  if(digest->input_token && !strstr(chlg, "stale=true"))
     return CURLE_BAD_CONTENT_ENCODING;
 
   /* Simply store the challenge for use later */


### PR DESCRIPTION
Bug: https://github.com/curl/curl/issues/928
Closes #928