### PR TITLE
Update gitignore and gitattribues for Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .libs
 .project
 .settings
+/.vs
 /build/
 /builds/
 __pycache__

--- a/projects/Windows/.gitattributes
+++ b/projects/Windows/.gitattributes
@@ -1,0 +1,1 @@
+*.sln eol=crlf


### PR DESCRIPTION
- ignore top-level `.vs` folder, which is generated when using the CMake build system from within Visual Studio
- force Visual Studio solutions to CRLF line endings as Visual Studio doesn't like the LF currently used in the release archives