### PR TITLE
AppVeyor: now really use CURL_WERROR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ environment:
 build_script:
     - mkdir build.%BDIR%
     - cd build.%BDIR%
-    - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL% -DCURL_STATICLIB=%STATICLIB% -DBUILD_TESTING=%TESTING% -DCURL_ERROR=ON
+    - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL% -DCURL_STATICLIB=%STATICLIB% -DBUILD_TESTING=%TESTING% -DCURL_WERROR=ON
     - cmake --build . --config %PRJ_CFG% --clean-first
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)


### PR DESCRIPTION
It was misspelled as CURL_ERROR in commit
2d86e8d1286e0fbe3d811e2e87fa0b5e53722db4.