### PR TITLE
Improve the readbility of the code by removing the else branch

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -810,8 +810,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 
         return CURLE_OK;
       }
-      else
-        infof(data, "Connection failed\n");
+      infof(data, "Connection failed\n");
     }
     else if(rc & CURL_CSELECT_ERR)
       (void)verifyconnect(conn->tempsock[i], &error);

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -130,8 +130,7 @@ inflate_stream(struct connectdata *conn,
         free(decomp);
         if(inflateEnd(z) == Z_OK)
           return exit_zlib(z, &k->zlib_init, result);
-        else
-          return exit_zlib(z, &k->zlib_init, process_zlib_error(conn, z));
+        return exit_zlib(z, &k->zlib_init, process_zlib_error(conn, z));
       }
 
       /* Done with these bytes, exit */

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -929,9 +929,8 @@ static char *get_line(char *buf, int len, FILE *input)
         }
         return b;
       }
-      else
-        /* read a partial, discard the next piece that ends with newline */
-        partial = TRUE;
+      /* read a partial, discard the next piece that ends with newline */
+      partial = TRUE;
     }
     else
       break;

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -469,11 +469,11 @@ Curl_addrinfo *Curl_str2addr(char *address, int port)
     /* This is a dotted IP address 123.123.123.123-style */
     return Curl_ip2addr(AF_INET, &in, address, port);
 #ifdef ENABLE_IPV6
-  else {
-    struct in6_addr in6;
-    if(Curl_inet_pton(AF_INET6, address, &in6) > 0)
-      /* This is a dotted IPv6 address ::1-style */
-      return Curl_ip2addr(AF_INET6, &in6, address, port);
+  {
+  struct in6_addr in6;
+  if(Curl_inet_pton(AF_INET6, address, &in6) > 0)
+    /* This is a dotted IPv6 address ::1-style */
+    return Curl_ip2addr(AF_INET6, &in6, address, port);
   }
 #endif
   return NULL; /* bad input format */

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -145,8 +145,7 @@ static int setcharset(unsigned char **p, unsigned char *charset)
       else if(c == ']') {
         if(something_found)
           return SETCHARSET_OK;
-        else
-          something_found = TRUE;
+        something_found = TRUE;
         state = CURLFNM_SCHS_RIGHTBR;
         charset[c] = 1;
         (*p)++;
@@ -244,7 +243,7 @@ static int setcharset(unsigned char **p, unsigned char *charset)
       if(c == ']') {
         return SETCHARSET_OK;
       }
-      else if(c == '\\') {
+      if(c == '\\') {
         c = *(++(*p));
         if(ISPRINT(c)) {
           charset[c] = 1;
@@ -345,8 +344,7 @@ static int loop(const unsigned char *pattern, const unsigned char *string)
       else if(*p == '\0') {
         if(*s == '\0')
           return CURL_FNMATCH_MATCH;
-        else
-          return CURL_FNMATCH_NOMATCH;
+        return CURL_FNMATCH_NOMATCH;
       }
       else if(*p == '\\') {
         state = CURLFNM_LOOP_BACKSLASH;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -773,8 +773,7 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
     curl_multi_cleanup(multi);
     if(mcode == CURLM_OUT_OF_MEMORY)
       return CURLE_OUT_OF_MEMORY;
-    else
-      return CURLE_FAILED_INIT;
+    return CURLE_FAILED_INIT;
   }
 
   sigpipe_ignore(data, &pipe_st);

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -113,9 +113,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
         testing_ptr = Curl_saferealloc(ns, alloc);
         if(!testing_ptr)
           return NULL;
-        else {
-          ns = testing_ptr;
-        }
+        ns = testing_ptr;
       }
 
       result = Curl_convert_to_network(data, &in, 1);

--- a/lib/file.c
+++ b/lib/file.c
@@ -355,8 +355,7 @@ static CURLcode file_upload(struct connectdata *conn)
       failf(data, "Can't get the size of %s", file->path);
       return CURLE_WRITE_ERROR;
     }
-    else
-      data->state.resume_from = (curl_off_t)file_stat.st_size;
+    data->state.resume_from = (curl_off_t)file_stat.st_size;
   }
 
   while(!result) {
@@ -519,8 +518,7 @@ static CURLcode file_do(struct connectdata *conn, bool *done)
       failf(data, "Can't get the size of file.");
       return CURLE_READ_ERROR;
     }
-    else
-      data->state.resume_from += (curl_off_t)statbuf.st_size;
+    data->state.resume_from += (curl_off_t)statbuf.st_size;
   }
 
   if(data->state.resume_from <= expected_size)

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -630,70 +630,68 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         return_value = CURL_FORMADD_INCOMPLETE;
         break;
       }
