### PR TITLE
url: Fix NO_PROXY env var to work properly with --proxy option.

### DIFF
--- a/docs/cmdline-opts/noproxy.d
+++ b/docs/cmdline-opts/noproxy.d
@@ -9,3 +9,7 @@ effectively disables the proxy. Each name in this list is matched as either
 a domain which contains the hostname, or the hostname itself. For example,
 local.com would match local.com, local.com:80, and www.local.com, but not
 www.notlocal.com.
+
+Since 7.52.2, This option overrides the environment variables that disable
+the proxy. If there's an environment variable disabling a proxy, you can set
+noproxy list to \&"" to override it.

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -23,6 +23,16 @@ Sets the proxy server to use if no protocol-specific proxy is set.
 .IP "NO_PROXY <comma-separated list of hosts>"
 list of host names that shouldn't go through any proxy. If set to a asterisk
 \&'*' only, it matches all hosts.
+
+Since 7.52.2, this environment variable disable the proxy even if specify
+--proxy option. That is
+.B NO_PROXY=direct.example.com curl -x http://proxy.example.com
+.B http://direct.example.com
+accesses the target URL directly, and
+.B NO_PROXY=direct.example.com curl -x http://proxy.example.com
+.B http://somewhere.example.com
+accesses the target URL through proxy.
+
 .SH "PROXY PROTOCOL PREFIXES"
 Since curl version 7.21.7, the proxy string may be specified with a
 protocol:// prefix to specify alternative proxy protocols.

--- a/lib/url.c
+++ b/lib/url.c
@@ -4792,7 +4792,6 @@ static char *detect_proxy(struct connectdata *conn)
 {
   char *proxy = NULL;
 
-#ifndef CURL_DISABLE_HTTP
   /* If proxy was not specified, we check for default proxy environment
    * variables, to enable i.e Lynx compliance:
    *
@@ -4810,62 +4809,46 @@ static char *detect_proxy(struct connectdata *conn)
    * For compatibility, the all-uppercase versions of these variables are
    * checked if the lowercase versions don't exist.
    */
-  char *no_proxy=NULL;
   char proxy_env[128];
+  const char *protop = conn->handler->scheme;
+  char *envp = proxy_env;
+  char *prox;
 
-  no_proxy=curl_getenv("no_proxy");
-  if(!no_proxy)
-    no_proxy=curl_getenv("NO_PROXY");
+  /* Now, build <protocol>_proxy and check for such a one to use */
+  while(*protop)
+    *envp++ = (char)tolower((int)*protop++);
 
-  if(!check_noproxy(conn->host.name, no_proxy)) {
-    /* It was not listed as without proxy */
-    const char *protop = conn->handler->scheme;
-    char *envp = proxy_env;
-    char *prox;
+  /* append _proxy */
+  strcpy(envp, "_proxy");
 
-    /* Now, build <protocol>_proxy and check for such a one to use */
-    while(*protop)
-      *envp++ = (char)tolower((int)*protop++);
+  /* read the protocol proxy: */
+  prox=curl_getenv(proxy_env);
 
-    /* append _proxy */
-    strcpy(envp, "_proxy");
-
-    /* read the protocol proxy: */
+  /*
+   * We don't try the uppercase version of HTTP_PROXY because of
+   * security reasons:
+   *
+   * When curl is used in a webserver application
+   * environment (cgi or php), this environment variable can
+   * be controlled by the web server user by setting the
+   * http header 'Proxy:' to some value.
+   *
+   * This can cause 'internal' http/ftp requests to be
+   * arbitrarily redirected by any external attacker.
+   */
+  if(!prox && !strcasecompare("http_proxy", proxy_env)) {
+    /* There was no lowercase variable, try the uppercase version: */
+    Curl_strntoupper(proxy_env, proxy_env, sizeof(proxy_env));
     prox=curl_getenv(proxy_env);
+  }
 
-    /*
-     * We don't try the uppercase version of HTTP_PROXY because of
-     * security reasons:
-     *
-     * When curl is used in a webserver application
-     * environment (cgi or php), this environment variable can
-     * be controlled by the web server user by setting the
-     * http header 'Proxy:' to some value.
-     *
-     * This can cause 'internal' http/ftp requests to be
-     * arbitrarily redirected by any external attacker.
-     */
-    if(!prox && !strcasecompare("http_proxy", proxy_env)) {
-      /* There was no lowercase variable, try the uppercase version: */
-      Curl_strntoupper(proxy_env, proxy_env, sizeof(proxy_env));
-      prox=curl_getenv(proxy_env);
-    }
-
-    if(prox)
-      proxy = prox; /* use this */
-    else {
-      proxy = curl_getenv("all_proxy"); /* default proxy to use */
-      if(!proxy)
-        proxy=curl_getenv("ALL_PROXY");
-    }
-  } /* if(!check_noproxy(conn->host.name, no_proxy)) - it wasn't specified
-       non-proxy */
-  free(no_proxy);
-
-#else /* !CURL_DISABLE_HTTP */
-
-  (void)conn;
-#endif /* CURL_DISABLE_HTTP */
+  if(prox)
+    proxy = prox; /* use this */
+  else {
+    proxy = curl_getenv("all_proxy"); /* default proxy to use */
+    if(!proxy)
+      proxy=curl_getenv("ALL_PROXY");
+  }
 
   return proxy;
 }
