### PR TITLE
test1422: add required file feature

### DIFF
--- a/tests/data/test1422
+++ b/tests/data/test1422
@@ -28,6 +28,7 @@ Content-Disposition: filename=name1422; charset=funny; option=str//nge
 # -O and -J output in, using the CURL_TESTDIR variable
 <features>
 debug
+file
 </features>
 <server>
 http


### PR DESCRIPTION
curl configured with `--enable-debug --disable-file` currently complains
on test1422:
`Info: Protocol "file" not supported or disabled in libcurl`

Make test1422 dependend on enabled FILE protocol to fix this.

Fixes https://github.com/curl/curl/issues/2741
Closes