### PR TITLE
curl_threads: fix MSVC compiler warning

### DIFF
--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -110,7 +110,7 @@ curl_thread_t Curl_thread_create(unsigned int (CURL_STDCALL *func) (void *),
 #else
   t = (curl_thread_t)_beginthreadex(NULL, 0, func, arg, 0, NULL);
 #endif
-  if((t == 0) || (t == (curl_thread_t)-1L)) {
+  if((t == 0) || (t == LongToHandle(-1L))) {
 #ifdef _WIN32_WCE
     DWORD gle = GetLastError();
     errno = ((gle == ERROR_ACCESS_DENIED ||


### PR DESCRIPTION
Use `LongToHandle` to convert from `long` to `HANDLE` in the Win32
implementation.
This should fix the following warning when compiling with
MSVC 11 (2012) in 64-bit mode visible in #1711:
```
lib\curl_threads.c(113): warning C4306: 'type cast' : conversion from 'long' to 'HANDLE' of greater size
```

`LongToHandle` is available in the February 2003 Platform SDK, so I think we should be safe. Alternatively, `INVALID_HANDLE_VALUE` could be used (the documented value in the `_beginthreadex` documentation is `-1L`, though).