### PR TITLE
lib1502: fix memory leak in torture test

### DIFF
--- a/tests/libtest/lib1502.c
+++ b/tests/libtest/lib1502.c
@@ -79,6 +79,8 @@ int test(char *URL)
     easy = dup;
   }
   else {
+    curl_slist_free_all(dns_cache_list);
+    curl_easy_cleanup(easy);
     return CURLE_OUT_OF_MEMORY;
   }
 


### PR DESCRIPTION
Reported-by: Marcel Raad
Fixes #2861