### PR TITLE
curl_setup: always define WIN32_LEAN_AND_MEAN on Windows

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -442,9 +442,6 @@
 /* CURL_PULL_WS2TCPIP_H is defined above when inclusion of header file  */
 /* ws2tcpip.h is required here to properly make type definitions below. */
 #ifdef CURL_PULL_WS2TCPIP_H
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
-#  endif
 #  include <windows.h>
 #  include <winsock2.h>
 #  include <ws2tcpip.h>

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -31,6 +31,17 @@
 #define WIN32
 #endif
 
+#ifdef WIN32
+/*
+ * Don't include unneeded stuff in Windows headers to avoid compiler
+ * warnings and macro clashes.
+ * Make sure to define this macro before including any Windows headers.
+ */
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#endif
+
 /*
  * Include configuration script results or hand-crafted
  * configuration file for platforms which lack config tool.
@@ -236,9 +247,6 @@
 #  endif
 #  if defined(_UNICODE) && !defined(UNICODE)
 #    define UNICODE
-#  endif
-#  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -60,7 +60,7 @@ CFLAGS     = /I. /I../lib /I../include /nologo /W3 /GX /DWIN32 /YX /FD /c /DBUIL
 !ELSE
 CC_NODEBUG  = $(CC) /O2 /DNDEBUG
 CC_DEBUG    = $(CC) /Od /D_DEBUG /RTC1 /Z7 /LDd /W3
-CFLAGS      = /I. /I ../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL /DWIN32_LEAN_AND_MEAN
+CFLAGS      = /I. /I ../lib /I../include /nologo /W3 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL
 !ENDIF
 
 LFLAGS     = /nologo /machine:$(MACHINE)


### PR DESCRIPTION
Make sure to always define WIN32_LEAN_AND_MEAN before including any
Windows headers to avoid pulling in unnecessary headers. This avoids
unnecessary macro clashes and compiler warnings.

Ref: https://github.com/curl/curl/issues/1562

Supersedes https://github.com/curl/curl/pull/1668 and part of https://github.com/curl/curl/pull/1667.