### PR TITLE
Avoid setting redundant CFLAGS to compile commands

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -288,8 +288,6 @@ CURL_CC         = $(CC)
 CURL_RC_FLAGS = /i../include /dDEBUGBUILD=0 /Fo $@ $(CURL_SRC_DIR)\curl.rc
 !ENDIF
 
-CURL_CC = $(CURL_CC) $(CURL_CFLAGS)
-
 !IF "$(AS_DLL)" == "true"
 
 LNK       = $(LNKDLL) $(WIN_LIBS) /out:$(LIB_DIROBJ)\$(TARGET)


### PR DESCRIPTION
In the 5 locations where `$(CURL_CC)` is used, `$(CURL_CFLAGS)` is always appended, so before this, all arguments in `CURL_CFLAGS` have been added twice.

Confirm the following snipped from the build log (indent added):

```
Copying libs...
    cl.exe /O2 /DNDEBUG /MD /DCURL_STATICLIB↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /Zm200 /Fo"..\builds\libcurl-vc14-x86-release-static-ipv6-sspi-winssl-obj-curl\tool_hugehelp.obj"↩
        ..\src\tool_hugehelp.c
tool_hugehelp.c
    cl.exe /O2 /DNDEBUG /MD /DCURL_STATICLIB↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /Fo"..\builds\libcurl-vc14-x86-release-static-ipv6-sspi-winssl-obj-curl\nonblock.obj"↩
        ../lib/nonblock.c
nonblock.c
    cl.exe /O2 /DNDEBUG /MD /DCURL_STATICLIB↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /Fo"..\builds\libcurl-vc14-x86-release-static-ipv6-sspi-winssl-obj-curl\rawstr.obj"↩
        ../lib/rawstr.c
rawstr.c
    cl.exe /O2 /DNDEBUG /MD /DCURL_STATICLIB↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /Fo"..\builds\libcurl-vc14-x86-release-static-ipv6-sspi-winssl-obj-curl\strtoofft.obj"↩
        ../lib/strtoofft.c
strtoofft.c
    cl.exe /O2 /DNDEBUG /MD /DCURL_STATICLIB↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /I../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c↩
        /Fo"..\builds\libcurl-vc14-x86-release-static-ipv6-sspi-winssl-obj-curl\warnless.obj"↩
        ../lib/warnless.c
warnless.c
```