### PR TITLE
unit1309: cleanup to fix clang warnings/errors

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -152,7 +152,8 @@ static int gtls_mapped_sockerrno(void)
 
 static ssize_t Curl_gtls_push(void *s, const void *buf, size_t len)
 {
-  ssize_t ret = swrite(CURLX_POINTER_TO_INTEGER_CAST(s), buf, len);
+  curl_socket_t sock = *(curl_socket_t *)s;
+  ssize_t ret = swrite(sock, buf, len);
 #if defined(USE_WINSOCK) && !defined(GNUTLS_MAPS_WINSOCK_ERRORS)
   if(ret < 0)
     gnutls_transport_set_global_errno(gtls_mapped_sockerrno());
@@ -162,7 +163,8 @@ static ssize_t Curl_gtls_push(void *s, const void *buf, size_t len)
 
 static ssize_t Curl_gtls_pull(void *s, void *buf, size_t len)
 {
-  ssize_t ret = sread(CURLX_POINTER_TO_INTEGER_CAST(s), buf, len);
+  curl_socket_t sock = *(curl_socket_t *)s;
+  ssize_t ret = sread(sock, buf, len);
 #if defined(USE_WINSOCK) && !defined(GNUTLS_MAPS_WINSOCK_ERRORS)
   if(ret < 0)
     gnutls_transport_set_global_errno(gtls_mapped_sockerrno());
@@ -848,7 +850,7 @@ gtls_connect_step1(struct connectdata *conn,
   }
   else {
     /* file descriptor for the socket */
-    transport_ptr = CURLX_INTEGER_TO_POINTER_CAST(conn->sock[sockindex]);
+    transport_ptr = &conn->sock[sockindex];
     gnutls_transport_push = Curl_gtls_push;
     gnutls_transport_pull = Curl_gtls_pull;
   }

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -25,11 +25,6 @@
 #ifdef USE_WINSOCK
 #include <curl/curl.h> /* for curl_socket_t */
 #endif
-
-#define CURLX_POINTER_TO_INTEGER_CAST(p) \
-  ((char *)(p) - (char *)NULL)
-#define CURLX_INTEGER_TO_POINTER_CAST(i) \
-  ((void *)((char *)NULL + (i)))
 
 unsigned short curlx_ultous(unsigned long ulnum);
 


### PR DESCRIPTION
unit1309.c:91:24: error: arithmetic on a null pointer treated as a cast
from integer to pointer is a GNU extension

Reported-by: Rikard Falkeborn

Fixes #2466