### PR TITLE
add unit tests for url.c

### DIFF
--- a/lib/url.h
+++ b/lib/url.h
@@ -34,7 +34,7 @@
 CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn);
 CURLcode Curl_open(struct Curl_easy **curl);
 CURLcode Curl_init_userdefined(struct Curl_easy *data);
-CURLcode Curl_dupset(struct Curl_easy * dst, struct Curl_easy * src);
+
 void Curl_freeset(struct Curl_easy * data);
 CURLcode Curl_close(struct Curl_easy *data); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, struct connectdata **,
@@ -57,9 +57,7 @@ int Curl_doing_getsock(struct connectdata *conn,
 CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userptr, char **passwdptr,
                                   char **optionsptr);
-bool Curl_isPipeliningEnabled(const struct Curl_easy *handle);
-CURLcode Curl_addHandleToPipeline(struct Curl_easy *handle,
-                                  struct curl_llist *pipeline);
+
 int Curl_removeHandleFromPipeline(struct Curl_easy *handle,
                                   struct curl_llist *pipeline);
 /* remove the specified connection from all (possible) pipelines and related
@@ -67,7 +65,6 @@ int Curl_removeHandleFromPipeline(struct Curl_easy *handle,
 void Curl_getoff_all_pipelines(struct Curl_easy *data,
                                struct connectdata *conn);
 
-void Curl_close_connections(struct Curl_easy *data);
 
 #define CURL_DEFAULT_PROXY_PORT 1080 /* default proxy port unless specified */
 #define CURL_DEFAULT_HTTPS_PROXY_PORT 443 /* default https proxy port unless

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -179,7 +179,7 @@ test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 \
 test1590 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
-test1608 test1609 \
+test1608 test1609 test1620 \
 \
 test1700 test1701 test1702 \
 \

--- a/tests/data/test1620
+++ b/tests/data/test1620
@@ -1,0 +1,26 @@
+<testcase>
+<info>
+<keywords>
+unittest
+URL
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+unit tests for url.c
+ </name>
+<tool>
+unit1620
+</tool>
+</client>
+
+</testcase>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UT_SRC
   unit1603.c
 # Broken link on Linux
 #  unit1604.c
+  unit1620.c
   )
 
 set(UT_COMMON_FILES ../libtest/first.c ../libtest/test.h curlcheck.h)

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -10,7 +10,7 @@ UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307	\
  unit1330 unit1394 unit1395 unit1396 unit1397 unit1398	\
  unit1399	\
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
- unit1608 unit1609
+ unit1608 unit1609 unit1620
 
 unit1300_SOURCES = unit1300.c $(UNITFILES)
 unit1300_CPPFLAGS = $(AM_CPPFLAGS)
@@ -95,3 +95,6 @@ unit1608_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1609_SOURCES = unit1609.c $(UNITFILES)
 unit1609_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1620_SOURCES = unit1620.c $(UNITFILES)
+unit1620_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1620.c
+++ b/tests/unit/unit1620.c
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include "urldata.h"
+#include "url.h"
+
+#include "memdebug.h" /* LAST include file */
+
+static CURLcode unit_setup(void)
+{
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+}
+
+UNITTEST_START
+{
+  int rc;
+  struct Curl_easy *empty;
+  const char *hostname = "hostname";
+  enum dupstring i;
+
+  bool async = FALSE;
+  bool protocol_connect = FALSE;
+
+  rc = Curl_open(&empty);
+  fail_unless(rc == CURLE_OK, "Curl_open() failed");
+
+  rc = Curl_connect(empty, &empty->easy_conn, &async, &protocol_connect);
+  fail_unless(rc == CURLE_URL_MALFORMAT,
+              "Curl_connect() failed to return CURLE_URL_MALFORMAT");
+
+  fail_unless(empty->magic == CURLEASY_MAGIC_NUMBER,
+              "empty->magic should be equal to CURLEASY_MAGIC_NUMBER");
+
+  rc = Curl_connect(empty, &empty->easy_conn, &async, &protocol_connect);
+  fail_unless(rc == CURLE_URL_MALFORMAT,
+              "Curl_connect() failed to return CURLE_URL_MALFORMAT");
+
+  rc = Curl_init_userdefined(empty);
+  fail_unless(rc == CURLE_OK, "Curl_userdefined() failed");
+
+  rc = Curl_init_do(empty, empty->easy_conn);
+  fail_unless(rc == CURLE_OK, "Curl_init_do() failed");
+
+  rc = Curl_parse_login_details(
+                          hostname, strlen(hostname), NULL, NULL, NULL);
+  fail_unless(rc == CURLE_OK,
+              "Curl_parse_login_details() failed");
+
+  rc = Curl_disconnect(empty, empty->easy_conn, FALSE);
+  fail_unless(rc == CURLE_OK,
+              "Curl_disconnect() with dead_connection set FALSE failed");
+
+  Curl_freeset(empty);
+  for(i = (enum dupstring)0; i < STRING_LAST; i++) {
+    fail_unless(empty->set.str[i] == NULL,
+                "Curl_free() did not set to NULL");
+  }
+
+  Curl_free_request_state(empty);
+
+  rc = Curl_close(empty);
+  fail_unless(rc == CURLE_OK, "Curl_close() failed");
+
+}
+UNITTEST_STOP


### PR DESCRIPTION
A very modest attempt at increasing coverage of primitives contained in url.c - this is not comprehensive but should light up a useful bit of the codepath.

While I was in the 'neighborhood' noticed a few func defs in url.h that have no impl eg. Curl_dupset(), Curl_isPipeliningEnabled(), Curl_addHandleToPipeline(), & Curl_close_connections() have been removed (confirmed with @bagder via irc).