### PR TITLE
Curl_expire_latest: ignore already expired timers

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3001,11 +3001,15 @@ void Curl_expire_latest(struct Curl_easy *data, time_t milli)
   if(expire->tv_sec || expire->tv_usec) {
     /* This means that the struct is added as a node in the splay tree.
        Compare if the new time is earlier, and only remove-old/add-new if it
-         is. */
+       is. */
     time_t diff = curlx_tvdiff(set, *expire);
-    if(diff > 0)
-      /* the new expire time was later than the top time, so just skip this */
+    if((diff > 0) && (diff < milli)) {
+      /* if the new expire time is later than the top time, skip it, but not
+         if the diff is larger than the new offset since then the previous
+         time is already expired! */
+      fprintf(stderr, "skip Curl_expire_latest = %d\n", (int)diff);
       return;
+    }
   }
 
   /* Just add the timeout like normal */

--- a/tests/data/test1238
+++ b/tests/data/test1238
@@ -10,7 +10,7 @@ TFTP RRQ
 # Server-side
 <reply>
 <servercmd>
-writedelay: 1
+writedelay: 2
 </servercmd>
 # ~1200 bytes (so that they don't fit in two 512 byte chunks)
 <data nocheck="yes">


### PR DESCRIPTION
If the existing timer is still in there but has expired, the new timer
should be added.

Reported-by: Rainer Canavan
Bug: https://curl.haxx.se/mail/lib-2017-04/0030.html