### PR TITLE
runtests.pl: fix warning 'use of uninitialized value'

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3909,7 +3909,8 @@ sub singletest {
 
     if((!$cmdhash{'option'}) || ($cmdhash{'option'} !~ /no-output/)) {
         #We may slap on --output!
-        if (!@validstdout || $cmdhash{'option'} =~ /force-output/) {
+        if (!@validstdout ||
+                ($cmdhash{'option'} && $cmdhash{'option'} =~ /force-output/)) {
             $out=" --output $CURLOUT ";
         }
     }


### PR DESCRIPTION
This fixes a warning that appeared in the autobuilds, e.g. https://curl.haxx.se/dev/log.cgi?id=20180325170037-30400#prob3