### PR TITLE
curl_ctype: private is*() type macros and functions

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -54,7 +54,7 @@ LIB_CFILES = file.c timeval.c base64.c hostip.c progress.c formdata.c   \
   http_ntlm.c curl_ntlm_wb.c curl_ntlm_core.c curl_sasl.c rand.c        \
   curl_multibyte.c hostcheck.c conncache.c pipeline.c dotdot.c          \
   x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c      \
-  mime.c sha256.c setopt.c curl_path.c
+  mime.c sha256.c setopt.c curl_path.c curl_ctype.c
 
 LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
   formdata.h cookie.h http.h sendf.h ftp.h url.h dict.h if2ip.h         \
@@ -74,7 +74,7 @@ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
   curl_setup_once.h multihandle.h setup-vms.h pipeline.h dotdot.h       \
   x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h           \
   curl_printf.h system_win32.h rand.h mime.h curl_sha256.h setopt.h     \
-  curl_path.h
+  curl_path.h curl_ctype.h
 
 LIB_RCFILES = libcurl.rc
 

--- a/lib/curl_ctype.c
+++ b/lib/curl_ctype.c
@@ -1,0 +1,114 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#define _U (1<<0) /* upper case */
+#define _L (1<<1) /* lower case */
+#define _N (1<<2) /* decimal numerical digit */
+#define _S (1<<3) /* space */
+#define _P (1<<4) /* punctuation */
+#define _C (1<<5) /* control */
+#define _X (1<<6) /* hexadecimal letter */
+#define _B (1<<7) /* blank */
+
+const unsigned char Curl_ctype[128] = {
+  _C,   _C,     _C,     _C,     _C,     _C,     _C,     _C,
+  _C,   _C|_S,  _C|_S,  _C|_S,  _C|_S,  _C|_S,  _C,     _C,
+  _C,   _C,     _C,     _C,     _C,     _C,     _C,     _C,
+  _C,   _C,     _C,     _C,     _C,     _C,     _C,     _C,
+  _S|_B, _P,    _P,     _P,     _P,     _P,     _P,     _P,
+  _P,   _P,     _P,     _P,     _P,     _P,     _P,     _P,
+  _N,   _N,     _N,     _N,     _N,     _N,     _N,     _N,
+  _N,   _N,     _P,     _P,     _P,     _P,     _P,     _P,
+  _P,   _U|_X,  _U|_X,  _U|_X,  _U|_X,  _U|_X,  _U|_X,  _U,
+  _U,   _U,     _U,     _U,     _U,     _U,     _U,     _U,
+  _U,   _U,     _U,     _U,     _U,     _U,     _U,     _U,
+  _U,   _U,     _U,     _P,     _P,     _P,     _P,     _P,
+  _P,   _L|_X,  _L|_X,  _L|_X,  _L|_X,  _L|_X,  _L|_X,  _L,
+  _L,   _L,     _L,     _L,     _L,     _L,     _L,     _L,
+  _L,   _L,     _L,     _L,     _L,     _L,     _L,     _L,
+  _L,   _L,     _L,     _P,     _P,     _P,     _P,     _C
+};
+
+int Curl_isspace(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & _S);
+}
+
+int Curl_isdigit(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & _N);
+}
+
+int Curl_isalnum(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & (_N|_U|_L));
+}
+
+int Curl_isxdigit(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & (_N|_X));
+}
+
+int Curl_isgraph(int c)
+{
+  if((c < 0) || (c >= 0x80) || (c == ' '))
+    return FALSE;
+  return (Curl_ctype[c] & (_N|_X|_U|_L|_P|_S));
+}
+
+int Curl_isprint(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & (_N|_X|_U|_L|_P|_S));
+}
+
+int Curl_isalpha(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & (_U|_L));
+}
+
+int Curl_isupper(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & (_U));
+}
+
+int Curl_islower(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (Curl_ctype[c] & (_L));
+}

--- a/lib/curl_ctype.c
+++ b/lib/curl_ctype.c
@@ -31,7 +31,7 @@
 #define _X (1<<6) /* hexadecimal letter */
 #define _B (1<<7) /* blank */
 
-const unsigned char Curl_ctype[128] = {
+static const unsigned char ascii[128] = {
   _C,   _C,     _C,     _C,     _C,     _C,     _C,     _C,
   _C,   _C|_S,  _C|_S,  _C|_S,  _C|_S,  _C|_S,  _C,     _C,
   _C,   _C,     _C,     _C,     _C,     _C,     _C,     _C,
@@ -54,61 +54,61 @@ int Curl_isspace(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & _S);
+  return (ascii[c] & _S);
 }
 
 int Curl_isdigit(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & _N);
+  return (ascii[c] & _N);
 }
 
 int Curl_isalnum(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & (_N|_U|_L));
+  return (ascii[c] & (_N|_U|_L));
 }
 
 int Curl_isxdigit(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & (_N|_X));
+  return (ascii[c] & (_N|_X));
 }
 
 int Curl_isgraph(int c)
 {
   if((c < 0) || (c >= 0x80) || (c == ' '))
     return FALSE;
-  return (Curl_ctype[c] & (_N|_X|_U|_L|_P|_S));
+  return (ascii[c] & (_N|_X|_U|_L|_P|_S));
 }
 
 int Curl_isprint(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & (_N|_X|_U|_L|_P|_S));
+  return (ascii[c] & (_N|_X|_U|_L|_P|_S));
 }
 
 int Curl_isalpha(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & (_U|_L));
+  return (ascii[c] & (_U|_L));
 }
 
 int Curl_isupper(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & (_U));
