### PR TITLE
Add --data-as-base64

### DIFF
--- a/docs/cmdline-opts/data-as-base64.d
+++ b/docs/cmdline-opts/data-as-base64.d
@@ -1,0 +1,10 @@
+Long: data-as-base64
+Arg: <data_b64>
+Help: HTTP POST binary data, passed in as base64
+Protocols: HTTP
+See-also: data data-raw
+Added: 7.62.0
+---
+This posts data similarly to --data but the data is
+specified in base64 encoding, allowing null bytes to
+be passed in command line arguments.

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -96,6 +96,8 @@ static const struct helptxt helptext[] = {
    "HTTP POST binary data"},
   {"    --data-raw <data>",
    "HTTP POST data, '@' allowed"},
+  {"    --data-as-base64 <data_b64>",
+   "HTTP POST binary data, passed in as base64"},
   {"    --data-urlencode <data>",
    "HTTP POST data url encoded"},
   {"    --delegation <LEVEL>",

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -201,4 +201,4 @@ test2064 test2065 test2066 test2067 test2068 test2069 \
 test2070 test2071 test2072 test2073 \
 test2074 test2075 \
 \
-test3000 test3001
+test3000 test3001 test3002

--- a/tests/data/test3002
+++ b/tests/data/test3002
@@ -1,0 +1,55 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+--data-as-base64
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK swsclose
+Server: Cool server/10.0
+Content-Length: 0
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+--data-as-base64
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/3002 --data-as-base64 bnVsbCBieXRlOiAAIGNyOiANIGxmOiAKZW5k
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<strippart>
+s/\x00/_NULL BYTE_/
+</strippart>
+<protocol nonewline="yes">
+POST /3002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Content-Length: 27
+Content-Type: application/x-www-form-urlencoded
+
+null byte: _NULL BYTE_ cr:  lf: 
+end
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Add a new way to specify HTTP POST/PUT/PATCH data on the command line.
The input is passed in base64-encoded, allowing null bytes to be present.
With `--data`, `--data-binary`, and `--data-raw`, this is only possible with a temporary file or a pipeline, because command-line arguments are null-terminated.
My use case for this is generating a curl invocation string that can be passed to reproduce a request with binary POST data, similarily to the way the Chrome Developer Tools do with the _Copy as cURL_ option in the network tab. Currently, the Chrome developer tools produce incorrect curl command lines when the request data contains null bytes - see https://phihag.de/2018/nullbyte/ for a demo.
Using a temporary file is not an option for me because the data may be sensitive (and touching the filesystem goes against the spirit of generating a reproducible command).
Using a pipeline and `--data @-` is not an option for me because it is highly system-specific, with neither `base64` nor `echo -e` being available on Windows.