### PR TITLE
 Refactor malloc+memset to use calloc

### DIFF
--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -336,7 +336,6 @@ static void new_conn(char *url, GlobalInfo *g)
   CURLMcode rc;
 
   conn = calloc(1, sizeof(ConnInfo));
-  memset(conn, 0, sizeof(ConnInfo));
   conn->error[0]='\0';
 
   conn->easy = curl_easy_init();

--- a/docs/examples/fopen.c
+++ b/docs/examples/fopen.c
@@ -237,11 +237,9 @@ URL_FILE *url_fopen(const char *url, const char *operation)
   URL_FILE *file;
   (void)operation;
 
-  file = malloc(sizeof(URL_FILE));
+  file = calloc(1, sizeof(URL_FILE));
   if(!file)
     return NULL;
-
-  memset(file, 0, sizeof(URL_FILE));
 
   file->handle.file = fopen(url, operation);
   if(file->handle.file)

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -339,7 +339,6 @@ static void new_conn(char *url, GlobalInfo *g)
   CURLMcode rc;
 
   conn = calloc(1, sizeof(ConnInfo));
-  memset(conn, 0, sizeof(ConnInfo));
   conn->error[0]='\0';
 
   conn->easy = curl_easy_init();

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -873,10 +873,9 @@ static contenc_writer *new_unencoding_writer(struct connectdata *conn,
                                              contenc_writer *downstream)
 {
   size_t sz = offsetof(contenc_writer, params) + handler->paramsize;
-  contenc_writer *writer = (contenc_writer *) malloc(sz);
+  contenc_writer *writer = (contenc_writer *) calloc(1, sz);
 
   if(writer) {
-    memset(writer, 0, sz);
     writer->handler = handler;
     writer->downstream = downstream;
     if(handler->init_writer(conn, writer)) {

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -745,11 +745,9 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
   len = NTLM_HMAC_MD5_LEN + NTLMv2_BLOB_LEN;
 
   /* Allocate the response */
-  ptr = malloc(len);
+  ptr = calloc(1, len);
   if(!ptr)
     return CURLE_OUT_OF_MEMORY;
-
-  memset(ptr, 0, len);
 
   /* Create the BLOB structure */
   snprintf((char *)ptr + NTLM_HMAC_MD5_LEN, NTLMv2_BLOB_LEN,

--- a/lib/nwlib.c
+++ b/lib/nwlib.c
@@ -186,11 +186,9 @@ int GetOrSetUpData(int id, libdata_t **appData,
 
     app_data = (libdata_t *) get_app_data(id);
     if(!app_data) {
-      app_data = malloc(sizeof(libdata_t));
+      app_data = calloc(1, sizeof(libdata_t));
 
       if(app_data) {
-        memset(app_data, 0, sizeof(libdata_t));
-
         app_data->tenbytes = malloc(10);
         app_data->lock     = NXMutexAlloc(0, 0, &liblock);
 

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -150,11 +150,9 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
       krb5->p_identity = NULL;
 
     /* Allocate our credentials handle */
-    krb5->credentials = malloc(sizeof(CredHandle));
+    krb5->credentials = calloc(1, sizeof(CredHandle));
     if(!krb5->credentials)
       return CURLE_OUT_OF_MEMORY;
-
-    memset(krb5->credentials, 0, sizeof(CredHandle));
 
     /* Acquire our credentials handle */
     status = s_pSecFn->AcquireCredentialsHandle(NULL,
@@ -167,11 +165,9 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
       return CURLE_LOGIN_DENIED;
 
     /* Allocate our new context handle */
-    krb5->context = malloc(sizeof(CtxtHandle));
+    krb5->context = calloc(1, sizeof(CtxtHandle));
     if(!krb5->context)
       return CURLE_OUT_OF_MEMORY;
-
-    memset(krb5->context, 0, sizeof(CtxtHandle));
   }
 
   if(chlg64 && *chlg64) {

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -125,11 +125,9 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
     ntlm->p_identity = NULL;
 
   /* Allocate our credentials handle */
-  ntlm->credentials = malloc(sizeof(CredHandle));
+  ntlm->credentials = calloc(1, sizeof(CredHandle));
   if(!ntlm->credentials)
     return CURLE_OUT_OF_MEMORY;
-
-  memset(ntlm->credentials, 0, sizeof(CredHandle));
 
   /* Acquire our credentials handle */
   status = s_pSecFn->AcquireCredentialsHandle(NULL,
@@ -141,11 +139,9 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
     return CURLE_LOGIN_DENIED;
 
   /* Allocate our new context handle */
-  ntlm->context = malloc(sizeof(CtxtHandle));
+  ntlm->context = calloc(1, sizeof(CtxtHandle));
   if(!ntlm->context)
     return CURLE_OUT_OF_MEMORY;
-
-  memset(ntlm->context, 0, sizeof(CtxtHandle));
 
   /* Setup the type-1 "output" security buffer */
   type_1_desc.ulVersion = SECBUFFER_VERSION;

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -153,11 +153,9 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       nego->p_identity = NULL;
 
     /* Allocate our credentials handle */
-    nego->credentials = malloc(sizeof(CredHandle));
+    nego->credentials = calloc(1, sizeof(CredHandle));
     if(!nego->credentials)
       return CURLE_OUT_OF_MEMORY;
-
-    memset(nego->credentials, 0, sizeof(CredHandle));
 
     /* Acquire our credentials handle */
     nego->status =
@@ -170,11 +168,9 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       return CURLE_LOGIN_DENIED;
 
     /* Allocate our new context handle */
-    nego->context = malloc(sizeof(CtxtHandle));
+    nego->context = calloc(1, sizeof(CtxtHandle));
     if(!nego->context)
       return CURLE_OUT_OF_MEMORY;
-
-    memset(nego->context, 0, sizeof(CtxtHandle));
   }
 
   if(chlg64 && *chlg64) {

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -620,11 +620,9 @@ polarssl_connect_step3(struct connectdata *conn,
     ssl_session *our_ssl_sessionid;
     void *old_ssl_sessionid = NULL;
 
-    our_ssl_sessionid = malloc(sizeof(ssl_session));
+    our_ssl_sessionid = calloc(1, sizeof(ssl_session));
     if(!our_ssl_sessionid)
       return CURLE_OUT_OF_MEMORY;
-
-    memset(our_ssl_sessionid, 0, sizeof(ssl_session));
 
     ret = ssl_get_session(&BACKEND->ssl, our_ssl_sessionid);
     if(ret) {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -363,12 +363,11 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
 
     /* allocate memory for the re-usable credential handle */
     BACKEND->cred = (struct curl_schannel_cred *)
-      malloc(sizeof(struct curl_schannel_cred));
+      calloc(1, sizeof(struct curl_schannel_cred));
     if(!BACKEND->cred) {
       failf(data, "schannel: unable to allocate memory");
       return CURLE_OUT_OF_MEMORY;
     }
-    memset(BACKEND->cred, 0, sizeof(struct curl_schannel_cred));
     BACKEND->cred->refcount = 1;
 
     /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa374716.aspx
@@ -466,12 +465,11 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
 
   /* allocate memory for the security context handle */
   BACKEND->ctxt = (struct curl_schannel_ctxt *)
-    malloc(sizeof(struct curl_schannel_ctxt));
+    calloc(1, sizeof(struct curl_schannel_ctxt));
   if(!BACKEND->ctxt) {
     failf(data, "schannel: unable to allocate memory");
     return CURLE_OUT_OF_MEMORY;
   }
-  memset(BACKEND->ctxt, 0, sizeof(struct curl_schannel_ctxt));
 
   host_name = Curl_convert_UTF8_to_tchar(hostname);
   if(!host_name)

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -451,11 +451,10 @@ static CURLcode file_or_stdin(curl_mimepart *part, const char *file)
   if(strcmp(file, "-"))
     return curl_mime_filedata(part, file);
 
-  sip = (standard_input *) malloc(sizeof *sip);
+  sip = (standard_input *) calloc(1, sizeof *sip);
   if(!sip)
     return CURLE_OUT_OF_MEMORY;
 
-  memset((char *) sip, 0, sizeof *sip);
   set_binmode(stdin);
 
   /* If stdin is a regular file, do not buffer data but read it when needed. */

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -727,23 +727,19 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   }
 
   /* allocate internal array for the internal data */
-  data = malloc(nfds * sizeof(struct select_ws_data));
+  data = calloc(nfds, sizeof(struct select_ws_data));
   if(data == NULL) {
     errno = ENOMEM;
     return -1;
   }
 
   /* allocate internal array for the internal event handles */
-  handles = malloc(nfds * sizeof(HANDLE));
+  handles = calloc(nfds, sizeof(HANDLE));
   if(handles == NULL) {
     free(data);
     errno = ENOMEM;
     return -1;
   }
-
-  /* clear internal arrays */
-  memset(data, 0, nfds * sizeof(struct select_ws_data));
-  memset(handles, 0, nfds * sizeof(HANDLE));
 
   /* loop over the handles in the input descriptor sets */
   for(fds = 0; fds < nfds; fds++) {


### PR DESCRIPTION
When a zeroed out allocation is required, most callsites in the code use `calloc()` rather than
`malloc()` followed by an explicit `memset()`. This PR refactors the remaining ones to use `calloc()` instead to make the code more consistent and to avoid the risk of subtle bugs when code is injected
between `malloc()` and `memset()` by accident. Spotted while reading code.

Also remove to calls to `memset()` on a `calloc()`d allocation which is already zeroed out.