### PR TITLE
mime: prevent curl_mime_subparts() from adding "itself"

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -26,6 +26,8 @@
 
 #include "mime.h"
 #include "non-ascii.h"
+#include "urldata.h"
+#include "sendf.h"
 
 #if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_SMTP) || \
     !defined(CURL_DISABLE_IMAP)
@@ -1394,6 +1396,11 @@ CURLcode curl_mime_subparts(curl_mimepart *part,
 {
   if(!part)
     return CURLE_BAD_FUNCTION_ARGUMENT;
+
+  if(subparts == part->parent) {
+    failf(part->parent->easy, "Can't add itself as a subpart!");
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  }
 
   /* Accept setting twice the same subparts. */
   if(part->kind == MIMEKIND_MULTIPART && part->arg == subparts)

--- a/tests/libtest/lib643.c
+++ b/tests/libtest/lib643.c
@@ -251,6 +251,21 @@ test_cleanup:
   return res;
 }
 
+static int add_itself(void)
+{
+  CURL *easy = curl_easy_init();
+  curl_mime *mime = curl_mime_init(easy);
+  curl_mimepart *part = curl_mime_addpart(mime);
+  CURLcode a1 = curl_mime_subparts(part, mime);
+  curl_mime_free(mime);
+  curl_easy_cleanup(easy);
+  if(a1 != CURLE_BAD_FUNCTION_ARGUMENT)
+    /* that should have failed */
+    return 1;
+
+  return 0;
+}
+
 int test(char *URL)
 {
   int res;
@@ -263,6 +278,9 @@ int test(char *URL)
   res = once(URL, TRUE); /* old */
   if(!res)
     res = once(URL, FALSE); /* new */
+
+  if(!res)
+    res = add_itself();
 
   curl_global_cleanup();
 


### PR DESCRIPTION
Refuse to add its own "ancestor".

Reported-by: Alexey Melnichuk
Fixes #1962