### PR TITLE
curlbuild: remove all CURL_SIZEOF_* public symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -725,20 +725,20 @@ endif(NOT HAVE_SIZEOF_SSIZE_T)
 
 # Different sizeofs, etc.
 
-#    define CURL_SIZEOF_LONG        4
+#    define SIZEOF_LONG        4
 #    define CURL_TYPEOF_CURL_OFF_T  long long
 #    define CURL_FORMAT_CURL_OFF_T  "lld"
 #    define CURL_FORMAT_CURL_OFF_TU "llu"
 #    define CURL_FORMAT_OFF_T       "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T  8
+#    define SIZEOF_CURL_OFF_T  8
 #    define CURL_SUFFIX_CURL_OFF_T  LL
 #    define CURL_SUFFIX_CURL_OFF_TU ULL
 
-set(CURL_SIZEOF_LONG ${SIZEOF_LONG})
+set(SIZEOF_LONG ${SIZEOF_LONG})
 
 if(SIZEOF_LONG EQUAL 8)
   set(CURL_TYPEOF_CURL_OFF_T long)
-  set(CURL_SIZEOF_CURL_OFF_T 8)
+  set(SIZEOF_CURL_OFF_T 8)
   set(CURL_FORMAT_CURL_OFF_T "ld")
   set(CURL_FORMAT_CURL_OFF_TU "lu")
   set(CURL_FORMAT_OFF_T "%ld")
@@ -748,7 +748,7 @@ endif(SIZEOF_LONG EQUAL 8)
 
 if(SIZEOF_LONG_LONG EQUAL 8)
   set(CURL_TYPEOF_CURL_OFF_T "long long")
-  set(CURL_SIZEOF_CURL_OFF_T 8)
+  set(SIZEOF_CURL_OFF_T 8)
   set(CURL_FORMAT_CURL_OFF_T "lld")
   set(CURL_FORMAT_CURL_OFF_TU "llu")
   set(CURL_FORMAT_OFF_T "%lld")
@@ -758,7 +758,7 @@ endif(SIZEOF_LONG_LONG EQUAL 8)
 
 if(NOT CURL_TYPEOF_CURL_OFF_T)
   set(CURL_TYPEOF_CURL_OFF_T ${ssize_t})
-  set(CURL_SIZEOF_CURL_OFF_T ${SIZEOF_SSIZE_T})
+  set(SIZEOF_CURL_OFF_T ${SIZEOF_SSIZE_T})
   # TODO: need adjustment here.
   set(CURL_FORMAT_CURL_OFF_T "ld")
   set(CURL_FORMAT_CURL_OFF_TU "lu")
@@ -1028,15 +1028,15 @@ if(HAVE_SOCKLEN_T)
   elseif(HAVE_SYS_SOCKET_H)
     set(CMAKE_EXTRA_INCLUDE_FILES "sys/socket.h")
   endif()
-  check_type_size("socklen_t" CURL_SIZEOF_CURL_SOCKLEN_T)
+  check_type_size("socklen_t" SIZEOF_CURL_SOCKLEN_T)
   set(CMAKE_EXTRA_INCLUDE_FILES)
-  if(NOT HAVE_CURL_SIZEOF_CURL_SOCKLEN_T)
+  if(NOT HAVE_SIZEOF_CURL_SOCKLEN_T)
     message(FATAL_ERROR
      "Check for sizeof socklen_t failed, see CMakeFiles/CMakerror.log")
   endif()
 else()
   set(CURL_TYPEOF_CURL_SOCKLEN_T int)
-  set(CURL_SIZEOF_CURL_SOCKLEN_T ${SIZEOF_INT})
+  set(SIZEOF_CURL_SOCKLEN_T ${SIZEOF_INT})
 endif()
 
 # TODO test which of these headers are required for the typedefs used in curlbuild.h
@@ -1115,7 +1115,7 @@ _add_if("unix-sockets"  USE_UNIX_SOCKETS)
 _add_if("libz"          HAVE_LIBZ)
 _add_if("AsynchDNS"     USE_ARES OR USE_THREADS_POSIX OR USE_THREADS_WIN32)
 _add_if("IDN"           HAVE_LIBIDN2)
-_add_if("Largefile"     (CURL_SIZEOF_CURL_OFF_T GREATER 4) AND
+_add_if("Largefile"     (SIZEOF_CURL_OFF_T GREATER 4) AND
                         ((SIZEOF_OFF_T GREATER 4) OR USE_WIN32_LARGE_FILES))
 # TODO SSP1 (WinSSL) check is missing
 _add_if("SSPI"          USE_WINDOWS_SSPI)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -2076,22 +2076,6 @@ _EOF
 ])
 
 
-dnl CURL_CONFIGURE_LONG
-dnl -------------------------------------------------
-dnl Find out the size of long as reported by sizeof() and define
-dnl CURL_SIZEOF_LONG as appropriate to be used in template file
-dnl include/curl/curlbuild.h.in to properly configure the library.
-dnl The size of long is a build time characteristic and as such
-dnl must be recorded in curlbuild.h
-
-AC_DEFUN([CURL_CONFIGURE_LONG], [
-  if test -z "$ac_cv_sizeof_long" ||
-    test "$ac_cv_sizeof_long" -eq "0"; then
-    AC_MSG_ERROR([cannot find out size of long.])
-  fi
-  CURL_DEFINE_UNQUOTED([CURL_SIZEOF_LONG], [$ac_cv_sizeof_long])
-])
-
 
 dnl CURL_CONFIGURE_CURL_SOCKLEN_T
 dnl -------------------------------------------------
@@ -2216,7 +2200,6 @@ AC_DEFUN([CURL_CONFIGURE_CURL_SOCKLEN_T], [
       ;;
   esac
   CURL_DEFINE_UNQUOTED([CURL_TYPEOF_CURL_SOCKLEN_T], [$curl_typeof_curl_socklen_t])
-  CURL_DEFINE_UNQUOTED([CURL_SIZEOF_CURL_SOCKLEN_T], [$curl_sizeof_curl_socklen_t])
 ])
 
 
