### PR TITLE
Fixes SFTP upload with --create-dirs when running via multi handle

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -918,6 +918,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
                                          &err_msg, NULL, 0);
         infof(data, "SSH public key authentication failed: %s\n", err_msg);
         state(conn, SSH_AUTH_PASS_INIT);
+        rc = 0; /* clear rc and continue */
       }
       break;
 
@@ -928,6 +929,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       }
       else {
         state(conn, SSH_AUTH_HOST_INIT);
+        rc = 0; /* clear rc and continue */
       }
       break;
 
@@ -989,6 +991,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         if(rc < 0) {
           infof(data, "Failure connecting to agent\n");
           state(conn, SSH_AUTH_KEY_INIT);
+          rc = 0; /* clear rc and continue */
         }
         else {
           state(conn, SSH_AUTH_AGENT_LIST);
@@ -1008,6 +1011,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       if(rc < 0) {
         infof(data, "Failure requesting identities to agent\n");
         state(conn, SSH_AUTH_KEY_INIT);
+        rc = 0; /* clear rc and continue */
       }
       else {
         state(conn, SSH_AUTH_AGENT);

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -1800,6 +1800,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
                   (data->set.ftp_create_missing_dirs &&
                    (strlen(sftp_scp->path) > 1))) {
             /* try to create the path remotely */
+            rc = 0; /* clear rc and continue */
             sshc->secondCreateDirs = 1;
             state(conn, SSH_SFTP_CREATE_DIRS_INIT);
             break;
@@ -1936,7 +1937,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       }
       *sshc->slash_pos = '/';
       ++sshc->slash_pos;
-      if(rc == -1) {
+      if(rc < 0) {
         /*
          * Abort if failure wasn't that the dir already exists or the
          * permission was denied (creation might succeed further down the
@@ -1950,6 +1951,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           state(conn, SSH_SFTP_CLOSE);
           sshc->actualcode = result?result:CURLE_SSH;
           break;
+        }
+        else {
+          rc = 0; /* clear rc and continue */
         }
       }
       state(conn, SSH_SFTP_CREATE_DIRS);


### PR DESCRIPTION
So this is odd.
```
curl -k sftp://foo:bar@localhost/~/1/2/3/4/5/6/7/8  --ftp-create-dirs -T file  -vvvv
```
will work fine and create the necessary dirs. 

If I do the equivalent but run it with a multi handle the socket will be retired due to the rc not being reset in line 1803.
Similarly, the rc needs to be reset to 0 if some part of the directory hierarchy exists (lines 1955-1957).
Finally, line 1939 takes all error codes into account.

Cheers,
Jean