### PR TITLE
vtls: provide curl_global_sslset() even in non-SSL builds

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1296,4 +1296,14 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
   return CURLSSLSET_UNKNOWN_BACKEND;
 }
 
-#endif /* USE_SSL */
+#else /* USE_SSL */
+CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
+                              const curl_ssl_backend ***avail)
+{
+  (void)id;
+  (void)name;
+  (void)avail;
+  return CURLSSLSET_UNKNOWN_BACKEND;
+}
+
+#endif /* !USE_SSL */


### PR DESCRIPTION
... it just returns error:

Bug: https://github.com/curl/curl/commit/1328f69d53f2f2e937696ea954c480412b018451#commitcomment-24470367
Reported-by: Marcel Raad