### PR TITLE
Manpage fixes

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
@@ -58,6 +58,9 @@ The Content-Length: servers send for a compressed response is supposed to
 indicate the length of the compressed content so when auto decoding is enabled
 it may not match the sum of bytes reported by the write callbacks (although,
 sending the length of the non-compressed content is a common server mistake).
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.3
@@ -46,6 +46,9 @@ option is supported for backward compatibility with other SSL engines, but it
 should not be set. If the option is not set, then curl will use the
 certificates in the system and user Keychain to verify the peer, which is the
 preferred method of verifying the peer's certificate chain.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 Built-in system specific
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_CAPATH.3
@@ -36,6 +36,9 @@ This makes sense only when used in combination with the
 
 The \fICURLOPT_CAPATH(3)\fP function apparently does not work in Windows due
 to some limitation in openssl.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_COOKIE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.3
@@ -55,6 +55,9 @@ previous ones.
 This option will not enable the cookie engine. Use \fICURLOPT_COOKIEFILE(3)\fP
 or \fICURLOPT_COOKIEJAR(3)\fP to enable parsing and sending cookies
 automatically.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL, no cookies
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
@@ -53,6 +53,9 @@ sub-domains) or use the Netscape format.
 
 If you use this option multiple times, you just add more files to read.
 Subsequent files will add more cookies.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
@@ -46,6 +46,9 @@ only visible feedback you get about this possibly lethal situation.
 
 Since 7.43.0 cookies that were imported in the Set-Cookie format without a
 domain name are not exported by this option.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.3
@@ -45,6 +45,9 @@ A specific error code (\fICURLE_SSL_CRL_BADFILE\fP) is defined with the
 option. It is returned when the SSL exchange fails because the CRL file cannot
 be loaded.  A failure in certificate verification due to a revocation
 information found in the CRL does not trigger this specific error.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
@@ -80,6 +80,9 @@ Normally a multiline response is returned which can be used, in conjunction
 with \fICURLOPT_MAIL_RCPT(3)\fP, to specify an EXPN request. If the
 \fICURLOPT_NOBODY(3)\fP option is specified then the request can be used to
 issue NOOP and RSET commands.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.3
+++ b/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.3
@@ -49,6 +49,9 @@ This option does not change the default proxy protocol (http).
 
 Without this option libcurl would make a guess based on the host, see
 \fICURLOPT_URL(3)\fP for details.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL (make a guess based on the host)
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
@@ -32,6 +32,9 @@ Pass a char * as parameter. Set the name of the network interface that the DNS
 resolver should bind to. This must be an interface name (not an address). Set
 this option to NULL to use the default setting (don't bind to a specific
 interface).
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
@@ -32,6 +32,9 @@ Set the local IPv4 \fIaddress\fP that the resolver should bind to. The
 argument should be of type char * and contain a single numerical IPv4 address
 as a string.  Set this option to NULL to use the default setting (don't bind
 to a specific IP address).
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
@@ -32,6 +32,9 @@ Set the local IPv6 \fIaddress\fP that the resolver should bind to. The
 argument should be of type char * and contain a single IPv6 address as a
 string.  Set this option to NULL to use the default setting (don't bind to a
 specific IP address).
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
@@ -36,6 +36,9 @@ host[:port][,host[:port]]...
 For example:
 
 192.168.1.100,192.168.1.101,3.4.5.6
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL - use system default
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
@@ -30,6 +30,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_EGDSOCKET, char *path);
 .SH DESCRIPTION
 Pass a char * to the zero terminated path name to the Entropy Gathering Daemon
 socket. It will be used to seed the random engine for SSL.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_FTPPORT.3
+++ b/docs/libcurl/opts/CURLOPT_FTPPORT.3
@@ -57,6 +57,9 @@ Examples with specified ports:
 
 You disable PORT again and go back to using the passive version by setting
 this option to NULL.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
@@ -31,6 +31,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_ACCOUNT, char *account);
 Pass a pointer to a zero terminated string (or NULL to disable). When an FTP
 server asks for "account data" after user name and password has been provided,
 this data is sent off using the ACCT command.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.3
@@ -35,6 +35,9 @@ authenticate if the usual FTP "USER user" and "PASS password" negotiation
 fails. This is currently only known to be required when connecting to
 Tumbleweed's Secure Transport FTPS server using client certificates for
 authentication.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.3
