### PR TITLE
tool_getparam: fix uninitialized variable warning

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1634,7 +1634,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         if(!file)
           warnf(global, "Failed to open %s!\n", &nextarg[1]);
         else {
-          if(PARAM_OK == file2memory(&string, &len, file)) {
+          err = file2memory(&string, &len, file);
+          if(PARAM_OK == err) {
             /* Allow strtok() here since this isn't used threaded */
             /* !checksrc! disable BANNEDFUNC 2 */
             char *h = strtok(string, "\r\n");


### PR DESCRIPTION
Since 84b9458837551a2749b45d924089f2015415a324, `err` could be returned
unintialized in line 1655 if `file2memory` did not return `PARAM_OK` in
line 1637. Fix this by initializing `err` with the return value of
`file2memory`.