### PR TITLE
url: use a fresh easy handle with connections from the cache

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2012 - 2016, Linus Nielsen Feltzing, <linus@haxx.se>
- * Copyright (C) 2012 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -451,6 +451,7 @@ bool Curl_conncache_return_conn(struct connectdata *conn)
   }
   CONN_LOCK(data);
   conn->inuse = FALSE; /* Mark the connection unused */
+  conn->data = NULL; /* no owner */
   CONN_UNLOCK(data);
 
   return (conn_candidate == conn) ? FALSE : TRUE;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1259,9 +1259,11 @@ curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
       return CURL_SOCKET_BAD;
     }
 
-    if(connp)
+    if(connp) {
       /* only store this if the caller cares for it */
       *connp = c;
+      c->data = data;
+    }
     return c->sock[FIRSTSOCKET];
   }
   else

--- a/lib/url.c
+++ b/lib/url.c
@@ -965,6 +965,7 @@ static bool extract_if_dead(struct connectdata *conn,
        use */
     bool dead;
 
+    conn->data = data;
     if(conn->handler->connection_check) {
       /* The protocol has a special method for checking the state of the
          connection. Use it to check if the connection is dead. */
@@ -979,7 +980,6 @@ static bool extract_if_dead(struct connectdata *conn,
     }
 
     if(dead) {
-      conn->data = data;
       infof(data, "Connection %ld seems to be dead!\n", conn->connection_id);
       Curl_conncache_remove_conn(conn, FALSE);
       return TRUE;


### PR DESCRIPTION
... and make sure to NULLify the ->data pointer when the connection is put
into the cache to make this mistake easier to detect in the future.

Reported-by: Will Dietz
Closes #2669