### PR TITLE
llist: no longer uses malloc

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -72,13 +72,11 @@ static void bundle_destroy(struct connectbundle *cb_ptr)
 
 /* Add a connection to a bundle */
 static CURLcode bundle_add_conn(struct connectbundle *cb_ptr,
-                              struct connectdata *conn)
+                                struct connectdata *conn)
 {
-  if(!Curl_llist_insert_next(&cb_ptr->conn_list, cb_ptr->conn_list.tail, conn))
-    return CURLE_OUT_OF_MEMORY;
-
+  Curl_llist_insert_next(&cb_ptr->conn_list, cb_ptr->conn_list.tail, conn,
+                         &conn->bundle_node);
   conn->bundle = cb_ptr;
-
   cb_ptr->num_connections++;
   return CURLE_OK;
 }

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2010 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2010 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -28,23 +28,19 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-struct curl_fileinfo *Curl_fileinfo_alloc(void)
+struct fileinfo *Curl_fileinfo_alloc(void)
 {
-  struct curl_fileinfo *tmp = malloc(sizeof(struct curl_fileinfo));
-  if(!tmp)
-    return NULL;
-  memset(tmp, 0, sizeof(struct curl_fileinfo));
-  return tmp;
+  return calloc(1, sizeof(struct fileinfo));
 }
 
 void Curl_fileinfo_dtor(void *user, void *element)
 {
-  struct curl_fileinfo *finfo = element;
+  struct fileinfo *finfo = element;
   (void) user;
   if(!finfo)
     return;
 
-  Curl_safefree(finfo->b_data);
+  Curl_safefree(finfo->info.b_data);
 
   free(finfo);
 }

--- a/lib/fileinfo.h
+++ b/lib/fileinfo.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2010, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2010, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,11 +23,15 @@
  ***************************************************************************/
 
 #include <curl/curl.h>
+#include "llist.h"
 
-struct curl_fileinfo *Curl_fileinfo_alloc(void);
+struct fileinfo {
+  struct curl_fileinfo info;
+  struct curl_llist_element list;
+};
+
+struct fileinfo *Curl_fileinfo_alloc(void);
 
 void Curl_fileinfo_dtor(void *, void *);
