### PR TITLE
vtls: Fail on unrecognized param for CURLOPT_SSLVERSION

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -174,12 +174,15 @@ cyassl_connect_step1(struct connectdata *conn,
     req_method = TLSv1_2_client_method();
     use_sni(TRUE);
     break;
+  case CURL_SSLVERSION_TLSv1_3:
+    failf(data, "CyaSSL: TLS 1.3 is not yet supported");
+    return CURLE_SSL_CONNECT_ERROR;
   case CURL_SSLVERSION_SSLv3:
 #ifdef WOLFSSL_ALLOW_SSLV3
     req_method = SSLv3_client_method();
     use_sni(FALSE);
 #else
-    failf(data, "No support for SSLv3");
+    failf(data, "CyaSSL does not support SSLv3");
     return CURLE_NOT_BUILT_IN;
 #endif
     break;

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1053,7 +1053,6 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
   if(SSLSetProtocolVersionMax != NULL) {
     switch(data->set.ssl.version) {
-      default:
       case CURL_SSLVERSION_DEFAULT:
       case CURL_SSLVERSION_TLSv1:
         (void)SSLSetProtocolVersionMin(connssl->ssl_ctx, kTLSProtocol1);
@@ -1072,7 +1071,7 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
         (void)SSLSetProtocolVersionMax(connssl->ssl_ctx, kTLSProtocol12);
         break;
       case CURL_SSLVERSION_TLSv1_3:
-        failf(data, "TLSv1.3 is not yet supported with this TLS backend");
+        failf(data, "DarwinSSL: TLS 1.3 is not yet supported");
         return CURLE_SSL_CONNECT_ERROR;
       case CURL_SSLVERSION_SSLv3:
         err = SSLSetProtocolVersionMin(connssl->ssl_ctx, kSSLProtocol3);
@@ -1089,6 +1088,10 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
           return CURLE_SSL_CONNECT_ERROR;
         }
         (void)SSLSetProtocolVersionMax(connssl->ssl_ctx, kSSLProtocol2);
+        break;
+      default:
+        failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+        return CURLE_SSL_CONNECT_ERROR;
     }
   }
   else {
@@ -1097,7 +1100,6 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
                                        kSSLProtocolAll,
                                        false);
     switch (data->set.ssl.version) {
-      default:
       case CURL_SSLVERSION_DEFAULT:
       case CURL_SSLVERSION_TLSv1:
         (void)SSLSetProtocolVersionEnabled(connssl->ssl_ctx,
@@ -1126,7 +1128,7 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
                                            true);
         break;
       case CURL_SSLVERSION_TLSv1_3:
-        failf(data, "TLSv1.3 is not yet supported with this TLS backend");
+        failf(data, "DarwinSSL: TLS 1.3 is not yet supported");
         return CURLE_SSL_CONNECT_ERROR;
       case CURL_SSLVERSION_SSLv3:
         err = SSLSetProtocolVersionEnabled(connssl->ssl_ctx,
@@ -1146,13 +1148,15 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
           return CURLE_SSL_CONNECT_ERROR;
         }
         break;
+      default:
+        failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+        return CURLE_SSL_CONNECT_ERROR;
     }
 #endif  /* CURL_SUPPORT_MAC_10_8 */
   }
 #else
   (void)SSLSetProtocolVersionEnabled(connssl->ssl_ctx, kSSLProtocolAll, false);
   switch(data->set.ssl.version) {
-    default:
     case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1:
     case CURL_SSLVERSION_TLSv1_0:
@@ -1187,6 +1191,9 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
         return CURLE_SSL_CONNECT_ERROR;
       }
       break;
+    default:
+      failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+      return CURLE_SSL_CONNECT_ERROR;
   }
 #endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
 

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -614,8 +614,6 @@ static CURLcode gskit_connect_step1(struct connectdata *conn, int sockindex)
     return result;
 
   /* Determine which SSL/TLS version should be enabled. */