@@ -2996,7 +2979,7 @@ AC_DEFUN([CURL_CONFIGURE_CURL_OFF_T], [
   CURL_DEFINE_UNQUOTED([CURL_FORMAT_CURL_OFF_T], ["$curl_format_curl_off_t"])
   CURL_DEFINE_UNQUOTED([CURL_FORMAT_CURL_OFF_TU], ["$curl_format_curl_off_tu"])
   CURL_DEFINE_UNQUOTED([CURL_FORMAT_OFF_T], ["%$curl_format_curl_off_t"])
-  CURL_DEFINE_UNQUOTED([CURL_SIZEOF_CURL_OFF_T], [$curl_sizeof_curl_off_t])
+  CURL_DEFINE_UNQUOTED([SIZEOF_CURL_OFF_T], [$curl_sizeof_curl_off_t])
   CURL_DEFINE_UNQUOTED([CURL_SUFFIX_CURL_OFF_T], [$curl_suffix_curl_off_t])
   CURL_DEFINE_UNQUOTED([CURL_SUFFIX_CURL_OFF_TU], [$curl_suffix_curl_off_tu])
   #

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -189,6 +189,9 @@ dnl Checks for programs.
 
 dnl Our curl_off_t internal and external configure settings
 CURL_CONFIGURE_CURL_OFF_T
+
+AC_DEFINE_UNQUOTED([SIZEOF_CURL_OFF_T], [$curl_sizeof_curl_off_t],
+[size of curl_off_t])
 
 dnl This defines _ALL_SOURCE for AIX
 CURL_CHECK_AIX_ALL_SOURCE
@@ -3151,7 +3154,6 @@ AC_CHECK_SIZEOF(size_t)
 AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(short)
-CURL_CONFIGURE_LONG
 AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(off_t)
 

--- a/include/curl/curlbuild.h.cmake
+++ b/include/curl/curlbuild.h.cmake
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2008, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -57,19 +57,9 @@
 /*  DEFINITION OF THESE SYMBOLS SHALL NOT TAKE PLACE ANYWHERE ELSE  */
 /* ================================================================ */
 
-#ifdef CURL_SIZEOF_LONG
-#error "CURL_SIZEOF_LONG shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_LONG_already_defined
-#endif
-
 #ifdef CURL_TYPEOF_CURL_SOCKLEN_T
 #error "CURL_TYPEOF_CURL_SOCKLEN_T shall not be defined except in curlbuild.h"
    Error Compilation_aborted_CURL_TYPEOF_CURL_SOCKLEN_T_already_defined
-#endif
-
-#ifdef CURL_SIZEOF_CURL_SOCKLEN_T
-#error "CURL_SIZEOF_CURL_SOCKLEN_T shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_SOCKLEN_T_already_defined
 #endif
 
 #ifdef CURL_TYPEOF_CURL_OFF_T
@@ -90,11 +80,6 @@
 #ifdef CURL_FORMAT_OFF_T
 #error "CURL_FORMAT_OFF_T shall not be defined except in curlbuild.h"
    Error Compilation_aborted_CURL_FORMAT_OFF_T_already_defined
-#endif
-
-#ifdef CURL_SIZEOF_CURL_OFF_T
-#error "CURL_SIZEOF_CURL_OFF_T shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_OFF_T_already_defined
 #endif
 
 #ifdef CURL_SUFFIX_CURL_OFF_T
@@ -158,14 +143,8 @@
 #  include <sys/poll.h>
 #endif
 
-/* The size of `long', as computed by sizeof. */
-#define CURL_SIZEOF_LONG ${CURL_SIZEOF_LONG}
-
 /* Integral data type used for curl_socklen_t. */
 #define CURL_TYPEOF_CURL_SOCKLEN_T ${CURL_TYPEOF_CURL_SOCKLEN_T}
-
-/* The size of `curl_socklen_t', as computed by sizeof. */
-#define CURL_SIZEOF_CURL_SOCKLEN_T ${CURL_SIZEOF_CURL_SOCKLEN_T}
 
 /* Data type definition of curl_socklen_t. */
 typedef CURL_TYPEOF_CURL_SOCKLEN_T curl_socklen_t;
@@ -184,9 +163,6 @@ typedef CURL_TYPEOF_CURL_OFF_T curl_off_t;
 
 /* curl_off_t formatting string directive with "%" conversion specifier. */
 #define CURL_FORMAT_OFF_T "${CURL_FORMAT_OFF_T}"
-
-/* The size of `curl_off_t', as computed by sizeof. */
-#define CURL_SIZEOF_CURL_OFF_T ${CURL_SIZEOF_CURL_OFF_T}
 
 /* curl_off_t constant suffix. */
 #define CURL_SUFFIX_CURL_OFF_T ${CURL_SUFFIX_CURL_OFF_T}

--- a/include/curl/curlbuild.h.dist
+++ b/include/curl/curlbuild.h.dist
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -108,19 +108,9 @@
 /*  DEFINITION OF THESE SYMBOLS SHALL NOT TAKE PLACE ANYWHERE ELSE  */
 /* ================================================================ */
 
-#ifdef CURL_SIZEOF_LONG
-#  error "CURL_SIZEOF_LONG shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_LONG_already_defined
-#endif
-
 #ifdef CURL_TYPEOF_CURL_SOCKLEN_T
 #  error "CURL_TYPEOF_CURL_SOCKLEN_T shall not be defined except in curlbuild.h"
    Error Compilation_aborted_CURL_TYPEOF_CURL_SOCKLEN_T_already_defined
-#endif
-
-#ifdef CURL_SIZEOF_CURL_SOCKLEN_T
-#  error "CURL_SIZEOF_CURL_SOCKLEN_T shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_SOCKLEN_T_already_defined
 #endif
 
 #ifdef CURL_TYPEOF_CURL_OFF_T
@@ -143,11 +133,6 @@
    Error Compilation_aborted_CURL_FORMAT_OFF_T_already_defined
 #endif
 
-#ifdef CURL_SIZEOF_CURL_OFF_T
-#  error "CURL_SIZEOF_CURL_OFF_T shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_OFF_T_already_defined
-#endif
-
 #ifdef CURL_SUFFIX_CURL_OFF_T
 #  error "CURL_SUFFIX_CURL_OFF_T shall not be defined except in curlbuild.h"
    Error Compilation_aborted_CURL_SUFFIX_CURL_OFF_T_already_defined
@@ -164,262 +149,201 @@
 
 #if defined(__DJGPP__) || defined(__GO32__)
 #  if defined(__DJGPP__) && (__DJGPP__ > 1)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  else
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     4
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__SALFORDC__)
-#  define CURL_SIZEOF_LONG           4
 #  define CURL_TYPEOF_CURL_OFF_T     long
 #  define CURL_FORMAT_CURL_OFF_T     "ld"
 #  define CURL_FORMAT_CURL_OFF_TU    "lu"
 #  define CURL_FORMAT_OFF_T          "%ld"
-#  define CURL_SIZEOF_CURL_OFF_T     4
 #  define CURL_SUFFIX_CURL_OFF_T     L
 #  define CURL_SUFFIX_CURL_OFF_TU    UL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__BORLANDC__)
 #  if (__BORLANDC__ < 0x520)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     4
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  else
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"
 #    define CURL_FORMAT_OFF_T          "%I64d"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     i64
 #    define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__TURBOC__)
-#  define CURL_SIZEOF_LONG           4
 #  define CURL_TYPEOF_CURL_OFF_T     long
 #  define CURL_FORMAT_CURL_OFF_T     "ld"
 #  define CURL_FORMAT_CURL_OFF_TU    "lu"
 #  define CURL_FORMAT_OFF_T          "%ld"
-#  define CURL_SIZEOF_CURL_OFF_T     4
 #  define CURL_SUFFIX_CURL_OFF_T     L
 #  define CURL_SUFFIX_CURL_OFF_TU    UL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__WATCOMC__)
 #  if defined(__386__)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"
 #    define CURL_FORMAT_OFF_T          "%I64d"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     i64
 #    define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  else
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     4
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__POCC__)
 #  if (__POCC__ < 280)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     4
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  elif defined(_MSC_VER)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"
 #    define CURL_FORMAT_OFF_T          "%I64d"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     i64
 #    define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  else
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__LCC__)
-#  define CURL_SIZEOF_LONG           4
 #  define CURL_TYPEOF_CURL_OFF_T     long
 #  define CURL_FORMAT_CURL_OFF_T     "ld"
 #  define CURL_FORMAT_CURL_OFF_TU    "lu"
 #  define CURL_FORMAT_OFF_T          "%ld"