+  return (ascii[c] & (_U));
 }
 
 int Curl_islower(int c)
 {
   if((c < 0) || (c >= 0x80))
     return FALSE;
-  return (Curl_ctype[c] & (_L));
+  return (ascii[c] & (_L));
 }

--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -1,0 +1,48 @@
+#ifndef HEADER_CURL_CTYPE_H
+#define HEADER_CURL_CTYPE_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+int Curl_isspace(int c);
+int Curl_isdigit(int c);
+int Curl_isalnum(int c);
+int Curl_isxdigit(int c);
+int Curl_isgraph(int c);
+int Curl_isprint(int c);
+int Curl_isalpha(int c);
+int Curl_isupper(int c);
+int Curl_islower(int c);
+
+#define ISSPACE(x)  (Curl_isspace((int)  ((unsigned char)x)))
+#define ISDIGIT(x)  (Curl_isdigit((int)  ((unsigned char)x)))
+#define ISALNUM(x)  (Curl_isalnum((int)  ((unsigned char)x)))
+#define ISXDIGIT(x) (Curl_isxdigit((int) ((unsigned char)x)))
+#define ISGRAPH(x)  (Curl_isgraph((int)  ((unsigned char)x)))
+#define ISALPHA(x)  (Curl_isalpha((int)  ((unsigned char)x)))
+#define ISPRINT(x)  (Curl_isprint((int)  ((unsigned char)x)))
+#define ISUPPER(x)  (Curl_isupper((int)  ((unsigned char)x)))
+#define ISLOWER(x)  (Curl_islower((int)  ((unsigned char)x)))
+#define ISASCII(x)  (((x) >= 0) && ((x) <= 0x80))
+#define ISBLANK(x)  (int)((((unsigned char)x) == ' ') ||        \
+                          (((unsigned char)x) == '\t'))
+
+#endif /* HEADER_CURL_CTYPE_H */

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2013, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -100,7 +100,6 @@
 #    endif
 #  endif
 #endif
-
 
 /*
  * Definition of timeval struct for platforms that don't have it.
@@ -274,25 +273,6 @@ struct timeval {
 #  define sfcntl  fcntl
 #endif
 
-/*
- * Uppercase macro versions of ANSI/ISO is*() functions/macros which
- * avoid negative number inputs with argument byte codes > 127.
- */
-
-#define ISSPACE(x)  (isspace((int)  ((unsigned char)x)))
-#define ISDIGIT(x)  (isdigit((int)  ((unsigned char)x)))
-#define ISALNUM(x)  (isalnum((int)  ((unsigned char)x)))
-#define ISXDIGIT(x) (isxdigit((int) ((unsigned char)x)))
-#define ISGRAPH(x)  (isgraph((int)  ((unsigned char)x)))
-#define ISALPHA(x)  (isalpha((int)  ((unsigned char)x)))
-#define ISPRINT(x)  (isprint((int)  ((unsigned char)x)))
-#define ISUPPER(x)  (isupper((int)  ((unsigned char)x)))
-#define ISLOWER(x)  (islower((int)  ((unsigned char)x)))
-#define ISASCII(x)  (isascii((int)  ((unsigned char)x)))
-
-#define ISBLANK(x)  (int)((((unsigned char)x) == ' ') || \
-                          (((unsigned char)x) == '\t'))
-
 #define TOLOWER(x)  (tolower((int)  ((unsigned char)x)))
 
 
@@ -347,6 +327,7 @@ struct timeval {
 #define FALSE false
 #endif
 
+#include "curl_ctype.h"
 
 /*
  * Macro WHILE_FALSE may be used to build single-iteration do-while loops,

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -73,15 +73,6 @@
    zero, followed by the trailer, which is terminated by an empty line.
 
  */
-
-/* Check for an ASCII hex digit.
- We avoid the use of isxdigit to accommodate non-ASCII hosts. */
-static bool Curl_isxdigit(char digit)
-{
-  return ( (digit >= 0x30 && digit <= 0x39) /* 0-9 */
-        || (digit >= 0x41 && digit <= 0x46) /* A-F */
-        || (digit >= 0x61 && digit <= 0x66) /* a-f */) ? TRUE : FALSE;
-}
 
 void Curl_httpchunk_init(struct connectdata *conn)
 {

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -12,13 +12,15 @@
 CURLX_CFILES = \
 	../lib/strtoofft.c \
 	../lib/nonblock.c \
-	../lib/warnless.c
+	../lib/warnless.c \
+        ../lib/curl_ctype.c
 
 CURLX_HFILES = \
 	../lib/curl_setup.h \
 	../lib/strtoofft.h \
 	../lib/nonblock.h \
-	../lib/warnless.h
+	../lib/warnless.h \
+        ../lib/curl_ctype.h
 
 CURL_CFILES = \
 	slist_wc.c \

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -4,13 +4,15 @@ CURLX_SRCS = \
  ../../lib/mprintf.c \
  ../../lib/nonblock.c \
  ../../lib/strtoofft.c \
- ../../lib/warnless.c
+ ../../lib/warnless.c \
+ ../../lib/curl_ctype.c
 
 CURLX_HDRS = \
  ../../lib/curlx.h \
  ../../lib/nonblock.h \
  ../../lib/strtoofft.h \
- ../../lib/warnless.h
+ ../../lib/warnless.h \
+ ../../lib/curl_ctype.h
 
 USEFUL = \
  getpart.c \


### PR DESCRIPTION
... since the libc provided one are locale dependent in a way we don't
want.