### PR TITLE
pause: when changing pause state, update socket state

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1099,6 +1099,10 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
       (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) )
     Curl_expire(data, 0, EXPIRE_RUN_NOW); /* get this handle going again */
 
+  /* This transfer may have been moved in or out of the bundle, update
+     the corresponding socket callback, if used */
+  Curl_updatesocket(data);
+
   return result;
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2421,6 +2421,12 @@ static void singlesocket(struct Curl_multi *multi,
   data->numsocks = num;
 }
 
+void Curl_updatesocket(struct Curl_easy *data)
+{
+  singlesocket(data->multi, data);
+}
+
+
 /*
  * Curl_multi_closed()
  *

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,6 +26,7 @@
  * Prototypes for library-wide functions provided by multi.c
  */
 
+void Curl_updatesocket(struct Curl_easy *data);
 void Curl_expire(struct Curl_easy *data, time_t milli, expire_id);
 void Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);


### PR DESCRIPTION
Especially unpausing a transfer might have to move the socket back to the
"currently used sockets" hash to get monitored. Otherwise it would never get
any more data and get stuck. Easily triggered with pausing using the
multi_socket API.

Reported-by: Philip Prindeville
Bug: https://curl.haxx.se/mail/lib-2018-03/0048.html