### PR TITLE
configure: fix curl_off_t check's include order

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3253,7 +3253,7 @@ AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(off_t)
 
 o=$CPPFLAGS
-CPPFLAGS="$CPPFLAGS -I$srcdir/include"
+CPPFLAGS="-I$srcdir/include $CPPFLAGS"
 AC_CHECK_SIZEOF(curl_off_t, unused , [
 #include <curl/system.h>
 ])


### PR DESCRIPTION
- Prepend srcdir include path instead of append.

Prior to this change it was possible that during the check for the size
of curl_off_t the include path of a user's already installed curl could
come before the include path of the to-be-built curl, resulting in the
system.h of the former being incorrectly included for that check.

Closes https://github.com/curl/curl/pull/1870

---

This is a problem I had in original mingw, this is how I'm building:
~~~
make distclean
./buildconf
CFLAGS=-DNGHTTP2_STATICLIB \
CPPFLAGS=-DMEMDEBUG_LOG_SYNC \
LDFLAGS=-static \
PKG_CONFIG="pkg-config --static" \
./configure \
  --disable-shared \
  --disable-threaded-resolver \
  --enable-static \
  --enable-debug \
  --enable-sspi \
  --prefix=c:/mingw/msys/1.0/local \
  --with-ssl=c:/mingw/msys/1.0/local \
  --with-nghttp2=c:/mingw/msys/1.0/local \
  >config.out 2>&1
make V=1 curl_LDFLAGS=-all-static >make.out 2>&1
~~~
That configure results in this test for sizeof curl_off_t, where -I./Include is last in CPPFLAGS:
~~~
gcc -o conftest.exe -DNGHTTP2_STATICLIB -Werror-implicit-function-declaration -g -O0 -pedantic -Wall -W -Wpointer-arith -Wwrite-strings -Wunused -Wshadow -Winline -Wnested-externs -Wmissing-declarations -Wmissing-prototypes -Wno-long-long -Wfloat-equal -Wno-multichar -Wsign-compare -Wundef -Wno-format-nonliteral -Wendif-labels -Wstrict-prototypes -Wdeclaration-after-statement -Wstrict-aliasing=3 -Wcast-align -Wtype-limits -Wold-style-declaration -Wmissing-parameter-type -Wempty-body -Wclobbered -Wignored-qualifiers -Wconversion -Wno-sign-conversion -Wvla -Wno-pedantic-ms-format -Wdouble-promotion -Wno-system-headers -DDEBUGBUILD -DCURLDEBUG -DMEMDEBUG_LOG_SYNC -Ic:/mingw/msys/1.0/local/include -Ic:/mingw/msys/1.0/local/include -Ic:/mingw/msys/1.0/local/include -I./include -static -Lc:/mingw/msys/1.0/local/lib -Lc:/mingw/msys/1.0/local/lib -Lc:/mingw/msys/1.0/local/lib conftest.c -lnghttp2 -lssl -lcrypto -lssl -lws2_32 -lgdi32 -lcrypt32 -lcrypto -lws2_32 -lgdi32 -lcrypt32 -lgdi32 -lwldap32 -lz -lws2_32
~~~
Because -Ic:/mingw/msys/1.0/local/include comes before -I./Include an older curl/system.h that is already installed comes first, screwing up the conftest.
