### PR TITLE
openssl: add missing includes

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -66,6 +66,8 @@
 #include <openssl/conf.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
+#include <openssl/bio.h>
+#include <openssl/buffer.h>
 
 #ifdef HAVE_OPENSSL_PKCS12_H
 #include <openssl/pkcs12.h>


### PR DESCRIPTION
lib/vtls/openssl.c uses OpenSSL APIs from BUF_MEM and BIO APIs. Include
their headers directly rather than relying on other OpenSSL headers
including things.