### PR TITLE
schannel: make CAinfo parsing resilient to CR/LF

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -54,7 +54,7 @@
 #define BACKEND connssl->backend
 
 #define MAX_CAFILE_SIZE 1048576 /* 1 MiB */
-#define BEGIN_CERT "-----BEGIN CERTIFICATE-----\n"
+#define BEGIN_CERT "-----BEGIN CERTIFICATE-----"
 #define END_CERT "\n-----END CERTIFICATE-----"
 
 typedef struct {
@@ -72,6 +72,10 @@ typedef struct {
   HCERTSTORE hExclusiveTrustedPeople;
 } CERT_CHAIN_ENGINE_CONFIG_WIN7, *PCERT_CHAIN_ENGINE_CONFIG_WIN7;
 
+static inline int is_cr_or_lf(char c)
+{
+  return c == '\r' || c == '\n';
+}
 
 static CURLcode add_certs_to_store(HCERTSTORE trust_store,
                                    const char *ca_file,
@@ -178,7 +182,7 @@ static CURLcode add_certs_to_store(HCERTSTORE trust_store,
   current_ca_file_ptr = ca_file_buffer;
   while(more_certs && *current_ca_file_ptr != '\0') {
     char *begin_cert_ptr = strstr(current_ca_file_ptr, BEGIN_CERT);
-    if(!begin_cert_ptr) {
+    if(!begin_cert_ptr || !is_cr_or_lf(begin_cert_ptr[strlen(BEGIN_CERT)])) {
       more_certs = 0;
     }
     else {


### PR DESCRIPTION
OpenSSL has supported --cacert for ages, always accepting LF-only line
endings ("Unix line endings") as well as CR/LF line endings ("Windows
line endings").

When we introduced support for --cacert also with Secure Channel (or in
cURL speak: "WinSSL"), we did not take care to support CR/LF line
endings, too, even if we are much more likely to receive input in that
form when using Windows.

Let's fix that.

Happily, CryptQueryObject(), the function we use to parse the ca-bundle,
accepts CR/LF input already, and the trailing LF before the END
CERTIFICATE marker catches naturally any CR/LF line ending, too. So all
we need to care about is the BEGIN CERTIFICATE marker. We do not
actually need to verify here that the line ending is CR/LF. Just
checking for a CR or an LF is really plenty enough.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>