### PR TITLE
configure: main language is C

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,12 +124,16 @@ AC_SUBST(libext)
 dnl figure out the libcurl version
 CURLVERSION=`$SED -ne 's/^#define LIBCURL_VERSION "\(.*\)".*/\1/p' ${srcdir}/include/curl/curlver.h`
 XC_CHECK_PROG_CC
-AC_PROG_CXX
 XC_AUTOMAKE
 AC_MSG_CHECKING([curl version])
 AC_MSG_RESULT($CURLVERSION)
 
 AC_SUBST(CURLVERSION)
+
+dnl
+dnl Signal that this program uses C and C++
+AC_PROG_CC
+AC_PROG_CXX
 
 dnl
 dnl we extract the numerical version for curl-config only


### PR DESCRIPTION
Try putting AC_PROG_CC before AC_PROG_CXX to signal to automake that C is our primary language and C++ is not.

---

I tested this in Docker by using gcc:4.9 on a clean codebase, deleting all c++ compilers on the system, and compiling libcurl. It looks like I can trivially build most things, but when I try to do "make fuzzer" it complains about a missing C++ compiler as expected. I'm not sure if this will definitely solve the autobuilds problem for good, but it may help.