### PR TITLE
tests: provide 'manual' as a feature to optionally require

### DIFF
--- a/tests/FILEFORMAT
+++ b/tests/FILEFORMAT
@@ -231,6 +231,7 @@ ipv6
 Kerberos
 large_file
 libz
+manual
 Metalink
 NSS
 NTLM

--- a/tests/data/test1026
+++ b/tests/data/test1026
@@ -13,6 +13,9 @@
 #
 # Client-side
 <client>
+<features>
+manual
+</features>
 <server>
 none
 </server>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -235,6 +235,7 @@ my $has_threadedres;# set if built with threaded resolver
 my $has_psl;        # set if libcurl is built with PSL support
 my $has_ldpreload;  # set if curl is built for systems supporting LD_PRELOAD
 my $has_multissl;   # set if curl is build with MultiSSL support
+my $has_manual;     # set if curl is built with built-in manual
 
 # this version is decided by the particular nghttp2 library that is being used
 my $h2cver = "h2c";
@@ -3033,6 +3034,17 @@ sub checksystem {
             "TrackMemory feature (--enable-curldebug)";
     }
 
+    open(M, "$CURL -M 2>&1|");
+    while(my $s = <M>) {
+        if($s =~ /built-in manual was disabled at build-time/) {
+            $has_manual = 0;
+            last;
+        }
+        $has_manual = 1;
+        last;
+    }
+    close(M);
+
     $has_shared = `sh $CURLCONFIG --built-shared`;
     chomp $has_shared;
 
@@ -3469,6 +3481,11 @@ sub singletest {
             }
             elsif($1 eq "PSL") {
                 if($has_psl) {
+                    next;
+                }
+            }
+            elsif($1 eq "manual") {
+                if($has_manual) {
                     next;
                 }
             }


### PR DESCRIPTION
... and make test 1026 rely on that feature so that --disable-manual
builds don't cause test failures.

Reported-by: Max Dymond and Anders Roxell
Fixes #2533