### PR TITLE
cmake: Don't require Perl; just skip docs/tests when it's not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ if(ENABLE_MANUAL)
   endif()
 endif()
 # Required for building manual, docs, tests
-find_package(Perl REQUIRED)
+find_package(Perl)
 
 # We need ansi c-flags, especially on HP
 set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS}")
@@ -1179,7 +1179,12 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-add_subdirectory(docs)
+if(PERL_FOUND)
+  add_subdirectory(docs)
+else()
+  message(WARNING "Perl not found - not building docs")
+endif()
+
 add_subdirectory(lib)
 if(BUILD_CURL_EXE)
   add_subdirectory(src)
@@ -1187,7 +1192,11 @@ endif()
 
 include(CTest)
 if(BUILD_TESTING)
-  add_subdirectory(tests)
+  if(PERL_FOUND)
+    add_subdirectory(tests)
+  else()
+    message(WARNING "Perl not found - not building tests")
+  endif()
 endif()
 
 # Helper to populate a list (_items) with a label when conditions (the remaining


### PR DESCRIPTION
See also https://github.com/curl/curl/pull/1600, https://github.com/curl/curl/pull/1421

The conclusion at the end of #1600 seemed to be that when Perl isn't found, the build should just skip doing the bits that need it; and the discussion in #1421 implied that a simple check would be fine. So this patch adds a simple check to skip the bits that use Perl when Perl isn't found.

I'd quite like to get this patch included, or one like it - I want libcurl to build on Windows without needing perl. So if this PR is no good as-is, please let me know what I need to do to improve its chances!

Thanks,

--Tom