### PR TITLE
test1531: Add timeout

### DIFF
--- a/tests/libtest/lib1531.c
+++ b/tests/libtest/lib1531.c
@@ -39,6 +39,8 @@ int test(char *URL)
   int msgs_left; /* how many messages are left */
   int res = CURLE_OK;
 
+  start_test_timing();
+
   global_init(CURL_GLOBAL_ALL);
 
   /* Allocate one CURL handle per transfer */
@@ -58,6 +60,8 @@ int test(char *URL)
 
   /* we start some action by calling perform right away */
   curl_multi_perform(multi_handle, &still_running);
+
+  abort_on_test_timeout();
 
   do {
     struct timeval timeout;
@@ -127,6 +131,8 @@ int test(char *URL)
       curl_multi_perform(multi_handle, &still_running);
       break;
     }
+
+    abort_on_test_timeout();
   } while(still_running);
 
   /* See how the transfers went */
@@ -136,14 +142,17 @@ int test(char *URL)
       printf("HTTP transfer completed with status %d\n", msg->data.result);
       break;
     }
+
+    abort_on_test_timeout();
   } while(msg);
 
+test_cleanup:
   curl_multi_cleanup(multi_handle);
 
   /* Free the CURL handles */
   curl_easy_cleanup(easy);
   curl_global_cleanup();
 
-  return 0;
+  return res;
 }
 


### PR DESCRIPTION
Related to #2852, TEST_HANG_TIMEOUT was unused, but it seems to make sense to add timing in this test case instead of removing the macro (I may be wrong, I'm mostly guessing here).