### PR TITLE
ossfuzz: Add basic fuzz target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ matrix:
           compiler: gcc
           dist: trusty
           env: T=distcheck
+        - os: linux
+          compiler: clang
+          dist: trusty
+          env: T=fuzzer
 
 install:
   - pip install --user cpp-coveralls
@@ -137,6 +141,12 @@ script:
              cd build && \
              cmake .. && \
              make)
+        fi
+    - |
+        if [ "$T" = "fuzzer" ]; then
+             cd tests/ossfuzz
+             make -f Makefile.fuzz clean
+             make -f Makefile.fuzz check
         fi
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)

--- a/tests/ossfuzz/Makefile.fuzz
+++ b/tests/ossfuzz/Makefile.fuzz
@@ -1,0 +1,36 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+# Build file for curl OSS-fuzzer.
+
+# By default, use our own standalone_fuzz_target_runner.
+# This runner does no fuzzing, but simply executes the inputs
+# provided via parameters.
+# Run e.g. "make all LIB_FUZZING_ENGINE=/path/to/libFuzzer.a"
+# to link the fuzzer(s) against a real fuzzing engine.
+#
+# OSS-Fuzz will define its own value for LIB_FUZZING_ENGINE.
+LIB_FUZZING_ENGINE ?= standalone_fuzz_target_runner.o
+
+# Values for CC, CFLAGS, CXX, CXXFLAGS are provided by OSS-Fuzz.
+# Outside of OSS-Fuzz use the ones you prefer or rely on the default values.
+# Do not use the -fsanitize=* flags by default.
+# OSS-Fuzz will use different -fsanitize=* flags for different builds (asan, ubsan, msan, ...)
+
+all: curl_fuzzer
+
+clean:
+	rm -fv *.a *.o *_fuzzer *_seed_corpus.zip crash-* *.zip
+
+# Continuous integration system should run "make clean && make check"
+check: all
+	./curl_fuzzer curl_fuzz_data/*
+
+# Fuzz target, links against $LIB_FUZZING_ENGINE, so that
+# you may choose which fuzzing engine to use.
+curl_fuzzer: curl_fuzzer.c $(LIB_FUZZING_ENGINE)
+	${CC} ${CFLAGS} $< ${LIB_FUZZING_ENGINE} -o $@
+	zip -q -r curl_fuzzer_seed_corpus.zip curl_fuzz_data
+
+# The standalone fuzz target runner.
+standalone_fuzz_target_runner.o: standalone_fuzz_target_runner.c

--- a/tests/ossfuzz/curl_fuzz_data/README
+++ b/tests/ossfuzz/curl_fuzz_data/README
@@ -1,0 +1,1 @@
+This folder contains curl fuzz data.

--- a/tests/ossfuzz/curl_fuzzer.c
+++ b/tests/ossfuzz/curl_fuzzer.c
@@ -1,0 +1,36 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2017, Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * Fuzzing entry point. This function is passed a buffer containing a test
+ * case.  This test case should drive the CURL API into making a request.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  /* Use a dummy function for now. */
+  printf("Data: %p  size: %zu \n", data, size);
+  return 0;
+}

--- a/tests/ossfuzz/standalone_fuzz_target_runner.c
+++ b/tests/ossfuzz/standalone_fuzz_target_runner.c
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2017, Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "standalone_fuzz_target_runner.h"
+
+/** 
+ * Main procedure for standalone fuzzing engine.
+ *
+ * Reads filenames from the argument array. For each filename, read the file
+ * into memory and then call the fuzzing interface with the data.
+ */
+int main(int argc, char **argv)
+{
+  int ii;
+  FILE *infile;
+  uint8_t *buffer = NULL;
+  size_t buffer_len;
+
+  for(ii = 1; ii < argc; ii++) {
+    /* Try and open the file. */
+    infile = fopen(argv[ii], "r");
+    if(infile) {
+      printf("[%s] Open succeeded! \n", argv[ii]);
+
+      /* Get the length of the file. */
+      fseek(infile, 0L, SEEK_END);
+      buffer_len = ftell(infile);
+
+      /* Reset the file indicator to the beginning of the file. */
+      fseek(infile, 0L, SEEK_SET);
+
+      /* Allocate a buffer for the file contents. */
+      buffer = (uint8_t *)calloc(buffer_len, sizeof(uint8_t));
+      if(buffer) {
+        /* Read all the text from the file into the buffer. */
+        fread(buffer, sizeof(uint8_t), buffer_len, infile);
+        printf("[%s] Read %zu bytes, calling fuzzer\n", argv[ii], buffer_len);
+
+        /* Call the fuzzer with the data. */
+        LLVMFuzzerTestOneInput(buffer, buffer_len);
+
+        printf("[%s] Fuzzing complete\n", argv[ii]);
+
+        /* Free the buffer as it's no longer needed. */
+        free(buffer);
+        buffer = NULL;
+      }
+      else
+      {
+        fprintf(stderr,
+                "[%s] Failed to allocate %zu bytes \n",
+                argv[ii],
+                buffer_len);
+      }
+
+      /* Close the file as it's no longer needed. */
+      fclose(infile);
+      infile = NULL;
+    }
+    else
+    {
+      /* Failed to open the file. Maybe wrong name or wrong permissions? */
+      fprintf(stderr, "[%s] Open failed. \n", argv[ii]);
+    }
+  }
+}

--- a/tests/ossfuzz/standalone_fuzz_target_runner.h
+++ b/tests/ossfuzz/standalone_fuzz_target_runner.h
@@ -1,0 +1,23 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2017, Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);


### PR DESCRIPTION
Use the standard code from the ossfuzz project. This doesn't yet fit
into the main CURL infrastructure.

Tie into CI for now to do a simple build of the Makefile.
---
This is the first step at moving towards https://github.com/google/oss-fuzz/blob/master/docs/ideal_integration.md. Out of the checklist it ticks:

- Is maintained by code owners in their RCS (Git, SVN, etc).
- Is built with the rest of the tests - no bit rot!

I have a plan for getting seed corpora working - I'm going to be testing that now.