### PR TITLE
tests/server/util: remove in6addr_any for recent MinGW

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -39,6 +39,9 @@
 #elif defined(HAVE_POLL_H)
 #include <poll.h>
 #endif
+#ifdef __MINGW32__
+#include <w32api.h>
+#endif
 
 #define ENABLE_CURLX_PRINTF
 /* make the curlx header define all printf() functions to use the curlx_*
@@ -55,9 +58,14 @@
 #define EINVAL  22 /* errno.h value */
 #endif
 
+/* MinGW with w32api version < 3.6 declared in6addr_any as extern,
+   but lacked the definition */
 #if defined(ENABLE_IPV6) && defined(__MINGW32__)
+#if (__W32API_MAJOR_VERSION < 3) || \
+    ((__W32API_MAJOR_VERSION == 3) && (__W32API_MINOR_VERSION < 6))
 const struct in6_addr in6addr_any = {{ IN6ADDR_ANY_INIT }};
-#endif
+#endif /* w32api < 3.6 */
+#endif /* ENABLE_IPV6 && __MINGW32__*/
 
 /* This function returns a pointer to STATIC memory. It converts the given
  * binary lump to a hex formatted string usable for output in logs or


### PR DESCRIPTION
In ancient MinGW versions, `in6addr_any` was declared as extern, but not
defined. Because of that, 22a0c57746ae12506b1ba0f0fafffd26c1907d6a added
definitions for `in6addr_any` when compiling with MinGW. The bug was fixed in
w32api version 3.6 from 2006, so this workaround is not needed anymore for
recent versions.

This fixes the following MinGW-w64 warnings because the MinGW-w64 version of
`IN6ADDR_ANY_INIT` has the two additional braces inside the macro:
util.c:59:14: warning: braces around scalar initializer
util.c:59:40: warning: excess elements in scalar initializer

Ref: https://sourceforge.net/p/mingw/mingw-org-wsl/ci/e4803e0da25c57ae1ad0fa75ae2b7182ff7fa339/tree/w32api/ChangeLog

An alternative would be to remove support for these ancient MinGW versions
and just remove the redefinition of `inaddr_any`, of course.