### PR TITLE
test1148: disable if decimal separator is not a point

### DIFF
--- a/tests/data/test1148
+++ b/tests/data/test1148
@@ -37,6 +37,9 @@ progress-bar
  <command>
 http://%HOSTIP:%HTTPPORT/1148 -# --stderr log/stderrlog1148
 </command>
+<precheck>
+perl -e '$ENV{"LC_NUMERIC"} = "en_US.UTF-8"; system("./libtest/chkdecimalpoint") and die("Test requires point as decimal separator");'
+</precheck>
 <setenv>
 LC_ALL=
 LC_NUMERIC=en_US.UTF-8

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -56,6 +56,9 @@ add_custom_command(
     "${CMAKE_SOURCE_DIR}/include/curl/curl.h"
   VERBATIM)
 
+set_property(TARGET chkdecimalpoint
+  APPEND PROPERTY COMPILE_DEFINITIONS "CURLX_NO_MEMORY_CALLBACKS;CURL_STATICLIB")
+
   # # files used only in some libcurl test programs
 # SET(TESTUTIL testutil.c testutil.h)
 

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -12,6 +12,7 @@ SUPPORTFILES = first.c test.h
 
 # These are all libcurl test programs
 noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
+ chkdecimalpoint                                                         \
  lib500 lib501 lib502 lib503 lib504 lib505 lib506 lib507 lib508 lib509   \
  lib510 lib511 lib512 lib513 lib514 lib515 lib516 lib517 lib518 lib519   \
  lib520 lib521 lib523 lib524 lib525 lib526 lib527 lib529 lib530 lib532   \
@@ -31,6 +32,12 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
  lib1900 \
  lib2033
+
+chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
+ ../../lib/curl_ctype.c
+chkdecimalpoint_LDADD =
+chkdecimalpoint_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB \
+ -DCURLX_NO_MEMORY_CALLBACKS
 
 chkhostname_SOURCES = chkhostname.c ../../lib/curl_gethostname.c
 chkhostname_LDADD = @CURL_NETWORK_LIBS@

--- a/tests/libtest/chkdecimalpoint.c
+++ b/tests/libtest/chkdecimalpoint.c
@@ -1,0 +1,41 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_printf.h"
+
+#include <string.h>
+#include <locale.h>
+
+#define TOTAL_STR_LEN 4
+
+int main(void)
+{
+  char zero[TOTAL_STR_LEN] = {'\0'};
+  int chars;
+
+  setlocale(LC_NUMERIC, "");
+  chars = snprintf(zero, TOTAL_STR_LEN, "%.1f", 0.0);
+  if((chars == (TOTAL_STR_LEN - 1)) && (strcmp(zero, "0.0") == 0))
+    return 0;
+  else
+    return 1;
+}


### PR DESCRIPTION
`LC_NUMERIC` doesn't work on Windows, so just replace the decimal comma
with a decimal point in the expected result.