### PR TITLE
build-openssl.bat: Support OpenSSL 1.1.x

### DIFF
--- a/projects/README
+++ b/projects/README
@@ -2,10 +2,18 @@ Building via IDE Project Files
 ==============================
 
    This document describes how to compile, build and install curl and libcurl
-   from sources using an IDE based development tool such as Visual Studio.
+   from source by using pre-generated project files and an IDE based
+   development tool such as Visual Studio. Currently only Visual Studio project
+   files for Windows are generated.
 
-   Project files are currently available for Visual C++ v6.0 to v14.0. The
-   following directory structure has been used to cater for this:
+   The project files contain configurations that match the most common curl
+   build configurations. Typically that is just SSL enabled with the link
+   location set to the default. If you need a more custom configuration (change
+   of dependency locations, more features, etc) you can adapt these project
+   files to suit your needs or use one of the other Visual C++ build methods
+   such as cmake or the makefile in the {curl-source}\winbuild directory.
+
+   The following directory structure has been used to cater for this:
 
    somedirectory\
     |_curl
@@ -26,7 +34,7 @@ Building via IDE Project Files
 Dependencies
 ============
 
-   The projects files also support build configurations that require third
+   The project files also support build configurations that require third
    party dependencies such as OpenSSL, wolfSSL and SSH2. If you wish to support
    these, you will also need to download and compile those libraries as well.
 
@@ -43,7 +51,7 @@ Dependencies
     |          |_lib
     |          |_src
     |
-    |_openssl
+    |_{openssl,wolfssl}
     | |_ build
     |    |_<architecture>
     |      |_VC <version>
@@ -58,7 +66,20 @@ Dependencies
    As OpenSSL and wolfSSL don't support side-by-side compilation when using
    different versions of Visual Studio, build helper batch files have been
    provided to assist with this. Please run "build-openssl -help" and/or
-   "build-wolfssl -help" for usage details.
+   "build-wolfssl -help" for usage details. Example:
+
+   build-openssl vc12 x64 release
+   openssl\build\Win64\VC12\DLL Release    <--- OpenSSL libs/dlls
+
+   If build-openssl is used to build OpenSSL 1.1.0+ then the build script will
+   also create a subdirectory named _package that contains a copy of the files
+   in a tree as if they were installed (ie ready to be packaged). Example:
+
+   openssl\build\Win64\VC12\DLL Release\_package
+   openssl\build\Win64\VC12\DLL Release\_package\Program Files\OpenSSL\bin
+   openssl\build\Win64\VC12\DLL Release\_package\Program Files\OpenSSL\lib
+   openssl\build\Win64\VC12\DLL Release\_package\Program Files\OpenSSL\include
+
 
 Building with Visual C++
 ========================
@@ -94,7 +115,7 @@ Running DLL based configurations
 
    If you are a developer and plan to run the curl tool from Visual Studio (eg
    you are debugging) with any third-party libraries (such as OpenSSL, wolfSSL
-   or LibSSH2) then you will need to add the search path of these DLLs to the
+   or LibSSH2) then you will need to add the search path of those DLLs to the
    configuration's PATH environment. To do that:
 
     * Open the 'curl-all.sln' or 'curl.sln' solutions
@@ -129,6 +150,19 @@ Running DLL based configurations
    (such as DLL Debug - DLL OpenSSL - DLL LibSSH2) then 'Path to DLL' will need
    to contain the path to both of these.
 
+Installing
+==========
+
+   There is no install routine for the project output, you would just copy the
+   binaries and dependencies wherever you need them. The location of the curl
+   binaries depends on a number of variables:
+   {curl-source}\build\{architecture}\{vcver}\{configuration}
+
+   For example:
+   {curl-source}\build\Win64\VC12\DLL Debug - DLL OpenSSL
+
+   For more information on the tree structure refer to section 'Dependencies'.
+
 Notes
 =====
 
@@ -148,7 +182,7 @@ Notes
    find bugs in the project files that need correcting, and would like to
    submit updated files back then please note that, whilst the solution files
    can be edited directly, the templates for the project files (which are 
-   stored in the git repositoty) will need to be modified rather than the
+   stored in the git repository) will need to be modified rather than the
    generated project files that Visual Studio uses.
 
 Legacy Windows and SSL

--- a/projects/build-openssl.bat
+++ b/projects/build-openssl.bat
@@ -7,6 +7,7 @@ rem *                            | (__| |_| |  _ <| |___
 rem *                             \___|\___/|_| \_\_____|
 rem *
 rem * Copyright (C) 2012 - 2016, Steve Holme, <steve_holme@hotmail.com>.
+rem * Copyright (C) 2015, Jay Satiro, <raysatiro@yahoo.com>.
 rem *
 rem * This software is licensed as described in the file COPYING, which
 rem * you should have received as part of this distribution. The terms
@@ -25,16 +26,25 @@ rem ***************************************************************************
   rem Check we are running on a Windows NT derived OS
   if not "%OS%" == "Windows_NT" goto nodos
 
-  rem Set our variables
-  setlocal
-  set VC_VER=
-  set BUILD_PLATFORM=
+  setlocal ENABLEEXTENSIONS
 
-  rem Ensure we have the required arguments
-  if /i "%~1" == "" goto syntax
+  rem Set our variables
+  set BUILD_CONFIG=
+  set BUILD_PLATFORM=
+  set "DEFAULT_START_DIR=%~dp0..\..\openssl"
+  set START_DIR=
+  set SUCCESSFUL_BUILDS=
+  set VC_DESC=
+  set VC_PATH=
+  set VC_VER=
 
 :parseArgs
-  if "%~1" == "" goto prerequisites
+  if /i "%~1" == "" goto syntax
+  if /i "%~1" == "-?" goto syntax
+  if /i "%~1" == "/?" goto syntax
+  if /i "%~1" == "-h" goto syntax
+  if /i "%~1" == "-help" goto syntax
+  if /i "%~1" == "--help" goto syntax
 
   if /i "%~1" == "vc6" (
     set VC_VER=6.0
@@ -72,39 +82,44 @@ rem ***************************************************************************
     set VC_VER=14.0
     set VC_DESC=VC14
     set "VC_PATH=Microsoft Visual Studio 14.0\VC"
-  ) else if /i "%~1%" == "x86" (
-    set BUILD_PLATFORM=x86
-  ) else if /i "%~1%" == "x64" (
-    set BUILD_PLATFORM=x64
-  ) else if /i "%~1%" == "debug" (
-    set BUILD_CONFIG=debug
-  ) else if /i "%~1%" == "release" (
-    set BUILD_CONFIG=release
-  ) else if /i "%~1" == "-?" (
-    goto syntax
-  ) else if /i "%~1" == "-h" (
-    goto syntax
-  ) else if /i "%~1" == "-help" (
-    goto syntax
-  ) else (
-    if not defined START_DIR (
-      set START_DIR=%~1%
-    ) else (
-      goto unknown
-    )
-  )
+  ) else goto unknown
 
