### PR TITLE
Set CHARSET & LANG to UTF-8 compatible values for idn tests

### DIFF
--- a/tests/data/test1035
+++ b/tests/data/test1035
@@ -32,7 +32,8 @@ http
 idn
 </features>
 <setenv>
-CHARSET=ISO8859-1
+CHARSET=UTF-8
+LANG=en_US.UTF-8
 </setenv>
  <name>
 HTTP over proxy with too long IDN host name

--- a/tests/data/test2046
+++ b/tests/data/test2046
@@ -42,6 +42,7 @@ idn
 </features>
 <setenv>
 CHARSET=UTF-8
+LANG=en_US.UTF-8
 </setenv>
  <name>
 Connection re-use with IDN host name

--- a/tests/data/test2047
+++ b/tests/data/test2047
@@ -43,6 +43,7 @@ idn
 </features>
 <setenv>
 CHARSET=UTF-8
+LANG=en_US.UTF-8
 </setenv>
  <name>
 Connection re-use with IDN host name over HTTP proxy


### PR DESCRIPTION
Tests 1035, 2046 and 2047 needs LANG set to a UTF-8 compatible value for correctly testing idn features.