-#  define CURL_SIZEOF_CURL_OFF_T     4
 #  define CURL_SUFFIX_CURL_OFF_T     L
 #  define CURL_SUFFIX_CURL_OFF_TU    UL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__SYMBIAN32__)
 #  if defined(__EABI__)  /* Treat all ARM compilers equally */
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__CW32__)
 #    pragma longlong on
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__VC32__)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__MWERKS__)
-#  define CURL_SIZEOF_LONG           4
 #  define CURL_TYPEOF_CURL_OFF_T     long long
 #  define CURL_FORMAT_CURL_OFF_T     "lld"
 #  define CURL_FORMAT_CURL_OFF_TU    "llu"
 #  define CURL_FORMAT_OFF_T          "%lld"
-#  define CURL_SIZEOF_CURL_OFF_T     8
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(_WIN32_WCE)
-#  define CURL_SIZEOF_LONG           4
 #  define CURL_TYPEOF_CURL_OFF_T     __int64
 #  define CURL_FORMAT_CURL_OFF_T     "I64d"
 #  define CURL_FORMAT_CURL_OFF_TU    "I64u"
 #  define CURL_FORMAT_OFF_T          "%I64d"
-#  define CURL_SIZEOF_CURL_OFF_T     8
 #  define CURL_SUFFIX_CURL_OFF_T     i64
 #  define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__MINGW32__)
-#  define CURL_SIZEOF_LONG           4
 #  define CURL_TYPEOF_CURL_OFF_T     long long
 #  define CURL_FORMAT_CURL_OFF_T     "I64d"
 #  define CURL_FORMAT_CURL_OFF_TU    "I64u"
 #  define CURL_FORMAT_OFF_T          "%I64d"
-#  define CURL_SIZEOF_CURL_OFF_T     8
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__VMS)
 #  if defined(__VAX)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     4
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  else
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 #elif defined(__OS400__)
 #  if defined(__ILEC400__)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #    define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
-#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
 #    define CURL_PULL_SYS_TYPES_H      1
 #    define CURL_PULL_SYS_SOCKET_H     1
 #  endif
 
 #elif defined(__MVS__)
 #  if defined(__IBMC__) || defined(__IBMCPP__)
-#    if defined(_ILP32)
-#      define CURL_SIZEOF_LONG           4
-#    elif defined(_LP64)
-#      define CURL_SIZEOF_LONG           8
-#    endif
 #    if defined(_LONG_LONG)
 #      define CURL_TYPEOF_CURL_OFF_T     long long
 #      define CURL_FORMAT_CURL_OFF_T     "lld"
 #      define CURL_FORMAT_CURL_OFF_TU    "llu"
 #      define CURL_FORMAT_OFF_T          "%lld"
-#      define CURL_SIZEOF_CURL_OFF_T     8
 #      define CURL_SUFFIX_CURL_OFF_T     LL
 #      define CURL_SUFFIX_CURL_OFF_TU    ULL
 #    elif defined(_LP64)
@@ -427,7 +351,6 @@
 #      define CURL_FORMAT_CURL_OFF_T     "ld"
 #      define CURL_FORMAT_CURL_OFF_TU    "lu"
 #      define CURL_FORMAT_OFF_T          "%ld"
-#      define CURL_SIZEOF_CURL_OFF_T     8
 #      define CURL_SUFFIX_CURL_OFF_T     L
 #      define CURL_SUFFIX_CURL_OFF_TU    UL
 #    else
@@ -435,29 +358,21 @@
 #      define CURL_FORMAT_CURL_OFF_T     "ld"
 #      define CURL_FORMAT_CURL_OFF_TU    "lu"
 #      define CURL_FORMAT_OFF_T          "%ld"
-#      define CURL_SIZEOF_CURL_OFF_T     4
 #      define CURL_SUFFIX_CURL_OFF_T     L
 #      define CURL_SUFFIX_CURL_OFF_TU    UL
 #    endif
 #    define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
-#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
 #    define CURL_PULL_SYS_TYPES_H      1
 #    define CURL_PULL_SYS_SOCKET_H     1
 #  endif
 
 #elif defined(__370__)
 #  if defined(__IBMC__) || defined(__IBMCPP__)
-#    if defined(_ILP32)
-#      define CURL_SIZEOF_LONG           4
-#    elif defined(_LP64)
-#      define CURL_SIZEOF_LONG           8
-#    endif
 #    if defined(_LONG_LONG)
 #      define CURL_TYPEOF_CURL_OFF_T     long long
 #      define CURL_FORMAT_CURL_OFF_T     "lld"
 #      define CURL_FORMAT_CURL_OFF_TU    "llu"
 #      define CURL_FORMAT_OFF_T          "%lld"
-#      define CURL_SIZEOF_CURL_OFF_T     8
 #      define CURL_SUFFIX_CURL_OFF_T     LL
 #      define CURL_SUFFIX_CURL_OFF_TU    ULL
 #    elif defined(_LP64)
@@ -465,7 +380,6 @@
 #      define CURL_FORMAT_CURL_OFF_T     "ld"
 #      define CURL_FORMAT_CURL_OFF_TU    "lu"
 #      define CURL_FORMAT_OFF_T          "%ld"
-#      define CURL_SIZEOF_CURL_OFF_T     8
 #      define CURL_SUFFIX_CURL_OFF_T     L
 #      define CURL_SUFFIX_CURL_OFF_TU    UL
 #    else
@@ -473,27 +387,22 @@
 #      define CURL_FORMAT_CURL_OFF_T     "ld"
 #      define CURL_FORMAT_CURL_OFF_TU    "lu"
 #      define CURL_FORMAT_OFF_T          "%ld"
-#      define CURL_SIZEOF_CURL_OFF_T     4
 #      define CURL_SUFFIX_CURL_OFF_T     L
 #      define CURL_SUFFIX_CURL_OFF_TU    UL
 #    endif
 #    define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
-#    define CURL_SIZEOF_CURL_SOCKLEN_T 4
 #    define CURL_PULL_SYS_TYPES_H      1
 #    define CURL_PULL_SYS_SOCKET_H     1
 #  endif
 
 #elif defined(TPF)
