### PR TITLE
mime: duplicate mime tree upon easy handle duplication.

### DIFF
--- a/docs/libcurl/curl_mime_data_cb.3
+++ b/docs/libcurl/curl_mime_data_cb.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -91,6 +91,12 @@ The callback function must return \fICURL_SEEKFUNC_OK\fP on success,
 is free to work around the problem if possible. The latter can sometimes be
 done by instead reading from the input or similar.
 
+Care must be taken if the part is bound to a curl easy handle that is later
+duplicated: the \fIarg\fP pointer argument is also duplicated, resulting in
+the pointed item to be shared between the original and the copied handle.
+In particular, special attention should be given to the \fIfreefunc\fP
+procedure code since it will be called twice with the same argument.
+
 .SH AVAILABILITY
 As long as at least one of HTTP, SMTP or IMAP is enabled. Added in 7.56.0.
 .SH RETURN VALUE
@@ -157,4 +163,5 @@ int seek_callback(void *arg, curl_off_t offset, int origin)
 .SH "SEE ALSO"
 .BR curl_mime_addpart "(3),"
 .BR curl_mime_data "(3),"
-.BR curl_mime_name "(3)"
+.BR curl_mime_name "(3),"
+.BR curl_easy_duphandle "(3)"

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -65,6 +65,7 @@
 #include "sendf.h" /* for failf function prototype */
 #include "connect.h" /* for Curl_getconnectinfo */
 #include "slist.h"
+#include "mime.h"
 #include "amigaos.h"
 #include "non-ascii.h"
 #include "warnless.h"
@@ -855,6 +856,7 @@ static CURLcode dupset(struct Curl_easy *dst, struct Curl_easy *src)
   /* Copy src->set into dst->set first, then deal with the strings
      afterwards */
   dst->set = src->set;
+  Curl_mime_initpart(&dst->set.mimepost, dst);
 
   /* clear all string pointers first */
   memset(dst->set.str, 0, STRING_LAST * sizeof(char *));
@@ -878,7 +880,10 @@ static CURLcode dupset(struct Curl_easy *dst, struct Curl_easy *src)
     dst->set.postfields = dst->set.str[i];
   }
 
-  return CURLE_OK;
+  /* Duplicate mime data. */
+  result = Curl_mime_duppart(&dst->set.mimepost, &src->set.mimepost);
+
+  return result;
 }
 
 /*

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1156,6 +1156,9 @@ CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src)
     break;
   case MIMEKIND_FILE:
     res = curl_mime_filedata(dst, src->data);
+    /* Do not abort duplication if file is not readable. */
+    if(res == CURLE_READ_ERROR)
+      res = CURLE_OK;
     break;
   case MIMEKIND_CALLBACK:
     res = curl_mime_data_cb(dst, src->datasize, src->readfunc,
@@ -1194,6 +1197,7 @@ CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src)
   }
 
   /* Duplicate other fields. */
+  dst->encoder = src->encoder;
   if(!res)
     res = curl_mime_type(dst, src->mimetype);
   if(!res)

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1152,7 +1152,7 @@ CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src)
   case MIMEKIND_NONE:
     break;
   case MIMEKIND_DATA:
-    res = curl_mime_data(dst, src->data, src->datasize);
+    res = curl_mime_data(dst, src->data, (size_t) src->datasize);
     break;
   case MIMEKIND_FILE:
     res = curl_mime_filedata(dst, src->data);

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1140,6 +1140,74 @@ void curl_mime_free(curl_mime *mime)
   }
 }
 
+CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src)
+{
+  curl_mime *mime;
+  curl_mimepart *d;
+  const curl_mimepart *s;
+  CURLcode res = CURLE_OK;
+
+  /* Duplicate content. */
+  switch(src->kind) {
+  case MIMEKIND_NONE:
+    break;
+  case MIMEKIND_DATA:
+    res = curl_mime_data(dst, src->data, src->datasize);
+    break;
+  case MIMEKIND_FILE:
+    res = curl_mime_filedata(dst, src->data);
+    break;
+  case MIMEKIND_CALLBACK:
+    res = curl_mime_data_cb(dst, src->datasize, src->readfunc,
+                            src->seekfunc, src->freefunc, src->arg);
+    break;
+  case MIMEKIND_MULTIPART:
+    /* No one knows about the cloned subparts, thus always attach ownership
+       to the part. */
+    mime = curl_mime_init(dst->easy);
+    res = mime? curl_mime_subparts(dst, mime): CURLE_OUT_OF_MEMORY;
+
+    /* Duplicate subparts. */
+    for(s = ((curl_mime *) src->arg)->firstpart; !res && s; s = s->nextpart) {
+      d = curl_mime_addpart(mime);
+      res = d? Curl_mime_duppart(d, s): CURLE_OUT_OF_MEMORY;
+    }
+    break;
+  default:  /* Invalid kind: should not occur. */
+    res = CURLE_BAD_FUNCTION_ARGUMENT;  /* Internal error? */
+    break;
+  }
+
+  /* Duplicate headers. */
+  if(!res && src->userheaders) {
+    struct curl_slist *hdrs = Curl_slist_duplicate(src->userheaders);
+
+    if(!hdrs)
+      res = CURLE_OUT_OF_MEMORY;
+    else {
+      /* No one but this procedure knows about the new header list,
+         so always take ownership. */
+      res = curl_mime_headers(dst, hdrs, TRUE);
+      if(res)
+        curl_slist_free_all(hdrs);
+    }
+  }
+
+  /* Duplicate other fields. */
+  if(!res)
+    res = curl_mime_type(dst, src->mimetype);
+  if(!res)
+    res = curl_mime_name(dst, src->name);
+  if(!res)
+    res = curl_mime_filename(dst, src->filename);
+
+  /* If an error occurred, rollback. */
+  if(res)
+    Curl_mime_cleanpart(dst);
+
+  return res;
+}
+
 /*
  * Mime build functions.
  */
