### PR TITLE
netrc: use a larger buffer

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -115,7 +115,7 @@ int Curl_parsenetrc(const char *host,
     char *tok;
     char *tok_buf;
     bool done = FALSE;
-    char netrcbuffer[256];
+    char netrcbuffer[4096];
     int  netrcbuffsize = (int)sizeof(netrcbuffer);
 
     while(!done && fgets(netrcbuffer, netrcbuffsize, file)) {


### PR DESCRIPTION
... to work with longer passwords etc.

Fixes #2676