### PR TITLE
Fixed initialisation of sizeof_ssl_backend_data

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -215,7 +215,9 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 #endif
   }
 
+#ifndef CURL_WITH_MULTI_SSL
   if(flags & CURL_GLOBAL_SSL)
+#endif
     if(!Curl_ssl_init()) {
       DEBUGF(fprintf(stderr, "Error: Curl_ssl_init failed\n"));
       return CURLE_FAILED_INIT;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1781,7 +1781,7 @@ static void llist_dtor(void *user, void *element)
 static struct connectdata *allocate_conn(struct Curl_easy *data)
 {
 #ifdef USE_SSL
-#define SSL_EXTRA + 4 * Curl_ssl->sizeof_ssl_backend_data - sizeof(long long)
+#define SSL_EXTRA (4 * Curl_ssl->sizeof_ssl_backend_data - sizeof(long long))
 #else
 #define SSL_EXTRA 0
 #endif


### PR DESCRIPTION
This patch properly initialise TLS backend size before use even if libcurl is initialised without CURL_GLOBAL_SSL flag.
This is alternative for #2083