### PR TITLE
SecureTransport/DarwinSSL: Implement public key pinning

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -103,6 +103,8 @@ PEM/DER support:
 
   7.49.0: PolarSSL
 
+  7.55.0: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
+
 sha256 support:
 
   7.44.0: OpenSSL, GnuTLS, NSS and wolfSSL/CyaSSL
@@ -110,6 +112,8 @@ sha256 support:
   7.47.0: mbedtls
 
   7.49.0: PolarSSL
+
+  7.55.0: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
 
 Other SSL backends not supported.
 .SH RETURN VALUE

--- a/lib/vtls/darwinssl.h
+++ b/lib/vtls/darwinssl.h
@@ -48,10 +48,33 @@ void Curl_darwinssl_md5sum(unsigned char *tmp, /* input */
                            size_t tmplen,
                            unsigned char *md5sum, /* output */
                            size_t md5len);
+void Curl_darwinssl_sha256sum(unsigned char *tmp, /* input */
+                           size_t tmplen,
+                           unsigned char *sha256sum, /* output */
+                           size_t sha256len);
 bool Curl_darwinssl_false_start(void);
 
 /* Set the API backend definition to SecureTransport */
 #define CURL_SSL_BACKEND CURLSSLBACKEND_DARWINSSL
+
+/* pinned public key support tests */
+
+/* version 1 supports macOS 10.12+ and iOS 10+ */
+#if ((TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || \
+    (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MIN_REQUIRED  >= 101200))
+#define DARWIN_SSL_PINNEDPUBKEY_V1 1
+#endif
+
+/* version 2 supports MacOSX 10.7+ */
+#if (!TARGET_OS_IPHONE && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
+#define DARWIN_SSL_PINNEDPUBKEY_V2 1
+#endif
+
+#if defined(DARWIN_SSL_PINNEDPUBKEY_V1) || defined(DARWIN_SSL_PINNEDPUBKEY_V2)
+/* this backend supports CURLOPT_PINNEDPUBLICKEY */
+#define DARWIN_SSL_PINNEDPUBKEY 1
+#define have_curlssl_pinnedpubkey 1
+#endif /* DARWIN_SSL_PINNEDPUBKEY */
 
 /* API setup for SecureTransport */
 #define curlssl_init() (1)
@@ -70,6 +93,7 @@ bool Curl_darwinssl_false_start(void);
 #define curlssl_data_pending(x,y) Curl_darwinssl_data_pending(x, y)
 #define curlssl_random(x,y,z) ((void)x, Curl_darwinssl_random(y,z))
 #define curlssl_md5sum(a,b,c,d) Curl_darwinssl_md5sum(a,b,c,d)
+#define curlssl_sha256sum(a,b,c,d) Curl_darwinssl_sha256sum(a,b,c,d)
 #define curlssl_false_start() Curl_darwinssl_false_start()
 
 #endif /* USE_DARWINSSL */

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2412,6 +2412,7 @@ sub checksystem {
            }
            elsif ($libcurl =~ /securetransport/i) {
                $has_darwinssl=1;
+               $has_sslpinning=1;
                $ssllib="DarwinSSL";
            }
            elsif ($libcurl =~ /BoringSSL/i) {


### PR DESCRIPTION
This has been a long time coming, refer to these links for history:

https://twitter.com/bagder/status/849732891995250689
https://curl.haxx.se/mail/lib-2016-05/0015.html
https://stackoverflow.com/questions/36843572/public-key-bytes-from-seckeyref

I have tested this with 2048 and 4096 bit RSA keys, and a ecDSA Secp256r1 key with these commands respectively:
```
./src/curl https://www.google.com --insecure --pinnedpubkey 'sha256//U9GGUC1+PGI7SLb8XVVuuBPLkQKbQ2LnfU5Wfe7WAAg=' -s -S -o /dev/null && echo success
./src/curl https://www.moparisthebest.com --insecure --pinnedpubkey 'sha256//t62CeU2tQiqkexU74Gxa2eg7fRbEgoChTociMee9wno=' -s -S -o /dev/null && echo success
./src/curl https://blog.joelj.org --insecure --pinnedpubkey 'sha256//1cCBZSdgsO2/rHuPlfHELChj+wCD2C7X5DnbefNoY0o=' -s -S -o /dev/null && echo success
```
Strangely Apple's API returns full DER encoding for the ecDSA key, but missing the header part for RSA keys.  So in theory this might work for all ecDSA keys (anyone know another site to test this with other curves?), but no other RSA keys.

I have no idea if the way I hard-coded the headers is decent, curl-like, or even valid C, but it works, looking forward to comments here.

I also stumbled upon another public key pinning implementation in Objective-C and it seems to do a similar thing:
https://github.com/datatheorem/TrustKit/blob/master/TrustKit/Pinning/public_key_utils.m

Either way, working for a subset of common keys seems better than not working at all which is the current situation.  This should simply fail with a pinning error when faced with other keys. (which is fail-closed, the correct way)

Lastly I have only tested this on an OSX El Capitan box I had access to, testing on other versions and/or iOS would be appreciated.  Thanks to everyone that already helped!