### PR TITLE
Changing behavior from from "FETCH" to "UID FETCH" and add "MAILINDEX"

### DIFF
--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -187,7 +187,10 @@ imap://user:password@mail.example.com/INBOX - Performs a folder list on the
 user's inbox
 
 imap://user:password@mail.example.com/INBOX/;UID=1 - Selects the user's inbox
-and fetches message 1
+and fetches message with uid = 1
+
+imap://user:password@mail.example.com/INBOX/;MAILINDEX=1 - Selects the user's inbox
+and fetches the first message in the mail box
 
 imap://user:password@mail.example.com/INBOX;UIDVALIDITY=50/;UID=2 - Selects
 the user's inbox, checks the UIDVALIDITY of the mailbox is 50 and fetches

--- a/lib/imap.h
+++ b/lib/imap.h
@@ -58,6 +58,7 @@ struct IMAP {
   char *mailbox;          /* Mailbox to select */
   char *uidvalidity;      /* UIDVALIDITY to check in select */
   char *uid;              /* Message UID to fetch */
+  char *mindex;           /* Index in mail box of mail to fetch */
   char *section;          /* Message SECTION to fetch */
   char *partial;          /* Message PARTIAL to fetch */
   char *query;            /* Query to search for */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -93,7 +93,7 @@ test809 test810 test811 test812 test813 test814 test815 test816 test817 \
 test818 test819 test820 test821 test822 test823 test824 test825 test826 \
 test827 test828 test829 test830 test831 test832 test833 test834 test835 \
 test836 test837 test838 test839 test840 test841 test842 test843 test844 \
-test845 test846 \
+test845 test846 test847 \
 \
 test850 test851 test852 test853 test854 test855 test856 test857 test858 \
 test859 test860 test861 test862 test863 test864 test865 test866 test867 \

--- a/tests/data/test1321
+++ b/tests/data/test1321
@@ -51,7 +51,7 @@ http
 IMAP FETCH tunneled through HTTP proxy
  </name>
  <command>
-'imap://imap.1321:%IMAPPORT/1321/;UID=1' -u user:secret -p -x %HOSTIP:%PROXYPORT
+'imap://imap.1321:%IMAPPORT/1321/;MAILINDEX=1' -u user:secret -p -x %HOSTIP:%PROXYPORT
 </command>
 </client>
 

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -36,7 +36,7 @@ imap
 SSL_CERT_FILE=
 </setenv>
 <command>
-'imap://%HOSTIP:%IMAPPORT/1420/;UID=1' -u user:secret --libcurl log/test1420.c
+'imap://%HOSTIP:%IMAPPORT/1420/;MAILINDEX=1' -u user:secret --libcurl log/test1420.c
 </command>
 </client>
 
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
-  curl_easy_setopt(hnd, CURLOPT_URL, "imap://%HOSTIP:%IMAPPORT/1420/;UID=1");
+  curl_easy_setopt(hnd, CURLOPT_URL, "imap://%HOSTIP:%IMAPPORT/1420/;MAILINDEX=1");
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "user:secret");
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/tests/data/test1552
+++ b/tests/data/test1552
@@ -39,7 +39,7 @@ IMAP multi transfer error without curl_multi_remove_handle
 lib1552
 </tool>
  <command>
-'imap://%HOSTIP:%IMAPPORT/1552/;UID=1'
+'imap://%HOSTIP:%IMAPPORT/1552/;MAILINDEX=1'
 </command>
 </client>
 

