### PR TITLE
test1521: fix compiler warnings

### DIFF
--- a/tests/libtest/lib1521.c
+++ b/tests/libtest/lib1521.c
@@ -31,9 +31,8 @@ struct data {
 
 #define LO LONG_MIN
 #define HI LONG_MAX
-#define OFF_VAL (curl_off_t) 3123123123
 #define OFF_LO (curl_off_t) LO
-#define OFF_HI (curl_off_t) HI
+#define OFF_HI (curl_off_t) ULONG_MAX
 #define OFF_NO (curl_off_t) 0
 
 /* Unexpected error.
@@ -1097,7 +1096,7 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, OFF_NO);
   if(UNEX(res)) {
     err("INFILESIZE_LARGE", res, __LINE__); goto test_cleanup; }
-  res = curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, OFF_VAL);
+  res = curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, OFF_HI);
   if(UNEX(res)) {
     err("INFILESIZE_LARGE", res, __LINE__); goto test_cleanup; }
   res = curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, OFF_LO);
@@ -1106,7 +1105,7 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, OFF_NO);
   if(UNEX(res)) {
     err("RESUME_FROM_LARGE", res, __LINE__); goto test_cleanup; }
-  res = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, OFF_VAL);
+  res = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, OFF_HI);
   if(UNEX(res)) {
     err("RESUME_FROM_LARGE", res, __LINE__); goto test_cleanup; }
   res = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, OFF_LO);
@@ -1115,7 +1114,7 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, OFF_NO);
   if(UNEX(res)) {
     err("MAXFILESIZE_LARGE", res, __LINE__); goto test_cleanup; }
-  res = curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, OFF_VAL);
+  res = curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, OFF_HI);
   if(UNEX(res)) {
     err("MAXFILESIZE_LARGE", res, __LINE__); goto test_cleanup; }
   res = curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, OFF_LO);
@@ -1142,7 +1141,7 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, OFF_NO);
   if(UNEX(res)) {
     err("POSTFIELDSIZE_LARGE", res, __LINE__); goto test_cleanup; }
-  res = curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, OFF_VAL);
+  res = curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, OFF_HI);
   if(UNEX(res)) {
     err("POSTFIELDSIZE_LARGE", res, __LINE__); goto test_cleanup; }
   res = curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, OFF_LO);
@@ -1293,7 +1292,7 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, OFF_NO);
   if(UNEX(res)) {
     err("MAX_SEND_SPEED_LARGE", res, __LINE__); goto test_cleanup; }
-  res = curl_easy_setopt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, OFF_VAL);
+  res = curl_easy_setopt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, OFF_HI);
   if(UNEX(res)) {
     err("MAX_SEND_SPEED_LARGE", res, __LINE__); goto test_cleanup; }
   res = curl_easy_setopt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, OFF_LO);
@@ -1302,7 +1301,7 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, OFF_NO);
   if(UNEX(res)) {
     err("MAX_RECV_SPEED_LARGE", res, __LINE__); goto test_cleanup; }
-  res = curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, OFF_VAL);
+  res = curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, OFF_HI);
   if(UNEX(res)) {
     err("MAX_RECV_SPEED_LARGE", res, __LINE__); goto test_cleanup; }
   res = curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, OFF_LO);
@@ -2315,6 +2314,12 @@ int test(char *URL)
   res = curl_easy_setopt(curl, CURLOPT_SUPPRESS_CONNECT_HEADERS, HI);
   if(UNEX(res)) {
     err("SUPPRESS_CONNECT_HEADERS", res, __LINE__); goto test_cleanup; }
+  res = curl_easy_setopt(curl, CURLOPT_REQUEST_TARGET, "string");
+  if(UNEX(res)) {
+    err("REQUEST_TARGET", res, __LINE__); goto test_cleanup; }
+  res = curl_easy_setopt(curl, CURLOPT_REQUEST_TARGET, NULL);
+  if(UNEX(res)) {
+    err("REQUEST_TARGET", res, __LINE__); goto test_cleanup; }
   res = curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &charp);
   if(UNEX(res)) {
     geterr("EFFECTIVE_URL", res, __LINE__); goto test_cleanup; }

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -27,6 +27,8 @@
 # minimum and maximum long signed values
 my $minlong = "LONG_MIN";
 my $maxlong = "LONG_MAX";
+# maximum long unsigned value
+my $maxulong = "ULONG_MAX";
 
 print <<HEADER
 /***************************************************************************
@@ -62,9 +64,8 @@ struct data {
 
 #define LO $minlong
 #define HI $maxlong
-#define OFF_VAL (curl_off_t) 3123123123
 #define OFF_LO (curl_off_t) LO
-#define OFF_HI (curl_off_t) HI
+#define OFF_HI (curl_off_t) $maxulong
 #define OFF_NO (curl_off_t) 0
 
 /* Unexpected error.
@@ -235,7 +236,7 @@ while(<STDIN>) {
         elsif($type eq "OFF_T") {
             # play conservative to work with 32bit curl_off_t
             print "${pref} OFF_NO);\n$check";
-            print "${pref} OFF_VAL);\n$check";
+            print "${pref} OFF_HI);\n$check";
             print "${pref} OFF_LO);\n$check";
         }
         else {


### PR DESCRIPTION
The integer literal `3123123123` doesn't fit into a 32-bit signed
integer, so GCC with 32-bit long warns in C90 mode:
`this decimal constant is unsigned only in ISO C90 [enabled by default]`
Fix this by using `ULONG_MAX`, which should fit in any curl_off_t and has
the correct suffix to not issue any warnings.
Also adds the missing `CURLOPT_REQUEST_TARGET` from commit
9b167fd090f596eac828817d48c247eeae53407f.