### PR TITLE
anyauthput: fix compiler warning on 64-bit Windows

### DIFF
--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -26,15 +26,18 @@
  */
 #include <stdio.h>
 #include <fcntl.h>
-#ifdef WIN32
-#  include <io.h>
-#else
-#  include <unistd.h>
-#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 
 #include <curl/curl.h>
+
+#ifdef WIN32
+#  include <io.h>
+#  define READ_3RD_ARG unsigned int
+#else
+#  include <unistd.h>
+#  define READ_3RD_ARG size_t
+#endif
 
 #if LIBCURL_VERSION_NUM < 0x070c03
 #error "upgrade your libcurl to no less than 7.12.3"
@@ -83,7 +86,7 @@ static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
   int *fdp = (int *)stream;
   int fd = *fdp;
 
-  retcode = read(fd, ptr, size * nmemb);
+  retcode = read(fd, ptr, (READ_3RD_ARG)(size * nmemb));
 
   nread = (curl_off_t)retcode;
 


### PR DESCRIPTION
On Windows, the read function from `<io.h>` is used, which has its byte
count parameter as `unsigned int` instead of `size_t` [0].

The warning is visible in the autobuilds: https://curl.haxx.se/dev/log.cgi?id=20180910161513-27869#prob1

[0] https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/read