### PR TITLE
darwinssl: fix compiler warning

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -37,7 +37,7 @@
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-pointer-compare"
-#endif __clang__
+#endif /* __clang__ */
 
 #ifdef HAVE_LIMITS_H
 #include <limits.h>


### PR DESCRIPTION
clang complains:
```
vtls/darwinssl.c:40:8: error: extra tokens at end of #endif directive [-Werror,-Wextra-tokens]
```

This breaks the darwinssl build on Travis. Fix it by making this token
a comment.