### PR TITLE
Curl_auth_decode_digest_http_message(): copy terminating NUL

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -341,7 +341,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
     return CURLE_BAD_CONTENT_ENCODING;
 
   /* Simply store the challenge for use later */
-  digest->input_token = (BYTE *) Curl_memdup(chlg, chlglen);
+  digest->input_token = (BYTE *) Curl_memdup(chlg, chlglen + 1);
   if(!digest->input_token)
     return CURLE_OUT_OF_MEMORY;
 


### PR DESCRIPTION
Curl_auth_decode_digest_http_message(): copy terminating NUL as later Curl_override_sspi_http_realm() expects a NUL-terminated string.