### PR TITLE
darwinssl: add support for ALPN negotiation

### DIFF
--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -55,14 +55,15 @@ The challenge is the ALPN and NPN support and all our different SSL
 backends. You may need a fairly updated SSL library version for it to provide
 the necessary TLS features. Right now we support:
 
-  - OpenSSL:   ALPN and NPN
-  - libressl:  ALPN and NPN
-  - BoringSSL: ALPN and NPN
-  - NSS:       ALPN and NPN
-  - GnuTLS:    ALPN
-  - mbedTLS:   ALPN
-  - SChannel:  ALPN
-  - wolfSSL:   ALPN
+  - OpenSSL:          ALPN and NPN
+  - libressl:         ALPN and NPN
+  - BoringSSL:        ALPN and NPN
+  - NSS:              ALPN and NPN
+  - GnuTLS:           ALPN
+  - mbedTLS:          ALPN
+  - SChannel:         ALPN
+  - wolfSSL:          ALPN
+  - Secure Transport: ALPN
 
 Multiplexing
 ------------


### PR DESCRIPTION
Rewrite of #500 using the public APIs introduced in macOS 10.13 and iOS 11.