### PR TITLE
FindWin32CACert: Use a temporary buffer on the stack

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -646,24 +646,18 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
   if(curlinfo->features & CURL_VERSION_SSL) {
 
     DWORD res_len;
-    DWORD buf_tchar_size = PATH_MAX + 1;
-    DWORD buf_bytes_size = sizeof(TCHAR) * buf_tchar_size;
+    char buf[PATH_MAX];
     char *ptr = NULL;
 
-    char *buf = malloc(buf_bytes_size);
-    if(!buf)
-      return CURLE_OUT_OF_MEMORY;
     buf[0] = '\0';
 
-    res_len = SearchPathA(NULL, bundle_file, NULL, buf_tchar_size, buf, &ptr);
+    res_len = SearchPathA(NULL, bundle_file, NULL, PATH_MAX, buf, &ptr);
     if(res_len > 0) {
       Curl_safefree(config->cacert);
       config->cacert = strdup(buf);
       if(!config->cacert)
         result = CURLE_OUT_OF_MEMORY;
     }
-
-    Curl_safefree(buf);
   }
 
   return result;


### PR DESCRIPTION
Don't malloc() the temporary buffer, and use the correct type:
SearchPath() works with TCHAR, but SearchPathA() works with char.
Set the buffer size to MAX_PATH, because the terminating null byte
is already included in MAX_PATH.