### PR TITLE
 Only include code coverage macros when compiler is gcc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,11 @@ CURL_CHECK_OPTION_ARES
 CURL_CHECK_OPTION_RT
 
 XC_CHECK_PATH_SEPARATOR
-AX_CODE_COVERAGE
+dnl Check if gcc is being used before adding AX_CODE_COVERAGE
+AS_IF([ test "$GCC" = "yes" ], [AX_CODE_COVERAGE],
+  # not using GCC so pass a test below - CODE_COVERAGE_ENABLED_TRUE is not zero length
+  CODE_COVERAGE_ENABLED_TRUE='#'
+)
 
 #
 # save the configure arguments


### PR DESCRIPTION
 in 18eac3d that what has changed is AC_SUBST([CODE_COVERAGE_RULES]) is now always included whereas prior to that it was only included if code coverage was enabled (AS_IF([ test "$enable_code_coverage" = "yes" ], [).

This change makes sure that "code coverage" is only included in the Makefiles generated if the compiler is gcc.