### PR TITLE
test320: treat curl320.out file as binary

### DIFF
--- a/tests/data/test320
+++ b/tests/data/test320
@@ -58,7 +58,7 @@ simple TLS-SRP HTTPS GET, check user in response
 <verify>
 <protocol>
 </protocol>
-<file name="log/curl320.out" mode="text">
+<file name="log/curl320.out">
 HTTP/1.0 200 OK
 Content-type: text/html
 


### PR DESCRIPTION
Otherwise, LF line endings are converted to CRLF on Windows,
but no conversion is done for the reply, so the test case fails.