### PR TITLE
curl: show headers in bold

### DIFF
--- a/docs/cmdline-opts/Makefile.inc
+++ b/docs/cmdline-opts/Makefile.inc
@@ -46,6 +46,7 @@ DPAGES = abstract-unix-socket.d anyauth.d append.d basic.d cacert.d capath.d cer
   tlsauthtype.d tlspassword.d tlsuser.d tlsv1.0.d tlsv1.1.d tlsv1.2.d   \
   tlsv1.3.d tlsv1.d trace-ascii.d trace.d trace-time.d tr-encoding.d    \
   unix-socket.d upload-file.d url.d use-ascii.d user-agent.d user.d     \
-  verbose.d version.d write-out.d xattr.d request-target.d
+  verbose.d version.d write-out.d xattr.d request-target.d              \
+  styled-output.d
 
 OTHERPAGES = page-footer page-header

--- a/docs/cmdline-opts/styled-output.d
+++ b/docs/cmdline-opts/styled-output.d
@@ -1,0 +1,6 @@
+Long: styled-output
+Help: Enable styled output for HTTP headers
+Added: 7.61.0
+---
+Enables the automatic use of bold font styles when writing HTTP headers to the
+terminal. Use --no-styled-output to switch them off.

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -163,7 +163,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
     if(!outs->stream && !tool_create_output_file(outs, FALSE))
       return failure;
 
-    if(hdrcbdata->global->isatty)
+    if(hdrcbdata->global->isatty && hdrcbdata->global->styled_output)
       value = memchr(ptr, ':', cb);
     if(value) {
       size_t namelen = value - ptr;

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,10 +31,19 @@
 #include "tool_doswin.h"
 #include "tool_msgs.h"
 #include "tool_cb_hdr.h"
+#include "tool_cb_wrt.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
 static char *parse_filename(const char *ptr, size_t len);
+
+#ifdef WIN32
+#define BOLD
+#define BOLDOFF
+#else
+#define BOLD "\x1b[1m"
+#define BOLDOFF "\x1b[21m"
+#endif
 
 /*
 ** callback for CURLOPT_HEADERFUNCTION
@@ -48,7 +57,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
   const char *str = ptr;
   const size_t cb = size * nmemb;
   const char *end = (char *)ptr + cb;
-  char *url = NULL;
+  long protocol = 0;
 
   /*
    * Once that libcurl has called back tool_header_cb() the returned value
@@ -88,11 +97,14 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
    * Content-Disposition header specifying a filename property.
    */
 
+  curl_easy_getinfo(outs->config->easy, CURLINFO_PROTOCOL, &protocol);
   if(hdrcbdata->honor_cd_filename &&
      (cb > 20) && checkprefix("Content-disposition:", str) &&
-     !curl_easy_getinfo(outs->config->easy, CURLINFO_EFFECTIVE_URL, &url) &&
-     url && (checkprefix("http://", url) || checkprefix("https://", url))) {
+     (protocol & (CURLPROTO_HTTPS|CURLPROTO_HTTP))) {
     const char *p = str + 20;
+
+    if(!outs->stream && !tool_create_output_file(outs, FALSE))
+      return failure;
 
     /* look for the 'filename=' parameter
        (encoded filenames (*=) are not supported) */
@@ -119,19 +131,49 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       len = (ssize_t)cb - (p - str);
       filename = parse_filename(p, len);
       if(filename) {
-        outs->filename = filename;
-        outs->alloc_filename = TRUE;
+        if(outs->stream) {
+          /* already opened and possibly written to */
+          if(outs->fopened)
+            fclose(outs->stream);
+          outs->stream = NULL;
+
+          /* rename the initial file name to the new file name */
+          rename(outs->filename, filename);
+          if(outs->alloc_filename)
+            free(outs->filename);
+        }
         outs->is_cd_filename = TRUE;
         outs->s_isreg = TRUE;
         outs->fopened = FALSE;
-        outs->stream = NULL;
-        hdrcbdata->honor_cd_filename = FALSE;
-        break;
+        outs->filename = filename;
+        outs->alloc_filename = TRUE;
+        hdrcbdata->honor_cd_filename = FALSE; /* done now! */
+        if(!tool_create_output_file(outs, TRUE))
+          return failure;
       }
-      return failure;
+      break;
     }
   }
 
