### PR TITLE
openssl: improve data-pending check for https proxy

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3386,12 +3386,13 @@ static bool Curl_ossl_data_pending(const struct connectdata *conn,
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   const struct ssl_connect_data *proxyssl = &conn->proxy_ssl[connindex];
-  if(BACKEND->handle)
-    /* SSL is in use */
-    return (0 != SSL_pending(BACKEND->handle) ||
-           (proxyssl->backend->handle &&
-            0 != SSL_pending(proxyssl->backend->handle))) ?
-           TRUE : FALSE;
+
+  if(connssl->backend->handle && SSL_pending(connssl->backend->handle))
+    return TRUE;
+
+  if(proxyssl->backend->handle && SSL_pending(proxyssl->backend->handle))
+    return TRUE;
+
   return FALSE;
 }
 


### PR DESCRIPTION
- Allow proxy_ssl to be checked for pending data even when connssl does
  not yet have an SSL handle.

This change is for posterity. Currently there doesn't seem to be a code
path that will cause a pending data check when proxyssl could have
pending data and the connssl handle doesn't yet exist *.

* Recall that an https proxy connection starts out in connssl but if the
destination is also https then the proxy SSL backend data is moved from
connssl to proxyssl, which means connssl handle is temporarily empty
until an SSL handle for the destination can be created.

Ref: https://github.com/curl/curl/commit/f4a6238#commitcomment-24396542

Closes #xxxx

---

Can someone confirm my understanding of this, specifically that connssl backend data is intended to only be moved over to proxy_ssl backend data if both are https?

/cc @dscho 
