### PR TITLE
timeval: introduce curlval as a struct timeval replacement

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -355,7 +355,7 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
   long timeout;
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
   struct Curl_dns_entry *temp_entry;
 
   if(entry)
@@ -400,7 +400,7 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else {
-      struct curlval now2 = Curl_tvnow();
+      struct curltime now2 = Curl_tvnow();
       time_t timediff = Curl_tvdiff(now2, now); /* spent time */
       if(timediff <= 0)
         timeout -= 1; /* always deduct at least 1 */

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -355,7 +355,7 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
   long timeout;
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
   struct Curl_dns_entry *temp_entry;
 
   if(entry)
@@ -400,7 +400,7 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else {
-      struct timeval now2 = Curl_tvnow();
+      struct curlval now2 = Curl_tvnow();
       time_t timediff = Curl_tvdiff(now2, now); /* spent time */
       if(timediff <= 0)
         timeout -= 1; /* always deduct at least 1 */

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -27,7 +27,7 @@ struct conncache {
   struct curl_hash hash;
   size_t num_connections;
   long next_connection_id;
-  struct curlval last_cleanup;
+  struct curltime last_cleanup;
 };
 
 #define BUNDLE_NO_MULTIUSE -1

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -27,7 +27,7 @@ struct conncache {
   struct curl_hash hash;
   size_t num_connections;
   long next_connection_id;
-  struct timeval last_cleanup;
+  struct curlval last_cleanup;
 };
 
 #define BUNDLE_NO_MULTIUSE -1

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -180,12 +180,12 @@ singleipconnect(struct connectdata *conn,
  * @unittest: 1303
  */
 time_t Curl_timeleft(struct Curl_easy *data,
-                     struct curlval *nowp,
+                     struct curltime *nowp,
                      bool duringconnect)
 {
   int timeout_set = 0;
   time_t timeout_ms = duringconnect?DEFAULT_CONNECT_TIMEOUT:0;
-  struct curlval now;
+  struct curltime now;
 
   /* if a timeout is set, use the most restrictive one */
 
@@ -723,7 +723,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
   CURLcode result = CURLE_OK;
   time_t allow;
   int error = 0;
-  struct curlval now;
+  struct curltime now;
   int rc;
   int i;
 
@@ -1136,7 +1136,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,  /* context */
                           const struct Curl_dns_entry *remotehost)
 {
   struct Curl_easy *data = conn->data;
-  struct curlval before = Curl_tvnow();
+  struct curltime before = Curl_tvnow();
   CURLcode result = CURLE_COULDNT_CONNECT;
 
   time_t timeout_ms = Curl_timeleft(data, &before, TRUE);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -180,12 +180,12 @@ singleipconnect(struct connectdata *conn,
  * @unittest: 1303
  */
 time_t Curl_timeleft(struct Curl_easy *data,
-                     struct timeval *nowp,
+                     struct curlval *nowp,
                      bool duringconnect)
 {
   int timeout_set = 0;
   time_t timeout_ms = duringconnect?DEFAULT_CONNECT_TIMEOUT:0;
-  struct timeval now;
+  struct curlval now;
 
   /* if a timeout is set, use the most restrictive one */
 
@@ -723,7 +723,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
   CURLcode result = CURLE_OK;
   time_t allow;
   int error = 0;
-  struct timeval now;
+  struct curlval now;
   int rc;
   int i;
 
@@ -1136,7 +1136,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,  /* context */
                           const struct Curl_dns_entry *remotehost)
 {
   struct Curl_easy *data = conn->data;
-  struct timeval before = Curl_tvnow();
+  struct curlval before = Curl_tvnow();
   CURLcode result = CURLE_COULDNT_CONNECT;
 
   time_t timeout_ms = Curl_timeleft(data, &before, TRUE);

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -36,7 +36,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,
 /* generic function that returns how much time there's left to run, according
    to the timeouts set */
 time_t Curl_timeleft(struct Curl_easy *data,
-                     struct curlval *nowp,
+                     struct curltime *nowp,
                      bool duringconnect);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -36,7 +36,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,
 /* generic function that returns how much time there's left to run, according
    to the timeouts set */
 time_t Curl_timeleft(struct Curl_easy *data,
-                     struct timeval *nowp,
+                     struct curlval *nowp,
                      bool duringconnect);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -572,8 +572,8 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     int numfds=0;
     int pollrc;
     int i;
-    struct timeval before;
-    struct timeval after;
+    struct curlval before;
+    struct curlval after;
 
     /* populate the fds[] array */
     for(m = ev->list, f=&fds[0]; m; m = m->next) {
@@ -670,7 +670,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
   bool done = FALSE;
   CURLMcode mcode = CURLM_OK;
   CURLcode result = CURLE_OK;
-  struct timeval before;
+  struct curlval before;
   int without_fds = 0;  /* count number of consecutive returns from
                            curl_multi_wait() without any filedescriptors */
 
@@ -683,7 +683,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
 
     if(!mcode) {
       if(!rc) {
-        struct timeval after = curlx_tvnow();
+        struct curlval after = curlx_tvnow();
 
         /* If it returns without any filedescriptor instantly, we need to
            avoid busy-looping during periods where it has nothing particular

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -572,8 +572,8 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     int numfds=0;
     int pollrc;
     int i;
-    struct curlval before;
-    struct curlval after;
+    struct curltime before;
+    struct curltime after;
 
     /* populate the fds[] array */
     for(m = ev->list, f=&fds[0]; m; m = m->next) {
@@ -670,7 +670,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
   bool done = FALSE;
   CURLMcode mcode = CURLM_OK;
   CURLcode result = CURLE_OK;
-  struct curlval before;
+  struct curltime before;
   int without_fds = 0;  /* count number of consecutive returns from
                            curl_multi_wait() without any filedescriptors */
 
@@ -683,7 +683,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
 
     if(!mcode) {
       if(!rc) {
-        struct curlval after = curlx_tvnow();
+        struct curltime after = curlx_tvnow();
 
         /* If it returns without any filedescriptor instantly, we need to
            avoid busy-looping during periods where it has nothing particular

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -336,7 +336,7 @@ static time_t ftp_timeleft_accept(struct Curl_easy *data)
 {
   time_t timeout_ms = DEFAULT_ACCEPT_TIMEOUT;
   time_t other;
-  struct timeval now;
+  struct curlval now;
 
   if(data->set.accepttimeout > 0)
     timeout_ms = data->set.accepttimeout;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -336,7 +336,7 @@ static time_t ftp_timeleft_accept(struct Curl_easy *data)
 {
   time_t timeout_ms = DEFAULT_ACCEPT_TIMEOUT;
   time_t other;
-  struct curlval now;
+  struct curltime now;
 
   if(data->set.accepttimeout > 0)
     timeout_ms = data->set.accepttimeout;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -70,7 +70,7 @@ static void singlesocket(struct Curl_multi *multi,
                          struct Curl_easy *data);
 static int update_timer(struct Curl_multi *multi);
 
-static CURLMcode add_next_timeout(struct timeval now,
+static CURLMcode add_next_timeout(struct curlval now,
                                   struct Curl_multi *multi,
                                   struct Curl_easy *d);
 static CURLMcode multi_timeout(struct Curl_multi *multi,
@@ -1297,7 +1297,7 @@ static CURLcode multi_do_more(struct connectdata *conn, int *complete)
 }
 
 static CURLMcode multi_runsingle(struct Curl_multi *multi,
-                                 struct timeval now,
+                                 struct curlval now,
                                  struct Curl_easy *data)
 {
   struct Curl_message *msg = NULL;
@@ -2142,7 +2142,7 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
   struct Curl_easy *data;
   CURLMcode returncode=CURLM_OK;
   struct Curl_tree *t;
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
 
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;
@@ -2492,11 +2492,11 @@ void Curl_multi_closed(struct connectdata *conn, curl_socket_t s)
  * The splay tree only has each sessionhandle as a single node and the nearest
  * timeout is used to sort it on.
  */
-static CURLMcode add_next_timeout(struct timeval now,
+static CURLMcode add_next_timeout(struct curlval now,
                                   struct Curl_multi *multi,
                                   struct Curl_easy *d)
 {
-  struct timeval *tv = &d->state.expiretime;
+  struct curlval *tv = &d->state.expiretime;
   struct curl_llist *list = &d->state.timeoutlist;
   struct curl_llist_element *e;
   struct time_node *node = NULL;
@@ -2547,7 +2547,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   CURLMcode result = CURLM_OK;
   struct Curl_easy *data = NULL;
   struct Curl_tree *t;
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
 
   if(checkall) {
     /* *perform() deals with running_handles on its own */
@@ -2773,11 +2773,11 @@ CURLMcode curl_multi_socket_all(struct Curl_multi *multi, int *running_handles)
 static CURLMcode multi_timeout(struct Curl_multi *multi,
                                long *timeout_ms)
 {
-  static struct timeval tv_zero = {0, 0};
+  static struct curlval tv_zero = {0, 0};
 
   if(multi->timetree) {
     /* we have a tree of expire times */
-    struct timeval now = Curl_tvnow();
+    struct curlval now = Curl_tvnow();
 
     /* splay the lowest to the bottom */
     multi->timetree = Curl_splay(tv_zero, multi->timetree);
@@ -2829,7 +2829,7 @@ static int update_timer(struct Curl_multi *multi)
     return -1;
   }
   if(timeout_ms < 0) {
-    static const struct timeval none={0, 0};
+    static const struct curlval none={0, 0};
     if(Curl_splaycomparekeys(none, multi->timer_lastcall)) {
       multi->timer_lastcall = none;
       /* there's no timeout now but there was one previously, tell the app to
@@ -2880,7 +2880,7 @@ multi_deltimeout(struct Curl_easy *data, expire_id eid)
  */
 static CURLMcode
 multi_addtimeout(struct Curl_easy *data,
-                 struct timeval *stamp,
+                 struct curlval *stamp,
                  expire_id eid)
 {
   struct curl_llist_element *e;
@@ -2928,9 +2928,9 @@ multi_addtimeout(struct Curl_easy *data,
 void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
 {
   struct Curl_multi *multi = data->multi;
-  struct timeval *nowp = &data->state.expiretime;
+  struct curlval *nowp = &data->state.expiretime;
   int rc;
-  struct timeval set;
+  struct curlval set;
 
   /* this is only interesting while there is still an associated multi struct
      remaining! */
@@ -2940,8 +2940,8 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
   DEBUGASSERT(id < EXPIRE_LAST);
 
   set = Curl_tvnow();
-  set.tv_sec += (long)(milli/1000);
-  set.tv_usec += (long)(milli%1000)*1000;
+  set.tv_sec += milli/1000;
+  set.tv_usec += (unsigned int)(milli%1000)*1000;
 
   if(set.tv_usec >= 1000000) {
     set.tv_sec++;
@@ -3003,7 +3003,7 @@ void Curl_expire_done(struct Curl_easy *data, expire_id id)
 void Curl_expire_clear(struct Curl_easy *data)
 {
   struct Curl_multi *multi = data->multi;
-  struct timeval *nowp = &data->state.expiretime;
+  struct curlval *nowp = &data->state.expiretime;
   int rc;
 
   /* this is only interesting while there is still an associated multi struct

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -70,7 +70,7 @@ static void singlesocket(struct Curl_multi *multi,
                          struct Curl_easy *data);
 static int update_timer(struct Curl_multi *multi);
 
-static CURLMcode add_next_timeout(struct curlval now,
+static CURLMcode add_next_timeout(struct curltime now,
                                   struct Curl_multi *multi,
                                   struct Curl_easy *d);
 static CURLMcode multi_timeout(struct Curl_multi *multi,
@@ -1297,7 +1297,7 @@ static CURLcode multi_do_more(struct connectdata *conn, int *complete)
 }
 
 static CURLMcode multi_runsingle(struct Curl_multi *multi,
-                                 struct curlval now,
+                                 struct curltime now,
                                  struct Curl_easy *data)
 {
   struct Curl_message *msg = NULL;
@@ -2142,7 +2142,7 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
   struct Curl_easy *data;
   CURLMcode returncode=CURLM_OK;
   struct Curl_tree *t;
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
 
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;
@@ -2492,11 +2492,11 @@ void Curl_multi_closed(struct connectdata *conn, curl_socket_t s)
  * The splay tree only has each sessionhandle as a single node and the nearest
  * timeout is used to sort it on.
  */
-static CURLMcode add_next_timeout(struct curlval now,
+static CURLMcode add_next_timeout(struct curltime now,
                                   struct Curl_multi *multi,
                                   struct Curl_easy *d)
 {
-  struct curlval *tv = &d->state.expiretime;
+  struct curltime *tv = &d->state.expiretime;
   struct curl_llist *list = &d->state.timeoutlist;
   struct curl_llist_element *e;
   struct time_node *node = NULL;
@@ -2547,7 +2547,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   CURLMcode result = CURLM_OK;
   struct Curl_easy *data = NULL;
   struct Curl_tree *t;
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
 
   if(checkall) {
     /* *perform() deals with running_handles on its own */
@@ -2773,11 +2773,11 @@ CURLMcode curl_multi_socket_all(struct Curl_multi *multi, int *running_handles)
 static CURLMcode multi_timeout(struct Curl_multi *multi,
                                long *timeout_ms)
 {
-  static struct curlval tv_zero = {0, 0};
+  static struct curltime tv_zero = {0, 0};
 
   if(multi->timetree) {
     /* we have a tree of expire times */
-    struct curlval now = Curl_tvnow();
+    struct curltime now = Curl_tvnow();
 
     /* splay the lowest to the bottom */
     multi->timetree = Curl_splay(tv_zero, multi->timetree);
@@ -2829,7 +2829,7 @@ static int update_timer(struct Curl_multi *multi)
     return -1;
   }
   if(timeout_ms < 0) {
-    static const struct curlval none={0, 0};
+    static const struct curltime none={0, 0};
     if(Curl_splaycomparekeys(none, multi->timer_lastcall)) {
       multi->timer_lastcall = none;
       /* there's no timeout now but there was one previously, tell the app to
@@ -2880,7 +2880,7 @@ multi_deltimeout(struct Curl_easy *data, expire_id eid)
  */
 static CURLMcode
 multi_addtimeout(struct Curl_easy *data,
-                 struct curlval *stamp,
+                 struct curltime *stamp,
                  expire_id eid)
 {
   struct curl_llist_element *e;
@@ -2928,9 +2928,9 @@ multi_addtimeout(struct Curl_easy *data,
 void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
 {
   struct Curl_multi *multi = data->multi;
-  struct curlval *nowp = &data->state.expiretime;
+  struct curltime *nowp = &data->state.expiretime;
   int rc;
-  struct curlval set;
+  struct curltime set;
 
   /* this is only interesting while there is still an associated multi struct
      remaining! */
@@ -3003,7 +3003,7 @@ void Curl_expire_done(struct Curl_easy *data, expire_id id)
 void Curl_expire_clear(struct Curl_easy *data)
 {
   struct Curl_multi *multi = data->multi;
-  struct curlval *nowp = &data->state.expiretime;
+  struct curltime *nowp = &data->state.expiretime;
   int rc;
 
   /* this is only interesting while there is still an associated multi struct

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -148,7 +148,7 @@ struct Curl_multi {
   /* timer callback and user data pointer for the *socket() API */
   curl_multi_timer_callback timer_cb;
   void *timer_userp;
-  struct timeval timer_lastcall; /* the fixed time for the timeout for the
+  struct curlval timer_lastcall; /* the fixed time for the timeout for the
                                     previous callback */
 };
 

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -148,7 +148,7 @@ struct Curl_multi {
   /* timer callback and user data pointer for the *socket() API */
   curl_multi_timer_callback timer_cb;
   void *timer_userp;
-  struct curlval timer_lastcall; /* the fixed time for the timeout for the
+  struct curltime timer_lastcall; /* the fixed time for the timeout for the
                                     previous callback */
 };
 

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -58,7 +58,7 @@ struct pingpong {
                      server */
   size_t sendleft; /* number of bytes left to send from the sendthis buffer */
   size_t sendsize; /* total size of the sendthis buffer */
-  struct curlval response; /* set to Curl_tvnow() when a command has been sent
+  struct curltime response; /* set to Curl_tvnow() when a command has been sent
                               off, used to time-out response reading */
   long response_time; /* When no timeout is given, this is the amount of
                          milliseconds we await for a server response. */

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -58,7 +58,7 @@ struct pingpong {
                      server */
   size_t sendleft; /* number of bytes left to send from the sendthis buffer */
   size_t sendsize; /* total size of the sendthis buffer */
-  struct timeval response; /* set to Curl_tvnow() when a command has been sent
+  struct curlval response; /* set to Curl_tvnow() when a command has been sent
                               off, used to time-out response reading */
   long response_time; /* When no timeout is given, this is the amount of
                          milliseconds we await for a server response. */

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -166,7 +166,7 @@ void Curl_pgrsResetTimesSizes(struct Curl_easy *data)
  */
 void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 {
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
   time_t *delta = NULL;
 
   switch(timer) {
@@ -260,8 +260,8 @@ void Curl_pgrsStartNow(struct Curl_easy *data)
 long Curl_pgrsLimitWaitTime(curl_off_t cursize,
                             curl_off_t startsize,
                             curl_off_t limit,
-                            struct timeval start,
-                            struct timeval now)
+                            struct curlval start,
+                            struct curlval now)
 {
   curl_off_t size = cursize - startsize;
   time_t minimum;
@@ -287,7 +287,7 @@ long Curl_pgrsLimitWaitTime(curl_off_t cursize,
 
 void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 {
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
 
   data->progress.downloaded = size;
 
@@ -305,7 +305,7 @@ void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 
 void Curl_pgrsSetUploadCounter(struct Curl_easy *data, curl_off_t size)
 {
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
 
   data->progress.uploaded = size;
 
@@ -351,7 +351,7 @@ void Curl_pgrsSetUploadSize(struct Curl_easy *data, curl_off_t size)
  */
 int Curl_pgrsUpdate(struct connectdata *conn)
 {
-  struct timeval now;
+  struct curlval now;
   int result;
   char max5[6][10];
   curl_off_t dlpercen=0;

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -166,7 +166,7 @@ void Curl_pgrsResetTimesSizes(struct Curl_easy *data)
  */
 void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 {
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
   time_t *delta = NULL;
 
   switch(timer) {
@@ -260,8 +260,8 @@ void Curl_pgrsStartNow(struct Curl_easy *data)
 long Curl_pgrsLimitWaitTime(curl_off_t cursize,
                             curl_off_t startsize,
                             curl_off_t limit,
-                            struct curlval start,
-                            struct curlval now)
+                            struct curltime start,
+                            struct curltime now)
 {
   curl_off_t size = cursize - startsize;
   time_t minimum;
@@ -287,7 +287,7 @@ long Curl_pgrsLimitWaitTime(curl_off_t cursize,
 
 void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 {
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
 
   data->progress.downloaded = size;
 
@@ -305,7 +305,7 @@ void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 
 void Curl_pgrsSetUploadCounter(struct Curl_easy *data, curl_off_t size)
 {
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
 
   data->progress.uploaded = size;
 
@@ -351,7 +351,7 @@ void Curl_pgrsSetUploadSize(struct Curl_easy *data, curl_off_t size)
  */
 int Curl_pgrsUpdate(struct connectdata *conn)
 {
-  struct curlval now;
+  struct curltime now;
   int result;
   char max5[6][10];
   curl_off_t dlpercen=0;

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -52,8 +52,8 @@ void Curl_pgrsTime(struct Curl_easy *data, timerid timer);
 long Curl_pgrsLimitWaitTime(curl_off_t cursize,
                             curl_off_t startsize,
                             curl_off_t limit,
-                            struct curlval start,
-                            struct curlval now);
+                            struct curltime start,
+                            struct curltime now);
 
 /* Don't show progress for sizes smaller than: */
 #define LEAST_SIZE_PROGRESS BUFSIZE

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -52,8 +52,8 @@ void Curl_pgrsTime(struct Curl_easy *data, timerid timer);
 long Curl_pgrsLimitWaitTime(curl_off_t cursize,
                             curl_off_t startsize,
                             curl_off_t limit,
-                            struct timeval start,
-                            struct timeval now);
+                            struct curlval start,
+                            struct curlval now);
 
 /* Don't show progress for sizes smaller than: */
 #define LEAST_SIZE_PROGRESS BUFSIZE

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -86,7 +86,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 #endif
 
   if(!seeded) {
-    struct curlval now = curlx_tvnow();
+    struct curltime now = curlx_tvnow();
     infof(data, "WARNING: Using weak random seed\n");
     randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
     randseed = randseed * 1103515245 + 12345;

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -86,7 +86,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 #endif
 
   if(!seeded) {
-    struct timeval now = curlx_tvnow();
+    struct curlval now = curlx_tvnow();
     infof(data, "WARNING: Using weak random seed\n");
     randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
     randseed = randseed * 1103515245 + 12345;

--- a/lib/select.c
+++ b/lib/select.c
@@ -76,9 +76,9 @@ int Curl_wait_ms(int timeout_ms)
 {
 #if !defined(MSDOS) && !defined(USE_WINSOCK)
 #ifndef HAVE_POLL_FINE
-  struct timeval pending_tv;
+  struct curlval pending_tv;
 #endif
-  struct timeval initial_tv;
+  struct curlval initial_tv;
   int pending_ms;
   int error;
 #endif
@@ -151,14 +151,14 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   struct pollfd pfd[3];
   int num;
 #else
-  struct timeval pending_tv;
-  struct timeval *ptimeout;
+  struct curlval pending_tv;
+  struct curlval *ptimeout;
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
   curl_socket_t maxfd;
 #endif
-  struct timeval initial_tv = {0, 0};
+  struct curlval initial_tv = {0, 0};
   int pending_ms = 0;
   int error;
   int r;
@@ -391,14 +391,14 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
 int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
 {
 #ifndef HAVE_POLL_FINE
-  struct timeval pending_tv;
-  struct timeval *ptimeout;
+  struct curlval pending_tv;
+  struct curlval *ptimeout;
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
   curl_socket_t maxfd;
 #endif
-  struct timeval initial_tv = {0, 0};
+  struct curlval initial_tv = {0, 0};
   bool fds_none = TRUE;
   unsigned int i;
   int pending_ms = 0;
@@ -571,8 +571,8 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
  *
  * Return values are the same as select's.
  */
-int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,
-                       fd_set* excepts, struct timeval* tv)
+int tpf_select_libcurl(int maxfds, fd_set *reads, fd_set *writes,
+                       fd_set *excepts, struct curlval *tv)
 {
    int rc;
 

--- a/lib/select.c
+++ b/lib/select.c
@@ -76,9 +76,9 @@ int Curl_wait_ms(int timeout_ms)
 {
 #if !defined(MSDOS) && !defined(USE_WINSOCK)
 #ifndef HAVE_POLL_FINE
-  struct curlval pending_tv;
+  struct curltime pending_tv;
 #endif
-  struct curlval initial_tv;
+  struct curltime initial_tv;
   int pending_ms;
   int error;
 #endif
@@ -151,14 +151,14 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   struct pollfd pfd[3];
   int num;
 #else
-  struct curlval pending_tv;
-  struct curlval *ptimeout;
+  struct curltime pending_tv;
+  struct curltime *ptimeout;
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
   curl_socket_t maxfd;
 #endif
-  struct curlval initial_tv = {0, 0};
+  struct curltime initial_tv = {0, 0};
   int pending_ms = 0;
   int error;
   int r;
@@ -391,14 +391,14 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
 int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
 {
 #ifndef HAVE_POLL_FINE
-  struct curlval pending_tv;
-  struct curlval *ptimeout;
+  struct curltime pending_tv;
+  struct curltime *ptimeout;
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
   curl_socket_t maxfd;
 #endif
-  struct curlval initial_tv = {0, 0};
+  struct curltime initial_tv = {0, 0};
   bool fds_none = TRUE;
   unsigned int i;
   int pending_ms = 0;
@@ -572,7 +572,7 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
  * Return values are the same as select's.
  */
 int tpf_select_libcurl(int maxfds, fd_set *reads, fd_set *writes,
-                       fd_set *excepts, struct curlval *tv)
+                       fd_set *excepts, struct curltime *tv)
 {
    int rc;
 

--- a/lib/select.c
+++ b/lib/select.c
@@ -76,7 +76,7 @@ int Curl_wait_ms(int timeout_ms)
 {
 #if !defined(MSDOS) && !defined(USE_WINSOCK)
 #ifndef HAVE_POLL_FINE
-  struct curltime pending_tv;
+  struct timeval pending_tv;
 #endif
   struct curltime initial_tv;
   int pending_ms;
@@ -151,8 +151,8 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   struct pollfd pfd[3];
   int num;
 #else
-  struct curltime pending_tv;
-  struct curltime *ptimeout;
+  struct timeval pending_tv;
+  struct timeval *ptimeout;
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
@@ -391,8 +391,8 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
 int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
 {
 #ifndef HAVE_POLL_FINE
-  struct curltime pending_tv;
-  struct curltime *ptimeout;
+  struct timeval pending_tv;
+  struct timeval *ptimeout;
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
@@ -572,7 +572,7 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
  * Return values are the same as select's.
  */
 int tpf_select_libcurl(int maxfds, fd_set *reads, fd_set *writes,
-                       fd_set *excepts, struct curltime *tv)
+                       fd_set *excepts, struct timeval *tv)
 {
    int rc;
 

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -30,14 +30,14 @@
 
 void Curl_speedinit(struct Curl_easy *data)
 {
-  memset(&data->state.keeps_speed, 0, sizeof(struct curlval));
+  memset(&data->state.keeps_speed, 0, sizeof(struct curltime));
 }
 
 /*
  * @unittest: 1606
  */
 CURLcode Curl_speedcheck(struct Curl_easy *data,
-                         struct curlval now)
+                         struct curltime now)
 {
   if((data->progress.current_speed >= 0) && data->set.low_speed_time) {
     if(data->progress.current_speed < data->set.low_speed_limit) {

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -30,14 +30,14 @@
 
 void Curl_speedinit(struct Curl_easy *data)
 {
-  memset(&data->state.keeps_speed, 0, sizeof(struct timeval));
+  memset(&data->state.keeps_speed, 0, sizeof(struct curlval));
 }
 
 /*
  * @unittest: 1606
  */
 CURLcode Curl_speedcheck(struct Curl_easy *data,
-                         struct timeval now)
+                         struct curlval now)
 {
   if((data->progress.current_speed >= 0) && data->set.low_speed_time) {
     if(data->progress.current_speed < data->set.low_speed_limit) {

--- a/lib/speedcheck.h
+++ b/lib/speedcheck.h
@@ -28,6 +28,6 @@
 
 void Curl_speedinit(struct Curl_easy *data);
 CURLcode Curl_speedcheck(struct Curl_easy *data,
-                         struct curlval now);
+                         struct curltime now);
 
 #endif /* HEADER_CURL_SPEEDCHECK_H */

--- a/lib/speedcheck.h
+++ b/lib/speedcheck.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2010, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -28,6 +28,6 @@
 
 void Curl_speedinit(struct Curl_easy *data);
 CURLcode Curl_speedcheck(struct Curl_easy *data,
-                         struct timeval now);
+                         struct curlval now);
 
 #endif /* HEADER_CURL_SPEEDCHECK_H */

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -37,7 +37,7 @@
  * Splay using the key i (which may or may not be in the tree.) The starting
  * root is t.
  */
-struct Curl_tree *Curl_splay(struct curlval i,
+struct Curl_tree *Curl_splay(struct curltime i,
                              struct Curl_tree *t)
 {
   struct Curl_tree N, *l, *r, *y;
@@ -97,11 +97,13 @@ struct Curl_tree *Curl_splay(struct curlval i,
  *
  * @unittest: 1309
  */
-struct Curl_tree *Curl_splayinsert(struct curlval i,
+struct Curl_tree *Curl_splayinsert(struct curltime i,
                                    struct Curl_tree *t,
                                    struct Curl_tree *node)
 {
-  static const struct curlval KEY_NOTUSED = {-1, -1}; /* will *NEVER* appear */
+  static const struct curltime KEY_NOTUSED = {
+    -1, -1
+  }; /* will *NEVER* appear */
 
   if(node == NULL)
     return t;
@@ -114,7 +116,7 @@ struct Curl_tree *Curl_splayinsert(struct curlval i,
          to the end of this list. */
 
       node->key = KEY_NOTUSED; /* we set the key in the sub node to NOTUSED
-                               to quickly identify this node as a subnode */
+                                  to quickly identify this node as a subnode */
       node->samen = t;
       node->samep = t->samep;
       t->samep->samen = node;
@@ -149,11 +151,11 @@ struct Curl_tree *Curl_splayinsert(struct curlval i,
 /* Finds and deletes the best-fit node from the tree. Return a pointer to the
    resulting tree.  best-fit means the smallest node if it is not larger than
    the key */
-struct Curl_tree *Curl_splaygetbest(struct curlval i,
+struct Curl_tree *Curl_splaygetbest(struct curltime i,
                                     struct Curl_tree *t,
                                     struct Curl_tree **removed)
 {
-  static struct curlval tv_zero = {0, 0};
+  static struct curltime tv_zero = {0, 0};
   struct Curl_tree *x;
 
   if(!t) {
@@ -209,7 +211,9 @@ int Curl_splayremovebyaddr(struct Curl_tree *t,
                            struct Curl_tree *removenode,
                            struct Curl_tree **newroot)
 {
-  static const struct curlval KEY_NOTUSED = {-1, -1}; /* will *NEVER* appear */
+  static const struct curltime KEY_NOTUSED = {
+    -1, -1
+  }; /* will *NEVER* appear */
   struct Curl_tree *x;
 
   if(!t || !removenode)

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1997 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1997 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -37,7 +37,7 @@
  * Splay using the key i (which may or may not be in the tree.) The starting
  * root is t.
  */
-struct Curl_tree *Curl_splay(struct timeval i,
+struct Curl_tree *Curl_splay(struct curlval i,
                              struct Curl_tree *t)
 {
   struct Curl_tree N, *l, *r, *y;
@@ -97,11 +97,11 @@ struct Curl_tree *Curl_splay(struct timeval i,
  *
  * @unittest: 1309
  */
-struct Curl_tree *Curl_splayinsert(struct timeval i,
+struct Curl_tree *Curl_splayinsert(struct curlval i,
                                    struct Curl_tree *t,
                                    struct Curl_tree *node)
 {
-  static const struct timeval KEY_NOTUSED = {-1, -1}; /* will *NEVER* appear */
+  static const struct curlval KEY_NOTUSED = {-1, -1}; /* will *NEVER* appear */
 
   if(node == NULL)
     return t;
@@ -149,11 +149,11 @@ struct Curl_tree *Curl_splayinsert(struct timeval i,
 /* Finds and deletes the best-fit node from the tree. Return a pointer to the
    resulting tree.  best-fit means the smallest node if it is not larger than
    the key */
-struct Curl_tree *Curl_splaygetbest(struct timeval i,
-                                       struct Curl_tree *t,
-                                       struct Curl_tree **removed)
+struct Curl_tree *Curl_splaygetbest(struct curlval i,
+                                    struct Curl_tree *t,
+                                    struct Curl_tree **removed)
 {
-  static struct timeval tv_zero = {0, 0};
+  static struct curlval tv_zero = {0, 0};
   struct Curl_tree *x;
 
   if(!t) {
@@ -209,7 +209,7 @@ int Curl_splayremovebyaddr(struct Curl_tree *t,
                            struct Curl_tree *removenode,
                            struct Curl_tree **newroot)
 {
-  static const struct timeval KEY_NOTUSED = {-1, -1}; /* will *NEVER* appear */
+  static const struct curlval KEY_NOTUSED = {-1, -1}; /* will *NEVER* appear */
   struct Curl_tree *x;
 
   if(!t || !removenode)

--- a/lib/splay.h
+++ b/lib/splay.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1997 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1997 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,30 +22,31 @@
  *
  ***************************************************************************/
 #include "curl_setup.h"
+#include "timeval.h"
 
 struct Curl_tree {
   struct Curl_tree *smaller; /* smaller node */
   struct Curl_tree *larger;  /* larger node */
   struct Curl_tree *samen;   /* points to the next node with identical key */
   struct Curl_tree *samep;   /* points to the prev node with identical key */
-  struct timeval key;        /* this node's "sort" key */
+  struct curlval key;        /* this node's "sort" key */
   void *payload;             /* data the splay code doesn't care about */
 };
 
-struct Curl_tree *Curl_splay(struct timeval i,
+struct Curl_tree *Curl_splay(struct curlval i,
                              struct Curl_tree *t);
 
-struct Curl_tree *Curl_splayinsert(struct timeval key,
+struct Curl_tree *Curl_splayinsert(struct curlval key,
                                    struct Curl_tree *t,
                                    struct Curl_tree *newnode);
 
 #if 0
-struct Curl_tree *Curl_splayremove(struct timeval key,
+struct Curl_tree *Curl_splayremove(struct curlval key,
                                    struct Curl_tree *t,
                                    struct Curl_tree **removed);
 #endif
 
-struct Curl_tree *Curl_splaygetbest(struct timeval key,
+struct Curl_tree *Curl_splaygetbest(struct curlval key,
                                     struct Curl_tree *t,
                                     struct Curl_tree **removed);
 

--- a/lib/splay.h
+++ b/lib/splay.h
@@ -29,24 +29,24 @@ struct Curl_tree {
   struct Curl_tree *larger;  /* larger node */
   struct Curl_tree *samen;   /* points to the next node with identical key */
   struct Curl_tree *samep;   /* points to the prev node with identical key */
-  struct curlval key;        /* this node's "sort" key */
+  struct curltime key;        /* this node's "sort" key */
   void *payload;             /* data the splay code doesn't care about */
 };
 
-struct Curl_tree *Curl_splay(struct curlval i,
+struct Curl_tree *Curl_splay(struct curltime i,
                              struct Curl_tree *t);
 
-struct Curl_tree *Curl_splayinsert(struct curlval key,
+struct Curl_tree *Curl_splayinsert(struct curltime key,
                                    struct Curl_tree *t,
                                    struct Curl_tree *newnode);
 
 #if 0
-struct Curl_tree *Curl_splayremove(struct curlval key,
+struct Curl_tree *Curl_splayremove(struct curltime key,
                                    struct Curl_tree *t,
                                    struct Curl_tree **removed);
 #endif
 
-struct Curl_tree *Curl_splaygetbest(struct curlval key,
+struct Curl_tree *Curl_splaygetbest(struct curltime key,
                                     struct Curl_tree *t,
                                     struct Curl_tree **removed);
 

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2827,7 +2827,7 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     time_t left = 1000;
-    struct curlval now = Curl_tvnow();
+    struct curltime now = Curl_tvnow();
 
     result = ssh_statemach_act(conn, &block);
     if(result)

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2827,7 +2827,7 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     time_t left = 1000;
-    struct timeval now = Curl_tvnow();
+    struct curlval now = Curl_tvnow();
 
     result = ssh_statemach_act(conn, &block);
     if(result)

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1327,7 +1327,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   curl_off_t total_ul = 0;
 #endif
   ssize_t nread;
-  struct timeval now;
+  struct curlval now;
   bool keepon = TRUE;
   char *buf = data->state.buffer;
   struct TELNET *tn;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1327,7 +1327,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   curl_off_t total_ul = 0;
 #endif
   ssize_t nread;
-  struct curlval now;
+  struct curltime now;
   bool keepon = TRUE;
   char *buf = data->state.buffer;
   struct TELNET *tn;

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -24,7 +24,7 @@
 
 #if defined(WIN32) && !defined(MSDOS)
 
-struct timeval curlx_tvnow(void)
+struct curltime curlx_tvnow(void)
 {
   /*
   ** GetTickCount() is available on _all_ Windows versions from W95 up
@@ -39,8 +39,8 @@ struct timeval curlx_tvnow(void)
   now.tv_usec = (milliseconds % 1000) * 1000;
 #else
   ULONGLONG milliseconds = GetTickCount64();
-  now.tv_sec = (long) (milliseconds / 1000);
-  now.tv_usec = (long) (milliseconds % 1000) * 1000;
+  now.tv_sec = (time_t) (milliseconds / 1000);
+  now.tv_usec = (unsigned int) (milliseconds % 1000) * 1000;
 #endif
 
   return now;

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -31,7 +31,7 @@ struct timeval curlx_tvnow(void)
   ** to nowadays. Returns milliseconds elapsed since last system boot,
   ** increases monotonically and wraps once 49.7 days have elapsed.
   */
-  struct timeval now;
+  struct curlval now;
 #if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
     (_WIN32_WINNT < _WIN32_WINNT_VISTA)
   DWORD milliseconds = GetTickCount();
@@ -48,7 +48,7 @@ struct timeval curlx_tvnow(void)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
-struct timeval curlx_tvnow(void)
+struct curlval curlx_tvnow(void)
 {
   /*
   ** clock_gettime() is granted to be increased monotonically when the
@@ -58,10 +58,11 @@ struct timeval curlx_tvnow(void)
   ** system has started up.
   */
   struct timeval now;
+  struct curlval cnow;
   struct timespec tsnow;
   if(0 == clock_gettime(CLOCK_MONOTONIC, &tsnow)) {
-    now.tv_sec = tsnow.tv_sec;
-    now.tv_usec = tsnow.tv_nsec / 1000;
+    cnow.tv_sec = tsnow.tv_sec;
+    cnow.tv_usec = (unsigned int)(tsnow.tv_nsec / 1000);
   }
   /*
   ** Even when the configure process has truly detected monotonic clock
@@ -69,20 +70,23 @@ struct timeval curlx_tvnow(void)
   ** run-time. When this occurs simply fallback to other time source.
   */
 #ifdef HAVE_GETTIMEOFDAY
-  else
+  else {
     (void)gettimeofday(&now, NULL);
+    cnow.tv_sec = now.tv_sec;
+    cnow.tv_usec = (unsigned int)now.tv_usec;
+  }
 #else
   else {
-    now.tv_sec = (long)time(NULL);
-    now.tv_usec = 0;
+    cnow.tv_sec = time(NULL);
+    cnow.tv_usec = 0;
   }
 #endif
-  return now;
+  return cnow;
 }
 
 #elif defined(HAVE_GETTIMEOFDAY)
 
-struct timeval curlx_tvnow(void)
+struct curlval curlx_tvnow(void)
 {
   /*
   ** gettimeofday() is not granted to be increased monotonically, due to
@@ -90,19 +94,22 @@ struct timeval curlx_tvnow(void)
   ** forward or backward in time.
   */
   struct timeval now;
+  struct curlval ret;
   (void)gettimeofday(&now, NULL);
-  return now;
+  ret.tv_sec = now.tv_sec;
+  ret.tv_usec = now.tv_usec;
+  return ret;
 }
 
 #else
 
-struct timeval curlx_tvnow(void)
+struct curlval curlx_tvnow(void)
 {
   /*
   ** time() returns the value of time in seconds since the Epoch.
   */
-  struct timeval now;
-  now.tv_sec = (long)time(NULL);
+  struct curlval now;
+  now.tv_sec = time(NULL);
   now.tv_usec = 0;
   return now;
 }
@@ -116,7 +123,7 @@ struct timeval curlx_tvnow(void)
  * Returns: the time difference in number of milliseconds. For large diffs it
  * returns 0x7fffffff on 32bit time_t systems.
  */
-time_t curlx_tvdiff(struct timeval newer, struct timeval older)
+time_t curlx_tvdiff(struct curlval newer, struct curlval older)
 {
 #if SIZEOF_TIME_T < 8
   /* for 32bit time_t systems, add a precaution to avoid overflow for really
@@ -136,7 +143,7 @@ time_t curlx_tvdiff(struct timeval newer, struct timeval older)
  * Returns: the time difference in number of microseconds. For too large diffs
  * it returns max value.
  */
-time_t Curl_tvdiff_us(struct timeval newer, struct timeval older)
+time_t Curl_tvdiff_us(struct curlval newer, struct curlval older)
 {
   time_t diff = newer.tv_sec-older.tv_sec;
 #if SIZEOF_TIME_T < 8

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -122,6 +122,8 @@ struct curltime curlx_tvnow(void)
  *
  * Returns: the time difference in number of milliseconds. For large diffs it
  * returns 0x7fffffff on 32bit time_t systems.
+ *
+ * @unittest: 1323
  */
 time_t curlx_tvdiff(struct curltime newer, struct curltime older)
 {
@@ -133,7 +135,7 @@ time_t curlx_tvdiff(struct curltime newer, struct curltime older)
     return 0x7fffffff;
 #endif
   return (newer.tv_sec-older.tv_sec)*1000+
-    (time_t)(newer.tv_usec-older.tv_usec)/1000;
+    (int)(newer.tv_usec-older.tv_usec)/1000;
 }
 
 /*

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -31,7 +31,7 @@ struct timeval curlx_tvnow(void)
   ** to nowadays. Returns milliseconds elapsed since last system boot,
   ** increases monotonically and wraps once 49.7 days have elapsed.
   */
-  struct curlval now;
+  struct curltime now;
 #if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
     (_WIN32_WINNT < _WIN32_WINNT_VISTA)
   DWORD milliseconds = GetTickCount();
@@ -48,7 +48,7 @@ struct timeval curlx_tvnow(void)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
-struct curlval curlx_tvnow(void)
+struct curltime curlx_tvnow(void)
 {
   /*
   ** clock_gettime() is granted to be increased monotonically when the
@@ -58,7 +58,7 @@ struct curlval curlx_tvnow(void)
   ** system has started up.
   */
   struct timeval now;
-  struct curlval cnow;
+  struct curltime cnow;
   struct timespec tsnow;
   if(0 == clock_gettime(CLOCK_MONOTONIC, &tsnow)) {
     cnow.tv_sec = tsnow.tv_sec;
@@ -86,7 +86,7 @@ struct curlval curlx_tvnow(void)
 
 #elif defined(HAVE_GETTIMEOFDAY)
 
-struct curlval curlx_tvnow(void)
+struct curltime curlx_tvnow(void)
 {
   /*
   ** gettimeofday() is not granted to be increased monotonically, due to
@@ -94,7 +94,7 @@ struct curlval curlx_tvnow(void)
   ** forward or backward in time.
   */
   struct timeval now;
-  struct curlval ret;
+  struct curltime ret;
   (void)gettimeofday(&now, NULL);
   ret.tv_sec = now.tv_sec;
   ret.tv_usec = now.tv_usec;
@@ -103,12 +103,12 @@ struct curlval curlx_tvnow(void)
 
 #else
 
-struct curlval curlx_tvnow(void)
+struct curltime curlx_tvnow(void)
 {
   /*
   ** time() returns the value of time in seconds since the Epoch.
   */
-  struct curlval now;
+  struct curltime now;
   now.tv_sec = time(NULL);
   now.tv_usec = 0;
   return now;
@@ -123,7 +123,7 @@ struct curlval curlx_tvnow(void)
  * Returns: the time difference in number of milliseconds. For large diffs it
  * returns 0x7fffffff on 32bit time_t systems.
  */
-time_t curlx_tvdiff(struct curlval newer, struct curlval older)
+time_t curlx_tvdiff(struct curltime newer, struct curltime older)
 {
 #if SIZEOF_TIME_T < 8
   /* for 32bit time_t systems, add a precaution to avoid overflow for really
@@ -143,7 +143,7 @@ time_t curlx_tvdiff(struct curlval newer, struct curlval older)
  * Returns: the time difference in number of microseconds. For too large diffs
  * it returns max value.
  */
-time_t Curl_tvdiff_us(struct curlval newer, struct curlval older)
+time_t Curl_tvdiff_us(struct curltime newer, struct curltime older)
 {
   time_t diff = newer.tv_sec-older.tv_sec;
 #if SIZEOF_TIME_T < 8

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -29,7 +29,12 @@
 
 #include "curl_setup.h"
 
-struct timeval curlx_tvnow(void);
+struct curlval {
+  time_t       tv_sec;     /* seconds */
+  unsigned int tv_usec;    /* microseconds */
+};
+
+struct curlval curlx_tvnow(void);
 
 /*
  * Make sure that the first argument (t1) is the more recent time and t2 is
@@ -37,7 +42,7 @@ struct timeval curlx_tvnow(void);
  *
  * Returns: the time difference in number of milliseconds.
  */
-time_t curlx_tvdiff(struct timeval t1, struct timeval t2);
+time_t curlx_tvdiff(struct curlval t1, struct curlval t2);
 
 /*
  * Make sure that the first argument (t1) is the more recent time and t2 is
@@ -45,7 +50,7 @@ time_t curlx_tvdiff(struct timeval t1, struct timeval t2);
  *
  * Returns: the time difference in number of microseconds.
  */
-time_t Curl_tvdiff_us(struct timeval newer, struct timeval older);
+time_t Curl_tvdiff_us(struct curlval newer, struct curlval older);
 
 /* These two defines below exist to provide the older API for library
    internals only. */

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -29,12 +29,12 @@
 
 #include "curl_setup.h"
 
-struct curlval {
+struct curltime {
   time_t       tv_sec;     /* seconds */
   unsigned int tv_usec;    /* microseconds */
 };
 
-struct curlval curlx_tvnow(void);
+struct curltime curlx_tvnow(void);
 
 /*
  * Make sure that the first argument (t1) is the more recent time and t2 is
@@ -42,7 +42,7 @@ struct curlval curlx_tvnow(void);
  *
  * Returns: the time difference in number of milliseconds.
  */
-time_t curlx_tvdiff(struct curlval t1, struct curlval t2);
+time_t curlx_tvdiff(struct curltime t1, struct curltime t2);
 
 /*
  * Make sure that the first argument (t1) is the more recent time and t2 is
@@ -50,7 +50,7 @@ time_t curlx_tvdiff(struct curlval t1, struct curlval t2);
  *
  * Returns: the time difference in number of microseconds.
  */
-time_t Curl_tvdiff_us(struct curlval newer, struct curlval older);
+time_t Curl_tvdiff_us(struct curltime newer, struct curltime older);
 
 /* These two defines below exist to provide the older API for library
    internals only. */

--- a/lib/url.c
+++ b/lib/url.c
@@ -3275,7 +3275,7 @@ Curl_oldest_idle_connection(struct Curl_easy *data)
   struct curl_hash_element *he;
   time_t highscore=-1;
   time_t score;
-  struct curlval now;
+  struct curltime now;
   struct connectdata *conn_candidate = NULL;
   struct connectbundle *bundle;
 
@@ -3338,7 +3338,7 @@ find_oldest_idle_connection_in_bundle(struct Curl_easy *data,
   struct curl_llist_element *curr;
   time_t highscore=-1;
   time_t score;
-  struct curlval now;
+  struct curltime now;
   struct connectdata *conn_candidate = NULL;
   struct connectdata *conn;
 
@@ -3426,7 +3426,7 @@ static int call_disconnect_if_dead(struct connectdata *conn,
  */
 static void prune_dead_connections(struct Curl_easy *data)
 {
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
   time_t elapsed = Curl_tvdiff(now, data->state.conn_cache->last_cleanup);
 
   if(elapsed >= 1000L) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -3275,7 +3275,7 @@ Curl_oldest_idle_connection(struct Curl_easy *data)
   struct curl_hash_element *he;
   time_t highscore=-1;
   time_t score;
-  struct timeval now;
+  struct curlval now;
   struct connectdata *conn_candidate = NULL;
   struct connectbundle *bundle;
 
@@ -3338,7 +3338,7 @@ find_oldest_idle_connection_in_bundle(struct Curl_easy *data,
   struct curl_llist_element *curr;
   time_t highscore=-1;
   time_t score;
-  struct timeval now;
+  struct curlval now;
   struct connectdata *conn_candidate = NULL;
   struct connectdata *conn;
 
@@ -3426,7 +3426,7 @@ static int call_disconnect_if_dead(struct connectdata *conn,
  */
 static void prune_dead_connections(struct Curl_easy *data)
 {
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
   time_t elapsed = Curl_tvdiff(now, data->state.conn_cache->last_cleanup);
 
   if(elapsed >= 1000L) {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -678,8 +678,8 @@ struct SingleRequest {
                              100 reply (without a following second response
                              code) result in a CURLE_GOT_NOTHING error code */
 
-  struct curlval start;         /* transfer started at this time */
-  struct curlval now;           /* current time */
+  struct curltime start;         /* transfer started at this time */
+  struct curltime now;           /* current time */
   bool header;                  /* incoming data has HTTP header */
   enum {
     HEADER_NORMAL,              /* no bad header at all */
@@ -701,7 +701,7 @@ struct SingleRequest {
                                    Content-Range: header */
   int httpcode;                 /* error code from the 'HTTP/1.? XXX' or
                                    'RTSP/1.? XXX' line */
-  struct curlval start100;      /* time stamp to wait for the 100 code from */
+  struct curltime start100;      /* time stamp to wait for the 100 code from */
   enum expect100 exp100;        /* expect 100 continue state */
   enum upgrade101 upgr101;      /* 101 upgrade state */
 
@@ -1016,8 +1016,8 @@ struct connectdata {
   int httpversion;        /* the HTTP version*10 reported by the server */
   int rtspversion;        /* the RTSP version*10 reported by the server */
 
-  struct curlval now;     /* "current" time */
-  struct curlval created; /* creation time */
+  struct curltime now;     /* "current" time */
+  struct curltime created; /* creation time */
   curl_socket_t sock[2]; /* two sockets, the second is used for the data
                             transfer when doing FTP */
   curl_socket_t tempsock[2]; /* temporary sockets for happy eyeballs */
@@ -1040,7 +1040,7 @@ struct connectdata {
  /* connecttime: when connect() is called on the current IP address. Used to
     be able to track when to move on to try next IP - but only when the multi
     interface is used. */
-  struct curlval connecttime;
+  struct curltime connecttime;
   /* The two fields below get set in Curl_connecthost */
   int num_addr; /* number of addresses to try to connect to */
   time_t timeoutms_per_addr; /* how long time in milliseconds to spend on
@@ -1250,22 +1250,22 @@ struct Progress {
   time_t t_starttransfer;
   time_t t_redirect;
 
-  struct curlval start;
-  struct curlval t_startsingle;
-  struct curlval t_startop;
-  struct curlval t_acceptdata;
+  struct curltime start;
+  struct curltime t_startsingle;
+  struct curltime t_startop;
+  struct curltime t_acceptdata;
 
   /* upload speed limit */
-  struct curlval ul_limit_start;
+  struct curltime ul_limit_start;
   curl_off_t ul_limit_size;
   /* download speed limit */
-  struct curlval dl_limit_start;
+  struct curltime dl_limit_start;
   curl_off_t dl_limit_size;
 
 #define CURR_TIME (5+1) /* 6 entries for 5 seconds */
 
   curl_off_t speeder[ CURR_TIME ];
-  struct curlval speeder_time[ CURR_TIME ];
+  struct curltime speeder_time[ CURR_TIME ];
   int speeder_c;
 };
 
@@ -1360,7 +1360,7 @@ typedef enum {
  */
 struct time_node {
   struct curl_llist_element list;
-  struct curlval time;
+  struct curltime time;
   expire_id eid;
 };
 
@@ -1375,7 +1375,7 @@ struct UrlState {
   bool multi_owned_by_easy;
 
   /* buffers to store authentication data in, as parsed from input options */
-  struct curlval keeps_speed; /* for the progress meter really */
+  struct curltime keeps_speed; /* for the progress meter really */
 
   struct connectdata *lastconnect; /* The last connection, NULL if undefined */
 
@@ -1429,7 +1429,7 @@ struct UrlState {
 #if defined(USE_OPENSSL) && defined(HAVE_OPENSSL_ENGINE_H)
   ENGINE *engine;
 #endif /* USE_OPENSSL */
-  struct curlval expiretime; /* set this with Curl_expire() only */
+  struct curltime expiretime; /* set this with Curl_expire() only */
   struct Curl_tree timenode; /* for the splay stuff */
   struct curl_llist timeoutlist; /* list of pending timeouts */
   struct time_node expires[EXPIRE_LAST]; /* nodes for each expire type */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -678,8 +678,8 @@ struct SingleRequest {
                              100 reply (without a following second response
                              code) result in a CURLE_GOT_NOTHING error code */
 
-  struct timeval start;         /* transfer started at this time */
-  struct timeval now;           /* current time */
+  struct curlval start;         /* transfer started at this time */
+  struct curlval now;           /* current time */
   bool header;                  /* incoming data has HTTP header */
   enum {
     HEADER_NORMAL,              /* no bad header at all */
@@ -701,7 +701,7 @@ struct SingleRequest {
                                    Content-Range: header */
   int httpcode;                 /* error code from the 'HTTP/1.? XXX' or
                                    'RTSP/1.? XXX' line */
-  struct timeval start100;      /* time stamp to wait for the 100 code from */
+  struct curlval start100;      /* time stamp to wait for the 100 code from */
   enum expect100 exp100;        /* expect 100 continue state */
   enum upgrade101 upgr101;      /* 101 upgrade state */
 
@@ -1016,8 +1016,8 @@ struct connectdata {
   int httpversion;        /* the HTTP version*10 reported by the server */
   int rtspversion;        /* the RTSP version*10 reported by the server */
 
-  struct timeval now;     /* "current" time */
-  struct timeval created; /* creation time */
+  struct curlval now;     /* "current" time */
+  struct curlval created; /* creation time */
   curl_socket_t sock[2]; /* two sockets, the second is used for the data
                             transfer when doing FTP */
   curl_socket_t tempsock[2]; /* temporary sockets for happy eyeballs */
@@ -1040,7 +1040,7 @@ struct connectdata {
  /* connecttime: when connect() is called on the current IP address. Used to
     be able to track when to move on to try next IP - but only when the multi
     interface is used. */
-  struct timeval connecttime;
+  struct curlval connecttime;
   /* The two fields below get set in Curl_connecthost */
   int num_addr; /* number of addresses to try to connect to */
   time_t timeoutms_per_addr; /* how long time in milliseconds to spend on
@@ -1250,22 +1250,22 @@ struct Progress {
   time_t t_starttransfer;
   time_t t_redirect;
 
-  struct timeval start;
-  struct timeval t_startsingle;
-  struct timeval t_startop;
-  struct timeval t_acceptdata;
+  struct curlval start;
+  struct curlval t_startsingle;
+  struct curlval t_startop;
+  struct curlval t_acceptdata;
 
   /* upload speed limit */
-  struct timeval ul_limit_start;
+  struct curlval ul_limit_start;
   curl_off_t ul_limit_size;
   /* download speed limit */
-  struct timeval dl_limit_start;
+  struct curlval dl_limit_start;
   curl_off_t dl_limit_size;
 
 #define CURR_TIME (5+1) /* 6 entries for 5 seconds */
 
   curl_off_t speeder[ CURR_TIME ];
-  struct timeval speeder_time[ CURR_TIME ];
+  struct curlval speeder_time[ CURR_TIME ];
   int speeder_c;
 };
 
@@ -1360,7 +1360,7 @@ typedef enum {
  */
 struct time_node {
   struct curl_llist_element list;
-  struct timeval time;
+  struct curlval time;
   expire_id eid;
 };
 
@@ -1375,7 +1375,7 @@ struct UrlState {
   bool multi_owned_by_easy;
 
   /* buffers to store authentication data in, as parsed from input options */
-  struct timeval keeps_speed; /* for the progress meter really */
+  struct curlval keeps_speed; /* for the progress meter really */
 
   struct connectdata *lastconnect; /* The last connection, NULL if undefined */
 
@@ -1429,7 +1429,7 @@ struct UrlState {
 #if defined(USE_OPENSSL) && defined(HAVE_OPENSSL_ENGINE_H)
   ENGINE *engine;
 #endif /* USE_OPENSSL */
-  struct timeval expiretime; /* set this with Curl_expire() only */
+  struct curlval expiretime; /* set this with Curl_expire() only */
   struct Curl_tree timenode; /* for the splay stuff */
   struct curl_llist timeoutlist; /* list of pending timeouts */
   struct time_node expires[EXPIRE_LAST]; /* nodes for each expire type */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -290,8 +290,8 @@ static CURLcode Curl_ossl_seed(struct Curl_easy *data)
     unsigned char randb[64];
     size_t len = sizeof(randb);
     size_t i, i_max;
-    for(i = 0, i_max = len / sizeof(struct curlval); i < i_max; ++i) {
-      struct curlval tv = curlx_tvnow();
+    for(i = 0, i_max = len / sizeof(struct curltime); i < i_max; ++i) {
+      struct curltime tv = curlx_tvnow();
       Curl_wait_ms(1);
       tv.tv_sec *= i + 1;
       tv.tv_usec *= (unsigned int)i + 2;
@@ -300,7 +300,8 @@ static CURLcode Curl_ossl_seed(struct Curl_easy *data)
       tv.tv_usec ^= (unsigned int) ((curlx_tvnow().tv_sec +
                                      curlx_tvnow().tv_usec) *
                                     (i + 4)) << 16;
-      memcpy(&randb[i * sizeof(struct curlval)], &tv, sizeof(struct curlval));
+      memcpy(&randb[i * sizeof(struct curltime)], &tv,
+             sizeof(struct curltime));
     }
     RAND_add(randb, (int)len, (double)len/2);
   } while(!rand_enough());

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -290,16 +290,17 @@ static CURLcode Curl_ossl_seed(struct Curl_easy *data)
     unsigned char randb[64];
     size_t len = sizeof(randb);
     size_t i, i_max;
-    for(i = 0, i_max = len / sizeof(struct timeval); i < i_max; ++i) {
-      struct timeval tv = curlx_tvnow();
+    for(i = 0, i_max = len / sizeof(struct curlval); i < i_max; ++i) {
+      struct curlval tv = curlx_tvnow();
       Curl_wait_ms(1);
       tv.tv_sec *= i + 1;
-      tv.tv_usec *= i + 2;
+      tv.tv_usec *= (unsigned int)i + 2;
       tv.tv_sec ^= ((curlx_tvnow().tv_sec + curlx_tvnow().tv_usec) *
                     (i + 3)) << 8;
-      tv.tv_usec ^= ((curlx_tvnow().tv_sec + curlx_tvnow().tv_usec) *
-                     (i + 4)) << 16;
-      memcpy(&randb[i * sizeof(struct timeval)], &tv, sizeof(struct timeval));
+      tv.tv_usec ^= (unsigned int) ((curlx_tvnow().tv_sec +
+                                     curlx_tvnow().tv_usec) *
+                                    (i + 4)) << 16;
+      memcpy(&randb[i * sizeof(struct curlval)], &tv, sizeof(struct curlval));
     }
     RAND_add(randb, (int)len, (double)len/2);
   } while(!rand_enough());

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -136,7 +136,7 @@ test1288 \
 test1298 test1299 \
 test1300 test1301 test1302 test1303 test1304 test1305 test1306 test1307 \
 test1308 test1309 test1310 test1311 test1312 test1313 test1314 test1315 \
-test1316 test1317 test1318 test1319 test1320 test1321 test1322          \
+test1316 test1317 test1318 test1319 test1320 test1321 test1322 test1323 \
          test1325 test1326 test1327 test1328 test1329 test1330 test1331 \
 test1332 test1333 test1334 test1335 test1336 test1337 test1338 test1339 \
 test1340 test1341 test1342 test1343 test1344 test1345 test1346 test1347 \

--- a/tests/data/test1323
+++ b/tests/data/test1323
@@ -1,0 +1,32 @@
+<testcase>
+<info>
+<keywords>
+unittest
+curlx_tvdiff
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+curlx_tvdiff
+</name>
+<tool>
+unit1323
+</tool>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -100,7 +100,7 @@ void logmsg(const char *msg, ...)
   char buffer[2048 + 1];
   FILE *logfp;
   int error;
-  struct timeval tv;
+  struct curlval tv;
   time_t sec;
   struct tm *now;
   char timebuf[20];
@@ -211,9 +211,9 @@ int wait_ms(int timeout_ms)
 {
 #if !defined(MSDOS) && !defined(USE_WINSOCK)
 #ifndef HAVE_POLL_FINE
-  struct timeval pending_tv;
+  struct curlval pending_tv;
 #endif
-  struct timeval initial_tv;
+  struct curlval initial_tv;
   int pending_ms;
   int error;
 #endif

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -100,7 +100,7 @@ void logmsg(const char *msg, ...)
   char buffer[2048 + 1];
   FILE *logfp;
   int error;
-  struct curlval tv;
+  struct curltime tv;
   time_t sec;
   struct tm *now;
   char timebuf[20];
@@ -211,9 +211,9 @@ int wait_ms(int timeout_ms)
 {
 #if !defined(MSDOS) && !defined(USE_WINSOCK)
 #ifndef HAVE_POLL_FINE
-  struct curlval pending_tv;
+  struct curltime pending_tv;
 #endif
-  struct curlval initial_tv;
+  struct curltime initial_tv;
   int pending_ms;
   int error;
 #endif

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -6,7 +6,8 @@ UNITFILES = curlcheck.h \
 
 # These are all unit test programs
 UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307	\
- unit1308 unit1309 unit1330 unit1394 unit1395 unit1396 unit1397 unit1398	\
+ unit1308 unit1309 unit1323 \
+ unit1330 unit1394 unit1395 unit1396 unit1397 unit1398	\
  unit1399	\
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606
 
@@ -36,6 +37,9 @@ unit1308_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1309_SOURCES = unit1309.c $(UNITFILES)
 unit1309_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1323_SOURCES = unit1323.c $(UNITFILES)
+unit1323_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1330_SOURCES = unit1330.c $(UNITFILES)
 unit1330_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -70,7 +70,7 @@ struct timetest {
 
 UNITTEST_START
 {
-  struct timeval now;
+  struct curlval now;
   time_t timeout;
   unsigned int i;
 

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -70,7 +70,7 @@ struct timetest {
 
 UNITTEST_START
 {
-  struct curlval now;
+  struct curltime now;
   time_t timeout;
   unsigned int i;
 

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -74,12 +74,12 @@ UNITTEST_START
   struct Curl_tree nodes[NUM_NODES*3];
   int rc;
   int i, j;
-  struct curlval tv_now = {0, 0};
+  struct curltime tv_now = {0, 0};
   root = NULL;              /* the empty tree */
 
   /* add nodes */
   for(i = 0; i < NUM_NODES; i++) {
-    struct curlval key;
+    struct curltime key;
     size_t payload;
 
     key.tv_sec = 0;
@@ -111,7 +111,7 @@ UNITTEST_START
 
   /* rebuild tree */
   for(i = 0; i < NUM_NODES; i++) {
-    struct curlval key;
+    struct curltime key;
 
     key.tv_sec = 0;
     key.tv_usec = (541*i)%1023;

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -74,17 +74,19 @@ UNITTEST_START
   struct Curl_tree nodes[NUM_NODES*3];
   int rc;
   int i, j;
-  struct timeval tv_now = {0, 0};
+  struct curlval tv_now = {0, 0};
   root = NULL;              /* the empty tree */
 
   /* add nodes */
   for(i = 0; i < NUM_NODES; i++) {
-    struct timeval key;
+    struct curlval key;
+    size_t payload;
 
     key.tv_sec = 0;
     key.tv_usec = (541*i)%1023;
+    payload = (size_t) key.tv_usec;
 
-    nodes[i].payload = (void *)key.tv_usec; /* for simplicity */
+    nodes[i].payload = (void *)payload; /* for simplicity */
     root = Curl_splayinsert(key, root, &nodes[i]);
   }
 
@@ -109,14 +111,15 @@ UNITTEST_START
 
   /* rebuild tree */
   for(i = 0; i < NUM_NODES; i++) {
-    struct timeval key;
+    struct curlval key;
 
     key.tv_sec = 0;
     key.tv_usec = (541*i)%1023;
 
     /* add some nodes with the same key */
     for(j = 0; j <= i % 3; j++) {
-      nodes[i*3+j].payload = (void *)(key.tv_usec*10 + j); /* for simplicity */
+      size_t payload = key.tv_usec*10 + j;
+      nodes[i*3+j].payload = (void *)payload; /* for simplicity */
       root = Curl_splayinsert(key, root, &nodes[i*3+j]);
     }
   }

--- a/tests/unit/unit1323.c
+++ b/tests/unit/unit1323.c
@@ -1,0 +1,66 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include "timeval.h"
+
+static CURLcode unit_setup(void)
+{
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+
+}
+
+struct a {
+  struct curltime first;
+  struct curltime second;
+  time_t result;
+};
+
+UNITTEST_START
+{
+  struct a tests[] = {
+    { {36762, 8345 }, {36761, 995926 }, 13 },
+    { {36761, 995926 }, {36762, 8345 }, -13 },
+    { {36761, 995926 }, {0, 0}, 36761995 },
+    { {0, 0}, {36761, 995926 }, -36761995 },
+  };
+  size_t i;
+
+  for(i=0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+    time_t result = curlx_tvdiff(tests[i].first, tests[i].second);
+    if(result != tests[i].result) {
+      printf("%d.%06u to %d.%06u got %d, but expected %d\n",
+             tests[i].first.tv_sec,
+             tests[i].first.tv_usec,
+             tests[i].second.tv_sec,
+             tests[i].second.tv_usec,
+             result,
+             tests[i].result);
+      fail("unexpected result!");
+    }
+  }
+}
+UNITTEST_STOP

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -48,7 +48,7 @@ static bool usec_matches_seconds(time_t time_usec, int expected_seconds)
 
 UNITTEST_START
   struct Curl_easy data;
-  struct timeval now = Curl_tvnow();
+  struct curlval now = Curl_tvnow();
 
   data.progress.t_starttransfer = 0;
   data.progress.t_redirect = 0;

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -48,7 +48,7 @@ static bool usec_matches_seconds(time_t time_usec, int expected_seconds)
 
 UNITTEST_START
   struct Curl_easy data;
-  struct curlval now = Curl_tvnow();
+  struct curltime now = Curl_tvnow();
 
   data.progress.t_starttransfer = 0;
   data.progress.t_redirect = 0;

--- a/tests/unit/unit1606.c
+++ b/tests/unit/unit1606.c
@@ -41,7 +41,7 @@ static int runawhile(struct Curl_easy *easy,
                      int dec)
 {
   int counter = 1;
-  struct timeval now = {1, 0};
+  struct curlval now = {1, 0};
   CURLcode result;
   int finaltime;
 

--- a/tests/unit/unit1606.c
+++ b/tests/unit/unit1606.c
@@ -41,7 +41,7 @@ static int runawhile(struct Curl_easy *easy,
                      int dec)
 {
   int counter = 1;
-  struct curlval now = {1, 0};
+  struct curltime now = {1, 0};
   CURLcode result;
   int finaltime;
 


### PR DESCRIPTION
... to make all libcurl internals able to use the same data types for
the struct members. The timeval struct differs subtly on several
platforms so it makes it cumbersome to use everywhere.

Ref: #1652