+  if(hdrcbdata->config->show_headers &&
+     (protocol & (CURLPROTO_HTTP|CURLPROTO_HTTPS|CURLPROTO_RTSP))) {
+    /* bold headers only happen for HTTP(S) and RTSP */
+    char *value = NULL;
+
+    if(!outs->stream && !tool_create_output_file(outs, FALSE))
+      return failure;
+
+    if(hdrcbdata->global->isatty)
+      value = memchr(ptr, ':', cb);
+    if(value) {
+      size_t namelen = value - ptr;
+      fprintf(outs->stream, BOLD "%.*s" BOLDOFF ":", namelen, ptr);
+      fwrite(&value[1], cb - namelen - 1, 1, outs->stream);
+    }
+    else
+      /* not "handled", just show it */
+      fwrite(ptr, cb, 1, outs->stream);
+  }
   return cb;
 }
 
@@ -233,4 +275,3 @@ static char *parse_filename(const char *ptr, size_t len)
 
   return copy;
 }
-

--- a/src/tool_cb_hdr.h
+++ b/src/tool_cb_hdr.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -39,6 +39,8 @@
  */
 
 struct HdrCbData {
+  struct GlobalConfig *global;
+  struct OperationConfig *config;
   struct OutStruct *outs;
   struct OutStruct *heads;
   bool honor_cd_filename;

--- a/src/tool_cb_wrt.h
+++ b/src/tool_cb_wrt.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -30,7 +30,7 @@
 size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata);
 
 /* create a local file for writing, return TRUE on success */
-bool tool_create_output_file(struct OutStruct *outs);
+bool tool_create_output_file(struct OutStruct *outs, bool append);
 
 #endif /* HEADER_CURL_TOOL_CB_WRT_H */
 

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -276,6 +276,7 @@ struct GlobalConfig {
   int progressmode;               /* CURL_PROGRESS_BAR / CURL_PROGRESS_STATS */
   char *libcurl;                  /* Output libcurl code to this file name */
   bool fail_early;                /* exit on first transfer error */
+  bool styled_output;             /* enable fancy output style detection */
   struct OperationConfig *first;
   struct OperationConfig *current;
   struct OperationConfig *last;   /* Always last in the struct */

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -100,7 +100,7 @@ struct OperationConfig {
   bool use_ascii;           /* select ascii or text transfer */
   bool autoreferer;         /* automatically set referer */
   bool failonerror;         /* fail on (HTTP) errors */
-  bool include_headers;     /* send headers to data output */
+  bool show_headers;        /* show headers to data output */
   bool no_body;             /* don't get the body */
   bool dirlistonly;         /* only get the FTP dir list */
   bool followlocation;      /* follow http redirects */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -260,6 +260,7 @@ static const struct LongShort aliases[]= {
   {"EB", "socks5-gssapi",            ARG_BOOL},
   {"f",  "fail",                     ARG_BOOL},
   {"fa", "fail-early",               ARG_BOOL},
+  {"fb", "styled-output",            ARG_BOOL},
   {"F",  "form",                     ARG_STRING},
   {"Fs", "form-string",              ARG_STRING},
   {"g",  "globoff",                  ARG_BOOL},
@@ -1643,8 +1644,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       case 'a': /* --fail-early */
         global->fail_early = toggle;
         break;
-      default:
-        /* fail hard on errors  */
+      case 'b': /* --styled-output */
+        global->styled_output = toggle;
+        break;
+      default: /* --fail (hard on errors)  */
         config->failonerror = toggle;
       }
       break;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1722,24 +1722,22 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       break;
     case 'i':
-      config->include_headers = toggle; /* include the headers as well in the
-                                           general output stream */
+      config->show_headers = toggle; /* show the headers as well in the
+                                        general output stream */
       break;
     case 'j':
       config->cookiesession = toggle;
       break;
-    case 'I':
-      /*
-       * no_body will imply include_headers later on
-       */
+    case 'I': /* --head */
       config->no_body = toggle;
+      config->show_headers = toggle;
       if(SetHTTPrequest(config,
                         (config->no_body)?HTTPREQ_HEAD:HTTPREQ_GET,
                         &config->httpreq))
         return PARAM_BAD_USE;
       break;
     case 'J': /* --remote-header-name */
-      if(config->include_headers) {
+      if(config->show_headers) {
         warnf(global,
               "--include and --remote-header-name cannot be combined.\n");
         return PARAM_BAD_USE;

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -414,6 +414,8 @@ static const struct helptxt helptext[] = {
    "Use SSLv3"},
   {"    --stderr",
    "Where to redirect stderr"},
+  {"    --styled-output",
+   "Enable styled output for HTTP headers"},
   {"    --suppress-connect-headers",
    "Suppress proxy CONNECT response headers"},
   {"    --tcp-fastopen",

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -147,6 +147,7 @@ static CURLcode main_init(struct GlobalConfig *config)
   /* Initialise the global config */
   config->showerror = -1;             /* Will show errors */
   config->errors = stderr;            /* Default errors to stderr */
+  config->styled_output = TRUE;       /* enable detection */
 
   /* Allocate the initial operate config */
   config->first = config->last = malloc(sizeof(struct OperationConfig));

--- a/tests/data/test1116
+++ b/tests/data/test1116
@@ -34,6 +34,8 @@ Transfer-Encoding: chunked
 Connection: mooo
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
+chunky-trailer: header data
+another-header: yes
 </datacheck>
 </reply>
 

--- a/tests/data/test1319
+++ b/tests/data/test1319
@@ -31,9 +31,6 @@ body
 </data>
 
 <datacheck>
-HTTP/1.1 200 Mighty fine indeed
-pop3: sure hit me
-
 From: me@somewhere
 To: fake@nowhere
 

--- a/tests/data/test1321
+++ b/tests/data/test1321
@@ -27,9 +27,6 @@ body
   yours sincerely
 </data>
 <datacheck>
-HTTP/1.1 200 Mighty fine indeed
-imap: sure hit me
-
 From: me@somewhere
 To: fake@nowhere
 

--- a/tests/data/test1400
+++ b/tests/data/test1400
@@ -70,7 +70,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1400");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);

--- a/tests/data/test1401
+++ b/tests/data/test1401
@@ -82,7 +82,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1401");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "fake:user");
   curl_easy_setopt(hnd, CURLOPT_HTTPAUTH, (long)CURLAUTH_BASIC);
   curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist1);

--- a/tests/data/test1402
+++ b/tests/data/test1402
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1402");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "foo=bar&baz=quux");
   curl_easy_setopt(hnd, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)16);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");

--- a/tests/data/test1403
+++ b/tests/data/test1403
@@ -72,7 +72,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1403?foo=bar&baz=quux");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -121,7 +121,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1404");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   mime1 = curl_mime_init(hnd);
   part1 = curl_mime_addpart(mime1);
   curl_mime_data(part1, "value", CURL_ZERO_TERMINATED);

--- a/tests/data/test1405
+++ b/tests/data/test1405
@@ -85,7 +85,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "ftp://%HOSTIP:%FTPPORT/1405");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_QUOTE, slist1);
   curl_easy_setopt(hnd, CURLOPT_POSTQUOTE, slist2);
   curl_easy_setopt(hnd, CURLOPT_PREQUOTE, slist3);

