### PR TITLE
http: unconditionally ignore body data upon range error.

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -127,7 +127,7 @@ test1120 test1121 test1122 test1123 test1124 test1125 test1126 test1127 \
 test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
-test1152 test1153 test1154 test1155 \
+test1152 test1153 test1154 test1155 test1156 \
 \
 test1160 test1161 test1162 test1163 test1164 \
 test1170 test1171 \

--- a/tests/data/test1156
+++ b/tests/data/test1156
@@ -1,0 +1,70 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+Content-Range
+Resume
+Range
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Content-Type: text/html
+Content-Length: 5
+
+body
+</data>
+
+<data1 nocheck="yes">
+HTTP/1.1 200 OK
+Content-Type: text/html
+Content-Length: 5
+Content-Range: bytes 3/7
+
+body
+</data1>
+
+<data2 nocheck="yes">
+HTTP/1.1 416 Requested Range Not Satisfiable
+Content-Type: text/html
+Content-Length: 5
+
+body
+</data2>
+
+<data3 nocheck="yes">
+HTTP/1.1 416 Requested Range Not Satisfiable
+Content-Type: text/html
+Content-Length: 5
+Content-Range: bytes */2
+
+body
+</data3>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+lib1156
+</tool>
+ <name>
+HTTP resume/range fail range-error content-range combinations
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/want/1156
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+0
+</errorcode>
+</testcase>

--- a/tests/data/test92
+++ b/tests/data/test92
@@ -23,6 +23,20 @@ Content-Type: image/gif
 
 bad
 </data>
+
+# The body should be ignored.
+<datacheck>
+HTTP/1.1 416 Requested Range Not Satisfiable
+Date: Fri, 24 Oct 2003 21:33:12 GMT
+Server: Apache/1.3.19 (Unix) (Red-Hat/Linux) mod_ssl/2.8.1 OpenSSL/0.9.6 PHP/4.3.1
+Last-Modified: Fri, 24 Oct 2003 18:01:23 GMT
+ETag: "ab57a-507-3f9968f3"
+Accept-Ranges: bytes
+Content-Length: 4
+Content-Range: bytes */87
+Content-Type: image/gif
+
+</datacheck>
 </reply>
 
 # Client-side

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -21,6 +21,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib571 lib572 lib573 lib574 lib575 lib576        lib578 lib579 lib582   \
  lib583 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598 lib599   \
  lib643 lib644 lib645 lib650 lib651 lib652 lib653 lib654 lib655 \
+ lib1156 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
  lib1520 lib1521 \
@@ -357,6 +358,10 @@ lib1505_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1505
 lib1506_SOURCES = lib1506.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1506_LDADD = $(TESTUTIL_LIBS)
 lib1506_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1506
+
+lib1156_SOURCES = lib1156.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1156_LDADD = $(TESTUTIL_LIBS)
+lib1156_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1156
 
 lib1507_SOURCES = lib1507.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1507_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -45,7 +45,7 @@ typedef struct {
   CURLcode result; /* Code that should be returned by curl_easy_perform(). */
 }  testparams;
 
