### PR TITLE
Winbuild documentation: Fixed language code in URL

### DIFF
--- a/winbuild/BUILD.WINDOWS.txt
+++ b/winbuild/BUILD.WINDOWS.txt
@@ -12,7 +12,7 @@ Building with Visual C++, prerequisites
 
    The latest Platform SDK can be downloaded freely from:
 
-    https://developer.microsoft.com/nl-nl/windows/downloads/sdk-archive
+    https://developer.microsoft.com/en-us/windows/downloads/sdk-archive
 
    If you are building with VC6 then you will also need the February 2003
    Edition of the Platform SDK which can be downloaded from:


### PR DESCRIPTION
Follow up on https://github.com/curl/curl/pull/2472.
Now using en-us instead of nl-nl as language code in the URL.