### PR TITLE
getparameter: avoid returning uninitialized 'usedarg'

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -443,6 +443,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   bool toggle = TRUE; /* how to switch boolean options, on or off. Controlled
                          by using --OPTION or --no-OPTION */
 
+  *usedarg = FALSE; /* default is that we don't use the arg */
 
   if(('-' != flag[0]) ||
      (('-' == flag[0]) && ('-' == flag[1]))) {
@@ -496,7 +497,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       letter = parse[0];
       subletter = parse[1];
     }
-    *usedarg = FALSE; /* default is that we don't use the arg */
 
     if(hit < 0) {
       for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -49,7 +49,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
   int res;
   FILE *file;
   char filebuffer[512];
-  bool usedarg;
+  bool usedarg = FALSE;
   char *home;
   int rc = 0;
   struct OperationConfig *operation = global->first;
@@ -220,7 +220,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #endif
       res = getparameter(option, param, &usedarg, global, operation);
 
-      if(param && *param && !usedarg)
+      if(!res && param && *param && !usedarg)
         /* we passed in a parameter that wasn't used! */
         res = PARAM_GOT_EXTRA_PARAMETER;
 


### PR DESCRIPTION
Fixes #1728