### PR TITLE
tool_operate: Don't append a filename to an SMTP URL

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -128,6 +128,17 @@ static bool is_fatal_error(CURLcode code)
   return FALSE;
 }
 
+static bool is_smtp_url(struct OperationConfig *config, char *this_url)
+{
+  return curl_strnequal(this_url, "smtp://", 7) ||
+         curl_strnequal(this_url, "smtps://", 8) ||
+         (!strstr(this_url, "://") &&
+          (config->proto_default ?
+           (curl_strequal(config->proto_default, "smtp") ||
+            curl_strequal(config->proto_default, "smtps")) :
+           curl_strnequal(this_url, "smtp.", 5)));
+}
+
 #ifdef __VMS
 /*
  * get_vms_file_size does what it takes to get the real size of the file
@@ -625,10 +636,15 @@ static CURLcode operate_do(struct GlobalConfig *global,
            */
           struct_stat fileinfo;
 
-          this_url = add_file_name_to_url(curl, this_url, uploadfile);
-          if(!this_url) {
-            result = CURLE_OUT_OF_MEMORY;
-            goto show_error;
+          /* Append uploadfile to the URL if it does not already end in a
+             filename and it is not an SMTP URL. Any SMTP URL path is sent as
+             the EHLO and it's incorrect for uploadfile to be part of that. */
+          if(!is_smtp_url(config, this_url)) {
+            this_url = add_file_name_to_url(curl, this_url, uploadfile);
+            if(!this_url) {
+              result = CURLE_OUT_OF_MEMORY;
+              goto show_error;
+            }
           }
           /* VMS Note:
            *


### PR DESCRIPTION
Prior to this change sending a message via SMTP file upload could cause the filename to be sent as the EHLO, for example:

```
curl -v -u user:pass --mail-rcpt my_username_at_gmail.com -T mail.txt \
     smtps://smtp.gmail.com
```
curl would change the URL to `smtps://smtp.gmail.com/mail.txt` and since SMTP URLs with a path have that sent as the EHLO that would then cause:
```
EHLO mail.txt
```