### PR TITLE
Choose proper settings compiling with Sun C++

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -298,7 +298,7 @@
 #  define CURL_PULL_SYS_TYPES_H      1
 #  define CURL_PULL_SYS_SOCKET_H     1
 
-#elif defined(__SUNPRO_C) /* Oracle Solaris Studio */
+#elif defined(__SUNPRO_C) || defined(__SUNPRO_CC) /* Oracle Solaris Studio */
 #  if !defined(__LP64) && (defined(__ILP32) ||                          \
                            defined(__i386) ||                           \
                            defined(__sparcv8) ||                        \


### PR DESCRIPTION
system.h selects the proper Sun settings when __SUNPRO_C is defined. The Sun compiler does not define it when compiling C++ files.
I'm adding a check also on __SUNPRO_CC to allow curl to work properly also when used in a C++ project on Sun Solaris.