### PR TITLE
tests/.../spnego.py: fix identifier typo

### DIFF
--- a/tests/python_dependencies/impacket/spnego.py
+++ b/tests/python_dependencies/impacket/spnego.py
@@ -226,7 +226,7 @@ class SPNEGO_NegTokenResp:
                     raise Exception('OID tag not found %x' % next_byte)
                 decode_data2 = decode_data2[1:]
                 item, total_bytes2 = asn1decode(decode_data2)
-                self['SuportedMech'] = item
+                self['SupportedMech'] = item
 
                 decode_data = decode_data[1:]
                 decode_data = decode_data[total_bytes:]


### PR DESCRIPTION
Detected by Coverity Analysis:

```
Error: IDENTIFIER_TYPO:
curl-7.58.0/tests/python_dependencies/impacket/spnego.py:229: identifier_typo: Using "SuportedMech" appears to be a typo:
* Identifier "SuportedMech" is only known to be referenced here, or in copies of this code.
* Identifier "SupportedMech" is referenced elsewhere at least 4 times.
curl-7.58.0/tests/python_dependencies/impacket/smbserver.py:2651: identifier_use: Example 1: Using identifier "SupportedMech".
curl-7.58.0/tests/python_dependencies/impacket/smbserver.py:2308: identifier_use: Example 2: Using identifier "SupportedMech".
curl-7.58.0/tests/python_dependencies/impacket/spnego.py:252: identifier_use: Example 3: Using identifier "SupportedMech" (2 total uses in this function).
curl-7.58.0/tests/python_dependencies/impacket/spnego.py:229: remediation: Should identifier "SuportedMech" be replaced by "SupportedMech"?
```