### PR TITLE
CURLOPT_SSL_VERIFYPEER.3: Add performance note

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -57,6 +57,15 @@ man-in-the-middle the communication without you knowing it. Disabling
 verification makes the communication insecure. Just having encryption on a
 transfer is not enough as you cannot be sure that you are communicating with
 the correct end-point.
+
+NOTE: even when this option is disabled, depending on the used TLS backend,
+curl may still load the certificate file specified in
+\fICURLOPT_CAINFO(3)\fP. curl default settings in some distributions might
+use quite a large file as a default setting for \fICURLOPT_CAINFO(3)\fP,
+so loading the file can be quite expensive, especially when dealing
+with many connections. Thus, in some situations, you might want to disable
+verification fully to save resources by setting \fICURLOPT_CAINFO(3)\f to
+NULL - but please also consider the warning above!
 .SH DEFAULT
 By default, curl assumes a value of 1.
 .SH PROTOCOLS
@@ -81,3 +90,4 @@ Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .BR CURLOPT_SSL_VERIFYHOST "(3), "
 .BR CURLOPT_PROXY_SSL_VERIFYPEER "(3), "
 .BR CURLOPT_PROXY_SSL_VERIFYHOST "(3), "
+.BR CURLOPT_CAINFO "(3), "


### PR DESCRIPTION
As a follow-up to PR #2290, extend the documentation of CURLOPT_SSL_VERIFYPEER to give a hint that verification will still be performed even though CURLOPT_SSL_VERIFYPEER is 0.