### PR TITLE
ssh: remove check for a NULL pointer (!)

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2347,8 +2347,8 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         }
         sshc->sftp_handle = NULL;
       }
-      if(sftp_scp)
-        Curl_safefree(sftp_scp->path);
+
+      Curl_safefree(sftp_scp->path);
 
       DEBUGF(infof(data, "SFTP DONE done\n"));
 


### PR DESCRIPTION
With this check present, scan-build warns that we might dereference this
point in other places where it isn't first checked for NULL. Thus, if it
*can* be NULL we have a problem on a few places. However, this pointer
should not be possible to be NULL here so I remove the check and thus
also three different scan-build warnings.