### PR TITLE
nss: try to connect even if libnssckbi.so fails to load

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1578,8 +1578,9 @@ static CURLcode nss_load_ca_certificates(struct connectdata *conn,
     infof(data, "%s %s\n", (result) ? "failed to load" : "loaded",
           trust_library);
     if(result == CURLE_FAILED_INIT)
-      /* make the error non-fatal if we are not going to verify peer */
-      result = CURLE_SSL_CACERT_BADFILE;
+      /* If libnssckbi.so is not available (or fails to load), one can still
+         use CA certificates stored in NSS database.  Ignore the failure. */
+      result = CURLE_OK;
   }
   else if(!use_trust_module && trust_module) {
     /* libnssckbi.so not needed but already loaded --> unload it! */


### PR DESCRIPTION
One can still use CA certificates stored in NSS database.

Reported-by: Maxime Legros
Bug: https://curl.haxx.se/mail/lib-2018-09/0077.html