### PR TITLE
[WIP] Support for SO_RCVBUF

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1856,6 +1856,9 @@ typedef enum {
   /* Disallow specifying username/login in URL. */
   CINIT(DISALLOW_USERNAME_IN_URL, LONG, 278),
 
+  /* SO_RCVBUF sockopt */
+  CINIT(SOCKOPT_RCVBUF, LONG, 279),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -162,6 +162,19 @@ tcpkeepalive(struct Curl_easy *data,
   }
 }
 
+static void
+Curl_sockopt_rcvbuf(struct Curl_easy *data,
+             curl_socket_t sockfd)
+{
+  int val = data->set.sockopt_rcvbuf;
+  int len = sizeof(val);
+
+  if(!val)
+    return;
+
+  setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, (const char *)&val, sizeof(val));
+}
+
 static CURLcode
 singleipconnect(struct connectdata *conn,
                 const Curl_addrinfo *ai, /* start connecting to this */
@@ -1028,6 +1041,7 @@ static CURLcode singleipconnect(struct connectdata *conn,
   nosigpipe(conn, sockfd);
 
   Curl_sndbufset(sockfd);
+  Curl_sockopt_rcvbuf(data, sockfd);
 
   if(is_tcp && data->set.tcp_keepalive)
     tcpkeepalive(data, sockfd);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2120,6 +2120,11 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     data->set.sockopt_client = va_arg(param, void *);
     break;
 
+  case CURLOPT_SOCKOPT_RCVBUF:
+    /* SO_RCVBUF sockopt */
+    data->set.sockopt_rcvbuf = va_arg(param, long);
+    break;
+
   case CURLOPT_OPENSOCKETFUNCTION:
     /*
      * open/create socket callback function: called instead of socket(),

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1662,6 +1662,7 @@ struct UserDefined {
   long tcp_keepidle;     /* seconds in idle before sending keepalive probe */
   long tcp_keepintvl;    /* seconds between TCP keepalive probes */
   bool tcp_fastopen;     /* use TCP Fast Open */
+  long sockopt_rcvbuf;   /* SO_RCVBUF sockopt */
 
   size_t maxconnects;  /* Max idle connections in the connection cache */
 

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -256,6 +256,7 @@ struct OperationConfig {
                                      0 is valid. default: CURL_HET_DEFAULT. */
   bool haproxy_protocol;          /* whether to send HAProxy protocol v1 */
   bool disallow_username_in_url;  /* disallow usernames in URLs */
+  long sockopt_rcvbuf;            /* SO_RCVBUF sockopt */
   struct GlobalConfig *global;
   struct OperationConfig *prev;
   struct OperationConfig *next;   /* Always last in the struct */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -193,6 +193,7 @@ static const struct LongShort aliases[]= {
   {"$Y", "suppress-connect-headers", ARG_BOOL},
   {"$Z", "compressed-ssh",           ARG_BOOL},
   {"$~", "happy-eyeballs-timeout-ms", ARG_STRING},
+  {"$@", "sockopt-rcvbuf",           ARG_STRING},
   {"0",   "http1.0",                 ARG_NONE},
   {"01",  "http1.1",                 ARG_NONE},
   {"02",  "http2",                   ARG_NONE},
@@ -1130,6 +1131,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         if(err)
           return err;
         /* 0 is a valid value for this timeout */
+        break;
+      case '@': /* --sockopt-rcvbuf */
+        err = str2unum(&config->sockopt_rcvbuf, nextarg);
+        if(err)
+          return err;
         break;
       }
       break;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -807,6 +807,9 @@ static CURLcode operate_do(struct GlobalConfig *global,
         if(config->tcp_fastopen)
           my_setopt(curl, CURLOPT_TCP_FASTOPEN, 1L);
 
+        if(config->sockopt_rcvbuf)
+          my_setopt(curl, CURLOPT_SOCKOPT_RCVBUF, config->sockopt_rcvbuf);
+
         /* where to store */
         my_setopt(curl, CURLOPT_WRITEDATA, &outs);
         my_setopt(curl, CURLOPT_INTERLEAVEDATA, &outs);


### PR DESCRIPTION
Setting `SO_RCVBUF` is a useful way of tuning TCP sockets, allowing the user to set the kernel receive buffer associated with the socket and thus the initial size of the TCP window.

Currently this can only be set by libcurl users, using the complicated SOCKOPTDATA and SOCKOPTFUNCTION options.

This PR adds a `curl --sockopt-rcvbuf` for CLI users.

Documentation is missing. I will update the PR if I can get some feedback on the name of the new parameter and the general approach within.