-const testparams params[] = {
+static const testparams params[] = {
   { 0,                                                             CURLE_OK },
   {                                 F_CONTENTRANGE,                CURLE_OK },
   {                        F_FAIL,                                 CURLE_OK },

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -1,0 +1,162 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+/*
+  Check range/resume returned error codes and data presence.
+
+  The input parameters are:
+  - CURLOPT_RANGE/CURLOPT_RESUME_FROM
+  - CURLOPT_FAILONERROR
+  - Returned http code (2xx/416)
+  - Content-Range header present in reply.
+
+*/
+
+#include "memdebug.h"
+
+#define F_RESUME        (1 << 0)        /* resume/range. */
+#define F_HTTP416       (1 << 1)        /* Server returns http code 416. */
+#define F_FAIL          (1 << 2)        /* Fail on error. */
+#define F_CONTENTRANGE  (1 << 3)        /* Server sends content-range hdr. */
+#define F_IGNOREBODY    (1 << 4)        /* Body should be ignored. */
+
+typedef struct {
+  unsigned int flags; /* ORed flags as above. */
+  CURLcode result; /* Code that should be returned by curl_easy_perform(). */
+}  testparams;
+
+const testparams params[] = {
+  { 0,                                                             CURLE_OK },
+  {                                 F_CONTENTRANGE,                CURLE_OK },
+  {                        F_FAIL,                                 CURLE_OK },
+  {                        F_FAIL | F_CONTENTRANGE,                CURLE_OK },
+  {            F_HTTP416,                                          CURLE_OK },
+  {            F_HTTP416 |          F_CONTENTRANGE,                CURLE_OK },
+  {            F_HTTP416 | F_FAIL |                  F_IGNOREBODY,
+                                                  CURLE_HTTP_RETURNED_ERROR },
+  {            F_HTTP416 | F_FAIL | F_CONTENTRANGE | F_IGNOREBODY,
+                                                  CURLE_HTTP_RETURNED_ERROR },
+  { F_RESUME |                                       F_IGNOREBODY,
+                                                          CURLE_RANGE_ERROR },
+  { F_RESUME |                      F_CONTENTRANGE,                CURLE_OK },
+  { F_RESUME |             F_FAIL |                  F_IGNOREBODY,
+                                                          CURLE_RANGE_ERROR },
+  { F_RESUME |             F_FAIL | F_CONTENTRANGE,                CURLE_OK },
+  { F_RESUME | F_HTTP416 |                           F_IGNOREBODY, CURLE_OK },
+  { F_RESUME | F_HTTP416 |          F_CONTENTRANGE | F_IGNOREBODY, CURLE_OK },
+  { F_RESUME | F_HTTP416 | F_FAIL |                  F_IGNOREBODY,
+                                                  CURLE_HTTP_RETURNED_ERROR },
+  { F_RESUME | F_HTTP416 | F_FAIL | F_CONTENTRANGE | F_IGNOREBODY,
+                                                  CURLE_HTTP_RETURNED_ERROR }
+};
+
+static int      hasbody;
+
+static size_t writedata(char *data, size_t size, size_t nmemb, void *userdata)
+{
+  (void) data;
+  (void) userdata;
+
+  if(size && nmemb)
+    hasbody = 1;
+  return size * nmemb;
+}
+
+static int onetest(CURL *curl, const char *url, const testparams *p)
+{
+  CURLcode res;
+  unsigned int replyselector;
+  char urlbuf[256];
+
+  replyselector = p->flags & F_CONTENTRANGE? 1: 0;
+  if(p->flags & F_HTTP416)
+    replyselector += 2;
+  snprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
+  test_setopt(curl, CURLOPT_URL, urlbuf);
+  test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME)? 3: 0);
+  test_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME)?
+                                   "3-1000000": (char *) NULL);
+  test_setopt(curl, CURLOPT_FAILONERROR, p->flags & F_FAIL? 1: 0);
+  hasbody = 0;
+  res = curl_easy_perform(curl);
+  if(res != p->result) {
+    fprintf(stderr, "bad error code (%d): resume=%s, fail=%s, http416=%s, "
+                    "content-range=%s, expected=%d\n", res,
+                    (p->flags & F_RESUME)? "yes": "no",
+                    (p->flags & F_FAIL)? "yes": "no",
+                    (p->flags & F_HTTP416)? "yes": "no",
+                    (p->flags & F_CONTENTRANGE)? "yes": "no",
+                    p->result);
+    return 1;
+  }
+  if(hasbody && (p->flags & F_IGNOREBODY)) {
+    fprintf(stderr, "body should be ignored and is not: resume=%s, fail=%s, "
+                    "http416=%s, content-range=%s\n",
+                    (p->flags & F_RESUME)? "yes": "no",
+                    (p->flags & F_FAIL)? "yes": "no",
+                    (p->flags & F_HTTP416)? "yes": "no",
+                    (p->flags & F_CONTENTRANGE)? "yes": "no");
+    return 1;
+  }
+  return 0;
+
+  test_cleanup:
+
+  return 1;
+}
+
+int test(char *URL)
+{
+  CURLcode res;
+  CURL *curl;
+  size_t i;
+  int status = 0;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, writedata);
+
+  for(i = 0; i < sizeof(params) / sizeof(params[0]); i++)
+    status |= onetest(curl, URL, params + i);
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+  return status;
+
+  test_cleanup:
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return (int)res;
+}


### PR DESCRIPTION
Since HTTP range errors are ignored, the error message may be append to
the already downloaded data in case of resume. This fix avoids this situation.
The drawback is: this is not possible anymore to get the error message data.

Test92 is updated to match this change.

This is an attempt to fix https://github.com/curl/curl/issues/1163

I'm not sure this is the proper way of fixing it. An alternative would be to check the http code in the curl tool write callback.