### PR TITLE
Fix include paths of tidy libraries

### DIFF
--- a/docs/examples/htmltidy.c
+++ b/docs/examples/htmltidy.c
@@ -28,8 +28,8 @@
  */
 
 #include <stdio.h>
-#include <tidy/tidy.h>
-#include <tidy/buffio.h>
+#include <tidy.h>
+#include <tidybuffio.h>
 #include <curl/curl.h>
 
 /* curl write callback, to fill tidy's input buffer...  */


### PR DESCRIPTION
I've noticed the paths of my tidy installation are as follows. This corresponds to the paths used in examples upstream, for example: http://api.html-tidy.org/tidy/tidylib_api_5.6.0/libtidy_04.html .