### PR TITLE
docs/BUG-BOUNTY: proposed additional docs [ci skip]

### DIFF
--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -22,10 +22,10 @@
  solely and exclusively determine the exact amount for each reported flaw on a
  case by case basis and keep the rights to adjust the amount as it sees fit.
 
- - Low         $500
- - Medium    $1,000
- - High      $5,000
- - Critical $10,000
+ - Low      USD 500
+ - Medium   USD 1,000
+ - High     USD 5,000
+ - Critical USD 10,000
 
 ## Who's eligible for a reward
 

--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -1,0 +1,78 @@
+# The curl bug bounty
+
+ The curl project runs a bug bounty program in association with
+ bountygraph.com.
+
+ After you have reported a security issue to the curl project, it has been
+ deemed credible and a patch and advisory has been made public you can be
+ eligible for a bounty from this program.
+
+ See all details at https://bountygraph.com/programs/curl
+
+ This bounty is relying on funds from sponsors. If you use curl professionally,
+ consider help funding this!
+
+## How much money is the bounty at
+
+ The curl projects offer monetary compensation for reported and published
+ security vulnerabilities. The amount of money rewarded depends on how serious
+ the flaw is determined to be.
+
+ We offer reward money *up to* these amounts. The curl security team will
+ solely and exclusively determine the exact amount for each reported flaw on a
+ case by case basis and keep the rights to adjust the amount as it sees fit.
+
+ - Low         $500
+ - Medium    $1,000
+ - High      $5,000
+ - Critical $10,000
+
+## Who's eligable for a reward
+
+ Everyone and anyone who reports a security problem in a released curl version
+ - that hasn't already been reported - can ask for a bounty.
+
+ The vulnerability has to be fixed and publicly announced (by the curl
+ project) before a bug bounty will be considered.
+
+ Bounties need to be requested within twelve months from the publication of
+ the vulnerability.
+
+## Product vulnerabilities only
+
+ The bug bounty only concerns the curl and libcurl products and thus their
+ respective source codes - when running on existing hardware. It does not
+ include documentation, web sites or other infrastructure.
+
+ The curl security team will be the sole arbiter if a reported flaw can be
+ subject to a bounty or not.
+
+## How are vulnerabilities graded
+
+ The grading of each reported vulernability that makes a reward claim will be
+ performed by the curl security team. The grading should be based on the CVSS
+ (Common Vulnerability Scoring System) 3.0.
+
+## How are reward amounts determined
+
+ The curl security team first gives the vulnerability a score, as mentioned
+ above, and based on that level the team may increase or decrease the bounty
+ amount from the general template depending on the specifics of the individual
+ case.
+
+ The curl security team will be the sole arbiter of the bounty amount.
+
+## What happens if the bounty fund is drained
+
+ The boundy fund depends on sponsors. If we pay out more bounties than we add,
+ the fund will eventually drain. If that end up happening, we will simply not
+ be able to pay out as high bounties as we would like and hope that we can
+ convince new sponsors to help us top up the fund again.
+
+## Regarding taxes etc on the bounties
+
+ In the event that the individual receiving a curl bug bounty needs to pay
+ taxes on the reward money, that's something for the receiver (and
+ bountygraph.com?) to work out and handle. The curl project or its security
+ team never actually receive any of this money, hold the money or pay out the
+ money.

--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -27,7 +27,7 @@
  - High      $5,000
  - Critical $10,000
 
-## Who's eligable for a reward
+## Who's eligible for a reward
 
  Everyone and anyone who reports a security problem in a released curl version
  that hasn't already been reported can ask for a bounty.
@@ -49,8 +49,8 @@
 
 ## How are vulnerabilities graded
 
- The grading of each reported vulernability that makes a reward claim will be
- performed by the curl security team. The grading should be based on the CVSS
+ The grading of each reported vulnerability that makes a reward claim will be
+ performed by the curl security team. The grading will be based on the CVSS
  (Common Vulnerability Scoring System) 3.0.
 
 ## How are reward amounts determined
@@ -64,7 +64,7 @@
 
 ## What happens if the bounty fund is drained
 
- The boundy fund depends on sponsors. If we pay out more bounties than we add,
+ The bounty fund depends on sponsors. If we pay out more bounties than we add,
  the fund will eventually drain. If that end up happening, we will simply not
  be able to pay out as high bounties as we would like and hope that we can
  convince new sponsors to help us top up the fund again.

--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -30,7 +30,7 @@
 ## Who's eligable for a reward
 
  Everyone and anyone who reports a security problem in a released curl version
- - that hasn't already been reported - can ask for a bounty.
+ that hasn't already been reported can ask for a bounty.
 
  The vulnerability has to be fixed and publicly announced (by the curl
  project) before a bug bounty will be considered.


### PR DESCRIPTION
Bug bounty explainer. See https://bountygraph.com/programs/curl

This is documentation and an explainer with additional details from my bounty [proposal on the mailing list](https://curl.haxx.se/mail/lib-2018-09/0120.html) yesterday.