### PR TITLE
openssl: acknowledge --tls-max for default version too

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2325,8 +2325,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   case CURL_SSLVERSION_TLSv1:
     ctx_options |= SSL_OP_NO_SSLv2;
     ctx_options |= SSL_OP_NO_SSLv3;
-    break;
-
+    /* FALLTHROUGH */
   case CURL_SSLVERSION_TLSv1_0:
   case CURL_SSLVERSION_TLSv1_1:
   case CURL_SSLVERSION_TLSv1_2:


### PR DESCRIPTION
... previously it only used the max setting if a TLS version was also
explicitly asked for.

Fixes #2571
Reported-by: byte_bucket