### PR TITLE
zlib/brotli: only include header files in modules needing them

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -25,6 +25,19 @@
 #include "urldata.h"
 #include <curl/curl.h>
 #include <stddef.h>
+
+#ifdef HAVE_ZLIB_H
+#include <zlib.h>
+#ifdef __SYMBIAN32__
+/* zlib pollutes the namespace with this definition */
+#undef WIN32
+#endif
+#endif
+
+#ifdef HAVE_BROTLI
+#include <brotli/decode.h>
+#endif
+
 #include "sendf.h"
 #include "http.h"
 #include "content_encoding.h"

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -88,18 +88,6 @@
 
 #include "timeval.h"
 
-#ifdef HAVE_ZLIB_H
-#include <zlib.h>               /* for content-encoding */
-#ifdef __SYMBIAN32__
-/* zlib pollutes the namespace with this definition */
-#undef WIN32
-#endif
-#endif
-
-#ifdef HAVE_BROTLI
-#include <brotli/decode.h>
-#endif
-
 #include <curl/curl.h>
 
 #include "http_chunks.h" /* for the structs and enum stuff */

--- a/lib/version.c
+++ b/lib/version.c
@@ -64,6 +64,18 @@
 #define CURL_LIBSSH2_VERSION LIBSSH2_VERSION
 #endif
 
+#ifdef HAVE_ZLIB_H
+#include <zlib.h>
+#ifdef __SYMBIAN32__
+/* zlib pollutes the namespace with this definition */
+#undef WIN32
+#endif
+#endif
+
+#ifdef HAVE_BROTLI
+#include <brotli/decode.h>
+#endif
+
 void Curl_version_init(void);
 
 /* For thread safety purposes this function is called by global_init so that


### PR DESCRIPTION
There is a conflict on symbol 'free_func' between openssl/crypto.h and
zlib.h on AIX. This is an attempt to resolve it.

Bug: https://curl.haxx.se/mail/lib-2017-11/0032.html
Reported-By: Michael Felt