### PR TITLE
content_encoding: handle zlib versions too old for Z_BLOCK

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -190,7 +190,13 @@ static CURLcode inflate_stream(struct connectdata *conn,
     z->next_out = (Bytef *) decomp;
     z->avail_out = DSIZ;
 
+#ifdef Z_BLOCK
+    /* Z_BLOCK is only available in zlib ver. >= 1.2.0.5 */
     status = inflate(z, Z_BLOCK);
+#else
+    /* fallback for zlib ver. < 1.2.0.5 */
+    status = inflate(z, Z_SYNC_FLUSH);
+#endif
 
     /* Flush output data if some. */
     if(z->avail_out != DSIZ) {


### PR DESCRIPTION
Fallback on Z_SYNC_FLUSH when Z_BLOCK is not available.

Closes #2606