### PR TITLE
makefile.m32: allow to override gcc, ar and ranlib

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -22,7 +22,7 @@
 
 ###########################################################################
 #
-## Makefile for building libcurl.a with MingW (GCC-3.2 or later)
+## Makefile for building libcurl.a with MingW (GCC-3.2 or later or LLVM/Clang)
 ## and optionally OpenSSL (1.0.2a), libssh2 (1.5), zlib (1.2.8), librtmp (2.4)
 ##
 ## Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
@@ -76,13 +76,23 @@ ifndef LIBCARES_PATH
 LIBCARES_PATH = $(PROOT)/ares
 endif
 
-CC	= $(CROSSPREFIX)gcc
+ifeq ($(CURL_CC),)
+CURL_CC := $(CROSSPREFIX)gcc
+endif
+ifeq ($(CURL_AR),)
+CURL_AR := $(CROSSPREFIX)ar
+endif
+ifeq ($(CURL_RANLIB),)
+CURL_RANLIB := $(CROSSPREFIX)ranlib
+endif
+
+CC	= $(CURL_CC)
 CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
 LDFLAGS	= $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL) -s
-AR	= $(CROSSPREFIX)ar
-RANLIB	= $(CROSSPREFIX)ranlib
+AR	= $(CURL_AR)
+RANLIB	= $(CURL_RANLIB)
 RC	= $(CROSSPREFIX)windres
 RCFLAGS	= --include-dir=$(PROOT)/include -DDEBUGBUILD=0 -O COFF
 STRIP	= $(CROSSPREFIX)strip -g

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -22,7 +22,7 @@
 
 ###########################################################################
 #
-## Makefile for building curl.exe with MingW (GCC-3.2 or later)
+## Makefile for building curl.exe with MingW (GCC-3.2 or later or LLVM/Clang)
 ## and optionally OpenSSL (1.0.2a), libssh2 (1.5), zlib (1.2.8), librtmp (2.4)
 ##
 ## Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
@@ -88,12 +88,19 @@ ifndef LIBCARES_PATH
 LIBCARES_PATH = $(PROOT)/ares
 endif
 
-CC	= $(CROSSPREFIX)gcc
+ifeq ($(CURL_CC),)
+CURL_CC := $(CROSSPREFIX)gcc
+endif
+ifeq ($(CURL_AR),)
+CURL_AR := $(CROSSPREFIX)ar
+endif
+
+CC	= $(CURL_CC)
 CFLAGS	= $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
 CFLAGS	+= -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
 LDFLAGS	= $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s
-AR	= $(CROSSPREFIX)ar
+AR	= $(CURL_AR)
 RC	= $(CROSSPREFIX)windres
 RCFLAGS	= --include-dir=$(PROOT)/include -O COFF
 STRIP	= $(CROSSPREFIX)strip -g


### PR DESCRIPTION
Allow to ovverride certain build tools, making it possible to
use LLVM/Clang to build curl. The default behavior is unchanged.
To build with clang (as offered by MSYS2), these settings can
be used:
```
CURL_CC=clang
CURL_AR=llvm-ar
CURL_RANLIB=llvm-ranlib
```