### PR TITLE
limit-rate: 'Curl' speed limit starting point external parameter definition.

### DIFF
--- a/docs/cmdline-opts/Makefile.inc
+++ b/docs/cmdline-opts/Makefile.inc
@@ -47,6 +47,7 @@ DPAGES = abstract-unix-socket.d anyauth.d append.d basic.d cacert.d capath.d cer
   tlsv1.3.d tlsv1.d trace-ascii.d trace.d trace-time.d tr-encoding.d    \
   unix-socket.d upload-file.d url.d use-ascii.d user-agent.d user.d     \
   verbose.d version.d write-out.d xattr.d request-target.d              \
-  styled-output.d tls13-ciphers.d proxy-tls13-ciphers.d
+  styled-output.d tls13-ciphers.d proxy-tls13-ciphers.d                 \
+  limit-rate-start-point.d
 
 OTHERPAGES = page-footer page-header

--- a/docs/cmdline-opts/limit-rate-start-point.d
+++ b/docs/cmdline-opts/limit-rate-start-point.d
@@ -1,0 +1,24 @@
+Long: limit-rate-start-point
+Arg: <starting point>
+Help: Control where the speed limit begins
+---
+Control where the speed limit begins - for both downloads and uploads.
+When you do not set this parameter, the starting point for limiting 
+the speed is before dns parsing.When you set the starting point does 
+not exist, the default starting point will be used (For example: HTTP
+without 'appok' starting point).This parameter is executed only when 
+the '--limit-rate' parameter setting is in effect.
+
+The 'starting point' argument should be one of the following 
+alternatives:
+.RS
+.IP dnsok 
+Speed limit starting point - DNS resolution is completed.
+.IP tcpok
+Speed limit starting point - TCP connect is completed.
+.IP appok
+Speed limit starting point - SSL/SSH/etc connect/handshake 
+to the remote host was completed.
+.IP ttfb
+Speed limit starting point - Time To First Byte.
+.RE

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -850,6 +850,25 @@ typedef enum {
   CURLFTPMETHOD_LAST       /* not an option, never use */
 } curl_ftpmethod;
 
+/* parameter for the CURLOPT_SEND_SPEED_LIMIT_START_POINT
+ * and CURLOPT_RECV_SPEED_LIMIT_START_POINT option.
+ *
+ *  |_______|_______|_______________|_____|
+ * (1) DNS (2) TCP (3) SSL/SSH/etc (4)   (5)TTFB
+ *
+ * If the starting point to be set does not exist,
+ * the default value will be used.
+ */
+typedef enum {
+    CURLSPEEDLIMIT_DEFAULT,     /* (1) before name resolve */
+    CURLSPEEDLIMIT_NAMELOOKUP,  /* (2) name resolving was completed */
+    CURLSPEEDLIMIT_CONNECT,     /* (3) TCP connetc completed */
+    CURLSPEEDLIMIT_APPCONNECT,  /* (4) SSL/SSH/etc
+                                   connect/handshake completed */
+    CURLSPEEDLIMIT_TTFB,        /* (5) time to first byte */
+    CURLSPEEDLIMIT_LAST         /* not an option, never use */
+} curl_speedlimitstartpoint;
+
 /* bitmask defines for CURLOPT_HEADEROPT */
 #define CURLHEADER_UNIFIED  0
 #define CURLHEADER_SEPARATE (1<<0)
