### PR TITLE
curl/system.h: GCC doesn't define __ppc__ on PowerPC, use __powerpc__ instead

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -426,7 +426,7 @@
 
 #elif defined(__GNUC__)
 #  if !defined(__LP64__) && (defined(__ILP32__) || \
-      defined(__i386__) || defined(__ppc__) || defined(__arm__) || \
+      defined(__i386__) || defined(__powerpc__) || defined(__arm__) || \
       defined(__sparc__) || defined(__mips__) || defined(__sh__) || \
       defined(__XTENSA__) || (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ == 4))
 #    define CURL_SIZEOF_LONG           4


### PR DESCRIPTION
There's a mistake in current `system,h` testing for generic PowerPC GCC. GCC doesn't define `__ppc__` for PowerPC arch, but defines `__powerpc__` instead. For instance, see [here](http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros)