### PR TITLE
make: build the docs subdir only from within src

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -154,8 +154,8 @@ CLEANFILES = $(VC6_LIBDSP) $(VC6_SRCDSP) $(VC7_LIBVCPROJ) $(VC7_SRCVCPROJ)	\
 
 bin_SCRIPTS = curl-config
 
-SUBDIRS = lib docs src include
-DIST_SUBDIRS = $(SUBDIRS) tests packages scripts
+SUBDIRS = lib src
+DIST_SUBDIRS = $(SUBDIRS) tests packages scripts include docs
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libcurl.pc

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -35,8 +35,8 @@ HTMLPAGES = $(GENHTMLPAGES) index.html
 
 # Build targets in this file (.) before cmdline-opts to ensure that
 # the curl.1 rule below runs first
-SUBDIRS = libcurl . cmdline-opts
-DIST_SUBDIRS = $(SUBDIRS) examples
+SUBDIRS = . cmdline-opts
+DIST_SUBDIRS = $(SUBDIRS) examples libcurl
 
 CLEANFILES = $(GENHTMLPAGES) $(PDFPAGES) $(MANDISTPAGES) curl.1
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 
 bin_PROGRAMS = curl
 
+SUBDIRS = ../docs
+
 if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,7 +83,6 @@ libcurltool_la_LDFLAGS = -static $(LINKFLAGS)
 libcurltool_la_SOURCES = $(curl_SOURCES)
 endif
 
-BUILT_SOURCES = tool_hugehelp.c
 CLEANFILES = tool_hugehelp.c
 # Use the C locale to ensure that only ASCII characters appear in the
 # embedded text.
@@ -102,9 +101,6 @@ HUGE=tool_hugehelp.c
 
 if USE_MANUAL
 # Here are the stuff to create a built-in manual
-
-$(MANPAGE):
-	cd $(top_builddir)/docs && $(MAKE)
 
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and


### PR DESCRIPTION
... and don't build at all in include

Prompted-by-work-by: Simon Warta
Ref: #1590