### PR TITLE
libcurl: support enlarging rececive buffer through CURLOPT_BUFFERSIZE

### DIFF
--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -190,7 +190,7 @@ Timeout for DNS cache. See \fICURLOPT_DNS_CACHE_TIMEOUT(3)\fP
 .IP CURLOPT_DNS_USE_GLOBAL_CACHE
 OBSOLETE Enable global DNS cache. See \fICURLOPT_DNS_USE_GLOBAL_CACHE(3)\fP
 .IP CURLOPT_BUFFERSIZE
-Ask for smaller buffer size. See \fICURLOPT_BUFFERSIZE(3)\fP
+Ask for alternate buffer size. See \fICURLOPT_BUFFERSIZE(3)\fP
 .IP CURLOPT_PORT
 Port number to connect to. See \fICURLOPT_PORT(3)\fP
 .IP CURLOPT_TCP_FASTOPEN

--- a/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
@@ -30,12 +30,12 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_BUFFERSIZE, long size);
 .SH DESCRIPTION
 Pass a long specifying your preferred \fIsize\fP (in bytes) for the receive
 buffer in libcurl.  The main point of this would be that the write callback
-gets called more often and with smaller chunks. This is just treated as a
-request, not an order. You cannot be guaranteed to actually get the given
-size.
+gets called more often and with smaller chunks. Secondly, for some protocols,
+there's a benefit of having a larger buffer for performance. This is just
+treated as a request, not an order. You cannot be guaranteed to actually get
+the given size.
 
-This size is by default set as big as possible (\fICURL_MAX_WRITE_SIZE\fP), so
-it only makes sense to use this option if you want it smaller.
+This size is by default is (\fICURL_MAX_WRITE_SIZE\fP).
 .SH DEFAULT
 CURL_MAX_WRITE_SIZE
 .SH PROTOCOLS

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -870,6 +870,12 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
    * get setup on-demand in the code, as that would probably decrease
    * the likeliness of us forgetting to init a buffer here in the future.
    */
+  outcurl->set.buffer_size = data->set.buffer_size;
+
+  outcurl->state.buffer = malloc(outcurl->set.buffer_size + 1);
+  if(!outcurl->state.buffer)
+    goto fail;
+
   outcurl->state.headerbuff = malloc(HEADERSIZE);
   if(!outcurl->state.headerbuff)
     goto fail;
