### PR TITLE
curl_fnmatch: return error on illegal wildcard pattern

### DIFF
--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -240,10 +240,10 @@ static int setcharset(unsigned char **p, unsigned char *charset)
         if(!ISPRINT(c))
           return SETCHARSET_FAIL;
       }
-      if(c == ']') {
+      else if(c == ']') {
         return SETCHARSET_OK;
       }
-      if(c == '\\') {
+      else if(c == '\\') {
         c = *(++(*p));
         if(ISPRINT(c)) {
           charset[c] = 1;
@@ -253,7 +253,7 @@ static int setcharset(unsigned char **p, unsigned char *charset)
         else
           return SETCHARSET_FAIL;
       }
-      if(c >= rangestart) {
+      else if(c >= rangestart) {
         if((ISLOWER(c) && ISLOWER(rangestart)) ||
            (ISDIGIT(c) && ISDIGIT(rangestart)) ||
            (ISUPPER(c) && ISUPPER(rangestart))) {
@@ -267,6 +267,8 @@ static int setcharset(unsigned char **p, unsigned char *charset)
         else
           return SETCHARSET_FAIL;
       }
+      else
+        return SETCHARSET_FAIL;
       break;
     case CURLFNM_SCHS_RIGHTBR:
       if(c == '[') {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -125,7 +125,7 @@ test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
 test1152 test1153 \
 \
-test1160 test1161 \
+test1160 test1161 test1162 \
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \
 test1208 test1209 test1210 test1211 test1212 test1213 test1214 test1215 \
 test1216 test1217 test1218 test1219 \

--- a/tests/data/test1162
+++ b/tests/data/test1162
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+FTP
+RETR
+LIST
+wildcardmatch
+ftplistparser
+flaky
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+<tool>
+lib576
+</tool>
+<name>
+FTP wildcard with crazy pattern
+</name>
+<command>
+"ftp://%HOSTIP:%FTPPORT/fully_simulated/DOS/[*\\s-'tl"
+</command>
+</client>
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+CWD fully_simulated
+CWD DOS
+EPSV
+TYPE A
+LIST
+QUIT
+</protocol>
+# 78 == CURLE_REMOTE_FILE_NOT_FOUND
+<errorcode>
+78
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
... instead of doing an infinite loop!

Added test 1162 to verify.

Reported-by: Max Dymond
Fixes #2015