### PR TITLE
ntlm_wb: Fix memory leaks in ntlm_wb_response errorcases

### DIFF
--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -295,12 +295,13 @@ static CURLcode ntlm_wb_response(struct connectdata *conn,
 
     if(len_out > MAX_NTLM_WB_RESPONSE) {
       failf(conn->data, "too large ntlm_wb response!");
-      goto fail;
+      free(buf);
+      return CURLE_OUT_OF_MEMORY;
     }
 
     newbuf = Curl_saferealloc(buf, len_out + NTLM_BUFSIZE);
     if(!newbuf)
-      goto fail;
+      return CURLE_OUT_OF_MEMORY;
 
     buf = newbuf;
   }
@@ -327,9 +328,6 @@ static CURLcode ntlm_wb_response(struct connectdata *conn,
 done:
   free(buf);
   return CURLE_REMOTE_ACCESS_DENIED;
-fail:
-  free(buf);
-  return CURLE_OUT_OF_MEMORY;
 }
 
 /*

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -295,12 +295,12 @@ static CURLcode ntlm_wb_response(struct connectdata *conn,
 
     if(len_out > MAX_NTLM_WB_RESPONSE) {
       failf(conn->data, "too large ntlm_wb response!");
-      return CURLE_OUT_OF_MEMORY;
+      goto fail;
     }
 
     newbuf = Curl_saferealloc(buf, len_out + NTLM_BUFSIZE);
     if(!newbuf)
-      return CURLE_OUT_OF_MEMORY;
+      goto fail;
 
     buf = newbuf;
   }
@@ -327,6 +327,9 @@ static CURLcode ntlm_wb_response(struct connectdata *conn,
 done:
   free(buf);
   return CURLE_REMOTE_ACCESS_DENIED;
+fail:
+  free(buf);
+  return CURLE_OUT_OF_MEMORY;
 }
 
 /*


### PR DESCRIPTION
When erroring out on either realloc failure, or a request being too large the existing buffer was leaked. Fix by adding a fail clause and free the buffer on the way out.