### PR TITLE
curl_multi_add_handle: clear errorbuffer if set

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
@@ -28,8 +28,8 @@ CURLOPT_ERRORBUFFER \- set error buffer for error messages
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ERRORBUFFER, char *buf);
 .SH DESCRIPTION
-Pass a char * to a buffer that the libcurl may store human readable error
-messages in on failures or problems. This may be more helpful than just the
+Pass a char * to a buffer that libcurl \fBmay\fP store human readable error
+messages on failures or problems. This may be more helpful than just the
 return code from \fIcurl_easy_perform(3)\fP and related functions. The buffer
 \fBmust be at least CURL_ERROR_SIZE bytes big\fP.
 
@@ -38,11 +38,13 @@ it. Failing to do so will cause very odd behavior or even crashes. libcurl
 will need it until you call \fIcurl_easy_cleanup(3)\fP or you set the same
 option again to use a different pointer.
 
+Do not rely on the contents of the buffer unless an error code was returned.
+Since 7.60.0 libcurl will initialize the contents of the error buffer to an
+empty string before performing the transfer. For earlier versions if an error
+code was returned but there was no error detail then the buffer is untouched.
+
 Consider \fICURLOPT_VERBOSE(3)\fP and \fICURLOPT_DEBUGFUNCTION(3)\fP to better
 debug and trace why errors happen.
-
-If the library does not return an error, the buffer may not have been
-touched. Do not rely on the contents in those cases.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -743,12 +743,12 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
   CURLcode result = CURLE_OK;
   SIGPIPE_VARIABLE(pipe_st);
 
+  if(!data)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+
   if(data->set.errorbuffer)
     /* clear this as early as possible */
     data->set.errorbuffer[0] = 0;
-
-  if(!data)
-    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   if(data->multi) {
     failf(data, "easy handle already used in multi handle");

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -743,6 +743,10 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
   CURLcode result = CURLE_OK;
   SIGPIPE_VARIABLE(pipe_st);
 
+  if(data->set.errorbuffer)
+    /* clear this as early as possible */
+    data->set.errorbuffer[0] = 0;
+
   if(!data)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -378,6 +378,8 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
    * potential multi's connection cache growing which won't be undone in this
    * function no matter what.
    */
+  if(data->set.errorbuffer)
+    data->set.errorbuffer[0] = 0;
 
   /* set the easy handle */
   multistate(data, CURLM_STATE_INIT);


### PR DESCRIPTION
To offer applications a more defined behavior.

Bug #2190