### PR TITLE
ftp: Ensure to include command in Curl_ftpsend() sendbuffer

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3963,10 +3963,14 @@ CURLcode Curl_ftpsend(struct connectdata *conn, const char *cmd)
   enum protection_level data_sec = conn->data_prot;
 #endif
 
-  write_len = strlen(cmd);
-  if(write_len > (sizeof(s) -3))
+  if(!cmd)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
+  write_len = strlen(cmd);
+  if(!write_len || write_len > (sizeof(s) -3))
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+
+  memcpy(&s, cmd, write_len);
   strcpy(&s[write_len], "\r\n"); /* append a trailing CRLF */
   write_len += 2;
   bytes_written = 0;

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -265,6 +265,7 @@ krb5_auth(void *app_data, struct connectdata *conn)
           result = CURLE_OUT_OF_MEMORY;
 
         free(p);
+        free(cmd);
 
         if(result) {
           ret = -2;


### PR DESCRIPTION
Commit 8238ba9 inadvertently removed the actual command to be sent from the send buffer in a refactoring. Add back copying the command into the buffer. Also add more guards against malformed input while at it. There seems to be a lack of testing of this module, but I'm not really sure how to improve that right now so I'll leave that for another PR.

Also comes with a bonus tiny memleak fix in krb5.c which was the original reason for spotting this.