### PR TITLE
multi: Fix error handling in the SENDPROTOCONNECT state

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1608,7 +1608,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case CURLM_STATE_SENDPROTOCONNECT:
       result = Curl_protocol_connect(data->easy_conn, &protocol_connect);
-      if(!protocol_connect)
+      if(!result && !protocol_connect)
         /* switch to waiting state */
         multistate(data, CURLM_STATE_PROTOCONNECT);
       else if(!result) {


### PR DESCRIPTION
If Curl_protocol_connect() returns an error code,
handle the error instead of switching to the next state.