### PR TITLE
cmake: disable tests and man generation if Perl not found

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -93,3 +93,32 @@ macro(CURL_INTERNAL_TEST_RUN CURL_TEST)
     endif(${CURL_TEST}_COMPILE AND NOT ${CURL_TEST})
   endif()
 endmacro(CURL_INTERNAL_TEST_RUN)
+
+macro(CURL_NROFF_CHECK)
+  find_program(NROFF NAMES gnroff nroff)
+  if(NROFF)
+    # Need a way to write to stdin, this will do
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt" "test")
+    # Tests for a valid nroff option to generate a manpage
+    foreach(_MANOPT "-man" "-mandoc")
+      execute_process(COMMAND "${NROFF}" ${_MANOPT}
+        OUTPUT_VARIABLE NROFF_MANOPT_OUTPUT
+        INPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt"
+        ERROR_QUIET)
+      # Save the option if it was valid
+      if(NROFF_MANOPT_OUTPUT)
+        message("Found *nroff option: -- ${_MANOPT}")
+        set(NROFF_MANOPT ${_MANOPT})
+        set(NROFF_USEFUL ON)
+        break()
+      endif()
+    endforeach()
+    # No need for the temporary file
+    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt")
+    if(NOT NROFF_USEFUL)
+      message(WARNING "Found no *nroff option to get plaintext from man pages")
+    endif()
+  else()
+    message(WARNING "Found no *nroff program")
+  endif()
+endmacro(CURL_NROFF_CHECK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ if(ENABLE_MANUAL)
       if(NROFF_MANOPT_OUTPUT)
         message("Found *nroff option: -- ${_MANOPT}")
         set(NROFF_MANOPT ${_MANOPT})
-        set(USE_MANUAL 1)
+        set(USE_MANUAL ON)
         break()
       endif()
     endforeach()
@@ -234,7 +234,12 @@ if(ENABLE_MANUAL)
   endif()
 endif()
 # Required for building manual, docs, tests
-find_package(Perl REQUIRED)
+find_package(Perl)
+if(NOT PERL_FOUND)
+  set(ENABLE_MANUAL OFF)
+  set(USE_MANUAL    OFF)
+  set(BUILD_TESTING OFF)
+endif()
 
 # We need ansi c-flags, especially on HP
 set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS}")
@@ -1149,8 +1154,12 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-add_subdirectory(docs)
+if(ENABLE_MANUAL)
+  add_subdirectory(docs)
+endif()
+
 add_subdirectory(lib)
+
 if(BUILD_CURL_EXE)
   add_subdirectory(src)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,42 +203,18 @@ if(ENABLE_IPV6 AND NOT WIN32)
   endif()
 endif()
 
-option(ENABLE_MANUAL "to provide the built-in manual" ON)
-unset(USE_MANUAL CACHE) # TODO: cache NROFF/NROFF_MANOPT/USE_MANUAL vars?
-if(ENABLE_MANUAL)
-  find_program(NROFF NAMES gnroff nroff)
-  if(NROFF)
-    # Need a way to write to stdin, this will do
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt" "test")
-    # Tests for a valid nroff option to generate a manpage
-    foreach(_MANOPT "-man" "-mandoc")
-      execute_process(COMMAND "${NROFF}" ${_MANOPT}
-        OUTPUT_VARIABLE NROFF_MANOPT_OUTPUT
-        INPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt"
-        ERROR_QUIET)
-      # Save the option if it was valid
-      if(NROFF_MANOPT_OUTPUT)
-        message("Found *nroff option: -- ${_MANOPT}")
-        set(NROFF_MANOPT ${_MANOPT})
-        set(USE_MANUAL ON)
-        break()
-      endif()
-    endforeach()
-    # No need for the temporary file
-    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt")
-    if(NOT USE_MANUAL)
-      message(WARNING "Found no *nroff option to get plaintext from man pages")
-    endif()
-  else()
-    message(WARNING "Found no *nroff program")
-  endif()
-endif()
-# Required for building manual, docs, tests
+CURL_NROFF_CHECK()
 find_package(Perl)
+
+CMAKE_DEPENDENT_OPTION(ENABLE_MANUAL "to provide the built-in manual"
+    ON "NROFF_USEFUL;PERL_FOUND"
+    OFF)
+
 if(NOT PERL_FOUND)
-  set(ENABLE_MANUAL OFF)
-  set(USE_MANUAL    OFF)
   set(BUILD_TESTING OFF)
+endif()
+if(ENABLE_MANUAL)
+  set(USE_MANUAL ON)
 endif()
 
 # We need ansi c-flags, especially on HP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ CMAKE_DEPENDENT_OPTION(ENABLE_MANUAL "to provide the built-in manual"
     OFF)
 
 if(NOT PERL_FOUND)
+  message(STATUS "Perl not found, testing disabled.")
   set(BUILD_TESTING OFF)
 endif()
 if(ENABLE_MANUAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1130,7 +1130,7 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
 
 endfunction()
 
-if(ENABLE_MANUAL)
+if(USE_MANUAL)
   add_subdirectory(docs)
 endif()
 


### PR DESCRIPTION
Removed Perl strong requirements for curl's build.
Disable docs (ENABLE_MANUAL) and tests(BUILD_TESTING) if Perl not found.
Fixed #1500 and #1662 