### PR TITLE
tests: stabilize test 1034

### DIFF
--- a/tests/data/test1034
+++ b/tests/data/test1034
@@ -6,6 +6,7 @@ HTTP GET
 HTTP proxy
 IDN
 FAILURE
+config file
 </keywords>
 </info>
 
@@ -44,8 +45,11 @@ HTTP over proxy with malformatted IDN host name
 
 # This host name contains an invalid UTF-8 byte sequence that can't be
 # converted into an IDN name
+<stdin>
+url = "http://invalid-utf8-‚ê.local/page/1034"
+</stdin>
  <command>
-http://invalid-utf8-‚ê.local/page/1034 -x %HOSTIP:%HTTPPORT
+-K - -x %HOSTIP:%HTTPPORT
 </command>
 </client>
 


### PR DESCRIPTION
Pass the invalid domain name on stdin. On some systems, the test
framework cannot pass invalid UTF-8 sequences on the command line.

This fixes the remaining test error on Solaris systems, see the [Autobuilds](https://curl.haxx.se/dev/builds.html).

I have discovered that Perl's system() function may modify the contents of the string (encoding conversion). The test framework uses system() to invoke the curl tool. Maybe some Perl expert has a better idea how to fix this problem?

@dago there's only one Solaris autobuild left, it would be great if you could have a quick look at it. https://buildfarm.opencsw.org/buildbot/builders/curl-unthreaded-solaris10-i386/ has git problems, https://buildfarm.opencsw.org/buildbot/builders/curl-unthreaded-solaris11-i386 and https://buildfarm.opencsw.org/buildbot/builders/curl-unthreaded-solaris11-sparc are not triggered anymore