### PR TITLE
Remove (some) unused macros

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -182,8 +182,6 @@ static struct thread_sync_data *conn_thread_sync_data(struct connectdata *conn)
   return &(((struct thread_data *)conn->async.os_specific)->tsd);
 }
 
-#define CONN_THREAD_SYNC_DATA(conn) &(((conn)->async.os_specific)->tsd);
-
 /* Destroy resolver thread synchronization data */
 static
 void destroy_thread_sync_data(struct thread_sync_data * tsd)

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -45,10 +45,6 @@
 #include "memdebug.h"
 
 
-/* What kind of Content-Type to use on un-specified files with unrecognized
-   extensions. */
-#define HTTPPOST_CONTENTTYPE_DEFAULT "application/octet-stream"
-
 #define HTTPPOST_PTRNAME CURL_HTTPPOST_PTRNAME
 #define HTTPPOST_FILENAME CURL_HTTPPOST_FILENAME
 #define HTTPPOST_PTRCONTENTS CURL_HTTPPOST_PTRCONTENTS

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -192,7 +192,6 @@ static CURLcode CONNECT(struct connectdata *conn,
 
 #define SELECT_OK      0
 #define SELECT_ERROR   1
-#define SELECT_TIMEOUT 2
 
   if(Curl_connect_complete(conn))
     return CURLE_OK; /* CONNECT is already completed */

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -52,10 +52,6 @@
 #include "connect.h"
 #include "progress.h"
 #include "system_win32.h"
-
-#define  TELOPTS
-#define  TELCMDS
-
 #include "arpa_telnet.h"
 #include "select.h"
 #include "strcase.h"

--- a/tests/libtest/lib1540.c
+++ b/tests/libtest/lib1540.c
@@ -79,8 +79,6 @@ static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
   return CURL_WRITEFUNC_PAUSE;
 }
 
-#define TEST_HANG_TIMEOUT 60 * 1000
-
 int test(char *URL)
 {
   CURL *curls = NULL;


### PR DESCRIPTION
I gave Clangs -Wunused-macros a go and it showed a couple of warnings. IMO the warning is far too noisy to turn on for normal builds (I don't think it is not worth conditionally defining certain macros depending on which platform/compiler/configuration is used, and it'd be silly to remove i.e. CURL_MASK_SCHAR from warnless.c even though it's not used since just about every other MASK exists and is used). The macros in this PR should be fine to remove. Perhaps I could have just squashed the commits, but one at the time makes it possible to be more verbose in the commit message. :)