### PR TITLE
mkhelp.pl: do not add current time into curl binary

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -129,7 +129,7 @@ if($c)
     my $content = join("", @out);
     my $gzippedContent;
     IO::Compress::Gzip::gzip(
-        \$content, \$gzippedContent, Level => 9, TextFlag => 1) or die "gzip failed:";
+        \$content, \$gzippedContent, Level => 9, TextFlag => 1, Time=>0) or die "gzip failed:";
     $gzip = length($content);
     $gzipped = length($gzippedContent);
 


### PR DESCRIPTION
mkhelp.pl: do not add current time into curl binary
as part of hugehelpgz rodata
to make build reproducible

See https://reproducible-builds.org/ for why this is good