### PR TITLE
multi: retry pending transfers less aggressively

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3071,17 +3071,19 @@ struct curl_llist *Curl_multi_pipelining_server_bl(struct Curl_multi *multi)
 static void process_pending_handles(struct Curl_multi *multi)
 {
   struct curl_llist_element *e = multi->pending.head;
-  struct Curl_easy *data = e->ptr;
+  if(e) {
+    struct Curl_easy *data = e->ptr;
 
-  DEBUGASSERT(data->mstate == CURLM_STATE_CONNECT_PEND);
+    DEBUGASSERT(data->mstate == CURLM_STATE_CONNECT_PEND);
 
-  multistate(data, CURLM_STATE_CONNECT);
+    multistate(data, CURLM_STATE_CONNECT);
 
-  /* Remove this node from the list */
-  Curl_llist_remove(&multi->pending, e, NULL);
+    /* Remove this node from the list */
+    Curl_llist_remove(&multi->pending, e, NULL);
 
-  /* Make sure that the handle will be processed soonish. */
-  Curl_expire(data, 0, EXPIRE_RUN_NOW);
+    /* Make sure that the handle will be processed soonish. */
+    Curl_expire(data, 0, EXPIRE_RUN_NOW);
+  }
 }
 
 void Curl_set_in_callback(struct Curl_easy *easy, bool value)

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -57,8 +57,6 @@ struct Curl_multi *Curl_multi_handle(int hashsize, int chashsize);
   */
 void Curl_multi_dump(struct Curl_multi *multi);
 #endif
-
-void Curl_multi_process_pending_handles(struct Curl_multi *multi);
 
 /* Return the value of the CURLMOPT_MAX_HOST_CONNECTIONS option */
 size_t Curl_multi_max_host_connections(struct Curl_multi *multi);


### PR DESCRIPTION
When a transfer is requested to get done and it is put in the pending
queue when limited by number of connections, total or per-host, libcurl
would previously very aggressively retry *ALL* pending transfers to get
them transferring. That was very time consuming.

By reducing the aggressiveness in how pending are being retried, we
waste MUCH less time on putting transfers back into pending again.

Reported-by: Cyril B
Fixes #2369