### PR TITLE
Winbuild

### DIFF
--- a/lib/Makefile.vc6
+++ b/lib/Makefile.vc6
@@ -51,6 +51,7 @@
 # ----------------------------------------------
 # Verify that current subdir is libcurl's 'lib'
 # ----------------------------------------------
+!MESSAGE Use of this make system is deprecated in favour of the one in winbuild.
 
 !IF ! EXIST(.\curl_addrinfo.c)
 !  MESSAGE Can not process this makefile from outside of libcurl's 'lib' subdirectory.

--- a/src/Makefile.vc6
+++ b/src/Makefile.vc6
@@ -35,6 +35,7 @@
 ##
 #
 #############################################################
+!MESSAGE Use of this make system is deprecated in favour of the one in winbuild.
 
 PROGRAM_NAME = curl.exe
 

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -63,11 +63,11 @@ where <options> is one or many of:
                                  Defaults to sibbling directory deps: ../deps
                                  Libraries can be fetched at http://windows.php.net/downloads/php-sdk/deps/
                                  Uncompress them into the deps folder.
-  WITH_SSL=<dll or static>     - Enable OpenSSL support, DLL or static
-  WITH_MBEDTLS=<dll or static> - Enable mbedTLS support, DLL or static
-  WITH_CARES=<dll or static>   - Enable c-ares support, DLL or static
-  WITH_ZLIB=<dll or static>    - Enable zlib support, DLL or static
-  WITH_SSH2=<dll or static>    - Enable libSSH2 support, DLL or static
+  WITH_SSL=<dll or static>     - Enable OpenSSL support, dll or static
+  WITH_MBEDTLS=<dll or static> - Enable mbedTLS support, dll or static
+  WITH_CARES=<dll or static>   - Enable c-ares support, dll or static
+  WITH_ZLIB=<dll or static>    - Enable zlib support, dll or static
+  WITH_SSH2=<dll or static>    - Enable libSSH2 support, dll or static
   ENABLE_SSPI=<yes or no>      - Enable SSPI support, defaults to yes
   ENABLE_IPV6=<yes or no>      - Enable IPv6, defaults to yes
   ENABLE_IDN=<yes or no>       - Enable use of Windows IDN APIs, defaults to yes

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -21,7 +21,7 @@ Building with Visual C++, prerequisites
 
    If you wish to support zlib, openssl, c-ares, ssh2, you will have to download
    them separately and copy them to the deps directory as shown below:
-   
+
    somedirectory\
     |_curl-src
     | |_winbuild
@@ -47,12 +47,12 @@ Open a Visual Studio Command prompt or the SDK CMD shell.
      Everything is already pre-configured by calling one of the command
      prompt.
 
-Once you are in the console, go to the winbuild directory in the Curl 
+Once you are in the console, go to the winbuild directory in the Curl
 sources:
     cd curl-src\winbuild
 
 Then you can call nmake /f Makefile.vc with the desired options (see below).
-The builds will be in the top src directory, builds\ directory, in 
+The builds will be in the top src directory, builds\ directory, in
 a directory named using the options given to the nmake call.
 
 nmake /f Makefile.vc mode=<static or dll> <options>

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -232,3 +232,10 @@ $(MODE):
 copy_from_lib:
 	echo copying .c...
 	FOR %%i IN ($(CURLX_CFILES:/=\)) DO copy %%i ..\src\
+
+clean:
+	@IF EXIST ..\include\curl\curlbuild.h ( \
+	   CALL ..\buildconf.bat -clean \
+	)
+	del CURL_OBJS.inc LIBCURL_OBJS.inc vc100.idb
+	rd/s/q ..\builds

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -107,11 +107,15 @@ SSL     = dll
 !ELSEIF "$(WITH_SSL)"=="static"
 USE_SSL = true
 SSL     = static
+!ELSEIF "$(WITH_SSL)"!=""
+!ERROR WITH_SSL=dll or WITH_SSL=static
 !ENDIF
 
 !IF "$(WITH_MBEDTLS)"=="dll" || "$(WITH_MBEDTLS)"=="static"
 USE_MBEDTLS = true
 MBEDTLS     = $(WITH_MBEDTLS)
+!ELSEIF "$(WITH_MBEDTLS)"!=""
+!ERROR WITH_MBEDTLS=dll or WITH_MBEDTLS=static
 !ENDIF
 
 !IF ( "$(USE_SSL)"=="true" && "$(USE_WINSSL)"=="true" ) \
@@ -126,6 +130,8 @@ CARES     = dll
 !ELSEIF "$(WITH_CARES)"=="static"
 USE_CARES = true
 CARES     = static
+!ELSEIF "$(WITH_CARES)"!=""
+!ERROR WITH_CARES=dll or WITH_CARES=static
 !ENDIF
 
 !IF "$(WITH_ZLIB)"=="dll"
@@ -134,6 +140,8 @@ ZLIB     = dll
 !ELSEIF "$(WITH_ZLIB)"=="static"
 USE_ZLIB = true
 ZLIB     = static
+!ELSEIF "$(WITH_ZLIB)"!=""
+!ERROR WITH_ZLIB=dll or WITH_ZLIB=static
 !ENDIF
 
 !IF "$(WITH_SSH2)"=="dll"
@@ -142,6 +150,8 @@ SSH2     = dll
 !ELSEIF "$(WITH_SSH2)"=="static"
 USE_SSH2 = true
 SSH2     = static
+!ELSEIF "$(WITH_SSH2)"!=""
+!ERROR WITH_SSH2=dll or WITH_SSH2=static
 !ENDIF
 
 CONFIG_NAME_LIB = $(CONFIG_NAME_LIB)-vc$(VC)-$(MACHINE)


### PR DESCRIPTION
A handful of minor fixes to the new "winbuild" stream.  The most obvious was that I got tripped up by specifying WITH_SSL=DLL, not WITH_SSL=dll.

Another minor nit was the inability to clean from the makefile.  What I've put is slightly ropy since it still needs MODE=whatever specified but it works and is less frightening that "git clean -f -x -d".  Maybe a MODE=clean is the better solution.
