### PR TITLE
gssapi: fix memory leak of output token in multi round context

### DIFF
--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -180,6 +180,10 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
   }
 
+  /* Free previous token */
+  if(nego->output_token.length && nego->output_token.value)
+    gss_release_buffer(&unused_status, &nego->output_token);
+
   nego->output_token = output_token;
 
   return CURLE_OK;


### PR DESCRIPTION
When multiple rounds are needed to establish a security context
(usually ntlm), we overwrite old token with a new one without free.
Found by proposed gss tests using stub a gss implementation (by
valgrind error), though I have confirmed the leak with a real
gssapi implementation as well.

(detached from PR #1687)