### PR TITLE
fix bug #1147: Missing Crypt32.lib when linking OpenSSL statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,8 @@ if(NOT UNIX)
         set(CURL_LIBS ${CURL_LIBS} "crypt32")
       endif()
     endif()
+  elseif(USE_OPENSSL)
+        set(CURL_LIBS ${CURL_LIBS} "crypt32")
   endif()
 endif(NOT UNIX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,7 @@ if(NOT UNIX)
       endif()
     endif()
   elseif(USE_OPENSSL)
-        set(CURL_LIBS ${CURL_LIBS} "crypt32")
+    set(CURL_LIBS ${CURL_LIBS} "crypt32")
   endif()
 endif(NOT UNIX)
 


### PR DESCRIPTION
fix for bug #1147 
I add the crypt32 library to dependency list in any case when using OpenSSL in Windows.