### PR TITLE
RTSP: avoid integer overflow on funny RTSP response

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3387,12 +3387,14 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
         }
       }
       else if(conn->handler->protocol & CURLPROTO_RTSP) {
+        char separator;
         nc = sscanf(HEADER1,
-                    " RTSP/%d.%d %3d",
+                    " RTSP/%1d.%1d%c%3d",
                     &rtspversion_major,
                     &conn->rtspversion,
+                    &separator,
                     &k->httpcode);
-        if(nc == 3) {
+        if((nc == 4) && (' ' == separator)) {
           conn->rtspversion += 10 * rtspversion_major;
           conn->httpversion = 11; /* For us, RTSP acts like HTTP 1.1 */
         }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -70,7 +70,7 @@ test536 test537 test538 test539 test540 test541 test542 test543 test544 \
 test545 test546 test547 test548 test549 test550 test551 test552 test553 \
 test554 test555 test556 test557 test558 test559 test560 test561 test562 \
 test563 test564 test565 test566 test567 test568 test569 test570 test571 \
-test572 test573 test574 test575 test576         test578 test579 test580 \
+test572 test573 test574 test575 test576 test577 test578 test579 test580 \
 test581 test582 test583 test584 test585 test586 test587 test588 test589 \
 test590 test591 test592 test593 test594 test595 test596 test597 test598 \
 test599 test600 test601 test602 test603 test604 test605 test606 test607 \

--- a/tests/data/test577
+++ b/tests/data/test577
@@ -1,0 +1,55 @@
+<testcase>
+
+#Informational
+<info>
+<keywords>
+RTSP
+OPTIONS
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+RTSP/1.1234567 200 OK
+Server: RTSPD/libcurl-test
+CSeq: 1
+Public: DESCRIBE, OPTIONS, SETUP, TEARDOWN, PLAY, PAUSE
+Curl-Private: swsclose
+</data>
+<datacheck>
+</datacheck>
+</reply>
+
+# Client-Side
+<client>
+<server>
+rtsp
+</server>
+<tool>
+lib567
+</tool>
+
+<name>
+Funny RTSP version in response
+</name>
+<command>
+rtsp://%HOSTIP:%RTSPPORT/577
+</command>
+</client>
+
+<verify>
+<protocol>
+OPTIONS rtsp://%HOSTIP:%RTSPPORT/577 RTSP/1.0
+CSeq: 1
+User-Agent: test567
+Test-Number: 567
+
+</protocol>
+# 8 == CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+
+</testcase>


### PR DESCRIPTION
... like a very large non-existing RTSP version number.

Added test 577 to verify.

Detected by OSS-fuzz.