### PR TITLE
CMake: set MSVC warning level to 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1161,6 +1161,11 @@ endif(WIN32)
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
+  if(CMAKE_C_FLAGS MATCHES "/W[0-4]")
+    string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  else(CMAKE_C_FLAGS MATCHES "/W[0-4]")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
+  endif(CMAKE_C_FLAGS MATCHES "/W[0-4]")
 endif(MSVC)
 
 # Ugly (but functional) way to include "Makefile.inc" by transforming it (= regenerate it).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND HHEADERS
 
 if(MSVC)
   list(APPEND CSOURCES libcurl.rc)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4127")
 endif()
 
 # SET(CSOURCES

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -1,5 +1,9 @@
 set(TARGET_LABEL_PREFIX "Test server ")
 
+if(MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4127 /wd4306")
+endif()
+
 function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
   add_executable( ${TEST_NAME} ${ARGN} )
   string(TOUPPER ${TEST_NAME} UPPER_TEST_NAME)


### PR DESCRIPTION
The MSVC warning level defaults to 3 in CMake. Change it to 4, which is
consistent with the Visual Studio and NMake builds. Disable level 4
warning C4127 for the library to get a clean CURL_WERROR build.

Also, /WX got added twice to the compiler flags for the release build and not
at all for the debug build. Fix this by using CMAKE_C_FLAGS instead of
CMAKE_C_FLAGS_RELEASE and CMAKE_C_FLAGS_DEBUG.