### PR TITLE
When reading cookies from a file, only run remove_expired once

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -820,7 +820,8 @@ Curl_cookie_add(struct Curl_easy *data,
      the same domain and path as this */
 
   /* at first, remove expired cookies */
-  if(!noexpire) remove_expired(c);
+  if(!noexpire)
+    remove_expired(c);
 
 #ifdef USE_LIBPSL
   /* Check if the domain is a Public Suffix and if yes, ignore the cookie.

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -368,6 +368,7 @@ Curl_cookie_add(struct Curl_easy *data,
 
                 struct CookieInfo *c,
                 bool httpheader, /* TRUE if HTTP header-style line */
+                bool noexpire, /* if TRUE, skip remove_expired() */
                 char *lineptr,   /* first character of the line */
                 const char *domain, /* default domain */
                 const char *path)   /* full path used when this cookie is set,
@@ -819,7 +820,7 @@ Curl_cookie_add(struct Curl_easy *data,
      the same domain and path as this */
 
   /* at first, remove expired cookies */
-  remove_expired(c);
+  if(!noexpire) remove_expired(c);
 
 #ifdef USE_LIBPSL
   /* Check if the domain is a Public Suffix and if yes, ignore the cookie.
@@ -1026,9 +1027,10 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
       while(*lineptr && ISBLANK(*lineptr))
         lineptr++;
 
-      Curl_cookie_add(data, c, headerline, lineptr, NULL, NULL);
+      Curl_cookie_add(data, c, headerline, TRUE, lineptr, NULL, NULL);
     }
     free(line); /* free the line buffer */
+    remove_expired(c); /* run this once, not on every cookie */
 
     if(fromfile)
       fclose(fp);

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -80,7 +80,8 @@ struct Curl_easy;
  */
 
 struct Cookie *Curl_cookie_add(struct Curl_easy *data,
-                               struct CookieInfo *, bool header, char *lineptr,
+                               struct CookieInfo *, bool header, bool noexpiry,
+                               char *lineptr,
                                const char *domain, const char *path);
 
 struct Cookie *Curl_cookie_getlist(struct CookieInfo *, const char *,

--- a/lib/http.c
+++ b/lib/http.c
@@ -3734,7 +3734,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE,
                       CURL_LOCK_ACCESS_SINGLE);
       Curl_cookie_add(data,
-                      data->cookies, TRUE, k->p + 11,
+                      data->cookies, TRUE, FALSE, k->p + 11,
                       /* If there is a custom-set Host: name, use it
                          here, or else use real peer host name. */
                       conn->allocptr.cookiehost?

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -781,11 +781,13 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
 
         if(checkprefix("Set-Cookie:", argptr))
           /* HTTP Header format line */
-          Curl_cookie_add(data, data->cookies, TRUE, FALSE, argptr + 11, NULL, NULL);
+          Curl_cookie_add(data, data->cookies, TRUE, FALSE, argptr + 11, NULL,
+                          NULL);
 
         else
           /* Netscape format line */
-          Curl_cookie_add(data, data->cookies, FALSE, FALSE, argptr, NULL, NULL);
+          Curl_cookie_add(data, data->cookies, FALSE, FALSE, argptr, NULL,
+                          NULL);
 
         Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
         free(argptr);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -781,11 +781,11 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
 
         if(checkprefix("Set-Cookie:", argptr))
           /* HTTP Header format line */
-          Curl_cookie_add(data, data->cookies, TRUE, argptr + 11, NULL, NULL);
+          Curl_cookie_add(data, data->cookies, TRUE, FALSE, argptr + 11, NULL, NULL);
 
         else
           /* Netscape format line */
-          Curl_cookie_add(data, data->cookies, FALSE, argptr, NULL, NULL);
+          Curl_cookie_add(data, data->cookies, FALSE, FALSE, argptr, NULL, NULL);
 
         Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
         free(argptr);


### PR DESCRIPTION
Combined with #2440, this drops the cookie load time for 8k cookies from 178ms to 15ms. All tests pass.