### PR TITLE
http2: handle on_begin_headers() called more than once

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -870,16 +870,12 @@ static int on_begin_headers(nghttp2_session *session,
     return 0;
   }
 
-  /* This is trailer HEADERS started.  Allocate buffer for them. */
-  H2BUGF(infof(data_s, "trailer field started\n"));
-
-  DEBUGASSERT(stream->trailer_recvbuf == NULL);
-
-  stream->trailer_recvbuf = Curl_add_buffer_init();
   if(!stream->trailer_recvbuf) {
-    return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+    stream->trailer_recvbuf = Curl_add_buffer_init();
+    if(!stream->trailer_recvbuf) {
+      return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+    }
   }
-
   return 0;
 }
 


### PR DESCRIPTION
This triggered an assert if called more than once in debug mode (and a
memory leak if not debug build). With the right sequence of HTTP/2
headers incoming it can happen.

Detected by OSS-Fuzz

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=7764