### PR TITLE
sasl_getmesssage: make sure we have a long enough string to pass

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -344,23 +344,28 @@ static bool imap_endofresp(struct connectdata *conn, char *line, size_t len,
  */
 static void imap_get_message(char *buffer, char **outptr)
 {
-  size_t len = 0;
+  size_t len = strlen(buffer);
   char *message = NULL;
 
-  /* Find the start of the message */
-  for(message = buffer + 2; *message == ' ' || *message == '\t'; message++)
-    ;
+  if(len > 2) {
+    /* Find the start of the message */
+    for(message = buffer + 2; *message == ' ' || *message == '\t'; message++)
+      ;
 
-  /* Find the end of the message */
-  for(len = strlen(message); len--;)
-    if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
-        message[len] != '\t')
-      break;
+    /* Find the end of the message */
+    for(len -= 2; len--;)
+      if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
+         message[len] != '\t')
+        break;
 
-  /* Terminate the message */
-  if(++len) {
-    message[len] = '\0';
+    /* Terminate the message */
+    if(++len) {
+      message[len] = '\0';
+    }
   }
+  else
+    /* junk input => zero length output */
+    message = &buffer[len];
 
   *outptr = message;
 }

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -243,23 +243,28 @@ static bool pop3_endofresp(struct connectdata *conn, char *line, size_t len,
  */
 static void pop3_get_message(char *buffer, char **outptr)
 {
-  size_t len = 0;
+  size_t len = strlen(buffer);
   char *message = NULL;
 
-  /* Find the start of the message */
-  for(message = buffer + 2; *message == ' ' || *message == '\t'; message++)
-    ;
+  if(len > 2) {
+    /* Find the start of the message */
+    for(message = buffer + 2; *message == ' ' || *message == '\t'; message++)
+      ;
 
-  /* Find the end of the message */
-  for(len = strlen(message); len--;)
-    if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
-        message[len] != '\t')
-      break;
+    /* Find the end of the message */
+    for(len -= 2; len--;)
+      if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
+         message[len] != '\t')
+        break;
 
-  /* Terminate the message */
-  if(++len) {
-    message[len] = '\0';
+    /* Terminate the message */
+    if(++len) {
+      message[len] = '\0';
+    }
   }
+  else
+    /* junk input => zero length output */
+    message = &buffer[len];
 
   *outptr = message;
 }

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -232,23 +232,28 @@ static bool smtp_endofresp(struct connectdata *conn, char *line, size_t len,
  */
 static void smtp_get_message(char *buffer, char **outptr)
 {
-  size_t len = 0;
+  size_t len = strlen(buffer);
   char *message = NULL;
 
-  /* Find the start of the message */
-  for(message = buffer + 4; *message == ' ' || *message == '\t'; message++)
-    ;
+  if(len > 4) {
+    /* Find the start of the message */
+    for(message = buffer + 4; *message == ' ' || *message == '\t'; message++)
+      ;
 
-  /* Find the end of the message */
-  for(len = strlen(message); len--;)
-    if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
-       message[len] != '\t')
-      break;
+    /* Find the end of the message */
+    for(len -= 4; len--;)
+      if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
+         message[len] != '\t')
+        break;
 
-  /* Terminate the message */
-  if(++len) {
-    message[len] = '\0';
+    /* Terminate the message */
+    if(++len) {
+      message[len] = '\0';
+    }
   }
+  else
+    /* junk input => zero length output */
+    message = &buffer[len];
 
   *outptr = message;
 }

--- a/tests/FILEFORMAT
+++ b/tests/FILEFORMAT
@@ -124,6 +124,8 @@ REPLY [command] [return value] [response string]
    evaluated as a perl string, so it can contain embedded \r\n, for example.
    There's a special [command] named "welcome" (without quotes) which is the
    string sent immediately on connect as a welcome.
+REPLYLF (like above but sends the response terminated with LF-only and not
+   CRLF)
 COUNT [command] [num]
  - Do the REPLY change for [command] only [num] times and then go back to the
    built-in approach

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -95,7 +95,7 @@ test850 test851 test852 test853 test854 test855 test856 test857 test858 \
 test859 test860 test861 test862 test863 test864 test865 test866 test867 \
 test868 test869 test870 test871 test872 test873 test874 test875 test876 \
 test877 test878 test879 test880 test881 test882 test883 test884 test885 \
-test886 test887 test888 test889 test890 \
+test886 test887 test888 test889 test890 test891 \
 \
 test900 test901 test902 test903 test904 test905 test906 test907 test908 \
 test909 test910 test911 test912 test913 test914 test915 test916 test917 \

--- a/tests/data/test891
+++ b/tests/data/test891
@@ -1,0 +1,47 @@
+<testcase>
+<info>
+<keywords>
+POP3
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<servercmd>
+AUTH CRAM-MD5
+REPLYLF AUTH +
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+pop3
+</server>
+<features>
+crypto
+</features>
+ <name>
+POP3 with short authentication response
+ </name>
+ <command>
+pop3://%HOSTIP:%POP3PORT/891 -u user:secret
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+CAPA
+AUTH CRAM-MD5
+dXNlciA1YzhkYjAzZjA0Y2VjMGY0M2JjYjA2MDAyMzkxNDE5MA==
+</protocol>
+# CURLE_LOGIN_DENIED
+<errorcode>
+67
+</errorcode>
+</verify>
+</testcase>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -2755,13 +2755,19 @@ sub customize {
             $fulltextreply{$1}=eval "qq{$2}";
             logmsg "FTPD: set custom reply for $1\n";
         }
-        elsif($_ =~ /REPLY ([A-Za-z0-9+\/=\*]*) (.*)/) {
-            $commandreply{$1}=eval "qq{$2}";
-            if($1 eq "") {
+        elsif($_ =~ /REPLY(LF|) ([A-Za-z0-9+\/=\*]*) (.*)/) {
+            $commandreply{$2}=eval "qq{$3}";
+            if($1 ne "LF") {
+                $commandreply{$2}.="\r\n";
+            }
+            else {
+                $commandreply{$2}.="\n";
+            }
+            if($2 eq "") {
                 logmsg "FTPD: set custom reply for empty command\n";
             }
             else {
-                logmsg "FTPD: set custom reply for $1 command\n";
+                logmsg "FTPD: set custom reply for $2 command\n";
             }
         }
         elsif($_ =~ /COUNT ([A-Z]+) (.*)/) {
@@ -3175,7 +3181,7 @@ while(1) {
                     $commandreply{$FTPCMD}="";
                 }
 
-                sendcontrol "$text\r\n";
+                sendcontrol $text;
                 $check = 0;
             }
             else {


### PR DESCRIPTION
For pop3/imap/smtp, added test 891 to somewhat verify the pop3
case.

For this, I enhanced the pingpong test server to be able to send back
responses with LF-only instead of always using CRLF.