### PR TITLE
resolve: reject host names containing spaces

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -134,7 +134,7 @@ test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 test1252 test1253 test1254 test1255 test1256 test1257 test1258 test1259 \
-test1260 test1261 test1262 \
+test1260 test1261 test1262 test1264 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 \

--- a/tests/data/test1264
+++ b/tests/data/test1264
@@ -1,0 +1,36 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+http
+</features>
+ <name>
+HTTP URL with space in host name
+ </name>
+ <command>
+-g "http://127.0.0.1 www.example.com/we/want/1264"
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# CURLE_COULDNT_RESOLVE_HOST == 6
+<errorcode>
+6
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Some implementations of getaddrinfo() resolve ``127.0.0.1 www.example.com``
to ``127.0.0.1``. Reject such invalid host names.

There are conference talks by Orange Tsai about this topic. He specifically mentions curl and explains why this is a problem:
- [Black Hat (slides)](https://www.blackhat.com/docs/us-17/thursday/us-17-Tsai-A-New-Era-Of-SSRF-Exploiting-URL-Parser-In-Trending-Programming-Languages.pdf)
- [HITB GSEC (video)](https://www.youtube.com/watch?v=D1S-G8rJrEk)

Affected getaddrinfo() implementations:
- glibc (Linux) - see [glibc bug 20018](https://sourceware.org/bugzilla/show_bug.cgi?id=20018)
- FreeBSD
- NetBSD

Not affected:
- OpenBSD
- Windows