-  shift & goto parseArgs
+  if "%~2" == "" goto prerequisites
+
+  if /i "%~2" == "x86" (
+    set BUILD_PLATFORM=x86
+  ) else if /i "%~2" == "x64" (
+    set BUILD_PLATFORM=x64
+  ) else if /i "%~2" == "both" (
+    set BUILD_PLATFORM=
+  ) else goto unknown
+
+  if "%~3" == "" goto prerequisites
+
+  if /i "%~3" == "debug" (
+    set BUILD_CONFIG=debug
+  ) else if /i "%~3" == "release" (
+    set BUILD_CONFIG=release
+  ) else if /i "%~3" == "both" (
+    set BUILD_CONFIG=
+  ) else goto unknown
+
+  if "%~4" == "" goto prerequisites
+
+  set "START_DIR=%~4"
+
+  if not "%~5" == "" goto unknown
 
 :prerequisites
-  rem Compiler and platform are required parameters.
+  rem Set the defaults
   if not defined VC_VER goto syntax
-  if not defined BUILD_PLATFORM goto syntax
+  if not defined START_DIR set "START_DIR=%DEFAULT_START_DIR%"
 
-  rem Default the start directory if one isn't specified
-  if not defined START_DIR set START_DIR=..\..\openssl
+  rem Check the start directory exists
+  if not exist "%START_DIR%" goto noopenssl
 
   rem Calculate the program files directory
