### PR TITLE
travis: use pip2 instead of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ matrix:
           env: T=fuzzer
 
 install:
-  - pip install --user cpp-coveralls
+  - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update > /dev/null; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall libtool > /dev/null; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install rtmpdump libssh2 c-ares libmetalink libressl nghttp2 libmetalink; fi


### PR DESCRIPTION
.. since now mac osx image expects pip2 or pip3, and doesn't know pip:


0.01s$ pip install --user cpp-coveralls
/Users/travis/.travis/job_stages: line 57: pip: command not found


Ref: https://github.com/travis-ci/travis-ci/issues/8829

Closes https://github.com/curl/curl/pull/2133

---

Our CI autobuilds that use osx in travis are failing since now it uses xcode 8.3 which apparently expects pip2 or pip3. I'm trying pip2, let's see what happens.