### PR TITLE
curl_setup_once: Remove ERRNO/SET_ERRNO macros

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -407,9 +407,7 @@ static bool init_resolve_thread(struct connectdata *conn,
 #endif
 
   if(!td->thread_hnd) {
-#ifndef _WIN32_WCE
     err = errno;
-#endif
     goto err_exit;
   }
 
@@ -418,8 +416,7 @@ static bool init_resolve_thread(struct connectdata *conn,
  err_exit:
   destroy_async_data(&conn->async);
 
-  SET_ERRNO(err);
-
+  errno = err;
   return FALSE;
 }
 
@@ -654,7 +651,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 
   /* fall-back to blocking version */
   infof(conn->data, "init_resolve_thread() failed for %s; %s\n",
-        hostname, Curl_strerror(conn, ERRNO));
+        hostname, Curl_strerror(conn, errno));
 
   error = Curl_getaddrinfo_ex(hostname, sbuf, &hints, &res);
   if(error) {

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -607,7 +607,8 @@ void Curl_persistconninfo(struct connectdata *conn)
   conn->data->info.conn_local_port = conn->local_port;
 }
 
-/* retrieves ip address and port from a sockaddr structure */
+/* retrieves ip address and port from a sockaddr structure.
+   note it calls Curl_inet_ntop which sets errno on fail, not SOCKERRNO. */
 static bool getaddressinfo(struct sockaddr *sa, char *addr,
                            long *port)
 {
@@ -654,7 +655,7 @@ static bool getaddressinfo(struct sockaddr *sa, char *addr,
 
   addr[0] = '\0';
   *port = 0;
-
+  errno = EAFNOSUPPORT;
   return FALSE;
 }
 
@@ -672,11 +673,9 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
     return;
 
   if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
-    int error;
-
     len = sizeof(struct Curl_sockaddr_storage);
     if(getpeername(sockfd, (struct sockaddr*) &ssrem, &len)) {
-      error = SOCKERRNO;
+      int error = SOCKERRNO;
       failf(data, "getpeername() failed with errno %d: %s",
             error, Curl_strerror(conn, error));
       return;
@@ -685,7 +684,7 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
     len = sizeof(struct Curl_sockaddr_storage);
     memset(&ssloc, 0, sizeof(ssloc));
     if(getsockname(sockfd, (struct sockaddr*) &ssloc, &len)) {
-      error = SOCKERRNO;
+      int error = SOCKERRNO;
       failf(data, "getsockname() failed with errno %d: %s",
             error, Curl_strerror(conn, error));
       return;
@@ -693,18 +692,16 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
 
     if(!getaddressinfo((struct sockaddr*)&ssrem,
                         conn->primary_ip, &conn->primary_port)) {
-      error = ERRNO;
       failf(data, "ssrem inet_ntop() failed with errno %d: %s",
-            error, Curl_strerror(conn, error));
+            errno, Curl_strerror(conn, errno));
       return;
     }
     memcpy(conn->ip_addr_str, conn->primary_ip, MAX_IPADR_LEN);
 
     if(!getaddressinfo((struct sockaddr*)&ssloc,
                        conn->local_ip, &conn->local_port)) {
-      error = ERRNO;
       failf(data, "ssloc inet_ntop() failed with errno %d: %s",
-            error, Curl_strerror(conn, error));
+            errno, Curl_strerror(conn, errno));
       return;
     }
 
@@ -1008,9 +1005,8 @@ static CURLcode singleipconnect(struct connectdata *conn,
   if(!getaddressinfo((struct sockaddr*)&addr.sa_addr,
                      ipaddress, &port)) {
     /* malformed address or bug in inet_ntop, try next address */
-    error = ERRNO;
     failf(data, "sa_addr inet_ntop() failed with errno %d: %s",
-          error, Curl_strerror(conn, error));
+          errno, Curl_strerror(conn, errno));
     Curl_closesocket(conn, sockfd);
     return CURLE_OK;
   }

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -123,7 +123,6 @@ static CURLcode ntlm_wb_init(struct connectdata *conn, const char *userp)
   struct passwd pw, *pw_res;
   char pwbuf[1024];
 #endif
-  int error;
 
   /* Return if communication with ntlm_auth already set up */
   if(conn->ntlm_auth_hlpr_socket != CURL_SOCKET_BAD ||
@@ -178,26 +177,23 @@ static CURLcode ntlm_wb_init(struct connectdata *conn, const char *userp)
     ntlm_auth = NTLM_WB_FILE;
 
   if(access(ntlm_auth, X_OK) != 0) {
-    error = ERRNO;
     failf(conn->data, "Could not access ntlm_auth: %s errno %d: %s",
-          ntlm_auth, error, Curl_strerror(conn, error));
+          ntlm_auth, errno, Curl_strerror(conn, errno));
     goto done;
   }
 
   if(socketpair(AF_UNIX, SOCK_STREAM, 0, sockfds)) {
-    error = ERRNO;
     failf(conn->data, "Could not open socket pair. errno %d: %s",
-          error, Curl_strerror(conn, error));
+          errno, Curl_strerror(conn, errno));
     goto done;
   }
 
   child_pid = fork();
   if(child_pid == -1) {
-    error = ERRNO;
     sclose(sockfds[0]);
     sclose(sockfds[1]);
     failf(conn->data, "Could not fork. errno %d: %s",
-          error, Curl_strerror(conn, error));
+          errno, Curl_strerror(conn, errno));
     goto done;
   }
   else if(!child_pid) {
@@ -208,16 +204,14 @@ static CURLcode ntlm_wb_init(struct connectdata *conn, const char *userp)
     /* Don't use sclose in the child since it fools the socket leak detector */
     sclose_nolog(sockfds[0]);
     if(dup2(sockfds[1], STDIN_FILENO) == -1) {
-      error = ERRNO;
       failf(conn->data, "Could not redirect child stdin. errno %d: %s",
-            error, Curl_strerror(conn, error));
+            errno, Curl_strerror(conn, errno));
       exit(1);
     }
 
     if(dup2(sockfds[1], STDOUT_FILENO) == -1) {
-      error = ERRNO;
       failf(conn->data, "Could not redirect child stdout. errno %d: %s",
-            error, Curl_strerror(conn, error));
+            errno, Curl_strerror(conn, errno));
       exit(1);
     }
 
