### PR TITLE
multi_cleanup: call DONE on handles that never got that

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -169,7 +169,7 @@ test1520 test1521 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 \
-test1550 test1551 \
+test1550 test1551 test1552 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 \
 \
 test1700 test1701 test1702 \

--- a/tests/data/test1552
+++ b/tests/data/test1552
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+FETCH
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+From: me@somewhere
+To: fake@nowhere
+
+body
+
+--
+  yours sincerely
+</data>
+<datacheck>
+</datacheck>
+<servercmd>
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP multi transfer error without curl_multi_remove_handle
+ </name>
+# tool is what to use instead of 'curl'
+<tool>
+lib1552
+</tool>
+ <command>
+'imap://%HOSTIP:%IMAPPORT/1552/;UID=1'
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -27,7 +27,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 \
- lib1550 lib1551 \
+ lib1550 lib1551 lib1552 \
  lib1900 \
  lib2033
 
@@ -453,6 +453,9 @@ lib1550_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1517
 
 lib1551_SOURCES = lib1551.c $(SUPPORTFILES)
 lib1551_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1552_SOURCES = lib1552.c $(SUPPORTFILES) $(TESTUTIL)
+lib1552_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1900_SOURCES = lib1900.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1900_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1552.c
+++ b/tests/libtest/lib1552.c
@@ -1,0 +1,93 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+#define TEST_HANG_TIMEOUT 60 * 1000
+
+int test(char *URL)
+{
+  CURL *curls = NULL;
+  CURLM *multi = NULL;
+  int still_running;
+  int i = 0;
+  int res = 0;
+  CURLMsg *msg;
+  int counter = 3;
+
+  start_test_timing();
+
+  global_init(CURL_GLOBAL_ALL);
+
+  multi_init(multi);
+
+  easy_init(curls);
+
+  easy_setopt(curls, CURLOPT_URL, URL);
+  easy_setopt(curls, CURLOPT_HEADER, 1L);
+  easy_setopt(curls, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curls, CURLOPT_USERPWD, "u:s");
+
+  multi_add_handle(multi, curls);
+
+  multi_perform(multi, &still_running);
+
+  abort_on_test_timeout();
+
+  while(still_running && counter--) {
+    int num;
+    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
+    if(res != CURLM_OK) {
+      printf("curl_multi_wait() returned %d\n", res);
+      res = TEST_ERR_MAJOR_BAD;
+      goto test_cleanup;
+    }
+
+    abort_on_test_timeout();
+
+    multi_perform(multi, &still_running);
+
+    abort_on_test_timeout();
+  }
+
+  msg = curl_multi_info_read(multi, &still_running);
+  if(msg)
+    /* this should now contain a result code from the easy handle,
+       get it */
+    i = msg->data.result;
+
+test_cleanup:
+
+  /* undocumented cleanup sequence - type UA */
+
+  curl_multi_cleanup(multi);
+  curl_easy_cleanup(curls);
+  curl_global_cleanup();
+
+  if(res)
+    i = res;
+
+  return i; /* return the final return code */
+}


### PR DESCRIPTION
... fixes a memory leak with at least IMAP when remove_handle is never
called and the transfer is abruptly just abandoned early.

Test 1552 added to verify

Assisted-by: Max Dymond