-#  define CURL_SIZEOF_LONG           8
 #  define CURL_TYPEOF_CURL_OFF_T     long
 #  define CURL_FORMAT_CURL_OFF_T     "ld"
 #  define CURL_FORMAT_CURL_OFF_TU    "lu"
 #  define CURL_FORMAT_OFF_T          "%ld"
-#  define CURL_SIZEOF_CURL_OFF_T     8
 #  define CURL_SUFFIX_CURL_OFF_T     L
 #  define CURL_SUFFIX_CURL_OFF_TU    UL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 /* ===================================== */
 /*    KEEP MSVC THE PENULTIMATE ENTRY    */
@@ -501,26 +410,21 @@
 
 #elif defined(_MSC_VER)
 #  if (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"
 #    define CURL_FORMAT_OFF_T          "%I64d"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     i64
 #    define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  else
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     4
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 
 /* ===================================== */
 /*    KEEP GENERIC GCC THE LAST ENTRY    */
@@ -530,27 +434,22 @@
 #  if !defined(__LP64__) && (defined(__ILP32__) || \
       defined(__i386__) || defined(__ppc__) || defined(__arm__) || \
       defined(__sparc__) || defined(__mips__) || defined(__sh__))
-#    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_FORMAT_OFF_T          "%lld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  elif defined(__LP64__) || \
         defined(__x86_64__) || defined(__ppc64__) || defined(__sparc64__)
-#    define CURL_SIZEOF_LONG           8
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_FORMAT_OFF_T          "%ld"
-#    define CURL_SIZEOF_CURL_OFF_T     8
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
-#  define CURL_SIZEOF_CURL_SOCKLEN_T 4
 #  define CURL_PULL_SYS_TYPES_H      1
 #  define CURL_PULL_SYS_SOCKET_H     1
 

--- a/include/curl/curlbuild.h.in
+++ b/include/curl/curlbuild.h.in
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -57,19 +57,9 @@
 /*  DEFINITION OF THESE SYMBOLS SHALL NOT TAKE PLACE ANYWHERE ELSE  */
 /* ================================================================ */
 
-#ifdef CURL_SIZEOF_LONG
-#error "CURL_SIZEOF_LONG shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_LONG_already_defined
-#endif
-
 #ifdef CURL_TYPEOF_CURL_SOCKLEN_T
 #error "CURL_TYPEOF_CURL_SOCKLEN_T shall not be defined except in curlbuild.h"
    Error Compilation_aborted_CURL_TYPEOF_CURL_SOCKLEN_T_already_defined
-#endif
-
-#ifdef CURL_SIZEOF_CURL_SOCKLEN_T
-#error "CURL_SIZEOF_CURL_SOCKLEN_T shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_SOCKLEN_T_already_defined
 #endif
 
 #ifdef CURL_TYPEOF_CURL_OFF_T
@@ -90,11 +80,6 @@
 #ifdef CURL_FORMAT_OFF_T
 #error "CURL_FORMAT_OFF_T shall not be defined except in curlbuild.h"
    Error Compilation_aborted_CURL_FORMAT_OFF_T_already_defined
-#endif
-
-#ifdef CURL_SIZEOF_CURL_OFF_T
-#error "CURL_SIZEOF_CURL_OFF_T shall not be defined except in curlbuild.h"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_OFF_T_already_defined
 #endif
 
 #ifdef CURL_SUFFIX_CURL_OFF_T
@@ -158,14 +143,8 @@
 #  include <sys/poll.h>
 #endif
 
-/* The size of `long', as computed by sizeof. */
-#undef CURL_SIZEOF_LONG
-
 /* Integral data type used for curl_socklen_t. */
 #undef CURL_TYPEOF_CURL_SOCKLEN_T
-
-/* The size of `curl_socklen_t', as computed by sizeof. */
-#undef CURL_SIZEOF_CURL_SOCKLEN_T
 
 /* Data type definition of curl_socklen_t. */
 typedef CURL_TYPEOF_CURL_SOCKLEN_T curl_socklen_t;
@@ -184,9 +163,6 @@ typedef CURL_TYPEOF_CURL_OFF_T curl_off_t;
 
 /* curl_off_t formatting string directive with "%" conversion specifier. */
 #undef CURL_FORMAT_OFF_T
-
-/* The size of `curl_off_t', as computed by sizeof. */
-#undef CURL_SIZEOF_CURL_OFF_T
 
 /* curl_off_t constant suffix. */
 #undef CURL_SUFFIX_CURL_OFF_T

--- a/include/curl/curlrules.h
+++ b/include/curl/curlrules.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -75,19 +75,9 @@
  * Verify that some macros are actually defined.
  */
 
-#ifndef CURL_SIZEOF_LONG
-#  error "CURL_SIZEOF_LONG definition is missing!"
-   Error Compilation_aborted_CURL_SIZEOF_LONG_is_missing
-#endif
-
 #ifndef CURL_TYPEOF_CURL_SOCKLEN_T
 #  error "CURL_TYPEOF_CURL_SOCKLEN_T definition is missing!"
    Error Compilation_aborted_CURL_TYPEOF_CURL_SOCKLEN_T_is_missing
-#endif
-
-#ifndef CURL_SIZEOF_CURL_SOCKLEN_T
-#  error "CURL_SIZEOF_CURL_SOCKLEN_T definition is missing!"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_SOCKLEN_T_is_missing
 #endif
 
 #ifndef CURL_TYPEOF_CURL_OFF_T
@@ -110,11 +100,6 @@
    Error Compilation_aborted_CURL_FORMAT_OFF_T_is_missing
 #endif
 
-#ifndef CURL_SIZEOF_CURL_OFF_T
-#  error "CURL_SIZEOF_CURL_OFF_T definition is missing!"
-   Error Compilation_aborted_CURL_SIZEOF_CURL_OFF_T_is_missing
-#endif
-
 #ifndef CURL_SUFFIX_CURL_OFF_T
 #  error "CURL_SUFFIX_CURL_OFF_T definition is missing!"
    Error Compilation_aborted_CURL_SUFFIX_CURL_OFF_T_is_missing
@@ -124,63 +109,6 @@
 #  error "CURL_SUFFIX_CURL_OFF_TU definition is missing!"
    Error Compilation_aborted_CURL_SUFFIX_CURL_OFF_TU_is_missing
 #endif
