### PR TITLE
Add support for Linux VRF via --interface

### DIFF
--- a/docs/cmdline-opts/interface.d
+++ b/docs/cmdline-opts/interface.d
@@ -10,3 +10,7 @@ name, IP address or host name. An example could look like:
  curl --interface eth0:1 https://www.example.com/
 
 If this option is used several times, the last one will be used.
+
+On Linux it can be used to specify a VRF, but the binary needs to either
+have CAP_NET_RAW or to be ran as root. More information about Linux VRF:
+https://www.kernel.org/doc/Documentation/networking/vrf.txt


### PR DESCRIPTION
The --interface command already uses SO_BINDTODEVICE on Linux, but it
tries to parse it as an interface or IP address first, which fails in
case the user passes a VRF.
Try to immediately use the socket option and only try to parse it as a
fallback instead.
Update the documentation to mention this feature, and that it requires
the binary to be ran by root or with CAP_NET_RAW capabilities.