### PR TITLE
SChannel/WinSSL: Implement public key pinning

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -105,6 +105,8 @@ PEM/DER support:
 
   7.54.1: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
 
+  7.58.0: SChannel/WinSSL
+
 sha256 support:
 
   7.44.0: OpenSSL, GnuTLS, NSS and wolfSSL/CyaSSL
@@ -114,6 +116,8 @@ sha256 support:
   7.49.0: PolarSSL
 
   7.54.1: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
+
+  7.58.0: SChannel/WinSSL Windows XP SP3+
 
 Other SSL backends not supported.
 .SH RETURN VALUE

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1936,6 +1936,15 @@ static void Curl_schannel_checksum(const unsigned char *input,
     CryptReleaseContext(hProv, 0);
 }
 
+void Curl_schannel_md5sum(unsigned char *input,
+                           size_t inputlen,
+                           unsigned char *md5sum,
+                           size_t md5len)
+{
+    Curl_schannel_checksum(input, inputlen, md5sum, md5len,
+                           PROV_RSA_FULL, CALG_MD5);
+}
+
 void Curl_schannel_sha256sum(unsigned char *input,
                            size_t inputlen,
                            unsigned char *sha256sum,
@@ -1981,7 +1990,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
   Curl_none_set_engine_default,      /* set_engine_default */
   Curl_none_engines_list,            /* engines_list */
   Curl_none_false_start,             /* false_start */
-  Curl_none_md5sum,                  /* md5sum */
+  Curl_schannel_md5sum,              /* md5sum */
   Curl_schannel_sha256sum            /* sha256sum */
 };
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2771,6 +2771,7 @@ sub checksystem {
             }
            if ($libcurl =~ /winssl/i) {
                $has_winssl=1;
+               $has_sslpinning=1;
                $ssllib="WinSSL";
            }
            elsif ($libcurl =~ /openssl/i) {


### PR DESCRIPTION
This implements public key pinning for the schannel backend.  Currently it works with pem/der/hashes, but only if the remote server has a RSA key with a length of 2048 or 4096 bits.  I'm looking for help with this error that occurs with ecDSA keys (regardless of PROV_RSA_FULL or PROV_RSA_AES):

https://github.com/moparisthebest/curl/commit/1d49e25d26137e2eee8f42f2e9b8f3539d9a5848#diff-2ba9d5898aad590d89cd83e17ad244fbR1658

And also *hoping* that I don't really have to resort to the horrible hard-coded header hacks that the apple backend had to do:

https://github.com/moparisthebest/curl/commit/1d49e25d26137e2eee8f42f2e9b8f3539d9a5848#diff-2ba9d5898aad590d89cd83e17ad244fbR1719

*Is* there a proper way to change a PUBLICKEYBLOB to a DER (or a PEM that I can convert)?

Also thoughts about this working on XP, 8, or 10 would be appreciated too, I've only tested on 7 SP1.