### PR TITLE
ftp: error out on memory pressure

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3213,9 +3213,11 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
           ftpc->prevpath[dlen] = 0; /* terminate */
       }
       else {
+        free(path);
         /* we never changed dir */
         ftpc->prevpath = strdup("");
-        free(path);
+        if(!ftpc->prevpath)
+          return CURLE_OUT_OF_MEMORY;
       }
       if(ftpc->prevpath)
         infof(data, "Remembering we are in dir \"%s\"\n", ftpc->prevpath);


### PR DESCRIPTION
In the unlikely event that strdup() fails for (""), ensure to error out with the appropriate errorcode. Also move freeing path up to above the strdup() call since there is little point in keeping it around across the strdup, and the separation makes for more readable code.