### PR TITLE
SECURITY-PROCESS: make links into hyperlinks

### DIFF
--- a/docs/SECURITY-PROCESS.md
+++ b/docs/SECURITY-PROCESS.md
@@ -131,10 +131,11 @@ After you have reported a security issue to the curl project, it has been
 deemed credible and a patch and advisory has been made public you can be
 eligible for a bounty from this program.
 
-See all details at https://bountygraph.com/programs/curl
+See all details at [BountyGraph](https://bountygraph.com/programs/curl).
 
-This bounty is relying on funds from sponsors. If you use curl professionally,
-consider help funding this!
+This bounty is relying on funds from
+[sponsors](https://bountygraph.com/programs/curl#publicpledges). If you use
+curl professionally, consider help funding this!
 
 Hackerone Internet Bug Bounty
 -----------------------------


### PR DESCRIPTION
Use proper Markdown hyperlink format for the Bountygraph links in order for the generated website page to be more user friendly. While it makes the document consistent in terms of linking (all other links are md links), the main benefit is making https://curl.haxx.se/dev/secprocess.html look better. Also link to the sponsors to give them a little extra credit.