### PR TITLE
Avoid sending illegal host name over SMTP when the local host name contains umlaut

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1541,8 +1541,16 @@ static CURLcode smtp_parse_url_path(struct connectdata *conn)
 
   /* Calculate the path if necessary */
   if(!*path) {
-    if(!Curl_gethostname(localhost, sizeof(localhost)))
+    if(!Curl_gethostname(localhost, sizeof(localhost))) {
+      /* Replace non printable US-ASCII excl. "[", "\", "]" chars with '?'.
+         See rfc5321#section-4.1.1.1 and rfc5321#section-4.1.3 */
+      char *p;
+      for(p = localhost; *p; p++)
+        if(*p < 33 || *p > 126 || (*p > 90 && *p < 94))
+          *p = '?';
+
       path = localhost;
+    }
     else
       path = "localhost";
   }

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1545,8 +1545,8 @@ static CURLcode smtp_parse_url_path(struct connectdata *conn)
       /* Sanitize the name, replace invalid chars with '_' */
       char *p;
       for(p = localhost; *p; p++)
-        if( !(*p >= 'a' && *p <= 'z') && !(*p >= 'A' && *p <= 'Z') &&
-            !(*p >= '0' && *p <= '9') && *p != '-' && *p != '_')
+        if(!(*p >= 'a' && *p <= 'z') && !(*p >= 'A' && *p <= 'Z') &&
+           !(*p >= '0' && *p <= '9') && *p != '-' && *p != '_')
           *p = '_';
 
       path = localhost;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1542,12 +1542,12 @@ static CURLcode smtp_parse_url_path(struct connectdata *conn)
   /* Calculate the path if necessary */
   if(!*path) {
     if(!Curl_gethostname(localhost, sizeof(localhost))) {
-      /* Replace non printable US-ASCII excl. "[", "\", "]" chars with '?'.
-         See rfc5321#section-4.1.1.1 and rfc5321#section-4.1.3 */
+      /* Sanitize the name, replace invalid chars with '_' */
       char *p;
       for(p = localhost; *p; p++)
-        if(*p < 33 || *p > 126 || (*p > 90 && *p < 94))
-          *p = '?';
+        if( !(*p >= 'a' && *p <= 'z') && !(*p >= 'A' && *p <= 'Z') &&
+            !(*p >= '0' && *p <= '9') && *p != '-' && *p != '_')
+          *p = '_';
 
       path = localhost;
     }


### PR DESCRIPTION
Fix issue #999 - SMTP connection refused, if the local host name contains umlaute

Any non printable US-ASCII excl. "[", "\", "]" chars in local host name are replaced with '?'.