### PR TITLE
tests: make the imap server not verify user+password

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1797,7 +1797,7 @@ static char *imap_atom(const char *str, bool escape_only)
     return strdup(str);
 
   /* Calculate the new string length */
-  newlen = strlen(str) + backsp_count + quote_count + (others_exists ? 2 : 0);
+  newlen = strlen(str) + backsp_count + quote_count + (escape_only ? 0 : 2);
 
   /* Allocate the new string */
   newstr = (char *) malloc((newlen + 1) * sizeof(char));
@@ -1806,7 +1806,7 @@ static char *imap_atom(const char *str, bool escape_only)
 
   /* Surround the string in quotes if necessary */
   p2 = newstr;
-  if(others_exists) {
+  if(!escape_only) {
     newstr[0] = '"';
     newstr[newlen - 1] = '"';
     p2++;

--- a/tests/data/test800
+++ b/tests/data/test800
@@ -31,7 +31,7 @@ imap
 IMAP FETCH message
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/800/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/800/;UID=1' -u "user*:secret{"
 </command>
 </client>
 
@@ -40,7 +40,7 @@ IMAP FETCH message
 <verify>
 <protocol>
 A001 CAPABILITY
-A002 LOGIN user secret
+A002 LOGIN "user*" "secret{"
 A003 SELECT 800
 A004 FETCH 1 BODY[]
 A005 LOGOUT

--- a/tests/data/test800
+++ b/tests/data/test800
@@ -31,7 +31,7 @@ imap
 IMAP FETCH message
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/800/;UID=1' -u "user*:secret{"
+'imap://%HOSTIP:%IMAPPORT/800/;UID=1' -u '"user:sec"ret{'
 </command>
 </client>
 
@@ -40,7 +40,7 @@ IMAP FETCH message
 <verify>
 <protocol>
 A001 CAPABILITY
-A002 LOGIN "user*" "secret{"
+A002 LOGIN "\"user" "sec\"ret{"
 A003 SELECT 800
 A004 FETCH 1 BODY[]
 A005 LOGOUT

--- a/tests/data/test856
+++ b/tests/data/test856
@@ -10,6 +10,9 @@ FAILURE
 #
 # Server-side
 <reply>
+<servercmd>
+REPLY PASS -ERR Login failure
+</servercmd>
 </reply>
 
 #

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2014, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -174,7 +174,6 @@ my $exit_signal;         # first signal handled in exit_signal_handler
 #**********************************************************************
 # Mail related definitions
 #
-my $TEXT_USERNAME = "user";
 my $TEXT_PASSWORD = "secret";
 my $POP3_TIMESTAMP = "<1972.987654321\@curl>";
 
@@ -1121,9 +1120,6 @@ sub LOGIN_imap {
     if ($user eq "") {
         sendcontrol "$cmdid BAD Command Argument\r\n";
     }
-    elsif (($user ne $TEXT_USERNAME) || ($password ne $TEXT_PASSWORD)) {
-        sendcontrol "$cmdid NO LOGIN failed\r\n";
-    }
     else {
         sendcontrol "$cmdid OK LOGIN completed\r\n";
     }
@@ -1681,7 +1677,7 @@ sub APOP_pop3 {
     else {
         my $digest = Digest::MD5::md5_hex($POP3_TIMESTAMP, $TEXT_PASSWORD);
 
-        if (($user ne $TEXT_USERNAME) || ($secret ne $digest)) {
+        if ($secret ne $digest) {
             sendcontrol "-ERR Login failure\r\n";
         }
         else {
@@ -1740,12 +1736,7 @@ sub PASS_pop3 {
 
     logmsg "PASS_pop3 got $password\n";
 
-    if (($username ne $TEXT_USERNAME) || ($password ne $TEXT_PASSWORD)) {
-        sendcontrol "-ERR Login failure\r\n";
-    }
-    else {
-        sendcontrol "+OK Login successful\r\n";
-    }
+    sendcontrol "+OK Login successful\r\n";
 
     return 0;
 }


### PR DESCRIPTION
... as the test cases themselves do that and it makes it easier to add
crazy test cases.

Test 800 updated to use user name + password that needs quoting.

Test 856 updated to trigger an auth fail differently.

Ref: #1902