### PR TITLE
tlsauthtype.d: works only if libcurl is built with TLS-SRP support

### DIFF
--- a/docs/cmdline-opts/tlsauthtype.d
+++ b/docs/cmdline-opts/tlsauthtype.d
@@ -5,4 +5,6 @@ Added: 7.21.4
 ---
 Set TLS authentication type. Currently, the only supported option is "SRP",
 for TLS-SRP (RFC 5054). If --tlsuser and --tlspassword are specified but
---tlsauthtype is not, then this option defaults to "SRP".
+--tlsauthtype is not, then this option defaults to "SRP".  This option works
+only if the underlying libcurl is built with TLS-SRP support, which requires
+OpenSSL or GnuTLS with TLS-SRP support.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/1542256