### PR TITLE
Basic support for OpenSSL 1.1.x on windows

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -114,11 +114,19 @@ LFLAGS         = $(LFLAGS) "/LIBPATH:$(DEVEL_LIB)"
 
 
 !IF "$(WITH_SSL)"=="dll"
+!IF EXISTS("$(DEVEL_LIB)\libssl.lib")
+SSL_LIBS     = libssl.lib libcrypto.lib
+!ELSE
 SSL_LIBS     = libeay32.lib ssleay32.lib
+!ENDIF
 USE_SSL      = true
 SSL          = dll
 !ELSEIF "$(WITH_SSL)"=="static"
+!IF EXISTS("$(DEVEL_LIB)\libssl.lib")
+SSL_LIBS     = libssl.lib libcrypto.lib ws2_32.lib crypt32.lib gdi32.lib user32.lib crypt32.lib
+!ELSE
 SSL_LIBS     = libeay32.lib ssleay32.lib gdi32.lib user32.lib crypt32.lib
+!ENDIF
 USE_SSL      = true
 SSL          = static
 !ENDIF

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -123,7 +123,7 @@ USE_SSL      = true
 SSL          = dll
 !ELSEIF "$(WITH_SSL)"=="static"
 !IF EXISTS("$(DEVEL_LIB)\libssl.lib")
-SSL_LIBS     = libssl.lib libcrypto.lib ws2_32.lib crypt32.lib gdi32.lib user32.lib crypt32.lib
+SSL_LIBS     = libssl.lib libcrypto.lib gdi32.lib user32.lib crypt32.lib
 !ELSE
 SSL_LIBS     = libeay32.lib ssleay32.lib gdi32.lib user32.lib crypt32.lib
 !ENDIF


### PR DESCRIPTION
As pointed out in https://github.com/curl/curl/issues/1201 already, the OpenSSL 1.1.x lib names have changed, which as consequence makes impossible to link cURL with OpenSSL > 1.0.2. While the aforementioned PR suggested to make lib names configurable, it were also dicussed to first care about the build process present currently. This PR goes for this, the library names are determined by checking the physical existence of the certain files. The newer OpenSSL libs are preferred, while in general there's no change to the current build approach. The only condition is, that the DEVEL dir has to contain either one or the other set of libs, not both at once. 