### PR TITLE
configure: remove the leading comma from the backends list

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1409,7 +1409,7 @@ if test -z "$ssl_backends" -o "x$OPT_DARWINSSL" != xno; then
     AC_MSG_RESULT(yes)
     AC_DEFINE(USE_DARWINSSL, 1, [to enable Apple OS native SSL/TLS support])
     AC_SUBST(USE_DARWINSSL, [1])
-    ssl_msg="$ssh_backends, Apple OS-native"
+    ssl_msg="Apple OS-native"
     test darwinssl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
     DARWINSSL_ENABLED=1
     LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"


### PR DESCRIPTION
... when darwinssl is used.

Reported-by: Viktor Szakats
Bug: https://github.com/curl/curl/commit/b0989cd3abaff4f9a0717b4875022fa79e33b481#commitcomment-23943493