### PR TITLE
docs/CURLOPT_URL: fix indentation

### DIFF
--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -284,6 +284,7 @@ and get cut off by libcurl if provided literally. You will instead have to
 escape it by providing it as backslash and its ASCII value in hexadecimal:
 "\\23".
 
+.RS 0
 The application does not have to keep the string around after setting this
 option.
 .SH ENCODING


### PR DESCRIPTION
The statement, “The application does not have to keep the string around
after setting this option,” appears to be indented under the RTMP
paragraph. It actually applies to all protocols, not just RTMP.
Eliminate the extra indentation.