### PR TITLE
libssh: replace ssh_get_publickey with ssh_get_server_publickey

### DIFF
--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -313,7 +313,7 @@ static int myssh_is_known(struct connectdata *conn)
   curl_sshkeycallback func =
     data->set.ssh_keyfunc;
 
-  rc = ssh_get_publickey(sshc->ssh_session, &pubkey);
+  rc = ssh_get_server_publickey(sshc->ssh_session, &pubkey);
   if(rc != SSH_OK)
     return rc;
 


### PR DESCRIPTION
The former is a deprecated function in new libssh releases.

Signed-off-by: Nikos Mavrogiannopoulos <nmav@gnutls.org>
Fixes #2135