### PR TITLE
share: add support for sharing the connection cache

### DIFF
--- a/debug/shared-conn.c
+++ b/debug/shared-conn.c
@@ -1,0 +1,68 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+/* <DESC>
+ * Two HTTP GET using connection sharing with the share inteface
+ * </DESC>
+ */
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void)
+{
+  CURL *curl;
+  CURLcode res;
+  CURLSH *share;
+  int i;
+
+  share = curl_share_init();
+  curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+
+  /* Loop the transfer and cleanup the handle properly every lap. This will
+     still reuse connections since the pool is in the shared object! */
+
+  for(i = 0; i < 3; i++) {
+    curl = curl_easy_init();
+    if(curl) {
+      curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+      /* example.com is redirected, so we tell libcurl to follow redirection */
+      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+      /* use the connection pool in the share object */
+      curl_easy_setopt(curl, CURLOPT_SHARE, share);
+
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+      /* Perform the request, res will get the return code */
+      res = curl_easy_perform(curl);
+      /* Check for errors */
+      if(res != CURLE_OK)
+        fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                curl_easy_strerror(res));
+
+      /* always cleanup */
+      curl_easy_cleanup(curl);
+    }
+  }
+
+  curl_share_cleanup(share);
+  return 0;
+}

--- a/docs/examples/Makefile.inc
+++ b/docs/examples/Makefile.inc
@@ -33,7 +33,8 @@ check_PROGRAMS = 10-at-a-time anyauthput cookie_interface debug fileupload \
   imap-search imap-create imap-delete imap-copy imap-noop imap-ssl         \
   imap-tls imap-multi url2file sftpget ftpsget postinmemory http2-download \
   http2-upload http2-serverpush getredirect ftpuploadfrommem               \
-  ftpuploadresume sslbackend postit2-formadd multi-formadd
+  ftpuploadresume sslbackend postit2-formadd multi-formadd                 \
+  shared-connection-cache
 
 # These examples require external dependencies that may not be commonly
 # available on POSIX systems, so don't bother attempting to compile them here.

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -117,11 +117,6 @@ static void free_bundle_hash_entry(void *freethis)
   bundle_destroy(b);
 }
 
-bool Curl_conncache_inited(struct conncache *connc)
-{
-  return connc->inited;
-}
-
 int Curl_conncache_init(struct conncache *connc, int size)
 {
   int rc;
@@ -137,10 +132,9 @@ int Curl_conncache_init(struct conncache *connc, int size)
     Curl_close(connc->closure_handle);
     connc->closure_handle = NULL;
   }
