### PR TITLE
dist: make the hugehelp.c not get regenerated unnecessarily

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,7 +170,7 @@ dist-hook:
 	(distit=`find $(srcdir) -name "*.dist" | grep -v ./ares/`; \
 	for file in $$distit; do \
 	  strip=`echo $$file | sed -e s/^$(srcdir)// -e s/\.dist//`; \
-	  cp $$file $(distdir)$$strip; \
+	  cp -p $$file $(distdir)$$strip; \
 	done)
 
 html:

--- a/maketgz
+++ b/maketgz
@@ -139,6 +139,9 @@ fi
 echo "update man pages"
 ./scripts/updatemanpages.pl $version
 
+# make the generated file newer than the man page
+touch src/tool_hugehelp.c
+
 ############################################################################
 #
 # Update the IDE files


### PR DESCRIPTION
The maketgz script now makes sure the generated hugehelp.c file in the
tarball is newer than the generated curl.1 man page, so that it doesn't
have to get unnecessarily rebuilt first thing in a typical build. It
thus also removes the need for perl to build off a plain release
tarball.

Fixes #1565