### PR TITLE
make: use the variable MAKE for recursive calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,10 +171,10 @@ dist-hook:
 	done)
 
 html:
-	cd docs && make html
+	cd docs && $(MAKE) html
 
 pdf:
-	cd docs && make pdf
+	cd docs && $(MAKE) pdf
 
 check: test examples check-docs
 
@@ -256,7 +256,7 @@ rpm:
 # gak - libtool requires an absolute directory, hence the pwd below...
 pkgadd:
 	umask 022 ; \
-	make install DESTDIR=`/bin/pwd`/packages/Solaris/root ; \
+	$(MAKE) install DESTDIR=`/bin/pwd`/packages/Solaris/root ; \
 	cat COPYING > $(srcdir)/packages/Solaris/copyright ; \
 	cd $(srcdir)/packages/Solaris && $(MAKE) package
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -47,13 +47,13 @@ MAN2HTML= roffit $< >$@
 SUFFIXES = .1 .html .pdf
 
 curl.1:
-	cd cmdline-opts && make
+	cd cmdline-opts && $(MAKE)
 
 html: $(HTMLPAGES)
-	cd libcurl && make html
+	cd libcurl && $(MAKE) html
 
 pdf: $(PDFPAGES)
-	cd libcurl && make pdf
+	cd libcurl && $(MAKE) pdf
 
 .1.html:
 	$(MAN2HTML)

--- a/docs/libcurl/Makefile.am
+++ b/docs/libcurl/Makefile.am
@@ -48,13 +48,13 @@ libcurl-symbols.3: $(srcdir)/symbols-in-versions $(srcdir)/mksymbolsmanpage.pl
 	perl $(srcdir)/mksymbolsmanpage.pl < $(srcdir)/symbols-in-versions > $@
 
 html: $(HTMLPAGES)
-	cd opts && make html
+	cd opts && $(MAKE) html
 
 .3.html:
 	$(MAN2HTML)
 
 pdf: $(PDFPAGES)
-	cd opts && make pdf
+	cd opts && $(MAKE) pdf
 
 .3.pdf:
 	@(foo=`echo $@ | sed -e 's/\.[0-9]$$//g'`; \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,7 +101,7 @@ if USE_MANUAL
 # Here are the stuff to create a built-in manual
 
 $(MANPAGE):
-	cd $(top_builddir)/docs && make curl.1
+	cd $(top_builddir)/docs && $(MAKE) curl.1
 
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and


### PR DESCRIPTION
Hello.
According to the manual of GNU make, recursive make commands should always use the variable MAKE, not the explicit command name 'make'. The value of this variable is the file name with which make was invoked. Using of explicit 'make' command for recursive calls may cause problems when non-default make utility is used (not the /usr/bin/make).