### PR TITLE
Fix errors detected by scan-build 

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1848,7 +1848,6 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
     goto fail;
   }
 
-  end = line_end;
   nva[2].name = (unsigned char *)":scheme";
   nva[2].namelen = strlen((char *)nva[2].name);
   if(conn->handler->flags & PROTOPT_SSL)

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1848,8 +1848,6 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
     goto fail;
   }
 
-  hdbuf = end + 1;
-
   end = line_end;
   nva[2].name = (unsigned char *)":scheme";
   nva[2].namelen = strlen((char *)nva[2].name);

--- a/lib/llist.c
+++ b/lib/llist.c
@@ -106,7 +106,11 @@ Curl_llist_remove(struct curl_llist *list, struct curl_llist_element *e,
       e->next->prev = NULL;
   }
   else {
-    e->prev->next = e->next;
+    if(!e->prev)
+      list->head = e->next;
+    else
+      e->prev->next = e->next;
+
     if(!e->next)
       list->tail = e->prev;
     else

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -722,7 +722,6 @@ static size_t readback_bytes(mime_state *state,
   sz = numbytes - state->offset;
 
   if(numbytes > state->offset) {
-    sz = numbytes - state->offset;
     bytes += state->offset;
   }
   else {

--- a/lib/url.c
+++ b/lib/url.c
@@ -569,32 +569,31 @@ CURLcode Curl_open(struct Curl_easy **curl)
     DEBUGF(fprintf(stderr, "Error: malloc of buffer failed\n"));
     result = CURLE_OUT_OF_MEMORY;
   }
-
-  Curl_mime_initpart(&data->set.mimepost, data);
-
-  data->state.headerbuff = malloc(HEADERSIZE);
-  if(!data->state.headerbuff) {
-    DEBUGF(fprintf(stderr, "Error: malloc of headerbuff failed\n"));
-    result = CURLE_OUT_OF_MEMORY;
-  }
   else {
-    result = Curl_init_userdefined(&data->set);
+    Curl_mime_initpart(&data->set.mimepost, data);
 
-    data->state.headersize = HEADERSIZE;
+    data->state.headerbuff = malloc(HEADERSIZE);
+    if(!data->state.headerbuff) {
+      DEBUGF(fprintf(stderr, "Error: malloc of headerbuff failed\n"));
+      result = CURLE_OUT_OF_MEMORY;
+    }
+    else {
+      result = Curl_init_userdefined(&data->set);
 
-    Curl_convert_init(data);
+      data->state.headersize = HEADERSIZE;
+      Curl_convert_init(data);
+      Curl_initinfo(data);
 
-    Curl_initinfo(data);
+      /* most recent connection is not yet defined */
+      data->state.lastconnect = NULL;
 
-    /* most recent connection is not yet defined */
-    data->state.lastconnect = NULL;
+      data->progress.flags |= PGRS_HIDE;
+      data->state.current_speed = -1; /* init to negative == impossible */
+      data->set.fnmatch = ZERO_NULL;
+      data->set.maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */
 
-    data->progress.flags |= PGRS_HIDE;
-    data->state.current_speed = -1; /* init to negative == impossible */
-    data->set.fnmatch = ZERO_NULL;
-    data->set.maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */
-
-    Curl_http2_init_state(&data->state);
+      Curl_http2_init_state(&data->state);
+    }
   }
 
   if(result) {

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -543,8 +543,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   else
     user = userp;
 
-  if(user)
-    userlen = strlen(user);
+  userlen = strlen(user);
 
   /* Get the machine's un-qualified host name as NTLM doesn't like the fully
      qualified domain name */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3067,12 +3067,12 @@ static CURLcode servercert(struct connectdata *conn,
   ASN1_TIME_print(mem, X509_get0_notBefore(BACKEND->server_cert));
   len = BIO_get_mem_data(mem, (char **) &ptr);
   infof(data, " start date: %.*s\n", len, ptr);
-  rc = BIO_reset(mem);
+  (void)BIO_reset(mem);
 
   ASN1_TIME_print(mem, X509_get0_notAfter(BACKEND->server_cert));
   len = BIO_get_mem_data(mem, (char **) &ptr);
   infof(data, " expire date: %.*s\n", len, ptr);
-  rc = BIO_reset(mem);
+  (void)BIO_reset(mem);
 
   BIO_free(mem);
 


### PR DESCRIPTION
I ran scan-build on the code and cleaned up some low hanging fruit. The automated scan-build I run uses a much older clang version and didn't catch any of these!