### PR TITLE
Add missing DarwinSSL block to curl_config.cmake

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -927,6 +927,9 @@
 /* if PolarSSL is enabled */
 #cmakedefine USE_POLARSSL 1
 
+/* if DarwinSSL is enabled */
+#cmakedefine USE_DARWINSSL 1
+
 /* if mbedTLS is enabled */
 #cmakedefine USE_MBEDTLS 1
 


### PR DESCRIPTION
This is a preparing step for #1228