### PR TITLE
docs: fix req->data in multi-uv example

### DIFF
--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -146,7 +146,7 @@ void curl_perform(uv_poll_t *req, int status, int events)
   if(events & UV_WRITABLE)
     flags |= CURL_CSELECT_OUT;
 
-  context = (curl_context_t *) req;
+  context = (curl_context_t *) req->data;
 
   curl_multi_socket_action(curl_handle, context->sockfd, flags,
                            &running_handles);


### PR DESCRIPTION
Even though the address of `curl_context_t` struct and the address of its first field (`poll_handle`) coincide, the `sockfd` field is not always allocated immediately after the `poll_handle` field. See §9.2 clause 12 in the 1998 or 2003 C++ standards:

```
Implementation alignment requirements might cause two adjacent members not to be allocated immediately after each other;
```