### PR TITLE
ssl: Update the current connection SSL params in curl_easy_setopt().

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2142,6 +2142,12 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
      */
     data->set.ssl.primary.verifypeer = (0 != va_arg(param, long)) ?
                                        TRUE : FALSE;
+
+    /* Update the current connection ssl_config. */
+    if(data->easy_conn) {
+      data->easy_conn->ssl_config.verifypeer =
+        data->set.ssl.primary.verifypeer;
+    }
     break;
   case CURLOPT_PROXY_SSL_VERIFYPEER:
     /*
@@ -2149,6 +2155,12 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
      */
     data->set.proxy_ssl.primary.verifypeer =
       (0 != va_arg(param, long))?TRUE:FALSE;
+
+    /* Update the current connection proxy_ssl_config. */
+    if(data->easy_conn) {
+      data->easy_conn->proxy_ssl_config.verifypeer =
+        data->set.proxy_ssl.primary.verifypeer;
+    }
     break;
   case CURLOPT_SSL_VERIFYHOST:
     /*
@@ -2167,6 +2179,12 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     }
 
     data->set.ssl.primary.verifyhost = (0 != arg) ? TRUE : FALSE;
+
+    /* Update the current connection ssl_config. */
+    if(data->easy_conn) {
+      data->easy_conn->ssl_config.verifyhost =
+        data->set.ssl.primary.verifyhost;
+    }
     break;
   case CURLOPT_PROXY_SSL_VERIFYHOST:
     /*
@@ -2185,6 +2203,12 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
     }
 
     data->set.proxy_ssl.primary.verifyhost = (0 != arg)?TRUE:FALSE;
+
+    /* Update the current connection proxy_ssl_config. */
+    if(data->easy_conn) {
+      data->easy_conn->proxy_ssl_config.verifyhost =
+        data->set.proxy_ssl.primary.verifyhost;
+    }
     break;
   case CURLOPT_SSL_VERIFYSTATUS:
     /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -2221,6 +2221,12 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
 
     data->set.ssl.primary.verifystatus = (0 != va_arg(param, long)) ?
                                          TRUE : FALSE;
+
+    /* Update the current connection ssl_config. */
+    if(data->easy_conn) {
+      data->easy_conn->ssl_config.verifystatus =
+        data->set.ssl.primary.verifystatus;
+    }
     break;
   case CURLOPT_SSL_CTX_FUNCTION:
     /*


### PR DESCRIPTION
Now VERIFYHOST and VERIFYPEER options change during active connection
updates the current connection's (i.e.'connectdata' structure)
appropriate ssl_config (and ssl_proxy_config) structures variables,
making these options effective for ongoing connection.

This functionality was available before and was broken by the
following change:
"proxy: Support HTTPS proxy and SOCKS+HTTP(s)"
CommitId: cb4e2be7c6d42ca0780f8e0a747cecf9ba45f151.

bug: https://github.com/curl/curl/issues/1941