### PR TITLE
lib/Makefile.m32: allow customizing dll suffixes

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -313,8 +313,12 @@ DLL_LIBS += -lws2_32
 # Makefile.inc provides the CSOURCES and HHEADERS defines
 include Makefile.inc
 
-libcurl_dll_LIBRARY = libcurl.dll
-libcurl_dll_a_LIBRARY = libcurldll.a
+ifeq ($(CURL_DLL_A_SUFFIX),)
+CURL_DLL_A_SUFFIX := dll
+endif
+
+libcurl_dll_LIBRARY = libcurl$(CURL_DLL_SUFFIX).dll
+libcurl_dll_a_LIBRARY = libcurl$(CURL_DLL_A_SUFFIX).a
 libcurl_a_LIBRARY = libcurl.a
 
 libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(strip $(CSOURCES)))


### PR DESCRIPTION
- New `CURL_DLL_SUFFIX` envvar will add a suffix to the generated
  libcurl dll name. Useful to add `-x64` to 64-bit builds so that
  it can live in the same directory as the 32-bit one. By default
  this is empty.

- New `CURL_DLL_A_SUFFIX` envvar to customize the suffix of the
  generated import library (implib) for libcurl .dll. It defaults
  to `dll`, and it's useful to modify that to `.dll` to have the
  standard naming scheme for mingw-built .dlls, i.e. `libcurl.dll.a`.