### PR TITLE
ci: whitelist branches to avoid testing feature branches twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,5 +90,10 @@ script:
             (tar xf curl-99.98.97.tar.gz && mkdir build && cd build && ../curl-99.98.97/configure && make && make TFLAGS=1 test)
         fi
 
+# whitelist branches to avoid testing feature branches twice (as branch and as pull request)
+branches:
+    only:
+        - master
+
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,3 +63,8 @@ build_script:
     - cd build.%BDIR%
     - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL% -DCURL_STATICLIB=%STATICLIB% -DBUILD_TESTING=%TESTING%
     - cmake --build . --config %PRJ_CFG% --clean-first
+
+# whitelist branches to avoid testing feature branches twice (as branch and as pull request)
+branches:
+    only:
+        - master


### PR DESCRIPTION
Technically building a feature branch and building a PR (i.e. the result of a change merged into master) tests different code but in practice, building short living feature branches adds very little to no additional insights.

Given that the workflow even for project contributors is to open a PR, those PRs can be tested the same way they are for external contributors.

This reduces the amount of checks for non-fork PRs and helps reducing the length of CI queues.

An example for the extra branch builds is https://github.com/curl/curl/pull/1593. Travis calls it /push, Appveyor calls it /branch.