### PR TITLE
vtls: fix support for mbedtls.

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -485,8 +485,9 @@ void Curl_ssl_close_all(struct Curl_easy *data)
 }
 
 #if defined(USE_OPENSSL) || defined(USE_GNUTLS) || defined(USE_SCHANNEL) || \
-    defined(USE_DARWINSSL) || defined(USE_NSS)
-/* This function is for OpenSSL, GnuTLS, darwinssl, and schannel only. */
+    defined(USE_DARWINSSL) || defined(USE_NSS) || defined(USE_MBEDTLS)
+/* This function is for OpenSSL, GnuTLS, darwinssl, mbedtls, and schannel
+   only. */
 int Curl_ssl_getsock(struct connectdata *conn, curl_socket_t *socks,
                      int numsocks)
 {


### PR DESCRIPTION
When using multi, mbedtls handshake is in non blocking mode.
vtls must set wait for read/write flags for the socket.