### PR TITLE
runtests: support variables in <strippart>

### DIFF
--- a/tests/data/test1455
+++ b/tests/data/test1455
@@ -35,7 +35,7 @@ http
 HTTP GET when PROXY Protocol enabled
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/1455 --haproxy-protocol --local-port 37756
+http://%HOSTIP:%HTTPPORT/1455 --haproxy-protocol
 </command>
 </client>
 
@@ -45,8 +45,11 @@ http://%HOSTIP:%HTTPPORT/1455 --haproxy-protocol --local-port 37756
 <strip>
 ^User-Agent:.*
 </strip>
+<strippart>
+s/^PROXY TCP4 %CLIENTIP %HOSTIP (\d*) %HTTPPORT/proxy-line/
+</strippart>
 <protocol>
-PROXY TCP4 %CLIENTIP %HOSTIP 37756 %HTTPPORT
+proxy-line
 GET /1455 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -4349,9 +4349,11 @@ sub singletest {
         # what parts to cut off from the protocol
         my @strippart = getpart("verify", "strippart");
         my $strip;
+        @strippart = fixarray(@strippart);
         for $strip (@strippart) {
             chomp $strip;
             for(@out) {
+                print STDERR ":::: $strip\n";
                 eval $strip;
             }
         }


### PR DESCRIPTION
... and make use of that to make 1455 work better without using a fixed
local port number.

Fixes #2649