### PR TITLE
lib/curl_setup.h: remove CURL_WANTS_CA_BUNDLE_ENV

### DIFF
--- a/lib/Makefile.Watcom
+++ b/lib/Makefile.Watcom
@@ -6,7 +6,7 @@
 #                             \___|\___/|_| \_\_____|
 #
 # Copyright (C) 2005 - 2009, Gisle Vanem <gvanem@yahoo.no>.
-# Copyright (C) 2005 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2005 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -81,7 +81,7 @@ RD = rmdir /q /s 2>NUL
 SYS_INCL = -I"$(%watcom)/h/nt" -I"$(%watcom)/h"
 
 CFLAGS = -3r -mf -hc -zff -zgf -zq -zm -zc -s -fr=con -w2 -fpi -oilrtfm &
-         -wcd=201 -bt=nt -d+ -dWIN32 -dCURL_WANTS_CA_BUNDLE_ENV         &
+         -wcd=201 -bt=nt -d+ -dWIN32 &
          -dBUILDING_LIBCURL -I. -I"../include" $(SYS_INCL)
 
 !ifdef %debug

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1999 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1999 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -250,8 +250,7 @@ ifdef SSL
   endif
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
   CFLAGS += -DUSE_OPENSSL -DHAVE_OPENSSL_ENGINE_H -DHAVE_OPENSSL_PKCS12_H \
-            -DHAVE_ENGINE_LOAD_BUILTIN_ENGINES -DOPENSSL_NO_KRB5 \
-            -DCURL_WANTS_CA_BUNDLE_ENV
+            -DHAVE_ENGINE_LOAD_BUILTIN_ENGINES -DOPENSSL_NO_KRB5
   DLL_LIBS += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
   ifdef SRP
     ifeq "$(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h)" "$(OPENSSL_INCLUDE)/openssl/srp.h"

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -640,6 +640,10 @@ int netware_init(void);
 #endif
 #endif
 
+#ifdef CURL_WANTS_CA_BUNDLE_ENV
+#error "No longer supported. Set CURLOPT_CAINFO at runtime instead."
+#endif
+
 /*
  * Provide a mechanism to silence picky compilers, such as gcc 4.6+.
  * Parameters should of course normally not be unused, but for example when

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -638,11 +638,6 @@ int netware_init(void);
 #  endif
 
 #endif
-#endif
-
-/* non-configure builds may define CURL_WANTS_CA_BUNDLE_ENV */
-#if defined(CURL_WANTS_CA_BUNDLE_ENV) && !defined(CURL_CA_BUNDLE)
-#define CURL_CA_BUNDLE getenv("CURL_CA_BUNDLE")
 #endif
 
 /*


### PR DESCRIPTION
When this define was set, libcurl would check the environment variable
named CURL_CA_BUNDLE at run-time and use that CA cert bundle. This
feature was only defined by the watcom and m32 makefiles and caused
inconsistent behaviours among libcurls built on different platforms.

The curl tool does already feature its own similar logic and the library
does not really need it, and it isn't documented libcurl behavior. So
this change removes it.

Ref: #1538