### PR TITLE
Add support for CURLINFO_CERTINFO on Darwin

### DIFF
--- a/docs/libcurl/opts/CURLINFO_CERTINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.3
@@ -71,8 +71,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-This option is only working in libcurl built with OpenSSL, NSS, schannel or
-GSKit support. schannel support added in 7.50.0
+This option is only working in libcurl built with OpenSSL, NSS, schannel,
+GSKit or Darwin support. schannel support added in 7.50.0
 
 Added in 7.19.1
 .SH RETURN VALUE

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -23,7 +23,7 @@
 #include "curl_setup.h"
 
 #if defined(USE_GSKIT) || defined(USE_NSS) || defined(USE_GNUTLS) || \
-    defined(USE_CYASSL) || defined(USE_SCHANNEL)
+    defined(USE_CYASSL) || defined(USE_SCHANNEL) || defined(USE_DARWINSSL)
 
 #include <curl/curl.h>
 #include "urldata.h"
@@ -1197,4 +1197,5 @@ CURLcode Curl_verifyhost(struct connectdata *conn,
   return CURLE_PEER_FAILED_VERIFICATION;
 }
 
-#endif /* USE_GSKIT */
+#endif /* USE_GSKIT or USE_NSS or USE_GNUTLS or USE_CYASSL or
+        * USE_SCHANNEL or USE_DARWINSSL */

--- a/lib/x509asn1.h
+++ b/lib/x509asn1.h
@@ -26,7 +26,7 @@
 #include "curl_setup.h"
 
 #if defined(USE_GSKIT) || defined(USE_NSS) || defined(USE_GNUTLS) || \
-    defined(USE_CYASSL) || defined(USE_SCHANNEL)
+    defined(USE_CYASSL) || defined(USE_SCHANNEL) || defined(USE_DARWINSSL)
 
 #include "urldata.h"
 
@@ -130,5 +130,6 @@ CURLcode Curl_extract_certinfo(struct connectdata *conn, int certnum,
                                const char *beg, const char *end);
 CURLcode Curl_verifyhost(struct connectdata *conn,
                          const char *beg, const char *end);
-#endif /* USE_GSKIT or USE_NSS or USE_GNUTLS or USE_CYASSL or USE_SCHANNEL */
+#endif /* USE_GSKIT or USE_NSS or USE_GNUTLS or USE_CYASSL or
+        * USE_SCHANNEL or USE_DARWINSSL */
 #endif /* HEADER_CURL_X509ASN1_H */


### PR DESCRIPTION
CURLINFO_CERTINFO is not currently supported by the Darwin back-end.

As the certificate information is already being fetched for logging this patch replaces the logging (performed by show_verbose_server_cert) with a method that feeds the certificate to Curl_extract_certinfo.

This also logs the certificate information so although what is logged is slightly different the certificate is still logged out, and is also available for curl_easy_getinfo.

