### PR TITLE
zsh.pl: produce a working completion script again

### DIFF
--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -1,5 +1,5 @@
 Long: cacert
-Arg: <CA certificate>
+Arg: <file>
 Help: CA certificate to verify peer against
 Protocols: TLS
 ---

--- a/scripts/zsh.pl
+++ b/scripts/zsh.pl
@@ -54,10 +54,11 @@ sub parse_main_opts {
         $option .= '}' if defined $short;
         $option .= '\'[' . trim($desc) . ']\'' if defined $desc;
 
-        $option .= ":$arg" if defined $arg;
+        $option .= ":'$arg'" if defined $arg;
 
         $option .= ':_files'
-            if defined $arg and ($arg eq 'FILE' || $arg eq 'DIR');
+            if defined $arg and ($arg eq '<file>' || $arg eq '<filename>'
+                || $arg eq '<dir>');
 
         push @list, $option;
     }

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -54,7 +54,7 @@ static const struct helptxt helptext[] = {
    "Append to target file when uploading"},
   {"    --basic",
    "Use HTTP Basic Authentication"},
-  {"    --cacert <CA certificate>",
+  {"    --cacert <file>",
    "CA certificate to verify peer against"},
   {"    --capath <dir>",
    "CA directory to verify peer against"},


### PR DESCRIPTION
Commit [curl-7_54_0-118-g8b2f22e](https://github.com/curl/curl/commit/curl-7_54_0-118-g8b2f22e) changed the output format of ```curl --help``` to use ```<file>``` and ```<dir>``` instead of ```FILE``` and ```DIR```, which caused ```zsh.pl``` to produce a broken completion script:
```
% curl --<TAB>
_curl:10: no such file or directory: seconds
```