### PR TITLE
mime cleanups

### DIFF
--- a/docs/libcurl/curl_mime_addpart.3
+++ b/docs/libcurl/curl_mime_addpart.3
@@ -40,8 +40,8 @@ As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 A mime part structure handle, or NULL upon failure.
 .SH EXAMPLE
 .nf
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* create a mime handle */
  mime = curl_mime_init(easy);

--- a/docs/libcurl/curl_mime_data.3
+++ b/docs/libcurl/curl_mime_data.3
@@ -50,8 +50,8 @@ As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 CURLE_OK or a CURL error code upon failure.
 .SH EXAMPLE
 .nf
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* create a mime handle */
  mime = curl_mime_init(easy);

--- a/docs/libcurl/curl_mime_filedata.3
+++ b/docs/libcurl/curl_mime_filedata.3
@@ -55,8 +55,8 @@ As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 CURLE_OK or a CURL error code upon failure.
 .SH EXAMPLE
 .nf
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* create a mime handle */
  mime = curl_mime_init(easy);

--- a/docs/libcurl/curl_mime_filename.3
+++ b/docs/libcurl/curl_mime_filename.3
@@ -48,8 +48,8 @@ As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 CURLE_OK or a CURL error code upon failure.
 .SH EXAMPLE
 .nf
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* create a mime handle */
  mime = curl_mime_init(easy);

--- a/docs/libcurl/curl_mime_init.3
+++ b/docs/libcurl/curl_mime_init.3
@@ -45,8 +45,8 @@ A mime struct handle, or NULL upon failure.
 .nf
 
  CURL *easy = curl_easy_init();
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* Build an HTTP form with a single field named "data", */
  mime = curl_mime_init(easy);

--- a/docs/libcurl/curl_mime_name.3
+++ b/docs/libcurl/curl_mime_name.3
@@ -50,8 +50,8 @@ As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 CURLE_OK or a CURL error code upon failure.
 .SH EXAMPLE
 .nf
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* create a mime handle */
  mime = curl_mime_init(easy);

--- a/docs/libcurl/curl_mime_type.3
+++ b/docs/libcurl/curl_mime_type.3
@@ -59,8 +59,8 @@ As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 CURLE_OK or a CURL error code upon failure.
 .SH EXAMPLE
 .nf
- struct curl_mime *mime;
- struct mimepart *part;
+ curl_mime *mime;
+ curl_mimepart *part;
 
  /* create a mime handle */
  mime = curl_mime_init(easy);

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1970,8 +1970,8 @@ CURL_EXTERN int curl_strequal(const char *s1, const char *s2);
 CURL_EXTERN int curl_strnequal(const char *s1, const char *s2, size_t n);
 
 /* Mime/form handling support. */
-typedef struct Curl_mime        curl_mime;      /* Mime context. */
-typedef struct Curl_mimepart    curl_mimepart;  /* Mime part context. */
+typedef struct curl_mime_s      curl_mime;      /* Mime context. */
+typedef struct curl_mimepart_s  curl_mimepart;  /* Mime part context. */
 
 /*
  * NAME curl_mime_init()
@@ -2038,7 +2038,7 @@ CURL_EXTERN CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype);
  *
  * Set mime data transfer encoder.
  */
