### PR TITLE
optimize negotiate and ntlm auth in first and reused connections.

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -475,15 +475,16 @@ static CURLcode http_perhapsrewind(struct connectdata *conn)
 
 CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
 {
-#if defined(USE_SPNEGO) || defined(USE_NTLM)
+  /*
+   * This resource requires authentication
+   */
   struct Curl_easy *data = conn->data;
-
-  struct auth *authp;
 
 #ifdef USE_SPNEGO
   struct negotiatedata *negdata = proxy ?
-      &data->state.proxyneg : &data->state.negotiate;
+    &data->state.proxyneg : &data->state.negotiate;
 #endif
+  struct auth *authp;
 
   if(proxy) {
     authp = &data->state.authproxy;
@@ -491,7 +492,7 @@ CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
   else {
     authp = &data->state.authhost;
   }
-#endif
+
 #ifdef USE_SPNEGO
   if(authp->picked == CURLAUTH_NEGOTIATE) {
     if(negdata->state == GSS_AUTHNONE) {

--- a/lib/http.c
+++ b/lib/http.c
@@ -475,27 +475,23 @@ static CURLcode http_perhapsrewind(struct connectdata *conn)
 
 CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
 {
-  /*
-   * This resource requires authentication
-   */
+#if defined(USE_SPNEGO) || defined(USE_NTLM)
   struct Curl_easy *data = conn->data;
+
+  struct auth *authp;
 
 #ifdef USE_SPNEGO
   struct negotiatedata *negdata = proxy ?
-    &data->state.proxyneg : &data->state.negotiate;
+      &data->state.proxyneg : &data->state.negotiate;
 #endif
-  unsigned long *availp;
-  struct auth *authp;
 
   if(proxy) {
-    availp = &data->info.proxyauthavail;
     authp = &data->state.authproxy;
   }
   else {
-    availp = &data->info.httpauthavail;
     authp = &data->state.authhost;
   }
-
+#endif
 #ifdef USE_SPNEGO
   if(authp->picked == CURLAUTH_NEGOTIATE) {
     if(negdata->state == GSS_AUTHNONE) {

--- a/lib/http.c
+++ b/lib/http.c
@@ -468,7 +468,7 @@ static CURLcode http_perhapsrewind(struct connectdata *conn)
   return CURLE_OK;
 }
 
-/* 
+/*
  * Curl_http_input_auth_init(). Init auth context for output
  * headers at next request. Uset for negotiate and ntlm auth
  */

--- a/lib/http.c
+++ b/lib/http.c
@@ -523,29 +523,6 @@ CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
     CURLcode result = Curl_input_ntlm(conn, proxy, "NTLM");
     if(!result) {
       data->state.authproblem = FALSE;
-#ifdef NTLM_WB_ENABLED
-      if(authp->picked == CURLAUTH_NTLM_WB) {
-        *availp &= ~CURLAUTH_NTLM;
-        authp->avail &= ~CURLAUTH_NTLM;
-        *availp |= CURLAUTH_NTLM_WB;
-        authp->avail |= CURLAUTH_NTLM_WB;
-
-        /* Get the challenge-message which will be passed to
-         * ntlm_auth for generating the type 3 message later */
-        while(*auth && ISSPACE(*auth))
-          auth++;
-        if(checkprefix("NTLM", auth)) {
-          auth += strlen("NTLM");
-          while(*auth && ISSPACE(*auth))
-            auth++;
-            if(*auth) {
-              conn->challenge_header = strdup(auth);
-              if(!conn->challenge_header)
-                return CURLE_OUT_OF_MEMORY;
-          }
-        }
-      }
-#endif
     }
     else {
       infof(data, "Authentication problem. Ignoring this.\n");

--- a/lib/http.c
+++ b/lib/http.c
@@ -470,10 +470,11 @@ static CURLcode http_perhapsrewind(struct connectdata *conn)
 
 /* 
  * Curl_http_input_auth_init(). Init auth context for output
- *headers at next request. Uset for negotiate and ntlm auth
+ * headers at next request. Uset for negotiate and ntlm auth
  */
 
-static CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
+static CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn,
+                                              bool proxy)
 {
   /*
    * This resource requires authentication

--- a/lib/http.c
+++ b/lib/http.c
@@ -473,7 +473,7 @@ static CURLcode http_perhapsrewind(struct connectdata *conn)
  *headers at next request. Uset for negotiate and ntlm auth
  */
 
-CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
+static CURLcode Curl_http_input_auth_init_ctx(struct connectdata *conn, bool proxy)
 {
   /*
    * This resource requires authentication

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -38,7 +38,6 @@ static CURLcode create_negotiate_ctx(struct connectdata *conn, bool proxy)
 {
   CURLcode result;
   struct Curl_easy *data = conn->data;
-  size_t len;
 
   /* Point to the username, password, service and host */
   const char *userp;

--- a/lib/url.c
+++ b/lib/url.c
@@ -4548,6 +4548,18 @@ static CURLcode create_conn(struct Curl_easy *data,
       data->state.authproxy.done = FALSE;
     }
 #endif
+#if defined(USE_SPNEGO)
+    /* If Negotiate is requested in a part of this connection,
+     * clear negotiate contexts for new auth requests */
+    if(((data->state.authhost.picked & CURLAUTH_NEGOTIATE) &&
+        data->state.negotiate.state == GSS_AUTHCOMPLETE) ||
+       ((data->state.authproxy.picked & CURLAUTH_NEGOTIATE) &&
+        data->state.proxyneg.state == GSS_AUTHCOMPLETE)) {
+      data->state.negotiate.state = GSS_AUTHNONE;
+      data->state.proxyneg.state = GSS_AUTHNONE;
+      Curl_cleanup_negotiate(data);
+    }
+#endif
   }
 
   /* Setup and init stuff before DO starts, in preparing for the transfer. */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -341,7 +341,7 @@ struct ntlmdata {
 struct negotiatedata {
   /* When doing Negotiate (SPNEGO) auth, we first need to send a token
      and then validate the received one. */
-  enum { GSS_AUTHNONE, GSS_AUTHRECV, GSS_AUTHSENT } state;
+  enum { GSS_AUTHNONE, GSS_AUTHRECV, GSS_AUTHSENT, GSS_AUTHCOMPLETE } state;
 #ifdef HAVE_GSSAPI
   OM_uint32 status;
   gss_ctx_id_t context;

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -103,7 +103,8 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   (void) data;
 #endif
 
-  if(nego->context && nego->status == SEC_E_OK) {
+  if(nego->context && nego->status == SEC_E_OK
+    && nego->state != GSS_AUTHCOMPLETE) {
     /* We finished successfully our part of authentication, but server
      * rejected it (since we're again here). Exit with an error since we
      * can't invent anything better */


### PR DESCRIPTION
now curl send 4 requests for new connection with negotiate auth (kerberos):
request 1: no authenticate headers
response: authenticate headers
request 2: no authecticate headers
response: authenticate headers
request 3: authenticate headers with first token
response: authenticate headers with token
request 4: authenticate headers with second token
response: authenticate headers with token, status 200 and response body

this PR remove second request without auth headers and requests will be like this:
request 1: no authecticate headers
response: authenticate headers
request 2: authenticate headers with first token
response: authenticate headers with token
request 3: authenticate headers with second token
response: authenticate headers with token, status 200 and response body

For reused connections forced using last selected authentication protocol:
request 1: authenticate headers with first token
response: authenticate headers with token
request 2: authenticate headers with second token
response: authenticate headers with token, status 200 and response body
