### PR TITLE
timeval.c: Use long long constant type for timeval assignment

### DIFF
--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -145,8 +145,8 @@ time_t Curl_tvdiff_us(struct timeval newer, struct timeval older)
     return 0x7fffffff;
 #else
   /* for 64bit time_t systems */
-  if(diff >= (0x7fffffffffffffff/1000000))
-    return 0x7fffffffffffffff;
+  if(diff >= (0x7fffffffffffffffLL/1000000))
+    return 0x7fffffffffffffffLL;
 #endif
   return (newer.tv_sec-older.tv_sec)*1000000+
     (time_t)(newer.tv_usec-older.tv_usec);


### PR DESCRIPTION
On a 64 bit host, sparse says:

timeval.c:148:15: warning: constant 0x7fffffffffffffff is so big it is long
timeval.c:149:12: warning: constant 0x7fffffffffffffff is so big it is long

so let's use long long constant types in order to prevent undesired overflow
failures.

Bug: https://curl.haxx.se/mail/lib-2017-07/0003.html

Signed-off-by: Martin Kepplinger <martink@posteo.de>