### PR TITLE
travis.yml: use --enable-werror on debug builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
         fi
     - |
         if [ "$BUILD_TYPE" = "debug" ]; then
-             ./configure --enable-debug
+             ./configure --enable-debug --enable-werror
              make
              make TFLAGS=-n test-nonflaky
         fi

--- a/src/tool_sleep.c
+++ b/src/tool_sleep.c
@@ -51,7 +51,7 @@ void tool_go_sleep(long ms)
   struct timeval timeout;
   timeout.tv_sec = ms / 1000L;
   ms = ms % 1000L;
-  timeout.tv_usec = (int)ms * 1000L;
+  timeout.tv_usec = (int)ms * 1000;
   select(0, NULL,  NULL, NULL, &timeout);
 #endif
 }

--- a/src/tool_sleep.c
+++ b/src/tool_sleep.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -51,7 +51,7 @@ void tool_go_sleep(long ms)
   struct timeval timeout;
   timeout.tv_sec = ms / 1000L;
   ms = ms % 1000L;
-  timeout.tv_usec = ms * 1000L;
+  timeout.tv_usec = (int)ms * 1000L;
   select(0, NULL,  NULL, NULL, &timeout);
 #endif
 }


### PR DESCRIPTION
... to better detect and fault on compiler warnings/errors