### PR TITLE
Add dictserver.py/negtelnetserver.py to EXTRA_DIST

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,7 +36,8 @@ EXTRA_DIST = ftpserver.pl httpserver.pl secureserver.pl runtests.pl getpart.pm \
  sshserver.pl sshhelp.pm pathhelp.pm testcurl.1 runtests.1 \
  serverhelp.pm tftpserver.pl rtspserver.pl directories.pm symbol-scan.pl \
  CMakeLists.txt mem-include-scan.pl valgrind.supp http_pipe.py extern-scan.pl \
- manpage-scan.pl nroff-scan.pl http2-server.pl $(SMBDEPS)
+ manpage-scan.pl nroff-scan.pl http2-server.pl dictserver.py \
+ negtelnetserver.py $(SMBDEPS)
 
 DISTCLEANFILES = configurehelp.pm
 


### PR DESCRIPTION
The 7.55.0 release's test suite fails owing to missing files:

```
sh: /src/net/curl/work/curl-7.55.0/tests/dictserver.py: No such file or directory
RUN: failed to start the DICT server
== Contents of files in the log/ dir after test 1450
sh: /src/net/curl/work/curl-7.55.0/tests/negtelnetserver.py: No such file or directory
RUN: failed to start the TELNET server
== Contents of files in the log/ dir after test 1452
```

This patch should fix it, but it'd also be good to ensure the release process involves running the test suite from the tarball in order to prevent this kind of problem in the future (e.g. "make distcheck").