### PR TITLE
curl-compilers.m4: disable warning spam with Cygwin's clang

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -903,7 +903,14 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only clang 3.2 or later
           if test "$compiler_num" -ge "302"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wmissing-variable-declarations"
+            case $host_os in
+            cygwin* | mingw*)
+              dnl libtool wrapper executable throws these warnings
+              ;;
+            *)
+              tmp_CFLAGS="$tmp_CFLAGS -Wmissing-variable-declarations"
+              ;;
+            esac
           fi
           #
           dnl Only clang 3.6 or later


### PR DESCRIPTION
When building with Cygwin or MinGW, libtool uses a wrapper executable
instead of a wrapper script [1], which is written in C and throws
missing-variable-declarations warnings. Don't enable these warnings on
Cygwin and MinGW in order to avoid warnings for every executable built,
which spams the test suite output when using Cygwin's clang.

[1] https://www.gnu.org/software/libtool/manual/html_node/Wrapper-executables.html