### PR TITLE
Miscellaneous cast fixes (detected on Windows)

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -206,7 +206,7 @@ static CURLcode rtmp_connect(struct connectdata *conn, bool *done)
   RTMP *r = conn->proto.generic;
   SET_RCVTIMEO(tv, 10);
 
-  r->m_sb.sb_socket = conn->sock[FIRSTSOCKET];
+  r->m_sb.sb_socket = (int)conn->sock[FIRSTSOCKET];
 
   /* We have to know if it's a write before we send the
    * connect request packet

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -293,11 +293,13 @@ static CURLcode Curl_ossl_seed(struct Curl_easy *data)
     for(i = 0, i_max = len / sizeof(struct timeval); i < i_max; ++i) {
       struct timeval tv = curlx_tvnow();
       Curl_wait_ms(1);
-      tv.tv_sec *= i + 1;
-      tv.tv_usec *= i + 2;
-      tv.tv_sec ^= ((curlx_tvnow().tv_sec + curlx_tvnow().tv_usec) *
+      tv.tv_sec *= (long)i + 1;
+      tv.tv_usec *= (long)i + 2;
+      tv.tv_sec ^= (long)
+                   ((curlx_tvnow().tv_sec + curlx_tvnow().tv_usec) *
                     (i + 3)) << 8;
-      tv.tv_usec ^= ((curlx_tvnow().tv_sec + curlx_tvnow().tv_usec) *
+      tv.tv_usec ^= (long)
+                    ((curlx_tvnow().tv_sec + curlx_tvnow().tv_usec) *
                      (i + 4)) << 16;
       memcpy(&randb[i * sizeof(struct timeval)], &tv, sizeof(struct timeval));
     }


### PR DESCRIPTION
On Windows, `long` is always 32-bit. This is a bit surprising to some code bases, and when compiling cURL with `./configure --disable-shared --enable-debug --enable-maintainer-mode --enable-werror --with-ssl` in Git for Windows' SDK (which is a special-purpose version of MSYS2, itself kind of a portable version of Cygwin), these fixes were necessary to complete the build.

Note: I am not quite certain what this does to other platforms, so I am curious to see what Travis spits out.