### PR TITLE
os400: implement mime api EBCDIC wrappers

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1345,3 +1345,80 @@ curl_pushheader_byname_ccsid(struct curl_pushheaders *h, const char *header,
 
   return d;
 }
+
+static CURLcode
+mime_string_call(curl_mimepart *part, const char *string, unsigned int ccsid,
+                 CURLcode (*mimefunc)(curl_mimepart *part, const char *string))
+
+{
+  char *s = (char *) NULL;
+  CURLcode result;
+
+  if(!string)
+    return mimefunc(part, string);
+  s = dynconvert(ASCII_CCSID, string, -1, ccsid);
+  if(!s)
+    return CURLE_OUT_OF_MEMORY;
+
+  result = mimefunc(part, s);
+  free(s);
+  return result;
+}
+
+CURLcode
+curl_mime_name_ccsid(curl_mimepart *part, const char *name, unsigned int ccsid)
+
+{
+  return mime_string_call(part, name, ccsid, curl_mime_name);
+}
+
+CURLcode
+curl_mime_filename_ccsid(curl_mimepart *part,
+                         const char *filename, unsigned int ccsid)
+
+{
+  return mime_string_call(part, filename, ccsid, curl_mime_filename);
+}
+
+CURLcode
+curl_mime_type_ccsid(curl_mimepart *part,
+                     const char *mimetype, unsigned int ccsid)
+
+{
+  return mime_string_call(part, mimetype, ccsid, curl_mime_type);
+}
+
+CURLcode
+curl_mime_encoder_ccsid(curl_mimepart *part,
+                       const char *encoding, unsigned int ccsid)
+
+{
+  return mime_string_call(part, encoding, ccsid, curl_mime_encoder);
+}
+
+CURLcode
+curl_mime_filedata_ccsid(curl_mimepart *part,
+                         const char *filename, unsigned int ccsid)
+
+{
+  return mime_string_call(part, filename, ccsid, curl_mime_filedata);
+}
+
+CURLcode
+curl_mime_data_ccsid(curl_mimepart *part,
+                     const char *data, size_t datasize, unsigned int ccsid)
+
+{
+  char *s = (char *) NULL;
+  CURLcode result;
+
+  if(!data)
+    return curl_mime_data(part, data, datasize);
+  s = dynconvert(ASCII_CCSID, data, datasize, ccsid);
+  if(!s)
+    return CURLE_OUT_OF_MEMORY;
+
+  result = curl_mime_data(part, s, datasize);
+  free(s);
+  return result;
+}

--- a/packages/OS400/ccsidcurl.h
+++ b/packages/OS400/ccsidcurl.h
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2013, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -67,5 +67,23 @@ CURL_EXTERN char *curl_pushheader_byname_ccsid(struct curl_pushheaders *h,
                                                const char *header,
                                                unsigned int ccsidin,
                                                unsigned int ccsidout);
+CURL_EXTERN CURLcode curl_mime_name_ccsid(curl_mimepart *part,
+                                          const char *name,
+                                          unsigned int ccsid);
+CURL_EXTERN CURLcode curl_mime_filename_ccsid(curl_mimepart *part,
+                                              const char *filename,
+                                              unsigned int ccsid);
+CURL_EXTERN CURLcode curl_mime_type_ccsid(curl_mimepart *part,
+                                          const char *mimetype,
+                                          unsigned int ccsid);
+CURL_EXTERN CURLcode curl_mime_encoder_ccsid(curl_mimepart *part,
+                                             const char *encoding,
+                                             unsigned int ccsid);
+CURL_EXTERN CURLcode curl_mime_filedata_ccsid(curl_mimepart *part,
+                                              const char *filename,
+                                              unsigned int ccsid);
+CURL_EXTERN CURLcode curl_mime_data_ccsid(curl_mimepart *part,
+                                          const char *data, size_t datasize,
+                                          unsigned int ccsid);
 
 #endif

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -291,6 +291,9 @@
      d CURL_REDIR_POST_ALL...
      d                 c                   7
       *
+     d CURL_ZERO_TERMINATED...
+     d                 c                   -1
+      *
      d CURL_POLL_NONE  c                   0
      d CURL_POLL_IN    c                   1
      d CURL_POLL_OUT   c                   2
