### PR TITLE
.gitattributes: turn off CRLF for Makefile.am

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ buildconf eol=lf
 configure.ac eol=lf
 *.m4 eol=lf
 *.in eol=lf
+*.am eol=lf


### PR DESCRIPTION
Otherwise, buildconf in a Windows checkout fails with:

> .ibtoolize: error: AC_CONFIG_MACRO_DIRS([m4]) conflicts with ACLOCAL_AMFLAGS=-I m4