### PR TITLE
configure: remove the C++ compiler check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,6 @@ AC_SUBST(libext)
 dnl figure out the libcurl version
 CURLVERSION=`$SED -ne 's/^#define LIBCURL_VERSION "\(.*\)".*/\1/p' ${srcdir}/include/curl/curlver.h`
 XC_CHECK_PROG_CC
-AC_PROG_CXX
 XC_AUTOMAKE
 AC_MSG_CHECKING([curl version])
 AC_MSG_RESULT($CURLVERSION)


### PR DESCRIPTION
... we used it only for the fuzzer, which we now have in a separate git
repo.