### PR TITLE
http-proxy: when not doing CONNECT, that phase is done immediately

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -137,7 +137,7 @@ CURLcode Curl_proxy_connect(struct connectdata *conn, int sockindex)
 
 bool Curl_connect_complete(struct connectdata *conn)
 {
-  return conn->connect_state &&
+  return !conn->connect_state ||
     (conn->connect_state->tunnel_state == TUNNEL_COMPLETE);
 }
 


### PR DESCRIPTION
`conn->connect_state` is NULL when doing a regular non-CONNECT request
over the proxy and should therefor be considered complete at once.

Fixes #1853
Reported-by: Lawrence Wagerfield