### PR TITLE
resolve: allow IP address within [] brackets

### DIFF
--- a/docs/cmdline-opts/resolve.d
+++ b/docs/cmdline-opts/resolve.d
@@ -14,4 +14,6 @@ different ports.
 The provided address set by this option will be used even if --ipv4 or --ipv6
 is set to make curl use another IP version.
 
+Support for providing the IP address within [brackets] was added in 7.57.0.
+
 This option can be used many times to add many host names to resolve.

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -55,6 +55,8 @@ Remove names from the DNS cache again, to stop providing these fake resolves,
 by including a string in the linked list that uses the format
 \&"-HOST:PORT". The host name must be prefixed with a dash, and the host name
 and port number must exactly match what was already added previously.
+
+Support for providing the ADDRESS within [brackets] was added in 7.57.0.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -142,7 +142,7 @@ test1298 test1299 \
 test1300 test1301 test1302 test1303 test1304 test1305 test1306 test1307 \
 test1308 test1309 test1310 test1311 test1312 test1313 test1314 test1315 \
 test1316 test1317 test1318 test1319 test1320 test1321 test1322 test1323 \
-         test1325 test1326 test1327 test1328 test1329 test1330 test1331 \
+test1324 test1325 test1326 test1327 test1328 test1329 test1330 test1331 \
 test1332 test1333 test1334 test1335 test1336 test1337 test1338 test1339 \
 test1340 test1341 test1342 test1343 test1344 test1345 test1346 test1347 \
 test1348 test1349 test1350 test1351 test1352 test1353 test1354 test1355 \

--- a/tests/data/test1324
+++ b/tests/data/test1324
@@ -1,0 +1,56 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+--resolve
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http-ipv6
+</server>
+<name>
+HTTP with --resolve and [ipv6address]
+</name>
+<command>
+--resolve example.com:%HTTP6PORT:%HOST6IP http://example.com:%HTTP6PORT/1324
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1324 HTTP/1.1
+Host: example.com:%HTTP6PORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
... so that IPv6 addresses can be passed like they can for connect-to
and how they're used in URLs.

Added test 1324 to verify
Reported-by: Alex Malinovich

Fixes #2087