### PR TITLE
http2: convert an assert to run-time check

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -624,8 +624,10 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
     }
 
     /* nghttp2 guarantees that :status is received, and we store it to
-       stream->status_code */
-    DEBUGASSERT(stream->status_code != -1);
+       stream->status_code. Fuzzing has proven this can still be reached
+       without status code having been set. */
+    if(stream->status_code == -1)
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
 
     /* Only final status code signals the end of header */
     if(stream->status_code / 100 != 1) {


### PR DESCRIPTION
Fuzzing has proven we can reach code in on_frame_recv with status_code
not having been set, so let's detect that in run-time (instead of with
assert) and error error accordingly.

Detected by OSS-Fuzz
Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=7903