+  set PF=
   if defined PROGRAMFILES (
     set "PF=%PROGRAMFILES%"
     set OS_PLATFORM=x86
@@ -120,72 +135,88 @@ rem ***************************************************************************
   rem Check we have Visual Studio installed
   if not exist "%PF%\%VC_PATH%" goto novc
 
+  rem These variables are passed to the vcvarsall script
+  set X86_PLATFORM_NAME=x86
+  set X64_PLATFORM_NAME=
+  if "%VC_VER%" == "6.0" set X64_PLATFORM_NAME=
+  if "%VC_VER%" == "7.0" set X64_PLATFORM_NAME=
+  if "%VC_VER%" == "7.1" set X64_PLATFORM_NAME=
+  if "%VC_VER%" == "8.0" set X64_PLATFORM_NAME=x86_amd64
+  if "%VC_VER%" == "9.0" set X64_PLATFORM_NAME=x64
+  if "%VC_VER%" == "10.0" set X64_PLATFORM_NAME=x64
+  if "%VC_VER%" == "11.0" set X64_PLATFORM_NAME=amd64
+  if "%VC_VER%" == "12.0" set X64_PLATFORM_NAME=amd64
+  if "%VC_VER%" == "14.0" set X64_PLATFORM_NAME=amd64
+
+  if defined X64_PLATFORM_NAME (
+    set X86_VC_INIT_CMDLINE=call "%PF%\%VC_PATH%\vcvarsall" %X86_PLATFORM_NAME%
+    set X64_VC_INIT_CMDLINE=call "%PF%\%VC_PATH%\vcvarsall" %X64_PLATFORM_NAME%
+  ) else (
+    rem Old VC versions without x64 support don't have vcvarsall
+    set X86_VC_INIT_CMDLINE=call "%PF%\%VC_PATH%\bin\vcvars32"
+    set X64_VC_INIT_CMDLINE=
+  )
+
   rem Check we have Perl in our path
-  echo %PATH% | findstr /I /C:"\Perl" 1>nul
-  if errorlevel 1 (
-    rem It isn't so check we have it installed and set the path if it is
-    if exist "%SystemDrive%\Perl" (
-      set "PATH=%SystemDrive%\Perl\bin;%PATH%"
-    ) else (
-      if exist "%SystemDrive%\Perl64" (
-        set "PATH=%SystemDrive%\Perl64\bin;%PATH%"
-      ) else (
-        goto noperl
+  set ADD_PERL_PATH=
+  perl -e "" 2>nul
+  if %ERRORLEVEL% neq 0 (
+    for %%a in ("\Perl\bin" "\Perl64\bin" "\Strawberry\perl\bin") do (
+      if not defined ADD_PERL_PATH (
+        "%SystemDrive%%%~a\perl" -e "" 2>nul
+        if errorlevel 0 if not errorlevel 1 (
+          set "ADD_PERL_PATH=%SystemDrive%%%~a"
+        )
+      )
+    )
+  )
+  if defined ADD_PERL_PATH set "PATH=%ADD_PERL_PATH%;%PATH%"
+  perl -e "" 2>nul
+  if %ERRORLEVEL% neq 0 goto noperl
+
+:start
+  set "SAVED_PATH=%CD%"
+  cd /d "%START_DIR%"
+  if %ERRORLEVEL% neq 0 echo Error: cd "%START_DIR%" failed! & goto error
+
+  rem Skip to legacy build for OpenSSL 1.0.2 and earlier
+  if exist ms\do_ms.bat goto build_legacy
+
+  set PLATFORMS=%BUILD_PLATFORM%
+  if not defined PLATFORMS set PLATFORMS=x86 x64
+
+  set CONFIGS=%BUILD_CONFIG%
+  if not defined CONFIGS set CONFIGS=debug release
+
+  set LIBTYPES=shared static
+
+  for %%a in (%PLATFORMS%) do (
+    for %%b in (%CONFIGS%) do (
+      for %%c in (%LIBTYPES%) do (
+        set SKIP_BUILD=
+        if %%a == x64 if not defined X64_PLATFORM_NAME set SKIP_BUILD=defined
+        if not defined SKIP_BUILD (
+          call :build %%a %%b %%c
+          if errorlevel 1 goto error
+        )
       )
     )
   )
 
-  rem Check the start directory exists
-  if not exist "%START_DIR%" goto noopenssl
+  goto success
 
-  rem Check that OpenSSL is not unsupported version 1.1.0
-  if not exist "%START_DIR%\ms\do_ms.bat" goto unsupported
+:build_legacy
+  rem Legacy build for OpenSSL 1.0.2 and earlier
+  rem BUILD_PLATFORM and/or BUILD_CONFIG may be unset
 
-:configure
-  if "%BUILD_PLATFORM%" == "" (
-    if "%VC_VER%" == "6.0" (
-      set BUILD_PLATFORM=x86
-    ) else if "%VC_VER%" == "7.0" (
-      set BUILD_PLATFORM=x86
-    ) else if "%VC_VER%" == "7.1" (
-      set BUILD_PLATFORM=x86
-    ) else (
-      set BUILD_PLATFORM=%OS_PLATFORM%
-    )
-  )
-
-  if "%BUILD_PLATFORM%" == "x86" (
-    set VCVARS_PLATFORM=x86
-  ) else if "%BUILD_PLATFORM%" == "x64" (
-    if "%VC_VER%" == "6.0" goto nox64
-    if "%VC_VER%" == "7.0" goto nox64
-    if "%VC_VER%" == "7.1" goto nox64
-    if "%VC_VER%" == "8.0" set VCVARS_PLATFORM=x86_amd64
-    if "%VC_VER%" == "9.0" set VCVARS_PLATFORM=%BUILD_PLATFORM%
-    if "%VC_VER%" == "10.0" set VCVARS_PLATFORM=%BUILD_PLATFORM%
-    if "%VC_VER%" == "11.0" set VCVARS_PLATFORM=amd64
-    if "%VC_VER%" == "12.0" set VCVARS_PLATFORM=amd64
-    if "%VC_VER%" == "14.0" set VCVARS_PLATFORM=amd64
-  )
-
-:start
-  echo.
-  if "%VC_VER%" == "6.0" (
-    call "%PF%\%VC_PATH%\bin\vcvars32"
-  ) else if "%VC_VER%" == "7.0" (
-    call "%PF%\%VC_PATH%\bin\vcvars32"
-  ) else if "%VC_VER%" == "7.1" (
-    call "%PF%\%VC_PATH%\bin\vcvars32"
-  ) else (
-    call "%PF%\%VC_PATH%\vcvarsall" %VCVARS_PLATFORM%
-  )
-
-  echo.
-  set SAVED_PATH=%CD%
-  if defined START_DIR CD %START_DIR%
-  goto %BUILD_PLATFORM%
+  if "%BUILD_PLATFORM%" == "x86" goto x86
 
 :x64
+  setlocal
+  if not defined X64_VC_INIT_CMDLINE goto x64done
+  %X64_VC_INIT_CMDLINE%
+  if %ERRORLEVEL% neq 0 echo Error: VC init failed! & goto error
+
   rem Calculate our output directory
   set OUTDIR=build\Win64\%VC_DESC%
   if not exist %OUTDIR% md %OUTDIR%
@@ -194,107 +225,276 @@ rem ***************************************************************************
 
 :x64debug
   rem Configuring 64-bit Debug Build
-  perl Configure debug-VC-WIN64A --prefix=%CD%
+  perl Configure debug-VC-WIN64A "--prefix=%CD%"
 
   rem Perform the build
-  call ms\do_win64a
-  nmake -f ms\nt.mak
-  nmake -f ms\ntdll.mak
+  call ms\do_win64a              ^
+  && nmake -f ms\nt.mak          ^
+  && nmake -f ms\nt.mak test     ^
+  && nmake -f ms\ntdll.mak       ^
+  && nmake -f ms\ntdll.mak test
+  if %ERRORLEVEL% neq 0 echo nmake failed to build x64debug! & goto error
 
-  rem Move the output directories
-  move out32.dbg "%OUTDIR%\LIB Debug"
-  move out32dll.dbg "%OUTDIR%\DLL Debug"
+  rem Copy the output
+  xcopy /E /I /Q /H /R /Y out32.dbg "%OUTDIR%\LIB Debug"                ^
+  && xcopy /E /I /Q /H /R /Y tmp32.dbg\lib.pdb "%OUTDIR%\LIB Debug"     ^
+  && xcopy /E /I /Q /H /R /Y out32dll.dbg "%OUTDIR%\DLL Debug"          ^
+  && xcopy /E /I /Q /H /R /Y tmp32dll.dbg\lib.pdb "%OUTDIR%\DLL Debug"
+  if %ERRORLEVEL% neq 0 echo xcopy failed to copy x64debug! & goto error
 
-  rem Move the PDB files
-  move tmp32.dbg\lib.pdb "%OUTDIR%\LIB Debug"
-  move tmp32dll.dbg\lib.pdb "%OUTDIR%\DLL Debug"
-  
   rem Remove the intermediate directories
-  rd tmp32.dbg /s /q
-  rd tmp32dll.dbg /s /q
+  for /d %%a in ("tmp32*" "out32*") do (rd "%%~a" /s /q)
 
-  if "%BUILD_CONFIG%" == "debug" goto success
-  
+  set SUCCESSFUL_BUILDS="x64 debug static" %SUCCESSFUL_BUILDS%
+  set SUCCESSFUL_BUILDS="x64 debug shared" %SUCCESSFUL_BUILDS%
+
+  if "%BUILD_CONFIG%" == "debug" goto x64done
+
 :x64release
   rem Configuring 64-bit Release Build
-  perl Configure VC-WIN64A --prefix=%CD%
-  
-  rem Perform the build
-  call ms\do_win64a
-  nmake -f ms\nt.mak
-  nmake -f ms\ntdll.mak
-  
-  rem Move the output directories
-  move out32 "%OUTDIR%\LIB Release"
-  move out32dll "%OUTDIR%\DLL Release"
+  perl Configure VC-WIN64A "--prefix=%CD%"
 
-  rem Move the PDB files
-  move tmp32\lib.pdb "%OUTDIR%\LIB Release"
-  move tmp32dll\lib.pdb "%OUTDIR%\DLL Release"
+  rem Perform the build
+  call ms\do_win64a              ^
+  && nmake -f ms\nt.mak          ^
+  && nmake -f ms\nt.mak test     ^
+  && nmake -f ms\ntdll.mak       ^
+  && nmake -f ms\ntdll.mak test
+  if %ERRORLEVEL% neq 0 echo nmake failed to build x64release! & goto error
+
+  rem Copy the output
+  xcopy /E /I /Q /H /R /Y out32 "%OUTDIR%\LIB Release"                  ^
+  && xcopy /E /I /Q /H /R /Y out32dll "%OUTDIR%\DLL Release"            ^
+  && xcopy /E /I /Q /H /R /Y tmp32\lib.pdb "%OUTDIR%\LIB Release"       ^
+  && xcopy /E /I /Q /H /R /Y tmp32dll\lib.pdb "%OUTDIR%\DLL Release"
+  if %ERRORLEVEL% neq 0 echo xcopy failed to copy x64release! & goto error
 
   rem Remove the intermediate directories
-  rd tmp32 /s /q
-  rd tmp32dll /s /q
+  for /d %%a in ("tmp32*" "out32*") do (rd "%%~a" /s /q)
 
-  goto success
-  
+  set SUCCESSFUL_BUILDS="x64 release static" %SUCCESSFUL_BUILDS%
+  set SUCCESSFUL_BUILDS="x64 release shared" %SUCCESSFUL_BUILDS%
+
+:x64done
+  rem Export SUCCESSFUL_BUILDS
+  endlocal & set SUCCESSFUL_BUILDS=%SUCCESSFUL_BUILDS%
+
+  if "%BUILD_PLATFORM%" == "x64" goto success
+
 :x86
+  setlocal
+  %X86_VC_INIT_CMDLINE%
+  if %ERRORLEVEL% neq 0 echo Error: VC init failed! & goto error
+
   rem Calculate our output directory
   set OUTDIR=build\Win32\%VC_DESC%
   if not exist %OUTDIR% md %OUTDIR%
 
   if "%BUILD_CONFIG%" == "release" goto x86release
-  
+
 :x86debug
   rem Configuring 32-bit Debug Build
-  perl Configure debug-VC-WIN32 no-asm --prefix=%CD%
+  perl Configure debug-VC-WIN32 no-asm "--prefix=%CD%"
 
   rem Perform the build
-  call ms\do_ms
-  nmake -f ms\nt.mak
-  nmake -f ms\ntdll.mak
+  call ms\do_ms                  ^
+  && nmake -f ms\nt.mak          ^
+  && nmake -f ms\nt.mak test     ^
+  && nmake -f ms\ntdll.mak       ^
+  && nmake -f ms\ntdll.mak test
+  if %ERRORLEVEL% neq 0 echo nmake failed to build x86debug! & goto error
 
-  rem Move the output directories
-  move out32.dbg "%OUTDIR%\LIB Debug"
-  move out32dll.dbg "%OUTDIR%\DLL Debug"
-
-  rem Move the PDB files
-  move tmp32.dbg\lib.pdb "%OUTDIR%\LIB Debug"
-  move tmp32dll.dbg\lib.pdb "%OUTDIR%\DLL Debug"
+  rem Copy the output
+  xcopy /E /I /Q /H /R /Y out32.dbg "%OUTDIR%\LIB Debug"                ^
+  && xcopy /E /I /Q /H /R /Y out32dll.dbg "%OUTDIR%\DLL Debug"          ^
+  && xcopy /E /I /Q /H /R /Y tmp32.dbg\lib.pdb "%OUTDIR%\LIB Debug"     ^
+  && xcopy /E /I /Q /H /R /Y tmp32dll.dbg\lib.pdb "%OUTDIR%\DLL Debug"
+  if %ERRORLEVEL% neq 0 echo xcopy failed to copy x86debug! & goto error
 
   rem Remove the intermediate directories
-  rd tmp32.dbg /s /q
-  rd tmp32dll.dbg /s /q
+  for /d %%a in ("tmp32*" "out32*") do (rd "%%~a" /s /q)
 
-  if "%BUILD_CONFIG%" == "debug" goto success
-  
+  set SUCCESSFUL_BUILDS="x86 debug static" %SUCCESSFUL_BUILDS%
+  set SUCCESSFUL_BUILDS="x86 debug shared" %SUCCESSFUL_BUILDS%
+
+  if "%BUILD_CONFIG%" == "debug" goto x86done
+
 :x86release
   rem Configuring 32-bit Release Build
-  perl Configure VC-WIN32 no-asm --prefix=%CD%
+  perl Configure VC-WIN32 no-asm "--prefix=%CD%"
 
   rem Perform the build
-  call ms\do_ms
-  nmake -f ms\nt.mak
-  nmake -f ms\ntdll.mak
-  
-  rem Move the output directories
-  move out32 "%OUTDIR%\LIB Release"
-  move out32dll "%OUTDIR%\DLL Release"
+  call ms\do_ms                  ^
+  && nmake -f ms\nt.mak          ^
+  && nmake -f ms\nt.mak test     ^
+  && nmake -f ms\ntdll.mak       ^
+  && nmake -f ms\ntdll.mak test
+  if %ERRORLEVEL% neq 0 echo nmake failed to build x86release! & goto error
 
-  rem Move the PDB files
-  move tmp32\lib.pdb "%OUTDIR%\LIB Release"
-  move tmp32dll\lib.pdb "%OUTDIR%\DLL Release"
+  rem Copy the output
+  xcopy /E /I /Q /H /R /Y out32 "%OUTDIR%\LIB Release"                  ^
+  && xcopy /E /I /Q /H /R /Y out32dll "%OUTDIR%\DLL Release"            ^
+  && xcopy /E /I /Q /H /R /Y tmp32\lib.pdb "%OUTDIR%\LIB Release"       ^
+  && xcopy /E /I /Q /H /R /Y tmp32dll\lib.pdb "%OUTDIR%\DLL Release"
+  if %ERRORLEVEL% neq 0 echo xcopy failed to copy x86release! & goto error
 
   rem Remove the intermediate directories
-  rd tmp32 /s /q
-  rd tmp32dll /s /q
+  for /d %%a in ("tmp32*" "out32*") do (rd "%%~a" /s /q)
+
+  set SUCCESSFUL_BUILDS="x86 release static" %SUCCESSFUL_BUILDS%
+  set SUCCESSFUL_BUILDS="x86 release shared" %SUCCESSFUL_BUILDS%
+
+:x86done
+  rem Export SUCCESSFUL_BUILDS
+  endlocal & set SUCCESSFUL_BUILDS=%SUCCESSFUL_BUILDS%
 
   goto success
+
+:build
+  rem This function builds OpenSSL 1.1.x or later.
+  rem Usage: CALL :build <x86|x64> <debug|release> <shared|static>
+  rem Before calling this function:
+  rem - The current directory must be the OpenSSL source directory.
+  rem Returns: 1 on fail, 0 on success.
+  rem An informational message should be shown before any return on fail.
+  rem Only return via an exit statement and not a goto (ie goto error) since
+  rem the main script/caller may be using those tags for cleanup and that code
+  rem could expect the entire batch file is terminating.
+
+  rem BEGIN block common to build-openssl build-wolfssl
+
+  setlocal ENABLEEXTENSIONS DISABLEDELAYEDEXPANSION
+  set ERR=Error: build:
+  set "SRC_PATH=%CD%"
+  rem PLATFORM cannot be used as a variable name since it's used by VC init
+  set "ARCH=%~1"
+  set "CONFIG=%~2"
+  set "LIBTYPE=%~3"
+  if not "%ARCH%" == "x86" if not "%ARCH%" == "x64" (
+    echo %ERR% Unrecognized architecture: "%ARCH%" & exit /b 1
+  )
+  if not "%CONFIG%" == "debug" if not "%CONFIG%" == "release" (
+    echo %ERR% Unrecognized configuration: "%CONFIG%" & exit /b 1
+  )
+  if not "%LIBTYPE%" == "shared" if not "%LIBTYPE%" == "static" (
+    echo %ERR% Unrecognized libtype: "%LIBTYPE%" & exit /b 1
+  )
+  set FRIENDLY_NAME="%ARCH% %CONFIG% %LIBTYPE%"
+  set ERR=%ERR% %FRIENDLY_NAME%:
+
+  if %ARCH% == x86 set "OUTDIR=build\Win32\%VC_DESC%"
+  if %ARCH% == x64 set "OUTDIR=build\Win64\%VC_DESC%"
+
+  rem The OUTDIR later has a LEAF appended to it (LIB Release, DLL Debug, etc)
+  if %LIBTYPE% == shared (set LEAF=DLL) else set LEAF=LIB
+  if %CONFIG% == debug (set LEAF=%LEAF% Debug) else set LEAF=%LEAF% Release
+
+  if %ARCH% == x86 set INIT_CMD=%X86_VC_INIT_CMDLINE%
+  if %ARCH% == x64 set INIT_CMD=%X64_VC_INIT_CMDLINE%
+  if not defined INIT_CMD echo %ERR% VC init not found! & exit /b 1
+  %INIT_CMD%
+  if %ERRORLEVEL% neq 0 echo %ERR% VC init failed! & exit /b 1
+
+  cd /d "%SRC_PATH%"
+  if %ERRORLEVEL% neq 0 echo %ERR% cd "%SRC_PATH%" failed! & exit /b 1
+
+  rem END block common to build-openssl build-wolfssl
+
+  echo. & echo.
+  echo Building and running tests for OpenSSL %FRIENDLY_NAME%.
+  echo. & echo.
+
+  rem This is the build name passed to OpenSSL's Configure
+  if %ARCH% == x86 (set VCTYPE=VC-WIN32) else set VCTYPE=VC-WIN64A
+  if %CONFIG% == debug set VCTYPE=debug-%VCTYPE%
+
+  rem OPTS will be passed unquoted since it may contain multiple options that
+  rem are expected to already be quoted if necessary.
+  set OPTS=
+  set OPTS=%OPTS% no-asm
+  if %LIBTYPE% == static set OPTS=%OPTS% no-shared
+
+  rem nmake installs to PKG_PATH and then we copy necessary files to DST_PATH
+  set "DST_PATH=%SRC_PATH%\%OUTDIR%\%LEAF%"
+  set "PKG_PATH=%DST_PATH%\_package"
+  set "TMP_PATH=%DST_PATH%\temp"
+
+  rem Build OpenSSL. Perform an out-of-tree style build from TMP_PATH so as not
+  rem to mix any artifacts from the different builds.
+
+  if not exist "%TMP_PATH%" mkdir "%TMP_PATH%"
+  cd /d "%TMP_PATH%"
+  if %ERRORLEVEL% neq 0 echo %ERR% cd "%TMP_PATH%" failed! & exit /b 1
+
+  perl "%SRC_PATH%\Configure" %VCTYPE% %OPTS%
+  if %ERRORLEVEL% neq 0 echo %ERR% Configure %VCTYPE% failed! & exit /b 1
+
+  nmake test
+  if %ERRORLEVEL% neq 0 echo %ERR% nmake test failed! & exit /b 1
+
+  nmake install "DESTDIR=%PKG_PATH%"
+  if %ERRORLEVEL% neq 0 echo %ERR% nmake install failed! & exit /b 1
+
+  rem Get the PROG_PATH that nmake actually installed to.
+  rem
+  rem nmake installed for packaging to PKG_PATH, meaning it used that as the
+  rem root and then appended the default prefix without the drive.
+  rem
+  rem Example:
+  rem C:\Program Files becomes PKG_PATH + \Program Files
+  rem C:\openssl_src\build\Win32\VC12\DLL Debug\_package\Program Files\OpenSSL
+  rem
+  rem From the OpenSSL NOTES.WIN document, default prefix uses these env vars:
+  rem
+  rem VC-WIN32: ProgramFiles(x86) or if that doesn't exist then ProgramFiles.
+  rem VC-WIN64: ProgramW6432 or if that doesn't exist then ProgramFiles.
+  rem
+  rem Note substring extraction in batch files is buggy in if statement
+  rem comparison when the variable does not exist or it's not the last colon in
+  rem the statement, so instead assign the substring to S and work from
+  rem multiple if statements.
+  set S=
+  set PROG_PATH=
+  if %ARCH% == x86 set "S=%ProgramFiles(x86):~1,1%"
+  if %ARCH% == x86 if "%S%" equ ":" set "PROG_PATH=%ProgramFiles(x86):~2%"
+  if %ARCH% == x64 set "S=%ProgramW6432:~1,1%"
+  if %ARCH% == x64 if "%S%" equ ":" set "PROG_PATH=%ProgramW6432:~2%"
+  set S=
+  if not defined PROG_PATH set "S=%ProgramFiles:~1,1%"
+  if "%S%" equ ":" set "PROG_PATH=%ProgramFiles:~2%"
+  if not defined PROG_PATH echo %ERR% Program Files dir not found! & exit /b 1
+  set "PROG_PATH=%PKG_PATH%\%PROG_PATH%\OpenSSL"
+  if not exist "%PROG_PATH%" (
+    echo %ERR% OpenSSL package not found in "%PROG_PATH%" & exit /b 1
+  )
+
+  xcopy /E /I /Q /H /R /Y "%PROG_PATH%\bin" "%DST_PATH%" 1>NUL
+  if %ERRORLEVEL% neq 0 echo %ERR% xcopy bin dir failed! & exit /b 1
+
+  xcopy /E /I /Q /H /R /Y "%PROG_PATH%\lib" "%DST_PATH%" 1>NUL
+  if %ERRORLEVEL% neq 0 echo %ERR% xcopy libs dir failed! & exit /b 1
+
+  xcopy /E /I /Q /H /R /Y "%PROG_PATH%\include" "%DST_PATH%\include" 1>NUL
+  if %ERRORLEVEL% neq 0 echo %ERR% xcopy include dir failed! & exit /b 1
+
+  cd /d "%DST_PATH%"
+  if %ERRORLEVEL% neq 0 echo %ERR% cd "%DST_PATH%" failed! & exit /b 1
+
+  echo. & echo.
+  echo Success: Built and all tests passed for OpenSSL %FRIENDLY_NAME%.
+  echo. & echo.
+
+  rem Remove the temporary build files (obj,test,etc)
+  rmdir /s /q "%TMP_PATH%" 1>NUL 2>&1
+
+  rem This line is necessary to export SUCCESSFUL_BUILDS back to the caller
+  endlocal & set SUCCESSFUL_BUILDS=%FRIENDLY_NAME% %SUCCESSFUL_BUILDS%
+  exit /b 0
 
 :syntax
   rem Display the help
   echo.
-  echo Usage: build-openssl ^<compiler^> ^<platform^> [configuration] [directory]
+  echo Usage: build-openssl ^<compiler^> [platform] [configuration] [directory]
   echo.
   echo Compiler:
   echo.
@@ -312,20 +512,24 @@ rem ***************************************************************************
   echo.
   echo x86       - Perform a 32-bit build
   echo x64       - Perform a 64-bit build
+  echo both      - Do both ^(default^)
   echo.
   echo Configuration:
   echo.
   echo debug     - Perform a debug build
   echo release   - Perform a release build
+  echo both      - Do both ^(default^)
   echo.
-  echo Other:
+  echo Directory:
   echo.
-  echo directory - Specifies the OpenSSL source directory
+  echo The OpenSSL source directory.
+  echo The default is "%DEFAULT_START_DIR%"
+  echo.
   goto error
 
 :unknown
   echo.
-  echo Error: Unknown argument '%1'
+  echo Error: Unknown argument, for usage run build-openssl /?
   goto error
 
 :nodos
@@ -355,15 +559,7 @@ rem ***************************************************************************
 
 :noopenssl
   echo.
-  echo Error: Cannot locate OpenSSL source directory
-  goto error
-
-:unsupported
-  echo.
-  echo Error: Unsupported OpenSSL version.
-  echo The pre-generated project files and this build script only support the
-  echo LTS version of OpenSSL ^(v1.0.2^). The next version of this build script
-  echo will support OpenSSL v1.1.0.
+  echo Error: Cannot locate OpenSSL source directory, expected "%START_DIR%"
   goto error
 
 :error
@@ -371,6 +567,16 @@ rem ***************************************************************************
   exit /B 1
 
 :success
-  cd %SAVED_PATH%
+  if defined SUCCESSFUL_BUILDS (
+    echo.
+    echo.
+    echo Build complete.
+    echo.
+    echo The following configurations were built and tested successfully:
+    echo.
+    echo %SUCCESSFUL_BUILDS%
+    echo.
+  )
+  cd /d "%SAVED_PATH%"
   endlocal
   exit /B 0

--- a/projects/build-wolfssl.bat
+++ b/projects/build-wolfssl.bat
@@ -26,17 +26,26 @@ rem ***************************************************************************
   rem Check we are running on a Windows NT derived OS
   if not "%OS%" == "Windows_NT" goto nodos
 
-  rem Set our variables
-  setlocal
-  set SUCCESSFUL_BUILDS=
-  set VC_VER=
-  set BUILD_PLATFORM=
+  setlocal ENABLEEXTENSIONS
 
-  rem Ensure we have the required arguments
-  if /i "%~1" == "" goto syntax
+  rem Set our variables
+  set BUILD_CONFIG=
+  set BUILD_PLATFORM=
+  set "DEFAULT_START_DIR=%~dp0..\..\wolfssl"
+  set START_DIR=
+  set SUCCESSFUL_BUILDS=
+  set VC_DESC=
+  set VC_PATH=
+  set VC_TOOLSET=
+  set VC_VER=
 
 :parseArgs
-  if "%~1" == "" goto prerequisites
+  if /i "%~1" == "" goto syntax
+  if /i "%~1" == "-?" goto syntax
+  if /i "%~1" == "/?" goto syntax
+  if /i "%~1" == "-h" goto syntax
+  if /i "%~1" == "-help" goto syntax
+  if /i "%~1" == "--help" goto syntax
 
   if /i "%~1" == "vc10" (
     set VC_VER=10.0
@@ -58,39 +67,44 @@ rem ***************************************************************************
     set VC_DESC=VC14
     set VC_TOOLSET=v140
     set "VC_PATH=Microsoft Visual Studio 14.0\VC"
-  ) else if /i "%~1" == "x86" (
-    set BUILD_PLATFORM=x86
-  ) else if /i "%~1" == "x64" (
-    set BUILD_PLATFORM=x64
-  ) else if /i "%~1" == "debug" (
-    set BUILD_CONFIG=debug
-  ) else if /i "%~1" == "release" (
-    set BUILD_CONFIG=release
-  ) else if /i "%~1" == "-?" (
-    goto syntax
-  ) else if /i "%~1" == "-h" (
-    goto syntax
-  ) else if /i "%~1" == "-help" (
-    goto syntax
-  ) else (
-    if not defined START_DIR (
-      set START_DIR=%~1
-    ) else (
-      goto unknown
-    )
-  )
+  ) else goto unknown
 
-  shift & goto parseArgs
+  if "%~2" == "" goto prerequisites
+
+  if /i "%~2" == "x86" (
+    set BUILD_PLATFORM=x86
+  ) else if /i "%~2" == "x64" (
+    set BUILD_PLATFORM=x64
+  ) else if /i "%~2" == "both" (
+    set BUILD_PLATFORM=
+  ) else goto unknown
+
+  if "%~3" == "" goto prerequisites
+
+  if /i "%~3" == "debug" (
+    set BUILD_CONFIG=debug
+  ) else if /i "%~3" == "release" (
+    set BUILD_CONFIG=release
+  ) else if /i "%~3" == "both" (
+    set BUILD_CONFIG=
+  ) else goto unknown
+
+  if "%~4" == "" goto prerequisites
+
+  set "START_DIR=%~4"
+
+  if not "%~5" == "" goto unknown
 
 :prerequisites
-  rem Compiler and platform are required parameters.
+  rem Set the defaults
   if not defined VC_VER goto syntax
-  if not defined BUILD_PLATFORM goto syntax
+  if not defined START_DIR set "START_DIR=%DEFAULT_START_DIR%"
 
-  rem Default the start directory if one isn't specified
-  if not defined START_DIR set START_DIR=..\..\wolfssl
+  rem Check the start directory exists
+  if not exist "%START_DIR%" goto nowolfssl
 
   rem Calculate the program files directory
+  set PF=
   if defined PROGRAMFILES (
     set "PF=%PROGRAMFILES%"
     set OS_PLATFORM=x86
@@ -106,139 +120,127 @@ rem ***************************************************************************
   rem Check we have Visual Studio installed
   if not exist "%PF%\%VC_PATH%" goto novc
 
-  rem Check the start directory exists
-  if not exist "%START_DIR%" goto nowolfssl
-
-:configure
-  if "%BUILD_PLATFORM%" == "" set BUILD_PLATFORM=%OS_PLATFORM%
-
-  if "%BUILD_PLATFORM%" == "x86" (
-    set VCVARS_PLATFORM=x86
-  ) else if "%BUILD_PLATFORM%" == "x64" (
-    if "%VC_VER%" == "10.0" set VCVARS_PLATFORM=%BUILD_PLATFORM%
-    if "%VC_VER%" == "11.0" set VCVARS_PLATFORM=amd64
-    if "%VC_VER%" == "12.0" set VCVARS_PLATFORM=amd64
-    if "%VC_VER%" == "14.0" set VCVARS_PLATFORM=amd64
+  rem These variables are passed to the vcvarsall script
+  set X86_PLATFORM_NAME=x86
+  set X64_PLATFORM_NAME=
+  if "%VC_VER%" == "10.0" set X64_PLATFORM_NAME=x64
+  if "%VC_VER%" == "11.0" set X64_PLATFORM_NAME=amd64
+  if "%VC_VER%" == "12.0" set X64_PLATFORM_NAME=amd64
+  if "%VC_VER%" == "14.0" set X64_PLATFORM_NAME=amd64
+  if not defined X64_PLATFORM_NAME (
+    echo Error: Missing X64_PLATFORM_NAME! & goto error
   )
 
+  set X86_VC_INIT_CMDLINE=call "%PF%\%VC_PATH%\vcvarsall" %X86_PLATFORM_NAME%
+  set X64_VC_INIT_CMDLINE=call "%PF%\%VC_PATH%\vcvarsall" %X64_PLATFORM_NAME%
+
 :start
-  echo.
-  call "%PF%\%VC_PATH%\vcvarsall" %VCVARS_PLATFORM%
+  set "SAVED_PATH=%CD%"
+  cd /d "%START_DIR%"
+  if %ERRORLEVEL% neq 0 echo Error: cd "%START_DIR%" failed! & goto error
 
-  echo.
-  set SAVED_PATH=%CD%
-  cd %START_DIR%
-  goto %BUILD_PLATFORM%
+  set PLATFORMS=%BUILD_PLATFORM%
+  if not defined PLATFORMS set PLATFORMS=x86 x64
 
-:x64
-  rem Calculate our output directory
-  set OUTDIR=build\Win64\%VC_DESC%
-  if not exist %OUTDIR% md %OUTDIR%
+  set CONFIGS=%BUILD_CONFIG%
+  if not defined CONFIGS set CONFIGS=debug release
 
-  if "%BUILD_CONFIG%" == "release" goto x64release
+  set LIBTYPES=shared static
 
-:x64debug
-  rem Perform 64-bit Debug Build
-
-  call :build Debug x64
-  if errorlevel 1 goto error
-
-  call :build "DLL Debug" x64
-  if errorlevel 1 goto error
-
-  if "%BUILD_CONFIG%" == "debug" goto success
-
-:x64release
-  rem Perform 64-bit Release Build
-
-  call :build Release x64
-  if errorlevel 1 goto error
-
-  call :build "DLL Release" x64
-  if errorlevel 1 goto error
-
-  goto success
-
-:x86
-  rem Calculate our output directory
-  set OUTDIR=build\Win32\%VC_DESC%
-  if not exist %OUTDIR% md %OUTDIR%
-
-  if "%BUILD_CONFIG%" == "release" goto x86release
-
-:x86debug
-  rem Perform 32-bit Debug Build
-
-  call :build Debug Win32
-  if errorlevel 1 goto error
-
-  call :build "DLL Debug" Win32
-  if errorlevel 1 goto error
-
-  if "%BUILD_CONFIG%" == "debug" goto success
-
-:x86release
-  rem Perform 32-bit Release Build
-
-  call :build Release Win32
-  if errorlevel 1 goto error
-
-  call :build "DLL Release" Win32
-  if errorlevel 1 goto error
+  for %%a in (%PLATFORMS%) do (
+    for %%b in (%CONFIGS%) do (
+      for %%c in (%LIBTYPES%) do (
+        set SKIP_BUILD=
+        if %%a == x64 if not defined X64_PLATFORM_NAME set SKIP_BUILD=defined
+        if not defined SKIP_BUILD (
+          call :build %%a %%b %%c
+          if errorlevel 1 goto error
+        )
+      )
+    )
+  )
 
   goto success
 
 :build
   rem This function builds wolfSSL.
-  rem Usage: CALL :build <configuration> <platform>
-  rem The current directory must be the wolfSSL directory.
-  rem VS Configuration: Debug, Release, DLL Debug or DLL Release.
-  rem VS Platform: Win32 or x64.
+  rem Usage: CALL :build <x86|x64> <debug|release> <shared|static>
+  rem Before calling this function:
+  rem - The current directory must be the wolfSSL source directory.
   rem Returns: 1 on fail, 0 on success.
-  rem An informational message should be shown before any return.
-  setlocal
-  set MSBUILD_CONFIG=%~1
-  set MSBUILD_PLATFORM=%~2
+  rem An informational message should be shown before any return on fail.
+  rem Only return via an exit statement and not a goto (ie goto error) since
+  rem the main script/caller may be using those tags for cleanup and that code
+  rem could expect the entire batch file is terminating.
+
+  rem BEGIN block common to build-openssl build-wolfssl
+
+  setlocal ENABLEEXTENSIONS DISABLEDELAYEDEXPANSION
+  set ERR=Error: build:
+  set "SRC_PATH=%CD%"
+  rem PLATFORM cannot be used as a variable name since it's used by VC init
+  set "ARCH=%~1"
+  set "CONFIG=%~2"
+  set "LIBTYPE=%~3"
+  if not "%ARCH%" == "x86" if not "%ARCH%" == "x64" (
+    echo %ERR% Unrecognized architecture: "%ARCH%" & exit /b 1
+  )
+  if not "%CONFIG%" == "debug" if not "%CONFIG%" == "release" (
+    echo %ERR% Unrecognized configuration: "%CONFIG%" & exit /b 1
+  )
+  if not "%LIBTYPE%" == "shared" if not "%LIBTYPE%" == "static" (
+    echo %ERR% Unrecognized libtype: "%LIBTYPE%" & exit /b 1
+  )
+  set FRIENDLY_NAME="%ARCH% %CONFIG% %LIBTYPE%"
+  set ERR=%ERR% %FRIENDLY_NAME%:
+
+  if %ARCH% == x86 set "OUTDIR=build\Win32\%VC_DESC%"
+  if %ARCH% == x64 set "OUTDIR=build\Win64\%VC_DESC%"
+
+  rem The OUTDIR later has a LEAF appended to it (LIB Release, DLL Debug, etc)
+  if %LIBTYPE% == shared (set LEAF=DLL) else set LEAF=LIB
+  if %CONFIG% == debug (set LEAF=%LEAF% Debug) else set LEAF=%LEAF% Release
+
+  if %ARCH% == x86 set INIT_CMD=%X86_VC_INIT_CMDLINE%
+  if %ARCH% == x64 set INIT_CMD=%X64_VC_INIT_CMDLINE%
+  if not defined INIT_CMD echo %ERR% VC init not found! & exit /b 1
+  %INIT_CMD%
+  if %ERRORLEVEL% neq 0 echo %ERR% VC init failed! & exit /b 1
+
+  cd /d "%SRC_PATH%"
+  if %ERRORLEVEL% neq 0 echo %ERR% cd "%SRC_PATH%" failed! & exit /b 1
+
+  rem END block common to build-openssl build-wolfssl
+
+  echo. & echo.
+  echo Building and running tests for wolfSSL %FRIENDLY_NAME%.
+  echo. & echo.
+
+  if %LIBTYPE% == static set MSBUILD_CONFIG=%CONFIG%
+  if %LIBTYPE% == shared set MSBUILD_CONFIG=DLL %CONFIG%
+
+  if %ARCH% == x86 set MSBUILD_PLATFORM=Win32
+  if %ARCH% == x64 set MSBUILD_PLATFORM=x64
+
+  rem DST_PATH and TMP_PATH must be full paths and not have trailing
+  rem backslashes, which are added later.
+  set "DST_PATH=%SRC_PATH%\%OUTDIR%\%LEAF%"
+  set "TMP_PATH=%DST_PATH%\temp"
 
   if not exist wolfssl64.sln (
-    echo.
-    echo Error: build: wolfssl64.sln not found in "%CD%"
-    exit /b 1
-  )
-
-  rem OUTDIR isn't a full path, only relative. MSBUILD_OUTDIR must be full and
-  rem not have trailing backslashes, which are handled later.
-  if "%MSBUILD_CONFIG%" == "Debug" (
-    set "MSBUILD_OUTDIR=%CD%\%OUTDIR%\LIB Debug"
-  ) else if "%MSBUILD_CONFIG%" == "Release" (
-    set "MSBUILD_OUTDIR=%CD%\%OUTDIR%\LIB Release"
-  ) else if "%MSBUILD_CONFIG%" == "DLL Debug" (
-    set "MSBUILD_OUTDIR=%CD%\%OUTDIR%\DLL Debug"
-  ) else if "%MSBUILD_CONFIG%" == "DLL Release" (
-    set "MSBUILD_OUTDIR=%CD%\%OUTDIR%\DLL Release"
-  ) else (
-    echo.
-    echo Error: build: Configuration not recognized.
-    exit /b 1
-  )
-
-  if not "%MSBUILD_PLATFORM%" == "Win32" if not "%MSBUILD_PLATFORM%" == "x64" (
-    echo.
-    echo Error: build: Platform not recognized.
+    echo %ERR% wolfssl64.sln not found in "%CD%"
     exit /b 1
   )
 
   copy /v /y "%~dp0\wolfssl_options.h" .\cyassl\options.h
   if %ERRORLEVEL% neq 0 (
-    echo.
-    echo Error: build: Couldn't replace .\cyassl\options.h
+    echo %ERR% Couldn't replace .\cyassl\options.h
     exit /b 1
   )
 
   copy /v /y "%~dp0\wolfssl_options.h" .\wolfssl\options.h
   if %ERRORLEVEL% neq 0 (
-    echo.
-    echo Error: build: Couldn't replace .\wolfssl\options.h
+    echo %ERR% Couldn't replace .\wolfssl\options.h
     exit /b 1
   )
 
@@ -248,38 +250,29 @@ rem ***************************************************************************
     -p:Configuration="%MSBUILD_CONFIG%" ^
     -p:Platform="%MSBUILD_PLATFORM%" ^
     -p:PlatformToolset="%VC_TOOLSET%" ^
-    -p:OutDir="%MSBUILD_OUTDIR%\\" ^
-    -p:IntDir="%MSBUILD_OUTDIR%\obj\\"
-
-  if %ERRORLEVEL% neq 0 (
-    echo.
-    echo Error: Failed building wolfSSL %MSBUILD_CONFIG%^|%MSBUILD_PLATFORM%.
-    exit /b 1
-  )
+    -p:OutDir="%DST_PATH%\\" ^
+    -p:IntDir="%TMP_PATH%\\"
+  if %ERRORLEVEL% neq 0 echo %ERR% msbuild failed! & exit /b 1
 
   rem For tests to run properly the wolfSSL directory must remain the current.
-  set "PATH=%MSBUILD_OUTDIR%;%PATH%"
-  "%MSBUILD_OUTDIR%\testsuite.exe"
+  "%DST_PATH%\testsuite.exe"
+  if %ERRORLEVEL% neq 0 echo %ERR% testsuite failed! & exit /b 1
 
-  if %ERRORLEVEL% neq 0 (
-    echo.
-    echo Error: Failed testing wolfSSL %MSBUILD_CONFIG%^|%MSBUILD_PLATFORM%.
-    exit /b 1
-  )
+  echo. & echo.
+  echo Success: Built and all tests passed for wolfSSL %FRIENDLY_NAME%.
+  echo. & echo.
 
-  echo.
-  echo Success: Built and tested wolfSSL %MSBUILD_CONFIG%^|%MSBUILD_PLATFORM%.
-  echo.
-  echo.
-  rem This is necessary to export our local variables back to the caller.
-  endlocal & set SUCCESSFUL_BUILDS="%MSBUILD_CONFIG%|%MSBUILD_PLATFORM%" ^
-    %SUCCESSFUL_BUILDS%
+  rem Remove the temporary build files (obj,test,etc)
+  rmdir /s /q "%TMP_PATH%" 1>NUL 2>&1
+
+  rem This line is necessary to export SUCCESSFUL_BUILDS back to the caller
+  endlocal & set SUCCESSFUL_BUILDS=%FRIENDLY_NAME% %SUCCESSFUL_BUILDS%
   exit /b 0
 
 :syntax
   rem Display the help
   echo.
-  echo Usage: build-wolfssl ^<compiler^> ^<platform^> [configuration] [directory]
+  echo Usage: build-wolfssl ^<compiler^> [platform] [configuration] [directory]
   echo.
   echo Compiler:
   echo.
@@ -292,20 +285,24 @@ rem ***************************************************************************
   echo.
   echo x86       - Perform a 32-bit build
   echo x64       - Perform a 64-bit build
+  echo both      - Do both ^(default^)
   echo.
   echo Configuration:
   echo.
   echo debug     - Perform a debug build
   echo release   - Perform a release build
+  echo both      - Do both ^(default^)
   echo.
-  echo Other:
+  echo Directory:
   echo.
-  echo directory - Specifies the wolfSSL source directory
+  echo The wolfSSL source directory.
+  echo The default is "%DEFAULT_START_DIR%"
+  echo.
   goto error
 
 :unknown
   echo.
-  echo Error: Unknown argument '%1'
+  echo Error: Unknown argument, for usage run build-wolfssl /?
   goto error
 
 :nodos
@@ -348,6 +345,6 @@ rem ***************************************************************************
     echo %SUCCESSFUL_BUILDS%
     echo.
   )
-  cd %SAVED_PATH%
+  cd /d "%SAVED_PATH%"
   endlocal
   exit /B 0

--- a/projects/wolfssl_override.props
+++ b/projects/wolfssl_override.props
@@ -27,7 +27,7 @@ file by using the CustomAfterMicrosoftCommonTargets property.
   </ItemDefinitionGroup>
   <!--
   The project GUID for wolfssl.vcxproj is 73973223-5EE8-41CA-8E88-1D60E89A237B.
-  Since we have are using certain options like fast math (TFM) in our options
+  Since we are using certain options like fast math (TFM) in our options
   file we must compile the corresponding units in wolfssl.vcxproj. If the user
   disables such an option the unit can still be compiled it just won't be used.
   -->


### PR DESCRIPTION
This moves the OpenSSL 1.0.x code to a legacy section and adds a
different build procedure for 1.1.x.

Additionally build-wolfssl has been changed to use the same updated
build methods.

Bug: https://github.com/curl/curl/issues/1002
Reported-by: SilverCookie@users.noreply.github.com

Closes #xxxx

---

This does not include the recent VS2017 support just added by @captain-caveman2k, so it will need to be updated for that. The build code had to be separate as 1.0.x and 1.1.x because the build systems are different.