### PR TITLE
Ensure that we have cookies before writing jar

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1442,6 +1442,10 @@ static int cookie_output(struct CookieInfo *c, const char *dumphere)
   /* at first, remove expired cookies */
   remove_expired(c);
 
+  /* make sure we still have cookies after expiration */
+  if(0 == c->numcookies)
+    return 0;
+
   if(!strcmp("-", dumphere)) {
     /* use stdout */
     out = stdout;


### PR DESCRIPTION
The jar should only be written if there are any cookies, but there is no re-check on `c->numcookies` after the removal of expired cookies. Add another check after expiration to be able to avoid an empty file, should all cookies be expired.