### PR TITLE
cmake: allow multiple SSL backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ collect_true(enabled_ssl_options enabled_ssl_options_count
   CMAKE_USE_MBEDTLS
 )
 if(enabled_ssl_options_count GREATER 1)
-  message(FATAL_ERROR "Multiple SSL options specified: ${enabled_ssl_options}. Please pick at most one and disable the rest.")
+  set(CURL_WITH_MULTI_SSL ON)
 endif()
 
 if(CMAKE_USE_WINSSL)

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -966,6 +966,9 @@
 /* to enable Windows SSL  */
 #cmakedefine USE_SCHANNEL 1
 
+/* enable multiple SSL backends */
+#cmakedefine CURL_WITH_MULTI_SSL 1
+
 /* Define to 1 if using yaSSL in OpenSSL compatibility mode. */
 #cmakedefine USE_YASSLEMUL 1
 


### PR DESCRIPTION
This will make possible to select the SSL backend (using curl_global_sslset()) even when the libcurl is built using CMake.