### PR TITLE
cookie: avoid NULL dereference

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -309,7 +309,7 @@ static void remove_expired(struct CookieInfo *cookies)
   while(co) {
     nx = co->next;
     if(co->expires && co->expires < now) {
-      if(co == cookies->cookies) {
+      if(!pv) {
         cookies->cookies = co->next;
       }
       else {


### PR DESCRIPTION
... when expiring old cookies.

Reported-by: Pavel Gushchin
Fixes #2032