### PR TITLE
CMake: added missing HAVE_BUILTIN_AVAILABLE, HAVE_CLOCK_GETTIME_MONOTONIC

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -549,3 +549,19 @@ main() {
   return 0;
 }
 #endif
+#ifdef HAVE_CLOCK_GETTIME_MONOTONIC
+#include <time.h>
+int
+main() {
+  struct timespec ts = {0, 0}; 
+  clock_gettime(CLOCK_MONOTONIC, &ts); 
+  return 0;
+}
+#endif
+#ifdef HAVE_BUILTIN_AVAILABLE
+int
+main() {
+  if(__builtin_available(macOS 10.12, *)) {}
+  return 0;
+}
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1017,6 +1017,12 @@ if(HAVE_INET_NTOA_R_DECL_REENTRANT)
   set(NEED_REENTRANT 1)
 endif()
 
+# Check clock_gettime(CLOCK_MONOTONIC, x) support
+curl_internal_test(HAVE_CLOCK_GETTIME_MONOTONIC)
+
+# Check compiler support of __builtin_available()
+curl_internal_test(HAVE_BUILTIN_AVAILABLE)
+
 # Some other minor tests
 
 if(NOT HAVE_IN_ADDR_T)

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -127,6 +127,9 @@
 /* Define to 1 if bool is an available type. */
 #cmakedefine HAVE_BOOL_T 1
 
+/* Define to 1 if you have the __builtin_available function. */
+#cmakedefine HAVE_BUILTIN_AVAILABLE 1
+
 /* Define to 1 if you have the clock_gettime function and monotonic timer. */
 #cmakedefine HAVE_CLOCK_GETTIME_MONOTONIC 1
 


### PR DESCRIPTION
Added missing HAVE_BUILTIN_AVAILABLE (define and test), HAVE_CLOCK_GETTIME_MONOTONIC (test). Tested with CMake on Apple OSX and Android NDK (r17b, Windows).