### PR TITLE
Winbuild doc

### DIFF
--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
+    https://msdn.microsoft.com/en-us/windows/bb980924
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:
@@ -49,23 +49,11 @@ Open a Visual Studio Command prompt or the SDK CMD shell.
     Using the CMD Shell:
      choose the right environment via the setenv command (see setenv /?)
      for the full list of options. setenv /xp /x86 /release for example.
-     See also:
-     https://msdn.microsoft.com/en-us/library/ff660764(v=vs.100).aspx.
-     Recent versions of the Windows SDK no longer contains a compiler
-     (cl.exe), but only header files and libraries. You need to install 
-     a (free) version of Visual Studio to get a compiler.
 
     Using the Visual Studio command prompt Shell:
+     Everything is already pre-configured by calling one of the command
+     prompt.
 
-     Using the 'Developer Command Prompt for VS <version>' menu entry:
-       where version is the Visual Studio version. See also: 
-       https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs
-
-     Using the 'VS <version> <platform> <type> Command Prompt' menu entry:
-       where version is the Visual Studio version, platform is e.g. x64
-       and type Native of Cross platform build. See also:
-       https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
-  
 Once you are in the console, go to the winbuild directory in the Curl
 sources:
     cd curl-src\winbuild

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
+    https://msdn.microsoft.com/en-us/windows/bb980924
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:
@@ -34,11 +34,6 @@ Building with Visual C++, prerequisites
    It is also possible to create the deps directory in some other random
    places and tell the Makefile its location using the WITH_DEVEL option.
 
-   Alternatively, if you cannot or don't want to copy deps to a fixed
-   location, you can use special environment variables, like INCLUDE, LIB,
-   LIBPATH, CL and _CL to set include and/or library paths and tell where
-   other deps reside.
-
 Building straight from git
 ==========================
 
@@ -49,13 +44,15 @@ Building straight from git
 Building with Visual C++
 ========================
 
-    Open Visual Studio command prompt Shell:
+Open a Visual Studio Command prompt or the SDK CMD shell.
+
+    Using the CMD Shell:
+     choose the right environment via the setenv command (see setenv /?)
+     for the full list of options. setenv /xp /x86 /release for example.
+
+    Using the Visual Studio command prompt Shell:
      Everything is already pre-configured by calling one of the command
      prompt.
-
-    Visual Studio comes with two different kinds of shells, either
-    related to VsDevCmd.bat or vcvarsall.bat. For more information,
-    please checkout related information on MSDN.
 
 Once you are in the console, go to the winbuild directory in the Curl
 sources:

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://msdn.microsoft.com/en-us/windows/bb980924
+    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:
@@ -34,6 +34,11 @@ Building with Visual C++, prerequisites
    It is also possible to create the deps directory in some other random
    places and tell the Makefile its location using the WITH_DEVEL option.
 
+   Alternatively, if you cannot or don't want to copy deps to a fixed
+   location, you can use special environment variables, like INCLUDE, LIB,
+   LIBPATH, CL and _CL to set include and/or library paths and tell where
+   other deps reside.
+
 Building straight from git
 ==========================
 
@@ -44,15 +49,13 @@ Building straight from git
 Building with Visual C++
 ========================
 
-Open a Visual Studio Command prompt or the SDK CMD shell.
-
-    Using the CMD Shell:
-     choose the right environment via the setenv command (see setenv /?)
-     for the full list of options. setenv /xp /x86 /release for example.
-
-    Using the Visual Studio command prompt Shell:
+    Open Visual Studio command prompt Shell:
      Everything is already pre-configured by calling one of the command
      prompt.
+
+    Visual Studio comes with two different kinds of shells, either
+    related to VsDevCmd.bat or vcvarsall.bat. For more information,
+    please checkout related information on MSDN.
 
 Once you are in the console, go to the winbuild directory in the Curl
 sources:

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://msdn.microsoft.com/en-us/windows/bb980924
+    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:
@@ -49,11 +49,23 @@ Open a Visual Studio Command prompt or the SDK CMD shell.
     Using the CMD Shell:
      choose the right environment via the setenv command (see setenv /?)
      for the full list of options. setenv /xp /x86 /release for example.
+     See also:
+     https://msdn.microsoft.com/en-us/library/ff660764(v=vs.100).aspx.
+     Recent versions of the Windows SDK no longer contains a compiler
+     (cl.exe), but only header files and libraries. You need to install 
+     a (free) version of Visual Studio to get a compiler.
 
     Using the Visual Studio command prompt Shell:
-     Everything is already pre-configured by calling one of the command
-     prompt.
 
