### PR TITLE
Unify error codes returned by various TLS backends

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -113,7 +113,7 @@ CURLE_SEND_ERROR                7.10
 CURLE_SEND_FAIL_REWIND          7.12.3
 CURLE_SHARE_IN_USE              7.9.6         7.17.0
 CURLE_SSH                       7.16.1
-CURLE_SSL_CACERT                7.10
+CURLE_SSL_CACERT                7.10          7.62.0
 CURLE_SSL_CACERT_BADFILE        7.16.0
 CURLE_SSL_CERTPROBLEM           7.10
 CURLE_SSL_CIPHER                7.10

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -517,8 +517,7 @@ typedef enum {
   CURLE_UNKNOWN_OPTION,          /* 48 - User specified an unknown option */
   CURLE_TELNET_OPTION_SYNTAX,    /* 49 - Malformed telnet option */
   CURLE_OBSOLETE50,              /* 50 - NOT USED */
-  CURLE_PEER_FAILED_VERIFICATION, /* 51 - peer's certificate or fingerprint
-                                     wasn't verified fine */
+  CURLE_OBSOLETE51,              /* 51 - NOT USED */
   CURLE_GOT_NOTHING,             /* 52 - when this is a specific error */
   CURLE_SSL_ENGINE_NOTFOUND,     /* 53 - SSL crypto engine not found */
   CURLE_SSL_ENGINE_SETFAILED,    /* 54 - can not set SSL crypto engine as
@@ -528,7 +527,8 @@ typedef enum {
   CURLE_OBSOLETE57,              /* 57 - NOT IN USE */
   CURLE_SSL_CERTPROBLEM,         /* 58 - problem with the local certificate */
   CURLE_SSL_CIPHER,              /* 59 - couldn't use specified cipher */
-  CURLE_SSL_CACERT,              /* 60 - problem with the CA cert (path?) */
+  CURLE_PEER_FAILED_VERIFICATION, /* 60 - peer's certificate or fingerprint
+                                     wasn't verified fine */
   CURLE_BAD_CONTENT_ENCODING,    /* 61 - Unrecognized/bad encoding */
   CURLE_LDAP_INVALID_URL,        /* 62 - Invalid LDAP URL */
   CURLE_FILESIZE_EXCEEDED,       /* 63 - Maximum file size exceeded */
@@ -583,6 +583,9 @@ typedef enum {
                                     inside a callback */
   CURL_LAST /* never use! */
 } CURLcode;
+
+/* added in 7.62.0 */
+#define CURLE_SSL_CACERT CURLE_PEER_FAILED_VERIFICATION
 
 #ifndef CURL_NO_OLDIES /* define this to test if your app builds with all
                           the obsolete stuff removed! */

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -191,9 +191,6 @@ curl_easy_strerror(CURLcode error)
   case CURLE_TELNET_OPTION_SYNTAX :
     return "Malformed telnet option";
 
-  case CURLE_PEER_FAILED_VERIFICATION:
-    return "SSL peer certificate or SSH remote key was not OK";
-
   case CURLE_GOT_NOTHING:
     return "Server returned nothing (no headers, no data)";
 
@@ -218,9 +215,8 @@ curl_easy_strerror(CURLcode error)
   case CURLE_SSL_CIPHER:
     return "Couldn't use specified SSL cipher";
 
-  case CURLE_SSL_CACERT:
-    return "Peer certificate cannot be authenticated with given CA "
-      "certificates";
+  case CURLE_PEER_FAILED_VERIFICATION:
+    return "SSL peer certificate or SSH remote key was not OK";
 
   case CURLE_SSL_CACERT_BADFILE:
     return "Problem with the SSL CA cert (path? access rights?)";
@@ -324,6 +320,7 @@ curl_easy_strerror(CURLcode error)
   case CURLE_OBSOLETE44:
   case CURLE_OBSOLETE46:
   case CURLE_OBSOLETE50:
+  case CURLE_OBSOLETE51:
   case CURLE_OBSOLETE57:
   case CURL_LAST:
     break;

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2411,14 +2411,30 @@ darwinssl_connect_step2(struct connectdata *conn, int sockindex)
       case errSSLNoRootCert:
         failf(data, "SSL certificate problem: No root certificate");
         return CURLE_SSL_CACERT;
+      case errSSLCertNotYetValid:
+        failf(data, "SSL certificate problem: The certificate chain had a "
+                    "certificate that is not yet valid");
+        return CURLE_SSL_CACERT;
       case errSSLCertExpired:
+      case errSSLPeerCertExpired:
         failf(data, "SSL certificate problem: Certificate chain had an "
               "expired certificate");
         return CURLE_SSL_CACERT;
       case errSSLBadCert:
+      case errSSLPeerBadCert:
         failf(data, "SSL certificate problem: Couldn't understand the server "
               "certificate format");
-        return CURLE_SSL_CONNECT_ERROR;
+        return CURLE_SSL_CACERT;
+      case errSSLPeerUnsupportedCert:
+        failf(data, "SSL certificate problem: An unsupported certificate "
+                    "format was encountered");
+        return CURLE_SSL_CACERT;
+      case errSSLPeerCertRevoked:
+        failf(data, "SSL certificate problem: The certificate was revoked");
+        return CURLE_SSL_CACERT;
+      case errSSLPeerCertUnknown:
+        failf(data, "SSL certificate problem: The certificate is unknown");
+        return CURLE_SSL_CACERT;
 
       /* These are all certificate problems with the client: */
       case errSecAuthFailed:

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2190,6 +2190,7 @@ static int verify_cert(const char *cafile, struct Curl_easy *data,
   }
   else if(ret != noErr) {
     CFRelease(array);
+    failf(data, "SSLCopyPeerTrust() returned error %d", ret);
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 
@@ -2197,12 +2198,14 @@ static int verify_cert(const char *cafile, struct Curl_easy *data,
   if(ret != noErr) {
     CFRelease(array);
     CFRelease(trust);
+    failf(data, "SecTrustSetAnchorCertificates() returned error %d", ret);
     return CURLE_PEER_FAILED_VERIFICATION;
   }
   ret = SecTrustSetAnchorCertificatesOnly(trust, true);
   if(ret != noErr) {
     CFRelease(array);
     CFRelease(trust);
+    failf(data, "SecTrustSetAnchorCertificatesOnly() returned error %d", ret);
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 
@@ -2211,6 +2214,7 @@ static int verify_cert(const char *cafile, struct Curl_easy *data,
   CFRelease(array);
   CFRelease(trust);
   if(ret != noErr) {
+    failf(data, "SecTrustEvaluate() returned error %d", ret);
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1783,107 +1783,118 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
      higher priority, but it's probably better that we not connect at all than
      to give the user a false sense of security if the server only supports
      insecure ciphers. (Note: We don't care about SSLv2-only ciphers.) */
-  (void)SSLGetNumberSupportedCiphers(BACKEND->ssl_ctx, &all_ciphers_count);
-  all_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
-  allowed_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
-  if(all_ciphers && allowed_ciphers &&
-     SSLGetSupportedCiphers(BACKEND->ssl_ctx, all_ciphers,
-       &all_ciphers_count) == noErr) {
-    for(i = 0UL ; i < all_ciphers_count ; i++) {
-#if CURL_BUILD_MAC
-     /* There's a known bug in early versions of Mountain Lion where ST's ECC
-        ciphers (cipher suite 0xC001 through 0xC032) simply do not work.
-        Work around the problem here by disabling those ciphers if we are
-        running in an affected version of OS X. */
-      if(darwinver_maj == 12 && darwinver_min <= 3 &&
-         all_ciphers[i] >= 0xC001 && all_ciphers[i] <= 0xC032) {
-        continue;
-      }
-#endif /* CURL_BUILD_MAC */
-      switch(all_ciphers[i]) {
-        /* Disable NULL ciphersuites: */
-        case SSL_NULL_WITH_NULL_NULL:
-        case SSL_RSA_WITH_NULL_MD5:
-        case SSL_RSA_WITH_NULL_SHA:
-        case 0x003B: /* TLS_RSA_WITH_NULL_SHA256 */
-        case SSL_FORTEZZA_DMS_WITH_NULL_SHA:
-        case 0xC001: /* TLS_ECDH_ECDSA_WITH_NULL_SHA */
-        case 0xC006: /* TLS_ECDHE_ECDSA_WITH_NULL_SHA */
-        case 0xC00B: /* TLS_ECDH_RSA_WITH_NULL_SHA */
-        case 0xC010: /* TLS_ECDHE_RSA_WITH_NULL_SHA */
-        case 0x002C: /* TLS_PSK_WITH_NULL_SHA */
-        case 0x002D: /* TLS_DHE_PSK_WITH_NULL_SHA */
-        case 0x002E: /* TLS_RSA_PSK_WITH_NULL_SHA */
-        case 0x00B0: /* TLS_PSK_WITH_NULL_SHA256 */
-        case 0x00B1: /* TLS_PSK_WITH_NULL_SHA384 */
-        case 0x00B4: /* TLS_DHE_PSK_WITH_NULL_SHA256 */
-        case 0x00B5: /* TLS_DHE_PSK_WITH_NULL_SHA384 */
-        case 0x00B8: /* TLS_RSA_PSK_WITH_NULL_SHA256 */
-        case 0x00B9: /* TLS_RSA_PSK_WITH_NULL_SHA384 */
-        /* Disable anonymous ciphersuites: */
-        case SSL_DH_anon_EXPORT_WITH_RC4_40_MD5:
-        case SSL_DH_anon_WITH_RC4_128_MD5:
-        case SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA:
-        case SSL_DH_anon_WITH_DES_CBC_SHA:
-        case SSL_DH_anon_WITH_3DES_EDE_CBC_SHA:
-        case TLS_DH_anon_WITH_AES_128_CBC_SHA:
-        case TLS_DH_anon_WITH_AES_256_CBC_SHA:
-        case 0xC015: /* TLS_ECDH_anon_WITH_NULL_SHA */
-        case 0xC016: /* TLS_ECDH_anon_WITH_RC4_128_SHA */
-        case 0xC017: /* TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA */
-        case 0xC018: /* TLS_ECDH_anon_WITH_AES_128_CBC_SHA */
-        case 0xC019: /* TLS_ECDH_anon_WITH_AES_256_CBC_SHA */
-        case 0x006C: /* TLS_DH_anon_WITH_AES_128_CBC_SHA256 */
-        case 0x006D: /* TLS_DH_anon_WITH_AES_256_CBC_SHA256 */
-        case 0x00A6: /* TLS_DH_anon_WITH_AES_128_GCM_SHA256 */
-        case 0x00A7: /* TLS_DH_anon_WITH_AES_256_GCM_SHA384 */
-        /* Disable weak key ciphersuites: */
-        case SSL_RSA_EXPORT_WITH_RC4_40_MD5:
-        case SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5:
-        case SSL_RSA_EXPORT_WITH_DES40_CBC_SHA:
-        case SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA:
-        case SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA:
-        case SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA:
-        case SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA:
-        case SSL_RSA_WITH_DES_CBC_SHA:
-        case SSL_DH_DSS_WITH_DES_CBC_SHA:
-        case SSL_DH_RSA_WITH_DES_CBC_SHA:
-        case SSL_DHE_DSS_WITH_DES_CBC_SHA:
-        case SSL_DHE_RSA_WITH_DES_CBC_SHA:
-        /* Disable IDEA: */
-        case SSL_RSA_WITH_IDEA_CBC_SHA:
-        case SSL_RSA_WITH_IDEA_CBC_MD5:
-        /* Disable RC4: */
-        case SSL_RSA_WITH_RC4_128_MD5:
-        case SSL_RSA_WITH_RC4_128_SHA:
-        case 0xC002: /* TLS_ECDH_ECDSA_WITH_RC4_128_SHA */
-        case 0xC007: /* TLS_ECDHE_ECDSA_WITH_RC4_128_SHA*/
-        case 0xC00C: /* TLS_ECDH_RSA_WITH_RC4_128_SHA */
-        case 0xC011: /* TLS_ECDHE_RSA_WITH_RC4_128_SHA */
-        case 0x008A: /* TLS_PSK_WITH_RC4_128_SHA */
-        case 0x008E: /* TLS_DHE_PSK_WITH_RC4_128_SHA */
-        case 0x0092: /* TLS_RSA_PSK_WITH_RC4_128_SHA */
-          break;
-        default: /* enable everything else */
-          allowed_ciphers[allowed_ciphers_count++] = all_ciphers[i];
-          break;
-      }
-    }
-    err = SSLSetEnabledCiphers(BACKEND->ssl_ctx, allowed_ciphers,
-                               allowed_ciphers_count);
-    if(err != noErr) {
-      failf(data, "SSL: SSLSetEnabledCiphers() failed: OSStatus %d", err);
-      return CURLE_SSL_CONNECT_ERROR;
-    }
+  err = SSLGetNumberSupportedCiphers(BACKEND->ssl_ctx, &all_ciphers_count);
+  if(err != noErr) {
+    failf(data, "SSL: SSLGetNumberSupportedCiphers() failed: OSStatus %d",
+          err);
+    return CURLE_SSL_CIPHER;
   }
-  else {
+  all_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
+  if(!all_ciphers) {
+    failf(data, "SSL: Failed to allocate memory for all ciphers");
+    return CURLE_OUT_OF_MEMORY;
+  }
+  allowed_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
+  if(!allowed_ciphers) {
     Curl_safefree(all_ciphers);
-    Curl_safefree(allowed_ciphers);
     failf(data, "SSL: Failed to allocate memory for allowed ciphers");
     return CURLE_OUT_OF_MEMORY;
   }
+  err = SSLGetSupportedCiphers(BACKEND->ssl_ctx, all_ciphers,
+                               &all_ciphers_count);
+  if(err != noErr) {
+    Curl_safefree(all_ciphers);
+    Curl_safefree(allowed_ciphers);
+    return CURLE_SSL_CIPHER;
+  }
+  for(i = 0UL ; i < all_ciphers_count ; i++) {
+#if CURL_BUILD_MAC
+   /* There's a known bug in early versions of Mountain Lion where ST's ECC
+      ciphers (cipher suite 0xC001 through 0xC032) simply do not work.
+      Work around the problem here by disabling those ciphers if we are
+      running in an affected version of OS X. */
+    if(darwinver_maj == 12 && darwinver_min <= 3 &&
+       all_ciphers[i] >= 0xC001 && all_ciphers[i] <= 0xC032) {
+      continue;
+    }
+#endif /* CURL_BUILD_MAC */
+    switch(all_ciphers[i]) {
+      /* Disable NULL ciphersuites: */
+      case SSL_NULL_WITH_NULL_NULL:
+      case SSL_RSA_WITH_NULL_MD5:
+      case SSL_RSA_WITH_NULL_SHA:
+      case 0x003B: /* TLS_RSA_WITH_NULL_SHA256 */
+      case SSL_FORTEZZA_DMS_WITH_NULL_SHA:
+      case 0xC001: /* TLS_ECDH_ECDSA_WITH_NULL_SHA */
+      case 0xC006: /* TLS_ECDHE_ECDSA_WITH_NULL_SHA */
+      case 0xC00B: /* TLS_ECDH_RSA_WITH_NULL_SHA */
+      case 0xC010: /* TLS_ECDHE_RSA_WITH_NULL_SHA */
+      case 0x002C: /* TLS_PSK_WITH_NULL_SHA */
+      case 0x002D: /* TLS_DHE_PSK_WITH_NULL_SHA */
+      case 0x002E: /* TLS_RSA_PSK_WITH_NULL_SHA */
+      case 0x00B0: /* TLS_PSK_WITH_NULL_SHA256 */
+      case 0x00B1: /* TLS_PSK_WITH_NULL_SHA384 */
+      case 0x00B4: /* TLS_DHE_PSK_WITH_NULL_SHA256 */
+      case 0x00B5: /* TLS_DHE_PSK_WITH_NULL_SHA384 */
+      case 0x00B8: /* TLS_RSA_PSK_WITH_NULL_SHA256 */
+      case 0x00B9: /* TLS_RSA_PSK_WITH_NULL_SHA384 */
+      /* Disable anonymous ciphersuites: */
+      case SSL_DH_anon_EXPORT_WITH_RC4_40_MD5:
+      case SSL_DH_anon_WITH_RC4_128_MD5:
+      case SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA:
+      case SSL_DH_anon_WITH_DES_CBC_SHA:
+      case SSL_DH_anon_WITH_3DES_EDE_CBC_SHA:
+      case TLS_DH_anon_WITH_AES_128_CBC_SHA:
+      case TLS_DH_anon_WITH_AES_256_CBC_SHA:
+      case 0xC015: /* TLS_ECDH_anon_WITH_NULL_SHA */
+      case 0xC016: /* TLS_ECDH_anon_WITH_RC4_128_SHA */
+      case 0xC017: /* TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA */
+      case 0xC018: /* TLS_ECDH_anon_WITH_AES_128_CBC_SHA */
+      case 0xC019: /* TLS_ECDH_anon_WITH_AES_256_CBC_SHA */
+      case 0x006C: /* TLS_DH_anon_WITH_AES_128_CBC_SHA256 */
+      case 0x006D: /* TLS_DH_anon_WITH_AES_256_CBC_SHA256 */
+      case 0x00A6: /* TLS_DH_anon_WITH_AES_128_GCM_SHA256 */
+      case 0x00A7: /* TLS_DH_anon_WITH_AES_256_GCM_SHA384 */
+      /* Disable weak key ciphersuites: */
+      case SSL_RSA_EXPORT_WITH_RC4_40_MD5:
+      case SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5:
+      case SSL_RSA_EXPORT_WITH_DES40_CBC_SHA:
+      case SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA:
+      case SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA:
+      case SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA:
+      case SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA:
+      case SSL_RSA_WITH_DES_CBC_SHA:
+      case SSL_DH_DSS_WITH_DES_CBC_SHA:
+      case SSL_DH_RSA_WITH_DES_CBC_SHA:
+      case SSL_DHE_DSS_WITH_DES_CBC_SHA:
+      case SSL_DHE_RSA_WITH_DES_CBC_SHA:
+      /* Disable IDEA: */
+      case SSL_RSA_WITH_IDEA_CBC_SHA:
+      case SSL_RSA_WITH_IDEA_CBC_MD5:
+      /* Disable RC4: */
+      case SSL_RSA_WITH_RC4_128_MD5:
+      case SSL_RSA_WITH_RC4_128_SHA:
+      case 0xC002: /* TLS_ECDH_ECDSA_WITH_RC4_128_SHA */
+      case 0xC007: /* TLS_ECDHE_ECDSA_WITH_RC4_128_SHA*/
+      case 0xC00C: /* TLS_ECDH_RSA_WITH_RC4_128_SHA */
+      case 0xC011: /* TLS_ECDHE_RSA_WITH_RC4_128_SHA */
+      case 0x008A: /* TLS_PSK_WITH_RC4_128_SHA */
+      case 0x008E: /* TLS_DHE_PSK_WITH_RC4_128_SHA */
+      case 0x0092: /* TLS_RSA_PSK_WITH_RC4_128_SHA */
+        break;
+      default: /* enable everything else */
+        allowed_ciphers[allowed_ciphers_count++] = all_ciphers[i];
+        break;
+    }
+  }
+  err = SSLSetEnabledCiphers(BACKEND->ssl_ctx, allowed_ciphers,
+                             allowed_ciphers_count);
   Curl_safefree(all_ciphers);
   Curl_safefree(allowed_ciphers);
+  if(err != noErr) {
+    failf(data, "SSL: SSLSetEnabledCiphers() failed: OSStatus %d", err);
+    return CURLE_SSL_CIPHER;
+  }
 
 #if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
   /* We want to enable 1/n-1 when using a CBC cipher unless the user

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2211,11 +2211,13 @@ static int verify_cert(const char *cafile, struct Curl_easy *data,
 
   ret = SecTrustSetAnchorCertificates(trust, array);
   if(ret != noErr) {
+    CFRelease(array);
     CFRelease(trust);
     return sslerr_to_curlerr(data, ret);
   }
   ret = SecTrustSetAnchorCertificatesOnly(trust, true);
   if(ret != noErr) {
+    CFRelease(array);
     CFRelease(trust);
     return sslerr_to_curlerr(data, ret);
   }

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2070,35 +2070,6 @@ static int read_cert(const char *file, unsigned char **out, size_t *outlen)
   return 0;
 }
 
-static int sslerr_to_curlerr(struct Curl_easy *data, int err)
-{
-  switch(err) {
-    case errSSLXCertChainInvalid:
-      failf(data, "SSL certificate problem: Invalid certificate chain");
-      return CURLE_SSL_CACERT;
-    case errSSLUnknownRootCert:
-      failf(data, "SSL certificate problem: Untrusted root certificate");
-      return CURLE_SSL_CACERT;
-    case errSSLNoRootCert:
-      failf(data, "SSL certificate problem: No root certificate");
-      return CURLE_SSL_CACERT;
-    case errSSLCertExpired:
-      failf(data, "SSL certificate problem: Certificate chain had an "
-            "expired certificate");
-      return CURLE_SSL_CACERT;
-    case errSSLBadCert:
-      failf(data, "SSL certificate problem: Couldn't understand the server "
-            "certificate format");
-      return CURLE_SSL_CONNECT_ERROR;
-    case errSSLHostNameMismatch:
-      failf(data, "SSL certificate peer hostname mismatch");
-      return CURLE_PEER_FAILED_VERIFICATION;
-    default:
-      failf(data, "SSL unexpected certificate error %d", err);
-      return CURLE_SSL_CACERT;
-  }
-}
-
 static int append_cert_to_array(struct Curl_easy *data,
                                 unsigned char *buf, size_t buflen,
                                 CFMutableArrayRef array)

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -64,6 +64,7 @@
 
 #define CURL_BUILD_IOS 0
 #define CURL_BUILD_IOS_7 0
+#define CURL_BUILD_IOS_9 0
 #define CURL_BUILD_IOS_11 0
 #define CURL_BUILD_MAC 1
 /* This is the maximum API level we are allowed to use when building: */
@@ -87,6 +88,7 @@
 #elif TARGET_OS_EMBEDDED || TARGET_OS_IPHONE
 #define CURL_BUILD_IOS 1
 #define CURL_BUILD_IOS_7 __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+#define CURL_BUILD_IOS_9 __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 #define CURL_BUILD_IOS_11 __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
 #define CURL_BUILD_MAC 0
 #define CURL_BUILD_MAC_10_5 0
@@ -94,6 +96,7 @@
 #define CURL_BUILD_MAC_10_7 0
 #define CURL_BUILD_MAC_10_8 0
 #define CURL_BUILD_MAC_10_9 0
+#define CURL_BUILD_MAC_10_11 0
 #define CURL_BUILD_MAC_10_13 0
 #define CURL_SUPPORT_MAC_10_5 0
 #define CURL_SUPPORT_MAC_10_6 0
@@ -2394,9 +2397,9 @@ darwinssl_connect_step2(struct connectdata *conn, int sockindex)
       case errSSLCrypto:
         failf(data, "An underlying cryptographic error was encountered");
         break;
-#if CURL_BUILD_MAC_10_11
+#if CURL_BUILD_MAC_10_11 || CURL_BUILD_IOS_9
       case errSSLWeakPeerEphemeralDHKey:
-        failf(data, "Indicates a weak ephemeral dh key");
+        failf(data, "Indicates a weak ephemeral Diffie-Hellman key");
         break;
 #endif
 
@@ -2543,7 +2546,7 @@ darwinssl_connect_step2(struct connectdata *conn, int sockindex)
       case errSSLPeerUnexpectedMsg:
         failf(data, "Peer rejected unexpected message");
         break;
-#if CURL_BUILD_MAC_10_11
+#if CURL_BUILD_MAC_10_11 || CURL_BUILD_IOS_9
       /* Treaing non-fatal error as fatal like before */
       case errSSLClientHelloReceived:
         failf(data, "A non-fatal result for providing a server name "

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -945,7 +945,7 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
 
   if(!c) {
     failf(data, "SSL: invalid CA certificate subject");
-    return CURLE_OUT_OF_MEMORY;
+    return CURLE_SSL_CACERT;
   }
 
   /* If the subject is already available as UTF-8 encoded (ie 'direct') then

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1646,6 +1646,8 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
         }
 
         CFRelease(cert);
+        if(result == CURLE_SSL_CACERT)
+          return CURLE_SSL_CERTPROBLEM;
         if(result)
           return result;
       }

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2096,7 +2096,7 @@ static int append_cert_to_array(struct Curl_easy *data,
     switch(result) {
       case CURLE_OK:
         break;
-      case CURLE_SSL_CACERT:
+      case CURLE_PEER_FAILED_VERIFICATION:
         return CURLE_SSL_CACERT_BADFILE;
       case CURLE_OUT_OF_MEMORY:
       default:

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -2202,24 +2202,24 @@ static int verify_cert(const char *cafile, struct Curl_easy *data,
   if(trust == NULL) {
     failf(data, "SSL: error getting certificate chain");
     CFRelease(array);
-    return CURLE_OUT_OF_MEMORY;
+    return CURLE_PEER_FAILED_VERIFICATION;
   }
   else if(ret != noErr) {
     CFRelease(array);
-    return sslerr_to_curlerr(data, ret);
+    return CURLE_PEER_FAILED_VERIFICATION;
   }
 
   ret = SecTrustSetAnchorCertificates(trust, array);
   if(ret != noErr) {
     CFRelease(array);
     CFRelease(trust);
-    return sslerr_to_curlerr(data, ret);
+    return CURLE_PEER_FAILED_VERIFICATION;
   }
   ret = SecTrustSetAnchorCertificatesOnly(trust, true);
   if(ret != noErr) {
     CFRelease(array);
     CFRelease(trust);
-    return sslerr_to_curlerr(data, ret);
+    return CURLE_PEER_FAILED_VERIFICATION;
   }
 
   SecTrustResultType trust_eval = 0;
@@ -2227,7 +2227,7 @@ static int verify_cert(const char *cafile, struct Curl_easy *data,
   CFRelease(array);
   CFRelease(trust);
   if(ret != noErr) {
-    return sslerr_to_curlerr(data, ret);
+    return CURLE_PEER_FAILED_VERIFICATION;
   }
 
   switch(trust_eval) {

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1522,7 +1522,6 @@ static bool is_nss_error(CURLcode err)
 {
   switch(err) {
   case CURLE_PEER_FAILED_VERIFICATION:
-  case CURLE_SSL_CACERT:
   case CURLE_SSL_CERTPROBLEM:
   case CURLE_SSL_CONNECT_ERROR:
   case CURLE_SSL_ISSUER_ERROR:

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3210,7 +3210,7 @@ static CURLcode servercert(struct connectdata *conn,
           ossl_strerror(ERR_get_error(), error_buffer,
                         sizeof(error_buffer)) );
     BIO_free(mem);
-    return 0;
+    return CURLE_OUT_OF_MEMORY;
   }
 
   BACKEND->server_cert = SSL_get_peer_certificate(BACKEND->handle);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3257,7 +3257,7 @@ static CURLcode servercert(struct connectdata *conn,
   if(rc) {
     if(strict)
       failf(data, "SSL: couldn't get X509-issuer name!");
-    result = CURLE_SSL_CONNECT_ERROR;
+    result = CURLE_PEER_FAILED_VERIFICATION;
   }
   else {
     infof(data, " issuer: %s\n", buffer);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -798,7 +798,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
       case SEC_E_WRONG_PRINCIPAL:
         failf(data, "schannel: SNI or certificate check failed: %s",
               Curl_sspi_strerror(conn, sspi_status));
-        return CURLE_SSL_CACERT;
+        return CURLE_PEER_FAILED_VERIFICATION;
       case SEC_E_INVALID_HANDLE:
       case SEC_E_INVALID_TOKEN:
       case SEC_E_LOGON_DENIED:
@@ -1035,7 +1035,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
         case SEC_E_WRONG_PRINCIPAL:
           failf(data, "schannel: SNI or certificate check failed: %s",
                 Curl_sspi_strerror(conn, sspi_status));
-          return CURLE_SSL_CACERT;
+          return CURLE_PEER_FAILED_VERIFICATION;
         case SEC_E_INVALID_HANDLE:
         case SEC_E_INVALID_TOKEN:
         case SEC_E_LOGON_DENIED:

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1230,7 +1230,7 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
 
     if((sspi_status != SEC_E_OK) || (ccert_context == NULL)) {
       failf(data, "schannel: failed to retrieve remote cert context");
-      return CURLE_SSL_CONNECT_ERROR;
+      return CURLE_PEER_FAILED_VERIFICATION;
     }
 
     result = Curl_ssl_init_certinfo(data, 1);

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -135,7 +135,7 @@ static CURLcode add_certs_to_store(HCERTSTORE trust_store,
     failf(data,
           "schannel: CA file exceeds max size of %u bytes",
           MAX_CAFILE_SIZE);
-    result = CURLE_OUT_OF_MEMORY;
+    result = CURLE_SSL_CACERT_BADFILE;
     goto cleanup;
   }
 

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -900,7 +900,7 @@ CURLcode Curl_extract_certinfo(struct connectdata *conn,
 
   /* Extract the certificate ASN.1 elements. */
   if(Curl_parseX509(&cert, beg, end))
-    return CURLE_OUT_OF_MEMORY;
+    return CURLE_PEER_FAILED_VERIFICATION;
 
   /* Subject. */
   ccp = Curl_DNtostr(&cert.subject);

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -83,7 +83,7 @@ e47: Number of redirects hit maximum amount
 e48: An unknown option was passed in to libcurl
 e49: Malformed telnet option
 e50: Unknown error
-e51: SSL peer certificate or SSH remote key was not OK
+e51: Unknown error
 e52: Server returned nothing (no headers, no data)
 e53: SSL crypto engine not found
 e54: Can not set SSL crypto engine as default
@@ -92,7 +92,7 @@ e56: Failure when receiving data from the peer
 e57: Unknown error
 e58: Problem with the local SSL certificate
 e59: Couldn't use specified SSL cipher
-e60: Peer certificate cannot be authenticated with given CA certificates
+e60: SSL peer certificate or SSH remote key was not OK
 e61: Unrecognized or bad HTTP Content or Transfer-Encoding
 e62: Invalid LDAP URL
 e63: Maximum file size exceeded

--- a/tests/data/test311
+++ b/tests/data/test311
@@ -37,7 +37,7 @@ perl -e "print 'Test requires default test server host' if ( '%HOSTIP' ne '127.0
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
-51
+60
 </errorcode>
 </verify>
 </testcase>

--- a/tests/data/test312
+++ b/tests/data/test312
@@ -37,7 +37,7 @@ perl -e "print 'Test requires default test server host' if ( '%HOSTIP' ne '127.0
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
-51
+60
 </errorcode>
 </verify>
 </testcase>

--- a/tests/data/test630
+++ b/tests/data/test630
@@ -25,7 +25,7 @@ SFTP incorrect host key
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
-51
+60
 </errorcode>
 <valgrind>
 disable

--- a/tests/data/test631
+++ b/tests/data/test631
@@ -25,7 +25,7 @@ SCP incorrect host key
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
-51
+60
 </errorcode>
 <valgrind>
 disable


### PR DESCRIPTION
## Reconciliation of host name validation error
The [original issue](https://github.com/curl/curl/issues/2729) regarding inconsistent error code returned by different TLS backends during server certificate verification is caused by mishandling of framework return codes on host name validation failure. For openssl, host name is verified by a custom routine `verifyhost` which returns CURLE_PEER_FAILED_VERIFICATION on failure. For darwinssl, host name is verified automatically by the framework when calling `SSLHandle`. However, the framework does not return errSSLHostNameMismatch on failure as we might expect. Instead it returns a generic errSSLXCertChainInvalid which is mapped to CURLE_SSL_CACERT by curl. **So the first thing I would like to clarify is the intended difference between CURLE_PEER_FAILED_VERIFICATION and CURLE_SSL_CACERT, and whether we can use them interchangeably.**

The other inconsistency comes from curl's handling of schannel return code on Windows. Similar to darwinssl, the schannel framework also verifies host name automatically and returns SEC_E_WRONG_PRINCIPAL on validation failure. Although curl correctly catches this error code returned by `InitializeSecurityContext`, it only prints a different error message instead of mapping it to a return code consistent with darwinssl. We should fix this problem by returning CURLE_SSL_CACERT instead (commit 2e57a07).

## Reconciliation of other discrepancies
As we looked deeper into the implementation of schannel, darwinssl, and openssl, we also discovered several other sources of discrepancy. The details of what each discrepancy is and how we think it should be resolved is elaborated in the commit messages of this PR. In general, **I think the principle we should follow is to return as specific an error code as possible that’s also semantically consistent with other TLS backends**. Since not everyone can be familiar with all backends, I would suggest that every TLS backend should try its best to align the error code with that of openssl. If it's not possible to be consistent, the difference should be documented. For example,
```
CURLE_SSL_ISSUER_ERROR (83)
	Issuer check failed. (Added in 7.19.0, only returned by curl when compiled with openssl backend).
```

## Test plan
https://badssl.com hosts an extensive set of URLs with intentionally misconfigured SSL certificates. We ran a test suite of curl compiled with different TLS backends against those URLs. The return codes from the different curl versions on different operating systems are consistent.