### PR TITLE
Split non-portable part off test 1133

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -127,7 +127,7 @@ test1120 test1121 test1122 test1123 test1124 test1125 test1126 test1127 \
 test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
-test1152 test1153 test1154 test1155 test1156 test1157 \
+test1152 test1153 test1154 test1155 test1156 test1157 test1158 \
 \
 test1160 test1161 test1162 test1163 test1164 \
 test1170 test1171 \

--- a/tests/data/test1158
+++ b/tests/data/test1158
@@ -22,14 +22,17 @@ blablabla
 <server>
 http
 </server>
- <name>
-HTTP RFC1867-type formposting with filename/data contains ',', ';', '"'
- </name>
- <command>
-http://%HOSTIP:%HTTPPORT/we/want/1133 -F "file=@\"log/test1133,and;.txt\";type=mo/foo;filename=\"faker,and;.txt\"" -F 'file2=@"log/test1133,and;.txt"' -F 'file3=@"log/test1133,and;.txt";type=m/f,"log/test1133,and;.txt"' -F a="{\"field1\":\"value1\",\"field2\":\"value2\"}" -F 'b=" \\value1;type=\"whatever\" "; type=text/foo; charset=utf-8 ; filename=param_b'
+<name>
+HTTP RFC1867-type formposting with filename containing '"'
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/we/want/1158 -F "file=@\"log/test1158\\\".txt\";type=mo/foo;filename=\"test1158\\\".txt\"" -F 'file2=@"log/test1158\".txt"' -F 'file3=@"log/test1158\".txt";type=m/f,"log/test1158\".txt"'
 </command>
+<precheck>
+perl -e "print 'Test requires a system supporting double quotes in file names' if ($^O eq 'msys');"
+</precheck>
 # We create this file before the command is invoked!
-<file name=log/test1133,and;.txt>
+<file name=log/test1158".txt>
 foo bar
 This is a bar foo
 bar
@@ -43,16 +46,15 @@ foo
 ^(User-Agent:|Content-Type: multipart/form-data;|Content-Type: multipart/mixed; boundary=|-------).*
 </strip>
 <protocol>
-POST /we/want/1133 HTTP/1.1
+POST /we/want/1158 HTTP/1.1
 User-Agent: curl/7.10.4 (i686-pc-linux-gnu) libcurl/7.10.4 OpenSSL/0.9.7a ipv6 zlib/1.1.3
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 1264
-Expect: 100-continue
+Content-Length: 954
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32
-Content-Disposition: form-data; name="file"; filename="faker,and;.txt"
+Content-Disposition: form-data; name="file"; filename="test1158\".txt"
 Content-Type: mo/foo
 
 foo bar
@@ -61,7 +63,7 @@ bar
 foo
 
 ------------------------------24e78000bd32
-Content-Disposition: form-data; name="file2"; filename="test1133,and;.txt"
+Content-Disposition: form-data; name="file2"; filename="test1158\".txt"
 Content-Type: text/plain
 
 foo bar
@@ -73,7 +75,7 @@ foo
 Content-Disposition: form-data; name="file3"
 Content-Type: multipart/mixed; boundary=----------------------------7f0e85a48b0b
 
-Content-Disposition: attachment; filename="test1133,and;.txt"
+Content-Disposition: attachment; filename="test1158\".txt"
 Content-Type: m/f
 
 foo bar
@@ -81,7 +83,7 @@ This is a bar foo
 bar
 foo
 
-Content-Disposition: attachment; filename="test1133,and;.txt"
+Content-Disposition: attachment; filename="test1158\".txt"
 Content-Type: text/plain
 
 foo bar
@@ -90,13 +92,6 @@ bar
 foo
 
 
-Content-Disposition: form-data; name="a"
-
-{"field1":"value1","field2":"value2"}
-Content-Disposition: form-data; name="b"; filename="param_b"
-Content-Type: text/foo; charset=utf-8
-
- \value1;type="whatever" 
 ------------------------------24e78000bd32--
 </protocol>
 </verify>


### PR DESCRIPTION
Split off testing file names with double quotes into new test 1158.
Disable it for MSYS using a precheck as it doesn't support file names
with double quotes (but Cygwin does, for example).

Fixes https://github.com/curl/curl/issues/2796