### PR TITLE
connect: add support for new TCP Fast Open API on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3275,6 +3275,7 @@ AC_CHECK_HEADERS(
         net/if.h \
         netinet/in.h \
         sys/un.h \
+        linux/tcp.h \
         netinet/tcp.h \
         netdb.h \
         sys/sockio.h \

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -22,6 +22,10 @@
 
 #include "curl_setup.h"
 
+#ifdef HAVE_LINUX_TCP_H
+#include <linux/tcp.h>
+#endif
+
 #include <curl/curl.h>
 
 #include "urldata.h"
@@ -360,7 +364,7 @@ ssize_t Curl_send_plain(struct connectdata *conn, int num,
      available. */
   pre_receive_plain(conn, num);
 
-#ifdef MSG_FASTOPEN /* Linux */
+#if defined(MSG_FASTOPEN) && !defined(TCP_FASTOPEN_CONNECT) /* Linux */
   if(conn->bits.tcp_fastopen) {
     bytes_written = sendto(sockfd, mem, len, MSG_FASTOPEN,
                            conn->ip_addr->ai_addr, conn->ip_addr->ai_addrlen);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -26,6 +26,10 @@
 #include <limits.h>
 #endif
 
+#ifdef HAVE_LINUX_TCP_H
+#include <linux/tcp.h>
+#endif
+
 #include "urldata.h"
 #include "url.h"
 #include "progress.h"
@@ -2450,7 +2454,8 @@ static CURLcode setopt(struct Curl_easy *data, CURLoption option,
     data->set.tcp_keepintvl = arg;
     break;
   case CURLOPT_TCP_FASTOPEN:
-#if defined(CONNECT_DATA_IDEMPOTENT) || defined(MSG_FASTOPEN)
+#if defined(CONNECT_DATA_IDEMPOTENT) || defined(MSG_FASTOPEN) || \
+   defined(TCP_FASTOPEN_CONNECT)
     data->set.tcp_fastopen = (0 != va_arg(param, long))?TRUE:FALSE;
 #else
     result = CURLE_NOT_BUILT_IN;


### PR DESCRIPTION
The new API [added](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=19f6d3f3c8422d65b5e3d2162e30ef07c6e21ea2) in Linux 4.11 only requires setting a socket option
before connecting, without the whole sento() machinery.

Notably, this makes it possible to use TFO with SSL connections on Linux
as well, without the need to mess around with OpenSSL (or whatever other
SSL library) internals.