### PR TITLE
NTLM: check for features with #ifdef instead of #if

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -501,7 +501,7 @@ CURLcode Curl_ntlm_core_mk_lm_hash(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
 static void ascii_to_unicode_le(unsigned char *dest, const char *src,
                                 size_t srclen)
 {
@@ -512,7 +512,7 @@ static void ascii_to_unicode_le(unsigned char *dest, const char *src,
   }
 }
 
-#if USE_NTLM_V2 && !defined(USE_WINDOWS_SSPI)
+#if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
 
 static void ascii_uppercase_to_unicode_le(unsigned char *dest,
                                           const char *src, size_t srclen)
@@ -597,7 +597,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#if USE_NTLM_V2 && !defined(USE_WINDOWS_SSPI)
+#if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
 
 /* This returns the HMAC MD5 digest */
 CURLcode Curl_hmac_md5(const unsigned char *key, unsigned int keylen,

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -33,31 +33,26 @@
       !defined(HEADER_SSL_H) && !defined(HEADER_MD5_H)
 #    error "curl_ntlm_core.h shall not be included before OpenSSL headers."
 #  endif
-#  ifdef OPENSSL_NO_MD4
-#    define USE_NTRESPONSES 0
-#    define USE_NTLM2SESSION 0
-#    define USE_NTLM_V2 0
-#  endif
 #endif
 
-/* Define USE_NTRESPONSES to 1 in order to make the type-3 message include
+/* Define USE_NTRESPONSES in order to make the type-3 message include
  * the NT response message. */
-#ifndef USE_NTRESPONSES
-#define USE_NTRESPONSES 1
+#if !defined(USE_OPENSSL) || !defined(OPENSSL_NO_MD4)
+#define USE_NTRESPONSES
 #endif
 
-/* Define USE_NTLM2SESSION to 1 in order to make the type-3 message include the
+/* Define USE_NTLM2SESSION in order to make the type-3 message include the
    NTLM2Session response message, requires USE_NTRESPONSES defined to 1 and a
    Crypto engine that we have curl_ssl_md5sum() for. */
-#if !defined(USE_NTLM2SESSION) && USE_NTRESPONSES && !defined(USE_WIN32_CRYPTO)
-#define USE_NTLM2SESSION 1
+#if defined(USE_NTRESPONSES) && !defined(USE_WIN32_CRYPTO)
+#define USE_NTLM2SESSION
 #endif
 
-/* Define USE_NTLM_V2 to 1 in order to allow the type-3 message to include the
+/* Define USE_NTLM_V2 in order to allow the type-3 message to include the
    LMv2 and NTLMv2 response messages, requires USE_NTRESPONSES defined to 1
    and support for 64-bit integers. */
-#if !defined(USE_NTLM_V2) && USE_NTRESPONSES && (CURL_SIZEOF_CURL_OFF_T > 4)
-#define USE_NTLM_V2 1
+#if defined(USE_NTRESPONSES) && (CURL_SIZEOF_CURL_OFF_T > 4)
+#define USE_NTLM_V2
 #endif
 
 void Curl_ntlm_core_lm_resp(const unsigned char *keys,
@@ -68,12 +63,12 @@ CURLcode Curl_ntlm_core_mk_lm_hash(struct Curl_easy *data,
                                    const char *password,
                                    unsigned char *lmbuffer /* 21 bytes */);
 
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
 CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
                                    const char *password,
                                    unsigned char *ntbuffer /* 21 bytes */);
 
-#if USE_NTLM_V2 && !defined(USE_WINDOWS_SSPI)
+#if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
 
 CURLcode Curl_hmac_md5(const unsigned char *key, unsigned int keylen,
                        const unsigned char *data, unsigned int datalen,

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -446,7 +446,7 @@ static CURLcode smb_send_setup(struct connectdata *conn)
 
   Curl_ntlm_core_mk_lm_hash(conn->data, conn->passwd, lm_hash);
   Curl_ntlm_core_lm_resp(lm_hash, smbc->challenge, lm);
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
   Curl_ntlm_core_mk_nt_hash(conn->data, conn->passwd, nt_hash);
   Curl_ntlm_core_lm_resp(nt_hash, smbc->challenge, nt);
 #else

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -394,7 +394,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(const char *userp,
   /* Clean up any former leftovers and initialise to defaults */
   Curl_auth_ntlm_cleanup(ntlm);
 
-#if USE_NTRESPONSES && USE_NTLM2SESSION
+#if defined(USE_NTRESPONSES) && defined(USE_NTLM2SESSION)
 #define NTLM2FLAG NTLMFLAG_NEGOTIATE_NTLM2_KEY
 #else
 #define NTLM2FLAG 0
@@ -509,7 +509,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   unsigned char ntlmbuf[NTLM_BUFSIZE];
   int lmrespoff;
   unsigned char lmresp[24]; /* fixed-size */
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
   int ntrespoff;
   unsigned int ntresplen = 24;
   unsigned char ntresp[24]; /* fixed-size */
@@ -552,7 +552,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
     hostlen = strlen(host);
   }
 
-#if USE_NTRESPONSES && USE_NTLM_V2
+#if defined(USE_NTRESPONSES) && defined(USE_NTLM_V2)
   if(ntlm->target_info_len) {
     unsigned char ntbuffer[0x18];
     unsigned int entropy[2];
@@ -590,7 +590,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   else
 #endif
 
-#if USE_NTRESPONSES && USE_NTLM2SESSION
+#if defined(USE_NTRESPONSES) && defined(USE_NTLM2SESSION)
   /* We don't support NTLM2 if we don't have USE_NTRESPONSES */
   if(ntlm->flags & NTLMFLAG_NEGOTIATE_NTLM2_KEY) {
     unsigned char ntbuffer[0x18];
@@ -630,12 +630,12 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 #endif
   {
 
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
     unsigned char ntbuffer[0x18];
 #endif
     unsigned char lmbuffer[0x18];
 
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
     result = Curl_ntlm_core_mk_nt_hash(data, passwdp, ntbuffer);
     if(result)
       return result;
@@ -661,7 +661,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   }
 
   lmrespoff = 64; /* size of the message header */
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
   ntrespoff = lmrespoff + 0x18;
   domoff = ntrespoff + ntresplen;
 #else
@@ -721,7 +721,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                   SHORTPAIR(lmrespoff),
                   0x0, 0x0,
 
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
                   SHORTPAIR(ntresplen),  /* NT-response length, twice */
                   SHORTPAIR(ntresplen),
                   SHORTPAIR(ntrespoff),
@@ -768,7 +768,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
     ntlm_print_hex(stderr, (char *)&ntlmbuf[lmrespoff], 0x18);
   });
 
-#if USE_NTRESPONSES
+#ifdef USE_NTRESPONSES
   if(size < (NTLM_BUFSIZE - ntresplen)) {
     DEBUGASSERT(size == (size_t)ntrespoff);
     memcpy(&ntlmbuf[size], ptr_ntresp, ntresplen);


### PR DESCRIPTION
Feature defines are normally checked with #ifdef instead of #if in the rest of
the codebase. Additionally, some compilers warn when a macro is implicitly
evaluated to 0 because it is not defined, which was the case here.

Ref: https://github.com/curl/curl/pull/1362#discussion_r108605101