### PR TITLE
Add support for IBM xlc C compiler

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -320,6 +320,24 @@
 #  define CURL_PULL_SYS_TYPES_H      1
 #  define CURL_PULL_SYS_SOCKET_H     1
 
+#elif defined(__xlc__) /* IBM xlc compiler */
+#  if !defined(_LP64)
+#    define CURL_TYPEOF_CURL_OFF_T     long long
+#    define CURL_FORMAT_CURL_OFF_T     "lld"
+#    define CURL_FORMAT_CURL_OFF_TU    "llu"
+#    define CURL_SUFFIX_CURL_OFF_T     LL
+#    define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  else
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#  endif
+#  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
+#  define CURL_PULL_SYS_TYPES_H      1
+#  define CURL_PULL_SYS_SOCKET_H     1
+
 /* ===================================== */
 /*    KEEP MSVC THE PENULTIMATE ENTRY    */
 /* ===================================== */


### PR DESCRIPTION
Added a section to system.h guarded with __xlc__ for the IBM xml C
compiler. Before this change the section titled 'generic "safe guess" on
old 32 bit style' was used, which resulted in a wrong definition of
CURL_TYPEOF_CURL_SOCKLEN_T, and for 64-bit also CURL_TYPEOF_CURL_OFF_T
was wrong.

Compilation warnings fixed with this change:

  CC       libcurl_la-ftp.lo
"ftp.c", line 290.55: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"ftp.c", line 293.48: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"ftp.c", line 1070.49: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"ftp.c", line 1154.53: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"ftp.c", line 1187.51: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
  CC       libcurl_la-connect.lo
"connect.c", line 448.56: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"connect.c", line 516.66: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"connect.c", line 687.55: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
"connect.c", line 696.55: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.
  CC       libcurl_la-tftp.lo
"tftp.c", line 1115.33: 1506-280 (W) Function argument assignment between types "unsigned long* restrict" and "int*" is not allowed.