### PR TITLE
ssl: Set engine implicitly when a PKCS#11 URI is provided

### DIFF
--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -23,6 +23,13 @@ nickname contains ":", it needs to be preceded by "\\" so that it is not
 recognized as password delimiter.  If the nickname contains "\\", it needs to
 be escaped as "\\\\" so that it is not recognized as an escape character.
 
+If curl is built against OpenSSL library, and the engine pkcs11 is available,
+then a PKCS#11 URI (RFC 7512) can be used to specify a certificate located in
+a PKCS#11 device. A string beginning with "pkcs11:" will be interpreted as a
+PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine option will be set
+as "pkcs11" if none was provided and the --cert-type option will be set as
+"ENG" if none was provided.
+
 (iOS and macOS only) If curl is built against Secure Transport, then the
 certificate string can either be the name of a certificate/private key in the
 system or user keychain, or the path to a PKCS#12-encoded certificate and

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -7,4 +7,11 @@ Private key file name. Allows you to provide your private key in this separate
 file. For SSH, if not specified, curl tries the following candidates in order:
 '~/.ssh/id_rsa', '~/.ssh/id_dsa', './id_rsa', './id_dsa'.
 
+If curl is built against OpenSSL library, and the engine pkcs11 is available,
+then a PKCS#11 URI (RFC 7512) can be used to specify a private key located in a
+PKCS#11 device. A string beginning with "pkcs11:" will be interpreted as a
+PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine option will be set
+as "pkcs11" if none was provided and the --key-type option will be set as
+"ENG" if none was provided.
+
 If this option is used several times, the last one will be used.

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -532,6 +532,20 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
   }
   return (UI_method_get_writer(UI_OpenSSL()))(ui, uis);
 }
