### PR TITLE
ssh: free the session on init failures

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -2926,7 +2926,7 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
     int rc;
     ssh->kh = libssh2_knownhost_init(ssh->ssh_session);
     if(!ssh->kh) {
-      /* eeek. TODO: free the ssh_session! */
+      libssh2_session_free(ssh->ssh_session);
       return CURLE_FAILED_INIT;
     }
 


### PR DESCRIPTION
Ensure to clear the session object in case the libssh2 initialization fails.

It could be argued that the libssh2 error function should be called to get a proper error message in this case. But since the only error path in libssh2_knownhost_init() is memory a allocation failure it's safest
to avoid since the libssh2 error handling allocates memory.