### PR TITLE
Fix file://c:\some\path\curl.out

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2053,7 +2053,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   ((('a' <= (str)[0] && (str)[0] <= 'z') || \
     ('A' <= (str)[0] && (str)[0] <= 'Z')) && \
    ((str)[1] == ':' || (str)[1] == '|') && \
-   ((str)[2] == '/' || (str)[2] == 0))
+   ((str)[2] == '/' || (str)[2] == '\\' || (str)[2] == 0))
 
   /* Don't mistake a drive letter for a scheme if the default protocol is file.
      curld --proto-default file c:/foo/bar.txt */


### PR DESCRIPTION
Sequel to https://github.com/curl/curl/issues/1187#issuecomment-348176804

The issue is essentially the same as in the opening post of https://github.com/curl/curl/issues/1187#issue-198380188 
`file://c:\some\path\curl.out`
is rejected wih error message:

> curl: (3) Invalid file://hostname/, expected localhost or 127.0.0.1 or none

`file://c:/some/path/curl.out`
is accepted. This is apparently intentional, according to the comment in https://github.com/curl/curl/blob/master/lib/url.c#L2121

>        * Additionally, there is an exception for URLs with a Windows drive
>        * letter in the authority (which was accidentally omitted from RFC 8089
>        * Appendix E, but believe me, it was meant to be there. --MK)

PHP uses the backslash format for file:// URL's. This PR aims to include URL's like file://c:\some\path\curl.out as well.