### PR TITLE
Avoiding extra processing in darwinssl when not in verbose

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -365,9 +365,7 @@ CF_INLINE const char *SSLCipherNameForNumber(SSLCipherSuite cipher)
   }
   return "SSL_NULL_WITH_NULL_NULL";
 }
-#endif /*  CURL_DISABLE_VERBOSE_STRINGS */
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
 CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
 {
   switch(cipher) {

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2041,8 +2041,9 @@ static CURLcode
 darwinssl_connect_step3(struct connectdata *conn,
                         int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+  struct Curl_easy *data = conn->data;
   CFStringRef server_cert_summary;
   char server_cert_summary_c[128];
   CFArrayRef server_certs = NULL;
@@ -2150,6 +2151,8 @@ darwinssl_connect_step3(struct connectdata *conn,
     CFRelease(server_certs);
   }
 #endif /* CURL_BUILD_MAC_10_7 || CURL_BUILD_IOS */
+
+#endif /* CURL_DISABLE_VERBOSE_STRINGS */
 
   connssl->connecting_state = ssl_connect_done;
   return CURLE_OK;

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -219,6 +219,7 @@ static OSStatus SocketWrite(SSLConnectionRef connection,
   return ortn;
 }
 
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
 CF_INLINE const char *SSLCipherNameForNumber(SSLCipherSuite cipher)
 {
   switch(cipher) {
@@ -364,7 +365,9 @@ CF_INLINE const char *SSLCipherNameForNumber(SSLCipherSuite cipher)
   }
   return "SSL_NULL_WITH_NULL_NULL";
 }
+#endif /*  CURL_DISABLE_VERBOSE_STRINGS */
 
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
 CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
 {
   switch(cipher) {
@@ -776,6 +779,7 @@ CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
   }
   return "TLS_NULL_WITH_NULL_NULL";
 }
+#endif /*  CURL_DISABLE_VERBOSE_STRINGS */
 
 #if CURL_BUILD_MAC
 CF_INLINE void GetDarwinVersionNumber(int *major, int *minor)


### PR DESCRIPTION
The information extracted from the server certificates in step 3 is only used when in verbose mode, and there is no error handling or validation performed as that has already been done. Only run the certificate information extraction when in verbose mode and avoid the extra processing with the CURL_DISABLE_VERBOSE_STRINGS macro when not in verbose mode. No huge optimization but might as well not spend extra memory operations when not needed.

Also includes a commit to fix a compiler warning on unused functions when not in verbose mode.