### PR TITLE
schannel: client certificate store opening fix

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -602,12 +602,15 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
         return result;
       }
 
-      cert_store = CertOpenStore(CURL_CERT_STORE_PROV_SYSTEM, 0,
-                                 (HCRYPTPROV)NULL,
-                                 cert_store_name, cert_store_path);
+      cert_store =
+        CertOpenStore(CURL_CERT_STORE_PROV_SYSTEM, 0,
+                      (HCRYPTPROV)NULL,
+                      CERT_STORE_OPEN_EXISTING_FLAG | cert_store_name,
+                      cert_store_path);
       if(!cert_store) {
-        failf(data, "schannel: Failed to open cert store %s %s",
-              cert_store_name, cert_store_path);
+        failf(data, "schannel: Failed to open cert store %x %s, "
+              "last error is %x",
+              cert_store_name, cert_store_path, GetLastError());
         Curl_unicodefree(cert_path);
         return CURLE_SSL_CONNECT_ERROR;
       }


### PR DESCRIPTION
1) Using CERT_STORE_OPEN_EXISTING_FLAG ( or CERT_STORE_READONLY_FLAG )
while opening certificate store would be sufficient in this scenario and
less-demanding in sense of required user credentials ( for example,
IIS_IUSRS will get "Access Denied" 0x05 error for existing CertOpenStore
call without any of flags mentioned above ),

2) as 'cert_store_name' is a DWORD, attempt to format its value like a
string ( in "Failed to open cert store" error message ) will throw null
pointer exception

3) adding GetLastError(), in my opinion, will make error message more
useful.

Bug: https://curl.haxx.se/mail/lib-2018-08/0198.html