### PR TITLE
Check sizeof long using the more portable LONG_BIT.

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -343,12 +343,14 @@
 /* ===================================== */
 
 #elif defined(__GNUC__)
+#  include <limits.h>                                           /* LONG_BIT */
 #  if !defined(__LP64__) &&                                             \
   (defined(__ILP32__) || defined(__i386__) || defined(__hppa__) ||      \
    defined(__ppc__) || defined(__powerpc__) || defined(__arm__) ||      \
    defined(__sparc__) || defined(__mips__) || defined(__sh__) ||        \
    defined(__XTENSA__) ||                                               \
-   (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ == 4))
+   (defined(__SIZEOF_LONG__) && __SIZEOF_LONG__ == 4) ||                \
+   (defined(LONG_BIT) && LONG_BIT == 32))
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"


### PR DESCRIPTION
The previous attempt (reverted with commit
272613df020c29a445738856dda29a9803b9bedb ) used macro SIZEOF_LONG which was
not a system include, but internal to cURL, defined from configure.ac
AC_CHECK_SIZEOF(long). Using LONG_BIT is more portable.

Even LONG_BIT though requires pulling in <limits.h> and _XOPEN_SOURCE to be
defined. We include <limits.h> only inside the specific ifdef in order to
avoid affecting other platforms that already work.