### PR TITLE
curl: detect and bail out early on parameter integer overflows

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -545,7 +545,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         GetStr(&config->oauth_bearer, nextarg);
         break;
       case 'c': /* connect-timeout */
-        err = str2udouble(&config->connecttimeout, nextarg);
+        err = str2udouble(&config->connecttimeout, nextarg,
+                          LONG_MAX/1000);
         if(err)
           return err;
         break;
@@ -1047,7 +1048,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           return err;
         break;
       case 'R': /* --expect100-timeout */
-        err = str2udouble(&config->expect100timeout, nextarg);
+        err = str2udouble(&config->expect100timeout, nextarg, LONG_MAX/1000);
         if(err)
           return err;
         break;
@@ -1713,7 +1714,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case 'm':
       /* specified max time */
-      err = str2udouble(&config->timeout, nextarg);
+      err = str2udouble(&config->timeout, nextarg, LONG_MAX/1000);
       if(err)
         return err;
       break;

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -41,6 +41,7 @@ typedef enum {
   PARAM_NO_MEM,
   PARAM_NEXT_OPERATION,
   PARAM_NO_PREFIX,
+  PARAM_NUMBER_TOO_LARGE,
   PARAM_LAST
 } ParameterError;
 

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -64,6 +64,8 @@ const char *param2text(int res)
     return "out of memory";
   case PARAM_NO_PREFIX:
     return "the given option can't be reversed with a --no- prefix";
+  case PARAM_NUMBER_TOO_LARGE:
+    return "too large number";
   default:
     return "unknown error";
   }

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -164,7 +164,11 @@ ParameterError str2num(long *val, const char *str)
 {
   if(str) {
     char *endptr;
-    long num = strtol(str, &endptr, 10);
+    long num;
+    errno = 0;
+    num = strtol(str, &endptr, 10);
+    if(errno == ERANGE)
+      return PARAM_NUMBER_TOO_LARGE;
     if((endptr != str) && (endptr == str + strlen(str))) {
       *val = num;
       return PARAM_OK;  /* Ok */
@@ -197,16 +201,27 @@ ParameterError str2unum(long *val, const char *str)
  * Parse the string and write the double in the given address. Return PARAM_OK
  * on success, otherwise a parameter specific error enum.
  *
+ * The 'max' argument is the maximum value allowed, as the numbers are often
+ * multiplied when later used.
+ *
  * Since this function gets called with the 'nextarg' pointer from within the
  * getparameter a lot, we must check it for NULL before accessing the str
  * data.
  */
 
-ParameterError str2double(double *val, const char *str)
+static ParameterError str2double(double *val, const char *str, long max)
 {
   if(str) {
     char *endptr;
-    double num = strtod(str, &endptr);
+    double num;
+    errno = 0;
+    num = strtod(str, &endptr);
+    if(errno == ERANGE)
+      return PARAM_NUMBER_TOO_LARGE;
+    if((long)val > max) {
+      /* too large */
+      return PARAM_NUMBER_TOO_LARGE;
+    }
     if((endptr != str) && (endptr == str + strlen(str))) {
       *val = num;
       return PARAM_OK;  /* Ok */
@@ -219,14 +234,17 @@ ParameterError str2double(double *val, const char *str)
  * Parse the string and write the double in the given address. Return PARAM_OK
  * on success, otherwise a parameter error enum. ONLY ACCEPTS POSITIVE NUMBERS!
  *
+ * The 'max' argument is the maximum value allowed, as the numbers are often
+ * multiplied when later used.
+ *
  * Since this function gets called with the 'nextarg' pointer from within the
  * getparameter a lot, we must check it for NULL before accessing the str
  * data.
  */
 
-ParameterError str2udouble(double *val, const char *str)
+ParameterError str2udouble(double *val, const char *str, long max)
 {
-  ParameterError result = str2double(val, str);
+  ParameterError result = str2double(val, str, max);
   if(result != PARAM_OK)
     return result;
   if(*val < 0)
@@ -384,11 +402,12 @@ ParameterError str2offset(curl_off_t *val, const char *str)
 #if(CURL_SIZEOF_CURL_OFF_T > CURL_SIZEOF_LONG)
   *val = curlx_strtoofft(str, &endptr, 0);
   if((*val == CURL_OFF_T_MAX || *val == CURL_OFF_T_MIN) && (errno == ERANGE))
-    return PARAM_BAD_NUMERIC;
+    return PARAM_NUMBER_TOO_LARGE;
 #else
+  errno = 0;
   *val = strtol(str, &endptr, 0);
   if((*val == LONG_MIN || *val == LONG_MAX) && errno == ERANGE)
-    return PARAM_BAD_NUMERIC;
+    return PARAM_NUMBER_TOO_LARGE;
 #endif
   if((endptr != str) && (endptr == str + strlen(str)))
     return PARAM_OK;

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -218,7 +218,7 @@ static ParameterError str2double(double *val, const char *str, long max)
     num = strtod(str, &endptr);
     if(errno == ERANGE)
       return PARAM_NUMBER_TOO_LARGE;
-    if((long)val > max) {
+    if((long)num > max) {
       /* too large */
       return PARAM_NUMBER_TOO_LARGE;
     }

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -33,8 +33,7 @@ void cleanarg(char *str);
 
 ParameterError str2num(long *val, const char *str);
 ParameterError str2unum(long *val, const char *str);
-ParameterError str2double(double *val, const char *str);
-ParameterError str2udouble(double *val, const char *str);
+ParameterError str2udouble(double *val, const char *str, long max);
 
 long proto2num(struct OperationConfig *config, long *val, const char *str);
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -151,7 +151,7 @@ test1396 test1397 test1398 test1399 \
 test1400 test1401 test1402 test1403 test1404 test1405 test1406 test1407 \
 test1408 test1409 test1410 test1411 test1412 test1413 test1414 test1415 \
 test1416 test1417 test1418 test1419 test1420 test1421 test1422 test1423 \
-test1424 test1425 test1426 \
+test1424 test1425 test1426 test1427 \
 test1428 test1429 test1430 test1431 test1432 test1433 test1434 test1435 \
 test1436 test1437 test1438 test1439 test1440 test1441 test1442 test1443 \
 test1444 test1445 test1446                            test1450 test1451 \

--- a/tests/data/test1427
+++ b/tests/data/test1427
@@ -1,0 +1,29 @@
+<testcase>
+<info>
+<keywords>
+integer overflow
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+ <name>
+too large -m timeout value
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/1427 -m 184467440737095510
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Make the number parser aware of the maximum limit curl accepts for a
value and return an error immediately if larger, instead of running an
integer overflow later.

Fixes #1730