@@ -235,10 +229,9 @@ static CURLcode ntlm_wb_init(struct connectdata *conn, const char *userp)
             "--username", username,
             NULL);
 
-    error = ERRNO;
     sclose_nolog(sockfds[1]);
     failf(conn->data, "Could not execl(). errno %d: %s",
-          error, Curl_strerror(conn, error));
+          errno, Curl_strerror(conn, errno));
     exit(1);
   }
 

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -436,20 +436,6 @@ typedef int sig_atomic_t;
 
 
 /*
- * Macro ERRNO / SET_ERRNO() returns / sets the NOT *socket-related* errno
- * (or equivalent) on this platform to hide platform details to code using it.
- */
-
-#if defined(WIN32) && !defined(USE_LWIPSOCK)
-#define ERRNO         ((int)GetLastError())
-#define SET_ERRNO(x)  (SetLastError((DWORD)(x)))
-#else
-#define ERRNO         (errno)
-#define SET_ERRNO(x)  (errno = (x))
-#endif
-
-
-/*
  * Portable error number symbolic names defined to Winsock error codes.
  */
 

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -104,15 +104,22 @@ int Curl_thread_join(curl_thread_t *hnd)
 curl_thread_t Curl_thread_create(unsigned int (CURL_STDCALL *func) (void *),
                                  void *arg)
 {
-#ifdef _WIN32_WCE
-  return CreateThread(NULL, 0, func, arg, 0, NULL);
-#else
   curl_thread_t t;
+#ifdef _WIN32_WCE
+  t = CreateThread(NULL, 0, func, arg, 0, NULL);
+#else
   t = (curl_thread_t)_beginthreadex(NULL, 0, func, arg, 0, NULL);
-  if((t == 0) || (t == (curl_thread_t)-1L))
-    return curl_thread_t_null;
-  return t;
 #endif
+  if((t == 0) || (t == (curl_thread_t)-1L)) {
+#ifdef _WIN32_WCE
+    DWORD gle = GetLastError();
+    errno = ((gle == ERROR_ACCESS_DENIED ||
+              gle == ERROR_NOT_ENOUGH_MEMORY) ?
+             EACCES : EINVAL);
+#endif
+    return curl_thread_t_null;
+  }
+  return t;
 }
 
 void Curl_thread_destroy(curl_thread_t hnd)