-      else {
-        if(((form->flags & HTTPPOST_FILENAME) ||
-            (form->flags & HTTPPOST_BUFFER)) &&
-           !form->contenttype) {
-          char *f = form->flags & HTTPPOST_BUFFER?
-            form->showfilename : form->value;
+      if(((form->flags & HTTPPOST_FILENAME) ||
+          (form->flags & HTTPPOST_BUFFER)) &&
+         !form->contenttype) {
+        char *f = form->flags & HTTPPOST_BUFFER?
+          form->showfilename : form->value;
 
-          /* our contenttype is missing */
-          form->contenttype = strdup(ContentTypeForFilename(f, prevtype));
-          if(!form->contenttype) {
-            return_value = CURL_FORMADD_MEMORY;
-            break;
-          }
-          form->contenttype_alloc = TRUE;
-        }
-        if(!(form->flags & HTTPPOST_PTRNAME) &&
-           (form == first_form) ) {
-          /* Note that there's small risk that form->name is NULL here if the
-             app passed in a bad combo, so we better check for that first. */
-          if(form->name) {
-            /* copy name (without strdup; possibly contains null characters) */
-            form->name = Curl_memdup(form->name, form->namelength?
-                                     form->namelength:
-                                     strlen(form->name)+1);
-          }
-          if(!form->name) {
-            return_value = CURL_FORMADD_MEMORY;
-            break;
-          }
-          form->name_alloc = TRUE;
-        }
-        if(!(form->flags & (HTTPPOST_FILENAME | HTTPPOST_READFILE |
-                            HTTPPOST_PTRCONTENTS | HTTPPOST_PTRBUFFER |
-                            HTTPPOST_CALLBACK)) && form->value) {
-          /* copy value (without strdup; possibly contains null characters) */
-          size_t clen  = (size_t) form->contentslength;
-          if(!clen)
-            clen = strlen(form->value)+1;
-
-          form->value = Curl_memdup(form->value, clen);
-
-          if(!form->value) {
-            return_value = CURL_FORMADD_MEMORY;
-            break;
-          }
-          form->value_alloc = TRUE;
-        }
-        post = AddHttpPost(form->name, form->namelength,
-                           form->value, form->contentslength,
-                           form->buffer, form->bufferlength,
-                           form->contenttype, form->flags,
-                           form->contentheader, form->showfilename,
-                           form->userp,
-                           post, httppost,
-                           last_post);
-
-        if(!post) {
+        /* our contenttype is missing */
+        form->contenttype = strdup(ContentTypeForFilename(f, prevtype));
+        if(!form->contenttype) {
           return_value = CURL_FORMADD_MEMORY;
           break;
         }
-
-        if(form->contenttype)
-          prevtype = form->contenttype;
+        form->contenttype_alloc = TRUE;
       }
+      if(!(form->flags & HTTPPOST_PTRNAME) &&
+         (form == first_form) ) {
+        /* Note that there's small risk that form->name is NULL here if the
+           app passed in a bad combo, so we better check for that first. */
+        if(form->name) {
+          /* copy name (without strdup; possibly contains null characters) */
+          form->name = Curl_memdup(form->name, form->namelength?
+                                   form->namelength:
+                                   strlen(form->name)+1);
+        }
+        if(!form->name) {
+          return_value = CURL_FORMADD_MEMORY;
+          break;
+        }
+        form->name_alloc = TRUE;
+      }
+      if(!(form->flags & (HTTPPOST_FILENAME | HTTPPOST_READFILE |
+                          HTTPPOST_PTRCONTENTS | HTTPPOST_PTRBUFFER |
+                          HTTPPOST_CALLBACK)) && form->value) {
+        /* copy value (without strdup; possibly contains null characters) */
+        size_t clen  = (size_t) form->contentslength;
+        if(!clen)
+          clen = strlen(form->value)+1;
+
+        form->value = Curl_memdup(form->value, clen);
+
+        if(!form->value) {
+          return_value = CURL_FORMADD_MEMORY;
+          break;
+        }
+        form->value_alloc = TRUE;
+      }
+      post = AddHttpPost(form->name, form->namelength,
+                         form->value, form->contentslength,
+                         form->buffer, form->bufferlength,
+                         form->contenttype, form->flags,
+                         form->contentheader, form->showfilename,
+                         form->userp,
+                         post, httppost,
+                         last_post);
+
+      if(!post) {
+        return_value = CURL_FORMADD_MEMORY;
+        break;
+      }
+
+      if(form->contenttype)
+        prevtype = form->contenttype;
     }
     if(CURL_FORMADD_OK != return_value) {
       /* On error, free allocated fields for nodes of the FormInfo linked
@@ -1463,8 +1461,7 @@ static size_t readfromfile(struct Form *form, char *buffer,
   if(callback) {
     if(form->fread_func == ZERO_NULL)
       return 0;
-    else
-      nread = form->fread_func(buffer, 1, size, form->data->line);
+    nread = form->fread_func(buffer, 1, size, form->data->line);
   }
   else {
     if(!form->fp) {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -916,8 +916,7 @@ static int ftp_domore_getsock(struct connectdata *conn, curl_socket_t *socks,
 
     return bits;
   }
-  else
-    return Curl_pp_getsock(&conn->proto.ftpc.pp, socks, numsocks);
+  return Curl_pp_getsock(&conn->proto.ftpc.pp, socks, numsocks);
 }
 
 /* This is called after the FTP_QUOTE state is passed.
@@ -1209,7 +1208,7 @@ static CURLcode ftp_state_use_port(struct connectdata *conn,
         possibly_non_local = FALSE; /* don't try this again */
         continue;
       }
-      else if(error != EADDRINUSE && error != EACCES) {
+      if(error != EADDRINUSE && error != EACCES) {
         failf(data, "bind(port=%hu) failed: %s", port,
               Curl_strerror(conn, error) );
         Curl_closesocket(conn, portsock);
@@ -1307,7 +1306,7 @@ static CURLcode ftp_state_use_port(struct connectdata *conn,
       }
       break;
     }
-    else if(PORT == fcmd) {
+    if(PORT == fcmd) {
       char *source = myhost;
       char *dest = tmp;
 
@@ -1674,31 +1673,29 @@ static CURLcode ftp_state_ul_setup(struct connectdata *conn,
     }
 
     if(seekerr != CURL_SEEKFUNC_OK) {
+      curl_off_t passed=0;
       if(seekerr != CURL_SEEKFUNC_CANTSEEK) {
         failf(data, "Could not seek stream");
         return CURLE_FTP_COULDNT_USE_REST;
       }
       /* seekerr == CURL_SEEKFUNC_CANTSEEK (can't seek to offset) */
-      else {
-        curl_off_t passed=0;
-        do {
-          size_t readthisamountnow =
-            (data->state.resume_from - passed > CURL_OFF_T_C(BUFSIZE)) ?
-            BUFSIZE : curlx_sotouz(data->state.resume_from - passed);
+      do {
+        size_t readthisamountnow =
+          (data->state.resume_from - passed > CURL_OFF_T_C(BUFSIZE)) ?
+          BUFSIZE : curlx_sotouz(data->state.resume_from - passed);
 
-          size_t actuallyread =
-            data->state.fread_func(data->state.buffer, 1, readthisamountnow,
-                                   data->state.in);
+        size_t actuallyread =
+          data->state.fread_func(data->state.buffer, 1, readthisamountnow,
+                                 data->state.in);
 
-          passed += actuallyread;
-          if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
-            /* this checks for greater-than only to make sure that the
-               CURL_READFUNC_ABORT return code still aborts */
-            failf(data, "Failed to read data");
-            return CURLE_FTP_COULDNT_USE_REST;
-          }
-        } while(passed < data->state.resume_from);
-      }
+        passed += actuallyread;
+        if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
+          /* this checks for greater-than only to make sure that the
+             CURL_READFUNC_ABORT return code still aborts */
+          failf(data, "Failed to read data");
+          return CURLE_FTP_COULDNT_USE_REST;
+        }
+      } while(passed < data->state.resume_from);
     }
     /* now, decrease the size of the read */
     if(data->state.infilesize>0) {
@@ -2412,8 +2409,7 @@ static CURLcode ftp_state_stor_resp(struct connectdata *conn,
 
     return CURLE_OK;
   }
-  else
-    return InitiateTransfer(conn);
+  return InitiateTransfer(conn);
 }
 
 /* for LIST and RETR responses */
@@ -2948,12 +2944,10 @@ static CURLcode ftp_statemach_act(struct connectdata *conn)
           state(conn, FTP_NAMEFMT);
           break;
         }
-        else {
-          /* Nothing special for the target server. */
-          /* remember target server OS */
-          Curl_safefree(ftpc->server_os);
-          ftpc->server_os = os;
-        }
+        /* Nothing special for the target server. */
+        /* remember target server OS */
+        Curl_safefree(ftpc->server_os);
+        ftpc->server_os = os;
       }
       else {
         /* Cannot identify server OS. Continue anyway and cross fingers. */
@@ -3800,12 +3794,10 @@ static CURLcode init_wc_data(struct connectdata *conn)
       result = ftp_parse_url_path(conn);
       return result;
     }
