### PR TITLE
headers: end all headers with guard comment

### DIFF
--- a/lib/curl_path.h
+++ b/lib/curl_path.h
@@ -44,4 +44,4 @@ CURLcode Curl_getworkingpath(struct connectdata *conn,
                              char **path);
 
 CURLcode Curl_get_pathname(const char **cpp, char **path, char *homedir);
-#endif
+#endif /* HEADER_CURL_PATH_H */

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -102,4 +102,4 @@ DOHcode doh_decode(unsigned char *doh,
                    struct dohentry *d);
 void de_cleanup(struct dohentry *d);
 #endif
-#endif
+#endif /* HEADER_CURL_DOH_H */

--- a/lib/dotdot.h
+++ b/lib/dotdot.h
@@ -22,4 +22,4 @@
  *
  ***************************************************************************/
 char *Curl_dedotdotify(const char *input);
-#endif
+#endif /* HEADER_CURL_DOTDOT_H */

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -30,4 +30,4 @@ bool Curl_is_absolute_url(const char *url, char *scheme, size_t buflen);
 char *Curl_concat_url(const char *base, const char *relurl);
 size_t Curl_strlen_url(const char *url, bool relative);
 void Curl_strcpy_url(char *output, const char *url, bool relative);
-#endif
+#endif /* HEADER_CURL_URLAPI_INT_H */


### PR DESCRIPTION
Most headerfiles end with a `/* <headerguard> */` comment, but it was missing from some. The comment isn't the most important part of our code documentation but consistency has an intrinsic value in itself. This adds header guard comments to the files that were lacking it.