### PR TITLE
openssl: Fix setting TLS 1.3 cipher suites

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3807,6 +3807,9 @@ const struct Curl_ssl Curl_ssl_openssl = {
   SSLSUPP_CERTINFO |
   SSLSUPP_PINNEDPUBKEY |
   SSLSUPP_SSL_CTX |
+#ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
+  SSLSUPP_TLS13_CIPHERSUITES |
+#endif
   SSLSUPP_HTTPS_PROXY,
 
   sizeof(struct ssl_backend_data),


### PR DESCRIPTION
The flag indicating TLS 1.3 cipher support in the OpenSSL backend was
missing.

Bug: https://github.com/curl/curl/pull/2607#issuecomment-417283187
Reported-by: Kamil Dudka

Closes #xxxx

---

/cc @kdudka