### PR TITLE
docs: Remove that --proto is just used for initial retrieval

### DIFF
--- a/docs/curl.1
+++ b/docs/curl.1
@@ -1354,10 +1354,9 @@ consistency. However, a server may require a POST to remain a POST after such
 a redirection. This option is meaningful only when using \fI-L, --location\fP
 (Added in 7.26.0)
 .IP "--proto <protocols>"
-Tells curl to use the listed protocols for its initial retrieval. Protocols
-are evaluated left to right, are comma separated, and are each a protocol
-name or 'all', optionally prefixed by zero or more modifiers. Available
-modifiers are:
+Tells curl to limit what protocols it may use in the transfer. Protocols are
+evaluated left to right, are comma separated, and are each a protocol name or
+'all', optionally prefixed by zero or more modifiers. Available modifiers are:
 .RS
 .TP 3
 .B +
@@ -1414,8 +1413,9 @@ for details.
 
 (Added in 7.45.0)
 .IP "--proto-redir <protocols>"
-Tells curl to use the listed protocols on redirect. See --proto for how
-protocols are represented.
+Tells curl to limit what protocols it may use on redirect. Protocols denied by
+--proto are not overridden by this option. See \fI--proto\fP for how protocols
+are represented.
 
 Example:
 

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
@@ -34,6 +34,9 @@ redirect when \fICURLOPT_FOLLOWLOCATION(3)\fP is enabled. This allows you to
 limit specific transfers to only be allowed to use a subset of protocols in
 redirections.
 
+Protocols denied by \fICURLOPT_PROTOCOLS(3)\fP are not overridden by this
+option.
+
 By default libcurl will allow all protocols on redirect except several disabled
 for security reasons: Since 7.19.4 FILE and SCP are disabled, and since 7.40.0
 SMB and SMBS are also disabled. \fICURLPROTO_ALL\fP enables all protocols on

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -127,7 +127,7 @@ test1216 test1217 test1218 test1219 \
 test1220 test1221 test1222 test1223 test1224 test1225 test1226 test1227 \
 test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
-test1244 \
+test1244 test1245 \
 \
 test1300 test1301 test1302 test1303 test1304 test1305 test1306 test1307 \
 test1308 test1309 test1310 test1311 test1312 test1313 test1314 test1315 \

--- a/tests/data/test1245
+++ b/tests/data/test1245
@@ -1,0 +1,63 @@
+<testcase>
+<info>
+<keywords>
+FTP
+HTTP
+HTTP GET
+--proto
+--proto-redir
+followlocation
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 301 OK swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 0
+Location: ftp://127.0.0.1:8992/1245
+Connection: close
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+ftp
+http
+</server>
+<name>
+--proto deny must override --proto-redir allow
+</name>
+<command>
+--location --proto +all,-ftp --proto-redir -all,+ftp http://%HOSTIP:%HTTPPORT/1245
+</command>
+# The data section doesn't do variable substitution, so we must assert this
+<precheck>
+perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%FTPPORT' ne '8992' );"
+</precheck>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1245 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+# 1 - Protocol ftp not supported or disabled in libcurl
+<errorcode>
+1
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
.. and add that --proto-redir and CURLOPT_REDIR_PROTOCOLS do not
override protocols denied by --proto and CURLOPT_PROTOCOLS.

- Add a test to enforce: --proto deny must override --proto-redir allow

--

I think saying "Tells curl to use the listed protocols for its initial retrieval" in [`--proto`](https://curl.haxx.se/docs/manpage.html#--proto) is misleading because protocols it denies can't be used on redirect, so I changed it to "Tells curl to limit what protocols it may use in the transfer" and added a test to make sure it stays that way. I wasn't able to go further back than 7.21 but I'd guess this holds true since inception.