### PR TITLE
tests/server/resolve.c: fix deprecation warning

### DIFF
--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -107,16 +107,8 @@ int main(int argc, char *argv[])
   atexit(win32_cleanup);
 #endif
 
-  if(!use_ipv6) {
-    /* gethostbyname() resolve */
-    struct hostent *he;
-
-    he = gethostbyname(host);
-
-    rc = !he;
-  }
-  else {
 #ifdef ENABLE_IPV6
+  if(use_ipv6) {
     /* Check that the system has IPv6 enabled before checking the resolver */
     curl_socket_t s = socket(PF_INET6, SOCK_DGRAM, 0);
     if(s == CURL_SOCKET_BAD)
@@ -125,28 +117,37 @@ int main(int argc, char *argv[])
     else {
       sclose(s);
     }
+  }
 
-    if(rc == 0) {
-      /* getaddrinfo() resolve */
-      struct addrinfo *ai;
-      struct addrinfo hints;
+  if(rc == 0) {
+    /* getaddrinfo() resolve */
+    struct addrinfo *ai;
+    struct addrinfo hints;
 
-      memset(&hints, 0, sizeof(hints));
-      hints.ai_family = PF_INET6;
-      hints.ai_socktype = SOCK_STREAM;
-      hints.ai_flags = AI_CANONNAME;
-      /* Use parenthesis around functions to stop them from being replaced by
-         the macro in memdebug.h */
-      rc = (getaddrinfo)(host, "80", &hints, &ai);
-      if(rc == 0)
-        (freeaddrinfo)(ai);
-    }
-
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = use_ipv6 ? PF_INET6 : PF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_CANONNAME;
+    /* Use parenthesis around functions to stop them from being replaced by
+       the macro in memdebug.h */
+    rc = (getaddrinfo)(host, "80", &hints, &ai);
+    if(rc == 0)
+      (freeaddrinfo)(ai);
+  }
 #else
+  if(use_ipv6) {
     puts("IPv6 support has been disabled in this program");
     return 1;
-#endif
   }
+  else {
+    /* gethostbyname() resolve */
+    struct hostent *he;
+
+    he = gethostbyname(host);
+
+    rc = !he;
+#endif
+
   if(rc)
     printf("Resolving %s '%s' didn't work\n", ipv_inuse, host);
 


### PR DESCRIPTION
MSVC warns that gethostbyname is deprecated. Always use getaddrinfo
instead to fix this when IPv6 is enabled, also for IPv4 resolves. This
is also consistent with what libcurl does.

I get the same test results on Ubuntu as before this change.

Required to change the MSVC warning level from 3 to 4 in the CMake build as proposed by @bagder in https://github.com/curl/curl/pull/1667#issuecomment-314082794.