### PR TITLE
Don't use Windows path %PWD for SSH tests

### DIFF
--- a/tests/data/test1446
+++ b/tests/data/test1446
@@ -24,7 +24,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/log/test1446.dir
 SFTP with --remote-time
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/test1446.dir/rofile.txt --insecure --remote-time
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test1446.dir/rofile.txt --insecure --remote-time
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/log/test1446.dir && \

--- a/tests/data/test2004
+++ b/tests/data/test2004
@@ -30,7 +30,7 @@ sftp
 TFTP RRQ followed by SFTP retrieval followed by FILE followed by SCP retrieval then again in reverse order
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//2004 sftp://%HOSTIP:%SSHPORT%PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt scp://%HOSTIP:%SSHPORT%PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt sftp://%HOSTIP:%SSHPORT%PWD/log/test2004.txt tftp://%HOSTIP:%TFTPPORT//2004 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//2004 sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt tftp://%HOSTIP:%TFTPPORT//2004 --insecure
 </command>
 <file name="log/test2004.txt">
 This is test data

--- a/tests/data/test582
+++ b/tests/data/test582
@@ -24,7 +24,7 @@ lib582
 SFTP upload using multi interface
  </name>
  <command>
-Sftp://%HOSTIP:%SSHPORT%PWD/log/upload582.txt %PWD/log/file582.txt %USER:
+Sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/upload582.txt %PWD/log/file582.txt %USER:
 </command>
 <file name="log/file582.txt">
 Moooooooooooo

--- a/tests/data/test583
+++ b/tests/data/test583
@@ -29,7 +29,7 @@ SFTP with multi interface, remove handle early
 # name resolve will cause it to return rather quickly and thus we could trigger
 # the problem we're looking to verify.
  <command>
-sftp://localhost:%SSHPORT%PWD/log/upload583.txt %USER:
+sftp://localhost:%SSHPORT%POSIX_PWD/log/upload583.txt %USER:
 </command>
 </client>
 

--- a/tests/data/test600
+++ b/tests/data/test600
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file600.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file600.txt --insecure
 </command>
 <file name="log/file600.txt">
 Test data

--- a/tests/data/test601
+++ b/tests/data/test601
@@ -24,7 +24,7 @@ scp
 SCP retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/log/file601.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file601.txt --insecure
 </command>
 <file name="log/file601.txt">
 Test data

--- a/tests/data/test602
+++ b/tests/data/test602
@@ -21,7 +21,7 @@ sftp
 SFTP put
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file602.txt sftp://%HOSTIP:%SSHPORT%PWD/log/upload.602 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file602.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/upload.602 --insecure
 </command>
 <file name="log/file602.txt">
 Test data

--- a/tests/data/test603
+++ b/tests/data/test603
@@ -21,7 +21,7 @@ scp
 SCP upload
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file603.txt scp://%HOSTIP:%SSHPORT%PWD/log/upload.603 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file603.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/upload.603 --insecure
 </command>
 <file name="log/file603.txt">
 Test data

--- a/tests/data/test604
+++ b/tests/data/test604
@@ -16,7 +16,7 @@ sftp
 SFTP retrieval of nonexistent file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/not-a-valid-file-moooo --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test605
+++ b/tests/data/test605
@@ -16,7 +16,7 @@ scp
 SCP retrieval of nonexistent file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/not-a-valid-file-moooo --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test606
+++ b/tests/data/test606
@@ -16,7 +16,7 @@ sftp
 SFTP invalid user login
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%PWD/not-a-valid-file-moooo --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test607
+++ b/tests/data/test607
@@ -16,7 +16,7 @@ scp
 SCP invalid user login
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u not-a-valid-user: scp://%HOSTIP:%SSHPORT%PWD/not-a-valid-file-moooo --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u not-a-valid-user: scp://%HOSTIP:%SSHPORT%POSIX_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test608
+++ b/tests/data/test608
@@ -24,7 +24,7 @@ sftp
 SFTP post-quote rename
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rename %PWD/log/file608.txt %PWD/log/file608-renamed.txt" sftp://%HOSTIP:%SSHPORT%PWD/log/file608.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rename %PWD/log/file608.txt %PWD/log/file608-renamed.txt" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file608.txt --insecure
 </command>
 # Verify that the file was renamed properly, then rename the file back to what
 # it was so the verify section works and the file can be cleaned up.

