### PR TITLE
docs: Explain --fail-early does not imply --fail

### DIFF
--- a/docs/cmdline-opts/fail-early.d
+++ b/docs/cmdline-opts/fail-early.d
@@ -2,7 +2,7 @@ Long: fail-early
 Help: Fail on first transfer error, do not continue
 Added: 7.52.0
 ---
-Fail and exit on first detected error.
+Fail and exit on the first detected transfer error.
 
 When curl is used to do multiple transfers on the command line, it will
 attempt to operate on each given URL, one by one. By default, it will ignore
@@ -15,4 +15,8 @@ that fails, independent on the amount of more URLs that are given on the
 command line. This way, no transfer failures go undetected by scripts and
 similar.
 
-This option will apply for all given URLs even if you use --next.
+This option is global and does not need to be specified for each --next.
+
+This option does not imply --fail, which causes transfers to fail due to the
+server's HTTP status code. You can combine the two options, however note --fail
+is not global and is therefore contained by --next.


### PR DESCRIPTION
I made a mistake in some scripts replacing --fail with --fail-early, not remembering the latter doesn't imply the former. You'd think I would know since it looks like I may have been one of the initial reviewers but I don't remember it.

For example I get a bunch of files using --fail-early --location --remote-name-all and they were all written even though one had failed. I think it's an easy mistake to make, and so it should be documented that it's for transfer errors and does not imply --fail but can be combined with it.

Not in this commit:
The short help could be modified as well, but it may be overkill?
~~~
 -f, --fail          Fail silently (no output at all) on HTTP errors (H)
     --fail-early    Fail and exit on first transfer error; can use with --fail
~~~