### PR TITLE
formdata: use the mime-content type function

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -573,9 +573,10 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
          !form->contenttype) {
         char *f = form->flags & HTTPPOST_BUFFER?
           form->showfilename : form->value;
-        char const *type = prevtype;
+        char const *type;
+        type = Curl_mime_contenttype(f);
         if(!type)
-          type = Curl_mime_contenttype(f);
+          type = prevtype;
         if(!type)
           type = FILE_CONTENTTYPE_DEFAULT;
 

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -51,10 +51,6 @@
 #endif
 
 
-#define FILE_CONTENTTYPE_DEFAULT        "application/octet-stream"
-#define MULTIPART_CONTENTTYPE_DEFAULT   "multipart/mixed"
-#define DISPOSITION_DEFAULT             "attachment"
-
 #define READ_ERROR                      ((size_t) -1)
 
 /* Encoders. */
@@ -1642,8 +1638,7 @@ static CURLcode add_content_type(struct curl_slist **slp,
                               boundary? boundary: "");
 }
 
-
-static const char *ContentTypeForFilename(const char *filename)
+const char *Curl_mime_contenttype(const char *filename)
 {
   unsigned int i;
 
@@ -1715,14 +1710,14 @@ CURLcode Curl_mime_prepare_headers(curl_mimepart *part,
       contenttype = MULTIPART_CONTENTTYPE_DEFAULT;
       break;
     case MIMEKIND_FILE:
-      contenttype = ContentTypeForFilename(part->filename);
+      contenttype = Curl_mime_contenttype(part->filename);
       if(!contenttype)
-        contenttype = ContentTypeForFilename(part->data);
+        contenttype = Curl_mime_contenttype(part->data);
       if(!contenttype && part->filename)
         contenttype = FILE_CONTENTTYPE_DEFAULT;
       break;
     default:
-      contenttype = ContentTypeForFilename(part->filename);
+      contenttype = Curl_mime_contenttype(part->filename);
       break;
     }
   }

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -30,6 +30,10 @@
 #define MIME_USERHEADERS_OWNER  (1 << 0)
 #define MIME_BODY_ONLY          (1 << 1)
 
+#define FILE_CONTENTTYPE_DEFAULT        "application/octet-stream"
+#define MULTIPART_CONTENTTYPE_DEFAULT   "multipart/mixed"
+#define DISPOSITION_DEFAULT             "attachment"
+
 /* Part source kinds. */
 enum mimekind {
   MIMEKIND_NONE = 0,            /* Part not set. */
@@ -134,5 +138,6 @@ size_t Curl_mime_read(char *buffer, size_t size, size_t nitems,
                       void *instream);
 CURLcode Curl_mime_rewind(curl_mimepart *part);
 CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...);
+const char *Curl_mime_contenttype(const char *filename);
 
 #endif /* HEADER_CURL_MIME_H */


### PR DESCRIPTION
Reduce code duplication by making Curl_mime_contenttype available and
used by the formdata function. This also makes the formdata function
recognize a set of more file extensions by default.

PR #2280 brought this to my attention.