### PR TITLE
checksrc: handle zero scoped ignore commands

### DIFF
--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -239,7 +239,16 @@ sub checksrc {
                 $scope=999999;
             }
 
-            if($ignore_set{$warn}) {
+            # Comparing for a literal zero rather than the scalar value zero
+            # covers the case where $scope contains the ending '*' from the
+            # comment. If we use a scalar comparison (==) we induce warnings
+            # on non-scalar contents.
+            if($scope eq "0") {
+                checkwarn("BADCOMMAND",
+                          $line, 0, $file, $l,
+                          "Disable zero not supported, did you mean to enable?");
+            }
+            elsif($ignore_set{$warn}) {
                 checkwarn("BADCOMMAND",
                           $line, 0, $file, $l,
                           "$warn already disabled from line $ignore_set{$warn}");


### PR DESCRIPTION
If a `!checksrc!` disable command specified to ignore zero errors, it was still added to the ignore block even though nothing was ignored. While there were no blocks ignored that shouldn't be ignored, the processing ended with with a warning.
```
<filename>:<line>:<col>: warning: Unused ignore: LONGLINE (UNUSEDIGNORE)
 /* !checksrc! disable LONGLINE 0 */
                    ^
```
 Fix by instead treating a zero ignore as a a bad command and throw a warning for that one.