### PR TITLE
Don't fire warnings/errors about "partial availability" on Apple platforms

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1872,6 +1872,12 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC], [
 #include <time.h>
 #endif
 #endif
+#ifdef __APPLE__
+#ifdef __clang__
+/* avoid problems with -Werror=partial-availablity -mmacosx-version-min=10.5 */
+#pragma clang diagnostic ignored "-Wpartial-availability"
+#endif
+#endif
       ]],[[
         struct timespec ts;
         (void)clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -1924,6 +1930,12 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
 #else
 #ifdef HAVE_TIME_H
 #include <time.h>
+#endif
+#endif
+#ifdef __APPLE__
+#ifdef __clang__
+/* avoid problems with -Werror=partial-availablity -mmacosx-version-min=10.5 */
+#pragma clang diagnostic ignored "-Wpartial-availability"
 #endif
 #endif
           ]],[[
@@ -1979,6 +1991,12 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
 #else
 #ifdef HAVE_TIME_H
 #include <time.h>
+#endif
+#endif
+#ifdef __APPLE__
+#ifdef __clang__
+/* avoid problems with -Werror=partial-availablity -mmacosx-version-min=10.5 */
+#pragma clang diagnostic ignored "-Wpartial-availability"
 #endif
 #endif
         ]],[[

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -48,6 +48,11 @@ struct timeval curlx_tvnow(void)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
+#ifdef __APPLE__
+/* redeclare without the availability flag, since we check the weak symbol. */
+int clock_gettime(clockid_t __clock_id, struct timespec *__tp) __attribute__((weak_import));
+#endif
+
 struct timeval curlx_tvnow(void)
 {
   /*
@@ -59,7 +64,7 @@ struct timeval curlx_tvnow(void)
   */
   struct timeval now;
   struct timespec tsnow;
-  if(0 == clock_gettime(CLOCK_MONOTONIC, &tsnow)) {
+  if((clock_gettime != NULL) && (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
     now.tv_sec = tsnow.tv_sec;
     now.tv_usec = tsnow.tv_nsec / 1000;
   }

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -50,7 +50,8 @@ struct timeval curlx_tvnow(void)
 
 #ifdef __APPLE__
 /* redeclare without the availability flag, since we check the weak symbol. */
-int clock_gettime(clockid_t __clock_id, struct timespec *__tp) __attribute__((weak_import));
+int clock_gettime(clockid_t __clock_id, struct timespec *__tp)
+    __attribute__((weak_import));
 #endif
 
 struct timeval curlx_tvnow(void)
@@ -64,7 +65,7 @@ struct timeval curlx_tvnow(void)
   */
   struct timeval now;
   struct timespec tsnow;
-  if((clock_gettime != NULL) && (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
+  if((NULL!=clock_gettime) && (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
     now.tv_sec = tsnow.tv_sec;
     now.tv_usec = tsnow.tv_nsec / 1000;
   }

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -124,20 +124,40 @@
  * redeclaring the symbol is the appropriate way to pacify the warning,
  * as it shows you probably meant to reference that symbol, even to check
  * it for NULL. */
-__nullable CFStringRef SecCertificateCopyLongDescription(CFAllocatorRef __nullable alloc, SecCertificateRef certificate, CFErrorRef *error) __attribute__((weak_import));
-CFStringRef SecCertificateCopySubjectSummary(SecCertificateRef certificate) __attribute__((weak_import));
-OSStatus SecItemCopyMatching(CFDictionaryRef query, CFTypeRef * __nullable CF_RETURNS_RETAINED result) __attribute__((weak_import));
-SecPolicyRef SecPolicyCreateSSL(Boolean server, CFStringRef __nullable hostname) __attribute__((weak_import));
-__nullable SSLContextRef SSLCreateContext(CFAllocatorRef __nullable alloc, SSLProtocolSide protocolSide, SSLConnectionType connectionType) __attribute__((weak_import));
-OSStatus SSLSetProtocolVersionMax(SSLContextRef context, SSLProtocol maxVersion) __attribute__((weak_import));
-OSStatus SSLSetProtocolVersionMin(SSLContextRef context, SSLProtocol minVersion) __attribute__((weak_import));
-OSStatus SSLSetSessionOption(SSLContextRef context, SSLSessionOption option, Boolean value) __attribute__((weak_import));
-__nullable SecCertificateRef SecCertificateCreateWithData(CFAllocatorRef __nullable allocator, CFDataRef data) __attribute__((weak_import));
-OSStatus SSLCopyPeerTrust(SSLContextRef context, SecTrustRef * __nonnull CF_RETURNS_RETAINED trust) __attribute__((weak_import));
-OSStatus SecTrustSetAnchorCertificatesOnly(SecTrustRef trust, Boolean anchorCertificatesOnly) __attribute__((weak_import));
-OSStatus SecTrustEvaluateAsync(SecTrustRef trust, dispatch_queue_t __nullable queue, SecTrustCallback result) __attribute__((weak_import));
-CFIndex SecTrustGetCertificateCount(SecTrustRef trust) __attribute__((weak_import));
-__nullable SecCertificateRef SecTrustGetCertificateAtIndex(SecTrustRef trust, CFIndex ix) __attribute__((weak_import));
+__nullable CFStringRef SecCertificateCopyLongDescription(
+    CFAllocatorRef __nullable alloc, SecCertificateRef certificate,
+    CFErrorRef *error) __attribute__((weak_import));
+CFStringRef SecCertificateCopySubjectSummary(SecCertificateRef certificate)
+    __attribute__((weak_import));
+OSStatus SecItemCopyMatching(CFDictionaryRef query,
+    CFTypeRef * __nullable CF_RETURNS_RETAINED result)
+    __attribute__((weak_import));
+SecPolicyRef SecPolicyCreateSSL(Boolean server,
+    CFStringRef __nullable hostname) __attribute__((weak_import));
+__nullable SSLContextRef SSLCreateContext(CFAllocatorRef __nullable alloc,
+    SSLProtocolSide protocolSide, SSLConnectionType connectionType)
+    __attribute__((weak_import));
+OSStatus SSLSetProtocolVersionMax(SSLContextRef context,
+    SSLProtocol maxVersion) __attribute__((weak_import));
+OSStatus SSLSetProtocolVersionMin(SSLContextRef context,
+    SSLProtocol minVersion) __attribute__((weak_import));
+OSStatus SSLSetSessionOption(SSLContextRef context, SSLSessionOption option,
+    Boolean value) __attribute__((weak_import));
+__nullable SecCertificateRef SecCertificateCreateWithData(
+    CFAllocatorRef __nullable allocator, CFDataRef data)
+    __attribute__((weak_import));
+OSStatus SSLCopyPeerTrust(SSLContextRef context,
+    SecTrustRef * __nonnull CF_RETURNS_RETAINED trust)
+    __attribute__((weak_import));
+OSStatus SecTrustSetAnchorCertificatesOnly(SecTrustRef trust,
+    Boolean anchorCertificatesOnly) __attribute__((weak_import));
+OSStatus SecTrustEvaluateAsync(SecTrustRef trust,
+    dispatch_queue_t __nullable queue,
+    SecTrustCallback result) __attribute__((weak_import));
+CFIndex SecTrustGetCertificateCount(SecTrustRef trust)
+    __attribute__((weak_import));
+__nullable SecCertificateRef SecTrustGetCertificateAtIndex(SecTrustRef trust,
+    CFIndex ix) __attribute__((weak_import));
 extern const CFStringRef kSecClassIdentity __attribute__((weak_import));
 extern const CFStringRef kSecClass __attribute__((weak_import));
 extern const CFStringRef kSecReturnRef __attribute__((weak_import));

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -113,6 +113,41 @@
 #define ioErr -36
 #define paramErr -50
 
+
+/* Several symbols are only available in newer Apple SDKs and will fire
+ * warnings about "partial availability" if you build this code with a
+ * earlier OS target. If one of these warnings arises:
+ * - Make sure you always check that symbol against NULL, which it will
+ * be when running on an OS that didn't offer the symbol. If NULL, respond
+ * appropriately: use a fallback, don't do something, report an error.
+ * - Add that symbol to the list below this comment. Clang reports that
+ * redeclaring the symbol is the appropriate way to pacify the warning,
+ * as it shows you probably meant to reference that symbol, even to check
+ * it for NULL. */
+__nullable CFStringRef SecCertificateCopyLongDescription(CFAllocatorRef __nullable alloc, SecCertificateRef certificate, CFErrorRef *error) __attribute__((weak_import));
+CFStringRef SecCertificateCopySubjectSummary(SecCertificateRef certificate) __attribute__((weak_import));
+OSStatus SecItemCopyMatching(CFDictionaryRef query, CFTypeRef * __nullable CF_RETURNS_RETAINED result) __attribute__((weak_import));
+SecPolicyRef SecPolicyCreateSSL(Boolean server, CFStringRef __nullable hostname) __attribute__((weak_import));
+__nullable SSLContextRef SSLCreateContext(CFAllocatorRef __nullable alloc, SSLProtocolSide protocolSide, SSLConnectionType connectionType) __attribute__((weak_import));
+OSStatus SSLSetProtocolVersionMax(SSLContextRef context, SSLProtocol maxVersion) __attribute__((weak_import));
+OSStatus SSLSetProtocolVersionMin(SSLContextRef context, SSLProtocol minVersion) __attribute__((weak_import));
+OSStatus SSLSetSessionOption(SSLContextRef context, SSLSessionOption option, Boolean value) __attribute__((weak_import));
+__nullable SecCertificateRef SecCertificateCreateWithData(CFAllocatorRef __nullable allocator, CFDataRef data) __attribute__((weak_import));
+OSStatus SSLCopyPeerTrust(SSLContextRef context, SecTrustRef * __nonnull CF_RETURNS_RETAINED trust) __attribute__((weak_import));
+OSStatus SecTrustSetAnchorCertificatesOnly(SecTrustRef trust, Boolean anchorCertificatesOnly) __attribute__((weak_import));
+OSStatus SecTrustEvaluateAsync(SecTrustRef trust, dispatch_queue_t __nullable queue, SecTrustCallback result) __attribute__((weak_import));
+CFIndex SecTrustGetCertificateCount(SecTrustRef trust) __attribute__((weak_import));
+__nullable SecCertificateRef SecTrustGetCertificateAtIndex(SecTrustRef trust, CFIndex ix) __attribute__((weak_import));
+extern const CFStringRef kSecClassIdentity __attribute__((weak_import));
+extern const CFStringRef kSecClass __attribute__((weak_import));
+extern const CFStringRef kSecReturnRef __attribute__((weak_import));
+extern const CFStringRef kSecMatchLimitAll __attribute__((weak_import));
+extern const CFStringRef kSecMatchLimit __attribute__((weak_import));
+extern const CFStringRef kSecMatchPolicy __attribute__((weak_import));
+extern const CFStringRef kSecAttrLabel __attribute__((weak_import));
+/* end of list of partial availability redeclarations. */
+
+
 /* The following two functions were ripped from Apple sample code,
  * with some modifications: */
 static OSStatus SocketRead(SSLConnectionRef connection,

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -52,6 +52,11 @@ struct timeval tool_tvnow(void)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
+#ifdef __APPLE__
+/* redeclare without the availability flag, since we check the weak symbol. */
+int clock_gettime(clockid_t __clock_id, struct timespec *__tp) __attribute__((weak_import));
+#endif
+
 struct timeval tool_tvnow(void)
 {
   /*
@@ -63,7 +68,7 @@ struct timeval tool_tvnow(void)
   */
   struct timeval now;
   struct timespec tsnow;
-  if(0 == clock_gettime(CLOCK_MONOTONIC, &tsnow)) {
+  if((clock_gettime != NULL) && (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
     now.tv_sec = tsnow.tv_sec;
     now.tv_usec = tsnow.tv_nsec / 1000;
   }

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -54,7 +54,8 @@ struct timeval tool_tvnow(void)
 
 #ifdef __APPLE__
 /* redeclare without the availability flag, since we check the weak symbol. */
-int clock_gettime(clockid_t __clock_id, struct timespec *__tp) __attribute__((weak_import));
+int clock_gettime(clockid_t __clock_id, struct timespec *__tp)
+    __attribute__((weak_import));
 #endif
 
 struct timeval tool_tvnow(void)
@@ -68,7 +69,7 @@ struct timeval tool_tvnow(void)
   */
   struct timeval now;
   struct timespec tsnow;
-  if((clock_gettime != NULL) && (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
+  if((NULL!=clock_gettime) && (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
     now.tv_sec = tsnow.tv_sec;
     now.tv_usec = tsnow.tv_nsec / 1000;
   }


### PR DESCRIPTION
In reference to https://github.com/curl/curl/issues/1333 ...

This will fix the compiler warnings (that manifest as compiler errors) when building curl for macOS and targeting older OSes with -mmacosx-version-min=10.?.

This makes sure that all the newer symbols are marked weak, compared against NULL at runtime, with a minimum of fuss.

Note that the configure script changes just turn off the compiler warning for the clock_gettime() tests, but it might be smarter to make sure the script doesn't add -Werror=partial-availability until the very end of the script, so no other tests in the future fail because of it. That change is safe to leave in here in any case, though.