### PR TITLE
metalink: adjust source code style

### DIFF
--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -880,7 +880,7 @@ size_t metalink_write_cb(void *buffer, size_t sz, size_t nmemb,
   if(!config)
     return failure;
 
-  rv = metalink_parse_update(outs->metalink_parser, buffer, sz *nmemb);
+  rv = metalink_parse_update(outs->metalink_parser, buffer, sz * nmemb);
   if(rv == 0)
     return sz * nmemb;
   else {


### PR DESCRIPTION
Just a minor style fix I stumbled across while fixing the build with GCC 7.1.0 (the `(sz * nmemb) ? 0 : 1` issue, which I would have fixed by comparing `>= 0` but in the meantime it was fixed by replacing the `*` by a `&&` :smile: ).