### PR TITLE
cmake: don't require OpenSSL if CMAKE_USE_OPENSSL=OFF

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -9,8 +9,8 @@ if(NOT CURL_FIND_COMPONENTS)
   endif()
 endif()
 
-include(CMakeFindDependencyMacro)
-if(CURL_FIND_REQUIRED_libcurl)
+if("@USE_OPENSSL@")
+    include(CMakeFindDependencyMacro)
     find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")
 endif()
 


### PR DESCRIPTION
User must have OpenSSL installed even if not used by libcurl at all since 7.61.1 release.
Broken at 7867aaa9a01decf93711428462335be8cef70212
More complex solution in #2849 (including this fix)