### PR TITLE
mbedtls: treat zero return from mbedtls_ssl_read() as non-error

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -795,7 +795,8 @@ static ssize_t mbed_recv(struct connectdata *conn, int num,
   if(ret <= 0) {
     if(ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
       return 0;
-
+    else if(!ret)
+      return 0;
     *curlcode = (ret == MBEDTLS_ERR_SSL_WANT_READ) ?
       CURLE_AGAIN : CURLE_RECV_ERROR;
     return -1;


### PR DESCRIPTION
Patch-by: @jshanab
Fixes #2899