--- a/tests/data/test1406
+++ b/tests/data/test1406
@@ -78,7 +78,6 @@ int main(int argc, char *argv[])
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_INFILESIZE_LARGE, (curl_off_t)38);
   curl_easy_setopt(hnd, CURLOPT_URL, "smtp://%HOSTIP:%SMTPPORT/1406");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_UPLOAD, 1L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/tests/data/test1407
+++ b/tests/data/test1407
@@ -59,7 +59,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "pop3://%HOSTIP:%POP3PORT/1407");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_DIRLISTONLY, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "user:secret");
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);

--- a/tests/data/test1417
+++ b/tests/data/test1417
@@ -35,6 +35,7 @@ Trailer: chunky-trailer
 Connection: mooo
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
+chunky-trailer: header data
 </datacheck>
 </reply>
 

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -65,7 +65,6 @@ int main(int argc, char *argv[])
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "imap://%HOSTIP:%IMAPPORT/1420/;UID=1");
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "user:secret");
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/tests/data/test2010
+++ b/tests/data/test2010
@@ -35,10 +35,10 @@ Metalink
 http
 </server>
  <name>
-Metalink local XML file, HTTP resource, using -o fname -i -D file
+Metalink local XML file, HTTP resource, using -o fname -D file
  </name>
 <command option="no-output,no-include">
---metalink file://%PWD/log/test2010.metalink -i -o log/outfile2010 -D log/heads2010
+--metalink file://%PWD/log/test2010.metalink -o log/outfile2010 -D log/heads2010
 </command>
 # local metalink file written before test command runs
 <file name="log/test2010.metalink">

--- a/tests/data/test266
+++ b/tests/data/test266
@@ -35,6 +35,7 @@ Trailer: chunky-trailer
 Connection: mooo
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
+chunky-trailer: header data
 </datacheck>
 </reply>
 


### PR DESCRIPTION
The feature is only enabled if the output is believed to be a tty.

-J: There's some minor differences and improvements in -J handling, as
now J should work with -i and it actually creates a file first using the
initial name and then *renames* that to the one found in
Content-Disposition (if any).

-i: only shows headers for HTTP transfers now (as documented).
Previously it would also show for pieces of the transfer that were HTTP
(for example when doing FTP over a HTTP proxy).

-i: now shows trailers as well. Previously they were not shown at all.

--libcurl: the CURLOPT_HEADER is no longer set, as the header output is
now done in the header callback.