### PR TITLE
SFTP fix

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2276,7 +2276,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to close libssh2 file\n");
+          infof(data, "Failed to close libssh2 file: %d\n", rc);
         }
         sshc->sftp_handle = NULL;
       }
@@ -2310,7 +2310,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to close libssh2 file\n");
+          infof(data, "Failed to close libssh2 file: %d\n", rc);
         }
         sshc->sftp_handle = NULL;
       }

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2276,9 +2276,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-			infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(
+             sshc->ssh_session, &err_msg, NULL, 0);
+          infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
         }
         sshc->sftp_handle = NULL;
       }
@@ -2312,9 +2313,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-        	char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-			infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(
+             sshc->ssh_session, &err_msg, NULL, 0);
+          infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
         }
         sshc->sftp_handle = NULL;
       }
@@ -2495,9 +2497,11 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to send libssh2 channel EOF: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(
+            sshc->ssh_session, &err_msg, NULL, 0);
+          infof(data, "Failed to send libssh2 channel EOF: %d %s\n",
+            rc, err_msg);
         }
       }
       state(conn, SSH_SCP_WAIT_EOF);
@@ -2510,9 +2514,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to get channel EOF: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(sshc->ssh_session,
+            &err_msg, NULL, 0);
+          infof(data, "Failed to get channel EOF: %d %s\n", rc, err_msg);
         }
       }
       state(conn, SSH_SCP_WAIT_CLOSE);
@@ -2525,9 +2530,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Channel failed to close: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(sshc->ssh_session,
+             &err_msg, NULL, 0);
+          infof(data, "Channel failed to close: %d %s\n", rc, err_msg);
         }
       }
       state(conn, SSH_SCP_CHANNEL_FREE);
@@ -2540,9 +2546,11 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to free libssh2 scp subsystem: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(
+            sshc->ssh_session, &err_msg, NULL, 0);
+          infof(data, "Failed to free libssh2 scp subsystem: %d %s\n",
+            rc, err_msg);
         }
         sshc->ssh_channel = NULL;
       }
@@ -2564,9 +2572,11 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to free libssh2 scp subsystem: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(sshc->ssh_session,
+            &err_msg, NULL, 0);
+          infof(data, "Failed to free libssh2 scp subsystem: %d %s\n",
+            rc, err_msg);
         }
         sshc->ssh_channel = NULL;
       }
@@ -2577,9 +2587,11 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to disconnect libssh2 session: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(sshc->ssh_session,
+            &err_msg, NULL, 0);
+          infof(data, "Failed to disconnect libssh2 session: %d %s\n",
+            rc, err_msg);
         }
       }
 
@@ -2604,9 +2616,11 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to disconnect from libssh2 agent: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(sshc->ssh_session,
+            &err_msg, NULL, 0);
+          infof(data, "Failed to disconnect from libssh2 agent: %d %s\n",
+            rc, err_msg);
         }
         libssh2_agent_free(sshc->ssh_agent);
         sshc->ssh_agent = NULL;
@@ -2624,9 +2638,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = NULL;
-        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
-  			infof(data, "Failed to free libssh2 session: %d %s\n", rc, err_msg);
+          char *err_msg = NULL;
+          (void)libssh2_session_last_error(sshc->ssh_session,
+            &err_msg, NULL, 0);
+          infof(data, "Failed to free libssh2 session: %d %s\n", rc, err_msg);
         }
         sshc->ssh_session = NULL;
       }

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -839,7 +839,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         state(conn, SSH_AUTH_DONE);
       }
       else {
-        char *err_msg = nil;
+        char *err_msg = NULL;
         (void)libssh2_session_last_error(sshc->ssh_session,
                                          &err_msg, NULL, 0);
         infof(data, "SSH public key authentication failed: %s\n", err_msg);
@@ -1046,7 +1046,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
        */
       sshc->sftp_session = libssh2_sftp_init(sshc->ssh_session);
       if(!sshc->sftp_session) {
-        char *err_msg = nil;
+        char *err_msg = NULL;
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {
           rc = LIBSSH2_ERROR_EAGAIN;
@@ -2276,7 +2276,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
 			infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
         }
@@ -2312,7 +2312,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-        	char *err_msg = nil;
+        	char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
 			infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
         }
@@ -2369,7 +2369,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
                  data->state.infilesize);
       if(!sshc->ssh_channel) {
         int ssh_err;
-        char *err_msg = nil;
+        char *err_msg = NULL;
 
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {
@@ -2442,7 +2442,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
       if(!sshc->ssh_channel) {
         int ssh_err;
-        char *err_msg = nil;
+        char *err_msg = NULL;
 
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {
@@ -2495,7 +2495,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to send libssh2 channel EOF: %d %s\n", rc, err_msg);
         }
@@ -2510,7 +2510,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to get channel EOF: %d %s\n", rc, err_msg);
         }
@@ -2525,7 +2525,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Channel failed to close: %d %s\n", rc, err_msg);
         }
@@ -2540,7 +2540,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to free libssh2 scp subsystem: %d %s\n", rc, err_msg);
         }
