### PR TITLE
winbuild: In MakefileBuild.vc fix typo DISTDIR->DIRDIST

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -502,7 +502,7 @@ package: $(TARGET)
 	@-$(ZIP) -9 -q -r ..\$(CONFIG_NAME_LIB).zip .>nul 2<&1
 	@cd $(MAKEDIR)
 
-$(TARGET): $(LIB_OBJS) $(LIB_DIROBJ) $(DISTDIR)
+$(TARGET): $(LIB_OBJS) $(LIB_DIROBJ) $(DIRDIST)
 	@echo Using SSL: $(USE_SSL)
 	@echo Using NGHTTP2: $(USE_NGHTTP2)
 	@echo Using c-ares: $(USE_CARES)


### PR DESCRIPTION
I assume this is a simple typo. This is the only place that uses $(DISTDIR) and $(DIRDIST) is used everywhere else in the file.