### PR TITLE
Speed caps: Update the timeouts if the speed is too low/high

### DIFF
--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -46,7 +46,7 @@ typedef struct curl_context_s {
   curl_socket_t sockfd;
 } curl_context_t;
 
-curl_context_t* create_curl_context(curl_socket_t sockfd)
+static curl_context_t* create_curl_context(curl_socket_t sockfd)
 {
   curl_context_t *context;
 
@@ -60,18 +60,18 @@ curl_context_t* create_curl_context(curl_socket_t sockfd)
   return context;
 }
 
-void curl_close_cb(uv_handle_t *handle)
+static void curl_close_cb(uv_handle_t *handle)
 {
   curl_context_t *context = (curl_context_t *) handle->data;
   free(context);
 }
 
-void destroy_curl_context(curl_context_t *context)
+static void destroy_curl_context(curl_context_t *context)
 {
   uv_close((uv_handle_t *) &context->poll_handle, curl_close_cb);
 }
 
-void add_download(const char *url, int num)
+static void add_download(const char *url, int num)
 {
   char filename[50];
   FILE *file;
@@ -129,13 +129,11 @@ static void check_multi_info(void)
   }
 }
 
-void curl_perform(uv_poll_t *req, int status, int events)
+static void curl_perform(uv_poll_t *req, int status, int events)
 {
   int running_handles;
   int flags = 0;
   curl_context_t *context;
-
-  uv_timer_stop(&timeout);
 
   if(events & UV_READABLE)
     flags |= CURL_CSELECT_IN;
@@ -150,7 +148,7 @@ void curl_perform(uv_poll_t *req, int status, int events)
   check_multi_info();
 }
 
-void on_timeout(uv_timer_t *req, int status)
+static void on_timeout(uv_timer_t *req, int status)
 {
   int running_handles;
   curl_multi_socket_action(curl_handle, CURL_SOCKET_TIMEOUT, 0,
@@ -158,15 +156,21 @@ void on_timeout(uv_timer_t *req, int status)
   check_multi_info();
 }
 
-void start_timeout(CURLM *multi, long timeout_ms, void *userp)
+static int start_timeout(CURLM *multi, long timeout_ms, void *userp)
 {
-  if(timeout_ms <= 0)
-    timeout_ms = 1; /* 0 means directly call socket_action, but we'll do it in
-                       a bit */
-  uv_timer_start(&timeout, on_timeout, timeout_ms, 0);
+  if(timeout_ms < 0) {
+    uv_timer_stop(&timeout);
+  }
+  else {
+    if(timeout_ms == 0)
+      timeout_ms = 1; /* 0 means directly call socket_action, but we'll do it in
+                         a bit */
+    uv_timer_start(&timeout, on_timeout, timeout_ms, 0);
+  }
+  return 0;
 }
 
-int handle_socket(CURL *easy, curl_socket_t s, int action, void *userp,
+static int handle_socket(CURL *easy, curl_socket_t s, int action, void *userp,
                   void *socketp)
 {
   curl_context_t *curl_context;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1307,6 +1307,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
   CURLcode result = CURLE_OK;
   struct SingleRequest *k;
   time_t timeout_ms;
+  time_t recv_timeout_ms;
+  time_t send_timeout_ms;
   int control;
 
   if(!GOOD_EASY_HANDLE(data))
@@ -1826,19 +1828,30 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       else
         result = Curl_speedcheck(data, now);
 
-      if(( (data->set.max_send_speed == 0) ||
-           (Curl_pgrsLimitWaitTime(data->progress.uploaded,
-                                   data->progress.ul_limit_size,
-                                   data->set.max_send_speed,
-                                   data->progress.ul_limit_start,
-                                   now) <= 0))  &&
-         ( (data->set.max_recv_speed == 0) ||
-           (Curl_pgrsLimitWaitTime(data->progress.downloaded,
-                                   data->progress.dl_limit_size,
-                                   data->set.max_recv_speed,
-                                   data->progress.dl_limit_start,
-                                   now) <= 0)))
-        multistate(data, CURLM_STATE_PERFORM);
+      if(!result) {
+        send_timeout_ms = 0;
+        if(data->set.max_send_speed > 0)
+          send_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.uploaded,
+                                data->progress.ul_limit_size,
+                                data->set.max_send_speed,
+                                data->progress.ul_limit_start,
+                                now);
+
+        recv_timeout_ms = 0;
+        if(data->set.max_recv_speed > 0)
+          recv_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.downloaded,
+                                data->progress.dl_limit_size,
+                                data->set.max_recv_speed,
+                                data->progress.dl_limit_start,
+                                now);
+
+        if(send_timeout_ms <= 0 && recv_timeout_ms <= 0)
+          multistate(data, CURLM_STATE_PERFORM);
+        else if(send_timeout_ms >= recv_timeout_ms)
+          Curl_expire_latest(data, send_timeout_ms);
+        else
+          Curl_expire_latest(data, recv_timeout_ms);
+      }
       break;
 
     case CURLM_STATE_PERFORM:
@@ -1848,31 +1861,30 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       bool comeback = FALSE;
 
       /* check if over send speed */
-      if(data->set.max_send_speed > 0) {
-        timeout_ms = Curl_pgrsLimitWaitTime(data->progress.uploaded,
-                                            data->progress.ul_limit_size,
-                                            data->set.max_send_speed,
-                                            data->progress.ul_limit_start,
-                                            now);
-        if(timeout_ms > 0) {
-          multistate(data, CURLM_STATE_TOOFAST);
-          Curl_expire_latest(data, timeout_ms);
-          break;
-        }
-      }
+      send_timeout_ms = 0;
+      if(data->set.max_send_speed > 0)
+        send_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.uploaded,
+                                                 data->progress.ul_limit_size,
+                                                 data->set.max_send_speed,
+                                                 data->progress.ul_limit_start,
+                                                 now);
 
       /* check if over recv speed */
-      if(data->set.max_recv_speed > 0) {
-        timeout_ms = Curl_pgrsLimitWaitTime(data->progress.downloaded,
-                                            data->progress.dl_limit_size,
-                                            data->set.max_recv_speed,
-                                            data->progress.dl_limit_start,
-                                            now);
-        if(timeout_ms > 0) {
-          multistate(data, CURLM_STATE_TOOFAST);
-          Curl_expire_latest(data, timeout_ms);
-          break;
-        }
+      recv_timeout_ms = 0;
+      if(data->set.max_recv_speed > 0)
+        recv_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.downloaded,
+                                                 data->progress.dl_limit_size,
+                                                 data->set.max_recv_speed,
+                                                 data->progress.dl_limit_start,
+                                                 now);
+
+      if(send_timeout_ms > 0 || recv_timeout_ms > 0) {
+        multistate(data, CURLM_STATE_TOOFAST);
+        if(send_timeout_ms >= recv_timeout_ms)
+          Curl_expire_latest(data, send_timeout_ms);
+        else
+          Curl_expire_latest(data, recv_timeout_ms);
+        break;
       }
 
       /* read/write data if it is ready to do so */


### PR DESCRIPTION
The first commit fixes a bug in the multi-uv example; the second commit fixes the timeout handling in libcurl when a speed limit is in place.