### PR TITLE
openssl: make the requested TLS version the *minimum* wanted

### DIFF
--- a/docs/cmdline-opts/tlsv1.1.d
+++ b/docs/cmdline-opts/tlsv1.1.d
@@ -3,4 +3,4 @@ Help: Use TLSv1.1
 Protocols: TLS
 Added: 7.34.0
 ---
-Forces curl to use TLS version 1.1 when connecting to a remote TLS server.
+Forces curl to use TLS version 1.1 or later when connecting to a remote TLS server.

--- a/docs/cmdline-opts/tlsv1.2.d
+++ b/docs/cmdline-opts/tlsv1.2.d
@@ -3,4 +3,4 @@ Help: Use TLSv1.2
 Protocols: TLS
 Added: 7.34.0
 ---
-Forces curl to use TLS version 1.2 when connecting to a remote TLS server.
+Forces curl to use TLS version 1.2 or later when connecting to a remote TLS server.

--- a/docs/cmdline-opts/tlsv1.3.d
+++ b/docs/cmdline-opts/tlsv1.3.d
@@ -3,7 +3,7 @@ Help: Use TLSv1.3
 Protocols: TLS
 Added: 7.52.0
 ---
-Forces curl to use TLS version 1.3 when connecting to a remote TLS server.
+Forces curl to use TLS version 1.3 or later when connecting to a remote TLS server.
 
 Note that TLS 1.3 is only supported by a subset of TLS backends. At the time
 of this writing, they are BoringSSL, NSS, and Secure Transport (on iOS 11 or

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -28,29 +28,34 @@ CURLOPT_SSLVERSION \- set preferred TLS/SSL version
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLVERSION, long version);
 .SH DESCRIPTION
-Pass a long as parameter to control which version of SSL/TLS to attempt to
+Pass a long as parameter to control which version range of SSL/TLS versions to
 use.
+
+The SSL and TLS versions have typically developed from the most insecure
+version to be more and more secure in this order through history: SSL v2,
+SSLv3, TLS v1.0, TSL v1.1, TSL v1.2 and the most recent TLS v1.3.
 
 Use one of the available defines for this purpose. The available options are:
 .RS
 .IP CURL_SSLVERSION_DEFAULT
-The default action. This will attempt to figure out the remote SSL protocol
-version.
+The default acceptable version range. The mimimum acceptable version is by
+default TLS 1.0 since 7.39.0 (unless the TLS library has a stricter rule).
 .IP CURL_SSLVERSION_TLSv1
-TLSv1.x
+TLS v1.0 or later
 .IP CURL_SSLVERSION_SSLv2
-SSLv2
+SSL v2 (but not SSLv3)
 .IP CURL_SSLVERSION_SSLv3
-SSLv3
+SSL v3 (but not SSLv2)
 .IP CURL_SSLVERSION_TLSv1_0
-TLSv1.0 (Added in 7.34.0)
+TLS v1.0 or later (Added in 7.34.0)
 .IP CURL_SSLVERSION_TLSv1_1
-TLSv1.1 (Added in 7.34.0)
+TLS v1.1 or later (Added in 7.34.0)
 .IP CURL_SSLVERSION_TLSv1_2
-TLSv1.2 (Added in 7.34.0)
+TLS v1.2 or later (Added in 7.34.0)
 .IP CURL_SSLVERSION_TLSv1_3
-TLSv1.3 (Added in 7.52.0)
+TLS v1.3 or later (Added in 7.52.0)
 .RE
+
 The maximum TLS version can be set by using \fIone\fP of the
 CURL_SSLVERSION_MAX_ macros below. It is also possible to OR \fIone\fP of the
 CURL_SSLVERSION_ macros with \fIone\fP of the CURL_SSLVERSION_MAX_ macros.
@@ -58,18 +63,20 @@ The MAX macros are not supported for SSL backends axTLS or wolfSSL.
 .RS
 .IP CURL_SSLVERSION_MAX_DEFAULT
 The flag defines the maximum supported TLS version by libcurl, or the default
