### PR TITLE
Do not set CURLOPT_SSLENGINEDEFAULT automatically

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1177,7 +1177,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
           result = res_setopt_str(curl, CURLOPT_SSLENGINE, config->engine);
           if(result)
             goto show_error;
-          my_setopt(curl, CURLOPT_SSLENGINE_DEFAULT, 1L);
         }
 
         /* new in curl 7.10.7, extended in 7.19.4. Modified to use


### PR DESCRIPTION
There were bugs in the PKCS#11 engine, and fixing them triggers bugs in
OpenSSL. Just don't get involved; there's no need to be making the engine
methods the default anyway.

https://github.com/OpenSC/libp11/pull/108
https://github.com/openssl/openssl/pull/1639