### PR TITLE
url: reject ASCII control characters and space in host names

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1688,7 +1688,7 @@ static bool is_ASCII_name(const char *hostname)
 /*
  * Perform any necessary IDN conversion of hostname
  */
-static void fix_hostname(struct connectdata *conn, struct hostname *host)
+static CURLcode fix_hostname(struct connectdata *conn, struct hostname *host)
 {
   size_t len;
   struct Curl_easy *data = conn->data;
@@ -1728,9 +1728,11 @@ static void fix_hostname(struct connectdata *conn, struct hostname *host)
         /* change the name pointer to point to the encoded hostname */
         host->name = host->encalloc;
       }
-      else
-        infof(data, "Failed to convert %s to ACE; %s\n", host->name,
+      else {
+        failf(data, "Failed to convert %s to ACE; %s\n", host->name,
               idn2_strerror(rc));
+        return CURLE_URL_MALFORMAT;
+      }
     }
 #elif defined(USE_WIN32_IDN)
     char *ace_hostname = NULL;
@@ -1740,12 +1742,24 @@ static void fix_hostname(struct connectdata *conn, struct hostname *host)
       /* change the name pointer to point to the encoded hostname */
       host->name = host->encalloc;
     }
-    else
-      infof(data, "Failed to convert %s to ACE;\n", host->name);
+    else {
+      failf(data, "Failed to convert %s to ACE;\n", host->name);
+      return CURLE_URL_MALFORMAT;
+    }
 #else
     infof(data, "IDN support not present, can't parse Unicode domains\n");
 #endif
   }
+  {
+    char *hostp;
+    for(hostp = host->name; *hostp; hostp++) {
+      if(*hostp <= 32) {
+        failf(data, "Host name '%s' contains bad letter", host->name);
+        return CURLE_URL_MALFORMAT;
+      }
+    }
+  }
+  return CURLE_OK;
 }
 
 /*
@@ -4179,13 +4193,24 @@ static CURLcode create_conn(struct Curl_easy *data,
   /*************************************************************
    * IDN-fix the hostnames
    *************************************************************/
-  fix_hostname(conn, &conn->host);
-  if(conn->bits.conn_to_host)
-    fix_hostname(conn, &conn->conn_to_host);
-  if(conn->bits.httpproxy)
-    fix_hostname(conn, &conn->http_proxy.host);
-  if(conn->bits.socksproxy)
-    fix_hostname(conn, &conn->socks_proxy.host);
+  result = fix_hostname(conn, &conn->host);
+  if(result)
+    goto out;
+  if(conn->bits.conn_to_host) {
+    result = fix_hostname(conn, &conn->conn_to_host);
+    if(result)
+      goto out;
+  }
+  if(conn->bits.httpproxy) {
+    result = fix_hostname(conn, &conn->http_proxy.host);
+    if(result)
+      goto out;
+  }
+  if(conn->bits.socksproxy) {
+    result = fix_hostname(conn, &conn->socks_proxy.host);
+    if(result)
+      goto out;
+  }
 
   /*************************************************************
    * Check whether the host and the "connect to host" are equal.

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -134,7 +134,7 @@ test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 test1252 test1253 test1254 test1255 test1256 test1257 test1258 test1259 \
-test1260 test1261 test1262 test1263 \
+test1260 test1261 test1262 test1263 test1264 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 \

--- a/tests/data/test1034
+++ b/tests/data/test1034
@@ -23,6 +23,7 @@ none
 </server>
 <features>
 idn
+http
 </features>
 <setenv>
 LC_ALL=

--- a/tests/data/test1034
+++ b/tests/data/test1034
@@ -13,21 +13,13 @@ config file
 #
 # Server-side
 <reply>
-<data>
-HTTP/1.0 503 Service Unavailable
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake swsclose
-Content-Type: text/html
-Funny-head: yesyes
-
-</data>
 </reply>
 
 #
 # Client-side
 <client>
 <server>
-http
+none
 </server>
 <features>
 idn
@@ -54,17 +46,9 @@ url = "http://invalid-utf8-‚ê.local/page/1034"
 </client>
 
 #
-# Verify data after the test has been "shot"
 <verify>
-<strip>
-^User-Agent:.*
-</strip>
-<protocol>
-GET http://invalid-utf8-‚ê.local/page/1034 HTTP/1.1
-Host: invalid-utf8-‚ê.local
-Accept: */*
-Proxy-Connection: Keep-Alive
-
-</protocol>
+<errorcode>
+3
+</errorcode>
 </verify>
 </testcase>

--- a/tests/data/test1035
+++ b/tests/data/test1035
@@ -12,21 +12,13 @@ FAILURE
 #
 # Server-side
 <reply>
-<data>
-HTTP/1.0 503 Service Unavailable
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake swsclose
-Content-Type: text/html
-Funny-head: yesyes
-
-</data>
 </reply>
 
 #
 # Client-side
 <client>
 <server>
-http
+none
 </server>
 <features>
 idn
@@ -52,12 +44,8 @@ http://too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local/page/10
 <strip>
 ^User-Agent:.*
 </strip>
-<protocol>
-GET http://too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local/page/1035 HTTP/1.1
-Host: too-long-IDN-name-cürl-rüles-la-la-la-dee-da-flooby-nooby.local
-Accept: */*
-Proxy-Connection: Keep-Alive
-
-</protocol>
+<errorcode>
+3
+</errorcode>
 </verify>
 </testcase>

--- a/tests/data/test1035
+++ b/tests/data/test1035
@@ -22,6 +22,7 @@ none
 </server>
 <features>
 idn
+http
 </features>
 <setenv>
 LC_ALL=

--- a/tests/data/test1264
+++ b/tests/data/test1264
@@ -1,0 +1,36 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+http
+</features>
+ <name>
+HTTP URL with space in host name
+ </name>
+ <command>
+-g "http://127.0.0.1 www.example.com/we/want/1264"
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# CURLE_URL_MALFORMAT == 3
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Host names like "127.0.0.1 moo" would otherwise be accepted by some
getaddrinfo() implementations.

Fixes #2073