### PR TITLE
typecheck-gcc: fix _curl_is_slist_info

### DIFF
--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -349,7 +349,7 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_slist,
 
 /* true if info expects a pointer to struct curl_slist * argument */
 #define _curl_is_slist_info(info)                                             \
-  (CURLINFO_SLIST < (info))
+  (CURLINFO_SLIST < (info) && (info) < CURLINFO_SOCKET)
 
 
 /* typecheck helpers -- check whether given expression has requested type*/


### PR DESCRIPTION
Info values starting with `CURLINFO_SOCKET` expect a `curl_socket_t`, not a
`curl_slist` argument.

This fixes the following GCC warning when building the examples with
`--enable-optimize`:

```
../../include/curl/typecheck-gcc.h:126:42: warning: call to
‘_curl_easy_getinfo_err_curl_slist’ declared with attribute warning:
curl_easy_getinfo expects a pointer to 'struct curl_slist *' for this
info [enabled by default]
sendrecv.c:90:11: note: in expansion of macro ‘curl_easy_getinfo’
res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
```

(I plan to add the missing options and infos soon in another PR.)