### PR TITLE
data-binary.d: clarify default content-type is x-www-form-urlencoded

### DIFF
--- a/docs/cmdline-opts/data-binary.d
+++ b/docs/cmdline-opts/data-binary.d
@@ -9,5 +9,10 @@ If you start the data with the letter @, the rest should be a filename.  Data
 is posted in a similar manner as --data does, except that newlines and
 carriage returns are preserved and conversions are never done.
 
+Like --data the default content-type sent to the server is
+application/x-www-form-urlencoded. If you want the data to be treated as
+arbitrary binary data by the server then set the content-type to octet-stream:
+-H "Content-Type: application/octet-stream".
+
 If this option is used several times, the ones following the first will append
 data as described in --data.


### PR DESCRIPTION
- Advise user that --data-binary sends a default content type of
  x-www-form-urlencoded, and to have the data treated as arbitrary
  binary data by the server set the content-type header to octet-stream.

Ref: https://github.com/curl/curl/pull/2852#issuecomment-426465094

Closes #xxxx

---

/cc @pps83