@@ -2564,7 +2564,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to free libssh2 scp subsystem: %d %s\n", rc, err_msg);
         }
@@ -2577,7 +2577,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to disconnect libssh2 session: %d %s\n", rc, err_msg);
         }
@@ -2604,7 +2604,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to disconnect from libssh2 agent: %d %s\n", rc, err_msg);
         }
@@ -2624,7 +2624,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-			char *err_msg = nil;
+			char *err_msg = NULL;
         	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
   			infof(data, "Failed to free libssh2 session: %d %s\n", rc, err_msg);
         }

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -839,7 +839,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         state(conn, SSH_AUTH_DONE);
       }
       else {
-        char *err_msg;
+        char *err_msg = nil;
         (void)libssh2_session_last_error(sshc->ssh_session,
                                          &err_msg, NULL, 0);
         infof(data, "SSH public key authentication failed: %s\n", err_msg);
@@ -1046,7 +1046,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
        */
       sshc->sftp_session = libssh2_sftp_init(sshc->ssh_session);
       if(!sshc->sftp_session) {
-        char *err_msg;
+        char *err_msg = nil;
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {
           rc = LIBSSH2_ERROR_EAGAIN;
@@ -2276,7 +2276,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to close libssh2 file: %d\n", rc);
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+			infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
         }
         sshc->sftp_handle = NULL;
       }
@@ -2310,7 +2312,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to close libssh2 file: %d\n", rc);
+        	char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+			infof(data, "Failed to close libssh2 file: %d %s\n", rc, err_msg);
         }
         sshc->sftp_handle = NULL;
       }
@@ -2365,7 +2369,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
                  data->state.infilesize);
       if(!sshc->ssh_channel) {
         int ssh_err;
-        char *err_msg;
+        char *err_msg = nil;
 
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {
@@ -2438,7 +2442,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
       if(!sshc->ssh_channel) {
         int ssh_err;
-        char *err_msg;
+        char *err_msg = nil;
 
         if(libssh2_session_last_errno(sshc->ssh_session) ==
            LIBSSH2_ERROR_EAGAIN) {
@@ -2517,7 +2521,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-          infof(data, "Channel failed to close: %d\n", rc);
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Channel failed to close: %d %s\n", rc, err_msg);
         }
       }
       state(conn, SSH_SCP_CHANNEL_FREE);

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2495,7 +2495,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-          infof(data, "Failed to send libssh2 channel EOF\n");
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to send libssh2 channel EOF: %d %s\n", rc, err_msg);
         }
       }
       state(conn, SSH_SCP_WAIT_EOF);
@@ -2508,7 +2510,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc) {
-          infof(data, "Failed to get channel EOF: %d\n", rc);
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to get channel EOF: %d %s\n", rc, err_msg);
         }
       }
       state(conn, SSH_SCP_WAIT_CLOSE);
@@ -2536,7 +2540,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to free libssh2 scp subsystem\n");
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to free libssh2 scp subsystem: %d %s\n", rc, err_msg);
         }
         sshc->ssh_channel = NULL;
       }
@@ -2558,7 +2564,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to free libssh2 scp subsystem\n");
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to free libssh2 scp subsystem: %d %s\n", rc, err_msg);
         }
         sshc->ssh_channel = NULL;
       }
@@ -2569,7 +2577,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to disconnect libssh2 session\n");
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to disconnect libssh2 session: %d %s\n", rc, err_msg);
         }
       }
 
@@ -2594,7 +2604,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to disconnect from libssh2 agent\n");
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to disconnect from libssh2 agent: %d %s\n", rc, err_msg);
         }
         libssh2_agent_free(sshc->ssh_agent);
         sshc->ssh_agent = NULL;
@@ -2612,7 +2624,9 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           break;
         }
         if(rc < 0) {
-          infof(data, "Failed to free libssh2 session\n");
+			char *err_msg = nil;
+        	(void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+  			infof(data, "Failed to free libssh2 session: %d %s\n", rc, err_msg);
         }
         sshc->ssh_session = NULL;
       }


### PR DESCRIPTION
We got people complaining about getting error with closing SFTP file and files only be partially uploaded.

So we added error details to the info messages.
All SFTP failures should be reported back with LibSSH2 error code and if possible an error message.