### PR TITLE
Fix RTSP example to report on error as intended, not only on success

### DIFF
--- a/docs/examples/rtsp.c
+++ b/docs/examples/rtsp.c
@@ -63,13 +63,13 @@ static int _getch(void)
 /* error handling macros */
 #define my_curl_easy_setopt(A, B, C)                             \
   res = curl_easy_setopt((A), (B), (C));                         \
-  if(!res)                                                       \
+  if(res != CURLE_OK)                                            \
     fprintf(stderr, "curl_easy_setopt(%s, %s, %s) failed: %d\n", \
             #A, #B, #C, res);
 
 #define my_curl_easy_perform(A)                                     \
   res = curl_easy_perform(A);                                       \
-  if(!res)                                                          \
+  if(res != CURLE_OK)                                              \
     fprintf(stderr, "curl_easy_perform(%s) failed: %d\n", #A, res);
 
 


### PR DESCRIPTION
CURLE_OK is 0 so the old statement if(!res) results in only CURLE_OK responses are printed to stderr and all errors are silent.  This change fixes that.