### PR TITLE
fnmatch: use the system one if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3623,7 +3623,8 @@ AC_CHECK_DECLS([getpwuid_r], [], [AC_DEFINE(HAVE_DECL_GETPWUID_R_MISSING, 1, "Se
           #include <sys/types.h>]])
 
 
-AC_CHECK_FUNCS([geteuid \
+AC_CHECK_FUNCS([fnmatch \
+  geteuid \
   getpass_r \
   getppid \
   getpwuid \

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -30,6 +30,17 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
+#ifndef HAVE_FNMATCH
+
+/*
+ * TODO:
+ *
+ * Make this function match POSIX. Test 1307 includes a set of test patterns
+ * that returns different results with a POSIX fnmatch() than with this
+ * implemenation and this is considered a bug where POSIX is the guiding
+ * light.
+ */
+
 #define CURLFNM_CHARSET_LEN (sizeof(char) * 256)
 #define CURLFNM_CHSET_SIZE (CURLFNM_CHARSET_LEN + 15)
 
@@ -357,3 +368,29 @@ int Curl_fnmatch(void *ptr, const char *pattern, const char *string)
   }
   return loop((unsigned char *)pattern, (unsigned char *)string, 2);
 }
+#else
+#include <fnmatch.h>
+/*
+ * @unittest: 1307
+ */
+int Curl_fnmatch(void *ptr, const char *pattern, const char *string)
+{
+  int rc;
+  (void)ptr; /* the argument is specified by the curl_fnmatch_callback
+                prototype, but not used by Curl_fnmatch() */
+  if(!pattern || !string) {
+    return CURL_FNMATCH_FAIL;
+  }
+  rc = fnmatch(pattern, string, 0);
+  switch(rc) {
+  case 0:
+    return CURL_FNMATCH_MATCH;
+  case FNM_NOMATCH:
+    return CURL_FNMATCH_NOMATCH;
+  default:
+    return CURL_FNMATCH_FAIL;
+  }
+  /* not reached */
+}
+
+#endif


### PR DESCRIPTION
If configure detects fnmatch to be available, use that instead of our
custom one for pattern matching. For standard compliance, to reduce our
footprint and to use already well tested and well exercised code.

A POSIX fnmatch behaves slightly different than the internal function
for a few test patterns currently, and test 1307 is adjusted for this.
This is considered a bug.