### PR TITLE
darwinssl: handle long strings in TLS certs (follow-up)

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -881,11 +881,26 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
 {
   CFStringRef c = getsubject(cert);
   CURLcode result = CURLE_OK;
+  const char *direct;
   char *cbuf = NULL;
   *certp = NULL;
 
-  /* If subject is not UTF-8 then check if it can be converted */
-  if(!CFStringGetCStringPtr(c, kCFStringEncodingUTF8)) {
+  if(!c) {
+    failf(data, "SSL: invalid CA certificate subject");
+    return CURLE_OUT_OF_MEMORY;
+  }
+
+  /* If the subject is already available as UTF-8 encoded (ie 'direct') then
+     use that, else convert it. */
+  direct = CFStringGetCStringPtr(c, kCFStringEncodingUTF8);
+  if(direct) {
+    *certp = strdup(direct);
+    if(!*certp) {
+      failf(data, "SSL: out of memory");
+      result = CURLE_OUT_OF_MEMORY;
+    }
+  }
+  else {
     size_t cbuf_size = ((size_t)CFStringGetLength(c) * 4) + 1;
     cbuf = calloc(cbuf_size, 1);
     if(cbuf) {


### PR DESCRIPTION
- Fix handling certificate subjects that are already UTF-8 encoded.

Follow-up to b3b75d1 from two days ago. Since then a copy would be
skipped if the subject was already UTF-8, possibly resulting in a NULL
deref later on.

Ref: https://github.com/curl/curl/issues/1823
Ref: https://github.com/curl/curl/pull/1831

Closes https://github.com/curl/curl/pull/1836

---

Someone will need to check this close, I am very unfamiliar with Apple API and don't build for DarwinSSL. This is based on my reading of [CFStringGetCStringPtr](https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr)