### PR TITLE
Fixed initialisation of sizeof_ssl_backend_data

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1781,7 +1781,7 @@ static void llist_dtor(void *user, void *element)
 static struct connectdata *allocate_conn(struct Curl_easy *data)
 {
 #ifdef USE_SSL
-#define SSL_EXTRA + 4 * Curl_ssl->sizeof_ssl_backend_data - sizeof(long long)
+#define SSL_EXTRA (4 * Curl_ssl->sizeof_ssl_backend_data - sizeof(long long))
 #else
 #define SSL_EXTRA 0
 #endif

--- a/lib/url.c
+++ b/lib/url.c
@@ -1781,7 +1781,7 @@ static void llist_dtor(void *user, void *element)
 static struct connectdata *allocate_conn(struct Curl_easy *data)
 {
 #ifdef USE_SSL
-#define SSL_EXTRA (4 * Curl_ssl->sizeof_ssl_backend_data - sizeof(long long))
+#define SSL_EXTRA (4 * Curl_ssl->get_sizeof_backend_data() - sizeof(long long))
 #else
 #define SSL_EXTRA 0
 #endif
@@ -1877,11 +1877,11 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
     char *p = (char *)&conn->align_data__do_not_use;
     conn->ssl[0].backend = (struct ssl_backend_data *)p;
     conn->ssl[1].backend =
-      (struct ssl_backend_data *)(p + Curl_ssl->sizeof_ssl_backend_data);
+      (struct ssl_backend_data *)(p + Curl_ssl->get_sizeof_backend_data());
     conn->proxy_ssl[0].backend =
-      (struct ssl_backend_data *)(p + Curl_ssl->sizeof_ssl_backend_data * 2);
+      (struct ssl_backend_data *)(p + Curl_ssl->get_sizeof_backend_data() * 2);
     conn->proxy_ssl[1].backend =
-      (struct ssl_backend_data *)(p + Curl_ssl->sizeof_ssl_backend_data * 3);
+      (struct ssl_backend_data *)(p + Curl_ssl->get_sizeof_backend_data() * 3);
   }
 #endif
 

--- a/lib/vtls/axtls.c
+++ b/lib/vtls/axtls.c
@@ -701,6 +701,11 @@ static void *Curl_axtls_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->ssl;
 }
 
