### PR TITLE
certdata.txt should be deleted also when the process is interrupted by "same certificate downloaded, exiting"

### DIFF
--- a/lib/mk-ca-bundle.pl
+++ b/lib/mk-ca-bundle.pl
@@ -377,6 +377,9 @@ my $newhash= sha256($txt);
 
 if(!$opt_f && $oldhash eq $newhash) {
     report "Downloaded file identical to previous run\'s source file. Exiting";
+    if($opt_u && -e $txt && !unlink($txt)) {
+        report "Failed to remove $txt: $!\n";
+    }
     exit;
 }
 


### PR DESCRIPTION
The certdata.txt is currently kept on disk even if you give the -u option