@@ -40,6 +40,9 @@ synchronously.  Using the if! format is highly recommended when using the
 multi interfaces to avoid allowing the code to block.  If "if!" is specified
 but the parameter does not match an existing interface, CURLE_INTERFACE_FAILED
 is returned from the libcurl function used to perform the transfer.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL, use whatever the TCP stack finds suitable
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
@@ -43,6 +43,9 @@ A specific error code (CURLE_SSL_ISSUER_ERROR) is defined with the option,
 which is returned if the setup of the SSL/TLS session has failed due to a
 mismatch with the issuer of peer certificate (\fICURLOPT_SSL_VERIFYPEER(3)\fP
 has to be set too for the check to fail). (Added in 7.19.0)
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
@@ -32,6 +32,9 @@ Pass a pointer to a zero terminated string as parameter. It will be used as
 the password required to use the \fICURLOPT_SSLKEY(3)\fP or
 \fICURLOPT_SSH_PRIVATE_KEYFILE(3)\fP private key.  You never needed a pass
 phrase to load a certificate but you need one to load your private key.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_KRBLEVEL.3
+++ b/docs/libcurl/opts/CURLOPT_KRBLEVEL.3
@@ -33,6 +33,9 @@ enables kerberos awareness.  This is a string that should match one of the
 following: \&'clear', \&'safe', \&'confidential' or \&'private'.  If the
 string is set but doesn't match one of these, 'private' will be used. Set the
 string to NULL to disable kerberos support for FTP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
@@ -38,6 +38,9 @@ IETF draft draft-earhart-url-smtp-00.txt
 options, such as the preferred authentication mechanism via "AUTH=NTLM" or
 "AUTH=*", and should be used in conjunction with the \fICURLOPT_USERNAME(3)\fP
 option.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
@@ -43,6 +43,9 @@ Unlike \fICURLOPT_MAIL_FROM(3)\fP and \fICURLOPT_MAIL_RCPT(3)\fP, the address
 should not be specified within a pair of angled brackets (<>). However, if an
 empty string is used then a pair of brackets will be sent by libcurl as
 required by RFC2554.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
@@ -36,6 +36,9 @@ around it, which if not specified will be added automatically.
 
 If this parameter is not specified then an empty address will be sent to the
 mail server which may cause the email to be rejected.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
@@ -33,6 +33,9 @@ the full path name to the \fIfile\fP you want libcurl to use as .netrc
 file. If this option is omitted, and \fICURLOPT_NETRC(3)\fP is set, libcurl
 will attempt to find a .netrc file in the current user's home
 directory.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -36,6 +36,9 @@ list is matched as either a domain which contains the hostname, or the
 hostname itself. For example, example.com would match example.com,
 example.com:80, and www.example.com, but not www.notanexample.com or
 example.com.othertld.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.3
@@ -33,6 +33,9 @@ password to use for the transfer.
 
 The \fICURLOPT_PASSWORD(3)\fP option should be used in conjunction with the
 \fICURLOPT_USERNAME(3)\fP option.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -39,6 +39,9 @@ if it does not exactly match the public key provided to this option, curl will
 abort the connection before sending or receiving any data.
 
 On mismatch, \fICURLE_SSL_PINNEDPUBKEYNOTMATCH\fP is returned.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PREQUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_PREQUOTE.3
