### PR TITLE
memdebug improvements

### DIFF
--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -343,12 +343,43 @@ curl_socket_t curl_socket(int domain, int type, int protocol,
     "FD %s:%d socket() = %ld\n" :
     "FD %s:%d socket() = %zd\n";
 
-  curl_socket_t sockfd = socket(domain, type, protocol);
+  curl_socket_t sockfd;
+
+  if(countcheck("socket", line, source))
+    return CURL_SOCKET_BAD;
+
+  sockfd = socket(domain, type, protocol);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_memlog(fmt, source, line, sockfd);
 
   return sockfd;
+}
+
+ssize_t curl_dosend(int sockfd, const void *buf, size_t len, int flags,
+                    int line, const char *source)
+{
+  ssize_t rc;
+  if(countcheck("send", line, source))
+    return -1;
+  rc = send(sockfd, buf, len, flags);
+  if(source)
+    curl_memlog("SEND %s:%d send(%zu) = %zd\n",
+                source, line, len, rc);
+  return rc;
+}
+
+ssize_t curl_dorecv(int sockfd, void *buf, size_t len, int flags,
+                    int line, const char *source)
+{
+  ssize_t rc;
+  if(countcheck("recv", line, source))
+    return -1;
+  rc = recv(sockfd, buf, len, flags);
+  if(source)
+    curl_memlog("RECV %s:%d recv(%zu) = %zd\n",
+                source, line, len, rc);
+  return rc;
 }
 
 #ifdef HAVE_SOCKETPAIR

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -8,7 +8,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -66,6 +66,12 @@ CURL_EXTERN int curl_socketpair(int domain, int type, int protocol,
                                 int line, const char *source);
 #endif
 
+/* send/receive sockets */
+CURL_EXTERN ssize_t curl_dosend(int sockfd, const void *buf, size_t len,
+                                int flags, int line, const char *source);
+CURL_EXTERN ssize_t curl_dorecv(int sockfd, void *buf, size_t len, int flags,
+                                int line, const char *source);
+
 /* FILE functions */
 CURL_EXTERN FILE *curl_fopen(const char *file, const char *mode, int line,
                              const char *source);
@@ -84,6 +90,8 @@ CURL_EXTERN int curl_fclose(FILE *file, int line, const char *source);
 #define calloc(nbelem,size) curl_docalloc(nbelem, size, __LINE__, __FILE__)
 #define realloc(ptr,size) curl_dorealloc(ptr, size, __LINE__, __FILE__)
 #define free(ptr) curl_dofree(ptr, __LINE__, __FILE__)
+#define send(a,b,c,d) curl_dosend(a,b,c,d, __LINE__, __FILE__)
+#define recv(a,b,c,d) curl_dorecv(a,b,c,d, __LINE__, __FILE__)
 
 #ifdef WIN32
 #  ifdef UNICODE

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -677,7 +677,7 @@ ldapsb_tls_read(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len)
   ber_slen_t ret;
   CURLcode err = CURLE_RECV_ERROR;
 
-  ret = li->recv(conn, FIRSTSOCKET, buf, len, &err);
+  ret = (li->recv)(conn, FIRSTSOCKET, buf, len, &err);
   if(ret < 0 && err == CURLE_AGAIN) {
     SET_SOCKERRNO(EWOULDBLOCK);
   }
@@ -692,7 +692,7 @@ ldapsb_tls_write(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len)
   ber_slen_t ret;
   CURLcode err = CURLE_SEND_ERROR;
 
-  ret = li->send(conn, FIRSTSOCKET, buf, len, &err);
+  ret = (li->send)(conn, FIRSTSOCKET, buf, len, &err);
   if(ret < 0 && err == CURLE_AGAIN) {
     SET_SOCKERRNO(EWOULDBLOCK);
   }

--- a/tests/memanalyze.pl
+++ b/tests/memanalyze.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2013, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -33,6 +33,9 @@ my $reallocs=0;
 my $strdups=0;
 my $wcsdups=0;
 my $showlimit;
