### PR TITLE
mbedTLS: CURLOPT_SSL_CTX_FUNCTION support added

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -22,7 +22,7 @@
 .\"
 .TH CURLOPT_SSL_CTX_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
 .SH NAME
-CURLOPT_SSL_CTX_FUNCTION \- SSL context callback for OpenSSL or wolfSSL/CyaSSL
+CURLOPT_SSL_CTX_FUNCTION \- SSL context callback for OpenSSL, wolfSSL/CyaSSL, or mbedTLS
 .SH SYNOPSIS
 .nf
 #include <curl/curl.h>
@@ -32,8 +32,8 @@ CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr);
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_FUNCTION,
                           ssl_ctx_callback);
 .SH DESCRIPTION
-This option only works for libcurl powered by OpenSSL or wolfSSL/CyaSSL. If
-libcurl was built against another SSL library this functionality is absent.
+This option only works for libcurl powered by OpenSSL, wolfSSL/CyaSSL, or mbedTLS. 
+If libcurl was built against another SSL library this functionality is absent.
 
 Pass a pointer to your callback function, which should match the prototype
 shown above.
@@ -42,13 +42,15 @@ This callback function gets called by libcurl just before the initialization
 of an SSL connection after having processed all other SSL related options to
 give a last chance to an application to modify the behaviour of the SSL
 initialization. The \fIssl_ctx\fP parameter is actually a pointer to the SSL
-library's \fISSL_CTX\fP. If an error is returned from the callback no attempt
-to establish a connection is made and the perform operation will return the
-callback's error code. Set the \fIuserptr\fP argument with the
+library's \fISSL_CTX\fP for OpenSSL or wolfSSL/CyaSSL, and a pointer to 
+\fImbedtls_ssl_config\fP for mbedTLS. If an error is returned from the callback 
+no attempt to establish a connection is made and the perform operation will 
+return the callback's error code. Set the \fIuserptr\fP argument with the
 \fICURLOPT_SSL_CTX_DATA(3)\fP option.
 
 This function will get called on all new connections made to a server, during
-the SSL negotiation. The SSL_CTX pointer will be a new one every time.
+the SSL negotiation. The SSL_CTX/mbedtls_ssl_config pointer will be a new one 
+every time.
 
 To use this properly, a non-trivial amount of knowledge of your SSL library is
 necessary. For example, you can use this function to call library-specific
@@ -133,8 +135,8 @@ int main(void)
 }
 .fi
 .SH AVAILABILITY
