### PR TITLE
Fix tiny memory leak upon edge case connecting to proxy

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -248,7 +248,7 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
                            useragent,
                            proxyconn);
 
-        if(host && *host)
+        if(host)
           free(host);
         free(hostheader);
 


### PR DESCRIPTION
[cURL][CID 11121] Possible tiny memory leak upon edge case connecting to proxy.

Bug found directly in source code by Coverity Connect bug-finding tool.

This is out-of-context, unusual approach. I cannot tell how serious the bug is when running the program. In any case, it purports to only leak a 1-byte '\0' NUL string terminator.

Low priority. In my opinion, this is not worth any release activity. If your org does fix it, perhaps it could go out with some more important change?

In curl-7.52.1/lib/http_proxy.c Coverity says:

221        if(!Curl_checkProxyheaders(conn, "Host:")) {
   13. alloc_fn: Storage is returned from allocation function curl_maprintf. [show details]
   14. var_assign: Assigning: host = storage returned from curl_maprintf("Host: %s\r\n", hostheader).
222          host = aprintf("Host: %s\r\n", hostheader);
...
   21. Condition host, taking true branch
   22. Condition *host, taking false branch
251        if(host && *host)
252          free(host);
...
   CID 11121 (#1 of 2): Resource leak (RESOURCE_LEAK)27. leaked_storage: Variable host going out of scope leaks the storage it points to.
272      }

An empty string containing only the 1-byte
'\0' NUL string terminator can be returned at
  13. alloc_fn: Storage is returned from allocation function curl_maprintf. [show details]
   14. var_assign: Assigning: host = storage returned from curl_maprintf("Host: %s\r\n", hostheader).
222          host = aprintf("Host: %s\r\n", hostheader);
via curl_maprintf at
curl-7.52.1/lib/mprintf.c:#L1100    return strdup("");

Remove ' && *host' from #L251 above? That would let it free an empty string.

Let me know if I should find an example run of the program which reproduces the problem.