### PR TITLE
Fix MinGW build

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -44,6 +44,9 @@
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
 #  endif
+#  ifndef NOGDI
+#    define NOGDI
+#  endif
 #endif
 
 /*

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -38,7 +38,8 @@
 #  define curl_thread_t          HANDLE
 #  define curl_thread_t_null     (HANDLE)0
 #  if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
-      (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+      (_WIN32_WINNT < _WIN32_WINNT_VISTA) || \
+      (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 #    define Curl_mutex_init(m)   InitializeCriticalSection(m)
 #  else
 #    define Curl_mutex_init(m)   InitializeCriticalSectionEx(m, 0, 1)

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -33,7 +33,8 @@ struct curltime Curl_now(void)
   */
   struct curltime now;
 #if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
-    (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+    (_WIN32_WINNT < _WIN32_WINNT_VISTA) || \
+    (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
   DWORD milliseconds = GetTickCount();
   now.tv_sec = milliseconds / 1000;
   now.tv_usec = (milliseconds % 1000) * 1000;

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -40,7 +40,8 @@ struct timeval tvnow(void)
   ** is typically in the range of 10 milliseconds to 16 milliseconds.
   */
   struct timeval now;
-#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600) && \
+    (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
   ULONGLONG milliseconds = GetTickCount64();
 #else
   DWORD milliseconds = GetTickCount();

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -414,7 +414,8 @@ static struct timeval tvnow(void)
   ** is typically in the range of 10 milliseconds to 16 milliseconds.
   */
   struct timeval now;
-#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600) && \
+    (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
   ULONGLONG milliseconds = GetTickCount64();
 #else
   DWORD milliseconds = GetTickCount();


### PR DESCRIPTION
- define `NOGDI` in addition to `WIN32_LEAN_AND_MEAN` on Windows
- don't use `GetTickCount64` and `InitializeCriticalSectionEx` on classic MinGW

This fixes 1) the MinGW CMake build and 2) MinGW targeting Windows Vista or later.