### PR TITLE
travis: explicitly specify dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,11 @@ matrix:
     include:
         - os: linux
           compiler: gcc
+          dist: trusty
           env: BUILD_TYPE=normal
         - os: linux
           compiler: clang
+          dist: trusty
           env: BUILD_TYPE=debug
         - os: osx
           compiler: gcc
@@ -49,9 +51,11 @@ matrix:
           env: BUILD_TYPE=cmake
         - os: linux
           compiler: gcc
+          dist: precise
           env: BUILD_TYPE=coverage
         - os: linux
           compiler: gcc
+          dist: trusty
           env: BUILD_TYPE=distcheck
 
 install:


### PR DESCRIPTION
This makes the builds more reproducible as travis is currently rolling
out trusty as default dist [1]. Specifically, this avoids coverage
check failures when trusty is used as seen in [2] until we figure out
what's wrong.

[1] https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
[2] https://github.com/curl/curl/pull/1692