--- a/lib/inet_ntop.c
+++ b/lib/inet_ntop.c
@@ -63,7 +63,7 @@ static char *inet_ntop4 (const unsigned char *src, char *dst, size_t size)
 
   len = strlen(tmp);
   if(len == 0 || len >= size) {
-    SET_ERRNO(ENOSPC);
+    errno = ENOSPC;
     return (NULL);
   }
   strcpy(dst, tmp);
@@ -142,7 +142,7 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
     if(i == 6 && best.base == 0 &&
         (best.len == 6 || (best.len == 5 && words[5] == 0xffff))) {
       if(!inet_ntop4(src+12, tp, sizeof(tmp) - (tp - tmp))) {
-        SET_ERRNO(ENOSPC);
+        errno = ENOSPC;
         return (NULL);
       }
       tp += strlen(tp);
@@ -160,7 +160,7 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
   /* Check for overflow, copy, and we're done.
    */
   if((size_t)(tp - tmp) > size) {
-    SET_ERRNO(ENOSPC);
+    errno = ENOSPC;
     return (NULL);
   }
   strcpy(dst, tmp);
@@ -177,8 +177,8 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
  *
  * On Windows we store the error in the thread errno, not
  * in the winsock error code. This is to avoid losing the
- * actual last winsock error. So use macro ERRNO to fetch the
- * errno this function sets when returning NULL, not SOCKERRNO.
+ * actual last winsock error. So when this function returns
+ * NULL, check errno not SOCKERRNO.
  */
 char *Curl_inet_ntop(int af, const void *src, char *buf, size_t size)
 {
@@ -190,7 +190,7 @@ char *Curl_inet_ntop(int af, const void *src, char *buf, size_t size)
     return inet_ntop6((const unsigned char *)src, buf, size);
 #endif
   default:
-    SET_ERRNO(EAFNOSUPPORT);
+    errno = EAFNOSUPPORT;
     return NULL;
   }
 }

--- a/lib/inet_pton.c
+++ b/lib/inet_pton.c
@@ -57,8 +57,8 @@ static int      inet_pton6(const char *src, unsigned char *dst);
  * notice:
  *      On Windows we store the error in the thread errno, not
  *      in the winsock error code. This is to avoid losing the
- *      actual last winsock error. So use macro ERRNO to fetch the
- *      errno this function sets when returning (-1), not SOCKERRNO.
+ *      actual last winsock error. So when this function returns
+ *      -1, check errno not SOCKERRNO.
  * author:
  *      Paul Vixie, 1996.
  */
@@ -73,7 +73,7 @@ Curl_inet_pton(int af, const char *src, void *dst)
     return (inet_pton6(src, (unsigned char *)dst));
 #endif
   default:
-    SET_ERRNO(EAFNOSUPPORT);
+    errno = EAFNOSUPPORT;
     return (-1);
   }
   /* NOTREACHED */

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -146,7 +146,7 @@ static bool countcheck(const char *func, int line, const char *source)
                 source, line, func);
         fflush(logfile); /* because it might crash now */
       }
-      SET_ERRNO(ENOMEM);
+      errno = ENOMEM;
       return TRUE; /* RETURN ERROR! */
     }
     else

