### PR TITLE
pipelining: check for doomed connections

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2908,8 +2908,7 @@ static bool IsPipeliningPossible(const struct Curl_easy *handle,
                                  const struct connectdata *conn)
 {
   /* If a HTTP protocol and pipelining is enabled */
-  if(!conn->bits.close &&
-      (conn->handler->protocol & PROTO_FAMILY_HTTP)) {
+  if((conn->handler->protocol & PROTO_FAMILY_HTTP) && !conn->bits.close) {
 
     if(Curl_pipeline_wanted(handle->multi, CURLPIPE_HTTP1) &&
        (handle->set.httpversion != CURL_HTTP_VERSION_1_0) &&
@@ -3284,10 +3283,6 @@ ConnectionExists(struct Curl_easy *data,
       pipeLen = check->send_pipe->size + check->recv_pipe->size;
 
       if(canPipeline) {
-        /*
-         * We can not use this connection if the connection is marked for
-         * closure due to an error (ie. a timeout)
-         */
         if(check->bits.close)
             continue;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -2908,7 +2908,8 @@ static bool IsPipeliningPossible(const struct Curl_easy *handle,
                                  const struct connectdata *conn)
 {
   /* If a HTTP protocol and pipelining is enabled */
-  if(conn->handler->protocol & PROTO_FAMILY_HTTP) {
+  if(!conn->bits.close &&
+      (conn->handler->protocol & PROTO_FAMILY_HTTP)) {
 
     if(Curl_pipeline_wanted(handle->multi, CURLPIPE_HTTP1) &&
        (handle->set.httpversion != CURL_HTTP_VERSION_1_0) &&
@@ -3283,6 +3284,12 @@ ConnectionExists(struct Curl_easy *data,
       pipeLen = check->send_pipe->size + check->recv_pipe->size;
 
       if(canPipeline) {
+        /*
+         * We can not use this connection if the connection is marked for
+         * closure due to an error (ie. a timeout)
+         */
+        if(check->bits.close)
+            continue;
 
         if(!check->bits.multiplex) {
           /* If not multiplexing, make sure the pipe has only GET requests */


### PR DESCRIPTION
Issue #627: Checks for doomed connections when selecting a connection for pipelining.  Restores checks by Carlo Wood.

It appears that Rider-Linden hasn't had time to upstream this. We were bitten by this bug with our fork of their project and found this commit message as I can replicate the problem without issue on ethernet over powerline within my home. They have been using this fix / workaround for several months now.

So, I took the liberty of getting his fork rebased into a single commit and will fix any code quality changes that are recommended by the community.