### PR TITLE
curl-config: add --ssl-backends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4040,6 +4040,9 @@ squeeze SUPPORT_PROTOCOLS
 
 XC_CHECK_BUILD_FLAGS
 
+SSL_BACKENDS=${ssl_backends}
+AC_SUBST(SSL_BACKENDS)
+
 if test "x$want_curldebug_assumed" = "xyes" &&
   test "x$want_curldebug" = "xyes" && test "x$USE_ARES" = "x1"; then
   ac_configure_args="$ac_configure_args --enable-curldebug"

--- a/curl-config.in
+++ b/curl-config.in
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2001 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2001 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -44,6 +44,7 @@ Available values for OPTION include:
   --libs      library linking information
   --prefix    curl install prefix
   --protocols newline separated list of enabled protocols
+  --ssl-backends output the SSL backends libcurl was built to support
   --static-libs static libcurl library linking information
   --version   output version information
   --vernum    output the version information as a number (hexadecimal)
@@ -152,6 +153,9 @@ while test $# -gt 0; do
         else
           echo ${CURLLIBDIR}-lcurl
         fi
+        ;;
+    --ssl-backends)
+        echo "@SSL_BACKENDS@"
         ;;
 
     --static-libs)

--- a/docs/curl-config.1
+++ b/docs/curl-config.1
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -63,6 +63,9 @@ the time of writing, this list may include HTTP, HTTPS, FTP, FTPS, FILE,
 TELNET, LDAP, DICT. Do not assume any particular order. The protocols will
 be listed using uppercase and are separated by newlines. There may be none,
 one, or several protocols in the list. (Added in 7.13.0)
+.IP "--ssl-backends"
+Lists the SSL backends that were enabled when libcurl was built (Added in
+7.58.0)
 .IP "--static-libs"
 Shows the complete set of libs and other linker options you will need in order
 to link your application with libcurl statically. (Added in 7.17.1)


### PR DESCRIPTION
Lists all SSL backends that were enabled at build-time.

Fixes #2128