### PR TITLE
Two cli tool -F option fixes

### DIFF
--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -57,6 +57,11 @@ or
 Note that if a filename/path is quoted by double-quotes, any double-quote
 or backslash within the filename must be escaped by backslash.
 
+Quoting must also be applied to non-file data if it contains semicolons,
+leading/trailing spaces or leading double quotes:
+
+ curl -F 'colors="red; green; blue";type=text/x-myapp' example.com
+
 You can add custom headers to the field by setting headers=, like
 
   curl -F "submit=OK;headers=\\"X-submit-type: OK\\"" example.com

--- a/tests/data/test1133
+++ b/tests/data/test1133
@@ -23,10 +23,10 @@ blablabla
 http
 </server>
  <name>
-HTTP RFC1867-type formposting with filename contains ',', ';', '"'
+HTTP RFC1867-type formposting with filename/data contains ',', ';', '"'
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/we/want/1133 -F "file=@\"log/test1133,a\\\"nd;.txt\";type=mo/foo;filename=\"faker,and;.txt\"" -F 'file2=@"log/test1133,a\"nd;.txt"' -F 'file3=@"log/test1133,a\"nd;.txt";type=m/f,"log/test1133,a\"nd;.txt"'
+http://%HOSTIP:%HTTPPORT/we/want/1133 -F "file=@\"log/test1133,a\\\"nd;.txt\";type=mo/foo;filename=\"faker,and;.txt\"" -F 'file2=@"log/test1133,a\"nd;.txt"' -F 'file3=@"log/test1133,a\"nd;.txt";type=m/f,"log/test1133,a\"nd;.txt"' -F a="{\"field1\":\"value1\",\"field2\":\"value2\"}" -F 'b=" \\value1;type=\"whatever\" "; type=text/foo; charset=utf-8 ; filename=param_b'
 </command>
 # We create this file before the command is invoked!
 <file name=log/test1133,a"nd;.txt>
@@ -47,7 +47,8 @@ POST /we/want/1133 HTTP/1.1
 User-Agent: curl/7.10.4 (i686-pc-linux-gnu) libcurl/7.10.4 OpenSSL/0.9.7a ipv6 zlib/1.1.3
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 969
+Content-Length: 1270
+Expect: 100-continue
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32
@@ -89,6 +90,13 @@ bar
 foo
 
 
+Content-Disposition: form-data; name="a"
+
+{"field1":"value1","field2":"value2"}
+Content-Disposition: form-data; name="b"; filename="param_b"
+Content-Type: text/foo; charset=utf-8
+
+ \value1;type="whatever" 
 ------------------------------24e78000bd32--
 </protocol>
 </verify>


### PR DESCRIPTION
Comma should not be a delimiter for non-file form fields.

Quoting does not apply to content types.