### PR TITLE
parse_proxy(): fix memory leak in case of invalid proxy server name

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -5149,11 +5149,14 @@ static CURLcode parse_proxy(struct Curl_easy *data,
       conn->port = port;
   }
   else {
-    if(proxyptr[0]=='/')
+    if(proxyptr[0]=='/') {
       /* If the first character in the proxy string is a slash, fail
          immediately. The following code will otherwise clear the string which
          will lead to code running as if no proxy was set! */
+      Curl_safefree(proxyuser);
+      Curl_safefree(proxypasswd);
       return CURLE_COULDNT_RESOLVE_PROXY;
+    }
 
     /* without a port number after the host name, some people seem to use
        a slash so we strip everything from the first slash */


### PR DESCRIPTION
Fixes the below leak:

$ valgrind --leak-check=full ~/install-curl-git/bin/curl --proxy "http://a:b@/x" http://127.0.0.1
==5048== Memcheck, a memory error detector
==5048== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==5048== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==5048== Command: /home/even/install-curl-git/bin/curl --proxy http://a:b@/x http://127.0.0.1
==5048==
curl: (5) Couldn't resolve proxy name
==5048==
==5048== HEAP SUMMARY:
==5048==     in use at exit: 532 bytes in 12 blocks
==5048==   total heap usage: 5,288 allocs, 5,276 frees, 445,271 bytes allocated
==5048==
==5048== 2 bytes in 1 blocks are definitely lost in loss record 1 of 12
==5048==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5048==    by 0x4E6CB79: parse_login_details (url.c:5614)
==5048==    by 0x4E6BA82: parse_proxy (url.c:5091)
==5048==    by 0x4E6C46D: create_conn_helper_init_proxy (url.c:5346)
==5048==    by 0x4E6EA18: create_conn (url.c:6498)
==5048==    by 0x4E6F9B4: Curl_connect (url.c:6967)
==5048==    by 0x4E86D05: multi_runsingle (multi.c:1436)
==5048==    by 0x4E88432: curl_multi_perform (multi.c:2160)
==5048==    by 0x4E7C515: easy_transfer (easy.c:708)
==5048==    by 0x4E7C74A: easy_perform (easy.c:794)
==5048==    by 0x4E7C7B1: curl_easy_perform (easy.c:813)
==5048==    by 0x414025: operate_do (tool_operate.c:1563)
==5048==
==5048== 2 bytes in 1 blocks are definitely lost in loss record 2 of 12
==5048==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5048==    by 0x4E6CBB6: parse_login_details (url.c:5621)
==5048==    by 0x4E6BA82: parse_proxy (url.c:5091)
==5048==    by 0x4E6C46D: create_conn_helper_init_proxy (url.c:5346)
==5048==    by 0x4E6EA18: create_conn (url.c:6498)
==5048==    by 0x4E6F9B4: Curl_connect (url.c:6967)
==5048==    by 0x4E86D05: multi_runsingle (multi.c:1436)
==5048==    by 0x4E88432: curl_multi_perform (multi.c:2160)
==5048==    by 0x4E7C515: easy_transfer (easy.c:708)
==5048==    by 0x4E7C74A: easy_perform (easy.c:794)
==5048==    by 0x4E7C7B1: curl_easy_perform (easy.c:813)
==5048==    by 0x414025: operate_do (tool_operate.c:1563)

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2984
Credit to OSS Fuzz for discovery