### PR TITLE
url: fix compilation warning with CURL_DISABLE_PROXY

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -6112,7 +6112,9 @@ static CURLcode create_conn(struct Curl_easy *data,
   bool reuse;
   char *proxy = NULL;
   char *socksproxy = NULL;
+#ifndef CURL_DISABLE_PROXY
   char *no_proxy = NULL;
+#endif
   bool prot_missing = FALSE;
   bool connections_available = TRUE;
   bool force_reuse = FALSE;


### PR DESCRIPTION
When CURL_DISABLE_PROXY is defined, MSVC complains:
warning C4189: 'no_proxy': local variable is initialized but not referenced

I haven't found any hint if there is a preferred way to fix this warning and the existing code also seems not to be consistent (#ifdef around the declaration, unconditional cast to void, cast to void inside the existing #ifdef block, ...), so I created this pull request to ask if there is any preference first.