### PR TITLE
curl-compilers.m4: fix unknown-warning-option on Apple clang

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -84,7 +84,16 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
   if test "$curl_cv_have_def___clang__" = "yes"; then
     AC_MSG_RESULT([yes])
     compiler_id="CLANG"
-    clangver=`$CC -v 2>&1 | grep version | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
+    fullclangver=`$CC -v 2>&1 | grep version`
+    clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
+    if test -z "$clangver"; then
+      if echo $fullclangver | grep "Apple LLVM version " >/dev/null; then
+        dnl Starting with XCode 7 / clang 3.7, Apple clang won't tell its upstream version
+        clangver=`3.7`
+      else
+        clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
+      fi
+    fi
     clangvhi=`echo $clangver | cut -d . -f1`
     clangvlo=`echo $clangver | cut -d . -f2`
     compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`


### PR DESCRIPTION
Since 5598b0bd63f690c151074494ce47ef872f004ab4, clang -v is used to
detect the clang version. The version number was expected to come after
the word "version". For Apple clang, this doesn't work as it has its
own versioning scheme.
The version number is now first searched after the string
"based on LLVM". This works for Apple clang before version 7, and also
for e.g. Ubuntu's clang up to version 3.7. If it's not found and the
version string contains "Apple LLVM version", clang version 3.7 is
assumed, which is the version that comes with Xcode 7. Otherwise, the
version number is still expected after the word "version", which works
for very old Apple clang versions.

Note: temporarily changing Apple clang on travis back to debug mode to
get that warning again.

Tested on Ubuntu clang 3.5, 3.7 and 3.8, the first two of which have the "based on LLVM" string in addition to the correct version number. There are no configure warnings and no build warnings.

Ref: https://trac.macports.org/wiki/XcodeVersionInfo
Fixes https://github.com/curl/curl/issues/1606