### PR TITLE
docs: Fix page-footer syntax

### DIFF
--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -20,10 +20,10 @@ protocol that curl supports and as specified in a URL. FTP, FTPS, POP3, IMAP,
 SMTP, LDAP etc.
 .IP "ALL_PROXY [protocol://]<host>[:port]"
 Sets the proxy server to use if no protocol-specific proxy is set.
-.IP "NO_PROXY <comma-separated list of hosts/domains>" list of host names that
-shouldn't go through any proxy. If set to an asterisk \&'*' only, it matches
-all hosts. Each name in this list is matched as either a domain name which
-contains the hostname, or the hostname itself.
+.IP "NO_PROXY <comma-separated list of hosts/domains>"
+list of host names that shouldn't go through any proxy. If set to an asterisk
+\&'*' only, it matches all hosts. Each name in this list is matched as either
+a domain name which contains the hostname, or the hostname itself.
 
 This environment variable disables use of the proxy even when specified with
 the --proxy option. That is


### PR DESCRIPTION
The second (optional) argument to .IP is supposed to be the
indentation level which is a numeric value.

This avoids a warning when running nroff -man curl.1:

    curl.1:2761: warning: numeric expression expected (got `l')

The warning is seen twice when generating tool_hugehelp.c.

It was introduced in a7ba60bb.