### PR TITLE
Only consider response code as FTP responses if FTP used

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1522,7 +1522,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
               RETRY_FTP,
               RETRY_LAST /* not used */
             } retry = RETRY_NO;
-            long response;
+            long response, protocol;
             if((CURLE_OPERATION_TIMEDOUT == result) ||
                (CURLE_COULDNT_RESOLVE_HOST == result) ||
                (CURLE_COULDNT_RESOLVE_PROXY == result) ||
@@ -1570,9 +1570,13 @@ static CURLcode operate_do(struct GlobalConfig *global,
               }
             } /* if CURLE_OK */
             else if(result) {
-              curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
+              long protocol;
 
-              if(response/100 == 4)
+              curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
+              curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
+
+              if((protocol == CURLPROTO_FTP || protocol == CURLPROTO_FTPS)
+                 && response/100 == 4)
                 /*
                  * This is typically when the FTP server only allows a certain
                  * amount of users and we are not one of them.  All 4xx codes


### PR DESCRIPTION
Only tread response code as FTP response codes in case the
protocol type is FTP.

This fixes an issue where an HTTP download was treated as FTP
in case libcurl returned with 33. This happens when the
download has already finished and the server responses 416:
  HTTP/1.1 416 Requested Range Not Satisfiable

This should not be treated as an FTP error.

Fixes #2464