### PR TITLE
CURLOPT_SSL_CTX_FUNCTION: adhere to documented behavior

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -200,9 +200,14 @@ cyassl_connect_step1(struct connectdata *conn,
     return CURLE_OUT_OF_MEMORY;
   }
 
-  if(conssl->ctx)
+  if(conssl->ctx) {
+    /* CURLOPT_SSL_CTX_FUNCTION says "pointer will be a new one every time" */
+    SSL_CTX *tmp = SSL_CTX_new(req_method);
     SSL_CTX_free(conssl->ctx);
-  conssl->ctx = SSL_CTX_new(req_method);
+    conssl->ctx = tmp;
+  }
+  else
+    conssl->ctx = SSL_CTX_new(req_method);
 
   if(!conssl->ctx) {
     failf(data, "SSL: couldn't create a context!");

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1783,9 +1783,14 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-  if(connssl->ctx)
+  if(connssl->ctx) {
+    /* CURLOPT_SSL_CTX_FUNCTION says "pointer will be a new one every time" */
+    SSL_CTX *tmp = SSL_CTX_new(req_method);
     SSL_CTX_free(connssl->ctx);
-  connssl->ctx = SSL_CTX_new(req_method);
+    connssl->ctx = tmp;
+  }
+  else
+    connssl->ctx = SSL_CTX_new(req_method);
 
   if(!connssl->ctx) {
     failf(data, "SSL: couldn't create a context: %s",


### PR DESCRIPTION
- Allocate a new CTX object before freeing the old one.
  This is because CURLOPT_SSL_CTX_FUNCTION manpage says:
  "pointer will be a new one every time".

- manpage: Fix formatting in EXAMPLE by escaping all backslashes.

- manpage: Document that CURLE_NOT_BUILT_IN is a RETURN VALUE.