### PR TITLE
cmake: fix strerror_r tests for cross-compiling

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -507,30 +507,30 @@ main ()
 #ifdef HAVE_GLIBC_STRERROR_R
 #include <string.h>
 #include <errno.h>
+
+void check(char c) {}
+
 int
 main () {
-  char buffer[1024]; /* big enough to play with */
-  char *string =
-    strerror_r(EACCES, buffer, sizeof(buffer));
-    /* this should've returned a string */
-    if(!string || !string[0])
-      return 99;
-    return 0;
+  char buffer[1024];
+  // This will not compile if strerror_r does not return a char*
+  check(strerror_r(EACCES, buffer, sizeof(buffer))[0]);
+  return 0;
 }
 #endif
 #ifdef HAVE_POSIX_STRERROR_R
 #include <string.h>
 #include <errno.h>
+
+// float, because a pointer can't be implicitly cast to float
+void check(float f) {}
+
 int
 main () {
-  char buffer[1024]; /* big enough to play with */
-  int error =
-    strerror_r(EACCES, buffer, sizeof(buffer));
-    /* This should've returned zero, and written an error string in the
-       buffer.*/
-    if(!buffer[0] || error)
-      return 99;
-    return 0;
+  char buffer[1024];
+  // This will not compile if strerror_r does not return an int
+  check(strerror_r(EACCES, buffer, sizeof(buffer)));
+  return 0;
 }
 #endif
 #ifdef HAVE_FSETXATTR_6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,7 +902,7 @@ endif()
 check_symbol_exists(fsetxattr "${CURL_INCLUDES}" HAVE_FSETXATTR)
 if(HAVE_FSETXATTR)
   foreach(CURL_TEST HAVE_FSETXATTR_5 HAVE_FSETXATTR_6)
-    curl_internal_test_run(${CURL_TEST})
+    curl_internal_test(${CURL_TEST})
   endforeach(CURL_TEST)
 endif(HAVE_FSETXATTR)
 
@@ -982,7 +982,7 @@ foreach(CURL_TEST
     HAVE_GLIBC_STRERROR_R
     HAVE_POSIX_STRERROR_R
     )
-  curl_internal_test_run(${CURL_TEST})
+  curl_internal_test(${CURL_TEST})
 endforeach(CURL_TEST)
 
 # Check for reentrant


### PR DESCRIPTION
Since we only need to differentiate between char* and int return types in strerror_r, I believe we don't need to actually run the code, but can rely on compiler's type checks when using the result of the function. This fixes strerror_r variant detection under CMake when cross-compiling for platforms that can't run the tests (like iOS).