@@ -1981,6 +1984,74 @@
       *                              Prototypes
       **************************************************************************
       *
+     d curl_mime_init  pr              *   extproc('curl_mime_init')            curl_mime *
+     d  easy                           *   value                                CURL *
+      *
+     d curl_mime_free  pr                  extproc('curl_mime_free')
+     d  mime                           *   value                                curl_mime *
+      *
+     d curl_mime_addpart...
+     d                 pr              *   extproc('curl_mime_addpart')         curl_mimepart *
+     d  mime                           *   value                                curl_mime *
+      *
+     d curl_mime_name  pr                  extproc('curl_mime_name')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  name                           *   value options(*string)
+      *
+     d curl_mime_filename...
+     d                 pr                  extproc('curl_mime_filename')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  filename                       *   value options(*string)
+      *
+     d curl_mime_type  pr                  extproc('curl_mime_type')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  mimetype                       *   value options(*string)
+      *
+     d curl_mime_encoder...
+     d                 pr                  extproc('curl_mime_encoder')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  encoding                       *   value options(*string)
+      *
+     d curl_mime_data  pr                  extproc('curl_mime_data')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  data                           *   value options(*string)
+     d  datasize                     10u 0                                      size_t
+      *
+     d curl_mime_filedata...
+     d                 pr                  extproc('curl_mime_filedata')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  filename                       *   value options(*string)
+      *
+     d curl_mime_data_cb...
+     d                 pr                  extproc('curl_mime_data_cb')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  datasize                           value like(curl_off_t)
+     d  readfunc                           value like(curl_read_callback)
+     d  seekfunc                           value like(curl_seek_callback)
+     d  freefunc                           value like(curl_free_callback)
+     d  arg                            *   value                                void *
+      *
+     d curl_mime_subparts...
+     d                 pr                  extproc('curl_mime_subparts')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  subparts                       *   value                                curl_mime *
+      *
+     d curl_mime_headers...
+     d                 pr                  extproc('curl_mime_headers')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  headers                        *   value                                curl_slist *
+     d  take_ownership...
+     d                               10i 0 value
+      *
       *  This procedure as a variable parameter list.
       *  This prototype allows use of an option array, or a single "object"
       *    option. Other argument lists may be implemented by alias procedure
@@ -2465,5 +2536,48 @@
      d  header                         *   value options(*string)               const char *
      d  ccsidin                      10u 0 value
      d  ccsidout                     10u 0 value
+      *
+     d curl_mime_name_ccsid...
+     d                 pr                  extproc('curl_mime_name_ccsid')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  name                           *   value options(*string)
+     d  ccsid                        10u 0 value
+      *
+     d curl_mime_filename_ccsid...
+     d                 pr                  extproc('curl_mime_filename_ccsid')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  filename                       *   value options(*string)
+     d  ccsid                        10u 0 value
+      *
+     d curl_mime_type_ccsid...
+     d                 pr                  extproc('curl_mime_type_ccsid')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  mimetype                       *   value options(*string)
+     d  ccsid                        10u 0 value
+      *
+     d curl_mime_encoder_ccsid...
+     d                 pr                  extproc('curl_mime_encoder_ccsid')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  encoding                       *   value options(*string)
+     d  ccsid                        10u 0 value
+      *
+     d curl_mime_data_ccsid...
+     d                 pr                  extproc('curl_mime_data_ccsid')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  data                           *   value options(*string)
+     d  datasize                     10u 0                                      size_t
+     d  ccsid                        10u 0 value
+      *
+     d curl_mime_filedata_ccsid...
+     d                 pr                  extproc('curl_mime_filedata_ccsid')
+     d                                     like(CURLcode)
+     d  part                           *   value                                curl_mimepart *
+     d  filename                       *   value options(*string)
+     d  ccsid                        10u 0 value
       *
       /endif


### PR DESCRIPTION
These are needed to use the mime api on OS400.

These changes only impact OS400 builds: I have not been able to compile and test this new code since I have no access to the target hardware anymore. However this will let a chance to OS400 users to test it and report problems if some (although I'm quite confident).