### PR TITLE
Darwinssl: Test for errSecSuccess in PKCS12 import rather than noErr

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -955,7 +955,7 @@ static OSStatus CopyIdentityFromPKCS12File(const char *cPath,
 
     /* Here we go: */
     status = SecPKCS12Import(pkcs_data, options, &items);
-    if(status == noErr && items && CFArrayGetCount(items)) {
+    if(status == errSecSuccess && items && CFArrayGetCount(items)) {
       CFDictionaryRef identity_and_trust = CFArrayGetValueAtIndex(items, 0L);
       const void *temp_identity = CFDictionaryGetValue(identity_and_trust,
         kSecImportItemIdentity);


### PR DESCRIPTION
Small nitpick: while `noErr` and `errSecSuccess` are defined as the same value, the API documentation states that `SecPKCS12Import()` returns `errSecSuccess` if there were no errors in importing. Ensure that a future change of the defined value doesn't break (however unlikely) and be consistent with the API docs.

https://developer.apple.com/reference/security/1396915-secpkcs12import