### PR TITLE
Add callback to compare server X509 certificate fingerprints

### DIFF
--- a/docs/libcurl/opts/CURLOPT_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -40,6 +40,9 @@ synchronously.  Using the if! format is highly recommended when using the
 multi interfaces to avoid allowing the code to block.  If "if!" is specified
 but the parameter does not match an existing interface, CURLE_INTERFACE_FAILED
 is returned from the libcurl function used to perform the transfer.
+
+libcurl does not support using network interface names for this option on
+Windows.
 
 The application does not have to keep the string around after setting this
 option.

--- a/docs/libcurl/opts/CURLOPT_SSL_CERT_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CERT_DATA.3
@@ -1,0 +1,50 @@
+.\" **************************************************************************
+.\" *                                  _   _ ____  _
+.\" *  Project                     ___| | | |  _ \| |
+.\" *                             / __| | | | |_) | |
+.\" *                            | (__| |_| |  _ <| |___
+.\" *                             \___|\___/|_| \_\_____|
+.\" *
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" *
+.\" * This software is licensed as described in the file COPYING, which
+.\" * you should have received as part of this distribution. The terms
+.\" * are also available at https://curl.haxx.se/docs/copyright.html.
+.\" *
+.\" * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+.\" * copies of the Software, and permit persons to whom the Software is
+.\" * furnished to do so, under the terms of the COPYING file.
+.\" *
+.\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+.\" * KIND, either express or implied.
+.\" *
+.\" **************************************************************************
+.\"
+.TH CURLOPT_SSL_CERT_DATA 3 "17 Jun 2018" "libcurl 7.61.0" "curl_easy_setopt options"
+.SH NAME
+CURLOPT_SSL_CTX_DATA \- custom pointer passed to fingerprint string pointer.
+.SH SYNOPSIS
+#include <curl/curl.h>
+
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_DATA, void *pointer);
+.SH DESCRIPTION
+Data \fIpointer\fP to pass to the ssl cert callback set by the option
+\fICURLOPT_SSL_CERT_FUNCTION(3)\fP, this is the pointer you'll get as third
+parameter.
+.SH DEFAULT
+NULL
+.SH PROTOCOLS
+All TLS based protocols: HTTPS, FTPS, IMAPS, POP3S, SMTPS etc.
+.SH EXAMPLE
+.nf
+See CURLOPT_SSL_CERT_FUNCTION example.
+.SH AVAILABILITY
+Added in 7.61.0 for OpenSSL. Other SSL backends not supported.
+.SH RETURN VALUE
+CURLE_OK if supported; or an error such as:
+
+CURLE_NOT_BUILT_IN - Not supported by the SSL backend
+
+CURLE_UNKNOWN_OPTION
+.SH "SEE ALSO"
+.BR CURLOPT_SSL_CERT_FUNCTION "(3)"