--- a/lib/non-ascii.c
+++ b/lib/non-ascii.c
@@ -98,19 +98,17 @@ CURLcode Curl_convert_to_network(struct Curl_easy *data,
     /* do the translation ourselves */
     char *input_ptr, *output_ptr;
     size_t in_bytes, out_bytes, rc;
-    int error;
 
     /* open an iconv conversion descriptor if necessary */
     if(data->outbound_cd == (iconv_t)-1) {
       data->outbound_cd = iconv_open(CURL_ICONV_CODESET_OF_NETWORK,
                                      CURL_ICONV_CODESET_OF_HOST);
       if(data->outbound_cd == (iconv_t)-1) {
-        error = ERRNO;
         failf(data,
               "The iconv_open(\"%s\", \"%s\") call failed with errno %i: %s",
               CURL_ICONV_CODESET_OF_NETWORK,
               CURL_ICONV_CODESET_OF_HOST,
-              error, strerror(error));
+              errno, strerror(errno));
         return CURLE_CONV_FAILED;
       }
     }
@@ -120,10 +118,9 @@ CURLcode Curl_convert_to_network(struct Curl_easy *data,
     rc = iconv(data->outbound_cd, (const char **)&input_ptr, &in_bytes,
                &output_ptr, &out_bytes);
     if((rc == ICONV_ERROR) || (in_bytes != 0)) {
-      error = ERRNO;
       failf(data,
             "The Curl_convert_to_network iconv call failed with errno %i: %s",
-            error, strerror(error));
+            errno, strerror(errno));
       return CURLE_CONV_FAILED;
     }
 #else
@@ -158,19 +155,17 @@ CURLcode Curl_convert_from_network(struct Curl_easy *data,
     /* do the translation ourselves */
     char *input_ptr, *output_ptr;
     size_t in_bytes, out_bytes, rc;
-    int error;
 
     /* open an iconv conversion descriptor if necessary */
     if(data->inbound_cd == (iconv_t)-1) {
       data->inbound_cd = iconv_open(CURL_ICONV_CODESET_OF_HOST,
                                     CURL_ICONV_CODESET_OF_NETWORK);
       if(data->inbound_cd == (iconv_t)-1) {
-        error = ERRNO;
         failf(data,
               "The iconv_open(\"%s\", \"%s\") call failed with errno %i: %s",
               CURL_ICONV_CODESET_OF_HOST,
               CURL_ICONV_CODESET_OF_NETWORK,
-              error, strerror(error));
+              errno, strerror(errno));
         return CURLE_CONV_FAILED;
       }
     }
@@ -180,10 +175,9 @@ CURLcode Curl_convert_from_network(struct Curl_easy *data,
     rc = iconv(data->inbound_cd, (const char **)&input_ptr, &in_bytes,
                &output_ptr, &out_bytes);
     if((rc == ICONV_ERROR) || (in_bytes != 0)) {
-      error = ERRNO;
       failf(data,
             "Curl_convert_from_network iconv call failed with errno %i: %s",
-            error, strerror(error));
+            errno, strerror(errno));
       return CURLE_CONV_FAILED;
     }
 #else
@@ -219,19 +213,17 @@ CURLcode Curl_convert_from_utf8(struct Curl_easy *data,
     const char *input_ptr;
     char *output_ptr;
     size_t in_bytes, out_bytes, rc;
-    int error;
 
     /* open an iconv conversion descriptor if necessary */
     if(data->utf8_cd == (iconv_t)-1) {
       data->utf8_cd = iconv_open(CURL_ICONV_CODESET_OF_HOST,
                                  CURL_ICONV_CODESET_FOR_UTF8);
       if(data->utf8_cd == (iconv_t)-1) {
-        error = ERRNO;
         failf(data,
               "The iconv_open(\"%s\", \"%s\") call failed with errno %i: %s",
               CURL_ICONV_CODESET_OF_HOST,
               CURL_ICONV_CODESET_FOR_UTF8,
-              error, strerror(error));
+              errno, strerror(errno));
         return CURLE_CONV_FAILED;
       }
     }
