### PR TITLE
Memory leak fix in Curl_ossl_cleanup (regression since 7.50.3).

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -737,6 +737,11 @@ void Curl_ossl_cleanup(void)
   /* Free engine list */
   ENGINE_cleanup();
 #endif
+  
+#ifdef HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
+  /* Free OpenSSL ex_data table */
+  CRYPTO_cleanup_all_ex_data();
+#endif
 
   /* Free OpenSSL error strings */
   ERR_free_strings();


### PR DESCRIPTION
Fixed memory leak due to missing CRYPTO_cleanup_all_ex_data in Curl_ossl_cleanup. It is a regression since 7.50.3. Memory leak was noticed under Windows, OpenSSL version 1.0.2g.