### PR TITLE
build: avoid GNU-makeism for docs/curl.1 use

### DIFF
--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -22,7 +22,7 @@
 
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
-MANPAGE = $(top_builddir)/docs/curl.1
+MANPAGE = $(abs_top_builddir)/docs/curl.1
 
 include Makefile.inc
 

--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -31,4 +31,14 @@ EXTRA_DIST = $(DPAGES) MANPAGE.md gen.pl $(OTHERPAGES) CMakeLists.txt
 all: $(MANPAGE)
 
 $(MANPAGE): $(DPAGES) $(OTHERPAGES)
-	@PERL@ $(srcdir)/gen.pl mainpage $(srcdir) > $(MANPAGE)
+	(if ! test -x "$(PERL)"; then \
+	  if ! test -f "$(top_srcdir)/docs/curl.1"; then \
+	    echo "Creating docs/curl.1 requires perl!"; \
+	    exit 2; \
+	  fi; \
+	  if test "$(top_srcdir)x" != "$(top_builddir)x"; then \
+	    cp $(top_srcdir)/docs/curl.1 $(MANPAGE); \
+	  fi \
+	else \
+	@PERL@ $(srcdir)/gen.pl mainpage $(srcdir) > $(MANPAGE); \
+	fi)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,7 +101,7 @@ if USE_MANUAL
 # Here are the stuff to create a built-in manual
 
 $(MANPAGE):
-	cd $(top_builddir)/docs && $(MAKE) curl.1
+	cd $(top_builddir)/docs && $(MAKE)
 
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and
@@ -111,15 +111,15 @@ if HAVE_LIBZ
 $(HUGE): $(MANPAGE) $(README) $(MKHELP)
 	echo '#include "tool_setup.h"' > $(HUGE)
 	echo '#ifndef HAVE_LIBZ' >> $(HUGE)
-	$(NROFF) $< | $(PERL) $(MKHELP) $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) $(README) >> $(HUGE)
 	echo '#else' >> $(HUGE)
-	$(NROFF) $< | $(PERL) $(MKHELP) -c $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) -c $(README) >> $(HUGE)
 	echo '#endif /* HAVE_LIBZ */' >> $(HUGE)
 else # HAVE_LIBZ
 # This generates the tool_hugehelp.c file uncompressed only
 $(HUGE): $(MANPAGE) $(README) mkhelp.pl
 	echo '#include "tool_setup.h"' > $(HUGE)
-	$(NROFF) $< | $(PERL) $(MKHELP) $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) $(README) >> $(HUGE)
 endif
 
 else # USE_MANUAL


### PR DESCRIPTION
... but keep out-of-tree builds functional.

Fixes #1432