### PR TITLE
travis: enable warnings also in release mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
         fi
     - |
         if [ "$BUILD_TYPE" = "normal" ]; then
-             ./configure --enable-werror
+             ./configure --enable-warnings --enable-werror
              make
              make test-nonflaky
         fi


### PR DESCRIPTION
This should hopefully find the GCC warning addressed in #1661. At least I think I've seen the warning in a build log some time ago, but couldn't reproduce it back then.