### PR TITLE
schannel: fix MinGW compile break

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -285,7 +285,11 @@ get_alg_id_by_name(char *name)
 #ifdef CALG_HMAC
   CIPHEROPTION(CALG_HMAC);
 #endif
+#if !defined(__W32API_VERSION) || defined(__MINGW64_VERSION_MAJOR)
+  /* CALG_TLS1PRF has a syntax error in MinGW's w32api,
+     see https://osdn.net/projects/mingw/ticket/38391 */
   CIPHEROPTION(CALG_TLS1PRF);
+#endif
 #ifdef CALG_HASH_REPLACE_OWF
   CIPHEROPTION(CALG_HASH_REPLACE_OWF);
 #endif


### PR DESCRIPTION
Original MinGW's w32api has a sytax error in its definition of
`CALG_TLS1PRF` [0]. Don't use original MinGW w32api's `CALG_TLS1PRF`
until this bug [1] is fixed.

I'm subscribed to the bug report and will update the `#ifdef` when it's fixed.

[0] https://osdn.net/projects/mingw/scm/git/mingw-org-wsl/blobs/d1d4a17e51a2b78e252ef0147d483267d56c90cc/w32api/include/wincrypt.h
[1] https://osdn.net/projects/mingw/ticket/38391

Fixes https://github.com/curl/curl/pull/2721#issuecomment-403636043