### PR TITLE
Prevent connection re-use when requesting different port number via http proxy

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3774,7 +3774,9 @@ ConnectionExists(struct Curl_easy *data,
       else {
         /* The requested connection is using the same HTTP proxy in normal
            mode (no tunneling) */
-        match = TRUE;
+        /* TODO(Oli): This is probably the wrong place for this check */
+        if(needle->remote_port == check->remote_port)
+          match = TRUE;
       }
 
       if(match) {


### PR DESCRIPTION
Link to issue: https://github.com/curl/curl/issues/1887

This is not an ideal solution - we should be able to re-use a HTTP proxy connection when requesting URL's with different port numbers. I'm new to this codebase so any pointers on how to fix would be welcomed.