### PR TITLE
Add advapi32 as explicit link library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,7 @@ if(CMAKE_USE_WINSSL)
   set(SSL_ENABLED ON)
   set(USE_SCHANNEL ON) # Windows native SSL/TLS support
   set(USE_WINDOWS_SSPI ON) # CMAKE_USE_WINSSL implies CURL_WINDOWS_SSPI
-  list(APPEND CURL_LIBS "crypt32")
+  list(APPEND CURL_LIBS "crypt32" "advapi32")
 endif()
 if(CURL_WINDOWS_SSPI)
   set(USE_WINDOWS_SSPI ON)


### PR DESCRIPTION
advapi32 is required by some of libcurl's functions:

[`CryptReleaseContext`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa380268(v=vs.85).aspx):
```
lib/curl_ntlm_core.c=352=static bool encrypt_des(const unsigned char *in, unsigned char *out,
lib/curl_ntlm_core.c:384:    CryptReleaseContext(hprov, 0);
lib/curl_ntlm_core.c:395:  CryptReleaseContext(hprov, 0);
lib/curl_ntlm_core.c=555=CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
lib/curl_ntlm_core.c:616:      CryptReleaseContext(hprov, 0);
lib/md5.c=154=static void MD5_Final(unsigned char digest[16], MD5_CTX *ctx)
lib/md5.c:163:    CryptReleaseContext(ctx->hCryptProv, 0);
lib/vtls/schannel.c=1671=static CURLcode Curl_schannel_random(struct Curl_easy *data UNUSED_PARAM,
lib/vtls/schannel.c:1683:    CryptReleaseContext(hCryptProv, 0UL);
lib/vtls/schannel.c:1687:  CryptReleaseContext(hCryptProv, 0UL);
lib/vtls/schannel.c=1893=static void Curl_schannel_checksum(const unsigned char *input,
lib/vtls/schannel.c:1939:    CryptReleaseContext(hProv, 0);
src/tool_metalink.c=385=static void win32_crypto_final(struct win32_crypto_hash *ctx,
src/tool_metalink.c:396:    CryptReleaseContext(ctx->hCryptProv, 0);
```

[`CryptGetHashParam`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa379947(v=vs.85).aspx):
```
lib/curl_ntlm_core.c=555=CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
lib/curl_ntlm_core.c:613:        CryptGetHashParam(hhash, HP_HASHVAL, ntbuffer, &length, 0);
lib/md5.c=154=static void MD5_Final(unsigned char digest[16], MD5_CTX *ctx)
lib/md5.c:157:  CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0);
lib/md5.c:159:    CryptGetHashParam(ctx->hHash, HP_HASHVAL, digest, &length, 0);
lib/vtls/schannel.c=1893=static void Curl_schannel_checksum(const unsigned char *input,
lib/vtls/schannel.c:1923:    if(!CryptGetHashParam(hHash, HP_HASHSIZE, (BYTE *)&cbHashSize,
lib/vtls/schannel.c:1931:    if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0))
src/tool_metalink.c=385=static void win32_crypto_final(struct win32_crypto_hash *ctx,
src/tool_metalink.c:390:  CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0);
src/tool_metalink.c:392:    CryptGetHashParam(ctx->hHash, HP_HASHVAL, digest, &length, 0);
```

As well as `CryptCreateHash`, `CryptHashData`, `CryptDestroyHash`, `CryptGenRandom`