### PR TITLE
lib/config-win32.h: let SMB/SMBS be enabled with OpenSSL/NSS

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -709,9 +709,7 @@ Vista
 #endif
 
 /* Define to use the Windows crypto library. */
-#if !defined(USE_OPENSSL) && !defined(USE_NSS)
 #define USE_WIN32_CRYPTO
-#endif
 
 /* ---------------------------------------------------------------- */
 /*                       ADDITIONAL DEFINITIONS                     */


### PR DESCRIPTION
The source code is now prepared to handle the case when both
Win32 Crypto and OpenSSL/NSS crypto backends are enabled
at the same time, making it possible to enable `USE_WIN32_CRYPTO`
whenever the targeted Windows version supports it. Since this
matches the minimum Windows version supported by curl
(Windows 2000), enable it unconditionally for the Win32 platform.

This in turn enables SMB (and SMBS) protocol support whenever
Win32 Crypto is available, regardless of what other crypto backends
are enabled.

Ref: https://github.com/curl/curl/pull/1840#issuecomment-325682052
