### PR TITLE
urlapi: don't set value which is never read

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -970,7 +970,6 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
     char *scheme;
     char *options = u->options;
     char *port = u->port;
-    urldecode = FALSE; /* not for the whole thing */
     if(u->scheme && strcasecompare("file", u->scheme)) {
       url = aprintf("file://%s%s%s",
                     u->path,


### PR DESCRIPTION
In the `CURLUPART_URL` case, there is no codepath which invokes url decoding so remove the assignment of the `urldecode` variable. This fixes the deadstore bug-report from clang static analysis.