### PR TITLE
ssh-libssh: fix infinite connect loop on invalid private key

### DIFF
--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -663,6 +663,7 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
         if(rc != SSH_OK) {
           failf(data, "Could not load private key file %s",
                 data->set.str[STRING_SSH_PRIVATE_KEY]);
+          MOVE_TO_ERROR_STATE(CURLE_LOGIN_DENIED);
           break;
         }
 

--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -618,6 +618,7 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
         sshc->auth_methods = ssh_userauth_list(sshc->ssh_session, NULL);
         if(sshc->auth_methods & SSH_AUTH_METHOD_PUBLICKEY) {
           state(conn, SSH_AUTH_PKEY_INIT);
+          infof(data, "Authentication using SSH public key file\n");
         }
         else if(sshc->auth_methods & SSH_AUTH_METHOD_GSSAPI_MIC) {
           state(conn, SSH_AUTH_GSSAPI);
@@ -670,8 +671,6 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
 
       }
       else {
-        infof(data, "Authentication using SSH public key file\n");
-
         rc = ssh_userauth_publickey_auto(sshc->ssh_session, NULL,
                                          data->set.ssl.key_passwd);
         if(rc == SSH_AUTH_AGAIN) {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -83,7 +83,7 @@ test617 test618 test619 test620 test621 test622 test623 test624 test625 \
 test626 test627 test628 test629 test630 test631 test632 test633 test634 \
 test635 test636 test637 test638 test639 test640 test641 test642 \
 test643 test644 test645 test646 test647 test648 test649 test650 test651 \
-test652 test653 test654 test655 \
+test652 test653 test654 test655 test656 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 \

--- a/tests/data/test656
+++ b/tests/data/test656
@@ -1,0 +1,33 @@
+<testcase>
+<info>
+<keywords>
+SFTP
+FAILURE
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+sftp
+</server>
+ <name>
+SFTP retrieval with nonexistent private key file
+ </name>
+ <command>
+--key DOES_NOT_EXIST --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/not-a-valid-file-moooo --insecure --connect-timeout 8
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<valgrind>
+disable
+</valgrind>
+<errorcode>
+67
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Added test 656 (based on test 604) to verify the fix.

Bug: https://bugzilla.redhat.com/1595135