### PR TITLE
(test) enhance unit test coverage on lib/url.c

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -179,7 +179,7 @@ test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 \
 test1590 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
-test1608 test1609 \
+test1608 test1609 test1620 \
 \
 test1700 test1701 test1702 \
 \

--- a/tests/data/test1620
+++ b/tests/data/test1620
@@ -1,0 +1,26 @@
+<testcase>
+<info>
+<keywords>
+unittest
+URL
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+URL
+ </name>
+<tool>
+unit1620
+</tool>
+</client>
+
+</testcase>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UT_SRC
   unit1603.c
 # Broken link on Linux
 #  unit1604.c
+  unit1620.c
   )
 
 set(UT_COMMON_FILES ../libtest/first.c ../libtest/test.h curlcheck.h)

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -10,7 +10,7 @@ UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307	\
  unit1330 unit1394 unit1395 unit1396 unit1397 unit1398	\
  unit1399	\
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
- unit1608 unit1609
+ unit1608 unit1609 unit1620
 
 unit1300_SOURCES = unit1300.c $(UNITFILES)
 unit1300_CPPFLAGS = $(AM_CPPFLAGS)
@@ -95,3 +95,6 @@ unit1608_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1609_SOURCES = unit1609.c $(UNITFILES)
 unit1609_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1620_SOURCES = unit1620.c $(UNITFILES)
+unit1620_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1620.c
+++ b/tests/unit/unit1620.c
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include "urldata.h"
+#include "url.h"
+
+#include "memdebug.h" /* LAST include file */
+
+static CURL *easy;
+CURLcode result;
+struct Curl_easy *data;
+
+static CURLcode unit_setup(void)
+{
+  int res = CURLE_OK;
+
+  global_init(CURL_GLOBAL_ALL);
+  easy = curl_easy_init();
+  if(!easy)
+    return CURLE_OUT_OF_MEMORY;
+  return res;
+}
+
+static void unit_stop(void)
+{
+  curl_easy_cleanup(easy);
+  curl_global_cleanup();
+}
+
+UNITTEST_START
+
+result = Curl_open(&data);
+
+if(result) {
+  fail("Curl_open failed");}
+
+fail_unless(1 == 1, "return code should be non-zero");
+
+UNITTEST_STOP


### PR DESCRIPTION
This is a test PR as a prelude to a real PR that enhances unit coverage on "lib/url.c".

I want to see how travis runs against PR and I would be grateful to get a review of the simple test w/ related meta to see if I got anything wrong (stylistically, etc.). 

Once I am feeling confident that I am playing 'nice' with the tools (and/or not stepping on any processes/people) will close this and raise real PR.