### PR TITLE
src/Makefile.am: avoid use of GNU-specific form of $<

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -22,7 +22,7 @@
 
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
-man_MANS = curl.1 curl-config.1
+man_MANS = $(abs_builddir)/curl.1 curl-config.1
 noinst_man_MANS = mk-ca-bundle.1
 GENHTMLPAGES = curl.html curl-config.html mk-ca-bundle.html
 PDFPAGES = curl.pdf curl-config.pdf mk-ca-bundle.pdf
@@ -30,7 +30,9 @@ MANDISTPAGES = curl.1.dist curl-config.1.dist
 
 HTMLPAGES = $(GENHTMLPAGES) index.html
 
-SUBDIRS = libcurl cmdline-opts
+# Build targets in this file (.) before cmdline-opts to ensure that
+# the curl.1 rule below runs first
+SUBDIRS = libcurl . cmdline-opts
 DIST_SUBDIRS = $(SUBDIRS) examples
 
 CLEANFILES = $(GENHTMLPAGES) $(PDFPAGES) $(MANDISTPAGES) curl.1
@@ -47,7 +49,17 @@ MAN2HTML= roffit $< >$@
 
 SUFFIXES = .1 .html .pdf
 
-curl.1:
+# $(abs_builddir) is to disable VPATH when searching for this file, which
+# would otherwise find the copy in $(srcdir) which breaks the $(HUGE)
+# rule in src/Makefile.am in out-of-tree builds that references the file in the
+# build directory.
+#
+# First, seed the used copy of curl.1 with the prebuilt copy (in an out-of-tree
+# build), then run make recursively to rebuild it only if its dependencies
+# have changed.
+$(abs_builddir)/curl.1:
+	if test "$(top_builddir)x" != "$(top_srcdir)x" -a -e "$(srcdir)/curl.1"; then \
+		cp -fp "$(srcdir)/curl.1" $@; fi
 	cd cmdline-opts && $(MAKE)
 
 html: $(HTMLPAGES)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,7 +92,8 @@ EXTRA_DIST = mkhelp.pl makefile.dj Makefile.b32		\
  macos/src/curl_GUSIConfig.cpp macos/src/macos_main.cpp makefile.amiga	\
  curl.rc Makefile.netware Makefile.inc Makefile.Watcom CMakeLists.txt
 
-MANPAGE=$(top_builddir)/docs/curl.1
+# Use absolute directory to disable VPATH
+MANPAGE=$(abs_top_builddir)/docs/curl.1
 README=$(top_srcdir)/docs/MANUAL
 MKHELP=$(top_srcdir)/src/mkhelp.pl
 HUGE=tool_hugehelp.c
@@ -101,25 +102,23 @@ if USE_MANUAL
 # Here are the stuff to create a built-in manual
 
 $(MANPAGE):
-	cd $(top_builddir)/docs && $(MAKE) curl.1
+	cd $(top_builddir)/docs && $(MAKE)
 
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and
-# compressed formats. $(MANPAGE) must be the first dependency so it
-# can be referenced with $< which points to the correct location in
-# the VPATH.
+# compressed formats.
 $(HUGE): $(MANPAGE) $(README) $(MKHELP)
 	echo '#include "tool_setup.h"' > $(HUGE)
 	echo '#ifndef HAVE_LIBZ' >> $(HUGE)
-	$(NROFF) $< | $(PERL) $(MKHELP) $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) $(README) >> $(HUGE)
 	echo '#else' >> $(HUGE)
-	$(NROFF) $< | $(PERL) $(MKHELP) -c $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) -c $(README) >> $(HUGE)
 	echo '#endif /* HAVE_LIBZ */' >> $(HUGE)
 else # HAVE_LIBZ
 # This generates the tool_hugehelp.c file uncompressed only
 $(HUGE): $(MANPAGE) $(README) mkhelp.pl
 	echo '#include "tool_setup.h"' > $(HUGE)
-	$(NROFF) $< | $(PERL) $(MKHELP) $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) $(README) >> $(HUGE)
 endif
 
 else # USE_MANUAL


### PR DESCRIPTION
$< is only allowed in implicit rules in some non-GNU makes (e.g. BSD,
AIX) so avoid this use by referencing the dependent curl.1 file directly
instead. This is somewhat tricky because the file is supplied in the
packaged tar ball (but not in git) but must still be able to be rebuilt
when its dependencies change. The right thing must happen in both tar
ball and git source trees, as well as in in-tree and out-of-tree builds.