### PR TITLE
URL: return error on malformed URLs with junk after IPv6 bracket

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3337,8 +3337,14 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
     portptr = strchr(conn->host.name, ']');
     if(portptr) {
       *portptr++ = '\0'; /* zero terminate, killing the bracket */
-      if(':' != *portptr)
-        portptr = NULL; /* no port number available */
+      if(*portptr) {
+        if (*portptr != ':') {
+          failf(data, "IPv6 closing bracket followed by '%c'", *portptr);
+          return CURLE_URL_MALFORMAT;
+        }
+      }
+      else
+       portptr = NULL; /* no port number available */
     }
   }
   else {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -134,7 +134,7 @@ test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 test1252 test1253 test1254 test1255 test1256 test1257 test1258 test1259 \
-test1260 test1261 test1262 \
+test1260 test1261 test1262 test1263 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 \

--- a/tests/data/test1263
+++ b/tests/data/test1263
@@ -1,0 +1,37 @@
+# similar to test 1260
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+http
+</features>
+ <name>
+HTTP URL with rubbish after IPv6 bracket
+ </name>
+ <command>
+-g "http://[%HOSTIP]test:%HTTPPORT/we/want/1263" "http://[%HOSTIP][%HOSTIP]:%HTTPPORT/we/want/1263" "http://user@[::1]@localhost"
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# CURLE_URL_MALFORMAT == 3
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Follow-up to aadb7c7. Verified by new test 1263.