### PR TITLE
ftp: Allow PSV mode on IPv6 connections if a proxy is being used

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1788,7 +1788,7 @@ static CURLcode ftp_epsv_disable(struct connectdata *conn)
 {
   CURLcode result = CURLE_OK;
 
-  if(conn->bits.ipv6) {
+  if(conn->bits.ipv6 && !(conn->bits.tunnel_proxy || conn->bits.socksproxy)) {
     /* We can't disable EPSV when doing IPv6, so this is instead a fail */
     failf(conn->data, "Failed EPSV attempt, exiting\n");
     return CURLE_WEIRD_SERVER_REPLY;


### PR DESCRIPTION
In the situation of a client connecting to an FTP server using an
IPv6 tunnel proxy, the connection info will indicate that the connection
is IPv6. However, because the server behind the proxy is IPv4, it is
permissible to attempt PSV mode. In the case of the FTP server being
IPv4 only, EPSV will always fail, and with the current logic curl will
be unable to connect to the server, as the IPv6 fwdproxy causes curl to
think that EPSV is impossible.

I've tested this privately, using a CONNECT IPv6 proxy to connect to an IPv4 host. I'm not sure if there is a better way to test if the connection is using a proxy (I stole this conditional from the control_address function below this one).