### PR TITLE
Remove unused macro from cookies.h

### DIFF
--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -69,7 +69,6 @@ struct CookieInfo {
 
 */
 #define MAX_COOKIE_LINE 5000
-#define MAX_COOKIE_LINE_TXT "4999"
 
 /* This is the maximum length of a cookie name or content we deal with: */
 #define MAX_NAME 4096


### PR DESCRIPTION
Commit 2bc230de63 made the macro `MAX_COOKIE_LINE_TXT` become unused, so remove as it's not part of the published API.