### PR TITLE
configure.ac: add zlib search with pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -895,6 +895,15 @@ else
     dnl check for the lib first without setting any new path, since many
     dnl people have it in the default path
 
+
+    PKG_CHECK_MODULES(ZLIB, zlib, 
+        [ LIBS="${ZLIB_LIBS} $LIBS"
+          CPPFLAGS="${ZLIB_CFLAGS} $CPPFLAGS"
+        ],
+        [
+        ])
+
+
     AC_CHECK_LIB(z, inflateEnd,
                    dnl libz found, set the variable
                    [HAVE_LIBZ="1"


### PR DESCRIPTION
zlib provides pkg-config file zlib.pc. CURL tries to search zlib in number of places, but not using pkg-config. This patch adds search of zlib with pkg-config so you do not need to define extra configure parameter --with-zlib=<path-to-zlib>