### PR TITLE
Allow older Linux dist to build curl

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -22,6 +22,10 @@
 
 #include "curl_setup.h"
 
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>
 #endif

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -26,6 +26,10 @@
 #include <limits.h>
 #endif
 
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>
 #endif


### PR DESCRIPTION
This PR relates to the mail thread "Compile errors on update to 7.57.0" in which Daniel graciously helped me track down the solution to my problem where curl no longer builds on CentOS 4.8 with gcc 4.8.5.