### PR TITLE
Fix usage of unavailable weak symbol clock_gettime() on Apple platform.

### DIFF
--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -66,14 +66,14 @@ struct curltime Curl_now(void)
   ** code compiles but fails during run-time if clock_gettime() is
   ** called on unsupported OS version.
   */
-#if HAVE_BUILTIN_AVAILABLE == 1
+#if defined(__APPLE__) && (HAVE_BUILTIN_AVAILABLE == 1)
   bool have_clock_gettime = FALSE;
   if(__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *))
       have_clock_gettime = TRUE;
 #endif
 
   if(
-#if HAVE_BUILTIN_AVAILABLE == 1
+#if defined(__APPLE__) && (HAVE_BUILTIN_AVAILABLE == 1)
      have_clock_gettime &&
 #endif
      (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -66,17 +66,14 @@ struct curltime Curl_now(void)
   ** code compiles but fails during run-time if clock_gettime() is
   ** called on unsupported OS version.
   */
-#if defined(__APPLE__) && defined(__clang__) && defined(__has_attribute)
-#if __has_attribute(availability)
-#define _USE_CLOCK_GETTIME_CHECK
-  static bool have_clock_gettime = FALSE;
+#if HAVE_BUILTIN_AVAILABLE == 1
+  bool have_clock_gettime = FALSE;
   if(__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *))
       have_clock_gettime = TRUE;
 #endif
-#endif
 
   if(
-#ifdef _USE_CLOCK_GETTIME_CHECK
+#if HAVE_BUILTIN_AVAILABLE == 1
      have_clock_gettime &&
 #endif
      (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -68,7 +68,7 @@ struct curltime Curl_now(void)
   */
 #if defined(__APPLE__) && defined(__clang__) && defined(__has_attribute)
 #if __has_attribute(availability)
-#define HAVE_CLOCK_GETTIME_CHECK
+#define _USE_CLOCK_GETTIME_CHECK
   static bool have_clock_gettime = FALSE;
   if(__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *))
       have_clock_gettime = TRUE;
@@ -76,7 +76,7 @@ struct curltime Curl_now(void)
 #endif
 
   if(
-#ifdef HAVE_CLOCK_GETTIME_CHECK
+#ifdef _USE_CLOCK_GETTIME_CHECK
      have_clock_gettime &&
 #endif
      (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -69,9 +69,9 @@ struct curltime Curl_now(void)
 #if defined(__APPLE__) && defined(__clang__) && defined(__has_attribute)
 #if __has_attribute(availability)
 #define HAVE_CLOCK_GETTIME_CHECK
-  static int have_clock_gettime = 0;
+  static bool have_clock_gettime = FALSE;
   if(__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *))
-      have_clock_gettime = 1;
+      have_clock_gettime = TRUE;
 #endif
 #endif
 

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -60,7 +60,26 @@ struct curltime Curl_now(void)
   struct timeval now;
   struct curltime cnow;
   struct timespec tsnow;
-  if(0 == clock_gettime(CLOCK_MONOTONIC, &tsnow)) {
+
+  /*
+  ** clock_gettime() may be defined by Apple's SDK as weak symbol thus 
+  ** code compiles but fails during run-time if clock_gettime() is 
+  ** called on unsupported OS version.
+  */
+#if defined(__APPLE__) && defined(__clang__) && defined(__has_attribute)
+#if __has_attribute(availability)
+#define HAVE_CLOCK_GETTIME_CHECK
+  static int have_clock_gettime = 0;
+  if(__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *))
+      have_clock_gettime = 1;
+#endif
+#endif
+    
+  if(
+#ifdef HAVE_CLOCK_GETTIME_CHECK
+     have_clock_gettime &&
+#endif
+     (0 == clock_gettime(CLOCK_MONOTONIC, &tsnow))) {
     cnow.tv_sec = tsnow.tv_sec;
     cnow.tv_usec = (unsigned int)(tsnow.tv_nsec / 1000);
   }

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -62,8 +62,8 @@ struct curltime Curl_now(void)
   struct timespec tsnow;
 
   /*
-  ** clock_gettime() may be defined by Apple's SDK as weak symbol thus 
-  ** code compiles but fails during run-time if clock_gettime() is 
+  ** clock_gettime() may be defined by Apple's SDK as weak symbol thus
+  ** code compiles but fails during run-time if clock_gettime() is
   ** called on unsupported OS version.
   */
 #if defined(__APPLE__) && defined(__clang__) && defined(__has_attribute)
@@ -74,7 +74,7 @@ struct curltime Curl_now(void)
       have_clock_gettime = 1;
 #endif
 #endif
-    
+
   if(
 #ifdef HAVE_CLOCK_GETTIME_CHECK
      have_clock_gettime &&


### PR DESCRIPTION
Latest Apple SDK declares clock_gettime() and it is available during compile time but it may not always be available during run time - weak symbol. E.g. code compiles but later will crash if clock_gettime() is used on unsupported version of Apple OS.

clock_gettime() is supported since these OS versions: macOS 10.12, iOS 10, tvOS 10, watchOS 3.

This fix uses __builtin_available() Clang's extension which tests OS version and does not allow to use clock_gettime() on unsupported OS version.

There is only small overhead on Apple OS due to have_clock_gettime variable check but it makes binary portable (clock_gettime() will not be used on unsupported OS version) and ready for usage of high-resolution monotonic clock on Apple OS (clock_gettime() will be used on supported OS version).

Other platforms are unaffected by this implementation due to HAVE_CLOCK_GETTIME_CHECK define used in place.
