### PR TITLE
darwinssl: fix iOS build and CFArrayRef leak

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -936,7 +936,11 @@ static OSStatus CopyIdentityWithLabel(char *label,
           (SecIdentityRef) CFArrayGetValueAtIndex(keys_list, i);
         err = SecIdentityCopyCertificate(*out_cert_and_key, &cert);
         if(err == noErr) {
+#if CURL_BUILD_IOS
+          common_name = SecCertificateCopySubjectSummary(cert);
+#else // CURL_BUILD_MAC_10_7
           SecCertificateCopyCommonName(cert, &common_name);
+#endif
           if(CFStringCompare(common_name, label_cf, 0) == kCFCompareEqualTo) {
             CFRelease(cert);
             CFRelease(common_name);

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -940,7 +940,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
         if(err == noErr) {
 #if CURL_BUILD_IOS
           common_name = SecCertificateCopySubjectSummary(cert);
-#else // CURL_BUILD_MAC_10_7
+#elif CURL_BUILD_MAC_10_7
           SecCertificateCopyCommonName(cert, &common_name);
 #endif
           if(CFStringCompare(common_name, label_cf, 0) == kCFCompareEqualTo) {
@@ -957,7 +957,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
       }
     }
 
-    if (keys_list)
+    if(keys_list)
       CFRelease(keys_list);
     CFRelease(query_dict);
     CFRelease(label_cf);


### PR DESCRIPTION
https://github.com/curl/curl/issues/1172

- use `SecCertificateCopySubjectSummary` on iOS as we do in `CopyCertSubject`
- retain the matching `SecIdentityRef` and release the others with `CFRelease(keys_list)`
- move locals into `#if CURL_BUILD_MAC_10_7 || CURL_BUILD_IOS` block to avoid unused locals warnings on other targets
- set `status = 1` in case `SecItemCopyMatching` yields an empty set

I haven't been able to independently verify whether client certificate matching works on any version of iOS or macOS, before or after this change. @schweikert, @nickzman, would you be able to help with that? Presumably, this change is no worse for iOS than what we had before https://github.com/curl/curl/pull/1105. 