@@ -1855,6 +1874,10 @@ typedef enum {
 
   /* Disallow specifying username/login in URL. */
   CINIT(DISALLOW_USERNAME_IN_URL, LONG, 278),
+
+  /* Set where the limit-rate parameter works */
+  CINIT(SEND_SPEED_LIMIT_START_POINT, LONG, 279),
+  CINIT(RECV_SPEED_LIMIT_START_POINT, LONG, 280),
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -55,6 +55,9 @@ timediff_t Curl_pgrsLimitWaitTime(curl_off_t cursize,
                                   curl_off_t limit,
                                   struct curltime start,
                                   struct curltime now);
+void Curl_pgrsSetLimitStartTime(struct Curl_easy *data,
+                                struct curltime now,
+                                timerid timer);
 
 #define PGRS_HIDE    (1<<4)
 #define PGRS_UL_SIZE_KNOWN (1<<5)

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1190,6 +1190,18 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
       return CURLE_BAD_FUNCTION_ARGUMENT;
     data->set.max_recv_speed = bigsize;
     break;
+  case CURLOPT_SEND_SPEED_LIMIT_START_POINT:
+    arg = va_arg(param, long);
+    if(arg < CURLSPEEDLIMIT_DEFAULT || arg > CURLSPEEDLIMIT_TTFB)
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    data->set.send_speed_start_point = arg;
+    break;
+  case CURLOPT_RECV_SPEED_LIMIT_START_POINT:
+    arg = va_arg(param, long);
+    if(arg < CURLSPEEDLIMIT_DEFAULT || arg > CURLSPEEDLIMIT_TTFB)
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    data->set.recv_speed_start_point = arg;
+    break;
   case CURLOPT_LOW_SPEED_TIME:
     /*
      * The low speed time that if transfers are below the set

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1530,6 +1530,10 @@ struct UserDefined {
   curl_off_t max_send_speed; /* high speed limit in bytes/second for upload */
   curl_off_t max_recv_speed; /* high speed limit in bytes/second for
                                 download */
+  curl_speedlimitstartpoint send_speed_start_point; /* high speed limit starting
+                                                       point for upload */
+  curl_speedlimitstartpoint recv_speed_start_point; /* high speed limit starting
+                                                       point for download */
   curl_off_t set_resume_from;  /* continue [ftp] transfer from here */
   struct curl_slist *headers; /* linked list of extra headers */
   struct curl_slist *proxyheaders; /* linked list of extra CONNECT headers */

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -184,6 +184,8 @@ struct OperationConfig {
   /* for bandwidth limiting features: */
   curl_off_t sendpersecond; /* send to peer */
   curl_off_t recvpersecond; /* receive from peer */
+  int send_speed_start_point;
+  int recv_speed_start_point;
 
   bool ftp_ssl;
   bool ftp_ssl_reqd;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -92,6 +92,7 @@ static const struct LongShort aliases[]= {
   {"*h", "trace-ascii",              ARG_STRING},
   {"*H", "alpn",                     ARG_BOOL},
   {"*i", "limit-rate",               ARG_STRING},
+  {"*I", "limit-rate-start-point",   ARG_STRING},
   {"*j", "compressed",               ARG_BOOL},
   {"*J", "tr-encoding",              ARG_BOOL},
   {"*k", "digest",                   ARG_BOOL},
@@ -659,6 +660,14 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
            return pe;
         config->recvpersecond = value;
         config->sendpersecond = value;
+      }
+      break;
+      case 'I': /* --limit-rate-start-point */
+      {
+        int value = 0;
+        value = limitratestartpoint(config, nextarg);
+        config->send_speed_start_point = value;
+        config->recv_speed_start_point = value;
       }
       break;
 

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -208,6 +208,8 @@ static const struct helptxt helptext[] = {
    "Dump libcurl equivalent code of this command line"},
   {"    --limit-rate <speed>",
    "Limit transfer speed to RATE"},
+  {"    --limit-rate-start-point <starting point>",
+   "Control where the speed limit begins"},
   {"-l, --list-only",
    "List only mode"},
   {"    --local-port <num/range>",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1003,6 +1003,14 @@ static CURLcode operate_do(struct GlobalConfig *global,
                   config->sendpersecond);
         my_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE,
                   config->recvpersecond);
+        if(config->sendpersecond > 0) {
+          my_setopt(curl, CURLOPT_SEND_SPEED_LIMIT_START_POINT,
+                    config->send_speed_start_point);
+        }
+        if(config->recvpersecond > 0) {
+          my_setopt(curl, CURLOPT_RECV_SPEED_LIMIT_START_POINT,
+                    config->send_speed_start_point);
+        }
 
         if(config->use_resume)
           my_setopt(curl, CURLOPT_RESUME_FROM_LARGE, config->resume_from);

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -494,6 +494,20 @@ ParameterError add2list(struct curl_slist **list, const char *ptr)
   return PARAM_OK;
 }
 
+int limitratestartpoint(struct OperationConfig *config, const char *str)
+{
+  if(curl_strequal("dnsok", str))
+    return CURLSPEEDLIMIT_NAMELOOKUP;
+  if(curl_strequal("appok", str))
+    return CURLSPEEDLIMIT_APPCONNECT;
+  if(curl_strequal("tcpok", str))
+    return CURLSPEEDLIMIT_CONNECT;
+  if(curl_strequal("ttfb", str))
+    return CURLSPEEDLIMIT_TTFB;
+
+  return CURLSPEEDLIMIT_DEFAULT;
+}
+
 int ftpfilemethod(struct OperationConfig *config, const char *str)
 {
   if(curl_strequal("singlecwd", str))

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -45,6 +45,8 @@ CURLcode get_args(struct OperationConfig *config, const size_t i);
 
 ParameterError add2list(struct curl_slist **list, const char *ptr);
 
+int limitratestartpoint(struct OperationConfig *config, const char *str);
+
 int ftpfilemethod(struct OperationConfig *config, const char *str);
 
 int ftpcccmethod(struct OperationConfig *config, const char *str);


### PR DESCRIPTION
1. Accurately  control where the 'limit-rate' parameter takes effect.Can start from any of the following locations:
```
|_________|________|________________|_____|
(1) DNS (2) TCP (3) SSL/SSH/etc (4)   (5)TTFB
```

2. Need to start speed limit from ttfb, so add this feature.I do not know if you are willing to accept？