### PR TITLE
memdebug: use send/recv signature for curl_dosend/curl_dorecv

### DIFF
--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -356,29 +356,32 @@ curl_socket_t curl_socket(int domain, int type, int protocol,
   return sockfd;
 }
 
-ssize_t curl_dosend(int sockfd, const void *buf, size_t len, int flags,
-                    int line, const char *source)
+SEND_TYPE_RETV curl_dosend(SEND_TYPE_ARG1 sockfd,
+                           SEND_QUAL_ARG2 SEND_TYPE_ARG2 buf,
+                           SEND_TYPE_ARG3 len, SEND_TYPE_ARG4 flags, int line,
+                           const char *source)
 {
-  ssize_t rc;
+  SEND_TYPE_RETV rc;
   if(countcheck("send", line, source))
     return -1;
   rc = send(sockfd, buf, len, flags);
   if(source)
-    curl_memlog("SEND %s:%d send(%zu) = %zd\n",
-                source, line, len, rc);
+    curl_memlog("SEND %s:%d send(%lu) = %ld\n",
+                source, line, (unsigned long)len, (long)rc);
   return rc;
 }
 
-ssize_t curl_dorecv(int sockfd, void *buf, size_t len, int flags,
-                    int line, const char *source)
+RECV_TYPE_RETV curl_dorecv(RECV_TYPE_ARG1 sockfd, RECV_TYPE_ARG2 buf,
+                           RECV_TYPE_ARG3 len, RECV_TYPE_ARG4 flags, int line,
+                           const char *source)
 {
-  ssize_t rc;
+  RECV_TYPE_RETV rc;
   if(countcheck("recv", line, source))
     return -1;
   rc = recv(sockfd, buf, len, flags);
   if(source)
-    curl_memlog("RECV %s:%d recv(%zu) = %zd\n",
-                source, line, len, rc);
+    curl_memlog("RECV %s:%d recv(%lu) = %ld\n",
+                source, line, (unsigned long)len, (long)rc);
   return rc;
 }
 

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -67,10 +67,15 @@ CURL_EXTERN int curl_socketpair(int domain, int type, int protocol,
 #endif
 
 /* send/receive sockets */
-CURL_EXTERN ssize_t curl_dosend(int sockfd, const void *buf, size_t len,
-                                int flags, int line, const char *source);
-CURL_EXTERN ssize_t curl_dorecv(int sockfd, void *buf, size_t len, int flags,
-                                int line, const char *source);
+CURL_EXTERN SEND_TYPE_RETV curl_dosend(SEND_TYPE_ARG1 sockfd,
+                                       SEND_QUAL_ARG2 SEND_TYPE_ARG2 buf,
+                                       SEND_TYPE_ARG3 len,
+                                       SEND_TYPE_ARG4 flags, int line,
+                                       const char *source);
+CURL_EXTERN RECV_TYPE_RETV curl_dorecv(RECV_TYPE_ARG1 sockfd,
+                                       RECV_TYPE_ARG2 buf, RECV_TYPE_ARG3 len,
+                                       RECV_TYPE_ARG4 flags, int line,
+                                       const char *source);
 
 /* FILE functions */
 CURL_EXTERN FILE *curl_fopen(const char *file, const char *mode, int line,


### PR DESCRIPTION
This avoids build errors and warnings caused by implicit casts, notably on Windows.

I hope I got the comment in https://github.com/curl/curl/commit/ad164eceb3ce6721d34a3418e0dacabd4f4ff904#commitcomment-25215855 right that we can do it this way.
An alternative would be to use `curl_socket_t` for the first argument and just use casts to the `*_TYPE_ARG_*` types in the send/recv macro definition as well as the function definition.