### PR TITLE
reuse_conn: don't copy flags that are known to be equal

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -6333,9 +6333,7 @@ static void reuse_conn(struct connectdata *old_conn,
   Curl_safefree(conn->host.rawalloc);
   Curl_safefree(conn->conn_to_host.rawalloc);
   conn->host = old_conn->host;
-  conn->bits.conn_to_host = old_conn->bits.conn_to_host;
   conn->conn_to_host = old_conn->conn_to_host;
-  conn->bits.conn_to_port = old_conn->bits.conn_to_port;
   conn->conn_to_port = old_conn->conn_to_port;
   conn->remote_port = old_conn->remote_port;
 


### PR DESCRIPTION
A connection can only be reused if the flags "conn_to_host" and
"conn_to_port" match. Therefore it is not necessary to copy these flags
in reuse_conn().