### PR TITLE
darwinssl: fixed regression causing compilation error

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1045,7 +1045,7 @@ CF_INLINE bool is_file(const char *filename)
 }
 
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
-static CURLcode darwinssl_version_from_curl(long *darwinver, long version)
+static CURLcode darwinssl_version_from_curl(long *darwinver, long ssl_version)
 {
   switch(ssl_version) {
     case CURL_SSLVERSION_TLSv1_0:


### PR DESCRIPTION
Regression was introduced in 6448f98c1857de521fb2dd3f9d4e5659845b5474