### PR TITLE
http2: add easymap layer to avoid stale pointers to freed memory

### DIFF
--- a/lib/http.h
+++ b/lib/http.h
@@ -124,6 +124,18 @@ CURLcode Curl_http_perhapsrewind(struct connectdata *conn);
 
 #endif /* CURL_DISABLE_HTTP */
 
+/* Allocate one of these for each HTTP/2 stream we put on the connection.
+   Tell nghttp2 to associate each stream_id with this node. To clear the
+   association, blank the 'easy' field.
+
+   The node is removed again from the list when nghttp2 calls on_stream_close.
+*/
+struct easymap {
+  struct curl_llist_element node;
+  struct Curl_easy *easy;
+  uint32_t stream_id;
+};
+
 /****************************************************************************
  * HTTP unique setup
  ***************************************************************************/
@@ -160,7 +172,7 @@ struct HTTP {
 #ifdef USE_NGHTTP2
   /*********** for HTTP/2 we store stream-local data here *************/
   int32_t stream_id; /* stream we are interested in */
-
+  struct easymap *emap; /* The map used for this stream */
   bool bodystarted;
   /* We store non-final and final response headers here, per-stream */
   Curl_send_buffer *header_recvbuf;
@@ -221,6 +233,7 @@ struct http_conn {
   nghttp2_settings_entry local_settings[3];
   size_t local_settings_num;
   uint32_t error_code; /* HTTP/2 error code */
+  struct curl_llist streamlist; /* a list of stream2easy nodes */
 #else
   int unused; /* prevent a compiler warning */
 #endif
@@ -253,4 +266,3 @@ Curl_http_output_auth(struct connectdata *conn,
                                             up the proxy tunnel */
 
 #endif /* HEADER_CURL_HTTP_H */
-

--- a/lib/http.h
+++ b/lib/http.h
@@ -124,6 +124,7 @@ CURLcode Curl_http_perhapsrewind(struct connectdata *conn);
 
 #endif /* CURL_DISABLE_HTTP */
 
+#ifdef USE_NGHTTP2
 /* Allocate one of these for each HTTP/2 stream we put on the connection.
    Tell nghttp2 to associate each stream_id with this node. To clear the
    association, blank the 'easy' field.
@@ -135,6 +136,7 @@ struct easymap {
   struct Curl_easy *easy;
   uint32_t stream_id;
 };
+#endif
 
 /****************************************************************************
  * HTTP unique setup


### PR DESCRIPTION
Instead of passing the easy handle directly to nghttp2 to map from
stream_id to our structs, we create an 'easymap' node (for each new
stream) and add to a per-connection linked list. The easymap struct
itself contains a pointer to the easy handle and the stream id. This
node *MUST* remain in the list until the 'on_stream_close' callback
comes. This node can survive the easy handle.

If we want to remove the association between a stream and an easy handle
before the stream end callback from nghtp2, we now call
disassociate_easymap() which "soft removes" the association in the
easymap struct only.

This is necesary since when nghttp2_submit_request() is called, the
stream<=>easy association isn't immediately done by nghttp2 and if we
then try to clear the assication at once (using
nghttp2_session_set_stream_user_data), that clearing fails and we risk
having the (by now) old assication getting done by nghttp2 and then risk
subsequently fetching a stale pointer to already freed data.

Fixes #2688
Fixes #2894