### PR TITLE
CMake: set postfix with CMAKE_DEBUG_POSTFIX

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -100,7 +100,7 @@ if(WIN32)
     set_target_properties(${LIB_NAME} PROPERTIES IMPORT_SUFFIX "_imp.lib")
 
     set_target_properties (${LIB_NAME} PROPERTIES
-       DEBUG_POSTFIX "-d"
+       DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}"
        # Note: no postfix for release variants, let user choose what style of release he wants
        # MINSIZEREL_POSTFIX "-z"
        # RELWITHDEBINFO_POSTFIX "-g"


### PR DESCRIPTION
This change makes DEBUG_POSTFIX handling consistent across all projects. It allows the user to set their own postfix via the CMake variable CMAKE_DEBUG_POSTFIX.