### PR TITLE
gcc7: fix ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool…

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -56,7 +56,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
    * it does not match then it fails with CURLE_WRITE_ERROR. So at this
    * point returning a value different from sz*nmemb indicates failure.
    */
-  size_t failure = (size * nmemb) ? 0 : 1;
+  size_t failure = (size && nmemb) ? 0 : 1;
 
   if(!heads->config)
     return failure;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -84,7 +84,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
    * it does not match then it fails with CURLE_WRITE_ERROR. So at this
    * point returning a value different from sz*nmemb indicates failure.
    */
-  const size_t failure = (sz * nmemb) ? 0 : 1;
+  const size_t failure = (sz && nmemb) ? 0 : 1;
 
   if(!config)
     return failure;


### PR DESCRIPTION
…-context]

May be also update the comment