### PR TITLE
Correct {infof, failf} format specifiers

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -301,8 +301,8 @@ CURLcode Curl_conncache_add_conn(struct conncache *connc,
   connc->num_conn++;
 
   DEBUGF(infof(conn->data, "Added connection %ld. "
-               "The cache now contains %" CURL_FORMAT_CURL_OFF_TU " members\n",
-               conn->connection_id, (curl_off_t) connc->num_conn));
+               "The cache now contains %zu members\n",
+               conn->connection_id, connc->num_conn));
 
   unlock:
   CONN_UNLOCK(data);
@@ -328,9 +328,8 @@ void Curl_conncache_remove_conn(struct connectdata *conn, bool lock)
     conn->bundle = NULL; /* removed from it */
     if(connc) {
       connc->num_conn--;
-      DEBUGF(infof(conn->data, "The cache now contains %"
-                   CURL_FORMAT_CURL_OFF_TU " members\n",
-                   (curl_off_t) connc->num_conn));
+      DEBUGF(infof(conn->data, "The cache now contains %zu members\n",
+                   connc->num_conn));
     }
     if(lock) {
       CONN_UNLOCK(conn->data);
@@ -501,9 +500,8 @@ Curl_conncache_extract_bundle(struct Curl_easy *data,
     /* remove it to prevent another thread from nicking it */
     bundle_remove_conn(bundle, conn_candidate);
     data->state.conn_cache->num_conn--;
-    DEBUGF(infof(data, "The cache now contains %"
-                 CURL_FORMAT_CURL_OFF_TU " members\n",
-                 (curl_off_t) data->state.conn_cache->num_conn));
+    DEBUGF(infof(data, "The cache now contains %zu members\n",
+                 data->state.conn_cache->num_conn));
   }
 
   return conn_candidate;
@@ -563,9 +561,8 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
     /* remove it to prevent another thread from nicking it */
     bundle_remove_conn(bundle_candidate, conn_candidate);
     connc->num_conn--;
-    DEBUGF(infof(data, "The cache now contains %"
-                 CURL_FORMAT_CURL_OFF_TU " members\n",
-                 (curl_off_t) connc->num_conn));
+    DEBUGF(infof(data, "The cache now contains %zu members\n",
+                 connc->num_conn));
   }
   CONN_UNLOCK(data);
 

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -496,7 +496,7 @@ Curl_cookie_add(struct Curl_easy *data,
              name + contents. Chrome and Firefox support 4095 or 4096 bytes
              combo. */
           freecookie(co);
-          infof(data, "oversized cookie dropped, name/val %d + %d bytes\n",
+          infof(data, "oversized cookie dropped, name/val %zu + %zu bytes\n",
                 nlen, len);
           return NULL;
         }

--- a/lib/http.c
+++ b/lib/http.c
@@ -2992,7 +2992,7 @@ static CURLcode header_append(struct Curl_easy *data,
     /* The reason to have a max limit for this is to avoid the risk of a bad
        server feeding libcurl with a never-ending header that will cause
        reallocs infinitely */
-    failf(data, "Rejected %zd bytes header (max is %d)!", newsize,
+    failf(data, "Rejected %zu bytes header (max is %d)!", newsize,
           CURL_MAX_HTTP_HEADER);
     return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -581,7 +581,7 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
       if(max_conn != httpc->settings.max_concurrent_streams) {
         /* only signal change if the value actually changed */
         infof(conn->data,
-              "Connection state changed (MAX_CONCURRENT_STREAMS == %d)!\n",
+              "Connection state changed (MAX_CONCURRENT_STREAMS == %u)!\n",
               httpc->settings.max_concurrent_streams);
         Curl_multi_connchanged(conn->data->multi);
       }
@@ -1280,7 +1280,7 @@ static int h2_process_pending_input(struct connectdata *conn,
   if(rv < 0) {
     failf(data,
           "h2_process_pending_input: nghttp2_session_mem_recv() returned "
-          "%d:%s\n", rv, nghttp2_strerror((int)rv));
+          "%zd:%s\n", rv, nghttp2_strerror((int)rv));
     *err = CURLE_RECV_ERROR;
     return -1;
   }
@@ -1388,7 +1388,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
     return -1;
   }
   else if(httpc->error_code != NGHTTP2_NO_ERROR) {
-    failf(data, "HTTP/2 stream %u was not closed cleanly: %s (err %d)",
+    failf(data, "HTTP/2 stream %d was not closed cleanly: %s (err %u)",
           stream->stream_id, Curl_http2_strerror(httpc->error_code),
           httpc->error_code);
     *err = CURLE_HTTP2_STREAM;
@@ -1396,7 +1396,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
   }
 
   if(!stream->bodystarted) {
-    failf(data, "HTTP/2 stream %u was closed cleanly, but before getting "
+    failf(data, "HTTP/2 stream %d was closed cleanly, but before getting "
           " all response header fields, treated as error",
           stream->stream_id);
     *err = CURLE_HTTP2_STREAM;
@@ -1552,7 +1552,7 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
     stream->pausedata += nread;
     stream->pauselen -= nread;
 
-    infof(data, "%zu data bytes written\n", nread);
+    infof(data, "%zd data bytes written\n", nread);
     if(stream->pauselen == 0) {
       H2BUGF(infof(data, "Unpaused by stream %u\n", stream->stream_id));
       DEBUGASSERT(httpc->pause_stream_id == stream->stream_id);
@@ -1635,7 +1635,7 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
     rv = nghttp2_session_mem_recv(httpc->h2, (const uint8_t *)inbuf, nread);
 
     if(nghttp2_is_fatal((int)rv)) {
-      failf(data, "nghttp2_session_mem_recv() returned %d:%s\n",
+      failf(data, "nghttp2_session_mem_recv() returned %zd:%s\n",
             rv, nghttp2_strerror((int)rv));
       *err = CURLE_RECV_ERROR;
       return -1;
@@ -2040,7 +2040,7 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
   }
 
   infof(conn->data, "Using Stream ID: %x (easy handle %p)\n",
-        stream_id, conn->data);
+        stream_id, (void *)conn->data);
   stream->stream_id = stream_id;
 
   /* this does not call h2_session_send() since there can not have been any

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -206,7 +206,7 @@ static CURLcode CONNECT(struct connectdata *conn,
       char *host_port;
       Curl_send_buffer *req_buffer;
 
-      infof(data, "Establish HTTP proxy tunnel to %s:%hu\n",
+      infof(data, "Establish HTTP proxy tunnel to %s:%d\n",
             hostname, remote_port);
 
         /* This only happens if we've looped here due to authentication

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1119,7 +1119,7 @@ static CURLcode imap_state_fetch_resp(struct connectdata *conn, int imapcode,
   }
 
   if(parsed) {
-    infof(data, "Found %" CURL_FORMAT_CURL_OFF_TU " bytes to download\n",
+    infof(data, "Found %" CURL_FORMAT_CURL_OFF_T " bytes to download\n",
           size);
     Curl_pgrsSetDownloadSize(data, size);
 
@@ -1144,10 +1144,8 @@ static CURLcode imap_state_fetch_resp(struct connectdata *conn, int imapcode,
 
       data->req.bytecount += chunk;
 
-      infof(data, "Written %" CURL_FORMAT_CURL_OFF_TU
-            " bytes, %" CURL_FORMAT_CURL_OFF_TU
-            " bytes are left for transfer\n", (curl_off_t)chunk,
-            size - chunk);
+      infof(data, "Written %zu bytes, %" CURL_FORMAT_CURL_OFF_TU
+            " bytes are left for transfer\n", chunk, size - chunk);
 
       /* Have we used the entire cache or just part of it?*/
       if(pp->cache_size > chunk) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -555,7 +555,7 @@ static CURLcode multi_done(struct connectdata **connp,
   if(conn->send_pipe.size || conn->recv_pipe.size) {
     /* Stop if pipeline is not empty . */
     data->easy_conn = NULL;
-    DEBUGF(infof(data, "Connection still in use %d/%d, "
+    DEBUGF(infof(data, "Connection still in use %zu/%zu, "
                  "no more multi_done now!\n",
                  conn->send_pipe.size, conn->recv_pipe.size));
     return CURLE_OK;
@@ -1083,7 +1083,7 @@ CURLMcode curl_multi_wait(struct Curl_multi *multi,
     int pollrc;
     /* wait... */
     pollrc = Curl_poll(ufds, nfds, timeout_ms);
-    DEBUGF(infof(data, "Curl_poll(%d ds, %d ms) == %d\n",
+    DEBUGF(infof(data, "Curl_poll(%u ds, %d ms) == %d\n",
                  nfds, timeout_ms, pollrc));
 
     if(pollrc > 0) {

--- a/lib/pipeline.c
+++ b/lib/pipeline.c
@@ -82,7 +82,8 @@ bool Curl_pipeline_penalized(struct Curl_easy *data,
       penalized = TRUE;
 
     infof(data, "Conn: %ld (%p) Receive pipe weight: (%"
-          CURL_FORMAT_CURL_OFF_T "/%zu), penalized: %s\n",
+          CURL_FORMAT_CURL_OFF_T "/%" CURL_FORMAT_CURL_OFF_T
+          "), penalized: %s\n",
           conn->connection_id, (void *)conn, recv_size,
           conn->chunk.datasize, penalized?"TRUE":"FALSE");
     return penalized;

--- a/lib/security.c
+++ b/lib/security.c
@@ -488,7 +488,7 @@ static CURLcode choose_mech(struct connectdata *conn)
 
   tmp_allocation = realloc(conn->app_data, mech->size);
   if(tmp_allocation == NULL) {
-    failf(data, "Failed realloc of size %u", mech->size);
+    failf(data, "Failed realloc of size %zu", mech->size);
     mech = NULL;
     return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -764,7 +764,7 @@ static void printsub(struct Curl_easy *data,
     switch(pointer[0]) {
     case CURL_TELOPT_NAWS:
       if(length > 4)
-        infof(data, "Width: %hu ; Height: %hu", (pointer[1]<<8) | pointer[2],
+        infof(data, "Width: %d ; Height: %d", (pointer[1]<<8) | pointer[2],
               (pointer[3]<<8) | pointer[4]);
       break;
     default:

--- a/lib/url.c
+++ b/lib/url.c
@@ -757,7 +757,7 @@ CURLcode Curl_disconnect(struct connectdata *conn, bool dead_connection)
    */
   if(!conn->bits.close &&
      (conn->send_pipe.size + conn->recv_pipe.size)) {
-    DEBUGF(infof(data, "Curl_disconnect, usecounter: %d\n",
+    DEBUGF(infof(data, "Curl_disconnect, usecounter: %zu\n",
                  conn->send_pipe.size + conn->recv_pipe.size));
     return CURLE_OK;
   }
@@ -2207,7 +2207,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
       size_t s = strlen(slashbuf);
       protop = protobuf;
       if(s != 2) {
-        infof(data, "Unwillingly accepted illegal URL using %d slash%s!\n",
+        infof(data, "Unwillingly accepted illegal URL using %zu slash%s!\n",
               s, s>1?"es":"");
 
         if(data->change.url_alloc)
@@ -2453,7 +2453,7 @@ static CURLcode setup_range(struct Curl_easy *data)
       free(s->range);
 
     if(s->resume_from)
-      s->range = aprintf("%" CURL_FORMAT_CURL_OFF_TU "-", s->resume_from);
+      s->range = aprintf("%" CURL_FORMAT_CURL_OFF_T "-", s->resume_from);
     else
       s->range = strdup(data->set.str[STRING_SET_RANGE]);
 
@@ -4478,7 +4478,7 @@ static CURLcode create_conn(struct Curl_easy *data,
           (void)Curl_disconnect(conn_candidate, /* dead_connection */ FALSE);
         }
         else {
-          infof(data, "No more connections allowed to host: %d\n",
+          infof(data, "No more connections allowed to host: %zu\n",
                 max_host_connections);
           connections_available = FALSE;
         }


### PR DESCRIPTION
This is a followup to #2561 but for infof and failf.