-value from the SSL library is used. (Added in 7.54.0)
+value from the SSL library is used. libcurl will use a sensible default
+maximum, which was TLS 1.2 up to before 7.61.0 and is TLS 1.3 since then -
+assuming the TLS library support it. (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_0
-The flag defines maximum supported TLS version as TLSv1.0.
+The flag defines maximum supported TLS version as TLS v1.0.
 (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_1
-The flag defines maximum supported TLS version as TLSv1.1.
+The flag defines maximum supported TLS version as TLS v1.1.
 (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_2
-The flag defines maximum supported TLS version as TLSv1.2.
+The flag defines maximum supported TLS version as TLS v1.2.
 (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_3
-The flag defines maximum supported TLS version as TLSv1.3.
+The flag defines maximum supported TLS version as TLS v1.3.
 (Added in 7.54.0)
 .RE
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2015, 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -57,9 +57,8 @@ CURL_SSLVERSION_ macros with \fIone\fP of the CURL_SSLVERSION_MAX_ macros.
 The MAX macros are not supported for SSL backends axTLS or wolfSSL.
 .RS
 .IP CURL_SSLVERSION_MAX_DEFAULT
-The flag defines the maximum supported TLS version as TLSv1.2, or the default
-value from the SSL library.
-(Added in 7.54.0)
+The flag defines the maximum supported TLS version by libcurl, or the default
+value from the SSL library is used. (Added in 7.54.0)
 .IP CURL_SSLVERSION_MAX_TLSv1_0
 The flag defines maximum supported TLS version as TLSv1.0.
 (Added in 7.54.0)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2078,10 +2078,6 @@ set_ssl_version_min_max(long *ctx_options, struct connectdata *conn,
   long ssl_version = SSL_CONN_CONFIG(version);
   long ssl_version_max = SSL_CONN_CONFIG(version_max);
 
-  if(ssl_version_max == CURL_SSLVERSION_MAX_NONE) {
-    ssl_version_max = ssl_version << 16;
-  }
-
   switch(ssl_version) {
     case CURL_SSLVERSION_TLSv1_3:
 #ifdef TLS1_3_VERSION
@@ -2113,6 +2109,7 @@ set_ssl_version_min_max(long *ctx_options, struct connectdata *conn,
 #endif
       /* FALLTHROUGH */
     case CURL_SSLVERSION_TLSv1_0:
+    case CURL_SSLVERSION_TLSv1:
       *ctx_options |= SSL_OP_NO_SSLv2;
       *ctx_options |= SSL_OP_NO_SSLv3;
       break;
@@ -2130,12 +2127,12 @@ set_ssl_version_min_max(long *ctx_options, struct connectdata *conn,
 #endif
       /* FALLTHROUGH */
     case CURL_SSLVERSION_MAX_TLSv1_2:
-    case CURL_SSLVERSION_MAX_DEFAULT:
 #ifdef TLS1_3_VERSION
       *ctx_options |= SSL_OP_NO_TLSv1_3;
 #endif
       break;
     case CURL_SSLVERSION_MAX_TLSv1_3:
+    case CURL_SSLVERSION_MAX_DEFAULT:
 #ifdef TLS1_3_VERSION
       break;
 #else

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2110,8 +2110,6 @@ set_ssl_version_min_max(long *ctx_options, struct connectdata *conn,
       /* FALLTHROUGH */
     case CURL_SSLVERSION_TLSv1_0:
     case CURL_SSLVERSION_TLSv1:
-      *ctx_options |= SSL_OP_NO_SSLv2;
-      *ctx_options |= SSL_OP_NO_SSLv3;
       break;
   }
 
@@ -2334,13 +2332,14 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 
   case CURL_SSLVERSION_DEFAULT:
   case CURL_SSLVERSION_TLSv1:
-    ctx_options |= SSL_OP_NO_SSLv2;
-    ctx_options |= SSL_OP_NO_SSLv3;
-    /* FALLTHROUGH */
   case CURL_SSLVERSION_TLSv1_0:
   case CURL_SSLVERSION_TLSv1_1:
   case CURL_SSLVERSION_TLSv1_2:
   case CURL_SSLVERSION_TLSv1_3:
+    /* asking for any TLS version as the minimum, means no SSL versions
+       allowed */
+    ctx_options |= SSL_OP_NO_SSLv2;
+    ctx_options |= SSL_OP_NO_SSLv3;
     result = set_ssl_version_min_max(&ctx_options, conn, sockindex);
     if(result != CURLE_OK)
        return result;


### PR DESCRIPTION
The code treated the set version as the *exact* version to require in
the TLS handshake, which is not what other TLS backends do and probably
not what most people expect either.

Reported-by: Andreas Olsson
Fixes #2691