### PR TITLE
Fix SSH state machine for ssh-agent authentication

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -955,11 +955,11 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
                                     sshc->sshagent_identity);
 
         if(rc < 0) {
-          if(rc != LIBSSH2_ERROR_EAGAIN)
+          if(rc != LIBSSH2_ERROR_EAGAIN) {
             /* tried and failed? go to next identity */
             sshc->sshagent_prev_identity = sshc->sshagent_identity;
-          else
-            break;
+          }
+          break;
         }
       }
 


### PR DESCRIPTION
In case an identity didn't match[0], the state machine would fail in
state SSH_AUTH_AGENT instead of progressing to the next identity in
ssh-agent. As a result, ssh-agent authentication only worked if the
identity required happened to be the first added to ssh-agent.

This was introduced as part of commit c4eb10e2f06fbd6cc904f1d78e4c7c5cc1afde63,
which stated that the "else" statement was required to prevent getting stuck
in state SSH_AUTH_AGENT. Given the state machine's logic and libssh2's
interface I couldn't see how this could happen or reproduce it and
I also couldn't find a more detailed description of the problem which
would explain a test case to reproduce the problem this was supposed to fix.

[0] libssh2_agent_userauth returning LIBSSH2_ERROR_AUTHENTICATION_FAILED