### PR TITLE
appveyor: save build artifacts (WIP)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,10 @@ test_script:
     - if %TESTING%==ON (
         C:\msys64\usr\bin\bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky !500 !1139" )
 
+artifacts:
+    - path: 'src\curl.exe'
+    - path: 'lib\libcurl.dll'
+
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)
 branches:
     only:


### PR DESCRIPTION
- Save what is built by appveyor so it can be downloaded.

Being able to download what is built may help reproduce issues only
seen in appveyor that can't be reproduced locally. This way maybe we'll
be able to determine if it has something to do with the way it's being
built or the way it's being run.

Ref: https://github.com/curl/curl/pull/3100#issuecomment-427274368

Closes #xxxx

---

WIP: trying this out to see if it works...

/cc @MarcelRaad
