### PR TITLE
Enable more compiler warnings

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -84,7 +84,7 @@ endif
 endif
 
 CC	= $(CROSSPREFIX)gcc
-CFLAGS	= -g -O2 -Wall
+CFLAGS	= -g -O2 -Wall -W
 CFLAGS	+= -fno-strict-aliasing
 ifeq ($(ARCH),w64)
 CFLAGS	+= -m64 -D_AMD64_

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -77,7 +77,7 @@ LIBCARES_PATH = $(PROOT)/ares
 endif
 
 CC	= $(CROSSPREFIX)gcc
-CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall
+CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
 LDFLAGS	= $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL) -s

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -901,6 +901,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           if test "$compiler_num" -ge "306"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"
           fi
+          #
+          dnl Only clang 3.9 or later
+          if test "$compiler_num" -ge "309"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wcomma"
+          fi
         fi
         ;;
         #

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -892,6 +892,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -Wshift-sign-overflow"
           fi
           #
+          dnl Only clang 3.2 or later
+          if test "$compiler_num" -ge "302"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wmissing-variable-declarations"
+          fi
+          #
           dnl Only clang 3.6 or later
           if test "$compiler_num" -ge "306"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -891,6 +891,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           if test "$compiler_num" -ge "209"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wshift-sign-overflow"
           fi
+          #
+          dnl Only clang 3.6 or later
+          if test "$compiler_num" -ge "306"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"
+          fi
         fi
         ;;
         #
@@ -1000,6 +1005,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             if test "$curl_cv_have_def__WIN32" = "yes"; then
               tmp_CFLAGS="$tmp_CFLAGS -Wno-pedantic-ms-format"
             fi
+          fi
+          #
+          dnl Only gcc 4.6 or later
+          if test "$compiler_num" -ge "406"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"
           fi
           #
         fi

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -882,6 +882,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -Wunused"
           fi
           #
+          dnl Only clang 2.8 or later
+          if test "$compiler_num" -ge "208"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wvla"
+          fi
+          #
           dnl Only clang 2.9 or later
           if test "$compiler_num" -ge "209"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wshift-sign-overflow"

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -89,7 +89,7 @@ LIBCARES_PATH = $(PROOT)/ares
 endif
 
 CC	= $(CROSSPREFIX)gcc
-CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall
+CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
 LDFLAGS	= $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s


### PR DESCRIPTION
- enable -Wvla also for clang; it was previously only enabled for GCC
- enable -W also for mingw32-make based build
- enable -Wdouble-promotion for both GCC and clang (typically warns when mixing float and double by accident)
- enable -Wmissing-variable-declarations for clang (typically warns when forgetting to declare variables static)
- enable -Wcomma for clang (see b875250e32048070401f5a3a23cdd9f47b15e114 for a typical case)

All of these are fixed and trivial to fix. Tested with all possible combinations of
- clang 3.5 to 5.0, GCC 5 to 7
- native Ubuntu, Cygwin64 on Windows, MinGW on Windows (MSYS), MinGW-w64 on Windows (MSYS2 and native), MinGW-w64 on Ubuntu
- 32 bit and 64 bit targets
- OpenSSL, GnuTLS, NSS, CyaSSL/WolfSSL, mbedTLS, PolarSSL, and WinSSL backends

I could also push a subset if anyone feels that some of these warnings make no sense.