### PR TITLE
easy_perform: use *multi_timeout() to get wait times

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -574,10 +574,10 @@ int Curl_resolver_getsock(struct connectdata *conn,
   (void)socks;
   (void)numsocks;
   ms = Curl_timediff(Curl_now(), reslv->start);
-  if(ms < 10)
-    milli = ms/3;
+  if(ms < 3)
+    milli = 0;
   else if(ms <= 50)
-    milli = 10;
+    milli = ms/3;
   else if(ms <= 250)
     milli = 50;
   else

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -661,38 +661,27 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
   bool done = FALSE;
   CURLMcode mcode = CURLM_OK;
   CURLcode result = CURLE_OK;
-  struct curltime before;
-  int without_fds = 0;  /* count number of consecutive returns from
-                           curl_multi_wait() without any filedescriptors */
 
   while(!done && !mcode) {
     int still_running = 0;
     int rc;
 
-    before = Curl_now();
     mcode = curl_multi_wait(multi, NULL, 0, 1000, &rc);
 
     if(!mcode) {
       if(!rc) {
-        struct curltime after = Curl_now();
+        long sleep_ms;
 
         /* If it returns without any filedescriptor instantly, we need to
            avoid busy-looping during periods where it has nothing particular
            to wait for */
-        if(Curl_timediff(after, before) <= 10) {
-          without_fds++;
-          if(without_fds > 2) {
-            int sleep_ms = without_fds < 10 ? (1 << (without_fds - 1)) : 1000;
-            Curl_wait_ms(sleep_ms);
-          }
+        curl_multi_timeout(multi, &sleep_ms);
+        if(sleep_ms) {
+          if(sleep_ms > 1000)
+            sleep_ms = 1000;
+          Curl_wait_ms((int)sleep_ms);
         }
-        else
-          /* it wasn't "instant", restart counter */
-          without_fds = 0;
       }
-      else
-        /* got file descriptor, restart counter */
-        without_fds = 0;
 
       mcode = curl_multi_perform(multi, &still_running);
     }


### PR DESCRIPTION
... and trim the threaded Curl_resolver_getsock() to return zero
millisecond wait times during the first three milliseconds so that
localhost or names in the OS resolver cache gets detected and used
faster.