### PR TITLE
axTLS: not considered fit for use

### DIFF
--- a/lib/vtls/axtls.c
+++ b/lib/vtls/axtls.c
@@ -29,6 +29,11 @@
 #include "curl_setup.h"
 
 #ifdef USE_AXTLS
+
+#error axTLS support has been disabled in curl due to doubts about quaility,
+#error user dedication and a lack of use/testing. We urge users to consider
+#error using a more established TLS backend instead.
+
 #include <axTLS/config.h>
 #include <axTLS/ssl.h>
 #include "axtls.h"


### PR DESCRIPTION
URL: https://curl.haxx.se/mail/lib-2018-06/0000.html

This is my proposed first step to discourage users from building and using curl with the axTLS backend.