### PR TITLE
nss: fix nssckbi module loading on Windows

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -217,10 +217,15 @@ static const cipher_s cipherlist[] = {
 #endif
 };
 
+#ifdef WIN32
+static const char *pem_library = "nsspem.dll";
+static const char *trust_library = "nssckbi.dll";
+#else
 static const char *pem_library = "libnsspem.so";
-static SECMODModule *pem_module = NULL;
-
 static const char *trust_library = "libnssckbi.so";
+#endif
+
+static SECMODModule *pem_module = NULL;
 static SECMODModule *trust_module = NULL;
 
 /* NSPR I/O layer we use to detect blocking direction during SSL handshake */


### PR DESCRIPTION
- Use .DLL extension instead of .so to load modules on Windows.

Bug: https://curl.haxx.se/mail/lib-2018-09/0077.html
Reported-by: Maxime Legros

Ref: https://github.com/curl/curl/pull/3016/#issuecomment-423069442

Closes #xxxx

---

/cc @kdudka