### PR TITLE
schannel: return CURLE_SSL_CACERT on failed verification

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -714,7 +714,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
         failf(data, "schannel: next InitializeSecurityContext failed: %s",
               Curl_sspi_strerror(conn, sspi_status));
       return sspi_status == SEC_E_UNTRUSTED_ROOT ?
-          CURLE_SSL_CACERT_BADFILE : CURLE_SSL_CONNECT_ERROR;
+          CURLE_SSL_CACERT : CURLE_SSL_CONNECT_ERROR;
     }
 
     /* check if there was additional remaining encrypted data */


### PR DESCRIPTION
... not *CACERT_BADFILE as it isn't really because of a bad file.

Bug: https://curl.haxx.se/mail/lib-2017-09/0002.html