### PR TITLE
avoid "GnuTLS recv error (-110): The TLS connection was non-properly terminated"

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1732,6 +1732,12 @@ static ssize_t gtls_recv(struct connectdata *conn, /* connection data */
     return -1;
   }
 
+  if(ret == GNUTLS_E_PREMATURE_TERMINATION) {
+    /* HTTPS connections without Content-Length can be terminated after
+       transfer */
+    return 0;
+  }
+
   if(ret < 0) {
     failf(conn->data, "GnuTLS recv error (%d): %s",
 


### PR DESCRIPTION
Some HTTP proxies convert chunked response body unchunked without
Content-Length: header. It causes "GnuTLS recv error (-110): The
TLS connection was non-properly terminated" error when using GNU
TLS. lib/vtls/openssl.c ignores the same case, so lib/vtls/gtls.c
can do it too.

Fixes #2866