### PR TITLE
examples/progressfunc: make it build on older libcurls

### DIFF
--- a/docs/examples/progressfunc.c
+++ b/docs/examples/progressfunc.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,11 +27,25 @@
 #include <stdio.h>
 #include <curl/curl.h>
 
-#define STOP_DOWNLOAD_AFTER_THIS_MANY_BYTES         6000
+#if LIBCURL_VERSION_NUM >= 0x073d00
+/* In libcurl 7.61.0, support was added for extracting the time in plain
+   microseconds. Older libcurl versions are stuck in using 'double' for this
+   information so we complicate this example a bit by supporting either
+   approach. */
+#define TIME_IN_US 1 /* microseconds */
+#define TIMETYPE curl_off_t
+#define TIMEOPT CURLINFO_TOTAL_TIME_T
 #define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL     3000000
+#else
+#define TIMETYPE double
+#define TIMEOPT CURLINFO_TOTAL_TIME
+#define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL     3
+#endif
+
+#define STOP_DOWNLOAD_AFTER_THIS_MANY_BYTES         6000
 
 struct myprogress {
-  curl_off_t lastruntime;
+  TIMETYPE lastruntime; /* type depends on version, see above */
   CURL *curl;
 };
 
@@ -42,17 +56,21 @@ static int xferinfo(void *p,
 {
   struct myprogress *myp = (struct myprogress *)p;
   CURL *curl = myp->curl;
-  curl_off_t curtime = 0;
+  TIMETYPE curtime = 0;
 
-  curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME_T, &curtime);
+  curl_easy_getinfo(curl, TIMEOPT, &curtime);
 
   /* under certain circumstances it may be desirable for certain functionality
      to only run every N seconds, in order to do this the transaction time can
      be used */
   if((curtime - myp->lastruntime) >= MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL) {
     myp->lastruntime = curtime;
+#ifdef TIME_IN_US
     fprintf(stderr, "TOTAL TIME: %" CURL_FORMAT_CURL_OFF_T ".%06ld\r\n",
             (curtime / 1000000), (long)(curtime % 1000000));
+#else
+    fprintf(stderr, "TOTAL TIME: %f \r\n", curtime);
+#endif
   }
 
   fprintf(stderr, "UP: %" CURL_FORMAT_CURL_OFF_T " of %" CURL_FORMAT_CURL_OFF_T
@@ -65,6 +83,7 @@ static int xferinfo(void *p,
   return 0;
 }
 
+#if LIBCURL_VERSION_NUM < 0x072000
 /* for libcurl older than 7.32.0 (CURLOPT_PROGRESSFUNCTION) */
 static int older_progress(void *p,
                           double dltotal, double dlnow,
@@ -76,7 +95,7 @@ static int older_progress(void *p,
                   (curl_off_t)ultotal,
                   (curl_off_t)ulnow);
 }
-
+#endif
 
 int main(void)
 {
@@ -90,10 +109,6 @@ int main(void)
     prog.curl = curl;
 
     curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/");
-
-    curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, older_progress);
-    /* pass the struct pointer into the progress function */
-    curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &prog);
 
 #if LIBCURL_VERSION_NUM >= 0x072000
     /* xferinfo was introduced in 7.32.0, no earlier libcurl versions will
@@ -110,6 +125,10 @@ int main(void)
     /* pass the struct pointer into the xferinfo function, note that this is
        an alias to CURLOPT_PROGRESSDATA */
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &prog);
+#else
+    curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, older_progress);
+    /* pass the struct pointer into the progress function */
+    curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &prog);
 #endif
 
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);


### PR DESCRIPTION
This example was changed in ce2140a8c1 to use the new microsecond based
getinfo option. This change makes it conditionally keep using the older
option so that the example still builds with older libcurl versions.