### PR TITLE
http2: getsock fix for uploads

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -108,6 +108,7 @@ static int http2_perform_getsock(const struct connectdata *conn,
                                  int numsocks)
 {
   const struct http_conn *c = &conn->proto.httpc;
+  struct SingleRequest *k = &conn->data->req;
   int bitmap = GETSOCK_BLANK;
   (void)numsocks;
 
@@ -119,7 +120,9 @@ static int http2_perform_getsock(const struct connectdata *conn,
      always be ready for one */
   bitmap |= GETSOCK_READSOCK(FIRSTSOCKET);
 
-  if(nghttp2_session_want_write(c->h2))
+  /* we're still uploading or the HTTP/2 layer wants to send data */
+  if((k->keepon & KEEP_SEND|KEEP_SEND_PAUSE) == KEEP_SEND) ||
+    nghttp2_session_want_write(c->h2))
     bitmap |= GETSOCK_WRITESOCK(FIRSTSOCKET);
 
   return bitmap;


### PR DESCRIPTION
When there's an upload in progress, make sure to wait for the socket to
become writable.

Detected-by: steini2000 on github
Bug: #2520