### PR TITLE
Do not translate `?' to `%09' for GOPHER

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -93,17 +93,10 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   }
   else {
     char *newp;
-    size_t j, i;
 
     /* Otherwise, drop / and the first character (i.e., item type) ... */
     newp = path;
     newp += 2;
-
-    /* ... then turn ? into TAB for search servers, Veronica, etc. ... */
-    j = strlen(newp);
-    for(i = 0; i<j; i++)
-      if(newp[i] == '?')
-        newp[i] = '\x09';
 
     /* ... and finally unescape */
     result = Curl_urldecode(data, newp, 0, &sel, &len, FALSE);

--- a/tests/data/test1202
+++ b/tests/data/test1202
@@ -26,7 +26,7 @@ gopher
 Gopher query
  </name>
  <command>
-"gopher://%HOSTIP:%GOPHERPORT/7/the/search/engine?query%20succeeded/1202"
+"gopher://%HOSTIP:%GOPHERPORT/7/the/search/engine%09query%20succeeded/1202"
 </command>
 </client>
 


### PR DESCRIPTION
I have tried to dig in the lib/gopher.c history but unfortunately
apart the comment I was not able to find other rationales regarding
the `?` -> `%09` translation. AFAIK RFC 1436 predates URIs but RFC
4266 - that standardize gopher:// URIs does not contain any note
regarding a possible `?` -> `%09` translation and also in "Section
2.1   Gopher URL Syntax" for the search types it is documented to
just use `%09` to separate `<selector>` and `<search>` fields.

At least geomyidae, PyGopherd and bucktooth supports CGI where the
`?` character is used and it is pretty common to find that in the
current gopherspace. Translating `?` to `%09` leads to surprising
results in these cases.


Thank you!

**EDIT:** Adjusted formatting (NFC)