### PR TITLE
http: fix behavior of multi_socket mode for high latency connections

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1371,7 +1371,7 @@ CURLcode Curl_http_connect(struct connectdata *conn, bool *done)
   if(CONNECT_FIRSTSOCKET_PROXY_SSL())
     return CURLE_OK; /* wait for HTTPS proxy SSL initialization to complete */
 
-  if(!Curl_connect_complete(conn))
+  if(Curl_connect_ongoing(conn))
     /* nothing else to do except wait right now - we're not done here. */
     return CURLE_OK;
 


### PR DESCRIPTION
This solves https://github.com/curl/curl/issues/1804