### PR TITLE
openssl: fix build with libressl 2.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1791,6 +1791,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
         AC_MSG_RESULT([no])
     ])
 
+    AC_CHECK_FUNCS( OpenSSL_version_num )
     AC_MSG_CHECKING([for libressl])
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -117,7 +117,7 @@
 #define X509_get0_notBefore(x) X509_get_notBefore(x)
 #define X509_get0_notAfter(x) X509_get_notAfter(x)
 #define CONST_EXTS /* nope */
-#ifdef LIBRESSL_VERSION_NUMBER
+#if !defined(HAVE_OPENSSL_VERSION_NUM) && defined(LIBRESSL_VERSION_NUMBER)
 static unsigned long OpenSSL_version_num(void)
 {
   return LIBRESSL_VERSION_NUMBER;


### PR DESCRIPTION
LibreSSL 2.7 introduced some of the OpenSSL 1.1 API.

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>