### PR TITLE
build-openssl.bat: Refer to VS2017 as VC14.1 instead of VC15

### DIFF
--- a/projects/build-openssl.bat
+++ b/projects/build-openssl.bat
@@ -82,11 +82,11 @@ rem ***************************************************************************
     set VC_VER=14.0
     set VC_DESC=VC14
     set "VC_PATH=Microsoft Visual Studio 14.0\VC"
-  ) else if /i "%~1" == "vc15" (
-    set VC_VER=15.0
-    set VC_DESC=VC15
+  ) else if /i "%~1" == "vc14.1" (
+    set VC_VER=14.1
+    set VC_DESC=VC14.1
 
-    rem Determine the VC15 path based on the installed edition in decending
+    rem Determine the VC14.1 path based on the installed edition in descending
     rem order (Enterprise, then Professional and finally Community)
     if exist "%PF%\Microsoft Visual Studio\2017\Enterprise\VC" (
       set "VC_PATH=Microsoft Visual Studio\2017\Enterprise\VC"
@@ -179,7 +179,7 @@ rem ***************************************************************************
     if "%VC_VER%" == "11.0" set VCVARS_PLATFORM=amd64
     if "%VC_VER%" == "12.0" set VCVARS_PLATFORM=amd64
     if "%VC_VER%" == "14.0" set VCVARS_PLATFORM=amd64
-    if "%VC_VER%" == "15.0" set VCVARS_PLATFORM=amd64
+    if "%VC_VER%" == "14.1" set VCVARS_PLATFORM=amd64
   )
 
 :start
@@ -192,15 +192,15 @@ rem ***************************************************************************
     call "%PF%\%VC_PATH%\bin\vcvars32"
   ) else if "%VC_VER%" == "7.1" (
     call "%PF%\%VC_PATH%\bin\vcvars32"
-  ) else if "%VC_VER%" == "15.0" (
+  ) else if "%VC_VER%" == "14.1" (
     call "%PF%\%VC_PATH%\Auxiliary\Build\vcvarsall" %VCVARS_PLATFORM%
   ) else (
     call "%PF%\%VC_PATH%\vcvarsall" %VCVARS_PLATFORM%
   )
 
   echo.
-  cd %SAVED_PATH%
-  cd %START_DIR%
+  cd /d %SAVED_PATH%
+  if defined START_DIR cd /d %START_DIR%
   goto %BUILD_PLATFORM%
 
 :x64
@@ -325,7 +325,7 @@ rem ***************************************************************************
   echo vc11      - Use Visual Studio 2012
   echo vc12      - Use Visual Studio 2013
   echo vc14      - Use Visual Studio 2015
-  echo vc15      - Use Visual Studio 2017
+  echo vc14.1    - Use Visual Studio 2017
   echo.
   echo Platform:
   echo.
@@ -390,6 +390,6 @@ rem ***************************************************************************
   exit /B 1
 
 :success
-  cd %SAVED_PATH%
+  cd /d %SAVED_PATH%
   endlocal
   exit /B 0

--- a/projects/build-wolfssl.bat
+++ b/projects/build-wolfssl.bat
@@ -68,12 +68,12 @@ rem ***************************************************************************
     set VC_DESC=VC14
     set VC_TOOLSET=v140
     set "VC_PATH=Microsoft Visual Studio 14.0\VC"
-  ) else if /i "%~1" == "vc15" (
-    set VC_VER=15.0
-    set VC_DESC=VC15
+  ) else if /i "%~1" == "vc14.1" (
+    set VC_VER=14.1
+    set VC_DESC=VC14.1
     set VC_TOOLSET=v141
 
-    rem Determine the VC15 path based on the installed edition in decending
+    rem Determine the VC14.1 path based on the installed edition in descending
     rem order (Enterprise, then Professional and finally Community)
     if exist "%PF%\Microsoft Visual Studio\2017\Enterprise\VC" (
       set "VC_PATH=Microsoft Visual Studio\2017\Enterprise\VC"
@@ -81,7 +81,7 @@ rem ***************************************************************************
       set "VC_PATH=Microsoft Visual Studio\2017\Professional\VC"
     ) else (
       set "VC_PATH=Microsoft Visual Studio\2017\Community\VC"
-    )    
+    )
   ) else if /i "%~1" == "x86" (
     set BUILD_PLATFORM=x86
   ) else if /i "%~1" == "x64" (
@@ -133,22 +133,22 @@ rem ***************************************************************************
     if "%VC_VER%" == "11.0" set VCVARS_PLATFORM=amd64
     if "%VC_VER%" == "12.0" set VCVARS_PLATFORM=amd64
     if "%VC_VER%" == "14.0" set VCVARS_PLATFORM=amd64
-    if "%VC_VER%" == "15.0" set VCVARS_PLATFORM=amd64
+    if "%VC_VER%" == "14.1" set VCVARS_PLATFORM=amd64
   )
 
 :start
   echo.
   set SAVED_PATH=%CD%
 
-  if "%VC_VER%" == "15.0" (
+  if "%VC_VER%" == "14.1" (
     call "%PF%\%VC_PATH%\Auxiliary\Build\vcvarsall" %VCVARS_PLATFORM%
   ) else (
     call "%PF%\%VC_PATH%\vcvarsall" %VCVARS_PLATFORM%
   )
 
   echo.
-  cd %SAVED_PATH%
-  cd %START_DIR%
+  cd /d %SAVED_PATH%
+  if defined START_DIR cd /d %START_DIR%
   goto %BUILD_PLATFORM%
 
 :x64
@@ -308,7 +308,7 @@ rem ***************************************************************************
   echo vc11      - Use Visual Studio 2012
   echo vc12      - Use Visual Studio 2013
   echo vc14      - Use Visual Studio 2015
-  echo vc15      - Use Visual Studio 2017
+  echo vc14.1    - Use Visual Studio 2017
   echo.
   echo Platform:
   echo.
@@ -370,6 +370,6 @@ rem ***************************************************************************
     echo %SUCCESSFUL_BUILDS%
     echo.
   )
-  cd %SAVED_PATH%
+  cd /d %SAVED_PATH%
   endlocal
   exit /B 0


### PR DESCRIPTION
.. and do the same for build-wolfssl.bat.

- Refer to VS2017 as VC14.1 instead of VC15.

- Support Enterprise and Professional variants.

Closes #xxxx

---

Another WIP. @captain-caveman2k as far as I can tell VS2017 is referred to as VC14.1 not VC15. I had some related confusion about this last year and I asked on the MS forums whether it's 14.10 or 14.1 and [they said 14.1](https://social.technet.microsoft.com/Forums/en-US/98c25d63-c345-4ac1-a522-9c6e93183250/does-visual-studio-2017-come-with-visual-c-141-or-1410?forum=visualstudiogeneral).

Regarding Enterprise/Professional I haven't tested them yet but I assume they are the same. Basically I added an autodetect so the build script could find the version in order of preference Enterprise -> Professional -> Community

Also there is a Microsoft tool [vswhere](https://github.com/Microsoft/vswhere/wiki) for more precise Visual Studio location for 2010+.