### PR TITLE
configure: Add dependent libraries after crypto

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1657,7 +1657,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
 
        dnl still no, but what about with -ldl?
        AC_MSG_CHECKING([OpenSSL linking with -ldl])
-       LIBS="$LIBS -ldl -lcrypto"
+       LIBS="$CLEANLIBS -lcrypto -ldl"
        AC_TRY_LINK(
        [
          #include <openssl/err.h>
@@ -1671,10 +1671,10 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
        ],
        [
          AC_MSG_RESULT(no)
-         dnl ok, so what about bouth -ldl and -lpthread?
+         dnl ok, so what about both -ldl and -lpthread?
 
          AC_MSG_CHECKING([OpenSSL linking with -ldl and -lpthread])
-         LIBS="$CLEANLIBS -ldl -lpthread -lcrypto"
+         LIBS="$CLEANLIBS -lcrypto -ldl -lpthread"
          AC_TRY_LINK(
          [
            #include <openssl/err.h>


### PR DESCRIPTION
The linker is pretty dumb and processes things left to right, keeping a
tally of symbols it hasn't resolved yet. So, we need -ldl to appear
after -lcrypto otherwise the linker won't find the dl functions.

---

This appears to fix the fuzzer build, but would appreciate an extra set of eyes.