### PR TITLE
openssl: fix debug messages

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1936,7 +1936,15 @@ static void ssl_tls_trace(int direction, int ssl_ver, int content_type,
     }
     else
 #endif
-    {
+    if(content_type == SSL3_RT_CHANGE_CIPHER_SPEC) {
+      msg_type = *(char *)buf;
+      msg_name = "Change cipher spec";
+    }
+    else if(content_type == SSL3_RT_ALERT) {
+      msg_type = (((char *)buf)[0] << 8) + ((char *)buf)[1];
+      msg_name = SSL_alert_desc_string_long(msg_type);
+    }
+    else {
       msg_type = *(char *)buf;
       msg_name = ssl_msg_type(ssl_ver, msg_type);
     }


### PR DESCRIPTION
Fixes #2806. 
Cipher spec message is based on https://tools.ietf.org/html/rfc5246#section-7.1 (note only one allowed enum value)
Alert message parsing is based on https://tools.ietf.org/html/rfc5246#section-7.2, which describes a struct with 2 enums, 1 byte each. I'm not logging AlertLevel, though that could be implemented using SSL_alert_type_string_long (see https://www.openssl.org/docs/man1.1.0/ssl/SSL_alert_type_string.html)