### PR TITLE
Add lgtm.yml for tweaking lgtm.com analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,10 @@
+extraction:
+  cpp:
+    prepare:
+      packages: # to avoid confusion with libopenafs-dev which also provides a des.h
+        - libssl-dev
+    after_prepare: # make sure lgtm.com doesn't use CMake (which generates and runs tests)
+      - rm -f CMakeLists.txt
+      - ./buildconf
+    configure: # enable as many optional features as possible
+      command: ./configure --enable-ares --with-libssh2 --with-gssapi --with-librtmp --with-libmetalink --with-libmetalink


### PR DESCRIPTION
When I set up Curl for C/C++ analysis on lgtm.com I had to slightly tweak the default build settings that were auto-detected by lgtm.com. This is the configuration that is currently in use; it's probably best to keep that in the Curl repository. 

Any changes to this file will automatically be picked up by lgtm.com. So if the build procedure changes in the future, then changing this file will be sufficient to change the behaviour of the lgtm.com analysis. More details on the ```lgtm.yml``` file format: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file

A few notes about what's in the file:
- lgtm.com automatically detects dependencies during the build process and uses 'apt-get install' to install these. The Curl build tries to read ```/usr/include/des.h```, which is provided by the 'libopenafs-dev' package. However, Curl actually depends on libssl-dev (which provides ```/usr/include/openssl/des.h```). The dependency auto-detection on lgtm.com will be fixed in a few weeks; in the meantime installing libssl-dev manually makes it works.
- Curl supports both CMake and regular 'make'. The CMake build generates and builds ```tests/libtest/lib1521.c``` (and other files), which I wanted to exclude from the analysis. The regular make build does not automatically generate and run tests. Removing ```CMakeLists.txt``` stops lgtm.com from trying to use CMake to build.
- Running ```./buildconf``` is required to build Curl, according to the documentation
- I've tried to include as many optional features in ```./configure```

(full disclosure: I'm part of the team behind lgtm.com)