### PR TITLE
Restore old behavior for file:////foo/bar URLs

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2067,15 +2067,6 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
       return CURLE_URL_MALFORMAT;
     }
 
-    if(url_has_scheme && path[0] == '/' && path[1] == '/' &&
-       path[2] == '/' && path[3] == '/') {
-      /* This appears to be a UNC string (usually indicating a SMB share).
-       * We don't do SMB in file: URLs. (TODO?)
-       */
-      failf(data, "SMB shares are not supported in file: URLs.");
-      return CURLE_URL_MALFORMAT;
-    }
-
     /* Extra handling URLs with an authority component (i.e. that start with
      * "file://")
      *
@@ -2113,25 +2104,6 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
         }
         ptr += 9; /* now points to the slash after the host */
       }
-
-      /*
-       * RFC 8089, Appendix D, Section D.1, says:
-       *
-       * > In a POSIX file system, the root of the file system is represented
-       * > as a directory with a zero-length name, usually written as "/"; the
-       * > presence of this root in a file URI can be taken as given by the
-       * > initial slash in the "path-absolute" rule.
-       *
-       * i.e. the first slash is part of the path.
-       *
-       * However in RFC 1738 the "/" between the host (or port) and the
-       * URL-path was NOT part of the URL-path.  Any agent that followed the
-       * older spec strictly, and wanted to refer to a file with an absolute
-       * path, would have included a second slash.  So if there are two
-       * slashes, swallow one.
-       */
-      if('/' == ptr[1]) /* note: the only way ptr[0]!='/' is if ptr[1]==':' */
-        ptr++;
 
       /* This cannot be done with strcpy, as the memory chunks overlap! */
       memmove(path, ptr, strlen(ptr) + 1);

--- a/tests/data/test2072
+++ b/tests/data/test2072
@@ -6,6 +6,13 @@ FILE
 </info>
 
 <reply>
+<data>
+foo
+   bar
+bar
+   foo
+moo
+</data>
 </reply>
 
 # Client-side
@@ -14,12 +21,15 @@ FILE
 file
 </server>
 <name>
-file:// with SMB path
+file:// with unix path resolution behavior for the case of extra slashes
 </name>
 <command>
-file:////bad-host%PWD/log/test1145.txt
+file:////%PWD/log/test2072.txt
 </command>
-<file name="log/test1145.txt">
+<precheck>
+perl -e "print 'Test requires a unix system' if ( $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'dos');"
+</precheck>
+<file name="log/test2072.txt">
 foo
    bar
 bar
@@ -30,9 +40,5 @@ moo
 
 # Verify data after the test has been "shot"
 <verify>
-# CURLE_URL_MALFORMAT is error code 3
-<errorcode>
-3
-</errorcode>
 </verify>
 </testcase>


### PR DESCRIPTION
This is a fairly common thing to end up in scripts via constructions that do
things like: file:///${VAR}

curl allowed this prior to 7.57.0 but it was broken by adding "support"
for UNC paths as defined in Appendix E.3.2 of RFC 8089. This appendix is
non-normative though and curl does not actually support it beyond rejecting
them. (In fact curl does not support any flavor of remote file: URLs.)

Given the fact that curl does not actually implement support for UNC paths I think it would be better to restore the old behavior.