### PR TITLE
tests: new tests for http raw mode

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -55,8 +55,8 @@ test280 test281 test282 test283 test284 test285 test286 test287 test288 \
 test289 test290 test291 test292 test293 test294 test295 test296 test297 \
 test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
-test316 test317 test318         test320 test321 test322 test323 test324 \
-test325 \
+test316 test317 test318 test319 test320 test321 test322 test323 test324 \
+test325 test326 \
 test350 test351 test352 test353 test354 \
 test393 test394 test395 \
 \

--- a/tests/data/test319
+++ b/tests/data/test319
@@ -1,0 +1,57 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+compressed
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data base64="yes">
+SFRUUC8xLjEgMjAwIE9LDQpEYXRlOiBNb24sIDI5IE5vdiAyMDA0IDIxOjU2OjUzIEdNVA0KU2Vy
+dmVyOiBBcGFjaGUvMS4zLjMxIChEZWJpYW4gR05VL0xpbnV4KSBtb2RfZ3ppcC8xLjMuMjYuMWEg
+UEhQLzQuMy45LTEgbW9kX3NzbC8yLjguMjAgT3BlblNTTC8wLjkuN2QgbW9kX3BlcmwvMS4yOQ0K
+Q29udGVudC1UeXBlOiB0ZXh0L2h0bWw7IGNoYXJzZXQ9SVNPLTg4NTktMQ0KVHJhbnNmZXItRW5j
+b2Rpbmc6IGd6aXANCkNvbnRlbnQtTGVuZ3RoOiA0NA0KDQofiwgIeZ6rQQADbGFsYWxhAMvJzEtV
+MORSyAHRRlwKEIYxFwAKAnFgGAAAAA==
+</data>
+
+<datacheck base64="yes">
+H4sICHmeq0EAA2xhbGFsYQDLycxLVTDkUsgB0UZcChCGMRcACgJxYBgAAAA=
+</datacheck>
+
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+libz
+</features>
+<server>
+http
+</server>
+ <name>
+HTTP GET gzip transfer-encoded data in raw mode
+ </name>
+ <command option="no-include">
+http://%HOSTIP:%HTTPPORT/319 --raw
+ </command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /319 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test326
+++ b/tests/data/test326
@@ -1,0 +1,66 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Mon, 29 Nov 2004 21:56:53 GMT
+Server: Apache/1.3.31 (Debian GNU/Linux) mod_gzip/1.3.26.1a PHP/4.3.9-1 mod_ssl/2.8.20 OpenSSL/0.9.7d mod_perl/1.29
+Content-Type: text/html; charset=ISO-8859-1
+Transfer-Encoding: chunked
+
+18
+line 1
+ line 2
+  line 3
+
+0
+
+</data>
+
+<datacheck>
+18
+line 1
+ line 2
+  line 3
+
+0
+
+</datacheck>
+
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP GET chunked data in raw mode
+ </name>
+ <command option="no-include">
+http://%HOSTIP:%HTTPPORT/326 --raw
+ </command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /326 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Test 319 checks proper raw mode data with non-chunked gzip
transfer-encoded server data.
Test 326 checks raw mode with chunked server data.