### PR TITLE
Update confusing example of using CURLINFO_TLS_SSL_PTR

### DIFF
--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
@@ -129,14 +129,36 @@ https://github.com/curl/curl/issues/685
 All TLS-based
 .SH EXAMPLE
 .nf
-CURL *curl = curl_easy_init();
-if(curl) {
-  CURLcode res;
-  struct curl_tlssessioninfo *tls;
-  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
-  res = curl_easy_perform(curl);
-  curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &tls);
-  curl_easy_cleanup(curl);
+#include <curl/curl.h>
+#include <openssl/ssl.h>
+
+CURL *curl;
+static size_t wf(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+  const struct curl_tlssessioninfo *info = NULL;
+  (void)stream;
+  (void)ptr;
+  CURLcode res = curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &info);
+  if(info && !res)
+  {
+      if(CURLSSLBACKEND_OPENSSL == info->backend)
+      {
+          printf("OpenSSL ver. %s\n", SSL_get_version((SSL*)info->internals));
+      }
+  }
+  return size * nmemb;
+}
+
+int main(int argc, char** argv) {
+    CURLcode res;
+    curl = curl_easy_init();
+    if(curl) {
+      curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
+      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, wf);
+      res = curl_easy_perform(curl);
+      curl_easy_cleanup(curl);
+    }
+    return res;
 }
 .fi
 .SH AVAILABILITY

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
@@ -133,16 +133,11 @@ All TLS-based
 #include <openssl/ssl.h>
 
 CURL *curl;
-static size_t wf(void *ptr, size_t size, size_t nmemb, void *stream)
-{
+static size_t wf(void *ptr, size_t size, size_t nmemb, void *stream) {
   const struct curl_tlssessioninfo *info = NULL;
-  (void)stream;
-  (void)ptr;
   CURLcode res = curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &info);
-  if(info && !res)
-  {
-      if(CURLSSLBACKEND_OPENSSL == info->backend)
-      {
+  if(info && !res) {
+      if(CURLSSLBACKEND_OPENSSL == info->backend) {
           printf("OpenSSL ver. %s\n", SSL_get_version((SSL*)info->internals));
       }
   }


### PR DESCRIPTION
Previous example was little bit confusing, because SSL* structure (or other "in use" SSL connection pointer) are not accessible after transfer, therefore working with raw TLS library specific pointer should be done during transfer.