### PR TITLE
cmake: fixed path used for docs/tests generation

### DIFF
--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MANPAGE "${CMAKE_BINARY_DIR}/docs/curl.1")
+set(MANPAGE "${CURL_BINARY_DIR}/docs/curl.1")
 
 # Load DPAGES and OTHERPAGES from shared file
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -105,7 +105,8 @@ if(WIN32)
 endif()
 
 target_include_directories(${LIB_NAME} INTERFACE
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CURL_SOURCE_DIR}/include>)
 
 install(TARGETS ${LIB_NAME}
   EXPORT libcurl-target

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -50,10 +50,10 @@ endif()
 
 add_custom_command(
   OUTPUT lib1521.c
-  COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl < ${CMAKE_SOURCE_DIR}/include/curl/curl.h > lib1521.c
+  COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl < ${CURL_SOURCE_DIR}/include/curl/curl.h > lib1521.c
   DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl"
-    "${CMAKE_SOURCE_DIR}/include/curl/curl.h"
+    "${CURL_SOURCE_DIR}/include/curl/curl.h"
   VERBATIM)
 
 set_property(TARGET chkdecimalpoint


### PR DESCRIPTION
**How to reproduce:**
Add curl as subproject using `add_subdirectory(curl)` (I've used [cpr](https://github.com/whoshuu/cpr) for test)

**Error:**
Scanning dependencies of target generate-curl.1
[ 16%] Generating ../../../../docs/curl.1
/bin/sh: .../cpr/build/docs/curl.1: No such file or directory
make[2]: *** [opt/curl/docs/cmdline-opts/CMakeFiles/generate-curl.1.dir/build.make:281: docs/curl.1] Error 1
make[1]: *** [CMakeFiles/Makefile2:1282: opt/curl/docs/cmdline-opts/CMakeFiles/generate-curl.1.dir/all] Error 2
make: *** [Makefile:141: all] Error 2

Thanks to @chenchuanyin for bringing this out and providing the fix.

Closes: #2906

