### PR TITLE
Fix crashes when http2 parent stream gets aborted.

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2094,6 +2094,80 @@ CURLcode Curl_http2_switched(struct connectdata *conn,
   return CURLE_OK;
 }
 
+void Curl_http2_add_child(struct Curl_easy *parent, struct Curl_easy *child, bool exclusive)
+{
+  struct Curl_http2_dep **tail;
+  struct Curl_http2_dep *dep = calloc(1, sizeof(struct Curl_http2_dep));
+  dep->data = child;
+
+  if(parent->set.stream_dependents && exclusive) {
+    struct Curl_http2_dep *node = parent->set.stream_dependents;
+    while(node) {
+      node->data->set.stream_depends_on = child;
+      node = node->next;
+    }
+
+    tail = &child->set.stream_dependents;
+    while(*tail)
+      tail = &(*tail)->next;
+
+    DEBUGASSERT(!*tail);
+    *tail = parent->set.stream_dependents;
+    parent->set.stream_dependents = 0;
+  }
+
+  tail = &parent->set.stream_dependents;
+  while(*tail) {
+    (*tail)->data->set.stream_depends_e = FALSE;
+    tail = &(*tail)->next;
+  }
+
+  DEBUGASSERT(!*tail);
+  *tail = dep;
+
+  child->set.stream_depends_on = parent;
+  child->set.stream_depends_e = exclusive;
+}
+
+void Curl_http2_remove_child(struct Curl_easy *parent, struct Curl_easy *child)
+{
+  struct Curl_http2_dep *last = 0;
+  struct Curl_http2_dep *data = parent->set.stream_dependents;
+  DEBUGASSERT(child->set.stream_depends_on == parent);
+
+  while(data && data->data != child) {
+    last = data;
+    data = data->next;
+  }
+
+  DEBUGASSERT(data);
+
+  if(data) {
+    if(last) {
+      last->next = data->next;
+    } else {
+      parent->set.stream_dependents = data->next;
+    }
+    free(data);
+  }
+
+  child->set.stream_depends_on = 0;
+  child->set.stream_depends_e = FALSE;
+}
+
+void Curl_http2_cleanup_dependencies(struct Curl_easy *data)
+{
+  while (data->set.stream_dependents) {
+    struct Curl_easy *tmp = data->set.stream_dependents->data;
+    Curl_http2_remove_child(data, tmp);
+    if(data->set.stream_depends_on)
+      Curl_http2_add_child(data->set.stream_depends_on, tmp, FALSE);
+  }
+
+  if(data->set.stream_depends_on)
+    Curl_http2_remove_child(data->set.stream_depends_on, data);
+}
+
 #else /* !USE_NGHTTP2 */
 
 /* Satisfy external references even if http2 is not compiled in. */

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -53,6 +53,9 @@ void Curl_http2_setup_conn(struct connectdata *conn);
 void Curl_http2_setup_req(struct Curl_easy *data);
 void Curl_http2_done(struct connectdata *conn, bool premature);
 CURLcode Curl_http2_done_sending(struct connectdata *conn);
+void Curl_http2_add_child(struct Curl_easy *parent, struct Curl_easy *child, bool exclusive);
+void Curl_http2_remove_child(struct Curl_easy *parent, struct Curl_easy *child);
+void Curl_http2_cleanup_dependencies(struct Curl_easy *data);
 #else /* USE_NGHTTP2 */
 #define Curl_http2_init(x) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_send_request(x) CURLE_UNSUPPORTED_PROTOCOL
@@ -65,6 +68,9 @@ CURLcode Curl_http2_done_sending(struct connectdata *conn);
 #define Curl_http2_init_userset(x)
 #define Curl_http2_done(x,y)
 #define Curl_http2_done_sending(x)
+#define Curl_http2_add_child(x, y, z)
+#define Curl_http2_remove_child(x, y)
+#define Curl_http2_cleanup_dependencies(x)
 #endif
 
 #endif /* HEADER_CURL_HTTP2_H */

--- a/lib/url.c
+++ b/lib/url.c
@@ -464,6 +464,7 @@ CURLcode Curl_close(struct Curl_easy *data)
   /* this destroys the channel and we cannot use it anymore after this */
   Curl_resolver_cleanup(data->state.resolver);
 
+  Curl_http2_cleanup_dependencies(data);
   Curl_convert_close(data);
 
   /* No longer a dirty share, if it exists */
@@ -2681,9 +2682,11 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     return CURLE_NOT_BUILT_IN;
 #else
     struct Curl_easy *dep = va_arg(param, struct Curl_easy *);