-CURL_EXTERN CURLcode curl_mime_encoder(struct Curl_mimepart *part,
+CURL_EXTERN CURLcode curl_mime_encoder(curl_mimepart *part,
                                        const char *encoding);
 
 /*

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -752,7 +752,7 @@ int curl_formget(struct curl_httppost *form, void *arg,
                  curl_formget_callback append)
 {
   CURLcode result;
-  struct Curl_mimepart toppart;
+  curl_mimepart toppart;
 
   Curl_mime_initpart(&toppart, NULL); /* default form is empty */
   result = Curl_getformdata(NULL, &toppart, form, NULL);
@@ -825,14 +825,14 @@ void curl_formfree(struct curl_httppost *form)
  */
 
 CURLcode Curl_getformdata(struct Curl_easy *data,
-                          struct Curl_mimepart *finalform,
+                          curl_mimepart *finalform,
                           struct curl_httppost *post,
                           curl_read_callback fread_func)
 {
   CURLcode result = CURLE_OK;
-  struct Curl_mime *form = NULL;
-  struct Curl_mime *multipart;
-  struct Curl_mimepart *part;
+  curl_mime *form = NULL;
+  curl_mime *multipart;
+  curl_mimepart *part;
   struct curl_httppost *file;
 
   Curl_mime_cleanpart(finalform); /* default form is empty */

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -44,7 +44,7 @@ typedef struct FormInfo {
 } FormInfo;
 
 CURLcode Curl_getformdata(struct Curl_easy *data,
-                          struct Curl_mimepart *,
+                          curl_mimepart *,
                           struct curl_httppost *post,
                           curl_read_callback fread_func);
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -130,7 +130,7 @@ CURLcode Curl_http_perhapsrewind(struct connectdata *conn);
  * HTTP unique setup
  ***************************************************************************/
 struct HTTP {
-  struct Curl_mimepart *sendit;
+  curl_mimepart *sendit;
   curl_off_t postsize; /* off_t to handle large file sizes */
   const char *postdata;
 
@@ -140,7 +140,7 @@ struct HTTP {
   curl_off_t writebytecount;
 
   /* For FORM posting */
-  struct Curl_mimepart form;
+  curl_mimepart form;
 
   struct back {
     curl_read_callback fread_func; /* backup storage for fread pointer */

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -283,7 +283,7 @@ static char *strippath(const char *fullfile)
 static size_t mime_mem_read(char *buffer, size_t size, size_t nitems,
                             void *instream)
 {
-  struct Curl_mimepart *part = (struct Curl_mimepart *) instream;
+  curl_mimepart *part = (curl_mimepart *) instream;
   size_t sz = (size_t) part->datasize - part->state.offset;
 
   (void) size;   /* Always 1.*/
@@ -300,7 +300,7 @@ static size_t mime_mem_read(char *buffer, size_t size, size_t nitems,
 
 static int mime_mem_seek(void *instream, curl_off_t offset, int whence)
 {
-  struct Curl_mimepart *part = (struct Curl_mimepart *) instream;
+  curl_mimepart *part = (curl_mimepart *) instream;
 
   switch(whence) {
   case SEEK_CUR:
@@ -320,7 +320,7 @@ static int mime_mem_seek(void *instream, curl_off_t offset, int whence)
 
 static void mime_mem_free(void *ptr)
 {
-  Curl_safefree(((struct Curl_mimepart *) ptr)->data);
+  Curl_safefree(((curl_mimepart *) ptr)->data);
 }
 
 
@@ -343,7 +343,7 @@ static int mime_file_seek(void *instream, curl_off_t offset, int whence)
 
 /* Named file callbacks. */
 /* Argument is a pointer to the mime part. */
-static int mime_open_namedfile(struct Curl_mimepart * part)
+static int mime_open_namedfile(curl_mimepart * part)
 {
   /* Open a MIMEKIND_NAMEDFILE part. */
 
@@ -356,7 +356,7 @@ static int mime_open_namedfile(struct Curl_mimepart * part)
 static size_t mime_namedfile_read(char *buffer, size_t size, size_t nitems,
                                   void *instream)
 {
-  struct Curl_mimepart *part = (struct Curl_mimepart *) instream;
+  curl_mimepart *part = (curl_mimepart *) instream;
 
   if(mime_open_namedfile(part))
     return READ_ERROR;
@@ -366,7 +366,7 @@ static size_t mime_namedfile_read(char *buffer, size_t size, size_t nitems,
 
 static int mime_namedfile_seek(void *instream, curl_off_t offset, int whence)
 {
-  struct Curl_mimepart *part = (struct Curl_mimepart *) instream;
+  curl_mimepart *part = (curl_mimepart *) instream;
 
   switch(whence) {
   case SEEK_CUR:
@@ -389,7 +389,7 @@ static int mime_namedfile_seek(void *instream, curl_off_t offset, int whence)
 
 static void mime_namedfile_free(void *ptr)
 {
-  struct Curl_mimepart *part = (struct Curl_mimepart *) ptr;
+  curl_mimepart *part = (curl_mimepart *) ptr;
 
   if(part->namedfp) {
     fclose(part->namedfp);
@@ -436,7 +436,7 @@ static size_t readback_bytes(struct mime_state *state,
 }
 
 /* Readback a mime part. */
-static size_t readback_part(struct Curl_mimepart *part,
+static size_t readback_part(curl_mimepart *part,
                             char *buffer, size_t bufsize)
 {
   size_t cursize = 0;
@@ -540,10 +540,10 @@ static size_t readback_part(struct Curl_mimepart *part,
 static size_t mime_subparts_read(char *buffer, size_t size, size_t nitems,
                                  void *instream)
 {
-  struct Curl_mime *mime = (struct Curl_mime *) instream;
+  curl_mime *mime = (curl_mime *) instream;
   size_t cursize = 0;
   size_t sz;
-  struct Curl_mimepart *part;
+  curl_mimepart *part;
 #ifdef CURL_DOES_CONVERSIONS
   char *convbuf = buffer;
 #endif
@@ -627,7 +627,7 @@ static size_t mime_subparts_read(char *buffer, size_t size, size_t nitems,
   return cursize;
 }
 
-static int mime_part_rewind(struct Curl_mimepart *part)
+static int mime_part_rewind(curl_mimepart *part)
 {
   int res = CURL_SEEKFUNC_OK;
   enum mimestate targetstate = MIMESTATE_BEGIN;
@@ -658,8 +658,8 @@ static int mime_part_rewind(struct Curl_mimepart *part)
 
 static int mime_subparts_seek(void *instream, curl_off_t offset, int whence)
 {
-  struct Curl_mime *mime = (struct Curl_mime *) instream;
-  struct Curl_mimepart *part;
+  curl_mime *mime = (curl_mime *) instream;
+  curl_mimepart *part;
   int result = CURL_SEEKFUNC_OK;
   int res;
 
@@ -683,13 +683,13 @@ static int mime_subparts_seek(void *instream, curl_off_t offset, int whence)
 
 static void mime_subparts_free(void *ptr)
 {
-  struct Curl_mime *mime = (struct Curl_mime *) ptr;
+  curl_mime *mime = (curl_mime *) ptr;
   curl_mime_free(mime);
 }
 
 
 /* Release part content. */
-static void cleanup_part_content(struct Curl_mimepart *part)
+static void cleanup_part_content(curl_mimepart *part)
 {
   if(part->freefunc)
     part->freefunc(part->arg);
@@ -705,7 +705,7 @@ static void cleanup_part_content(struct Curl_mimepart *part)
   part->kind = MIMEKIND_NONE;
 }
 
-void Curl_mime_cleanpart(struct Curl_mimepart *part)
+void Curl_mime_cleanpart(curl_mimepart *part)
 {
   cleanup_part_content(part);
   curl_slist_free_all(part->curlheaders);
@@ -718,9 +718,9 @@ void Curl_mime_cleanpart(struct Curl_mimepart *part)
 }
 
 /* Recursively delete a mime handle and its parts. */
-void curl_mime_free(struct Curl_mime *mime)
+void curl_mime_free(curl_mime *mime)
 {
-  struct Curl_mimepart *part;
+  curl_mimepart *part;
 
   if(mime) {
     while(mime->firstpart) {
@@ -740,11 +740,11 @@ void curl_mime_free(struct Curl_mime *mime)
  */
 
 /* Create a mime handle. */
-struct Curl_mime *curl_mime_init(struct Curl_easy *easy)
+curl_mime *curl_mime_init(struct Curl_easy *easy)
 {
-  struct Curl_mime *mime;
+  curl_mime *mime;
 
-  mime = (struct Curl_mime *) malloc(sizeof *mime);
+  mime = (curl_mime *) malloc(sizeof *mime);
 
   if(mime) {
     mime->easy = easy;
@@ -769,7 +769,7 @@ struct Curl_mime *curl_mime_init(struct Curl_easy *easy)
 }
 
 /* Initialize a mime part. */
-void Curl_mime_initpart(struct Curl_mimepart *part, struct Curl_easy *easy)
+void Curl_mime_initpart(curl_mimepart *part, struct Curl_easy *easy)
 {
   memset((char *) part, 0, sizeof *part);
   part->easy = easy;
@@ -777,14 +777,14 @@ void Curl_mime_initpart(struct Curl_mimepart *part, struct Curl_easy *easy)
 }
 
 /* Create a mime part and append it to a mime handle's part list. */
-struct Curl_mimepart *curl_mime_addpart(struct Curl_mime *mime)
+curl_mimepart *curl_mime_addpart(curl_mime *mime)
 {
-  struct Curl_mimepart *part;
+  curl_mimepart *part;
 
   if(!mime)
     return NULL;
 
-  part = (struct Curl_mimepart *) malloc(sizeof *part);
+  part = (curl_mimepart *) malloc(sizeof *part);
 
   if(part) {
     Curl_mime_initpart(part, mime->easy);
@@ -802,7 +802,7 @@ struct Curl_mimepart *curl_mime_addpart(struct Curl_mime *mime)
 }
 
 /* Set mime part name. */
-CURLcode curl_mime_name(struct Curl_mimepart *part,
+CURLcode curl_mime_name(curl_mimepart *part,
                         const char *name, size_t namesize)
 {
   if(!part)
@@ -828,7 +828,7 @@ CURLcode curl_mime_name(struct Curl_mimepart *part,
 }
 
 /* Set mime part remote file name. */
-CURLcode curl_mime_filename(struct Curl_mimepart *part, const char *filename)
+CURLcode curl_mime_filename(curl_mimepart *part, const char *filename)
 {
   if(!part)
     return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -846,7 +846,7 @@ CURLcode curl_mime_filename(struct Curl_mimepart *part, const char *filename)
 }
 
 /* Set mime part content from memory data. */
-CURLcode curl_mime_data(struct Curl_mimepart *part,
+CURLcode curl_mime_data(curl_mimepart *part,
                         const char *data, size_t datasize)
 {
   if(!part)
@@ -879,7 +879,7 @@ CURLcode curl_mime_data(struct Curl_mimepart *part,
 }
 
 /* Set mime part content from opened file. */
-CURLcode Curl_mime_file(struct Curl_mimepart *part,
+CURLcode Curl_mime_file(curl_mimepart *part,
                         FILE *fp, int closewhendone)
 {
   if(!part || !fp)
@@ -910,7 +910,7 @@ CURLcode Curl_mime_file(struct Curl_mimepart *part,
 }
 
 /* Set mime part content from named local file. */
-CURLcode curl_mime_filedata(struct Curl_mimepart *part, const char *filename)
+CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
 {
   CURLcode result = CURLE_OK;
   struct_stat sbuf;
@@ -956,7 +956,7 @@ CURLcode curl_mime_filedata(struct Curl_mimepart *part, const char *filename)
 }
 
 /* Set mime part type. */
-CURLcode curl_mime_type(struct Curl_mimepart *part, const char *mimetype)
+CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype)
 {
   if(!part)
     return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -974,7 +974,7 @@ CURLcode curl_mime_type(struct Curl_mimepart *part, const char *mimetype)
 }
 
 /* Set mime data transfer encoder. */
-CURLcode curl_mime_encoder(struct Curl_mimepart *part, const char *encoding)
+CURLcode curl_mime_encoder(curl_mimepart *part, const char *encoding)
 {
   CURLcode result = CURLE_OK;
 
@@ -990,7 +990,7 @@ CURLcode curl_mime_encoder(struct Curl_mimepart *part, const char *encoding)
 }
 
 /* Set mime part headers. */
-CURLcode curl_mime_headers(struct Curl_mimepart *part,
+CURLcode curl_mime_headers(curl_mimepart *part,
                            struct curl_slist *headers, int take_ownership)
 {
   if(!part)
@@ -1007,7 +1007,7 @@ CURLcode curl_mime_headers(struct Curl_mimepart *part,
 }
 
 /* Set mime part content from callback. */
-CURLcode curl_mime_data_cb(struct Curl_mimepart *part, curl_off_t datasize,
+CURLcode curl_mime_data_cb(curl_mimepart *part, curl_off_t datasize,
                            curl_read_callback readfunc,
                            curl_seek_callback seekfunc,
                            curl_free_callback freefunc, void *arg)
@@ -1030,8 +1030,8 @@ CURLcode curl_mime_data_cb(struct Curl_mimepart *part, curl_off_t datasize,
 }
 
 /* Set mime part content from subparts. */
-CURLcode curl_mime_subparts(struct Curl_mimepart *part,
-                            struct Curl_mime *subparts)
+CURLcode curl_mime_subparts(curl_mimepart *part,
+                            curl_mime *subparts)
 {
   if(!part)
     return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -1068,14 +1068,14 @@ CURLcode curl_mime_subparts(struct Curl_mimepart *part,
 /* Argument is the dummy top part. */
 size_t Curl_mime_read(char *buffer, size_t size, size_t nitems, void *instream)
 {
-  struct Curl_mimepart *part = (struct Curl_mimepart *) instream;
+  curl_mimepart *part = (curl_mimepart *) instream;
 
   (void) size;   /* Always 1. */
   return readback_part(part, buffer, nitems);
 }
 
 /* Rewind mime stream. */
-CURLcode Curl_mime_rewind(struct Curl_mimepart *part)
+CURLcode Curl_mime_rewind(curl_mimepart *part)
 {
   return mime_part_rewind(part) == CURL_SEEKFUNC_OK?
          CURLE_OK: CURLE_SEND_FAIL_REWIND;
@@ -1095,12 +1095,12 @@ static size_t slist_size(struct curl_slist *s,
 }
 
 /* Get/compute multipart size. */
-static curl_off_t multipart_size(struct Curl_mime *mime)
+static curl_off_t multipart_size(curl_mime *mime)
 {
   curl_off_t size;
   curl_off_t sz;
   size_t boundarysize;
-  struct Curl_mimepart *part;
+  curl_mimepart *part;
 
   if(!mime)
     return 0;           /* Not present -> empty. */
@@ -1122,7 +1122,7 @@ static curl_off_t multipart_size(struct Curl_mime *mime)
 }
 
 /* Get/compute mime size. */
-curl_off_t Curl_mime_size(struct Curl_mimepart *part)
+curl_off_t Curl_mime_size(curl_mimepart *part)
 {
   curl_off_t size;
 
@@ -1211,12 +1211,12 @@ static const char *ContentTypeForFilename(const char *filename)
   return NULL;
 }
 
-CURLcode Curl_mime_prepare_headers(struct Curl_mimepart *part,
+CURLcode Curl_mime_prepare_headers(curl_mimepart *part,
                                    const char *contenttype,
                                    const char *disposition,
                                    enum mimestrategy strategy)
 {
-  struct Curl_mime *mime = NULL;
+  curl_mime *mime = NULL;
   const char *boundary = NULL;
   char *s;
   CURLcode ret = CURLE_OK;
@@ -1259,7 +1259,7 @@ CURLcode Curl_mime_prepare_headers(struct Curl_mimepart *part,
   }
 
   if(part->kind == MIMEKIND_MULTIPART) {
-    mime = (struct Curl_mime *) part->arg;
+    mime = (curl_mime *) part->arg;
     if(mime)
       boundary = mime->boundary;
   }
@@ -1331,7 +1331,7 @@ CURLcode Curl_mime_prepare_headers(struct Curl_mimepart *part,
 
   /* Process subparts. */
   if(part->kind == MIMEKIND_MULTIPART && mime) {
-    struct Curl_mimepart *subpart;
+    curl_mimepart *subpart;
 
     disposition = NULL;
     if(strcasecompare(contenttype, "multipart/form-data"))
@@ -1388,7 +1388,7 @@ CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype)
   return CURLE_NOT_BUILT_IN;
 }
 
-CURLcode curl_mime_encoder(struct Curl_mimepart *part, const char *encoding)
+CURLcode curl_mime_encoder(curl_mimepart *part, const char *encoding)
 {
   (void) part;
   (void) encoding;
@@ -1451,18 +1451,18 @@ CURLcode curl_mime_headers(curl_mimepart *part,
   return CURLE_NOT_BUILT_IN;
 }
 
-void Curl_mime_initpart(struct Curl_mimepart *part, struct Curl_easy *easy)
+void Curl_mime_initpart(curl_mimepart *part, struct Curl_easy *easy)
 {
   (void) part;
   (void) data;
 }
 
-void Curl_mime_cleanpart(struct Curl_mimepart *part)
+void Curl_mime_cleanpart(curl_mimepart *part)
 {
   (void) part;
 }
 
-CURLcode Curl_mime_prepare_headers(struct Curl_mimepart *part,
+CURLcode Curl_mime_prepare_headers(curl_mimepart *part,
                                    const char *contenttype,
                                    const char *disposition,
                                    enum mimestrategy strategy)
@@ -1474,7 +1474,7 @@ CURLcode Curl_mime_prepare_headers(struct Curl_mimepart *part,
   return CURLE_NOT_BUILT_IN;
 }
 
-curl_off_t Curl_mime_size(struct Curl_mimepart *part)
+curl_off_t Curl_mime_size(curl_mimepart *part)
 {
   (void) part;
   return (curl_off_t) -1;
@@ -1489,7 +1489,7 @@ size_t Curl_mime_read(char *buffer, size_t size, size_t nitems, void *instream)
   return 0;
 }
 
-CURLcode Curl_mime_rewind(struct Curl_mimepart *part)
+CURLcode Curl_mime_rewind(curl_mimepart *part)
 {
   (void) part;
   return CURLE_NOT_BUILT_IN;

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -63,56 +63,56 @@ enum mimestrategy {
 /* Mime readback state. */
 struct mime_state {
   enum mimestate state;       /* Current state token. */
-  void *         ptr;         /* State-dependent pointer. */
-  size_t         offset;      /* State-dependent offset. */
+  void *ptr;                  /* State-dependent pointer. */
+  size_t offset;              /* State-dependent offset. */
 };
 
 /* A mime context. */
-struct Curl_mime {
-  struct Curl_easy *     easy;         /* The associated easy handle. */
-  struct Curl_mimepart * parent;       /* Parent part. */
-  struct Curl_mimepart * firstpart;    /* First part. */
-  struct Curl_mimepart * lastpart;     /* Last part. */
-  char *                 boundary;     /* The part boundary. */
-  struct mime_state      state;        /* Current readback state. */
+struct curl_mime_s {
+  struct Curl_easy *easy;          /* The associated easy handle. */
+  curl_mimepart *parent;           /* Parent part. */
+  curl_mimepart *firstpart;        /* First part. */
+  curl_mimepart *lastpart;         /* Last part. */
+  char *boundary;                  /* The part boundary. */
+  struct mime_state state;         /* Current readback state. */
 };
 
 /* A mime part. */
-struct Curl_mimepart {
-  struct Curl_easy *     easy;         /* The associated easy handle. */
-  struct Curl_mime *     parent;       /* Parent mime structure. */
-  struct Curl_mimepart * nextpart;     /* Forward linked list. */
-  enum mimekind          kind;         /* The part kind. */
-  char *                 data;         /* Memory data or file name. */
-  curl_read_callback     readfunc;     /* Read function. */
-  curl_seek_callback     seekfunc;     /* Seek function. */
-  curl_free_callback     freefunc;     /* Argument free function. */
-  void *                 arg;          /* Argument to callback functions. */
-  FILE *                 namedfp;      /* Named file pointer. */
-  struct curl_slist *    curlheaders;  /* Part headers. */
-  struct curl_slist *    userheaders;  /* Part headers. */
-  char *                 mimetype;     /* Part mime type. */
-  char *                 filename;     /* Remote file name. */
-  char *                 name;         /* Data name. */
-  size_t                 namesize;     /* Data name size. */
-  curl_off_t             origin;       /* Origin file offset. */
-  curl_off_t             datasize;     /* Expected data size. */
-  unsigned int           flags;        /* Flags. */
-  struct mime_state      state;        /* Current readback state. */
+struct curl_mimepart_s {
+  struct Curl_easy *easy;          /* The associated easy handle. */
+  curl_mime *parent;               /* Parent mime structure. */
+  curl_mimepart *nextpart;         /* Forward linked list. */
+  enum mimekind kind;              /* The part kind. */
+  char *data;                      /* Memory data or file name. */
+  curl_read_callback readfunc;     /* Read function. */
+  curl_seek_callback seekfunc;     /* Seek function. */
+  curl_free_callback freefunc;     /* Argument free function. */
+  void *arg;                       /* Argument to callback functions. */
+  FILE *namedfp;                   /* Named file pointer. */
+  struct curl_slist *curlheaders;  /* Part headers. */
+  struct curl_slist *userheaders;  /* Part headers. */
+  char *mimetype;                  /* Part mime type. */
+  char *filename;                  /* Remote file name. */
+  char *name;                      /* Data name. */
+  size_t namesize;                 /* Data name size. */
+  curl_off_t origin;               /* Origin file offset. */
+  curl_off_t datasize;             /* Expected data size. */
+  unsigned int flags;              /* Flags. */
+  struct mime_state state;         /* Current readback state. */
 };
 
 
 /* Prototypes. */
-void Curl_mime_initpart(struct Curl_mimepart *part, struct Curl_easy *easy);
-void Curl_mime_cleanpart(struct Curl_mimepart *part);
-CURLcode Curl_mime_prepare_headers(struct Curl_mimepart *part,
+void Curl_mime_initpart(curl_mimepart *part, struct Curl_easy *easy);
+void Curl_mime_cleanpart(curl_mimepart *part);
+CURLcode Curl_mime_prepare_headers(curl_mimepart *part,
                                    const char *contenttype,
                                    const char *disposition,
                                    enum mimestrategy strategy);
-curl_off_t Curl_mime_size(struct Curl_mimepart *part);
+curl_off_t Curl_mime_size(curl_mimepart *part);
 size_t Curl_mime_read(char *buffer, size_t size, size_t nitems,
                       void *instream);
-CURLcode Curl_mime_rewind(struct Curl_mimepart *part);
+CURLcode Curl_mime_rewind(curl_mimepart *part);
 CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...);
 CURLcode Curl_mime_file(curl_mimepart *part, FILE *fp, int closewhendone);
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -242,7 +242,7 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, int bytes, int *nreadp)
 CURLcode Curl_readrewind(struct connectdata *conn)
 {
   struct Curl_easy *data = conn->data;
-  struct Curl_mimepart *mimepart = &data->set.mimepost;
+  curl_mimepart *mimepart = &data->set.mimepost;
 
   conn->bits.rewindaftersend = FALSE; /* we rewind now */
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1560,7 +1560,7 @@ struct UserDefined {
   struct curl_slist *headers; /* linked list of extra headers */
   struct curl_slist *proxyheaders; /* linked list of extra CONNECT headers */
   struct curl_httppost *httppost;  /* linked list of old POST data */
-  struct Curl_mimepart mimepost;  /* MIME/POST data. */
+  curl_mimepart mimepost;  /* MIME/POST data. */
   bool sep_headers;     /* handle host and proxy headers separately */
   bool cookiesession;   /* new cookie session? */
   bool crlf;            /* convert crlf on ftp upload(?) */

--- a/tests/data/test1135
+++ b/tests/data/test1135
@@ -36,7 +36,7 @@ CURL_EXTERN curl_mimepart *curl_mime_addpart(curl_mime *mime);
 CURL_EXTERN CURLcode curl_mime_name(curl_mimepart *part,
 CURL_EXTERN CURLcode curl_mime_filename(curl_mimepart *part,
 CURL_EXTERN CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype);
-CURL_EXTERN CURLcode curl_mime_encoder(struct Curl_mimepart *part,
+CURL_EXTERN CURLcode curl_mime_encoder(curl_mimepart *part,
 CURL_EXTERN CURLcode curl_mime_data(curl_mimepart *part,
 CURL_EXTERN CURLcode curl_mime_filedata(curl_mimepart *part,
 CURL_EXTERN CURLcode curl_mime_data_cb(curl_mimepart *part,


### PR DESCRIPTION
I noticed a variable type mistake in the curl_mime*.3 examples I just added, and then I noticed the `Curl_` symbol we added to `curl.h`. We should try to stick to `curl_` for public symbols so I modified the struct to instead use a `_s` suffix and then I made sure we use the typedef'ed version everwhere instead of mixing.

Finally I edited `mime.h` somewhat to keep the variables together with the asterisk like `*name` and not `*  name`, as that's how existing code already does it.

/cc @monnerat 