### PR TITLE
Add condition for sparcv8plus to knows instruction sets

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -300,7 +300,9 @@
 
 #elif defined(__SUNPRO_C) /* Oracle Solaris Studio */
 #  if !defined(__LP64) && (defined(__ILP32) ||                          \
-                           defined(__i386) || defined(__sparcv8))
+                           defined(__i386) ||                           \
+                           defined(__sparcv8) ||                        \
+                           defined(__sparcv8plus))
 #    define CURL_TYPEOF_CURL_OFF_T     long long
 #    define CURL_FORMAT_CURL_OFF_T     "lld"
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"


### PR DESCRIPTION
With specific compiler options selecting the arch like `-xarch=sparc` on newer compilers like Oracle Studio 12.4 there is no definition of `__sparcv8` but `__sparcv8plus` which means the V9 ISA, but limited to the 32–bit subset defined by the V8plus ISA specification, without the Visual Instruction Set (VIS), and without other implementation-specific ISA extensions. So it should be the same as `__sparcv8`.