-    if(dep && GOOD_EASY_HANDLE(dep)) {
-      data->set.stream_depends_on = dep;
-      data->set.stream_depends_e = (option == CURLOPT_STREAM_DEPENDS_E);
+    if(!dep || GOOD_EASY_HANDLE(dep)) {
+      if(data->set.stream_depends_on) {
+        Curl_http2_remove_child(data->set.stream_depends_on, data);
+      }
+      Curl_http2_add_child(dep, data, (option == CURLOPT_STREAM_DEPENDS_E));
     }
     break;
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1242,6 +1242,11 @@ struct auth {
                    be RFC compliant */
 };
 
+struct Curl_http2_dep {
+  struct Curl_http2_dep *next;
+  struct Curl_easy *data;
+};
+
 struct UrlState {
 
   /* Points to the connection cache */
@@ -1695,6 +1700,8 @@ struct UserDefined {
   struct Curl_easy *stream_depends_on;
   bool stream_depends_e; /* set or don't set the Exclusive bit */
   int stream_weight;
+
+  struct Curl_http2_dep *stream_dependents;
 };
 
 struct Names {


### PR DESCRIPTION
I can reproduce a use-after-free situation with libcurl and http2 by doing the following:

send A 
send B which depends on A, apply dependency
abort B using curl_multi_remove_handle and subsequently free it using curl_easy_cleanup

Since A knows nothing about B's dependency on it we can't clean this up.

The patch fixes this by keeping a list of all children. 

I believe the reprioritization is correct but it should be checked. I couldn't clearly understand what is supposed to happen if you do the following:

B depends on A
C depends on A exclusively 
D depends on A

My assumption is that this should lead to:

D
C
B
A

E.g. C would lose its exclusivity when someone's dependency is applied afterwards. I'm not 100 sure this is correct.

The patch also allows for unsetting dependencies. 

This is the output from our app reproducing the problem:

```0xded82400 is malloc'ed for url: https://some-server.somewhere:1234/files/data-10m?aaaaa
0xded96400 is malloc'ed for url: https://some-server.somewhere:1234/files/data-9m?bbbbb
0xded96400 depends on 0xded82400 (https://some-server.somewhere:1234/files/data-9m?bbbbb depends on https://some-server.somewhere:1234/files/data-10m?aaaaa)
0xded82400 is free'd for url: https://some-server.somewhere:1234/files/data-10m?aaaaa
=================================================================
==20684==ERROR: AddressSanitizer: heap-use-after-free on address 0xded82540 at pc 0x0a295b30 bp 0xf20fe708 sp 0xf20fe6fc
READ of size 4 at 0xded82540 thread T13 (RESOURCE_HTTP)
    #0 0xa295b2f in h2_pri_spec .../3rdparty/curl/lib/http2.c:1310

0xded82540 is located 320 bytes inside of 34700-byte region [0xded82400,0xded8ab8c)
freed by thread T13 (RESOURCE_HTTP) here:
    #0 0xf72b95c2 in __interceptor_free .../gcc-6.2.0/libsanitizer/asan/asan_malloc_linux.cc:45
    #1 0xa23c2cc in Curl_close .../3rdparty/curl/lib/url.c:494
    #2 0xa2037ff in curl_easy_cleanup .../3rdparty/curl/lib/easy.c:860
    #3 0x9f37f2d in ...
    #4 0x9efffa8 in ...
    #5 0x9f0ba4b in ...
    #6 0x9f1594d in ...
    #7 0xa58dc35 in ...
    #8 0xf7243780 in asan_thread_start .../gcc-6.2.0/libsanitizer/asan/asan_interceptors.cc:226
    #9 0xf44deeed in __clone (/lib/i386-linux-gnu/libc.so.6+0xe6eed)

previously allocated by thread T13 (RESOURCE_HTTP) here:
    #0 0xf72b9a27 in __interceptor_calloc .../gcc-6.2.0/libsanitizer/asan/asan_malloc_linux.cc:70
    #1 0xa23d1c6 in Curl_open .../3rdparty/curl/lib/url.c:631
    #2 0xa203160 in curl_easy_init .../3rdparty/curl/lib/easy.c:386
    #3 0x9f23c57 in ...
    #4 0x9f09c95 in ...
    #5 0x9f1590c in ...
    #6 0xa58dc35 in ...
    #7 0xf7243780 in asan_thread_start .../gcc-6.2.0/libsanitizer/asan/asan_interceptors.cc:226
    #8 0xf44deeed in __clone (/lib/i386-linux-gnu/libc.so.6+0xe6eed)

SUMMARY: AddressSanitizer: heap-use-after-free .../3rdparty/curl/lib/http2.c:1310 in h2_pri_spec
Shadow bytes around the buggy address:
  0x3bdb0450: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x3bdb0460: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x3bdb0470: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x3bdb0480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x3bdb0490: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x3bdb04a0: fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd
  0x3bdb04b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x3bdb04c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x3bdb04d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x3bdb04e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x3bdb04f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==20684==ABORTING
SIGNAL [6] at address 0x50cc!
    #0 0xf72c1ec4 in __sanitizer_print_stack_trace .../gcc-6.2.0/libsanitizer/asan/asan_stack.cc:36
    #1 0x8a0e389 in gibbon_signalHandler .../main.cpp:369

```