-    else {
-      wildcard->pattern = strdup(last_slash);
-      if(!wildcard->pattern)
-        return CURLE_OUT_OF_MEMORY;
-      last_slash[0] = '\0'; /* cut file from path */
-    }
+    wildcard->pattern = strdup(last_slash);
+    if(!wildcard->pattern)
+      return CURLE_OUT_OF_MEMORY;
+    last_slash[0] = '\0'; /* cut file from path */
   }
   else { /* there is only 'wildcard pattern' or nothing */
     if(path[0]) {
@@ -3890,8 +3882,7 @@ static CURLcode wc_statemach(struct connectdata *conn)
     if(wildcard->state == CURLWC_CLEAN)
       /* only listing! */
       break;
-    else
-      wildcard->state = result ? CURLWC_ERROR : CURLWC_MATCHING;
+    wildcard->state = result ? CURLWC_ERROR : CURLWC_MATCHING;
     break;
 
   case CURLWC_MATCHING: {
@@ -3909,7 +3900,7 @@ static CURLcode wc_statemach(struct connectdata *conn)
       wildcard->state = CURLWC_CLEAN;
       return wc_statemach(conn);
     }
-    else if(wildcard->filelist->size == 0) {
+    if(wildcard->filelist->size == 0) {
       /* no corresponding file */
       wildcard->state = CURLWC_CLEAN;
       return CURLE_REMOTE_FILE_NOT_FOUND;

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -433,10 +433,8 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
                 PL_ERROR(conn, CURLE_FTP_BAD_FILE_LIST);
                 return bufflen;
               }
-              else {
-                parser->state.UNIX.main = PL_UNIX_FILETYPE;
-                finfo->b_used = 0;
-              }
+              parser->state.UNIX.main = PL_UNIX_FILETYPE;
+              finfo->b_used = 0;
             }
             else {
               PL_ERROR(conn, CURLE_FTP_BAD_FILE_LIST);

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -91,10 +91,8 @@ Curl_hash_init(struct curl_hash *h,
     }
     return 0; /* fine */
   }
-  else {
-    h->slots = 0;
-    return 1; /* failure */
-  }
+  h->slots = 0;
+  return 1; /* failure */
 }
 
 static struct curl_hash_element *
@@ -347,10 +345,8 @@ Curl_hash_next_element(struct curl_hash_iterator *iter)
     struct curl_hash_element *he = iter->current_element->ptr;
     return he;
   }
