### PR TITLE
docs/CURLOPT_WRITEFUNCTION: size is always 1

### DIFF
--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -36,7 +36,7 @@ shown above.
 
 This callback function gets called by libcurl as soon as there is data
 received that needs to be saved.  \fIptr\fP points to the delivered data, and
-the size of that data is \fIsize\fP multiplied with \fInmemb\fP.
+the size of that data is \fInmemb\fP; \fIsize\fP is always 1.
 
 The callback function will be passed as much data as possible in all invokes,
 but you must not make any assumptions. It may be one byte, it may be


### PR DESCRIPTION
For compatibility with `fwrite`, the `CURLOPT_WRITEFUNCTION` callback is
passed two `size_t` parameters which, when multiplied, designate the
number of bytes of data passed in. In practice, CURL always sets the
first parameter (`size`) to 1.

This practice is also enshrined in documentation and cannot be changed
in future. The documentation states that the default callback is
`fwrite`, which means `fwrite` must be a suitable function for this
purpose. However, the documentation also states that the callback must
return the number of *bytes* it successfully handled, whereas ISO C
`fwrite` returns the number of items (each of size `size`) which it
wrote. The only way these numbers can be equal is if `size` is 1.

Since `size` is 1 and can never be changed in future anyway, document
that fact explicitly and let users rely on it.