### PR TITLE
sendf: use macro indirection and ensure concatenation has whitespace

### DIFF
--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -206,7 +206,7 @@ krb5_auth(void *app_data, struct connectdata *conn)
     if(maj != GSS_S_COMPLETE) {
       gss_release_name(&min, &gssname);
       if(service == srv_host) {
-        Curl_failf(data, "Error importing service name %s@%s", service, host);
+        failf(data, "Error importing service name %s@%s", service, host);
         return AUTH_ERROR;
       }
       service = srv_host;
@@ -290,8 +290,7 @@ krb5_auth(void *app_data, struct connectdata *conn)
                                       (unsigned char **)&_gssresp.value,
                                       &_gssresp.length);
           if(result) {
-            Curl_failf(data, "base64-decoding: %s",
-                       curl_easy_strerror(result));
+            failf(data, "base64-decoding: %s", curl_easy_strerror(result));
             ret = AUTH_CONTINUE;
             break;
           }

--- a/lib/security.c
+++ b/lib/security.c
@@ -422,7 +422,7 @@ static int sec_set_protection_level(struct connectdata *conn)
 
   if(!conn->sec_complete) {
     infof(conn->data, "Trying to change the protection level after the"
-                      "completion of the data exchange.\n");
+                      " completion of the data exchange.\n");
     return -1;
   }
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -244,7 +244,7 @@ static CURLcode add_certs_to_store(HCERTSTORE trust_store,
             CertFreeCertificateContext(cert_context);
             if(!add_cert_result) {
               failf(data,
-                    "schannel: failed to add certificate from CA file '%s'"
+                    "schannel: failed to add certificate from CA file '%s' "
                     "to certificate store: %s",
                     ca_file, Curl_strerror(conn, GetLastError()));
               result = CURLE_SSL_CACERT_BADFILE;


### PR DESCRIPTION
Two small `infof()`/`failf()` related fixups that I happened to note when skimming code. There were two callsites using the function names rather than the macro indirection, and two `infof()` strings which lacked proper whitespace in the concatenation.