### PR TITLE
CONNECT_TO: fail attempt to set an IPv6 numerical without IPv6 support

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -3612,6 +3612,7 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
 
   /* detect and extract RFC6874-style IPv6-addresses */
   if(*hostptr == '[') {
+#ifdef ENABLE_IPV6
     char *ptr = ++hostptr; /* advance beyond the initial bracket */
     while(*ptr && (ISXDIGIT(*ptr) || (*ptr == ':') || (*ptr == '.')))
       ptr++;
@@ -3635,6 +3636,11 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
      * hostptr first, but I can't see anything wrong with that as no host
      * name nor a numeric can legally start with a bracket.
      */
+#else
+    failf(data, "Use of IPv6 in *_CONNECT_TO without IPv6 support built-in!");
+    free(host_dup);
+    return CURLE_NOT_BUILT_IN;
+#endif
   }
 
   /* Get port number off server.com:1080 */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -161,7 +161,7 @@ test1424 test1425 test1426 test1427 \
 test1428 test1429 test1430 test1431 test1432 test1433 test1434 test1435 \
 test1436 test1437 test1438 test1439 test1440 test1441 test1442 test1443 \
 test1444 test1445 test1446 test1447 test1448 test1449 test1450 test1451 \
-test1452 test1453 \
+test1452 test1453 test1454 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
 test1516 test1517 \

--- a/tests/data/test1454
+++ b/tests/data/test1454
@@ -1,0 +1,38 @@
+<testcase>
+<info>
+<keywords>
+--connect-to
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+!ipv6
+</features>
+<server>
+http
+</server>
+ <name>
+--connect-to with IPv6 address w/o IPv6 support!
+ </name>
+<command>
+--connect-to localhost:80:[::1]:80 localhost
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# 4 == CURLE_NOT_BUILT_IN
+<errorcode>
+4
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Bug: https://curl.haxx.se/mail/lib-2018-01/0087.html
Reported-by: John Hascall