### PR TITLE
Add Winbuild config option ENABLE_NGHTTP2

### DIFF
--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -21,6 +21,8 @@ CFGSET=true
 !MESSAGE                                  Libraries can be fetched at http://pecl2.php.net/downloads/php-windows-builds/
 !MESSAGE                                  Uncompress them into the deps folder.
 !MESSAGE   WITH_SSL=<dll or static>     - Enable OpenSSL support, DLL or static
+!MESSAGE   ENABLE_NGHTTP2=<yes or no>   - Enable HTTP/2 support, defaults to no
+!MESSAGE                                  Requires OpenSSL
 !MESSAGE   WITH_CARES=<dll or static>   - Enable c-ares support, DLL or static
 !MESSAGE   WITH_ZLIB=<dll or static>    - Enable zlib support, DLL or static
 !MESSAGE   WITH_SSH2=<dll or static>    - Enable libSSH2 support, DLL or static
@@ -107,6 +109,16 @@ SSL     = dll
 !ELSEIF "$(WITH_SSL)"=="static"
 USE_SSL = true
 SSL     = static
+!ENDIF
+
+!IF "$(USE_SSL)"=="true"
+!IF "$(ENABLE_NGHTTP2)"=="yes"
+USE_NGHTTP2 = true
+!ENDIF
+!ENDIF
+
+!IFNDEF USE_NGHTTP2
+USE_NGHTTP2 = false
 !ENDIF
 
 !IF "$(WITH_MBEDTLS)"=="dll" || "$(WITH_MBEDTLS)"=="static"
@@ -213,6 +225,7 @@ $(MODE):
 
 	@SET CONFIG_NAME_LIB=$(CONFIG_NAME_LIB)
 	@SET MACHINE=$(MACHINE)
+	@SET USE_NGHTTP2=$(USE_NGHTTP2)
 	@SET USE_IDN=$(USE_IDN)
 	@SET USE_IPV6=$(USE_IPV6)
 	@SET USE_SSPI=$(USE_SSPI)

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -123,8 +123,22 @@ USE_SSL      = true
 SSL          = static
 !ENDIF
 
+!IFNDEF USE_NGHTTP2
+USE_NGHTTP2  = false
+!ENDIF
+
 !IFDEF USE_SSL
 SSL_CFLAGS   = /DUSE_OPENSSL /I"$(DEVEL_INCLUDE)/openssl"
+
+!IF "$(USE_NGHTTP2)"=="yes"
+USE_NGHTTP2  = true
+!ENDIF
+
+!IF "$(USE_NGHTTP2)"=="true"
+SSL_CFLAGS   = $(SSL_CFLAGS) /DUSE_NGHTTP2
+SSL_LIBS     = $(SSL_LIBS) nghttp2.lib
+!ENDIF
+
 !ENDIF
 
 !IF "$(WITH_MBEDTLS)"=="dll" || "$(WITH_MBEDTLS)"=="static"
@@ -416,6 +430,7 @@ package: $(TARGET)
 
 $(TARGET): $(LIB_OBJS) $(LIB_DIROBJ) $(DISTDIR)
 	@echo Using SSL: $(USE_SSL)
+	@echo Using NGHTTP2: $(USE_NGHTTP2)
 	@echo Using c-ares: $(USE_CARES)
 	@echo Using SSH2: $(USE_SSH2)
 	@echo Using ZLIB: $(USE_ZLIB)


### PR DESCRIPTION
At every new release of curl, I am editing winbuild/MakefileBuild.vc. The edits:
1. Add nghttp2.lib to the SSL_LIBS
2. Add /DUSE_NGHTTP2 to the SSL_CFLAGS

Of course, I'd rather change my nmake /f Makefile.vc build line. This PR adds an extra option ENABLE_NGHTTP2=yes. ENABLE_NGHTTP2 defaults to 'no' to avoid breaks in current build lines.