### PR TITLE
http-proxy: treat all 2xx as CONNECT success

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -567,7 +567,7 @@ static CURLcode CONNECT(struct connectdata *conn,
       if(error)
         return CURLE_RECV_ERROR;
 
-      if(data->info.httpproxycode != 200) {
+      if(data->info.httpproxycode/100 != 2) {
         /* Deal with the possibly already received authenticate
            headers. 'newurl' is set to a new URL if we must loop. */
         result = Curl_http_auth_act(conn);
@@ -598,7 +598,7 @@ static CURLcode CONNECT(struct connectdata *conn,
 
   } while(data->req.newurl);
 
-  if(200 != data->req.httpcode) {
+  if(data->info.httpproxycode/100 != 2) {
     if(closeConnection && data->req.newurl) {
       conn->bits.proxy_connect_closed = TRUE;
       infof(data, "Connect me again please\n");

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -173,7 +173,7 @@ test1700 test1701 test1702 \
 \
 test1800 test1801 \
 \
-test1900 test1901 test1902 test1903 \
+test1900 test1901 test1902 test1903 test1904 \
 \
 test2000 test2001 test2002 test2003 test2004 test2005 test2006 test2007 \
 test2008 test2009 test2010 test2011 test2012 test2013 test2014 test2015 \

--- a/tests/data/test1904
+++ b/tests/data/test1904
@@ -1,0 +1,79 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP CONNECT
+HTTP proxy
+proxytunnel
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data>
+<connect>
+HTTP/1.1 204 Sure go ahead
+
+</connect>
+<datacheck>
+HTTP/1.1 204 Sure go ahead
+
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+http-proxy
+</server>
+ <name>
+HTTP CONNECT with 204 response
+ </name>
+ <command>
+http://test.1904:%HTTPPORT/we/want/that/page/1904 -p --proxy %HOSTIP:%PROXYPORT
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<proxy>
+CONNECT test.1904:%HTTPPORT HTTP/1.1
+Host: test.1904:%HTTPPORT
+User-Agent: curl/7.10.7-pre2 (i686-pc-linux-gnu) libcurl/7.10.7-pre2 OpenSSL/0.9.7a zlib/1.1.3
+Proxy-Connection: Keep-Alive
+
+</proxy>
+<protocol>
+GET /we/want/that/page/1904 HTTP/1.1
+Host: test.1904:%HTTPPORT
+User-Agent: curl/7.10.7-pre2 (i686-pc-linux-gnu) libcurl/7.10.7-pre2 OpenSSL/0.9.7a zlib/1.1.3
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Reported-by: Lawrence Wagerfield
Fixes #1859