### PR TITLE
cmake: Support extended attributes when built with cmake

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -533,3 +533,19 @@ main () {
     return 0;
 }
 #endif
+#ifdef HAVE_FSETXATTR_6
+#include <sys/xattr.h> /* header from libc, not from libattr */
+int
+main() {
+  fsetxattr(0, 0, 0, 0, 0, 0);
+  return 0;
+}
+#endif
+#ifdef HAVE_FSETXATTR_5
+#include <sys/xattr.h> /* header from libc, not from libattr */
+int
+main() {
+  fsetxattr(0, 0, 0, 0, 0);
+  return 0;
+}
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,10 +571,6 @@ else()
   unset(USE_UNIX_SOCKETS CACHE)
 endif()
 
-option(CURL_XATTR "Set to ON to enable building cURL with xattr support." ON)
-mark_as_advanced(CURL_XATTR)
-set(HAVE_FSETXATTR_5 OFF)
-set(HAVE_FSETXATTR_6 OFF)
 
 # Check for header files
 if(NOT UNIX)
@@ -825,23 +821,12 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
 # symbol exists in win32, but function does not.
 check_function_exists(inet_pton HAVE_INET_PTON)
 
-if(CURL_XATTR)
-  check_symbol_exists(fsetxattr "${CURL_INCLUDES}" HAVE_FSETXATTR)
-  if(HAVE_FSETXATTR)
-    add_definitions(-DHAVE_FSETXATTR)
-    foreach(CURL_TEST HAVE_FSETXATTR_5 HAVE_FSETXATTR_6)
-      curl_internal_test_run(${CURL_TEST})
-    endforeach(CURL_TEST)
-    if(HAVE_FSETXATTR_5)
-      set_source_files_properties(tool_xattr.c PROPERTIES
-        COMPILE_FLAGS "-DHAVE_FSETXATTR_5")
-    endif()
-    if(HAVE_FSETXATTR_6)
-      set_source_files_properties(tool_xattr.c PROPERTIES
-        COMPILE_FLAGS "-DHAVE_FSETXATTR_6")
-    endif()
-  endif()
-endif()
+check_symbol_exists(fsetxattr "${CURL_INCLUDES}" HAVE_FSETXATTR)
+if(HAVE_FSETXATTR)
+  foreach(CURL_TEST HAVE_FSETXATTR_5 HAVE_FSETXATTR_6)
+    curl_internal_test_run(${CURL_TEST})
+  endforeach(CURL_TEST)
+endif(HAVE_FSETXATTR)
 
 # sigaction and sigsetjmp are special. Use special mechanism for
 # detecting those, but only if previous attempt failed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,10 @@ else()
   unset(USE_UNIX_SOCKETS CACHE)
 endif()
 
+option(CURL_XATTR "Set to ON to enable building cURL with xattr support." ON)
+mark_as_advanced(CURL_XATTR)
+set(HAVE_FSETXATTR_5 OFF)
+set(HAVE_FSETXATTR_6 OFF)
 
 # Check for header files
 if(NOT UNIX)
@@ -609,6 +613,7 @@ check_include_file_concat("sys/types.h"      HAVE_SYS_TYPES_H)
 check_include_file_concat("sys/uio.h"        HAVE_SYS_UIO_H)
 check_include_file_concat("sys/un.h"         HAVE_SYS_UN_H)
 check_include_file_concat("sys/utime.h"      HAVE_SYS_UTIME_H)
+check_include_file_concat("sys/xattr.h"      HAVE_SYS_XATTR_H)
 check_include_file_concat("alloca.h"         HAVE_ALLOCA_H)
 check_include_file_concat("arpa/inet.h"      HAVE_ARPA_INET_H)
 check_include_file_concat("arpa/tftp.h"      HAVE_ARPA_TFTP_H)
@@ -819,6 +824,24 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
 
 # symbol exists in win32, but function does not.
 check_function_exists(inet_pton HAVE_INET_PTON)
+
+if(CURL_XATTR)
+  check_symbol_exists(fsetxattr "${CURL_INCLUDES}" HAVE_FSETXATTR)
+  if(HAVE_FSETXATTR)
+    add_definitions(-DHAVE_FSETXATTR)
+    foreach(CURL_TEST HAVE_FSETXATTR_5 HAVE_FSETXATTR_6)
+      curl_internal_test_run(${CURL_TEST})
+    endforeach(CURL_TEST)
+    if(HAVE_FSETXATTR_5)
+      set_source_files_properties(tool_xattr.c PROPERTIES
+        COMPILE_FLAGS "-DHAVE_FSETXATTR_5")
+    endif()
+    if(HAVE_FSETXATTR_6)
+      set_source_files_properties(tool_xattr.c PROPERTIES
+        COMPILE_FLAGS "-DHAVE_FSETXATTR_6")
+    endif()
+  endif()
+endif()
 
 # sigaction and sigsetjmp are special. Use special mechanism for
 # detecting those, but only if previous attempt failed.

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -518,6 +518,15 @@
 /* Define to 1 if you have the send function. */
 #cmakedefine HAVE_SEND 1
 
+/* Define to 1 if you have the 'fsetxattr' function. */
+#cmakedefine HAVE_FSETXATTR 1
+
+/* fsetxattr() takes 5 args */
+#cmakedefine HAVE_FSETXATTR_5 1
+
+/* fsetxattr() takes 6 args */
+#cmakedefine HAVE_FSETXATTR_6 1
+
 /* Define to 1 if you have the <setjmp.h> header file. */
 #cmakedefine HAVE_SETJMP_H 1
 


### PR DESCRIPTION
Several months ago a [patch](https://curl.haxx.se/mail/lib-2016-07/0063.html) was proposed on the mailing list to support xattr in cmake builds, but it appears to have slipped through the cracks. It is now the commit in this PR. Can a dev familiar with cmake please review?

/cc @sburford @Lekensteyn @snikulov @jzakrzewski 