### PR TITLE
leave certificate name untouched in decode()

### DIFF
--- a/lib/mk-ca-bundle.pl
+++ b/lib/mk-ca-bundle.pl
@@ -136,6 +136,7 @@ if ($opt_i) {
   print "Perl Version                     : $]\n";
   print "Operating System Name            : $^O\n";
   print "Getopt::Std.pm Version           : ${Getopt::Std::VERSION}\n";
+  print "Encode::Encoding.pm Version      : ${Encode::Encoding::VERSION}\n";
   print "MIME::Base64.pm Version          : ${MIME::Base64::VERSION}\n";
   print "LWP::UserAgent.pm Version        : ${LWP::UserAgent::VERSION}\n" if($LWP::UserAgent::VERSION);
   print "LWP.pm Version                   : ${LWP::VERSION}\n" if($LWP::VERSION);
@@ -479,6 +480,7 @@ while (<TXT>) {
 
     if ( !should_output_cert(%trust_purposes_by_level) ) {
       $skipnum ++;
+      report "Skipping: $caname" if ($opt_v);
     } else {
       my $encoded = MIME::Base64::encode_base64($data, '');
       $encoded =~ s/(.{1,${opt_w}})/$1\n/g;
@@ -487,7 +489,7 @@ while (<TXT>) {
               . "-----END CERTIFICATE-----\n";
       print CRT "\n$caname\n";
       print CRT @precert if($opt_m);
-      my $maxStringLength = length(decode('UTF-8', $caname, Encode::FB_CROAK));
+      my $maxStringLength = length(decode('UTF-8', $caname, Encode::FB_CROAK | Encode::LEAVE_SRC));
       if ($opt_t) {
         foreach my $key (keys %trust_purposes_by_level) {
            my $string = $key . ": " . join(", ", @{$trust_purposes_by_level{$key}});


### PR DESCRIPTION
When running `mk-ca-bundle.pl` with the -v option, it fails to report the certificate name. This is happening due to the `decode()` call from `Encode` module having `CHECK` set without the `Encode::LEAVE_SRC` bit.

https://perldoc.perl.org/Encode.html#LEAVE_SRC says:

> If the Encode::LEAVE_SRC bit is not set but CHECK is set, then the source string to encode() or decode() will be overwritten in place. If you're not interested in this, then bitwise-OR it with the bitmask.

This simple change adds the bit and also reports skipped certificates (which is handy in the light of https://www.imperialviolet.org/2012/01/30/mozillaroots.html).

Thank you.