### PR TITLE
Cookie handling changed to match most browsers behavior.

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -818,7 +818,7 @@ Curl_cookie_add(struct Curl_easy *data,
 
       if(clist->domain && co->domain) {
         if(Curl_raw_equal(clist->domain, co->domain) &&
-          clist->tailmatch == co->tailmatch)
+          (clist->tailmatch == co->tailmatch))
           /* The domains are identical */
           replace_old=TRUE;
       }

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -817,7 +817,8 @@ Curl_cookie_add(struct Curl_easy *data,
       /* the names are identical */
 
       if(clist->domain && co->domain) {
-        if(Curl_raw_equal(clist->domain, co->domain))
+        if(Curl_raw_equal(clist->domain, co->domain) &&
+          clist->tailmatch == co->tailmatch)
           /* The domains are identical */
           replace_old=TRUE;
       }

--- a/tests/data/test506
+++ b/tests/data/test506
@@ -41,10 +41,12 @@ Content-Type: text/html
 Funny-head: yesyes
 Set-Cookie: test4=overwritten4; domain=host.foo.com; expires=Sat May 5 GMT 11:56:27 2035
 Set-Cookie: test1=overwritten1; domain=foo.com; expires=Thu Mar 3 GMT 11:56:27 2033
+Set-Cookie: test6=six; domain=.www.host.foo.com; expires=Thu Mar 3 GMT 11:56:27 2033
+Set-Cookie: test6=six_more; expires=Thu Mar 3 GMT 11:56:27 2033
 Content-Type: text/html
-Content-Length: 32
+Content-Length: 73
 
-run 3: overwrite cookie 1 and 4
+run 3: overwrite cookie 1 and 4, set cookie 6 with and without tailmatch
 </data3>
 </reply>
 
@@ -166,24 +168,28 @@ lock:   cookie [Pigs in space]: 60
 unlock: cookie [Pigs in space]: 61
 lock:   cookie [Pigs in space]: 62
 unlock: cookie [Pigs in space]: 63
-run 3: overwrite cookie 1 and 4
-lock:   dns    [Pigs in space]: 64
-unlock: dns    [Pigs in space]: 65
-CLEANUP
+lock:   cookie [Pigs in space]: 64
+unlock: cookie [Pigs in space]: 65
 lock:   cookie [Pigs in space]: 66
 unlock: cookie [Pigs in space]: 67
-lock:   share  [Pigs in space]: 68
-unlock: share  [Pigs in space]: 69
+run 3: overwrite cookie 1 and 4, set cookie 6 with and without tailmatch
+lock:   dns    [Pigs in space]: 68
+unlock: dns    [Pigs in space]: 69
+CLEANUP
+lock:   cookie [Pigs in space]: 70
+unlock: cookie [Pigs in space]: 71
+lock:   share  [Pigs in space]: 72
+unlock: share  [Pigs in space]: 73
 CURLOPT_SHARE
-lock:   share  [Pigs in space]: 70
-unlock: share  [Pigs in space]: 71
+lock:   share  [Pigs in space]: 74
+unlock: share  [Pigs in space]: 75
 CURLOPT_COOKIELIST ALL
-lock:   cookie [Pigs in space]: 72
-unlock: cookie [Pigs in space]: 73
+lock:   cookie [Pigs in space]: 76
+unlock: cookie [Pigs in space]: 77
 CURLOPT_COOKIEJAR
 CURLOPT_COOKIELIST RELOAD
-lock:   cookie [Pigs in space]: 74
-unlock: cookie [Pigs in space]: 75
+lock:   cookie [Pigs in space]: 78
+unlock: cookie [Pigs in space]: 79
 loaded cookies:
 -----------------
   .host.foo.com	TRUE	/	FALSE	1896263787	injected	yes
@@ -192,19 +198,21 @@ loaded cookies:
   .foo.com	TRUE	/	FALSE	1896263787	test3	three
   .host.foo.com	TRUE	/	FALSE	2061978987	test4	overwritten4
   .host.foo.com	TRUE	/	FALSE	1896263787	test5	five
+  .www.host.foo.com	TRUE	/	FALSE	1993463787	test6	six
+  www.host.foo.com	FALSE	/	FALSE	1993463787	test6	six_more
 -----------------
 try SHARE_CLEANUP...
-lock:   share  [Pigs in space]: 76
-unlock: share  [Pigs in space]: 77
-SHARE_CLEANUP failed, correct
-CLEANUP
-lock:   cookie [Pigs in space]: 78
-unlock: cookie [Pigs in space]: 79
 lock:   share  [Pigs in space]: 80
 unlock: share  [Pigs in space]: 81
+SHARE_CLEANUP failed, correct
+CLEANUP
+lock:   cookie [Pigs in space]: 82
+unlock: cookie [Pigs in space]: 83
+lock:   share  [Pigs in space]: 84
+unlock: share  [Pigs in space]: 85
 SHARE_CLEANUP
-lock:   share  [Pigs in space]: 82
-unlock: share  [Pigs in space]: 83
+lock:   share  [Pigs in space]: 86
+unlock: share  [Pigs in space]: 87
 GLOBAL_CLEANUP
 </stdout>
 <stderr>
@@ -221,6 +229,8 @@ http://%HOSTIP:%HTTPPORT/506
 .foo.com	TRUE	/	FALSE	1896263787	test3	three
 .host.foo.com	TRUE	/	FALSE	2061978987	test4	overwritten4
 .host.foo.com	TRUE	/	FALSE	1896263787	test5	five
+.www.host.foo.com	TRUE	/	FALSE	1993463787	test6	six
+www.host.foo.com	FALSE	/	FALSE	1993463787	test6	six_more
 </file>
 </verify>
 </testcase>


### PR DESCRIPTION
Cokie with the same domain but different tailmatching property are
now considered different and do not replace each other.
If header contains following lines then two cookies will be set:
Set-Cookie: foo=bar; domain=.foo.com; expires=Thu Mar 3 GMT 8:56:27 2033
Set-Cookie: foo=baz; domain=foo.com; expires=Thu Mar 3 GMT 8:56:27 2033

This matches Chrome, Opera, Safari, and Firefox behavior. When sending
stored tokens to foo.com Chrome, Opera, and Firefox send them in the
stored order, while Safari pre-sort the cookies.