### PR TITLE
update "file:" URL handling in url.c

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2079,7 +2079,8 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
       return CURLE_URL_MALFORMAT;
     }
 
-    if(url_has_scheme && path[0] == '/' && path[1] == '/' && path[2] == '/' && path[3] == '/') {
+    if(url_has_scheme && path[0] == '/' && path[1] == '/' &&
+       path[2] == '/' && path[3] == '/') {
       /* This appears to be a UNC string (usually indicating a SMB share).
        * We don't do SMB in file: URLs. (TODO?)
        */
@@ -2106,12 +2107,12 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
        *
        *  o the hostname is a FQDN that resolves to this machine.
        *
-       * For brevity, we only consider URLs with empty, "localhost", or "127.0.0.1"
-       * hostnames as local.
+       * For brevity, we only consider URLs with empty, "localhost", or
+       * "127.0.0.1" hostnames as local.
        *
-       * Additionally, there is an exception for URLs with a Windows drive letter
-       * in the authority (which was accidentally omitted from RFC 8089, Appendix E,
-       * but believe me, it was meant to be there. --MK)
+       * Additionally, there is an exception for URLs with a Windows drive
+       * letter in the authority (which was accidentally omitted from RFC 8089
+       * Appendix E, but believe me, it was meant to be there. --MK)
        */
       if(ptr[0] != '/' && !STARTS_WITH_URL_DRIVE_PREFIX(ptr)) {
         /* the URL includes a host name, it must match "localhost" or
@@ -2128,17 +2129,18 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
       /*
        * RFC 8089, Appendix D, Section D.1, says:
        *
-       * > In a POSIX file system, the root of the file system is represented as
-       * > a directory with a zero-length name, usually written as "/"; the
+       * > In a POSIX file system, the root of the file system is represented
+       * > as a directory with a zero-length name, usually written as "/"; the
        * > presence of this root in a file URI can be taken as given by the
        * > initial slash in the "path-absolute" rule.
        *
        * i.e. the first slash is part of the path.
        *
-       * However in RFC 1738 the "/" between the host (or port) and the URL-path
-       * was NOT part of the URL-path.  Any agent that followed the older spec
-       * strictly, and wanted to refer to a file with an absolute path, would
-       * have included a second slash.  So if there's a second slash, swallow one.
+       * However in RFC 1738 the "/" between the host (or port) and the
+       * URL-path was NOT part of the URL-path.  Any agent that followed the
+       * older spec strictly, and wanted to refer to a file with an absolute
+       * path, would have included a second slash.  So if there are two
+       * slashes, swallow one.
        */
       if('/' == ptr[1]) /* note: the only way ptr[0]!='/' is if ptr[1]==':' */
         ptr++;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -187,4 +187,6 @@ test2032 test2033 test2034 test2035 test2036 test2037 test2038 test2039 \
 test2040 test2041 test2042 test2043 test2044 test2045 test2046 test2047 \
 test2048 test2049 test2050 test2051 test2052 test2053 test2054 test2055 \
 test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
-test2064 test2065 test2066 test2067 test2068 test2069
+test2064 test2065 test2066 test2067 test2068 test2069 \
+\
+test2070 test2071

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -189,4 +189,4 @@ test2048 test2049 test2050 test2051 test2052 test2053 test2054 test2055 \
 test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 \
 \
-test2070 test2071
+test2070 test2071 test2072

--- a/tests/data/test2070
+++ b/tests/data/test2070
@@ -1,0 +1,41 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<reply>
+<data>
+foo
+   bar
+bar
+   foo
+moo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+file
+</server>
+ <name>
+basic file:// file with no authority
+ </name>
+ <command>
+file:%PWD/log/test2070.txt
+</command>
+<file name="log/test2070.txt">
+foo
+   bar
+bar
+   foo
+moo
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/data/test2071
+++ b/tests/data/test2071
@@ -1,0 +1,41 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<reply>
+<data>
+foo
+   bar
+bar
+   foo
+moo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+file
+</server>
+ <name>
+basic file:// file with "127.0.0.1" hostname
+ </name>
+ <command>
+file://127.0.0.1/%PWD/log/test2070.txt
+</command>
+<file name="log/test2070.txt">
+foo
+   bar
+bar
+   foo
+moo
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/data/test2072
+++ b/tests/data/test2072
@@ -1,0 +1,38 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+file
+</server>
+<name>
+file:// with SMB path
+</name>
+<command>
+file:////bad-host%PWD/log/test1145.txt
+</command>
+<file name="log/test1145.txt">
+foo
+   bar
+bar
+   foo
+moo
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# CURLE_URL_MALFORMAT is error code 3
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
url: updates "file:" URI handling in url.c

* LOTS of comment updates (especially about RFC 8089)
* explicit error for SMB shares (e.g. `file:////share/path/file`) with test
* more strict handling of authority (i.e. `//hostname`)
* now accepts dodgy old `C|` drive letters
* more precise handling of drive letters in and out of Windows
  (especially recognising both `file:c:/` and `file:/c:/`)
* new tests for `file:path` and `file://127.0.0.1/path` URLs