### PR TITLE
pipelining: deprecated

### DIFF
--- a/docs/THANKS-filter
+++ b/docs/THANKS-filter
@@ -79,3 +79,4 @@ s/Henrik S. Gaßmann$/Henrik Gaßmann/
 s/moteus on github/Alexey Melnichuk/
 s/Rich Moore/Richard Moore/
 s/kdekker/Kees Dekker/
+s/Daniel Jelinski/Daniel Jeliński/

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -57,6 +57,8 @@ Default, which means doing no attempts at pipelining or multiplexing.
 .IP CURLPIPE_HTTP1 (1)
 If this bit is set, libcurl will try to pipeline HTTP/1.1 requests on
 connections that are already established and in use to hosts.
+
+This bit is deprecated and has no effect since version 7.62.0.
 .IP CURLPIPE_MULTIPLEX (2)
 If this bit is set, libcurl will try to multiplex the new transfer over an
 existing connection if possible. This requires HTTP/2.

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2705,7 +2705,7 @@ CURLMcode curl_multi_setopt(struct Curl_multi *multi,
     multi->push_userp = va_arg(param, void *);
     break;
   case CURLMOPT_PIPELINING:
-    multi->pipelining = va_arg(param, long);
+    multi->pipelining = va_arg(param, long) & CURLPIPE_MULTIPLEX;
     break;
   case CURLMOPT_TIMERFUNCTION:
     multi->timer_cb = va_arg(param, curl_multi_timer_callback);

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -20,3 +20,12 @@
 1903
 # fnmatch differences are just too common to make testing them sensible
 1307
+# Pipelining is deprecated
+530
+536
+584
+1900
+1901
+1902
+2033
+

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -142,7 +142,6 @@ my $GOPHER6PORT;         # Gopher IPv6 server port
 my $HTTPTLSPORT;         # HTTP TLS (non-stunnel) server port
 my $HTTPTLS6PORT;        # HTTP TLS (non-stunnel) IPv6 server port
 my $HTTPPROXYPORT;       # HTTP proxy port, when using CONNECT
-my $HTTPPIPEPORT;        # HTTP pipelining port
 my $HTTPUNIXPATH;        # HTTP server Unix domain socket path
 my $HTTP2PORT;           # HTTP/2 server port
 my $DICTPORT;            # DICT server port
@@ -716,11 +715,11 @@ sub stopserver {
     # All servers relative to the given one must be stopped also
     #
     my @killservers;
-    if($server =~ /^(ftp|http|imap|pop3|smtp|httppipe)s((\d*)(-ipv6|-unix|))$/) {
+    if($server =~ /^(ftp|http|imap|pop3|smtp)s((\d*)(-ipv6|-unix|))$/) {
         # given a stunnel based ssl server, also kill non-ssl underlying one
         push @killservers, "${1}${2}";
     }
-    elsif($server =~ /^(ftp|http|imap|pop3|smtp|httppipe)((\d*)(-ipv6|-unix|))$/) {
+    elsif($server =~ /^(ftp|http|imap|pop3|smtp)((\d*)(-ipv6|-unix|))$/) {
         # given a non-ssl server, also kill stunnel based ssl piggybacking one
         push @killservers, "${1}s${2}";
     }
@@ -1296,7 +1295,6 @@ my %protofunc = ('http' => \&verifyhttp,
                  'pop3' => \&verifyftp,
                  'imap' => \&verifyftp,
                  'smtp' => \&verifyftp,
-                 'httppipe' => \&verifyhttp,
                  'ftps' => \&verifyftp,
                  'tftp' => \&verifyftp,
                  'ssh' => \&verifyssh,
@@ -1435,12 +1433,6 @@ sub runhttpserver {
         # basically the same, but another ID
         $idnum = 2;
     }
-    elsif($alt eq "pipe") {
-        # basically the same, but another ID
-        $idnum = 3;
-        $exe = "python $srcdir/http_pipe.py";
-        $verbose_flag .= "1 ";
-    }
     elsif($alt eq "unix") {
         # IP (protocol) is mutually exclusive with Unix sockets
         $ipvnum = "unix";
@@ -1491,81 +1483,6 @@ sub runhttpserver {
 
     # Server is up. Verify that we can speak to it.
     my $pid3 = verifyserver($proto, $ipvnum, $idnum, $ip, $port_or_path);
-    if(!$pid3) {
-        logmsg "RUN: $srvrname server failed verification\n";
-        # failed to talk to it properly. Kill the server and return failure
-        stopserver($server, "$httppid $pid2");
-        displaylogs($testnumcheck);
-        $doesntrun{$pidfile} = 1;
-        return (0,0);
-    }
-    $pid2 = $pid3;
-
-    if($verbose) {
-        logmsg "RUN: $srvrname server is now running PID $httppid\n";
-    }
-
-    sleep(1);
-
-    return ($httppid, $pid2);
-}
-
-#######################################################################
-# start the http server
-#
-sub runhttp_pipeserver {
-    my ($proto, $verbose, $alt, $port) = @_;
-    my $ip = $HOSTIP;
-    my $ipvnum = 4;
-    my $idnum = 1;
-    my $server;
-    my $srvrname;
-    my $pidfile;
-    my $logfile;
-    my $flags = "";
-
-    if($alt eq "ipv6") {
-        # No IPv6
-    }
-
-    $server = servername_id($proto, $ipvnum, $idnum);
-
-    $pidfile = $serverpidfile{$server};
-
-    # don't retry if the server doesn't work
-    if ($doesntrun{$pidfile}) {
-        return (0,0);
-    }
-
-    my $pid = processexists($pidfile);
-    if($pid > 0) {
-        stopserver($server, "$pid");
-    }
-    unlink($pidfile) if(-f $pidfile);
-
-    $srvrname = servername_str($proto, $ipvnum, $idnum);
-
-    $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
-
-    $flags .= "--verbose 1 " if($debugprotocol);
-    $flags .= "--pidfile \"$pidfile\" --logfile \"$logfile\" ";
-    $flags .= "--id $idnum " if($idnum > 1);
-    $flags .= "--port $port --srcdir \"$srcdir\"";
-
-    my $cmd = "$srcdir/http_pipe.py $flags";
-    my ($httppid, $pid2) = startnew($cmd, $pidfile, 15, 0);
-
-    if($httppid <= 0 || !pidexists($httppid)) {
-        # it is NOT alive
-        logmsg "RUN: failed to start the $srvrname server\n";
-        stopserver($server, "$pid2");
-        displaylogs($testnumcheck);
-        $doesntrun{$pidfile} = 1;
-        return (0,0);
-    }
-
-    # Server is up. Verify that we can speak to it.
-    my $pid3 = verifyserver($proto, $ipvnum, $idnum, $ip, $port);
     if(!$pid3) {
         logmsg "RUN: $srvrname server failed verification\n";
         # failed to talk to it properly. Kill the server and return failure
@@ -2843,9 +2760,6 @@ sub checksystem {
             # 'http-proxy' is used in test cases to do CONNECT through
             push @protocols, 'http-proxy';
 
-            # 'http-pipe' is the special server for testing pipelining
-            push @protocols, 'http-pipe';
-
             # 'none' is used in test cases to mean no server
             push @protocols, 'none';
         }
@@ -3117,7 +3031,6 @@ sub checksystem {
             }
             logmsg "\n";
         }
-        logmsg sprintf("*   HTTP-PIPE/%d \n", $HTTPPIPEPORT);
 
         if($has_unix) {
             logmsg "* Unix socket paths:\n";
@@ -3154,7 +3067,6 @@ sub subVariables {
   $$thing =~ s/%HTTPSPORT/$HTTPSPORT/g;
   $$thing =~ s/%HTTP2PORT/$HTTP2PORT/g;
   $$thing =~ s/%HTTPPORT/$HTTPPORT/g;
-  $$thing =~ s/%HTTPPIPEPORT/$HTTPPIPEPORT/g;
   $$thing =~ s/%PROXYPORT/$HTTPPROXYPORT/g;
 
   $$thing =~ s/%IMAP6PORT/$IMAP6PORT/g;
@@ -4847,23 +4759,6 @@ sub startservers {
                 $run{'http-ipv6'}="$pid $pid2";
             }
         }
-        elsif($what eq "http-pipe") {
-            if($torture && $run{'http-pipe'} &&
-               !responsive_http_server("http", $verbose, "pipe",
-                                       $HTTPPIPEPORT)) {
-                stopserver('http-pipe');
-            }
-            if(!$run{'http-pipe'}) {
-                ($pid, $pid2) = runhttpserver("http", $verbose, "pipe",
-                                              $HTTPPIPEPORT);
-                if($pid <= 0) {
-                    return "failed starting HTTP-pipe server";
-                }
-                logmsg sprintf ("* pid http-pipe => %d %d\n", $pid, $pid2)
-                    if($verbose);
-                $run{'http-pipe'}="$pid $pid2";
-            }
-        }
         elsif($what eq "rtsp") {
             if($torture && $run{'rtsp'} &&
                !responsive_rtsp_server($verbose)) {
@@ -5576,7 +5471,6 @@ $GOPHER6PORT     = $base++; # Gopher IPv6 server port
 $HTTPTLSPORT     = $base++; # HTTP TLS (non-stunnel) server port
 $HTTPTLS6PORT    = $base++; # HTTP TLS (non-stunnel) IPv6 server port
 $HTTPPROXYPORT   = $base++; # HTTP proxy port, when using CONNECT
-$HTTPPIPEPORT    = $base++; # HTTP pipelining port
 $HTTP2PORT       = $base++; # HTTP/2 port
 $DICTPORT        = $base++; # DICT port
 $SMBPORT         = $base++; # SMB port


### PR DESCRIPTION
Transparently. The related curl_multi_setopt() options all still return OK when pipelining is selected.

To re-enable the support, the single line change in lib/multi.c needs to be reverted.

See [DEPRECATE](https://curl.haxx.se/dev/deprecate.html) for the explanation and plan.