### PR TITLE
curl_threads: fix classic MinGW compile break

### DIFF
--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -104,13 +104,21 @@ int Curl_thread_join(curl_thread_t *hnd)
 curl_thread_t Curl_thread_create(unsigned int (CURL_STDCALL *func) (void *),
                                  void *arg)
 {
-  curl_thread_t t;
 #ifdef _WIN32_WCE
-  t = CreateThread(NULL, 0, func, arg, 0, NULL);
+  typedef HANDLE curl_win_thread_handle_t;
+#elif defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
+  typedef unsigned long curl_win_thread_handle_t;
 #else
-  uintptr_t thread_handle = _beginthreadex(NULL, 0, func, arg, 0, NULL);
-  t = (curl_thread_t)thread_handle;
+  typedef uintptr_t curl_win_thread_handle_t;
 #endif
+  curl_thread_t t;
+  curl_win_thread_handle_t thread_handle;
+#ifdef _WIN32_WCE
+  thread_handle = CreateThread(NULL, 0, func, arg, 0, NULL);
+#else
+  thread_handle = _beginthreadex(NULL, 0, func, arg, 0, NULL);
+#endif
+  t = (curl_thread_t)thread_handle;
   if((t == 0) || (t == LongToHandle(-1L))) {
 #ifdef _WIN32_WCE
     DWORD gle = GetLastError();


### PR DESCRIPTION
Classic MinGW still has `_beginthreadex`'s return type as `unsigned long`
instead of `uintptr_t` [0]. `uintptr_t` is not even defined because of [1].

[0] https://sourceforge.net/p/mingw/mingw-org-wsl/ci/wsl-5.1-release/tree/mingwrt/include/process.h#l167
[1] https://sourceforge.net/p/mingw/mingw-org-wsl/ci/wsl-5.1-release/tree/mingwrt/include/process.h#l90

Bug: https://github.com/curl/curl/issues/2924#issuecomment-424334807
Closes