### PR TITLE
curl_compilers.m4: accept -Og flag

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -158,7 +158,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_GNU_C], [
     flags_dbg_all="$flags_dbg_all -gvms"
     flags_dbg_yes="-g"
     flags_dbg_off=""
-    flags_opt_all="-O -O0 -O1 -O2 -O3 -Os"
+    flags_opt_all="-O -O0 -O1 -O2 -O3 -Os -Og -Ofast"
     flags_opt_yes="-O2"
     flags_opt_off="-O0"
     CURL_CHECK_DEF([_WIN32], [], [silent])


### PR DESCRIPTION
`-Og`, introduced in GCC 4.8, optimizes for debugging experience. When
specified in `CFLAGS`, it was always overridden by `-O0` or `-O2`. Fix this
by adding it to flags_opt_all.

Ref: https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Optimize-Options.html
Ref: https://github.com/curl/curl/pull/1404#issuecomment-296401570