### PR TITLE
wolfSSL/CyaSSL: Fix memory leak in Curl_cyassl_random

### DIFF
--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -968,6 +968,8 @@ static CURLcode Curl_cyassl_random(struct Curl_easy *data,
     return CURLE_FAILED_INIT;
   if(RNG_GenerateBlock(&rng, entropy, (unsigned)length))
     return CURLE_FAILED_INIT;
+  if(FreeRng(&rng))
+    return CURLE_FAILED_INIT;
   return CURLE_OK;
 }
 


### PR DESCRIPTION
RNG structure must be freed by call to FreeRng after its use in
Curl_cyassl_random. This call fixes Valgrind failures when running the
test suite with wolfSSL.