### PR TITLE
unit1309: fix warning on Windows x64

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -60,15 +60,6 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-#ifndef GNUTLS_POINTER_TO_SOCKET_CAST
-#define GNUTLS_POINTER_TO_SOCKET_CAST(p) \
-  ((curl_socket_t) ((char *)(p) - (char *)NULL))
-#endif
-#ifndef GNUTLS_SOCKET_TO_POINTER_CAST
-#define GNUTLS_SOCKET_TO_POINTER_CAST(s) \
-  ((void *) ((char *)NULL + (s)))
-#endif
-
 /* Enable GnuTLS debugging by defining GTLSDEBUG */
 /*#define GTLSDEBUG */
 
@@ -161,7 +152,7 @@ static int gtls_mapped_sockerrno(void)
 
 static ssize_t Curl_gtls_push(void *s, const void *buf, size_t len)
 {
-  ssize_t ret = swrite(GNUTLS_POINTER_TO_SOCKET_CAST(s), buf, len);
+  ssize_t ret = swrite(CURLX_POINTER_TO_INTEGER_CAST(s), buf, len);
 #if defined(USE_WINSOCK) && !defined(GNUTLS_MAPS_WINSOCK_ERRORS)
   if(ret < 0)
     gnutls_transport_set_global_errno(gtls_mapped_sockerrno());
@@ -171,7 +162,7 @@ static ssize_t Curl_gtls_push(void *s, const void *buf, size_t len)
 
 static ssize_t Curl_gtls_pull(void *s, void *buf, size_t len)
 {
-  ssize_t ret = sread(GNUTLS_POINTER_TO_SOCKET_CAST(s), buf, len);
+  ssize_t ret = sread(CURLX_POINTER_TO_INTEGER_CAST(s), buf, len);
 #if defined(USE_WINSOCK) && !defined(GNUTLS_MAPS_WINSOCK_ERRORS)
   if(ret < 0)
     gnutls_transport_set_global_errno(gtls_mapped_sockerrno());
@@ -857,7 +848,7 @@ gtls_connect_step1(struct connectdata *conn,
   }
   else {
     /* file descriptor for the socket */
-    transport_ptr = GNUTLS_SOCKET_TO_POINTER_CAST(conn->sock[sockindex]);
+    transport_ptr = CURLX_INTEGER_TO_POINTER_CAST(conn->sock[sockindex]);
     gnutls_transport_push = Curl_gtls_push;
     gnutls_transport_pull = Curl_gtls_pull;
   }

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -26,6 +26,11 @@
 #include <curl/curl.h> /* for curl_socket_t */
 #endif
 
+#define CURLX_POINTER_TO_INTEGER_CAST(p) \
+  ((char *)(p) - (char *)NULL)
+#define CURLX_INTEGER_TO_POINTER_CAST(i) \
+  ((void *)((char *)NULL + (i)))
+
 unsigned short curlx_ultous(unsigned long ulnum);
 
 unsigned char curlx_ultouc(unsigned long ulnum);

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -22,6 +22,7 @@
 #include "curlcheck.h"
 
 #include "splay.h"
+#include "warnless.h"
 
 
 static CURLcode unit_setup(void)
@@ -86,7 +87,8 @@ UNITTEST_START
     key.tv_usec = (541*i)%1023;
     payload = (size_t) key.tv_usec;
 
-    nodes[i].payload = (void *)payload; /* for simplicity */
+    /* for simplicity */
+    nodes[i].payload = CURLX_INTEGER_TO_POINTER_CAST(payload);
     root = Curl_splayinsert(key, root, &nodes[i]);
   }
 
@@ -98,7 +100,7 @@ UNITTEST_START
     printf("Tree look:\n");
     splayprint(root, 0, 1);
     printf("remove pointer %d, payload %ld\n", rem,
-           (long)(nodes[rem].payload));
+           CURLX_POINTER_TO_INTEGER_CAST(nodes[rem].payload));
     rc = Curl_splayremovebyaddr(root, &nodes[rem], &root);
     if(rc) {
       /* failed! */
@@ -119,7 +121,8 @@ UNITTEST_START
     /* add some nodes with the same key */
     for(j = 0; j <= i % 3; j++) {
       size_t payload = key.tv_usec*10 + j;
-      nodes[i * 3 + j].payload = (void *)payload; /* for simplicity */
+      /* for simplicity */
+      nodes[i * 3 + j].payload = CURLX_INTEGER_TO_POINTER_CAST(payload);
       root = Curl_splayinsert(key, root, &nodes[i * 3 + j]);
     }
   }
@@ -130,8 +133,9 @@ UNITTEST_START
     tv_now.tv_usec = i;
     root = Curl_splaygetbest(tv_now, root, &removed);
     while(removed != NULL) {
-      printf("removed payload %ld[%ld]\n", (long)(removed->payload) / 10,
-             (long)(removed->payload) % 10);
+      printf("removed payload %ld[%ld]\n",
+             CURLX_POINTER_TO_INTEGER_CAST(removed->payload) / 10,
+             CURLX_POINTER_TO_INTEGER_CAST(removed->payload) % 10);
       root = Curl_splaygetbest(tv_now, root, &removed);
     }
   }


### PR DESCRIPTION
When targeting x64, MinGW-w64 complains about conversions between
32-bit long and 64-bit pointers. Fix this by reusing the
`GNUTLS_POINTER_TO_SOCKET_CAST` / `GNUTLS_SOCKET_TO_POINTER_CAST` logic
from gtls.c, moving it to warnless.h as `CURLX_POINTER_TO_INTEGER_CAST` /
`CURLX_INTEGER_TO_POINTER_CAST`.