### PR TITLE
cmake: set -d postfix for debug builds if not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,9 @@ if (ENABLE_CURLDEBUG)
 endif()
 
 # For debug libs and exes, add "-d" postfix
-set(CMAKE_DEBUG_POSTFIX "-d" CACHE STRING "Set debug library postfix")
+if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX "-d")
+endif()
 
 # initialize CURL_LIBS
 set(CURL_LIBS "")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -98,13 +98,6 @@ if(WIN32)
   if(NOT CURL_STATICLIB)
     # Add "_imp" as a suffix before the extension to avoid conflicting with the statically linked "libcurl.lib"
     set_target_properties(${LIB_NAME} PROPERTIES IMPORT_SUFFIX "_imp.lib")
-
-    set_target_properties (${LIB_NAME} PROPERTIES
-       DEBUG_POSTFIX "-d"
-       # Note: no postfix for release variants, let user choose what style of release he wants
-       # MINSIZEREL_POSTFIX "-z"
-       # RELWITHDEBINFO_POSTFIX "-g"
-       )
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,10 +70,6 @@ target_link_libraries( ${EXE_NAME} libcurl ${CURL_LIBS})
 #SET_TARGET_PROPERTIES(${EXE_NAME} RUNTIME_OUTPUT_DIRECTORY "blah blah blah")
 #SET_TARGET_PROPERTIES(${EXE_NAME} LIBRARY_OUTPUT_DIRECTORY "blah blah blah")
 
-# Add the postfix to the executable since it is not added automatically as for modules and shared libraries
-set_target_properties(${EXE_NAME} PROPERTIES
-  DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
-
 #INCLUDE(ModuleInstall OPTIONAL)
 
 install(TARGETS ${EXE_NAME} EXPORT curl-target DESTINATION bin)

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -20,12 +20,6 @@ function(SETUP_TEST TEST_NAME)          # ARGN are the files in the test
     PROPERTIES COMPILE_DEFINITIONS ${UPPER_TEST_NAME})
   set_target_properties(${TEST_NAME}
     PROPERTIES PROJECT_LABEL "${TARGET_LABEL_PREFIX}${TEST_NAME}")
-
-  # Add the postfix to the executable since it is
-  # not added automatically as for modules and shared libraries
-  set_target_properties(${TEST_NAME}
-    PROPERTIES DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
-
 endfunction()
 
 

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -31,12 +31,6 @@ function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
   endif()
   set_target_properties(${TEST_NAME} PROPERTIES
     PROJECT_LABEL "${TARGET_LABEL_PREFIX}${TEST_NAME}")
-
-  # Add the postfix to the executable since it is not added
-  # automatically as for modules and shared libraries
-  set_target_properties(${TEST_NAME} PROPERTIES
-    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
-
 endfunction()
 
 


### PR DESCRIPTION
      Set `-d` postfix for debug builds if `-DCMAKE_DEBUG_POSTFIX` not specified

       fixes #2121, obsoletes #2384