### PR TITLE
travis: removed option to rebuild autotool from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: c
 
 install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update > /dev/null; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall -s libtool > /dev/null; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall libtool > /dev/null; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl libidn rtmpdump libssh2 c-ares libmetalink libressl nghttp2; fi
 
 before_script:


### PR DESCRIPTION
Improvement - as per discussion from #934 removed ```-s``` options from reinstall which re-builds libtool from source.