### PR TITLE
test1143: disable MSYS2's POSIX path conversion

### DIFF
--- a/tests/data/test1143
+++ b/tests/data/test1143
@@ -28,6 +28,9 @@ HTTP URL with http:/ (one slash!)
  <command>
 http:/%HOSTIP:%HTTPPORT/want/1143
 </command>
+<setenv>
+MSYS2_ARG_CONV_EXCL=http:/
+</setenv>
 </client>
 
 # Verify data after the test has been "shot"


### PR DESCRIPTION
By default, the MSYS2 bash interprets `http:/%HOSTIP:%HTTPPORT/want/1143`
as a POSIX file list and converts it to a Windows file list.
Disable this with `MSYS2_ARG_CONV_EXCL` for the test to pass.