### PR TITLE
curl_sspi: Use Unicode identity in non-UNICODE SSPI builds

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -24,8 +24,8 @@
 
 #include <curl/curl.h>
 
-#if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
-                                defined(USE_WIN32_LDAP)) && defined(UNICODE))
+#if defined(USE_WIN32_IDN) || defined(USE_WINDOWS_SSPI) || \
+    (defined(USE_WIN32_LDAP) && defined(UNICODE))
 
  /*
   * MultiByte conversions using Windows kernel32 library.

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -23,8 +23,8 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
-                                defined(USE_WIN32_LDAP)) && defined(UNICODE))
+#if defined(USE_WIN32_IDN) || defined(USE_WINDOWS_SSPI) || \
+    (defined(USE_WIN32_LDAP) && defined(UNICODE))
 
  /*
   * MultiByte conversions using Windows kernel32 library.

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -24,6 +24,8 @@
 
 #ifdef USE_WINDOWS_SSPI
 
+#include <wchar.h>
+
 #include <curl/curl.h>
 #include "curl_sspi.h"
 #include "curl_multibyte.h"
@@ -126,7 +128,7 @@ void Curl_sspi_global_cleanup(void)
  * Curl_create_sspi_identity()
  *
  * This is used to populate a SSPI identity structure based on the supplied
- * username and password.
+ * username and password. The username and password must be UTF-8 encoded.
  *
  * Parameters:
  *
@@ -139,77 +141,48 @@ void Curl_sspi_global_cleanup(void)
 CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
                                    SEC_WINNT_AUTH_IDENTITY *identity)
 {
-  xcharp_u useranddomain;
-  xcharp_u user, dup_user;
-  xcharp_u domain, dup_domain;
-  xcharp_u passwd, dup_passwd;
-  size_t domlen = 0;
-
-  domain.const_tchar_ptr = TEXT("");
+  wchar_t *p, *useranddomain;
 
   /* Initialize the identity */
   memset(identity, 0, sizeof(*identity));
 
-  useranddomain.tchar_ptr = Curl_convert_UTF8_to_tchar((char *)userp);
-  if(!useranddomain.tchar_ptr)
+  useranddomain = Curl_convert_UTF8_to_wchar(userp);
+  if(!useranddomain)
     return CURLE_OUT_OF_MEMORY;
 
-  user.const_tchar_ptr = _tcschr(useranddomain.const_tchar_ptr, TEXT('\\'));
-  if(!user.const_tchar_ptr)
-    user.const_tchar_ptr = _tcschr(useranddomain.const_tchar_ptr, TEXT('/'));
+  p = wcschr(useranddomain, L'\\');
+  if(!p)
+    p = wcschr(useranddomain, L'/');
 
-  if(user.tchar_ptr) {
-    domain.tchar_ptr = useranddomain.tchar_ptr;
-    domlen = user.tchar_ptr - useranddomain.tchar_ptr;
-    user.tchar_ptr++;
+  /* if a domain is prepended then separate it from user */
+  if(p) {
+    *p = 0;
+    identity->Domain = (void *)wcsdup(useranddomain);
+    identity->User = (void *)wcsdup(p + 1);
   }
   else {
-    user.tchar_ptr = useranddomain.tchar_ptr;
-    domain.const_tchar_ptr = TEXT("");
-    domlen = 0;
+    identity->Domain = (void *)wcsdup(L"");
+    identity->User = (void *)wcsdup(useranddomain);
   }
 
-  /* Setup the identity's user and length */
-  dup_user.tchar_ptr = _tcsdup(user.tchar_ptr);
-  if(!dup_user.tchar_ptr) {
-    Curl_unicodefree(useranddomain.tchar_ptr);
+  Curl_safefree(useranddomain);
+
+  identity->Password = (void *)Curl_convert_UTF8_to_wchar(passwdp);
+
+  if(!identity->Domain || !identity->User || !identity->Password) {
+    Curl_sspi_free_identity(identity);
     return CURLE_OUT_OF_MEMORY;
   }
-  identity->User = dup_user.tbyte_ptr;
-  identity->UserLength = curlx_uztoul(_tcslen(dup_user.tchar_ptr));
-  dup_user.tchar_ptr = NULL;
 
-  /* Setup the identity's domain and length */
-  dup_domain.tchar_ptr = malloc(sizeof(TCHAR) * (domlen + 1));
-  if(!dup_domain.tchar_ptr) {
-    Curl_unicodefree(useranddomain.tchar_ptr);
-    return CURLE_OUT_OF_MEMORY;
-  }
-  _tcsncpy(dup_domain.tchar_ptr, domain.tchar_ptr, domlen);
-  *(dup_domain.tchar_ptr + domlen) = TEXT('\0');
-  identity->Domain = dup_domain.tbyte_ptr;
-  identity->DomainLength = curlx_uztoul(domlen);
-  dup_domain.tchar_ptr = NULL;
+  /* The doc says the length must be "Number of characters" of strings that are
+     "ANSI or UNICODE" (our case is the latter). What they actually want is a
+     count of wchar_t (ie UTF-16 code units), not a Unicode character count. */
+  identity->DomainLength = curlx_uztoul(wcslen((wchar_t *)identity->Domain));
+  identity->UserLength = curlx_uztoul(wcslen((wchar_t *)identity->User));
+  identity->PasswordLength =
+    curlx_uztoul(wcslen((wchar_t *)identity->Password));
 
-  Curl_unicodefree(useranddomain.tchar_ptr);
-
-  /* Setup the identity's password and length */
-  passwd.tchar_ptr = Curl_convert_UTF8_to_tchar((char *)passwdp);
-  if(!passwd.tchar_ptr)
-    return CURLE_OUT_OF_MEMORY;
-  dup_passwd.tchar_ptr = _tcsdup(passwd.tchar_ptr);
-  if(!dup_passwd.tchar_ptr) {
-    Curl_unicodefree(passwd.tchar_ptr);
-    return CURLE_OUT_OF_MEMORY;
-  }
-  identity->Password = dup_passwd.tbyte_ptr;
-  identity->PasswordLength = curlx_uztoul(_tcslen(dup_passwd.tchar_ptr));
-  dup_passwd.tchar_ptr = NULL;
-
-  Curl_unicodefree(passwd.tchar_ptr);
-
-  /* Setup the identity's flags */
-  identity->Flags = SECFLAG_WINNT_AUTH_IDENTITY;
+  identity->Flags = SEC_WINNT_AUTH_IDENTITY_UNICODE;
 
   return CURLE_OK;
 }

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -138,7 +138,7 @@ bool Curl_auth_user_contains_domain(const char *user)
   }
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   else
-    /* User and domain are obtained from the GSS-API credientials cache or the
+    /* User and domain are obtained from the GSS-API credentials cache or the
        currently logged in user from Windows */
     valid = TRUE;
 #endif


### PR DESCRIPTION
- Make it so SSPI non-UNICODE builds can handle Unicode user/pass.

Prior to this change those builds attempted to create an identity in the
local codepage but that didn't work.

Ref: https://github.com/curl/curl/issues/2120