### PR TITLE
Fix docs/examples/multi-uv.c deprecated symbol

### DIFF
--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -148,7 +148,7 @@ static void curl_perform(uv_poll_t *req, int status, int events)
   check_multi_info();
 }
 
-static void on_timeout(uv_timer_t *req, int status)
+static void on_timeout(uv_timer_t *req)
 {
   int running_handles;
   curl_multi_socket_action(curl_handle, CURL_SOCKET_TIMEOUT, 0,


### PR DESCRIPTION
I found one of libuv's symbol is outdated in `docs/examples/multi-uv`.

When I compile this example, I get a warning such as:

```
$ gcc -I../../include -I../../out/include/curl -I../../../../libuv/libuv/out/include multi-uv.c
multi-uv.c: In function ‘start_timeout’:        
multi-uv.c:168:30: warning: passing argument 2 of ‘uv_timer_start’ from incompatible pointer type [-Wincompatible-pointer-types]
     uv_timer_start(&timeout, on_timeout, timeout_ms, 0);           
                              ^~~~~~~~~~                                   
In file included from multi-uv.c:37:0:                              
../../../../libuv/libuv/out/include/uv.h:785:15: note: expected ‘uv_timer_cb {aka void (*)(struct uv_timer_s *)}’ but argument is of type ‘void (*)(uv_timer_t *, int) {aka void (*)(struct uv_timer_s *, int)}’
 UV_EXTERN int uv_timer_start(uv_timer_t* handle,
```

I checked libuv/libuv repository and found symbol `void (*uv_timer_cb)(uv_timer_t* handle, int status);` is outdated.
(diff: https://github.com/libuv/libuv/commit/db2a9072bce129630214904be5e2eedeaafc9835#diff-56343bd7ad8bf449c2693082fb3e4081L408 )