@@ -26,7 +26,8 @@ CURLOPT_PREQUOTE \- commands to run before FTP or SFTP transfer
 .SH SYNOPSIS
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PREQUOTE, char *cmds);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PREQUOTE,
+                          struct curl_slist *cmds);
 .SH DESCRIPTION
 Pass a pointer to a linked list of FTP or SFTP commands to pass to the server
 after the transfer type is set. The linked list should be a fully valid list

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
@@ -50,6 +50,9 @@ be used. Otherwise SOCKS4 is used as default.
 
 Setting the pre proxy string to "" (an empty string) will explicitly disable
 the use of a pre proxy.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 Default is NULL, meaning no pre proxy is used.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -62,6 +62,9 @@ use of a proxy, even if there is an environment variable set for it.
 
 A proxy host string can also include protocol scheme (http://) and embedded
 user + password.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 Default is NULL, meaning no proxy is used.
 

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
@@ -33,6 +33,9 @@ password to use for authentication with the proxy.
 
 The \fICURLOPT_PROXYPASSWORD(3)\fP option should be used in conjunction with
 the \fICURLOPT_PROXYUSERNAME(3)\fP option.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
@@ -37,6 +37,9 @@ user name to use for the transfer.
 authentication with the proxy.
 
 To specify the proxy password use the \fICURLOPT_PROXYPASSWORD(3)\fP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
@@ -35,6 +35,9 @@ should encode it as %3A. (This is different to how \fICURLOPT_USERPWD(3)\fP is
 used - beware.)
 
 Use \fICURLOPT_PROXYAUTH(3)\fP to specify the authentication method.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 This is NULL by default.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
@@ -48,6 +48,9 @@ option is supported for backward compatibility with other SSL engines, but it
 should not be set. If the option is not set, then curl will use the
 certificates in the system and user Keychain to verify the peer, which is the
 preferred method of verifying the peer's certificate chain.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 Built-in system specific
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
@@ -33,6 +33,9 @@ CA certificates to verify the HTTPS proxy with. If libcurl is built against
 OpenSSL, the certificate directory must be prepared using the openssl c_rehash
 utility. This makes sense only when \fICURLOPT_SSL_VERIFYPEER(3)\fP is enabled
 (which it is by default).
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
@@ -47,6 +47,9 @@ A specific error code (\fICURLE_SSL_CRL_BADFILE\fP) is defined with the
 option. It is returned when the SSL exchange fails because the CRL file cannot
 be loaded.  A failure in certificate verification due to a revocation
 information found in the CRL does not trigger this specific error.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
@@ -34,6 +34,9 @@ Pass a pointer to a zero terminated string as parameter. It will be used as
 the password required to use the \fICURLOPT_PROXY_SSLKEY(3)\fP private key.
 You never needed a pass phrase to load a certificate but you need one to load
 your private key.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
@@ -39,6 +39,9 @@ if it does not exactly match the public key provided to this option, curl will
 abort the connection before sending or receiving any data.
 
 On mismatch, \fICURLE_SSL_PINNEDPUBKEYNOTMATCH\fP is returned.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.3
@@ -31,6 +31,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SERVICE_NAME, char *name);
 Pass a char * as parameter to a string holding the \fIname\fP of the
 service. The default service name is "HTTP" for HTTP based proxies and "rcmd"
 for SOCKS5. This option allows you to change it.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 See above
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
@@ -42,6 +42,9 @@ prefix, in order to avoid confusion with a nickname.
 
 When using a client certificate, you most likely also need to provide a
 private key with \fICURLOPT_PROXY_SSLKEY(3)\fP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
@@ -34,6 +34,9 @@ the format of your client certificate used when connecting to a HTTPS proxy.
 Supported formats are "PEM" and "DER", except with Secure Transport. OpenSSL
 (versions 0.9.3 and later) and Secure Transport (on iOS 5 or later, or OS X
 10.7 or later) also support "P12" for PKCS#12-encoded files.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 "PEM"
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
@@ -36,6 +36,9 @@ default format is "PEM" and can be changed with
 (iOS and Mac OS X only) This option is ignored if curl was built against
 Secure Transport. Secure Transport expects the private key to be already
 present in the keychain or PKCS#12 file containing the certificate.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
@@ -32,6 +32,9 @@ This option is for connecting to a HTTPS proxy, not a HTTPS server.
 
 Pass a pointer to a zero terminated string as parameter. The string should be
 the format of your private key. Supported formats are "PEM", "DER" and "ENG".
+
+The application does not have to keep the string around after setting this
+option.
 .SH PROTOCOLS
 Used with HTTPS proxy
 .SH EXAMPLE

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
@@ -50,6 +50,9 @@ enabled.
 You'll find more details about the NSS cipher lists on this URL:
 
  http://git.fedorahosted.org/cgit/mod_nss.git/plain/docs/mod_nss.html#Directives
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL, use internal default
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
@@ -32,6 +32,9 @@ Pass a char * as parameter, which should point to the zero terminated password
 to use for the TLS authentication method specified with the
 \fICURLOPT_PROXY_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_PROXY_TLSAUTH_USERNAME(3)\fP option also be set.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
