### PR TITLE
curl with c-ares: No DNS requests if a file lookup is successful

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -535,16 +535,16 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
   }
 
   /* File Lookup, if successful we do not need make a DNS request */
-  if (family == PF_UNSPEC && Curl_ipv6works()) {
+  if(family == PF_UNSPEC && Curl_ipv6works()) {
     struct hostent* host;
     Curl_addrinfo* ai = NULL;
-    if (ares_gethostbyname_file((ares_channel)data->state.resolver, hostname,
-      PF_INET, &host))
+    if(ares_gethostbyname_file((ares_channel)data->state.resolver, hostname,
+                               PF_INET, &host) == ARES_SUCCESS)
       ai = Curl_he2ai(host, port);
-    if (ares_gethostbyname_file((ares_channel)data->state.resolver, hostname,
-      PF_INET6, &host))
+    if(ares_gethostbyname_file((ares_channel)data->state.resolver, hostname,
+                               PF_INET6, &host) == ARES_SUCCESS)
       compound_results(&ai, Curl_he2ai(host, port));
-    if (ai)
+    if(ai)
       return ai;
   }
 #endif /* CURLRES_IPV6 */

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -541,6 +541,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
                        ARES_OPT_LOOKUPS) == ARES_SUCCESS &&
      opt->lookups && *opt->lookups == 'f') {
     ares_delete_options(opt);
+    opt = NULL;
     struct hostent* host;
     Curl_addrinfo* ai = NULL;
     if(ares_gethostbyname_file((ares_channel)data->state.resolver, hostname,

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -553,7 +553,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
     if(ai)
       return ai;
   }
-  if (opt)
+  if(opt)
     ares_delete_options(opt);
 #endif /* CURLRES_IPV6 */
 


### PR DESCRIPTION
curl with enabled c-ares `--enable-ares` calls `ares_gethostbyname` for both families (`AF_INET` and `AF_INET6`). Even if one family could be resolved through a file lookup, the other family is requested through a DNS lookup. 

curl without c-ares on the other hand uses `getaddrinfo` which does not make a DNS lookup if a file lookup was successful. This is different behavior (E.g. I observed curl with ares timed out on a specific host, while curl without ares did not)

This patch solves this problem by making an explicit file lookup with `ares_gethostbyname_file` before doing any DNS requests. If the file lookup is successful `Curl_resolver_getaddrinfo` returns before calling `ares_gethostbyname`.