### PR TITLE
INTERNALS: escape reference to parameter

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -680,8 +680,8 @@ Content Encoding
  that will work (besides "identity," which does nothing) are "deflate",
  "gzip" and "br". If a response is encoded using the "compress" or methods,
  libcurl will return an error indicating that the response could
- not be decoded.  If <string> is NULL no Accept-Encoding header is generated.
- If <string> is a zero-length string, then an Accept-Encoding header
+ not be decoded.  If `<string>` is NULL no Accept-Encoding header is generated.
+ If `<string>` is a zero-length string, then an Accept-Encoding header
  containing all supported encodings will be generated.
 
  The [`CURLOPT_ACCEPT_ENCODING`][5] must be set to any non-NULL value for


### PR DESCRIPTION
The parameter reference `<string>` was causing rendering issues in the generated HTML page, as 
`<string>` isn't a valid HTML tag. Fix by backtick escaping it.