### PR TITLE
schannel: avoid incompatible pointer warning

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -214,7 +214,7 @@ static CURLcode add_certs_to_store(HCERTSTORE trust_store,
                              NULL,
                              NULL,
                              NULL,
-                             &cert_context)) {
+                             (const void **)&cert_context)) {
 
           failf(data,
                 "schannel: failed to extract certificate from CA file "


### PR DESCRIPTION
with clang-6.0:
```
vtls/schannel_verify.c: In function 'add_certs_to_store':
vtls/schannel_verify.c:212:30: warning: passing argument 11 of 'CryptQueryObject' from incompatible pointer type [-Wincompatible-pointer-types]
                              &cert_context)) {
                              ^
In file included from /usr/share/mingw-w64/include/schannel.h:10:0,
                 from /usr/share/mingw-w64/include/schnlsp.h:9,
                 from vtls/schannel.h:29,
                 from vtls/schannel_verify.c:40:
/usr/share/mingw-w64/include/wincrypt.h:4437:26: note: expected 'const void **' but argument is of type 'CERT_CONTEXT ** {aka struct _CERT_CONTEXT **}'
   WINIMPM WINBOOL WINAPI CryptQueryObject (DWORD dwObjectType, const void *pvObject, DWORD dwExpectedContentTypeFlags, DWORD dwExpectedFormatTypeFlags, DWORD dwFlags, DWORD *pdwMsgAndCertEncodingType, DWORD *pdwContentType, DWORD *pdwFormatType, HCERTSTORE *phCertStore, HCRYPTMSG *phMsg, const void **ppvContext);
                          ^~~~~~~~~~~~~~~~
```