### PR TITLE
pingpong: return error when trying to send without connection

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -711,12 +711,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
      curl_easy_cleanup is called. */
   Curl_expire_clear(data);
 
-  if(data->dns.hostcachetype == HCACHE_MULTI) {
-    /* stop using the multi handle's DNS cache */
-    data->dns.hostcache = NULL;
-    data->dns.hostcachetype = HCACHE_NONE;
-  }
-
   if(data->easy_conn) {
 
     /* we must call multi_done() here (if we still own the connection) so that
@@ -733,6 +727,13 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
     else
       /* Clear connection pipelines, if multi_done above was not called */
       Curl_getoff_all_pipelines(data, data->easy_conn);
+  }
+
+  if(data->dns.hostcachetype == HCACHE_MULTI) {
+    /* stop using the multi handle's DNS cache, *after* the possible
+       multi_done() call above */
+    data->dns.hostcache = NULL;
+    data->dns.hostcachetype = HCACHE_NONE;
   }
 
   Curl_wildcard_dtor(&data->wildcard);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -537,6 +537,12 @@ static CURLcode multi_done(struct connectdata **connp,
     /* Stop if multi_done() has already been called */
     return CURLE_OK;
 
+  if(data->mstate == CURLM_STATE_WAITRESOLVE) {
+    /* done while still waiting for the resolve to complete */
+    struct Curl_dns_entry *throw_away;
+    (void)Curl_resolver_wait_resolv(conn, &throw_away);
+  }
+
   Curl_getoff_all_pipelines(data, conn);
 
   /* Cleanup possible redirect junk */

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -168,15 +168,21 @@ CURLcode Curl_pp_vsendf(struct pingpong *pp,
   char *s;
   CURLcode result;
   struct connectdata *conn = pp->conn;
-  struct Curl_easy *data = conn->data;
+  struct Curl_easy *data;
 
 #ifdef HAVE_GSSAPI
-  enum protection_level data_sec = conn->data_prot;
+  enum protection_level data_sec;
 #endif
 
   DEBUGASSERT(pp->sendleft == 0);
   DEBUGASSERT(pp->sendsize == 0);
   DEBUGASSERT(pp->sendthis == NULL);
+
+  if(!conn)
+    /* can't send without a connection! */
+    return CURLE_SEND_ERROR;
+
+  data = conn->data;
 
   fmt_crlf = aprintf("%s\r\n", fmt); /* append a trailing CRLF */
   if(!fmt_crlf)
@@ -205,6 +211,7 @@ CURLcode Curl_pp_vsendf(struct pingpong *pp,
   result = Curl_write(conn, conn->sock[FIRSTSOCKET], s, write_len,
                      &bytes_written);
 #ifdef HAVE_GSSAPI
+  data_sec = conn->data_prot;
   DEBUGASSERT(data_sec > PROT_NONE && data_sec < PROT_LAST);
   conn->data_prot = data_sec;
 #endif

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -169,7 +169,7 @@ test1520 test1521 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 \
-test1550 test1551 test1552 \
+test1550 test1551 test1552 test1553 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 \
 \
 test1700 test1701 test1702 \

--- a/tests/data/test1553
+++ b/tests/data/test1553
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+FETCH
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+From: me@somewhere
+To: fake@nowhere
+
+body
+
+--
+  yours sincerely
+</data>
+<datacheck>
+</datacheck>
+<servercmd>
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP cleanup before a connection was created
+ </name>
+# tool is what to use instead of 'curl'
+<tool>
+lib1553
+</tool>
+ <command>
+imap://non-existing-host.haxx.se:%IMAPPORT/1553
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -27,7 +27,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 \
- lib1550 lib1551 lib1552 \
+ lib1550 lib1551 lib1552 lib1553 \
  lib1900 \
  lib2033
 
@@ -456,6 +456,9 @@ lib1551_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1552_SOURCES = lib1552.c $(SUPPORTFILES) $(TESTUTIL)
 lib1552_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1553_SOURCES = lib1553.c $(SUPPORTFILES) $(TESTUTIL)
+lib1553_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1900_SOURCES = lib1900.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1900_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1553.c
+++ b/tests/libtest/lib1553.c
@@ -1,0 +1,109 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+#define TEST_HANG_TIMEOUT 60 * 1000
+
+static int xferinfo(void *p,
+                    curl_off_t dltotal, curl_off_t dlnow,
+                    curl_off_t ultotal, curl_off_t ulnow)
+{
+  (void)p;
+  (void)dlnow;
+  (void)dltotal;
+  (void)ulnow;
+  (void)ultotal;
+  fprintf(stderr, "xferinfo fail!\n");
+  return 1; /* fail as fast as we can */
+}
+
+int test(char *URL)
+{
+  CURL *curls = NULL;
+  CURLM *multi = NULL;
+  int still_running;
+  int i = 0;
+  int res = 0;
+  curl_mimepart *field = NULL;
+  curl_mime *mime = NULL;
+  int counter = 1;
+
+  start_test_timing();
+
+  global_init(CURL_GLOBAL_ALL);
+
+  multi_init(multi);
+
+  easy_init(curls);
+
+  mime = curl_mime_init(curls);
+  field = curl_mime_addpart(mime);
+  curl_mime_name(field, "name");
+  curl_mime_data(field, "value", CURL_ZERO_TERMINATED);
+
+  easy_setopt(curls, CURLOPT_URL, URL);
+  easy_setopt(curls, CURLOPT_HEADER, 1L);
+  easy_setopt(curls, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curls, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curls, CURLOPT_USERPWD, "u:s");
+  easy_setopt(curls, CURLOPT_XFERINFOFUNCTION, xferinfo);
+  easy_setopt(curls, CURLOPT_NOPROGRESS, 1L);
+
+  multi_add_handle(multi, curls);
+
+  multi_perform(multi, &still_running);
+
+  abort_on_test_timeout();
+
+  while(still_running && counter--) {
+    int num;
+    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
+    if(res != CURLM_OK) {
+      printf("curl_multi_wait() returned %d\n", res);
+      res = TEST_ERR_MAJOR_BAD;
+      goto test_cleanup;
+    }
+
+    abort_on_test_timeout();
+
+    multi_perform(multi, &still_running);
+
+    abort_on_test_timeout();
+  }
+
+test_cleanup:
+
+  curl_mime_free(mime);
+  curl_multi_remove_handle(multi, curls);
+  curl_multi_cleanup(multi);
+  curl_easy_cleanup(curls);
+  curl_global_cleanup();
+
+  if(res)
+    i = res;
+
+  return i; /* return the final return code */
+}


### PR DESCRIPTION
When imap_done() got called before a connection is setup, it would try
to "finish up" and dereffed a NULL pointer.

Test case 1553 managed to reproduce. I had to actually use a host name
to try to resolve to slow it down, as using the normal local server IP
will make libcurl get a connection in the first curl_multi_perform()
loop and then the bug doesn't trigger.

Fixes #1953
Assisted-by: Max Dymond