### PR TITLE
expire: remove Curl_expire_latest()

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1070,7 +1070,7 @@ static CURLcode singleipconnect(struct connectdata *conn,
 
   conn->connecttime = Curl_tvnow();
   if(conn->num_addr > 1)
-    Curl_expire_latest(data, conn->timeoutms_per_addr, EXPIRE_DNS_PER_NAME);
+    Curl_expire(data, conn->timeoutms_per_addr, EXPIRE_DNS_PER_NAME);
 
   /* Connect TCP sockets, bind UDP */
   if(!isconnected && (conn->socktype == SOCK_STREAM)) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1840,9 +1840,9 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         if(send_timeout_ms <= 0 && recv_timeout_ms <= 0)
           multistate(data, CURLM_STATE_PERFORM);
         else if(send_timeout_ms >= recv_timeout_ms)
-          Curl_expire_latest(data, send_timeout_ms, EXPIRE_TOOFAST);
+          Curl_expire(data, send_timeout_ms, EXPIRE_TOOFAST);
         else
-          Curl_expire_latest(data, recv_timeout_ms, EXPIRE_TOOFAST);
+          Curl_expire(data, recv_timeout_ms, EXPIRE_TOOFAST);
       }
       break;
 
@@ -1873,9 +1873,9 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(send_timeout_ms > 0 || recv_timeout_ms > 0) {
         multistate(data, CURLM_STATE_TOOFAST);
         if(send_timeout_ms >= recv_timeout_ms)
-          Curl_expire_latest(data, send_timeout_ms, EXPIRE_TOOFAST);
+          Curl_expire(data, send_timeout_ms, EXPIRE_TOOFAST);
         else
-          Curl_expire_latest(data, recv_timeout_ms, EXPIRE_TOOFAST);
+          Curl_expire(data, recv_timeout_ms, EXPIRE_TOOFAST);
         break;
       }
 
@@ -1936,8 +1936,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
         /* expire the new receiving pipeline head */
         if(data->easy_conn->recv_pipe.head)
-          Curl_expire_latest(data->easy_conn->recv_pipe.head->ptr, 0,
-                             EXPIRE_RUN_NOW);
+          Curl_expire(data->easy_conn->recv_pipe.head->ptr, 0, EXPIRE_RUN_NOW);
 
         /* Check if we can move pending requests to send pipe */
         Curl_multi_process_pending_handles(multi);
@@ -2977,49 +2976,6 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
 }
 
 /*
- * Curl_expire_latest()
- *
- * This is like Curl_expire() but will only add a timeout node to the list of
- * timers if there is no timeout that will expire before the given time.
- *
- * Use this function if the code logic risks calling this function many times
- * or if there's no particular conditional wait in the code for this specific
- * time-out period to expire.
- *
- */
-void Curl_expire_latest(struct Curl_easy *data, time_t milli, expire_id id)
-{
-  struct timeval *expire = &data->state.expiretime;
-
-  struct timeval set;
-
-  set = Curl_tvnow();
-  set.tv_sec += (long)(milli / 1000);
-  set.tv_usec += (long)(milli % 1000) * 1000;
-
-  if(set.tv_usec >= 1000000) {
-    set.tv_sec++;
-    set.tv_usec -= 1000000;
-  }
-
-  if(expire->tv_sec || expire->tv_usec) {
-    /* This means that the struct is added as a node in the splay tree.
-       Compare if the new time is earlier, and only remove-old/add-new if it
-       is. */
-    time_t diff = curlx_tvdiff(set, *expire);
-    if((diff > 0) && (diff < milli)) {
-      /* if the new expire time is later than the top time, skip it, but not
-         if the diff is larger than the new offset since then the previous
-         time is already expired! */
-      return;
-    }
-  }
-
-  /* Just add the timeout like normal */
-  Curl_expire(data, milli, id);
-}
-
-/*
  * Curl_expire_done()
  *
  * Removes the expire timer. Marks it as done.
@@ -3134,7 +3090,7 @@ void Curl_multi_process_pending_handles(struct Curl_multi *multi)
       Curl_llist_remove(&multi->pending, e, NULL);
 
       /* Make sure that the handle will be processed soonish. */
-      Curl_expire_latest(data, 0, EXPIRE_RUN_NOW);
+      Curl_expire(data, 0, EXPIRE_RUN_NOW);
     }
 
     e = next; /* operate on next handle */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -28,7 +28,6 @@
 
 void Curl_expire(struct Curl_easy *data, time_t milli, expire_id);
 void Curl_expire_clear(struct Curl_easy *data);
-void Curl_expire_latest(struct Curl_easy *data, time_t milli, expire_id);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
 bool Curl_pipeline_wanted(const struct Curl_multi* multi, int bits);
 void Curl_multi_handlePipeBreak(struct Curl_easy *data);

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -67,7 +67,7 @@ CURLcode Curl_speedcheck(struct Curl_easy *data,
   if(data->set.low_speed_limit)
     /* if low speed limit is enabled, set the expire timer to make this
        connection's speed get checked again in a second */
-    Curl_expire_latest(data, 1000, EXPIRE_SPEEDCHECK);
+    Curl_expire(data, 1000, EXPIRE_SPEEDCHECK);
 
   return CURLE_OK;
 }


### PR DESCRIPTION
With the introduction of expire IDs and the fact that existing timers
can be removed now and thus never expire, the oncept with adding a
"latest" timer is not working anymore as it risks to not expire then.

So, to be certain the timers actually are in line and will expire, the
plain Curl_expire() needs to be used. The _latest() function was added
as a sort of shortcut in the past that's quite simply not necessary
anymore.

Follow-up to 31b39c40cf90

Reported-by: Paul Harris