### PR TITLE
configure: remove checks for 5 functions never used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3281,23 +3281,18 @@ case $host in
     ;;
 esac
 
-AC_CHECK_FUNCS([fork \
-  geteuid \
+AC_CHECK_FUNCS([geteuid \
   getpass_r \
   getppid \
-  getprotobyname \
   getpwuid \
   getpwuid_r \
   getrlimit \
   gettimeofday \
   if_nametoindex \
-  inet_addr \
-  perror \
   pipe \
   setlocale \
   setmode \
   setrlimit \
-  uname \
   utime \
   utimes
 ],[

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -879,19 +879,6 @@ void Curl_tcpnodelay(struct connectdata *conn, curl_socket_t sockfd)
   curl_socklen_t onoff = (curl_socklen_t) 1;
   int level = IPPROTO_TCP;
 
-#if 0
-  /* The use of getprotobyname() is disabled since it isn't thread-safe on
-     numerous systems. On these getprotobyname_r() should be used instead, but
-     that exists in at least one 4 arg version and one 5 arg version, and
-     since the proto number rarely changes anyway we now just use the hard
-     coded number. The "proper" fix would need a configure check for the
-     correct function much in the same style the gethostbyname_r versions are
-     detected. */
-  struct protoent *pe = getprotobyname("tcp");
-  if(pe)
-    level = pe->p_proto;
-#endif
-
 #if defined(CURL_DISABLE_VERBOSE_STRINGS)
   (void) conn;
 #endif


### PR DESCRIPTION
fork, getprotobyname, inet_addr, perror, uname