### PR TITLE
dedotdot: fixed output for ".." and "." only input

### DIFF
--- a/lib/dotdot.c
+++ b/lib/dotdot.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -147,6 +147,7 @@ char *Curl_dedotdotify(const char *input)
 
     else if(!strcmp(".", clone) || !strcmp("..", clone)) {
       *clone=0;
+      *out=0;
     }
 
     else {

--- a/tests/unit/unit1395.c
+++ b/tests/unit/unit1395.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -65,6 +65,13 @@ UNITTEST_START
     { "/", "/" },
     { "", "" },
     { "/.../", "/.../" },
+    { "./moo", "moo" },
+    { "../moo", "moo" },
+    { "/.", "/" },
+    { "/..", "/" },
+    { "/moo/..", "/" },
+    { "..", "" },
+    { ".", "" },
   };
 
   for(i=0; i < sizeof(pairs)/sizeof(pairs[0]); i++) {


### PR DESCRIPTION
Found when updating test 1395, which I did to increase test coverage of
this source file...