### PR TITLE
timeval: fixed type truncation warning

### DIFF
--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -128,7 +128,7 @@ struct curltime Curl_now(void)
   struct curltime ret;
   (void)gettimeofday(&now, NULL);
   ret.tv_sec = now.tv_sec;
-  ret.tv_usec = now.tv_usec;
+  ret.tv_usec = (int)now.tv_usec;
   return ret;
 }
 


### PR DESCRIPTION
Fixed warning when `-Werror` used for compilation. Related to #2358

How to reproduce:

1. Generate build with `cmake .. -DCURL_WERROR=ON`
2. make curl

Error:

```
[  0%] Building C object lib/CMakeFiles/libcurl.dir/timeval.c.o
.../curl/lib/timeval.c: In function ‘Curl_now’:
.../curl/lib/timeval.c:131:20: error: conversion to ‘int’ from ‘__suseconds_t’ may alter its value [-Werror=conversion]
   ret.tv_usec = now.tv_usec;
                    ^
cc1: all warnings being treated as errors
make[2]: *** [lib/CMakeFiles/libcurl.dir/timeval.c.o] Error 1
make[1]: *** [lib/CMakeFiles/libcurl.dir/all] Error 2
make: *** [all] Error 2

```

