### PR TITLE
win32: fix a potential memory leak in Curl_load_library

### DIFF
--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -281,8 +281,8 @@ HMODULE Curl_load_library(LPCTSTR filename)
           pLoadLibraryEx(path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH) :
           LoadLibrary(path);
 
-        free(path);
       }
+      free(path);
     }
   }
 


### PR DESCRIPTION
If a call to GetSystemDirectory fails, the `path` pointer that was
previously allocated would be leaked. This makes sure that `path` is
always freed.