### PR TITLE
unit1650: fix "null pointer passed as argument 1 to memcmp"

### DIFF
--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -170,7 +170,7 @@ UNITTEST_START
       fprintf(stderr, "DNS encode made: %s\n", hexdump(buffer, size));
       return 2;
     }
-    else if(memcmp(req[i].packet, buffer, size)) {
+    else if(req[i].packet && memcmp(req[i].packet, buffer, size)) {
       fprintf(stderr, "DNS encode made: %s\n", hexdump(buffer, size));
       fprintf(stderr, "... instead of: %s\n",
              hexdump((unsigned char *)req[i].packet, size));


### PR DESCRIPTION
Detected by UndefinedBehaviorSanitizer