### PR TITLE
configure.ac: append extra linker flags instead of prepending them.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1656,7 +1656,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
 
        dnl still no, but what about with -ldl?
        AC_MSG_CHECKING([OpenSSL linking with -ldl])
-       LIBS="-ldl $LIBS"
+       LIBS="$LIBS -ldl"
        AC_TRY_LINK(
        [
          #include <openssl/err.h>
@@ -1673,7 +1673,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
          dnl ok, so what about bouth -ldl and -lpthread?
 
          AC_MSG_CHECKING([OpenSSL linking with -ldl and -lpthread])
-         LIBS="-lpthread $LIBS"
+         LIBS="$LIBS -lpthread"
          AC_TRY_LINK(
          [
            #include <openssl/err.h>


### PR DESCRIPTION
Link order should list libraries after the libraries that use them,
so when we're guessing that we might also need to add -ldl in order
to use -lssl, we should add -ldl after -lssl.