### PR TITLE
tests: stabilize test 2032 and 2033

### DIFF
--- a/tests/data/test2032
+++ b/tests/data/test2032
@@ -5,7 +5,6 @@ HTTP
 HTTP GET
 HTTP Basic auth
 HTTP NTLM auth
-flaky
 </keywords>
 </info>
 # Server-side
@@ -55,34 +54,9 @@ Finally, this is the real page!
 </data1202>
 
 <datacheck>
-HTTP/1.1 401 Need Basic or NTLM auth
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
-WWW-Authenticate: NTLM
-WWW-Authenticate: Basic realm="testrealm"
-
-This is a bad password page!
-HTTP/1.1 401 Need Basic or NTLM auth
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
-WWW-Authenticate: NTLM
-WWW-Authenticate: Basic realm="testrealm"
-
-This is a bad password page!
-HTTP/1.1 401 NTLM intermediate (2)
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 33
-WWW-Authenticate: NTLM TlRMTVNTUAACAAAACAAIADAAAAAGggEAq6U1NAWaJCIAAAAAAAAAAAAAAAA4AAAATlRMTUF1dGg=
-
-HTTP/1.1 200 Things are fine in server land
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 32
-
-Finally, this is the real page!
+Data connection 0: 228
+Data connection 1: 228
+Data connection 2: 402
 </datacheck>
 
 </reply>

--- a/tests/data/test2033
+++ b/tests/data/test2033
@@ -6,7 +6,6 @@ HTTP GET
 HTTP Basic auth
 HTTP NTLM auth
 pipelining
-flaky
 </keywords>
 </info>
 # Server-side
@@ -56,34 +55,9 @@ Finally, this is the real page!
 </data1202>
 
 <datacheck>
-HTTP/1.1 401 Need Basic or NTLM auth
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
-WWW-Authenticate: NTLM
-WWW-Authenticate: Basic realm="testrealm"
-
-This is a bad password page!
-HTTP/1.1 401 Need Basic or NTLM auth
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
-WWW-Authenticate: NTLM
-WWW-Authenticate: Basic realm="testrealm"
-
-This is a bad password page!
-HTTP/1.1 401 NTLM intermediate (2)
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 33
-WWW-Authenticate: NTLM TlRMTVNTUAACAAAACAAIADAAAAAGggEAq6U1NAWaJCIAAAAAAAAAAAAAAAA4AAAATlRMTUF1dGg=
-
-HTTP/1.1 200 Things are fine in server land
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 32
-
-Finally, this is the real page!
+Data connection 0: 228
+Data connection 1: 228
+Data connection 2: 402
 </datacheck>
 
 </reply>

--- a/tests/libtest/libntlmconnect.c
+++ b/tests/libtest/libntlmconnect.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -33,6 +33,7 @@
 #define TEST_HANG_TIMEOUT 5 * 1000
 #define MAX_EASY_HANDLES 3
 
+static int counter[MAX_EASY_HANDLES];
 static CURL *easy[MAX_EASY_HANDLES];
 static curl_socket_t sockets[MAX_EASY_HANDLES];
 static int res = 0;
@@ -46,17 +47,7 @@ static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
 
   const size_t failure = (size && nmemb) ? 0 : 1;
 
-  char *output = malloc(size * nmemb + 1);
-  if(!output) {
-    fprintf(stderr, "output, malloc() failed\n");
-    res = TEST_ERR_MAJOR_BAD;
-    return failure;
-  }
-
-  memcpy(output, ptr, size * nmemb);
-  output[size * nmemb] = '\0';
-  fprintf(stdout, "%s", output);
-  free(output);
+  counter[idx] += (int)(size * nmemb);
 
   /* Get socket being used for this easy handle, otherwise CURL_SOCKET_BAD */
   code = curl_easy_getinfo(easy[idx], CURLINFO_LASTSOCKET, &longdata);
@@ -182,50 +173,6 @@ int test(char *url)
 
     /* At this point, maxfd is guaranteed to be greater or equal than -1. */
 
-    /* Any socket which is new in fdread is associated with the new handle */
-    for(i = 0; i <= maxfd; ++i) {
-      bool socket_exists = FALSE;
-      curl_socket_t curfd = (curl_socket_t)i;
-
-      if(!FD_ISSET(curfd, &fdread)) {
-        continue;
-      }
-
-      /* Check if this socket was already detected for an earlier handle (or
-         for this handle, num_handles-1, in the callback */
-      for(j = 0; j < num_handles; ++j) {
-        if(sockets[j] == curfd) {
-          socket_exists = TRUE;
-          break;
-        }
-      }
-      if(socket_exists) {
-        continue;
-      }
-
-      if(found_new_socket || state != NeedSocketForNewHandle) {
-        fprintf(stderr, "Unexpected new socket\n");
-        res = TEST_ERR_MAJOR_BAD;
-        goto test_cleanup;
-      }
-
-      /* Now we know the socket is for the most recent handle, num_handles-1 */
-      if(sockets[num_handles-1] != CURL_SOCKET_BAD) {
-        /* A socket for this handle was already detected in the callback; if it
-           matched socket_exists should be true and we would never get here */
-        assert(curfd != sockets[num_handles-1]);
-        fprintf(stderr, "Handle %d wrote to socket %d then detected on %d\n",
-                num_handles-1, (int)sockets[num_handles-1], (int)curfd);
-        res = TEST_ERR_MAJOR_BAD;
-        goto test_cleanup;
-      }
-      else {
-        sockets[num_handles-1] = curfd;
-        found_new_socket = TRUE;
-        /* continue to make sure there's only one new handle */
-      }
-    }
-
     if(state == NeedSocketForNewHandle) {
       if(maxfd != -1 && !found_new_socket) {
         fprintf(stderr, "Warning: socket did not open immediately for new "
@@ -270,6 +217,7 @@ test_cleanup:
   /* proper cleanup sequence - type PB */
 
   for(i = 0; i < MAX_EASY_HANDLES; i++) {
+    printf("Data connection %d: %d\n", i, counter[i]);
     curl_multi_remove_handle(multi, easy[i]);
     curl_easy_cleanup(easy[i]);
   }


### PR DESCRIPTION
Both these tests run the same underlying test code: libntlmconnect.c -
this test code made some assumptions about socket ordering when it used
curl_easy_fdset() and when we changed timing or got accidental changes
in libcurl the tests would fail.

The tests verify that the different transfers keep using the same
connections, which I now instead made sure by adding the number of bytes
each transfer gets and then verifies that they always get the same
amount as when these tests worked.