### PR TITLE
FILE: fix CURLOPT_NOBODY and CURLOPT_HEADER output

### DIFF
--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -85,7 +85,6 @@ CURLcode Curl_initinfo(struct Curl_easy *data)
 #ifdef USE_SSL
   Curl_ssl_free_certinfo(data);
 #endif
-
   return CURLE_OK;
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3745,6 +3745,7 @@ static CURLcode create_conn(struct Curl_easy *data,
     /* this is supposed to be the connect function so we better at least check
        that the file is present here! */
     DEBUGASSERT(conn->handler->connect_it);
+    Curl_persistconninfo(conn);
     result = conn->handler->connect_it(conn, &done);
 
     /* Setup a "faked" transfer that'll do nothing */

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -157,24 +157,24 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       return failure;
   }
 
-  if(hdrcbdata->config->show_headers &&
-     (protocol & (CURLPROTO_HTTP|CURLPROTO_HTTPS|CURLPROTO_RTSP))) {
-    /* bold headers only happen for HTTP(S) and RTSP */
-    char *value = NULL;
-
-    if(!outs->stream && !tool_create_output_file(outs, FALSE))
-      return failure;
-
-    if(hdrcbdata->global->isatty && hdrcbdata->global->styled_output)
-      value = memchr(ptr, ':', cb);
-    if(value) {
-      size_t namelen = value - ptr;
-      fprintf(outs->stream, BOLD "%.*s" BOLDOFF ":", namelen, ptr);
-      fwrite(&value[1], cb - namelen - 1, 1, outs->stream);
+  if(hdrcbdata->config->show_headers) {
+    if(protocol &
+       (CURLPROTO_HTTP|CURLPROTO_HTTPS|CURLPROTO_RTSP|CURLPROTO_FILE)) {
+      /* bold headers only for selected protocols */
+      char *value = NULL;
+      if(!outs->stream && !tool_create_output_file(outs, FALSE))
+        return failure;
+      if(hdrcbdata->global->isatty && hdrcbdata->global->styled_output)
+        value = memchr(ptr, ':', cb);
+      if(value) {
+        size_t namelen = value - ptr;
+        fprintf(outs->stream, BOLD "%.*s" BOLDOFF ":", namelen, ptr);
+        fwrite(&value[1], cb - namelen - 1, 1, outs->stream);
+      }
+      else
+        /* not "handled", just show it */
+        fwrite(ptr, cb, 1, outs->stream);
     }
-    else
-      /* not "handled", just show it */
-      fwrite(ptr, cb, 1, outs->stream);
   }
   return cb;
 }

--- a/tests/data/test1016
+++ b/tests/data/test1016
@@ -22,7 +22,7 @@ file
  <name>
 X-Y range on a file:// URL to stdout
  </name>
- <command>
+<command option="no-include">
 -r 1-4 file://localhost/%PWD/log/test1016.txt 
 </command>
 <file name="log/test1016.txt">

--- a/tests/data/test1017
+++ b/tests/data/test1017
@@ -23,7 +23,7 @@ file
  <name>
 0-Y range on a file:// URL to stdout
  </name>
- <command>
+<command option="no-include">
 -r 0-3 file://localhost/%PWD/log/test1017.txt 
 </command>
 <file name="log/test1017.txt">

--- a/tests/data/test1018
+++ b/tests/data/test1018
@@ -22,7 +22,7 @@ file
  <name>
 X-X range on a file:// URL to stdout
  </name>
- <command>
+<command option="no-include">
 -r 4-4 file://localhost/%PWD/log/test1018.txt 
 </command>
 <file name="log/test1018.txt">

--- a/tests/data/test1019
+++ b/tests/data/test1019
@@ -23,7 +23,7 @@ file
  <name>
 X- range on a file:// URL to stdout
  </name>
- <command>
+<command option="no-include">
 -r 7- file://localhost/%PWD/log/test1019.txt 
 </command>
 <file name="log/test1019.txt">

--- a/tests/data/test1020
+++ b/tests/data/test1020
@@ -23,7 +23,7 @@ file
  <name>
 -Y range on a file:// URL to stdout
  </name>
- <command>
+<command option="no-include">
 -r -9 file://localhost/%PWD/log/test1020.txt 
 </command>
 <file name="log/test1020.txt">

--- a/tests/data/test1029
+++ b/tests/data/test1029
@@ -29,7 +29,7 @@ http
  <name>
 HTTP Location: and 'redirect_url' check
  </name>
- <command>
+<command>
 http://%HOSTIP:%HTTPPORT/we/want/our/1029 -w '%{redirect_url}\n'
 </command>
 </client>

--- a/tests/data/test1146
+++ b/tests/data/test1146
@@ -24,7 +24,7 @@ file
 <name>
 --proto-default file
 </name>
-<command>
+<command option="no-include">
 --proto-default file %PWD/log/test1146.txt
 </command>
 <file name="log/test1146.txt">

--- a/tests/data/test1220
+++ b/tests/data/test1220
@@ -20,7 +20,7 @@ file
  <name>
 file:// URLs with query string
  </name>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/test1220.txt?a_query=foobar#afragment
 </command>
 <file name="log/test1220.txt">

--- a/tests/data/test200
+++ b/tests/data/test200
@@ -23,7 +23,7 @@ file
  <name>
 basic file:// file
  </name>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/test200.txt
 </command>
 <file name="log/test200.txt">

--- a/tests/data/test2000
+++ b/tests/data/test2000
@@ -31,7 +31,7 @@ file
  <name>
 FTP RETR followed by FILE
  </name>
- <command>
+<command option="no-include">
 ftp://%HOSTIP:%FTPPORT/2000 file://localhost/%PWD/log/test2000.txt
 </command>
 <file name="log/test2000.txt">

--- a/tests/data/test2001
+++ b/tests/data/test2001
@@ -48,7 +48,7 @@ file
  <name>
 HTTP GET followed by FTP RETR followed by FILE
  </name>
- <command>
+<command option="no-include">
 http://%HOSTIP:%HTTPPORT/20010001 ftp://%HOSTIP:%FTPPORT/20010002 file://localhost/%PWD/log/test2001.txt
 </command>
 <file name="log/test2001.txt">
@@ -81,17 +81,6 @@ RETR 20010002
 QUIT
 </protocol>
 <stdout>
-HTTP/1.1 200 OK
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake
-Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
-ETag: "21025-dc7-39462498"
-Accept-Ranges: bytes
-Content-Length: 6
-Connection: close
-Content-Type: text/html
-Funny-head: yesyes
-
 -foo-
 data
     to

--- a/tests/data/test2002
+++ b/tests/data/test2002
@@ -57,7 +57,7 @@ tftp
  <name>
 HTTP GET followed by FTP RETR followed by FILE followed by TFTP RRQ
  </name>
- <command>
+<command option="no-include">
 http://%HOSTIP:%HTTPPORT/20020001 ftp://%HOSTIP:%FTPPORT/20020002 file://localhost/%PWD/log/test2002.txt tftp://%HOSTIP:%TFTPPORT//20020003
 </command>
 <file name="log/test2002.txt">
@@ -96,17 +96,6 @@ filename: /20020003
 QUIT
 </protocol>
 <stdout>
-HTTP/1.1 200 OK
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake
-Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
-ETag: "21025-dc7-39462498"
-Accept-Ranges: bytes
-Content-Length: 6
-Connection: close
-Content-Type: text/html
-Funny-head: yesyes
-
 -foo-
 data
     to

--- a/tests/data/test2003
+++ b/tests/data/test2003
@@ -57,8 +57,8 @@ tftp
  <name>
 HTTP GET followed by FTP RETR followed by FILE followed by TFTP RRQ then again in reverse order
  </name>
- <command>
-http://%HOSTIP:%HTTPPORT/20030001 ftp://%HOSTIP:%FTPPORT/20030002 file://localhost/%PWD/log/test2003.txt tftp://%HOSTIP:%TFTPPORT//20030003 tftp://%HOSTIP:%TFTPPORT//20030003 file://localhost/%PWD/log/test2003.txt ftp://%HOSTIP:%FTPPORT/20030002 http://%HOSTIP:%HTTPPORT/20030001 
+<command option="no-include">
+http://%HOSTIP:%HTTPPORT/20030001 ftp://%HOSTIP:%FTPPORT/20030002 file://localhost/%PWD/log/test2003.txt tftp://%HOSTIP:%TFTPPORT//20030003 tftp://%HOSTIP:%TFTPPORT//20030003 file://localhost/%PWD/log/test2003.txt ftp://%HOSTIP:%FTPPORT/20030002 http://%HOSTIP:%HTTPPORT/20030001
 </command>
 <file name="log/test2003.txt">
 foo
@@ -109,17 +109,6 @@ Accept: */*
 QUIT
 </protocol>
 <stdout>
-HTTP/1.1 200 OK
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake
-Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
-ETag: "21025-dc7-39462498"
-Accept-Ranges: bytes
-Content-Length: 6
-Connection: close
-Content-Type: text/html
-Funny-head: yesyes
-
 -foo-
 data
     to
@@ -151,17 +140,6 @@ data
 that FTP
 works
   so does it?
-HTTP/1.1 200 OK
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake
-Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
-ETag: "21025-dc7-39462498"
-Accept-Ranges: bytes
-Content-Length: 6
-Connection: close
-Content-Type: text/html
-Funny-head: yesyes
-
 -foo-
 </stdout>
 </verify>

--- a/tests/data/test2004
+++ b/tests/data/test2004
@@ -29,7 +29,7 @@ sftp
  <name>
 TFTP RRQ followed by SFTP retrieval followed by FILE followed by SCP retrieval then again in reverse order
  </name>
- <command>
+<command option="no-include">
 --key curl_client_key --pubkey curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//2004 sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt tftp://%HOSTIP:%TFTPPORT//2004 --insecure
 </command>
 <file name="log/test2004.txt">

--- a/tests/data/test2006
+++ b/tests/data/test2006
@@ -4,6 +4,7 @@
 Metalink
 HTTP
 HTTP GET
+FILE
 </keywords>
 </info>
 
@@ -85,6 +86,10 @@ Accept: */*
 Some data delivered from an HTTP resource
 </file1>
 <file2 name="log/heads2006">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 14:49:01 GMT
 Server: test-server/fake
@@ -105,6 +110,9 @@ Metalink: fetching (log/download2006) from (http://%HOSTIP:%HTTPPORT/2006) OK
 Metalink: validating (log/download2006)...
 Metalink: validating (log/download2006) [sha-256] OK
 </file4>
+<stripfile2>
+s/Last-Modified:.*//
+</stripfile2>
 <stripfile4>
 $_ = '' if (($_ !~ /^Metalink: /) && ($_ !~ /error/i) && ($_ !~ /warn/i))
 </stripfile4>

--- a/tests/data/test2007
+++ b/tests/data/test2007
@@ -5,6 +5,7 @@ Metalink
 HTTP
 HTTP GET
 -J
+FILE
 </keywords>
 </info>
 
@@ -85,7 +86,14 @@ Accept: */*
 <file1 name="log/download2007">
 Something delivered from an HTTP resource
 </file1>
+<stripfile2>
+s/Last-Modified:.*//
+</stripfile2>
 <file2 name="log/heads2007">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 14:50:02 GMT
 Server: test-server/fake

--- a/tests/data/test2008
+++ b/tests/data/test2008
@@ -4,6 +4,7 @@
 Metalink
 HTTP
 HTTP GET
+FILE
 </keywords>
 </info>
 
@@ -77,7 +78,14 @@ Accept: */*
 <file1 name="log/download2008">
 Some stuff delivered from an HTTP resource
 </file1>
+<stripfile2>
+s/Last-Modified:.*//
+</stripfile2>
 <file2 name="log/heads2008">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 15:23:48 GMT
 Server: test-server/fake

--- a/tests/data/test2009
+++ b/tests/data/test2009
@@ -5,6 +5,7 @@ Metalink
 HTTP
 HTTP GET
 -J
+FILE
 </keywords>
 </info>
 
@@ -78,7 +79,14 @@ Accept: */*
 <file1 name="log/download2009">
 Some contents delivered from an HTTP resource
 </file1>
+<stripfile2>
+s/Last-Modified:.*//
+</stripfile2>
 <file2 name="log/heads2009">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 16:27:17 GMT
 Server: test-server/fake

--- a/tests/data/test2010
+++ b/tests/data/test2010
@@ -4,6 +4,7 @@
 Metalink
 HTTP
 HTTP GET
+FILE
 </keywords>
 </info>
 
@@ -77,7 +78,14 @@ Accept: */*
 <file1 name="log/download2010">
 Contents delivered from an HTTP resource
 </file1>
+<stripfile2>
+s/Last-Modified:.*//
+</stripfile2>
 <file2 name="log/heads2010">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 17:37:27 GMT
 Server: test-server/fake

--- a/tests/data/test202
+++ b/tests/data/test202
@@ -19,7 +19,7 @@ file
  <name>
 two file:// URLs to stdout
  </name>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/test202.txt FILE://localhost/%PWD/log/test202.txt
 </command>
 <file name="log/test202.txt">

--- a/tests/data/test203
+++ b/tests/data/test203
@@ -24,7 +24,7 @@ file
  <name>
 file:/path URL with a single slash
  </name>
- <command>
+<command option="no-include">
 file:%PWD/log/test203.txt
 </command>
 <file name="log/test203.txt">

--- a/tests/data/test204
+++ b/tests/data/test204
@@ -15,7 +15,7 @@ file
  <name>
 "upload" with file://
  </name>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/result204.txt -T log/upload204.txt
 </command>
 <file name="log/upload204.txt">

--- a/tests/data/test205
+++ b/tests/data/test205
@@ -16,7 +16,7 @@ file
  <name>
 "upload" with file://
  </name>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/nonexisting/result205.txt -T log/upload205.txt
 </command>
 <file name="log/upload205.txt">

--- a/tests/data/test2070
+++ b/tests/data/test2070
@@ -23,7 +23,7 @@ file
  <name>
 basic file:// file with no authority
  </name>
- <command>
+<command option="no-include">
 file:%PWD/log/test2070.txt
 </command>
 <file name="log/test2070.txt">

--- a/tests/data/test2071
+++ b/tests/data/test2071
@@ -23,7 +23,7 @@ file
  <name>
 basic file:// file with "127.0.0.1" hostname
  </name>
- <command>
+<command option="no-include">
 file://127.0.0.1/%PWD/log/test2070.txt
 </command>
 <file name="log/test2070.txt">

--- a/tests/data/test2072
+++ b/tests/data/test2072
@@ -23,7 +23,7 @@ file
 <name>
 file:// with unix path resolution behavior for the case of extra slashes
 </name>
-<command>
+<command option="no-include">
 file:////%PWD/log/test2072.txt
 </command>
 <precheck>

--- a/tests/data/test210
+++ b/tests/data/test210
@@ -22,7 +22,7 @@ ftp
  <name>
 Get two FTP files from the same remote dir: no second CWD
  </name>
- <command>
+<command option="no-include">
 ftp://%HOSTIP:%FTPPORT/a/path/210 ftp://%HOSTIP:%FTPPORT/a/path/210
 </command>
 <stdout>

--- a/tests/data/test231
+++ b/tests/data/test231
@@ -22,7 +22,7 @@ file
  <name>
 file:// with resume
  </name>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/test231.txt -C 10
 </command>
 <file name="log/test231.txt">

--- a/tests/data/test288
+++ b/tests/data/test288
@@ -30,7 +30,7 @@ file:// with (unsupported) proxy, authentication and range
 <setenv>
 all_proxy=http://fake:user@%HOSTIP:%HTTPPORT/
 </setenv>
- <command>
+<command option="no-include">
 file://localhost/%PWD/log/test288.txt
 </command>
 <file name="log/test288.txt">


### PR DESCRIPTION
Now FILE transfers send headers to the header callback like HTTP and
other protocols. Also made curl_easy_getinfo(...CURLINFO_PROTOCOL...)
work for FILE in the callbacks.

Makes "curl -i file://.." and "curl -I file://.." work like before
again. Applied the bold header logic to them too.

Regression from c1c2762 (7.61.0)

Reported-by: Shaun Jackman
Fixes #3083