### PR TITLE
configure: only check for CA bundle for those SSL backends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1818,6 +1818,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
        fi
     fi
     CURL_CHECK_OPENSSL_API
+    check_for_ca_bundle=1
   fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
@@ -1967,7 +1968,7 @@ if test -z "$ssl_backends" -o "x$OPT_GNUTLS" != xno; then
 
       if test "x$USE_GNUTLS" = "xyes"; then
         AC_MSG_NOTICE([detected GnuTLS version $version])
-
+        check_for_ca_bundle=1
         if test -n "$gtlslib"; then
           dnl when shared libs were found in a path that the run-time
           dnl linker doesn't search through, we need to add it to
@@ -2101,7 +2102,7 @@ if test -z "$ssl_backends" -o "x$OPT_POLARSSL" != xno; then
 
     if test "x$USE_POLARSSL" = "xyes"; then
       AC_MSG_NOTICE([detected PolarSSL])
-
+      check_for_ca_bundle=1
       LIBS="-lpolarssl $LIBS"
 
       if test -n "$polarssllib"; then
@@ -2192,6 +2193,7 @@ if test -z "$ssl_backends" -o "x$OPT_MBEDTLS" != xno; then
 
     if test "x$USE_MBEDTLS" = "xyes"; then
       AC_MSG_NOTICE([detected mbedTLS])
+      check_for_ca_bundle=1
 
       LIBS="-lmbedtls -lmbedx509 -lmbedcrypto $LIBS"
 
@@ -2343,6 +2345,7 @@ if test -z "$ssl_backends" -o "x$OPT_CYASSL" != xno; then
 
     if test "x$USE_CYASSL" = "xyes"; then
       AC_MSG_NOTICE([detected $cyassllibname])
+      check_for_ca_bundle=1
 
       dnl cyassl/ctaocrypt/types.h needs SIZEOF_LONG_LONG defined!
       AC_CHECK_SIZEOF(long long)
@@ -2558,6 +2561,7 @@ if test -z "$ssl_backends" -o "x$OPT_AXTLS" != xno; then
       AC_DEFINE(USE_AXTLS, 1, [if axTLS is enabled])
       AC_SUBST(USE_AXTLS, [1])
       AXTLS_ENABLED=1
+      check_for_ca_bundle=1
       USE_AXTLS="yes"
       ssl_msg="axTLS"
       test axtls != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
@@ -2619,7 +2623,9 @@ dnl **********************************************************************
 dnl Check for the CA bundle
 dnl **********************************************************************
 
-CURL_CHECK_CA_BUNDLE
+if test "$check_for_ca_bundle" -gt 0; then
+  CURL_CHECK_CA_BUNDLE
+fi
 
 dnl **********************************************************************
 dnl Check for libpsl


### PR DESCRIPTION
... when only building with SSL backends that don't use the CA bundle
file (by default), skip the check.

Fixes #2543
Fixes #2180