### PR TITLE
CMake: Respect BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ include_directories(${CURL_SOURCE_DIR}/include)
 option(CURL_WERROR "Turn compiler warnings into errors" OFF)
 option(PICKY_COMPILER "Enable picky compiler options" ON)
 option(BUILD_CURL_EXE "Set to ON to build curl executable." ON)
-option(CURL_STATICLIB "Set to ON to build libcurl with static linking." OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(ENABLE_ARES "Set to ON to enable c-ares support" OFF)
 if(WIN32)
   option(CURL_STATIC_CRT "Set to ON to build libcurl with static CRT on Windows (/MT)." OFF)
@@ -1247,11 +1247,12 @@ set(CONFIGURE_OPTIONS       "")
 # TODO when to set "-DCURL_STATICLIB" for CPPFLAG_CURL_STATICLIB?
 set(CPPFLAG_CURL_STATICLIB  "")
 set(CURLVERSION             "${CURL_VERSION}")
-set(ENABLE_SHARED           "yes")
-if(CURL_STATICLIB)
-  set(ENABLE_STATIC         "yes")
-else()
+if(BUILD_SHARED_LIBS)
+  set(ENABLE_SHARED         "yes")
   set(ENABLE_STATIC         "no")
+else()
+  set(ENABLE_SHARED         "no")
+  set(ENABLE_STATIC         "yes")
 endif()
 set(exec_prefix             "\${prefix}")
 set(includedir              "\${prefix}/include")
@@ -1275,6 +1276,9 @@ set(REQUIRE_LIB_DEPS        "no")
 set(VERSIONNUM              "${CURL_VERSION_NUM}")
 
 # Finally generate a "curl-config" matching this config
+# Use:
+# * ENABLE_SHARED
+# * ENABLE_STATIC
 configure_file("${CURL_SOURCE_DIR}/curl-config.in"
                "${CURL_BINARY_DIR}/curl-config" @ONLY)
 install(FILES "${CURL_BINARY_DIR}/curl-config"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,66 +7,66 @@ environment:
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: OFF
-        STATICLIB: OFF
+        SHARED: ON
       - PRJ_GEN: "Visual Studio 12 2013 Win64"
         BDIR: msvc2013
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: OFF
-        STATICLIB: OFF
+        SHARED: ON
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         BDIR: msvc2015
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: OFF
-        STATICLIB: OFF
+        SHARED: ON
       - PRJ_GEN: "Visual Studio 11 2012 Win64"
         BDIR: msvc2012
         PRJ_CFG: Release
         OPENSSL: ON
         TESTING: OFF
-        STATICLIB: OFF
+        SHARED: ON
       - PRJ_GEN: "Visual Studio 12 2013 Win64"
         BDIR: msvc2013
         PRJ_CFG: Release
         OPENSSL: ON
         TESTING: OFF
-        STATICLIB: OFF
+        SHARED: ON
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         BDIR: msvc2015
         PRJ_CFG: Release
         OPENSSL: ON
         TESTING: OFF
-        STATICLIB: OFF
+        SHARED: ON
       - PRJ_GEN: "Visual Studio 11 2012 Win64"
         BDIR: msvc2012
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: ON
-        STATICLIB: ON
+        SHARED: OFF
       - PRJ_GEN: "Visual Studio 12 2013 Win64"
         BDIR: msvc2013
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: ON
-        STATICLIB: ON
+        SHARED: OFF
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         BDIR: msvc2015
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: ON
-        STATICLIB: ON
+        SHARED: OFF
       - PRJ_GEN: "Visual Studio 14 2015"
         BDIR: msvc2015
         PRJ_CFG: Release
         OPENSSL: OFF
         TESTING: ON
-        STATICLIB: ON
+        SHARED: OFF
 
 build_script:
     - mkdir build.%BDIR%
     - cd build.%BDIR%
-    - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL% -DCURL_STATICLIB=%STATICLIB% -DBUILD_TESTING=%TESTING% -DCURL_WERROR=ON
+    - cmake .. -G"%PRJ_GEN%" -DCMAKE_USE_OPENSSL=%OPENSSL% -DBUILD_SHARED_LIBS=%SHARED% -DBUILD_TESTING=%TESTING% -DCURL_WERROR=ON
     - cmake --build . --config %PRJ_CFG% --clean-first
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,13 @@
 set(LIB_NAME libcurl)
 
+if(BUILD_SHARED_LIBS)
+  set(CURL_STATICLIB NO)
+else()
+  set(CURL_STATICLIB YES)
+endif()
+
+# Use:
+# * CURL_STATICLIB
 configure_file(curl_config.h.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/curl_config.h)
 
@@ -59,21 +67,12 @@ if(USE_ARES)
   include_directories(${CARES_INCLUDE_DIR})
 endif()
 
-if(CURL_STATICLIB)
-  # Static lib
-  set(CURL_USER_DEFINED_DYNAMIC_OR_STATIC STATIC)
-else()
-  # DLL / so dynamic lib
-  set(CURL_USER_DEFINED_DYNAMIC_OR_STATIC SHARED)
-endif()
-
 add_library(
   ${LIB_NAME}
-  ${CURL_USER_DEFINED_DYNAMIC_OR_STATIC}
   ${HHEADERS} ${CSOURCES}
   )
 
-if(MSVC AND CURL_STATICLIB)
+if(MSVC AND NOT BUILD_SHARED_LIBS)
   set_target_properties(${LIB_NAME} PROPERTIES STATIC_LIBRARY_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
 endif()
 
@@ -95,7 +94,7 @@ set_target_properties(${LIB_NAME} PROPERTIES PREFIX "")
 set_target_properties(${LIB_NAME} PROPERTIES IMPORT_PREFIX "")
 
 if(WIN32)
-  if(NOT CURL_STATICLIB)
+  if(BUILD_SHARED_LIBS)
     # Add "_imp" as a suffix before the extension to avoid conflicting with the statically linked "libcurl.lib"
     set_target_properties(${LIB_NAME} PROPERTIES IMPORT_SUFFIX "_imp.lib")
   endif()

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -25,7 +25,7 @@ function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
   # to build the servers.  In order to achieve proper linkage of these
   # files on Win32 targets it is necessary to build the test servers
   # with CURL_STATICLIB defined, independently of how libcurl is built.
-  if(NOT CURL_STATICLIB)
+  if(BUILD_SHARED_LIBS)
     set_target_properties(${TEST_NAME} PROPERTIES
       COMPILE_DEFINITIONS CURL_STATICLIB)       # ${UPPER_TEST_NAME}
   endif()


### PR DESCRIPTION
Use standard CMake variable BUILD_SHARED_LIBS instead of introducing
custom option CURL_STATICLIB.