### PR TITLE
travis-ci: enable -Werror for CMake builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,7 +187,7 @@ script:
         if [ "$T" = "cmake" ]; then
              mkdir build
              cd build
-             cmake ..
+             cmake .. -DCURL_WERROR=ON
              make
         fi
     - |


### PR DESCRIPTION
Enforce warnings as error using -DCURL_WERROR=ON for Travis-CI builds

Exposes issue described in #2358
Depends on #2411, #2417