### PR TITLE
http2: fix handle leak in error path

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -408,6 +408,7 @@ static int push_promise(struct Curl_easy *data,
     stream = data->req.protop;
     if(!stream) {
       failf(data, "Internal NULL stream!\n");
+      (void)Curl_close(newhandle);
       rv = 1;
       goto fail;
     }


### PR DESCRIPTION
Add missing newhandle free call in push_promise().