### PR TITLE
SPNEGO - Use IP address if canonic. is enabled

### DIFF
--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -67,6 +67,12 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
     neg_ctx = &data->state.negotiate;
   }
 
+  /* If the authentication will canonicalize the host ip, we must give
+     it the ip address to prevent inconsistent resolution */
+  if(Curl_auth_will_canonicalize_spnego_host()) {
+    host = conn->primary_ip;
+  }
+
   /* Not set means empty */
   if(!userp)
     userp = "";

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -63,6 +63,25 @@ bool Curl_auth_is_spnego_supported(void)
 }
 
 /*
+ * Curl_auth_will_canonicalize_spnego_host()
+ *
+ * This method returns whether or not the authentication will
+ * canonicalize the host. This is important because if the
+ * canonicalization happens on a round-robin DNS record, the
+ * authentication may canonicalize to a different host than what we're
+ * connecting to.
+ *
+ * This is currently not supported on SSPI, pending implementation.
+ * Returns FALSE.
+ */
+bool Curl_auth_will_canonicalize_spnego_host(void)
+{
+  /* This is the old behavior, someone may be interested in adding
+     this support on the windows API. */
+  return FALSE;
+}
+
+/*
  * Curl_auth_decode_spnego_message()
  *
  * This is used to decode an already encoded SPNEGO (Negotiate) challenge

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -180,6 +180,13 @@ void Curl_auth_gssapi_cleanup(struct kerberos5data *krb5);
 /* This is used to evaluate if SPNEGO (Negotiate) is supported */
 bool Curl_auth_is_spnego_supported(void);
 
+/* This method returns whether or not the authentication will
+   canonicalize the host. This is important because if the
+   canonicalization happens on a round-robin DNS record, the
+   authentication may canonicalize to a different host than what we're
+   connecting to. */
+bool Curl_auth_will_canonicalize_spnego_host(void);
+
 /* This is used to decode a base64 encoded SPNEGO (Negotiate) challenge
    message */
 CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,


### PR DESCRIPTION
If the target host we're connecting to is a round-robin DNS and the
authentication library will canonicalize the host (by doing a forward
and a reverse lookup), curl and gssapi will frequently disagree over
the Service Principal Name.

Introduce a new function in vauth.h to infer whether or not
canonicalization is happening in that particular mechanics.

For gssapi when using krb5, we implement the configuration profile
parsing to determine whether or not the "rdns" option in "libdefaults"
is set to false.

Every other implementation defaults to the current behavior of sending
the original hostname.

In theory, the correct thing would be to always give the ip address
unconditionally since according to the GSSAPI standard, the
canonicalization is not optional (and it is indeed a fundamental part
of the security model). However, that'd be a breaking change for
people that have set "rdns" to "false" in their krb5 configuration.

I am not familiar enough with the Windows SPI API to know whether or
not that is an option there.