### PR TITLE
WinSSL: Implement option for HTTPS proxy revocation check

### DIFF
--- a/docs/cmdline-opts/Makefile.inc
+++ b/docs/cmdline-opts/Makefile.inc
@@ -28,7 +28,8 @@ DPAGES = abstract-unix-socket.d anyauth.d append.d basic.d cacert.d capath.d cer
   proxy-crlfile.d proxy.d proxy-digest.d proxy-header.d                 \
   proxy-insecure.d proxy-key.d proxy-key-type.d proxy-negotiate.d       \
   proxy-ntlm.d proxy-pass.d proxy-service-name.d                        \
-  proxy-ssl-allow-beast.d proxy-tlsauthtype.d proxy-tlspassword.d       \
+  proxy-ssl-allow-beast.d proxy-ssl-no-revoke.d                         \
+  proxy-tlsauthtype.d proxy-tlspassword.d                               \
   proxy-tlsuser.d proxy-tlsv1.d proxytunnel.d proxy-user.d pubkey.d     \
   quote.d random-file.d range.d raw.d referer.d remote-header-name.d    \
   remote-name-all.d remote-name.d remote-time.d request.d resolve.d     \

--- a/docs/cmdline-opts/proxy-ssl-no-revoke.d
+++ b/docs/cmdline-opts/proxy-ssl-no-revoke.d
@@ -1,0 +1,5 @@
+Long: proxy-ssl-no-revoke
+Help: Disable cert revocation checks for HTTPS proxy (WinSSL)
+Added: 7.57.1
+---
+(WinSSL) Same as --ssl-no-revoke but used in HTTPS proxy context.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -299,14 +299,13 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
         SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 #else
       schannel_cred.dwFlags = SCH_CRED_AUTO_CRED_VALIDATION;
-      /* TODO s/data->set.ssl.no_revoke/SSL_SET_OPTION(no_revoke)/g */
-      if(data->set.ssl.no_revoke)
+      if(SSL_SET_OPTION(no_revoke))
         schannel_cred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
                                  SCH_CRED_IGNORE_REVOCATION_OFFLINE;
       else
         schannel_cred.dwFlags |= SCH_CRED_REVOCATION_CHECK_CHAIN;
 #endif
-      if(data->set.ssl.no_revoke)
+      if(SSL_SET_OPTION(no_revoke))
         infof(data, "schannel: disabled server certificate revocation "
                     "checks\n");
       else
@@ -1702,7 +1701,7 @@ static CURLcode verify_certificate(struct connectdata *conn, int sockindex)
                                 NULL,
                                 pCertContextServer->hCertStore,
                                 &ChainPara,
