### PR TITLE
Fix boringssl inclusion in winbuild build system

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -60,7 +60,7 @@ CFLAGS     = /I. /I../lib /I../include /nologo /W3 /GX /DWIN32 /YX /FD /c /DBUIL
 !ELSE
 CC_NODEBUG  = $(CC) /O2 /DNDEBUG
 CC_DEBUG    = $(CC) /Od /D_DEBUG /RTC1 /Z7 /LDd /W3
-CFLAGS      = /I. /I ../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL
+CFLAGS      = /I. /I ../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL /DWIN32_LEAN_AND_MEAN
 !ENDIF
 
 LFLAGS     = /nologo /machine:$(MACHINE)
@@ -133,6 +133,9 @@ SSL          = static
 
 !IFDEF USE_SSL
 SSL_CFLAGS   = /DUSE_OPENSSL /I"$(DEVEL_INCLUDE)/openssl"
+!IF EXISTS("$(DEVEL_INCLUDE)\openssl\is_boringssl.h")
+SSL_CFLAGS   = $(SSL_CFLAGS) /DHAVE_BORINGSSL
+!ENDIF
 !ENDIF
 
 !IF "$(WITH_NGHTTP2)"=="dll"


### PR DESCRIPTION
Compile with `WIN32_LEAN_AND_MEAN` which prevents `windows.h` from including too much clutter including `wincrypt.h` which in turn contains some preprocessor macros that clash with boringssl symbols.

Detect boringssl by checking the existance of `is_boringssl.h` and set the corresponding `HAVE_BORINGSSL` for compilation which is used in `ldap.c` to undefine the evil macros.

Fixes #1562 