### PR TITLE
nss: work around race condition in PK11_FindSlotByName

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -360,7 +360,12 @@ static CURLcode nss_create_object(struct ssl_connect_data *ssl,
   if(!slot_name)
     return CURLE_OUT_OF_MEMORY;
 
+  /* Work around race condition in nssSlot_IsTokenPresent() causing spurious
+   * SEC_ERROR_NO_TOKEN. For more details, go to
+   * <https://bugzilla.mozilla.org/show_bug.cgi?id=1297397>. */
+  PR_Lock(nss_initlock);
   slot = PK11_FindSlotByName(slot_name);
+  PR_Unlock(nss_initlock);
   free(slot_name);
   if(!slot)
     return result;


### PR DESCRIPTION
Serialise the call to PK11_FindSlotByName in nss_create_object to avoid
spurious errors in a multi-threaded environment. The underlying cause
is a race condition in nssSlot_IsTokenPresent.

There are other paths into nssSlot_IsTokenPresent which may potentially
have the same problem, e.g. other calls to PK11_FindSlotByName, but this
is one path for which we have a test case.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1297397