### PR TITLE
curl: allow --header and --proxy-header read from file

### DIFF
--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -1,10 +1,9 @@
 Long: header
 Short: H
-Arg: <header>
-Help: Pass custom header LINE to server
+Arg: <header/@file>
+Help: Pass custom header(s) to server
 Protocols: HTTP
 ---
-
 Extra header to include in the request when sending HTTP to a server. You may
 specify any number of extra headers. Note that if you should add a custom
 header that has the same name as one of the internal ones curl would use, your
@@ -20,6 +19,10 @@ curl will make sure that each header you add/replace is sent with the proper
 end-of-line marker, you should thus \fBnot\fP add that as a part of the header
 content: do not add newlines or carriage returns, they will only mess things up
 for you.
+
+Starting in 7.55.0, this option can take an argument in @filename style, which
+then adds a header for each line in the input file. Using @- will make curl
+read the header file from stdin.
 
 See also the --user-agent and --referer options.
 

--- a/docs/cmdline-opts/proxy-header.d
+++ b/docs/cmdline-opts/proxy-header.d
@@ -1,6 +1,6 @@
 Long: proxy-header
-Arg: <header>
-Help: Pass custom header LINE to proxy
+Arg: <header/@file>
+Help: Pass custom header(s) to proxy
 Protocols: HTTP
 Added: 7.37.0
 ---
@@ -16,5 +16,9 @@ up for you.
 
 Headers specified with this option will not be included in requests that curl
 knows will not be sent to a proxy.
+
+Starting in 7.55.0, this option can take an argument in @filename style, which
+then adds a header for each line in the input file. Using @- will make curl
+read the header file from stdin.
 
 This option can be used multiple times to add/replace/remove multiple headers.

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -120,7 +120,7 @@ test1112 test1113 test1114 test1115 test1116 test1117 test1118 test1119 \
 test1120 test1121 test1122 test1123 test1124 test1125 test1126 test1127 \
 test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
-test1144 test1145 test1146 \
+test1144 test1145 test1146 test1147 \
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \
 test1208 test1209 test1210 test1211 test1212 test1213 test1214 test1215 \
 test1216 test1217 test1218 test1219 \

--- a/tests/data/test1147
+++ b/tests/data/test1147
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+-H
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+Get -H headers from a file
+ </name>
+<file name="log/heads1147.txt">
+One: 1
+Two: 2
+ And A Funny One : wohoo
+User-Agent:
+</file>
+ <command>
+http://%HOSTIP:%HTTPPORT/1147 -H @log/heads1147.txt
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /1147 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+One: 1
+Two: 2
+ And A Funny One : wohoo
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
So many headers can be provided as @filename.

Suggested-by: Timothe Litt