### PR TITLE
strdup is deprecated in Visual Studio 2005 and above.

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -152,7 +152,7 @@ static long          init_flags;
  * ways, but at this point it must be defined as the system-supplied strdup
  * so the callback pointer is initialized correctly.
  */
-#if defined(_WIN32_WCE)
+#if defined(_WIN32_WCE) || _MSC_VER >= 1400
 #define system_strdup _strdup
 #elif !defined(HAVE_STRDUP)
 #define system_strdup curlx_strdup


### PR DESCRIPTION
Using strdup in Visual Studio 2005 and above can lead to problems, like the
subsequent free() throwing an exception in debug builds. _strdup should be used instead.