### PR TITLE
build: make sure CFLAGS (including -werror) be used for examples and …

### DIFF
--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -52,6 +52,9 @@ LDADD = $(LIBDIR)/libcurl.la @LIBCURL_LIBS@
 else
 LDADD = $(LIBDIR)/libcurl.la
 endif
+
+# This might hold -Werror
+CFLAGS += @CURL_CFLAG_EXTRAS@
 
 # Makefile.inc provides the check_PROGRAMS and COMPLICATED_EXAMPLES defines
 include Makefile.inc

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -48,6 +48,8 @@ EXTRA_DIST = test75.pl test307.pl test610.pl test613.pl test1013.pl	\
 test1022.pl Makefile.inc notexists.pl CMakeLists.txt mk-lib1521.pl
 
 CFLAG_CURL_SYMBOL_HIDING = @CFLAG_CURL_SYMBOL_HIDING@
+
+CFLAGS += @CURL_CFLAG_EXTRAS@
 
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)

--- a/tests/libtest/lib655.c
+++ b/tests/libtest/lib655.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,7 +23,7 @@
 
 #include "memdebug.h"
 
-static const char TEST_DATA_STRING[] = "Test data";
+static const char *TEST_DATA_STRING = "Test data";
 static int cb_count = 0;
 
 static int

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -49,6 +49,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 endif
 
 EXTRA_DIST = Makefile.inc CMakeLists.txt
+
+CFLAGS += @CURL_CFLAG_EXTRAS@
 
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -28,7 +28,7 @@
 #include "memdebug.h" /* LAST include file */
 
 static struct Curl_easy *easy;
-struct curl_hash *hostcache;
+static struct curl_hash *hostcache;
 
 static CURLcode unit_setup(void)
 {


### PR DESCRIPTION
…tests

... so that the CI and more detects compiler warnings/errors properly!