### PR TITLE
lib: revise exporting of symbols

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -106,6 +106,8 @@ endif
 
 if CURL_LT_SHLIB_USE_VERSIONED_SYMBOLS
 libcurl_la_LDFLAGS_EXTRA += -Wl,--version-script=libcurl.vers
+else
+libcurl_la_LDFLAGS_EXTRA += -export-symbols-regex '^curl_.*'
 endif
 
 if USE_CPPFLAG_CURL_STATICLIB


### PR DESCRIPTION
Static-Linking dependencies to *curl* I noticed that *curl* re-exports those other symbols, which is unexpected.