### PR TITLE
curl-compilers.m4: enable -Wshift-sign-overflow for clang

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -881,6 +881,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           if test "$compiler_num" -ge "101"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wunused"
           fi
+          #
+          dnl Only clang 2.9 or later
+          if test "$compiler_num" -ge "209"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wshift-sign-overflow"
+          fi
         fi
         ;;
         #


### PR DESCRIPTION
clang 2.9+ supports -Wshift-sign-overflow, which warns about undefined
behavior on signed left shifts when shifting by too many places.

Before the fix in 35682764a9dc7eb0fed3fbb1c0074f1c34dd60b2, this would result in:
```
lib557.c:1625:45: warning: signed shift result (0x80000000) sets the sign bit of the shift expression's type ('int') and becomes negative
      [-Wshift-sign-overflow]
  curl_msnprintf(buf, sizeof(buf), "%*f", (1<<31), 9.1);
                                           ~^ ~~
```

Ref: https://github.com/curl/curl/issues/1516