### PR TITLE
curlx cleanup!

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -612,43 +612,6 @@ curlx
    strtoll() (or equivalent) function exist on your platform. If `curl_off_t`
    is only a 32 bit number on your platform, this macro uses strtol().
 
-`curlx_tvnow()`
----------------
-   returns a struct timeval for the current time.
-
-`curlx_tvdiff()`
---------------
-   returns the difference between two timeval structs, in number of
-   milliseconds.
-
-`curlx_tvdiff_secs()`
----------------------
-   returns the same as `curlx_tvdiff` but with full usec resolution (as a
-   double)
-
-Future
-------
-
- Several functions will be removed from the public `curl_` name space in a
- future libcurl release. They will then only become available as `curlx_`
- functions instead. To make the transition easier, we already today provide
- these functions with the `curlx_` prefix to allow sources to be built
- properly with the new function names. The concerned functions are:
-
- - `curlx_getenv`
- - `curlx_strequal`
- - `curlx_strnequal`
- - `curlx_mvsnprintf`
- - `curlx_msnprintf`
- - `curlx_maprintf`
- - `curlx_mvaprintf`
- - `curlx_msprintf`
- - `curlx_mprintf`
- - `curlx_mfprintf`
- - `curlx_mvsprintf`
- - `curlx_mvprintf`
- - `curlx_mvfprintf`
-
 <a name="contentencoding"></a>
 Content Encoding
 ================

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -71,14 +71,14 @@ static size_t decodeQuantum(unsigned char *dest, const char *src)
   }
 
   if(padding < 1)
-    dest[2] = curlx_ultouc(x & 0xFFUL);
+    dest[2] = Curl_ultouc(x & 0xFFUL);
 
   x >>= 8;
   if(padding < 2)
-    dest[1] = curlx_ultouc(x & 0xFFUL);
+    dest[1] = Curl_ultouc(x & 0xFFUL);
 
   x >>= 8;
-  dest[0] = curlx_ultouc(x & 0xFFUL);
+  dest[0] = Curl_ultouc(x & 0xFFUL);
 
   return 3 - padding;
 }

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -132,7 +132,7 @@ tcpkeepalive(struct Curl_easy *data,
     }
 #else
 #ifdef TCP_KEEPIDLE