+my $sends=0;
+my $recvs=0;
+my $sockets=0;
 
 while(1) {
     if($ARGV[0] eq "-v") {
@@ -258,6 +261,7 @@ while(<FILE>) {
             $filedes{$1}=1;
             $getfile{$1}="$source:$linenum";
             $openfile++;
+            $sockets++; # number of socket() calls
         }
         elsif($function =~ /socketpair\(\) = (\d*) (\d*)/) {
             $filedes{$1}=1;
@@ -313,6 +317,14 @@ while(<FILE>) {
     # GETNAME url.c:1901 getnameinfo()
     elsif($_ =~ /^GETNAME ([^ ]*):(\d*) (.*)/) {
         # not much to do
+    }
+    # SEND url.c:1901 send(83) = 83
+    elsif($_ =~ /^SEND ([^ ]*):(\d*) (.*)/) {
+        $sends++;
+    }
+    # RECV url.c:1901 recv(102400) = 256
+    elsif($_ =~ /^RECV ([^ ]*):(\d*) (.*)/) {
+        $recvs++;
     }
 
     # ADDR url.c:1282 getaddrinfo() = 0x5ddd
@@ -398,12 +410,16 @@ if($addrinfos) {
 
 if($verbose) {
     print "Mallocs: $mallocs\n",
-    "Reallocs: $reallocs\n",
-    "Callocs: $callocs\n",
-    "Strdups:  $strdups\n",
-    "Wcsdups:  $wcsdups\n",
-    "Frees: $frees\n",
-    "Allocations: ".($mallocs + $callocs + $reallocs + $strdups + $wcsdups)."\n";
+        "Reallocs: $reallocs\n",
+        "Callocs: $callocs\n",
+        "Strdups:  $strdups\n",
+        "Wcsdups:  $wcsdups\n",
+        "Frees: $frees\n",
+        "Sends: $sends\n",
+        "Recvs: $recvs\n",
+        "Sockets: $sockets\n",
+        "Allocations: ".($mallocs + $callocs + $reallocs + $strdups + $wcsdups)."\n",
+        "Operations: ".($mallocs + $callocs + $reallocs + $strdups + $wcsdups + $sends + $recvs + $sockets)."\n";
 
     print "Maximum allocated: $maxmem\n";
 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -576,17 +576,17 @@ sub torture {
     my $count=0;
     my @out = `$memanalyze -v $memdump`;
     for(@out) {
-        if(/^Allocations: (\d+)/) {
+        if(/^Operations: (\d+)/) {
             $count = $1;
             last;
         }
     }
     if(!$count) {
-        logmsg " found no allocs to make fail\n";
+        logmsg " found no functions to make fail\n";
         return 0;
     }
 
-    logmsg " $count allocations to make fail\n";
+    logmsg " $count functions to make fail\n";
 
     for ( 1 .. $count ) {
         my $limit = $_;
@@ -601,7 +601,7 @@ sub torture {
             my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
                 localtime(time());
             my $now = sprintf("%02d:%02d:%02d ", $hour, $min, $sec);
-            logmsg "Fail alloc no: $limit at $now\r";
+            logmsg "Fail funcion no: $limit at $now\r";
         }
 
         # make the memory allocation function number $limit return failure
@@ -610,7 +610,7 @@ sub torture {
         # remove memdump first to be sure we get a new nice and clean one
         unlink($memdump);
 
-        logmsg "*** Alloc number $limit is now set to fail ***\n" if($gdbthis);
+        logmsg "*** Function number $limit is now set to fail ***\n" if($gdbthis);
 
         my $ret = 0;
         if($gdbthis) {
@@ -655,7 +655,7 @@ sub torture {
             }
         }
         if($fail) {
-            logmsg " Failed on alloc number $limit in test.\n",
+            logmsg " Failed on function number $limit in test.\n",
             " invoke with \"-t$limit\" to repeat this single case.\n";
             stopservers($verbose);
             return 1;
@@ -5377,7 +5377,7 @@ Usage: runtests.pl [options] [test selection(s)]
   -rf      full run time statistics
   -s       short output
   -am      automake style output PASS/FAIL: [number] [name]
-  -t[N]    torture (simulate memory alloc failures); N means fail Nth alloc
+  -t[N]    torture (simulate function failures); N means fail Nth function
   -v       verbose output
   -vc path use this curl only to verify the existing servers
   [num]    like "5 6 9" or " 5 to 22 " to run those tests only


### PR DESCRIPTION
I bring two changes in this set:

1. the _memdebug_ system now also covers send, recv and socket properly. They're logged and they're affected by the "memlimit" system that's used by the torture tests which means that by setting the correct environment variable we can make those calls return failures as well. `runtests.pl -t` that covers more exit paths for each test.
2. Starting now, valgrind is used for the torture tests as well if found and not disabled. Previously, the torture tests only used the internal memory debug system which is *disabled* when libcurl is built with the threaded resolver! Valgrind of course detects leaks and memory problems even better and with better error reporting. Using valgrind on torture tests makes them **MUCH** slower so beware.