### PR TITLE
Don't retry requests with CURLOPT_NOBODY except for HTTP retries

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1843,12 +1843,17 @@ CURLcode Curl_retry_request(struct connectdata *conn,
     return CURLE_OK;
 
   if((data->req.bytecount + data->req.headerbytecount == 0) &&
-     conn->bits.reuse &&
-     (data->set.rtspreq != RTSPREQ_RECEIVE)) {
-    /* We didn't get a single byte when we attempted to re-use a
-       connection. This might happen if the connection was left alive when we
-       were done using it before, but that was closed when we wanted to use it
-       again. Bad luck. Retry the same request on a fresh connect! */
+      conn->bits.reuse &&
+      (!data->set.opt_no_body
+        || (conn->handler->protocol & PROTO_FAMILY_HTTP)) &&
+      (data->set.rtspreq != RTSPREQ_RECEIVE)) {
+    /* We got no data, we attempted to re-use a connection. For HTTP this
+       can be a retry so we try again regardless if we expected a body.
+       For other protocols we only try again only if we expected a body.
+
+       This might happen if the connection was left alive when we were
+       done using it before, but that was closed when we wanted to read from
+       it again. Bad luck. Retry the same request on a fresh connect! */
     infof(conn->data, "Connection died, retrying a fresh connect\n");
     *url = strdup(conn->data->change.url);
     if(!*url)


### PR DESCRIPTION
This reverts commit 31e33a9a4663e0bf62b0815d22af879f2209bf6f.

Using sftp to delete a file with CURLOPT_NOBODY set with a reused connection would fail as curl expected to get some data. Thus it would retry the command again which fails as the file has already been deleted.

This issue had originally been fixed in 12f5c67bf5d32baefd27757b8e6bc08683e7bef9 which I found out about from https://curl.haxx.se/mail/lib-2006-02/0029.html. However the fix got removed in 31e33a9a4663e0bf62b0815d22af879f2209bf6f. A straight revert as this PR does currently is perhaps not sufficient as there should at least be a comment explaining the reason for the `!data->set.opt_no_body` check (should it perhaps only be for FTP to not interfere with HTTP as mentioned in 31e33a9a4663e0bf62b0815d22af879f2209bf6f?) so I'd be happy to amend this PR with a better fix. 