### PR TITLE
multi: provide a socket to wait for in Curl_protocol_getsock

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1554,7 +1554,11 @@ int Curl_protocol_getsock(struct connectdata *conn,
 {
   if(conn->handler->proto_getsock)
     return conn->handler->proto_getsock(conn, socks, numsocks);
-  return GETSOCK_BLANK;
+  /* Backup getsock logic. Since there is a live socket in use, we must wait
+     for it or it will be removed from watching when the multi_socket API is
+     used. */
+  socks[0] = conn->sock[FIRSTSOCKET];
+  return GETSOCK_READSOCK(0) | GETSOCK_WRITESOCK(0);
 }
 
 int Curl_doing_getsock(struct connectdata *conn,


### PR DESCRIPTION
... even when there's no protocol specific handler setup.

Bug: https://curl.haxx.se/mail/lib-2018-05/0062.html
Reported-by: Sean Miller