### PR TITLE
Properly print HTTP string in verbose output when using HTTP/2

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1509,6 +1509,20 @@ static bool use_http_1_1plus(const struct Curl_easy *data,
           (data->set.httpversion >= CURL_HTTP_VERSION_1_1));
 }
 
+static const char *get_http_string(const struct Curl_easy *data,
+                                   const struct connectdata *conn)
+{
+#ifdef USE_NGHTTP2
+  if(conn->proto.httpc.h2)
+    return "2";
+#endif
+
+  if(use_http_1_1plus(data, conn))
+    return "1.1";
+
+  return "1.0";
+}
+
 /* check and possibly add an Expect: header */
 static CURLcode expect100(struct Curl_easy *data,
                           struct connectdata *conn,
@@ -2223,9 +2237,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
     }
   }
 
-  /* Use 1.1 unless the user specifically asked for 1.0 or the server only
-     supports 1.0 */
-  httpstring= use_http_1_1plus(data, conn)?"1.1":"1.0";
+  httpstring = get_http_string(data, conn);
 
   /* initialize a dynamic send-buffer */
   req_buffer = Curl_add_buffer_init();


### PR DESCRIPTION
Before:
```
 % src/curl https://sigsegv.ninja/ -v --http2
...
> GET / HTTP/1.1
> Host: sigsegv.ninja
> User-Agent: curl/7.52.2-DEV
> Accept: */*
>
...
```

After:
```
 % src/curl https://sigsegv.ninja/ -v --http2
...
> GET / HTTP/2
> Host: sigsegv.ninja
> User-Agent: curl/7.52.2-DEV
> Accept: */*
>
```

---

This seems like a no brainer, but since it hasn't been done so far I suspect there might be a reason against doing this. Do speak up if that's the case :)