### PR TITLE
Support for HPE NonStop NSE and NSX systems for IPv6 compatibility

### DIFF
--- a/lib/curl_addrinfo.h
+++ b/lib/curl_addrinfo.h
@@ -26,6 +26,9 @@
 
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
+#if defined (__TANDEM)
+#  include <netinet/in6.h>
+#endif
 #endif
 #ifdef HAVE_NETDB_H
 #  include <netdb.h>

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -320,8 +320,8 @@
 #include <assert.h>
 #endif
 
-#ifdef __TANDEM /* for nsr-tandem-nsk systems */
-#include <floss.h>
+#ifdef __TANDEM /* for nsx-, nse-, nsr-tandem-nsk systems */
+#include <floss.h(floss_read,floss_write,floss_getpwuid)>
 #endif
 
 #ifndef STDC_HEADERS /* no standard C headers! */

--- a/lib/hostcheck.c
+++ b/lib/hostcheck.c
@@ -30,6 +30,9 @@
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#if defined (__TANDEM)
+#include <netinet/in6.h>
+#endif
 #endif
 
 #include "hostcheck.h"

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -24,6 +24,9 @@
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#if defined (__TANDEM)
+#include <netinet/in6.h>
+#endif
 #endif
 #ifdef HAVE_NETDB_H
 #include <netdb.h>

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -84,6 +84,9 @@
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#if defined (__TANDEM)
+#include <netinet/in6.h>
+#endif
 #endif
 
 #include "timeval.h"

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -32,6 +32,10 @@
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#if defined (__TANDEM)
+#include <netinet/in6.h>
+const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+#endif
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -88,6 +88,10 @@
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#if defined (__TANDEM)
+#include <netinet/in6.h>
+const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+#endif
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -33,6 +33,10 @@
 #endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#if defined (__TANDEM)
+#include <netinet/in6.h>
+const struct in6_addr in6addr_any = IN6ADDR_ANY_INIT;
+#endif
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>


### PR DESCRIPTION
These are changes needed at 7.53.0 for compilation on the NonStop platform formerly known as TANDEM. Changes are wrapped in `#if defined(__TANDEM)`/`#endif` so should have no impact on other platforms. Essentially, these are `#include <netinet/in6.h>`, which is the location of IPv6 definitions on that platform, which are not included in the configure.ac detection, nor specially handled in code.