### PR TITLE
.github/stale.yml: enable the stale bot [a github service]

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Issues and PRs with no activity for 90 days will get marked as stale,
and if no further activity happens within 14 more days, the issue gets
closed.

This follows our established policy of not letting stalled bugs "get in
the way": https://curl.haxx.se/docs/bugs.html#Closing_off_stalled_bugs