### PR TITLE
fix SSL client certificate not found on macOS Sierra

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -913,10 +913,9 @@ static OSStatus CopyIdentityWithLabel(char *label,
   values[4] = label_cf;
   keys[4] = kSecAttrLabel;
   query_dict = CFDictionaryCreate(NULL, (const void **)keys,
-                                 (const void **)values, 5L,
-                                 &kCFCopyStringDictionaryKeyCallBacks,
-                                 &kCFTypeDictionaryValueCallBacks);
-  CFRelease(values[3]);
+                                  (const void **)values, 5L,
+                                  &kCFCopyStringDictionaryKeyCallBacks,
+                                  &kCFTypeDictionaryValueCallBacks);
 
   /* Do we have a match? */
   status = SecItemCopyMatching(query_dict, (CFTypeRef *) &keys_list);
@@ -948,6 +947,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
     }
   }
 
+  CFRelease(values[3]);
   CFRelease(query_dict);
   CFRelease(label_cf);
 #else

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -889,8 +889,8 @@ static OSStatus CopyIdentityWithLabel(char *label,
      kSecClassIdentity was introduced in Lion. If both exist, let's use them
      to find the certificate. */
   if(SecItemCopyMatching != NULL && kSecClassIdentity != NULL) {
-    CFTypeRef keys[4];
-    CFTypeRef values[4];
+    CFTypeRef keys[5];
+    CFTypeRef values[5];
     CFDictionaryRef query_dict;
     CFStringRef label_cf = CFStringCreateWithCString(NULL, label,
       kCFStringEncodingUTF8);
@@ -903,8 +903,10 @@ static OSStatus CopyIdentityWithLabel(char *label,
     values[2] = kSecMatchLimitOne; /* one is enough, thanks */
     keys[2] = kSecMatchLimit;
     /* identity searches need a SecPolicyRef in order to work */
-    values[3] = SecPolicyCreateSSL(false, label_cf);
+    values[3] = SecPolicyCreateSSL(false, NULL);
     keys[3] = kSecMatchPolicy;
+    values[4] = label_cf;
+    keys[4] = kSecMatchSubjectContains;
     query_dict = CFDictionaryCreate(NULL, (const void **)keys,
                                    (const void **)values, 4L,
                                    &kCFCopyStringDictionaryKeyCallBacks,

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1244,7 +1244,6 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
       err = CopyIdentityWithLabel(data->set.str[STRING_CERT], &cert_and_key);
 
     if(err == noErr) {
-
       SecCertificateRef cert = NULL;
       CFTypeRef certs_c[1];
       CFArrayRef certs;

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -908,7 +908,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
     values[4] = label_cf;
     keys[4] = kSecMatchSubjectContains;
     query_dict = CFDictionaryCreate(NULL, (const void **)keys,
-                                   (const void **)values, 4L,
+                                   (const void **)values, 5L,
                                    &kCFCopyStringDictionaryKeyCallBacks,
                                    &kCFTypeDictionaryValueCallBacks);
     CFRelease(values[3]);

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -953,7 +953,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
 #else
   /* On Leopard and Snow Leopard, fall back to SecKeychainSearch. */
   status = CopyIdentityWithLabelOldSchool(label, out_cert_and_key);
-#endif /* CURL_SUPPORT_MAC_10_6 */
+#endif /* CURL_BUILD_MAC_10_7 || CURL_BUILD_IOS */
 
   return status;
 }

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1238,7 +1238,6 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
       err = CopyIdentityWithLabel(data->set.str[STRING_CERT], &cert_and_key);
 
     if(err == noErr) {
-
       SecCertificateRef cert = NULL;
       CFTypeRef certs_c[1];
       CFArrayRef certs;

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -903,18 +903,19 @@ static OSStatus CopyIdentityWithLabel(char *label,
     keys[0] = kSecClass;
     values[1] = kCFBooleanTrue;    /* we want a reference */
     keys[1] = kSecReturnRef;
-    values[2] = kSecMatchLimitAll; /* one is enough, thanks */
+    values[2] = kSecMatchLimitAll; /* kSecMatchLimitOne would be better, if the label matching below would work correctly */
     keys[2] = kSecMatchLimit;
     /* identity searches need a SecPolicyRef in order to work */
     values[3] = SecPolicyCreateSSL(false, NULL);
     keys[3] = kSecMatchPolicy;
-    /* match the name of the certificate (this doesn't seem to work :( ) */
+    /* match the name of the certificate (this doesn't seem to work in Macos Sierra :( ) */
     values[4] = label_cf;
     keys[4] = kSecAttrLabel;
     query_dict = CFDictionaryCreate(NULL, (const void **)keys,
                                    (const void **)values, 4L,
                                    &kCFCopyStringDictionaryKeyCallBacks,
                                    &kCFTypeDictionaryValueCallBacks);
+    CFRelease(values[3]);
 
     /* Do we have a match? */
     status = SecItemCopyMatching(query_dict, (CFTypeRef *) &keys_list);

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -892,75 +892,69 @@ static OSStatus CopyIdentityWithLabel(char *label,
   /* SecItemCopyMatching() was introduced in iOS and Snow Leopard.
      kSecClassIdentity was introduced in Lion. If both exist, let's use them
      to find the certificate. */
-  if(SecItemCopyMatching != NULL && kSecClassIdentity != NULL) {
-    CFTypeRef keys[5];
-    CFTypeRef values[5];
-    CFDictionaryRef query_dict;
-    CFStringRef label_cf = CFStringCreateWithCString(NULL, label,
-      kCFStringEncodingUTF8);
+  CFTypeRef keys[5];
+  CFTypeRef values[5];
+  CFDictionaryRef query_dict;
+  CFStringRef label_cf = CFStringCreateWithCString(NULL, label,
+    kCFStringEncodingUTF8);
 
-    /* Set up our search criteria and expected results: */
-    values[0] = kSecClassIdentity; /* we want a certificate and a key */
-    keys[0] = kSecClass;
-    values[1] = kCFBooleanTrue;    /* we want a reference */
-    keys[1] = kSecReturnRef;
-    values[2] = kSecMatchLimitAll; /* kSecMatchLimitOne would be better, if the label matching below would work correctly */
-    keys[2] = kSecMatchLimit;
-    /* identity searches need a SecPolicyRef in order to work */
-    values[3] = SecPolicyCreateSSL(false, NULL);
-    keys[3] = kSecMatchPolicy;
-    /* match the name of the certificate (this doesn't seem to work in Macos Sierra :( ) */
-    values[4] = label_cf;
-    keys[4] = kSecAttrLabel;
-    query_dict = CFDictionaryCreate(NULL, (const void **)keys,
-                                   (const void **)values, 4L,
-                                   &kCFCopyStringDictionaryKeyCallBacks,
-                                   &kCFTypeDictionaryValueCallBacks);
-    CFRelease(values[3]);
+  /* Set up our search criteria and expected results: */
+  values[0] = kSecClassIdentity; /* we want a certificate and a key */
+  keys[0] = kSecClass;
+  values[1] = kCFBooleanTrue;    /* we want a reference */
+  keys[1] = kSecReturnRef;
+  values[2] = kSecMatchLimitAll; /* kSecMatchLimitOne would be better if the
+                                  * label matching below worked correctly */
+  keys[2] = kSecMatchLimit;
+  /* identity searches need a SecPolicyRef in order to work */
+  values[3] = SecPolicyCreateSSL(false, NULL);
+  keys[3] = kSecMatchPolicy;
+  /* match the name of the certificate (doesn't work in macOS 10.12.1) */
+  values[4] = label_cf;
+  keys[4] = kSecAttrLabel;
+  query_dict = CFDictionaryCreate(NULL, (const void **)keys,
+                                 (const void **)values, 5L,
+                                 &kCFCopyStringDictionaryKeyCallBacks,
+                                 &kCFTypeDictionaryValueCallBacks);
+  CFRelease(values[3]);
 
-    /* Do we have a match? */
-    status = SecItemCopyMatching(query_dict, (CFTypeRef *) &keys_list);
+  /* Do we have a match? */
+  status = SecItemCopyMatching(query_dict, (CFTypeRef *) &keys_list);
 
-    /* Because kSecAttrLabel matching doesn't work with kSecClassIdentity,
-     * we need to find the correct identity ourselves */
-    if(status == noErr) {
-        keys_list_count = CFArrayGetCount( keys_list );
-        *out_cert_and_key = NULL;
-        for(i=0; i<keys_list_count; i++) {
-            OSStatus err = noErr;
-            SecCertificateRef cert = NULL;
-            *out_cert_and_key = (SecIdentityRef) CFArrayGetValueAtIndex(keys_list, i);
-            err = SecIdentityCopyCertificate(*out_cert_and_key, &cert);
-            if(err == noErr) {
-                SecCertificateCopyCommonName(cert, &common_name);
-                if(CFStringCompare(common_name, label_cf, NULL) == kCFCompareEqualTo) {
-                    CFRelease(cert);
-                    CFRelease(common_name);
-                    status = noErr;
-                    break;
-                }
-                CFRelease(common_name);
-            }
-            *out_cert_and_key = NULL;
-            status = 1;
-            CFRelease(cert);
+  /* Because kSecAttrLabel matching doesn't work with kSecClassIdentity,
+   * we need to find the correct identity ourselves */
+  if(status == noErr) {
+    keys_list_count = CFArrayGetCount(keys_list);
+    *out_cert_and_key = NULL;
+    for(i=0; i<keys_list_count; i++) {
+      OSStatus err = noErr;
+      SecCertificateRef cert = NULL;
+      *out_cert_and_key =
+        (SecIdentityRef) CFArrayGetValueAtIndex(keys_list, i);
+      err = SecIdentityCopyCertificate(*out_cert_and_key, &cert);
+      if(err == noErr) {
+        SecCertificateCopyCommonName(cert, &common_name);
+        if(CFStringCompare(common_name, label_cf, 0) == kCFCompareEqualTo) {
+          CFRelease(cert);
+          CFRelease(common_name);
+          status = noErr;
+          break;
         }
+        CFRelease(common_name);
+      }
+      *out_cert_and_key = NULL;
+      status = 1;
+      CFRelease(cert);
     }
+  }
 
-    CFRelease(query_dict);
-    CFRelease(label_cf);
-  }
-  else {
-#if CURL_SUPPORT_MAC_10_6
-    /* On Leopard and Snow Leopard, fall back to SecKeychainSearch. */
-    status = CopyIdentityWithLabelOldSchool(label, out_cert_and_key);
-#endif /* CURL_SUPPORT_MAC_10_6 */
-  }
-#elif CURL_SUPPORT_MAC_10_6
-  /* For developers building on older cats, we have no choice but to fall back
-     to SecKeychainSearch. */
+  CFRelease(query_dict);
+  CFRelease(label_cf);
+#else
+  /* On Leopard and Snow Leopard, fall back to SecKeychainSearch. */
   status = CopyIdentityWithLabelOldSchool(label, out_cert_and_key);
-#endif /* CURL_BUILD_MAC_10_7 || CURL_BUILD_IOS */
+#endif /* CURL_SUPPORT_MAC_10_6 */
+
   return status;
 }
 
@@ -1244,6 +1238,7 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
       err = CopyIdentityWithLabel(data->set.str[STRING_CERT], &cert_and_key);
 
     if(err == noErr) {
+
       SecCertificateRef cert = NULL;
       CFTypeRef certs_c[1];
       CFArrayRef certs;


### PR DESCRIPTION
curl can't retrieve a client certificate on MacOS Sierra. The reason seems to be that the search for the identity is not done correctly. See also this, which a symptom for the same problem:
https://github.com/git/git-scm.com/issues/850