### PR TITLE
STARTTLS: Don't print response character in denied messages

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -952,7 +952,7 @@ static CURLcode imap_state_starttls_resp(struct connectdata *conn,
 
   if(imapcode != 'O') {
     if(data->set.use_ssl != CURLUSESSL_TRY) {
-      failf(data, "STARTTLS denied. %c", imapcode);
+      failf(data, "STARTTLS denied");
       result = CURLE_USE_SSL_FAILED;
     }
     else

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -799,7 +799,7 @@ static CURLcode pop3_state_starttls_resp(struct connectdata *conn,
 
   if(pop3code != '+') {
     if(data->set.use_ssl != CURLUSESSL_TRY) {
-      failf(data, "STARTTLS denied. %c", pop3code);
+      failf(data, "STARTTLS denied");
       result = CURLE_USE_SSL_FAILED;
     }
     else


### PR DESCRIPTION
Both IMAP and POP3 response characters are used internally, but when
appended to the STARTTLS denial message likely could confuse the user.

---

If nobody likes this there is still the problem if the response code is set -1 and that's printed as a character. At the very least I think we should do something like `(ISALPHA(resp) ? resp : ' ')` so that we don't print weird symbols. SMTP doesn't have this problem because libcurl is using its numeric response codes, so I've already fixed that separately in 4e6f483