### PR TITLE
cookies: extend domain checks to non psl builds

### DIFF
--- a/tests/data/test8
+++ b/tests/data/test8
@@ -46,6 +46,7 @@ Set-Cookie: trailingspace    = removed; path=/we/want;
 Set-Cookie: nocookie=yes; path=/WE;
 Set-Cookie: blexp=yesyes; domain=%HOSTIP; domain=%HOSTIP; expiry=totally bad;
 Set-Cookie: partialip=nono; domain=.0.0.1;
+Set-Cookie: chocolate=chip; domain=curl; path=/we/want;
 
 </file>
 <precheck>


### PR DESCRIPTION
Ensure to perform the checks we have to enforce a sane domain in the cookie request. The check for non-PSL enabled builds is quite basic but it's better than nothing.

The preprocessor juggling around the PSL block which ends on an `else` may not be too everyones liking; I'm happy to refactor in that case.