### PR TITLE
imap: support PREAUTH

### DIFF
--- a/lib/imap.h
+++ b/lib/imap.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2009 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2009 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -71,6 +71,7 @@ struct imap_conn {
   struct pingpong pp;
   imapstate state;            /* Always use imap.c:state() to change state! */
   bool ssldone;               /* Is connect() over SSL done? */
+  bool preauth;               /* Is this connection PREAUTH? */
   struct SASL sasl;           /* SASL-related parameters */
   unsigned int preftype;      /* Preferred authentication type */
   int cmdid;                  /* Last used command ID */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -87,7 +87,7 @@ test809 test810 test811 test812 test813 test814 test815 test816 test817 \
 test818 test819 test820 test821 test822 test823 test824 test825 test826 \
 test827 test828 test829 test830 test831 test832 test833 test834 test835 \
 test836 test837 test838 test839 test840 test841 test842 test843 test844 \
-test845 \
+test845 test846 \
 \
 test850 test851 test852 test853 test854 test855 test856 test857 test858 \
 test859 test860 test861 test862 test863 test864 test865 test866 test867 \

--- a/tests/data/test846
+++ b/tests/data/test846
@@ -1,0 +1,50 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<servercmd>
+REPLY welcome * PREAUTH ready to serve already!
+REPLY CAPABILITY * CAPABILITY IMAP4REV1 I18NLEVEL=1 LITERAL+ IDLE UIDPLUS NAMESPACE CHILDREN MAILBOX-REFERRALS BINARY UNSELECT ESEARCH WITHIN SCAN SORT THREAD=REFERENCES THREAD=ORDEREDSUBJECT MULTIAPPEND SASL-IR LOGIN-REFERRALS STARTTLS LOGINDISABLED\r\nA001 OK CAPABILITY completed
+</servercmd>
+<data>
+From: me@somewhere
+To: fake@nowhere
+
+body
+
+--
+  yours sincerely
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP PREAUTH response
+ </name>
+ <command>
+'imap://%HOSTIP:%IMAPPORT/846/;UID=1' -u notused:still-provided
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+A001 CAPABILITY
+A002 SELECT 846
+A003 FETCH 1 BODY[]
+A004 LOGOUT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
It is a defined possible greeting at server startup that means the
connection is already authenticated. See
https://tools.ietf.org/html/rfc3501#section-7.1.4

Test 846 added to verify.

Fixes #1818