### PR TITLE
content_encoding: fix inflate_stream for no bytes available

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -139,6 +139,11 @@ inflate_stream(struct connectdata *conn, contenc_writer *writer)
   /* because the buffer size is fixed, iteratively decompress and transfer to
      the client via client_write. */
   for(;;) {
+    if(z->avail_in == 0) {
+      free(decomp);
+      return result;
+    }
+
     /* (re)set buffer for decompressed output for every iteration */
     z->next_out = (Bytef *) decomp;
     z->avail_out = DSIZ;


### PR DESCRIPTION
- Don't call zlib's inflate() when avail_in stream bytes is 0.

Prior to this change libcurl's inflate_stream could call zlib's inflate
even when no bytes were available, causing inflate to return
Z_BUF_ERROR, and then inflate_stream would treat that as a hard error
and return CURLE_BAD_CONTENT_ENCODING.

According to the zlib FAQ, Z_BUF_ERROR is not fatal.

This bug would happen randomly since packet sizes are arbitrary. A test
of 10,000 transfers had 55 fail (ie 0.55%).

Ref: https://zlib.net/zlib_faq.html#faq05

Closes https://github.com/curl/curl/pull/2060

---

Bug first seen in CI:
https://travis-ci.org/curl/curl/jobs/297978443#L4332
https://github.com/curl/curl/pull/2056#issuecomment-342323746

sprinkle:
~~~diff
diff --git a/lib/content_encoding.c b/lib/content_encoding.c
index 6b31685..4cdf3a1 100644
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -129,6 +129,7 @@ inflate_stream(struct connectdata *conn, contenc_writer *writer)
   CURLcode result = CURLE_OK;   /* Curl_client_write status */
   char *decomp;                 /* Put the decompressed data here. */
 
+  fprintf(stderr, ">>>inflate_stream\n");
   /* Dynamically allocate a buffer for decompression because it's uncommonly
      large to hold on the stack */
   decomp = malloc(DSIZ);
@@ -143,7 +144,12 @@ inflate_stream(struct connectdata *conn, contenc_writer *writer)
     z->next_out = (Bytef *) decomp;
     z->avail_out = DSIZ;
 
+    fprintf(stderr, "before inflate: z->avail_in: %d, z->avail_out: %d\n",
+            z->avail_in, z->avail_out);
     status = inflate(z, Z_SYNC_FLUSH);
+    fprintf(stderr, "after inflate: status %d, z->avail_in: %d, "
+                    "z->avail_out: %d\n",
+            status, z->avail_in, z->avail_out);
     if(status == Z_OK || status == Z_STREAM_END) {
       allow_restart = 0;
       result = Curl_unencode_write(conn, writer->downstream, decomp,
~~~

success case example:
~~~
>>>inflate_stream
before inflate: z->avail_in: 214, z->avail_out: 16384
after inflate: status 0, z->avail_in: 0, z->avail_out: 16185
>>>inflate_stream
before inflate: z->avail_in: 199, z->avail_out: 16384
after inflate: status 0, z->avail_in: 0, z->avail_out: 16170
>>>inflate_stream
before inflate: z->avail_in: 1114, z->avail_out: 16384
after inflate: status 1, z->avail_in: 0, z->avail_out: 15278
>>>inflate_stream
before inflate: z->avail_in: 1106, z->avail_out: 16384
after inflate: status 1, z->avail_in: 0, z->avail_out: 11557
~~~

fail case example:
~~~
>>>inflate_stream
before inflate: z->avail_in: 14, z->avail_out: 16384
after inflate: status 0, z->avail_in: 0, z->avail_out: 16384
>>>inflate_stream
before inflate: z->avail_in: 0, z->avail_out: 16384
after inflate: status -5, z->avail_in: 0, z->avail_out: 16384
~~~
[Z_BUF_ERROR (-5)](https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zlib.h#L177-L188). inflate_stream treats it as a hard error, but according to the zlib FAQ [it's not](https://zlib.net/zlib_faq.html#faq05).

rather than deal with the error this change prevents it from occurring in the first place by returning when there are no bytes available