### PR TITLE
Verify host name against subjectAltName on non-ASCII platforms

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1426,8 +1426,8 @@ static CURLcode verifyhost(struct connectdata *conn, X509 *server_cert)
              */
             char *altptr2 = strdup(altptr);
             if(altptr2) {
-              if(Curl_convert_from_network(data, altptr2, altlen) == CURLE_OK)
-                                                                          {
+              if(Curl_convert_from_network(data, altptr2, altlen)
+                                                            == CURLE_OK) {
 #else
                 const char *altptr2 = altptr;
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1323,6 +1323,48 @@ static void Curl_ossl_close_all(struct Curl_easy *data)
 
 /* ====================================================== */
 
+/*
+ * Match subjectAltName against the host name. This requires a conversion
+ * in CURL_DOES_CONVERSIONS builds.
+ */
+static int subj_alt_hostcheck(struct Curl_easy *data,
+        const char *match_pattern, const char *hostname,
+        const char *dispname)
+{
+  int res = 0;
+
+#ifdef CURL_DOES_CONVERSIONS
+  /* Curl_cert_hostcheck uses host encoding, but we get ASCII from
+     OpenSSl.
+   */
+  char *match_pattern2 = strdup(match_pattern);
+
+  if(match_pattern2) {
+    if(Curl_convert_from_network(data, match_pattern2,
+                                strlen(match_pattern2)) == CURLE_OK) {
+      if(Curl_cert_hostcheck(match_pattern2, hostname)) {
+        res = 1;
+        infof(data,
+                " subjectAltName: host \"%s\" matched cert's \"%s\"\n",
+                dispname, match_pattern2);
+      }
+    }
+    free(match_pattern2);
+  }
+  else {
+    failf(data,
+        "SSL: out of memory when allocating temporary for subjectAltName");
+  }
+#else
+  if(Curl_cert_hostcheck(match_pattern, hostname)) {
+    res = 1;
+    infof(data, " subjectAltName: host \"%s\" matched cert's \"%s\"\n",
+                  dispname, match_pattern);
+  }
+#endif
+
+  return res;
+}
 
 /* Quote from RFC2818 section 3.1 "Server Identity"
 
@@ -1419,36 +1461,11 @@ static CURLcode verifyhost(struct connectdata *conn, X509 *server_cert)
              "I checked the 0.9.6 and 0.9.8 sources before my patch and
              it always 0-terminates an IA5String."
           */
-          if(altlen == strlen(altptr)) {
-#ifdef CURL_DOES_CONVERSIONS
-            /* Curl_cert_hostcheck uses host encoding, but we get ASCII from
-               OpenSSl.
-             */
-            char *altptr2 = strdup(altptr);
-            if(altptr2) {
-              if(Curl_convert_from_network(data, altptr2, altlen)
-                                                            == CURLE_OK) {
-#else
-                const char *altptr2 = altptr;
-#endif
-                /* if this isn't true, there was an embedded zero in the name
-                   string and we cannot match it. */
-                if(Curl_cert_hostcheck(altptr2, hostname)) {
-                  dnsmatched = TRUE;
-                  infof(data,
-                        " subjectAltName: host \"%s\" matched cert's \"%s\"\n",
-                        dispname, altptr2);
-                }
-#ifdef CURL_DOES_CONVERSIONS
-              }
-              free(altptr2);
-            }
-            else {
-              failf(data,
-                    "SSL: out of memory when allocating temporary for "
-                    "subjectAltName");
-            }
-#endif
+          if((altlen == strlen(altptr)) &&
+             /* if this isn't true, there was an embedded zero in the name
+                string and we cannot match it. */
+              subj_alt_hostcheck(data, altptr, hostname, dispname)) {
+            dnsmatched = TRUE;
           }
           break;
 


### PR DESCRIPTION
Curl_cert_hostcheck operates with the host character set, therefore the ASCII subjectAltName string retrieved with OpenSSL must be converted to the host encoding before comparison.

This was discovered on a z/OS machine with EBCDIC encoding, where HTTPS connections to servers with subjectAltName in the server certificate failed.