### PR TITLE
[WIP] Avoid using free'd easy handles referenced from connection cache

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1273,6 +1273,12 @@ curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
  */
 bool Curl_connalive(struct connectdata *conn)
 {
+  /* kludge around use-after-free */
+  if(!conn->data || !GOOD_EASY_HANDLE(conn->data)
+     || conn->data->easy_conn != conn) {
+    return false;
+  }
+
   /* First determine if ssl */
   if(conn->ssl[FIRSTSOCKET].use) {
     /* use the SSL context */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -198,7 +198,8 @@ static bool http2_connisdead(struct connectdata *conn)
   }
   else if(sval & CURL_CSELECT_IN) {
     /* readable with no error. could still be closed */
-    dead = !Curl_connalive(conn);
+    dead = !conn->data || !GOOD_EASY_HANDLE(conn->data)
+           || !Curl_connalive(conn);
     if(!dead) {
       /* This happens before we've sent off a request and the connection is
          not in use by any other thransfer, there shouldn't be any data here,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -205,6 +205,7 @@ static bool http2_connisdead(struct connectdata *conn)
          only "protocol frames" */
       CURLcode result;
       struct http_conn *httpc = &conn->proto.httpc;
+      assert(httpc);
       ssize_t nread = -1;
       if(httpc->recv_underlying)
         /* if called "too early", this pointer isn't setup yet! */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -206,8 +206,8 @@ static bool http2_connisdead(struct connectdata *conn)
          only "protocol frames" */
       CURLcode result;
       struct http_conn *httpc = &conn->proto.httpc;
-      assert(httpc);
       ssize_t nread = -1;
+      assert(httpc);
       if(httpc->recv_underlying)
         /* if called "too early", this pointer isn't setup yet! */
         nread = ((Curl_recv *)httpc->recv_underlying)(


### PR DESCRIPTION
For a while now I've been trying to sort out a problem with Nix's usage of libcurl,
one that is especially apparent when building with address sanitizer enabled
or building against musl.

----------------

The commits in this PR appear to "resolve" the issue but I don't believe are really the right answer,
as they only mask the real problem: free'd handles end up being referred to from the connection cache.

----------------

The usage is this:

* we create a multi handle that lives more or less forever
* single thread handles everything curl-related, processes
  a queue of requests populated by other threads and for each
  creates an easy handle and adds to multi.
* A mapping of easy handle to our own datastructure is maintained, AFAIK this works
  (similar to the ASIO example or one of those, as I recall)
* Loop is basically this:
  * `curl_multi_perform`
  * Read all available messages from `curl_multi_info_read`, freeing the handles as we go
  * `curl_multi_wait` (we add an extra FD that's a wake-up pipe when new requests are added)
  * Create handles for any new requests and add to the multi handle
  * (minor: check if thread has been asked to quit, otherwise keep looping)

We make many many requests that use http2/openssl and enable multiplexing (but not http1 pipelining).

If it matters we also enable PIPEWAIT and MAXCONNECTS is set to 25.

-----------------

Eventually, and almost immediately with ASAN or quickly with musl, it appears the memory for a deallocated handle
is used for something else and everything goes south when curl attempts to "check if the connection is dead"
which involves -- for http2+ssl at least-- using data-structures and buffers that are no longer present.

I guess glibc is either less quick to recycle free'd memory or its use of thread-local arenas mostly
mitigates the problem since the thread creating/free'ing curl handles really does nothing else and so
is less likely to run into problems.

These commits workaround this by checking if the magic bit is unset, but that of course only works sometimes
and still requires accessing free'd memory and hoping for the best.

------------------

Here's an example report from address sanitizer: https://gist.github.com/dtzWill/4b02c8943ec3be4875ab54186e2cc176

------------------

I see that in general it's known to be problematic to remove handles possibly involved in pipelines,
but I thought I'd double-check that this particular problem is known/expected and to perhaps ask
if there's a recommendation for avoiding these problems.

As far as I can tell the easy handles added to a multi handle are expected to outlive the multi-handle
(although this is not mentioned elsewhere, so I'd appreciate confirmation) since they may be referenced
from the multi handle's connection cache indefinitely and there is no way to clear or query this cache.

I tried using a pool of ~100 connection handles --and basically never free them (curl_easy_cleanup) until we're entirely done.
This seems to mitigate the issue but I don't know that this can be relied upon as it may only appear to work
by making it less problematic when multi handle attempts to deference easy handles that have been removed
(since the pool ensures this memory will likely be unused for at least a while) but in the worst case
might break if the cache refers to a handle long enough for us to cycle through the pool, in which case
the connection check might do something silly like attempt to read into the buffer of a new handle
that may or may not really be part of the cached connection referencing it.

Anyway-- I suppose this is a bug report of sorts, but also a request for insights into what we're doing wrong
or how to restructure things to use the libcurl API in a more expected/supported manner.

Thank you for your time!

----------------

FWIW this issue seems particularly problematic in 7.60 (and still in latest git), it does not happen in 7.59 or the handful of previous versions I tested.