### PR TITLE
cmake: fix for #1502 - system architecture and os detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ message(STATUS "curl version=[${CURL_VERSION}]")
 # SET(PACKAGE_STRING "curl-")
 # SET(PACKAGE_BUGREPORT "a suitable curl mailing list => https://curl.haxx.se/mail/")
 set(OPERATING_SYSTEM "${CMAKE_SYSTEM_NAME}")
-set(OS "\"${CMAKE_SYSTEM_NAME}\"")
+string(TOLOWER "\"${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}\"" OS)
 
 include_directories(${PROJECT_BINARY_DIR}/include/curl)
 include_directories( ${CURL_SOURCE_DIR}/include )


### PR DESCRIPTION
Will generate OS string as {ARCH}-{OS}
For example:

> [snikulov@localhost build]$ src/curl --version
curl 7.55.0-DEV (x86_64-linux) libcurl/7.55.0-DEV OpenSSL/1.1.0f zlib/1.2.11