### PR TITLE
CURLOPT_MAXREDIRS: allow -1 as a value

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1043,7 +1043,7 @@ CURLcode Curl_setopt(struct Curl_easy *data, CURLoption option,
      * headers. This should mostly be used to detect never-ending loops.
      */
     arg = va_arg(param, long);
-    if(arg < 0)
+    if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     data->set.maxredirs = arg;
     break;

--- a/tests/libtest/lib501.c
+++ b/tests/libtest/lib501.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -43,6 +43,7 @@ int test(char *URL)
   }
 
   test_setopt(curl, CURLOPT_HEADER, 1L);
+  test_setopt(curl, CURLOPT_MAXREDIRS, -1L);
 
   res = curl_easy_perform(curl);
 


### PR DESCRIPTION
... which is valid according to documentation. Regression since
f121575c0b5f.

Reported-by: cbartl on github
Fixes #2038