### PR TITLE
tests/README: make "Run" section foolproof

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -94,10 +94,10 @@ The curl Test Suite
 
  1.4 Run
 
-  'make test'. This builds the test suite support code and invokes the
-  'runtests.pl' perl script to run all the tests. Edit the top variables
-  of that script in case you have some specific needs, or run the script
-  manually (after the support code has been built).
+  './configure && make && make test'. This builds the test suite support code
+  and invokes the 'runtests.pl' perl script to run all the tests. Edit the top
+  variables of that script in case you have some specific needs, or run the
+  script manually (after the support code has been built).
 
   The script breaks on the first test that doesn't do OK. Use -a to prevent
   the script from aborting on the first error. Run the script with -v for more


### PR DESCRIPTION
This is probably obvious to linux users, but wasn't to me as a mainly Windows user when I first read this and the error messages are not very helpful ("don't know how to make target test" if you forget ./configure and "cannot get curl version" if you forget make).