### PR TITLE
krb5: use nondeprecated functions

### DIFF
--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -85,7 +85,7 @@ krb5_decode(void *app_data, void *buf, int len,
 
   enc.value = buf;
   enc.length = len;
-  maj = gss_unseal(&min, *context, &enc, &dec, NULL, NULL);
+  maj = gss_unwrap(&min, *context, &enc, &dec, NULL, NULL);
   if(maj != GSS_S_COMPLETE) {
     if(len >= 4)
       strcpy(buf, "599 ");
@@ -119,11 +119,11 @@ krb5_encode(void *app_data, const void *from, int length, int level, void **to)
   int len;
 
   /* NOTE that the cast is safe, neither of the krb5, gnu gss and heimdal
-   * libraries modify the input buffer in gss_seal()
+   * libraries modify the input buffer in gss_wrap()
    */
   dec.value = (void *)from;
   dec.length = length;
-  maj = gss_seal(&min, *context,
+  maj = gss_wrap(&min, *context,
                  level == PROT_PRIVATE,
                  GSS_C_QOP_DEFAULT,
                  &dec, &state, &enc);


### PR DESCRIPTION
`gss_seal`/`gss_unseal` have been deprecated in favor of
`gss_wrap`/`gss_unwrap` with GSS-API v2 from January 1997 [1]. The first
version of "The Kerberos Version 5 GSS-API Mechanism" [2] from June
1996 already says "GSS_Wrap() (formerly GSS_Seal())" and
"GSS_Unwrap() (formerly GSS_Unseal())".

Use the nondeprecated functions to avoid deprecation warnings.

[1] https://tools.ietf.org/html/rfc2078
[2] https://tools.ietf.org/html/rfc1964