### PR TITLE
memory: ensure to check allocation results

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3213,9 +3213,11 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
           ftpc->prevpath[dlen] = 0; /* terminate */
       }
       else {
+        free(path);
         /* we never changed dir */
         ftpc->prevpath = strdup("");
-        free(path);
+        if(!ftpc->prevpath)
+          return CURLE_OUT_OF_MEMORY;
       }
       if(ftpc->prevpath)
         infof(data, "Remembering we are in dir \"%s\"\n", ftpc->prevpath);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -957,6 +957,8 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
       stream->push_headers_alloc = 10;
       stream->push_headers = malloc(stream->push_headers_alloc *
                                     sizeof(char *));
+      if(!stream->push_headers)
+        return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
       stream->push_headers_used = 0;
     }
     else if(stream->push_headers_used ==

--- a/lib/nwlib.c
+++ b/lib/nwlib.c
@@ -214,6 +214,8 @@ int GetOrSetUpData(int id, libdata_t **appData,
           err = set_app_data(gLibId, app_data);
 
           if(err) {
+            if(app_data->lock)
+              NXMutexFree(app_data->lock);
             free(app_data->tenbytes);
             free(app_data);
             app_data = (libdata_t *) NULL;

--- a/lib/nwlib.c
+++ b/lib/nwlib.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -195,7 +195,8 @@ int GetOrSetUpData(int id, libdata_t **appData,
         if(!app_data->tenbytes || !app_data->lock) {
           if(app_data->lock)
             NXMutexFree(app_data->lock);
-
+          if(app_data->tenbytes)
+            free(app_data->tenbytes);
           free(app_data);
           app_data = (libdata_t *) NULL;
           err      = ENOMEM;
@@ -213,6 +214,7 @@ int GetOrSetUpData(int id, libdata_t **appData,
           err = set_app_data(gLibId, app_data);
 
           if(err) {
+            free(app_data->tenbytes);
             free(app_data);
             app_data = (libdata_t *) NULL;
             err      = ENOMEM;

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -781,6 +781,8 @@ static CURLcode _Curl_auth_create_digest_http_message(
   */
 
   hashthis = (unsigned char *) aprintf("%s:%s", request, uripath);
+  if(!hashthis)
+    return CURLE_OUT_OF_MEMORY;
 
   if(digest->qop && strcasecompare(digest->qop, "auth-int")) {
     /* We don't support auth-int for PUT or POST at the moment.

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -319,6 +319,10 @@ static CURLcode verify_host(struct Curl_easy *data,
    * embedded null bytes. This appears to be undocumented behavior.
    */
   cert_hostname_buff = (LPTSTR)malloc(len * sizeof(TCHAR));
+  if(!cert_hostname_buff) {
+    result = CURLE_OUT_OF_MEMORY;
+    goto cleanup;
+  }
   actual_len = CertGetNameString(pCertContextServer,
                                  CERT_NAME_DNS_TYPE,
                                  name_flags,


### PR DESCRIPTION
The result of a memory allocation should always be checked, as we may run under memory pressure where even a small allocation can fail. This adds checking and error handling to a few cases where the allocation wasn't checked for success. Also bumps the copyright years on affected files.

This is based on manual static analysis/code reading, no live bugs have been observed.