### PR TITLE
lib: fix warnings about undefined macros

### DIFF
--- a/lib/select.c
+++ b/lib/select.c
@@ -164,7 +164,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   int r;
   int ret;
 
-#if SIZEOF_LONG != SIZEOF_INT
+#if SIZEOF_TIME_T != SIZEOF_INT
   /* wrap-around precaution */
   if(timeout_ms >= INT_MAX)
     timeout_ms = INT_MAX;


### PR DESCRIPTION
At least under Windows, there is no `SIZEOF_LONG`, so it evaluates to 0 even
though `sizeof(int) == sizeof(long)`. This should probably have been
`CURL_SIZEOF_LONG`, but the type of `timeout_ms` changed from `long` to `time_t`
anyway.
Also defaulted `USE_NTLM2SESSION` to 0 if it's not defined so that MSVC warning
C4668 about implicitly replacing undefined macros with '0' can now be enabled.