### PR TITLE
ftp: reject illegal IPport in PASV 227 response

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1874,8 +1874,8 @@ static CURLcode ftp_state_pasv_resp(struct connectdata *conn,
   else if((ftpc->count1 == 1) &&
           (ftpcode == 227)) {
     /* positive PASV response */
-    int ip[4];
-    int port[2];
+    unsigned int ip[4];
+    unsigned int port[2];
 
     /*
      * Scan for a sequence of six comma-separated numbers and use them as
@@ -1887,14 +1887,15 @@ static CURLcode ftp_state_pasv_resp(struct connectdata *conn,
      * "227 Entering passive mode. 127,0,0,1,4,51"
      */
     while(*str) {
-      if(6 == sscanf(str, "%d,%d,%d,%d,%d,%d",
+      if(6 == sscanf(str, "%u,%u,%u,%u,%u,%u",
                      &ip[0], &ip[1], &ip[2], &ip[3],
                      &port[0], &port[1]))
         break;
       str++;
     }
 
-    if(!*str) {
+    if(!*str || (ip[0] > 255) || (ip[1] > 255)  || (ip[2] > 255)  ||
+       (ip[3] > 255) || (port[0] > 255)  || (port[1] > 255) ) {
       failf(data, "Couldn't interpret the 227-response");
       return CURLE_FTP_WEIRD_227_FORMAT;
     }

--- a/tests/data/test237
+++ b/tests/data/test237
@@ -30,13 +30,9 @@ ftp://%HOSTIP:%FTPPORT/237 --disable-epsv
 # certain hosts with buggy resolver code, the resulting address (192.0.2.127)
 # is from an address block that is guaranteed never to be assigned (RFC3330).
 <verify>
-# curl: (15) Can't resolve new host 1216.256.2.127:32639
-# 15 => CURLE_FTP_CANT_GET_HOST
-# some systems just don't fail on the illegal host name/address but instead
-# moves on and attempt to connect to... yes, to what?
-# 7= CURLE_COULDNT_CONNECT
+# 14 = CURLE_FTP_WEIRD_227_FORMAT
 <errorcode>
-15, 7
+14
 </errorcode>
 <protocol>
 USER anonymous


### PR DESCRIPTION
... by using range checks. Among other things, this avoids an undefined
behavior for a left shift that could happen on negative or very large
values.

Detected by OSS-fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3694