-  protoflags = CURL_GSKPROTO_TLSV10_MASK | CURL_GSKPROTO_TLSV11_MASK |
-               CURL_GSKPROTO_TLSV12_MASK;
   sni = conn->host.name;
   switch (data->set.ssl.version) {
   case CURL_SSLVERSION_SSLv2:
@@ -626,6 +624,7 @@ static CURLcode gskit_connect_step1(struct connectdata *conn, int sockindex)
     protoflags = CURL_GSKPROTO_SSLV3_MASK;
     sni = (char *) NULL;
     break;
+  case CURL_SSLVERSION_DEFAULT:
   case CURL_SSLVERSION_TLSv1:
     protoflags = CURL_GSKPROTO_TLSV10_MASK |
                  CURL_GSKPROTO_TLSV11_MASK | CURL_GSKPROTO_TLSV12_MASK;
@@ -640,8 +639,11 @@ static CURLcode gskit_connect_step1(struct connectdata *conn, int sockindex)
     protoflags = CURL_GSKPROTO_TLSV12_MASK;
     break;
   case CURL_SSLVERSION_TLSv1_3:
-    failf(data, "TLS 1.3 not yet supported");
-    return CURLE_SSL_CIPHER;
+    failf(data, "GSKit: TLS 1.3 is not yet supported");
+    return CURLE_SSL_CONNECT_ERROR;
+  default:
+    failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+    return CURLE_SSL_CONNECT_ERROR;
   }
 
   /* Process SNI. Ignore if not supported (on OS400 < V7R1). */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -409,7 +409,6 @@ gtls_connect_step1(struct connectdata *conn,
   if(!gtls_inited)
     Curl_gtls_init();
 
-  /* GnuTLS only supports SSLv3 and TLSv1 */
   if(data->set.ssl.version == CURL_SSLVERSION_SSLv2) {
     failf(data, "GnuTLS does not support SSLv2");
     return CURLE_SSL_CONNECT_ERROR;
@@ -569,15 +568,16 @@ gtls_connect_step1(struct connectdata *conn,
       break;
     case CURL_SSLVERSION_TLSv1_2:
       protocol_priority[0] = GNUTLS_TLS1_2;
+      break;
     case CURL_SSLVERSION_TLSv1_3:
-      failf(data, "GnuTLS does not support TLSv1.3");
+      failf(data, "GnuTLS: TLS 1.3 is not yet supported");
       return CURLE_SSL_CONNECT_ERROR;
-    break;
-      case CURL_SSLVERSION_SSLv2:
-    default:
+    case CURL_SSLVERSION_SSLv2:
       failf(data, "GnuTLS does not support SSLv2");
       return CURLE_SSL_CONNECT_ERROR;
-      break;
+    default:
+      failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+      return CURLE_SSL_CONNECT_ERROR;
   }
   rc = gnutls_protocol_set_priority(session, protocol_priority);
   if(rc != GNUTLS_E_SUCCESS) {
@@ -611,13 +611,14 @@ gtls_connect_step1(struct connectdata *conn,
                      "+VERS-TLS1.2:" GNUTLS_SRP;
       break;
     case CURL_SSLVERSION_TLSv1_3:
-      failf(data, "GnuTLS does not support TLSv1.3");
+      failf(data, "GnuTLS: TLS 1.3 is not yet supported");
       return CURLE_SSL_CONNECT_ERROR;
     case CURL_SSLVERSION_SSLv2:
-    default:
       failf(data, "GnuTLS does not support SSLv2");
       return CURLE_SSL_CONNECT_ERROR;
-      break;
+    default:
+      failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+      return CURLE_SSL_CONNECT_ERROR;
   }
   rc = gnutls_priority_set_direct(session, prioritylist, &err);
   if((rc == GNUTLS_E_INVALID_REQUEST) && err) {

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -351,8 +351,11 @@ mbed_connect_step1(struct connectdata *conn,
                                  MBEDTLS_SSL_MINOR_VERSION_3);
     infof(data, "mbedTLS: Set SSL version to TLS 1.2\n");
     break;
+  case CURL_SSLVERSION_TLSv1_3:
+    failf(data, "mbedTLS: TLS 1.3 is not yet supported");
+    return CURLE_SSL_CONNECT_ERROR;
   default:
-    failf(data, "mbedTLS: Unsupported SSL protocol version");
+    failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
     return CURLE_SSL_CONNECT_ERROR;
   }
 

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1555,8 +1555,8 @@ static CURLcode nss_init_sslver(SSLVersionRange *sslver,
     break;
 
   default:
-    /* unsupported SSL/TLS version */
-    break;
+    failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+    return CURLE_SSL_CONNECT_ERROR;
   }
 
   failf(data, "TLS minor version cannot be set");

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -272,7 +272,6 @@ polarssl_connect_step1(struct connectdata *conn,
   }
 
   switch(data->set.ssl.version) {
-  default:
   case CURL_SSLVERSION_DEFAULT:
   case CURL_SSLVERSION_TLSv1:
     ssl_set_min_version(&connssl->ssl, SSL_MAJOR_VERSION_3,
@@ -308,6 +307,9 @@ polarssl_connect_step1(struct connectdata *conn,
     break;
   case CURL_SSLVERSION_TLSv1_3:
     failf(data, "PolarSSL: TLS 1.3 is not yet supported");
+    return CURLE_SSL_CONNECT_ERROR;
+  default:
+    failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
     return CURLE_SSL_CONNECT_ERROR;
   }
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -197,7 +197,6 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     }
 
     switch(data->set.ssl.version) {
-    default:
     case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1:
       schannel_cred.grbitEnabledProtocols = SP_PROT_TLS1_0_CLIENT |
@@ -214,7 +213,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
       schannel_cred.grbitEnabledProtocols = SP_PROT_TLS1_2_CLIENT;
       break;
     case CURL_SSLVERSION_TLSv1_3:
-      failf(data, "schannel: TLS 1.3 is not yet supported");
+      failf(data, "Schannel: TLS 1.3 is not yet supported");
       return CURLE_SSL_CONNECT_ERROR;
     case CURL_SSLVERSION_SSLv3:
       schannel_cred.grbitEnabledProtocols = SP_PROT_SSL3_CLIENT;
@@ -222,6 +221,9 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     case CURL_SSLVERSION_SSLv2:
       schannel_cred.grbitEnabledProtocols = SP_PROT_SSL2_CLIENT;
       break;
+    default:
+      failf(data, "Unrecognized parameter passed via CURLOPT_SSLVERSION");
+      return CURLE_SSL_CONNECT_ERROR;
     }
 
     /* allocate memory for the re-usable credential handle */


### PR DESCRIPTION
- Fix GnuTLS code for CURL_SSLVERSION_TLSv1_2 that broke when the
TLS 1.3 support was added in 6ad3add. (@kdudka I missed [this](https://github.com/curl/curl/commit/6ad3add60654182a747f5971afb40817488ef0e8#diff-e5979e9031cb887bed25573bf055e67cR571) during review)

- Homogenize across code for all backends the error message when TLS 1.3
is not available to "<backend>: TLS 1.3 is not yet supported".

- Return an error when a user-specified ssl version is unrecognized.

---

Prior to this change our code for some of the backends used the
'default' label in the switch statement (ie ver unrecognized) for
ssl.version and treated it the same as CURL_SSLVERSION_DEFAULT.

Bug: https://curl.haxx.se/mail/lib-2016-11/0048.html
Reported-by: Kamil Dudka