### PR TITLE
[doc] CURLOPT_SSLVERSION: Correct define name in example.

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -79,7 +79,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* ask libcurl to use TLS version 1.1 or later */
-  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1.1 |
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1 |
                    CURL_SSLVERSION_MAX_DEFAULT);
 
   /* Perform the request */


### PR DESCRIPTION
Correct a define name in the example given for CURLOPT_SSLVERSION

Incorrect name (compile fails): CURL_SSLVERSION_TLSv1.1

Correct name: CURL_SSLVERSION_TLSv1_1