@@ -6206,7 +6189,13 @@ static CURLcode create_conn(struct Curl_easy *data,
     Curl_safefree(socksproxy);
   }
   else if(!proxy && !socksproxy)
-    proxy = detect_proxy(conn);
+#ifndef CURL_DISABLE_HTTP
+    /* if the host is not in the noproxy list, detect proxy. */
+    if(!check_noproxy(conn->host.name, no_proxy))
+      proxy = detect_proxy(conn);
+#else  /* !CURL_DISABLE_HTTP */
+    proxy = NULL;
+#endif /* CURL_DISABLE_HTTP */
 
   Curl_safefree(no_proxy);
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -6191,8 +6191,7 @@ static CURLcode create_conn(struct Curl_easy *data,
   else if(!proxy && !socksproxy)
 #ifndef CURL_DISABLE_HTTP
     /* if the host is not in the noproxy list, detect proxy. */
-    if(!check_noproxy(conn->host.name, no_proxy))
-      proxy = detect_proxy(conn);
+    proxy = detect_proxy(conn);
 #else  /* !CURL_DISABLE_HTTP */
     proxy = NULL;
 #endif /* CURL_DISABLE_HTTP */

--- a/lib/url.c
+++ b/lib/url.c
@@ -6018,6 +6018,7 @@ static CURLcode create_conn(struct Curl_easy *data,
   bool reuse;
   char *proxy = NULL;
   char *socksproxy = NULL;
+  char *no_proxy = NULL;
   bool prot_missing = FALSE;
   bool connections_available = TRUE;
   bool force_reuse = FALSE;
@@ -6194,13 +6195,20 @@ static CURLcode create_conn(struct Curl_easy *data,
     }
   }
 
-  if(data->set.str[STRING_NOPROXY] &&
-     check_noproxy(conn->host.name, data->set.str[STRING_NOPROXY])) {
+  no_proxy = curl_getenv("no_proxy");
+  if(!no_proxy)
+    no_proxy = curl_getenv("NO_PROXY");
+
+  if(check_noproxy(conn->host.name, data->set.str[STRING_NOPROXY]) ||
+     (!data->set.str[STRING_NOPROXY] &&
+      check_noproxy(conn->host.name, no_proxy))) {
     Curl_safefree(proxy);
     Curl_safefree(socksproxy);
   }
   else if(!proxy && !socksproxy)
     proxy = detect_proxy(conn);
+
+  Curl_safefree(no_proxy);
 
 #ifdef USE_UNIX_SOCKETS
   if(data->set.str[STRING_UNIX_SOCKET_PATH]) {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -127,7 +127,7 @@ test1216 test1217 test1218 test1219 \
 test1220 test1221 test1222 test1223 test1224 test1225 test1226 test1227 \
 test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
-test1244 test1245 test1246 test1247 \
+test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 \
 test1280 test1281 test1282 \
 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -128,6 +128,7 @@ test1220 test1221 test1222 test1223 test1224 test1225 test1226 test1227 \
 test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
+test1252 test1253 test1254 test1255 test1256 test1257 \
 \
 test1280 test1281 test1282 \
 \

--- a/tests/data/test1248
+++ b/tests/data/test1248
@@ -1,0 +1,49 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Access a non-proxied host with using the combination of --proxy option and --noproxy option
+</name>
+<command>
+http://user:secret@%HOSTIP:%HTTPPORT/1248 --proxy http://dummy:%PROXYPORT/ --noproxy %HOSTIP --max-time 5
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1248 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjpzZWNyZXQ=
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1249
+++ b/tests/data/test1249
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Access a non-proxied host with using the combination of --proxy option and NO_PROXY env var
+</name>
+<setenv>
+NO_PROXY=%HOSTIP
+</setenv>
+<command>
+http://user:secret@%HOSTIP:%HTTPPORT/1249 --proxy http://dummy:%PROXYPORT/ --max-time 5
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1249 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjpzZWNyZXQ=
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1250
+++ b/tests/data/test1250
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+http_proxy
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Access a non-proxied host with using the combination of http_proxy env var and --noproxy option
+</name>
+<setenv>
+http_proxy=http://dummy:%PROXYPORT/
+</setenv>
+<command>
+http://user:secret@%HOSTIP:%HTTPPORT/1250 --noproxy %HOSTIP --max-time 5
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1250 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjpzZWNyZXQ=
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1251
+++ b/tests/data/test1251
@@ -1,0 +1,54 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+http_proxy
+NO_PROXY
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Access a non-proxied host with using the combination of http_proxy env var and NO_PROXY env var
+</name>
+<setenv>
+http_proxy=http://dummy:%PROXYPORT/
+NO_PROXY=%HOSTIP
+</setenv>
+<command>
+http://user:secret@%HOSTIP:%HTTPPORT/1251 --max-time 5
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1251 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjpzZWNyZXQ=
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1252
+++ b/tests/data/test1252
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Under condition using --proxy, override NO_PROXY by --nproxy and access target URL directly
+</name>
+<setenv>
+NO_PROXY=example.com
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/1252 --proxy http://%HOSTIP:%HTTPPORT --noproxy %HOSTIP
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1252 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1253
+++ b/tests/data/test1253
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Under condition using --proxy, override NO_PROXY by --nproxy and access target URL through proxy
+</name>
+<setenv>
+NO_PROXY=example.com
+</setenv>
+<command>
+http://somewhere.example.com/1253 --proxy http://%HOSTIP:%HTTPPORT --noproxy %HOSTIP
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://somewhere.example.com/1253 HTTP/1.1
+Host: somewhere.example.com
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1254
+++ b/tests/data/test1254
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Under condition using --proxy, override NO_PROXY by --nproxy and access target URL through proxy
+</name>
+<setenv>
+NO_PROXY=example.com
+</setenv>
+<command>
+http://somewhere.example.com/1254 --proxy http://%HOSTIP:%HTTPPORT --noproxy ""
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://somewhere.example.com/1254 HTTP/1.1
+Host: somewhere.example.com
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1255
+++ b/tests/data/test1255
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Under condition using http_proxy, override NO_PROXY by --nproxy and access target URL directly
+</name>
+<setenv>
+http_proxy=http://%HOSTIP:%HTTPPORT
+NO_PROXY=example.com
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/1255 --noproxy %HOSTIP
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1255 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1256
+++ b/tests/data/test1256
@@ -1,0 +1,54 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Under condition using http_proxy, override NO_PROXY by --nproxy and access target URL through proxy
+</name>
+<setenv>
+http_proxy=http://%HOSTIP:%HTTPPORT
+NO_PROXY=example.com
+</setenv>
+<command>
+http://somewhere.example.com/1256 --noproxy %HOSTIP
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://somewhere.example.com/1256 HTTP/1.1
+Host: somewhere.example.com
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1257
+++ b/tests/data/test1257
@@ -1,0 +1,54 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Under condition using http_proxy, override NO_PROXY by --nproxy and access target URL through proxy
+</name>
+<setenv>
+http_proxy=http://%HOSTIP:%HTTPPORT
+NO_PROXY=example.com
+</setenv>
+<command>
+http://somewhere.example.com/1257 --noproxy ""
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://somewhere.example.com/1257 HTTP/1.1
+Host: somewhere.example.com
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
The combination of --noproxy option and http_proxy env var works well 
both for proxied hosts and non-proxied hosts.

However, when combining NO_PROXY env var with --proxy option, 
non-proxied hosts are not reachable while proxied host is OK.

This patch allows us to access non-proxied hosts even if using NO_PROXY
env var with --proxy option.
