### PR TITLE
NO_PROXY: fix for IPv6 numericals in the URL

### DIFF
--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -43,6 +43,11 @@ use for both "www.example.com" as well as for "foo.example.com".
 
 Setting the noproxy string to "" (an empty string) will explicitly enable the
 proxy for all host names, even if there is an environment variable set for it.
+
+Enter IPv6 numerical addresses in the list of host names without enclosing
+brackets:
+
+ "example.com,::1,localhost"
 
 The application does not have to keep the string around after setting this
 option.

--- a/lib/url.c
+++ b/lib/url.c
@@ -2574,7 +2574,15 @@ static bool check_noproxy(const char *name, const char *no_proxy)
     /* NO_PROXY was specified and it wasn't just an asterisk */
 
     no_proxy_len = strlen(no_proxy);
-    endptr = strchr(name, ':');
+    if(name[0] == '[') {
+      /* IPv6 numerical address */
+      endptr = strchr(name, ']');
+      if(!endptr)
+        return FALSE;
+      name++;
+    }
+    else
+      endptr = strchr(name, ':');
     if(endptr)
       namelen = endptr - name;
     else

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -135,7 +135,7 @@ test1228 test1229 test1230 test1231 test1232 test1233 test1234 test1235 \
 test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 test1252 test1253 test1254 test1255 test1256 test1257 test1258 test1259 \
-test1260 test1261 test1262 test1263 test1264 \
+test1260 test1261 test1262 test1263 test1264 test1265 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 \

--- a/tests/data/test1265
+++ b/tests/data/test1265
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+NO_PROXY
+noproxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http-ipv6
+</server>
+<name>
+NO_PROXY with IPv6 numerical address
+</name>
+<setenv>
+http_proxy=http://%HOSTIP:%HTTPPORT
+NO_PROXY=::1
+</setenv>
+<command>
+http://%HOST6IP:%HTTP6PORT/1265
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1265 HTTP/1.1
+Host: %HOST6IP:%HTTP6PORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Reported-by: steelman on github
Fixes #2353