### PR TITLE
curl: avoid styled output with binary output

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -166,7 +166,8 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
     if(!outs->stream && !tool_create_output_file(outs, FALSE))
       return failure;
 
-    if(hdrcbdata->global->isatty && hdrcbdata->global->styled_output)
+    if(hdrcbdata->global->isatty && hdrcbdata->global->styled_output &&
+       !hdrcbdata->config->terminal_binary_ok)
       value = memchr(ptr, ':', cb);
     if(value) {
       size_t namelen = value - ptr;


### PR DESCRIPTION
# Description

For the purpose of binary output, The curl program should output as is
without styled code.

# Observed behaviour
![before](https://user-images.githubusercontent.com/2715745/43039347-6022415e-8d66-11e8-8e8d-5a0c43696dda.png)

# Expected behaviour
![after](https://user-images.githubusercontent.com/2715745/43039348-639455a2-8d66-11e8-949d-f3f409afa442.png)

