### PR TITLE
configure: remove --enable-soname-bump and SONAME_BUMP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3257,8 +3257,6 @@ AC_CHECK_SIZEOF(curl_off_t, unused , [
 ])
 CPPFLAGS=$o
 
-soname_bump=no
-
 AC_CHECK_TYPE(long long,
    [AC_DEFINE(HAVE_LONGLONG, 1,
       [Define to 1 if the compiler supports the 'long long' data type.])]
@@ -3736,26 +3734,6 @@ dnl hiding of library internal symbols
 dnl
 CURL_CONFIGURE_SYMBOL_HIDING
 
-dnl ************************************************************
-dnl enforce SONAME bump
-dnl
-
-AC_MSG_CHECKING([whether to enforce SONAME bump])
-AC_ARG_ENABLE(soname-bump,
-AC_HELP_STRING([--enable-soname-bump],[Enable enforced SONAME bump])
-AC_HELP_STRING([--disable-soname-bump],[Disable enforced SONAME bump]),
-[ case "$enableval" in
-  yes)   AC_MSG_RESULT(yes)
-         soname_bump=yes
-         ;;
-  *)
-         AC_MSG_RESULT(no)
-         ;;
-  esac ],
-        AC_MSG_RESULT($soname_bump)
-)
-AM_CONDITIONAL(SONAME_BUMP, test x$soname_bump = xyes)
-
 dnl
 dnl All the library dependencies put into $LIB apply to libcurl only.
 dnl
@@ -4039,14 +4017,3 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   HTTP2 support:    ${curl_h2_msg}
   Protocols:        ${SUPPORT_PROTOCOLS}
 ])
-
-if test "x$soname_bump" = "xyes"; then
-
-cat <<EOM
-  SONAME bump:     yes - WARNING: this library will be built with the SONAME
-                   number bumped due to (a detected) ABI breakage.
-                   See lib/README.curl_off_t for details on this.
-EOM
-
-fi
-

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -66,21 +66,7 @@ endif
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
-if SONAME_BUMP
-#
-# Bumping of SONAME conditionally may seem like a weird thing to do, and yeah
-# it is. The problem is that we try to avoid the bump as hard as possible, but
-# yet it is still necessary for a few rare situations. The configure script will
-# attempt to figure out these situations, and it can be forced to consider this
-# to be such a case! See README.curl_off_t for further details.
-#
-# This conditional soname bump SHOULD be removed at next "proper" bump.
-#
-VERSIONINFO=-version-info 10:0:5
-else
 VERSIONINFO=-version-info 9:0:5
-endif
-
 # This flag accepts an argument of the form current[:revision[:age]]. So,
 # passing -version-info 3:12:1 sets current to 3, revision to 12, and age to
 # 1.


### PR DESCRIPTION
Back in 2008, (and commit 3f3d6ebe665f3) we changed the logic in how we
determine the native type for `curl_off_t`. To really make sure we
didn't break ABI without bumping SONAME, we introduced logic that
attempted to detect that it would use a different size and thus not be
compatible. We also provided a manual switch that allowed users to tell
configure to bump SONAME by force.

Today, we know of no one who ever got a SONAME bump auto-detected and we
don't know of anyone who's using the manual bump feature. The auto-
detection is also no longer working since we introduced defining
curl_off_t in system.h (7.55.0).

Finally, this bumping logic is not present in the cmake build.