### PR TITLE
content_encoding: Skip checking support for "none" encoding

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -726,7 +726,7 @@ static void identity_close_writer(struct connectdata *conn,
 
 static const content_encoding identity_encoding = {
   "identity",
-  NULL,
+  "none",
   identity_init_writer,
   identity_unencode_write,
   identity_close_writer,


### PR DESCRIPTION
 Some servers return a "content-encoding" header with a "none" value.

 libcurl does not recognise "none" as a special value, which can cause
 unrecognised content encoding type errors.

 This patch fixes that issue.