### PR TITLE
winbuild: clean target cannot be called

### DIFF
--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
+    https://msdn.microsoft.com/en-us/windows/bb980924
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:
@@ -34,11 +34,6 @@ Building with Visual C++, prerequisites
    It is also possible to create the deps directory in some other random
    places and tell the Makefile its location using the WITH_DEVEL option.
 
-   Alternatively, if you cannot or don't want to copy deps to a fixed
-   location, you can use special environment variables, like INCLUDE, LIB,
-   LIBPATH, CL and _CL to set include and/or library paths and tell where
-   other deps reside.
-
 Building straight from git
 ==========================
 
@@ -49,13 +44,15 @@ Building straight from git
 Building with Visual C++
 ========================
 
-    Open Visual Studio command prompt Shell:
+Open a Visual Studio Command prompt or the SDK CMD shell.
+
+    Using the CMD Shell:
+     choose the right environment via the setenv command (see setenv /?)
+     for the full list of options. setenv /xp /x86 /release for example.
+
+    Using the Visual Studio command prompt Shell:
      Everything is already pre-configured by calling one of the command
      prompt.
-
-    Visual Studio comes with two different kinds of shells, either
-    related to VsDevCmd.bat or vcvarsall.bat. For more information,
-    please checkout related information on MSDN.
 
 Once you are in the console, go to the winbuild directory in the Curl
 sources:

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://msdn.microsoft.com/en-us/windows/bb980924
+    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:
@@ -34,6 +34,11 @@ Building with Visual C++, prerequisites
    It is also possible to create the deps directory in some other random
    places and tell the Makefile its location using the WITH_DEVEL option.
 
+   Alternatively, if you cannot or don't want to copy deps to a fixed
+   location, you can use special environment variables, like INCLUDE, LIB,
+   LIBPATH, CL and _CL to set include and/or library paths and tell where
+   other deps reside.
+
 Building straight from git
 ==========================
 
@@ -44,15 +49,13 @@ Building straight from git
 Building with Visual C++
 ========================
 
-Open a Visual Studio Command prompt or the SDK CMD shell.
-
-    Using the CMD Shell:
-     choose the right environment via the setenv command (see setenv /?)
-     for the full list of options. setenv /xp /x86 /release for example.
-
-    Using the Visual Studio command prompt Shell:
+    Open Visual Studio command prompt Shell:
      Everything is already pre-configured by calling one of the command
      prompt.
+
+    Visual Studio comes with two different kinds of shells, either
+    related to VsDevCmd.bat or vcvarsall.bat. For more information,
+    please checkout related information on MSDN.
 
 Once you are in the console, go to the winbuild directory in the Curl
 sources:

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -270,3 +270,6 @@ $(MODE):
 copy_from_lib:
 	echo copying .c...
 	FOR %%i IN ($(CURLX_CFILES:/=\)) DO copy %%i ..\src\
+
+clean:
+	$(MAKE) /NOLOGO /F MakefileBuild.vc $@

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -426,17 +426,7 @@ CURL_LINK = link.exe /incremental:no /libpath:"$(DIRDIST)\lib"
 #######################
 # Only the clean target can be used if a config was not provided.
 #
-!IF "$(CFGSET)" == "FALSE"
-clean:
-	@-erase /s *.dll 2> NUL
-	@-erase /s *.exp 2> NUL
-	@-erase /s *.idb 2> NUL
-	@-erase /s *.lib 2> NUL
-	@-erase /s *.obj 2> NUL
-	@-erase /s *.pch 2> NUL
-	@-erase /s *.pdb 2> NUL
-	@-erase /s *.res 2> NUL
-!ELSE
+!IF "$(CFGSET)" != "FALSE"
 # A mode was provided, so the library can be built.
 #
 !include CURL_OBJS.inc
@@ -563,3 +553,17 @@ $(CURL_DIROBJ)\curl.res: $(CURL_SRC_DIR)\curl.rc
 	rc $(CURL_RC_FLAGS)
 
 !ENDIF  # End of case where a config was provided.
+
+clean:
+	@-erase /s *.dll 2> NUL
+	@-erase /s *.exp 2> NUL
+	@-erase /s *.idb 2> NUL
+	@-erase /s *.lib 2> NUL
+	@-erase /s *.obj 2> NUL
+	@-erase /s *.pch 2> NUL
+	@-erase /s *.pdb 2> NUL
+	@-erase /s *.res 2> NUL
+	@if exist $(LIB_DIROBJ) rd /s/q $(LIB_DIROBJ)
+	@if exist $(CURL_DIROBJ)rd /s/q $(CURL_DIROBJ)
+	@if exist $(DIRDIST) rd /s/q $(DIRDIST)
+


### PR DESCRIPTION
Due to the check in Makefile.vc:313:

!IF "$(CFGSET)" == "FALSE"
!ERROR please choose a valid mode
!ENDIF

and the condition at line 429:

#######################
# Only the clean target can be used if a config was not provided.
#
!IF "$(CFGSET)" == "FALSE"
clean:
...
!ENDIF

the clean target was unreachable. 

No nmake call can be invoked unless a build-type was specified. The clean target only existed when a build type was specified. Now added a clean target unconditional in MakefileBuild.vc + added a clean target in Makefile.vc that propagates to MakefileBuild.vc.