-
-/*
- * Macros private to this header file.
- */
-
-#define CurlchkszEQ(t, s) sizeof(t) == s ? 1 : -1
-
-#define CurlchkszGE(t1, t2) sizeof(t1) >= sizeof(t2) ? 1 : -1
-
-/*
- * Verify that the size previously defined and expected for long
- * is the same as the one reported by sizeof() at compile time.
- */
-
-typedef char
-  __curl_rule_01__
-    [CurlchkszEQ(long, CURL_SIZEOF_LONG)];
-
-/*
- * Verify that the size previously defined and expected for
- * curl_off_t is actually the the same as the one reported
- * by sizeof() at compile time.
- */
-
-typedef char
-  __curl_rule_02__
-    [CurlchkszEQ(curl_off_t, CURL_SIZEOF_CURL_OFF_T)];
-
-/*
- * Verify at compile time that the size of curl_off_t as reported
- * by sizeof() is greater or equal than the one reported for long
- * for the current compilation.
- */
-
-typedef char
-  __curl_rule_03__
-    [CurlchkszGE(curl_off_t, long)];
-
-/*
- * Verify that the size previously defined and expected for
- * curl_socklen_t is actually the the same as the one reported
- * by sizeof() at compile time.
- */
-
-typedef char
-  __curl_rule_04__
-    [CurlchkszEQ(curl_socklen_t, CURL_SIZEOF_CURL_SOCKLEN_T)];
-
-/*
- * Verify at compile time that the size of curl_socklen_t as reported
- * by sizeof() is greater or equal than the one reported for int for
- * the current compilation.
- */
-
-typedef char
-  __curl_rule_05__
-    [CurlchkszGE(curl_socklen_t, int)];
 
 /* ================================================================ */
 /*          EXTERNALLY AND INTERNALLY VISIBLE DEFINITIONS           */
@@ -233,13 +161,6 @@ typedef char
 #  define CURL_OFF_T_C(Val)  __CURL_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_T)
 #  define CURL_OFF_TU_C(Val) __CURL_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_TU)
 #endif
-
-/*
- * Get rid of macros private to this header file.
- */
-
-#undef CurlchkszEQ
-#undef CurlchkszGE
 
 /*
  * Get rid of macros not intended to exist beyond this point.

--- a/lib/Makefile.netware
+++ b/lib/Makefile.netware
@@ -764,25 +764,25 @@ $(CURL_INC)/curl/curlbuild.h: Makefile.netware FORCE
 	@echo $(DL)#ifndef __CURL_CURLBUILD_H$(DL) >> $@
 	@echo $(DL)#define __CURL_CURLBUILD_H$(DL) >> $@
 ifeq ($(LIBARCH),LIBC)
-	@echo $(DL)#define CURL_SIZEOF_LONG 4$(DL) >> $@
+	@echo $(DL)#define SIZEOF_LONG 4$(DL) >> $@
 	@echo $(DL)#define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int$(DL) >> $@
-	@echo $(DL)#define CURL_SIZEOF_CURL_SOCKLEN_T 4$(DL) >> $@
+	@echo $(DL)#define SIZEOF_CURL_SOCKLEN_T 4$(DL) >> $@
 	@echo $(DL)#define CURL_TYPEOF_CURL_OFF_T long long$(DL) >> $@
 	@echo $(DL)#define CURL_FORMAT_CURL_OFF_T "lld"$(DL) >> $@
 	@echo $(DL)#define CURL_FORMAT_CURL_OFF_TU "llu"$(DL) >> $@
 	@echo $(DL)#define CURL_FORMAT_OFF_T "$(PCT)lld"$(DL) >> $@
-	@echo $(DL)#define CURL_SIZEOF_CURL_OFF_T 8$(DL) >> $@
+	@echo $(DL)#define SIZEOF_CURL_OFF_T 8$(DL) >> $@
 	@echo $(DL)#define CURL_SUFFIX_CURL_OFF_T LL$(DL) >> $@
 	@echo $(DL)#define CURL_SUFFIX_CURL_OFF_TU ULL$(DL) >> $@
 else
-	@echo $(DL)#define CURL_SIZEOF_LONG 4$(DL) >> $@
+	@echo $(DL)#define SIZEOF_LONG 4$(DL) >> $@
 	@echo $(DL)#define CURL_TYPEOF_CURL_SOCKLEN_T int$(DL) >> $@
-	@echo $(DL)#define CURL_SIZEOF_CURL_SOCKLEN_T 4$(DL) >> $@
+	@echo $(DL)#define SIZEOF_CURL_SOCKLEN_T 4$(DL) >> $@
 	@echo $(DL)#define CURL_TYPEOF_CURL_OFF_T long$(DL) >> $@
 	@echo $(DL)#define CURL_FORMAT_CURL_OFF_T "ld"$(DL) >> $@
 	@echo $(DL)#define CURL_FORMAT_CURL_OFF_TU "lu"$(DL) >> $@
 	@echo $(DL)#define CURL_FORMAT_OFF_T "$(PCT)ld"$(DL) >> $@
-	@echo $(DL)#define CURL_SIZEOF_CURL_OFF_T 4$(DL) >> $@
+	@echo $(DL)#define SIZEOF_CURL_OFF_T 4$(DL) >> $@
 	@echo $(DL)#define CURL_SUFFIX_CURL_OFF_T L$(DL) >> $@
 	@echo $(DL)#define CURL_SUFFIX_CURL_OFF_TU UL$(DL) >> $@
 endif

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -390,6 +390,9 @@
 /* Define to the size of `int', as computed by sizeof. */
 #define SIZEOF_INT 4
 
+/* Define to the size of `long', as computed by sizeof. */
+#define SIZEOF_LONG 4
+
 /* Define to the size of `long double', as computed by sizeof. */
 #define SIZEOF_LONG_DOUBLE 16
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -891,6 +891,9 @@
 /* The size of `off_t', as computed by sizeof. */
 #cmakedefine SIZEOF_OFF_T ${SIZEOF_OFF_T}
 
+/* The size of `curl_off_t', as computed by sizeof. */
+#cmakedefine SIZEOF_CURL_OFF_T ${SIZEOF_CURL_OFF_T}
+
 /* The size of `size_t', as computed by sizeof. */
 #cmakedefine SIZEOF_SIZE_T ${SIZEOF_SIZE_T}
 

--- a/lib/curl_endian.c
+++ b/lib/curl_endian.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -62,7 +62,7 @@ unsigned int Curl_read32_le(const unsigned char *buf)
          ((unsigned int)buf[2] << 16) | ((unsigned int)buf[3] << 24);
 }
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 /*
  * Curl_read64_le()
  *
@@ -98,7 +98,7 @@ unsigned __int64 Curl_read64_le(const unsigned char *buf)
 }
 #endif
 
-#endif /* CURL_SIZEOF_CURL_OFF_T > 4 */
+#endif /* SIZEOF_CURL_OFF_T > 4 */
 
 /*
  * Curl_read16_be()
@@ -138,7 +138,7 @@ unsigned int Curl_read32_be(const unsigned char *buf)
          ((unsigned int)buf[2] << 8) | ((unsigned int)buf[3]);
 }
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 /*
  * Curl_read64_be()
  *
@@ -174,7 +174,7 @@ unsigned __int64 Curl_read64_be(const unsigned char *buf)
 }
 #endif
 
-#endif /* CURL_SIZEOF_CURL_OFF_T > 4 */
+#endif /* SIZEOF_CURL_OFF_T > 4 */
 
 /*
  * Curl_write16_le()
@@ -212,7 +212,7 @@ void Curl_write32_le(const int value, unsigned char *buffer)
   buffer[3] = (char)((value & 0xFF000000) >> 24);
 }
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 /*
  * Curl_write64_le()
  *
@@ -233,4 +233,4 @@ void Curl_write64_le(const __int64 value, unsigned char *buffer)
   Curl_write32_le((int)value, buffer);
   Curl_write32_le((int)(value >> 32), buffer + 4);
 }
-#endif /* CURL_SIZEOF_CURL_OFF_T > 4 */
+#endif /* SIZEOF_CURL_OFF_T > 4 */

