### PR TITLE
ftplistparser: keep state between invokes (take 3!)

### DIFF
--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2010 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2010 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -33,14 +33,11 @@ struct fileinfo *Curl_fileinfo_alloc(void)
   return calloc(1, sizeof(struct fileinfo));
 }
 
-void Curl_fileinfo_dtor(void *user, void *element)
+void Curl_fileinfo_cleanup(struct fileinfo *finfo)
 {
-  struct fileinfo *finfo = element;
-  (void) user;
   if(!finfo)
     return;
 
   Curl_safefree(finfo->info.b_data);
-
   free(finfo);
 }

--- a/lib/fileinfo.h
+++ b/lib/fileinfo.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2010, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2010 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,7 +31,6 @@ struct fileinfo {
 };
 
 struct fileinfo *Curl_fileinfo_alloc(void);
-
-void Curl_fileinfo_dtor(void *, void *);
+void Curl_fileinfo_cleanup(struct fileinfo *finfo);
 
 #endif /* HEADER_CURL_FILEINFO_H */

--- a/lib/wildcard.c
+++ b/lib/wildcard.c
@@ -30,9 +30,15 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+static void fileinfo_dtor(void *user, void *element)
+{
+  (void)user;
+  Curl_fileinfo_cleanup(element);
+}
+
 CURLcode Curl_wildcard_init(struct WildcardData *wc)
 {
-  Curl_llist_init(&wc->filelist, Curl_fileinfo_dtor);
+  Curl_llist_init(&wc->filelist, fileinfo_dtor);
   wc->state = CURLWC_INIT;
 
   return CURLE_OK;


### PR DESCRIPTION
Fixes FTP wildcard parsing when doing over a number of read buffers.

Regression from f786d1f14

Reported-by: wncboy on github
Fixes #2445
Closes #2519