### PR TITLE
authneg: add Content-Length:0 while negotiating auth

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2512,7 +2512,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
       postsize = data->state.infilesize;
 
     if((postsize != -1) && !data->req.upload_chunky &&
-       !Curl_checkheaders(conn, "Content-Length:")) {
+       (conn->bits.authneg || !Curl_checkheaders(conn, "Content-Length:"))) {
       /* only add Content-Length if not uploading chunked */
       result = Curl_add_bufferf(req_buffer,
                                 "Content-Length: %" CURL_FORMAT_CURL_OFF_T
@@ -2564,7 +2564,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
        we don't upload data chunked, as RFC2616 forbids us to set both
        kinds of headers (Transfer-Encoding: chunked and Content-Length) */
     if((postsize != -1) && !data->req.upload_chunky &&
-       !Curl_checkheaders(conn, "Content-Length:")) {
+       (conn->bits.authneg || !Curl_checkheaders(conn, "Content-Length:"))) {
       /* we allow replacing this header if not during auth negotiation,
          although it isn't very wise to actually set your own */
       result = Curl_add_bufferf(req_buffer,


### PR DESCRIPTION
Even if the user supplied custom content-length header it
should be set to 0 for both HTTPREQ_POST and HTTPREQ_PUT flows.
This is what we do already in HTTPREQ_POST_FORM and what we
did in the HTTPREQ_POST case prior to commit:
afd288b28f2087fca1f9ae860a05e77750ef44a7

Otherwise, if the user set custom header we'd end up skipping
the content-length header altogether.

Signed-off-by: Isaac Boukris <iboukris@gmail.com>
Reported-by: Hölzl, Dominik <Dominik.Hoelzl@fabasoft.com>