### PR TITLE
Fix connection ownership issue #2217

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1045,6 +1045,8 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
     unsigned int i;
     unsigned int count = data->state.tempcount;
     struct tempbuf writebuf[3]; /* there can only be three */
+    struct connectdata *conn = data->easy_conn;
+    struct Curl_easy *saved_data = NULL;
 
     /* copy the structs to allow for immediate re-pausing */
     for(i = 0; i < data->state.tempcount; i++) {
@@ -1053,23 +1055,26 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
     }
     data->state.tempcount = 0;
 
+    if(conn && conn->data != data) {
+      /* Make sure we set the connection's current owner */
+      saved_data = conn->data;
+      conn->data = data;
+    }
+
     for(i = 0; i < count; i++) {
       /* even if one function returns error, this loops through and frees all
          buffers */
-      if(!result) {
-        struct connectdata *conn = data->easy_conn;
-        if(conn && conn->data != data && data->mstate > CURLM_STATE_CONNECT &&
-          data->mstate < CURLM_STATE_COMPLETED)
-          /* Make sure we set the connection's current owner */
-          conn->data = data;
-
+      if(!result)
         result = Curl_client_chop_write(conn,
                                         writebuf[i].type,
                                         writebuf[i].buf,
                                         writebuf[i].len);
-      }
       free(writebuf[i].buf);
     }
+    /* recover previous owner of the connection */
+    if(saved_data)
+      conn->data = saved_data;
+
     if(result)
       return result;
   }


### PR DESCRIPTION
Before calling Curl_client_chop_write(), change the owner of connection
to the current Curl_easy handle. This will fix the issue #2217.