### PR TITLE
CURLOPT_DEBUGFUNCTION.3: unused argument warning

### DIFF
--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
@@ -119,6 +119,7 @@ int my_trace(CURL *handle, curl_infotype type,
 {
   const char *text;
   (void)handle; /* prevent compiler warning */
+  (void)userp;
 
   switch (type) {
   case CURLINFO_TEXT:


### PR DESCRIPTION
The 'userp' argument is unused in this example code.