### PR TITLE
tool_operate: Add http code 408 to transient list for --retry

### DIFF
--- a/docs/cmdline-opts/retry.d
+++ b/docs/cmdline-opts/retry.d
@@ -6,7 +6,7 @@ Help: Retry request if transient problems occur
 If a transient error is returned when curl tries to perform a transfer, it
 will retry this number of times before giving up. Setting the number to 0
 makes curl do no retries (which is the default). Transient error means either:
-a timeout, an FTP 4xx response code or an HTTP 5xx response code.
+a timeout, an FTP 4xx response code or an HTTP 408 or 5xx response code.
 
 When curl is about to retry a transfer, it will first wait one second and then
 for all forthcoming retries it will double the waiting time until it reaches

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1631,6 +1631,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
                 curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
 
                 switch(response) {
+                case 408: /* Request Timeout */
                 case 500: /* Internal Server Error */
                 case 502: /* Bad Gateway */
                 case 503: /* Service Unavailable */


### PR DESCRIPTION
- Treat 408 request timeout as transient so that curl will retry the
  request if --retry was used.

Closes #xxxx

---

for example from curl-for-win appveyor [log](https://ci.appveyor.com/project/vszakats/curl-for-win-pnpk2/build/1.0.38#L2691)
~~~
+ curl -fsS --connect-timeout 15 --retry 3+  https://pgp.mit.edu/pks/lookup?search=0x27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2&op=get
gpg --batch --keyserver-options timeout=15 --keyid-format LONG --import --status-fd 1
curl: (22) The requested URL returned error: 408 Request Timeout
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
[GNUPG:] NODATA 1
[GNUPG:] IMPORT_RES 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
~~~
(I'm not sure why it says `--retry 3+` instead of just `--retry 3`, I can only assume that's a formatting error on appveyor's part)

/cc @vszakats
