### PR TITLE
winbuild: allow _WIN32_WINNT to be overridden

### DIFF
--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -77,6 +77,7 @@ where <options> is one or many of:
   GEN_PDB=<yes or no>          - Generate Program Database (debug symbols for release build)
   DEBUG=<yes or no>            - Debug builds
   MACHINE=<x86 or x64>         - Target architecture (default is x86)
+  WIN32_WINNT=<value>          - Override value of WIN32_WINNT to target an earlier version of the WIN32 API
 
 Static linking of Microsoft's C RunTime (CRT):
 ==============================================

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -36,6 +36,7 @@ CFGSET=true
 !MESSAGE   GEN_PDB=<yes or no>          - Generate Program Database (debug symbols for release build)
 !MESSAGE   DEBUG=<yes or no>            - Debug builds
 !MESSAGE   MACHINE=<x86 or x64>         - Target architecture (default x64 on AMD64, x86 on others)
+!MESSAGE   WIN32_WINNT=<value>          - Override value of WIN32_WINNT to target an earlier version of the WIN32 API
 !ERROR please choose a valid mode
 
 !ENDIF

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -63,6 +63,10 @@ CC_DEBUG    = $(CC) /Od /D_DEBUG /RTC1 /Z7 /LDd /W3
 CFLAGS      = /I. /I ../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL
 !ENDIF
 
+!IFDEF WIN32_WINNT
+CFLAGS = $(CFLAGS) /D_WIN32_WINNT=$(WIN32_WINNT)
+!ENDIF
+
 LFLAGS     = /nologo /machine:$(MACHINE)
 LNKDLL     = link.exe /DLL
 LNKLIB     = link.exe /lib


### PR DESCRIPTION
Modifications:
- Add a directive to Makefile.vc to allow the _WIN32_WINNT value to
  be overridden in an nmake build. This facilitates targeting
  a specific version of the WIN32 API, regardless of the version
  on which the binaries are being built. For example, Windows
  Server 2008 can be targeted while building on Windows
  Server 2012r2.