### PR TITLE
openssl: load built-in engines too

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -978,7 +978,7 @@ static int Curl_ossl_init(void)
 
   OPENSSL_load_builtin_modules();
 
-#ifdef HAVE_ENGINE_LOAD_BUILTIN_ENGINES
+#ifdef USE_OPENSSL_ENGINE
   ENGINE_load_builtin_engines();
 #endif
 


### PR DESCRIPTION
Regression since 38203f1

Reported-by: Jean Fabrice
Fixes #3023