-Added in 7.11.0 for OpenSSL. Added in 7.42.0 for wolfSSL/CyaSSL. Other SSL
-backends not supported.
+Added in 7.11.0 for OpenSSL. Added in 7.42.0 for wolfSSL/CyaSSL. Added in
+7.54.0 for mbedTLS. Other SSL backends not supported.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -449,8 +449,8 @@ mbed_connect_step1(struct connectdata *conn,
     ret = (*data->set.ssl.fsslctx)(data, &connssl->config,
                                    data->set.ssl.fsslctxp);
     if(ret) {
-      failf(data, "error signaled by mbedTLS ctx callback");
-      return CURLE_SSL_CERTPROBLEM;
+      failf(data, "error signaled by ssl ctx callback");
+      return ret;
     }
   }
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -447,7 +447,7 @@ mbed_connect_step1(struct connectdata *conn,
   /* give application a chance to interfere with mbedTLS set up. */
   if(data->set.ssl.fsslctx) {
     ret = (*data->set.ssl.fsslctx)(data, &connssl->config, 
-    							   data->set.ssl.fsslctxp);
+                                   data->set.ssl.fsslctxp);
     if(ret) {
       failf(data, "error signaled by mbedTLS ctx callback");
       return CURLE_SSL_CERTPROBLEM;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -446,7 +446,7 @@ mbed_connect_step1(struct connectdata *conn,
 
   /* give application a chance to interfere with mbedTLS set up. */
   if(data->set.ssl.fsslctx) {
-    ret = (*data->set.ssl.fsslctx)(data, &connssl->config, 
+    ret = (*data->set.ssl.fsslctx)(data, &connssl->config,
                                    data->set.ssl.fsslctxp);
     if(ret) {
       failf(data, "error signaled by mbedTLS ctx callback");

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -444,6 +444,15 @@ mbed_connect_step1(struct connectdata *conn,
   mbedtls_debug_set_threshold(4);
 #endif
 
+  /* give application a chance to interfere with mbedTLS set up. */
+  if(data->set.ssl.fsslctx) {
+    ret = (*data->set.ssl.fsslctx)(data, &connssl->config, data->set.ssl.fsslctxp);
+    if(ret) {
+      failf(data, "error signaled by mbedTLS ctx callback");
+      return CURLE_SSL_CERTPROBLEM;
+    }
+  }
+
   connssl->connecting_state = ssl_connect_2;
 
   return CURLE_OK;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -446,7 +446,8 @@ mbed_connect_step1(struct connectdata *conn,
 
   /* give application a chance to interfere with mbedTLS set up. */
   if(data->set.ssl.fsslctx) {
-    ret = (*data->set.ssl.fsslctx)(data, &connssl->config, data->set.ssl.fsslctxp);
+    ret = (*data->set.ssl.fsslctx)(data, &connssl->config, 
+    							   data->set.ssl.fsslctxp);
     if(ret) {
       failf(data, "error signaled by mbedTLS ctx callback");
       return CURLE_SSL_CERTPROBLEM;

--- a/lib/vtls/mbedtls.h
+++ b/lib/vtls/mbedtls.h
@@ -56,6 +56,9 @@ CURLcode Curl_mbedtls_random(struct Curl_easy *data, unsigned char *entropy,
 /* this backends supports CURLOPT_PINNEDPUBLICKEY */
 #define have_curlssl_pinnedpubkey 1
 
+/* this backend supports CURLOPT_SSL_CTX_* */
+#define have_curlssl_ssl_ctx 1
+
 /* API setup for mbedTLS */
 #define curlssl_init() Curl_mbedtls_init()
 #define curlssl_cleanup() Curl_mbedtls_cleanup()


### PR DESCRIPTION
I need to add mbedTLS ca certs from memory, so I added the same code as used in OpenSSL implementation. It's done at the end of step1 and it works out great.

Example (based on OpenSSL example from https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html):
```c
/* mbedTLS specific */
 
#include <mbedtls/net.h>
#include <curl/curl.h>
#include <stdio.h>
 
static CURLcode sslctx_function(CURL *curl, void *sslctx, void *parm)
{
  mbedtls_ssl_config *config=(mbedtls_ssl_config*)sslctx;
  char *mypem = /* example CA cert PEM - shortened */
    "-----BEGIN CERTIFICATE-----n"\
    "MIIHPTCCBSWgAwIBAgIBADANBgkqhkiG9w0BAQQFADB5MRAwDgYDVQQKEwdSb290n"\
    "IENBMR4wHAYDVQQLExVodHRwOi8vd3d3LmNhY2VydC5vcmcxIjAgBgNVBAMTGUNBn"\
    "IENlcnQgU2lnbmluZyBBdXRob3JpdHkxITAfBgkqhkiG9w0BCQEWEnN1cHBvcnRAn"\
    "Y2FjZXJ0Lm9yZzAeFw0wMzAzMzAxMjI5NDlaFw0zMzAzMjkxMjI5NDlaMHkxEDAOn"\
    "GCSNe9FINSkYQKyTYOGWhlC0elnYjyELn8+CkcY7v2vcB5G5l1YjqrZslMZIBjzkn"\
    "zk6q5PYvCdxTby78dOs6Y5nCpqyJvKeyRKANihDjbPIky/qbn3BHLt4Ui9SyIAmWn"\
    "omTxJBzcoTWcFbLUvFUufQb1nA5V9FrWk9p2rSVzTMVDn"\
    "-----END CERTIFICATE-----n";
  /* add our certificate to this config */
  if(mbedtls_x509_crt_parse(config->ca_chain, (const unsigned char*)mypem, strlen(mypem) + 1))
    printf("mbedtls_x509_crt_parse failed...\n");
  /* all set to go */
  return CURLE_OK;
}
```
