### PR TITLE
tests: fixes for Windows line endlings

### DIFF
--- a/tests/data/test1148
+++ b/tests/data/test1148
@@ -56,7 +56,7 @@ Accept: */*
 </protocol>
 # This allows the last 4 letters of the bar to get updated without it
 # matters. We're mostly checking the width of it anyway.
-<file name="log/stderrlog1148">
+<file name="log/stderrlog1148" mode="text">
 bar 100.0%
 </file>
 <stripfile>

--- a/tests/data/test1164
+++ b/tests/data/test1164
@@ -45,7 +45,7 @@ Host: %HOSTIP:%HTTPPORT
 Accept: */*
 
 </protocol>
-<stdout>
+<stdout mode="text">
 208
 </stdout>
 </verify>


### PR DESCRIPTION
Set `mode="text"` when line endings depend on the system representation.