### PR TITLE
openssl: Integrate Peter Wu's SSLKEYLOGFILE implementation

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -453,6 +453,14 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
   int rv;
   size_t left, ncopy;
   int32_t stream_id = frame->hd.stream_id;
+  const char *name[] = {
+    "DATA", "HEADERS", "PRIORITY", "RST_STREAM", "SETTINGS", "PUSH_PROMISE",
+    "PING", "GOAWAY", "WINDOW_UPDATE", "CONTINUATION", "ALTSVC"
+  };
+
+  DEBUGF(infof(conn->data, "on_frame_recv: %s\n",
+               ((frame->hd.type < sizeof name / sizeof name[0]) ?
+                name[frame->hd.type] : "unknown frame")));
 
   if(!stream_id) {
     /* stream ID zero is for connection-oriented stuff */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -249,6 +249,13 @@ struct curl_schannel_ctxt {
 };
 #endif
 
+#ifdef USE_OPENSSL
+typedef struct ssl_tap_state {
+  int master_key_length;
+  unsigned char master_key[SSL_MAX_MASTER_KEY_LENGTH];
+} ssl_tap_state_t;
+#endif
+
 /* enum for the nonblocking SSL connection state machine */
 typedef enum {
   ssl_connect_1,
@@ -278,6 +285,8 @@ struct ssl_connect_data {
   SSL_CTX* ctx;
   SSL*     handle;
   X509*    server_cert;
+  /* tap_state holds the last seen master key if we're logging them */
+  ssl_tap_state_t tap_state;
 #elif defined(USE_GNUTLS)
   gnutls_session_t session;
   gnutls_certificate_credentials_t cred;


### PR DESCRIPTION
I adapted Peter Wu's SSLKEYLOGFILE implementation for libcurl's
openssl.c so that I can dump ssl master secrets to a logfile.

*His code is GPL licensed, do not merge in master.*

For this to work set environment variable SSLKEYLOGFILE to a filename.
And in Wireshark: Edit > Preferences > Protocols > SSL > Master-Secret

https://git.lekensteyn.nl/peter/wireshark-notes/tree/src/sslkeylog.c

This commit is mostly to help diagnose an issue we are working on in
libcurl, 'HTTP/2 final frames not processed on server disconnect'. It
also changes http2.c on_frame_recv to dump the frame name in debug
builds of libcurl.