### PR TITLE
Do not jump over semicolons when filename contains a path

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -161,8 +161,13 @@ static char *parse_filename(const char *ptr, size_t len)
   else
     stop = ';';
 
+  /* scan for the end letter and stop there */
+  q = strchr(p, stop);
+  if(q)
+    *q = '\0';
+
   /* if the filename contains a path, only use filename portion */
-  q = strrchr(copy, '/');
+  q = strrchr(p, '/');
   if(q) {
     p = q + 1;
     if(!*p) {
@@ -180,14 +185,6 @@ static char *parse_filename(const char *ptr, size_t len)
     if(!*p) {
       Curl_safefree(copy);
       return NULL;
-    }
-  }
-
-  /* scan for the end letter and stop there */
-  for(q = p; *q; ++q) {
-    if(*q == stop) {
-      *q = '\0';
-      break;
     }
   }
 


### PR DESCRIPTION
`Content-Disposition: attachment; filename=correct.jpg; somethingelse=/wrong.jpg`
`curl -O -J` saves to `wrong.jpg` when it should probably save to `correct.jpg`.