### PR TITLE
Fixes for building on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,14 +226,8 @@ if(ENABLE_MANUAL)
     message(WARNING "Found no *nroff program")
   endif()
 endif()
-
-option(ENABLE_DOCS "to build docs" ON)
-option(BUILD_TESTING "to build tests" ON)
-
-if(ENABLE_MANUAL OR ENABLE_DOCS OR BUILD_TESTING)
-   # Required for building manual, docs, tests
-   find_package(Perl REQUIRED)
-endif()
+# Required for building manual, docs, tests
+find_package(Perl REQUIRED)
 
 # We need ansi c-flags, especially on HP
 set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS}")
@@ -1185,10 +1179,7 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-if(ENABLE_DOCS)
-  add_subdirectory(docs)
-endif()
-
+add_subdirectory(docs)
 add_subdirectory(lib)
 if(BUILD_CURL_EXE)
   add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ if (ENABLE_CURLDEBUG)
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS CURLDEBUG)
 endif()
 
+# For debug libs and exes, add "-d" postfix
+set(CMAKE_DEBUG_POSTFIX "-d" CACHE STRING "Set debug library postfix" FORCE)
+
 # initialize CURL_LIBS
 set(CURL_LIBS "")
 
@@ -116,11 +119,6 @@ if(ENABLE_ARES)
   find_package(CARES REQUIRED)
   list(APPEND CURL_LIBS ${CARES_LIBRARY} )
   set(CURL_LIBS ${CURL_LIBS} ${CARES_LIBRARY})
-endif()
-
-if(MSVC)
-  option(BUILD_RELEASE_DEBUG_DIRS "Set OFF to build each configuration to a separate directory" OFF)
-  mark_as_advanced(BUILD_RELEASE_DEBUG_DIRS)
 endif()
 
 include(CurlSymbolHiding)
@@ -228,8 +226,14 @@ if(ENABLE_MANUAL)
     message(WARNING "Found no *nroff program")
   endif()
 endif()
-# Required for building manual, docs, tests
-find_package(Perl REQUIRED)
+
+option(ENABLE_DOCS "to build docs" ON)
+option(BUILD_TESTING "to build tests" ON)
+
+if(ENABLE_MANUAL OR ENABLE_DOCS OR BUILD_TESTING)
+   # Required for building manual, docs, tests
+   find_package(Perl REQUIRED)
+endif()
 
 # We need ansi c-flags, especially on HP
 set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS}")
@@ -1181,7 +1185,10 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-add_subdirectory(docs)
+if(ENABLE_DOCS)
+  add_subdirectory(docs)
+endif()
+
 add_subdirectory(lib)
 if(BUILD_CURL_EXE)
   add_subdirectory(src)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -97,6 +97,13 @@ if(WIN32)
   if(NOT CURL_STATICLIB)
     # Add "_imp" as a suffix before the extension to avoid conflicting with the statically linked "libcurl.lib"
     set_target_properties(${LIB_NAME} PROPERTIES IMPORT_SUFFIX "_imp.lib")
+
+    set_target_properties (${LIB_NAME} PROPERTIES
+       DEBUG_POSTFIX "-d"
+       # Note: no postfix for release variants, let user choose what style of release he wants
+       # MINSIZEREL_POSTFIX "-z"
+       # RELWITHDEBINFO_POSTFIX "-g"
+       )
   endif()
 endif()
 


### PR DESCRIPTION
I had to make these changes to allow cmake and MSVC to build libcurl the typical way I would expect - ie with postfixes.

And, I had to avoid finding the required Perl package, which seems to be only required for docs (and testing).