### PR TITLE
configure: include all libraries in ssl-libs fetch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1623,7 +1623,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
 
     if test "$PKGCONFIG" != "no" ; then
       SSL_LIBS=`CURL_EXPORT_PCDIR([$OPENSSL_PCDIR]) dnl
-        $PKGCONFIG --libs-only-l openssl 2>/dev/null`
+        $PKGCONFIG --libs-only-l --libs-only-other openssl 2>/dev/null`
 
       SSL_LDFLAGS=`CURL_EXPORT_PCDIR([$OPENSSL_PCDIR]) dnl
         $PKGCONFIG --libs-only-L openssl 2>/dev/null`


### PR DESCRIPTION
When compiling a collection of SSL libraries to link against (SSL_LIBS), ensure all libraries are included. The call `--libs-only-l` can produce only a subset of found in a `--libs` call (e.x. pthread may be excluded). Adding `--libs-only-other` ensures other libraries are also included in the list. This corrects select build environments compiling against a static version of OpenSSL. Before the change, the following could be observed:

```
checking for openssl options with pkg-config... found
configure: pkg-config: SSL_LIBS: "-lssl -lz -ldl -lcrypto -lz -ldl "
configure: pkg-config: SSL_LDFLAGS: "-L/home/jdknight/<workdir>/staging/usr/lib -L/home/jdknight/<workdir>/staging/usr/lib "
configure: pkg-config: SSL_CPPFLAGS: "-I/home/jdknight/<workdir>/staging/usr/include "
checking for HMAC_Update in -lcrypto... no
checking for HMAC_Init_ex in -lcrypto... no
checking OpenSSL linking with -ldl... no
checking OpenSSL linking with -ldl and -lpthread... no
configure: WARNING: SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.
configure: WARNING: Use --with-ssl, --with-gnutls, --with-polarssl, --with-cyassl, --with-nss, --with-axtls, --with-winssl, or --with-darwinssl to address this.
...
SSL support:      no      (--with-{ssl,gnutls,nss,polarssl,mbedtls,cyassl,axtls,winssl,darwinssl} )
...
```

And include the other libraries when compiling SSL_LIBS succeeds with:

```
checking for openssl options with pkg-config... found
configure: pkg-config: SSL_LIBS: "-lssl -lz -ldl -pthread -lcrypto -lz -ldl -pthread "
configure: pkg-config: SSL_LDFLAGS: "-L/home/jdknight/<workdir>/staging/usr/lib -L/home/jdknight/<workdir>/staging/usr/lib "
configure: pkg-config: SSL_CPPFLAGS: "-I/home/jdknight/<workdir>/staging/usr/include "
checking for HMAC_Update in -lcrypto... yes
checking for SSL_connect in -lssl... yes
...
SSL support:      enabled (OpenSSL)
...
```

----

This issue was observed in an environment where OpenSSL package (v1.1.1) was being built as a static-only library (`./config no-dso no-shared ...`). Adding the option `--libs-only-other` to the pkg-config check allowed libcurl to build with (at least) the following options set:

    ... --disable-shared --with-ssl ...

And the following environment variables set:

    PKG_CONFIG: pkg-config --static
    PKG_CONFIG_PATH: <staging>/usr/lib/pkgconfig

It is assumed the introduction of the argument `--libs-only-other` is not an issue since it has been available in `pkg-config` since [v0.24](https://cgit.freedesktop.org/pkg-config/tree/main.c?h=pkg-config-0.24#n232) (~8 years ago).

This may also relate to #567.