@@ -241,10 +233,9 @@ CURLcode Curl_convert_from_utf8(struct Curl_easy *data,
     rc = iconv(data->utf8_cd, &input_ptr, &in_bytes,
                &output_ptr, &out_bytes);
     if((rc == ICONV_ERROR) || (in_bytes != 0)) {
-      error = ERRNO;
       failf(data,
             "The Curl_convert_from_utf8 iconv call failed with errno %i: %s",
-            error, strerror(error));
+            errno, strerror(errno));
       return CURLE_CONV_FAILED;
     }
     if(output_ptr < input_ptr) {

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -404,12 +404,12 @@ static int parsedate(const char *date, time_t *output)
         int error;
         int old_errno;
 
-        old_errno = ERRNO;
-        SET_ERRNO(0);
+        old_errno = errno;
+        errno = 0;
         lval = strtol(date, &end, 10);
-        error = ERRNO;
-        if(error != old_errno)
-          SET_ERRNO(old_errno);
+        error = errno;
+        if(errno != old_errno)
+          errno = old_errno;
 
         if(error)
           return PARSEDATE_FAIL;

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -132,7 +132,7 @@ curlx_strtoll(const char *nptr, char **endptr, int base)
     else
       value = CURL_OFF_T_MAX;
 
-    SET_ERRNO(ERANGE);
+    errno = ERANGE;
   }
 
   if(endptr)

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1356,14 +1356,14 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   /* load ws2_32.dll and get the function pointers we need. */
   wsock2 = Curl_load_library(TEXT("WS2_32.DLL"));
   if(wsock2 == NULL) {
-    failf(data, "failed to load WS2_32.DLL (%d)", ERRNO);
+    failf(data, "failed to load WS2_32.DLL (%u)", GetLastError());
     return CURLE_FAILED_INIT;
   }
 
   /* Grab a pointer to WSACreateEvent */
   create_event_func = GetProcAddress(wsock2, "WSACreateEvent");
   if(create_event_func == NULL) {
-    failf(data, "failed to find WSACreateEvent function (%d)", ERRNO);
+    failf(data, "failed to find WSACreateEvent function (%u)", GetLastError());
     FreeLibrary(wsock2);
     return CURLE_FAILED_INIT;
   }
@@ -1371,7 +1371,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   /* And WSACloseEvent */
   close_event_func = GetProcAddress(wsock2, "WSACloseEvent");
   if(close_event_func == NULL) {
-    failf(data, "failed to find WSACloseEvent function (%d)", ERRNO);
+    failf(data, "failed to find WSACloseEvent function (%u)", GetLastError());
     FreeLibrary(wsock2);
     return CURLE_FAILED_INIT;
   }
@@ -1379,7 +1379,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   /* And WSAEventSelect */
   event_select_func = GetProcAddress(wsock2, "WSAEventSelect");
   if(event_select_func == NULL) {
-    failf(data, "failed to find WSAEventSelect function (%d)", ERRNO);
+    failf(data, "failed to find WSAEventSelect function (%u)", GetLastError());
     FreeLibrary(wsock2);
     return CURLE_FAILED_INIT;
   }
@@ -1387,7 +1387,8 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   /* And WSAEnumNetworkEvents */
   enum_netevents_func = GetProcAddress(wsock2, "WSAEnumNetworkEvents");
   if(enum_netevents_func == NULL) {
-    failf(data, "failed to find WSAEnumNetworkEvents function (%d)", ERRNO);
+    failf(data, "failed to find WSAEnumNetworkEvents function (%u)",
+          GetLastError());
     FreeLibrary(wsock2);
     return CURLE_FAILED_INIT;
   }
@@ -1580,7 +1581,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
 
   /* We called LoadLibrary, so call FreeLibrary */
   if(!FreeLibrary(wsock2))
