### PR TITLE
vtls: set conn->data when closing TLS

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -314,7 +314,6 @@ void Curl_conncache_remove_conn(struct connectdata *conn, bool lock)
     if(lock) {
       CONN_LOCK(data);
     }
-    conn->data = NULL; /* detach */
     bundle_remove_conn(bundle, conn);
     if(bundle->num_connections == 0)
       conncache_remove_bundle(connc, bundle);

--- a/lib/url.c
+++ b/lib/url.c
@@ -788,6 +788,9 @@ CURLcode Curl_disconnect(struct Curl_easy *data,
   free_fixed_hostname(&conn->http_proxy.host);
   free_fixed_hostname(&conn->socks_proxy.host);
 
+  DEBUGASSERT(conn->data == data);
+  /* this assumes that the pointer is still there after the connection was
+     detected from the cache */
   Curl_ssl_close(conn, FIRSTSOCKET);
 
   conn_free(conn);
@@ -969,6 +972,7 @@ static bool extract_if_dead(struct connectdata *conn,
     if(dead) {
       infof(data, "Connection %ld seems to be dead!\n", conn->connection_id);
       Curl_conncache_remove_conn(conn, FALSE);
+      conn->data = NULL; /* detach */
       return TRUE;
     }
   }


### PR DESCRIPTION
Follow-up to 1b76c38904f0. The VTLS backends that close down the TLS
layer for a connection still needs a Curl_easy handle for the session_id
cache etc.

Fixes #2764