### PR TITLE
Fix for compiling with lwIP

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -37,7 +37,7 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(USE_LWIPSOCK)
 #define setsockopt(a,b,c,d,e) (setsockopt)(a,b,c,(const char *)d,(int)e)
 #define SET_RCVTIMEO(tv,s)   int tv = s*1000
 #else

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -37,8 +37,10 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-#if defined(_WIN32) && !defined(USE_LWIPSOCK)
+#if defined(WIN32) && !defined(USE_LWIPSOCK)
 #define setsockopt(a,b,c,d,e) (setsockopt)(a,b,c,(const char *)d,(int)e)
+#define SET_RCVTIMEO(tv,s)   int tv = s*1000
+#elif defined(LWIP_SO_SNDRCVTIMEO_NONSTANDARD)
 #define SET_RCVTIMEO(tv,s)   int tv = s*1000
 #else
 #define SET_RCVTIMEO(tv,s)   struct timeval tv = {s,0}


### PR DESCRIPTION
Compiling on Windows (`_WIN32`) with `USE_LWIPSOCK`, causes this error:
```c
  curl_rtmp.c(223,3):  error: use of undeclared identifier 'setsockopt'
    setsockopt(r->m_sb.sb_socket, SOL_SOCKET, SO_RCVTIMEO,
    ^
  curl_rtmp.c(41,32):  note: expanded from macro 'setsockopt'
  #define setsockopt(a,b,c,d,e) (setsockopt)(a,b,c,(const char *)d,(int)e)
                                 ^  
```
(from with clang-cl). 
Since `setsockopt()`  is really `lwip_setsockopt()` in `<LWIP_ROOT>/src/include/lwip\sockets.h`, do not redefine it.