### PR TITLE
Fix proxy connection reuse with basic-auth

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2312,20 +2312,10 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
                      te
       );
 
-  /* clear userpwd to avoid re-using credentials from re-used connections */
+  /* clear userpwd and proxyuserpwd to avoid re-using old credentials
+   * from re-used connections */
   Curl_safefree(conn->allocptr.userpwd);
-
-  /*
-   * Free proxyuserpwd for Negotiate/NTLM. Cannot reuse as it is associated
-   * with the connection and shouldn't be repeated over it either.
-   */
-  switch(data->state.authproxy.picked) {
-  case CURLAUTH_NEGOTIATE:
-  case CURLAUTH_NTLM:
-  case CURLAUTH_NTLM_WB:
-    Curl_safefree(conn->allocptr.proxyuserpwd);
-    break;
-  }
+  Curl_safefree(conn->allocptr.proxyuserpwd);
 
   if(result)
     return result;

--- a/lib/url.c
+++ b/lib/url.c
@@ -3277,9 +3277,7 @@ proxy_info_matches(const struct proxy_info* data,
 {
   if((data->proxytype == needle->proxytype) &&
      (data->port == needle->port) &&
-     Curl_safe_strcasecompare(data->host.name, needle->host.name) &&
-     Curl_safe_strcasecompare(data->user, needle->user) &&
-     Curl_safe_strcasecompare(data->passwd, needle->passwd))
+     Curl_safe_strcasecompare(data->host.name, needle->host.name))
     return TRUE;
 
   return FALSE;

--- a/tests/data/test540
+++ b/tests/data/test540
@@ -40,6 +40,10 @@ Content-Length: 21
 Server: no
 
 Nice proxy auth sir!
+HTTP/1.1 407 Authorization Required to proxy me my dear
+Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
+Content-Length: 33
+
 HTTP/1.1 200 OK
 Content-Length: 21
 Server: no
@@ -83,6 +87,11 @@ Proxy-Connection: Keep-Alive
 GET http://test.remote.example.com/path/540 HTTP/1.1
 Host: custom.set.host.name
 Proxy-Authorization: Digest username="silly", realm="weirdorealm", nonce="12345", uri="/path/540", response="ca507dcf189196b6a5374d3233042261"
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://test.remote.example.com/path/540 HTTP/1.1
+Host: custom.set.host.name
 Accept: */*
 Proxy-Connection: Keep-Alive
 


### PR DESCRIPTION
When using basic-auth, connections and proxy connections
can be re-used with different Authorization headers since
it does not authenticate the connection (like NTLM does).

For instance, the below command should re-use the proxy
connection, but it currently doesn't:
curl -v -U alice:a -x http://localhost:8181 http://localhost/
  --next -U bob:b -x http://localhost:8181 http://localhost/

This is a regression since refactoring of ConnectionExists()
as part of: cb4e2be7c6d42ca0780f8e0a747cecf9ba45f151

Fix the above by removing the username and password compare
when re-using proxy connection at proxy_info_matches().

However, this fix brings back another bug would make curl
to re-print the old proxy-authorization header of previous
proxy basic-auth connection because it wasn't cleared.

For instance, in the below command the second request should
fail if the proxy requires authentication, but would succeed
after the above fix (and before aforementioned commit):
curl -v -U alice:a -x http://localhost:8181 http://localhost/
  --next -x http://localhost:8181 http://localhost/

Fix this by clearing conn->allocptr.proxyuserpwd after use
unconditionally, same as we do for conn->allocptr.userpwd.

Signed-off-by: Isaac Boukris <iboukris@gmail.com>