### PR TITLE
http2: avoid strstr() on data not zero terminated

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1851,8 +1851,11 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
     return -1;
   }
 
-  /* Extract :method, :path from request line */
-  line_end = strstr(hdbuf, "\r\n");
+  /* Extract :method, :path from request line
+     We do line endings with CRLF so checking for CR is enough */
+  line_end = memchr(hdbuf, '\r', len);
+  if(!line_end)
+    goto fail;
 
   /* Method does not contain spaces */
   end = memchr(hdbuf, ' ', line_end - hdbuf);


### PR DESCRIPTION
It's not strictly clear if the API contract allows us to call strstr()
on a string that isn't zero terminated even when we know it will find
the substring, and clang's ASAN check dislikes us for it.

Also added a check of the return code in case it fails, even if I can't
think of a situation how that can trigger.

Detected by OSS-Fuzz

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=7760