### PR TITLE
Fix maketgz to resolve sed issues on OSX

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -78,7 +78,7 @@ fi
 datestamp=`date +"%F"`
 
 # Replace version number in header file:
-sed -i -e 's/^#define LIBCURL_VERSION .*/#define LIBCURL_VERSION "'$libversion'"/g' \
+sed -i.bak -e 's/^#define LIBCURL_VERSION .*/#define LIBCURL_VERSION "'$libversion'"/g' \
     -e 's/^#define LIBCURL_VERSION_NUM .*/#define LIBCURL_VERSION_NUM 0x'$numeric'/g' \
     -e 's/^#define LIBCURL_VERSION_MAJOR .*/#define LIBCURL_VERSION_MAJOR '$major'/g' \
     -e 's/^#define LIBCURL_VERSION_MINOR .*/#define LIBCURL_VERSION_MINOR '$minor'/g' \
@@ -87,10 +87,10 @@ sed -i -e 's/^#define LIBCURL_VERSION .*/#define LIBCURL_VERSION "'$libversion'"
  $HEADER
 
 # Replace version number in header file:
-sed -i 's/#define CURL_VERSION .*/#define CURL_VERSION "'$curlversion'"/g' $CHEADER
+sed -i.bak 's/#define CURL_VERSION .*/#define CURL_VERSION "'$curlversion'"/g' $CHEADER
 
 # Replace version number in plist file:
-sed -i "s/7\.12\.3/$libversion/g" $PLIST
+sed -i.bak "s/7\.12\.3/$libversion/g" $PLIST
 
 if test -n "$only"; then
     # done!


### PR DESCRIPTION
Curl build uses maketgz to create release tarball and removes the -DEV string in curl version (e.g. 7.58.0-DEV), else -DEV shows up on command line when curl is run. Upstream provided
maketgz works fine on linux but fails on OSX. Problem is with the sed commands that use option -i without an extension. Maketgz expects GNU sed instead of BSD and this simply won't work on OSX. Adding a backup extension .bak after -i fixes this issue

Running the script as is on OSX gives this error:

sed: -e: No such file or directory

Adding a .bak extension resolves it

Overall, maketgz uses lot of stuff from the path and ignores
environment variables. Might be something the upstream team should
consider