### PR TITLE
curl/system.h: add check for XTENSA for 32bit gcc

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -402,7 +402,8 @@
 #elif defined(__GNUC__)
 #  if !defined(__LP64__) && (defined(__ILP32__) || \
       defined(__i386__) || defined(__ppc__) || defined(__arm__) || \
-      defined(__sparc__) || defined(__mips__) || defined(__sh__))
+      defined(__sparc__) || defined(__mips__) || defined(__sh__) || \
+      defined(__XTENSA__))
 #    define CURL_SIZEOF_LONG           4
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"


### PR DESCRIPTION
Reported-by: Neil Kolban
Fixes: 1598