### PR TITLE
reuse_conn(): free old_conn->options

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3971,6 +3971,7 @@ static void reuse_conn(struct connectdata *old_conn,
 
   Curl_safefree(old_conn->user);
   Curl_safefree(old_conn->passwd);
+  Curl_safefree(old_conn->options);
   Curl_safefree(old_conn->http_proxy.user);
   Curl_safefree(old_conn->socks_proxy.user);
   Curl_safefree(old_conn->http_proxy.passwd);


### PR DESCRIPTION
This fixes a memory leak when CURLOPT_LOGIN_OPTIONS is used, together with
connection reuse.

I found this with oss-fuzz on GDAL and curl master:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=9582
I couldn't reproduce with the oss-fuzz original test case, but looking
at curl source code pointed to this well reproducable leak.