--- a/tests/data/test609
+++ b/tests/data/test609
@@ -25,7 +25,7 @@ sftp
 SFTP post-quote mkdir failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-mkdir %PWD/log/file609.txt" sftp://%HOSTIP:%SSHPORT%PWD/log/file609.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-mkdir %PWD/log/file609.txt" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file609.txt --insecure
 </command>
 <file name="log/file609.txt">
 Test file for mkdir test

--- a/tests/data/test610
+++ b/tests/data/test610
@@ -27,7 +27,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/log/test610.dir
 SFTP post-quote rmdir
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rmdir %PWD/log/test610.dir" sftp://%HOSTIP:%SSHPORT%PWD/log/file610.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rmdir %PWD/log/test610.dir" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file610.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl gone %PWD/log/test610.dir

--- a/tests/data/test611
+++ b/tests/data/test611
@@ -27,7 +27,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/log/test611.dir
 SFTP post-quote rename
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rename %PWD/log/test611.dir %PWD/log/test611.new" sftp://%HOSTIP:%SSHPORT%PWD/log/file611.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rename %PWD/log/test611.dir %PWD/log/test611.new" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file611.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl rmdir %PWD/log/test611.new

--- a/tests/data/test612
+++ b/tests/data/test612
@@ -24,7 +24,7 @@ sftp
 SFTP post-quote remove file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file612.txt -Q "-rm %PWD/log/file612.txt" sftp://%HOSTIP:%SSHPORT%PWD/log/upload.612  --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file612.txt -Q "-rm %PWD/log/file612.txt" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/upload.612  --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl gone %PWD/log/test612.txt

--- a/tests/data/test613
+++ b/tests/data/test613
@@ -31,7 +31,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/log/test613.dir
 SFTP directory retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/test613.dir/ --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test613.dir/ --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/log/test613.dir %PWD/log/curl613.out

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -32,7 +32,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/log/test614.dir
 SFTP pre-quote chmod
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "chmod 444 %PWD/log/test614.dir/plainfile.txt" sftp://%HOSTIP:%SSHPORT%PWD/log/test614.dir/ --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "chmod 444 %PWD/log/test614.dir/plainfile.txt" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test614.dir/ --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/log/test614.dir %PWD/log/curl614.out

--- a/tests/data/test615
+++ b/tests/data/test615
@@ -20,7 +20,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/log/test615.dir
 SFTP put remote failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file615.txt sftp://%HOSTIP:%SSHPORT%PWD/log/test615.dir/rofile.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file615.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test615.dir/rofile.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/log/test615.dir

--- a/tests/data/test616
+++ b/tests/data/test616
@@ -23,7 +23,7 @@ sftp
 SFTP retrieval of empty file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file616.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file616.txt --insecure
 </command>
 <file name="log/file616.txt">
 </file>

--- a/tests/data/test617
+++ b/tests/data/test617
@@ -23,7 +23,7 @@ scp
 SCP retrieval of empty file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/log/file617.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file617.txt --insecure
 </command>
 <file name="log/file617.txt">
 </file>

--- a/tests/data/test618
+++ b/tests/data/test618
@@ -15,7 +15,7 @@ sftp
 SFTP retrieval of two files
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file618.txt sftp://%HOSTIP:%SSHPORT%PWD/log/file618.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file618.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file618.txt --insecure
 </command>
 <file name="log/file618.txt">
 Test data

--- a/tests/data/test619
+++ b/tests/data/test619
@@ -15,7 +15,7 @@ scp
 SCP retrieval of two files
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/log/file619.txt scp://%HOSTIP:%SSHPORT%PWD/log/file619.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file619.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file619.txt --insecure
 </command>
 <file name="log/file619.txt">
 Test data

--- a/tests/data/test620
+++ b/tests/data/test620
@@ -16,7 +16,7 @@ sftp
 SFTP retrieval of missing file followed by good file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/not-a-valid-file-moooo sftp://%HOSTIP:%SSHPORT%PWD/log/file620.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/not-a-valid-file-moooo sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file620.txt --insecure
 </command>
 <file name="log/file620.txt">
 Test data

--- a/tests/data/test621
+++ b/tests/data/test621
@@ -16,7 +16,7 @@ scp
 SCP retrieval of missing file followed by good file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/log/not-a-valid-file-moooo scp://%HOSTIP:%SSHPORT%PWD/log/file621.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/not-a-valid-file-moooo scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file621.txt --insecure
 </command>
 <file name="log/file621.txt">
 Test data

