### PR TITLE
configure: fix for -lpthread detection with OpenSSL and pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1650,7 +1650,10 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
      LIBS="-lcrypto $LIBS"
      ],[
      LDFLAGS="$CLEANLDFLAGS -L$LIB_OPENSSL"
-     CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include/openssl -I$PREFIX_OPENSSL/include"
+     if test "$PKGCONFIG" = "no" ; then
+       # only set this if pkg-config wasn't used
+       CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include/openssl -I$PREFIX_OPENSSL/include"
+     fi
      AC_CHECK_LIB(crypto, HMAC_Init_ex,[
        HAVECRYPTO="yes"
        LIBS="-lcrypto $LIBS"], [


### PR DESCRIPTION
... by making sure it uses the -I provided by pkg-config!

Reported-by: pszemus on github
Fixes #2848