### PR TITLE
Memory leak in case *outlen is zero

### DIFF
--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -265,8 +265,10 @@ CURLcode Curl_auth_create_spnego_message(struct Curl_easy *data,
   if(result)
     return result;
 
-  if(!*outptr || !*outlen)
+  if(!*outptr || !*outlen) {
+    free(*outptr);
     return CURLE_REMOTE_ACCESS_DENIED;
+  }
 
   return CURLE_OK;
 }


### PR DESCRIPTION
This was found during static analysis.  In case of memory being allocated by Curl_base64_encode, but output length being zero, the memory pointed to by *outptr is never freed.