### PR TITLE
smb: don't mark it done in smb_do

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -941,11 +941,11 @@ static CURLcode smb_do(struct connectdata *conn, bool *done)
   struct smb_conn *smbc = &conn->proto.smbc;
   struct smb_request *req = conn->data->req.protop;
 
+  *done = FALSE;
   if(smbc->share) {
     req->path = strchr(smbc->share, '\0');
     if(req->path) {
       req->path++;
-      *done = TRUE;
       return CURLE_OK;
     }
   }


### PR DESCRIPTION
Follow-up to 09e401e01bf9. The SMB protocol handler needs to use its
doing function too, which requires smb_do() to not mark itself as
done...