### PR TITLE
cmake: fix problems when building with mbed TLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ if(CMAKE_USE_MBEDTLS)
   set(SSL_ENABLED ON)
   set(USE_MBEDTLS ON)
   list(APPEND CURL_LIBS ${MBEDTLS_LIBRARIES})
-  include_directories(${MBEDTLS_INCLUDE_DIR})
+  include_directories(${MBEDTLS_INCLUDE_DIRS})
 endif()
 
 option(USE_NGHTTP2 "Use Nghttp2 library" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,9 +688,9 @@ elseif(CURL_CA_PATH_AUTODETECT OR CURL_CA_BUNDLE_AUTODETECT)
     endif()
 endif()
 
-if(CURL_CA_PATH_SET AND NOT USE_OPENSSL)
+if(CURL_CA_PATH_SET AND NOT USE_OPENSSL AND NOT USE_MBEDTLS)
     message(FATAL_ERROR
-            "CA path only supported by OpenSSL, GnuTLS or PolarSSL. "
+            "CA path only supported by OpenSSL, GnuTLS or mbed TLS. "
             "Set CURL_CA_PATH=none or enable one of those TLS backends.")
 endif()
 


### PR DESCRIPTION
This allows for building with mbed TLS support. 

Before this commit, trying to do so resulted in this:

```-- Found CA bundle: /etc/ssl/certs/ca-certificates.crt
CMake Error at CMakeLists.txt:692 (message):
  CA path only supported by OpenSSL, GnuTLS or PolarSSL.  Set
  CURL_CA_PATH=none or enable one of those TLS backends.


-- Configuring incomplete, errors occurred!
```

Someone just forgot to add the mbed TLS next to OpenSSL in an `if()` clause.

I also fixed a little inconsistency regarding the include directory variables (someone forgot a trailing s).