-  else {
-    iter->current_element = NULL;
-    return NULL;
-  }
+  iter->current_element = NULL;
+  return NULL;
 }
 
 #if 0 /* useful function for debugging hashes and their contents */

--- a/lib/hostcheck.c
+++ b/lib/hostcheck.c
@@ -87,7 +87,7 @@ static int hostmatch(char *hostname, char *pattern)
   if(Curl_inet_pton(AF_INET, hostname, &ignored) > 0)
     return CURL_HOST_NOMATCH;
 #ifdef ENABLE_IPV6
-  else if(Curl_inet_pton(AF_INET6, hostname, &si6.sin6_addr) > 0)
+  if(Curl_inet_pton(AF_INET6, hostname, &si6.sin6_addr) > 0)
     return CURL_HOST_NOMATCH;
 #endif
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1197,8 +1197,7 @@ CURLcode Curl_add_buffer_send(Curl_send_buffer *in,
            This needs FIXing.
         */
         return CURLE_SEND_ERROR;
-      else
-        Curl_pipeline_leave_write(conn);
+      Curl_pipeline_leave_write(conn);
     }
   }
   Curl_add_buffer_free(in);
@@ -2147,32 +2146,31 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
       }
 
       if(seekerr != CURL_SEEKFUNC_OK) {
+        curl_off_t passed=0;
+
         if(seekerr != CURL_SEEKFUNC_CANTSEEK) {
           failf(data, "Could not seek stream");
           return CURLE_READ_ERROR;
         }
         /* when seekerr == CURL_SEEKFUNC_CANTSEEK (can't seek to offset) */
-        else {
-          curl_off_t passed=0;
-          do {
-            size_t readthisamountnow =
-              (data->state.resume_from - passed > CURL_OFF_T_C(BUFSIZE)) ?
-              BUFSIZE : curlx_sotouz(data->state.resume_from - passed);
+        do {
+          size_t readthisamountnow =
+            (data->state.resume_from - passed > CURL_OFF_T_C(BUFSIZE)) ?
+            BUFSIZE : curlx_sotouz(data->state.resume_from - passed);
 
-            size_t actuallyread =
-              data->state.fread_func(data->state.buffer, 1, readthisamountnow,
-                                     data->state.in);
+          size_t actuallyread =
+            data->state.fread_func(data->state.buffer, 1, readthisamountnow,
+                                   data->state.in);
 
-            passed += actuallyread;
-            if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
-              /* this checks for greater-than only to make sure that the
-                 CURL_READFUNC_ABORT return code still aborts */
-              failf(data, "Could only read %" CURL_FORMAT_CURL_OFF_T
-                    " bytes from the input", passed);
-              return CURLE_READ_ERROR;
-            }
-          } while(passed < data->state.resume_from);
-        }
+          passed += actuallyread;
+          if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
+            /* this checks for greater-than only to make sure that the
+               CURL_READFUNC_ABORT return code still aborts */
+            failf(data, "Could only read %" CURL_FORMAT_CURL_OFF_T
+                  " bytes from the input", passed);
+            return CURLE_READ_ERROR;
+          }
+        } while(passed < data->state.resume_from);
       }
 
       /* now, decrease the size of the read */
