### PR TITLE
Added note about the --compressed flag

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -147,9 +147,15 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   if(is_tty && (outs->bytes < 2000) && !config->terminal_binary_ok) {
     /* binary output to terminal? */
     if(memchr(buffer, 0, bytes)) {
-      warnf(config->global, "Binary output can mess up your terminal. "
+      warnf(config->global,
+            "Binary output detected; this can mess up your terminal. "
             "Use \"--output -\" to tell curl to output it to your terminal "
-            "anyway, or consider \"--output <FILE>\" to save to a file.\n");
+            "anyway, or consider \"--output <FILE>\" to save to a file."
+#ifdef HAVE_ZLIB_H
+            " If the response is compressed using gzip or deflate, you can "
+            "also use the --compressed flag to enable automatic decompression."
+#endif
+            "\n");
       config->synthetic_error = ERR_BINARY_TERMINAL;
       return failure;
     }


### PR DESCRIPTION
When attempting to output binary data to the standard output, chances are that the data is actually compressed. This change makes the user aware of the fact that they can use the `--compressed` flag in this case.

See #2062

----

My particular use case: copying a web request from a browser (Chrome/Firefox) using the "copy as cURL" option. The original web request included the `Accept-Encoding` header => the browser would give me compressed content. This change helps me, and others, remember how to use the `--compressed` option to decompress the content for us.

Possible future enhancements could be to detect the presence of encoded content (for example by sniffing the Content-Encoding response header), but this is a somewhat simpler approach for now.

----

How I've verified this locally:

    ./src/curl https://www.google.se -v -H 'Accept-Encoding: deflate, gzip'`

I also ran the test suite locally (`make test`) with this change in place, and it seemed to run fine. (no failures, 258 skipped because of my local configuration.)
