### PR TITLE
SSH: Fix incorrect timeout failures on disconnects.

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2830,35 +2830,38 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
     if(result)
       break;
 
-    if(Curl_pgrsUpdate(conn))
-      return CURLE_ABORTED_BY_CALLBACK;
-
-    result = Curl_speedcheck(data, now);
-    if(result)
-      break;
-
-    left = Curl_timeleft(data, NULL, duringconnect);
-    if(left < 0) {
-      failf(data, "Operation timed out");
-      return CURLE_OPERATION_TIMEDOUT;
-    }
+    /* In some disconnect situations, progress values will have been replaced
+       with zero values, so no calculations should be performed with them. */
+    if(data->progress.start.tv_sec) {
+      if(Curl_pgrsUpdate(conn))
+        return CURLE_ABORTED_BY_CALLBACK;
+  
+      result = Curl_speedcheck(data, now);
+      if(result)
+        break;
+  
+      left = Curl_timeleft(data, NULL, duringconnect);
+      if(left < 0) {
+        failf(data, "Operation timed out");
+        return CURLE_OPERATION_TIMEDOUT;
+      }
 
 #ifdef HAVE_LIBSSH2_SESSION_BLOCK_DIRECTION
-    if(!result && block) {
-      int dir = libssh2_session_block_directions(sshc->ssh_session);
-      curl_socket_t sock = conn->sock[FIRSTSOCKET];
-      curl_socket_t fd_read = CURL_SOCKET_BAD;
-      curl_socket_t fd_write = CURL_SOCKET_BAD;
-      if(LIBSSH2_SESSION_BLOCK_INBOUND & dir)
-        fd_read = sock;
-      if(LIBSSH2_SESSION_BLOCK_OUTBOUND & dir)
-        fd_write = sock;
-      /* wait for the socket to become ready */
-      (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD, fd_write,
-                              left>1000?1000:left); /* ignore result */
-    }
+      if(!result && block) {
+        int dir = libssh2_session_block_directions(sshc->ssh_session);
+        curl_socket_t sock = conn->sock[FIRSTSOCKET];
+        curl_socket_t fd_read = CURL_SOCKET_BAD;
+        curl_socket_t fd_write = CURL_SOCKET_BAD;
+        if(LIBSSH2_SESSION_BLOCK_INBOUND & dir)
+          fd_read = sock;
+        if(LIBSSH2_SESSION_BLOCK_OUTBOUND & dir)
+          fd_write = sock;
+        /* wait for the socket to become ready */
+        (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD, fd_write,
+                                left>1000?1000:left); /* ignore result */
+      }
 #endif
-
+    }
   }
 
   return result;


### PR DESCRIPTION
libcurl is leaking memory when using sftp and a timeout. This was first reported [on the mailing list](https://curl.haxx.se/mail/lib-2017-04/0024.html).

The memory leak reported on the mailing list is a symptom of a larger problem - SSH sessions are not freed when a timeout is used. I suspect this problem is also present on other platforms, but may not manifest itself as a memory leak on all platforms.

I used the Visual Studio memory analysis tools to find that libssh2 is leaking some WinCNG structs for each connection. This is because libcurl is never calling the `libssh2_session_free` function when a timeout is set. Without a timeout, the function is called and things get cleaned up correctly.

In a disconnect situation, the `close_all_connections` function replaces the easy handle associated with a connection with a 'closure handle'. This will reset all progress values associated with the connection to zero values. As a result, calculations using these values will return incorrect values.

The `close_all_connections` function eventually calls into the `sftp_disconnect` function, which runs the `ssh_block_statemach` function. In this function, if a timeout is set, the "time left" value will always be negative, because the start time has been reset to zero. This means that if a timeout is set, disconnections always fail with a timeout error, rather than finish successfully. Since the easy handle has been replaced with the closure handle, this timeout error will not be reported, regardless of the verbose setting used on the original easy handle.