-    infof(data, "FreeLibrary(wsock2) failed (%d)", ERRNO);
+    infof(data, "FreeLibrary(wsock2) failed (%u)", GetLastError());
 #else
   pfd[0].fd = sockfd;
   pfd[0].events = POLLIN;

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -50,7 +50,7 @@
 
 static void show_dir_errno(FILE *errors, const char *name)
 {
-  switch(ERRNO) {
+  switch(errno) {
 #ifdef EACCES
   case EACCES:
     fprintf(errors, "You don't have permission to create %s.\n", name);

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -383,11 +383,11 @@ ParameterError str2offset(curl_off_t *val, const char *str)
 
 #if(CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
   *val = curlx_strtoofft(str, &endptr, 0);
-  if((*val == CURL_OFF_T_MAX || *val == CURL_OFF_T_MIN) && (ERRNO == ERANGE))
+  if((*val == CURL_OFF_T_MAX || *val == CURL_OFF_T_MIN) && (errno == ERANGE))
     return PARAM_BAD_NUMERIC;
 #else
   *val = strtol(str, &endptr, 0);
-  if((*val == LONG_MIN || *val == LONG_MAX) && ERRNO == ERANGE)
+  if((*val == LONG_MIN || *val == LONG_MAX) && errno == ERANGE)
     return PARAM_BAD_NUMERIC;
 #endif
   if((endptr != str) && (endptr == str + strlen(str)))

--- a/tests/libtest/lib505.c
+++ b/tests/libtest/lib505.c
@@ -42,7 +42,6 @@ int test(char *URL)
   int hd;
   struct_stat file_info;
   struct curl_slist *hl;
-  int error;
 
   struct curl_slist *headerlist=NULL;
   const char *buf_1 = "RNFR 505";
@@ -55,9 +54,8 @@ int test(char *URL)
 
   hd_src = fopen(libtest_arg2, "rb");
   if(NULL == hd_src) {
-    error = ERRNO;
     fprintf(stderr, "fopen failed with error: %d %s\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "Error opening file: %s\n", libtest_arg2);
     return TEST_ERR_MAJOR_BAD; /* if this happens things are major weird */
   }
@@ -66,9 +64,8 @@ int test(char *URL)
   hd = fstat(fileno(hd_src), &file_info);
   if(hd == -1) {
     /* can't open file, bail out */
-    error = ERRNO;
     fprintf(stderr, "fstat() failed with error: %d %s\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "ERROR: cannot open file %s\n", libtest_arg2);
     fclose(hd_src);
     return TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -86,7 +86,7 @@ static int fopen_works(void)
   for(i = 0; i < 3; i++) {
     fpa[i] = fopen(DEV_NULL, FOPEN_READTEXT);
     if(fpa[i] == NULL) {
-      store_errmsg("fopen failed", ERRNO);
+      store_errmsg("fopen failed", errno);
       fprintf(stderr, "%s\n", msgbuff);
       ret = 0;
       break;
@@ -122,7 +122,7 @@ static int rlimit(int keep_open)
   /* get initial open file limits */
 
   if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
-    store_errmsg("getrlimit() failed", ERRNO);
+    store_errmsg("getrlimit() failed", errno);
     fprintf(stderr, "%s\n", msgbuff);
     return -1;
   }
@@ -169,7 +169,7 @@ static int rlimit(int keep_open)
       rl.rlim_cur = OPEN_MAX;
       if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
         /* on failure don't abort just issue a warning */
-        store_errmsg("setrlimit() failed", ERRNO);
+        store_errmsg("setrlimit() failed", errno);
         fprintf(stderr, "%s\n", msgbuff);
         msgbuff[0] = '\0';
       }
@@ -180,7 +180,7 @@ static int rlimit(int keep_open)
     rl.rlim_cur = rl.rlim_max;
     if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
       /* on failure don't abort just issue a warning */
-      store_errmsg("setrlimit() failed", ERRNO);
+      store_errmsg("setrlimit() failed", errno);
       fprintf(stderr, "%s\n", msgbuff);
       msgbuff[0] = '\0';
     }
@@ -188,7 +188,7 @@ static int rlimit(int keep_open)
     /* get current open file limits */
 
     if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
-      store_errmsg("getrlimit() failed", ERRNO);
+      store_errmsg("getrlimit() failed", errno);
       fprintf(stderr, "%s\n", msgbuff);
       return -3;
     }
@@ -268,7 +268,7 @@ static int rlimit(int keep_open)
     }
   } while(nitems && !memchunk);
   if(!memchunk) {
-    store_errmsg("memchunk, malloc() failed", ERRNO);
+    store_errmsg("memchunk, malloc() failed", errno);
     fprintf(stderr, "%s\n", msgbuff);
     return -5;
   }
@@ -303,7 +303,7 @@ static int rlimit(int keep_open)
 
   fd = malloc(sizeof(*fd) * (size_t)(num_open.rlim_max));
   if(!fd) {
-    store_errmsg("fd, malloc() failed", ERRNO);
+    store_errmsg("fd, malloc() failed", errno);
     fprintf(stderr, "%s\n", msgbuff);
     free(memchunk);
     return -7;
@@ -326,7 +326,7 @@ static int rlimit(int keep_open)
   fd[0] = open(DEV_NULL, O_RDONLY);
   if(fd[0] < 0) {
     snprintf(strbuff, sizeof(strbuff), "opening of %s failed", DEV_NULL);
-    store_errmsg(strbuff, ERRNO);
+    store_errmsg(strbuff, errno);
     fprintf(stderr, "%s\n", msgbuff);
     free(fd);
     fd = NULL;

--- a/tests/libtest/lib525.c
+++ b/tests/libtest/lib525.c
@@ -35,7 +35,6 @@ int test(char *URL)
   CURL *curl = NULL;
   FILE *hd_src = NULL;
   int hd;
-  int error;
   struct_stat file_info;
   CURLM *m = NULL;
   int running;
@@ -55,9 +54,8 @@ int test(char *URL)
 
   hd_src = fopen(libtest_arg2, "rb");
   if(NULL == hd_src) {
-    error = ERRNO;
     fprintf(stderr, "fopen failed with error: %d (%s)\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "Error opening file: (%s)\n", libtest_arg2);
     return TEST_ERR_FOPEN;
   }
@@ -66,9 +64,8 @@ int test(char *URL)
   hd = fstat(fileno(hd_src), &file_info);
   if(hd == -1) {
     /* can't open file, bail out */
-    error = ERRNO;
     fprintf(stderr, "fstat() failed with error: %d (%s)\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "ERROR: cannot open file (%s)\n", libtest_arg2);
     fclose(hd_src);
     return TEST_ERR_FSTAT;

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -87,7 +87,7 @@ static int fopen_works(void)
   for(i = 0; i < 3; i++) {
     fpa[i] = fopen(DEV_NULL, FOPEN_READTEXT);
     if(fpa[i] == NULL) {
-      store_errmsg("fopen failed", ERRNO);
+      store_errmsg("fopen failed", errno);
       fprintf(stderr, "%s\n", msgbuff);
       ret = 0;
       break;
@@ -123,7 +123,7 @@ static int rlimit(int keep_open)
   /* get initial open file limits */
 
   if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
-    store_errmsg("getrlimit() failed", ERRNO);
+    store_errmsg("getrlimit() failed", errno);
     fprintf(stderr, "%s\n", msgbuff);
     return -1;
   }
@@ -164,7 +164,7 @@ static int rlimit(int keep_open)
       rl.rlim_cur = OPEN_MAX;
       if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
         /* on failure don't abort just issue a warning */
-        store_errmsg("setrlimit() failed", ERRNO);
+        store_errmsg("setrlimit() failed", errno);
         fprintf(stderr, "%s\n", msgbuff);
         msgbuff[0] = '\0';
       }
@@ -175,7 +175,7 @@ static int rlimit(int keep_open)
     rl.rlim_cur = rl.rlim_max;
     if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
       /* on failure don't abort just issue a warning */
-      store_errmsg("setrlimit() failed", ERRNO);
+      store_errmsg("setrlimit() failed", errno);
       fprintf(stderr, "%s\n", msgbuff);
       msgbuff[0] = '\0';
     }
@@ -183,7 +183,7 @@ static int rlimit(int keep_open)
     /* get current open file limits */
 
     if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
-      store_errmsg("getrlimit() failed", ERRNO);
+      store_errmsg("getrlimit() failed", errno);
       fprintf(stderr, "%s\n", msgbuff);
       return -3;
     }
@@ -242,7 +242,7 @@ static int rlimit(int keep_open)
     }
   } while(nitems && !memchunk);
   if(!memchunk) {
-    store_errmsg("memchunk, malloc() failed", ERRNO);
+    store_errmsg("memchunk, malloc() failed", errno);
     fprintf(stderr, "%s\n", msgbuff);
     return -4;
   }
@@ -297,7 +297,7 @@ static int rlimit(int keep_open)
     }
   } while(num_open.rlim_max && !fd);
   if(!fd) {
-    store_errmsg("fd, malloc() failed", ERRNO);
+    store_errmsg("fd, malloc() failed", errno);
     fprintf(stderr, "%s\n", msgbuff);
     free(memchunk);
     return -6;
@@ -320,7 +320,7 @@ static int rlimit(int keep_open)
   fd[0] = open(DEV_NULL, O_RDONLY);
   if(fd[0] < 0) {
     snprintf(strbuff, sizeof(strbuff), "opening of %s failed", DEV_NULL);
-    store_errmsg(strbuff, ERRNO);
+    store_errmsg(strbuff, errno);
     fprintf(stderr, "%s\n", msgbuff);
     free(fd);
     fd = NULL;

--- a/tests/libtest/lib541.c
+++ b/tests/libtest/lib541.c
@@ -38,7 +38,6 @@ int test(char *URL)
   FILE *hd_src;
   int hd;
   struct_stat file_info;
-  int error;
 
   if(!libtest_arg2) {
     fprintf(stderr, "Usage: <url> <file-to-upload>\n");
@@ -47,9 +46,8 @@ int test(char *URL)
 
   hd_src = fopen(libtest_arg2, "rb");
   if(NULL == hd_src) {
-    error = ERRNO;
     fprintf(stderr, "fopen failed with error: %d %s\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "Error opening file: %s\n", libtest_arg2);
     return -2; /* if this happens things are major weird */
   }
@@ -58,9 +56,8 @@ int test(char *URL)
   hd = fstat(fileno(hd_src), &file_info);
   if(hd == -1) {
     /* can't open file, bail out */
-    error = ERRNO;
     fprintf(stderr, "fstat() failed with error: %d %s\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "ERROR: cannot open file %s\n", libtest_arg2);
     fclose(hd_src);
     return TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -228,7 +228,6 @@ int test(char *URL)
   CURL *curl = NULL;
   FILE *hd_src = NULL;
   int hd;
-  int error;
   struct_stat file_info;
   CURLM *m = NULL;
   struct ReadWriteSockets sockets = {{NULL, 0, 0}, {NULL, 0, 0}};
@@ -244,9 +243,8 @@ int test(char *URL)
 
   hd_src = fopen(libtest_arg2, "rb");
   if(NULL == hd_src) {
-    error = ERRNO;
     fprintf(stderr, "fopen() failed with error: %d (%s)\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "Error opening file: (%s)\n", libtest_arg2);
     return TEST_ERR_FOPEN;
   }
@@ -255,9 +253,8 @@ int test(char *URL)
   hd = fstat(fileno(hd_src), &file_info);
   if(hd == -1) {
     /* can't open file, bail out */
-    error = ERRNO;
     fprintf(stderr, "fstat() failed with error: %d (%s)\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "ERROR: cannot open file (%s)\n", libtest_arg2);
     fclose(hd_src);
     return TEST_ERR_FSTAT;

--- a/tests/libtest/lib591.c
+++ b/tests/libtest/lib591.c
@@ -44,15 +44,13 @@ int test(char *URL)
   int msgs_left;
   CURLMsg *msg;
   FILE *upload = NULL;
-  int error;
 
   start_test_timing();
 
   upload = fopen(libtest_arg3, "rb");
   if(!upload) {
-    error = ERRNO;
     fprintf(stderr, "fopen() failed with error: %d (%s)\n",
-            error, strerror(error));
+            errno, strerror(errno));
     fprintf(stderr, "Error opening file: (%s)\n", libtest_arg3);
     return TEST_ERR_FOPEN;
   }


### PR DESCRIPTION
Prior to this change (SET_)ERRNO mapped to GetLastError/SetLastError
for Win32 and regular errno otherwise.

I reviewed the code and found no justifiable reason for conflating errno
on WIN32 with GetLastError/SetLastError. All Win32 CRTs support errno,
and any Win32 multithreaded CRT supports thread-local errno.

Fixes https://github.com/curl/curl/issues/895