### PR TITLE
http2: avoid set_stream_user_data() before stream is assigned

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1178,7 +1178,8 @@ void Curl_http2_done(struct connectdata *conn, bool premature)
       httpc->pause_stream_id = 0;
     }
   }
-  if(http->stream_id) {
+  /* -1 means unassigned and 0 means cleared */
+  if(http->stream_id > 0) {
     int rv = nghttp2_session_set_stream_user_data(httpc->h2,
                                                   http->stream_id, 0);
     if(rv) {


### PR DESCRIPTION
... before the stream is started, we have it set to -1.

Fixes #2894