### PR TITLE
http-proxy: fix EAGAIN and chunked-encoding regressions from 5113ad0424

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -188,7 +188,6 @@ static CURLcode CONNECT(struct connectdata *conn,
   CURLcode result;
   curl_socket_t tunnelsocket = conn->sock[sockindex];
   bool closeConnection = FALSE;
-  bool chunked_encoding = FALSE;
   time_t check;
   struct http_connect_state *s = conn->connect_state;
 
@@ -454,7 +453,7 @@ static CURLcode CONNECT(struct connectdata *conn,
               infof(data, "Ignore %" CURL_FORMAT_CURL_OFF_T
                     " bytes of response-body\n", s->cl);
             }
-            else if(chunked_encoding) {
+            else if(s->chunked_encoding) {
               CHUNKcode r;
 
               infof(data, "Ignore chunked response-body\n");
@@ -541,7 +540,7 @@ static CURLcode CONNECT(struct connectdata *conn,
           else if(Curl_compareheader(s->line_start,
                                      "Transfer-Encoding:", "chunked")) {
             infof(data, "CONNECT responded chunked\n");
-            chunked_encoding = TRUE;
+            s->chunked_encoding = TRUE;
             /* init our chunky engine */
             Curl_httpchunk_init(conn);
           }

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -311,6 +311,7 @@ static CURLcode CONNECT(struct connectdata *conn,
         return result;
 
       s->tunnel_state = TUNNEL_CONNECT;
+      s->perline = 0;
     } /* END CONNECT PHASE */
 
     check = Curl_timeleft(data, NULL, TRUE);
@@ -327,8 +328,6 @@ static CURLcode CONNECT(struct connectdata *conn,
 
     { /* READING RESPONSE PHASE */
       int error = SELECT_OK;
-
-      s->perline = 0;
 
       while(s->keepon && !error) {
         ssize_t gotbytes;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -905,6 +905,7 @@ struct http_connect_state {
   char *line_start;
   char *ptr; /* where to store more data */
   curl_off_t cl; /* size of content to read and ignore */
+  bool chunked_encoding;
   enum {
     TUNNEL_INIT,    /* init/default/no tunnel state */
     TUNNEL_CONNECT, /* CONNECT has been sent off */

--- a/tests/data/test1061
+++ b/tests/data/test1061
@@ -8,7 +8,6 @@ HTTP proxy
 chunked Transfer-Encoding
 proxytunnel
 HTTP proxy Digest auth
-flaky
 </keywords>
 </info>
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1194,12 +1194,12 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
 
   responsesize = count;
   do {
-    /* Ok, we send no more than 200 bytes at a time, just to make sure that
+    /* Ok, we send no more than N bytes at a time, just to make sure that
        larger chunks are split up so that the client will need to do multiple
        recv() calls to get it and thus we exercise that code better */
     size_t num = count;
-    if(num > 200)
-      num = 200;
+    if(num > 20)
+      num = 20;
 
     retry:
     written = swrite(sock, buffer, num);
@@ -1210,9 +1210,6 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
       }
       sendfailure = TRUE;
       break;
-    }
-    else {
-      logmsg("Sent off %zd bytes", written);
     }
 
     /* write to file as well */


### PR DESCRIPTION
... the previous code would reset the header length wrongly (since
5113ad0424). This makes test 1060 reliable again.

Also: make sws send even smaller chunks of data to increase the
likeliness of this happening.