### PR TITLE
cmake: add support for transitive ZLIB target

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -1,15 +1,12 @@
 @PACKAGE_INIT@
 
-if("@USE_OPENSSL@" OR "@CURL_ZLIB@" )
-    include(CMakeFindDependencyMacro)
-    if ("@USE_OPENSSL@")
-        find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")
-    endif()
-    if("@CURL_ZLIB@")
-	find_dependency(ZLIB "@ZLIB_VERSION_MAJOR@")
-    endif()
+include(CMakeFindDependencyMacro)
+if(@USE_OPENSSL@)
+  find_dependency(OpenSSL @OPENSSL_VERSION_MAJOR@)
 endif()
-
+if(@USE_ZLIB@)
+  find_dependency(ZLIB @ZLIB_VERSION_MAJOR@)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -1,9 +1,15 @@
 @PACKAGE_INIT@
 
-if("@USE_OPENSSL@")
+if("@USE_OPENSSL@" OR "@CURL_ZLIB@" )
     include(CMakeFindDependencyMacro)
-    find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")
+    if ("@USE_OPENSSL@")
+        find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")
+    endif()
+    if("@CURL_ZLIB@")
+	find_dependency(ZLIB "@ZLIB_VERSION_MAJOR@")
+    endif()
 endif()
+
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,13 +508,13 @@ check_library_exists("${CURL_LIBS}" dlopen "" HAVE_DLOPEN)
 option(CURL_ZLIB "Set to ON to enable building curl with zlib support." ON)
 set(HAVE_LIBZ OFF)
 set(HAVE_ZLIB_H OFF)
-set(HAVE_ZLIB OFF)
+set(USE_ZLIB OFF)
 if(CURL_ZLIB)
   find_package(ZLIB QUIET)
   if(ZLIB_FOUND)
     set(HAVE_ZLIB_H ON)
-    set(HAVE_ZLIB ON)
     set(HAVE_LIBZ ON)
+    set(USE_ZLIB ON)
 
     # Depend on ZLIB via imported targets if supported by the running
     # version of CMake.  This allows our dependents to get our dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,8 +515,16 @@ if(CURL_ZLIB)
     set(HAVE_ZLIB_H ON)
     set(HAVE_ZLIB ON)
     set(HAVE_LIBZ ON)
-    list(APPEND CURL_LIBS ${ZLIB_LIBRARIES})
-    include_directories(${ZLIB_INCLUDE_DIRS})
+
+    # Depend on ZLIB via imported targets if supported by the running
+    # version of CMake.  This allows our dependents to get our dependencies
+    # transitively.
+    if(NOT CMAKE_VERSION VERSION_LESS 3.4)
+      list(APPEND CURL_LIBS ZLIB::ZLIB)
+    else()
+      list(APPEND CURL_LIBS ${ZLIB_LIBRARIES})
+      include_directories(${ZLIB_INCLUDE_DIRS})
+    endif()
     list(APPEND CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIRS})
   endif()
 endif()


### PR DESCRIPTION
Create transitive CMake targets for ZLIB similarly to OpenSSL. The changes follow the convention as in #3055.