### PR TITLE
timeval: make timediff_t also work on 32bit windows

### DIFF
--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -27,15 +27,7 @@
 #if SIZEOF_TIME_T < 8
 typedef int timediff_t;
 #else
-/* use a suitable 64 bit type */
-#ifdef HAVE_LONGLONG
-typedef long long timediff_t;
-#elif defined(_MSC_VER) && (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
-typedef __int64 timediff_t;
-#else
-/* hopeless case */
-typedef long timediff_t;
-#endif
+typedef curl_off_t timediff_t;
 #endif
 
 struct curltime {

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -27,7 +27,15 @@
 #if SIZEOF_TIME_T < 8
 typedef int timediff_t;
 #else
-typedef ssize_t timediff_t;
+/* use a suitable 64 bit type */
+#ifdef HAVE_LONGLONG
+typedef long long timediff_t;
+#elif defined(_MSC_VER) && (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
+typedef __int64 timediff_t;
+#else
+/* hopeless case */
+typedef long timediff_t;
+#endif
 #endif
 
 struct curltime {


### PR DESCRIPTION
... by improving the typedef used.

Reported-by: Gisle Vanem
Bug: https://github.com/curl/curl/commit/b9d25f9a6b3ca791385b80a6a3c3fa5ae113e1e0#co
mmitcomment-25205058