-                                (data->set.ssl.no_revoke ? 0 :
+                                (SSL_SET_OPTION(no_revoke) ? 0 :
                                  CERT_CHAIN_REVOCATION_CHECK_CHAIN),
                                 NULL,
                                 &pChainContext)) {

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -225,10 +225,11 @@ struct OperationConfig {
   bool xattr;               /* store metadata in extended attributes */
   long gssapi_delegation;
   bool ssl_allow_beast;     /* allow this SSL vulnerability */
-  bool proxy_ssl_allow_beast; /* allow this SSL vulnerability for proxy*/
+  bool proxy_ssl_allow_beast; /* allow this SSL vulnerability for proxy */
 
   bool ssl_no_revoke;       /* disable SSL certificate revocation checks */
-  /*bool proxy_ssl_no_revoke; */
+  bool proxy_ssl_no_revoke; /* disable SSL certificate revocation checks for
+                               proxy */
 
   bool use_metalink;        /* process given URLs as metalink XML file */
   metalinkfile *metalinkfile_list; /* point to the first node */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -254,6 +254,7 @@ static const struct LongShort aliases[]= {
   {"E9", "proxy-tlsv1",              ARG_NONE},
   {"EA", "socks5-basic",             ARG_BOOL},
   {"EB", "socks5-gssapi",            ARG_BOOL},
+  {"EC", "proxy-ssl-no-revoke",      ARG_BOOL},
   {"f",  "fail",                     ARG_BOOL},
   {"fa", "fail-early",               ARG_BOOL},
   {"F",  "form",                     ARG_STRING},
@@ -1585,6 +1586,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           config->socks5_auth |= CURLAUTH_GSSAPI;
         else
           config->socks5_auth &= ~CURLAUTH_GSSAPI;
+        break;
+
+      case 'C': /* --proxy-ssl-no-revoke */
+        if(curlinfo->features & CURL_VERSION_SSL)
+          config->proxy_ssl_no_revoke = TRUE;
         break;
 
       default: /* unknown flag */

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -318,6 +318,8 @@ static const struct helptxt helptext[] = {
    "SPNEGO proxy service name"},
   {"    --proxy-ssl-allow-beast",
    "Allow security flaw for interop for HTTPS proxy"},
+  {"    --proxy-ssl-no-revoke",
+   "Disable cert revocation checks for HTTPS proxy (WinSSL)"},
   {"    --proxy-tlsauthtype <type>",
    "TLS authentication type for HTTPS proxy"},
   {"    --proxy-tlspassword <string>",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1473,11 +1473,13 @@ static CURLcode operate_do(struct GlobalConfig *global,
                       (config->ssl_no_revoke ? CURLSSLOPT_NO_REVOKE : 0);
           if(mask)
             my_setopt_bitmask(curl, CURLOPT_SSL_OPTIONS, mask);
-        }
 
-        if(config->proxy_ssl_allow_beast)
-          my_setopt(curl, CURLOPT_PROXY_SSL_OPTIONS,
-                    (long)CURLSSLOPT_ALLOW_BEAST);
+          mask =
+            (config->proxy_ssl_allow_beast ? CURLSSLOPT_ALLOW_BEAST : 0) |
+            (config->proxy_ssl_no_revoke ? CURLSSLOPT_NO_REVOKE : 0);
+          if(mask)
+            my_setopt_bitmask(curl, CURLOPT_PROXY_SSL_OPTIONS, mask);
+        }
 
         if(config->mail_auth)
           my_setopt_str(curl, CURLOPT_MAIL_AUTH, config->mail_auth);

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -67,6 +67,7 @@ extern const NameValueUnsigned setopt_nv_CURLAUTH[];
 #define setopt_nv_CURLOPT_FTP_SSL_CCC setopt_nv_CURLFTPSSL_CCC
 #define setopt_nv_CURLOPT_USE_SSL setopt_nv_CURLUSESSL
 #define setopt_nv_CURLOPT_SSL_OPTIONS setopt_nv_CURLSSLOPT
+#define setopt_nv_CURLOPT_PROXY_SSL_OPTIONS setopt_nv_CURLSSLOPT
 #define setopt_nv_CURLOPT_NETRC setopt_nv_CURL_NETRC
 #define setopt_nv_CURLOPT_PROTOCOLS setopt_nv_CURLPROTO
 #define setopt_nv_CURLOPT_REDIR_PROTOCOLS setopt_nv_CURLPROTO


### PR DESCRIPTION
Prior to this change it appears it was intended for the existing SSL
revocation check to be complemented with its own proxy variant based on
the CURLOPT_PROXY_SSL_OPTIONS documentation [1] and TODO comment in
schannel.c [2]. It likely didn't happen because we don't yet have HTTPS
proxy support for WinSSL.

There is no immediate effect, however when HTTPS proxy support is added
for WinSSL the effect of this change will be it's not possible to
disable HTTPS proxy SSL revocation check using --ssl-no-revoke or
CURLSSLOPT_NO_REVOKE set in CURLOPT_SSL_OPTIONS. The proxy variant would
have to be used instead:

tool: --proxy-ssl-no-revoke
library: CURLSSLOPT_NO_REVOKE set in CURLOPT_PROXY_SSL_OPTIONS

[1]: https://curl.haxx.se/libcurl/c/CURLOPT_PROXY_SSL_OPTIONS.html
[2]: https://github.com/curl/curl/blob/c514af5/lib/vtls/schannel.c#L302


Closes #xxxx

---

This is unneeded at the moment since we don't support HTTPS proxy in WinSSL builds yet but I'm opening anyway for review.

/cc @dscho 