### PR TITLE
Avoid magic allocation of SSL backend specific data

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -860,6 +860,9 @@ struct connectdata {
 #endif /* USE_RECV_BEFORE_SEND_WORKAROUND */
   struct ssl_connect_data ssl[2]; /* this is for ssl-stuff */
   struct ssl_connect_data proxy_ssl[2]; /* this is for proxy ssl-stuff */
+#ifdef USE_SSL
+  void *ssl_extra; /* separately allocated backend-specific data */
+#endif
   struct ssl_primary_config ssl_config;
   struct ssl_primary_config proxy_ssl_config;
   bool tls_upgraded;


### PR DESCRIPTION
Originally, my idea was to allocate the two structures (or more
precisely, the connectdata structure and the four SSL backend-specific
strucutres required for ssl[0..1] and proxy_ssl[0..1]) in one go, so
that they all could be free()d together.

However, getting the alignment right is tricky. Too tricky.

So let's just bite the bullet and allocate the SSL backend-specific
data separately.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>