### PR TITLE
Fix usage of error codes defined under CURL_NO_OLDIES

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -899,7 +899,7 @@ static CURLcode check_telnet_options(struct connectdata *conn)
       }
 
       failf(data, "Unknown telnet option %s", head->data);
-      result = CURLE_UNKNOWN_TELNET_OPTION;
+      result = CURLE_UNKNOWN_OPTION;
       break;
     }
     failf(data, "Syntax error in telnet option: %s", head->data);

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1345,7 +1345,7 @@ static CURLcode tftp_do(struct connectdata *conn, bool *done)
 
   state = (tftp_state_data_t *)conn->proto.tftpc;
   if(!state)
-    return CURLE_BAD_CALLING_ORDER;
+    return CURLE_TFTP_ILLEGAL;
 
   result = tftp_perform(conn, done);
 


### PR DESCRIPTION
Fixes https://github.com/curl/curl/issues/1688