### PR TITLE
Docs: Fix link to CONTRIBUTE document in Github contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Join the community
 
  2. Subscribe to the suitable [mailing lists](https://curl.haxx.se/mail/)
 
-Read [CONTRIBUTE](../docs/CONTRIBUTE)
+Read [CONTRIBUTE](../docs/CONTRIBUTE.md)
 ---------------------------------------
 
 Send your suggestions using one of these methods:


### PR DESCRIPTION
The current CONTRIBUTE link yields a 404 due to missing fileformat ending (.md)