### PR TITLE
curl: show the libcurl release date in --version output

### DIFF
--- a/include/curl/curlver.h
+++ b/include/curl/curlver.h
@@ -64,11 +64,11 @@
  * timestamp is not stored in git, as the timestamp is properly set in the
  * tarballs by the maketgz script.
  *
- * The format of the date should follow this template:
+ * The format of the date follows this template:
  *
- * "Mon Feb 12 11:35:33 UTC 2007"
+ * "2007-11-23"
  */
-#define LIBCURL_TIMESTAMP "DEV"
+#define LIBCURL_TIMESTAMP "[unreleased]"
 
 #define CURL_VERSION_BITS(x,y,z) ((x)<<16|(y)<<8|z)
 #define CURL_AT_LEAST_VERSION(x,y,z) \

--- a/maketgz
+++ b/maketgz
@@ -67,8 +67,8 @@ if test -z "$only"; then
     PLIST="$PLIST$ext"
 fi
 
-# requires a date command that knows -u for UTC time zone
-datestamp=`LC_TIME=C date -u`
+# requires a date command that knows + for format
+datestamp=`date +"%F"`
 
 # Replace version number in header file:
 sed -i -e 's/^#define LIBCURL_VERSION .*/#define LIBCURL_VERSION "'$libversion'"/g' \

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -516,6 +516,12 @@ void tool_version_info(void)
   const char *const *proto;
 
   printf(CURL_ID "%s\n", curl_version());
+#ifdef CURL_PATCHSTAMP
+  printf("Release-Date: %s, security patched: %s\n",
+         LIBCURL_TIMESTAMP, CURL_PATCHSTAMP);
+#else
+  printf("Release-Date: %s\n", LIBCURL_TIMESTAMP);
+#endif
   if(curlinfo->protocols) {
     printf("Protocols: ");
     for(proto = curlinfo->protocols; *proto; ++proto) {


### PR DESCRIPTION
... and support and additional "security patched" date for those who
enhance older versions that way.

Also: change the date format generated in the `curlver.h` file to only be
"NNN DD YYYY" (no name of day, no time, no time zone) to make it easier
on the eye and easier to parse. Example (new) date string: "May 09
2017".

Suggested-by: Brian Childs