--- a/tests/data/test800
+++ b/tests/data/test800
@@ -31,7 +31,7 @@ imap
 IMAP FETCH message
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/800/;UID=1' -u '"user:sec"ret{'
+'imap://%HOSTIP:%IMAPPORT/800/;MAILINDEX=1' -u '"user:sec"ret{'
 </command>
 </client>
 

--- a/tests/data/test801
+++ b/tests/data/test801
@@ -25,10 +25,10 @@ body
 imap
 </server>
  <name>
-IMAP FETCH message by UID and SECTION
+IMAP FETCH message by MAILINDEX and SECTION
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/801/;UID=123/;SECTION=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/801/;MAILINDEX=123/;SECTION=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test802
+++ b/tests/data/test802
@@ -29,7 +29,7 @@ imap
 IMAP SELECT UIDVALIDITY Success
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/802;UIDVALIDITY=3857529045/;UID=123/;SECTION=TEXT' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/802;UIDVALIDITY=3857529045/;MAILINDEX=123/;SECTION=TEXT' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test803
+++ b/tests/data/test803
@@ -24,7 +24,7 @@ imap
 IMAP SELECT UIDVALIDITY Failure
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/803;UIDVALIDITY=12345/;UID=123' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/803;UIDVALIDITY=12345/;MAILINDEX=123' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test804
+++ b/tests/data/test804
@@ -28,7 +28,7 @@ imap
 IMAP doesn't perform SELECT if re-using the same mailbox
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/804/;UID=123/;SECTION=1' 'imap://%HOSTIP:%IMAPPORT/804/;UID=456/;SECTION=2.3' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/804/;MAILINDEX=123/;SECTION=1' 'imap://%HOSTIP:%IMAPPORT/804/;MAILINDEX=456/;SECTION=2.3' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test819
+++ b/tests/data/test819
@@ -37,7 +37,7 @@ imap
 IMAP plain authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/819/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/819/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test820
+++ b/tests/data/test820
@@ -37,7 +37,7 @@ imap
 IMAP login authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/820/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/820/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test821
+++ b/tests/data/test821
@@ -40,7 +40,7 @@ crypto
 IMAP CRAM-MD5 authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/821/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/821/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test822
+++ b/tests/data/test822
@@ -48,7 +48,7 @@ CURL_GETHOSTNAME=curlhost
 LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
  </setenv>
  <command>
-'imap://%HOSTIP:%IMAPPORT/822/;UID=1' -u testuser:testpass
+'imap://%HOSTIP:%IMAPPORT/822/;MAILINDEX=1' -u testuser:testpass
 </command>
 <precheck>
 chkhostname curlhost

--- a/tests/data/test823
+++ b/tests/data/test823
@@ -43,7 +43,7 @@ crypto
 IMAP DIGEST-MD5 authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/823/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/823/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test824
+++ b/tests/data/test824
@@ -37,7 +37,7 @@ imap
 IMAP OAuth 2.0 (XOAUTH2) authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/824/;UID=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
+'imap://%HOSTIP:%IMAPPORT/824/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
 </client>
 

--- a/tests/data/test825
+++ b/tests/data/test825
@@ -38,7 +38,7 @@ imap
 IMAP plain authentication with initial response
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/825/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/825/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test826
+++ b/tests/data/test826
@@ -38,7 +38,7 @@ imap
 IMAP login authentication with initial response
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/826/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/826/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test827
+++ b/tests/data/test827
@@ -49,7 +49,7 @@ CURL_GETHOSTNAME=curlhost
 LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
  </setenv>
  <command>
-'imap://%HOSTIP:%IMAPPORT/827/;UID=1' -u testuser:testpass
+'imap://%HOSTIP:%IMAPPORT/827/;MAILINDEX=1' -u testuser:testpass
 </command>
 <precheck>
 chkhostname curlhost

--- a/tests/data/test828
+++ b/tests/data/test828
@@ -38,7 +38,7 @@ imap
 IMAP OAuth 2.0 (XOAUTH2) authentication with initial response
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/828/;UID=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
+'imap://%HOSTIP:%IMAPPORT/828/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
 </client>
 

--- a/tests/data/test830
+++ b/tests/data/test830
@@ -33,7 +33,7 @@ crypto
 IMAP CRAM-MD5 graceful cancellation
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/830/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/830/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test831
+++ b/tests/data/test831
@@ -40,7 +40,7 @@ CURL_GETHOSTNAME=curlhost
 LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
  </setenv>
  <command>
-'imap://%HOSTIP:%IMAPPORT/831/;UID=1' -u testuser:testpass
+'imap://%HOSTIP:%IMAPPORT/831/;MAILINDEX=1' -u testuser:testpass
 </command>
 <precheck>
 chkhostname curlhost

--- a/tests/data/test832
+++ b/tests/data/test832
@@ -35,7 +35,7 @@ crypto
 IMAP DIGEST-MD5 graceful cancellation
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/832/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/832/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test833
+++ b/tests/data/test833
@@ -44,7 +44,7 @@ crypto
 IMAP CRAM-MD5 authentication with SASL downgrade
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/833/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/833/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test834
+++ b/tests/data/test834
@@ -51,7 +51,7 @@ CURL_GETHOSTNAME=curlhost
 LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
  </setenv>
  <command>
-'imap://%HOSTIP:%IMAPPORT/834/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/834/;MAILINDEX=1' -u user:secret
 </command>
 <precheck>
 chkhostname curlhost

--- a/tests/data/test835
+++ b/tests/data/test835
@@ -46,7 +46,7 @@ crypto
 IMAP DIGEST-MD5 authentication with SASL downgrade
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/835/;UID=1' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/835/;MAILINDEX=1' -u user:secret
 </command>
 </client>
 

--- a/tests/data/test836
+++ b/tests/data/test836
@@ -36,7 +36,7 @@ imap
 IMAP multiple connection authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/836/;UID=1' -u user.one:secret -: 'imap://%HOSTIP:%IMAPPORT/836/;UID=2' -u user.two:secret
+'imap://%HOSTIP:%IMAPPORT/836/;MAILINDEX=1' -u user.one:secret -: 'imap://%HOSTIP:%IMAPPORT/836/;UID=2' -u user.two:secret
 </command>
 </client>
 

--- a/tests/data/test838
+++ b/tests/data/test838
@@ -37,7 +37,7 @@ imap
 IMAP external authentication without credentials
  </name>
  <command>
-'imap://;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/838/;UID=1'
+'imap://;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/838/;MAILINDEX=1'
 </command>
 </client>
 

--- a/tests/data/test839
+++ b/tests/data/test839
@@ -38,7 +38,7 @@ imap
 IMAP external authentication with initial response
  </name>
  <command>
-'imap://user;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/839/;UID=1'
+'imap://user;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/839/;MAILINDEX=1'
 </command>
 </client>
 

--- a/tests/data/test840
+++ b/tests/data/test840
@@ -38,7 +38,7 @@ imap
 IMAP external authentication with initial response without credentials
  </name>
  <command>
-'imap://;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/840/;UID=1'
+'imap://;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/840/;MAILINDEX=1'
 </command>
 </client>
 

--- a/tests/data/test842
+++ b/tests/data/test842
@@ -38,7 +38,7 @@ imap
 IMAP OAuth 2.0 (OAUTHBEARER) authentication
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/842/;UID=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
+'imap://%HOSTIP:%IMAPPORT/842/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
 # The protocol section doesn't support ways of specifying the raw data in the
 # base64 encoded message so we must assert this

--- a/tests/data/test843
+++ b/tests/data/test843
@@ -39,7 +39,7 @@ imap
 IMAP OAuth 2.0 (OAUTHBEARER) authentication with initial response
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/843/;UID=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
+'imap://%HOSTIP:%IMAPPORT/843/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
 # The protocol section doesn't support ways of specifying the raw data in the
 # base64 encoded message so we must assert this

--- a/tests/data/test844
+++ b/tests/data/test844
@@ -30,7 +30,7 @@ imap
 IMAP OAuth 2.0 (OAUTHBEARER) failure as continuation
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/844/;UID=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
+'imap://%HOSTIP:%IMAPPORT/844/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
 # The protocol section doesn't support ways of specifying the raw data in the
 # base64 encoded message so we must assert this

--- a/tests/data/test845
+++ b/tests/data/test845
@@ -31,7 +31,7 @@ imap
 IMAP OAuth 2.0 (OAUTHBEARER) failure as continuation with initial response
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/845/;UID=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
+'imap://%HOSTIP:%IMAPPORT/845/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
 # The protocol section doesn't support ways of specifying the raw data in the
 # base64 encoded message so we must assert this

--- a/tests/data/test846
+++ b/tests/data/test846
@@ -33,7 +33,7 @@ imap
 IMAP PREAUTH response
  </name>
  <command>
-'imap://%HOSTIP:%IMAPPORT/846/;UID=1' -u notused:still-provided
+'imap://%HOSTIP:%IMAPPORT/846/;MAILINDEX=1' -u notused:still-provided
 </command>
 </client>
 

--- a/tests/data/test847
+++ b/tests/data/test847
@@ -2,20 +2,14 @@
 <info>
 <keywords>
 IMAP
-SASL
-SASL AUTH EXTERNAL
-RFC4422
+Clear Text
+FETCH
 </keywords>
 </info>
 
 #
 # Server-side
 <reply>
-<servercmd>
-AUTH EXTERNAL
-REPLY AUTHENTICATE +
-REPLY dXNlcg== A002 OK AUTHENTICATE completed
-</servercmd>
 <data>
 From: me@somewhere
 To: fake@nowhere
@@ -34,10 +28,10 @@ body
 imap
 </server>
  <name>
-IMAP external authentication
+IMAP FETCH message
  </name>
  <command>
-'imap://user;AUTH=EXTERNAL@%HOSTIP:%IMAPPORT/837/;MAILINDEX=1'
+'imap://%HOSTIP:%IMAPPORT/847/;UID=1' -u '"user:sec"ret{'
 </command>
 </client>
 
@@ -46,10 +40,9 @@ IMAP external authentication
 <verify>
 <protocol>
 A001 CAPABILITY
-A002 AUTHENTICATE EXTERNAL
-dXNlcg==
-A003 SELECT 837
-A004 FETCH 1 BODY[]
+A002 LOGIN "\"user" "sec\"ret{"
+A003 SELECT 847
+A004 UID FETCH 1 BODY[]
 A005 LOGOUT
 </protocol>
 </verify>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -1560,7 +1560,13 @@ sub UID_imap {
     if ($selected eq "") {
         sendcontrol "$cmdid BAD Command received in Invalid state\r\n";
     }
-    elsif (($command ne "COPY") && ($command ne "FETCH") &&
+    elsif (substr($command, 0, 5) eq "FETCH"){
+        my $func = $commandfunc{"FETCH"};
+        if($func) {
+            &$func($args, $command);
+        }
+    }
+    elsif (($command ne "COPY") &&
            ($command ne "STORE") && ($command ne "SEARCH")) {
         sendcontrol "$cmdid BAD Command Argument\r\n";
     }


### PR DESCRIPTION
As described in #2789, this is a suggested solution.
Changing UID=xx to actually get mail with UID xx and add "MAILINDEX"
to get a mail with a special index in the mail box (old behavior).
So MAILINDEX=1 gives the first non deleted mail in the mail box.