### PR TITLE
enable multiplexing and HTTP/2 when over HTTPS - by default

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -61,7 +61,9 @@ connections that are already established and in use to hosts.
 If this bit is set, libcurl will try to multiplex the new transfer over an
 existing connection if possible. This requires HTTP/2.
 .SH DEFAULT
-0 (both pipeline and multiplexing are off)
+Since 7.62.0, \fBCURLPIPE_MULTIPLEX\bP is enabled by default.
+
+Before that, default was \fBCURLPIPE_NOTHING\fP.
 .SH PROTOCOLS
 HTTP(S)
 .SH EXAMPLE

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -60,7 +60,9 @@ prior knowledge that the server supports HTTP/2 straight away. HTTPS requests
 will still do HTTP/2 the standard way with negotiated protocol version in the
 TLS handshake. (Added in 7.49.0)
 .SH DEFAULT
-CURL_HTTP_VERSION_NONE
+Since curl 7.62.0: CURL_HTTP_VERSION_2TLS
+
+Before that: CURL_HTTP_VERSION_1_1
 .SH PROTOCOLS
 HTTP
 .SH EXAMPLE

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -347,6 +347,7 @@ struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
   Curl_llist_init(&multi->pending, multi_freeamsg);
 
   multi->max_pipeline_length = 5;
+  multi->pipelining = CURLPIPE_MULTIPLEX;
 
   /* -1 means it not set by user, use the default value */
   multi->maxconnects = -1;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -841,6 +841,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
 #else
     if(arg > CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE)
       return CURLE_UNSUPPORTED_PROTOCOL;
+    if(arg == CURL_HTTP_VERSION_NONE)
+      arg = CURL_HTTP_VERSION_2TLS;
 #endif
     data->set.httpversion = arg;
     break;

--- a/lib/url.c
+++ b/lib/url.c
@@ -516,25 +516,27 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->wildcard_enabled = FALSE;
   set->chunk_bgn      = ZERO_NULL;
   set->chunk_end      = ZERO_NULL;
-
-  /* tcp keepalives are disabled by default, but provide reasonable values for
-   * the interval and idle times.
-   */
   set->tcp_keepalive = FALSE;
   set->tcp_keepintvl = 60;
   set->tcp_keepidle = 60;
   set->tcp_fastopen = FALSE;
   set->tcp_nodelay = TRUE;
-
   set->ssl_enable_npn = TRUE;
   set->ssl_enable_alpn = TRUE;
-
   set->expect_100_timeout = 1000L; /* Wait for a second by default. */
   set->sep_headers = TRUE; /* separated header lists by default */
   set->buffer_size = READBUFFER_SIZE;
   set->upload_buffer_size = UPLOAD_BUFSIZE;
   set->happy_eyeballs_timeout = CURL_HET_DEFAULT;
-
+  set->fnmatch = ZERO_NULL;
+  set->maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */
+  set->httpversion =
+#ifdef USE_NGHTTP2
+    CURL_HTTP_VERSION_2TLS
+#else
+    CURL_HTTP_VERSION_1_1
+#endif
+    ;
   Curl_http2_init_userset(set);
   return result;
 }
@@ -594,8 +596,6 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
       data->progress.flags |= PGRS_HIDE;
       data->state.current_speed = -1; /* init to negative == impossible */
-      data->set.fnmatch = ZERO_NULL;
-      data->set.maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */
 
       Curl_http2_init_state(&data->state);
     }


### PR DESCRIPTION
Starting 7.62.0, multiplexing is enabled by default in multi handles.

[Enable multiplexing by default mail](https://curl.haxx.se/mail/lib-2018-07/0024.html)

[Enable HTTP/2 when using HTTPS, by default mail](https://curl.haxx.se/mail/lib-2018-07/0027.html)