### PR TITLE
Fix leaks on realloc() failures

### DIFF
--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -52,7 +52,13 @@ size_t grow_buffer(void *contents, size_t sz, size_t nmemb, void *ctx)
 {
   size_t realsize = sz * nmemb;
   memory *mem = (memory*) ctx;
-  mem->buf = realloc(mem->buf, mem->size + realsize);
+  char *ptr = realloc(mem->buf, mem->size + realsize);
+  if(!ptr) {
+    /* out of memory */
+    printf("not enough memory (realloc returned NULL)\n");
+    return 0;
+  }
+  mem->buf = ptr;
   memcpy(&(mem->buf[mem->size]), contents, realsize);
   mem->size += realsize;
   return realsize;

--- a/docs/examples/curlx.c
+++ b/docs/examples/curlx.c
@@ -515,12 +515,20 @@ int main(int argc, char **argv)
   curl_easy_setopt(p.curl, CURLOPT_SSL_CTX_DATA, &p);
 
   {
+    char *ptr;
     int lu; int i = 0;
     while((lu = BIO_read(in, &binaryptr[i], tabLength-i)) >0) {
       i += lu;
       if(i == tabLength) {
         tabLength += 100;
-        binaryptr = realloc(binaryptr, tabLength); /* should be more careful */
+        ptr = realloc(binaryptr, tabLength); /* should be more careful */
+        if(!ptr) {
+          /* out of memory */
+          BIO_printf(p.errorbio, "out of memory (realloc returned NULL)\n");
+          goto fail;
+        }
+        binaryptr = ptr;
+        ptr = NULL;
       }
     }
     tabLength = i;
@@ -551,7 +559,7 @@ int main(int argc, char **argv)
   /*** code d'erreur si accept mime ***, egalement code return HTTP != 200 ***/
 
 /* free the header list*/
-
+fail:
   curl_slist_free_all(headers);
 
   /* always cleanup */

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -42,13 +42,14 @@ WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;
 
-  mem->memory = realloc(mem->memory, mem->size + realsize + 1);
-  if(mem->memory == NULL) {
+  char *ptr = realloc(mem->memory, mem->size + realsize + 1);
+  if(ptr == NULL) {
     /* out of memory! */
     printf("not enough memory (realloc returned NULL)\n");
     return 0;
   }
 
+  mem->memory = ptr;
   memcpy(&(mem->memory[mem->size]), contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -39,13 +39,14 @@ WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;
 
-  mem->memory = realloc(mem->memory, mem->size + realsize + 1);
-  if(mem->memory == NULL) {
+  char *ptr = realloc(mem->memory, mem->size + realsize + 1);
+  if(!ptr) {
     /* out of memory! */
     printf("not enough memory (realloc returned NULL)\n");
     return 0;
   }
 
+  mem->memory = ptr;
   memcpy(&(mem->memory[mem->size]), contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;

--- a/docs/examples/xmlstream.c
+++ b/docs/examples/xmlstream.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -69,14 +69,15 @@ static void characterDataHandler(void *userData, const XML_Char *s, int len)
   struct ParserStruct *state = (struct ParserStruct *) userData;
   struct MemoryStruct *mem = &state->characters;
 
-  mem->memory = realloc(mem->memory, mem->size + len + 1);
-  if(mem->memory == NULL) {
+  char *ptr = realloc(mem->memory, mem->size + len + 1);
+  if(!ptr) {
     /* Out of memory. */
     fprintf(stderr, "Not enough memory (realloc returned NULL).\n");
     state->ok = 0;
     return;
   }
 
+  mem->memory = ptr;
   memcpy(&(mem->memory[mem->size]), s, len);
   mem->size += len;
   mem->memory[mem->size] = 0;

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -120,6 +120,7 @@
 #include "vtls.h"
 #include "darwinssl.h"
 #include "curl_printf.h"
+#include "strdup.h"
 
 #include "curl_memory.h"
 /* The last #include file should be: */
@@ -2056,7 +2057,7 @@ static int read_cert(const char *file, unsigned char **out, size_t *outlen)
 
     if(len + n >= cap) {
       cap *= 2;
-      data = realloc(data, cap);
+      data = Curl_saferealloc(data, cap);
       if(!data) {
         close(fd);
         return -1;


### PR DESCRIPTION
Fix a few `realloc()` calls which overwrote the original pointer with the return value, causing a memory leak in case the reallocation failed.
 
This extends and replaces #2997 with additional fixes of the same kind in the examples as the one submitted there. The second commit fixes a memleak in darwinssl which was found by looking at this PR.

@CrazyHackGUT I've editorialized your commit a bit by fixing the other copy/paste `realloc()` issues in examples. 