### PR TITLE
curl: don't set CURLOPT_INTERLEAVEDATA

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -864,7 +864,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
 
         /* where to store */
         my_setopt(curl, CURLOPT_WRITEDATA, &outs);
-        my_setopt(curl, CURLOPT_INTERLEAVEDATA, &outs);
+
         if(metalink || !config->use_metalink)
           /* what call to write */
           my_setopt(curl, CURLOPT_WRITEFUNCTION, tool_write_cb);

--- a/tests/data/test1400
+++ b/tests/data/test1400
@@ -81,7 +81,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1401
+++ b/tests/data/test1401
@@ -100,7 +100,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1402
+++ b/tests/data/test1402
@@ -88,7 +88,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1403
+++ b/tests/data/test1403
@@ -83,7 +83,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -152,7 +152,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1405
+++ b/tests/data/test1405
@@ -97,7 +97,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1406
+++ b/tests/data/test1406
@@ -90,7 +90,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1407
+++ b/tests/data/test1407
@@ -70,7 +70,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer


### PR DESCRIPTION
That data is only ever used by the CURLOPT_INTERLEAVEFUNCTION callback
and that option isn't set or used by the curl tool!

Updates the 9 tests that verify --libcurl