--- a/lib/curl_endian.h
+++ b/lib/curl_endian.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -28,7 +28,7 @@ unsigned short Curl_read16_le(const unsigned char *buf);
 /* Converts a 32-bit integer from little endian */
 unsigned int Curl_read32_le(const unsigned char *buf);
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 /* Converts a 64-bit integer from little endian */
 #if defined(HAVE_LONGLONG)
 unsigned long long Curl_read64_le(const unsigned char *buf);
@@ -43,7 +43,7 @@ unsigned short Curl_read16_be(const unsigned char *buf);
 /* Converts a 32-bit integer from big endian */
 unsigned int Curl_read32_be(const unsigned char *buf);
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 /* Converts a 64-bit integer from big endian */
 #if defined(HAVE_LONGLONG)
 unsigned long long Curl_read64_be(const unsigned char *buf);
@@ -58,7 +58,7 @@ void Curl_write16_le(const short value, unsigned char *buffer);
 /* Converts a 32-bit integer to little endian */
 void Curl_write32_le(const int value, unsigned char *buffer);
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 /* Converts a 64-bit integer to little endian */
 #if defined(HAVE_LONGLONG)
 void Curl_write64_le(const long long value, unsigned char *buffer);

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -690,7 +690,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
 
   CURLcode result = CURLE_OK;
 
-#if CURL_SIZEOF_CURL_OFF_T < 8
+#if SIZEOF_CURL_OFF_T < 8
 #error "this section needs 64bit support to work"
 #endif
 

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -51,7 +51,7 @@
 /* Define USE_NTLM_V2 in order to allow the type-3 message to include the
    LMv2 and NTLMv2 response messages, requires USE_NTRESPONSES defined to 1
    and support for 64-bit integers. */
-#if defined(USE_NTRESPONSES) && (CURL_SIZEOF_CURL_OFF_T > 4)
+#if defined(USE_NTRESPONSES) && (SIZEOF_CURL_OFF_T > 4)
 #define USE_NTLM_V2
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -136,15 +136,6 @@
  */
 
 #include <curl/curlrules.h>
-
-/*
- * Ensure that no one is using the old SIZEOF_CURL_OFF_T macro
- */
-
-#ifdef SIZEOF_CURL_OFF_T
-#  error "SIZEOF_CURL_OFF_T shall not be defined!"
-   Error Compilation_aborted_SIZEOF_CURL_OFF_T_shall_not_be_defined
-#endif
 
 /*
  * Disable other protocols when http is the only one desired.

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -839,7 +839,7 @@ static CURLcode AddFormData(struct FormData **formp,
     /* we make it easier for plain strings: */
     if(!length)
       length = strlen((char *)line);
