### PR TITLE
travis: use trusty for coverage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ matrix:
           env: T=cmake
         - os: linux
           compiler: gcc
-          dist: precise
+          dist: trusty
           env: T=coverage
         - os: linux
           compiler: gcc


### PR DESCRIPTION
This works now and precise is in the process of being decommissioned.