### PR TITLE
proofread README.netware README.win32

### DIFF
--- a/docs/README.netware
+++ b/docs/README.netware
@@ -11,17 +11,17 @@ README.netware
   Curl has been successfully compiled with gcc / nlmconv on different flavours
   of Linux as well as with the official Metrowerks CodeWarrior compiler.
   While not being the main development target, a continuously growing share of
-  curl users are NetWare-based, specially also consuming the lib from PHP.
+  curl users are NetWare-based, especially also consuming the lib from PHP.
 
-  The unix-style man pages are tricky to read on windows, so therefore are all
-  those pages converted to HTML as well as pdf, and included in the release
-  archives.
+  The unix-style man pages are tricky to read on windows, so therefore all
+  those pages have been converted to HTML as well as pdf, and included in the 
+  release archives.
 
   The main curl.1 man page is also "built-in" in the command line tool. Use a
   command line similar to this in order to extract a separate text file:
 
         curl -M >manual.txt
 
-  Read the INSTALL file for instructions how to compile curl self.
+  Read the INSTALL file for instructions on how to compile curl self.
 
 

--- a/docs/README.win32
+++ b/docs/README.win32
@@ -12,15 +12,15 @@ README.win32
   systems. While not being the main develop target, a fair share of curl users
   are win32-based.
 
-  The unix-style man pages are tricky to read on windows, so therefore are all
-  those pages converted to HTML as well as pdf, and included in the release
-  archives.
+  The unix-style man pages are tricky to read on windows, so therefore all
+  those pages have been converted to HTML as well as pdf, and included in the 
+  release archives.
 
   The main curl.1 man page is also "built-in" in the command line tool. Use a
   command line similar to this in order to extract a separate text file:
 
         curl -M >manual.txt
 
-  Read the INSTALL file for instructions how to compile curl self.
+  Read the INSTALL file for instructions on how to compile curl self.
 
 


### PR DESCRIPTION
Small grammar changes and make  "instructions **on** how to compile" consistent with README.cmake