### PR TITLE
fixup: do bounds check using a double comparison

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -218,7 +218,7 @@ static ParameterError str2double(double *val, const char *str, long max)
     num = strtod(str, &endptr);
     if(errno == ERANGE)
       return PARAM_NUMBER_TOO_LARGE;
-    if((long)num > max) {
+    if(num > max) {
       /* too large */
       return PARAM_NUMBER_TOO_LARGE;
     }


### PR DESCRIPTION
The fix for this in 8661a0aacc01492e0436275ff36a21734f2541bb wasn't
complete: if the parsed number in num is larger than will fit in a
long, the conversion is undefined behaviour (causing test1427 to fail
for me on IA32 with GCC 7.1, although it passes on AMD64 and ARMv7).
Getting rid of the cast means the comparison will be done using doubles.

It might make more sense for the max argument to also be a double...