### PR TITLE
Fix HTTPS proxy regressions caused by the MultiSSL patches

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3366,10 +3366,12 @@ static bool Curl_ossl_data_pending(const struct connectdata *conn,
                                    int connindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
+  const struct ssl_connect_data *proxyssl = &conn->proxy_ssl[connindex];
   if(BACKEND->handle)
     /* SSL is in use */
     return (0 != SSL_pending(BACKEND->handle) ||
-           (BACKEND->handle && 0 != SSL_pending(BACKEND->handle))) ?
+           (proxyssl->backend->handle &&
+            0 != SSL_pending(proxyssl->backend->handle))) ?
            TRUE : FALSE;
   return FALSE;
 }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2457,10 +2457,10 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     BIO *const bio = BIO_new(BIO_f_ssl());
     SSL *handle = conn->proxy_ssl[sockindex].backend->handle;
     DEBUGASSERT(ssl_connection_complete == conn->proxy_ssl[sockindex].state);
-    DEBUGASSERT(BACKEND->handle != NULL);
+    DEBUGASSERT(handle != NULL);
     DEBUGASSERT(bio != NULL);
     BIO_set_ssl(bio, handle, FALSE);
-    SSL_set_bio(handle, bio, bio);
+    SSL_set_bio(BACKEND->handle, bio, bio);
   }
   else if(!SSL_set_fd(BACKEND->handle, (int)sockfd)) {
     /* pass the raw socket into the SSL layers */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -206,10 +206,20 @@ ssl_connect_init_proxy(struct connectdata *conn, int sockindex)
   DEBUGASSERT(conn->bits.proxy_ssl_connected[sockindex]);
   if(ssl_connection_complete == conn->ssl[sockindex].state &&
      !conn->proxy_ssl[sockindex].use) {
+    struct ssl_backend_data *pbdata;
+
     if(!Curl_ssl->support_https_proxy)
       return CURLE_NOT_BUILT_IN;
+
+    /* The pointers to the ssl backend data, which is opaque here, are swapped
+       rather than move the contents. */
+    pbdata = conn->proxy_ssl[sockindex].backend;
     conn->proxy_ssl[sockindex] = conn->ssl[sockindex];
+
     memset(&conn->ssl[sockindex], 0, sizeof(conn->ssl[sockindex]));
+    memset(pbdata, 0, Curl_ssl->sizeof_ssl_backend_data);
+
+    conn->ssl[sockindex].backend = pbdata;
   }
   return CURLE_OK;
 }


### PR DESCRIPTION
As reported in https://github.com/curl/curl/issues/1855, HTTPS proxy support was broken by my patches in #1601.

@jay kindly investigated, diagnosed correctly an issue in my design where a pointer would be reset incorrectly by a `memset(..., 0, ...)` call and provided the diff of the first commit of this Pull Request.

It took me a while to figure out how to test cURL with HTTP proxies, as the command line provided in the ticket did not work for me. I had to use this command line instead:

```sh
./src/curl -v --proxy-insecure --proxy https:https://127.0.0.1:443 https://www.google.com
```

(note the "repeated" `https:`, but it seems that this has been somehow fixed in `master` since I started investigating), after I enabled `proxy_connect` in my local Apache installation, turned `ProxyRequests on` and allowed access from localhost via `Require ip 127.0.0.1` in a new `<Proxy *>` section.

Turns out that my manual fixups of the largely mechanical conversion from `connssl->` to `BACKEND->` in preparation for encapsulating the SSL backends' private data out of `struct ssl_connect_data` were not quite right.

In particular, [these](https://github.com/curl/curl/commit/d65e6cc4fc9f68da4cbf8788c27714622ef9eead#diff-7dafef8d70eee3940c9184e4e4e93448L2276) two [replacements](https://github.com/curl/curl/commit/d65e6cc4fc9f68da4cbf8788c27714622ef9eead#diff-7dafef8d70eee3940c9184e4e4e93448L2279) were incorrect, inserting `BACKEND->` into the wrong line.

Clearly a late-night snafu, so I decided to revisit the entire commit, turning up another, similar problem in `Curl_ossl_data_pending()`.

I also ran into a problem in that commit's changes to `lib/vtls/polarssl.c` where `conn` was replaced with `BACKEND` by mistake, but @bagder already fixed that in https://github.com/curl/curl/commit/5734f73f0d5d13f7b66de7e323da5ca9e7bb2b06 (along with another bug that I did not catch, where I must have mistyped `ssl[sockindex]` as `sock[sockindex]` while trying to avoid copy/paste).

Of course I *hope* that there are no other bugs lurking in that commit, I really tried my best to spot issues. At least with this PR, three problems get addressed.