-#if (SIZEOF_SIZE_T < CURL_SIZEOF_CURL_OFF_T)
+#if (SIZEOF_SIZE_T < SIZEOF_CURL_OFF_T)
     else if(length >= (curl_off_t)(size_t)-1) {
       result = CURLE_BAD_FUNCTION_ARGUMENT;
       goto error;

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1999 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1999 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -51,7 +51,7 @@
  */
 
 #ifndef SIZEOF_SIZE_T
-#  define SIZEOF_SIZE_T CURL_SIZEOF_LONG
+#  define SIZEOF_SIZE_T SIZEOF_LONG
 #endif
 
 #ifdef HAVE_LONGLONG
@@ -330,7 +330,7 @@ static int dprintf_Pass1(const char *format, va_stack_t *vto, char **endpos,
           break;
 #if defined(MP_HAVE_INT_EXTENSIONS)
         case 'I':
-#if (CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
+#if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)
           flags |= FLAGS_LONGLONG;
 #else
           flags |= FLAGS_LONG;
@@ -352,14 +352,14 @@ static int dprintf_Pass1(const char *format, va_stack_t *vto, char **endpos,
         case 'z':
           /* the code below generates a warning if -Wunreachable-code is
              used */
-#if (SIZEOF_SIZE_T > CURL_SIZEOF_LONG)
+#if (SIZEOF_SIZE_T > SIZEOF_LONG)
           flags |= FLAGS_LONGLONG;
 #else
           flags |= FLAGS_LONG;
 #endif
           break;
         case 'O':
-#if (CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
+#if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)
           flags |= FLAGS_LONGLONG;
 #else
           flags |= FLAGS_LONG;

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -79,7 +79,7 @@ static char *max5data(curl_off_t bytes, char *max5)
              CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE,
              (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/CURL_OFF_T_C(10)) );
 
-#if (CURL_SIZEOF_CURL_OFF_T > 4)
+#if (SIZEOF_CURL_OFF_T > 4)
 
   else if(bytes < CURL_OFF_T_C(10000) * ONE_MEGABYTE)
     /* 'XXXXM' is good until we're at 10000MB or above */

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -24,7 +24,7 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_SMB) && defined(USE_NTLM) &&  \
-  (CURL_SIZEOF_CURL_OFF_T > 4)
+  (SIZEOF_CURL_OFF_T > 4)
 
 #if !defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO)
 
@@ -979,4 +979,4 @@ static CURLcode smb_parse_url_path(struct connectdata *conn)
 
 #endif /* !USE_WINDOWS_SSPI || USE_WIN32_CRYPTO */
 
-#endif /* CURL_DISABLE_SMB && USE_NTLM && CURL_SIZEOF_CURL_OFF_T > 4 */
+#endif /* CURL_DISABLE_SMB && USE_NTLM && SIZEOF_CURL_OFF_T > 4 */

--- a/lib/smb.h
+++ b/lib/smb.h
@@ -257,7 +257,7 @@ struct smb_tree_disconnect {
 #endif /* BUILDING_CURL_SMB_C */
 
 #if !defined(CURL_DISABLE_SMB) && defined(USE_NTLM) && \
-    (CURL_SIZEOF_CURL_OFF_T > 4)
+    (SIZEOF_CURL_OFF_T > 4)
 
 #if !defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO)
 
@@ -266,6 +266,6 @@ extern const struct Curl_handler Curl_handler_smbs;
 
 #endif /* !USE_WINDOWS_SSPI || USE_WIN32_CRYPTO */
 
-#endif /* CURL_DISABLE_SMB && USE_NTLM && CURL_SIZEOF_CURL_OFF_T > 4 */
+#endif /* CURL_DISABLE_SMB && USE_NTLM && SIZEOF_CURL_OFF_T > 4 */
 
 #endif /* HEADER_CURL_SMB_H */

--- a/lib/strtoofft.h
+++ b/lib/strtoofft.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -40,7 +40,7 @@
  * of 'long' the conversion function to use is strtol().
  */
 
-#if (CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
+#if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)
 #  ifdef HAVE_STRTOLL
 #    define curlx_strtoofft strtoll
 #  else
@@ -64,10 +64,10 @@
 #  define curlx_strtoofft strtol
 #endif
 
-#if (CURL_SIZEOF_CURL_OFF_T == 4)
+#if (SIZEOF_CURL_OFF_T == 4)
 #  define CURL_OFF_T_MAX CURL_OFF_T_C(0x7FFFFFFF)
 #else
-   /* assume CURL_SIZEOF_CURL_OFF_T == 8 */
+   /* assume SIZEOF_CURL_OFF_T == 8 */
 #  define CURL_OFF_T_MAX CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
 #endif
 #define CURL_OFF_T_MIN (-CURL_OFF_T_MAX - CURL_OFF_T_C(1))

--- a/lib/url.c
+++ b/lib/url.c
@@ -207,7 +207,7 @@ static const struct Curl_handler * const protocols[] = {
 #endif
 
 #if !defined(CURL_DISABLE_SMB) && defined(USE_NTLM) && \
-   (CURL_SIZEOF_CURL_OFF_T > 4) && \
+   (SIZEOF_CURL_OFF_T > 4) && \
    (!defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO))
   &Curl_handler_smb,
 #ifdef USE_SSL

--- a/lib/version.c
+++ b/lib/version.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -239,7 +239,7 @@ static const char * const protocols[] = {
   "sftp",
 #endif
 #if !defined(CURL_DISABLE_SMB) && defined(USE_NTLM) && \
-   (CURL_SIZEOF_CURL_OFF_T > 4) && \
+   (SIZEOF_CURL_OFF_T > 4) && \
    (!defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO))
   "smb",
 #  ifdef USE_SSL
@@ -305,7 +305,7 @@ static curl_version_info_data version_info = {
 #ifdef CURLRES_ASYNCH
   | CURL_VERSION_ASYNCHDNS
 #endif
-#if (CURL_SIZEOF_CURL_OFF_T > 4) && \
+#if (SIZEOF_CURL_OFF_T > 4) && \
     ( (SIZEOF_OFF_T > 4) || defined(USE_WIN32_LARGE_FILES) )
   | CURL_VERSION_LARGEFILE
 #endif

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -69,36 +69,36 @@
 #  error "SIZEOF_INT not defined"
 #endif
 
-#if (CURL_SIZEOF_LONG == 2)
+#if (SIZEOF_LONG == 2)
 #  define CURL_MASK_SLONG  0x7FFFL
 #  define CURL_MASK_ULONG  0xFFFFUL
-#elif (CURL_SIZEOF_LONG == 4)
+#elif (SIZEOF_LONG == 4)
 #  define CURL_MASK_SLONG  0x7FFFFFFFL
 #  define CURL_MASK_ULONG  0xFFFFFFFFUL
-#elif (CURL_SIZEOF_LONG == 8)
+#elif (SIZEOF_LONG == 8)
 #  define CURL_MASK_SLONG  0x7FFFFFFFFFFFFFFFL
 #  define CURL_MASK_ULONG  0xFFFFFFFFFFFFFFFFUL
-#elif (CURL_SIZEOF_LONG == 16)
+#elif (SIZEOF_LONG == 16)
 #  define CURL_MASK_SLONG  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL
 #  define CURL_MASK_ULONG  0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFUL
 #else
-#  error "CURL_SIZEOF_LONG not defined"
+#  error "SIZEOF_LONG not defined"
 #endif
 
-#if (CURL_SIZEOF_CURL_OFF_T == 2)
+#if (SIZEOF_CURL_OFF_T == 2)
 #  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFF)
 #  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFF)
-#elif (CURL_SIZEOF_CURL_OFF_T == 4)
+#elif (SIZEOF_CURL_OFF_T == 4)
 #  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFFFFFF)
 #  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFFFFFF)
-#elif (CURL_SIZEOF_CURL_OFF_T == 8)
+#elif (SIZEOF_CURL_OFF_T == 8)
 #  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
 #  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFFFFFFFFFFFFFF)
-#elif (CURL_SIZEOF_CURL_OFF_T == 16)
+#elif (SIZEOF_CURL_OFF_T == 16)
 #  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
 #  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
 #else
-#  error "CURL_SIZEOF_CURL_OFF_T not defined"
+#  error "SIZEOF_CURL_OFF_T not defined"
 #endif
 
 #if (SIZEOF_SIZE_T == SIZEOF_SHORT)
@@ -107,10 +107,10 @@
 #elif (SIZEOF_SIZE_T == SIZEOF_INT)
 #  define CURL_MASK_SSIZE_T  CURL_MASK_SINT
 #  define CURL_MASK_USIZE_T  CURL_MASK_UINT
-#elif (SIZEOF_SIZE_T == CURL_SIZEOF_LONG)
+#elif (SIZEOF_SIZE_T == SIZEOF_LONG)
 #  define CURL_MASK_SSIZE_T  CURL_MASK_SLONG
 #  define CURL_MASK_USIZE_T  CURL_MASK_ULONG
-#elif (SIZEOF_SIZE_T == CURL_SIZEOF_CURL_OFF_T)
+#elif (SIZEOF_SIZE_T == SIZEOF_CURL_OFF_T)
 #  define CURL_MASK_SSIZE_T  CURL_MASK_SCOFFT
 #  define CURL_MASK_USIZE_T  CURL_MASK_UCOFFT
 #else
@@ -226,7 +226,7 @@ unsigned long curlx_uztoul(size_t uznum)
 # pragma warning(disable:810) /* conversion may lose significant bits */
 #endif
 
-#if (CURL_SIZEOF_LONG < SIZEOF_SIZE_T)
+#if (SIZEOF_LONG < SIZEOF_SIZE_T)
   DEBUGASSERT(uznum <= (size_t) CURL_MASK_ULONG);
 #endif
   return (unsigned long)(uznum & (size_t) CURL_MASK_ULONG);
@@ -269,7 +269,7 @@ int curlx_sltosi(long slnum)
 #endif
 
   DEBUGASSERT(slnum >= 0);
-#if (SIZEOF_INT < CURL_SIZEOF_LONG)
+#if (SIZEOF_INT < SIZEOF_LONG)
   DEBUGASSERT((unsigned long) slnum <= (unsigned long) CURL_MASK_SINT);
 #endif
   return (int)(slnum & (long) CURL_MASK_SINT);
@@ -291,7 +291,7 @@ unsigned int curlx_sltoui(long slnum)
 #endif
 
   DEBUGASSERT(slnum >= 0);
-#if (SIZEOF_INT < CURL_SIZEOF_LONG)
+#if (SIZEOF_INT < SIZEOF_LONG)
   DEBUGASSERT((unsigned long) slnum <= (unsigned long) CURL_MASK_UINT);
 #endif
   return (unsigned int)(slnum & (long) CURL_MASK_UINT);

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -48,7 +48,7 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 {
   struct InStruct *in = userdata;
 
-#if(CURL_SIZEOF_CURL_OFF_T > SIZEOF_OFF_T) && !defined(USE_WIN32_LARGE_FILES)
+#if(SIZEOF_CURL_OFF_T > SIZEOF_OFF_T) && !defined(USE_WIN32_LARGE_FILES)
 
   /* The offset check following here is only interesting if curl_off_t is
      larger than off_t and we are not using the WIN32 large file support

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1755,7 +1755,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
 #endif
 
 #if defined(HAVE_UTIME) || \
-    (defined(WIN32) && (CURL_SIZEOF_CURL_OFF_T >= 8))
+    (defined(WIN32) && (SIZEOF_CURL_OFF_T >= 8))
         /* File time can only be set _after_ the file has been closed */
         if(!result && config->remote_time && outs.s_isreg && outs.filename) {
           /* Ask libcurl if we got a remote file time */
@@ -1765,7 +1765,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
 /* Windows utime() may attempt to adjust our unix gmt 'filetime' by a daylight
    saving time offset and since it's GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass utime and set the times directly. */
-#if defined(WIN32) && (CURL_SIZEOF_CURL_OFF_T >= 8)
+#if defined(WIN32) && (SIZEOF_CURL_OFF_T >= 8)
             /* 910670515199 is the maximum unix filetime that can be used as a
                Windows FILETIME without overflow: 30827-12-31T23:59:59. */
             if(filetime <= CURL_OFF_T_C(910670515199)) {
@@ -1812,7 +1812,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
           }
         }
 #endif /* defined(HAVE_UTIME) || \
-          (defined(WIN32) && (CURL_SIZEOF_CURL_OFF_T >= 8)) */
+          (defined(WIN32) && (SIZEOF_CURL_OFF_T >= 8)) */
 
 #ifdef USE_METALINK
         if(!metalink && config->use_metalink && result == CURLE_OK) {

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -381,7 +381,7 @@ ParameterError str2offset(curl_off_t *val, const char *str)
     /* offsets aren't negative, this indicates weird input */
     return PARAM_NEGATIVE_NUMERIC;
 
-#if(CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
+#if(SIZEOF_CURL_OFF_T > SIZEOF_LONG)
   *val = curlx_strtoofft(str, &endptr, 0);
   if((*val == CURL_OFF_T_MAX || *val == CURL_OFF_T_MIN) && (ERRNO == ERANGE))
     return PARAM_BAD_NUMERIC;

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -29,7 +29,7 @@
 #include "memdebug.h"
 
 
-#if (CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
+#if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)
 #  define MPRNT_SUFFIX_CURL_OFF_T  LL
 #else
 #  define MPRNT_SUFFIX_CURL_OFF_T  L
@@ -774,7 +774,7 @@ static int test_unsigned_long_formatting(void)
   int num_ulong_tests;
   int failed = 0;
 
-#if (CURL_SIZEOF_LONG == 2)
+#if (SIZEOF_LONG == 2)
 
   i=1; ul_test[i].num = 0xFFFFUL; ul_test[i].expected = "65535";
   i++; ul_test[i].num = 0xFF00UL; ul_test[i].expected = "65280";
@@ -795,7 +795,7 @@ static int test_unsigned_long_formatting(void)
 
   num_ulong_tests = i;
 
-#elif (CURL_SIZEOF_LONG == 4)
+#elif (SIZEOF_LONG == 4)
 
   i=1; ul_test[i].num = 0xFFFFFFFFUL; ul_test[i].expected = "4294967295";
   i++; ul_test[i].num = 0xFFFF0000UL; ul_test[i].expected = "4294901760";
@@ -829,7 +829,7 @@ static int test_unsigned_long_formatting(void)
 
   num_ulong_tests = i;
 
-#elif (CURL_SIZEOF_LONG == 8)
+#elif (SIZEOF_LONG == 8)
 
   i=1; ul_test[i].num = 0xFFFFFFFFFFFFFFFFUL; ul_test[i].expected = "18446744073709551615";
   i++; ul_test[i].num = 0xFFFFFFFF00000000UL; ul_test[i].expected = "18446744069414584320";
@@ -923,7 +923,7 @@ static int test_signed_long_formatting(void)
   int num_slong_tests;
   int failed = 0;
 
-#if (CURL_SIZEOF_LONG == 2)
+#if (SIZEOF_LONG == 2)
 
   i=1; sl_test[i].num = 0x7FFFL; sl_test[i].expected = "32767";
   i++; sl_test[i].num = 0x7FFEL; sl_test[i].expected = "32766";
@@ -966,7 +966,7 @@ static int test_signed_long_formatting(void)
 
   num_slong_tests = i;
 
-#elif (CURL_SIZEOF_LONG == 4)
+#elif (SIZEOF_LONG == 4)
 
   i=1; sl_test[i].num = 0x7FFFFFFFL; sl_test[i].expected = "2147483647";
   i++; sl_test[i].num = 0x7FFFFFFEL; sl_test[i].expected = "2147483646";
@@ -1033,7 +1033,7 @@ static int test_signed_long_formatting(void)
 
   num_slong_tests = i;
 
-#elif (CURL_SIZEOF_LONG == 8)
+#elif (SIZEOF_LONG == 8)
 
   i=1; sl_test[i].num = 0x7FFFFFFFFFFFFFFFL; sl_test[i].expected = "9223372036854775807";
   i++; sl_test[i].num = 0x7FFFFFFFFFFFFFFEL; sl_test[i].expected = "9223372036854775806";
@@ -1151,7 +1151,7 @@ static int test_curl_off_t_formatting(void)
   int num_cofft_tests;
   int failed = 0;
 
-#if (CURL_SIZEOF_CURL_OFF_T == 2)
+#if (SIZEOF_CURL_OFF_T == 2)
 
   i=1; co_test[i].num = MPRNT_OFF_T_C(0x7FFF); co_test[i].expected = "32767";
   i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFE); co_test[i].expected = "32766";
@@ -1194,7 +1194,7 @@ static int test_curl_off_t_formatting(void)
 
   num_cofft_tests = i;
 
-#elif (CURL_SIZEOF_CURL_OFF_T == 4)
+#elif (SIZEOF_CURL_OFF_T == 4)
 
   i=1; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFF); co_test[i].expected = "2147483647";
   i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFE); co_test[i].expected = "2147483646";
@@ -1261,7 +1261,7 @@ static int test_curl_off_t_formatting(void)
 
   num_cofft_tests = i;
 
-#elif (CURL_SIZEOF_CURL_OFF_T == 8)
+#elif (SIZEOF_CURL_OFF_T == 8)
 
   i=1; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFF); co_test[i].expected = "9223372036854775807";
   i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFE); co_test[i].expected = "9223372036854775806";


### PR DESCRIPTION
... and use SIZEOF_* internally.

This is an attempted first step towards making `curl/curlbuild.h` become a fixed content header file that doesn't need to get generated at build-time. First remove symbols that aren't used in the public headers and thus don't need to be there.