### PR TITLE
curl: set a 100K buffer size by default

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -246,6 +246,8 @@ static void setfiletime(long filetime, const char *filename,
 #endif /* defined(HAVE_UTIME) || \
           (defined(WIN32) && (CURL_SIZEOF_CURL_OFF_T >= 8)) */
 
+#define BUFFER_SIZE (100*1024)
+
 static CURLcode operate_do(struct GlobalConfig *global,
                            struct OperationConfig *config)
 {
@@ -888,10 +890,12 @@ static CURLcode operate_do(struct GlobalConfig *global,
         my_setopt(curl, CURLOPT_SEEKDATA, &input);
         my_setopt(curl, CURLOPT_SEEKFUNCTION, tool_seek_cb);
 
-        if(config->recvpersecond)
-          /* tell libcurl to use a smaller sized buffer as it allows us to
-             make better sleeps! 7.9.9 stuff! */
+        if(config->recvpersecond &&
+           (config->recvpersecond < BUFFER_SIZE))
+          /* use a smaller sized buffer for better sleeps */
           my_setopt(curl, CURLOPT_BUFFERSIZE, (long)config->recvpersecond);
+        else
+          my_setopt(curl, CURLOPT_BUFFERSIZE, (long)BUFFER_SIZE);
 
         /* size of uploaded file: */
         if(uploadfilesize != -1)

--- a/tests/data/test1400
+++ b/tests/data/test1400
@@ -68,6 +68,7 @@ int main(int argc, char *argv[])
   CURL *hnd;
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1400");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");

--- a/tests/data/test1401
+++ b/tests/data/test1401
@@ -80,6 +80,7 @@ int main(int argc, char *argv[])
   slist1 = curl_slist_append(slist1, "X-Men: cyclops, iceman");
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1401");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "fake:user");

--- a/tests/data/test1402
+++ b/tests/data/test1402
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
   CURL *hnd;
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1402");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "foo=bar&baz=quux");

--- a/tests/data/test1403
+++ b/tests/data/test1403
@@ -70,6 +70,7 @@ int main(int argc, char *argv[])
   CURL *hnd;
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1403?foo=bar&baz=quux");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -123,6 +123,7 @@ int main(int argc, char *argv[])
                CURLFORM_END);
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1404");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_HTTPPOST, post1);

--- a/tests/data/test1405
+++ b/tests/data/test1405
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
   slist3 = curl_slist_append(slist3, "*FAIL HARD");
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "ftp://%HOSTIP:%FTPPORT/1405");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_QUOTE, slist1);

--- a/tests/data/test1406
+++ b/tests/data/test1406
@@ -75,6 +75,7 @@ int main(int argc, char *argv[])
   slist1 = curl_slist_append(slist1, "recipient.two@example.com");
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_INFILESIZE_LARGE, (curl_off_t)38);
   curl_easy_setopt(hnd, CURLOPT_URL, "smtp://%HOSTIP:%SMTPPORT/1406");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);

--- a/tests/data/test1407
+++ b/tests/data/test1407
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
   CURL *hnd;
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "pop3://%HOSTIP:%POP3PORT/1407");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_DIRLISTONLY, 1L);

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -63,6 +63,7 @@ int main(int argc, char *argv[])
   CURL *hnd;
 
   hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "imap://%HOSTIP:%IMAPPORT/1420/;UID=1");
   curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "user:secret");


### PR DESCRIPTION
Test command 'time curl http://localhost/80GB -so /dev/null' on a Debian
Linux.

Before (middle performing run out 9):

 real    0m28.078s
 user    0m11.240s
 sys     0m12.876s

After (middle performing run out 9)

 real    0m26.356s (93.9%)
 user    0m5.324s  (47.4%)
 sys     0m8.368s  (65.0%)