+static size_t Curl_axtls_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_axtls = {
   { CURLSSLBACKEND_AXTLS, "axtls" }, /* info */
 
@@ -710,7 +715,7 @@ const struct Curl_ssl Curl_ssl_axtls = {
   0, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_axtls_get_backend_size,    /* get_sizeof_backend_data */
 
   /*
    * axTLS has no global init.  Everything is done through SSL and SSL_CTX

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -977,6 +977,11 @@ static void *Curl_cyassl_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->handle;
 }
 
+static size_t Curl_cyassl_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_cyassl = {
   { CURLSSLBACKEND_WOLFSSL, "WolfSSL" }, /* info */
 
@@ -990,7 +995,7 @@ const struct Curl_ssl Curl_ssl_cyassl = {
   1, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_cyassl_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_cyassl_init,                /* init */
   Curl_none_cleanup,               /* cleanup */

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2976,6 +2976,11 @@ static void *Curl_darwinssl_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->ssl_ctx;
 }
 
+static size_t Curl_darwinssl_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_darwinssl = {
   { CURLSSLBACKEND_DARWINSSL, "darwinssl" }, /* info */
 
@@ -2989,7 +2994,7 @@ const struct Curl_ssl Curl_ssl_darwinssl = {
   0, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_darwinssl_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_none_init,                     /* init */
   Curl_none_cleanup,                  /* cleanup */

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1352,6 +1352,11 @@ static void *Curl_gskit_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->handle;
 }
 
+static size_t Curl_gskit_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_gskit = {
   { CURLSSLBACKEND_GSKIT, "gskit" }, /* info */
 
@@ -1362,7 +1367,7 @@ const struct Curl_ssl Curl_ssl_gskit = {
   /* TODO: convert to 1 and fix test #1014 (if need) */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_gskit_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_gskit_init,                /* init */
   Curl_gskit_cleanup,             /* cleanup */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1805,6 +1805,11 @@ static void *Curl_gtls_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->session;
 }
 
+static size_t Curl_gtls_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_gnutls = {
   { CURLSSLBACKEND_GNUTLS, "gnutls" }, /* info */
 
@@ -1814,7 +1819,7 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   0, /* have_ssl_ctx */
   1, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_gtls_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_gtls_init,                /* init */
   Curl_gtls_cleanup,             /* cleanup */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1039,6 +1039,11 @@ static void *Curl_mbedtls_get_internals(struct ssl_connect_data *connssl,
   return &BACKEND->ssl;
 }
 
+static size_t Curl_mbedtls_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_mbedtls = {
   { CURLSSLBACKEND_MBEDTLS, "mbedtls" }, /* info */
 
@@ -1048,7 +1053,7 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   1, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_mbedtls_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_mbedtls_init,                /* init */
   Curl_mbedtls_cleanup,             /* cleanup */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2342,6 +2342,11 @@ static void *Curl_nss_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->handle;
 }
 
+static size_t Curl_nss_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_nss = {
   { CURLSSLBACKEND_NSS, "nss" }, /* info */
 
@@ -2351,7 +2356,7 @@ const struct Curl_ssl Curl_ssl_nss = {
   0, /* have_ssl_ctx */
   1, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_nss_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_nss_init,                /* init */
   Curl_nss_cleanup,             /* cleanup */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3621,6 +3621,11 @@ static void *Curl_ossl_get_internals(struct ssl_connect_data *connssl,
          (void *)BACKEND->ctx : (void *)BACKEND->handle;
 }
 
+static size_t Curl_ossl_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_openssl = {
   { CURLSSLBACKEND_OPENSSL, "openssl" }, /* info */
 
@@ -3630,7 +3635,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   1, /* have_ssl_ctx */
   1, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_ossl_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_ossl_init,                /* init */
   Curl_ossl_cleanup,             /* cleanup */

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -898,6 +898,11 @@ static void *Curl_polarssl_get_internals(struct ssl_connect_data *connssl,
   return &BACKEND->ssl;
 }
 
+static size_t Curl_polarssl_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_polarssl = {
   { CURLSSLBACKEND_POLARSSL, "polarssl" }, /* info */
 
@@ -907,7 +912,7 @@ const struct Curl_ssl Curl_ssl_polarssl = {
   0, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_polarssl_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_polarssl_init,                /* init */
   Curl_polarssl_cleanup,             /* cleanup */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1816,6 +1816,11 @@ static void *Curl_schannel_get_internals(struct ssl_connect_data *connssl,
   return &BACKEND->ctxt->ctxt_handle;
 }
 
+static size_t Curl_schannel_get_backend_size(void)
+{
+  return sizeof(struct ssl_backend_data);
+}
+
 const struct Curl_ssl Curl_ssl_schannel = {
   { CURLSSLBACKEND_SCHANNEL, "schannel" }, /* info */
 
@@ -1825,7 +1830,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
   0, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  sizeof(struct ssl_backend_data),
+  Curl_schannel_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_schannel_init,                /* init */
   Curl_schannel_cleanup,             /* cleanup */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -220,7 +220,7 @@ ssl_connect_init_proxy(struct connectdata *conn, int sockindex)
     conn->proxy_ssl[sockindex] = conn->ssl[sockindex];
 
     memset(&conn->ssl[sockindex], 0, sizeof(conn->ssl[sockindex]));
-    memset(pbdata, 0, Curl_ssl->sizeof_ssl_backend_data);
+    memset(pbdata, 0, Curl_ssl->get_sizeof_backend_data());
 
     conn->ssl[sockindex].backend = pbdata;
   }
@@ -1088,6 +1088,13 @@ CURLcode Curl_none_md5sum(unsigned char *input UNUSED_PARAM,
 }
 #endif
 
+static size_t Curl_multissl_get_backend_size(void)
+{
+  if(multissl_init(NULL))
+    return 0;
+  return Curl_ssl->get_sizeof_backend_data();
+}
+
 static int Curl_multissl_init(void)
 {
   if(multissl_init(NULL))
@@ -1134,7 +1141,7 @@ static const struct Curl_ssl Curl_ssl_multi = {
   0, /* have_ssl_ctx */
   0, /* support_https_proxy */
 
-  (size_t)-1, /* something insanely large to be on the safe side */
+  Curl_multissl_get_backend_size,    /* get_sizeof_backend_data */
 
   Curl_multissl_init,                /* init */
   Curl_none_cleanup,                 /* cleanup */

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -40,7 +40,7 @@ struct Curl_ssl {
 
   unsigned support_https_proxy:1; /* supports access via HTTPS proxies */
 
-  size_t sizeof_ssl_backend_data;
+  size_t (*get_sizeof_backend_data)(void);
 
   int (*init)(void);
   void (*cleanup)(void);


### PR DESCRIPTION
This patch properly initialise TLS backend size before use.