### PR TITLE
fnmatch: insist on escaped bracket to match

### DIFF
--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -334,9 +334,9 @@ static int loop(const unsigned char *pattern, const unsigned char *string,
         s++;
         break;
       }
+      /* Syntax error in set; mismatch! */
+      return CURL_FNMATCH_NOMATCH;
 
-      /* Syntax error in set: this must be taken as a regular character. */
-      /* FALLTHROUGH */
     default:
       if(*p++ != *s++)
         return CURL_FNMATCH_NOMATCH;

--- a/tests/unit/unit1307.c
+++ b/tests/unit/unit1307.c
@@ -34,9 +34,17 @@ struct testcase {
 
 static const struct testcase tests[] = {
   /* brackets syntax */
+  {"*[*[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["
+   "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["
+   "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[\001\177[[[[[[[[[[[[[[[[[[[[[",
+   "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["
+   "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["
+   "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[",
+   NOMATCH},
+
   { "\\[",                      "[",                      MATCH },
-  { "[",                        "[",                      MATCH },
-  { "[]",                       "[]",                     MATCH },
+  { "[",                        "[",                      NOMATCH },
+  { "[]",                       "[]",                     NOMATCH },
   { "[][]",                     "[",                      MATCH },
   { "[][]",                     "]",                      MATCH },
   { "[[]",                      "[",                      MATCH },
@@ -230,8 +238,9 @@ UNITTEST_START
   for(i = 0; i < testnum; i++) {
     rc = Curl_fnmatch(NULL, tests[i].pattern, tests[i].string);
     if(rc != tests[i].result) {
-      printf("Curl_fnmatch(\"%s\", \"%s\") should return %d (returns %d)\n",
-             tests[i].pattern, tests[i].string, tests[i].result, rc);
+      printf("Curl_fnmatch(\"%s\", \"%s\") should return %d (returns %d)"
+             " [%d]\n",
+             tests[i].pattern, tests[i].string, tests[i].result, rc, i);
       fail("pattern mismatch");
     }
   }


### PR DESCRIPTION
A non-escaped bracket ([) is for a character group - as documented. It
will *not* match an individual bracket anymore. Test case 1307 updated
accordingly to match.

Problem detected by OSS-Fuzz, although this fix is probably not a final
fix for the notorious timeout issues.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=8525