### PR TITLE
setopt: less *or equal* than INT_MAX/1000 should be fine

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -277,7 +277,7 @@ static CURLcode setopt(struct Curl_easy *data, CURLoption option,
      * before it is considered failure. For pingpong protocols.
      */
     arg = va_arg(param, long);
-    if((arg >= 0) && (arg < (INT_MAX/1000)))
+    if((arg >= 0) && (arg <= (INT_MAX/1000)))
       data->set.server_response_timeout = arg * 1000;
     else
       return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -1202,7 +1202,7 @@ static CURLcode setopt(struct Curl_easy *data, CURLoption option,
      * operation.
      */
     arg = va_arg(param, long);
-    if((arg >= 0) && (arg < (INT_MAX/1000)))
+    if((arg >= 0) && (arg <= (INT_MAX/1000)))
       data->set.timeout = arg * 1000;
     else
       return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -1220,7 +1220,7 @@ static CURLcode setopt(struct Curl_easy *data, CURLoption option,
      * The maximum time you allow curl to use to connect.
      */
     arg = va_arg(param, long);
-    if((arg >= 0) && (arg < (INT_MAX/1000)))
+    if((arg >= 0) && (arg <= (INT_MAX/1000)))
       data->set.connecttimeout = arg * 1000;
     else
       return CURLE_BAD_FUNCTION_ARGUMENT;


### PR DESCRIPTION
... for the CURLOPT_TIMEOUT, CURLOPT_CONNECTTIMEOUT and
CURLOPT_SERVER_RESPONSE_TIMEOUT range checks.

Reported-by: Dominik Hölzl
Bug: https://curl.haxx.se/mail/lib-2017-12/0037.html