### PR TITLE
formdata: Add PNG to well-known list

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -180,6 +180,7 @@ static const char *ContentTypeForFilename(const char *filename,
     {".gif",  "image/gif"},
     {".jpg",  "image/jpeg"},
     {".jpeg", "image/jpeg"},
+    {".png", "image/png"},
     {".txt",  "text/plain"},
     {".html", "text/html"},
     {".xml", "application/xml"}


### PR DESCRIPTION
First of all, thanks for `curl`. It's one of the most invaluable tools on my system 🙂 

I noticed recently that `curl`, by default, sends PNGs as `application/octet-stream`s unless told to do so otherwise by `-H`.

Seeing how `curl` contains special cases for GIFs and JPEGs due to their ubiquity, I figure that it makes sense to add a similar case for PNGs (which are just as popular, if not more). I think this single line is the only change necessary, but please let me know if there's anything else I need to modify/update.

Thank you!