### PR TITLE
macOS: connectx() function is weak linked to fix crash in 10.8

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1075,17 +1075,25 @@ static CURLcode singleipconnect(struct connectdata *conn,
   /* Connect TCP sockets, bind UDP */
   if(!isconnected && (conn->socktype == SOCK_STREAM)) {
     if(conn->bits.tcp_fastopen) {
-#if defined(CONNECT_DATA_IDEMPOTENT) /* OS X */
-      sa_endpoints_t endpoints;
-      endpoints.sae_srcif = 0;
-      endpoints.sae_srcaddr = NULL;
-      endpoints.sae_srcaddrlen = 0;
-      endpoints.sae_dstaddr = &addr.sa_addr;
-      endpoints.sae_dstaddrlen = addr.addrlen;
+#if defined(CONNECT_DATA_IDEMPOTENT) /* Darwin */
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpartial-availability"
+        if(connectx != NULL) {
+          sa_endpoints_t endpoints;
+          endpoints.sae_srcif = 0;
+          endpoints.sae_srcaddr = NULL;
+          endpoints.sae_srcaddrlen = 0;
+          endpoints.sae_dstaddr = &addr.sa_addr;
+          endpoints.sae_dstaddrlen = addr.addrlen;
 
-      rc = connectx(sockfd, &endpoints, SAE_ASSOCID_ANY,
-                    CONNECT_RESUME_ON_READ_WRITE | CONNECT_DATA_IDEMPOTENT,
-                    NULL, 0, NULL, NULL);
+          rc = connectx(sockfd, &endpoints, SAE_ASSOCID_ANY,
+                        CONNECT_RESUME_ON_READ_WRITE | CONNECT_DATA_IDEMPOTENT,
+                        NULL, 0, NULL, NULL);
+        }
+        else {
+          return CURLE_NOT_BUILT_IN;
+        }
+#  pragma GCC diagnostic pop
 #elif defined(MSG_FASTOPEN) /* Linux */
       if(conn->given->flags & PROTOPT_SSL)
         rc = connect(sockfd, &addr.sa_addr, addr.addrlen);

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -762,4 +762,18 @@ endings either CRLF or LF so 't' is appropriate.
 #  endif
 # endif
 
+/* Detect Darwin connectx() function availability.
+ * The connectx() function call appeared in Darwin 15.0.0
+ * but it's not declared using availability attribute.
+ */
+
+#if defined(CONNECT_DATA_IDEMPOTENT)
+/* multiple function declarations with attributes is allowed in GNU extension */
+extern int connectx(int socket, const sa_endpoints_t *endpoints,
+                    sae_associd_t associd, unsigned int flags,
+                    const struct iovec *iov, unsigned int iovcnt,
+                    size_t *len, sae_connid_t *connid)
+                    __OSX_AVAILABLE_STARTING(__MAC_10_11, __IPHONE_9_0);
+#endif
+
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -768,7 +768,7 @@ endings either CRLF or LF so 't' is appropriate.
  */
 
 #if defined(CONNECT_DATA_IDEMPOTENT)
-/* multiple function declarations with attributes is allowed in GNU extension */
+/* multiple function attributes declarations are allowed in GNU extension */
 extern int connectx(int socket, const sa_endpoints_t *endpoints,
                     sae_associd_t associd, unsigned int flags,
                     const struct iovec *iov, unsigned int iovcnt,


### PR DESCRIPTION
The connectx() function call appeared in Darwin 15.0.0
That covers OS X 10.11, iOS 9 and tvOS 9.

connectx() is not declared with weak_import attribute in sys/socket.h,
but it’s allowed to redeclare it with missing availability and weak_import attributes
which opens possibility to build libcurl that supports range of OS versions
with or without connectx() functionality.

Because libcurl uses -Wpartial-availability to warn about symbols not available
for all system targets, use of weak linked symbols need to be done within
pragma blocks isolating those specific cases.

[Bug: https://github.com/curl/curl/issues/1330]