+
+/*
+ * Check if a given string is a PKCS#11 URI
+ */
+static bool is_pkcs11_uri(const char *string)
+{
+  if(!strncmp(string, "pkcs11:", 7)) {
+    return TRUE;
+  }
+  else {
+    return FALSE;
+  }
+}
+
 #endif
 
 static CURLcode Curl_ossl_set_engine(struct Curl_easy *data,
@@ -602,7 +616,7 @@ int cert_stuff(struct connectdata *conn,
         /* Implicitly use pkcs11 engine if none was provided and the
          * cert_file is a PKCS#11 URI */
         if(!data->state.engine) {
-          if(!strncmp(cert_file, "pkcs11:", 7)) {
+          if(is_pkcs11_uri(cert_file)) {
             if(Curl_ossl_set_engine(data, "pkcs11") != CURLE_OK) {
               return 0;
             }
@@ -779,7 +793,7 @@ int cert_stuff(struct connectdata *conn,
         /* Implicitly use pkcs11 engine if none was provided and the
          * key_file is a PKCS#11 URI */
         if(!data->state.engine) {
-          if(!strncmp(key_file, "pkcs11:", 7)) {
+          if(is_pkcs11_uri(key_file)) {
             if(Curl_ossl_set_engine(data, "pkcs11") != CURLE_OK) {
               return 0;
             }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -538,7 +538,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
  */
 static bool is_pkcs11_uri(const char *string)
 {
-  if(!strncmp(string, "pkcs11:", 7)) {
+  if(strncasecompare(string, "pkcs11:", 7)) {
     return TRUE;
   }
   else {

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -337,7 +337,7 @@ void parse_cert_parameter(const char *cert_parameter,
    * looks like a RFC7512 PKCS#11 URI which can be used as-is.
    * Also if cert_parameter contains no colon nor backslash, this
    * means no passphrase was given and no characters escaped */
-  if(!strncmp(cert_parameter, "pkcs11:", 7) ||
+  if(curl_strnequal(cert_parameter, "pkcs11:", 7) ||
      !strpbrk(cert_parameter, ":\\")) {
     *certname = strdup(cert_parameter);
     return;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1057,6 +1057,46 @@ static CURLcode operate_do(struct GlobalConfig *global,
           my_setopt_str(curl, CURLOPT_PINNEDPUBLICKEY, config->pinnedpubkey);
 
         if(curlinfo->features & CURL_VERSION_SSL) {
+          /* Check if config->cert is a PKCS#11 URI and set the
+           * config->cert_type if necessary */
+          if(config->cert) {
+            if(!strncmp(config->cert, "pkcs11:", 7)) {
+              if(!config->cert_type) {
+                config->cert_type = strdup("ENG");
+              }
+            }
+          }
+
+          /* Check if config->key is a PKCS#11 URI and set the
+           * config->key_type if necessary */
+          if(config->key) {
+            if(!strncmp(config->key, "pkcs11:", 7)) {
+              if(!config->key_type) {
+                config->key_type = strdup("ENG");
+              }
+            }
+          }
+
+          /* Check if config->proxy_cert is a PKCS#11 URI and set the
+           * config->proxy_type if necessary */
+          if(config->proxy_cert) {
+            if(!strncmp(config->proxy_cert, "pkcs11:", 7)) {
+              if(!config->proxy_cert_type) {
+                config->proxy_cert_type = strdup("ENG");
+              }
+            }
+          }
+
+          /* Check if config->proxy_key is a PKCS#11 URI and set the
+           * config->proxy_key_type if necessary */
+          if(config->proxy_key) {
+            if(!strncmp(config->proxy_key, "pkcs11:", 7)) {
+              if(!config->proxy_key_type) {
+                config->proxy_key_type = strdup("ENG");
+              }
+            }
+          }
+
           my_setopt_str(curl, CURLOPT_SSLCERT, config->cert);
           my_setopt_str(curl, CURLOPT_PROXY_SSLCERT, config->proxy_cert);
           my_setopt_str(curl, CURLOPT_SSLCERTTYPE, config->cert_type);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -118,7 +118,7 @@ static bool is_fatal_error(CURLcode code)
  */
 static bool is_pkcs11_uri(const char *string)
 {
-  if(!strncmp(string, "pkcs11:", 7)) {
+  if(curl_strnequal(string, "pkcs11:", 7)) {
     return TRUE;
   }
   else {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -113,6 +113,19 @@ static bool is_fatal_error(CURLcode code)
   return FALSE;
 }
 
+/*
+ * Check if a given string is a PKCS#11 URI
+ */
+static bool is_pkcs11_uri(const char *string)
+{
+  if(!strncmp(string, "pkcs11:", 7)) {
+    return TRUE;
+  }
+  else {
+    return FALSE;
+  }
+}
+
 #ifdef __VMS
 /*
  * get_vms_file_size does what it takes to get the real size of the file
@@ -1060,8 +1073,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           /* Check if config->cert is a PKCS#11 URI and set the
            * config->cert_type if necessary */
           if(config->cert) {
-            if(!strncmp(config->cert, "pkcs11:", 7)) {
-              if(!config->cert_type) {
+            if(!config->cert_type) {
+              if(is_pkcs11_uri(config->cert)) {
                 config->cert_type = strdup("ENG");
               }
             }
@@ -1070,8 +1083,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           /* Check if config->key is a PKCS#11 URI and set the
            * config->key_type if necessary */
           if(config->key) {
-            if(!strncmp(config->key, "pkcs11:", 7)) {
-              if(!config->key_type) {
+            if(!config->key_type) {
+              if(is_pkcs11_uri(config->key)) {
                 config->key_type = strdup("ENG");
               }
             }
@@ -1080,8 +1093,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           /* Check if config->proxy_cert is a PKCS#11 URI and set the
            * config->proxy_type if necessary */
           if(config->proxy_cert) {
-            if(!strncmp(config->proxy_cert, "pkcs11:", 7)) {
-              if(!config->proxy_cert_type) {
+            if(!config->proxy_cert_type) {
+              if(is_pkcs11_uri(config->proxy_cert)) {
                 config->proxy_cert_type = strdup("ENG");
               }
             }
@@ -1090,8 +1103,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           /* Check if config->proxy_key is a PKCS#11 URI and set the
            * config->proxy_key_type if necessary */
           if(config->proxy_key) {
-            if(!strncmp(config->proxy_key, "pkcs11:", 7)) {
-              if(!config->proxy_key_type) {
+            if(!config->proxy_key_type) {
+              if(is_pkcs11_uri(config->proxy_key)) {
                 config->proxy_key_type = strdup("ENG");
               }
             }

--- a/tests/unit/unit1394.c
+++ b/tests/unit/unit1394.c
@@ -56,6 +56,9 @@ UNITTEST_START
     "foo:bar\\\\",            "foo",                "bar\\\\",
     "foo:bar:",               "foo",                "bar:",
     "foo\\::bar\\:",          "foo:",               "bar\\:",
+    "pkcs11:foobar",          "pkcs11:foobar",      NULL,
+    "PKCS11:foobar",          "PKCS11:foobar",      NULL,
+    "PkCs11:foobar",          "PkCs11:foobar",      NULL,
 #ifdef WIN32
     "c:\\foo:bar:baz",        "c:\\foo",            "bar:baz",
     "c:\\foo\\:bar:baz",      "c:\\foo:bar",        "baz",


### PR DESCRIPTION
This allows the use of PKCS#11 URI (RFC 7512) for certificates and keys without setting the corresponding type as "ENG" explicitly. If a PKCS#11 URI is provided for certificate, key, proxy_certificate, or proxy_key, the corresponding type is set as "ENG" when not provided explicitly.

If OpenSSL is used as the cryptographic library and a PKCS#11 URI is provided, the engine is set to "pkcs11" when not provided explicitly. This uses the engine_pkcs11 engine (https://github.com/OpenSC/libp11).

A test script can be found here:
https://github.com/ansasaki/toolbox/blob/master/curl-with-p11.sh

The test uses GnuTLS as the test server and SoftHSM as the PKCS#11 device.

This is related with #974 