### PR TITLE
CMake: Require Perl only when it's needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ else()
 endif()
 option(ENABLE_DEBUG "Set to ON to enable curl debug features" OFF)
 option(ENABLE_CURLDEBUG "Set to ON to build with TrackMemory feature enabled" OFF)
-option(ENABLE_DOCS "Set to ON to enable docs" ON)
 
 if (ENABLE_DEBUG)
   # DEBUGBUILD will be defined only for Debug builds
@@ -225,12 +224,21 @@ if(ENABLE_MANUAL)
     message(WARNING "Found no *nroff program")
   endif()
 endif()
-# Required for building manual, docs, tests
-if (BUILD_TESTING OR ENABLE_DOCS OR ENABLE_MANUAL)
+# Required for building docs including manual, and tests
+if (BUILD_TESTING OR ENABLE_MANUAL)
   find_package(Perl)
   if (NOT PERL_FOUND)
-    message(FATAL_ERROR
-      "Package perl not found. Make perl available or configure with ENABLE_DOCS=OFF, ENABLE_MANUAL=OFF and BUILD_TESTING=OFF")
+    if (BUILD_TESTING)
+      message(FATAL_ERROR "Perl was not found, but building of tests was enabled with BUILD_TESTING option.\
+Make perl available or do not build tests by not turning on BUILD_TESTING option")
+    endif()
+    if (ENABLE_MANUAL)
+      message("Warning: perl was not found, which is required to build manual. This means when \
+you build curl the manual will not be available (curl --man^). Integration of \
+the manual is not required and a summary of the options will still be available \
+(curl --help^). To integrate the manual your PATH is required to have \
+groff/nroff, perl and optionally gzip for compression. ")
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,10 @@ endif()
 # Required for building manual, docs, tests
 if (BUILD_TESTING OR ENABLE_DOCS OR ENABLE_MANUAL)
   find_package(Perl REQUIRED)
+  if (NOT PERL_FOUND)
+    message(FATAL_ERROR
+      "Package perl not found. Make perl available or configure with ENABLE_DOCS=OFF, ENABLE_MANUAL=OFF and BUILD_TESTING=OFF")
+  endif()
 endif()
 
 # We need ansi c-flags, especially on HP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ if (BUILD_TESTING OR ENABLE_MANUAL)
     if (BUILD_TESTING)
       message("Warning: Perl was not found, but building of tests was enabled through BUILD_TESTING option. \
 Building of tests will be disables.")
+      unset(BUILD_TESTING CACHE)
     endif()
     if (ENABLE_MANUAL)
       message("Warning: perl was not found, which is required to build manual. This means when \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ you build curl the manual will not be available (curl --man^). Integration of \
 the manual is not required and a summary of the options will still be available \
 (curl --help^). To integrate the manual your PATH is required to have \
 groff/nroff, perl and optionally gzip for compression. ")
+      unset(ENABLE_MANUAL CACHE)
     endif()
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if(ENABLE_IPV6 AND NOT WIN32)
   endif()
 endif()
 
-option(ENABLE_MANUAL "to provide the built-in manual" ON)
+option(ENABLE_MANUAL "to provide the built-in manual and docs" ON)
 unset(USE_MANUAL CACHE) # TODO: cache NROFF/NROFF_MANOPT/USE_MANUAL vars?
 if(ENABLE_MANUAL)
   find_program(NROFF NAMES gnroff nroff)
@@ -224,13 +224,15 @@ if(ENABLE_MANUAL)
     message(WARNING "Found no *nroff program")
   endif()
 endif()
-# Required for building docs including manual, and tests
+
+include(CTest)
+# Perl is required for building manuals including docs, and tests
 if (BUILD_TESTING OR ENABLE_MANUAL)
   find_package(Perl)
   if (NOT PERL_FOUND)
     if (BUILD_TESTING)
-      message(FATAL_ERROR "Perl was not found, but building of tests was enabled with BUILD_TESTING option.\
-Make perl available or do not build tests by not turning on BUILD_TESTING option")
+      message("Warning: Perl was not found, but building of tests was enabled through BUILD_TESTING option. \
+Building of tests will be disables.")
     endif()
     if (ENABLE_MANUAL)
       message("Warning: perl was not found, which is required to build manual. This means when \
@@ -1099,7 +1101,7 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-if(ENABLE_DOCS)
+if(ENABLE_MANUAL)
   add_subdirectory(docs)
 endif()
 add_subdirectory(lib)
@@ -1107,7 +1109,6 @@ if(BUILD_CURL_EXE)
   add_subdirectory(src)
 endif()
 
-include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ if(ENABLE_MANUAL)
 endif()
 # Required for building manual, docs, tests
 if (BUILD_TESTING OR ENABLE_DOCS OR ENABLE_MANUAL)
-  find_package(Perl REQUIRED)
+  find_package(Perl)
   if (NOT PERL_FOUND)
     message(FATAL_ERROR
       "Package perl not found. Make perl available or configure with ENABLE_DOCS=OFF, ENABLE_MANUAL=OFF and BUILD_TESTING=OFF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ else()
 endif()
 option(ENABLE_DEBUG "Set to ON to enable curl debug features" OFF)
 option(ENABLE_CURLDEBUG "Set to ON to build with TrackMemory feature enabled" OFF)
+option(ENABLE_DOCS "Set to ON to enable docs" ON)
 
 if (ENABLE_DEBUG)
   # DEBUGBUILD will be defined only for Debug builds
@@ -225,7 +226,9 @@ if(ENABLE_MANUAL)
   endif()
 endif()
 # Required for building manual, docs, tests
-find_package(Perl REQUIRED)
+if (BUILD_TESTING OR ENABLE_DOCS OR ENABLE_MANUAL)
+  find_package(Perl REQUIRED)
+endif()
 
 # We need ansi c-flags, especially on HP
 set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS}")
@@ -1084,7 +1087,9 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-add_subdirectory(docs)
+if(ENABLE_DOCS)
+  add_subdirectory(docs)
+endif()
 add_subdirectory(lib)
 if(BUILD_CURL_EXE)
   add_subdirectory(src)


### PR DESCRIPTION
Currently CMakeLists.txt requires Perl unconditionally, though it is required only to build man, tests and docs. This complicates the usage of the library as a CMake subdirectory (subproject) in a project. This PR adds checks for BUILD_TESTING, ENABLE_MANUAL as well as introduces ENABLE_DOCS CMake option and a corresponding check. As a result, projects, that include CURL as a CMake subdirectory become easily portable on platforms that do not have Perl, like Windows, and use CURL just as a library.