### PR TITLE
Force indentation of lines after an else in checksrc

### DIFF
--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -511,7 +511,7 @@ sub scanfile {
                 if($expect != $second) {
                     my $diff = $second - $first;
                     checkwarn("INDENTATION", $line, length($1), $file, $ol,
-                              "not indented $indent steps, uses $diff)");
+                              "not indented $indent steps (uses $diff)");
 
                 }
             }

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -499,9 +499,9 @@ sub scanfile {
         }
 
         # if the previous line starts with if/while/for AND ends with an open
-        # brace, check that this line is indented $indent more steps, if not
-        # a cpp line
-        if($prevl =~ /^( *)(if|while|for)\(.*\{\z/) {
+        # brace, or an else statement, check that this line is indented $indent
+        # more steps, if not a cpp line
+        if($prevl =~ /^( *)((if|while|for)\(.*\{|else)\z/) {
             my $first = length($1);
 
             # this line has some character besides spaces

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1798,8 +1798,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if((data->easy_conn->sockfd != CURL_SOCKET_BAD) ||
          (data->easy_conn->writesockfd != CURL_SOCKET_BAD))
         multistate(data, CURLM_STATE_WAITPERFORM);
-      else
-      {
+      else {
         if(data->state.wildcardmatch &&
            ((data->easy_conn->handler->flags & PROTOPT_WILDCARD) == 0)) {
            data->wildcard.state = CURLWC_DONE;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -764,8 +764,7 @@ CURLcode rtp_client_write(struct connectdata *conn, char *ptr, size_t len)
     writeit = data->set.fwrite_rtp;
     user_ptr = data->set.rtp_out;
   }
-  else
-  {
+  else {
     writeit = data->set.fwrite_func;
     user_ptr = data->set.out;
   }

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1203,8 +1203,7 @@ CURLcode telrcv(struct connectdata *conn,
           CURL_SB_ACCUM(tn, c);
           tn->telrcv_state = CURL_TS_SB;
         }
-        else
-        {
+        else {
           CURL_SB_ACCUM(tn, CURL_IAC);
           CURL_SB_ACCUM(tn, CURL_SE);
           tn->subpointer -= 2;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -544,8 +544,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     InitSecBuffer(&inbuf, SECBUFFER_APPLICATION_PROTOCOLS, alpn_buffer, cur);
     InitSecBufferDesc(&inbuf_desc, &inbuf, 1);
   }
-  else
-  {
+  else {
     InitSecBuffer(&inbuf, SECBUFFER_EMPTY, NULL, 0);
     InitSecBufferDesc(&inbuf_desc, &inbuf, 1);
   }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -456,8 +456,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
            the number of resources as urlnum. */
         urlnum = count_next_metalink_resource(mlfile);
       }
-      else
-      if(!config->globoff) {
+      else if(!config->globoff) {
         /* Unless explicitly shut off, we expand '{...}' and '[...]'
            expressions and return total number of URLs in pattern set */
         result = glob_url(&urls, urlnode->url, &urlnum,
@@ -1858,8 +1857,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
              */
             break;
         }
-        else
-        if(urlnum > 1) {
+        else if(urlnum > 1) {
           /* when url globbing, exit loop upon critical error */
           if(is_fatal_error(result))
             break;

--- a/tests/libtest/stub_gssapi.c
+++ b/tests/libtest/stub_gssapi.c
@@ -324,7 +324,7 @@ OM_uint32 gss_display_status(OM_uint32 *min,
     if(status_string->value)
       status_string->length = strlen(status_string->value);
     else
-       return GSS_S_FAILURE;
+      return GSS_S_FAILURE;
   }
 
   return GSS_S_COMPLETE;


### PR DESCRIPTION
This extends the `INDENTATION` case to also handle `else` statements and require proper indentation on the following line. Included are also fixes for the offending cases found in the codebase.