### PR TITLE
global_init: ignore CURL_GLOBAL_SSL's absense

### DIFF
--- a/docs/libcurl/curl_global_init.3
+++ b/docs/libcurl/curl_global_init.3
@@ -62,6 +62,9 @@ Initialize everything possible. This sets all known bits except
 \fBCURL_GLOBAL_ACK_EINTR\fP.
 
 .IP CURL_GLOBAL_SSL
+(This flag's presence or absense serves no meaning since 7.57.0. The
+description below is for older libcurl versions.)
+
 Initialize SSL.
 
 The implication here is that if this bit is not set, the initialization of the

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2514,7 +2514,7 @@ typedef enum {
   CURLCLOSEPOLICY_LAST /* last, never use this */
 } curl_closepolicy;
 
-#define CURL_GLOBAL_SSL (1<<0)
+#define CURL_GLOBAL_SSL (1<<0) /* no purpose since since 7.57.0 */
 #define CURL_GLOBAL_WIN32 (1<<1)
 #define CURL_GLOBAL_ALL (CURL_GLOBAL_SSL|CURL_GLOBAL_WIN32)
 #define CURL_GLOBAL_NOTHING 0

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -215,11 +215,10 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 #endif
   }
 
-  if(flags & CURL_GLOBAL_SSL)
-    if(!Curl_ssl_init()) {
-      DEBUGF(fprintf(stderr, "Error: Curl_ssl_init failed\n"));
-      return CURLE_FAILED_INIT;
-    }
+  if(!Curl_ssl_init()) {
+    DEBUGF(fprintf(stderr, "Error: Curl_ssl_init failed\n"));
+    return CURLE_FAILED_INIT;
+  }
 
   if(flags & CURL_GLOBAL_WIN32)
     if(win32_init()) {
@@ -319,10 +318,7 @@ void curl_global_cleanup(void)
     return;
 
   Curl_global_host_cache_dtor();
-
-  if(init_flags & CURL_GLOBAL_SSL)
-    Curl_ssl_cleanup();
-
+  Curl_ssl_cleanup();
   Curl_resolver_global_cleanup();
 
   if(init_flags & CURL_GLOBAL_WIN32)


### PR DESCRIPTION
This bit is no longer used. It is not clear what it meant for users to
"init the TLS" in a world with different TLS backends and since the
introduction of multissl, libcurl didn't properly work if inited without
this bit set.

Not a single user responded to the call for users of it:
https://curl.haxx.se/mail/lib-2017-11/0072.html

Reported-by: Evgeny Grin

Fixes #2089
Fixes #2083