### PR TITLE
Only try to call mbedtls_md4 if it's enabled

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -634,11 +634,17 @@ int netware_init(void);
 /* Single point where USE_NTLM definition might be defined */
 #if !defined(CURL_DISABLE_NTLM) && !defined(CURL_DISABLE_CRYPTO_AUTH)
 #if defined(USE_OPENSSL) || defined(USE_WINDOWS_SSPI) || \
-    defined(USE_GNUTLS) || defined(USE_MBEDTLS) || defined(USE_NSS) || \
-    defined(USE_DARWINSSL) || defined(USE_OS400CRYPTO) || \
-    defined(USE_WIN32_CRYPTO)
+    defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_DARWINSSL) || \
+    defined(USE_OS400CRYPTO) || defined(USE_WIN32_CRYPTO)
 
 #define USE_NTLM
+
+#elif defined(USE_MBEDTLS)
+#  include <mbedtls/md4.h>
+#  if defined(MBEDTLS_MD4_C)
+#define USE_NTLM
+#  endif
+
 #endif
 #endif
 


### PR DESCRIPTION
otherwise this is an undefined reference in the default build of mbedtls
https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.3.0/include/mbedtls/config.h#L1901-L1911