### PR TITLE
test1650: make it depend on http/2

### DIFF
--- a/tests/data/test1650
+++ b/tests/data/test1650
@@ -14,6 +14,7 @@ none
 </server>
 <features>
 unittest
+http/2
 </features>
  <name>
 DOH

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -33,6 +33,7 @@ static void unit_stop(void)
 
 }
 
+#ifdef USE_NGHTTP2
 #define DNS_PREAMBLE "\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00"
 #define LABEL_TEST "\x04\x74\x65\x73\x74"
 #define LABEL_HOST "\x04\x68\x6f\x73\x74"
@@ -281,3 +282,13 @@ UNITTEST_START
   }
 }
 UNITTEST_STOP
+
+#else /* USE_NGHTTP2 */
+UNITTEST_START
+{
+  return 1; /* nothing to do, just fail */
+}
+UNITTEST_STOP
+
+
+#endif


### PR DESCRIPTION
Follow-up to 570008c99da0ccbb as it gets link errors.

Reported-by: Michael Kaufmann