### PR TITLE
travis: enable typecheck-gcc warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ matrix:
     include:
         - os: linux
           compiler: gcc
-          env: BUILD_TYPE=debug
+          env: BUILD_TYPE=normal
         - os: linux
           compiler: clang
-          env: BUILD_TYPE=normal
+          env: BUILD_TYPE=debug
         - os: osx
           compiler: gcc
-          env: BUILD_TYPE=normal
+          env: BUILD_TYPE=debug
         - os: osx
           compiler: clang
-          env: BUILD_TYPE=debug
+          env: BUILD_TYPE=normal
         - os: linux
           compiler: gcc
           dist: trusty
@@ -69,7 +69,7 @@ script:
         fi
     - |
         if [ "$BUILD_TYPE" = "normal" ]; then
-             ./configure
+             ./configure --enable-werror
              make
              make TFLAGS=-n test-nonflaky
         fi


### PR DESCRIPTION
- switch debug and release configurations so that we get an optimized
  build with GCC 4.3+ as required by typecheck-gcc
- enable compiler warnings also for release builds

Testing if this works before merging #1592.