@@ -38,6 +38,9 @@ defined in RFC5054 and provides mutual authentication if both sides have a
 shared secret. To use TLS-SRP, you must also set the
 \fICURLOPT_PROXY_TLSAUTH_USERNAME(3)\fP and
 \fICURLOPT_PROXY_TLSAUTH_PASSWORD(3)\fP options.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
@@ -32,6 +32,9 @@ Pass a char * as parameter, which should point to the zero terminated username
 to use for the HTTPS proxy TLS authentication method specified with the
 \fICURLOPT_PROXY_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_PROXY_TLSAUTH_PASSWORD(3)\fP option also be set.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
@@ -30,6 +30,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RANDOM_FILE, char *path);
 .SH DESCRIPTION
 Pass a char * to a zero terminated file name. The file will be used to read
 from to seed the random engine for SSL and more.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL, not used
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_RANGE.3
+++ b/docs/libcurl/opts/CURLOPT_RANGE.3
@@ -44,6 +44,9 @@ RTSP, byte ranges are \fBnot\fP permitted. Instead, ranges should be given in
 npt, utc, or smpte formats.
 
 Pass a NULL to this option to disable the use of ranges.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_REFERER.3
+++ b/docs/libcurl/opts/CURLOPT_REFERER.3
@@ -32,6 +32,9 @@ Pass a pointer to a zero terminated string as parameter. It will be used to
 set the Referer: header in the http request sent to the remote server. This
 can be used to fool servers or scripts. You can also set any custom header
 with \fICURLOPT_HTTPHEADER(3)\fP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.3
@@ -34,6 +34,9 @@ set to any non-NULL value, libcurl will return \fICURLE_RTSP_SESSION_ERROR\fP
 if ID received from the server does not match. If unset (or set to NULL),
 libcurl will automatically set the ID the first time the server sets it in a
 response.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.3
@@ -38,6 +38,9 @@ with RTSP, the \fICURLOPT_RTSP_STREAM_URI(3)\fP indicates what URL to send to
 the server in the request header while the \fICURLOPT_URL(3)\fP indicates
 where to make the connection to.  (e.g. the \fICURLOPT_URL(3)\fP for the above
 examples might be set to \fIrtsp://foo/twister\fP
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 '*'
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.3
@@ -34,6 +34,9 @@ Pass a char * to tell libcurl what to pass for the Transport: header for this
 RTSP session. This is mainly a convenience method to avoid needing to set a
 custom Transport: header for every SETUP request. The application must set a
 Transport: header before issuing a SETUP request.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
@@ -32,6 +32,9 @@ Pass a char * as parameter to a string holding the \fIname\fP of the service
 for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms. The default
 service names are "ftp", "HTTP", "imap", "pop" and "smtp". This option allows
 you to change them.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 See above
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.3
@@ -33,6 +33,9 @@ Deprecated since 7.49.0. Use \fICURLOPT_PROXY_SERVICE_NAME(3)\fP instead.
 Pass a char * as parameter to a string holding the \fIname\fP of the service.
 The default service name for a SOCKS5 server is "rcmd". This option allows you
 to change it.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 See above
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.3
@@ -33,6 +33,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_HOST_PUBLIC_KEY_MD5,
 Pass a char * pointing to a string containing 32 hexadecimal digits. The
 string should be the 128 bit MD5 checksum of the remote host's public key, and
 libcurl will reject the connection to the host unless the md5sums match.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
@@ -34,6 +34,9 @@ format as supported by libssh2. If this file is specified, libcurl will only
 accept connections with hosts that are known and present in that file, with a
 matching public key. Use \fICURLOPT_SSH_KEYFUNCTION(3)\fP to alter the default
 behavior on host and key (mis)matching.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.3
@@ -36,6 +36,9 @@ is set, and just "id_dsa" in the current directory if HOME is not set.
 
 If the file is password-protected, set the password with
 \fICURLOPT_KEYPASSWD(3)\fP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 As explained above
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.3
@@ -38,6 +38,9 @@ set.
 If NULL (or an empty string) is passed, libcurl will pass no public key to
 libssh2, which then tries to compute it from the private key.  This is known
 to work with libssh2 1.4.0+ linked against OpenSSL.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.3
@@ -40,6 +40,9 @@ prefix, in order to avoid confusion with a nickname.
 
 When using a client certificate, you most likely also need to provide a
 private key with \fICURLOPT_SSLKEY(3)\fP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
@@ -33,6 +33,9 @@ the format of your certificate. Supported formats are "PEM" and "DER", except
 with Secure Transport. OpenSSL (versions 0.9.3 and later) and Secure Transport
 (on iOS 5 or later, or OS X 10.7 or later) also support "P12" for
 PKCS#12-encoded files.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 "PEM"
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE.3
@@ -30,6 +30,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLENGINE, char *id);
 .SH DESCRIPTION
 Pass a pointer to a zero terminated string as parameter. It will be used as
 the identifier for the crypto engine you want to use for your private key.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.3
