### PR TITLE
Silence integer overflow in Curl_hash_str()

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -254,6 +254,9 @@ Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
   }
 }
 
+#ifdef __clang__
+__attribute__((no_sanitize("integer")))
+#endif
 size_t Curl_hash_str(void *key, size_t key_length, size_t slots_num)
 {
   const char *key_str = (const char *) key;


### PR DESCRIPTION
Hash functions often make integer overflows on purpose. Silence clang's UBSAN on Curl_hash_str().

Example output of clang:
hash.c:264:7: runtime error: unsigned integer overflow: 13689011417853977260 + 13773251676007585152 cannot be represented in type 'unsigned long'
    #0 0x716e8a in Curl_hash_str /home/tim/src/curl/lib/hash.c:264:7
    #1 0x71599c in Curl_hash_pick /home/tim/src/curl/lib/hash.c:166:9
    #2 0x5841d7 in Curl_conncache_find_bundle /home/tim/src/curl/lib/conncache.c:222:14
    #3 0x69cf65 in ConnectionExists /home/tim/src/curl/lib/url.c:1079:12
    #4 0x68169a in create_conn /home/tim/src/curl/lib/url.c:3862:13
    #5 0x67bd9c in Curl_connect /home/tim/src/curl/lib/url.c:4120:12
    #6 0x55524b in multi_runsingle /home/tim/src/curl/lib/multi.c:1442:16
    #7 0x54ca2b in curl_multi_perform /home/tim/src/curl/lib/multi.c:2178:14
    #8 0x527a1b in easy_transfer /home/tim/src/curl/lib/easy.c:686:15
    #9 0x51fdaa in easy_perform /home/tim/src/curl/lib/easy.c:779:42
