### PR TITLE
use *.sourceforge.io and misc URL updates

### DIFF
--- a/CHANGES.0
+++ b/CHANGES.0
@@ -10807,7 +10807,7 @@ Daniel (23 June)
 - Eric Glass provided us with a better doc on NTLM details, and I added more
   comments and clarified the current code more. Using the new knowledge, we
   should be able to make the NTLM stuff work even better.
-  Eric's original URL: http://davenport.sourceforge.net/ntlm.html
+  Eric's original URL: https://davenport.sourceforge.io/ntlm.html
   Version stored and provided at curl site: https://curl.haxx.se/rfc/ntlm.html
 
 - Fixed the minor compile problems pre3 had if built without GSSAPI and/or
@@ -14064,7 +14064,7 @@ Daniel (30 May 2001)
   we discussed and added a few CURL_GLOBAL_* flags in include/curl.h
 
 - Kjetil Jacobsen privately announced his python interface to libcurl,
-  available at http://pycurl.sourceforge.net/
+  available at http://pycurl.io/
 
 Daniel (29 May 2001)
 - Sterling Hughes fixed a strtok() problem in libcurl. It is not a thread-

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -16,14 +16,14 @@ libcurl bindings
 
 [C++](http://curlpp.org/) Written by Jean-Philippe Barrette-LaPierre
 
-[Ch](http://chcurl.sourceforge.net/) Written by Stephen Nestinger and Jonathan Rogado
+[Ch](https://chcurl.sourceforge.io/) Written by Stephen Nestinger and Jonathan Rogado
 
 Cocoa: [BBHTTP](https://github.com/brunodecarvalho/BBHTTP) written by Bruno de Carvalho
-[curlhandle](http://curlhandle.sourceforge.net/) Written by Dan Wood
+[curlhandle](https://github.com/karelia/curlhandle) Written by Dan Wood
 
-[D](http://dlang.org/library/std/net/curl.html) Written by Kenneth Bogert
+[D](https://dlang.org/library/std/net/curl.html) Written by Kenneth Bogert
 
-[Dylan](http://dylanlibs.sourceforge.net/) Written by Chris Double
+[Dylan](https://dylanlibs.sourceforge.io/) Written by Chris Double
 
 [Eiffel](https://room.eiffel.com/library/curl) Written by Eiffel Software
 
@@ -33,7 +33,7 @@ Cocoa: [BBHTTP](https://github.com/brunodecarvalho/BBHTTP) written by Bruno de C
 
 [Ferite](http://www.ferite.org/) Written by Paul Querna
 
-[Gambas](http://gambas.sourceforge.net/)
+[Gambas](https://gambas.sourceforge.io/)
 
 [glib/GTK+](http://atterer.net/glibcurl/) Written by Richard Atterer
 
@@ -41,17 +41,17 @@ Cocoa: [BBHTTP](https://github.com/brunodecarvalho/BBHTTP) written by Bruno de C
 
 [Harbour](https://github.com/vszakats/harbour-core/tree/master/contrib/hbcurl) Written by Viktor Szakáts
 
-[Haskell](http://hackage.haskell.org/cgi-bin/hackage-scripts/package/curl) Written by Galois, Inc
+[Haskell](https://hackage.haskell.org/cgi-bin/hackage-scripts/package/curl) Written by Galois, Inc
 
 [Java](https://github.com/pjlegato/curl-java)
 
 [Julia](https://github.com/forio/Curl.jl) Written by Paul Howe
 
-[Lisp](http://common-lisp.net/project/cl-curl/) Written by Liam Healy
+[Lisp](https://common-lisp.net/project/cl-curl/) Written by Liam Healy
 
 Lua: [luacurl](http://luacurl.luaforge.net/) by Alexander Marinov, [Lua-cURL](http://luaforge.net/projects/lua-curl/) by Jürgen Hötzel
 
-[Mono](http://forge.novell.com/modules/xfmod/project/?libcurl-mono) Written by Jeffrey Phillips
+[Mono](https://forge.novell.com/modules/xfmod/project/?libcurl-mono) Written by Jeffrey Phillips
 
 [.NET](https://sourceforge.net/projects/libcurl-net/) libcurl-net by Jeffrey Phillips
 
@@ -69,11 +69,11 @@ Lua: [luacurl](http://luacurl.luaforge.net/) by Alexander Marinov, [Lua-cURL](ht
 
 [PostgreSQL](http://gborg.postgresql.org/project/pgcurl/projdisplay.php) Written by Gian Paolo Ciceri
 
-[Python](http://pycurl.sourceforge.net/) PycURL by Kjetil Jacobsen
+[Python](http://pycurl.io/) PycURL by Kjetil Jacobsen
 
-[R](http://cran.r-project.org/package=curl)
+[R](https://cran.r-project.org/package=curl)
 
-[Rexx](http://rexxcurl.sourceforge.net/) Written Mark Hessling
+[Rexx](https://rexxcurl.sourceforge.io/) Written Mark Hessling
 
 RPG, support for ILE/RPG on OS/400 is included in source distribution
 
@@ -81,7 +81,7 @@ Ruby: [curb](http://curb.rubyforge.org/) written by Ross Bamford, [ruby-curl-mul
 
 [Rust](https://github.com/carllerche/curl-rust) curl-rust - by Carl Lerche
 
-[Scheme](http://www.metapaper.net/lisovsky/web/curl/) Bigloo binding by Kirill Lisovsky
+[Scheme](https://www.metapaper.net/lisovsky/web/curl/) Bigloo binding by Kirill Lisovsky
 
 [S-Lang](http://www.jedsoft.org/slang/modules/curl.html) by John E Davis
 
@@ -97,9 +97,9 @@ Ruby: [curb](http://curb.rubyforge.org/) written by Ross Bamford, [ruby-curl-mul
 
 [Visual Foxpro](http://www.ctl32.com.ar/libcurl.asp) by Carlos Alloatti
 
-[Q](http://q-lang.sourceforge.net/) The libcurl module is part of the default install
+[Q](https://q-lang.sourceforge.io/) The libcurl module is part of the default install
 
-[wxWidgets](http://wxcode.sourceforge.net/components/wxcurl/) Written by Casey O'Donnell
+[wxWidgets](https://wxcode.sourceforge.io/components/wxcurl/) Written by Casey O'Donnell
 
 [XBLite](http://perso.wanadoo.fr/xblite/libraries.html) Written by David Szafranski
 

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -243,5 +243,5 @@ For unix-like operating systems:
 
 For Windows:
 
- - [http://gnuwin32.sourceforge.net/packages/patch.htm](http://gnuwin32.sourceforge.net/packages/patch.htm)
- - [http://gnuwin32.sourceforge.net/packages/diffutils.htm](http://gnuwin32.sourceforge.net/packages/diffutils.htm)
+ - [https://gnuwin32.sourceforge.io/packages/patch.htm](https://gnuwin32.sourceforge.io/packages/patch.htm)
+ - [https://gnuwin32.sourceforge.io/packages/diffutils.htm](https://gnuwin32.sourceforge.io/packages/diffutils.htm)

--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -34,7 +34,7 @@
  *
  * The function is a port of the Java based oddParity() function over at:
  *
- * http://davenport.sourceforge.net/ntlm.html
+ * https://davenport.sourceforge.io/ntlm.html
  *
  * Parameters:
  *

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -27,7 +27,7 @@
 /*
  * NTLM details:
  *
- * http://davenport.sourceforge.net/ntlm.html
+ * https://davenport.sourceforge.io/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -28,7 +28,7 @@
 /*
  * NTLM details:
  *
- * http://davenport.sourceforge.net/ntlm.html
+ * https://davenport.sourceforge.io/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -27,7 +27,7 @@
 /*
  * NTLM details:
  *
- * http://davenport.sourceforge.net/ntlm.html
+ * https://davenport.sourceforge.io/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -27,7 +27,7 @@
 /*
  * NTLM details:
  *
- * http://davenport.sourceforge.net/ntlm.html
+ * https://davenport.sourceforge.io/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 
@@ -651,7 +651,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
     /* A safer but less compatible alternative is:
      *   Curl_ntlm_core_lm_resp(ntbuffer, &ntlm->nonce[0], lmresp);
-     * See http://davenport.sourceforge.net/ntlm.html#ntlmVersion2 */
+     * See https://davenport.sourceforge.io/ntlm.html#ntlmVersion2 */
   }
 
   if(unicode) {

--- a/lib/vauth/ntlm.h
+++ b/lib/vauth/ntlm.h
@@ -32,7 +32,7 @@
 /* Stuff only required for curl_ntlm_msgs.c */
 #ifdef BUILDING_CURL_NTLM_MSGS_C
 
-/* Flag bits definitions based on http://davenport.sourceforge.net/ntlm.html */
+/* Flag bits definitions based on https://davenport.sourceforge.io/ntlm.html */
 
 #define NTLMFLAG_NEGOTIATE_UNICODE               (1<<0)
 /* Indicates that Unicode strings are supported for use in security buffer


### PR DESCRIPTION
Ref: https://sourceforge.net/blog/introducing-https-for-project-websites/