### PR TITLE
http2: get rid of another strstr()

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1923,8 +1923,10 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
 
     hdbuf = line_end + 2;
 
-    line_end = strstr(hdbuf, "\r\n");
-    if(line_end == hdbuf)
+    /* check for next CR, but only within the piece of data left in the given
+       buffer */
+    line_end = memchr(hdbuf, '\r', len - (hdbuf - (char *)mem));
+    if(!line_end || (line_end == hdbuf))
       goto fail;
 
     /* header continuation lines are not supported */


### PR DESCRIPTION
Follow-up to 1514c44655e12e: replace another strstr() call done on a
buffer that might not be zero terminated - with a memchr() call, even if
we know the substring will be found.

Assisted-by: Max Dymond

Detected by OSS-Fuzz
Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=8021