### PR TITLE
Fix WARNING: OpenSSL headers and library versions do not match

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -32,8 +32,8 @@ dnl actually be a single double-quoted string concatenating all them.
 AC_DEFUN([CURL_CHECK_DEF], [
   AC_REQUIRE([CURL_CPP_P])dnl
   OLDCPPFLAGS=$CPPFLAGS
-  # CPPPFLAGS comes from CURL_CPP_P
-  CPPFLAGS="$CPPPFLAGS"
+  # CPPPFLAG comes from CURL_CPP_P
+  CPPFLAGS="$CPPFLAGS $CPPPFLAG"
   AS_VAR_PUSHDEF([ac_HaveDef], [curl_cv_have_def_$1])dnl
   AS_VAR_PUSHDEF([ac_Def], [curl_cv_def_$1])dnl
   if test -z "$SED"; then
@@ -3187,12 +3187,15 @@ TEST EINVAL TEST
     if test "x$cpp_p" = "xno"; then
       AC_MSG_WARN([failed to figure out cpp -P alternative])
       # without -P
-      CPPPFLAGS=$OLDCPPFLAGS
+      CPPPFLAG=""
     else
       # with -P
-      CPPPFLAGS=$CPPFLAGS
+      CPPPFLAG="-P"
     fi
     dnl restore CPPFLAGS
     CPPFLAGS=$OLDCPPFLAGS
+  else
+    # without -P
+    CPPPFLAG=""
   fi
 ])


### PR DESCRIPTION
I noticed that when I specified an OpenSSL dir with `--with-ssl`, the configure script would still find the OpenSSL library version in the system headers, not in my specified library:

```
checking for OpenSSL headers version... 1.0.1 - 0x1000105fL
checking for OpenSSL library version... 1.0.2
checking for OpenSSL headers and library versions matching... no
configure: WARNING: OpenSSL headers and library versions do not match.
```

I looked through config.log and found that the headers check, which is done with the preprocessor (`gcc -E`), was not using the include directories in CPPFLAGS:

```
configure:22624: checking for OpenSSL headers version
configure:22654: gcc -E  conftest.c
configure:22654: $? = 0
configure:22715: result: 1.0.1 - 0x1000105fL
```

Here is a fix. I've changed the code that defines `CPPPFLAGS`. Previously, `CPPPFLAGS` would contain the contents of `CPPFLAGS` and potentially an added `-P`. Now, there is a variable `CPPPFLAG` that can either be empty or `-P`. This is so `-P` can be appended to the current value of `CPPFLAGS`, not whatever `CPPFLAGS` was when `CURL_CPP_P` was run.

My new output:
```
checking for OpenSSL headers version... 1.0.2 - 0x1000208fL
checking for OpenSSL library version... 1.0.2
checking for OpenSSL headers and library versions matching... yes
```

EDIT: Made an attempt at a proper fix.
