### PR TITLE
make: fix docs build on OpenBSD

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -102,6 +102,9 @@ HUGE=tool_hugehelp.c
 if USE_MANUAL
 # Here are the stuff to create a built-in manual
 
+$(MANPAGE):
+	cd $(top_builddir)/docs && $(MAKE)
+
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and
 # compressed formats.


### PR DESCRIPTION
I noticed that I wasn't able to build curl on OpenBSD and git-bisected back to d24838d. I was able to fix the build by making the change included in this PR, but given the discussion in #1591 I'm not sure whether this is a desirable change or not.

Interestingly, building on FreeBSD worked fine for me. I'm not sure what the difference is between `make` on each, or if there's something else that's off about my OpenBSD env.

The error I received was:
```
make: don't know how to make /docs/curl.1 (prerequisite of: tool_hugehelp.c)
Stop in src 
*** Error 1 in src (Makefile:1696 'all-recursive')
*** Error 1 in /root/curl-autobuild/curl (Makefile:784 'all-recursive')
```

The machine I ran this on was a fresh OpenBSD install with only a few required packages added:
```
pkg_add git \
  autoconf-2.69p2 \
  automake-1.9.6p12 \
  libtool \
  m4 \
  stunnel \
  groff \
  nghttp2
```

Then I cloned the repo, and did `./buildconf && ./configure && make`.

I'm happy to provide access to the OpenBSD box if helpful, or try other proposed solutions on the machine and report back. (And I noticed OpenBSD is on the autobuild wishlist. I can set up an OpenBSD machine for autobuild, just not sure if it would be best to wait until this issue is resolved.)