### PR TITLE
SSL: Call SSL initialization and de-initialization always

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -215,11 +215,10 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 #endif
   }
 
-  if(flags & CURL_GLOBAL_SSL)
-    if(!Curl_ssl_init()) {
-      DEBUGF(fprintf(stderr, "Error: Curl_ssl_init failed\n"));
-      return CURLE_FAILED_INIT;
-    }
+  if(!Curl_ssl_init(flags)) {
+    DEBUGF(fprintf(stderr, "Error: Curl_ssl_init failed\n"));
+    return CURLE_FAILED_INIT;
+  }
 
   if(flags & CURL_GLOBAL_WIN32)
     if(win32_init()) {
@@ -320,8 +319,7 @@ void curl_global_cleanup(void)
 
   Curl_global_host_cache_dtor();
 
-  if(init_flags & CURL_GLOBAL_SSL)
-    Curl_ssl_cleanup();
+  Curl_ssl_cleanup(init_flags);
 
   Curl_resolver_global_cleanup();
 

--- a/lib/vtls/axtls.c
+++ b/lib/vtls/axtls.c
@@ -701,6 +701,35 @@ static void *Curl_axtls_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->ssl;
 }
 
+/*
+ * Init.
+ * This is called by curl_global_init with the global init flags.
+ * This is not thread-safe since curl_global_init is not thread-safe.
+ * Any required SSL library specific initialization (ie initialization routines
+ * not in libcurl) should take place only if CURL_GLOBAL_SSL is set in flags.
+ *
+ * @retval 0 error initializing SSL
+ * @retval 1 SSL initialized successfully
+ */
+static int Curl_axtls_init(long flags)
+{
+  (void)flags;
+  return 1;
+}
+
+/*
+ * Cleanup.
+ * This is called by curl_global_cleanup with the global init flags.
+ * This is not thread-safe since curl_global_cleanup is not thread-safe.
+ * Any required SSL library specific de-initialization (ie de-initialization
+ * routines not in libcurl) should take place only if CURL_GLOBAL_SSL is set in
+ * init_flags.
+ */
+static void Curl_axtls_cleanup(long init_flags)
+{
+  (void)init_flags;
+}
+
 const struct Curl_ssl Curl_ssl_axtls = {
   { CURLSSLBACKEND_AXTLS, "axtls" }, /* info */
 
@@ -716,9 +745,8 @@ const struct Curl_ssl Curl_ssl_axtls = {
    * axTLS has no global init.  Everything is done through SSL and SSL_CTX
    * structs stored in connectdata structure.
    */
-  Curl_none_init,                 /* init */
-  /* axTLS has no global cleanup. */
-  Curl_none_cleanup,              /* cleanup */
+  Curl_axtls_init,                /* init */
+  Curl_axtls_cleanup,             /* cleanup */
   Curl_axtls_version,             /* version */
   Curl_axtls_check_cxn,           /* check_cxn */
   Curl_axtls_shutdown,            /* shutdown */

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2976,6 +2976,35 @@ static void *Curl_darwinssl_get_internals(struct ssl_connect_data *connssl,
   return BACKEND->ssl_ctx;
 }
 
+/*
+ * Init.
+ * This is called by curl_global_init with the global init flags.
+ * This is not thread-safe since curl_global_init is not thread-safe.
+ * Any required SSL library specific initialization (ie initialization routines
+ * not in libcurl) should take place only if CURL_GLOBAL_SSL is set in flags.
+ *
+ * @retval 0 error initializing SSL
+ * @retval 1 SSL initialized successfully
+ */
+static int Curl_darwinssl_init(long flags)
+{
+  (void)flags;
+  return 1;
+}
+
+/*
+ * Cleanup.
+ * This is called by curl_global_cleanup with the global init flags.
+ * This is not thread-safe since curl_global_cleanup is not thread-safe.
+ * Any required SSL library specific de-initialization (ie de-initialization
+ * routines not in libcurl) should take place only if CURL_GLOBAL_SSL is set in
+ * init_flags.
+ */
+static void Curl_darwinssl_cleanup(long init_flags)
+{
+  (void)init_flags;
+}
+
 const struct Curl_ssl Curl_ssl_darwinssl = {
   { CURLSSLBACKEND_DARWINSSL, "darwinssl" }, /* info */
 
@@ -2991,8 +3020,8 @@ const struct Curl_ssl Curl_ssl_darwinssl = {
 
   sizeof(struct ssl_backend_data),
 
-  Curl_none_init,                     /* init */
-  Curl_none_cleanup,                  /* cleanup */
+  Curl_darwinssl_init,                /* init */
+  Curl_darwinssl_cleanup,             /* cleanup */
   Curl_darwinssl_version,             /* version */
   Curl_darwinssl_check_cxn,           /* check_cxn */
   Curl_darwinssl_shutdown,            /* shutdown */

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -435,17 +435,34 @@ static CURLcode set_ciphers(struct connectdata *conn,
 }
 
 
-static int Curl_gskit_init(void)
+/*
+ * Init.
+ * This is called by curl_global_init with the global init flags.
+ * This is not thread-safe since curl_global_init is not thread-safe.
+ * Any required SSL library specific initialization (ie initialization routines
+ * not in libcurl) should take place only if CURL_GLOBAL_SSL is set in flags.
+ *
+ * @retval 0 error initializing SSL
+ * @retval 1 SSL initialized successfully
+ */
+static int Curl_gskit_init(long flags)
 {
-  /* No initialisation needed. */
-
+  (void)flags;
   return 1;
 }
 
 
-static void Curl_gskit_cleanup(void)
+/*
+ * Cleanup.
+ * This is called by curl_global_cleanup with the global init flags.
+ * This is not thread-safe since curl_global_cleanup is not thread-safe.
+ * Any required SSL library specific de-initialization (ie de-initialization
+ * routines not in libcurl) should take place only if CURL_GLOBAL_SSL is set in
+ * init_flags.
+ */
+static void Curl_gskit_cleanup(long init_flags)
 {
-  /* Nothing to do. */
+  (void)init_flags;
 }
 
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1003,16 +1003,32 @@ static CURLcode Curl_mbedtls_connect(struct connectdata *conn, int sockindex)
 }
 
 /*
- * return 0 error initializing SSL
- * return 1 SSL initialized successfully
+ * Init.
+ * This is called by curl_global_init with the global init flags.
+ * This is not thread-safe since curl_global_init is not thread-safe.
+ * Any required SSL library specific initialization (ie initialization routines
+ * not in libcurl) should take place only if CURL_GLOBAL_SSL is set in flags.
+ *
+ * @retval 0 error initializing SSL
+ * @retval 1 SSL initialized successfully
  */
-static int Curl_mbedtls_init(void)
+static int Curl_mbedtls_init(long flags)
 {
-  return Curl_polarsslthreadlock_thread_setup();
+  (void)flags;
+  return (Curl_polarsslthreadlock_thread_setup() ? 1 : 0);
 }
 
-static void Curl_mbedtls_cleanup(void)
+/*
+ * Cleanup.
+ * This is called by curl_global_cleanup with the global init flags.
+ * This is not thread-safe since curl_global_cleanup is not thread-safe.
+ * Any required SSL library specific de-initialization (ie de-initialization
+ * routines not in libcurl) should take place only if CURL_GLOBAL_SSL is set in
+ * init_flags.
+ */
+static void Curl_mbedtls_cleanup(long init_flags)
 {
+  (void)init_flags;
   (void)Curl_polarsslthreadlock_thread_cleanup();
 }
 

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -862,16 +862,32 @@ static CURLcode Curl_polarssl_connect(struct connectdata *conn, int sockindex)
 }
 
 /*
- * return 0 error initializing SSL
- * return 1 SSL initialized successfully
+ * Init.
+ * This is called by curl_global_init with the global init flags.
+ * This is not thread-safe since curl_global_init is not thread-safe.
+ * Any required SSL library specific initialization (ie initialization routines
+ * not in libcurl) should take place only if CURL_GLOBAL_SSL is set in flags.
+ *
+ * @retval 0 error initializing SSL
+ * @retval 1 SSL initialized successfully
  */
-static int Curl_polarssl_init(void)
+static int Curl_polarssl_init(long flags)
 {
-  return Curl_polarsslthreadlock_thread_setup();
+  (void)flags;
+  return (Curl_polarsslthreadlock_thread_setup() ? 1 : 0);
 }
 
-static void Curl_polarssl_cleanup(void)
+/*
+ * Cleanup.
+ * This is called by curl_global_cleanup with the global init flags.
+ * This is not thread-safe since curl_global_cleanup is not thread-safe.
+ * Any required SSL library specific de-initialization (ie de-initialization
+ * routines not in libcurl) should take place only if CURL_GLOBAL_SSL is set in
+ * init_flags.
+ */
+static void Curl_polarssl_cleanup(long init_flags)
 {
+  (void)init_flags;
   (void)Curl_polarsslthreadlock_thread_cleanup();
 }
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -158,23 +158,23 @@ static bool init_ssl = FALSE;
  * @retval 0 error initializing SSL
  * @retval 1 SSL initialized successfully
  */
-int Curl_ssl_init(void)
+int Curl_ssl_init(long flags)
 {
   /* make sure this is only done once */
   if(init_ssl)
     return 1;
   init_ssl = TRUE; /* never again */
 
-  return Curl_ssl->init();
+  return Curl_ssl->init(flags);
 }
 
 
 /* Global cleanup */
-void Curl_ssl_cleanup(void)
+void Curl_ssl_cleanup(long init_flags)
 {
   if(init_ssl) {
     /* only cleanup if we did a previous init */
-    Curl_ssl->cleanup();
+    Curl_ssl->cleanup(init_flags);
     init_ssl = FALSE;
   }
 }
@@ -979,13 +979,16 @@ bool Curl_ssl_false_start(void)
  * Default implementations for unsupported functions.
  */
 
-int Curl_none_init(void)
+int Curl_none_init(long flags)
 {
+  (void)flags;
   return 1;
 }
 
-void Curl_none_cleanup(void)
-{ }
+void Curl_none_cleanup(long init_flags)
+{
+  (void)init_flags;
+}
 
 int Curl_none_shutdown(struct connectdata *conn UNUSED_PARAM,
                        int sockindex UNUSED_PARAM)
@@ -1088,11 +1091,11 @@ CURLcode Curl_none_md5sum(unsigned char *input UNUSED_PARAM,
 }
 #endif
 
-static int Curl_multissl_init(void)
+static int Curl_multissl_init(long flags)
 {
   if(multissl_init(NULL))
     return 1;
-  return Curl_ssl->init();
+  return Curl_ssl->init(flags);
 }
 
 static CURLcode Curl_multissl_connect(struct connectdata *conn, int sockindex)

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -42,8 +42,8 @@ struct Curl_ssl {
 
   size_t sizeof_ssl_backend_data;
 
-  int (*init)(void);
-  void (*cleanup)(void);
+  int (*init)(long flags);
+  void (*cleanup)(long init_flags);
 
   size_t (*version)(char *buffer, size_t size);
   int (*check_cxn)(struct connectdata *cxn);
@@ -80,8 +80,8 @@ struct Curl_ssl {
 extern const struct Curl_ssl *Curl_ssl;
 #endif
 
-int Curl_none_init(void);
-void Curl_none_cleanup(void);
+int Curl_none_init(long flags);
+void Curl_none_cleanup(long init_flags);
 int Curl_none_shutdown(struct connectdata *conn, int sockindex);
 int Curl_none_check_cxn(struct connectdata *conn);
 CURLcode Curl_none_random(struct Curl_easy *data, unsigned char *entropy,
@@ -146,8 +146,8 @@ int Curl_ssl_getsock(struct connectdata *conn, curl_socket_t *socks,
 int Curl_ssl_backend(void);
 
 #ifdef USE_SSL
-int Curl_ssl_init(void);
-void Curl_ssl_cleanup(void);
+int Curl_ssl_init(long flags);
+void Curl_ssl_cleanup(long init_flags);
 CURLcode Curl_ssl_connect(struct connectdata *conn, int sockindex);
 CURLcode Curl_ssl_connect_nonblocking(struct connectdata *conn,
                                       int sockindex,
@@ -248,8 +248,8 @@ bool Curl_ssl_false_start(void);
 #else
 
 /* When SSL support is not present, just define away these function calls */
-#define Curl_ssl_init() 1
-#define Curl_ssl_cleanup() Curl_nop_stmt
+#define Curl_ssl_init(x) 1
+#define Curl_ssl_cleanup(x) Curl_nop_stmt
 #define Curl_ssl_connect(x,y) CURLE_NOT_BUILT_IN
 #define Curl_ssl_close_all(x) Curl_nop_stmt
 #define Curl_ssl_close(x,y) Curl_nop_stmt


### PR DESCRIPTION
- Call SSL initialization even when CURL_GLOBAL_SSL is not set as a
  global init flag. For backwards compatibility the SSL library-specific
  part of the initialization (ie initialization routines not in libcurl)
  will only be run if CURL_GLOBAL_SSL is set.

Prior to this change if CURL_GLOBAL_SSL was not set then no SSL
initialization or de-initialization would take place in libcurl,
regardless of whether it was a libcurl initialization routine (ie code
we always must run) or an SSL library-specific initialization routine
(ie code the user can choose to run themselves by not setting
CURL_GLOBAL_SSL). By passing the global init flags to the ssl init
function we can now handle those things separately.

Note for two of the SSL backends SChannel (WinSSL) and NSS, libcurl must
handle the SSL library-specific part of the initialization. If libcurl
is built against one of those backends and CURL_GLOBAL_SSL is not set
then curl_global_init will return error CURLE_FAILED_INIT.

Closes https://github.com/curl/curl/pull/2083
Closes https://github.com/curl/curl/pull/2089
Closes https://github.com/curl/curl/pull/2107
Closes https://github.com/curl/curl/pull/2112

---

Alternate proposal to handle the SSL libcurl-specific initialization separately from the SSL library-specific initialization. This is mostly because I want to retain CURL_GLOBAL_SSL behavior since I suspect if we remove it we could break something for anyone who is doing their own OpenSSL initialization and de-initialization in a version earlier than 1.1.x.