### PR TITLE
URL: on connection re-use, still pick the new remote port

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -6337,6 +6337,7 @@ static void reuse_conn(struct connectdata *old_conn,
   conn->conn_to_host = old_conn->conn_to_host;
   conn->bits.conn_to_port = old_conn->bits.conn_to_port;
   conn->conn_to_port = old_conn->conn_to_port;
+  conn->remote_port = old_conn->remote_port;
 
   /* persist connection info in session handle */
   Curl_persistconninfo(conn);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -121,7 +121,8 @@ test1112 test1113 test1114 test1115 test1116 test1117 test1118 test1119 \
 test1120 test1121 test1122 test1123 test1124 test1125 test1126 test1127 \
 test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
-test1144 test1145 test1146 test1147 test1148 test1149 \
+test1144 test1145 test1146 test1147 test1148 test1149 test1150 \
+\
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \
 test1208 test1209 test1210 test1211 test1212 test1213 test1214 test1215 \
 test1216 test1217 test1218 test1219 \

--- a/tests/data/test1150
+++ b/tests/data/test1150
@@ -1,0 +1,55 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP proxy
+</keywords>
+</info>
+# Server-side
+<reply>
+
+# this is returned when we get a GET!
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 7
+Content-Type: text/html
+Funny-head: yesyes
+
+daniel
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP proxy with URLs using different ports
+ </name>
+ <command>
+--proxy http://%HOSTIP:%HTTPPORT http://test.remote.example.com.1150:150/path http://test.remote.example.com.1150:1234/path/
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent: curl/.*
+</strip>
+<protocol>
+GET http://test.remote.example.com.1150:150/path HTTP/1.1
+Host: test.remote.example.com.1150:150
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://test.remote.example.com.1150:1234/path/ HTTP/1.1
+Host: test.remote.example.com.1150:1234
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
... as when a proxy connection is being re-used, it can still get a
different remote port.

Fixes #1887
Reported-by: Oli Kingshott