### PR TITLE
Fixed typo in Curl_saferealloc docblock

### DIFF
--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -81,7 +81,7 @@ void *Curl_memdup(const void *src, size_t length)
  * Curl_saferealloc(ptr, size)
  *
  * Does a normal realloc(), but will free the data pointer if the realloc
- * fails. If 'size' is zero, it will free the data and return a failure.
+ * fails. If 'size' is non-zero, it will free the data and return a failure.
  *
  * This convenience function is provided and used to help us avoid a common
  * mistake pattern when we could pass in a zero, catch the NULL return and end


### PR DESCRIPTION
`data` is freed when `size` is non-zero.