### PR TITLE
mprintf: Avoid integer overflow warning from clang

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -835,7 +835,7 @@ static int dprintf_formatf(
           while(width-- > 0)
             OUTCHAR(' ');
 
-        while((len-- > 0) && *str)
+        for(; len && *str; len--)
           OUTCHAR(*str++);
         if(p->flags&FLAGS_LEFT)
           while(width-- > 0)


### PR DESCRIPTION
A simple curl_easy_init() triggers an unsigned integer overflow in dprintf_formatf():

mprintf.c:838:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
    #0 0x6d9dcf in dprintf_formatf /home/tim/src/curl/lib/mprintf.c:838:19
    #1 0x6d71d7 in curl_mvsnprintf /home/tim/src/curl/lib/mprintf.c:1006:13
    #2 0x6dcf29 in curl_msnprintf /home/tim/src/curl/lib/mprintf.c:1023:13
    #3 0x81d17b in Curl_ossl_version /home/tim/src/curl/lib/vtls/openssl.c:3739:10
    #4 0x6d4cd8 in curl_version /home/tim/src/curl/lib/version.c:119:11
    #5 0x6d4bf4 in Curl_version_init /home/tim/src/curl/lib/version.c:86:3
    #6 0x51f245 in global_init /home/tim/src/curl/lib/easy.c:271:3
    #7 0x51f52b in curl_easy_init /home/tim/src/curl/lib/easy.c:361:14

While this likely has no real world impact in normal operation, it is annoying when doing UBSAN / fuzzing tests. Good programming practice would be to avoid it.

There are certain possible fixes to it. I chose the most obviously and any decent compiler optimizes this into a single CPU opcode, so speed impact should be near zero.