@@ -1853,6 +1921,13 @@ void Curl_mime_initpart(curl_mimepart *part, struct Curl_easy *easy)
 void Curl_mime_cleanpart(curl_mimepart *part)
 {
   (void) part;
+}
+
+CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src)
+{
+  (void) dst;
+  (void) src;
+  return CURLE_OK;    /* Nothing to duplicate: always succeed. */
 }
 
 CURLcode Curl_mime_set_subparts(curl_mimepart *part,

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -122,6 +122,7 @@ struct curl_mimepart_s {
 /* Prototypes. */
 void Curl_mime_initpart(curl_mimepart *part, struct Curl_easy *easy);
 void Curl_mime_cleanpart(curl_mimepart *part);
+CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src);
 CURLcode Curl_mime_set_subparts(curl_mimepart *part,
                                 curl_mime *subparts, int take_ownership);
 CURLcode Curl_mime_prepare_headers(curl_mimepart *part,

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -80,7 +80,7 @@ test617 test618 test619 test620 test621 test622 test623 test624 test625 \
 test626 test627 test628 test629 test630 test631 test632 test633 test634 \
 test635 test636 test637 test638 test639 test640 test641 test642 \
 test643 test644 test645 test646 test647 test648 test649 test650 test651 \
-test652 test653 \
+test652 test653 test654 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 \

--- a/tests/data/test654
+++ b/tests/data/test654
@@ -1,0 +1,93 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+HTTP MIME POST
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Connection: close
+Content-Type: text/html
+
+hello
+</data>
+<datacheck>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Connection: close
+Content-Type: text/html
+
+hello
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Connection: close
+Content-Type: text/html
+
+hello
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib654
+</tool>
+
+ <name>
+HTTP duplicate easy handle with mime data
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/654
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strippart>
+s/^--------------------------[a-z0-9]*/------------------------------/
+s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+</strippart>
+# Note that the stripping above removes 12 bytes from every occurrence of the
+# boundary string and since 5 of them are in the body contents, we see
+# (5*12) == 60 bytes less
+<protocol>
+POST /654 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Content-Length: 0
+
+POST /654 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Transfer-Encoding: chunked
+Content-Type: multipart/form-data; boundary=----------------------------
+Expect: 100-continue
+
+ab
+------------------------------
+Content-Disposition: form-data
+
+this is what we post to the silly web server
+
+--------------------------------
+
+0
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test654
+++ b/tests/data/test654
@@ -53,6 +53,9 @@ HTTP duplicate easy handle with mime data
  <command>
 http://%HOSTIP:%HTTPPORT/654
 </command>
+<file name="log/file654.txt">
+This is data from a file
+</file>
 </client>
 
 #
@@ -78,7 +81,20 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-ab
+20c
+------------------------------
+Content-Disposition: form-data; name="greeting"
+Content-Type: application/X-Greeting
+Content-Transfer-Encoding: base64
+X-Test-Number: 654
+
+aGVsbG8=
+------------------------------
+Content-Disposition: form-data; filename="file654.txt"
+Content-Type: text/plain
+
+This is data from a file
+
 ------------------------------
 Content-Disposition: form-data
 

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -20,7 +20,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib559 lib560 lib562 lib564 lib565 lib566 lib567 lib568 lib569 lib570   \
  lib571 lib572 lib573 lib574 lib575 lib576        lib578 lib579 lib582   \
  lib583 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598 lib599   \
- lib643 lib644 lib645 lib650 lib651 lib652 lib653 \
+ lib643 lib644 lib645 lib650 lib651 lib652 lib653 lib654 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
  lib1520 lib1521 \
@@ -323,6 +323,9 @@ lib652_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib653_SOURCES = lib653.c $(SUPPORTFILES)
 lib653_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib654_SOURCES = lib654.c $(SUPPORTFILES)
+lib654_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1500_SOURCES = lib1500.c $(SUPPORTFILES) $(TESTUTIL)
 lib1500_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib654.c
+++ b/tests/libtest/lib654.c
@@ -1,0 +1,166 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "memdebug.h"
+
+static char data[]=
+#ifdef CURL_DOES_CONVERSIONS
+  /* ASCII representation with escape sequences for non-ASCII platforms */
+  "\x74\x68\x69\x73\x20\x69\x73\x20\x77\x68\x61\x74\x20\x77\x65\x20\x70"
+  "\x6f\x73\x74\x20\x74\x6f\x20\x74\x68\x65\x20\x73\x69\x6c\x6c\x79\x20"
+  "\x77\x65\x62\x20\x73\x65\x72\x76\x65\x72\x0a";
+#else
+  "this is what we post to the silly web server\n";
+#endif
+
+struct WriteThis {
+  char *readptr;
+  curl_off_t sizeleft;
+  int freecount;
+};
+
+static void free_callback(void *userp)
+{
+  struct WriteThis *pooh = (struct WriteThis *) userp;
+
+  pooh->freecount++;
+}
+
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
+{
+  struct WriteThis *pooh = (struct WriteThis *)userp;
+  int eof = !*pooh->readptr;
+
+  if(size*nmemb < 1)
+    return 0;
+
+  eof = pooh->sizeleft <= 0;
+  if(!eof)
+    pooh->sizeleft--;
+
+  if(!eof) {
+    *ptr = *pooh->readptr;           /* copy one single byte */
+    pooh->readptr++;                 /* advance pointer */
+    return 1;                        /* we return 1 byte at a time! */
+  }
+
+  return 0;                         /* no more data left to deliver */
+}
+
+int test(char *URL)
+{
+  CURL *easy = NULL;
+  CURL *easy2 = NULL;
+  curl_mime *mime = NULL;
+  curl_mimepart *part;
+  CURLcode result;
+  int res = TEST_ERR_FAILURE;
+  struct WriteThis pooh;
+
+  /*
+   * Check proper copy/release of mime post data bound to a duplicated
+   * easy handle.
+   */
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  easy = curl_easy_init();
+
+  /* First set the URL that is about to receive our POST. */
+  test_setopt(easy, CURLOPT_URL, URL);
+
+  /* get verbose debug output please */
+  test_setopt(easy, CURLOPT_VERBOSE, 1L);
+
+  /* include headers in the output */
+  test_setopt(easy, CURLOPT_HEADER, 1L);
+
+  /* Prepare the callback structure. */
+  pooh.readptr = data;
+  pooh.sizeleft = (curl_off_t) strlen(data);
+  pooh.freecount = 0;
+
+  mime = curl_mime_init(easy);
+  part = curl_mime_addpart(mime);
+  result = curl_mime_data_cb(part, (curl_off_t) -1, read_callback,
+                             NULL, free_callback, &pooh);
+
+  if(res) {
+    fprintf(stderr, "curl_mime_data_cb() failed\n");
+    goto test_cleanup;
+  }
+
+  /* Bind mime data to its easy handle. */
+  test_setopt(easy, CURLOPT_MIMEPOST, mime);
+
+  /* Duplicate the handle. */
+  easy2 = curl_easy_duphandle(easy);
+  if(!easy2) {
+    fprintf(stderr, "curl_easy_duphandle() failed\n");
+    goto test_cleanup;
+  }
+
+  /* Now free the mime structure: it should unbind it from the first
+     easy handle. */
+  curl_mime_free(mime);
+  mime = NULL;  /* Already cleaned up. */
+
+  /* Perform on the first handle: should not send any data. */
+  result = curl_easy_perform(easy);
+  if(result) {
+    fprintf(stderr, "curl_easy_perform(original) failed\n");
+    goto test_cleanup;
+  }
+
+  /* Perform on the second handle: if the bound mime structure has not been
+     duplicated properly, it should cause a valgrind error. */
+  result = curl_easy_perform(easy2);
+  if(result) {
+    fprintf(stderr, "curl_easy_perform(duplicated) failed\n");
+    goto test_cleanup;
+  }
+
+  /* Free the duplicated handle: it should call free_callback again.
+     If the mime copy was bad or not automatically released, valgrind
+     will signal it. */
+  curl_easy_cleanup(easy2);
+  easy2 = NULL;  /* Already cleaned up. */
+
+  if(pooh.freecount != 2) {
+    fprintf(stderr, "free_callback() called %d times instead of 2\n",
+            pooh.freecount);
+    goto test_cleanup;
+  }
+
+  res = 0;
+
+test_cleanup:
+  curl_easy_cleanup(easy);
+  curl_easy_cleanup(easy2);
+  curl_mime_free(mime);
+  curl_global_cleanup();
+  return res;
+}


### PR DESCRIPTION
A mime tree attached to an easy handle using CURLOPT_MIMEPOST is
strongly bound to the handle: there is a pointer to the easy handle in
each item of the mime tree and following the parent pointer list
of mime items ends in a dummy part stored within the handle.

Because of this binding, a mime tree cannot be shared between different
easy handles, thus it needs to be cloned upon easy handle duplication.

There is no way for the caller to get the duplicated mime tree
handle: it is then set to be automatically destroyed upon freeing the
new easy handle.

New test 654 checks proper mime structure duplication/release.

Add a warning note in curl_mime_data_cb() documentation about sharing
user data between duplicated handles.