### PR TITLE
curl: remove __EMX__ #ifdefs

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -4635,22 +4635,8 @@ CURLcode Curl_setup_conn(struct connectdata *conn,
     Curl_verboseconnect(conn);
   }
 
-  conn->now = Curl_now(); /* time this *after* the connect is done, we
-                               set this here perhaps a second time */
-
-#ifdef __EMX__
-  /*
-   * This check is quite a hack. We're calling _fsetmode to fix the problem
-   * with fwrite converting newline characters (you get mangled text files,
-   * and corrupted binary files when you download to stdout and redirect it to
-   * a file).
-   */
-
-  if((data->set.out)->_handle == NULL) {
-    _fsetmode(stdout, "b");
-  }
-#endif
-
+  conn->now = Curl_now(); /* time this *after* the connect is done, we set
+                             this here perhaps a second time */
   return result;
 }
 

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -120,10 +120,6 @@ int tool_progress_cb(void *clientp,
 void progressbarinit(struct ProgressData *bar,
                      struct OperationConfig *config)
 {
-#ifdef __EMX__
-  /* 20000318 mgs */
-  int scr_size[2];
-#endif
   char *colp;
 
   memset(bar, 0, sizeof(struct ProgressData));
@@ -134,12 +130,6 @@ void progressbarinit(struct ProgressData *bar,
   if(config->use_resume)
     bar->initial_size = config->resume_from;
 
-/* TODO: get terminal width through ansi escapes or something similar.
-   try to update width when xterm is resized... - 19990617 larsa */
-#ifndef __EMX__
-  /* 20000318 mgs
-   * OS/2 users most likely won't have this env var set, and besides that
-   * we're using our own way to determine screen width */
   colp = curlx_getenv("COLUMNS");
   if(colp) {
     char *endptr;
@@ -152,16 +142,6 @@ void progressbarinit(struct ProgressData *bar,
   }
   else
     bar->width = 79;
-#else
-  /* 20000318 mgs
-   * We use this emx library call to get the screen width, and subtract
-   * one from what we got in order to avoid a problem with the cursor
-   * advancing to the next line if we print a string that is as long as
-   * the screen is wide. */
-
-  _scrsize(scr_size);
-  bar->width = scr_size[0] - 1;
-#endif
 
   bar->out = config->global->errors;
 }


### PR DESCRIPTION
These are OS/2-specific things added to the code in the year 2000. They
were always ugly. If there's any user left, they still don't need this
kludge.