### PR TITLE
Curl_initinfo not called consistently

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -927,6 +927,8 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
 
   Curl_convert_setup(outcurl);
 
+  Curl_initinfo(outcurl);
+
   outcurl->magic = CURLEASY_MAGIC_NUMBER;
 
   /* we reach this point and thus we are OK */

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -36,8 +36,11 @@
 #include "memdebug.h"
 
 /*
- * This is supposed to be called in the beginning of a perform() session and
- * in curl_easy_reset() and should reset all session-info variables.
+ * Initialize statistical and informational data.
+ *
+ * This function is called in curl_easy_reset, curl_easy_duphandle and at the
+ * beginning of a perform session. It must reset the session-info variables,
+ * in particular all variables in struct PureInfo.
  */
 CURLcode Curl_initinfo(struct Curl_easy *data)
 {

--- a/lib/url.c
+++ b/lib/url.c
@@ -92,6 +92,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
 #include "warnless.h"
 #include "non-ascii.h"
 #include "inet_pton.h"
+#include "getinfo.h"
 
 /* And now for the protocols */
 #include "ftp.h"
@@ -645,6 +646,8 @@ CURLcode Curl_open(struct Curl_easy **curl)
     data->state.headersize=HEADERSIZE;
 
     Curl_convert_init(data);
+
+    Curl_initinfo(data);
 
     /* most recent connection is not yet defined */
     data->state.lastconnect = NULL;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1105,7 +1105,7 @@ struct connectdata {
 
 /*
  * Struct to keep statistical and informational data.
- * All variables in this struct must be reset in Curl_initinfo().
+ * All variables in this struct must be initialized/reset in Curl_initinfo().
  */
 struct PureInfo {
   int httpcode;  /* Recent HTTP, FTP, RTSP or SMTP response code */


### PR DESCRIPTION
With the latest libcurl (v7.51.0) I ran into an odd behavior caused by Curl_initinfo not being called/copied over consistently. As a result, CURLINFO_FILETIME may oscillate between 0 and -1 unexpectedly.

- If you run `curl_easy_init`, `Curl_initinfo` is not called. That means `CURLINFO_FILETIME` will be set to 0.
- If you call `curl_easy_reset` on that handle, `Curl_initinfo` is called. This behavior is new starting in 22cfeac730d5b115b04f6b6ebf2f0a74f0bc978d. That means `CURLINFO_FILETIME` will be set to -1.
- If you call `curl_easy_duphandle` on that handle, `Curl_initinfo` is not called and the info is never set. That means `CURLINFO_FILETIME` will be set to 0.

This came up because of a test in HHVM (PHP interpreter) that tried to verify that two handles had the same info after calling `curl_easy_duphandle`. `curl_init` in HHVM would call `curl_easy_init` and `curl_easy_reset` internally, so `CURLINFO_FILETIME` would be set to -1. If you called `curl_easy_duphandle` the new handle would have `CURLINFO_FILETIME` set to 0.

It seems like for consistency the code could be doing a couple things to make the behavior consistent:

1. Calling `Curl_initinfo` inside `curl_easy_init`
2. Either calling `Curl_initinfo` in `curl_easy_duphandle` (if we don't care about not exactly duplicating the handle) or copying the data explicitly from one handle to the other.