### PR TITLE
cookies: fix leak when writing cookies to file

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1508,10 +1508,9 @@ static int cookie_output(struct CookieInfo *c, const char *dumphere)
     format_ptr = get_netscape_format(array[i]);
     if(format_ptr == NULL) {
       fprintf(out, "#\n# Fatal libcurl error\n");
-      if(!use_stdout) {
-        free(array);
+      free(array);
+      if(!use_stdout)
         fclose(out);
-      }
       return 1;
     }
     fprintf(out, "%s\n", format_ptr);


### PR DESCRIPTION
If the formatting fails, we error out on a fatal error and clean up on the way out. The array was however freed within the wrong scope and was thus never freed in case the cookies were written to a file instead of STDOUT.