### PR TITLE
Add support for the HA-PROXY protocol in HTTP(S) requests

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1774,6 +1774,9 @@ typedef enum {
      this option is used only if PROXY_SSL_VERIFYPEER is true */
   CINIT(PROXY_PINNEDPUBLICKEY, STRINGPOINT, 264),
 
+  /* send HAProxy PROXY protocol header? */
+  CINIT(HAPROXYPROTOCOL, LONG, 265),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -92,6 +92,8 @@ static int http_getsock_do(struct connectdata *conn,
                            int numsocks);
 static int http_should_fail(struct connectdata *conn);
 
+static void add_haproxy_protocol_header(struct connectdata *conn, bool *done);
+
 #ifdef USE_SSL
 static CURLcode https_connecting(struct connectdata *conn, bool *done);
 static int https_getsock(struct connectdata *conn,
@@ -1363,6 +1365,11 @@ CURLcode Curl_http_connect(struct connectdata *conn, bool *done)
     /* nothing else to do except wait right now - we're not done here. */
     return CURLE_OK;
 
+  if(conn->data->set.haproxyprotocol) {
+    /* add HAProxy PROXY protocol header */
+    add_haproxy_protocol_header(conn, done);
+  }
+
   if(conn->given->flags & PROTOPT_SSL) {
     /* perform SSL initialization */
     result = https_connecting(conn, done);
@@ -1386,6 +1393,37 @@ static int http_getsock_do(struct connectdata *conn,
   (void)numsocks; /* unused, we trust it to be at least 1 */
   socks[0] = conn->sock[FIRSTSOCKET];
   return GETSOCK_WRITESOCK(0);
+}
+
+static void add_haproxy_protocol_header(struct connectdata *conn, bool *done)
+{
+  char proxy_header[128];
+  Curl_send_buffer *req_buffer;
+  CURLcode result;
+  char tcp_version[5];
+
+  /* Emit the correct prefix for IPv6 */
+  if (conn->bits.ipv6) {
+    strcpy(tcp_version, "TCP6");
+  } else {
+    strcpy(tcp_version, "TCP4");
+  }
+
+  snprintf(proxy_header,
+           sizeof proxy_header,
+           "PROXY %s %s %s %i %i\r\n",
+           tcp_version,
+           conn->data->info.conn_local_ip,
+           conn->data->info.conn_primary_ip,
+           conn->data->info.conn_local_port,
+           conn->data->info.conn_primary_port);
+  req_buffer = Curl_add_buffer_init();
+  Curl_add_bufferf(req_buffer, proxy_header);
+  result = Curl_add_buffer_send(req_buffer,
+                                conn,
+                                &conn->data->info.request_size,
+                                0,
+                                FIRSTSOCKET);
 }
 
 #ifdef USE_SSL

--- a/lib/http.c
+++ b/lib/http.c
@@ -1395,7 +1395,8 @@ static int http_getsock_do(struct connectdata *conn,
   return GETSOCK_WRITESOCK(0);
 }
 
-static void add_haproxy_protocol_header(struct connectdata *conn, bool *done)
+static CURLcode add_haproxy_protocol_header(struct connectdata *conn,
+                                            bool *done)
 {
   char proxy_header[128];
   Curl_send_buffer *req_buffer;
@@ -1403,9 +1404,10 @@ static void add_haproxy_protocol_header(struct connectdata *conn, bool *done)
   char tcp_version[5];
 
   /* Emit the correct prefix for IPv6 */
-  if (conn->bits.ipv6) {
+  if(conn->bits.ipv6) {
     strcpy(tcp_version, "TCP6");
-  } else {
+  }
+  else {
     strcpy(tcp_version, "TCP4");
   }
 
@@ -1424,6 +1426,8 @@ static void add_haproxy_protocol_header(struct connectdata *conn, bool *done)
                                 &conn->data->info.request_size,
                                 0,
                                 FIRSTSOCKET);
+
+  return result;
 }
 
 #ifdef USE_SSL

--- a/lib/url.c
+++ b/lib/url.c
@@ -2056,6 +2056,12 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
      */
     data->set.localport = curlx_sltous(va_arg(param, long));
     break;
+  case CURLOPT_HAPROXYPROTOCOL:
+    /*
+     * Sends the HAProxy PROXY protcol header.
+     */
+    data->set.haproxyprotocol = (0 != va_arg(param, long))?TRUE:FALSE;
+    break;
   case CURLOPT_LOCALPORTRANGE:
     /*
      * Set number of local ports to try, starting with CURLOPT_LOCALPORT.

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1753,6 +1753,8 @@ struct UserDefined {
   bool stream_depends_e; /* set or don't set the Exclusive bit */
   int stream_weight;
 
+  bool haproxyprotocol; /* whether to send HAProxy PROXY protocol header */
+
   struct Curl_http2_dep *stream_dependents;
 };
 

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -235,6 +235,7 @@ struct OperationConfig {
   bool falsestart;
   bool path_as_is;
   double expect100timeout;
+  bool haproxy_protocol;          /* whether to send HAProxy PROXY protocol */
   struct GlobalConfig *global;
   struct OperationConfig *prev;
   struct OperationConfig *next;   /* Always last in the struct */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -109,6 +109,7 @@ static const struct LongShort aliases[]= {
   {"*x", "krb",                      TRUE},
   {"*x", "krb4",                     TRUE},
          /* 'krb4' is the previous name */
+  {"*X", "haproxy-protocol",         FALSE},
   {"*y", "max-filesize",             TRUE},
   {"*z", "disable-eprt",             FALSE},
   {"*Z", "eprt",                     FALSE},
@@ -739,6 +740,9 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
           GetStr(&config->krblevel, nextarg);
         else
           return PARAM_LIBCURL_DOESNT_SUPPORT;
+        break;
+      case 'X': /* --haproxy-protocol */
+        config->haproxy_protocol = toggle;
         break;
       case 'y': /* --max-filesize */
         err = str2offset(&config->max_filesize, nextarg);

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -105,6 +105,7 @@ static const char *const helptext[] = {
   "clear for transfer (F)",
   " -G, --get           Send the -d data with a HTTP GET (H)",
   " -g, --globoff       Disable URL sequences and ranges using {} and []",
+  "     --haproxy-protocol  Send HAProxy PROXY protocol header (H)",
   " -H, --header LINE   Pass custom header LINE to server (H)",
   " -I, --head          Show document info only",
   " -h, --help          This help text",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1281,6 +1281,9 @@ static CURLcode operate_do(struct GlobalConfig *global,
                         (long)config->localportrange);
         }
 
+        my_setopt(curl, CURLOPT_HAPROXYPROTOCOL,
+                  config->haproxy_protocol?1L:0L);
+
         /* curl 7.15.5 */
         my_setopt_str(curl, CURLOPT_FTP_ALTERNATIVE_TO_USER,
                       config->ftp_alternative_to_user);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -45,7 +45,7 @@ test190 test191 test192 test193 test194 test195 test196 test197 test198 \
 test199 test200 test201 test202 test203 test204 test205 test206 test207 \
 test208 test209 test210 test211 test212 test213 test214 test215 test216 \
 test217 test218 test219 test220 test221 test222 test223 test224 test225 \
-test226 test227 test228 test229         test231         test233 test234 \
+test226 test227 test228 test229 test230 test231 test232 test233 test234 \
 test235 test236 test237 test238 test239 test240 test241 test242 test243 \
         test245 test246 test247 test248 test249 test250 test251 test252 \
 test253 test254 test255 test256 test257 test258 test259 test260 test261 \

--- a/tests/data/test230
+++ b/tests/data/test230
@@ -1,0 +1,56 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply name="230">
+<data nocheck=yes>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: barkbark
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP GET when PROXY Protocol enabled
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/230 --haproxy-protocol --local-port 37756
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+PROXY TCP4 %CLIENTIP %HOSTIP 37756 %HTTPPORT
+GET /230 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test232
+++ b/tests/data/test232
@@ -1,0 +1,59 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+IPv6
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data nocheck=yes>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+ipv6
+</features>
+<server>
+http-ipv6
+</server>
+ <name>
+HTTP-IPv6 GET with PROXY protocol
+ </name>
+ <command>
+-g "http://%HOST6IP:%HTTP6PORT/232" --local-port 44444 --haproxy-protocol
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:
+</strip>
+<protocol>
+PROXY TCP6 ::1 ::1 44444 %HTTP6PORT
+GET /232 HTTP/1.1
+Host: %HOST6IP:%HTTP6PORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
I've wanted to be able to curl against proxies which expect the PROXY protocol (http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt), and so have added support for it to curl. This is my first experience of writing C for a project such as this so I expect it probably needs some tidying up, but it works; I can curl against HAProxy which expects PROXY protocol over both HTTP and HTTPS and receive sensible and correct responses.