### PR TITLE
multi: remove redundant condition in curl_multi_wait

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1014,7 +1014,7 @@ CURLMcode curl_multi_wait(struct Curl_multi *multi,
   curlfds = nfds; /* number of internal file descriptors */
   nfds += extra_nfds; /* add the externally provided ones */
 
-  if(nfds || extra_nfds) {
+  if(nfds) {
     if(nfds > NUM_POLLS_ON_STACK) {
       ufds = malloc(nfds * sizeof(struct pollfd));
       if(!ufds)


### PR DESCRIPTION
`if(nfds || extra_nfds) {` is followed by `malloc(nfds * ...)`.

If `extra_fs` could be non-zero when `nfds` was zero, then we have `malloc(0)` which is allowed to return `NULL`.  malloc returning NULL for success is a troublesome edge case.  In this code, the next line would treat the NULL as an allocation failure.

It turns out, if `nfds` is zero then `extra_nfds` must also be zero.  The final value of `nfds` includes `extra_nfds`.  So the test for `extra_nfds` is redundant.  It can only confuse the reader.