### PR TITLE
curl_setup_once: use SEND_QUAL_ARG2 for swrite

### DIFF
--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -196,7 +196,7 @@ struct timeval {
   /* */
 #else
 #define swrite(x,y,z) (ssize_t)send((SEND_TYPE_ARG1)(x), \
-                                    (SEND_TYPE_ARG2)(y), \
+                                    (SEND_QUAL_ARG2 SEND_TYPE_ARG2)(y), \
                                     (SEND_TYPE_ARG3)(z), \
                                     (SEND_TYPE_ARG4)(SEND_4TH_ARG))
 #endif


### PR DESCRIPTION
SEND_QUAL_ARG2 had to be set, but was never used. Use it in swrite to
avoid warnings about casting away low-level const.