### PR TITLE
Fix parsing of IP addresses in the subject alternative name (SAN) field of a certificate.

### DIFF
--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -1131,8 +1131,8 @@ CURLcode Curl_verifyhost(struct connectdata *conn,
           break;
 
         case 7: /* IP address. */
-          matched = (size_t) (name.end - q) == addrlen &&
-                    !memcmp(&addr, q, addrlen);
+          matched = (size_t) (name.end - name.beg) == addrlen &&
+                    !memcmp(&addr, name.beg, addrlen);
           break;
         }
       }


### PR DESCRIPTION


For IP addresses in the subject alternative name field, the length
of the IP address (and hence the number of bytes to perform a
memcmp on) is incorrectly calculated to be zero. The code previously
subtracted q from name.end. where in a successful case q = name.end
and therefore addrlen equalled 0. The change modifies the code to
subtract name.beg from name.end to calculate the length correctly.

Fixes #3102