### PR TITLE
openssl: allow TLS 1.3 by default

### DIFF
--- a/docs/cmdline-opts/tlsv1.d
+++ b/docs/cmdline-opts/tlsv1.d
@@ -8,5 +8,5 @@ Requires: TLS
 See-also: http1.1 http2
 Help: Use TLSv1.0 or greater
 ---
-Tells curl to use TLS version 1.x when negotiating with a remote TLS
-server. That means TLS version 1.0, 1.1 or 1.2.
+Tells curl to use at least TLS version 1.x when negotiating with a remote TLS
+server. That means TLS version 1.0 or higher

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2130,12 +2130,12 @@ set_ssl_version_min_max(long *ctx_options, struct connectdata *conn,
 #endif
       /* FALLTHROUGH */
     case CURL_SSLVERSION_MAX_TLSv1_2:
-    case CURL_SSLVERSION_MAX_DEFAULT:
 #ifdef TLS1_3_VERSION
       *ctx_options |= SSL_OP_NO_TLSv1_3;
 #endif
       break;
     case CURL_SSLVERSION_MAX_TLSv1_3:
+    case CURL_SSLVERSION_MAX_DEFAULT:
 #ifdef TLS1_3_VERSION
       break;
 #else


### PR DESCRIPTION
Reported-by: Andreas Olsson
Fixes #2692