### PR TITLE
http2.c: fix incorrect trailer buffer size

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -925,8 +925,8 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
 
   if(stream->bodystarted) {
     /* This is trailer fields. */
-    /* 3 is for ":" and "\r\n". */
-    uint32_t n = (uint32_t)(namelen + valuelen + 3);
+    /* 4 is for ": " and "\r\n". */
+    uint32_t n = (uint32_t)(namelen + valuelen + 4);
 
     DEBUGF(infof(data_s, "h2 trailer: %.*s: %.*s\n", namelen, name, valuelen,
                  value));


### PR DESCRIPTION
When read trailer, pointer will read wrong address (which [trailer_pos](https://github.com/curl/curl/blob/9554c3c6e56e23153d4e1025b62c7a6402464a7c/lib/http2.c#L1367)[0] = '\0') at the second loop, which will mess up all the trailers after.

PR [`http2: Add space between colon and header` ](https://github.com/curl/curl/commit/0761a51ee0551ad9e523cbdba24ce00d22fff9c1) adds this space.