### PR TITLE
smtp: fix processing of initial dot in data

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1289,6 +1289,11 @@ static CURLcode smtp_perform(struct connectdata *conn, bool *connected,
   /* Store the first recipient (or NULL if not specified) */
   smtp->rcpt = data->set.mail_rcpt;
 
+  /* Initial data character is the first character in line: it is implicitly
+     preceded by a virtual CRLF. */
+  smtp->trailing_crlf = TRUE;
+  smtp->eob = 2;
+
   /* Start the first command in the DO phase */
   if((data->set.upload || data->set.mimepost.kind) && data->set.mail_rcpt)
     /* MAIL transfer */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -103,7 +103,7 @@ test909 test910 test911 test912 test913 test914 test915 test916 test917 \
 test918 test919 test920 test921 test922 test923 test924 test925 test926 \
 test927 test928 test929 test930 test931 test932 test933 test934 test935 \
 test936 test937 test938 test939 test940 test941 test942 test943 test944 \
-test945 test946 test947 test948 test949 test950 \
+test945 test946 test947 test948 test949 test950 test951 test952 \
 \
 test1000 test1001 test1002 test1003 test1004 test1005 test1006 test1007 \
 test1008 test1009 test1010 test1011 test1012 test1013 test1014 test1015 \

--- a/tests/data/test951
+++ b/tests/data/test951
@@ -17,15 +17,13 @@ SMTP
 smtp
 </server>
  <name>
-SMTP with no mail data
+SMTP data with dot as first character
  </name>
-
-<stdin nonewline="yes">
-
+<stdin>
+.This first line starts with a dot
 </stdin>
-
- <command>
-smtp://%HOSTIP:%SMTPPORT/911 --mail-rcpt recipient@example.com --mail-from sender@example.com -T -
+<command>
+smtp://%HOSTIP:%SMTPPORT/951 --mail-rcpt recipient@example.com --mail-from sender@example.com -T -
 </command>
 </client>
 
@@ -33,13 +31,14 @@ smtp://%HOSTIP:%SMTPPORT/911 --mail-rcpt recipient@example.com --mail-from sende
 # Verify data after the test has been "shot"
 <verify>
 <protocol>
-EHLO 911
+EHLO 951
 MAIL FROM:<sender@example.com>
 RCPT TO:<recipient@example.com>
 DATA
 QUIT
 </protocol>
 <upload>
+..This first line starts with a dot
 .
 </upload>
 </verify>

--- a/tests/data/test952
+++ b/tests/data/test952
@@ -17,15 +17,13 @@ SMTP
 smtp
 </server>
  <name>
-SMTP with no mail data
+SMTP data with single dot-only line
  </name>
-
-<stdin nonewline="yes">
-
+<stdin>
+.
 </stdin>
-
- <command>
-smtp://%HOSTIP:%SMTPPORT/911 --mail-rcpt recipient@example.com --mail-from sender@example.com -T -
+<command>
+smtp://%HOSTIP:%SMTPPORT/952 --mail-rcpt recipient@example.com --mail-from sender@example.com -T -
 </command>
 </client>
 
@@ -33,13 +31,14 @@ smtp://%HOSTIP:%SMTPPORT/911 --mail-rcpt recipient@example.com --mail-from sende
 # Verify data after the test has been "shot"
 <verify>
 <protocol>
-EHLO 911
+EHLO 952
 MAIL FROM:<sender@example.com>
 RCPT TO:<recipient@example.com>
 DATA
 QUIT
 </protocol>
 <upload>
+..
 .
 </upload>
 </verify>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2014, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -920,7 +920,7 @@ sub DATA_smtp {
                 print FILE $line if(!$nosave);
 
                 $raw .= $line;
-                if($raw =~ /\x0d\x0a\x2e\x0d\x0a/) {
+                if($raw =~ /(?:^|\x0d\x0a)\x2e\x0d\x0a/) {
                     # end of data marker!
                     $eob = 1;
                 }


### PR DESCRIPTION
This fixes a long standing bug in SMTP.
Even test 911 was inaccurate. Test server did not handle the case.