### PR TITLE
Fix multiple errors when using the flag CURL_DISABLE_VERBOSE_STRINGS

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -884,9 +884,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 void Curl_tcpnodelay(struct connectdata *conn, curl_socket_t sockfd)
 {
 #if defined(TCP_NODELAY)
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
   struct Curl_easy *data = conn->data;
-#endif
   curl_socklen_t onoff = (curl_socklen_t) 1;
   int level = IPPROTO_TCP;
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -912,9 +912,8 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
       char *entry_id;
       size_t entry_len;
       char address[64];
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
       char *addresses = NULL;
-#endif
+
       char *addr_begin;
       char *addr_end;
       char *port_ptr;
@@ -937,9 +936,8 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
         goto err;
 
       port = (int)tmp_port;
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
       addresses = end_ptr + 1;
-#endif
+
 
       while(*end_ptr) {
         size_t alen;

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -138,9 +138,8 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
   char addrbuf[128];
 #endif
   int pf;
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
   struct Curl_easy *data = conn->data;
-#endif
+
 
   *waitp = 0; /* synchronous response only */
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -589,9 +589,7 @@ output_auth_headers(struct connectdata *conn,
 {
   const char *auth = NULL;
   CURLcode result = CURLE_OK;
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS) || defined(USE_SPNEGO)
   struct Curl_easy *data = conn->data;
-#endif
 #ifdef USE_SPNEGO
   struct negotiatedata *negdata = proxy ?
     &data->state.proxyneg : &data->state.negotiate;


### PR DESCRIPTION
Now it can be used and compiles with no errors