### PR TITLE
tool_cb_hdr: handle failure of rename()

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -132,15 +132,24 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       filename = parse_filename(p, len);
       if(filename) {
         if(outs->stream) {
+          int rc;
           /* already opened and possibly written to */
           if(outs->fopened)
             fclose(outs->stream);
           outs->stream = NULL;
 
           /* rename the initial file name to the new file name */
-          rename(outs->filename, filename);
+          rc = rename(outs->filename, filename);
+          if(rc != 0) {
+            warnf(outs->config->global, "Failed to rename %s -> %s: %s\n",
+                  outs->filename, filename, strerror(errno));
+          }
           if(outs->alloc_filename)
-            free(outs->filename);
+            Curl_safefree(outs->filename);
+          if(rc != 0) {
+            free(filename);
+            return failure;
+          }
         }
         outs->is_cd_filename = TRUE;
         outs->s_isreg = TRUE;


### PR DESCRIPTION
Detected by Coverity.