### PR TITLE
HTTP: Don't attempt to needlessly decompress redirect body

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -797,7 +797,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
                                            nread);
             }
           }
-          else
+          else if(!k->ignorebody)
             result = Curl_unencode_write(conn, k->writer_stack, k->str, nread);
         }
         k->badheader = HEADER_NORMAL; /* taken care of now */


### PR DESCRIPTION
This change fixes a regression where redirect body would needlessly be decompressed even though it was to be ignored anyway. As it happens this causes secondary issues since there appears to be a bug in apache2 that it in certain conditions generates a corrupt zlib response. The regression was created by commit: dbcced8e32b50c068ac297106f0502ee200a1ebd

To reproduce the issue use a affectred curl version and attempt to:

`curl --referer something --compressed -L http://morph.zone`

With this change the problem disappears (read: the server bug is happily ignored).