### PR TITLE
Revert "openssl: Don't add verify locations when verifypeer==0"

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2338,11 +2338,10 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 #endif
 
   if(ssl_cafile || ssl_capath) {
-    if(verifypeer) {
-      /* tell SSL where to find CA certificates that are used to verify
-         the servers certificate. */
-      if(!SSL_CTX_load_verify_locations(BACKEND->ctx,
-                                        ssl_cafile, ssl_capath)) {
+    /* tell SSL where to find CA certificates that are used to verify
+       the servers certificate. */
+    if(!SSL_CTX_load_verify_locations(BACKEND->ctx, ssl_cafile, ssl_capath)) {
+      if(verifypeer) {
         /* Fail if we insist on successfully verifying the server. */
         failf(data, "error setting certificate verify locations:\n"
               "  CAfile: %s\n  CApath: %s",
@@ -2350,18 +2349,20 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
               ssl_capath ? ssl_capath : "none");
         return CURLE_SSL_CACERT_BADFILE;
       }
-      else {
-        /* Everything is fine. */
-        infof(data, "successfully set certificate verify locations:\n"
-              "  CAfile: %s\n  CApath: %s\n",
-              ssl_cafile ? ssl_cafile : "none",
-              ssl_capath ? ssl_capath : "none");
-      }
+      /* Just continue with a warning if no strict  certificate verification
+         is required. */
+      infof(data, "error setting certificate verify locations,"
+            " continuing anyway:\n");
     }
     else {
-      infof(data, "ignoring certificate verify locations due to "
-            "disabled peer verification\n");
+      /* Everything is fine. */
+      infof(data, "successfully set certificate verify locations:\n");
     }
+    infof(data,
+          "  CAfile: %s\n"
+          "  CApath: %s\n",
+          ssl_cafile ? ssl_cafile : "none",
+          ssl_capath ? ssl_capath : "none");
   }
 #ifdef CURL_CA_FALLBACK
   else if(verifypeer) {


### PR DESCRIPTION
This reverts commit dc85437736e1fc90e689bb1f6c51c8f1aa9430eb.

libcurl (with the OpenSSL backend) performs server certificate verification
even if verifypeer == 0 and the verification result is available using
CURLINFO_SSL_VERIFYRESULT. The commit that is being reverted caused the
CURLINFO_SSL_VERIFYRESULT to not have useful information for the
verifypeer == 0 use case (it would always have
X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY).