### PR TITLE
cmake: support sudo make uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1333,3 +1333,14 @@ if(MSVC_VERSION EQUAL 1600)
     file(APPEND "${CURL_SLN_FILENAME}" "\n# This should be regenerated!\n")
   endif()
 endif()
+
+if(NOT TARGET uninstall)
+  configure_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+      IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+      COMMAND ${CMAKE_COMMAND} -P
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,26 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+if (NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set (CMAKE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+endif ()
+ message(${CMAKE_INSTALL_PREFIX})
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
This features reduces the pain of having to remove the installed libraries and headers in /usr/local/ one by one.

Before this change, after sudo make install

``````
Install the project...
-- Install configuration: ""
-- Up-to-date: /usr/local/bin/curl-config
-- Up-to-date: /usr/local/lib/pkgconfig/libcurl.pc
-- Up-to-date: /usr/local/include/curl/curlbuild.h
-- Up-to-date: /usr/local/include/curl
-- Up-to-date: /usr/local/include/curl/multi.h
-- Up-to-date: /usr/local/include/curl/easy.h
-- Up-to-date: /usr/local/include/curl/mprintf.h
-- Up-to-date: /usr/local/include/curl/curl.h
-- Up-to-date: /usr/local/include/curl/curlrules.h
-- Up-to-date: /usr/local/include/curl/typecheck-gcc.h
-- Up-to-date: /usr/local/include/curl/curlver.h
-- Up-to-date: /usr/local/include/curl/stdcheaders.h
-- Up-to-date: /usr/local/lib/libcurl.so
-- Up-to-date: /usr/local/bin/curl
``````

there is no easy ways to remove these files, but with this change we can simply type sudo make uninstall and

``````
Scanning dependencies of target uninstall
/usr/local
-- Uninstalling /usr/local/bin/curl-config
-- Uninstalling /usr/local/lib/pkgconfig/libcurl.pc
-- Uninstalling /usr/local/include/curl/curlbuild.h
-- Uninstalling /usr/local/include/curl/multi.h
-- Uninstalling /usr/local/include/curl/easy.h
-- Uninstalling /usr/local/include/curl/mprintf.h
-- Uninstalling /usr/local/include/curl/curl.h
-- Uninstalling /usr/local/include/curl/curlrules.h
-- Uninstalling /usr/local/include/curl/typecheck-gcc.h
-- Uninstalling /usr/local/include/curl/curlver.h
-- Uninstalling /usr/local/include/curl/stdcheaders.h
-- Uninstalling /usr/local/lib/libcurl.so
-- Uninstalling /usr/local/bin/curl
Built target uninstall
``````