### PR TITLE
ldap: fix MinGW compiler warning

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -235,7 +235,6 @@ static int ldap_win_bind(struct connectdata *conn, LDAP *server,
                          const char *user, const char *passwd)
 {
   int rc = LDAP_INVALID_CREDENTIALS;
-  ULONG method = LDAP_AUTH_SIMPLE;
 
   PTCHAR inuser = NULL;
   PTCHAR inpass = NULL;
@@ -244,7 +243,7 @@ static int ldap_win_bind(struct connectdata *conn, LDAP *server,
     inuser = Curl_convert_UTF8_to_tchar((char *) user);
     inpass = Curl_convert_UTF8_to_tchar((char *) passwd);
 
-    rc = ldap_bind_s(server, inuser, inpass, method);
+    rc = ldap_simple_bind_s(server, inuser, inpass);
 
     Curl_unicodefree(inuser);
     Curl_unicodefree(inpass);


### PR DESCRIPTION
`ldap_bind_s` is marked as deprecated in w32api's winldap.h shipping with
the latest original MinGW, resulting in compiler warnings since commit
f0fe66f13c93d3d0af45d9fb1231c9164e0f9dc8. Fix this for the non-SSPI
case by using `ldap_simple_bind_s` again instead of `ldap_bind_s` with
`LDAP_AUTH_SIMPLE`.