### PR TITLE
Make sure to set LANG variable before running tests

### DIFF
--- a/tests/data/test1035
+++ b/tests/data/test1035
@@ -32,13 +32,14 @@ http
 idn
 </features>
 <setenv>
-CHARSET=ISO8859-1
+CHARSET=UTF-8
+LANG=en_US.UTF-8
 </setenv>
  <name>
 HTTP over proxy with too long IDN host name
  </name>
  <command>
-http://too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local/page/1035 -x %HOSTIP:%HTTPPORT
+http://too-long-IDN-name-cÃ¼rl-rÃ¼les-la-la-la-dee-da-flooby-nooby.local/page/1035 -x %HOSTIP:%HTTPPORT
 </command>
 </client>
 
@@ -49,8 +50,8 @@ http://too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local/page/1035
 ^User-Agent:.*
 </strip>
 <protocol>
-GET http://too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local/page/1035 HTTP/1.1
-Host: too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local
+GET http://too-long-IDN-name-cÃ¼rl-rÃ¼les-la-la-la-dee-da-flooby-nooby.local/page/1035 HTTP/1.1
+Host: too-long-IDN-name-cÃ¼rl-rÃ¼les-la-la-la-dee-da-flooby-nooby.local
 Accept: */*
 Proxy-Connection: Keep-Alive
 

--- a/tests/data/test2046
+++ b/tests/data/test2046
@@ -42,6 +42,7 @@ idn
 </features>
 <setenv>
 CHARSET=UTF-8
+LANG=en_US.UTF-8
 </setenv>
  <name>
 Connection re-use with IDN host name

--- a/tests/data/test2047
+++ b/tests/data/test2047
@@ -43,6 +43,7 @@ idn
 </features>
 <setenv>
 CHARSET=UTF-8
+LANG=en_US.UTF-8
 </setenv>
  <name>
 Connection re-use with IDN host name over HTTP proxy

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -111,9 +111,6 @@ require "getpart.pm"; # array functions
 require "valgrind.pm"; # valgrind report parser
 require "ftp.pm";
 
-# Make sure we run a UTF-8 locale for idn tests
-$ENV{'LANG'} = 'en_US.UTF-8';
-
 my $HOSTIP="127.0.0.1";   # address on which the test server listens
 my $HOST6IP="[::1]";      # address on which the test server listens
 my $CLIENTIP="127.0.0.1"; # address which curl uses for incoming connections

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -111,6 +111,9 @@ require "getpart.pm"; # array functions
 require "valgrind.pm"; # valgrind report parser
 require "ftp.pm";
 
+# Make sure we run a UTF-8 locale for idn tests
+$ENV{'LANG'} = 'en_US.UTF-8';
+
 my $HOSTIP="127.0.0.1";   # address on which the test server listens
 my $HOST6IP="[::1]";      # address on which the test server listens
 my $CLIENTIP="127.0.0.1"; # address which curl uses for incoming connections


### PR DESCRIPTION
We should set LANG variable to a UTF-8 capable locale so we can run idn tests correctly.
Fixes #1277