### PR TITLE
replace rawgit links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![curl logo](https://cdn.rawgit.com/curl/curl-www/master/logo/curl-logo.svg)
+![curl logo](https://curl.haxx.se/logo/curl-logo.svg)
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/63/badge)](https://bestpractices.coreinfrastructure.org/projects/63)
 [![Coverity passed](https://scan.coverity.com/projects/curl/badge.svg)](https://scan.coverity.com/projects/curl)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-![curl logo](https://cdn.rawgit.com/curl/curl-www/master/logo/curl-logo.svg)
+![curl logo](https://curl.haxx.se/logo/curl-logo.svg)
 
 # Documentation
 


### PR DESCRIPTION
Ref: https://rawgit.com/ "RawGit has reached the end of its useful life"
Ref: https://news.ycombinator.com/item?id=18202481
