### PR TITLE
fixes from PVS-Studio

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -312,7 +312,7 @@ static void remove_expired(struct CookieInfo *cookies)
       if(co == cookies->cookies) {
         cookies->cookies = co->next;
       }
-      else {
+      else if (pv) {
         pv->next = co->next;
       }
       cookies->numcookies--;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V522](https://www.viva64.com/en/w/v522/) Dereferencing of the null pointer 'pv' might take place. cookie.c 316