### PR TITLE
curl: warn when --insecure is used

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1145,6 +1145,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           if(config->insecure_ok) {
             my_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
             my_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+            warnf(config->global,
+                  "Your SSL connection is INSECURE (due to --insecure)\n");
           }
           else {
             my_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
@@ -1154,6 +1156,9 @@ static CURLcode operate_do(struct GlobalConfig *global,
           if(config->proxy_insecure_ok) {
             my_setopt(curl, CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
             my_setopt(curl, CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
+            warnf(config->global,
+                  "Your proxy SSL connection is now INSECURE "
+                  "(due to --proxy-insecure)\n");
           }
           else {
             my_setopt(curl, CURLOPT_PROXY_SSL_VERIFYPEER, 1L);


### PR DESCRIPTION
As mentioned in #1810, the `--insecure` (and its short version `-k`) command line option is used very widely by programs and scripts all over the world (hundreds of thousands of times in github hosted code alone). 

Presumably, not all users of this option fully aware of the implications. One way to try to make more people aware, is to add a warning message in the output when this option is used.

This PR adds such a warning and I figured it could be used as a sort of discussion-starter of what we can do to raise people's awareness and encourage that users rather make **secure** SSL connections.