### PR TITLE
Tests: make them pass with CRLF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ configure.ac eol=lf
 *.m4 eol=lf
 *.in eol=lf
 *.am eol=lf
+*.sh eol=lf

--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,7 @@ if test -f ${srcdir}/include/curl/curlbuild.h; then
 fi
 
 dnl figure out the libcurl version
-CURLVERSION=`$SED -ne 's/^#define LIBCURL_VERSION "\(.*\)"/\1/p' ${srcdir}/include/curl/curlver.h`
+CURLVERSION=`$SED -ne 's/^#define LIBCURL_VERSION "\(.*\)".*/\1/p' ${srcdir}/include/curl/curlver.h`
 XC_CHECK_PROG_CC
 XC_AUTOMAKE
 AC_MSG_CHECKING([curl version])
@@ -136,7 +136,7 @@ AC_SUBST(CURLVERSION)
 
 dnl
 dnl we extract the numerical version for curl-config only
-VERSIONNUM=`$SED -ne 's/^#define LIBCURL_VERSION_NUM 0x\(.*\)/\1/p' ${srcdir}/include/curl/curlver.h`
+VERSIONNUM=`$SED -ne 's/^#define LIBCURL_VERSION_NUM 0x\([0-9A-Fa-f]*\).*/\1/p' ${srcdir}/include/curl/curlver.h`
 AC_SUBST(VERSIONNUM)
 
 dnl Solaris pkgadd support definitions

--- a/lib/.gitattributes
+++ b/lib/.gitattributes
@@ -1,0 +1,1 @@
+objnames.inc eol=lf

--- a/tests/extern-scan.pl
+++ b/tests/extern-scan.pl
@@ -49,7 +49,9 @@ sub scanheader {
     open H, "<$f" || die;
     while(<H>) {
         if (/^(CURL_EXTERN.*)/) {
-            print "$1\n";
+            my $decl = $1;
+            $decl =~ s/\r$//;
+            print "$decl\n";
         }
     }
     close H;


### PR DESCRIPTION
There are currently 5 tests failing with CRLF line endings:

Tests 1221 and 1222:
They are failing on Linux because Bash (and other shells) errors out on CR characters with "\r: command not found" in otherwise empty lines, so force them to LF line endings.

Test 1035:
This test is failing (also on Windows) because data/test1035 expects the CURL_EXTERN lines to have LF line endings. Strip trailing CR in extern-scan.pl to fix this.

Tests 1022 and 1023:
They are failing because the CR is treated as part of the version number. Fix this by ignoring everything that comes after the version number.

Ref: https://github.com/curl/curl/pull/1344#issuecomment-289243166