### PR TITLE
mkhelp.pl: support reproducible build

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -102,11 +102,9 @@ while(<READ>) {
 }
 close(READ);
 
-$now = localtime;
 print <<HEAD
 /*
  * NEVER EVER edit this manually, fix the mkhelp.pl script instead!
- * Generation time: $now
  */
 #ifdef USE_MANUAL
 #include "tool_hugehelp.h"


### PR DESCRIPTION
If the environment contains SOURCE_DATE_EPOCH, generate output such as:

* Generation time: reproducible build, date unspecified

Instead of the usual output based on the current date such as:

* Generation time: Tue Oct-24 18:01:41 2017

This will improve reproducibility. The generated string is only
part of a comment, so there should be no adverse consequences.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>