### PR TITLE
win: fix Universal Windows Platform build

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -130,9 +130,6 @@ tcpkeepalive(struct Curl_easy *data,
       infof(data, "Failed to set SIO_KEEPALIVE_VALS on fd %d: %d\n",
             (int)sockfd, WSAGetLastError());
     }
-#elif defined(CURL_WINDOWS_APP)
-    (void)majorVersion;
-    detectOsState = DETECT_OS_VISTA_OR_LATER;
 #else
 #ifdef TCP_KEEPIDLE
     optval = curlx_sltosi(data->set.tcp_keepidle);

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -83,7 +83,39 @@ bool Curl_verify_windows_version(const unsigned int majorVersion,
 {
   bool matched = FALSE;
 
-#if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_WIN2K) || \
+#if defined(CURL_WINDOWS_APP)
+  /* We have no way to determine the Windows version from Windows apps,
+     so let's assume we're running on the target Windows version. */
+  const WORD fullVersion = MAKEWORD(minorVersion, majorVersion);
+  const WORD targetVersion = (WORD)_WIN32_WINNT;
+
+  switch(condition) {
+  case VERSION_LESS_THAN:
+    matched = targetVersion < fullVersion;
+    break;
+
+  case VERSION_LESS_THAN_EQUAL:
+    matched = targetVersion <= fullVersion;
+    break;
+
+  case VERSION_EQUAL:
+    matched = targetVersion == fullVersion;
+    break;
+
+  case VERSION_GREATER_THAN_EQUAL:
+    matched = targetVersion >= fullVersion;
+    break;
+
+  case VERSION_GREATER_THAN:
+    matched = targetVersion > fullVersion;
+    break;
+  }
+
+  if(matched && (platform == PLATFORM_WINDOWS)) {
+    /* we're always running on PLATFORM_WINNT */
+    matched = FALSE;
+  }
+#elif !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_WIN2K) || \
     (_WIN32_WINNT < _WIN32_WINNT_WIN2K)
   OSVERSIONINFO osver;
 


### PR DESCRIPTION
As reported by @joycepg here: https://github.com/curl/curl/pull/820#issuecomment-250889878

This fixes a merge error in commit 7f3df80 caused by commit 332e8d6.

Additionally, this disables Curl_verify_windows_version for Windows App
builds. There seems to be no way to determine the Windows version from
a UWP app. Neither GetVersion(Ex), nor VerifyVersionInfo, nor the
Version Helper functions are supported.