### PR TITLE
ConnectionExists: make sure conn->data is set when "taking" a connection

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1465,6 +1465,7 @@ ConnectionExists(struct Curl_easy *data,
   if(chosen) {
     /* mark it as used before releasing the lock */
     chosen->inuse = TRUE;
+    chosen->data = data; /* own it! */
     Curl_conncache_unlock(needle);
     *usethis = chosen;
     return TRUE; /* yes, we found one to use! */


### PR DESCRIPTION
Follow-up to 2c15693.

Fixes #2674