--- a/docs/libcurl/opts/CURLOPT_SSL_CERT_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CERT_FUNCTION.3
@@ -1,0 +1,105 @@
+.\" **************************************************************************
+.\" *                                  _   _ ____  _
+.\" *  Project                     ___| | | |  _ \| |
+.\" *                             / __| | | | |_) | |
+.\" *                            | (__| |_| |  _ <| |___
+.\" *                             \___|\___/|_| \_\_____|
+.\" *
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" *
+.\" * This software is licensed as described in the file COPYING, which
+.\" * you should have received as part of this distribution. The terms
+.\" * are also available at https://curl.haxx.se/docs/copyright.html.
+.\" *
+.\" * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+.\" * copies of the Software, and permit persons to whom the Software is
+.\" * furnished to do so, under the terms of the COPYING file.
+.\" *
+.\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+.\" * KIND, either express or implied.
+.\" *
+.\" **************************************************************************
+.\"
+.TH CURLOPT_SSL_CERT_FUNCTION 3 "17 Jun 2018" "libcurl 7.61.0" "curl_easy_setopt options"
+.SH NAME
+CURLOPT_SSL_CERT_FUNCTION \- SSL server certificate callback for OpenSSL
+.SH SYNOPSIS
+.nf
+#include <curl/curl.h>
+
+CURLcode ssl_cert_callback(CURL *curl, void *cert, void *userptr);
+
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CERT_FUNCTION,
+                          ssl_cert_callback);
+.SH DESCRIPTION
+This option only works for libcurl powered by OpenSSL.
+If libcurl was built against another SSL library this functionality is
+absent.
+
+Pass a pointer to your callback function, which should match the prototype
+shown above.
+
+The \fIcert\fP parameter is actually a pointer to the SSL
+library's \fIX509\fP for OpenSSL. Set the \fIuserptr\fP argument with the
+\fICURLOPT_SSL_CERT_DATA(3)\fP option.
+
+This function will get called on all new connections made to a server, during
+the SSL negotiation. The function cab be used to implement a validation of the
+server certificate by comparing their fingerprints as shown in the example.
+
+To use this properly, a non-trivial amount of knowledge of your SSL library is
+necessary. For example, you can use this function to call library-specific
+callbacks to add additional validation code for certificates, and even to
+change the actual URI of an HTTPS request.
+.SH DEFAULT
+NULL
+.SH PROTOCOLS
+All TLS based protocols: HTTPS, FTPS, IMAPS, POP3S, SMTPS etc.
+.SH EXAMPLE
+.nf
+static const char *get_cert_fingerprint(X509 *cert) {
+  unsigned char md[EVP_MAX_MD_SIZE];
+  unsigned int len;
+
+  if (!X509_digest(cert, EVP_sha256(), md, &len))
+     return NULL;
+
+  char *mds = (char *)malloc(2 * len + 1);
+  for (int i = 0; i < len; i++) {
+    snprintf(mds + i * 2, 2 * len + 1 - 2 * i, "%02x",  md[i]);
+  }
+  mds[2 * len] = '\0';
+
+ return mds;
+}
+
+CURLcode ssl_cert_callback(CURL *curl, void *cert, void *param) {
+
+  if (cert == NULL || param == NULL)
+    return CURLE_SSL_PEER_CERTIFICATE;
+
+  const char **stored_digest = (const char **)param;
+  const char *server_digest = get_cert_fingerprint((X509 *)cert);
+
+  if (server_digest == NULL)
+    return CURLE_SSL_PEER_CERTIFICATE;
+
+  int rc = *stored_digest != NULL
+           && strcmp(*stored_digest, server_digest) != 0
+             ? CURLE_PEER_FAILED_VERIFICATION : CURLE_OK;
+
+  *stored_digest = server_digest;
+	
+  return rc;
+}
+.fi
+.SH AVAILABILITY
+Added in 7.61.0 for OpenSSL. Other SSL backends not supported.
+.SH RETURN VALUE
+CURLE_OK if supported; or an error such as:
+
+CURLE_SSL_PEER_CERTIFICATE - If the server certificate is not available.
+
+CURLE_PEER_FAILED_VERIFICATION - If the fingerprints differ
+.SH "SEE ALSO"
+.BR CURLOPT_SSL_CERT_DATA "(3)"

--- a/docs/libcurl/opts/Makefile.inc
+++ b/docs/libcurl/opts/Makefile.inc
@@ -289,6 +289,8 @@ man_MANS =                                      \
   CURLOPT_SSLKEYTYPE.3                          \
   CURLOPT_SSLVERSION.3                          \
   CURLOPT_SSL_CIPHER_LIST.3                     \
+  CURLOPT_SSL_CERT_DATA.3                       \
+  CURLOPT_SSL_CERT_FUNCTION.3                   \
   CURLOPT_SSL_CTX_DATA.3                        \
   CURLOPT_SSL_CTX_FUNCTION.3                    \
   CURLOPT_SSL_ENABLE_ALPN.3                     \

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -666,9 +666,13 @@ typedef CURLcode (*curl_ssl_ctx_callback)(CURL *curl,    /* easy handle */
                                           void *userptr);
 
 typedef CURLcode(*curl_ssl_cert_callback)(CURL *curl,  /* easy handle */
-	                                      void *cert, /* actually an
-				                                         OpenSSL X509 */
+                                          void *cert, /* actually an
+                                                         OpenSSL X509 */
                                           void *userptr);
