### PR TITLE
Openldap debugging

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -51,6 +51,25 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+/*
+ * Uncommenting this will enable the built-in debug logging of the openldap
+ * library. The debug log level can be set using the CURL_OPENLDAP_TRACE
+ * environment variable. The debug output is written to stderr.
+ * 
+ * The library supports the following debug flags: 
+ * LDAP_DEBUG_NONE         0x0000
+ * LDAP_DEBUG_TRACE        0x0001
+ * LDAP_DEBUG_CONSTRUCT    0x0002
+ * LDAP_DEBUG_DESTROY      0x0004
+ * LDAP_DEBUG_PARAMETER    0x0008
+ * LDAP_DEBUG_ANY          0xffff 
+ * 
+ * For example, use CURL_OPENLDAP_TRACE=0 for no debug,
+ * CURL_OPENLDAP_TRACE=2 for LDAP_DEBUG_CONSTRUCT messages only,
+ * CURL_OPENLDAP_TRACE=65535 for all debug message levels.
+ */
+/* #define CURL_OPENLDAP_DEBUG */
+
 #ifndef _LDAP_PVT_H
 extern int ldap_pvt_url_scheme2proto(const char *);
 extern int ldap_init_fd(ber_socket_t fd, int proto, const char *url,
@@ -203,6 +222,15 @@ static CURLcode ldap_connect(struct connectdata *conn, bool *done)
     *ptr++ = 's';
   snprintf(ptr, sizeof(hosturl)-(ptr-hosturl), "://%s:%d",
     conn->host.name, conn->remote_port);
+
+#ifdef CURL_OPENLDAP_DEBUG
+  static int do_trace = 0;
+  const char *env = getenv("CURL_TRACE");
+  do_trace = (env && strtol(env, NULL, 10) > 0);
+  if (do_trace) {
+    ldap_set_option(li->ld, LDAP_OPT_DEBUG_LEVEL, &do_trace);
+  }
+#endif
 
   rc = ldap_init_fd(conn->sock[FIRSTSOCKET], li->proto, hosturl, &li->ld);
   if(rc) {

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -225,7 +225,7 @@ static CURLcode ldap_connect(struct connectdata *conn, bool *done)
 
 #ifdef CURL_OPENLDAP_DEBUG
   static int do_trace = 0;
-  const char *env = getenv("CURL_TRACE");
+  const char *env = getenv("CURL_OPENLDAP_TRACE");
   do_trace = (env && strtol(env, NULL, 10) > 0);
   if (do_trace) {
     ldap_set_option(li->ld, LDAP_OPT_DEBUG_LEVEL, &do_trace);


### PR DESCRIPTION
This commit adds a #define CURL_OPENLDAP_DEBUG that enables the built-in openldap debug messages to stderr based on CURL_OPENLDAP_TRACE environment variable value (the log level).