-  else {
+  else
     connc->closure_handle->state.conn_cache = connc;
-    connc->inited = TRUE;
-  }
+
   return rc;
 }
 

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -24,7 +24,6 @@
  ***************************************************************************/
 
 struct conncache {
-  bool inited; /* FALSE until inited */
   struct curl_hash hash;
   size_t num_connections;
   long next_connection_id;
@@ -46,7 +45,6 @@ struct connectbundle {
 
 /* returns 1 on error, 0 is fine */
 int Curl_conncache_init(struct conncache *, int size);
-bool Curl_conncache_inited(struct conncache *);
 void Curl_conncache_destroy(struct conncache *connc);
 
 /* return the correct bundle, to a host or a proxy */

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -24,10 +24,13 @@
  ***************************************************************************/
 
 struct conncache {
+  bool inited; /* FALSE until inited */
   struct curl_hash hash;
   size_t num_connections;
   long next_connection_id;
   struct curltime last_cleanup;
+  /* handle used for closing cached connections */
+  struct Curl_easy *closure_handle;
 };
 
 #define BUNDLE_NO_MULTIUSE -1
@@ -41,8 +44,9 @@ struct connectbundle {
   struct curl_llist conn_list;  /* The connectdata members of the bundle */
 };
 
+/* returns 1 on error, 0 is fine */
 int Curl_conncache_init(struct conncache *, int size);
-
+bool Curl_conncache_inited(struct conncache *);
 void Curl_conncache_destroy(struct conncache *connc);
 
 /* return the correct bundle, to a host or a proxy */
@@ -55,7 +59,8 @@ CURLcode Curl_conncache_add_conn(struct conncache *connc,
 void Curl_conncache_remove_conn(struct conncache *connc,
                                 struct connectdata *conn);
 
-void Curl_conncache_foreach(struct conncache *connc,
+void Curl_conncache_foreach(struct Curl_easy *data,
+                            struct conncache *connc,
                             void *param,
                             int (*func)(struct connectdata *conn,
                                         void *param));
@@ -63,6 +68,9 @@ void Curl_conncache_foreach(struct conncache *connc,
 struct connectdata *
 Curl_conncache_find_first_connection(struct conncache *connc);
 
+struct connectdata *
+Curl_conncache_oldest_idle(struct Curl_easy *data);
+void Curl_conncache_close_all_connections(struct conncache *connc);
 void Curl_conncache_print(struct conncache *connc);
 
 #endif /* HEADER_CURL_CONNCACHE_H */

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1225,7 +1225,7 @@ curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
     find.tofind = data->state.lastconnect;
     find.found = FALSE;
 
-    Curl_conncache_foreach(data->multi_easy?
+    Curl_conncache_foreach(data, data->multi_easy?
                            &data->multi_easy->conn_cache:
                            &data->multi->conn_cache, &find, conn_is_conn);
 

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -114,10 +114,6 @@ struct Curl_multi {
   /* Shared connection cache (bundles)*/
   struct conncache conn_cache;
 
-  /* This handle will be used for closing the cached connections in
-     curl_multi_cleanup() */
-  struct Curl_easy *closure_handle;
-
   long maxconnects; /* if >0, a fixed limit of the maximum number of entries
                        we're allowed to grow the connection cache to */
 

--- a/lib/share.c
+++ b/lib/share.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -102,6 +102,8 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       break;
 
     case CURL_LOCK_DATA_CONNECT:     /* not supported (yet) */
+      if(Curl_conncache_init(&share->conn_cache, 103))
+        return CURLSHE_NOMEM;
       break;
 
     default:
@@ -186,7 +188,11 @@ curl_share_cleanup(struct Curl_share *share)
     return CURLSHE_IN_USE;
   }
 
-  Curl_hash_destroy(&share->hostcache);
+  if(Curl_conncache_inited(&share->conn_cache)) {
+    Curl_conncache_close_all_connections(&share->conn_cache);
+    Curl_conncache_destroy(&share->conn_cache);
+    Curl_hash_destroy(&share->hostcache);
+  }
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
   Curl_cookie_cleanup(share->cookies);

--- a/lib/share.c
+++ b/lib/share.c
@@ -188,11 +188,9 @@ curl_share_cleanup(struct Curl_share *share)
     return CURLSHE_IN_USE;
   }
 
-  if(Curl_conncache_inited(&share->conn_cache)) {
-    Curl_conncache_close_all_connections(&share->conn_cache);
-    Curl_conncache_destroy(&share->conn_cache);
-    Curl_hash_destroy(&share->hostcache);
-  }
+  Curl_conncache_close_all_connections(&share->conn_cache);
+  Curl_conncache_destroy(&share->conn_cache);
+  Curl_hash_destroy(&share->hostcache);
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
   Curl_cookie_cleanup(share->cookies);

--- a/lib/share.h
+++ b/lib/share.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,6 +26,7 @@
 #include <curl/curl.h>
 #include "cookie.h"
 #include "urldata.h"
+#include "conncache.h"
 
 /* SalfordC says "A structure member may not be volatile". Hence:
  */
@@ -43,7 +44,7 @@ struct Curl_share {
   curl_lock_function lockfunc;
   curl_unlock_function unlockfunc;
   void *clientdata;
-
+  struct conncache conn_cache;
   struct curl_hash hostcache;
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
   struct CookieInfo *cookies;

--- a/lib/url.c
+++ b/lib/url.c
@@ -3443,58 +3443,6 @@ static void signalPipeClose(struct curl_llist *pipeline, bool pipe_broke)
   }
 }
 
-/*
- * This function finds the connection in the connection
- * cache that has been unused for the longest time.
- *
- * Returns the pointer to the oldest idle connection, or NULL if none was
- * found.
- */
-struct connectdata *
-Curl_oldest_idle_connection(struct Curl_easy *data)
-{
-  struct conncache *bc = data->state.conn_cache;
-  struct curl_hash_iterator iter;
-  struct curl_llist_element *curr;
-  struct curl_hash_element *he;
-  timediff_t highscore =- 1;
-  timediff_t score;
-  struct curltime now;
-  struct connectdata *conn_candidate = NULL;
-  struct connectbundle *bundle;
-
-  now = Curl_now();
-
-  Curl_hash_start_iterate(&bc->hash, &iter);
-
-  he = Curl_hash_next_element(&iter);
-  while(he) {
-    struct connectdata *conn;
-
-    bundle = he->ptr;
-
-    curr = bundle->conn_list.head;
-    while(curr) {
-      conn = curr->ptr;
-
-      if(!conn->inuse) {
-        /* Set higher score for the age passed since the connection was used */
-        score = Curl_timediff(now, conn->now);
-
-        if(score > highscore) {
-          highscore = score;
-          conn_candidate = conn;
-        }
-      }
-      curr = curr->next;
-    }
-
-    he = Curl_hash_next_element(&iter);
-  }
-
-  return conn_candidate;
-}
-
 static bool
 proxy_info_matches(const struct proxy_info* data,
                    const struct proxy_info* needle)
@@ -3614,7 +3562,7 @@ static void prune_dead_connections(struct Curl_easy *data)
   time_t elapsed = Curl_timediff(now, data->state.conn_cache->last_cleanup);
 
   if(elapsed >= 1000L) {
-    Curl_conncache_foreach(data->state.conn_cache, data,
+    Curl_conncache_foreach(data, data->state.conn_cache, data,
                            call_disconnect_if_dead);
     data->state.conn_cache->last_cleanup = now;
   }
@@ -6991,7 +6939,7 @@ static CURLcode create_conn(struct Curl_easy *data,
       struct connectdata *conn_candidate;
 
       /* The cache is full. Let's see if we can kill a connection. */
-      conn_candidate = Curl_oldest_idle_connection(data);
+      conn_candidate = Curl_conncache_oldest_idle(data);
 
       if(conn_candidate) {
         /* Set the connection's owner correctly, then kill it */

--- a/lib/url.h
+++ b/lib/url.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -57,8 +57,6 @@ CURLcode Curl_addHandleToPipeline(struct Curl_easy *handle,
                                   struct curl_llist *pipeline);
 int Curl_removeHandleFromPipeline(struct Curl_easy *handle,
                                   struct curl_llist *pipeline);
-struct connectdata *
-Curl_oldest_idle_connection(struct Curl_easy *data);
 /* remove the specified connection from all (possible) pipelines and related
    queues */
 void Curl_getoff_all_pipelines(struct Curl_easy *data,

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -170,7 +170,7 @@ test1520 test1521 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 \
-test1550 test1551 test1552 test1553 \
+test1550 test1551 test1552 test1553 test1554 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 \
 \
 test1700 test1701 test1702 \

--- a/tests/data/test1554
+++ b/tests/data/test1554
@@ -1,0 +1,77 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+shared connections
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Content-Length: 29
+
+run 1: foobar and so on fun!
+</data>
+<datacheck>
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+run 1: foobar and so on fun!
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+run 1: foobar and so on fun!
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+run 1: foobar and so on fun!
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with shared connection cache
+</name>
+<tool>
+lib1554
+</tool>
+<command>
+http://%HOSTIP:%HTTPPORT/1554
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -27,7 +27,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 \
- lib1550 lib1551 lib1552 lib1553 \
+ lib1550 lib1551 lib1552 lib1553 lib1554 \
  lib1900 \
  lib2033
 
@@ -470,6 +470,9 @@ lib1552_CPPFLAGS = $(AM_CPPFLAGS)
 lib1553_SOURCES = lib1553.c $(SUPPORTFILES) $(TESTUTIL)
 lib1553_LDADD = $(TESTUTIL_LIBS)
 lib1553_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1554_SOURCES = lib1554.c $(SUPPORTFILES)
+lib1554_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1900_SOURCES = lib1900.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1900_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1554.c
+++ b/tests/libtest/lib1554.c
@@ -1,0 +1,81 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+#include "memdebug.h"
+
+static void my_lock(CURL *handle, curl_lock_data data,
+                    curl_lock_access laccess, void *useptr)
+{
+  (void)handle;
+  (void)data;
+  (void)laccess;
+  (void)useptr;
+  printf("-> Mutex lock\n");
+}
+
+static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
+{
+  (void)handle;
+  (void)data;
+  (void)useptr;
+  printf("<- Mutex unlock\n");
+}
+
+/* test function */
+int test(char *URL)
+{
+  CURL *curl;
+  CURLcode res;
+  CURLSH *share;
+  int i;
+
+  share = curl_share_init();
+  curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+  curl_share_setopt(share, CURLSHOPT_LOCKFUNC, my_lock);
+  curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, my_unlock);
+
+  /* Loop the transfer and cleanup the handle properly every lap. This will
+     still reuse connections since the pool is in the shared object! */
+
+  for(i = 0; i < 3; i++) {
+    curl = curl_easy_init();
+    if(curl) {
+      curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+      /* use the share object */
+      curl_easy_setopt(curl, CURLOPT_SHARE, share);
+
+      /* Perform the request, res will get the return code */
+      res = curl_easy_perform(curl);
+      /* Check for errors */
+      if(res != CURLE_OK)
+        fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                curl_easy_strerror(res));
+
+      /* always cleanup */
+      curl_easy_cleanup(curl);
+    }
+  }
+
+  curl_share_cleanup(share);
+  return 0;
+}


### PR DESCRIPTION
This is my first take at supporting a shared connection cache (work in progress, not the final version). This allows multiple threads/handles to share the same connection cache. `debug/shared-conn.c` shows how to use it.

I'm interested in feedback.