### PR TITLE
fix for http/2 connection unnecessary closed when single transfer sto…

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -581,7 +581,8 @@ static CURLcode multi_done(struct connectdata **connp,
       && !(conn->ntlm.state == NTLMSTATE_TYPE2 ||
            conn->proxyntlm.state == NTLMSTATE_TYPE2)
 #endif
-     ) || conn->bits.close || premature) {
+     ) || conn->bits.close
+       || (premature && !(conn->handler->flags & PROTOPT_STREAM))) {
     CURLcode res2 = Curl_disconnect(conn, premature); /* close connection */
 
     /* If we had an error already, make sure we return that one. But


### PR DESCRIPTION
Proposed fix for this
https://github.com/curl/curl/issues/2237

I am able to verify that it fixes the issues of connection "teardown", but want to be sure that it won't cause problems elsewhere(regression). I did some load testing for a couple of hours and didn't see any memory leaks. Basically the patch says that once we know that the protocol supports "logical streams", even if the transfer didn't reach DONE state, it is sufficient to close/reset the underlying stream(which happens in function Curl_http2_done by calling nghttp2_submit_rst_stream API) and therefore there is no need to "teardown" the underlying TCP connection.