### PR TITLE
curl: avoid int overflow on arches with 32bit long

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -218,7 +218,7 @@ static ParameterError str2double(double *val, const char *str, long max)
     num = strtod(str, &endptr);
     if(errno == ERANGE)
       return PARAM_NUMBER_TOO_LARGE;
-    if((long)num > max) {
+    if(num > (double)LONG_MAX || (long)num > max) {
       /* too large */
       return PARAM_NUMBER_TOO_LARGE;
     }


### PR DESCRIPTION
This makes test1427 pass on i386.