### PR TITLE
sendf.c: Updates connection info when using TCP Fast Open

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -576,6 +576,9 @@ struct ConnectBits {
   bool proxy_ssl_connected[2]; /* TRUE when SSL initialization for HTTPS proxy
                                   is complete */
   bool socksproxy_connecting; /* connecting through a socks proxy */
+  bool needs_update; /* a non-blocking socket was created and a
+                        call to Curl_updateconninfo() should be made
+                        as soon as a successful read or write has happened */
 };
 
 struct hostname {


### PR DESCRIPTION
 * Adds a ``needs_update`` bit to the connection info struct
 * When using TFO, set the ``needs_update`` bit on the first send
 * If the ``needs_update`` bit is set, when a successful read or write is
   completed, update the connection info and clear the ``needs_udpate`` bit

This closes #1332.