### PR TITLE
transfer: make HTTP without headers count correct body size

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -717,7 +717,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
 #endif   /* CURL_DISABLE_HTTP */
 
       /* Account for body content stored in the header buffer */
-      if(k->badheader && !k->ignorebody) {
+      if((k->badheader == HEADER_PARTHEADER) && !k->ignorebody) {
         DEBUGF(infof(data, "Increasing bytecount by %zu from hbuflen\n",
                      k->hbuflen));
         k->bytecount += k->hbuflen;

--- a/tests/FILEFORMAT
+++ b/tests/FILEFORMAT
@@ -293,8 +293,8 @@ command is run. They are cleared again after the command has been run.
 Variables are first substituted as in the <command> section.
 </setenv>
 
-<command [option="no-output/no-include"] [timeout="secs"] [delay="secs"]
-         [type="perl"]>
+<command [option="no-output/no-include/force-output"] [timeout="secs"]
+         [delay="secs"][type="perl"]>
 command line to run, there's a bunch of %variables that get replaced
 accordingly.
 
@@ -316,6 +316,9 @@ there's no memory debugging and valgrind gets shut off for this test.
 Set option="no-output" to prevent the test script to slap on the --output
 argument that directs the output to a file. The --output is also not added if
 the verify/stdout section is used.
+
+Set option="force-output" to make use of --output even when the test is
+otherwise written to verify stdout.
 
 Set option="no-include" to prevent the test script to slap on the --include
 argument.

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -129,7 +129,7 @@ test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
 test1152 test1153 test1154 \
 \
-test1160 test1161 test1162 test1163 \
+test1160 test1161 test1162 test1163 test1164 \
 test1170 test1171 \
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \
 test1208 test1209 test1210 test1211 test1212 test1213 test1214 test1215 \

--- a/tests/data/test1164
+++ b/tests/data/test1164
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+# perl -e 'print "swsclose" . "\0" x 200;' | base64
+# 'swsclose' is there to force server to close after send
+<data nocheck="yes" base64="yes">
+c3dzY2xvc2UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP/0.9 GET and all zeroes
+ </name>
+ <command option="force-output">
+http://%HOSTIP:%HTTPPORT/1164 -w '%{size_download}\n'
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1164 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+<stdout>
+208
+</stdout>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3909,7 +3909,7 @@ sub singletest {
 
     if((!$cmdhash{'option'}) || ($cmdhash{'option'} !~ /no-output/)) {
         #We may slap on --output!
-        if (!@validstdout) {
+        if (!@validstdout || $cmdhash{'option'} =~ /force-output/) {
             $out=" --output $CURLOUT ";
         }
     }


### PR DESCRIPTION
This is what "HTTP/0.9" basically looks like.