### PR TITLE
time: fix type conversions and compiler warnings

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -373,7 +373,6 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
   /* Wait for the name resolve query to complete. */
   while(!result) {
     struct timeval *tvp, tv, store;
-    long timediff;
     int itimeout;
     int timeout_ms;
 
@@ -402,8 +401,13 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
       result = CURLE_ABORTED_BY_CALLBACK;
     else {
       struct timeval now2 = Curl_tvnow();
-      timediff = Curl_tvdiff(now2, now); /* spent time */
-      timeout -= timediff?timediff:1; /* always deduct at least 1 */
+      time_t timediff = Curl_tvdiff(now2, now); /* spent time */
+      if(timediff <= 0)
+        timeout -= 1; /* always deduct at least 1 */
+      else if(timediff > timeout)
+        timeout = -1;
+      else
+        timeout -= (long)timediff;
       now = now2; /* for next loop */
     }
     if(timeout < 0)

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -615,12 +615,18 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
         }
       }
 
-      if(!ev->msbump)
+      if(!ev->msbump) {
         /* If nothing updated the timeout, we decrease it by the spent time.
          * If it was updated, it has the new timeout time stored already.
          */
-        ev->ms += (long)curlx_tvdiff(after, before);
-
+        time_t timediff = curlx_tvdiff(after, before);
+        if(timediff > 0) {
+          if(timediff > ev->ms)
+            ev->ms = 0;
+          else
+            ev->ms -= (long)timediff;
+        }
+      }
     }
     else
       return CURLE_RECV_ERROR;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -596,7 +596,7 @@ int Curl_resolv_timeout(struct connectdata *conn,
     /* Ignore the timeout when signals are disabled */
     timeout = 0;
   else
-    timeout = timeoutms;
+    timeout = (timeoutms > LONG_MAX) ? LONG_MAX : (long)timeoutms;
 
   if(!timeout)
     /* USE_ALARM_TIMEOUT defined, but no timeout actually requested */
@@ -688,10 +688,11 @@ clean_up:
      the time we spent until now! */
   if(prev_alarm) {
     /* there was an alarm() set before us, now put it back */
-    unsigned long elapsed_ms = Curl_tvdiff(Curl_tvnow(), conn->created);
+    unsigned long elapsed_secs = (unsigned long) (Curl_tvdiff(Curl_tvnow(),
+                                   conn->created) / 1000);
 
     /* the alarm period is counted in even number of seconds */
-    unsigned long alarm_set = prev_alarm - elapsed_ms/1000;
+    unsigned long alarm_set = prev_alarm - elapsed_secs;
 
     if(!alarm_set ||
        ((alarm_set >= 0x80000000) && (prev_alarm < 0x80000000)) ) {

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -141,9 +141,3 @@ double curlx_tvdiff_secs(struct timeval newer, struct timeval older)
       (double)(newer.tv_usec-older.tv_usec)/1000000.0;
   return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
-
-/* return the number of seconds in the given input timeval struct */
-time_t Curl_tvlong(struct timeval t1)
-{
-  return t1.tv_sec;
-}

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -46,8 +46,6 @@ time_t curlx_tvdiff(struct timeval t1, struct timeval t2);
  */
 double curlx_tvdiff_secs(struct timeval t1, struct timeval t2);
 
-time_t Curl_tvlong(struct timeval t1);
-
 /* These two defines below exist to provide the older API for library
    internals only. */
 #define Curl_tvnow() curlx_tvnow()

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -121,8 +121,8 @@ struct timeval tool_tvnow(void)
  */
 long tool_tvdiff(struct timeval newer, struct timeval older)
 {
-  return (newer.tv_sec-older.tv_sec)*1000+
-    (newer.tv_usec-older.tv_usec)/1000;
+  return (long)(newer.tv_sec-older.tv_sec)*1000+
+    (long)(newer.tv_usec-older.tv_usec)/1000;
 }
 
 /*
@@ -137,10 +137,3 @@ double tool_tvdiff_secs(struct timeval newer, struct timeval older)
       (double)(newer.tv_usec-older.tv_usec)/1000000.0;
   return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
-
-/* return the number of seconds in the given input timeval struct */
-long tool_tvlong(struct timeval t1)
-{
-  return t1.tv_sec;
-}
-

--- a/src/tool_util.h
+++ b/src/tool_util.h
@@ -45,12 +45,10 @@ long tool_tvlong(struct timeval t1);
 #undef tvnow
 #undef tvdiff
 #undef tvdiff_secs
-#undef tvlong
 
 #define tvnow()           tool_tvnow()
 #define tvdiff(a,b)       tool_tvdiff((a), (b))
 #define tvdiff_secs(a,b)  tool_tvdiff_secs((a), (b))
-#define tvlong(a)         tool_tvlong((a))
 
 #endif /* HEADER_CURL_TOOL_UTIL_H */
 

--- a/tests/libtest/lib1501.c
+++ b/tests/libtest/lib1501.c
@@ -31,22 +31,7 @@
 
 /* 500 milliseconds allowed. An extreme number but lets be really conservative
    to allow old and slow machines to run this test too */
-#define MAX_BLOCKED_TIME_US 500000
-
-/* return the number of microseconds between two time stamps */
-static int elapsed(struct timeval *before,
-                   struct timeval *after)
-{
-  ssize_t result;
-
-  result = (after->tv_sec - before->tv_sec) * 1000000 +
-    after->tv_usec - before->tv_usec;
-  if(result < 0)
-    result = 0;
-
-  return curlx_sztosi(result);
-}
-
+#define MAX_BLOCKED_TIME_MS 500
 
 int test(char *URL)
 {
@@ -80,7 +65,7 @@ int test(char *URL)
     int maxfd = -99;
     struct timeval before;
     struct timeval after;
-    int e;
+    long e;
 
     timeout.tv_sec = 0;
     timeout.tv_usec = 100000L; /* 100 ms */
@@ -105,10 +90,10 @@ int test(char *URL)
     abort_on_test_timeout();
 
     after = tutil_tvnow();
-    e = elapsed(&before, &after);
-    fprintf(stderr, "pong = %d\n", e);
+    e = tutil_tvdiff(after, before);
+    fprintf(stderr, "pong = %ld\n", e);
 
-    if(e > MAX_BLOCKED_TIME_US) {
+    if(e > MAX_BLOCKED_TIME_MS) {
       res = 100;
       break;
     }

--- a/tests/libtest/lib1507.c
+++ b/tests/libtest/lib1507.c
@@ -44,23 +44,6 @@ static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
   return CURL_READFUNC_ABORT;
 }
 
-static struct timeval tvnow(void)
-{
-  /*
-  ** time() returns the value of time in seconds since the Epoch.
-  */
-  struct timeval now;
-  now.tv_sec = (long)time(NULL);
-  now.tv_usec = 0;
-  return now;
-}
-
-static long tvdiff(struct timeval newer, struct timeval older)
-{
-  return (newer.tv_sec-older.tv_sec)*1000+
-    (newer.tv_usec-older.tv_usec)/1000;
-}
-
 int test(char *URL)
 {
    int res = 0;
@@ -93,7 +76,7 @@ int test(char *URL)
    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
    multi_add_handle(mcurl, curl);
 
-   mp_start = tvnow();
+   mp_start = tutil_tvnow();
 
   /* we start some action by calling perform right away */
   curl_multi_perform(mcurl, &still_running);
@@ -137,7 +120,7 @@ int test(char *URL)
 
     rc = select(maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
 
-    if(tvdiff(tvnow(), mp_start) > MULTI_PERFORM_HANG_TIMEOUT) {
+    if(tutil_tvdiff(tutil_tvnow(), mp_start) > MULTI_PERFORM_HANG_TIMEOUT) {
       fprintf(stderr, "ABORTING TEST, since it seems "
               "that it would have run forever.\n");
       break;

--- a/tests/libtest/lib1900.c
+++ b/tests/libtest/lib1900.c
@@ -167,7 +167,6 @@ int test(char *URL)
   for(;;) {
     struct timeval interval;
     struct timeval now;
-    long int msnow, mslast;
     fd_set rd, wr, exc;
     int maxfd = -99;
     long timeout;
@@ -177,9 +176,7 @@ int test(char *URL)
 
     if(handlenum < num_handles) {
       now = tutil_tvnow();
-      msnow = now.tv_sec * 1000 + now.tv_usec / 1000;
-      mslast = last_handle_add.tv_sec * 1000 + last_handle_add.tv_usec / 1000;
-      if((msnow - mslast) >= urltime[handlenum]) {
+      if(tutil_tvdiff(now, last_handle_add) >= urltime[handlenum]) {
         fprintf(stdout, "Adding handle %d\n", handlenum);
         setup_handle(URL, m, handlenum);
         last_handle_add = now;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -174,8 +174,8 @@ static int getMicroSecondTimeout(struct timeval* timeout)
   struct timeval now;
   ssize_t result;
   now = tutil_tvnow();
-  result = (timeout->tv_sec - now.tv_sec) * 1000000 +
-    timeout->tv_usec - now.tv_usec;
+  result = (ssize_t)((timeout->tv_sec - now.tv_sec) * 1000000 +
+    timeout->tv_usec - now.tv_usec);
   if(result < 0)
     result = 0;
 

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -111,9 +111,10 @@ struct timeval tutil_tvnow(void)
  */
 long tutil_tvdiff(struct timeval newer, struct timeval older)
 {
-  return (newer.tv_sec-older.tv_sec)*1000+
-    (newer.tv_usec-older.tv_usec)/1000;
+  return (long)(newer.tv_sec-older.tv_sec)*1000+
+    (long)(newer.tv_usec-older.tv_usec)/1000;
 }
+
 
 /*
  * Same as tutil_tvdiff but with full usec resolution.
@@ -125,13 +126,5 @@ double tutil_tvdiff_secs(struct timeval newer, struct timeval older)
   if(newer.tv_sec != older.tv_sec)
     return (double)(newer.tv_sec-older.tv_sec)+
       (double)(newer.tv_usec-older.tv_usec)/1000000.0;
-  else
-    return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
+  return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
-
-/* return the number of seconds in the given input timeval struct */
-long tutil_tvlong(struct timeval t1)
-{
-  return t1.tv_sec;
-}
-

--- a/tests/libtest/testutil.h
+++ b/tests/libtest/testutil.h
@@ -40,8 +40,6 @@ long tutil_tvdiff(struct timeval t1, struct timeval t2);
  */
 double tutil_tvdiff_secs(struct timeval t1, struct timeval t2);
 
-long tutil_tvlong(struct timeval t1);
-
 
 #endif  /* HEADER_CURL_LIBTEST_TESTUTIL_H */
 


### PR DESCRIPTION
Fix bugs and compiler warnings on systems with 32-bit long and
64-bit time_t.