### PR TITLE
travis: install gnutls-bin package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
             - libunistring-dev # for libidn2 needed by libpsl
             - libnss3-dev
+            - gnutls-bin
 
 matrix:
     include:


### PR DESCRIPTION
This is required for gnutls-serv, which enables a few more tests.