### PR TITLE
Allow quoted commands to use relative paths

### DIFF
--- a/lib/curl_path.h
+++ b/lib/curl_path.h
@@ -41,5 +41,4 @@ CURLcode Curl_getworkingpath(struct connectdata *conn,
                              char *homedir,
                              char **path);
 
-CURLcode
-Curl_get_pathname(const char **cpp, char **path);
+CURLcode Curl_get_pathname(const char **cpp, char **path, char *homedir);

--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -2534,7 +2534,7 @@ static void sftp_quote(struct connectdata *conn)
    * also, every command takes at least one argument so we get that
    * first argument right now
    */
-  result = Curl_get_pathname(&cp, &sshc->quote_path1);
+  result = Curl_get_pathname(&cp, &sshc->quote_path1, sshc->homedir);
   if(result) {
     if(result == CURLE_OUT_OF_MEMORY)
       failf(data, "Out of memory");
@@ -2559,7 +2559,7 @@ static void sftp_quote(struct connectdata *conn)
 
     /* sshc->quote_path1 contains the mode to set */
     /* get the destination */
-    result = Curl_get_pathname(&cp, &sshc->quote_path2);
+    result = Curl_get_pathname(&cp, &sshc->quote_path2, sshc->homedir);
     if(result) {
       if(result == CURLE_OUT_OF_MEMORY)
         failf(data, "Out of memory");
@@ -2581,7 +2581,7 @@ static void sftp_quote(struct connectdata *conn)
     /* symbolic linking */
     /* sshc->quote_path1 is the source */
     /* get the destination */
-    result = Curl_get_pathname(&cp, &sshc->quote_path2);
+    result = Curl_get_pathname(&cp, &sshc->quote_path2, sshc->homedir);
     if(result) {
       if(result == CURLE_OUT_OF_MEMORY)
         failf(data, "Out of memory");
@@ -2605,7 +2605,7 @@ static void sftp_quote(struct connectdata *conn)
     /* rename file */
     /* first param is the source path */
     /* second param is the dest. path */
-    result = Curl_get_pathname(&cp, &sshc->quote_path2);
+    result = Curl_get_pathname(&cp, &sshc->quote_path2, sshc->homedir);
     if(result) {
       if(result == CURLE_OUT_OF_MEMORY)
         failf(data, "Out of memory");

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -1205,7 +1205,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
          * also, every command takes at least one argument so we get that
          * first argument right now
          */
-        result = Curl_get_pathname(&cp, &sshc->quote_path1);
+        result = Curl_get_pathname(&cp, &sshc->quote_path1, sshc->homedir);
         if(result) {
           if(result == CURLE_OUT_OF_MEMORY)
             failf(data, "Out of memory");
@@ -1230,7 +1230,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
           /* sshc->quote_path1 contains the mode to set */
           /* get the destination */
-          result = Curl_get_pathname(&cp, &sshc->quote_path2);
+          result = Curl_get_pathname(&cp, &sshc->quote_path2, sshc->homedir);
           if(result) {
             if(result == CURLE_OUT_OF_MEMORY)
               failf(data, "Out of memory");
@@ -1252,7 +1252,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           /* symbolic linking */
           /* sshc->quote_path1 is the source */
           /* get the destination */
-          result = Curl_get_pathname(&cp, &sshc->quote_path2);
+          result = Curl_get_pathname(&cp, &sshc->quote_path2, sshc->homedir);
           if(result) {
             if(result == CURLE_OUT_OF_MEMORY)
               failf(data, "Out of memory");
@@ -1277,7 +1277,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           /* rename file */
           /* first param is the source path */
           /* second param is the dest. path */
-          result = Curl_get_pathname(&cp, &sshc->quote_path2);
+          result = Curl_get_pathname(&cp, &sshc->quote_path2, sshc->homedir);
           if(result) {
             if(result == CURLE_OUT_OF_MEMORY)
               failf(data, "Out of memory");


### PR DESCRIPTION
When using the sftp quoted rename function it was necessary to know the full path on the server in order to work. This change allows using a relative path.

Note: This is another attempt at merging this in after I figured out how to run the tests. I couldn't figure out how to add a test for the relative path. In order to do it you need to know in the test script the full path. I tried using /home/$USER/Test as a path but it couldn't find it. If you could please add a test where the file is uploaded using a relative path and the rename uses a relative path (no / in front).