@@ -940,6 +946,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   if(outcurl) {
     curl_slist_free_all(outcurl->change.cookielist);
     outcurl->change.cookielist = NULL;
+    Curl_safefree(outcurl->state.buffer);
     Curl_safefree(outcurl->state.headerbuff);
     Curl_safefree(outcurl->change.url);
     Curl_safefree(outcurl->change.referer);

--- a/lib/http.c
+++ b/lib/http.c
@@ -1669,6 +1669,7 @@ CURLcode Curl_add_timecondition(struct Curl_easy *data,
 {
   const struct tm *tm;
   char *buf = data->state.buffer;
+  const long buf_size = data->set.buffer_size;
   struct tm keeptime;
   CURLcode result;
 
@@ -1691,7 +1692,7 @@ CURLcode Curl_add_timecondition(struct Curl_easy *data,
    */
 
   /* format: "Tue, 15 Nov 1994 12:45:26 GMT" */
-  snprintf(buf, BUFSIZE-1,
+  snprintf(buf, buf_size-1,
            "%s, %02d %s %4d %02d:%02d:%02d GMT",
            Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
            tm->tm_mday,
@@ -2142,9 +2143,10 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
         else {
           curl_off_t passed=0;
           do {
+            const long buf_size = data->set.buffer_size;
             size_t readthisamountnow =
-              (data->state.resume_from - passed > CURL_OFF_T_C(BUFSIZE)) ?
-              BUFSIZE : curlx_sotouz(data->state.resume_from - passed);
+              (data->state.resume_from - passed > buf_size) ?
+              buf_size : curlx_sotouz(data->state.resume_from - passed);
 
             size_t actuallyread =
               data->state.fread_func(data->state.buffer, 1, readthisamountnow,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -303,6 +303,7 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
       ssize_t gotbytes;
       char *ptr;
       char *line_start;
+      const long buf_size = data->set.buffer_size;
 
       ptr=data->state.buffer;
       line_start = ptr;
@@ -310,7 +311,7 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
       nread=0;
       perline=0;
 
-      while((nread<BUFSIZE) && (keepon && !error)) {
+      while((nread<buf_size) && (keepon && !error)) {
 
         check = Curl_timeleft(data, NULL, TRUE);
         if(check <= 0) {
@@ -328,7 +329,7 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
         case 0: /* timeout */
           break;
         default:
-          if(ptr >= &data->state.buffer[BUFSIZE]) {
+          if(ptr >= &data->state.buffer[buf_size]) {
             failf(data, "CONNECT response too large!");
             return CURLE_RECV_ERROR;
           }

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -602,7 +602,8 @@ static CURLcode smb_send_and_recv(struct connectdata *conn, void **msg)
 
   /* Check if there is data in the transfer buffer */
   if(!smbc->send_size && smbc->upload_size) {
-    int nread = smbc->upload_size > BUFSIZE ? BUFSIZE :
+    const size_t buf_size = conn->data->set.buffer_size;
+    int nread = smbc->upload_size > buf_size ? buf_size :
                                               (int) smbc->upload_size;
     conn->data->req.upload_fromhere = conn->data->state.uploadbuffer;
     result = Curl_fillreadbuffer(conn, nread, &nread);

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1590,7 +1590,7 @@ CURLcode Curl_smtp_escape_eob(struct connectdata *conn, const ssize_t nread)
   if(!scratch || data->set.crlf) {
     oldscratch = scratch;
 
-    scratch = newscratch = malloc(2 * BUFSIZE);
+    scratch = newscratch = malloc(2 * DEFAULT_BUFSIZE);
     if(!newscratch) {
       failf(data, "Failed to alloc scratch buffer!");
 

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -1838,11 +1838,12 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           }
           /* seekerr == CURL_SEEKFUNC_CANTSEEK (can't seek to offset) */
           else {
+	    const long buf_size = data->set.buffer_size;
             curl_off_t passed=0;
             do {
               size_t readthisamountnow =
-                (data->state.resume_from - passed > CURL_OFF_T_C(BUFSIZE)) ?
-                BUFSIZE : curlx_sotouz(data->state.resume_from - passed);
+                (data->state.resume_from - passed > buf_size) ?
+                buf_size : curlx_sotouz(data->state.resume_from - passed);
 
               size_t actuallyread =
                 data->state.fread_func(data->state.buffer, 1,

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1309,6 +1309,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   struct timeval now;
   bool keepon = TRUE;
   char *buf = data->state.buffer;
+  const long buf_size = data->set.buffer_size;
   struct TELNET *tn;
 
   *done = TRUE; /* unconditionally */
@@ -1423,7 +1424,8 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
       for(;;) {
         if(data->set.is_fread_set) {
           /* read from user-supplied method */
-          result = (int)data->state.fread_func(buf, 1, BUFSIZE - 1,
+
+          result = (int)data->state.fread_func(buf, 1, buf_size - 1,
                                                data->state.in);
           if(result == CURL_READFUNC_ABORT) {
             keepon = FALSE;
@@ -1499,7 +1501,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
       }
       if(events.lNetworkEvents & FD_READ) {
         /* read data from network */
-        result = Curl_read(conn, sockfd, buf, BUFSIZE - 1, &nread);
+        result = Curl_read(conn, sockfd, buf, buf_size - 1, &nread);
         /* read would've blocked. Loop again */
         if(result == CURLE_AGAIN)
           break;
@@ -1588,7 +1590,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     default:                    /* read! */
       if(pfd[0].revents & POLLIN) {
         /* read data from network */
-        result = Curl_read(conn, sockfd, buf, BUFSIZE - 1, &nread);
+        result = Curl_read(conn, sockfd, buf, buf_size - 1, &nread);
         /* read would've blocked. Loop again */
         if(result == CURLE_AGAIN)
           break;
@@ -1624,12 +1626,12 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
       nread = 0;
       if(poll_cnt == 2) {
         if(pfd[1].revents & POLLIN) { /* read from in file */
-          nread = read(pfd[1].fd, buf, BUFSIZE - 1);
+          nread = read(pfd[1].fd, buf, buf_size - 1);
         }
       }
       else {
         /* read from user-supplied method */
-        nread = (int)data->state.fread_func(buf, 1, BUFSIZE - 1,
+        nread = (int)data->state.fread_func(buf, 1, buf_size - 1,
                                             data->state.in);
         if(nread == CURL_READFUNC_ABORT) {
           keepon = FALSE;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -405,9 +405,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
   /* This is where we loop until we have read everything there is to
      read or we get a CURLE_AGAIN */
   do {
-    size_t buffersize = data->set.buffer_size?
-      data->set.buffer_size : BUFSIZE;
-    size_t bytestoread = buffersize;
+    size_t bytestoread = data->set.buffer_size;
 
     if(
 #if defined(USE_NGHTTP2)
@@ -861,6 +859,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
   CURLcode result;
   ssize_t nread; /* number of bytes read */
   bool sending_http_headers = FALSE;
+  const long buf_size = data->set.buffer_size;
 
   if((k->bytecount == 0) && (k->writebytecount == 0))
     Curl_pgrsTime(data, TIMER_STARTTRANSFER);
@@ -905,7 +904,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
             sending_http_headers = FALSE;
         }
 
-        result = Curl_fillreadbuffer(conn, BUFSIZE, &fillcount);
+        result = Curl_fillreadbuffer(conn, buf_size, &fillcount);
         if(result)
           return result;
 
@@ -937,7 +936,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
          (data->set.crlf))) {
         /* Do we need to allocate a scratch buffer? */
         if(!data->state.scratch) {
-          data->state.scratch = malloc(2 * BUFSIZE);
+          data->state.scratch = malloc(2 * buf_size);
           if(!data->state.scratch) {
             failf(data, "Failed to alloc scratch buffer!");
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -452,6 +452,7 @@ CURLcode Curl_close(struct Curl_easy *data)
   }
   data->change.url = NULL;
 
+  Curl_safefree(data->state.buffer);
   Curl_safefree(data->state.headerbuff);
 
   Curl_flush_cookies(data, 1);
@@ -641,6 +642,14 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
   /* We do some initial setup here, all those fields that can't be just 0 */
 
+  data->set.buffer_size = DEFAULT_BUFSIZE;
+
+  data->state.buffer = malloc(data->set.buffer_size + 1);
+  if(!data->state.buffer) {
+    DEBUGF(fprintf(stderr, "Error: malloc of buffer failed\n"));
+    result = CURLE_OUT_OF_MEMORY;
+  }
+
   data->state.headerbuff = malloc(HEADERSIZE);
   if(!data->state.headerbuff) {
     DEBUGF(fprintf(stderr, "Error: malloc of headerbuff failed\n"));
@@ -671,6 +680,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
   if(result) {
     Curl_resolver_cleanup(data->state.resolver);
+    free(data->state.buffer);
     free(data->state.headerbuff);
     Curl_freeset(data);
     free(data);
@@ -2262,17 +2272,30 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     break;
 
   case CURLOPT_BUFFERSIZE:
+  {
     /*
      * The application kindly asks for a differently sized receive buffer.
      * If it seems reasonable, we'll use it.
      */
+    const long original_buffer_size = data->set.buffer_size;
     data->set.buffer_size = va_arg(param, long);
 
-    if((data->set.buffer_size> (BUFSIZE -1)) ||
+    DEBUGASSERT(DEFAULT_BUFSIZE <= MAX_BUFSIZE);
+
+    if((data->set.buffer_size> (MAX_BUFSIZE -1)) ||
        (data->set.buffer_size < 1))
-      data->set.buffer_size = 0; /* huge internal default */
+      data->set.buffer_size= MAX_BUFSIZE; /* huge internal default */
+
+    if (original_buffer_size < data->set.buffer_size) {
+      data->state.buffer = realloc(data->state.buffer, data->set.buffer_size + 1);
+      if(!data->state.buffer) {
+        DEBUGF(fprintf(stderr, "Error: realloc of buffer failed\n"));
+        result = CURLE_OUT_OF_MEMORY;
+      }
+    }
 
     break;
+  }
 
   case CURLOPT_NOSIGNAL:
     /*
@@ -4158,8 +4181,9 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
 
   if(Curl_pipeline_wanted(data->multi, CURLPIPE_HTTP1) &&
      !conn->master_buffer) {
+	  fprintf(stderr, "master buffer?!!\n");
     /* Allocate master_buffer to be used for HTTP/1 pipelining */
-    conn->master_buffer = calloc(BUFSIZE, sizeof(char));
+    conn->master_buffer = calloc(DEFAULT_BUFSIZE, sizeof (char));
     if(!conn->master_buffer)
       goto error;
   }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -199,8 +199,8 @@
 #endif /* HAVE_LIBSSH2_H */
 
 /* Download buffer size, keep it fairly big for speed reasons */
-#undef BUFSIZE
-#define BUFSIZE CURL_MAX_WRITE_SIZE
+#define DEFAULT_BUFSIZE CURL_MAX_WRITE_SIZE
+#define MAX_BUFSIZE 524288
 
 /* Initial size of the buffer to store headers in, it'll be enlarged in case
    of need. */
@@ -1303,8 +1303,8 @@ struct UrlState {
   char *headerbuff; /* allocated buffer to store headers in */
   size_t headersize;   /* size of the allocation */
 
-  char buffer[BUFSIZE+1]; /* download buffer */
-  char uploadbuffer[BUFSIZE+1]; /* upload buffer */
+  char *buffer; /* download buffer */
+  char uploadbuffer[DEFAULT_BUFSIZE]; /* upload buffer */
   curl_off_t current_speed;  /* the ProgressShow() funcion sets this,
                                 bytes / second */
   bool this_is_a_follow; /* this is a followed Location: request */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -222,7 +222,7 @@ static void showtime(struct Curl_easy *data,
     return;
 
   snprintf(data->state.buffer,
-           BUFSIZE,
+           data->set.buffer_size,
            "\t %s: %s, %02d %s %4d %02d:%02d:%02d GMT",
            text,
            Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -189,6 +189,7 @@ static CURLcode Curl_ossl_seed(struct Curl_easy *data)
      time-consuming seedings in vain */
   static bool ssl_seeded = FALSE;
   char *buf = data->state.buffer; /* point to the big buffer */
+  const long buf_size = data->set.buffer_size;
   int nread=0;
 
   if(ssl_seeded)
@@ -250,7 +251,7 @@ static CURLcode Curl_ossl_seed(struct Curl_easy *data)
 
   /* generates a default path for the random seed file */
   buf[0]=0; /* blank it first */
-  RAND_file_name(buf, BUFSIZE);
+  RAND_file_name(buf, buf_size);
   if(buf[0]) {
     /* we got a file name to try */
     nread += RAND_load_file(buf, RAND_LOAD_LENGTH);
@@ -2758,6 +2759,7 @@ static CURLcode servercert(struct connectdata *conn,
   X509 *issuer;
   FILE *fp;
   char *buffer = data->state.buffer;
+  const long buffer_size = data->set.buffer_size;
   const char *ptr;
   long * const certverifyresult = SSL_IS_PROXY() ?
     &data->set.proxy_ssl.certverifyresult : &data->set.ssl.certverifyresult;
@@ -2779,7 +2781,7 @@ static CURLcode servercert(struct connectdata *conn,
   infof(data, "%s certificate:\n", SSL_IS_PROXY() ? "Proxy" : "Server");
 
   rc = x509_name_oneline(X509_get_subject_name(connssl->server_cert),
-                         buffer, BUFSIZE);
+                         buffer, buffer_size);
   infof(data, " subject: %s\n", rc?"[NONE]":buffer);
 
   ASN1_TIME_print(mem, X509_get0_notBefore(connssl->server_cert));
@@ -2804,7 +2806,7 @@ static CURLcode servercert(struct connectdata *conn,
   }
 
   rc = x509_name_oneline(X509_get_issuer_name(connssl->server_cert),
-                         buffer, BUFSIZE);
+                         buffer, buffer_size);
   if(rc) {
     if(strict)
       failf(data, "SSL: couldn't get X509-issuer name!");


### PR DESCRIPTION
Replace use of fixed macro BUFSIZE to define the size of the receive
buffer. Upon setting CURLOPT_BUFFERSIZE, resize buffer if larger than
the current default size up to a MAX_BUFSIZE (512KB). This can
benefit protocols like SFTP.

https://daniel.haxx.se/blog/2014/05/14/why-sftp-is-still-slow-in-curl