### PR TITLE
cmake: Allow user to override CMAKE_DEBUG_POSTFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if (ENABLE_CURLDEBUG)
 endif()
 
 # For debug libs and exes, add "-d" postfix
-set(CMAKE_DEBUG_POSTFIX "-d" CACHE STRING "Set debug library postfix" FORCE)
+set(CMAKE_DEBUG_POSTFIX "-d" CACHE STRING "Set debug library postfix")
 
 # initialize CURL_LIBS
 set(CURL_LIBS "")


### PR DESCRIPTION
In #1649 the cache variable CMAKE_DEBUG_POSTFIX was set to "-d" by FORCE, giving the user no chance to override it to the desired value. This change keeps "-d" as default but allows users to change the value.

## Current master

```
$ mkdir build && cd build
$ cmake -DCMAKE_BUILD_TYPE=Debug ..
$ DESTDIR=installation make install
```

> -- Installing: installation/usr/local/lib/libcurl-d.so

```
$ mkdir build && cd build
$ cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DEBUG_POSTFIX=_bar ..
$ DESTDIR=installation make install
```

> -- Installing: installation/usr/local/lib/libcurl-d.so

## This PR

```
$ mkdir build && cd build
$ cmake -DCMAKE_BUILD_TYPE=Debug ..
$ DESTDIR=installation make install
```

> -- Installing: installation/usr/local/lib/libcurl-d.so

```
$ mkdir build && cd build
$ cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DEBUG_POSTFIX=_bar ..
$ DESTDIR=installation make install
```

> -- Installing: installation/usr/local/lib/libcurl_bar.so

cc @paulharris