### PR TITLE
openssl: fix pinned public key build error in FIPS mode

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3580,11 +3580,15 @@ static CURLcode Curl_ossl_md5sum(unsigned char *tmp, /* input */
                                  unsigned char *md5sum /* output */,
                                  size_t unused)
 {
-  MD5_CTX MD5pw;
-  (void)unused;
-  MD5_Init(&MD5pw);
-  MD5_Update(&MD5pw, tmp, tmplen);
-  MD5_Final(md5sum, &MD5pw);
+  EVP_MD_CTX *mdctx;
+  unsigned int len = 0;
+  (void) unused;
+
+  mdctx = EVP_MD_CTX_create();
+  EVP_DigestInit_ex(mdctx, EVP_md5(), NULL);
+  EVP_DigestUpdate(mdctx, tmp, tmplen);
+  EVP_DigestFinal_ex(mdctx, md5sum, &len);
+  EVP_MD_CTX_destroy(mdctx);
   return CURLE_OK;
 }
 
@@ -3594,11 +3598,15 @@ static void Curl_ossl_sha256sum(const unsigned char *tmp, /* input */
                                 unsigned char *sha256sum /* output */,
                                 size_t unused)
 {
-  SHA256_CTX SHA256pw;
-  (void)unused;
-  SHA256_Init(&SHA256pw);
-  SHA256_Update(&SHA256pw, tmp, tmplen);
-  SHA256_Final(sha256sum, &SHA256pw);
+  EVP_MD_CTX *mdctx;
+  unsigned int len = 0;
+  (void) unused;
+
+  mdctx =  EVP_MD_CTX_create();
+  EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL);
+  EVP_DigestUpdate(mdctx, tmp, tmplen);
+  EVP_DigestFinal_ex(mdctx, sha256sum, &len);
+  EVP_MD_CTX_destroy(mdctx);
 }
 #endif
 


### PR DESCRIPTION
Here is a version that should work with all versions of openssl 0.9.7
through 1.1.0.

Links to the docs:
https://www.openssl.org/docs/man1.0.2/crypto/EVP_DigestInit.html
https://www.openssl.org/docs/man1.1.0/crypto/EVP_DigestInit.html

At the very bottom of the 1.1.0 documentation there is a history section
that states, " stack allocated EVP_MD_CTXs are no longer supported."

If EVP_MD_CTX_create and EVP_MD_CTX_destroy are not defined, then a
simple mapping can be used as described here:
https://wiki.openssl.org/index.php/Talk:OpenSSL_1.1.0_Changes