### PR TITLE
ntlm: move NTLM_NEEDS_NSS_INIT define into core NTLM header

### DIFF
--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -26,6 +26,15 @@
 
 #if defined(USE_NTLM)
 
+/* If NSS is the first available SSL backend (see order in curl_ntlm_core.c)
+   then it must be initialized to be used by NTLM. */
+#if !defined(USE_OPENSSL) && \
+    !defined(USE_GNUTLS_NETTLE) && \
+    !defined(USE_GNUTLS) && \
+    defined(USE_NSS)
+#define NTLM_NEEDS_NSS_INIT
+#endif
+
 #if !defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO)
 
 #ifdef USE_OPENSSL

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -48,6 +48,7 @@
 #include "sendf.h"
 #include "select.h"
 #include "vauth/ntlm.h"
+#include "curl_ntlm_core.h"
 #include "curl_ntlm_wb.h"
 #include "url.h"
 #include "strerror.h"

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -37,6 +37,7 @@
 #include "sendf.h"
 #include "strcase.h"
 #include "http_ntlm.h"
+#include "curl_ntlm_core.h"
 #include "curl_ntlm_wb.h"
 #include "vauth/vauth.h"
 #include "url.h"

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -29,6 +29,7 @@
 #include "vauth/vauth.h"
 #include "urldata.h"
 #include "curl_base64.h"
+#include "curl_ntlm_core.h"
 #include "warnless.h"
 #include "curl_multibyte.h"
 #include "sendf.h"

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -124,15 +124,6 @@ CURLcode Curl_none_md5sum(unsigned char *input, size_t inputlen,
 #define ALPN_HTTP_1_1_LENGTH 8
 #define ALPN_HTTP_1_1 "http/1.1"
 
-/* If NTLM is the first available SSL backend (see order in curl_ntlm_core)
-   then it must be initialized to be used by NTLM. */
-#if !defined(USE_OPENSSL) && \
-    !defined(USE_GNUTLS_NETTLE) && \
-    !defined(USE_GNUTLS) && \
-    defined(USE_NSS)
-#define NTLM_NEEDS_NSS_INIT
-#endif
-
 /* set of helper macros for the backends to access the correct fields. For the
    proxy or for the remote host - to properly support HTTPS proxy */
 


### PR DESCRIPTION
.. and include the core NTLM header in all NTLM-related source files.

Follow up to 6f86022. Since then http_ntlm checks NTLM_NEEDS_NSS_INIT
but did not include vtls.h where it was defined.

---

I missed during review of #1848 that http_ntlm did not include vtls.h. My suggested fix is moving NTLM_NEEDS_NSS_INIT from vtls.h into the ntlm core header instead and then including that in all ntlm source. I think this should work but let's see what the CI says...

/cc @vszakats
