### PR TITLE
SNI: Update SNI related log messages

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1423,6 +1423,10 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
             "the OS.\n");
     }
   }
+  else {
+     infof(data, "WARNING: disabling hostname validatation also disables "
+           "SNI.\n");
+  }
 
   /* Disable cipher suites that ST supports but are not safe. These ciphers
      are unlikely to be used in any case since ST gives other ciphers a much

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -130,6 +130,14 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
   infof(data, "schannel: SSL/TLS connection with %s port %hu (step 1/3)\n",
         hostname, conn->remote_port);
 
+  if(Curl_verify_windows_version(5, 1, PLATFORM_WINNT,
+                                 VERSION_LESS_THAN_EQUAL)) {
+     /* SChannel in Windows XP (OS version 5.1) uses legacy handshakes and
+        algorithms that may not be supported by all servers. */
+     infof(data, "schannel: WinSSL version is old and may not be able to "
+           "connect to some servers due to lack of SNI, algorithms, etc.\n");
+  }
+
 #ifdef HAS_ALPN
   /* ALPN is only supported on Windows 8.1 / Server 2012 R2 and above.
      Also it doesn't seem to be supported for Wine, see curl bug #983. */
@@ -197,7 +205,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
       schannel_cred.dwFlags |= SCH_CRED_NO_SERVERNAME_CHECK;
       infof(data, "schannel: verifyhost setting prevents Schannel from "
             "comparing the supplied target name with the subject "
-            "names in server certificates. Also disables SNI.\n");
+            "names in server certificates.\n");
     }
 
     switch(conn->ssl_config.version) {


### PR DESCRIPTION
Update debug log messages related to SNI:
schannel: Turning off host validation does not turn off SNI
darwinssl: Turning off host validation does turn off SNI

I recently came across a case which worked on Windows using SChannel but not on a Mac using DarwinSSL. It turns out the request was accessing a machine on AWS which required SNI in the TLS handshake. The request was setup to turn off host validation.

Apparently, turning off host validation on DarwinSSL also turns off SNI, which is why the request failed on the Mac. I have added a debug message when this happens, as I think it will be useful for future debugging.

With SChannel , the debug messages claimed that turning off host validation also turned off SNI, but this is not the case. I have updated that debug message as well. See the attached screenshots for verification. It is possible that this behaviour differs between the various windows versions. I only have access to Windows 10.

Both OpenSSL and GnuTLS have the same behaviour as SChannel, SNI is still used when the verify host option is disabled.

![curl_output](https://cloud.githubusercontent.com/assets/1085125/22570502/6e822cc0-e950-11e6-870e-3331356198c6.png)

![wireshark_output](https://cloud.githubusercontent.com/assets/1085125/22570514/7ba9fbc6-e950-11e6-8bc2-8de29ab7b6c7.png)