### PR TITLE
Fixes cmake include directories and headers lookup path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,6 @@ message(STATUS "curl version=[${CURL_VERSION}]")
 set(OPERATING_SYSTEM "${CMAKE_SYSTEM_NAME}")
 set(OS "\"${CMAKE_SYSTEM_NAME}\"")
 
-include_directories(${PROJECT_BINARY_DIR}/include/curl)
-include_directories( ${CURL_SOURCE_DIR}/include )
-
 option(BUILD_CURL_EXE "Set to ON to build curl executable." ON)
 option(CURL_STATICLIB "Set to ON to build libcurl with static linking." OFF)
 option(ENABLE_ARES "Set to ON to enable c-ares support" OFF)

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -34,9 +34,9 @@
 #define CURL_STRICTER
 #endif
 
-#include "curlver.h"         /* libcurl version defines   */
-#include "curlbuild.h"       /* libcurl build definitions */
-#include "curlrules.h"       /* libcurl rules enforcement */
+#include <curl/curlver.h>       /* libcurl version defines   */
+#include <curl/curlbuild.h>     /* libcurl build definitions */
+#include <curl/curlrules.h>     /* libcurl rules enforcement */
 
 /*
  * Define WIN32 when build target is Win32 API

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,12 +51,13 @@ endif()
 
 # The rest of the build
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../include)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(
+  ${CURL_BINARY_DIR}/include/curl # for generated curlbuild.h from curl.h
+  ${CURL_BINARY_DIR}/include      # for generated curlbuild.h from lib/curl_setup.h
+  ${CURL_SOURCE_DIR}/include      # for libcurl's external include files
+  ${CURL_BINARY_DIR}/lib          # for libcurl's generated lib/curl_config.h
+  ${CURL_SOURCE_DIR}/lib          # for libcurl's lib/curl_setup.h and other "borrowed" files
+)
 if(USE_ARES)
   include_directories(${CARES_INCLUDE_DIR})
 endif()

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -38,7 +38,7 @@
 
 #ifdef HAVE_CONFIG_H
 
-#include "curl_config.h"
+#include <curl_config.h>
 
 #else /* HAVE_CONFIG_H */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,12 +54,14 @@ source_group("curl source files" FILES ${CURL_CFILES})
 source_group("curl header files" FILES ${CURL_HFILES})
 
 include_directories(
-  ${CURL_SOURCE_DIR}/lib        # To be able to reach "curl_setup_once.h"
-  ${CURL_BINARY_DIR}/lib        # To be able to reach "curl_config.h"
-  ${CURL_BINARY_DIR}/include    # To be able to reach "curl/curlbuild.h"
-  # This is needed as tool_hugehelp.c is generated in the binary dir
-  ${CURL_SOURCE_DIR}/src        # To be able to reach "tool_hugehelp.h"
-  )
+  ${CURL_BINARY_DIR}/include/curl # for generated curlbuild.h from curl.h
+  ${CURL_BINARY_DIR}/include      # for generated curlbuild.h from lib/curl_setup.h
+  ${CURL_SOURCE_DIR}/include      # for libcurl's external include files
+  ${CURL_BINARY_DIR}/lib          # for libcurl's generated lib/curl_config.h
+  #${CURL_BINARY_DIR}/src          # for curl's generated src/curl_config.h
+  ${CURL_SOURCE_DIR}/lib          # for libcurl's lib/curl_setup.h and other "borrowed" files
+  ${CURL_SOURCE_DIR}/src          # for curl's src/tool_setup.h and "curl-private" files
+)
 
 #Build curl executable
 target_link_libraries( ${EXE_NAME} libcurl ${CURL_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,15 @@
+# Inherited by libtest, server and unit
+include_directories(
+  ${CURL_BINARY_DIR}/include/curl # for generated curlbuild.h from curl.h
+  ${CURL_BINARY_DIR}/include      # for generated curlbuild.h from lib/curl_setup.h
+  ${CURL_SOURCE_DIR}/include      # for libcurl's external include files
+  ${CURL_BINARY_DIR}/lib          # for libcurl's generated lib/curl_config.h
+  ${CURL_SOURCE_DIR}/lib          # for libcurl's lib/curl_setup.h and other "borrowed" files
+)
+if(USE_ARES)
+  include_directories(${CARES_INCLUDE_DIR})
+endif()
+
 add_subdirectory(data)
 add_subdirectory(libtest)
 add_subdirectory(server)

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -4,15 +4,6 @@ function(SETUP_TEST TEST_NAME)          # ARGN are the files in the test
   add_executable( ${TEST_NAME} ${ARGN} )
   string(TOUPPER ${TEST_NAME} UPPER_TEST_NAME)
 
-  include_directories(
-    ${CURL_SOURCE_DIR}/lib          # To be able to reach "curl_setup_once.h"
-    ${CURL_BINARY_DIR}/lib          # To be able to reach "curl_config.h"
-    ${CURL_BINARY_DIR}/include      # To be able to reach "curl/curlbuild.h"
-    )
-  if(USE_ARES)
-    include_directories(${CARES_INCLUDE_DIR})
-  endif()
-
   target_link_libraries( ${TEST_NAME} libcurl ${CURL_LIBS})
 
   set_target_properties(${TEST_NAME}

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -4,15 +4,6 @@ function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
   add_executable( ${TEST_NAME} ${ARGN} )
   string(TOUPPER ${TEST_NAME} UPPER_TEST_NAME)
 
-  include_directories(
-    ${CURL_SOURCE_DIR}/lib      # To be able to reach "curl_setup_once.h"
-    ${CURL_BINARY_DIR}/lib      # To be able to reach "curl_config.h"
-    ${CURL_BINARY_DIR}/include  # To be able to reach "curl/curlbuild.h"
-    )
-  if(USE_ARES)
-    include_directories(${CARES_INCLUDE_DIR})
-  endif()
-
   target_link_libraries(${TEST_NAME} ${CURL_LIBS})
 
   # Test servers simply are standalone programs that do not use libcurl

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,11 +25,8 @@ set(UT_SRC
 
 set(UT_COMMON_FILES ../libtest/first.c ../libtest/test.h curlcheck.h)
 include_directories(
-  ${CURL_SOURCE_DIR}/lib          # To be able to reach "curl_setup_once.h"
-  ${CURL_SOURCE_DIR}/tests/libtest
   ${CURL_SOURCE_DIR}/src
-  ${CURL_BINARY_DIR}/lib          # To be able to reach "curl_config.h"
-  ${CURL_BINARY_DIR}/include      # To be able to reach "curl/curlbuild.h"
+  ${CURL_SOURCE_DIR}/tests/libtest
 )
 
 foreach(_testfile ${UT_SRC})


### PR DESCRIPTION
While working on cmake improvements I had very strange build failures (attempt to use nghttp2 even if it was disabled in the config). Turns out that autotools remainders caused confusion so here are patches to address that:

 - cmake: ensure that the build directory gets precedence
 - Fix libcurl headers to respect the include dir

Reproducer to trigger the issues:
```sh
echo '#error should not include' > include/curl/curlbuild.h
echo '#error should not include' > lib/curl_config.h
```

Before this patch it would upset both cmake and autotools, after this patch it will look for the header files the build directory as expected. The curl.h header is public, see commit message for a possible concern.