### PR TITLE
curl_threads: silence bad-function-cast warning

### DIFF
--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -108,7 +108,8 @@ curl_thread_t Curl_thread_create(unsigned int (CURL_STDCALL *func) (void *),
 #ifdef _WIN32_WCE
   t = CreateThread(NULL, 0, func, arg, 0, NULL);
 #else
-  t = (curl_thread_t)_beginthreadex(NULL, 0, func, arg, 0, NULL);
+  uintptr_t thread_handle = _beginthreadex(NULL, 0, func, arg, 0, NULL);
+  t = (curl_thread_t)thread_handle;
 #endif
   if((t == 0) || (t == LongToHandle(-1L))) {
 #ifdef _WIN32_WCE


### PR DESCRIPTION
As uintptr_t and HANDLE are always the same size, this warning is
harmless. Just silence it using an intermediate uintptr_t variable.

This patch silences this warning from the MinGW autobuilds:
https://curl.haxx.se/dev/log.cgi?id=20180823035209-27962#prob3

It will probably break ancient versions of Visual C++ (6 and maybe .NET/2002, if they're not already broken) as they lack `uintptr_t` and `_beginthreadex` returns unsigned long for them, if I remember correctly. But I can only guess because we have no testing for them (they won't even install without hacks on modern Windows versions) and my computer refuses to search through 30,000 pages of PDF documentation, which is still downloadable here:
https://docs.microsoft.com/en-us/previous-versions/visualstudio/

Any opinion of how to handle this? Get this in as-is and let possible users of these compilers complain (hopefully there are none) or guess on a fix?