### PR TITLE
darwinssl: add support for TLSv1.3

### DIFF
--- a/docs/cmdline-opts/tlsv1.3.d
+++ b/docs/cmdline-opts/tlsv1.3.d
@@ -6,4 +6,5 @@ Added: 7.52.0
 Forces curl to use TLS version 1.3 when connecting to a remote TLS server.
 
 Note that TLS 1.3 is only supported by a subset of TLS backends. At the time
-of writing this, those are BoringSSL and NSS only.
+of this writing, they are BoringSSL, NSS, and Secure Transport (on iOS 11 or
+later, and macOS 10.13 or later).


### PR DESCRIPTION
This is for a feature Apple has publicly announced and documented, but
it's still technically in beta, since it requires Xcode 9.x to build,
and iOS 11 or macOS 10.13 to use the feature. We should probably hold
off on merging this change until the gold masters are released.