### PR TITLE
http2: fix drain counters out of sync 

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -162,6 +162,7 @@ static CURLcode http2_disconnect(struct connectdata *conn,
   nghttp2_session_del(c->h2);
   Curl_safefree(c->inbuf);
   http2_stream_free(conn->data->req.protop);
+  conn->data->state.drain = 0;
 
   H2BUGF(infof(conn->data, "HTTP/2 DISCONNECT done\n"));
 


### PR DESCRIPTION
This fixes the notorious "httpc->drain_total >= data->state.drain"
assert.

Reported-by: Anders Bakken

Fixes #1680