### PR TITLE
Session ticket

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1856,6 +1856,9 @@ typedef enum {
   /* Disallow specifying username/login in URL. */
   CINIT(DISALLOW_USERNAME_IN_URL, LONG, 278),
 
+  /* TLS session tickets*/
+  CINIT(TLS_USE_SESSION_TICKETS, LONG, 279),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2050,6 +2050,11 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     break;
 
 #endif
+
+  case CURLOPT_TLS_USE_SESSION_TICKETS:
+    data->set.ssl.sessionticket = (0 != va_arg(param, long)) ? TRUE : FALSE;
+    break;
+
   case CURLOPT_FTPSSLAUTH:
     /*
      * Set a specific auth for FTP-SSL transfers.

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -242,6 +242,7 @@ struct ssl_config_data {
   void *fsslctxp;        /* parameter for call back */
   bool certinfo;         /* gather lots of certificate info */
   bool falsestart;
+  bool sessionticket;
 
   char *cert; /* client certificate file name */
   char *cert_type; /* format for certificate (default: PEM)*/

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1497,6 +1497,7 @@ static void nss_close(struct ssl_connect_data *connssl)
 static void Curl_nss_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl_proxy = &conn->proxy_ssl[sockindex];
 
   if(BACKEND->handle || connssl_proxy->backend->handle) {
@@ -1506,7 +1507,7 @@ static void Curl_nss_close(struct connectdata *conn, int sockindex)
     conn->sock[sockindex] = CURL_SOCKET_BAD;
   }
 
-  if(BACKEND->handle)
+  if(BACKEND->handle && !data->set.ssl.sessionticket)
     /* nss_close(connssl) will transitively close also
        connssl_proxy->backend->handle if both are used. Clear it to avoid
        a double close leading to crash. */
@@ -1830,8 +1831,11 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
     goto error;
 
   /* do not use SSL cache if disabled or we are not going to verify peer */
-  ssl_no_cache = (SSL_SET_OPTION(primary.sessionid)
-                  && SSL_CONN_CONFIG(verifypeer)) ? PR_FALSE : PR_TRUE;
+  /* ssl_no_cache = (SSL_SET_OPTION(primary.sessionid) */
+                  /* && SSL_CONN_CONFIG(verifypeer)) ? PR_FALSE : PR_TRUE; */
+
+   ssl_no_cache = (data->set.ssl.primary.sessionid && data->set.ssl.primary.verifypeer) ?
+     PR_FALSE : PR_TRUE;
   if(SSL_OptionSet(model, SSL_NO_CACHE, ssl_no_cache) != SECSuccess)
     goto error;
 

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2031,6 +2031,11 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
   }
 #endif
 
+   if (data->set.ssl.sessionticket) {
+           if (SSL_OptionSet(BACKEND->handle, SSL_ENABLE_SESSION_TICKETS, PR_TRUE) != SECSuccess) {
+               goto error;
+           }
+   }
 
   /* Force handshake on next I/O */
   if(SSL_ResetHandshake(BACKEND->handle, /* asServer */ PR_FALSE)

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -232,6 +232,7 @@ struct OperationConfig {
 
   bool ssl_no_revoke;       /* disable SSL certificate revocation checks */
   /*bool proxy_ssl_no_revoke; */
+  bool tls_use_session_ticket;  /*enable tls session tickets*/
 
   bool use_metalink;        /* process given URLs as metalink XML file */
   metalinkfile *metalinkfile_list; /* point to the first node */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -261,6 +261,7 @@ static const struct LongShort aliases[]= {
   {"E9", "proxy-tlsv1",              ARG_NONE},
   {"EA", "socks5-basic",             ARG_BOOL},
   {"EB", "socks5-gssapi",            ARG_BOOL},
+  {"EC", "tls-use-session-tickets",  FALSE},
   {"f",  "fail",                     ARG_BOOL},
   {"fa", "fail-early",               ARG_BOOL},
   {"fb", "styled-output",            ARG_BOOL},
@@ -1646,6 +1647,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         else
           config->socks5_auth &= ~CURLAUTH_GSSAPI;
         break;
+
+     case 'C': /* --tls-use-session-tickets */
+           config->tls_use_session_ticket = TRUE;
+		break;
 
       default: /* unknown flag */
         return PARAM_OPTION_UNKNOWN;

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -330,6 +330,8 @@ static const struct helptxt helptext[] = {
    "TLS 1.3 proxy cipher suites"},
   {"    --proxy-tlsauthtype <type>",
    "TLS authentication type for HTTPS proxy"},
+  {"    --tls-use-session-tickets",
+   "Enable TLS session tickets with NSS"},
   {"    --proxy-tlspassword <string>",
    "TLS password for HTTPS proxy"},
   {"    --proxy-tlsuser <name>",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1426,6 +1426,10 @@ static CURLcode operate_do(struct GlobalConfig *global,
           my_setopt(curl, CURLOPT_PROXY_SSL_OPTIONS,
                     (long)CURLSSLOPT_ALLOW_BEAST);
 
+	if (config->tls_use_session_ticket) {
+          my_setopt(curl, CURLOPT_TLS_USE_SESSION_TICKETS, 1L);
+        }
+
         if(config->mail_auth)
           my_setopt_str(curl, CURLOPT_MAIL_AUTH, config->mail_auth);
 


### PR DESCRIPTION
In our project we needed the TLS Session Tickets Feature for curl build against NSS. Formaly this patch was for curl 7.44. But I reworked it against curl 7.60. So hopefully its now usefull for the community. Please comment for improvements.  