### PR TITLE
travis: add a build using the synchronous name resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,10 @@ matrix:
         - os: linux
           compiler: clang
           dist: trusty
+          env: T=debug C="--disable-threaded-resolver"
+        - os: linux
+          compiler: clang
+          dist: trusty
           env: T=debug C="--with-nss --without-ssl" NOTESTS=1 CPPFLAGS="-isystem /usr/include/nss"
         - os: linux
           compiler: gcc


### PR DESCRIPTION
... since default uses the threaded one and we test the c-ares build
already.