### PR TITLE
Fix nonce-count generation in Curl_auth_create_digest_http_message()

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -408,6 +408,8 @@ struct digestdata {
 #if defined(USE_WINDOWS_SSPI)
   BYTE *input_token;
   size_t input_token_len;
+  bool have_context;
+  CtxtHandle context;
 #else
   char *nonce;
   char *cnonce;

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -379,21 +379,13 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                               char **outptr, size_t *outlen)
 {
   size_t token_max;
-  CredHandle credentials;
-  CtxtHandle context;
   char *resp;
   BYTE *output_token;
+  size_t output_token_len;
   PSecPkgInfo SecurityPackage;
-  SEC_WINNT_AUTH_IDENTITY identity;
-  SEC_WINNT_AUTH_IDENTITY *p_identity;
-  SecBuffer chlg_buf[3];
-  SecBuffer resp_buf;
+  SecBuffer chlg_buf[5];
   SecBufferDesc chlg_desc;
-  SecBufferDesc resp_desc;
   SECURITY_STATUS status;
-  unsigned long attrs;
-  TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
-  TCHAR *spn;
 
   (void) data;
 
@@ -408,123 +400,160 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
   /* Release the package buffer as it is not required anymore */
   s_pSecFn->FreeContextBuffer(SecurityPackage);
 
-  if(userp && *userp) {
-    /* Populate our identity structure */
-    if(Curl_create_sspi_identity(userp, passwdp, &identity))
-      return CURLE_OUT_OF_MEMORY;
-
-    /* Populate our identity domain */
-    if(Curl_override_sspi_http_realm((const char *) digest->input_token,
-                                     &identity))
-      return CURLE_OUT_OF_MEMORY;
-
-    /* Allow proper cleanup of the identity structure */
-    p_identity = &identity;
-  }
-  else
-    /* Use the current Windows user */
-    p_identity = NULL;
-
-  /* Acquire our credentials handle */
-  status = s_pSecFn->AcquireCredentialsHandle(NULL,
-                                              (TCHAR *) TEXT(SP_NAME_DIGEST),
-                                              SECPKG_CRED_OUTBOUND, NULL,
-                                              p_identity, NULL, NULL,
-                                              &credentials, &expiry);
-  if(status != SEC_E_OK) {
-    Curl_sspi_free_identity(p_identity);
-
-    return CURLE_LOGIN_DENIED;
-  }
-
   /* Allocate the output buffer according to the max token size as indicated
      by the security package */
   output_token = malloc(token_max);
   if(!output_token) {
-    s_pSecFn->FreeCredentialsHandle(&credentials);
-
-    Curl_sspi_free_identity(p_identity);
-
     return CURLE_OUT_OF_MEMORY;
   }
 
-  /* Setup the challenge "input" security buffer if present */
-  chlg_desc.ulVersion    = SECBUFFER_VERSION;
-  chlg_desc.cBuffers     = 3;
-  chlg_desc.pBuffers     = chlg_buf;
-  chlg_buf[0].BufferType = SECBUFFER_TOKEN;
-  chlg_buf[0].pvBuffer   = digest->input_token;
-  chlg_buf[0].cbBuffer   = curlx_uztoul(digest->input_token_len);
-  chlg_buf[1].BufferType = SECBUFFER_PKG_PARAMS;
-  chlg_buf[1].pvBuffer   = (void *) request;
-  chlg_buf[1].cbBuffer   = curlx_uztoul(strlen((const char *) request));
-  chlg_buf[2].BufferType = SECBUFFER_PKG_PARAMS;
-  chlg_buf[2].pvBuffer   = NULL;
-  chlg_buf[2].cbBuffer   = 0;
+  if(!digest->have_context) {
+    CredHandle credentials;
+    SEC_WINNT_AUTH_IDENTITY identity;
+    SEC_WINNT_AUTH_IDENTITY *p_identity;
+    SecBuffer resp_buf;
+    SecBufferDesc resp_desc;
+    unsigned long attrs;
+    TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
+    TCHAR *spn;
 
-  /* Setup the response "output" security buffer */
-  resp_desc.ulVersion = SECBUFFER_VERSION;
-  resp_desc.cBuffers  = 1;
-  resp_desc.pBuffers  = &resp_buf;
-  resp_buf.BufferType = SECBUFFER_TOKEN;
-  resp_buf.pvBuffer   = output_token;
-  resp_buf.cbBuffer   = curlx_uztoul(token_max);
+    if(userp && *userp) {
+      /* Populate our identity structure */
+      if(Curl_create_sspi_identity(userp, passwdp, &identity)) {
+        free(output_token);
+        return CURLE_OUT_OF_MEMORY;
+      }
 
-  spn = Curl_convert_UTF8_to_tchar((char *) uripath);
-  if(!spn) {
+      /* Populate our identity domain */
+      if(Curl_override_sspi_http_realm((const char *) digest->input_token,
+                                       &identity)) {
+        free(output_token);
+        return CURLE_OUT_OF_MEMORY;
+      }
+
+      /* Allow proper cleanup of the identity structure */
+      p_identity = &identity;
+    }
+    else
+      /* Use the current Windows user */
+      p_identity = NULL;
+
+    /* Acquire our credentials handle */
+    status = s_pSecFn->AcquireCredentialsHandle(NULL,
+                                                (TCHAR *) TEXT(SP_NAME_DIGEST),
+                                                SECPKG_CRED_OUTBOUND, NULL,
+                                                p_identity, NULL, NULL,
+                                                &credentials, &expiry);
+    if(status != SEC_E_OK) {
+      Curl_sspi_free_identity(p_identity);
+      free(output_token);
+
+      return CURLE_LOGIN_DENIED;
+    }
+
+    /* Setup the challenge "input" security buffer if present */
+    chlg_desc.ulVersion    = SECBUFFER_VERSION;
+    chlg_desc.cBuffers     = 3;
+    chlg_desc.pBuffers     = chlg_buf;
+    chlg_buf[0].BufferType = SECBUFFER_TOKEN;
+    chlg_buf[0].pvBuffer   = digest->input_token;
+    chlg_buf[0].cbBuffer   = curlx_uztoul(digest->input_token_len);
+    chlg_buf[1].BufferType = SECBUFFER_PKG_PARAMS;
+    chlg_buf[1].pvBuffer   = (void *) request;
+    chlg_buf[1].cbBuffer   = curlx_uztoul(strlen((const char *) request));
+    chlg_buf[2].BufferType = SECBUFFER_PKG_PARAMS;
+    chlg_buf[2].pvBuffer   = NULL;
+    chlg_buf[2].cbBuffer   = 0;
+
+    /* Setup the response "output" security buffer */
+    resp_desc.ulVersion = SECBUFFER_VERSION;
+    resp_desc.cBuffers  = 1;
+    resp_desc.pBuffers  = &resp_buf;
+    resp_buf.BufferType = SECBUFFER_TOKEN;
+    resp_buf.pvBuffer   = output_token;
+    resp_buf.cbBuffer   = curlx_uztoul(token_max);
+
+    spn = Curl_convert_UTF8_to_tchar((char *) uripath);
+    if(!spn) {
+      s_pSecFn->FreeCredentialsHandle(&credentials);
+
+      Curl_sspi_free_identity(p_identity);
+      free(output_token);
+
+      return CURLE_OUT_OF_MEMORY;
+    }
+
+    /* Generate our reponse message */
+    status = s_pSecFn->InitializeSecurityContext(&credentials, NULL,
+                                                 spn,
+                                                 ISC_REQ_USE_HTTP_STYLE, 0, 0,
+                                                 &chlg_desc, 0,
+                                                 &digest->context,
+                                                 &resp_desc, &attrs, &expiry);
+    Curl_unicodefree(spn);
+
+    if(status == SEC_I_COMPLETE_NEEDED ||
+       status == SEC_I_COMPLETE_AND_CONTINUE)
+      s_pSecFn->CompleteAuthToken(&credentials, &resp_desc);
+    else if(status != SEC_E_OK && status != SEC_I_CONTINUE_NEEDED) {
+      s_pSecFn->FreeCredentialsHandle(&credentials);
+
+      Curl_sspi_free_identity(p_identity);
+      free(output_token);
+
+      return CURLE_OUT_OF_MEMORY;
+    }
+
+    digest->have_context = TRUE;
+    output_token_len = resp_buf.cbBuffer;
+
     s_pSecFn->FreeCredentialsHandle(&credentials);
-
     Curl_sspi_free_identity(p_identity);
-    free(output_token);
+  }
+  else {
+    chlg_desc.ulVersion    = SECBUFFER_VERSION;
+    chlg_desc.cBuffers     = 5;
+    chlg_desc.pBuffers     = chlg_buf;
+    chlg_buf[0].BufferType = SECBUFFER_TOKEN;
+    chlg_buf[0].pvBuffer   = NULL;
+    chlg_buf[0].cbBuffer   = 0;
+    chlg_buf[1].BufferType = SECBUFFER_PKG_PARAMS;
+    chlg_buf[1].pvBuffer   = (void *) request;
+    chlg_buf[1].cbBuffer   = curlx_uztoul(strlen((const char *) request));
+    chlg_buf[2].BufferType = SECBUFFER_PKG_PARAMS;
+    chlg_buf[2].pvBuffer   = (void *) uripath;
+    chlg_buf[2].cbBuffer   = curlx_uztoul(strlen((const char *) uripath));
+    chlg_buf[3].BufferType = SECBUFFER_PKG_PARAMS;
+    chlg_buf[3].pvBuffer   = NULL;
+    chlg_buf[3].cbBuffer   = 0;
+    chlg_buf[4].BufferType = SECBUFFER_PADDING;
+    chlg_buf[4].pvBuffer   = output_token;
+    chlg_buf[4].cbBuffer   = curlx_uztoul(token_max);
 
-    return CURLE_OUT_OF_MEMORY;
+    status = s_pSecFn->MakeSignature(&digest->context, 0, &chlg_desc, 0);
+    if(status != SEC_E_OK) {
+      free(output_token);
+
+      return CURLE_OUT_OF_MEMORY;
+    }
+
+    output_token_len = chlg_buf[4].cbBuffer;
   }
 
-  /* Generate our reponse message */
-  status = s_pSecFn->InitializeSecurityContext(&credentials, NULL,
-                                               spn,
-                                               ISC_REQ_USE_HTTP_STYLE, 0, 0,
-                                               &chlg_desc, 0, &context,
-                                               &resp_desc, &attrs, &expiry);
-  Curl_unicodefree(spn);
-
-  if(status == SEC_I_COMPLETE_NEEDED ||
-     status == SEC_I_COMPLETE_AND_CONTINUE)
-    s_pSecFn->CompleteAuthToken(&credentials, &resp_desc);
-  else if(status != SEC_E_OK && status != SEC_I_CONTINUE_NEEDED) {
-    s_pSecFn->FreeCredentialsHandle(&credentials);
-
-    Curl_sspi_free_identity(p_identity);
-    free(output_token);
-
-    return CURLE_OUT_OF_MEMORY;
-  }
-
-  resp = malloc(resp_buf.cbBuffer + 1);
+  resp = malloc(output_token_len + 1);
   if(!resp) {
-    s_pSecFn->DeleteSecurityContext(&context);
-    s_pSecFn->FreeCredentialsHandle(&credentials);
-
-    Curl_sspi_free_identity(p_identity);
     free(output_token);
 
     return CURLE_OUT_OF_MEMORY;
   }
 
   /* Copy the generated reponse */
-  memcpy(resp, resp_buf.pvBuffer, resp_buf.cbBuffer);
-  resp[resp_buf.cbBuffer] = 0x00;
+  memcpy(resp, output_token, output_token_len);
+  resp[output_token_len] = 0x00;
 
   /* Return the response */
   *outptr = resp;
-  *outlen = resp_buf.cbBuffer;
-
-  /* Free our handles */
-  s_pSecFn->DeleteSecurityContext(&context);
-  s_pSecFn->FreeCredentialsHandle(&credentials);
-
-  /* Free the identity structure */
-  Curl_sspi_free_identity(p_identity);
+  *outlen = output_token_len;
 
   /* Free the response buffer */
   free(output_token);
@@ -549,6 +578,12 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
 
   /* Reset any variables */
   digest->input_token_len = 0;
+
+  /* Delete security context */
+  if(digest->have_context) {
+    s_pSecFn->DeleteSecurityContext(&digest->context);
+    digest->have_context = FALSE;
+  }
 }
 
 #endif /* USE_WINDOWS_SSPI && !CURL_DISABLE_CRYPTO_AUTH */


### PR DESCRIPTION
- on the first invocation: keep security context returned by
InitializeSecurityContext()
- on subsequent invocations: use MakeSignature() instead of
InitializeSecurityContext() to generate HTTP digest response

Fixes #870 