### PR TITLE
Don't use certificate after transfering ownership

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -498,16 +498,14 @@ int cert_stuff(struct connectdata *conn,
            * sk_X509_pop_free() call.
            */
           X509 *x = sk_X509_pop(ca);
+          if(!SSL_CTX_add_client_CA(ctx, x)) {
+            X509_free(x);
+            failf(data, "cannot add certificate to client CA list");
+            goto fail;
+          }
           if(!SSL_CTX_add_extra_chain_cert(ctx, x)) {
             X509_free(x);
             failf(data, "cannot add certificate to certificate chain");
-            goto fail;
-          }
-          /* SSL_CTX_add_client_CA() seems to work with either sk_* function,
-           * presumably because it duplicates what we pass to it.
-           */
-          if(!SSL_CTX_add_client_CA(ctx, x)) {
-            failf(data, "cannot add certificate to client CA list");
             goto fail;
           }
         }


### PR DESCRIPTION
SSL_CTX_add_extra_chain_cert takes ownership of the given certificate
while, despite the similar name, SSL_CTX_add_client_CA does not. Thus
it's best to call SSL_CTX_add_client_CA before
SSL_CTX_add_extra_chain_cert, while the code still has ownership of the
argument.