### PR TITLE
configure: check for C++ compiler after C, to make it non-fatal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,6 @@ CURL_CHECK_OPTION_RT
 
 XC_CHECK_PATH_SEPARATOR
 AX_CODE_COVERAGE
-AC_PROG_CXX
 
 #
 # save the configure arguments
@@ -125,6 +124,7 @@ AC_SUBST(libext)
 dnl figure out the libcurl version
 CURLVERSION=`$SED -ne 's/^#define LIBCURL_VERSION "\(.*\)".*/\1/p' ${srcdir}/include/curl/curlver.h`
 XC_CHECK_PROG_CC
+AC_PROG_CXX
 XC_AUTOMAKE
 AC_MSG_CHECKING([curl version])
 AC_MSG_RESULT($CURLVERSION)


### PR DESCRIPTION
The tests for object file/executable file extensions are presumably only
done for the first of these macros in the configure file.

Bug: https://github.com/curl/curl/pull/1851#issuecomment-327597515
Reported-by: Marcel Raad