### PR TITLE
Truncate messages which are too large to fully send through schannel

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1047,8 +1047,7 @@ schannel_send(struct connectdata *conn, int sockindex,
 
   /* check if the buffer is longer than the maximum message length */
   if(len > BACKEND->stream_sizes.cbMaximumMessage) {
-    *err = CURLE_SEND_ERROR;
-    return -1;
+    len = BACKEND->stream_sizes.cbMaximumMessage;
   }
 
   /* calculate the complete message length and allocate a buffer for it */


### PR DESCRIPTION
Schannel can only encrypt a certain amount of data at once.  Instead of
failing when too much data is sent at once, send as much data as we can
and let the caller send the remaining data by calling send again.

Bug: https://curl.haxx.se/mail/lib-2014-07/0033.html