### PR TITLE
Remove extraneous null check in curlx_strtoofft()

### DIFF
--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -219,7 +219,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
   curl_off_t number;
   errno = 0;
   *num = 0; /* clear by default */
-  while(str && *str && ISSPACE(*str))
+  while(*str && ISSPACE(*str))
     str++;
   if('-' == *str) {
     if(endp)


### PR DESCRIPTION
Closes #1950: curlx_strtoofft() doesn't fully protect against null 'str'
argument.