### PR TITLE
http: fix write counter in Curl_add_buffer_send

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1212,7 +1212,7 @@ CURLcode Curl_add_buffer_send(Curl_send_buffer *in,
     if(http) {
       /* if we sent a piece of the body here, up the byte counter for it
          accordingly */
-      http->writebytecount += bodylen;
+      http->writebytecount += amount;
 
       if((size_t)amount != size) {
         /* The whole request could not be sent in one system call. We must


### PR DESCRIPTION
A problem would occur if the entire buffer couldn't be sent at once and
it could cause an infinte POST loop.

Reported-by: vfloyd6 on github
Fixes #2947