### PR TITLE
http_proxy: a compilation error was fixed

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -410,7 +410,7 @@ static CURLcode CONNECT(struct connectdata *conn,
         }
 
         /* convert from the network encoding */
-        result = Curl_convert_from_network(data, line_start, perline);
+        result = Curl_convert_from_network(data, s->line_start, s->perline);
         /* Curl_convert_from_network calls failf if unsuccessful */
         if(result)
           return result;


### PR DESCRIPTION
Hello.
I faced a compilation error when was building cURL with CURL_DOES_CONVERSIONS defined. The problem occurred because some variables in [curl/lib/http_proxy.c](https://github.com/curl/curl/blob/master/lib/http_proxy.c) were moved to the structure http_connect_state in 5113ad0424044458ac497fa1458ebe0101356b22.
The issue is present only when CURL_DOES_CONVERSIONS defined because, otherwise, calls of Curl_convert_from_network are removed from the code at the preprocessing stage. 