### PR TITLE
vtls: compare and clone ssl configs properly

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -210,13 +210,13 @@ struct ssl_primary_config {
   bool verifypeer;       /* set TRUE if this is desired */
   bool verifyhost;       /* set TRUE if CN/SAN must match hostname */
   bool verifystatus;     /* set TRUE if certificate status must be checked */
+  bool sessionid;        /* cache session IDs or not */
   char *CApath;          /* certificate dir (doesn't work on windows) */
   char *CAfile;          /* certificate to verify peer against */
   char *clientcert;
   char *random_file;     /* path to file containing "random" data */
   char *egdsocket;       /* path to file containing the EGD daemon socket */
   char *cipher_list;     /* list of ciphers to use */
-  bool sessionid;        /* cache session IDs or not */
 };
 
 struct ssl_config_data {

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -90,9 +90,13 @@ Curl_ssl_config_matches(struct ssl_primary_config* data,
      (data->version_max == needle->version_max) &&
      (data->verifypeer == needle->verifypeer) &&
      (data->verifyhost == needle->verifyhost) &&
+     (data->verifystatus == needle->verifystatus) &&
+     (data->sessionid == needle->sessionid) &&
      Curl_safe_strcasecompare(data->CApath, needle->CApath) &&
      Curl_safe_strcasecompare(data->CAfile, needle->CAfile) &&
      Curl_safe_strcasecompare(data->clientcert, needle->clientcert) &&
+     Curl_safe_strcasecompare(data->random_file, needle->random_file) &&
+     Curl_safe_strcasecompare(data->egdsocket, needle->egdsocket) &&
      Curl_safe_strcasecompare(data->cipher_list, needle->cipher_list))
     return TRUE;
 
@@ -103,31 +107,31 @@ bool
 Curl_clone_primary_ssl_config(struct ssl_primary_config *source,
                               struct ssl_primary_config *dest)
 {
-  dest->verifyhost = source->verifyhost;
-  dest->verifypeer = source->verifypeer;
   dest->version = source->version;
   dest->version_max = source->version_max;
+  dest->verifypeer = source->verifypeer;
+  dest->verifyhost = source->verifyhost;
+  dest->verifystatus = source->verifystatus;
+  dest->sessionid = source->sessionid;
 
-  CLONE_STRING(CAfile);
   CLONE_STRING(CApath);
-  CLONE_STRING(cipher_list);
-  CLONE_STRING(egdsocket);
-  CLONE_STRING(random_file);
+  CLONE_STRING(CAfile);
   CLONE_STRING(clientcert);
+  CLONE_STRING(random_file);
+  CLONE_STRING(egdsocket);
+  CLONE_STRING(cipher_list);
 
-  /* Disable dest sessionid cache if a client cert is used, CVE-2016-5419. */
-  dest->sessionid = (dest->clientcert ? false : source->sessionid);
   return TRUE;
 }
 
 void Curl_free_primary_ssl_config(struct ssl_primary_config* sslc)
 {
-  Curl_safefree(sslc->CAfile);
   Curl_safefree(sslc->CApath);
-  Curl_safefree(sslc->cipher_list);
-  Curl_safefree(sslc->egdsocket);
-  Curl_safefree(sslc->random_file);
+  Curl_safefree(sslc->CAfile);
   Curl_safefree(sslc->clientcert);
+  Curl_safefree(sslc->random_file);
+  Curl_safefree(sslc->egdsocket);
+  Curl_safefree(sslc->cipher_list);
 }
 
 #ifdef USE_SSL

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -91,7 +91,6 @@ Curl_ssl_config_matches(struct ssl_primary_config* data,
      (data->verifypeer == needle->verifypeer) &&
      (data->verifyhost == needle->verifyhost) &&
      (data->verifystatus == needle->verifystatus) &&
-     (data->sessionid == needle->sessionid) &&
      Curl_safe_strcasecompare(data->CApath, needle->CApath) &&
      Curl_safe_strcasecompare(data->CAfile, needle->CAfile) &&
      Curl_safe_strcasecompare(data->clientcert, needle->clientcert) &&


### PR DESCRIPTION
Compare these settings in Curl_ssl_config_matches():
- verifystatus (CURLOPT_SSL_VERIFYSTATUS)
- sessionid (CURLOPT_SSL_SESSIONID_CACHE)
- random_file (CURLOPT_RANDOM_FILE)
- egdsocket (CURLOPT_EGDSOCKET)

Also copy the setting "verifystatus" in Curl_clone_primary_ssl_config(),
and copy the setting "sessionid" unconditionally.

This means that reusing connections that are secured with a client
certificate is now possible, and the statement "TLS session resumption
is disabled when a client certificate is used" in the old advisory at
https://curl.haxx.se/docs/adv_20170419.html is obsolete.

---

**Additional information:**

If you (the reviewers) agree, reusing connections that are secured with a client certificate is now officially possible. It was also possible before because of a bug. I think that it's OK to resume the TLS session if all the TLS settings (including the client certificate) are the same.

I have asked the curl security team whether it's OK to post this as a normal pull request, and they agreed.

These old advisories state that TLS session resumption is disabled when a client certificate is used:
- https://curl.haxx.se/docs/adv_20160803A.html
- https://curl.haxx.se/docs/adv_20170419.html

... but that's not true. I have tested with curl 7.55.1:
```
curl -v -k --cert /path/to/cert.pem --key /path/to/key.pem -H "Connection: close" https://localhost/1 https://localhost/2
```

Output:
```
* Closing connection 0
...
* SSL re-using session ID
...
* Closing connection 1
```

*Source code analysis:*

There's this code in Curl_clone_primary_ssl_config(), vtls.c:
```
dest->sessionid = (dest->clientcert ? false : source->sessionid);
```

This sets the "sessionid" flag in the connection object (struct connectdata). But the code that checks whether TLS session resumption is possible does not look at the connection, it looks at the easy handle (struct Curl_easy).

In Curl_ssl_getsessionid():
```
  if(!SSL_SET_OPTION(primary.sessionid))
    /* session ID re-use is disabled */
    return TRUE;
```

In ossl_connect_step1():
```
  /* Check if there's a cached ID we can/should use here! */
  if(SSL_SET_OPTION(primary.sessionid)) {
```

This pull request cleans things up and allows reusing connections that are secured with a client certificate.