### PR TITLE
libssh: goto DISCONNECT state on error, not SSH_SESSION_FREE

### DIFF
--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -418,7 +418,7 @@ cleanup:
 }
 
 #define MOVE_TO_ERROR_STATE(_r) { \
-  state(conn, SSH_SESSION_FREE); \
+  state(conn, SSH_SESSION_DISCONNECT); \
   sshc->actualcode = _r; \
   rc = SSH_ERROR; \
   break; \


### PR DESCRIPTION
... because otherwise not everything get closed down correctly.

Fixes #2708