### PR TITLE
Have linker generate proper PDB for windows build

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -68,7 +68,7 @@ LNKDLL     = link.exe /DLL
 LNKLIB     = link.exe /lib
 
 CFLAGS_PDB = /Zi
-LFLAGS_PDB = /incremental:no /opt:ref,icf
+LFLAGS_PDB = /incremental:no /opt:ref,icf /DEBUG
 
 CFLAGS_LIBCURL_STATIC  = /DCURL_STATICLIB
 


### PR DESCRIPTION
Link.exe requires /DEBUG to properly generate a full pdb file on release
builds.