### PR TITLE
win32: define SIZEOF_LONG to avoid build errors

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -399,6 +399,9 @@
 /* Define to the size of `short', as computed by sizeof. */
 #define SIZEOF_SHORT 2
 
+/* Define to the size of `long', as computed by sizeof. */
+#define SIZEOF_LONG 4
+
 /* Define to the size of `size_t', as computed by sizeof. */
 #if defined(_WIN64)
 #  define SIZEOF_SIZE_T 8


### PR DESCRIPTION
Fixes:
```
warnless.c:85:4: error: #error "SIZEOF_LONG not defined"
 #  error "SIZEOF_LONG not defined"
    ^~~~~
```
(and further errors arising from the above)

Ref: https://ci.appveyor.com/project/vsz/harbour-deps/build/1.0.1062#L4016
Ref: https://software.intel.com/articles/size-of-long-integer-type-on-different-architecture-and-os