### PR TITLE
bagder/Curl_tvdiff_us: fix the math

### DIFF
--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -158,5 +158,5 @@ time_t Curl_tvdiff_us(struct curltime newer, struct curltime older)
     return 0x7fffffffffffffffLL;
 #endif
   return (newer.tv_sec-older.tv_sec)*1000000+
-    (time_t)(newer.tv_usec-older.tv_usec);
+    (int)(newer.tv_usec-older.tv_usec);
 }


### PR DESCRIPTION
Regression since adef394ac5 (released in 7.55.0)

Reported-by: Han Qiao
Fixes #1769