### PR TITLE
timeval: use mach time on MacOS if necessary

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2970,3 +2970,28 @@ AC_DEFUN([CURL_SUPPORTS_BUILTIN_AVAILABLE], [
     AC_MSG_RESULT([no])
   ])
 ])
+
+
+dnl CURL_CHECK_FUNC_MACH_ABSOLUTE_TIME
+dnl -------------------------------------------------
+dnl Check if mach_absolute_time is available.
+
+AC_DEFUN([CURL_CHECK_FUNC_MACH_ABSOLUTE_TIME], [
+  AC_CHECK_HEADERS(mach/mach_time.h)
+  AC_MSG_CHECKING([for mach_absolute_time])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+#include <mach/mach_time.h>
+    ]],[[
+      mach_timebase_info_data_t timebase;
+      (void) mach_timebase_info(&timebase);
+      (void) mach_absolute_time();
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE_UNQUOTED(HAVE_MACH_ABSOLUTE_TIME, 1,
+      [Define to 1 if you have the mach_absolute_time function.])
+  ],[
+    AC_MSG_RESULT([no])
+  ])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -3656,6 +3656,8 @@ CURL_CHECK_OPTION_NTLM_WB
 
 CURL_CHECK_NTLM_WB
 
+CURL_CHECK_FUNC_MACH_ABSOLUTE_TIME
+
 dnl ************************************************************
 dnl disable TLS-SRP authentication
 dnl

--- a/docs/INSTALL.cmake
+++ b/docs/INSTALL.cmake
@@ -35,6 +35,7 @@ Current flaws in the curl CMake build
    - Doesn't find or use krb4 or GSS
    - Rebuilds test files too eagerly, but still can't run the tests
    - Does't detect the correct strerror_r flavor when cross-compiling (issue #1123)
+   - Doesn't detect mach_absolute_time on MacOS
 
 
 Command Line CMake

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -130,6 +130,9 @@
 /* Define to 1 if you have the clock_gettime function and monotonic timer. */
 #cmakedefine HAVE_CLOCK_GETTIME_MONOTONIC 1
 
+/* Define to 1 if you have the mach_absolute_time function. */
+#cmakedefine HAVE_MACH_ABSOLUTE_TIME 1
+
 /* Define to 1 if you have the `closesocket' function. */
 #cmakedefine HAVE_CLOSESOCKET 1
 

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -84,7 +84,7 @@ struct curltime curlx_tvnow(void)
   return cnow;
 }
 
-#elif defined(__APPLE__)
+#elif defined(HAVE_MACH_ABSOLUTE_TIME)
 
 #include <stdint.h>
 #include <mach/mach_time.h>

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -84,6 +84,37 @@ struct curltime curlx_tvnow(void)
   return cnow;
 }
 
+#elif defined(__APPLE__)
+
+#include <stdint.h>
+#include <mach/mach_time.h>
+
+struct curltime curlx_tvnow(void)
+{
+  /*
+  ** Monotonic timer on Mac OS is provided by mach_absolute_time(), which
+  ** returns time in Mach "absolute time units," which are platform-dependent.
+  ** To convert to nanoseconds, one must use conversion factors specified by
+  ** mach_timebase_info().
+  */
+  static mach_timebase_info_data_t timebase;
+  struct curltime cnow;
+  uint64_t usecs;
+
+  if(0 == timebase.denom)
+    (void) mach_timebase_info(&timebase);
+
+  usecs = mach_absolute_time();
+  usecs *= timebase.numer;
+  usecs /= timebase.denom;
+  usecs /= 1000;
+
+  cnow.tv_sec = usecs / 1000000;
+  cnow.tv_usec = usecs % 1000000;
+
+  return cnow;
+}
+
 #elif defined(HAVE_GETTIMEOFDAY)
 
 struct curltime curlx_tvnow(void)


### PR DESCRIPTION
If clock_gettime() is not supported, one can use mach_absolute_time().