@@ -35,6 +35,9 @@ changed with \fICURLOPT_SSLKEYTYPE(3)\fP.
 (iOS and Mac OS X only) This option is ignored if curl was built against
 Secure Transport. Secure Transport expects the private key to be already
 present in the keychain or PKCS#12 file containing the certificate.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
@@ -35,6 +35,9 @@ The format "ENG" enables you to load the private key from a crypto engine. In
 this case \fICURLOPT_SSLKEY(3)\fP is used as an identifier passed to the
 engine. You have to set the crypto engine with \fICURLOPT_SSLENGINE(3)\fP.
 \&"DER" format key file currently does not work because of a bug in OpenSSL.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 "PEM"
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -49,6 +49,9 @@ enabled.
 
 For WolfSSL, valid examples of cipher lists include
 \'ECDHE-RSA-RC4-SHA\', 'AES256-SHA:AES256-SHA256', etc.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL, use internal default
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
@@ -32,6 +32,9 @@ Pass a char * as parameter, which should point to the zero terminated password
 to use for the TLS authentication method specified with the
 \fICURLOPT_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_TLSAUTH_USERNAME(3)\fP option also be set.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
@@ -37,6 +37,9 @@ defined in RFC5054 and provides mutual authentication if both sides have a
 shared secret. To use TLS-SRP, you must also set the
 \fICURLOPT_TLSAUTH_USERNAME(3)\fP and \fICURLOPT_TLSAUTH_PASSWORD(3)\fP
 options.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
@@ -32,6 +32,9 @@ Pass a char * as parameter, which should point to the zero terminated username
 to use for the TLS authentication method specified with the
 \fICURLOPT_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_TLSAUTH_PASSWORD(3)\fP option also be set.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
@@ -46,6 +46,9 @@ are not supported. Proxy options such as
 .BR CURLOPT_PROXY "(3)
 have no effect either as these are TCP-oriented, and asking a proxy server to
 connect to a certain Unix domain socket is not possible.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 Default is NULL, meaning that no Unix domain sockets are used.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -283,6 +283,9 @@ user wants to pass in a '#' (hash) character it will be treated as a fragment
 and get cut off by libcurl if provided literally. You will instead have to
 escape it by providing it as backslash and its ASCII value in hexadecimal:
 "\\23".
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 There is no default URL. If this option isn't set, no transfer can be
 performed.

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.3
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.3
@@ -32,6 +32,9 @@ Pass a pointer to a zero terminated string as parameter. It will be used to
 set the User-Agent: header in the HTTP request sent to the remote server. This
 can be used to fool servers or scripts. You can also set any custom header
 with \fICURLOPT_HTTPHEADER(3)\fP.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL, no User-Agent: header is used by default.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.3
@@ -55,6 +55,9 @@ authentication as well.
 
 To specify the password and login options, along with the user name, use the
 \fICURLOPT_PASSWORD(3)\fP and \fICURLOPT_LOGIN_OPTIONS(3)\fP options.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 blank
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_USERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.3
@@ -61,6 +61,9 @@ SMTP options.
 The user and password strings are not URL decoded, so there's no way to send
 in a user name containing a colon using this option. Use
 \fICURLOPT_USERNAME(3)\fP for that, or include it in the URL.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
@@ -34,6 +34,9 @@ the OAuth 2.0 Authorization Framework.
 
 Note: The user name used to generate the Bearer Token should be supplied via
 the \fICURLOPT_USERNAME(3)\fP option.
+
+The application does not have to keep the string around after setting this
+option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS


### PR DESCRIPTION
One bug (prototype in CURLOPT_PREQUOTE), and clarifications about not needing to keep strings around to all char* options (apart from POSTFIELDS). I did check the code, and all of the handlers do indeed copy strings if necessary, so the clarifications are correct.