### PR TITLE
file_range: avoid integer overflow when figuring out byte range

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -165,6 +165,9 @@ static CURLcode file_range(struct connectdata *conn)
     else {
       /* X-Y */
       totalsize = to-from;
+      if(totalsize == CURL_OFF_T_MAX)
+        /* this is too big to increase, so bail out */
+        return CURLE_RANGE_ERROR;
       data->req.maxdownload = totalsize + 1; /* include last byte */
       data->state.resume_from = from;
       DEBUGF(infof(data, "RANGE from %" CURL_FORMAT_CURL_OFF_T


### PR DESCRIPTION
When trying to bump the value with one and the value is already at max,
it causes an integer overflow.

Detected by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3465

Assisted-by: Max Dymond (@cmeister2)