### PR TITLE
build: remove WIN32_LEAN_AND_MEAN from individual build systems

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -199,8 +199,6 @@ AC_DEFUN([CURL_CHECK_HEADER_WINDOWS], [
     yes)
       AC_DEFINE_UNQUOTED(HAVE_WINDOWS_H, 1,
         [Define to 1 if you have the windows.h header file.])
-      AC_DEFINE_UNQUOTED(WIN32_LEAN_AND_MEAN, 1,
-        [Define to avoid automatic inclusion of winsock.h])
       ;;
   esac
 ])

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -972,9 +972,6 @@
 /* Version number of package */
 #cmakedefine VERSION ${VERSION}
 
-/* Define to avoid automatic inclusion of winsock.h */
-#cmakedefine WIN32_LEAN_AND_MEAN 1
-
 /* Define to 1 if OS is AIX. */
 #ifndef _ALL_SOURCE
 #  undef _ALL_SOURCE


### PR DESCRIPTION
It's defined for all build systems in curl_setup.h since commit
beb08481d01a07a8b10938b1078a5e298b1c2912. This caused macro
redefinition warnings in the configure builds.

Tested with a configure-based MinGW build and hoping that AppVeyor can test CMake...

The warnings are visible in the MinGW autobuilds, for example:
https://curl.haxx.se/dev/log.cgi?id=20170711114045-21847