### PR TITLE
darwinssl: make requested TLS version the minimum

### DIFF
--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -1304,8 +1304,6 @@ set_ssl_version_min_max(struct connectdata *conn, int sockindex)
 
   switch(ssl_version_max) {
     case CURL_SSLVERSION_MAX_NONE:
-      ssl_version_max = ssl_version << 16;
-      break;
     case CURL_SSLVERSION_MAX_DEFAULT:
       ssl_version_max = max_supported_version_by_os;
       break;


### PR DESCRIPTION
Make the requested TLS version the minimum and allow for any higher protocol in the negotiation, rather than capping the protocol version to the requested. This fixes Secure Transport (darwinssl) to behave like OpenSSL as it was changed in #2694 (reported in #2969).