### PR TITLE
travis: build darwinssl on macos 10.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ matrix:
           env: T=debug C="--with-ssl=/usr/local/opt/libressl --with-libmetalink"
         - os: osx
           compiler: clang
+          osx_image: xcode9.2
           env: T=debug C="--without-ssl --with-darwinssl --with-libmetalink"
         - os: osx
           compiler: clang


### PR DESCRIPTION
... as building on 10.13.x before 10.13.4 leads to link errors.

Fixes #2835