### PR TITLE
Remove dead code in darwinssl for 10.6 support

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -920,7 +920,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
 #if CURL_SUPPORT_MAC_10_6
     /* On Leopard and Snow Leopard, fall back to SecKeychainSearch. */
     status = CopyIdentityWithLabelOldSchool(label, out_cert_and_key);
-#endif /* CURL_SUPPORT_MAC_10_7 */
+#endif /* CURL_SUPPORT_MAC_10_6 */
   }
 #elif CURL_SUPPORT_MAC_10_6
   /* For developers building on older cats, we have no choice but to fall back


### PR DESCRIPTION
The block supporting macOS 10.6 in `CopyIdentityWithLabel()` was duplicated with one copy sitting inside the block only covering 10.7+ and iOS. Remove the block while leaving the live one in place. Passes `make test` in a build with `--enable-darwinssl --enable-debug`.