### PR TITLE
getdate: return -1 for out of range

### DIFF
--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -561,14 +561,10 @@ time_t curl_getdate(const char *p, const time_t *now)
   int rc = parsedate(p, &parsed);
   (void)now; /* legacy argument from the past that we ignore */
 
-  switch(rc) {
-  case PARSEDATE_OK:
+  if(rc == PARSEDATE_OK) {
     if(parsed == -1)
       /* avoid returning -1 for a working scenario */
       parsed++;
-    /* fallthrough */
-  case PARSEDATE_LATER:
-  case PARSEDATE_SOONER:
     return parsed;
   }
   /* everything else is fail */


### PR DESCRIPTION
...as that's how the function is documented to work.

Reported-by: Michael Kaufmann
Bug found in an autobuild with 32 bit time_t