### PR TITLE
test1086: increase timeout to 9 seconds

### DIFF
--- a/tests/data/test1086
+++ b/tests/data/test1086
@@ -87,7 +87,7 @@ ftp
 FTP download with strict timeout and slow data transfer
  </name>
  <command timeout="1">
-ftp://%HOSTIP:%FTPPORT/1086 -m 7
+ftp://%HOSTIP:%FTPPORT/1086 -m 9
 </command>
 </client>
 


### PR DESCRIPTION
This test just won't pass on my machine with a lower timeout. All other tests work fine, including the flaky ones.