### PR TITLE
cyassl: call it the "WolfSSL" backend

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -978,7 +978,7 @@ static void *Curl_cyassl_get_internals(struct ssl_connect_data *connssl,
 }
 
 const struct Curl_ssl Curl_ssl_cyassl = {
-  { CURLSSLBACKEND_CYASSL, "cyassl" }, /* info */
+  { CURLSSLBACKEND_WOLFSSL, "WolfSSL" }, /* info */
 
   0, /* have_ca_path */
   0, /* have_certinfo */


### PR DESCRIPTION
... instead of cyassl.

The casing of the names is interesting. Should we use the "correct" casing or use all lowercase?

Should we do the *sslset() name matching case insensitively?