### PR TITLE
Fix ASCII dependency in strcpy_url and strlen_url

### DIFF
--- a/lib/curl_ctype.c
+++ b/lib/curl_ctype.c
@@ -123,4 +123,11 @@ int Curl_islower(int c)
   return (ascii[c] & (_L));
 }
 
+int Curl_iscntrl(int c)
+{
+  if((c < 0) || (c >= 0x80))
+    return FALSE;
+  return (ascii[c] & (_C));
+}
+
 #endif /* !CURL_DOES_CONVERSIONS */

--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -45,6 +45,7 @@
 #define ISPRINT(x)  (isprint((int)  ((unsigned char)x)))
 #define ISUPPER(x)  (isupper((int)  ((unsigned char)x)))
 #define ISLOWER(x)  (islower((int)  ((unsigned char)x)))
+#define ISCNTRL(x)  (iscntrl((int)  ((unsigned char)x)))
 #define ISASCII(x)  (isascii((int)  ((unsigned char)x)))
 
 #else
@@ -58,6 +59,7 @@ int Curl_isprint(int c);
 int Curl_isalpha(int c);
 int Curl_isupper(int c);
 int Curl_islower(int c);
+int Curl_iscntrl(int c);
 
 #define ISSPACE(x)  (Curl_isspace((int)  ((unsigned char)x)))
 #define ISDIGIT(x)  (Curl_isdigit((int)  ((unsigned char)x)))
@@ -68,6 +70,7 @@ int Curl_islower(int c);
 #define ISPRINT(x)  (Curl_isprint((int)  ((unsigned char)x)))
 #define ISUPPER(x)  (Curl_isupper((int)  ((unsigned char)x)))
 #define ISLOWER(x)  (Curl_islower((int)  ((unsigned char)x)))
+#define ISCNTRL(x)  (Curl_iscntrl((int)  ((unsigned char)x)))
 #define ISASCII(x)  (((x) >= 0) && ((x) <= 0x80))
 
 #endif

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1447,6 +1447,16 @@ static const char *find_host_sep(const char *url)
 }
 
 /*
+ * Decide in an encoding-independent manner whether a character in an
+ * URL must be escaped. The same criterion must be used in strlen_url()
+ * and strcpy_url().
+ */
+static bool urlchar_needs_escaping(int c)
+{
+    return !(ISCNTRL(c) || ISSPACE(c) || ISGRAPH(c));
+}
+
+/*
  * strlen_url() returns the length of the given URL if the spaces within the
  * URL were properly URL encoded.
  * URL encoding should be skipped for host names, otherwise IDN resolution
@@ -1474,7 +1484,7 @@ static size_t strlen_url(const char *url, bool relative)
       left = FALSE;
       /* fall through */
     default:
-      if(*ptr >= 0x80)
+      if(urlchar_needs_escaping(*ptr))
         newlen += 2;
       newlen++;
       break;
@@ -1519,7 +1529,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
       left = FALSE;
       /* fall through */
     default:
-      if(*iptr >= 0x80) {
+      if(urlchar_needs_escaping(*iptr)) {
         snprintf(optr, 4, "%%%02x", *iptr);
         optr += 3;
       }


### PR DESCRIPTION
Commit 3c630f9b0af097663a64e5c875c580aa9808a92b partially reverted
the changes from commit dd7521bcc1b7a6fcb53c31f9bd1192fcc884bd56 because of
the problem that strcpy_url() was modified unilaterally without also
modifying strlen_url(). As a consequence strcpy_url() was again depending
on ASCII encoding.

This change fixes strlen_url() and strcpy_url() in parallel to use a
common host-encoding independent criterion for deciding whether an URL
character must be %-escaped.