### PR TITLE
MacOSX-Framework: Added --without-ca-bundle to configure lines

### DIFF
--- a/MacOSX-Framework
+++ b/MacOSX-Framework
@@ -82,7 +82,7 @@ MINVER64='-mmacosx-version-min='$MACVER64
 if test ! -z $SDK32; then
   echo "----Configuring libcurl for 32 bit universal framework..."
   make clean
-  ./configure --disable-dependency-tracking --disable-static --with-gssapi --with-darwinssl \
+  ./configure --disable-dependency-tracking --disable-static --with-gssapi --with-darwinssl --without-ca-bundle \
     CFLAGS="-Os -isysroot $SDK32_DIR $ARCHES32" \
     LDFLAGS="-Wl,-syslibroot,$SDK32_DIR $ARCHES32 -Wl,-headerpad_max_install_names" \
     CC=$CC
@@ -111,7 +111,7 @@ if test ! -z $SDK32; then
     popd
     make clean
     echo "----Configuring libcurl for 64 bit universal framework..."
-    ./configure --disable-dependency-tracking --disable-static --with-gssapi --with-darwinssl \
+    ./configure --disable-dependency-tracking --disable-static --with-gssapi --with-darwinssl --without-ca-bundle \
       CFLAGS="-Os -isysroot $SDK64_DIR $ARCHES64" \
       LDFLAGS="-Wl,-syslibroot,$SDK64_DIR $ARCHES64 -Wl,-headerpad_max_install_names" \
       CC=$CC


### PR DESCRIPTION
When I'm using my own libcurl built with the MacOSX-Framework script in my applications I've found that in Sierra at least, the included libcurl installation is configured with --without-ca-bundle while a framework produced from MacOSX-Framework doesn't.

Because of that, it is producing different results (cURL error code 51, SSL code 5) instead of outputting page data when attempting to connect to a server with a self-signed certificate that is already trusted in a keychain because it's looking in /etc/ssl/cert.pem instead of the keychains. Looking at /etc/ssl/cert.pem seems to be a really bad idea as certain valid certificates in the System Roots keychain are not appearing in the file (Sierra at least) which should be like the Deutsche Telekom, Certum and Visa ones for example.

The pull request is simply adding --without-ca-bundle to the configure lines in the MacOSX-Framework script so that it looks at the keychains instead of /etc/ssl/cert.pem.

Potential problem is issue #2103 - Apple has swapped SecureTransport for BoringSSL in High Sierra - based on this I'll test it on High Sierra and update this part of the pull request message.

I'm assuming that MacOSX-Framework should still be using SecureTransport?