### PR TITLE
Fix format strings

### DIFF
--- a/docs/examples/debug.c
+++ b/docs/examples/debug.c
@@ -44,12 +44,12 @@ void dump(const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n",
-          text, (long)size, (long)size);
+  fprintf(stream, "%s, %10.10lu bytes (0x%8.8lx)\n",
+          text, size, size);
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stream, "%4.4lx: ", (long)i);
+    fprintf(stream, "%4.4lx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -100,7 +100,7 @@ int main(void)
      * Do something nice with it!
      */
 
-    printf("%lu bytes retrieved\n", (long)chunk.size);
+    printf("%lu bytes retrieved\n", chunk.size);
   }
 
   /* cleanup curl stuff */

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -71,12 +71,12 @@ void dump(const char *text, int num, unsigned char *ptr, size_t size,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stderr, "%d %s, %ld bytes (0x%lx)\n",
-          num, text, (long)size, (long)size);
+  fprintf(stderr, "%d %s, %lu bytes (0x%lx)\n",
+          num, text, size, size);
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stderr, "%4.4lx: ", (long)i);
+    fprintf(stderr, "%4.4lx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/docs/examples/http2-serverpush.c
+++ b/docs/examples/http2-serverpush.c
@@ -51,12 +51,12 @@ void dump(const char *text, unsigned char *ptr, size_t size,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stderr, "%s, %ld bytes (0x%lx)\n",
-          text, (long)size, (long)size);
+  fprintf(stderr, "%s, %lu bytes (0x%lx)\n",
+          text, size, size);
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stderr, "%4.4lx: ", (long)i);
+    fprintf(stderr, "%4.4lx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */
@@ -180,12 +180,12 @@ static int server_push_callback(CURL *parent,
   /* write to this file */
   curl_easy_setopt(easy, CURLOPT_WRITEDATA, out);
 
-  fprintf(stderr, "**** push callback approves stream %u, got %d headers!\n",
-          count, (int)num_headers);
+  fprintf(stderr, "**** push callback approves stream %u, got %lu headers!\n",
+          count, num_headers);
 
   for(i = 0; i<num_headers; i++) {
     headp = curl_pushheader_bynum(headers, i);
-    fprintf(stderr, "**** header %u: %s\n", (int)i, headp);
+    fprintf(stderr, "**** header %lu: %s\n", i, headp);
   }
 
   headp = curl_pushheader_byname(headers, ":path");

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -72,12 +72,12 @@ void dump(const char *text, int num, unsigned char *ptr, size_t size,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stderr, "%d %s, %ld bytes (0x%lx)\n",
-          num, text, (long)size, (long)size);
+  fprintf(stderr, "%d %s, %lu bytes (0x%lx)\n",
+          num, text, size, size);
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stderr, "%4.4lx: ", (long)i);
+    fprintf(stderr, "%4.4lx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -51,12 +51,12 @@ void dump(const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s, %10.10ld bytes (0x%8.8lx)\n",
-          text, (long)size, (long)size);
+  fprintf(stream, "%s, %10.10lu bytes (0x%8.8lx)\n",
+          text, size, size);
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stream, "%4.4lx: ", (long)i);
+    fprintf(stream, "%4.4lx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/docs/examples/sessioninfo.c
+++ b/docs/examples/sessioninfo.c
@@ -63,7 +63,7 @@ static size_t wrfu(void *ptr, size_t size, size_t nmemb, void *stream)
                gnutls_x509_crt_import(cert, &chainp[i], GNUTLS_X509_FMT_DER)) {
               if(GNUTLS_E_SUCCESS ==
                  gnutls_x509_crt_print(cert, GNUTLS_CRT_PRINT_FULL, &dn)) {
-                fprintf(stderr, "Certificate #%d: %.*s", i, dn.size, dn.data);
+                fprintf(stderr, "Certificate #%u: %.*s", i, dn.size, dn.data);
 
                 gnutls_free(dn.data);
               }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1910,13 +1910,13 @@ static CURLcode ftp_state_pasv_resp(struct connectdata *conn,
     if(data->set.ftp_skip_ip) {
       /* told to ignore the remotely given IP but instead use the host we used
          for the control connection */
-      infof(data, "Skip %d.%d.%d.%d for data connection, re-use %s instead\n",
+      infof(data, "Skip %u.%u.%u.%u for data connection, re-use %s instead\n",
             ip[0], ip[1], ip[2], ip[3],
             conn->host.name);
       ftpc->newhost = strdup(control_address(conn));
     }
     else
-      ftpc->newhost = aprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+      ftpc->newhost = aprintf("%u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
 
     if(!ftpc->newhost)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/http.c
+++ b/lib/http.c
@@ -1407,7 +1407,7 @@ static CURLcode add_haproxy_protocol_header(struct connectdata *conn)
 
   snprintf(proxy_header,
            sizeof proxy_header,
-           "PROXY %s %s %s %i %i\r\n",
+           "PROXY %s %s %s %li %li\r\n",
            tcp_version,
            conn->data->info.conn_local_ip,
            conn->data->info.conn_primary_ip,
@@ -2132,7 +2132,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
                                     host,
                                     conn->bits.ipv6_ip?"]":"");
     else
-      conn->allocptr.host = aprintf("Host: %s%s%s:%hu\r\n",
+      conn->allocptr.host = aprintf("Host: %s%s%s:%d\r\n",
                                     conn->bits.ipv6_ip?"[":"",
                                     host,
                                     conn->bits.ipv6_ip?"]":"",

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -221,7 +221,7 @@ static CURLcode CONNECT(struct connectdata *conn,
       if(!req_buffer)
         return CURLE_OUT_OF_MEMORY;
 
-      host_port = aprintf("%s:%hu", hostname, remote_port);
+      host_port = aprintf("%s:%d", hostname, remote_port);
       if(!host_port) {
         Curl_add_buffer_free(req_buffer);
         return CURLE_OUT_OF_MEMORY;
@@ -245,7 +245,7 @@ static CURLcode CONNECT(struct connectdata *conn,
         if(hostname != conn->host.name)
           ipv6_ip = (strchr(hostname, ':') != NULL);
         hostheader = /* host:port with IPv6 support */
-          aprintf("%s%s%s:%hu", ipv6_ip?"[":"", hostname, ipv6_ip?"]":"",
+          aprintf("%s%s%s:%d", ipv6_ip?"[":"", hostname, ipv6_ip?"]":"",
                   remote_port);
         if(!hostheader) {
           Curl_add_buffer_free(req_buffer);

--- a/lib/url.c
+++ b/lib/url.c
@@ -3419,7 +3419,7 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
        * stripped off. It would be better to work directly from the original
        * URL and simply replace the port part of it.
        */
-      url = aprintf("%s://%s%s%s:%hu%s%s%s", conn->given->scheme,
+      url = aprintf("%s://%s%s%s:%d%s%s%s", conn->given->scheme,
                     conn->bits.ipv6_ip?"[":"", conn->host.name,
                     conn->bits.ipv6_ip?"]":"", conn->remote_port,
                     data->state.slash_removed?"/":"", data->state.path,

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -63,9 +63,9 @@
 /* "NTLMSSP" signature is always in ASCII regardless of the platform */
 #define NTLMSSP_SIGNATURE "\x4e\x54\x4c\x4d\x53\x53\x50"
 
-#define SHORTPAIR(x) ((x) & 0xff), (((x) >> 8) & 0xff)
-#define LONGQUARTET(x) ((x) & 0xff), (((x) >> 8) & 0xff), \
-  (((x) >> 16) & 0xff), (((x) >> 24) & 0xff)
+#define SHORTPAIR(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff))
+#define LONGQUARTET(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff)), \
+  ((int)(((x) >> 16) & 0xff)), ((int)(((x) >> 24) & 0xff))
 
 #if DEBUG_ME
 # define DEBUG_OUT(x) x

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -815,7 +815,7 @@ static void Curl_mbedtls_session_free(void *ptr)
 static size_t Curl_mbedtls_version(char *buffer, size_t size)
 {
   unsigned int version = mbedtls_version_get_number();
-  return snprintf(buffer, size, "mbedTLS/%d.%d.%d", version>>24,
+  return snprintf(buffer, size, "mbedTLS/%u.%u.%u", version>>24,
                   (version>>16)&0xff, (version>>8)&0xff);
 }
 

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -146,7 +146,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
         if(!config->isatty || ((output != stderr) && (output != stdout))) {
           if(!newl)
             fprintf(output, "%s%s ", timebuf, s_infotype[type]);
-          fprintf(output, "[%zd bytes data]\n", size);
+          fprintf(output, "[%zu bytes data]\n", size);
           newl = FALSE;
           traced_data = TRUE;
         }
@@ -229,7 +229,7 @@ static void dump(const char *timebuf, const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s%s, %zd bytes (0x%zx)\n", timebuf, text, size, size);
+  fprintf(stream, "%s%s, %zu bytes (0x%zx)\n", timebuf, text, size, size);
 
   for(i = 0; i < size; i += width) {
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -579,7 +579,7 @@ CURLcode glob_next_url(char **globbed, URLGlob *glob)
       }
       break;
     case UPTNumRange:
-      snprintf(buf, buflen, "%0*ld",
+      snprintf(buf, buflen, "%0*lu",
                pat->content.NumRange.padlength,
                pat->content.NumRange.ptr_n);
       len = strlen(buf);

--- a/tests/libtest/lib1509.c
+++ b/tests/libtest/lib1509.c
@@ -69,7 +69,7 @@ int test(char *URL)
     goto test_cleanup;
   }
 
-  printf("header length is ........: %lu\n", headerSize);
+  printf("header length is ........: %ld\n", headerSize);
   printf("header length should be..: %lu\n", realHeaderSize);
 
 test_cleanup:

--- a/tests/libtest/lib1535.c
+++ b/tests/libtest/lib1535.c
@@ -71,7 +71,7 @@ int test(char *URL)
   }
   if(protocol != CURLPROTO_HTTP) {
     fprintf(stderr, "%s:%d protocol of http resource is incorrect; "
-            "expected %ld but is %ld\n",
+            "expected %d but is %ld\n",
             __FILE__, __LINE__, CURLPROTO_HTTP, protocol);
     res = CURLE_HTTP_RETURNED_ERROR;
     goto test_cleanup;

--- a/tests/libtest/lib1536.c
+++ b/tests/libtest/lib1536.c
@@ -72,7 +72,7 @@ int test(char *URL)
   if(memcmp(scheme, "HTTP", 5) != 0) {
     fprintf(stderr, "%s:%d scheme of http resource is incorrect; "
             "expected 'HTTP' but is %s\n",
-            __FILE__, __LINE__, CURLPROTO_HTTP,
+            __FILE__, __LINE__,
             (scheme == NULL ? "NULL" : "invalid"));
     res = CURLE_HTTP_RETURNED_ERROR;
     goto test_cleanup;

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -46,11 +46,11 @@ void dump(const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s, %d bytes (0x%x)\n", text, (int)size, (int)size);
+  fprintf(stream, "%s, %zu bytes (0x%zx)\n", text, size, size);
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stream, "%04x: ", (int)i);
+    fprintf(stream, "%04zx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -43,12 +43,12 @@ void libtest_debug_dump(const char *timebuf, const char *text, FILE *stream,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s%s, %d bytes (0x%x)\n", timebuf, text,
-          (int)size, (int)size);
+  fprintf(stream, "%s%s, %zu bytes (0x%zx)\n", timebuf, text,
+          size, size);
 
   for(i = 0; i < size; i += width) {
 
-    fprintf(stream, "%04x: ", (int)i);
+    fprintf(stream, "%04zx: ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/tests/server/fake_ntlm.c
+++ b/tests/server/fake_ntlm.c
@@ -37,7 +37,7 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#define LOGFILE "log/fake_ntlm%d.log"
+#define LOGFILE "log/fake_ntlm%ld.log"
 
 const char *serverlogfile;
 

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -97,7 +97,7 @@ UNITTEST_START
     int rem = (i + 7)%NUM_NODES;
     printf("Tree look:\n");
     splayprint(root, 0, 1);
-    printf("remove pointer %d, payload %zd\n", rem,
+    printf("remove pointer %d, payload %zu\n", rem,
            *(size_t *)nodes[rem].payload);
     rc = Curl_splayremovebyaddr(root, &nodes[rem], &root);
     if(rc) {
@@ -130,7 +130,7 @@ UNITTEST_START
     tv_now.tv_usec = i;
     root = Curl_splaygetbest(tv_now, root, &removed);
     while(removed != NULL) {
-      printf("removed payload %zd[%zd]\n",
+      printf("removed payload %zu[%zu]\n",
              (*(size_t *)removed->payload) / 10,
              (*(size_t *)removed->payload) % 10);
       root = Curl_splaygetbest(tv_now, root, &removed);

--- a/tests/unit/unit1395.c
+++ b/tests/unit/unit1395.c
@@ -79,13 +79,13 @@ UNITTEST_START
     abort_unless(out != NULL, "returned NULL!");
 
     if(strcmp(out, pairs[i].output)) {
-      fprintf(stderr, "Test %d: '%s' gave '%s' instead of '%s'\n",
+      fprintf(stderr, "Test %u: '%s' gave '%s' instead of '%s'\n",
               i, pairs[i].input, out, pairs[i].output);
       fail("Test case output mismatched");
       fails++;
     }
     else
-      fprintf(stderr, "Test %d: OK\n", i);
+      fprintf(stderr, "Test %u: OK\n", i);
     free(out);
   }
 


### PR DESCRIPTION
This is a series of commits cleaning up format specifiers for the curl_*printf functions as a preparation for the last commit where an __attribute__ is added to show which arguments are the format string, and which are the format specifiers.

A few comments on some of the commits:

tests: Fix format specifiers - In unit1323.c, the exact types for the members of the timeval struct is not specified, perhaps I should have added a cast to avoid protential problems on other platforms?

Make sure format length is int - Apparently, the standard says field precision specifiers should be of type int. I just added a cast to the variables. I have no idea if there's a risk it will overflow or wrap...

Add attribute to teach Gcc about printf-functions - A big bummer is that curl printf extensions (such as %.-2f) now gives warnings). I was not able to figure out if there was a way tell gcc about these extensions. It also means anyone using curl/mprintf.h with nonstandard extensions will get a warning.