@@ -2818,8 +2816,7 @@ checkrtspprefix(struct Curl_easy *data,
 #endif /* CURL_DOES_CONVERSIONS */
   if(checkprefix("RTSP/", s))
     return TRUE;
-  else
-    return FALSE;
+  return FALSE;
 }
 #endif /* CURL_DISABLE_RTSP */
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -293,10 +293,8 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
       if(!Curl_conn_data_pending(conn, sockindex))
         /* return so we'll be called again polling-style */
         return CURLE_OK;
-      else {
-        DEBUGF(infof(data,
-               "Read response immediately from proxy CONNECT\n"));
-      }
+      DEBUGF(infof(data,
+             "Read response immediately from proxy CONNECT\n"));
     }
 
     /* at this point, the tunnel_connecting phase is over. */
@@ -344,7 +342,7 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
           }
           continue;
         }
-        else if(result) {
+        if(result) {
           keepon = FALSE;
           break;
         }
@@ -617,11 +615,9 @@ CURLcode Curl_proxyCONNECT(struct connectdata *conn,
     if(conn->bits.proxy_connect_closed)
       /* this is not an error, just part of the connection negotiation */
       return CURLE_OK;
-    else {
-      failf(data, "Received HTTP code %d from proxy after CONNECT",
-            data->req.httpcode);
-      return CURLE_RECV_ERROR;
-    }
+    failf(data, "Received HTTP code %d from proxy after CONNECT",
+          data->req.httpcode);
+    return CURLE_RECV_ERROR;
   }
 
   conn->tunnel_state[sockindex] = TUNNEL_COMPLETE;

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1096,8 +1096,7 @@ char *curl_maprintf(const char *format, ...)
     info.buffer[info.len] = 0; /* we terminate this with a zero byte */
     return info.buffer;
   }
-  else
-    return strdup("");
+  return strdup("");
 }
 
 char *curl_mvaprintf(const char *format, va_list ap_save)
@@ -1121,8 +1120,7 @@ char *curl_mvaprintf(const char *format, va_list ap_save)
     info.buffer[info.len] = 0; /* we terminate this with a zero byte */
     return info.buffer;
   }
-  else
-    return strdup("");
+  return strdup("");
 }
 
 static int storebuffer(int output, FILE *data)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -959,10 +959,8 @@ CURLMcode curl_multi_fdset(struct Curl_multi *multi,
       if(s == CURL_SOCKET_BAD)
         /* this socket is unused, break out of loop */
         break;
-      else {
-        if((int)s > this_max_fd)
-          this_max_fd = (int)s;
-      }
+      if((int)s > this_max_fd)
+        this_max_fd = (int)s;
     }
 
     data = data->next; /* check next handle */
@@ -2277,8 +2275,7 @@ CURLMcode curl_multi_cleanup(struct Curl_multi *multi)
 
     return CURLM_OK;
   }
-  else
-    return CURLM_BAD_HANDLE;
+  return CURLM_BAD_HANDLE;
 }
 
 /*
@@ -2313,8 +2310,7 @@ CURLMsg *curl_multi_info_read(struct Curl_multi *multi, int *msgs_in_queue)
 
     return &msg->extmsg;
   }
-  else
-    return NULL;
+  return NULL;
 }
 
 /*
@@ -2575,7 +2571,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
     /* or should we fall-through and do the timer-based stuff? */
     return result;
   }
