### PR TITLE
setopt: fix SSLVERSION to allow CURL_SSLVERSION_MAX_ values

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
@@ -46,10 +46,14 @@ TLSv1.1
 TLSv1.2
 .IP CURL_SSLVERSION_TLSv1_3
 TLSv1.3
+.RE
+OpenSSL and NSS allow setting the maximum TLS version by using one of the
+CURL_SSLVERSION_MAX_ defines below. It is also possible to OR \fIone\fP of the
+CURL_SSLVERSION_ defines with \fIone\fP of the CURL_SSLVERSION_MAX_ defines.
+.RS
 .IP CURL_SSLVERSION_MAX_DEFAULT
 The flag defines the maximum supported TLS version as TLSv1.2, or the default
-value from the SSL library. Only the NSS library currently allows one to get
-the maximum supported TLS version.
+value from the SSL library.
 (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_0
 The flag defines maximum supported TLS version as TLSv1.0.
@@ -75,8 +79,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* ask libcurl to use TLS version 1.0 or later */
-  curl_easy_setopt(curl, CURLOPT_PROXY_SSLVERSION, CURL_SSLVERSION_TLSv1_1 |
-                   CURL_SSLVERSION_MAX_DEFAULT);
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 
   /* Perform the request */
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -50,10 +50,14 @@ TLSv1.1 (Added in 7.34.0)
 TLSv1.2 (Added in 7.34.0)
 .IP CURL_SSLVERSION_TLSv1_3
 TLSv1.3 (Added in 7.52.0)
+.RE
+OpenSSL and NSS allow setting the maximum TLS version by using one of the
+CURL_SSLVERSION_MAX_ defines below. It is also possible to OR \fIone\fP of the
+CURL_SSLVERSION_ defines with \fIone\fP of the CURL_SSLVERSION_MAX_ defines.
+.RS
 .IP CURL_SSLVERSION_MAX_DEFAULT
 The flag defines the maximum supported TLS version as TLSv1.2, or the default
-value from the SSL library. Only the NSS library currently allows one to get
-the maximum supported TLS version.
+value from the SSL library.
 (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_0
 The flag defines maximum supported TLS version as TLSv1.0.
@@ -78,9 +82,8 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
-  /* ask libcurl to use TLS version 1.1 or later */
-  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1 |
-                   CURL_SSLVERSION_MAX_DEFAULT);
+  /* ask libcurl to use TLS version 1.0 or later */
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 
   /* Perform the request */
   curl_easy_perform(curl);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -360,32 +360,34 @@ static CURLcode setopt(struct Curl_easy *data, CURLoption option,
      */
     data->set.timevalue = (time_t)va_arg(param, long);
     break;
+
   case CURLOPT_SSLVERSION:
+  case CURLOPT_PROXY_SSLVERSION:
     /*
      * Set explicit SSL version to try to connect with, as some SSL
      * implementations are lame.
      */
 #ifdef USE_SSL
-    arg = va_arg(param, long);
-    if((arg < CURL_SSLVERSION_DEFAULT) || (arg > CURL_SSLVERSION_TLSv1_3))
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ssl.primary.version = C_SSLVERSION_VALUE(arg);
-    data->set.ssl.primary.version_max = C_SSLVERSION_MAX_VALUE(arg);
-#else
-    result = CURLE_UNKNOWN_OPTION;
-#endif
-    break;
-  case CURLOPT_PROXY_SSLVERSION:
-    /*
-     * Set explicit SSL version to try to connect with for proxy, as some SSL
-     * implementations are lame.
-     */
-#ifdef USE_SSL
-    arg = va_arg(param, long);
-    if((arg < CURL_SSLVERSION_DEFAULT) || (arg > CURL_SSLVERSION_TLSv1_3))
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.proxy_ssl.primary.version = C_SSLVERSION_VALUE(arg);
-    data->set.proxy_ssl.primary.version_max = C_SSLVERSION_MAX_VALUE(arg);
+    {
+      long version, version_max;
+      struct ssl_primary_config *primary = (option == CURLOPT_SSLVERSION ?
+                                            &data->set.ssl.primary :
+                                            &data->set.proxy_ssl.primary);
+
+      arg = va_arg(param, long);
+
+      version = C_SSLVERSION_VALUE(arg);
+      version_max = C_SSLVERSION_MAX_VALUE(arg);
+
+      if(version < CURL_SSLVERSION_DEFAULT ||
+         version >= CURL_SSLVERSION_LAST ||
+         version_max < CURL_SSLVERSION_MAX_NONE ||
+         version_max >= CURL_SSLVERSION_MAX_LAST)
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+
+      primary->version = version;
+      primary->version_max = version_max;
+    }
 #else
     result = CURLE_UNKNOWN_OPTION;
 #endif


### PR DESCRIPTION
Regression since f121575 (precedes 7.56.1).

Fixes https://github.com/curl/curl/issues/2225
Closes https://github.com/curl/curl/pull/2227

  