### PR TITLE
winbuild: In gen_resp_file.bat only attempt to delete OUTFILE if it exists

### DIFF
--- a/winbuild/gen_resp_file.bat
+++ b/winbuild/gen_resp_file.bat
@@ -1,5 +1,7 @@
 @echo OFF
-@del %OUTFILE%
+@if exist %OUTFILE% (
+    del %OUTFILE%
+)
 @echo %MACRO_NAME% = \> %OUTFILE%
 @for %%i in (%*) do @echo		%DIROBJ%/%%i \>>  %OUTFILE%
 @echo. >>  %OUTFILE%


### PR DESCRIPTION
This removes the slightly annoying "Could not file LIBCURL_OBJS.inc" and "Could not find CURL_OBJS.inc" messages when building into a clean folder.