### PR TITLE
Do not unconditionally add gcc-specific flags

### DIFF
--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -117,7 +117,7 @@ noinst_LTLIBRARIES += libstubgss.la
 
 libstubgss_la_CPPFLAGS = $(AM_CPPFLAGS)
 libstubgss_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version -rpath /nowhere
-libstubgss_la_CFLAGS = $(AM_CFLAGS) -g -Wno-unused-parameter
+libstubgss_la_CFLAGS = $(AM_CFLAGS) -g
 
 libstubgss_la_SOURCES = stub_gssapi.c stub_gssapi.h
 


### PR DESCRIPTION
The warning flag leads e.g. Sun Studio compiler to bail out.