### PR TITLE
Add support for %{stderr} and %{stdout} for --write-out

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -150,7 +150,6 @@
  18.8 offer color-coded HTTP header output
  18.9 Choose the name of file in braces for complex URLs
  18.10 improve how curl works in a windows console window
- 18.11 -w output to stderr
  18.12 keep running, read instructions from pipe/socket
  18.13 support metalink in http headers
  18.14 --fail without --location should treat 3xx as a failure
@@ -1013,14 +1012,6 @@ that doesn't exist on the server, just like --ftp-create-dirs.
  If you pull the scrollbar when transferring with curl in a Windows console
  window, the transfer is interrupted and can get disconnected. This can
  probably be improved. See https://github.com/curl/curl/issues/322
-
-18.11 -w output to stderr
-
- -w is quite useful, but not to those of us who use curl without -o or -O
- (such as for scripting through a higher level language). It would be nice to
- have an option that is exactly like -w but sends it to stderr
- instead. Proposed name: --write-stderr. See
- https://github.com/curl/curl/issues/613
 
 18.12 keep running, read instructions from pipe/socket
 

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -15,6 +15,9 @@ text that curl thinks fit, as described below. All variables are specified as
 output a newline by using \\n, a carriage return with \\r and a tab space with
 \\t.
 
+The output will be written to standard output, but this can be switched to
+standard error by using %{stderr}.
+
 .B NOTE:
 The %-symbol is a special symbol in the win32-environment, where all
 occurrences of % must be doubled when using this option.
@@ -102,6 +105,13 @@ second.
 .B ssl_verify_result
 The result of the SSL peer certificate verification that was requested. 0
 means the verification was successful. (Added in 7.19.0)
+.TP
+.B stderr
+From this point on, the --write-out output will be written to standard error.
+.TP
+.B stdout
+From this point on, the --write-out output will be written to standard output.
+This is the default, but can be used to switch back after switching to stderr.
 .TP
 .B time_appconnect
 The time, in seconds, it took from the start until the SSL/SSH/etc

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -60,6 +60,8 @@ typedef enum {
   VAR_LOCAL_PORT,
   VAR_HTTP_VERSION,
   VAR_SCHEME,
+  VAR_STDOUT,
+  VAR_STDERR,
   VAR_NUM_OF_VARS /* must be the last */
 } replaceid;
 
@@ -101,6 +103,8 @@ static const struct variable replacements[]={
   {"local_port", VAR_LOCAL_PORT},
   {"http_version", VAR_HTTP_VERSION},
   {"scheme", VAR_SCHEME},
+  {"stdout", VAR_STDOUT},
+  {"stderr", VAR_STDERR},
   {NULL, VAR_NONE}
 };
 
@@ -320,6 +324,11 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
                    curl_easy_getinfo(curl, CURLINFO_SCHEME,
                                      &stringp))
                   fprintf(stream, "%s", stringp);
+              case VAR_STDOUT:
+                stream = stdout;
+                break;
+              case VAR_STDERR:
+                stream = stderr;
                 break;
               default:
                 break;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -166,7 +166,7 @@ test1424 test1425 test1426 test1427 \
 test1428 test1429 test1430 test1431 test1432 test1433 test1434 test1435 \
 test1436 test1437 test1438 test1439 test1440 test1441 test1442 test1443 \
 test1444 test1445 test1446 test1447 test1448 test1449 test1450 test1451 \
-test1452 test1453 test1454 test1455 test1456 \
+test1452 test1453 test1454 test1455 test1456 test1457 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
 test1516 test1517 \

--- a/tests/data/test1457
+++ b/tests/data/test1457
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+protocol
+--write-out
+</keywords>
+</info>
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 9
+Connection: close
+Content-Type: text/plain
+
+testdata
+</data>
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+
+<name>
+Check if %{stderr} and %{stdout} switch between stdout and stderr.
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/1457 --write-out 'line1%{stderr}line2%{stdout}line3'
+</command>
+</client>
+
+# Verify data
+<verify>
+<stdout nonewline="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 9
+Connection: close
+Content-Type: text/plain
+
+testdata
+line1line3
+</stdout>
+#note: as of now <stderr> doesn't actually exist in runtests.pl
+<stderr nonewline="yes">
+line2
+</stderr>
+<protocol>
+GET /1457 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+<strip>
+^User-Agent:.*
+</strip>
+</verify>
+</testcase>


### PR DESCRIPTION
Note that the actual stderr test is incomplete: runtests.pl doesn't have easy support for stderr