### PR TITLE
poll: prefer <poll.h> over <sys/poll.h>

### DIFF
--- a/lib/select.h
+++ b/lib/select.h
@@ -24,10 +24,10 @@
 
 #include "curl_setup.h"
 
-#ifdef HAVE_SYS_POLL_H
-#include <sys/poll.h>
-#elif defined(HAVE_POLL_H)
+#ifdef HAVE_POLL_H
 #include <poll.h>
+#elif defined(HAVE_SYS_POLL_H)
+#include <sys/poll.h>
 #endif
 
 /*

--- a/src/tool_sleep.c
+++ b/src/tool_sleep.c
@@ -25,10 +25,10 @@
 #  include <sys/select.h>
 #endif
 
-#ifdef HAVE_SYS_POLL_H
-#  include <sys/poll.h>
-#elif defined(HAVE_POLL_H)
+#ifdef HAVE_POLL_H
 #  include <poll.h>
+#elif defined(HAVE_SYS_POLL_H)
+#  include <sys/poll.h>
 #endif
 
 #ifdef MSDOS


### PR DESCRIPTION
The POSIX standard location is <poll.h>. Using <sys/poll.h> results in
warning spam when using the musl standard library.