### PR TITLE
Check for GnuTLS alpn and ocsp during configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1847,7 +1847,7 @@ if test "$curl_ssl_msg" = "$init_ssl_msg"; then
             AC_MSG_NOTICE([Added $gtlslib to LD_LIBRARY_PATH])
           fi
         fi
-        AC_CHECK_FUNCS(gnutls_certificate_set_x509_key_file2)
+        AC_CHECK_FUNCS([gnutls_certificate_set_x509_key_file2 gnutls_alpn_set_protocols gnutls_ocsp_req_init])
       fi
 
     fi

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -92,11 +92,11 @@ static bool gtls_inited = FALSE;
 #    define GNUTLS_MAPS_WINSOCK_ERRORS 1
 #  endif
 
-#  if (GNUTLS_VERSION_NUMBER >= 0x030200)
+#  if HAVE_GNUTLS_ALPN_SET_PROTOCOLS
 #    define HAS_ALPN
 #  endif
 
-#  if (GNUTLS_VERSION_NUMBER >= 0x03020d)
+#  if HAVE_GNUTLS_OCSP_REQ_INIT
 #    define HAS_OCSP
 #  endif
 


### PR DESCRIPTION
Check for presence of gnutls_alpn_* and gnutls_ocsp_* functions
during configure instead of relying on the version number.
GnuTLS has options to turn these features off and we ca just work
with with such builds like we work with older versions.

Signed-off-by: Marcus Hoffmann <m.hoffmann@cartelsol.com>