+     Using the 'Developer Command Prompt for VS <version>' menu entry:
+       where version is the Visual Studio version. See also: 
+       https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs
+
+     Using the 'VS <version> <platform> <type> Command Prompt' menu entry:
+       where version is the Visual Studio version, platform is e.g. x64
+       and type Native of Cross platform build. See also:
+       https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
+  
 Once you are in the console, go to the winbuild directory in the Curl
 sources:
     cd curl-src\winbuild

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -49,11 +49,31 @@ Open a Visual Studio Command prompt or the SDK CMD shell.
     Using the CMD Shell:
      choose the right environment via the setenv command (see setenv /?)
      for the full list of options. setenv /xp /x86 /release for example.
+<<<<<<< HEAD
+     See also:
+     https://msdn.microsoft.com/en-us/library/ff660764(v=vs.100).aspx.
+     Recent versions of the Windows SDK no longer contains a compiler
+     (cl.exe), but only header files and libraries. You need to install 
+     a (free) version of Visual Studio to get a compiler.
+
+    Using the Visual Studio command prompt Shell:
+
+     Using the 'Developer Command Prompt for VS <version>' menu entry:
+       where version is the Visual Studio version. See also: 
+       https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs
+
+     Using the 'VS <version> <platform> <type> Command Prompt' menu entry:
+       where version is the Visual Studio version, platform is e.g. x64
+       and type Native of Cross platform build. See also:
+       https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
+  
+=======
 
     Using the Visual Studio command prompt Shell:
      Everything is already pre-configured by calling one of the command
      prompt.
 
+>>>>>>> parent of d01d6e338... setenv command does not exist anymore
 Once you are in the console, go to the winbuild directory in the Curl
 sources:
     cd curl-src\winbuild

--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -61,11 +61,20 @@ Open a Visual Studio Command prompt or the SDK CMD shell.
      Using the 'Developer Command Prompt for VS <version>' menu entry:
        where version is the Visual Studio version. See also: 
        https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs
+       Note that the developer prompt at default builds in x86 mode. It is
+       required to call Vcvarsall.bat to setup the prompt for the machine type
+       you want. See also: 
+       https://docs.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line
+       The location of the Vcvarsall.bat is Visual Studio version dependent.
+       This type of command prompt may not exist in all Visual Studio
+       versions.
 
      Using the 'VS <version> <platform> <type> Command Prompt' menu entry:
        where version is the Visual Studio version, platform is e.g. x64
        and type Native of Cross platform build. See also:
        https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx
+       This type of command prompt may not exist in all Visual Studio
+       versions.
   
 =======
 

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -270,3 +270,6 @@ $(MODE):
 copy_from_lib:
 	echo copying .c...
 	FOR %%i IN ($(CURLX_CFILES:/=\)) DO copy %%i ..\src\
+
+clean:
+	$(MAKE) /NOLOGO /F MakefileBuild.vc $@

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -426,17 +426,7 @@ CURL_LINK = link.exe /incremental:no /libpath:"$(DIRDIST)\lib"
 #######################
 # Only the clean target can be used if a config was not provided.
 #
-!IF "$(CFGSET)" == "FALSE"
-clean:
-	@-erase /s *.dll 2> NUL
-	@-erase /s *.exp 2> NUL
-	@-erase /s *.idb 2> NUL
-	@-erase /s *.lib 2> NUL
-	@-erase /s *.obj 2> NUL
-	@-erase /s *.pch 2> NUL
-	@-erase /s *.pdb 2> NUL
-	@-erase /s *.res 2> NUL
-!ELSE
+!IF "$(CFGSET)" != "FALSE"
 # A mode was provided, so the library can be built.
 #
 !include CURL_OBJS.inc
@@ -563,3 +553,17 @@ $(CURL_DIROBJ)\curl.res: $(CURL_SRC_DIR)\curl.rc
 	rc $(CURL_RC_FLAGS)
 
 !ENDIF  # End of case where a config was provided.
+
+clean:
+	@-erase /s *.dll 2> NUL
+	@-erase /s *.exp 2> NUL
+	@-erase /s *.idb 2> NUL
+	@-erase /s *.lib 2> NUL
+	@-erase /s *.obj 2> NUL
+	@-erase /s *.pch 2> NUL
+	@-erase /s *.pdb 2> NUL
+	@-erase /s *.res 2> NUL
+	@if exist $(LIB_DIROBJ) rd /s/q $(LIB_DIROBJ)
+	@if exist $(CURL_DIROBJ)rd /s/q $(CURL_DIROBJ)
+	@if exist $(DIRDIST) rd /s/q $(DIRDIST)
+


### PR DESCRIPTION
Updated documention:

- Setenv has gone. 
- A compiler (cl.exe) is not part of more recent Windows (platform) SDK's (all after v7.1)

Not updated: if a visual studio command prompt is used, the cl.exe PATH has been setup, and setting the VC variable is actually of no sense (you may like to use the VisualStudioVersion for that purpose).

Yuo may even consider drop support for ancient Visual Studio 6, resulting in the possibility to cleanup more.