-    optval = curlx_sltosi(data->set.tcp_keepidle);
+    optval = Curl_sltosi(data->set.tcp_keepidle);
     KEEPALIVE_FACTOR(optval);
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
           (void *)&optval, sizeof(optval)) < 0) {
@@ -140,7 +140,7 @@ tcpkeepalive(struct Curl_easy *data,
     }
 #endif
 #ifdef TCP_KEEPINTVL
-    optval = curlx_sltosi(data->set.tcp_keepintvl);
+    optval = Curl_sltosi(data->set.tcp_keepintvl);
     KEEPALIVE_FACTOR(optval);
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
           (void *)&optval, sizeof(optval)) < 0) {
@@ -149,7 +149,7 @@ tcpkeepalive(struct Curl_easy *data,
 #endif
 #ifdef TCP_KEEPALIVE
     /* Mac OS X style */
-    optval = curlx_sltosi(data->set.tcp_keepidle);
+    optval = Curl_sltosi(data->set.tcp_keepidle);
     KEEPALIVE_FACTOR(optval);
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE,
           (void *)&optval, sizeof(optval)) < 0) {

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -768,7 +768,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 
     if(rc == 0) { /* no connection yet */
       error = 0;
-      if(curlx_tvdiff(now, conn->connecttime) >= conn->timeoutms_per_addr) {
+      if(Curl_tvdiff(now, conn->connecttime) >= conn->timeoutms_per_addr) {
         infof(data, "After %ldms connect time, move on!\n",
               conn->timeoutms_per_addr);
         error = ETIMEDOUT;
@@ -776,7 +776,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 
       /* should we try another protocol family? */
       if(i == 0 && conn->tempaddr[1] == NULL &&
-         curlx_tvdiff(now, conn->connecttime) >= HAPPY_EYEBALLS_TIMEOUT) {
+         Curl_tvdiff(now, conn->connecttime) >= HAPPY_EYEBALLS_TIMEOUT) {
         trynextip(conn, sockindex, 1);
       }
     }

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -641,7 +641,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_hash(const char *user, size_t userlen,
   ascii_uppercase_to_unicode_le(identity, user, userlen);
   ascii_to_unicode_le(identity + (userlen << 1), domain, domlen);
 
-  result = Curl_hmac_md5(ntlmhash, 16, identity, curlx_uztoui(identity_len),
+  result = Curl_hmac_md5(ntlmhash, 16, identity, Curl_uztoui(identity_len),
                          ntlmv2hash);
 
   free(identity);

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -5,7 +5,7 @@
  *                | (__| |_| |  _ <| |___
  *                 \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  * Copyright (C) 2010, Howard Chu, <hyc@highlandsun.com>
  *
  * This software is licensed as described in the file COPYING, which
@@ -277,7 +277,7 @@ static ssize_t rtmp_recv(struct connectdata *conn, int sockindex, char *buf,
 
   (void)sockindex; /* unused */
 
-  nread = RTMP_Read(r, buf, curlx_uztosi(len));
+  nread = RTMP_Read(r, buf, Curl_uztosi(len));
   if(nread < 0) {
     if(r->m_read.status == RTMP_READ_COMPLETE ||
         r->m_read.status == RTMP_READ_EOF) {
@@ -298,7 +298,7 @@ static ssize_t rtmp_send(struct connectdata *conn, int sockindex,
 
   (void)sockindex; /* unused */
 
-  num = RTMP_Write(r, (char *)buf, curlx_uztosi(len));
+  num = RTMP_Write(r, (char *)buf, Curl_uztosi(len));
   if(num < 0)
     *err = CURLE_SEND_ERROR;
 

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -50,51 +50,5 @@
   curlx_uztosi()
 */
 
-/* Now setup curlx_ * names for the functions that are to become curlx_ and
-   be removed from a future libcurl official API:
-   curlx_mprintf (and its variations)
-   curlx_strcasecompare
-   curlx_strncasecompare
-
-*/
-
-#define curlx_mvsnprintf curl_mvsnprintf
-#define curlx_msnprintf curl_msnprintf
-#define curlx_maprintf curl_maprintf
-#define curlx_mvaprintf curl_mvaprintf
-#define curlx_msprintf curl_msprintf
-#define curlx_mprintf curl_mprintf
-#define curlx_mfprintf curl_mfprintf
-#define curlx_mvsprintf curl_mvsprintf
-#define curlx_mvprintf curl_mvprintf
-#define curlx_mvfprintf curl_mvfprintf
-
-#ifdef ENABLE_CURLX_PRINTF
-/* If this define is set, we define all "standard" printf() functions to use
-   the curlx_* version instead. It makes the source code transparent and
-   easier to understand/patch. Undefine them first. */
-# undef printf
-# undef fprintf
-# undef sprintf
-# undef snprintf
-# undef vprintf
-# undef vfprintf
-# undef vsprintf
-# undef vsnprintf
-# undef aprintf
-# undef vaprintf
-
-# define printf curlx_mprintf
-# define fprintf curlx_mfprintf
-# define sprintf curlx_msprintf
-# define snprintf curlx_msnprintf
-# define vprintf curlx_mvprintf
-# define vfprintf curlx_mvfprintf
-# define vsprintf curlx_mvsprintf
-# define vsnprintf curlx_mvsnprintf
-# define aprintf curlx_maprintf
-# define vaprintf curlx_mvaprintf
-#endif /* ENABLE_CURLX_PRINTF */
-
 #endif /* HEADER_CURL_CURLX_H */
 

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -29,11 +29,6 @@
  * be.
  */
 
-#include <curl/mprintf.h>
-/* this is still a public header file that provides the curl_mprintf()
-   functions while they still are offered publicly. They will be made library-
-   private one day */
-
 #include "strtoofft.h"
 /* "strtoofft.h" provides this function: curlx_strtoofft(), returns a
    curl_off_t number from a given string.
@@ -41,14 +36,6 @@
 
 #include "nonblock.h"
 /* "nonblock.h" provides curlx_nonblock() */
-
-#include "warnless.h"
-/* "warnless.h" provides functions:
-
-  curlx_ultous()
-  curlx_ultouc()
-  curlx_uztosi()
-*/
 
 #endif /* HEADER_CURL_CURLX_H */
 

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -34,22 +34,9 @@
    functions while they still are offered publicly. They will be made library-
    private one day */
 
-#include "strcase.h"
-/* "strcase.h" provides the strcasecompare protos */
-
 #include "strtoofft.h"
 /* "strtoofft.h" provides this function: curlx_strtoofft(), returns a
    curl_off_t number from a given string.
-*/
-
-#include "timeval.h"
-/*
-  "timeval.h" sets up a 'struct timeval' even for platforms that otherwise
-  don't have one and has protos for these functions:
-
-  curlx_tvnow()
-  curlx_tvdiff()
-  curlx_tvdiff_secs()
 */
 
 #include "nonblock.h"

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -52,14 +52,12 @@
 
 /* Now setup curlx_ * names for the functions that are to become curlx_ and
    be removed from a future libcurl official API:
-   curlx_getenv
    curlx_mprintf (and its variations)
    curlx_strcasecompare
    curlx_strncasecompare
 
 */
 
-#define curlx_getenv curl_getenv
 #define curlx_mvsnprintf curl_mvsnprintf
 #define curlx_msnprintf curl_msnprintf
 #define curlx_maprintf curl_maprintf

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -586,12 +586,12 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     }
 
     /* get the time stamp to use to figure out how long poll takes */
-    before = curlx_tvnow();
+    before = Curl_tvnow();
 
     /* wait for activity or timeout */
     pollrc = Curl_poll(fds, numfds, (int)ev->ms);
 
-    after = curlx_tvnow();
+    after = Curl_tvnow();
 
     ev->msbump = FALSE; /* reset here */
 
@@ -619,7 +619,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
         /* If nothing updated the timeout, we decrease it by the spent time.
          * If it was updated, it has the new timeout time stored already.
          */
-        time_t timediff = curlx_tvdiff(after, before);
+        time_t timediff = Curl_tvdiff(after, before);
         if(timediff > 0) {
           if(timediff > ev->ms)
             ev->ms = 0;
@@ -678,17 +678,17 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
     int still_running = 0;
     int rc;
 
-    before = curlx_tvnow();
+    before = Curl_tvnow();
     mcode = curl_multi_wait(multi, NULL, 0, 1000, &rc);
 
     if(!mcode) {
       if(!rc) {
-        struct timeval after = curlx_tvnow();
+        struct timeval after = Curl_tvnow();
 
         /* If it returns without any filedescriptor instantly, we need to
            avoid busy-looping during periods where it has nothing particular
            to wait for */
-        if(curlx_tvdiff(after, before) <= 10) {
+        if(Curl_tvdiff(after, before) <= 10) {
           without_fds++;
           if(without_fds > 2) {
             int sleep_ms = without_fds < 10 ? (1 << (without_fds - 1)) : 1000;

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -171,7 +171,7 @@ CURLcode Curl_urldecode(struct Curl_easy *data,
 
       hex = strtoul(hexstr, &ptr, 16);
 
-      in = curlx_ultouc(hex); /* this long is never bigger than 255 anyway */
+      in = Curl_ultouc(hex); /* this long is never bigger than 255 anyway */
 
       result = Curl_convert_from_network(data, &in, 1);
       if(result) {
@@ -224,7 +224,7 @@ char *curl_easy_unescape(struct Curl_easy *data, const char *string,
 
     if(olen) {
       if(outputlen <= (size_t) INT_MAX)
-        *olen = curlx_uztosi(outputlen);
+        *olen = Curl_uztosi(outputlen);
       else
         /* too large to return in an int, fail! */
         Curl_safefree(str);

--- a/lib/file.c
+++ b/lib/file.c
@@ -559,7 +559,7 @@ static CURLcode file_do(struct connectdata *conn, bool *done)
 
     if(size_known) {
       bytestoread = (expected_size < data->set.buffer_size) ?
-        curlx_sotouz(expected_size) : (size_t)data->set.buffer_size;
+        Curl_sotouz(expected_size) : (size_t)data->set.buffer_size;
     }
     else
       bytestoread = data->set.buffer_size-1;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -602,7 +602,7 @@ static bool ftp_endofresp(struct connectdata *conn, char *line, size_t len,
   (void)conn;
 
   if((len > 3) && LASTLINE(line)) {
-    *code = curlx_sltosi(strtol(line, NULL, 10));
+    *code = Curl_sltosi(strtol(line, NULL, 10));
     return TRUE;
   }
 
@@ -1067,10 +1067,10 @@ static CURLcode ftp_state_use_port(struct connectdata *conn,
     if(ip_end != NULL) {
       port_start = strchr(ip_end, ':');
       if(port_start) {
-        port_min = curlx_ultous(strtoul(port_start+1, NULL, 10));
+        port_min = Curl_ultous(strtoul(port_start+1, NULL, 10));
         port_sep = strchr(port_start, '-');
         if(port_sep) {
-          port_max = curlx_ultous(strtoul(port_sep + 1, NULL, 10));
+          port_max = Curl_ultous(strtoul(port_sep + 1, NULL, 10));
         }
         else
           port_max = port_min;
@@ -1681,7 +1681,7 @@ static CURLcode ftp_state_ul_setup(struct connectdata *conn,
         size_t readthisamountnow =
           (data->state.resume_from - passed > data->set.buffer_size) ?
           (size_t)data->set.buffer_size :
-          curlx_sotouz(data->state.resume_from - passed);
+          Curl_sotouz(data->state.resume_from - passed);
 
         size_t actuallyread =
           data->state.fread_func(data->state.buffer, 1, readthisamountnow,

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -113,7 +113,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
 
   /* We use Curl_write instead of Curl_sendf to make sure the entire buffer is
      sent, which could be sizeable with long selectors. */
-  k = curlx_uztosz(len);
+  k = Curl_uztosz(len);
 
   for(;;) {
     result = Curl_write(conn, sockfd, sel, k, &amount);

--- a/lib/http.c
+++ b/lib/http.c
@@ -2172,7 +2172,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
           size_t readthisamountnow =
             (data->state.resume_from - passed > data->set.buffer_size) ?
             (size_t)data->set.buffer_size :
-            curlx_sotouz(data->state.resume_from - passed);
+            Curl_sotouz(data->state.resume_from - passed);
 
           size_t actuallyread =
             data->state.fread_func(data->state.buffer, 1, readthisamountnow,

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -186,7 +186,7 @@ CHUNKcode Curl_httpchunk_read(struct connectdata *conn,
       /* We expect 'datasize' of data. We have 'length' right now, it can be
          more or less than 'datasize'. Get the smallest piece.
       */
-      piece = curlx_sotouz((ch->datasize >= length)?length:ch->datasize);
+      piece = Curl_sotouz((ch->datasize >= length)?length:ch->datasize);
 
       /* Write the data portion available */
 #ifdef HAVE_LIBZ
@@ -347,7 +347,7 @@ CHUNKcode Curl_httpchunk_read(struct connectdata *conn,
 
         /* Record the length of any data left in the end of the buffer
            even if there's no more chunks to read */
-        ch->dataleft = curlx_sotouz(length);
+        ch->dataleft = Curl_sotouz(length);
 
         return CHUNKE_STOP; /* return stop */
       }

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -34,7 +34,8 @@
 #include "progress.h"
 #include "non-ascii.h"
 #include "connect.h"
-#include "curlx.h"
+#include "strcase.h"
+#include "strtoofft.h"
 #include "vtls/vtls.h"
 
 /* The last 3 #include files should be in this order */

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1767,7 +1767,7 @@ static CURLcode imap_sendf(struct connectdata *conn, const char *fmt, ...)
 
   /* Calculate the tag based on the connection ID and command ID */
   snprintf(imapc->resptag, sizeof(imapc->resptag), "%c%03d",
-           'A' + curlx_sltosi(conn->connection_id % 26), imapc->cmdid);
+           'A' + Curl_sltosi(conn->connection_id % 26), imapc->cmdid);
 
   /* Prefix the format with the tag */
   taggedfmt = aprintf("%s %s", imapc->resptag, fmt);

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -93,7 +93,7 @@ krb5_decode(void *app_data, void *buf, int len,
   }
 
   memcpy(buf, dec.value, dec.length);
-  len = curlx_uztosi(dec.length);
+  len = Curl_uztosi(dec.length);
   gss_release_buffer(&min, &dec);
 
   return len;
@@ -137,7 +137,7 @@ krb5_encode(void *app_data, const void *from, int length, int level, void **to)
   if(!*to)
     return -1;
   memcpy(*to, enc.value, enc.length);
-  len = curlx_uztosi(enc.length);
+  len = Curl_uztosi(enc.length);
   gss_release_buffer(&min, &enc);
   return len;
 }

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -513,7 +513,7 @@ void Curl_md5it(unsigned char *outbuffer, /* 16 bytes */
 {
   MD5_CTX ctx;
   MD5_Init(&ctx);
-  MD5_Update(&ctx, input, curlx_uztoui(strlen((char *)input)));
+  MD5_Update(&ctx, input, Curl_uztoui(strlen((char *)input)));
   MD5_Final(outbuffer, &ctx);
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2501,7 +2501,7 @@ static CURLMcode add_next_timeout(struct timeval now,
     struct curl_llist_element *n = e->next;
     time_t diff;
     node = (struct time_node *)e->ptr;
-    diff = curlx_tvdiff(node->time, now);
+    diff = Curl_tvdiff(node->time, now);
     if(diff <= 0)
       /* remove outdated entry */
       Curl_llist_remove(list, e, NULL);
@@ -2777,7 +2777,7 @@ static CURLMcode multi_timeout(struct Curl_multi *multi,
 
     if(Curl_splaycomparekeys(multi->timetree->key, now) > 0) {
       /* some time left before expiration */
-      *timeout_ms = (long)curlx_tvdiff(multi->timetree->key, now);
+      *timeout_ms = (long)Curl_tvdiff(multi->timetree->key, now);
       if(!*timeout_ms)
         /*
          * Since we only provide millisecond resolution on the returned value
@@ -2893,7 +2893,7 @@ multi_addtimeout(struct Curl_easy *data,
     /* find the correct spot in the list */
     for(e = timeoutlist->head; e; e = e->next) {
       struct time_node *check = (struct time_node *)e->ptr;
-      time_t diff = curlx_tvdiff(check->time, node->time);
+      time_t diff = Curl_tvdiff(check->time, node->time);
       if(diff > 0)
         break;
       prev = e;
@@ -2945,7 +2945,7 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
     /* This means that the struct is added as a node in the splay tree.
        Compare if the new time is earlier, and only remove-old/add-new if it
        is. */
-    time_t diff = curlx_tvdiff(set, *nowp);
+    time_t diff = Curl_tvdiff(set, *nowp);
 
     /* remove the previous timer first, if there */
     multi_deltimeout(data, id);
@@ -3006,7 +3006,7 @@ void Curl_expire_latest(struct Curl_easy *data, time_t milli, expire_id id)
     /* This means that the struct is added as a node in the splay tree.
        Compare if the new time is earlier, and only remove-old/add-new if it
        is. */
-    time_t diff = curlx_tvdiff(set, *expire);
+    time_t diff = Curl_tvdiff(set, *expire);
     if((diff > 0) && (diff < milli)) {
       /* if the new expire time is later than the top time, skip it, but not
          if the diff is larger than the new offset since then the previous

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2293,7 +2293,7 @@ CURLMsg *curl_multi_info_read(struct Curl_multi *multi, int *msgs_in_queue)
     /* remove the extracted entry */
     Curl_llist_remove(&multi->msglist, e, NULL);
 
-    *msgs_in_queue = curlx_uztosi(Curl_llist_count(&multi->msglist));
+    *msgs_in_queue = Curl_uztosi(Curl_llist_count(&multi->msglist));
 
     return &msg->extmsg;
   }

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -419,7 +419,7 @@ static int parsedate(const char *date, time_t *output)
           return PARSEDATE_FAIL;
 #endif
 
-        val = curlx_sltosi(lval);
+        val = Curl_sltosi(lval);
 
         if((tzoff == -1) &&
            ((end - date) == 4) &&

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -476,10 +476,10 @@ static CURLcode pop3_perform_apop(struct connectdata *conn)
     return CURLE_OUT_OF_MEMORY;
 
   Curl_MD5_update(ctxt, (const unsigned char *) pop3c->apoptimestamp,
-                  curlx_uztoui(strlen(pop3c->apoptimestamp)));
+                  Curl_uztoui(strlen(pop3c->apoptimestamp)));
 
   Curl_MD5_update(ctxt, (const unsigned char *) conn->passwd,
-                  curlx_uztoui(strlen(conn->passwd)));
+                  Curl_uztoui(strlen(conn->passwd)));
 
   /* Finalise the digest */
   Curl_MD5_final(ctxt, digest);

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -361,7 +361,7 @@ int Curl_pgrsUpdate(struct connectdata *conn)
   now = Curl_tvnow(); /* what time is it */
 
   /* The time spent so far (from the start) */
-  data->progress.timespent = curlx_tvdiff_secs(now, data->progress.start);
+  data->progress.timespent = Curl_tvdiff_secs(now, data->progress.start);
   timespent = (curl_off_t)data->progress.timespent;
 
   /* The average download speed this far */

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -86,7 +86,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 #endif
 
   if(!seeded) {
-    struct timeval now = curlx_tvnow();
+    struct timeval now = Curl_tvnow();
     infof(data, "WARNING: Using weak random seed\n");
     randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
     randseed = randseed * 1103515245 + 12345;

--- a/lib/security.c
+++ b/lib/security.c
@@ -7,7 +7,7 @@
  * rewrite to work around the paragraph 2 in the BSD licenses as explained
  * below.
  *
- * Copyright (c) 1998, 1999 Kungliga Tekniska Högskolan
+ * Copyright (c) 1998, 1999, 2017 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  *
  * Copyright (C) 2001 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
@@ -297,7 +297,7 @@ static void do_sec_send(struct connectdata *conn, curl_socket_t fd,
     return; /* error */
 
   if(iscmd) {
-    error = Curl_base64_encode(conn->data, buffer, curlx_sitouz(bytes),
+    error = Curl_base64_encode(conn->data, buffer, Curl_sitouz(bytes),
                                &cmd_buffer, &cmd_size);
     if(error) {
       free(buffer);
@@ -321,7 +321,7 @@ static void do_sec_send(struct connectdata *conn, curl_socket_t fd,
   else {
     htonl_bytes = htonl(bytes);
     socket_write(conn, fd, &htonl_bytes, sizeof(htonl_bytes));
-    socket_write(conn, fd, buffer, curlx_sitouz(bytes));
+    socket_write(conn, fd, buffer, Curl_sitouz(bytes));
   }
   free(buffer);
 }
@@ -332,14 +332,14 @@ static ssize_t sec_write(struct connectdata *conn, curl_socket_t fd,
   ssize_t tx = 0, len = conn->buffer_size;
 
   len -= conn->mech->overhead(conn->app_data, conn->data_prot,
-                              curlx_sztosi(len));
+                              Curl_sztosi(len));
   if(len <= 0)
     len = length;
   while(length) {
     if(length < (size_t)len)
       len = length;
 
-    do_sec_send(conn, fd, buffer, curlx_sztosi(len));
+    do_sec_send(conn, fd, buffer, Curl_sztosi(len));
     length -= len;
     buffer += len;
     tx += len;
@@ -381,7 +381,7 @@ int Curl_sec_read_msg(struct connectdata *conn, char *buffer,
     free(buf);
     return -1;
   }
-  decoded_len = curlx_uztosi(decoded_sz);
+  decoded_len = Curl_uztosi(decoded_sz);
 
   decoded_len = conn->mech->decode(conn->app_data, buf, decoded_len,
                                    level, conn);

--- a/lib/select.c
+++ b/lib/select.c
@@ -51,7 +51,7 @@
 #include "warnless.h"
 
 /* Convenience local macros */
-#define ELAPSED_MS()  (int)curlx_tvdiff(curlx_tvnow(), initial_tv)
+#define ELAPSED_MS()  (int)Curl_tvdiff(Curl_tvnow(), initial_tv)
 
 int Curl_ack_eintr = 0;
 #define ERROR_NOT_EINTR(error) (Curl_ack_eintr || error != EINTR)
@@ -96,7 +96,7 @@ int Curl_wait_ms(int timeout_ms)
   Sleep(timeout_ms);
 #else
   pending_ms = timeout_ms;
-  initial_tv = curlx_tvnow();
+  initial_tv = Curl_tvnow();
   do {
 #if defined(HAVE_POLL_FINE)
     r = poll(NULL, 0, pending_ms);
@@ -177,14 +177,14 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
     return r;
   }
 
-  /* Avoid initial timestamp, avoid curlx_tvnow() call, when elapsed
+  /* Avoid initial timestamp, avoid Curl_tvnow() call, when elapsed
      time in this function does not need to be measured. This happens
      when function is called with a zero timeout or a negative timeout
      value indicating a blocking call should be performed. */
 
   if(timeout_ms > 0) {
     pending_ms = (int)timeout_ms;
-    initial_tv = curlx_tvnow();
+    initial_tv = Curl_tvnow();
   }
 
 #ifdef HAVE_POLL_FINE
@@ -418,14 +418,14 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
     return r;
   }
 
-  /* Avoid initial timestamp, avoid curlx_tvnow() call, when elapsed
+  /* Avoid initial timestamp, avoid Curl_tvnow() call, when elapsed
      time in this function does not need to be measured. This happens
      when function is called with a zero timeout or a negative timeout
      value indicating a blocking call should be performed. */
 
   if(timeout_ms > 0) {
     pending_ms = timeout_ms;
-    initial_tv = curlx_tvnow();
+    initial_tv = Curl_tvnow();
   }
 
 #ifdef HAVE_POLL_FINE

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -257,7 +257,7 @@ static bool smtp_endofresp(struct connectdata *conn, char *line, size_t len,
      only send the response code instead as per Section 4.2. */
   if(line[3] == ' ' || len == 5) {
     result = TRUE;
-    *resp = curlx_sltosi(strtol(line, NULL, 10));
+    *resp = Curl_sltosi(strtol(line, NULL, 10));
 
     /* Make sure real server never sends internal value */
     if(*resp == 1)

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -107,10 +107,10 @@
 #define HAS_STATVFS_SUPPORT 1
 #endif
 
-#define sftp_libssh2_last_error(s) curlx_ultosi(libssh2_sftp_last_error(s))
+#define sftp_libssh2_last_error(s) Curl_ultosi(libssh2_sftp_last_error(s))
 
 #define sftp_libssh2_realpath(s,p,t,m) \
-        libssh2_sftp_symlink_ex((s), (p), curlx_uztoui(strlen(p)), \
+        libssh2_sftp_symlink_ex((s), (p), Curl_uztoui(strlen(p)), \
                                 (t), (m), LIBSSH2_SFTP_REALPATH)
 
 
@@ -232,7 +232,7 @@ kbd_callback(const char *name, int name_len, const char *instruction,
 #endif  /* CURL_LIBSSH2_DEBUG */
   if(num_prompts == 1) {
     responses[0].text = strdup(conn->passwd);
-    responses[0].length = curlx_uztoui(strlen(conn->passwd));
+    responses[0].length = Curl_uztoui(strlen(conn->passwd));
   }
   (void)prompts;
   (void)abstract;
@@ -771,7 +771,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
        */
       sshc->authlist = libssh2_userauth_list(sshc->ssh_session,
                                              conn->user,
-                                             curlx_uztoui(strlen(conn->user)));
+                                             Curl_uztoui(strlen(conn->user)));
 
       if(!sshc->authlist) {
         if(libssh2_userauth_authenticated(sshc->ssh_session)) {
@@ -892,7 +892,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
        */
       rc = libssh2_userauth_publickey_fromfile_ex(sshc->ssh_session,
                                                   conn->user,
-                                                  curlx_uztoui(
+                                                  Curl_uztoui(
                                                     strlen(conn->user)),
                                                   sshc->rsa_pub,
                                                   sshc->rsa, sshc->passphrase);
@@ -931,9 +931,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_AUTH_PASS:
       rc = libssh2_userauth_password_ex(sshc->ssh_session, conn->user,
-                                        curlx_uztoui(strlen(conn->user)),
+                                        Curl_uztoui(strlen(conn->user)),
                                         conn->passwd,
-                                        curlx_uztoui(strlen(conn->passwd)),
+                                        Curl_uztoui(strlen(conn->passwd)),
                                         NULL);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
@@ -1071,7 +1071,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       /* Authentication failed. Continue with keyboard-interactive now. */
       rc = libssh2_userauth_keyboard_interactive_ex(sshc->ssh_session,
                                                     conn->user,
-                                                    curlx_uztoui(
+                                                    Curl_uztoui(
                                                       strlen(conn->user)),
                                                     &kbd_callback);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
@@ -1435,7 +1435,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
          * first.  This takes an extra protocol round trip.
          */
         rc = libssh2_sftp_stat_ex(sshc->sftp_session, sshc->quote_path2,
-                                  curlx_uztoui(strlen(sshc->quote_path2)),
+                                  Curl_uztoui(strlen(sshc->quote_path2)),
                                   LIBSSH2_SFTP_STAT,
                                   &sshc->quote_attrs);
         if(rc == LIBSSH2_ERROR_EAGAIN) {
@@ -1506,7 +1506,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SFTP_QUOTE_SETSTAT:
       rc = libssh2_sftp_stat_ex(sshc->sftp_session, sshc->quote_path2,
-                                curlx_uztoui(strlen(sshc->quote_path2)),
+                                Curl_uztoui(strlen(sshc->quote_path2)),
                                 LIBSSH2_SFTP_SETSTAT,
                                 &sshc->quote_attrs);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
@@ -1528,9 +1528,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SFTP_QUOTE_SYMLINK:
       rc = libssh2_sftp_symlink_ex(sshc->sftp_session, sshc->quote_path1,
-                                   curlx_uztoui(strlen(sshc->quote_path1)),
+                                   Curl_uztoui(strlen(sshc->quote_path1)),
                                    sshc->quote_path2,
-                                   curlx_uztoui(strlen(sshc->quote_path2)),
+                                   Curl_uztoui(strlen(sshc->quote_path2)),
                                    LIBSSH2_SFTP_SYMLINK);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
@@ -1551,7 +1551,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SFTP_QUOTE_MKDIR:
       rc = libssh2_sftp_mkdir_ex(sshc->sftp_session, sshc->quote_path1,
-                                 curlx_uztoui(strlen(sshc->quote_path1)),
+                                 Curl_uztoui(strlen(sshc->quote_path1)),
                                  data->set.new_directory_perms);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
@@ -1570,9 +1570,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SFTP_QUOTE_RENAME:
       rc = libssh2_sftp_rename_ex(sshc->sftp_session, sshc->quote_path1,
-                                  curlx_uztoui(strlen(sshc->quote_path1)),
+                                  Curl_uztoui(strlen(sshc->quote_path1)),
                                   sshc->quote_path2,
-                                  curlx_uztoui(strlen(sshc->quote_path2)),
+                                  Curl_uztoui(strlen(sshc->quote_path2)),
                                   LIBSSH2_SFTP_RENAME_OVERWRITE |
                                   LIBSSH2_SFTP_RENAME_ATOMIC |
                                   LIBSSH2_SFTP_RENAME_NATIVE);
@@ -1595,7 +1595,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SFTP_QUOTE_RMDIR:
       rc = libssh2_sftp_rmdir_ex(sshc->sftp_session, sshc->quote_path1,
-                                 curlx_uztoui(strlen(sshc->quote_path1)));
+                                 Curl_uztoui(strlen(sshc->quote_path1)));
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
       }
@@ -1613,7 +1613,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
     case SSH_SFTP_QUOTE_UNLINK:
       rc = libssh2_sftp_unlink_ex(sshc->sftp_session, sshc->quote_path1,
-                                  curlx_uztoui(strlen(sshc->quote_path1)));
+                                  Curl_uztoui(strlen(sshc->quote_path1)));
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
       }
@@ -1634,7 +1634,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
     {
       LIBSSH2_SFTP_STATVFS statvfs;
       rc = libssh2_sftp_statvfs(sshc->sftp_session, sshc->quote_path1,
-                                curlx_uztoui(strlen(sshc->quote_path1)),
+                                Curl_uztoui(strlen(sshc->quote_path1)),
                                 &statvfs);
 
       if(rc == LIBSSH2_ERROR_EAGAIN) {
@@ -1698,7 +1698,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       LIBSSH2_SFTP_ATTRIBUTES attrs;
 
       rc = libssh2_sftp_stat_ex(sshc->sftp_session, sftp_scp->path,
-                                curlx_uztoui(strlen(sftp_scp->path)),
+                                Curl_uztoui(strlen(sftp_scp->path)),
                                 LIBSSH2_SFTP_STAT, &attrs);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
@@ -1736,7 +1736,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         LIBSSH2_SFTP_ATTRIBUTES attrs;
         if(data->state.resume_from < 0) {
           rc = libssh2_sftp_stat_ex(sshc->sftp_session, sftp_scp->path,
-                                    curlx_uztoui(strlen(sftp_scp->path)),
+                                    Curl_uztoui(strlen(sftp_scp->path)),
                                     LIBSSH2_SFTP_STAT, &attrs);
           if(rc == LIBSSH2_ERROR_EAGAIN) {
             break;
@@ -1767,7 +1767,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
       sshc->sftp_handle =
         libssh2_sftp_open_ex(sshc->sftp_session, sftp_scp->path,
-                             curlx_uztoui(strlen(sftp_scp->path)),
+                             Curl_uztoui(strlen(sftp_scp->path)),
                              flags, data->set.new_file_perms,
                              LIBSSH2_SFTP_OPENFILE);
 
@@ -1840,7 +1840,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
             size_t readthisamountnow =
               (data->state.resume_from - passed > data->set.buffer_size) ?
               (size_t)data->set.buffer_size :
-              curlx_sotouz(data->state.resume_from - passed);
+              Curl_sotouz(data->state.resume_from - passed);
 
             size_t actuallyread =
               data->state.fread_func(data->state.buffer, 1,
@@ -1924,7 +1924,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
     case SSH_SFTP_CREATE_DIRS_MKDIR:
       /* 'mode' - parameter is preliminary - default to 0644 */
       rc = libssh2_sftp_mkdir_ex(sshc->sftp_session, sftp_scp->path,
-                                 curlx_uztoui(strlen(sftp_scp->path)),
+                                 Curl_uztoui(strlen(sftp_scp->path)),
                                  data->set.new_directory_perms);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;
@@ -1964,7 +1964,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
        */
       sshc->sftp_handle = libssh2_sftp_open_ex(sshc->sftp_session,
                                                sftp_scp->path,
-                                               curlx_uztoui(
+                                               Curl_uztoui(
                                                  strlen(sftp_scp->path)),
                                                0, 0, LIBSSH2_SFTP_OPENDIR);
       if(!sshc->sftp_handle) {
@@ -2097,7 +2097,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       sshc->readdir_len =
         libssh2_sftp_symlink_ex(sshc->sftp_session,
                                 sshc->readdir_linkPath,
-                                curlx_uztoui(strlen(sshc->readdir_linkPath)),
+                                Curl_uztoui(strlen(sshc->readdir_linkPath)),
                                 sshc->readdir_filename,
                                 PATH_MAX, LIBSSH2_SFTP_READLINK);
       if(sshc->readdir_len == LIBSSH2_ERROR_EAGAIN) {
@@ -2177,7 +2177,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
        */
       sshc->sftp_handle =
         libssh2_sftp_open_ex(sshc->sftp_session, sftp_scp->path,
-                             curlx_uztoui(strlen(sftp_scp->path)),
+                             Curl_uztoui(strlen(sftp_scp->path)),
                              LIBSSH2_FXF_READ, data->set.new_file_perms,
                              LIBSSH2_SFTP_OPENFILE);
       if(!sshc->sftp_handle) {
@@ -2202,7 +2202,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       LIBSSH2_SFTP_ATTRIBUTES attrs;
 
       rc = libssh2_sftp_stat_ex(sshc->sftp_session, sftp_scp->path,
-                                curlx_uztoui(strlen(sftp_scp->path)),
+                                Curl_uztoui(strlen(sftp_scp->path)),
                                 LIBSSH2_SFTP_STAT, &attrs);
       if(rc == LIBSSH2_ERROR_EAGAIN) {
         break;

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -43,7 +43,7 @@ char Curl_raw_toupper(char in);
 
 /* checkprefix() is a shorter version of the above, used when the first
    argument is zero-byte terminated */
-#define checkprefix(a,b)    curl_strnequal(a,b,strlen(a))
+#define checkprefix(a,b)    Curl_strncasecompare(a,b,strlen(a))
 
 void Curl_strntoupper(char *dest, const char *src, size_t n);
 char Curl_raw_toupper(char in);

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -48,7 +48,7 @@ struct timeval curlx_tvnow(void)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
-struct timeval curlx_tvnow(void)
+struct timeval Curl_tvnow(void)
 {
   /*
   ** clock_gettime() is granted to be increased monotonically when the
@@ -82,7 +82,7 @@ struct timeval curlx_tvnow(void)
 
 #elif defined(HAVE_GETTIMEOFDAY)
 
-struct timeval curlx_tvnow(void)
+struct timeval Curl_tvnow(void)
 {
   /*
   ** gettimeofday() is not granted to be increased monotonically, due to
@@ -96,7 +96,7 @@ struct timeval curlx_tvnow(void)
 
 #else
 
-struct timeval curlx_tvnow(void)
+struct timeval Curl_tvnow(void)
 {
   /*
   ** time() returns the value of time in seconds since the Epoch.
@@ -116,7 +116,7 @@ struct timeval curlx_tvnow(void)
  * Returns: the time difference in number of milliseconds. For large diffs it
  * returns 0x7fffffff on 32bit time_t systems.
  */
-time_t curlx_tvdiff(struct timeval newer, struct timeval older)
+time_t Curl_tvdiff(struct timeval newer, struct timeval older)
 {
 #if SIZEOF_TIME_T < 8
   /* for 32bit time_t systems, add a precaution to avoid overflow for really
@@ -130,11 +130,11 @@ time_t curlx_tvdiff(struct timeval newer, struct timeval older)
 }
 
 /*
- * Same as curlx_tvdiff but with full usec resolution.
+ * Same as Curl_tvdiff but with full usec resolution.
  *
  * Returns: the time difference in seconds with subsecond resolution.
  */
-double curlx_tvdiff_secs(struct timeval newer, struct timeval older)
+double Curl_tvdiff_secs(struct timeval newer, struct timeval older)
 {
   if(newer.tv_sec != older.tv_sec)
     return (double)(newer.tv_sec-older.tv_sec)+

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,14 +22,9 @@
  *
  ***************************************************************************/
 
-/*
- * CAUTION: this header is designed to work when included by the app-side
- * as well as the library. Do not mix with library internals!
- */
-
 #include "curl_setup.h"
 
-struct timeval curlx_tvnow(void);
+struct timeval Curl_tvnow(void);
 
 /*
  * Make sure that the first argument (t1) is the more recent time and t2 is
@@ -37,20 +32,14 @@ struct timeval curlx_tvnow(void);
  *
  * Returns: the time difference in number of milliseconds.
  */
-time_t curlx_tvdiff(struct timeval t1, struct timeval t2);
+time_t Curl_tvdiff(struct timeval t1, struct timeval t2);
 
 /*
  * Same as curlx_tvdiff but with full usec resolution.
  *
  * Returns: the time difference in seconds with subsecond resolution.
  */
-double curlx_tvdiff_secs(struct timeval t1, struct timeval t2);
-
-/* These two defines below exist to provide the older API for library
-   internals only. */
-#define Curl_tvnow() curlx_tvnow()
-#define Curl_tvdiff(x,y) curlx_tvdiff(x,y)
-#define Curl_tvdiff_secs(x,y) curlx_tvdiff_secs(x,y)
+double Curl_tvdiff_secs(struct timeval t1, struct timeval t2);
 
 #endif /* HEADER_CURL_TIMEVAL_H */
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -381,7 +381,7 @@ CURLcode Curl_dupset(struct Curl_easy *dst, struct Curl_easy *src)
   if(src->set.postfieldsize && src->set.str[i]) {
     /* postfieldsize is curl_off_t, Curl_memdup() takes a size_t ... */
     dst->set.str[i] = Curl_memdup(src->set.str[i],
-                                  curlx_sotouz(src->set.postfieldsize));
+                                  Curl_sotouz(src->set.postfieldsize));
     if(!dst->set.str[i])
       return CURLE_OUT_OF_MEMORY;
     /* point to the new copy */
@@ -2078,7 +2078,7 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     arg = va_arg(param, long);
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.localport = curlx_sltous(arg);
+    data->set.localport = Curl_sltous(arg);
     break;
   case CURLOPT_LOCALPORTRANGE:
     /*
@@ -2087,7 +2087,7 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     arg = va_arg(param, long);
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.localportrange = curlx_sltosi(arg);
+    data->set.localportrange = Curl_sltosi(arg);
     break;
   case CURLOPT_KRBLEVEL:
     /*
@@ -2616,7 +2616,7 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
      * know that an unsigned int will always hold the value so we blindly
      * typecast to this type
      */
-    data->set.scope_id = curlx_sltoui(va_arg(param, long));
+    data->set.scope_id = Curl_sltoui(va_arg(param, long));
     break;
 
   case CURLOPT_PROTOCOLS:
@@ -5735,7 +5735,7 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
 
     if(rest != &portptr[1]) {
       *portptr = '\0'; /* cut off the name there */
-      conn->remote_port = curlx_ultous(port);
+      conn->remote_port = Curl_ultous(port);
     }
     else {
       /* Browser behavior adaptation. If there's a colon with no digits after,

--- a/lib/vauth/cram.c
+++ b/lib/vauth/cram.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -106,14 +106,14 @@ CURLcode Curl_auth_create_cram_md5_message(struct Curl_easy *data,
   /* Compute the digest using the password as the key */
   ctxt = Curl_HMAC_init(Curl_HMAC_MD5,
                         (const unsigned char *) passwdp,
-                        curlx_uztoui(strlen(passwdp)));
+                        Curl_uztoui(strlen(passwdp)));
   if(!ctxt)
     return CURLE_OUT_OF_MEMORY;
 
   /* Update the digest with the given challenge */
   if(chlglen > 0)
     Curl_HMAC_update(ctxt, (const unsigned char *) chlg,
-                     curlx_uztoui(chlglen));
+                     Curl_uztoui(chlglen));
 
   /* Finalise the digest */
   Curl_HMAC_final(ctxt, digest);

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -397,13 +397,13 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   Curl_MD5_update(ctxt, (const unsigned char *) userp,
-                  curlx_uztoui(strlen(userp)));
+                  Curl_uztoui(strlen(userp)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) realm,
-                  curlx_uztoui(strlen(realm)));
+                  Curl_uztoui(strlen(realm)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) passwdp,
-                  curlx_uztoui(strlen(passwdp)));
+                  Curl_uztoui(strlen(passwdp)));
   Curl_MD5_final(ctxt, digest);
 
   ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
@@ -413,10 +413,10 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   Curl_MD5_update(ctxt, (const unsigned char *) digest, MD5_DIGEST_LEN);
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) nonce,
-                  curlx_uztoui(strlen(nonce)));
+                  Curl_uztoui(strlen(nonce)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) cnonce,
-                  curlx_uztoui(strlen(cnonce)));
+                  Curl_uztoui(strlen(cnonce)));
   Curl_MD5_final(ctxt, digest);
 
   /* Convert calculated 16 octet hex into 32 bytes string */
@@ -437,10 +437,10 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   }
 
   Curl_MD5_update(ctxt, (const unsigned char *) method,
-                  curlx_uztoui(strlen(method)));
+                  Curl_uztoui(strlen(method)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) spn,
-                  curlx_uztoui(strlen(spn)));
+                  Curl_uztoui(strlen(spn)));
   Curl_MD5_final(ctxt, digest);
 
   for(i = 0; i < MD5_DIGEST_LEN; i++)
@@ -457,17 +457,17 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   Curl_MD5_update(ctxt, (const unsigned char *) HA1_hex, 2 * MD5_DIGEST_LEN);
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) nonce,
-                  curlx_uztoui(strlen(nonce)));
+                  Curl_uztoui(strlen(nonce)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
 
   Curl_MD5_update(ctxt, (const unsigned char *) nonceCount,
-                  curlx_uztoui(strlen(nonceCount)));
+                  Curl_uztoui(strlen(nonceCount)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) cnonce,
-                  curlx_uztoui(strlen(cnonce)));
+                  Curl_uztoui(strlen(cnonce)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
   Curl_MD5_update(ctxt, (const unsigned char *) qop,
-                  curlx_uztoui(strlen(qop)));
+                  Curl_uztoui(strlen(qop)));
   Curl_MD5_update(ctxt, (const unsigned char *) ":", 1);
 
   Curl_MD5_update(ctxt, (const unsigned char *) HA2_hex, 2 * MD5_DIGEST_LEN);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -214,7 +214,7 @@ static int passwd_callback(char *buf, int num, int encrypting,
   DEBUGASSERT(0 == encrypting);
 
   if(!encrypting) {
-    int klen = curlx_uztosi(strlen((char *)global_passwd));
+    int klen = Curl_uztosi(strlen((char *)global_passwd));
     if(num > klen) {
       memcpy(buf, global_passwd, klen+1);
       return klen;
@@ -1278,7 +1278,7 @@ static CURLcode verifyhost(struct connectdata *conn, X509 *server_cert)
         else /* not a UTF8 name */
           j = ASN1_STRING_to_UTF8(&peer_CN, tmp);
 
-        if(peer_CN && (curlx_uztosi(strlen((char *)peer_CN)) != j)) {
+        if(peer_CN && (Curl_uztosi(strlen((char *)peer_CN)) != j)) {
           /* there was a terminating zero before the end of string, this
              cannot match and we return failure! */
           failf(data, "SSL: illegal cert name field");
@@ -3334,7 +3334,7 @@ CURLcode Curl_ossl_random(struct Curl_easy *data, unsigned char *entropy,
       return CURLE_FAILED_INIT;
   }
   /* RAND_bytes() returns 1 on success, 0 otherwise.  */
-  rc = RAND_bytes(entropy, curlx_uztosi(length));
+  rc = RAND_bytes(entropy, Curl_uztosi(length));
   return (rc == 1 ? CURLE_OK : CURLE_FAILED_INIT);
 }
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -889,7 +889,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
      * if the size of our certificate is bigger than the file
      * size then it can't match
      */
-    size = curlx_sotouz((curl_off_t) filesize);
+    size = Curl_sotouz((curl_off_t) filesize);
     if(pubkeylen > size)
       break;
 
@@ -953,7 +953,7 @@ CURLcode Curl_ssl_md5sum(unsigned char *tmp, /* input */
   MD5pw = Curl_MD5_init(Curl_DIGEST_MD5);
   if(!MD5pw)
     return CURLE_OUT_OF_MEMORY;
-  Curl_MD5_update(MD5pw, tmp, curlx_uztoui(tmplen));
+  Curl_MD5_update(MD5pw, tmp, Curl_uztoui(tmplen));
   Curl_MD5_final(MD5pw, md5sum);
 #endif
   return CURLE_OK;

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -121,7 +121,7 @@
 ** unsigned long to unsigned short
 */
 
-unsigned short curlx_ultous(unsigned long ulnum)
+unsigned short Curl_ultous(unsigned long ulnum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -140,7 +140,7 @@ unsigned short curlx_ultous(unsigned long ulnum)
 ** unsigned long to unsigned char
 */
 
-unsigned char curlx_ultouc(unsigned long ulnum)
+unsigned char Curl_ultouc(unsigned long ulnum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -159,7 +159,7 @@ unsigned char curlx_ultouc(unsigned long ulnum)
 ** unsigned long to signed int
 */
 
-int curlx_ultosi(unsigned long ulnum)
+int Curl_ultosi(unsigned long ulnum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -178,7 +178,7 @@ int curlx_ultosi(unsigned long ulnum)
 ** unsigned size_t to signed curl_off_t
 */
 
-curl_off_t curlx_uztoso(size_t uznum)
+curl_off_t Curl_uztoso(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -200,7 +200,7 @@ curl_off_t curlx_uztoso(size_t uznum)
 ** unsigned size_t to signed int
 */
 
-int curlx_uztosi(size_t uznum)
+int Curl_uztosi(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -219,7 +219,7 @@ int curlx_uztosi(size_t uznum)
 ** unsigned size_t to unsigned long
 */
 
-unsigned long curlx_uztoul(size_t uznum)
+unsigned long Curl_uztoul(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
 # pragma warning(push)
@@ -240,7 +240,7 @@ unsigned long curlx_uztoul(size_t uznum)
 ** unsigned size_t to unsigned int
 */
 
-unsigned int curlx_uztoui(size_t uznum)
+unsigned int Curl_uztoui(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
 # pragma warning(push)
@@ -261,7 +261,7 @@ unsigned int curlx_uztoui(size_t uznum)
 ** signed long to signed int
 */
 
-int curlx_sltosi(long slnum)
+int Curl_sltosi(long slnum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -283,7 +283,7 @@ int curlx_sltosi(long slnum)
 ** signed long to unsigned int
 */
 
-unsigned int curlx_sltoui(long slnum)
+unsigned int Curl_sltoui(long slnum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -305,7 +305,7 @@ unsigned int curlx_sltoui(long slnum)
 ** signed long to unsigned short
 */
 
-unsigned short curlx_sltous(long slnum)
+unsigned short Curl_sltous(long slnum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -325,7 +325,7 @@ unsigned short curlx_sltous(long slnum)
 ** unsigned size_t to signed ssize_t
 */
 
-ssize_t curlx_uztosz(size_t uznum)
+ssize_t Curl_uztosz(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -344,7 +344,7 @@ ssize_t curlx_uztosz(size_t uznum)
 ** signed curl_off_t to unsigned size_t
 */
 
-size_t curlx_sotouz(curl_off_t sonum)
+size_t Curl_sotouz(curl_off_t sonum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -363,7 +363,7 @@ size_t curlx_sotouz(curl_off_t sonum)
 ** signed ssize_t to signed int
 */
 
-int curlx_sztosi(ssize_t sznum)
+int Curl_sztosi(ssize_t sznum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -385,7 +385,7 @@ int curlx_sztosi(ssize_t sznum)
 ** unsigned int to unsigned short
 */
 
-unsigned short curlx_uitous(unsigned int uinum)
+unsigned short Curl_uitous(unsigned int uinum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -404,7 +404,7 @@ unsigned short curlx_uitous(unsigned int uinum)
 ** unsigned int to unsigned char
 */
 
-unsigned char curlx_uitouc(unsigned int uinum)
+unsigned char Curl_uitouc(unsigned int uinum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -423,7 +423,7 @@ unsigned char curlx_uitouc(unsigned int uinum)
 ** unsigned int to signed int
 */
 
-int curlx_uitosi(unsigned int uinum)
+int Curl_uitosi(unsigned int uinum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -442,7 +442,7 @@ int curlx_uitosi(unsigned int uinum)
 ** signed int to unsigned size_t
 */
 
-size_t curlx_sitouz(int sinum)
+size_t Curl_sitouz(int sinum)
 {
 #ifdef __INTEL_COMPILER
 #  pragma warning(push)
@@ -463,7 +463,7 @@ size_t curlx_sitouz(int sinum)
 ** curl_socket_t to signed int
 */
 
-int curlx_sktosi(curl_socket_t s)
+int Curl_sktosi(curl_socket_t s)
 {
   return (int)((ssize_t) s);
 }
@@ -472,7 +472,7 @@ int curlx_sktosi(curl_socket_t s)
 ** signed int to curl_socket_t
 */
 
-curl_socket_t curlx_sitosk(int i)
+curl_socket_t Curl_sitosk(int i)
 {
   return (curl_socket_t)((ssize_t) i);
 }
@@ -481,21 +481,21 @@ curl_socket_t curlx_sitosk(int i)
 
 #if defined(WIN32) || defined(_WIN32)
 
-ssize_t curlx_read(int fd, void *buf, size_t count)
+ssize_t Curl_read(int fd, void *buf, size_t count)
 {
-  return (ssize_t)read(fd, buf, curlx_uztoui(count));
+  return (ssize_t)read(fd, buf, Curl_uztoui(count));
 }
 
-ssize_t curlx_write(int fd, const void *buf, size_t count)
+ssize_t Curl_write(int fd, const void *buf, size_t count)
 {
-  return (ssize_t)write(fd, buf, curlx_uztoui(count));
+  return (ssize_t)write(fd, buf, Curl_uztoui(count));
 }
 
 #endif /* WIN32 || _WIN32 */
 
 #if defined(__INTEL_COMPILER) && defined(__unix__)
 
-int curlx_FD_ISSET(int fd, fd_set *fdset)
+int Curl_FD_ISSET(int fd, fd_set *fdset)
 {
   #pragma warning(push)
   #pragma warning(disable:1469) /* clobber ignored */
@@ -503,7 +503,7 @@ int curlx_FD_ISSET(int fd, fd_set *fdset)
   #pragma warning(pop)
 }
 
-void curlx_FD_SET(int fd, fd_set *fdset)
+void Curl_FD_SET(int fd, fd_set *fdset)
 {
   #pragma warning(push)
   #pragma warning(disable:1469) /* clobber ignored */
@@ -511,7 +511,7 @@ void curlx_FD_SET(int fd, fd_set *fdset)
   #pragma warning(pop)
 }
 
-void curlx_FD_ZERO(fd_set *fdset)
+void Curl_FD_ZERO(fd_set *fdset)
 {
   #pragma warning(push)
   #pragma warning(disable:593) /* variable was set but never used */
@@ -519,7 +519,7 @@ void curlx_FD_ZERO(fd_set *fdset)
   #pragma warning(pop)
 }
 
-unsigned short curlx_htons(unsigned short usnum)
+unsigned short Curl_htons(unsigned short usnum)
 {
 #if (__INTEL_COMPILER == 910) && defined(__i386__)
   return (unsigned short)(((usnum << 8) & 0xFF00) | ((usnum >> 8) & 0x00FF));
@@ -531,7 +531,7 @@ unsigned short curlx_htons(unsigned short usnum)
 #endif
 }
 
-unsigned short curlx_ntohs(unsigned short usnum)
+unsigned short Curl_ntohs(unsigned short usnum)
 {
 #if (__INTEL_COMPILER == 910) && defined(__i386__)
   return (unsigned short)(((usnum << 8) & 0xFF00) | ((usnum >> 8) & 0x00FF));

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,88 +26,61 @@
 #include <curl/curl.h> /* for curl_socket_t */
 #endif
 
-unsigned short curlx_ultous(unsigned long ulnum);
-
-unsigned char curlx_ultouc(unsigned long ulnum);
-
-int curlx_ultosi(unsigned long ulnum);
-
-int curlx_uztosi(size_t uznum);
-
-curl_off_t curlx_uztoso(size_t uznum);
-
-unsigned long curlx_uztoul(size_t uznum);
-
-unsigned int curlx_uztoui(size_t uznum);
-
-int curlx_sltosi(long slnum);
-
-unsigned int curlx_sltoui(long slnum);
-
-unsigned short curlx_sltous(long slnum);
-
-ssize_t curlx_uztosz(size_t uznum);
-
-size_t curlx_sotouz(curl_off_t sonum);
-
-int curlx_sztosi(ssize_t sznum);
-
-unsigned short curlx_uitous(unsigned int uinum);
-
-unsigned char curlx_uitouc(unsigned int uinum);
-
-int curlx_uitosi(unsigned int uinum);
-
-size_t curlx_sitouz(int sinum);
+unsigned short Curl_ultous(unsigned long ulnum);
+unsigned char Curl_ultouc(unsigned long ulnum);
+int Curl_ultosi(unsigned long ulnum);
+int Curl_uztosi(size_t uznum);
+curl_off_t Curl_uztoso(size_t uznum);
+unsigned long Curl_uztoul(size_t uznum);
+unsigned int Curl_uztoui(size_t uznum);
+int Curl_sltosi(long slnum);
+unsigned int Curl_sltoui(long slnum);
+unsigned short Curl_sltous(long slnum);
+ssize_t Curl_uztosz(size_t uznum);
+size_t Curl_sotouz(curl_off_t sonum);
+int Curl_sztosi(ssize_t sznum);
+unsigned short Curl_uitous(unsigned int uinum);
+unsigned char Curl_uitouc(unsigned int uinum);
+int Curl_uitosi(unsigned int uinum);
+size_t Curl_sitouz(int sinum);
 
 #ifdef USE_WINSOCK
-
-int curlx_sktosi(curl_socket_t s);
-
-curl_socket_t curlx_sitosk(int i);
-
+int Curl_sktosi(curl_socket_t s);
+curl_socket_t Curl_sitosk(int i);
 #endif /* USE_WINSOCK */
 
 #if defined(WIN32) || defined(_WIN32)
-
-ssize_t curlx_read(int fd, void *buf, size_t count);
-
-ssize_t curlx_write(int fd, const void *buf, size_t count);
+ssize_t Curl_read(int fd, void *buf, size_t count);
+ssize_t Curl_write(int fd, const void *buf, size_t count);
 
 #ifndef BUILDING_WARNLESS_C
 #  undef  read
-#  define read(fd, buf, count)  curlx_read(fd, buf, count)
+#  define read(fd, buf, count)  Curl_read(fd, buf, count)
 #  undef  write
-#  define write(fd, buf, count) curlx_write(fd, buf, count)
+#  define write(fd, buf, count) Curl_write(fd, buf, count)
 #endif
 
 #endif /* WIN32 || _WIN32 */
 
 #if defined(__INTEL_COMPILER) && defined(__unix__)
-
-int curlx_FD_ISSET(int fd, fd_set *fdset);
-
-void curlx_FD_SET(int fd, fd_set *fdset);
-
-void curlx_FD_ZERO(fd_set *fdset);
-
-unsigned short curlx_htons(unsigned short usnum);
-
-unsigned short curlx_ntohs(unsigned short usnum);
+int Curl_FD_ISSET(int fd, fd_set *fdset);
+void Curl_FD_SET(int fd, fd_set *fdset);
+void Curl_FD_ZERO(fd_set *fdset);
+unsigned short Curl_htons(unsigned short usnum);
+unsigned short Curl_ntohs(unsigned short usnum);
 
 #ifndef BUILDING_WARNLESS_C
 #  undef  FD_ISSET
-#  define FD_ISSET(a,b) curlx_FD_ISSET((a),(b))
+#  define FD_ISSET(a,b) Curl_FD_ISSET((a),(b))
 #  undef  FD_SET
-#  define FD_SET(a,b)   curlx_FD_SET((a),(b))
+#  define FD_SET(a,b)   Curl_FD_SET((a),(b))
 #  undef  FD_ZERO
-#  define FD_ZERO(a)    curlx_FD_ZERO((a))
+#  define FD_ZERO(a)    Curl_FD_ZERO((a))
 #  undef  htons
-#  define htons(a)      curlx_htons((a))
+#  define htons(a)      Curl_htons((a))
 #  undef  ntohs
-#  define ntohs(a)      curlx_ntohs((a))
+#  define ntohs(a)      Curl_ntohs((a))
 #endif
 
 #endif /* __INTEL_COMPILER && __unix__ */
-
 #endif /* HEADER_CURL_WARNLESS_H */

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -11,14 +11,12 @@
 # the official API, but we re-use the code here to avoid duplication.
 CURLX_CFILES = \
 	../lib/strtoofft.c \
-	../lib/nonblock.c \
-	../lib/warnless.c
+	../lib/nonblock.c
 
 CURLX_HFILES = \
 	../lib/curl_setup.h \
 	../lib/strtoofft.h \
-	../lib/nonblock.h \
-	../lib/warnless.h
+	../lib/nonblock.h
 
 CURL_CFILES = \
 	slist_wc.c \

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -21,8 +21,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -220,7 +220,7 @@ static char *parse_filename(const char *ptr, size_t len)
    */
 #ifdef DEBUGBUILD
   {
-    char *tdir = curlx_getenv("CURL_TESTDIR");
+    char *tdir = curl_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
       snprintf(buffer, sizeof(buffer), "%s/%s", tdir, copy);

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -20,11 +20,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -123,7 +123,7 @@ void progressbarinit(struct ProgressData *bar,
   /* 20000318 mgs
    * OS/2 users most likely won't have this env var set, and besides that
    * we're using our own way to determine screen width */
-  colp = curlx_getenv("COLUMNS");
+  colp = curl_getenv("COLUMNS");
   if(colp) {
     char *endptr;
     long num = strtol(colp, &endptr, 10);

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,9 +26,6 @@
 #ifdef WIN32
 #  include <direct.h>
 #endif
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_dirhie.h"

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -24,9 +24,6 @@
 #include "slist_wc.h"
 
 #ifndef CURL_DISABLE_LIBCURL_OPTION
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"
@@ -111,7 +108,7 @@ CURLcode easysrc_addf(struct slist_wc **plist, const char *fmt, ...)
   char *bufp;
   va_list ap;
   va_start(ap, fmt);
-  bufp = curlx_mvaprintf(fmt, ap);
+  bufp = curl_mvaprintf(fmt, ap);
   va_end(ap);
   if(! bufp) {
     ret = CURLE_OUT_OF_MEMORY;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,11 +20,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -22,9 +22,6 @@
 #include "tool_setup.h"
 
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_binmode.h"
@@ -419,6 +416,7 @@ GetFileAndPassword(char *nextarg, char **file, char **password)
   }
   cleanarg(nextarg);
 }
+
 
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1330,7 +1330,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
            &-letter */
         char *oldpost = config->postfields;
         curl_off_t oldlen = config->postfieldsize;
-        curl_off_t newlen = oldlen + curlx_uztoso(size) + 2;
+        curl_off_t newlen = oldlen + (curl_off_t)size + 2;
         config->postfields = malloc((size_t)newlen);
         if(!config->postfields) {
           Curl_safefree(oldpost);
@@ -1348,7 +1348,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       else {
         config->postfields = postdata;
-        config->postfieldsize = curlx_uztoso(size);
+        config->postfieldsize = (curl_off_t)size;
       }
     }
     /*

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -22,9 +22,6 @@
 #include "tool_setup.h"
 
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,9 +22,6 @@
 #include "tool_setup.h"
 
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_libinfo.h"

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -94,7 +94,7 @@ static void memory_tracking_init(void)
 {
   char *env;
   /* if CURL_MEMDEBUG is set, this starts memory tracking message logging */
-  env = curlx_getenv("CURL_MEMDEBUG");
+  env = curl_getenv("CURL_MEMDEBUG");
   if(env) {
     /* use the value as file name */
     char fname[CURL_MT_LOGFNAME_BUFSIZE];
@@ -108,7 +108,7 @@ static void memory_tracking_init(void)
        log a free() without an alloc! */
   }
   /* if CURL_MEMLIMIT is set, this enables fail-on-alloc-number-N feature */
-  env = curlx_getenv("CURL_MEMLIMIT");
+  env = curl_getenv("CURL_MEMLIMIT");
   if(env) {
     char *endptr;
     long num = strtol(env, &endptr, 10);

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -32,8 +32,6 @@
 #include <plarenas.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -93,10 +93,7 @@ struct win32_crypto_hash {
 #  error "Can't compile METALINK support without a crypto library."
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
-
 #include "tool_getparam.h"
 #include "tool_paramhlp.h"
 #include "tool_cfgable.h"

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2015, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -316,7 +316,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
      !config->capath &&
      !config->insecure_ok) {
     char *env;
-    env = curlx_getenv("CURL_CA_BUNDLE");
+    env = curl_getenv("CURL_CA_BUNDLE");
     if(env) {
       config->cacert = strdup(env);
       if(!config->cacert) {
@@ -327,7 +327,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
       }
     }
     else {
-      env = curlx_getenv("SSL_CERT_DIR");
+      env = curl_getenv("SSL_CERT_DIR");
       if(env) {
         config->capath = strdup(env);
         if(!config->capath) {
@@ -339,7 +339,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
         capath_from_env = true;
       }
       else {
-        env = curlx_getenv("SSL_CERT_FILE");
+        env = curl_getenv("SSL_CERT_FILE");
         if(env) {
           config->cacert = strdup(env);
           if(!config->cacert) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -40,9 +40,6 @@
 #endif
 
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_binmode.h"
@@ -837,12 +834,12 @@ static CURLcode operate_do(struct GlobalConfig *global,
            * Then append ? followed by the get fields to the url.
            */
           if(pc)
-            urlbuffer = aprintf("%s%c%s", this_url, sep, httpgetfields);
+            urlbuffer = curl_maprintf("%s%c%s", this_url, sep, httpgetfields);
           else
             /* Append  / before the ? to create a well-formed url
                if the url contains a hostname only
             */
-            urlbuffer = aprintf("%s/?%s", this_url, httpgetfields);
+            urlbuffer = curl_maprintf("%s/?%s", this_url, httpgetfields);
 
           if(!urlbuffer) {
             result = CURLE_OUT_OF_MEMORY;
@@ -1181,7 +1178,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
             result = CURLE_OUT_OF_MEMORY;
             home = homedir();
             if(home) {
-              file = aprintf("%s/%sssh/known_hosts", home, DOT_CHAR);
+              file = curl_maprintf("%s/%sssh/known_hosts", home, DOT_CHAR);
               if(file) {
                 /* new in curl 7.19.6 */
                 result = res_setopt_str(curl, CURLOPT_SSH_KNOWNHOSTS, file);

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -173,7 +173,7 @@ CURLcode get_url_file_name(char **filename, const char *url)
    */
 #ifdef DEBUGBUILD
   {
-    char *tdir = curlx_getenv("CURL_TESTDIR");
+    char *tdir = curl_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
       snprintf(buffer, sizeof(buffer), "%s/%s", tdir, *filename);

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -22,9 +22,6 @@
 #include "tool_setup.h"
 
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"
@@ -104,10 +101,10 @@ char *add_file_name_to_url(CURL *curl, char *url, const char *filename)
       char *urlbuffer;
       if(ptr)
         /* there is a trailing slash on the URL */
-        urlbuffer = aprintf("%s%s", url, encfile);
+        urlbuffer = curl_maprintf("%s%s", url, encfile);
       else
         /* there is no trailing slash on the URL */
-        urlbuffer = aprintf("%s/%s", url, encfile);
+        urlbuffer = curl_maprintf("%s/%s", url, encfile);
 
       curl_free(encfile);
       Curl_safefree(url);

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,9 +22,6 @@
 #include "tool_setup.h"
 
 #include "strcase.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"
@@ -426,14 +423,14 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
 
     /* build a nice-looking prompt */
     if(!i && last)
-      curlx_msnprintf(prompt, sizeof(prompt),
-                      "Enter %s password for user '%s':",
-                      kind, *userpwd);
+      curl_msnprintf(prompt, sizeof(prompt),
+                     "Enter %s password for user '%s':",
+                     kind, *userpwd);
     else
-      curlx_msnprintf(prompt, sizeof(prompt),
-                      "Enter %s password for user '%s' on URL #%"
-                      CURL_FORMAT_CURL_OFF_TU ":",
-                      kind, *userpwd, (curl_off_t) (i + 1));
+      curl_msnprintf(prompt, sizeof(prompt),
+                     "Enter %s password for user '%s' on URL #%"
+                     CURL_FORMAT_CURL_OFF_TU ":",
+                     kind, *userpwd, (curl_off_t) (i + 1));
 
     /* get password */
     getpass_r(prompt, passwd, sizeof(passwd));

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,9 +22,6 @@
 #include "tool_setup.h"
 
 #ifndef CURL_DISABLE_LIBCURL_OPTION
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -40,6 +40,25 @@
  */
 
 #include <curl/curl.h> /* external interface */
+#include <curl/mprintf.h>
+
+# undef printf
+# undef fprintf
+# undef sprintf
+# undef snprintf
+# undef vprintf
+# undef vfprintf
+# undef vsprintf
+# undef vsnprintf
+
+# define printf curl_mprintf
+# define fprintf curl_mfprintf
+# define sprintf curl_msprintf
+# define snprintf curl_msnprintf
+# define vprintf curl_mvprintf
+# define vfprintf curl_mvfprintf
+# define vsprintf curl_mvsprintf
+# define vsnprintf curl_mvsnprintf
 
 /*
  * Platform specific stuff.

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,9 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_doswin.h"

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,10 +27,7 @@
     defined(__CRTL_VER) && (__CRTL_VER >= 70301000)
 #include <unixlib.h>
 #endif
-
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h"
-
 #include "curlmsg_vms.h"
 #include "tool_vms.h"
 

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -20,8 +20,6 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_writeout.h"


### PR DESCRIPTION
The existing `curlx_` prefix system for functions that exist in libcurl but have no public API and thus are used/shared by the tool as source code, is confusing and complicated. It would simplify things if we can remove this concept.

The system was originally introduced with a plan that curl could use several functions from the library that we would *remove* from the API, but we never did and we now have no plans to do so. Thus many of the curlx_ functions are already properly exported and usable via the regular API.

This patch series removes as many of the `curlx_` functions as possible and moves them over to the standard `Curl_` prefix for library internal globals, leaving only two still used by the tool:

1. curlx_nonblock
2. curlx_strtoofft

I haven't really decided what the best way forward is regarding these two.