-  else if(s != CURL_SOCKET_TIMEOUT) {
+  if(s != CURL_SOCKET_TIMEOUT) {
 
     struct Curl_sh_entry *entry = sh_getentry(&multi->sockhash, s);
 

--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -58,8 +58,7 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
   flags = sfcntl(sockfd, F_GETFL, 0);
   if(nonblock)
     return sfcntl(sockfd, F_SETFL, flags | O_NONBLOCK);
-  else
-    return sfcntl(sockfd, F_SETFL, flags & (~O_NONBLOCK));
+  return sfcntl(sockfd, F_SETFL, flags & (~O_NONBLOCK));
 
 #elif defined(HAVE_IOCTL_FIONBIO)
 

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -267,8 +267,8 @@ long Curl_pgrsLimitWaitTime(curl_off_t cursize,
   if(actual < minimum)
     /* this is a conversion on some systems (64bit time_t => 32bit long) */
     return (long)(minimum - actual);
-  else
-    return 0;
+
+  return 0;
 }
 
 void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
@@ -454,7 +454,7 @@ int Curl_pgrsUpdate(struct connectdata *conn)
         failf(data, "Callback aborted");
       return result;
     }
-    else if(data->set.fprogress) {
+    if(data->set.fprogress) {
       /* The older deprecated callback is set, call that */
       result= data->set.fprogress(data->set.progress_client,
                                   (double)data->progress.size_dl,

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -565,10 +565,9 @@ CURLcode Curl_client_chop_write(struct connectdata *conn,
           failf(data, "Write callback asked for PAUSE when not supported!");
           return CURLE_WRITE_ERROR;
         }
-        else
-          return pausewrite(data, type, ptr, len);
+        return pausewrite(data, type, ptr, len);
       }
-      else if(wrote != chunklen) {
+      if(wrote != chunklen) {
         failf(data, "Failed writing body (%zu != %zu)", wrote, chunklen);
         return CURLE_WRITE_ERROR;
       }
@@ -652,8 +651,7 @@ CURLcode Curl_read_plain(curl_socket_t sockfd,
 #endif
     if(return_error)
       return CURLE_AGAIN;
-    else
-      return CURLE_RECV_ERROR;
+    return CURLE_RECV_ERROR;
   }
 
   /* we only return number of bytes read when we return OK */

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -73,7 +73,7 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
     result = Curl_read_plain(sockfd, buf, buffersize, &nread);
     if(CURLE_AGAIN == result)
       continue;
-    else if(result)
+    if(result)
       break;
 
     if(buffersize == nread) {
@@ -416,7 +416,7 @@ CURLcode Curl_SOCKS5(const char *proxy_name,
     failf(conn->data, "SOCKS5: no connection here");
     return CURLE_COULDNT_CONNECT;
   }
-  else if(0 == result) {
+  if(0 == result) {
     failf(conn->data, "SOCKS5: connection timeout");
     return CURLE_OPERATION_TIMEDOUT;
   }
@@ -457,7 +457,7 @@ CURLcode Curl_SOCKS5(const char *proxy_name,
     failf(conn->data, "SOCKS5 nothing to read");
     return CURLE_COULDNT_CONNECT;
   }
-  else if(0 == result) {
+  if(0 == result) {
     failf(conn->data, "SOCKS5 read timeout");
     return CURLE_OPERATION_TIMEDOUT;
   }
@@ -553,7 +553,7 @@ CURLcode Curl_SOCKS5(const char *proxy_name,
             "SOCKS5 GSSAPI per-message authentication is not supported.");
       return CURLE_COULDNT_CONNECT;
     }
-    else if(socksreq[1] == 255) {
+    if(socksreq[1] == 255) {
 #endif
       if(!proxy_name || !*proxy_name) {
         failf(data,
@@ -772,9 +772,7 @@ CURLcode Curl_SOCKS5(const char *proxy_name,
     }
     return CURLE_COULDNT_CONNECT;
   }
-  else {
-    infof(data, "SOCKS5 request granted.\n");
-  }
+  infof(data, "SOCKS5 request granted.\n");
 
   (void)curlx_nonblock(sock, TRUE);
   return CURLE_OK; /* Proxy was successful! */

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -55,10 +55,8 @@ CURLcode Curl_speedcheck(struct Curl_easy *data,
             data->set.low_speed_time);
       return CURLE_OPERATION_TIMEDOUT;
     }
-    else {
-      /* wait complete low_speed_time */
-      Curl_expire_latest(data, nextcheck);
-    }
+    /* wait complete low_speed_time */
+    Curl_expire_latest(data, nextcheck);
   }
   else {
     /* we keep up the required speed all right */

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -201,10 +201,8 @@ struct Curl_tree *Curl_splaygetbest(struct timeval i,
 
     return x;
   }
-  else {
-    *removed = NULL; /* no match */
-    return t;        /* It wasn't there */
-  }
+  *removed = NULL; /* no match */
+  return t;        /* It wasn't there */
 }
 
 

--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -125,9 +125,9 @@ int Curl_safe_strcasecompare(const char *first, const char *second)
   if(first && second)
     /* both pointers point to something then compare them */
     return Curl_strcasecompare(first, second);
-  else
-    /* if both pointers are NULL then treat them as equal */
-    return (NULL == first && NULL == second);
+
+  /* if both pointers are NULL then treat them as equal */
+  return (NULL == first && NULL == second);
 }
 
 /*

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -899,11 +899,9 @@ static CURLcode check_telnet_options(struct connectdata *conn)
       result = CURLE_UNKNOWN_TELNET_OPTION;
       break;
     }
-    else {
-      failf(data, "Syntax error in telnet option: %s", head->data);
-      result = CURLE_TELNET_OPTION_SYNTAX;
-      break;
-    }
+    failf(data, "Syntax error in telnet option: %s", head->data);
+    result = CURLE_TELNET_OPTION_SYNTAX;
+    break;
   }
 
   if(result) {
@@ -1594,7 +1592,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
         if(result == CURLE_AGAIN)
           break;
         /* returned not-zero, this an error */
-        else if(result) {
+        if(result) {
           keepon = FALSE;
           break;
         }

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -359,7 +359,7 @@ static CURLcode tftp_parse_option_ack(tftp_state_data_t *state,
         failf(data, "invalid blocksize value in OACK packet");
         return CURLE_TFTP_ILLEGAL;
       }
-      else if(blksize > TFTP_BLKSIZE_MAX) {
+      if(blksize > TFTP_BLKSIZE_MAX) {
         failf(data, "%s (%d)", "blksize is larger than max supported",
               TFTP_BLKSIZE_MAX);
         return CURLE_TFTP_ILLEGAL;
@@ -1189,7 +1189,7 @@ static long tftp_state_timeout(struct connectdata *conn, tftp_event_t *event)
     state->state = TFTP_STATE_FIN;
     return 0;
   }
-  else if(current > state->rx_time+state->retry_time) {
+  if(current > state->rx_time+state->retry_time) {
     if(event)
       *event = TFTP_EVENT_TIMEOUT;
     time(&state->rx_time); /* update even though we received nothing */
@@ -1223,7 +1223,7 @@ static CURLcode tftp_multi_statemach(struct connectdata *conn, bool *done)
     failf(data, "TFTP response timeout");
     return CURLE_OPERATION_TIMEDOUT;
   }
-  else if(event != TFTP_EVENT_NONE) {
+  if(event != TFTP_EVENT_NONE) {
     result = tftp_state_machine(state, event);
     if(result)
       return result;

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -139,8 +139,7 @@ double curlx_tvdiff_secs(struct timeval newer, struct timeval older)
   if(newer.tv_sec != older.tv_sec)
     return (double)(newer.tv_sec-older.tv_sec)+
       (double)(newer.tv_usec-older.tv_usec)/1000000.0;
-  else
-    return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
+  return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
 
 /* return the number of seconds in the given input timeval struct */

--- a/lib/url.c
+++ b/lib/url.c
@@ -3681,7 +3681,7 @@ ConnectionExists(struct Curl_easy *data,
                            check->connection_id));
               continue;
             }
-            else if(check->ssl[FIRSTSOCKET].state != ssl_connection_complete) {
+            if(check->ssl[FIRSTSOCKET].state != ssl_connection_complete) {
               foundPendingCandidate = TRUE;
               DEBUGF(infof(data,
                            "Connection #%ld has not started SSL connect, "

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -775,7 +775,7 @@ int Curl_ossl_check_cxn(struct connectdata *conn)
                (RECV_TYPE_ARG3)1, (RECV_TYPE_ARG4)MSG_PEEK);
   if(nread == 0)
     return 0; /* connection has been closed */
-  else if(nread == 1)
+  if(nread == 1)
     return 1; /* connection still in place */
   else if(nread == -1) {
       int err = SOCKERRNO;
@@ -2085,12 +2085,10 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
               ssl_capath ? ssl_capath : "none");
         return CURLE_SSL_CACERT_BADFILE;
       }
-      else {
-        /* Just continue with a warning if no strict  certificate verification
-           is required. */
-        infof(data, "error setting certificate verify locations,"
-              " continuing anyway:\n");
-      }
+      /* Just continue with a warning if no strict  certificate verification
+         is required. */
+      infof(data, "error setting certificate verify locations,"
+            " continuing anyway:\n");
     }
     else {
       /* Everything is fine. */
@@ -2120,12 +2118,11 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
       failf(data, "error loading CRL file: %s", ssl_crlfile);
       return CURLE_SSL_CRL_BADFILE;
     }
-    else {
-      /* Everything is fine. */
-      infof(data, "successfully load CRL file:\n");
-      X509_STORE_set_flags(SSL_CTX_get_cert_store(connssl->ctx),
-                           X509_V_FLAG_CRL_CHECK|X509_V_FLAG_CRL_CHECK_ALL);
-    }
+    /* Everything is fine. */
+    infof(data, "successfully load CRL file:\n");
+    X509_STORE_set_flags(SSL_CTX_get_cert_store(connssl->ctx),
+                         X509_V_FLAG_CRL_CHECK|X509_V_FLAG_CRL_CHECK_ALL);
+
     infof(data, "  CRLfile: %s\n", ssl_crlfile);
   }
 
@@ -2253,7 +2250,7 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
       connssl->connecting_state = ssl_connect_2_reading;
       return CURLE_OK;
     }
-    else if(SSL_ERROR_WANT_WRITE == detail) {
+    if(SSL_ERROR_WANT_WRITE == detail) {
       connssl->connecting_state = ssl_connect_2_writing;
       return CURLE_OK;
     }
@@ -3066,16 +3063,14 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
         return CURLE_SSL_CONNECT_ERROR;
       }
-      else if(0 == what) {
+      if(0 == what) {
         if(nonblocking) {
           *done = FALSE;
           return CURLE_OK;
         }
-        else {
-          /* timeout */
-          failf(data, "SSL connection timeout");
-          return CURLE_OPERATION_TIMEDOUT;
-        }
+        /* timeout */
+        failf(data, "SSL connection timeout");
+        return CURLE_OPERATION_TIMEDOUT;
       }
       /* socket is readable or writable */
     }
@@ -3145,8 +3140,7 @@ bool Curl_ossl_data_pending(const struct connectdata *conn, int connindex)
            (conn->proxy_ssl[connindex].handle &&
             0 != SSL_pending(conn->proxy_ssl[connindex].handle))) ?
            TRUE : FALSE;
-  else
-    return FALSE;
+  return FALSE;
 }
 
 static ssize_t ossl_send(struct connectdata *conn,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -515,7 +515,7 @@ int Curl_ssl_getsock(struct connectdata *conn, curl_socket_t *socks,
     socks[0] = conn->sock[FIRSTSOCKET];
     return GETSOCK_WRITESOCK(0);
   }
-  else if(connssl->connecting_state == ssl_connect_2_reading) {
+  if(connssl->connecting_state == ssl_connect_2_reading) {
     /* read mode */
     socks[0] = conn->sock[FIRSTSOCKET];
     return GETSOCK_READSOCK(0);

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -128,8 +128,7 @@ size_t tool_header_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
         hdrcbdata->honor_cd_filename = FALSE;
         break;
       }
-      else
-        return failure;
+      return failure;
     }
   }
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -782,11 +782,10 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
 
         if(!url)
           return PARAM_NO_MEM;
-        else {
-          /* fill in the URL */
-          GetStr(&url->url, nextarg);
-          url->flags |= GETOUT_URL;
-        }
+
+        /* fill in the URL */
+        GetStr(&url->url, nextarg);
+        url->flags |= GETOUT_URL;
       }
       }
       break;
@@ -877,7 +876,7 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
                     &config->localportrange);
         if(!rc)
           return PARAM_BAD_USE;
-        else if(rc == 1)
+        if(rc == 1)
           config->localportrange = 1; /* default number of ports to try */
         else {
           config->localportrange -= config->localport;
@@ -1724,21 +1723,20 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
 
       if(!url)
         return PARAM_NO_MEM;
-      else {
-        /* fill in the outfile */
-        if('o' == letter) {
-          GetStr(&url->outfile, nextarg);
-          url->flags &= ~GETOUT_USEREMOTE; /* switch off */
-        }
-        else {
-          url->outfile = NULL; /* leave it */
-          if(toggle)
-            url->flags |= GETOUT_USEREMOTE;  /* switch on */
-          else
-            url->flags &= ~GETOUT_USEREMOTE; /* switch off */
-        }
-        url->flags |= GETOUT_OUTFILE;
+
+      /* fill in the outfile */
+      if('o' == letter) {
+        GetStr(&url->outfile, nextarg);
+        url->flags &= ~GETOUT_USEREMOTE; /* switch off */
       }
+      else {
+        url->outfile = NULL; /* leave it */
+        if(toggle)
+          url->flags |= GETOUT_USEREMOTE;  /* switch on */
+        else
+          url->flags &= ~GETOUT_USEREMOTE; /* switch off */
+      }
+      url->flags |= GETOUT_OUTFILE;
     }
     break;
     case 'P':
@@ -1863,14 +1861,13 @@ ParameterError getparameter(char *flag,    /* f or -long-flag */
 
       if(!url)
         return PARAM_NO_MEM;
+
+      url->flags |= GETOUT_UPLOAD; /* mark -T used */
+      if(!*nextarg)
+        url->flags |= GETOUT_NOUPLOAD;
       else {
-        url->flags |= GETOUT_UPLOAD; /* mark -T used */
-        if(!*nextarg)
-          url->flags |= GETOUT_NOUPLOAD;
-        else {
-          /* "-" equals stdin, but keep the string around for now */
-          GetStr(&url->infile, nextarg);
-        }
+        /* "-" equals stdin, but keep the string around for now */
+        GetStr(&url->infile, nextarg);
       }
     }
     break;

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -207,18 +207,16 @@ static bool ttyecho(bool enable, int fd)
 #endif
     return TRUE; /* disabled */
   }
-  else {
-    /* re-enable echo, assumes we disabled it before (and set the structs we
-       now use to reset the terminal status) */
+  /* re-enable echo, assumes we disabled it before (and set the structs we
+     now use to reset the terminal status) */
 #ifdef HAVE_TERMIOS_H
-    tcsetattr(fd, TCSAFLUSH, &withecho);
+  tcsetattr(fd, TCSAFLUSH, &withecho);
 #elif defined(HAVE_TERMIO_H)
-    ioctl(fd, TCSETA, &withecho);
+  ioctl(fd, TCSETA, &withecho);
 #else
-    return FALSE; /* not enabled */
+  return FALSE; /* not enabled */
 #endif
-    return TRUE; /* enabled */
-  }
+  return TRUE; /* enabled */
 }
 
 char *getpass_r(const char *prompt, /* prompt to display */

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -135,8 +135,7 @@ double tool_tvdiff_secs(struct timeval newer, struct timeval older)
   if(newer.tv_sec != older.tv_sec)
     return (double)(newer.tv_sec-older.tv_sec)+
       (double)(newer.tv_usec-older.tv_usec)/1000000.0;
-  else
-    return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
+  return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
 
 /* return the number of seconds in the given input timeval struct */


### PR DESCRIPTION
after a return, break or continue.

Found by clang-tidy
