### PR TITLE
tool_main: turn off MinGW CRT's globbing

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -62,6 +62,15 @@
 int vms_show = 0;
 #endif
 
+#ifdef __MINGW32__
+/*
+ * There seems to be no way to escape "*" in command-line arguments with MinGW
+ * when command-line argument globbing is enabled under the MSYS shell, so turn
+ * it off.
+ */
+int _CRT_glob = 0;
+#endif /* __MINGW32__ */
+
 /* if we build a static library for unit tests, there is no main() function */
 #ifndef UNITTESTS
 


### PR DESCRIPTION
By default, the MinGW CRT globs command-line arguments. This prevents
getting a single asterisk into an argument as test 1299 does. Turn off
globbing by setting the global variable _CRT_glob to 0 for MinGW.

Fixes https://github.com/curl/curl/issues/1751