### PR TITLE
gskit: make sure to terminate version string

### DIFF
--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1314,8 +1314,7 @@ static int Curl_gskit_shutdown(struct connectdata *conn, int sockindex)
 
 static size_t Curl_gskit_version(char *buffer, size_t size)
 {
-  strncpy(buffer, "GSKit", size);
-  return strlen(buffer);
+  return snprintf(buffer, size, "GSKit");
 }
 
 


### PR DESCRIPTION
In case a very small buffer was passed to the version function, it could result in the buffer not being NULL-terminated since `strncpy()` doesn't guarantee a terminator on an overflowed buffer. Rather than adding code to terminate (and handle zero-sized buffers), move to using `snprintf()` instead like all the other vtls backends.