### PR TITLE
Fix a small typo in the tests README

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -164,7 +164,7 @@ The cURL Test Suite
 
  1.8 Logs
 
-  All logs are generated in the logs/ subdirectory (it is emptied first in the
+  All logs are generated in the log/ subdirectory (it is emptied first in the
   runtests.pl script). Use runtests.pl -k to force it to keep the temporary
   files after the test run since successful runs will clean it up otherwise.
 


### PR DESCRIPTION
The subdirectory for logs in tests/ is named log/ without an 's' at the end.