### PR TITLE
url: make the original string get used on subsequent transfers

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1288,6 +1288,13 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     failf(data, "No URL set!");
     return CURLE_URL_MALFORMAT;
   }
+  /* since the URL may have been redirected in a previous use of this handle */
+  if(data->change.url_alloc) {
+    /* the already set URL is allocated, free it first! */
+    Curl_safefree(data->change.url);
+    data->change.url_alloc = FALSE;
+  }
+  data->change.url = data->set.str[STRING_SET_URL];
 
   /* Init the SSL session ID cache here. We do it here since we want to do it
      after the *_setopt() calls (that could specify the size of the cache) but

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -165,7 +165,7 @@ test1520 test1521 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 \
-test1550 \
+test1550 test1551 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 \
 \
 test1700 test1701 test1702 \

--- a/tests/data/test1551
+++ b/tests/data/test1551
@@ -1,0 +1,72 @@
+<testcase>
+<info>
+<keywords>
+multi
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Location: /15510002
+
+-foo-
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 11
+
+redirected
+</data2>
+<datacheck>
+redirected
+redirected
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib1551
+</tool>
+
+ <name>
+re-run redirected transfer without setting URL again
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/1551
+</command>
+</client>
+
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1551 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /15510002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /1551 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /15510002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -26,7 +26,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 \
- lib1550 \
+ lib1550 lib1551 \
  lib1900 \
  lib2033
 
@@ -434,6 +434,9 @@ lib1540_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1550_SOURCES = lib1550.c $(SUPPORTFILES)
 lib1550_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1517
+
+lib1551_SOURCES = lib1551.c $(SUPPORTFILES)
+lib1551_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1900_SOURCES = lib1900.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1900_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1551.c
+++ b/tests/libtest/lib1551.c
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "memdebug.h"
+
+#include <curl/multi.h>
+
+int test(char *URL)
+{
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_URL, URL);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    res = curl_easy_perform(curl);
+
+    fprintf(stderr, "****************************** Do it again\n");
+    res = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+  }
+  return (int)res;
+}


### PR DESCRIPTION
... since CURLOPT_URL should follow the same rules as other options:
they remain set until changed or cleared.

Added test 1551 to verify.

Fixes #1631
Reported-by: Pavel Rochnyak