### PR TITLE
curl_setup: Improve detection of CURL_WINDOWS_APP

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -751,7 +751,7 @@ endings either CRLF or LF so 't' is appropriate.
 
 /* Detect Windows App environment which has a restricted access
  * to the Win32 APIs. */
-# if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)
+# if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || defined(WINAPI_FAMILY)
 #  include <winapifamily.h>
 #  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)


### PR DESCRIPTION
If WINAPI_FAMILY is defined, it should be safe to try to include
winapifamily.h to check what the define evaluates to.

This should fix detection of CURL_WINDOWS_APP if building with
_WIN32_WINNT set to 0x0600.