### PR TITLE
Improve documentation for client schannel certificate support

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.3
@@ -33,19 +33,26 @@ the file name of your client certificate. The default format is "P12" on
 Secure Transport and "PEM" on other engines, and can be changed with
 \fICURLOPT_SSLCERTTYPE(3)\fP.
 
-With NSS or Secure Transport, this can also be the nickname of the certificate
-you wish to authenticate with as it is named in the security database. If you
-want to use a file from the current directory, please precede it with "./"
-prefix, in order to avoid confusion with a nickname.
-
-With WinSSL, this can be expression like "CurrentUser\\MY\\<thumbprint>" to
-refer to a certificate in the system certificates store.
-
 When using a client certificate, you most likely also need to provide a
 private key with \fICURLOPT_SSLKEY(3)\fP.
 
 The application does not have to keep the string around after setting this
 option.
+.SH SECURITY DATABASE
+With NSS or Secure Transport, this can also be the nickname of the certificate
+you wish to authenticate with as it is named in the security database. If you
+want to use a file from the current directory, please precede it with "./"
+prefix, in order to avoid confusion with a nickname.
+
+With WinSSL, this can be a path expression like
+"<store location>\\<store name>\\<thumbprint>" to refer to a certificate
+in the system certificates store, for example,
+"CurrentUser\\MY\\934a7ac6f8a5d579285a74fa61e19f23ddfe8d7a". Thumbprint is
+usually a SHA-1 hex string which you can see in certificate details. Following
+store locations are supported: CurrentUser, LocalMachine, CurrentService,
+Services, CurrentUserGroupPolicy, LocalMachineGroupPolicy,
+LocalMachineEnterprise. Currently loading from a PFX file is not supported.
+You can import it to the system certificates store first.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -433,7 +433,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
       cert_thumbprint.cbData = CERT_THUMBPRINT_DATA_LEN;
 
       if(!CryptStringToBinary(cert_thumbprint_str, CERT_THUMBPRINT_STR_LEN,
-                              CRYPT_STRING_HEXRAW,
+                              CRYPT_STRING_HEX,
                               cert_thumbprint_data, &cert_thumbprint.cbData,
                               NULL, NULL)) {
         Curl_unicodefree(cert_path);


### PR DESCRIPTION
Descriptions of security database are organized into a separate section. CI failure on Windows XP is also fixed.