### PR TITLE
curl/system.h: check for __ppc__ as well

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -344,8 +344,8 @@
 
 #elif defined(__GNUC__)
 #  if !defined(__LP64__) &&                                             \
-  (defined(__ILP32__) ||                                                \
-   defined(__i386__) || defined(__powerpc__) || defined(__arm__) ||     \
+  (defined(__ILP32__) || defined(__i386__) ||                           \
+   defined(__ppc__) || defined(__powerpc__) || defined(__arm__) ||      \
    defined(__sparc__) || defined(__mips__) || defined(__sh__) ||        \
    defined(__XTENSA__) ||                                               \
    (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ == 4))


### PR DESCRIPTION
... regression since issue #1774 (commit 10b3df10596a) since obviously
some older gcc doesn't know `__powerpc__` while some newer doesn't know
`__ppc__` ...

Fixes #1797
Reported-by: Ryan Schmidt