### PR TITLE
openssl: fix CURLINFO_SSL_VERIFYRESULT

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2186,7 +2186,8 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
          (reason == SSL_R_CERTIFICATE_VERIFY_FAILED)) {
         result = CURLE_SSL_CACERT;
 
-        lerr = SSL_get_verify_result(connssl->handle);
+        lerr = data->set.ssl.certverifyresult =
+          SSL_get_verify_result(connssl->handle);
         if(lerr != X509_V_OK) {
           snprintf(error_buffer, sizeof(error_buffer),
                    "SSL certificate problem: %s",


### PR DESCRIPTION
CURLINFO_SSL_VERIFYRESULT does not get the certificate verification
result when SSL_connect fails because of a certificate verification
error.

This fix saves the result of SSL_get_verify_result so that it is
returned by CURLINFO_SSL_VERIFYRESULT.