### PR TITLE
test1450: add simple testing for DICT

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -74,6 +74,7 @@ The curl Test Suite
   - TCP/9013 for HTTP proxy server for CONNECT
   - TCP/9014 for HTTP pipelining server
   - TCP/9015 for HTTP/2 server
+  - TCP/9016 for DICT server
 
  1.3 Test servers
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -154,7 +154,7 @@ test1416 test1417 test1418 test1419 test1420 test1421 test1422 test1423 \
 test1424 test1425 test1426 \
 test1428 test1429 test1430 test1431 test1432 test1433 test1434 test1435 \
 test1436 test1437 test1438 test1439 test1440 test1441 test1442 test1443 \
-test1444 test1445 test1446 \
+test1444 test1445 test1446                            test1450 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1450
+++ b/tests/data/test1450
@@ -1,0 +1,34 @@
+<testcase>
+<info>
+<keywords>
+DICT
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+dict
+</server>
+<features>
+dict
+</features>
+ <name>
+Basic DICT lookup
+ </name>
+ <command>
+dict://%HOSTIP:%DICTPORT/d:basic
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/dictserver.py
+++ b/tests/dictserver.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+""" DICT server """
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import argparse
+import os
+import sys
+import logging
+try:  # Python 2
+    import SocketServer as socketserver
+except ImportError:  # Python 3
+    import socketserver
+
+
+log = logging.getLogger(__name__)
+HOST = "localhost"
+
+# The strings that indicate the test framework is checking our aliveness
+VERIFIED_REQ = b"verifiedserver"
+VERIFIED_RSP = "WE ROOLZ: {pid}"
+
+
+def dictserver(options):
+    """
+    Starts up a TCP server with a DICT handler and serves DICT requests
+    forever.
+    """
+    if options.pidfile:
+        pid = os.getpid()
+        with open(options.pidfile, "w") as f:
+            f.write("{0}".format(pid))
+
+    local_bind = (HOST, options.port)
+    log.info("[DICT] Listening on %s", local_bind)
+
+    # Need to set the allow_reuse on the class, not on the instance.
+    socketserver.TCPServer.allow_reuse_address = True
+    server = socketserver.TCPServer(local_bind, DictHandler)
+    server.serve_forever()
+
+    return ScriptRC.SUCCESS
+
+
+class DictHandler(socketserver.BaseRequestHandler):
+    """Handler class for DICT connections.
+
+    """
+    def handle(self):
+        """
+        Simple function which responds to all queries with a 552.
+        """
+
+        # First, send a response to allow the server to continue.
+        rsp = "220 dictserver <xnooptions> <msgid@msgid>\n"
+        self.request.sendall(rsp.encode("utf-8"))
+
+        # Receive the request.
+        data = self.request.recv(1024).strip()
+        log.debug("[DICT] Incoming data: %r", data)
+
+        if VERIFIED_REQ in data:
+            log.debug("[DICT] Received verification request from test "
+                      "framework")
+            response_data = VERIFIED_RSP.format(pid=os.getpid())
+        else:
+            log.debug("[DICT] Received normal request")
+            response_data = "No matches"
+
+        # Send back a failure to find.
+        response = "552 {0}\n".format(response_data)
+        log.debug("[DICT] Responding with %r", response)
+        self.request.sendall(response.encode("utf-8"))
+
+
+def get_options():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--port", action="store", default=9016,
+                      type=int, help="port to listen on")
+    parser.add_argument("--verbose", action="store", type=int, default=0,
+                        help="verbose output")
+    parser.add_argument("--pidfile", action="store",
+                        help="file name for the PID")
+    parser.add_argument("--logfile", action="store",
+                        help="file name for the log")
+    parser.add_argument("--srcdir", action="store", help="test directory")
+    parser.add_argument("--id", action="store", help="server ID")
+    parser.add_argument("--ipv4", action="store_true", default=0,
+                        help="IPv4 flag")
+
+    return parser.parse_args()
+
+
+def setup_logging(options):
+    """
+    Set up logging from the command line options
+    """
+    root_logger = logging.getLogger()
+    add_stdout = False
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)-5.5s %(message)s")
+
+    # Write out to a logfile
+    if options.logfile:
+        handler = logging.FileHandler(options.logfile, mode="w")
+        handler.setFormatter(formatter)
+        handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(handler)
+    else:
+        # The logfile wasn't specified. Add a stdout logger.
+        add_stdout = True
+
+    if options.verbose:
+        # Add a stdout logger as well in verbose mode
+        root_logger.setLevel(logging.DEBUG)
+        add_stdout = True
+    else:
+        root_logger.setLevel(logging.INFO)
+
+    if add_stdout:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setFormatter(formatter)
+        stdout_handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(stdout_handler)
+
+
+class ScriptRC(object):
+    """Enum for script return codes"""
+    SUCCESS = 0
+    FAILURE = 1
+    EXCEPTION = 2
+
+
+class ScriptException(Exception):
+    pass
+
+
+if __name__ == '__main__':
+    # Get the options from the user.
+    options = get_options()
+
+    # Setup logging using the user options
+    setup_logging(options)
+
+    # Run main script.
+    try:
+        rc = dictserver(options)
+    except Exception as e:
+        log.exception(e)
+        rc = ScriptRC.EXCEPTION
+
+    log.info("[DICT] Returning %d", rc)
+    sys.exit(rc)

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -105,7 +105,7 @@ sub servername_str {
 
     $proto = uc($proto) if($proto);
     die "unsupported protocol: '$proto'" unless($proto &&
-        ($proto =~ /^(((FTP|HTTP|HTTP\/2|IMAP|POP3|SMTP|HTTP-PIPE)S?)|(TFTP|SFTP|SOCKS|SSH|RTSP|GOPHER|HTTPTLS))$/));
+        ($proto =~ /^(((FTP|HTTP|HTTP\/2|IMAP|POP3|SMTP|HTTP-PIPE)S?)|(TFTP|SFTP|SOCKS|SSH|RTSP|GOPHER|HTTPTLS|DICT))$/));
 
     $ipver = (not $ipver) ? 'ipv4' : lc($ipver);
     die "unsupported IP version: '$ipver'" unless($ipver &&


### PR DESCRIPTION
Add a new server which provides a DICT interface. This is intended to begin coverage testing for lib/dict.c.

In local testing this gets lib/dict.c up to 57.1% line coverage.
Tested with both Python 2 and Python 3.