--- a/tests/data/test622
+++ b/tests/data/test622
@@ -22,7 +22,7 @@ sftp
 SFTP put failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file622.txt sftp://%HOSTIP:%SSHPORT%PWD/log/nonexistent-directory/nonexistent-file --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file622.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/nonexistent-directory/nonexistent-file --insecure
 </command>
 <file name="log/file622.txt">
 Test data

--- a/tests/data/test623
+++ b/tests/data/test623
@@ -22,7 +22,7 @@ scp
 SCP upload failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file623.txt scp://%HOSTIP:%SSHPORT%PWD/log/nonexistent-directory/nonexistent-file --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file623.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/nonexistent-directory/nonexistent-file --insecure
 </command>
 <file name="log/file623.txt">
 Test data

--- a/tests/data/test624
+++ b/tests/data/test624
@@ -22,7 +22,7 @@ sftp
 SFTP put with --ftp-create-dirs
  </name>
  <command>
---ftp-create-dirs --key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file624.txt sftp://%HOSTIP:%SSHPORT%PWD/log/test624.dir/upload.624 --insecure
+--ftp-create-dirs --key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file624.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test624.dir/upload.624 --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl move %PWD/log/test624.dir/upload.624 %PWD/log/upload.624 rmdir %PWD/log/test624.dir

--- a/tests/data/test625
+++ b/tests/data/test625
@@ -22,7 +22,7 @@ sftp
 SFTP put with --ftp-create-dirs twice
  </name>
  <command>
---ftp-create-dirs --key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file625.txt sftp://%HOSTIP:%SSHPORT%PWD/log/test625.a/upload.625 -T log/file625.txt sftp://%HOSTIP:%SSHPORT%PWD/log/test625.b/upload.625 --insecure
+--ftp-create-dirs --key curl_client_key --pubkey curl_client_key.pub -u %USER: -T log/file625.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test625.a/upload.625 -T log/file625.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test625.b/upload.625 --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl move %PWD/log/test625.a/upload.625 %PWD/log/upload.625 rmdir %PWD/log/test625.a rm %PWD/log/test625.b/upload.625 rmdir %PWD/log/test625.b

--- a/tests/data/test626
+++ b/tests/data/test626
@@ -22,7 +22,7 @@ sftp
 SFTP invalid quote command
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "invalid-command foo bar" sftp://%HOSTIP:%SSHPORT%PWD/log/file626.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "invalid-command foo bar" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file626.txt --insecure
 </command>
 <file name="log/file626.txt">
 Test file for rename test

--- a/tests/data/test628
+++ b/tests/data/test628
@@ -16,7 +16,7 @@ sftp
 SFTP invalid user login (password authentication)
  </name>
  <command>
--u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%PWD/irrelevant-file  --insecure
+-u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/irrelevant-file  --insecure
 </command>
 </client>
 

--- a/tests/data/test629
+++ b/tests/data/test629
@@ -16,7 +16,7 @@ scp
 SCP invalid user login (password authentication)
  </name>
  <command>
--u not-a-valid-user: scp://%HOSTIP:%SSHPORT%PWD/irrelevant-file --insecure
+-u not-a-valid-user: scp://%HOSTIP:%SSHPORT%POSIX_PWD/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test630
+++ b/tests/data/test630
@@ -17,7 +17,7 @@ sftp
 SFTP incorrect host key
  </name>
  <command>
---hostpubmd5 00000000000000000000000000000000 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/irrelevant-file --insecure
+--hostpubmd5 00000000000000000000000000000000 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test631
+++ b/tests/data/test631
@@ -17,7 +17,7 @@ scp
 SCP incorrect host key
  </name>
  <command>
---hostpubmd5 00000000000000000000000000000000 --key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/log/irrelevant-file --insecure
+--hostpubmd5 00000000000000000000000000000000 --key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test632
+++ b/tests/data/test632
@@ -20,7 +20,7 @@ sftp
 SFTP syntactically invalid host key
  </name>
  <command>
---hostpubmd5 00 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/irrelevant-file --insecure
+--hostpubmd5 00 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test633
+++ b/tests/data/test633
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval with byte range
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file633.txt -r 5-9 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file633.txt -r 5-9 --insecure
 </command>
 <file name="log/file633.txt">
 Test data

