### PR TITLE
curl-compilers.m4: turn implicit function declarations into errors

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -577,8 +577,11 @@ AC_DEFUN([CURL_SET_COMPILER_BASIC_OPTS], [
         #
       GNU_C)
         #
-        dnl Placeholder
-        tmp_CFLAGS="$tmp_CFLAGS"
+        dnl turn implicit-function-declaration warning into error,
+        dnl at least gcc 2.95 and later support this
+        if test "$compiler_num" -ge "295"; then
+          tmp_CFLAGS="$tmp_CFLAGS -Werror-implicit-function-declaration"
+        fi
         ;;
         #
       HP_UX_C)


### PR DESCRIPTION
This adds -Werror-implicit-function-declaration for GCC 2.95+ so that
these errors are visible at the point where they occur instead of only
at link time.
Implicit function delcarations are illegal in C99 and C++ anyway, and
the same warning has been turned into an error for ICC in commit
3072c5b8a127057aa922b7c51051bbb4a630b091.

This would have GCC tell the exact location of the source of problems like https://github.com/curl/curl/issues/1401, for example.

Ref: https://gcc.gnu.org/onlinedocs/gcc-2.95.2/gcc_2.html#SEC8
Ref: https://curl.haxx.se/mail/lib-2017-04/0001.html