### PR TITLE
Fix one more haxx.se http URL

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
@@ -9,7 +9,7 @@
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
-.\" * are also available at http://curl.haxx.se/docs/copyright.html.
+.\" * are also available at https://curl.haxx.se/docs/copyright.html.
 .\" *
 .\" * You may opt to use, copy, modify, merge, publish, distribute and/or sell
 .\" * copies of the Software, and permit persons to whom the Software is


### PR DESCRIPTION
This file wasn't included in commit 4af40b3646d3b09 which updated all haxx.se http urls to https. The file was committed prior to that update, but may have been merged after it and hence didn't get updated.