--- a/tests/data/test634
+++ b/tests/data/test634
@@ -25,7 +25,7 @@ sftp
 SFTP retrieval with byte range past end of file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file634.txt -r 5-99 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file634.txt -r 5-99 --insecure
 </command>
 <file name="log/file634.txt">
 Test data

--- a/tests/data/test635
+++ b/tests/data/test635
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval with byte range relative to end of file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file635.txt -r -9 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file635.txt -r -9 --insecure
 </command>
 <file name="log/file635.txt">
 Test data

--- a/tests/data/test636
+++ b/tests/data/test636
@@ -25,7 +25,7 @@ sftp
 SFTP retrieval with X- byte range
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file636.txt -r 5- --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file636.txt -r 5- --insecure
 </command>
 <file name="log/file636.txt">
 Test data

--- a/tests/data/test637
+++ b/tests/data/test637
@@ -23,7 +23,7 @@ sftp
 SFTP retrieval with invalid X- range
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file637.txt -r 99- --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file637.txt -r 99- --insecure
 </command>
 <file name="log/file637.txt">
 Test data

--- a/tests/data/test638
+++ b/tests/data/test638
@@ -29,7 +29,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/log/test638.dir
 SFTP post-quote rename * asterisk accept-fail
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/log/test638.dir %PWD/log/test638.new" sftp://%HOSTIP:%SSHPORT%PWD/log/file638.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/log/test638.dir %PWD/log/test638.new" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file638.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl rmdir %PWD/log/test638.new

--- a/tests/data/test639
+++ b/tests/data/test639
@@ -29,7 +29,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/log/test639.dir
 SFTP post-quote rename * asterisk accept-fail
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/log/test639-not-exists-dir %PWD/log/test639.new" sftp://%HOSTIP:%SSHPORT%PWD/log/file639.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/log/test639-not-exists-dir %PWD/log/test639.new" sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file639.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl rmdir %PWD/log/test639.dir

--- a/tests/data/test640
+++ b/tests/data/test640
@@ -23,7 +23,7 @@ sftp
 SFTP --head retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/log/file640.txt --insecure --head
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file640.txt --insecure --head
 </command>
 <file name="log/file640.txt">
 Test data

--- a/tests/data/test641
+++ b/tests/data/test641
@@ -23,7 +23,7 @@ scp
 SCP --head retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%PWD/log/file641.txt --insecure --head
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file641.txt --insecure --head
 </command>
 <file name="log/file641.txt">
 Test data

--- a/tests/data/test642
+++ b/tests/data/test642
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: --compressed-ssh sftp://%HOSTIP:%SSHPORT%PWD/log/file642.txt --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: --compressed-ssh sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/file642.txt --insecure
 </command>
 <file name="log/file642.txt">
 Test data

--- a/tests/data/test656
+++ b/tests/data/test656
@@ -16,7 +16,7 @@ sftp
 SFTP retrieval with nonexistent private key file
  </name>
  <command>
---key DOES_NOT_EXIST --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%PWD/not-a-valid-file-moooo --insecure --connect-timeout 8
+--key DOES_NOT_EXIST --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%POSIX_PWD/not-a-valid-file-moooo --insecure --connect-timeout 8
 </command>
 </client>
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -195,6 +195,7 @@ my $memdump="$LOGDIR/memdump";
 my $memanalyze="$perl $srcdir/memanalyze.pl";
 
 my $pwd = getcwd();          # current working directory
+my $posix_pwd = $pwd;
 
 my $start;
 my $ftpchecktime=1; # time it took to verify our test FTP server
@@ -3200,6 +3201,7 @@ sub subVariables {
 
   $$thing =~ s/%CURL/$CURL/g;
   $$thing =~ s/%PWD/$pwd/g;
+  $$thing =~ s/%POSIX_PWD/$posix_pwd/g;
   $$thing =~ s/%SRCDIR/$srcdir/g;
   $$thing =~ s/%USER/$USER/g;
 


### PR DESCRIPTION
All these tests failed on Windows because something like
`sftp://%HOSTIP:%SSHPORT%PWD/`
expanded to
`sftp://127.0.0.1:1234c:/msys64/home/bla/curl/`
and then curl complained about the port number ending with a letter.

Use the original POSIX path instead instead of the Windows path created
in checksystem to fix this.