### PR TITLE
Fix CURLOPT_DNS_SHUFFLE_ADDRESSES

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -455,7 +455,7 @@ Curl_cache_addr(struct Curl_easy *data,
   /* shuffle addresses if requested */
   if(data->set.dns_shuffle_addresses) {
     CURLcode result = Curl_shuffle_addr(data, &addr);
-    if(!result)
+    if(result != CURLE_OK)
       return NULL;
   }
 


### PR DESCRIPTION
Further error handling was added during merging of #1694, changing the return type of `Curl_shuffle_addr` from void to `CURLcode`. Unfortunately an incorrect check on the return type made its way in, causing `Curl_cache_addr` to always fail if `CURLOPT_DNS_SHUFFLE_ADDRESSES` is enabled.

The unit test for `CURLOPT_DNS_SHUFFLE_ADDRESSES` (1608) did not catch this because it does not call `Curl_cache_addr`, only verifying that:
1. `curl_easy_setopt` succeeds
2. `Curl_shuffle_addr` returns success
3. The ordering of addresses actually changes

This PR just fixes the one return value comparison mentioned and things seem to work as expected after that. Let me know if you think it would be worth any test changes, but this can probably just be considered the one time introductory pain of a rarely used new option :)