-
-struct curl_fileinfo *Curl_fileinfo_dup(const struct curl_fileinfo *src);
 
 #endif /* HEADER_CURL_FILEINFO_H */

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -124,17 +124,9 @@ Curl_hash_add(struct curl_hash *h, void *key, size_t key_len, void *p)
 
   he = mk_hash_element(key, key_len, p);
   if(he) {
-    if(Curl_llist_insert_next(l, l->tail, he)) {
-      ++h->size;
-      return p; /* return the new entry */
-    }
-    /*
-     * Couldn't insert it, destroy the 'he' element and the key again. We
-     * don't call hash_element_dtor() since that would also call the
-     * "destructor" for the actual data 'p'. When we fail, we shall not touch
-     * that data.
-     */
-    free(he);
+    Curl_llist_insert_next(l, l->tail, he, &he->list);
+    ++h->size;
+    return p; /* return the new entry */
   }
 
   return NULL; /* failure */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -57,6 +57,7 @@ struct curl_hash {
 };
 
 struct curl_hash_element {
+  struct curl_llist_element list;
   void   *ptr;
   size_t key_len;
   char   key[1]; /* allocated memory following the struct */

--- a/lib/llist.h
+++ b/lib/llist.h
@@ -29,7 +29,6 @@ typedef void (*curl_llist_dtor)(void *, void *);
 
 struct curl_llist_element {
   void *ptr;
-
   struct curl_llist_element *prev;
   struct curl_llist_element *next;
 };
@@ -37,21 +36,19 @@ struct curl_llist_element {
 struct curl_llist {
   struct curl_llist_element *head;
   struct curl_llist_element *tail;
-
   curl_llist_dtor dtor;
-
   size_t size;
 };
 
 void Curl_llist_init(struct curl_llist *, curl_llist_dtor);
-int Curl_llist_insert_next(struct curl_llist *, struct curl_llist_element *,
-                           const void *);
-int Curl_llist_remove(struct curl_llist *, struct curl_llist_element *,
-                      void *);
+void Curl_llist_insert_next(struct curl_llist *, struct curl_llist_element *,
+                            const void *, struct curl_llist_element *node);
+void Curl_llist_remove(struct curl_llist *, struct curl_llist_element *,
+                       void *);
 size_t Curl_llist_count(struct curl_llist *);
 void Curl_llist_destroy(struct curl_llist *, void *);
-int Curl_llist_move(struct curl_llist *, struct curl_llist_element *,
-                    struct curl_llist *, struct curl_llist_element *);
+void Curl_llist_move(struct curl_llist *, struct curl_llist_element *,
+                     struct curl_llist *, struct curl_llist_element *);
 
 #endif /* HEADER_CURL_LLIST_H */
 

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -25,6 +25,7 @@
 #include "conncache.h"
 
 struct Curl_message {
+  struct curl_llist_element list;
   /* the 'CURLMsg' is the part that is visible to the external user */
   struct CURLMsg extmsg;
 };

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -898,6 +898,8 @@ struct connectdata {
      connection is used! */
   struct Curl_easy *data;
 
+  struct curl_llist_element bundle_node; /* conncache */
+
   /* chunk is for HTTP chunked encoding, but is in the general connectdata
      struct only because we can do just about any protocol through a HTTP proxy
      and a HTTP proxy may in fact respond using chunked encoding */
@@ -1804,6 +1806,8 @@ struct Curl_easy {
   struct Curl_easy *prev;
 
   struct connectdata *easy_conn;     /* the "unit's" connection */
+  struct curl_llist_element connect_queue;
+  struct curl_llist_element pipeline_queue;
 
   CURLMstate mstate;  /* the handle's state */
   CURLcode result;   /* previous result */

--- a/tests/unit/unit1300.c
+++ b/tests/unit/unit1300.c
@@ -48,15 +48,20 @@ static void unit_stop(void)
 }
 
 UNITTEST_START
+{
   int unusedData_case1 = 1;
   int unusedData_case2 = 2;
   int unusedData_case3 = 3;
+  struct curl_llist_element case1_list;
+  struct curl_llist_element case2_list;
+  struct curl_llist_element case3_list;
+  struct curl_llist_element case4_list;
+  struct curl_llist_element case5_list;
   struct curl_llist_element *head;
   struct curl_llist_element *element_next;
   struct curl_llist_element *element_prev;
   struct curl_llist_element *to_remove;
   size_t llist_size = Curl_llist_count(&llist);
-  int curlErrCode = 0;
 
   /**
    * testing llist_init
@@ -85,67 +90,49 @@ UNITTEST_START
    * 3: list tail will be the same as list head
    */
 
-  curlErrCode = Curl_llist_insert_next(&llist, llist.head, &unusedData_case1);
-  if(curlErrCode == 1) {
-    fail_unless(Curl_llist_count(&llist) == 1,
-                 "List size should be 1 after adding a new element");
-    /*test that the list head data holds my unusedData */
-    fail_unless(llist.head->ptr == &unusedData_case1,
-                 "List size should be 1 after adding a new element");
-    /*same goes for the list tail */
-    fail_unless(llist.tail == llist.head,
-                 "List size should be 1 after adding a new element");
+  Curl_llist_insert_next(&llist, llist.head, &unusedData_case1, &case1_list);
 
-    /**
-     * testing Curl_llist_insert_next
-     * case 2:
-     * list has 1 element, adding one element after the head
-     * @assumptions:
-     * 1: the element next to head should be our newly created element
-     * 2: the list tail should be our newly created element
-     */
+  fail_unless(Curl_llist_count(&llist) == 1,
+              "List size should be 1 after adding a new element");
+  /*test that the list head data holds my unusedData */
+  fail_unless(llist.head->ptr == &unusedData_case1,
+              "head ptr should be first entry");
+  /*same goes for the list tail */
+  fail_unless(llist.tail == llist.head,
+              "tail and head should be the same");
 
-    curlErrCode = Curl_llist_insert_next(&llist, llist.head,
-                                         &unusedData_case3);
-    if(curlErrCode == 1) {
-      fail_unless(llist.head->next->ptr == &unusedData_case3,
-                  "the node next to head is not getting set correctly");
-      fail_unless(llist.tail->ptr == &unusedData_case3,
-                  "the list tail is not getting set correctly");
-    }
-    else {
-      printf("skipping Curl_llist_insert_next as a non "
-             "success error code was returned\n");
-    }
+  /**
+   * testing Curl_llist_insert_next
+   * case 2:
+   * list has 1 element, adding one element after the head
+   * @assumptions:
+   * 1: the element next to head should be our newly created element
+   * 2: the list tail should be our newly created element
+   */
 
-    /**
-     * testing Curl_llist_insert_next
-     * case 3:
-     * list has >1 element, adding one element after "NULL"
-     * @assumptions:
-     * 1: the element next to head should be our newly created element
-     * 2: the list tail should different from newly created element
-     */
+  Curl_llist_insert_next(&llist, llist.head,
+                         &unusedData_case3, &case3_list);
+  fail_unless(llist.head->next->ptr == &unusedData_case3,
+              "the node next to head is not getting set correctly");
+  fail_unless(llist.tail->ptr == &unusedData_case3,
+              "the list tail is not getting set correctly");
 
-    curlErrCode = Curl_llist_insert_next(&llist, llist.head,
-                                         &unusedData_case2);
-    if(curlErrCode == 1) {
-      fail_unless(llist.head->next->ptr == &unusedData_case2,
-                  "the node next to head is not getting set correctly");
-      /* better safe than sorry, check that the tail isn't corrupted */
-      fail_unless(llist.tail->ptr != &unusedData_case2,
-                  "the list tail is not getting set correctly");
-    }
-    else {
-      printf("skipping Curl_llist_insert_next as a non "
-             "success error code was returned\n");
-    }
+  /**
+   * testing Curl_llist_insert_next
+   * case 3:
+   * list has >1 element, adding one element after "NULL"
+   * @assumptions:
+   * 1: the element next to head should be our newly created element
+   * 2: the list tail should different from newly created element
+   */
 
-  }
-  else {
-    printf("skipping Curl_llist_insert_next as a non "
-           "success error code was returned\n");
-  }
+  Curl_llist_insert_next(&llist, llist.head,
+                         &unusedData_case2, &case2_list);
+  fail_unless(llist.head->next->ptr == &unusedData_case2,
+              "the node next to head is not getting set correctly");
+  /* better safe than sorry, check that the tail isn't corrupted */
+  fail_unless(llist.tail->ptr != &unusedData_case2,
+              "the list tail is not getting set correctly");
 
   /* unit tests for Curl_llist_remove */
 
@@ -183,8 +170,11 @@ UNITTEST_START
    * 2: element->previous->next will be element->next
    * 3: element->next->previous will be element->previous
    */
-  Curl_llist_insert_next(&llist, llist.head, &unusedData_case3);
+  Curl_llist_insert_next(&llist, llist.head, &unusedData_case3,
+                         &case4_list);
   llist_size = Curl_llist_count(&llist);
+  fail_unless(llist_size == 3, "should be 3 list members");
+
   to_remove = llist.head->next;
   abort_unless(to_remove, "to_remove is NULL");
   element_next = to_remove->next;
@@ -248,20 +238,17 @@ UNITTEST_START
   * add one element to the list
   */
 
-  curlErrCode = Curl_llist_insert_next(&llist, llist.head, &unusedData_case1);
+  Curl_llist_insert_next(&llist, llist.head, &unusedData_case1,
+                         &case5_list);
   /* necessary assertions */
 
-  abort_unless(curlErrCode == 1,
-  "Curl_llist_insert_next returned an error, Can't move on with test");
   abort_unless(Curl_llist_count(&llist) == 1,
   "Number of list elements is not as expected, Aborting");
   abort_unless(Curl_llist_count(&llist_destination) == 0,
   "Number of list elements is not as expected, Aborting");
 
   /*actual testing code*/
-  curlErrCode = Curl_llist_move(&llist, llist.head, &llist_destination, NULL);
-  abort_unless(curlErrCode == 1,
-  "Curl_llist_move returned an error, Can't move on with test");
+  Curl_llist_move(&llist, llist.head, &llist_destination, NULL);
   fail_unless(Curl_llist_count(&llist) == 0,
       "moving element from llist didn't decrement the size");
 
@@ -279,7 +266,5 @@ UNITTEST_START
 
   fail_unless(llist_destination.tail == llist_destination.tail,
             "llist_destination tail doesn't equal llist_destination head");
-
-
-
+}
 UNITTEST_STOP


### PR DESCRIPTION
The 'list element' struct now has to be located within the data that is being added to the list. Removes 16.6% (tiny) mallocs from a simple HTTP transfer. (96 => 80)

Also removed return codes since the llist functions can't fail now.

Test 1300 updated accordingly.