### PR TITLE
url: Fix parsing for when 'file' is the default protocol

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -4383,6 +4383,13 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
                         ('A' <= path[0] && path[0] <= 'Z')) && path[1] == ':';
     }
 
+#if !defined(MSDOS) && !defined(WIN32) && !defined(__CYGWIN__)
+    if(path_has_drive) {
+      failf(data, "File drive letters are only accepted in MSDOS/Windows.");
+      return CURLE_URL_MALFORMAT;
+    }
+#endif
+
     protop = "file"; /* protocol string */
   }
   else {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -120,7 +120,7 @@ test1112 test1113 test1114 test1115 test1116 test1117 test1118 test1119 \
 test1120 test1121 test1122 test1123 test1124 test1125 test1126 test1127 \
 test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
-test1144 \
+test1144 test1145 test1146 \
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \
 test1208 test1209 test1210 test1211 test1212 test1213 test1214 test1215 \
 test1216 test1217 test1218 test1219 \

--- a/tests/data/test1145
+++ b/tests/data/test1145
@@ -1,0 +1,40 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+file
+</server>
+<name>
+file:// bad host
+</name>
+# This command should not succeed since we only accept
+# file:/// file://localhost/ file://127.0.0.1/
+<command>
+file://bad-host%PWD/log/test1145.txt
+</command>
+<file name="log/test1145.txt">
+foo
+   bar
+bar
+   foo
+moo
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# CURLE_URL_MALFORMAT is error code 3
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1146
+++ b/tests/data/test1146
@@ -1,0 +1,45 @@
+<testcase>
+<info>
+<keywords>
+FILE
+--proto-default
+</keywords>
+</info>
+
+<reply>
+<data>
+foo
+   bar
+bar
+   foo
+moo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+file
+</server>
+<name>
+--proto-default file
+</name>
+<command>
+--proto-default file %PWD/log/test1146.txt
+</command>
+<file name="log/test1146.txt">
+foo
+   bar
+bar
+   foo
+moo
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1534
+++ b/tests/data/test1534
@@ -27,7 +27,7 @@ http
 lib1534
 </tool>
 <name>
-Test CURLINFO_RESPONSE_CODE
+CURLINFO_FILETIME init and reset
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/1534


### PR DESCRIPTION
Follow-up to 3463408.

Prior to this set of changes hostnames were silently stripped and the
file scheme did not work properly as the default protocol.

Ref: https://curl.haxx.se/mail/lib-2016-11/0081.html

---

Also I thought the error message on `file://foo/bar` was confusing so I changed it
~~~
Before: curl: (3) Valid host name with slash missing in URL
After:  curl: (3) Invalid file://hostname/, expected localhost or 127.0.0.1 or none
~~~