### PR TITLE
Restore ctype.h character classification for non-ASCII platforms

### DIFF
--- a/lib/curl_ctype.c
+++ b/lib/curl_ctype.c
@@ -22,6 +22,8 @@
 
 #include "curl_setup.h"
 
+#ifndef CURL_DOES_CONVERSIONS
+
 #undef _U
 #define _U (1<<0) /* upper case */
 #undef _L
@@ -120,3 +122,5 @@ int Curl_islower(int c)
     return FALSE;
   return (ascii[c] & (_L));
 }
+
+#endif /* !CURL_DOES_CONVERSIONS */

--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -22,6 +22,33 @@
  *
  ***************************************************************************/
 
+#include "curl_setup.h"
+
+#ifdef CURL_DOES_CONVERSIONS
+
+/*
+ * Uppercase macro versions of ANSI/ISO is*() functions/macros which
+ * avoid negative number inputs with argument byte codes > 127.
+ *
+ * For non-ASCII platforms the C library character classification routines
+ * are used despite being locale-dependent, because this is better than
+ * not to work at all.
+ */
+#include <ctype.h>
+
+#define ISSPACE(x)  (isspace((int)  ((unsigned char)x)))
+#define ISDIGIT(x)  (isdigit((int)  ((unsigned char)x)))
+#define ISALNUM(x)  (isalnum((int)  ((unsigned char)x)))
+#define ISXDIGIT(x) (isxdigit((int) ((unsigned char)x)))
+#define ISGRAPH(x)  (isgraph((int)  ((unsigned char)x)))
+#define ISALPHA(x)  (isalpha((int)  ((unsigned char)x)))
+#define ISPRINT(x)  (isprint((int)  ((unsigned char)x)))
+#define ISUPPER(x)  (isupper((int)  ((unsigned char)x)))
+#define ISLOWER(x)  (islower((int)  ((unsigned char)x)))
+#define ISASCII(x)  (isascii((int)  ((unsigned char)x)))
+
+#else
+
 int Curl_isspace(int c);
 int Curl_isdigit(int c);
 int Curl_isalnum(int c);
@@ -42,6 +69,9 @@ int Curl_islower(int c);
 #define ISUPPER(x)  (Curl_isupper((int)  ((unsigned char)x)))
 #define ISLOWER(x)  (Curl_islower((int)  ((unsigned char)x)))
 #define ISASCII(x)  (((x) >= 0) && ((x) <= 0x80))
+
+#endif
+
 #define ISBLANK(x)  (int)((((unsigned char)x) == ' ') ||        \
                           (((unsigned char)x) == '\t'))
 

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -74,6 +74,7 @@
 
  */
 
+#ifdef CURL_DOES_CONVERSIONS
 /* Check for an ASCII hex digit.
    We avoid the use of ISXDIGIT to accommodate non-ASCII hosts. */
 static bool Curl_isxdigit_ascii(char digit)
@@ -82,6 +83,9 @@ static bool Curl_isxdigit_ascii(char digit)
         || (digit >= 0x41 && digit <= 0x46) /* A-F */
         || (digit >= 0x61 && digit <= 0x66); /* a-f */
 }
+#else
+#define Curl_isxdigit_ascii(x) Curl_isxdigit(x)
+#endif
 
 void Curl_httpchunk_init(struct connectdata *conn)
 {

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -74,6 +74,15 @@
 
  */
 
+/* Check for an ASCII hex digit.
+   We avoid the use of ISXDIGIT to accommodate non-ASCII hosts. */
+static bool Curl_isxdigit_ascii(char digit)
+{
+  return (digit >= 0x30 && digit <= 0x39) /* 0-9 */
+        || (digit >= 0x41 && digit <= 0x46) /* A-F */
+        || (digit >= 0x61 && digit <= 0x66) /* a-f */;
+}
+
 void Curl_httpchunk_init(struct connectdata *conn)
 {
   struct Curl_chunker *chunk = &conn->chunk;
@@ -119,7 +128,7 @@ CHUNKcode Curl_httpchunk_read(struct connectdata *conn,
   while(length) {
     switch(ch->state) {
     case CHUNK_HEX:
-      if(Curl_isxdigit(*datap)) {
+      if(Curl_isxdigit_ascii(*datap)) {
         if(ch->hexindex < MAXNUM_SIZE) {
           ch->hexbuffer[ch->hexindex] = *datap;
           datap++;

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -80,7 +80,7 @@ static bool Curl_isxdigit_ascii(char digit)
 {
   return (digit >= 0x30 && digit <= 0x39) /* 0-9 */
         || (digit >= 0x41 && digit <= 0x46) /* A-F */
-        || (digit >= 0x61 && digit <= 0x66) /* a-f */;
+        || (digit >= 0x61 && digit <= 0x66); /* a-f */
 }
 
 void Curl_httpchunk_init(struct connectdata *conn)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1519,7 +1519,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
       left = FALSE;
       /* fall through */
     default:
-      if(*iptr >= 0x80) {
+      if(!ISPRINT(*iptr)) {
         snprintf(optr, 4, "%%%02x", *iptr);
         optr += 3;
       }


### PR DESCRIPTION
With commit 4272a0b0fc49a1ac0ceab5c4a365c9f6ab8bf8e2 curl-specific
character classification macros and functions were introduced
in curl_ctype.[ch] to avoid dependencies on the locale. This broke
curl on non-ASCII, e.g. EBCDIC platforms. This change restores the
previous set of character classification macros when
CURL_DOES_CONVERSIONS is defined.

This was discovered on a z/OS machine with EBCDIC encoding, where Content-type headers could no longer be matched because leading blanks were no longer stripped off by curl.