### PR TITLE
Fix link with ssh2 built with a static mbedtls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2766,7 +2766,7 @@ if test X"$OPT_LIBSSH2" != Xno; then
     CURL_CHECK_PKGCONFIG(libssh2)
 
     if test "$PKGCONFIG" != "no" ; then
-      LIB_SSH2=`$PKGCONFIG --libs-only-l libssh2`
+      LIB_SSH2=`$PKGCONFIG --libs libssh2`
       LD_SSH2=`$PKGCONFIG --libs-only-L libssh2`
       CPP_SSH2=`$PKGCONFIG --cflags-only-I libssh2`
       version=`$PKGCONFIG --modversion libssh2`


### PR DESCRIPTION
The ssh2 pkg-config file could contain the following lines when build
with a static version of mbedtls:
   Libs: -L${libdir} -lssh2 /xxx/libmbedcrypto.a
   Libs.private: /xxx/libmbedcrypto.a

This static mbedtls library must be used to correctly detect ssh2
support and this library must be copied in libcurl.pc otherwise
compilation of any application (such as upmpdcli) with libcurl will fail
when trying to found mbedtls functions included in libssh2.
So, replace pkg-config --libs-only-l by pkg-config --libs.

Fixes:
 - http://autobuild.buildroot.net/results/43e24b22a77f616d6198c10435dcc23cc3b9088a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>