### PR TITLE
Fix typos in comments

### DIFF
--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -135,7 +135,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
   }
 
   if(!krb5->credentials) {
-    /* Do we have credientials to use or are we using single sign-on? */
+    /* Do we have credentials to use or are we using single sign-on? */
     if(userp && *userp) {
       /* Populate our identity structure */
       result = Curl_create_sspi_identity(userp, passwdp, &krb5->identity);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -138,7 +138,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
  }
 
   if(!nego->credentials) {
-    /* Do we have credientials to use or are we using single sign-on? */
+    /* Do we have credentials to use or are we using single sign-on? */
     if(user && *user) {
       /* Populate our identity structure */
       result = Curl_create_sspi_identity(user, password, &nego->identity);

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -115,8 +115,8 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
 * User@Domain (User Principal Name)
 *
 * Note: The user name may be empty when using a GSS-API library or Windows SSPI
-* as the user and domain are either obtained from the credientals cache when
-* using GSS-API or via the currently logged in user's credientals when using
+* as the user and domain are either obtained from the credentials cache when
+* using GSS-API or via the currently logged in user's credentials when using
 * Windows SSPI.
 *
 * Parameters:
@@ -138,7 +138,7 @@ bool Curl_auth_user_contains_domain(const char *user)
   }
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   else
-    /* User and domain are obtained from the GSS-API credientials cache or the
+    /* User and domain are obtained from the GSS-API credentials cache or the
        currently logged in user from Windows */
     valid = TRUE;
 #endif


### PR DESCRIPTION
Address various spellings of "credentials", spotted while reading code.