### PR TITLE
ldap: show precise LDAP call in error message on Windows

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -474,7 +474,13 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
 #endif
   }
   if(rc != 0) {
-    failf(data, "LDAP local: ldap_simple_bind_s %s", ldap_err2string(rc));
+#ifdef USE_WIN32_LDAP
+    failf(data, "LDAP local: bind via ldap_win_bind %s",
+          ldap_err2string(rc));
+#else
+    failf(data, "LDAP local: bind via ldap_simple_bind_s %s",
+          ldap_err2string(rc));
+#endif
     result = CURLE_LDAP_CANNOT_BIND;
     goto quit;
   }


### PR DESCRIPTION
Also add a unique but common text ('bind via') to make it easy to grep this specific failure regardless of platform.

Ref: https://github.com/curl/curl/pull/878/files#diff-7a636f08047c4edb53a240f540b4ecf6R468