### PR TITLE
CMake: fix CURL_WERROR for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ endif(BORLAND)
 if(CURL_WERROR)
   if(MSVC_VERSION)
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /WX")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_RELEASE} /WX")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /WX")
   else()
     # this assumes clang or gcc style options
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")


### PR DESCRIPTION
/WX got added twice to the compiler flags for the release build and not
at all for the debug build. Fix this by using CMAKE_C_FLAGS instead of
CMAKE_C_FLAGS_RELEASE and CMAKE_C_FLAGS_DEBUG.

Split from #1711 because I'm totally confused now.