### PR TITLE
now: update 'now' as part of the easy handle instead of local variables

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -355,13 +355,13 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
   long timeout;
-  struct curltime now = Curl_tvnow();
   struct Curl_dns_entry *temp_entry;
+  data->state.now = curlx_tvnow();
 
   if(entry)
     *entry = NULL; /* clear on entry */
 
-  timeout = Curl_timeleft(data, &now, TRUE);
+  timeout = Curl_timeleft(data, TRUE);
   if(timeout < 0) {
     /* already expired! */
     connclose(conn, "Timed out before name resolve started");
@@ -400,15 +400,15 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else {
-      struct curltime now2 = Curl_tvnow();
-      time_t timediff = Curl_tvdiff(now2, now); /* spent time */
+      struct curltime now2 = curlx_tvnow();
+      time_t timediff = curlx_tvdiff(now2, data->state.now); /* spent time */
       if(timediff <= 0)
         timeout -= 1; /* always deduct at least 1 */
       else if(timediff > timeout)
         timeout = -1;
       else
         timeout -= (long)timediff;
-      now = now2; /* for next loop */
+      data->state.now = now2; /* for next loop */
     }
     if(timeout < 0)
       result = CURLE_OPERATION_TIMEDOUT;

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -522,7 +522,10 @@ CURLcode Curl_resolver_is_resolved(struct connectdata *conn,
   }
   else {
     /* poll for name lookup done with exponential backoff up to 250ms */
-    time_t elapsed = Curl_tvdiff(Curl_tvnow(), data->progress.t_startsingle);
+    time_t elapsed;
+    data->state.now = curlx_tvnow();
+    elapsed = curlx_tvdiff(data->state.now,
+                           data->progress.t_startsingle);
     if(elapsed < 0)
       elapsed = 0;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -179,13 +179,10 @@ singleipconnect(struct connectdata *conn,
  *
  * @unittest: 1303
  */
-time_t Curl_timeleft(struct Curl_easy *data,
-                     struct curltime *nowp,
-                     bool duringconnect)
+time_t Curl_timeleft(struct Curl_easy *data, bool duringconnect)
 {
   int timeout_set = 0;
   time_t timeout_ms = duringconnect?DEFAULT_CONNECT_TIMEOUT:0;
-  struct curltime now;
 
   /* if a timeout is set, use the most restrictive one */
 
@@ -217,18 +214,13 @@ time_t Curl_timeleft(struct Curl_easy *data,
     break;
   }
 
-  if(!nowp) {
-    now = Curl_tvnow();
-    nowp = &now;
-  }
+  /* subtract elapsed time, since this most recent connect started or since
+     the entire operation started */
 
-  /* subtract elapsed time */
-  if(duringconnect)
-    /* since this most recent connect started */
-    timeout_ms -= Curl_tvdiff(*nowp, data->progress.t_startsingle);
-  else
-    /* since the entire operation started */
-    timeout_ms -= Curl_tvdiff(*nowp, data->progress.t_startop);
+  data->state.now = curlx_tvnow();
+  timeout_ms -= curlx_tvdiff(data->state.now, duringconnect?
+                             data->progress.t_startsingle:
+                             data->progress.t_startop);
   if(!timeout_ms)
     /* avoid returning 0 as that means no timeout! */
     return -1;
@@ -723,7 +715,6 @@ CURLcode Curl_is_connected(struct connectdata *conn,
   CURLcode result = CURLE_OK;
   time_t allow;
   int error = 0;
-  struct curltime now;
   int rc;
   int i;
 
@@ -737,10 +728,10 @@ CURLcode Curl_is_connected(struct connectdata *conn,
     return CURLE_OK;
   }
 
-  now = Curl_tvnow();
+  data->state.now = curlx_tvnow();
 
   /* figure out how long time we have left to connect */
-  allow = Curl_timeleft(data, &now, TRUE);
+  allow = Curl_timeleft(data, TRUE);
 
   if(allow < 0) {
     /* time-out, bail out, go home */
@@ -765,7 +756,8 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 
     if(rc == 0) { /* no connection yet */
       error = 0;
-      if(curlx_tvdiff(now, conn->connecttime) >= conn->timeoutms_per_addr) {
+      if(curlx_tvdiff(data->state.now, conn->connecttime) >=
+         conn->timeoutms_per_addr) {
         infof(data, "After %ldms connect time, move on!\n",
               conn->timeoutms_per_addr);
         error = ETIMEDOUT;
@@ -773,7 +765,8 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 
       /* should we try another protocol family? */
       if(i == 0 && conn->tempaddr[1] == NULL &&
-         curlx_tvdiff(now, conn->connecttime) >= HAPPY_EYEBALLS_TIMEOUT) {
+         curlx_tvdiff(data->state.now, conn->connecttime) >=
+         HAPPY_EYEBALLS_TIMEOUT) {
         trynextip(conn, sockindex, 1);
       }
     }
@@ -1051,7 +1044,7 @@ static CURLcode singleipconnect(struct connectdata *conn,
   /* set socket non-blocking */
   (void)curlx_nonblock(sockfd, TRUE);
 
-  conn->connecttime = Curl_tvnow();
+  data->state.now = conn->connecttime = curlx_tvnow();
   if(conn->num_addr > 1)
     Curl_expire(data, conn->timeoutms_per_addr, EXPIRE_DNS_PER_NAME);
 
@@ -1136,10 +1129,10 @@ CURLcode Curl_connecthost(struct connectdata *conn,  /* context */
                           const struct Curl_dns_entry *remotehost)
 {
   struct Curl_easy *data = conn->data;
-  struct curltime before = Curl_tvnow();
   CURLcode result = CURLE_COULDNT_CONNECT;
+  time_t timeout_ms;
 
-  time_t timeout_ms = Curl_timeleft(data, &before, TRUE);
+  timeout_ms = Curl_timeleft(data, TRUE);
 
   if(timeout_ms < 0) {
     /* a precaution, no need to continue if time already is up */

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -35,9 +35,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,
 
 /* generic function that returns how much time there's left to run, according
    to the timeouts set */
-time_t Curl_timeleft(struct Curl_easy *data,
-                     struct curltime *nowp,
-                     bool duringconnect);
+time_t Curl_timeleft(struct Curl_easy *data, bool duringconnect);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 #define HAPPY_EYEBALLS_TIMEOUT     200 /* milliseconds to wait between

--- a/lib/file.c
+++ b/lib/file.c
@@ -398,8 +398,10 @@ static CURLcode file_upload(struct connectdata *conn)
 
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
-    else
-      result = Curl_speedcheck(data, Curl_tvnow());
+    else {
+      data->state.now = curlx_tvnow();
+      result = Curl_speedcheck(data, data->state.now);
+    }
   }
   if(!result && Curl_pgrsUpdate(conn))
     result = CURLE_ABORTED_BY_CALLBACK;
@@ -583,8 +585,10 @@ static CURLcode file_do(struct connectdata *conn, bool *done)
 
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
-    else
-      result = Curl_speedcheck(data, Curl_tvnow());
+    else {
+      data->state.now = curlx_tvnow();
+      result = Curl_speedcheck(data, data->state.now);
+    }
   }
   if(Curl_pgrsUpdate(conn))
     result = CURLE_ABORTED_BY_CALLBACK;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -336,22 +336,21 @@ static time_t ftp_timeleft_accept(struct Curl_easy *data)
 {
   time_t timeout_ms = DEFAULT_ACCEPT_TIMEOUT;
   time_t other;
-  struct curltime now;
 
   if(data->set.accepttimeout > 0)
     timeout_ms = data->set.accepttimeout;
 
-  now = Curl_tvnow();
+  data->state.now = curlx_tvnow();
 
   /* check if the generic timeout possibly is set shorter */
-  other =  Curl_timeleft(data, &now, FALSE);
+  other =  Curl_timeleft(data, FALSE);
   if(other && (other < timeout_ms))
     /* note that this also works fine for when other happens to be negative
        due to it already having elapsed */
     timeout_ms = other;
   else {
     /* subtract elapsed time */
-    timeout_ms -= Curl_tvdiff(now, data->progress.t_acceptdata);
+    timeout_ms -= curlx_tvdiff(data->state.now, data->progress.t_acceptdata);
     if(!timeout_ms)
       /* avoid returning 0 as that means no timeout! */
       return -1;
@@ -3254,7 +3253,7 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
     long old_time = pp->response_time;
 
     pp->response_time = 60*1000; /* give it only a minute for now */
-    pp->response = Curl_tvnow(); /* timeout relative now */
+    data->state.now = pp->response = curlx_tvnow(); /* timeout relative now */
 
     result = Curl_GetFTPResponse(&nread, conn, &ftpcode);
 
@@ -3374,7 +3373,7 @@ CURLcode ftp_sendquote(struct connectdata *conn, struct curl_slist *quote)
 
       PPSENDF(&conn->proto.ftpc.pp, "%s", cmd);
 
-      pp->response = Curl_tvnow(); /* timeout relative now */
+      conn->data->state.now = pp->response = curlx_tvnow();
 
       result = Curl_GetFTPResponse(&nread, conn, &ftpcode);
       if(result)

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -688,11 +688,14 @@ clean_up:
      the time we spent until now! */
   if(prev_alarm) {
     /* there was an alarm() set before us, now put it back */
-    unsigned long elapsed_secs = (unsigned long) (Curl_tvdiff(Curl_tvnow(),
-                                   conn->created) / 1000);
+    unsigned long elapsed_secs;
+    unsigned long alarm_set;
+    data->state.now = curlx_tvnow();
+    elapsed_secs =
+      (unsigned long) (curlx_tvdiff(data->state.now, conn->created) / 1000);
 
     /* the alarm period is counted in even number of seconds */
-    unsigned long alarm_set = prev_alarm - elapsed_secs;
+    alarm_set = prev_alarm - elapsed_secs;
 
     if(!alarm_set ||
        ((alarm_set >= 0x80000000) && (prev_alarm < 0x80000000)) ) {

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -313,7 +313,7 @@ static CURLcode CONNECT(struct connectdata *conn,
       s->perline = 0;
     } /* END CONNECT PHASE */
 
-    check = Curl_timeleft(data, NULL, TRUE);
+    check = Curl_timeleft(data, TRUE);
     if(check <= 0) {
       failf(data, "Proxy CONNECT aborted due to timeout");
       return CURLE_OPERATION_TIMEDOUT;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1301,7 +1301,6 @@ static CURLcode multi_do_more(struct connectdata *conn, int *complete)
 }
 
 static CURLMcode multi_runsingle(struct Curl_multi *multi,
-                                 struct curltime now,
                                  struct Curl_easy *data)
 {
   struct Curl_message *msg = NULL;
@@ -1320,6 +1319,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
   if(!GOOD_EASY_HANDLE(data))
     return CURLM_BAD_EASY_HANDLE;
+
+  data->state.now = curlx_tvnow();
 
   do {
     /* A "stream" here is a logical stream if the protocol can handle that
@@ -1371,31 +1372,29 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /* we need to wait for the connect state as only then is the start time
          stored, but we must not check already completed handles */
 
-      timeout_ms = Curl_timeleft(data, &now,
-                                 (data->mstate <= CURLM_STATE_WAITDO)?
+      timeout_ms = Curl_timeleft(data, (data->mstate <= CURLM_STATE_WAITDO)?
                                  TRUE:FALSE);
-
       if(timeout_ms < 0) {
         /* Handle timed out */
         if(data->mstate == CURLM_STATE_WAITRESOLVE)
           failf(data, "Resolving timed out after %ld milliseconds",
-                Curl_tvdiff(now, data->progress.t_startsingle));
+                curlx_tvdiff(data->state.now, data->progress.t_startsingle));
         else if(data->mstate == CURLM_STATE_WAITCONNECT)
           failf(data, "Connection timed out after %ld milliseconds",
-                Curl_tvdiff(now, data->progress.t_startsingle));
+                curlx_tvdiff(data->state.now, data->progress.t_startsingle));
         else {
           k = &data->req;
           if(k->size != -1) {
             failf(data, "Operation timed out after %ld milliseconds with %"
                   CURL_FORMAT_CURL_OFF_T " out of %"
                   CURL_FORMAT_CURL_OFF_T " bytes received",
-                  Curl_tvdiff(now, data->progress.t_startsingle),
+                  curlx_tvdiff(data->state.now, data->progress.t_startsingle),
                   k->bytecount, k->size);
           }
           else {
             failf(data, "Operation timed out after %ld milliseconds with %"
                   CURL_FORMAT_CURL_OFF_T " bytes received",
-                  Curl_tvdiff(now, data->progress.t_startsingle),
+                  curlx_tvdiff(data->state.now, data->progress.t_startsingle),
                   k->bytecount);
           }
         }
@@ -1830,24 +1829,26 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(Curl_pgrsUpdate(data->easy_conn))
         result = CURLE_ABORTED_BY_CALLBACK;
       else
-        result = Curl_speedcheck(data, now);
+        result = Curl_speedcheck(data, data->state.now);
 
       if(!result) {
         send_timeout_ms = 0;
         if(data->set.max_send_speed > 0)
-          send_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.uploaded,
-                                data->progress.ul_limit_size,
-                                data->set.max_send_speed,
-                                data->progress.ul_limit_start,
-                                now);
+          send_timeout_ms =
+            Curl_pgrsLimitWaitTime(data->progress.uploaded,
+                                   data->progress.ul_limit_size,
+                                   data->set.max_send_speed,
+                                   data->progress.ul_limit_start,
+                                   data->state.now);
 
         recv_timeout_ms = 0;
         if(data->set.max_recv_speed > 0)
-          recv_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.downloaded,
-                                data->progress.dl_limit_size,
-                                data->set.max_recv_speed,
-                                data->progress.dl_limit_start,
-                                now);
+          recv_timeout_ms =
+            Curl_pgrsLimitWaitTime(data->progress.downloaded,
+                                   data->progress.dl_limit_size,
+                                   data->set.max_recv_speed,
+                                   data->progress.dl_limit_start,
+                                   data->state.now);
 
         if(send_timeout_ms <= 0 && recv_timeout_ms <= 0)
           multistate(data, CURLM_STATE_PERFORM);
@@ -1871,7 +1872,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
                                                  data->progress.ul_limit_size,
                                                  data->set.max_send_speed,
                                                  data->progress.ul_limit_start,
-                                                 now);
+                                                 data->state.now);
 
       /* check if over recv speed */
       recv_timeout_ms = 0;
@@ -1880,7 +1881,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
                                                  data->progress.dl_limit_size,
                                                  data->set.max_recv_speed,
                                                  data->progress.dl_limit_start,
-                                                 now);
+                                                 data->state.now);
 
       if(send_timeout_ms > 0 || recv_timeout_ms > 0) {
         multistate(data, CURLM_STATE_TOOFAST);
@@ -2146,7 +2147,7 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
   struct Curl_easy *data;
   CURLMcode returncode=CURLM_OK;
   struct Curl_tree *t;
-  struct curltime now = Curl_tvnow();
+  struct curltime now;
 
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;
@@ -2157,7 +2158,7 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
     SIGPIPE_VARIABLE(pipe_st);
 
     sigpipe_ignore(data, &pipe_st);
-    result = multi_runsingle(multi, now, data);
+    result = multi_runsingle(multi, data);
     sigpipe_restore(&pipe_st);
 
     if(result)
@@ -2176,6 +2177,7 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
    * then and then we risk this loop to remove timers that actually have not
    * been handled!
    */
+  now = curlx_tvnow();
   do {
     multi->timetree = Curl_splaygetbest(now, multi->timetree, &t);
     if(t)
@@ -2551,7 +2553,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   CURLMcode result = CURLM_OK;
   struct Curl_easy *data = NULL;
   struct Curl_tree *t;
-  struct curltime now = Curl_tvnow();
+  struct curltime now = curlx_tvnow();
 
   if(checkall) {
     /* *perform() deals with running_handles on its own */
@@ -2608,7 +2610,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
         data->easy_conn->cselect_bits = ev_bitmask;
 
       sigpipe_ignore(data, &pipe_st);
-      result = multi_runsingle(multi, now, data);
+      result = multi_runsingle(multi, data);
       sigpipe_restore(&pipe_st);
 
       if(data->easy_conn &&
@@ -2627,8 +2629,8 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
 
       data = NULL; /* set data to NULL again to avoid calling
                       multi_runsingle() in case there's no need to */
-      now = Curl_tvnow(); /* get a newer time since the multi_runsingle() loop
-                             may have taken some time */
+      now = curlx_tvnow(); /* get a newer time since the multi_runsingle()
+                              loop may have taken some time */
     }
   }
   else {
@@ -2650,7 +2652,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
       SIGPIPE_VARIABLE(pipe_st);
 
       sigpipe_ignore(data, &pipe_st);
-      result = multi_runsingle(multi, now, data);
+      result = multi_runsingle(multi, data);
       sigpipe_restore(&pipe_st);
 
       if(CURLM_OK >= result)
@@ -2781,7 +2783,7 @@ static CURLMcode multi_timeout(struct Curl_multi *multi,
 
   if(multi->timetree) {
     /* we have a tree of expire times */
-    struct curltime now = Curl_tvnow();
+    struct curltime now = curlx_tvnow();
 
     /* splay the lowest to the bottom */
     multi->timetree = Curl_splay(tv_zero, multi->timetree);
@@ -2943,7 +2945,7 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
 
   DEBUGASSERT(id < EXPIRE_LAST);
 
-  set = Curl_tvnow();
+  set = curlx_tvnow();
   set.tv_sec += milli/1000;
   set.tv_usec += (unsigned int)(milli%1000)*1000;
 

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -58,8 +58,8 @@ struct pingpong {
                      server */
   size_t sendleft; /* number of bytes left to send from the sendthis buffer */
   size_t sendsize; /* total size of the sendthis buffer */
-  struct curltime response; /* set to Curl_tvnow() when a command has been sent
-                              off, used to time-out response reading */
+  struct curltime response; /* set this when a command has been sent off, used
+                               to time-out response reading */
   long response_time; /* When no timeout is given, this is the amount of
                          milliseconds we await for a server response. */
 

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -166,8 +166,9 @@ void Curl_pgrsResetTimesSizes(struct Curl_easy *data)
  */
 void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 {
-  struct curltime now = Curl_tvnow();
+  struct curltime now = curlx_tvnow();
   time_t *delta = NULL;
+  data->state.now = now;
 
   switch(timer) {
   default:
@@ -181,6 +182,7 @@ void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
   case TIMER_STARTSINGLE:
     /* This is set at the start of each single fetch */
     data->progress.t_startsingle = now;
+    infof(data, "TIMER_STARTSINGLE\n");
     break;
   case TIMER_STARTACCEPT:
     data->progress.t_acceptdata = now;
@@ -229,7 +231,7 @@ void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 void Curl_pgrsStartNow(struct Curl_easy *data)
 {
   data->progress.speeder_c = 0; /* reset the progress meter display */
-  data->progress.start = Curl_tvnow();
+  data->progress.start = curlx_tvnow();
   data->progress.ul_limit_start.tv_sec = 0;
   data->progress.ul_limit_start.tv_usec = 0;
   data->progress.dl_limit_start.tv_sec = 0;
@@ -276,7 +278,7 @@ long Curl_pgrsLimitWaitTime(curl_off_t cursize,
     return -1;
 
   minimum = (time_t) (CURL_OFF_T_C(1000) * size / limit);
-  actual = Curl_tvdiff(now, start);
+  actual = curlx_tvdiff(now, start);
 
   if(actual < minimum)
     /* this is a conversion on some systems (64bit time_t => 32bit long) */
@@ -287,8 +289,8 @@ long Curl_pgrsLimitWaitTime(curl_off_t cursize,
 
 void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 {
-  struct curltime now = Curl_tvnow();
-
+  struct curltime now = curlx_tvnow();
+  data->state.now = now;
   data->progress.downloaded = size;
 
   /* download speed limit */
@@ -305,7 +307,7 @@ void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 
 void Curl_pgrsSetUploadCounter(struct Curl_easy *data, curl_off_t size)
 {
-  struct curltime now = Curl_tvnow();
+  struct curltime now = curlx_tvnow();
 
   data->progress.uploaded = size;
 
@@ -372,7 +374,7 @@ int Curl_pgrsUpdate(struct connectdata *conn)
   curl_off_t total_estimate;
   bool shownow=FALSE;
 
-  now = Curl_tvnow(); /* what time is it */
+  now = curlx_tvnow(); /* what time is it */
 
   /* The time spent so far (from the start) */
   data->progress.timespent = Curl_tvdiff_us(now, data->progress.start);
@@ -424,8 +426,8 @@ int Curl_pgrsUpdate(struct connectdata *conn)
         data->progress.speeder_c%CURR_TIME:0;
 
       /* Figure out the exact time for the time span */
-      span_ms = Curl_tvdiff(now,
-                            data->progress.speeder_time[checkindex]);
+      span_ms = curlx_tvdiff(now,
+                             data->progress.speeder_time[checkindex]);
       if(0 == span_ms)
         span_ms=1; /* at least one millisecond MUST have passed */
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1196,7 +1196,7 @@ static CURLcode smtp_done(struct connectdata *conn, CURLcode status,
     }
     else {
       /* Successfully sent so adjust the response timeout relative to now */
-      pp->response = Curl_tvnow();
+      pp->response = curlx_tvnow();
 
       free(eob);
     }

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -60,7 +60,7 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
   time_t timeleft;
   *n = 0;
   for(;;) {
-    timeleft = Curl_timeleft(conn->data, NULL, TRUE);
+    timeleft = Curl_timeleft(conn->data, TRUE);
     if(timeleft < 0) {
       /* we already got the timeout */
       result = CURLE_OPERATION_TIMEDOUT;
@@ -121,7 +121,7 @@ CURLcode Curl_SOCKS4(const char *proxy_user,
   curl_socket_t sock = conn->sock[sockindex];
   struct Curl_easy *data = conn->data;
 
-  if(Curl_timeleft(data, NULL, TRUE) < 0) {
+  if(Curl_timeleft(data, TRUE) < 0) {
     /* time-out, bail out, go home */
     failf(data, "Connection time-out");
     return CURLE_OPERATION_TIMEDOUT;
@@ -402,7 +402,7 @@ CURLcode Curl_SOCKS5(const char *proxy_user,
   }
 
   /* get timeout */
-  timeout = Curl_timeleft(data, NULL, TRUE);
+  timeout = Curl_timeleft(data, TRUE);
 
   if(timeout < 0) {
     /* time-out, bail out, go home */

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -46,7 +46,7 @@ CURLcode Curl_speedcheck(struct Curl_easy *data,
         data->state.keeps_speed = now;
       else {
         /* how long has it been under the limit */
-        time_t howlong = Curl_tvdiff(now, data->state.keeps_speed);
+        time_t howlong = curlx_tvdiff(now, data->state.keeps_speed);
 
         if(howlong >= data->set.low_speed_time * 1000) {
           /* too long */

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2827,7 +2827,7 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     time_t left = 1000;
-    struct curltime now = Curl_tvnow();
+    data->state.now = curlx_tvnow();
 
     result = ssh_statemach_act(conn, &block);
     if(result)
@@ -2837,11 +2837,11 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
       if(Curl_pgrsUpdate(conn))
         return CURLE_ABORTED_BY_CALLBACK;
 
-      result = Curl_speedcheck(data, now);
+      result = Curl_speedcheck(data, data->state.now);
       if(result)
         break;
 
-      left = Curl_timeleft(data, NULL, FALSE);
+      left = Curl_timeleft(data, FALSE);
       if(left < 0) {
         failf(data, "Operation timed out");
         return CURLE_OPERATION_TIMEDOUT;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1327,7 +1327,6 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   curl_off_t total_ul = 0;
 #endif
   ssize_t nread;
-  struct curltime now;
   bool keepon = TRUE;
   char *buf = data->state.buffer;
   struct TELNET *tn;
@@ -1560,8 +1559,8 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     }
 
     if(data->set.timeout) {
-      now = Curl_tvnow();
-      if(Curl_tvdiff(now, conn->created) >= data->set.timeout) {
+      data->state.now = curlx_tvnow();
+      if(curlx_tvdiff(data->state.now, conn->created) >= data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;
         keepon = FALSE;
@@ -1678,8 +1677,8 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     } /* poll switch statement */
 
     if(data->set.timeout) {
-      now = Curl_tvnow();
-      if(Curl_tvdiff(now, conn->created) >= data->set.timeout) {
+      data->state.now = curlx_tvnow();
+      if(curlx_tvdiff(data->state.now, conn->created) >= data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;
         keepon = FALSE;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -206,7 +206,7 @@ static CURLcode tftp_set_timeouts(tftp_state_data_t *state)
   time(&state->start_time);
 
   /* Compute drop-dead time */
-  timeout_ms = Curl_timeleft(state->conn->data, NULL, start);
+  timeout_ms = Curl_timeleft(state->conn->data, start);
 
   if(timeout_ms < 0) {
     /* time-out, bail out, go home */
@@ -1287,7 +1287,7 @@ static CURLcode tftp_doing(struct connectdata *conn, bool *dophase_done)
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else
-      result = Curl_speedcheck(conn->data, Curl_tvnow());
+      result = Curl_speedcheck(conn->data, curlx_tvnow());
   }
   return result;
 }

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -24,7 +24,7 @@
 
 #if defined(WIN32) && !defined(MSDOS)
 
-struct curltime curlx_tvnow(void)
+static struct curltime tvnow(void)
 {
   /*
   ** GetTickCount() is available on _all_ Windows versions from W95 up
@@ -48,7 +48,7 @@ struct curltime curlx_tvnow(void)
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
 
-struct curltime curlx_tvnow(void)
+static struct curltime tvnow(void)
 {
   /*
   ** clock_gettime() is granted to be increased monotonically when the
@@ -86,7 +86,7 @@ struct curltime curlx_tvnow(void)
 
 #elif defined(HAVE_GETTIMEOFDAY)
 
-struct curltime curlx_tvnow(void)
+static struct curltime tvnow(void)
 {
   /*
   ** gettimeofday() is not granted to be increased monotonically, due to
@@ -103,7 +103,7 @@ struct curltime curlx_tvnow(void)
 
 #else
 
-struct curltime curlx_tvnow(void)
+static struct curltime tvnow(void)
 {
   /*
   ** time() returns the value of time in seconds since the Epoch.
@@ -116,6 +116,27 @@ struct curltime curlx_tvnow(void)
 
 #endif
 
+#ifdef CURLDEBUG
+/* for testing purposes, this allows a fake time to be returned */
+static struct curltime fake_now;
+struct curltime curlx_tvnow(void)
+{
+  if(fake_now.tv_sec || fake_now.tv_usec)
+    return fake_now;
+  else
+    return tvnow();
+}
+void curlx_tvnow_set(struct curltime now)
+{
+  fake_now = now;
+}
+
+#else
+struct curltime curlx_tvnow(void)
+{
+  return tvnow();
+}
+#endif
 /*
  * Make sure that the first argument is the more recent time, as otherwise
  * we'll get a weird negative time-diff back...

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -52,10 +52,10 @@ time_t curlx_tvdiff(struct curltime t1, struct curltime t2);
  */
 time_t Curl_tvdiff_us(struct curltime newer, struct curltime older);
 
-/* These two defines below exist to provide the older API for library
-   internals only. */
-#define Curl_tvnow() curlx_tvnow()
-#define Curl_tvdiff(x,y) curlx_tvdiff(x,y)
+#ifdef CURLDEBUG
+void curlx_tvnow_set(struct curltime now);
+#endif
+
+
 
 #endif /* HEADER_CURL_TIMEVAL_H */
-

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -450,7 +450,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
       Curl_pgrsTime(data, TIMER_STARTTRANSFER);
       if(k->exp100 > EXP100_SEND_DATA)
         /* set time stamp to compare with when waiting for the 100 */
-        k->start100 = Curl_tvnow();
+        k->start100 = curlx_tvnow();
     }
 
     *didwhat |= KEEP_RECV;
@@ -885,7 +885,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
              go into the Expect: 100 state and await such a header */
           k->exp100 = EXP100_AWAITING_CONTINUE; /* wait for the header */
           k->keepon &= ~KEEP_SEND;         /* disable writing */
-          k->start100 = Curl_tvnow();       /* timeout count starts now */
+          k->start100 = curlx_tvnow();       /* timeout count starts now */
           *didwhat &= ~KEEP_SEND;  /* we didn't write anything actually */
 
           /* set a timeout for the multi interface */
@@ -1110,7 +1110,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
       return result;
   }
 
-  k->now = Curl_tvnow();
+  data->state.now = curlx_tvnow();
   if(didwhat) {
     /* Update read/write counters */
     if(k->bytecountp)
@@ -1134,7 +1134,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
 
       */
 
-      time_t ms = Curl_tvdiff(k->now, k->start100);
+      time_t ms = curlx_tvdiff(data->state.now, k->start100);
       if(ms >= data->set.expect_100_timeout) {
         /* we've waited long enough, continue anyway */
         k->exp100 = EXP100_SEND_DATA;
@@ -1148,23 +1148,24 @@ CURLcode Curl_readwrite(struct connectdata *conn,
   if(Curl_pgrsUpdate(conn))
     result = CURLE_ABORTED_BY_CALLBACK;
   else
-    result = Curl_speedcheck(data, k->now);
+    result = Curl_speedcheck(data, data->state.now);
   if(result)
     return result;
 
   if(k->keepon) {
-    if(0 > Curl_timeleft(data, &k->now, FALSE)) {
+    if(0 > Curl_timeleft(data, FALSE)) {
       if(k->size != -1) {
         failf(data, "Operation timed out after %ld milliseconds with %"
               CURL_FORMAT_CURL_OFF_T " out of %"
               CURL_FORMAT_CURL_OFF_T " bytes received",
-              Curl_tvdiff(k->now, data->progress.t_startsingle), k->bytecount,
-              k->size);
+              curlx_tvdiff(data->state.now, data->progress.t_startsingle),
+              k->bytecount, k->size);
       }
       else {
         failf(data, "Operation timed out after %ld milliseconds with %"
               CURL_FORMAT_CURL_OFF_T " bytes received",
-              Curl_tvdiff(k->now, data->progress.t_startsingle), k->bytecount);
+              curlx_tvdiff(data->state.now, data->progress.t_startsingle),
+              k->bytecount);
       }
       return CURLE_OPERATION_TIMEDOUT;
     }
@@ -1951,7 +1952,7 @@ Curl_setup_transfer(
          (http->sending == HTTPSEND_BODY)) {
         /* wait with write until we either got 100-continue or a timeout */
         k->exp100 = EXP100_AWAITING_CONTINUE;
-        k->start100 = Curl_tvnow();
+        k->start100 = curlx_tvnow();
 
         /* Set a timeout for the multi interface. Add the inaccuracy margin so
            that we don't fire slightly too early and get denied to run. */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -679,7 +679,6 @@ struct SingleRequest {
                              code) result in a CURLE_GOT_NOTHING error code */
 
   struct curltime start;         /* transfer started at this time */
-  struct curltime now;           /* current time */
   bool header;                  /* incoming data has HTTP header */
   enum {
     HEADER_NORMAL,              /* no bad header at all */
@@ -1016,7 +1015,8 @@ struct connectdata {
   int httpversion;        /* the HTTP version*10 reported by the server */
   int rtspversion;        /* the RTSP version*10 reported by the server */
 
-  struct curltime now;     /* "current" time */
+  struct curltime setup_time; /* when the connection was setup to get used (or
+                                 reused) */
   struct curltime created; /* creation time */
   curl_socket_t sock[2]; /* two sockets, the second is used for the data
                             transfer when doing FTP */
@@ -1376,7 +1376,7 @@ struct UrlState {
 
   /* buffers to store authentication data in, as parsed from input options */
   struct curltime keeps_speed; /* for the progress meter really */
-
+  struct curltime now;         /* time right now */
   struct connectdata *lastconnect; /* The last connection, NULL if undefined */
 
   char *headerbuff; /* allocated buffer to store headers in */

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -806,7 +806,7 @@ cyassl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1==connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -824,7 +824,7 @@ cyassl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2446,7 +2446,7 @@ darwinssl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1==connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -2464,7 +2464,7 @@ darwinssl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -907,7 +907,7 @@ static CURLcode gskit_connect_step1(struct connectdata *conn, int sockindex)
   if(!result) {
     /* Compute the handshake timeout. Since GSKit granularity is 1 second,
        we round up the required value. */
-    timeout = Curl_timeleft(data, NULL, TRUE);
+    timeout = Curl_timeleft(data, TRUE);
     if(timeout < 0)
       result = CURLE_OPERATION_TIMEDOUT;
     else
@@ -1021,7 +1021,7 @@ static CURLcode gskit_connect_step2(struct connectdata *conn, int sockindex,
   /* Poll or wait for end of SSL asynchronous handshake. */
 
   for(;;) {
-    timeout_ms = nonblocking? 0: Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = nonblocking? 0: Curl_timeleft(data, TRUE);
     if(timeout_ms < 0)
       timeout_ms = 0;
     stmv.tv_sec = timeout_ms / 1000;
@@ -1163,7 +1163,7 @@ static CURLcode gskit_connect_common(struct connectdata *conn, int sockindex,
   /* Step 1: create session, start handshake. */
   if(connssl->connecting_state == ssl_connect_1) {
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -1182,7 +1182,7 @@ static CURLcode gskit_connect_common(struct connectdata *conn, int sockindex,
   /* Step 2: check if handshake is over. */
   if(!result && connssl->connecting_state == ssl_connect_2) {
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -285,7 +285,7 @@ static CURLcode handshake(struct connectdata *conn,
 
   for(;;) {
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, duringconnect);
+    timeout_ms = Curl_timeleft(data, duringconnect);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -871,7 +871,7 @@ mbed_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1==connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -888,7 +888,7 @@ mbed_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2049,7 +2049,7 @@ static CURLcode nss_do_connect(struct connectdata *conn, int sockindex)
 
 
   /* check timeout situation */
-  const time_t time_left = Curl_timeleft(data, NULL, TRUE);
+  const time_t time_left = Curl_timeleft(data, TRUE);
   if(time_left < 0) {
     failf(data, "timed out before SSL handshake");
     result = CURLE_OPERATION_TIMEDOUT;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3059,7 +3059,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -3077,7 +3077,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  * Copyright (C) 2010 - 2011, Hoi-Ho Chan, <hoiho.chan@gmail.com>
  *
  * This software is licensed as described in the file COPYING, which
@@ -732,7 +732,7 @@ polarssl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -750,7 +750,7 @@ polarssl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -844,7 +844,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* check out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -862,7 +862,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -1026,7 +1026,7 @@ schannel_send(struct connectdata *conn, int sockindex,
 
       this_write = 0;
 
-      timeleft = Curl_timeleft(conn->data, NULL, FALSE);
+      timeleft = Curl_timeleft(conn->data, FALSE);
       if(timeleft < 0) {
         /* we already got the timeout */
         failf(conn->data, "schannel: timed out sending data "

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -59,8 +59,8 @@ static void unit_stop(void)
  */
 
 struct timetest {
-  int now_s;
-  int now_us;
+  time_t now_s;
+  unsigned int now_us;
   int timeout_ms;
   int connecttimeout_ms;
   bool connecting;
@@ -137,9 +137,12 @@ UNITTEST_START
   for(i=0; i < sizeof(run)/sizeof(run[0]); i++) {
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
-    timeout =  Curl_timeleft(data, &now, run[i].connecting);
-    if(timeout != run[i].result)
+    curlx_tvnow_set(now);
+    timeout =  Curl_timeleft(data, run[i].connecting);
+    if(timeout != run[i].result) {
+      fprintf(stderr, "test %d returned %d\n", i, timeout);
       fail(run[i].comment);
+    }
   }
 }
 UNITTEST_STOP

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -48,7 +48,7 @@ static bool usec_matches_seconds(time_t time_usec, int expected_seconds)
 
 UNITTEST_START
   struct Curl_easy data;
-  struct curltime now = Curl_tvnow();
+  struct curltime now = curlx_tvnow();
 
   data.progress.t_starttransfer = 0;
   data.progress.t_redirect = 0;


### PR DESCRIPTION
... as the mix of both passing in current time and figuring it out
locally sometimes made "now" move in time in unexpected ways.

Curl_timeleft() got an updated prototype. The old defines for
Curl_tvnow() and Curl_tvdiff() are now removed.

Renamed the conn->new member to setup_time and fixed its use somewhat.

Moved the 'now' field from the SingleRequest struct within the easy
handle to the struct UrlState.