### PR TITLE
travis:  re-install libtool for OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: c
 
 install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update > /dev/null; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall -s libtool > /dev/null; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl libidn rtmpdump libssh2 c-ares libmetalink libressl nghttp2; fi
 
 before_script:


### PR DESCRIPTION
Fix for #934

Same as https://github.com/neovim/homebrew-neovim/issues/167

Related to broken brew.

Solution - reinstall libtool