### PR TITLE
Fix for use-after-free reported in issue 2782.

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -170,8 +170,9 @@ int main(void)
       }
     }
 
-    while((msg = curl_multi_info_read(cm, &Q))) {
-      if(msg->msg == CURLMSG_DONE) {
+    do {
+      if((msg = curl_multi_info_read(cm, &Q)) &&
+         (msg->msg == CURLMSG_DONE)) {
         char *url;
         CURL *e = msg->easy_handle;
         curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE, &url);
@@ -188,7 +189,7 @@ int main(void)
         U++; /* just to prevent it from remaining at 0 if there are more
                 URLs to get */
       }
-    }
+    } while(Q);
   }
 
   curl_multi_cleanup(cm);

--- a/docs/examples/asiohiper.cpp
+++ b/docs/examples/asiohiper.cpp
@@ -154,8 +154,9 @@ static void check_multi_info(GlobalInfo *g)
 
   fprintf(MSG_OUT, "\nREMAINING: %d", g->still_running);
 
-  while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
-    if(msg->msg == CURLMSG_DONE) {
+  do {
+    if((msg = curl_multi_info_read(g->multi, &msgs_left)) &&
+       (msg->msg == CURLMSG_DONE)) {
       easy = msg->easy_handle;
       res = msg->data.result;
       curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
@@ -166,7 +167,7 @@ static void check_multi_info(GlobalInfo *g)
       curl_easy_cleanup(easy);
       free(conn);
     }
-  }
+  } while(msgs_left);
 }
 
 /* Called by asio when there is an action on a socket */

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -180,8 +180,9 @@ static void check_multi_info(GlobalInfo *g)
   CURLcode res;
 
   fprintf(MSG_OUT, "REMAINING: %d\n", g->still_running);
-  while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
-    if(msg->msg == CURLMSG_DONE) {
+  do {
+    if((msg = curl_multi_info_read(g->multi, &msgs_left)) &&
+       (msg->msg == CURLMSG_DONE)) {
       easy = msg->easy_handle;
       res = msg->data.result;
       curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
@@ -191,8 +192,8 @@ static void check_multi_info(GlobalInfo *g)
       free(conn->url);
       curl_easy_cleanup(easy);
       free(conn);
-    }
-  }
+	}
+  } while(msgs_left);
 }
 
 

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -124,8 +124,9 @@ static void check_multi_info(GlobalInfo *g)
   CURLcode res;
 
   MSG_OUT("REMAINING: %d\n", g->still_running);
-  while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
-    if(msg->msg == CURLMSG_DONE) {
+  do {
+    if((msg = curl_multi_info_read(g->multi, &msgs_left)) &&
+       (msg->msg == CURLMSG_DONE)) {
       easy = msg->easy_handle;
       res = msg->data.result;
       curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
@@ -136,7 +137,7 @@ static void check_multi_info(GlobalInfo *g)
       curl_easy_cleanup(easy);
       free(conn);
     }
-  }
+  } while(msgs_left);
 }
 
 /* Called by glib when our timeout expires */

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -168,8 +168,9 @@ static void check_multi_info(GlobalInfo *g)
   CURLcode res;
 
   fprintf(MSG_OUT, "REMAINING: %d\n", g->still_running);
-  while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
-    if(msg->msg == CURLMSG_DONE) {
+  do {
+    if((msg = curl_multi_info_read(g->multi, &msgs_left)) &&
+       (msg->msg == CURLMSG_DONE)) {
       easy = msg->easy_handle;
       res = msg->data.result;
       curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
@@ -180,7 +181,7 @@ static void check_multi_info(GlobalInfo *g)
       curl_easy_cleanup(easy);
       free(conn);
     }
-  }
+  } while(msgs_left);
 }
 
 

--- a/docs/examples/http2-serverpush.c
+++ b/docs/examples/http2-serverpush.c
@@ -304,7 +304,7 @@ int main(void)
      */
 
     do {
-      int msgq = 0;;
+      int msgq;
       m = curl_multi_info_read(multi_handle, &msgq);
       if(m && (m->msg == CURLMSG_DONE)) {
         CURL *e = m->easy_handle;
@@ -312,7 +312,7 @@ int main(void)
         curl_multi_remove_handle(multi_handle, e);
         curl_easy_cleanup(e);
       }
-    } while(m);
+    } while(msgq);
 
   } while(transfers); /* as long as we have transfers going */
 

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -145,8 +145,9 @@ int main(void)
   } while(still_running);
 
   /* See how the transfers went */
-  while((msg = curl_multi_info_read(multi_handle, &msgs_left))) {
-    if(msg->msg == CURLMSG_DONE) {
+  do {
+    if((msg = curl_multi_info_read(multi_handle, &msgs_left)) &&
+       (msg->msg == CURLMSG_DONE)) {
       int idx, found = 0;
 
       /* Find out which handle this message is about */
@@ -165,7 +166,7 @@ int main(void)
         break;
       }
     }
-  }
+  } while(msgs_left);
 
   curl_multi_cleanup(multi_handle);
 


### PR DESCRIPTION
In external loop applications, the CURL* handle will be cleaned up during delivery of a completed easy handle.
In this case, the 2nd call to the curl_multi_info_read will be pointing to the freed struct.
The fix uses the pending counter to determine whether curl_multi_info_read needs to be called.
Still, there is a bug here. If the application frees the CURL* handle while there are still pending easy handles, curl_multi_info_read will still be called on a freed struct.

This is a partial fix for issue #2782 