### PR TITLE
ftp: fix wrong poll on the secondary socket

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -911,7 +911,7 @@ static int ftp_domore_getsock(struct connectdata *conn, curl_socket_t *socks,
     }
     else {
       socks[1] = conn->sock[SECONDARYSOCKET];
-      bits |= GETSOCK_WRITESOCK(1);
+      bits |= GETSOCK_WRITESOCK(1) | GETSOCK_READSOCK(1);
     }
 
     return bits;


### PR DESCRIPTION
When we're uploading using FTP and the server issues a tiny pause
between opening the connection to the client's secondary socket, the
client's initial poll() times out, which leads to second poll() which
does not wait for POLLIN on the secondary socket. So that poll() also
has to time out, creating a long (200ms) pause.

This patch adds the correct flag to the secondary socket, making the
second poll() correctly wait for the connection there too.

Signed-off-by: Ales Novak <alnovak@suse.cz>