### PR TITLE
Prefer documented zlib library names

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -181,8 +181,12 @@ CARES          = static
 CARES_CFLAGS   = /DUSE_ARES /I"$(DEVEL_INCLUDE)/cares"
 !ENDIF
 
+# Depending on how zlib is built the libraries have different names, we 
+# try to handle them all. 
 !IF "$(WITH_ZLIB)"=="dll"
-!IF EXISTS("$(DEVEL_LIB)\zdll.lib")
+!IF EXISTS("$(DEVEL_LIB)\zlibwapi.lib")
+ZLIB_LIBS = zlibwapi.lib
+!ELSEIF EXISTS("$(DEVEL_LIB)\zdll.lib")
 ZLIB_LIBS   = zdll.lib
 !ELSE
 ZLIB_LIBS   = zlib.lib
@@ -190,7 +194,9 @@ ZLIB_LIBS   = zlib.lib
 USE_ZLIB    = true
 ZLIB        = dll
 !ELSEIF "$(WITH_ZLIB)"=="static"
-!IF EXISTS("$(DEVEL_LIB)\zlib.lib")
+!IF EXISTS("$(DEVEL_LIB)\zlibstat.lib")
+ZLIB_LIBS   = zlibstat.lib
+!ELSEIF EXISTS("$(DEVEL_LIB)\zlib.lib")
 ZLIB_LIBS   = zlib.lib
 !ELSE
 ZLIB_LIBS   = zlib_a.lib

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -182,11 +182,19 @@ CARES_CFLAGS   = /DUSE_ARES /I"$(DEVEL_INCLUDE)/cares"
 !ENDIF
 
 !IF "$(WITH_ZLIB)"=="dll"
+!IF EXISTS("$(DEVEL_LIB)\zdll.lib")
+ZLIB_LIBS   = zdll.lib
+!ELSE
 ZLIB_LIBS   = zlib.lib
+!ENDIF
 USE_ZLIB    = true
 ZLIB        = dll
 !ELSEIF "$(WITH_ZLIB)"=="static"
+!IF EXISTS("$(DEVEL_LIB)\zlib.lib")
+ZLIB_LIBS   = zlib.lib
+!ELSE
 ZLIB_LIBS   = zlib_a.lib
+!ENDIF
 USE_ZLIB    = true
 ZLIB        = static
 !ENDIF


### PR DESCRIPTION
As promised on mailing list "Building on Windows: zlib library names in winbuild/MakeBuild.vc" this PR means can build on Windows with zlib without needing to modify zlib library names.

Check for existence of import and static libraries with documented names and use them if they do. Fallback to previous names.

According to https://github.com/madler/zlib/blob/master/win32/README-WIN32.txt on Windows, the names of the import library is "zdll.lib" and static library is "zlib.lib".