### PR TITLE
configure: override AR_FLAGS to silence warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,7 +188,8 @@ AC_CANONICAL_HOST
 dnl Get system canonical name
 AC_DEFINE_UNQUOTED(OS, "${host}", [cpu-machine-OS])
 
-dnl Checks for programs.
+# Silence warning: ar: 'u' modifier ignored since 'D' is the default
+AC_SUBST(AR_FLAGS, [cr])
 
 dnl This defines _ALL_SOURCE for AIX
 CURL_CHECK_AIX_ALL_SOURCE


### PR DESCRIPTION
The automake default ar flags are 'cru', but the 'u' flag in there
causes warnings on many modern Linux distros. Removing 'u' may have a
minor performance impact on older distros but should not cause harm.

Explained on the automake mailing list already back in April 2015:

https://www.mail-archive.com/automake-patches@gnu.org/msg07705.html

Fixes #2617