### PR TITLE
header output: switch off all styles, not just unbold

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -42,7 +42,10 @@ static char *parse_filename(const char *ptr, size_t len);
 #define BOLDOFF
 #else
 #define BOLD "\x1b[1m"
-#define BOLDOFF "\x1b[21m"
+/* Switch off bold by settting "all attributes off" since the explicit
+   bold-off code (21) isn't supported everywhere - like in the mac
+   Terminal. */
+#define BOLDOFF "\x1b[0m"
 #endif
 
 /*


### PR DESCRIPTION
... the "unbold" sequence doesn't work on the mac Terminal.

Fixes #2736