### PR TITLE
Fix potential use of uninitialized variables.

### DIFF
--- a/lib/dict.c
+++ b/lib/dict.c
@@ -92,7 +92,7 @@ const struct Curl_handler Curl_handler_dict = {
 
 static char *unescape_word(struct Curl_easy *data, const char *inputbuff)
 {
-  char *newp;
+  char *newp = NULL;
   char *dictp;
   char *ptr;
   size_t len;

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -78,7 +78,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
 
   curl_off_t *bytecount = &data->req.bytecount;
   char *path = data->state.path;
-  char *sel;
+  char *sel = NULL;
   char *sel_org = NULL;
   ssize_t amount, k;
   size_t len;


### PR DESCRIPTION
MSVC with LTCG detects this at warning level 4.