### PR TITLE
[WIP] libcurl: add new API function curl_global_sslget

### DIFF
--- a/docs/libcurl/Makefile.inc
+++ b/docs/libcurl/Makefile.inc
@@ -21,4 +21,5 @@ man_MANS = curl_easy_cleanup.3 curl_easy_getinfo.3 curl_easy_init.3      \
   curl_mime_init.3 curl_mime_free.3 curl_mime_addpart.3 curl_mime_name.3 \
   curl_mime_data.3 curl_mime_data_cb.3 curl_mime_filedata.3              \
   curl_mime_filename.3 curl_mime_subparts.3                              \
-  curl_mime_type.3 curl_mime_headers.3 curl_mime_encoder.3
+  curl_mime_type.3 curl_mime_headers.3 curl_mime_encoder.3               \
+  curl_global_sslget.3

--- a/docs/libcurl/curl_global_sslget.3
+++ b/docs/libcurl/curl_global_sslget.3
@@ -1,0 +1,73 @@
+.\" **************************************************************************
+.\" *                                  _   _ ____  _
+.\" *  Project                     ___| | | |  _ \| |
+.\" *                             / __| | | | |_) | |
+.\" *                            | (__| |_| |  _ <| |___
+.\" *                             \___|\___/|_| \_\_____|
+.\" *
+.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" *
+.\" * This software is licensed as described in the file COPYING, which
+.\" * you should have received as part of this distribution. The terms
+.\" * are also available at https://curl.haxx.se/docs/copyright.html.
+.\" *
+.\" * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+.\" * copies of the Software, and permit persons to whom the Software is
+.\" * furnished to do so, under the terms of the COPYING file.
+.\" *
+.\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+.\" * KIND, either express or implied.
+.\" *
+.\" **************************************************************************
+.TH curl_global_sslget 3 "November 8 2017" "libcurl 7.57.1" "libcurl Manual"
+.SH NAME
+curl_global_sslget - Get the SSL backend selected to be used by libcurl
+.SH SYNOPSIS
+.B #include <curl/curl.h>
+.nf
+
+typedef struct {
+  curl_sslbackend id;
+  const char *name;
+} curl_ssl_backend;
+
+typedef enum {
+  CURLSSLBACKEND_NONE = 0,
+  CURLSSLBACKEND_OPENSSL = 1,
+  CURLSSLBACKEND_GNUTLS = 2,
+  CURLSSLBACKEND_NSS = 3,
+  CURLSSLBACKEND_GSKIT = 5,
+  CURLSSLBACKEND_POLARSSL = 6,
+  CURLSSLBACKEND_WOLFSSL = 7,
+  CURLSSLBACKEND_SCHANNEL = 8,
+  CURLSSLBACKEND_DARWINSSL = 9,
+  CURLSSLBACKEND_AXTLS = 10,
+  CURLSSLBACKEND_MBEDTLS = 11
+} curl_sslbackend;
+
+.B "const curl_ssl_backend *curl_global_sslget();"
+.fi
+.SH DESCRIPTION
+This function gets the SSL backend selected to be used by libcurl. This
+function is not thread safe if it is called before \fIcurl_global_init(3)\fP.
+
+If libcurl was built without SSL support then \fIid\fP is CURLSSLBACKEND_NONE.
+
+If libcurl was built with support for multiple SSL backends but a backend has
+not yet been selected by \fIcurl_global_sslset(3)\fP then \fIid\fP is
+CURLSSLBACKEND_NONE.
+
+If the curl_ssl_backend returned by this function has an \fIid\fP other than
+CURLSSLBACKEND_NONE then it will not change. That is because libcurl selects
+the SSL library to use only once.
+.SH AVAILABILITY
+This function was added in libcurl 7.57.1. Before this version, only
+\fICURLINFO_TLS_SSL_PTR(3)\fP could be used to obtain the SSL backend id.
+.SH RETURN VALUE
+This function will always return a valid pointer to curl_ssl_backend that
+should not be freed.
+.SH "SEE ALSO"
+.BR curl_global_init "(3), "
+.BR curl_global_sslset "(3), "
+.BR CURLINFO_TLS_SSL_PTR "(3), "
+.BR libcurl "(3) "

--- a/docs/libcurl/curl_global_sslset.3
+++ b/docs/libcurl/curl_global_sslset.3
@@ -94,4 +94,5 @@ If this libcurl was built completely without SSL support, with no backends at
 all, this function returns \fICURLSSLSET_NO_BACKENDS\fP.
 .SH "SEE ALSO"
 .BR curl_global_init "(3), "
+.BR curl_global_sslget "(3), "
 .BR libcurl "(3) "

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -184,5 +184,5 @@ entry.
 .SH RETURN VALUE
 A pointer to a curl_version_info_data struct.
 .SH "SEE ALSO"
-\fIcurl_version(3)\fP
-
+.BR curl_version "(3), "
+.BR curl_global_sslget "(3) "

--- a/docs/libcurl/libcurl.3
+++ b/docs/libcurl/libcurl.3
@@ -40,7 +40,9 @@ details.
 
 If libcurl was compiled with support for multiple SSL backends, the function
 \fIcurl_global_sslset(3)\fP can be called before \fIcurl_global_init(3)\fP
-to select the active SSL backend.
+to select the active SSL backend. \fIcurl_global_sslget(3)\fP can be used to
+retrieve the selected SSL backend even if multiple SSL backends are not
+supported.
 
 To transfer files, you create an "easy handle" using \fIcurl_easy_init(3)\fP
 for a single individual transfer (in either direction). You then set your

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2378,6 +2378,9 @@ typedef enum {
 CURL_EXTERN CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
                                           const curl_ssl_backend ***avail);
 
+/* Get the selected SSL backend. */
+CURL_EXTERN const curl_ssl_backend *curl_global_sslget(void);
+
 /*
  * NAME curl_slist_append()
  *

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1313,6 +1313,11 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
   return CURLSSLSET_UNKNOWN_BACKEND;
 }
 
+const curl_ssl_backend *curl_global_sslget(void)
+{
+  return &Curl_ssl->info;
+}
+
 #else /* USE_SSL */
 CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
                               const curl_ssl_backend ***avail)
@@ -1321,6 +1326,12 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
   (void)name;
   (void)avail;
   return CURLSSLSET_NO_BACKENDS;
+}
+
+const curl_ssl_backend *curl_global_sslget(void)
+{
+  static curl_ssl_backend b = { CURLSSLBACKEND_NONE, "none" };
+  return &b;
 }
 
 #endif /* !USE_SSL */


### PR DESCRIPTION
I wanted an easy way to tell the SSL backend in use without a curl easy handle. CURLINFO_TLS_SSL_PTR can do it but only with an easy handle. I wanted to be able to tell earlier in the process. curl_version_info sslversion string gives an idea:
~~~
CURL_SSL_BACKEND=
CURL_SSL_BACKEND=openssl
sslversion: OpenSSL/1.0.2m (WinSSL)

CURL_SSL_BACKEND=schannel
sslversion: (OpenSSL/1.0.2m) WinSSL
~~~
I can parse that of course but I thought it would be easier if I could do this:
if(curl_global_sslget()->id == CURLSSLBACKEND_SCHANNEL)

I'm unclear on the thread safety, specifically whether we can guarantee that once the backend id != CURLSSLBACKEND_NONE that it's not going to change, because if it is then this call is not thread safe which I'd imagine would make it a lot less desirable for users.

This is a work in progress and I'm not totally committed to it. I'm looking at a situation in the tool where we might need the backend information before easy handle creation and I didn't want to parse sslversion.

/cc @dscho 
