### PR TITLE
configure: try ldap/lber in reversed order first

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -790,8 +790,8 @@ AC_DEFUN([CURL_CHECK_LIBS_LDAP], [
   #
   for x_nlibs in '' "$u_libs" \
     '-lldap' \
-    '-llber -lldap' \
     '-lldap -llber' \
+    '-llber -lldap' \
     '-lldapssl -lldapx -lldapsdk' \
     '-lldapsdk -lldapx -lldapssl' ; do
     if test "$curl_cv_ldap_LIBS" = "unknown"; then


### PR DESCRIPTION
When scanning for which LDAP libraries to use, try the -lldap -llber
combination before the reversed order since it has a greater chance of
working when linking with libcurl statically.

Fixes #1619
Reported-by: David E. Narváez