+
+typedef CURLcode(*curl_password_callback)(CURL *curl,  /* easy handle */
+    char **user,
+    char **password);
 
 
 typedef enum {
@@ -1870,6 +1874,9 @@ typedef enum {
   /* Set the userdata for the ssl context callback function's third
      argument */
   CINIT(SSL_CERT_DATA, OBJECTPOINT, 280),
+
+  /* Set the password callback function. */
+  CINIT(PASSWORD_FUNCTION, FUNCTIONPOINT, 281),
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -665,6 +665,12 @@ typedef CURLcode (*curl_ssl_ctx_callback)(CURL *curl,    /* easy handle */
                                                             OpenSSL SSL_CTX */
                                           void *userptr);
 
+typedef CURLcode(*curl_ssl_cert_callback)(CURL *curl,  /* easy handle */
+	                                      void *cert, /* actually an
+				                                         OpenSSL X509 */
+                                          void *userptr);
+
+
 typedef enum {
   CURLPROXY_HTTP = 0,   /* added in 7.10, new in 7.19.4 default is to use
                            CONNECT HTTP/1.1 */
@@ -1855,6 +1861,15 @@ typedef enum {
 
   /* Disallow specifying username/login in URL. */
   CINIT(DISALLOW_USERNAME_IN_URL, LONG, 278),
+
+  /* Set the ssl context callback function, currently only for OpenSSL ssl_ctx
+     second argument. The function must be matching the
+     curl_ssl_ctx_callback proto. */
+  CINIT(SSL_CERT_FUNCTION, FUNCTIONPOINT, 279),
+
+  /* Set the userdata for the ssl context callback function's third
+     argument */
+  CINIT(SSL_CERT_DATA, OBJECTPOINT, 280),
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/lib/http.c
+++ b/lib/http.c
@@ -288,7 +288,7 @@ static CURLcode http_output_basic(struct connectdata *conn, bool proxy)
   else {
     userp = &conn->allocptr.userpwd;
     if(data->set.fpassword) {
-      if((*data->set.fpassword)(data, &(char *)user, &(char *)pwd) != CURLE_OK)
+      if((*data->set.fpassword)(data, (char **)&(char *)user, (char **)&pwd) != CURLE_OK)
         return CURLE_LOGIN_DENIED;
     }
     else {

--- a/lib/http.c
+++ b/lib/http.c
@@ -90,7 +90,7 @@ do {\
     *_p = '\0';\
     _p++;\
   }\
-} while (0)
+} while(0)
 
 /*
  * Forward declarations.
@@ -288,7 +288,8 @@ static CURLcode http_output_basic(struct connectdata *conn, bool proxy)
   else {
     userp = &conn->allocptr.userpwd;
     if(data->set.fpassword) {
-      if((*data->set.fpassword)(data, (char **)&user, (char **)&pwd) != CURLE_OK)
+      if((*data->set.fpassword)(data, (char **)&user,
+            (char **)&pwd) != CURLE_OK)
         return CURLE_LOGIN_DENIED;
     }
     else {
@@ -300,8 +301,8 @@ static CURLcode http_output_basic(struct connectdata *conn, bool proxy)
   out = aprintf("%s:%s", user, pwd);
 
   if(data->set.fpassword) {
-	ZEROSTR(user);
-	ZEROSTR(pwd);
+    ZEROSTR(user);
+    ZEROSTR(pwd);
   }
 
   if(!out)
@@ -2488,7 +2489,8 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
 
   /* clear userpwd and proxyuserpwd to avoid re-using old credentials
    * from re-used connections */
-  ZEROSTR(conn->allocptr.userpwd);
+  if(conn->allocptr.userpwd)
+    ZEROSTR(conn->allocptr.userpwd);
   Curl_safefree(conn->allocptr.userpwd);
   Curl_safefree(conn->allocptr.proxyuserpwd);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -2489,8 +2489,9 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
 
   /* clear userpwd and proxyuserpwd to avoid re-using old credentials
    * from re-used connections */
-  if(conn->allocptr.userpwd)
-    ZEROSTR(conn->allocptr.userpwd);
+  if (conn->allocptr.userpwd) {
+      ZEROSTR(conn->allocptr.userpwd);
+  }
   Curl_safefree(conn->allocptr.userpwd);
   Curl_safefree(conn->allocptr.proxyuserpwd);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -288,7 +288,7 @@ static CURLcode http_output_basic(struct connectdata *conn, bool proxy)
   else {
     userp = &conn->allocptr.userpwd;
     if(data->set.fpassword) {
-      if((*data->set.fpassword)(data, (char **)&(char *)user, (char **)&pwd) != CURLE_OK)
+      if((*data->set.fpassword)(data, (char **)&user, (char **)&pwd) != CURLE_OK)
         return CURLE_LOGIN_DENIED;
     }
     else {

--- a/lib/http.c
+++ b/lib/http.c
@@ -2489,8 +2489,8 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
 
   /* clear userpwd and proxyuserpwd to avoid re-using old credentials
    * from re-used connections */
-  if (conn->allocptr.userpwd) {
-      ZEROSTR(conn->allocptr.userpwd);
+  if(conn->allocptr.userpwd) {
+    ZEROSTR(conn->allocptr.userpwd);
   }
   Curl_safefree(conn->allocptr.userpwd);
   Curl_safefree(conn->allocptr.proxyuserpwd);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2594,6 +2594,29 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     data->set.disallow_username_in_url =
       (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
+  case CURLOPT_SSL_CERT_FUNCTION:
+#ifdef USE_SSL
+	  /*
+	  * Set a SSL_CERT callback
+	  */
+	  if (Curl_ssl->supports & SSLSUPP_SSL_CERT)
+		data->set.ssl.fsslcert = va_arg(param, curl_ssl_cert_callback);
+	  else
+#endif
+	  result = CURLE_NOT_BUILT_IN;
+	  break;
+
+  case CURLOPT_SSL_CERT_DATA:
+#ifdef USE_SSL
+	  /*
+	  * Set a SSL_CERT callback parameter pointer
+	  */
+	  if (Curl_ssl->supports & SSLSUPP_SSL_CERT)
+	    data->set.ssl.fsslcertp = va_arg(param, void *);
+	  else
+#endif
+	  result = CURLE_NOT_BUILT_IN;
+	  break;
   default:
     /* unknown tag and its companion, just ignore: */
     result = CURLE_UNKNOWN_OPTION;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2596,27 +2596,29 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     break;
   case CURLOPT_SSL_CERT_FUNCTION:
 #ifdef USE_SSL
-	  /*
-	  * Set a SSL_CERT callback
-	  */
-	  if (Curl_ssl->supports & SSLSUPP_SSL_CERT)
-		data->set.ssl.fsslcert = va_arg(param, curl_ssl_cert_callback);
-	  else
+     /*
+      * Set a SSL_CERT callback
+      */
+      if(Curl_ssl->supports & SSLSUPP_SSL_CERT)
+        data->set.ssl.fsslcert = va_arg(param, curl_ssl_cert_callback);
+      else
 #endif
-	  result = CURLE_NOT_BUILT_IN;
-	  break;
-
+      result = CURLE_NOT_BUILT_IN;
+      break;
   case CURLOPT_SSL_CERT_DATA:
 #ifdef USE_SSL
-	  /*
-	  * Set a SSL_CERT callback parameter pointer
-	  */
-	  if (Curl_ssl->supports & SSLSUPP_SSL_CERT)
-	    data->set.ssl.fsslcertp = va_arg(param, void *);
-	  else
+     /*
+      * Set a SSL_CERT callback parameter pointer
+      */
+      if(Curl_ssl->supports & SSLSUPP_SSL_CERT)
+        data->set.ssl.fsslcertp = va_arg(param, void *);
+      else
 #endif
-	  result = CURLE_NOT_BUILT_IN;
-	  break;
+      result = CURLE_NOT_BUILT_IN;
+      break;
+  case CURLOPT_PASSWORD_FUNCTION:
+      data->set.fpassword = va_arg(param, curl_password_callback);
+      break;
   default:
     /* unknown tag and its companion, just ignore: */
     result = CURLE_UNKNOWN_OPTION;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1881,7 +1881,8 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
 
 #endif /* CURL_DISABLE_PROXY */
 
-  conn->bits.user_passwd = (data->set.str[STRING_USERNAME] || data->set.fpassword) ? TRUE : FALSE;
+  conn->bits.user_passwd = (data->set.str[STRING_USERNAME]
+     || data->set.fpassword) ? TRUE : FALSE;
   conn->bits.ftp_use_epsv = data->set.ftp_use_epsv;
   conn->bits.ftp_use_eprt = data->set.ftp_use_eprt;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -1881,7 +1881,7 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
 
 #endif /* CURL_DISABLE_PROXY */
 
-  conn->bits.user_passwd = (data->set.str[STRING_USERNAME]) ? TRUE : FALSE;
+  conn->bits.user_passwd = (data->set.str[STRING_USERNAME] || data->set.fpassword) ? TRUE : FALSE;
   conn->bits.ftp_use_epsv = data->set.ftp_use_epsv;
   conn->bits.ftp_use_eprt = data->set.ftp_use_eprt;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1690,6 +1690,8 @@ struct UserDefined {
                                                   before resolver start */
   void *resolver_start_client; /* pointer to pass to resolver start callback */
   bool disallow_username_in_url; /* disallow username in url */
+
+  curl_password_callback fpassword; /* callback function retruning the password of the user. */
 };
 
 struct Names {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1691,7 +1691,8 @@ struct UserDefined {
   void *resolver_start_client; /* pointer to pass to resolver start callback */
   bool disallow_username_in_url; /* disallow username in url */
 
-  curl_password_callback fpassword; /* callback function retruning the password of the user. */
+  curl_password_callback fpassword; /* callback function returning
+                                       the password of the user. */
 };
 
 struct Names {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -240,6 +240,8 @@ struct ssl_config_data {
   char *issuercert;/* optional issuer certificate filename */
   curl_ssl_ctx_callback fsslctx; /* function to initialize ssl ctx */
   void *fsslctxp;        /* parameter for call back */
+  curl_ssl_cert_callback fsslcert; /* function to initialize ssl cert */
+  void *fsslcertp;       /* parameter for call back */
   bool certinfo;         /* gather lots of certificate info */
   bool falsestart;
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -29,6 +29,8 @@
 
 #include "curl_setup.h"
 
+#define USE_MBEDTLS 1
+
 #ifdef USE_MBEDTLS
 
 #include <mbedtls/version.h>
@@ -596,6 +598,14 @@ mbed_connect_step2(struct connectdata *conn,
   }
 
   peercert = mbedtls_ssl_get_peer_cert(&BACKEND->ssl);
+  if(data->set.ssl.fsslcert) {
+    CURLcode rc = (*data->set.ssl.fsslcert)(data, (void *)peercert,
+    data->set.ssl.fsslcertp);
+    if(rc) {
+      failf(data, "error signaled by ssl cert callback");
+      return rc;
+    }
+  }
 
   if(peercert && data->set.verbose) {
     const size_t bufsize = 16384;
@@ -1051,7 +1061,8 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
 
   SSLSUPP_CA_PATH |
   SSLSUPP_PINNEDPUBKEY |
-  SSLSUPP_SSL_CTX,
+  SSLSUPP_SSL_CTX |
+  SSLSUPP_SSL_CERT,
 
   sizeof(struct ssl_backend_data),
 
@@ -1078,3 +1089,4 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
 };
 
 #endif /* USE_MBEDTLS */
+

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3187,6 +3187,14 @@ static CURLcode servercert(struct connectdata *conn,
   }
 
   BACKEND->server_cert = SSL_get_peer_certificate(BACKEND->handle);
+  if(data->set.ssl.fsslcert) {
+    rc = (*data->set.ssl.fsslcert)(data, BACKEND->server_cert,
+           data->set.ssl.fsslcertp);
+    if(rc) {
+      failf(data, "error signaled by ssl cert callback");
+      return rc;
+    }
+  }
   if(!BACKEND->server_cert) {
     BIO_free(fp);
     BIO_free(mem);
@@ -3780,7 +3788,8 @@ const struct Curl_ssl Curl_ssl_openssl = {
   SSLSUPP_CERTINFO |
   SSLSUPP_PINNEDPUBKEY |
   SSLSUPP_SSL_CTX |
-  SSLSUPP_HTTPS_PROXY,
+  SSLSUPP_HTTPS_PROXY |
+  SSLSUPP_SSL_CERT,
 
   sizeof(struct ssl_backend_data),
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -32,6 +32,7 @@ struct ssl_connect_data;
 #define SSLSUPP_SSL_CTX      (1<<3) /* supports CURLOPT_SSL_CTX */
 #define SSLSUPP_HTTPS_PROXY  (1<<4) /* supports access via HTTPS proxies */
 #define SSLSUPP_TLS13_CIPHERSUITES (1<<5) /* supports TLS 1.3 ciphersuites */
+#define SSLSUPP_SSL_CERT     (1<<6) /* supports CURLOPT_SSL_CERT */
 
 struct Curl_ssl {
   /*

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -122,6 +122,7 @@ static curl_progress_callback progresscb;
 static curl_write_callback headercb;
 static curl_debug_callback debugcb;
 static curl_ssl_ctx_callback ssl_ctx_cb;
+static curl_ssl_cert_callback ssl_cert_cb;
 static curl_ioctl_callback ioctlcb;
 static curl_sockopt_callback sockoptcb;
 static curl_opensocket_callback opensocketcb;
@@ -133,6 +134,7 @@ static curl_fnmatch_callback fnmatch_cb;
 static curl_closesocket_callback closesocketcb;
 static curl_xferinfo_callback xferinfocb;
 static curl_resolver_start_callback resolver_start_cb;
+static curl_password_callback password_cb;
 
 int test(char *URL)
 {

--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -54,6 +54,7 @@ CFGSET=true
 !MESSAGE   ENABLE_SSPI=<yes or no>        - Enable SSPI support, defaults to yes
 !MESSAGE   ENABLE_WINSSL=<yes or no>      - Enable native Windows SSL support, defaults to yes
 !MESSAGE   GEN_PDB=<yes or no>            - Generate Program Database (debug symbols for release build)
+!MESSAGE   HTTP_ONLY=<yes or no>          - Generate an HTTP only build
 !MESSAGE   DEBUG=<yes or no>              - Debug builds
 !MESSAGE   MACHINE=<x86 or x64>           - Target architecture (default x64 on AMD64, x86 on others)
 !MESSAGE   CARES_PATH=<path to cares>     - Custom path for c-ares

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -349,6 +349,9 @@ WIN_LIBS    = $(WIN_LIBS) Crypt32.lib
 GEN_PDB = true
 !ENDIF
 
+!IF "$(HTTP_ONLY)"=="yes"
+HTTP_ONLY = true
+!ENDIF
 
 !IFDEF EMBED_MANIFEST
 MANIFESTTOOL = $(MT) -manifest $(DIRDIST)\bin\$(PROGRAM_NAME).manifest -outputresource:$(DIRDIST)\bin\$(PROGRAM_NAME);1
@@ -474,6 +477,10 @@ CFLAGS = $(CFLAGS) $(CFLAGS_PDB) /Fd"$(LIB_DIROBJ)\$(PDB)"
 LFLAGS = $(LFLAGS) $(LFLAGS_PDB)
 !ENDIF
 
+!IF "$(HTTP_ONLY)"=="true"
+CFLAGS = $(CFLAGS) /DHTTP_ONLY
+!ENDIF
+
 LIB_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-lib
 CURL_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-curl
 DIRDIST = ..\builds\$(CONFIG_NAME_LIB)\
@@ -517,6 +524,7 @@ $(TARGET): $(LIB_OBJS) $(LIB_DIROBJ) $(DIRDIST)
 	@echo CFLAGS:     $(CFLAGS)
 	@echo LFLAGS:     $(LFLAGS)
 	@echo GenPDB:     $(GEN_PDB)
+	@echo HTTP only:  $(HTTP_ONLY)
 	@echo Debug:      $(DEBUG)
 	@echo Machine:    $(MACHINE)
 	$(LNK) $(LIB_OBJS)


### PR DESCRIPTION
This pull request is a new version of a previous one (#2666) which was made on a old version.

It provides a way to compare the fingerprint of the server certificate to a locally store one.
It's only support OpenSSL for now.

Contrarily to CURLOPT_PINNEDPUBLICKEY which doesn’t enable a calling application to get the fingerprint automatically during the first connection, CURLOPT_SSL_CERT call back can return an updated fingerprint in addition to the return code.