### PR TITLE
curl: revert #3011 and write UTF-8 in current console code page.

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -157,7 +157,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   }
 
 #ifdef _WIN32
-  if (is_tty) {
+  if(is_tty) {
     DWORD in_len = (DWORD)(sz * nmemb);
     wchar_t* wc_buf;
     DWORD wc_len;
@@ -165,13 +165,13 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     /* calculate buffer size for wide characters */
     wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len,  NULL, 0);
     wc_buf = (wchar_t*) malloc(wc_len * sizeof(wchar_t));
-    if (!wc_buf)
+    if(!wc_buf)
       return failure;
 
     /* calculate buffer size for multi-byte characters */
     wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len, wc_buf, wc_len);
 
-    if (!WriteConsoleW(
+    if(!WriteConsoleW(
         (HANDLE) _get_osfhandle(fileno(outs->stream)),
         wc_buf,
         wc_len,

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -157,7 +157,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   }
 
 #ifdef _WIN32
-  if(is_tty) {
+  if(isatty(fileno(outs->stream))) {
     DWORD in_len = (DWORD)(sz * nmemb);
     wchar_t* wc_buf;
     DWORD wc_len;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -156,7 +156,36 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     }
   }
 
-  rc = fwrite(buffer, sz, nmemb, outs->stream);
+#ifdef _WIN32
+  if (is_tty) {
+    DWORD in_len = (DWORD)(sz * nmemb);
+    wchar_t* wc_buf;
+    DWORD wc_len;
+
+    /* calculate buffer size for wide characters */
+    wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len,  NULL, 0);
+    wc_buf = (wchar_t*) malloc(wc_len * sizeof(wchar_t));
+    if (!wc_buf)
+      return failure;
+
+    /* calculate buffer size for multi-byte characters */
+    wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len, wc_buf, wc_len);
+
+    if (!WriteConsoleW(
+        (HANDLE) _get_osfhandle(fileno(outs->stream)),
+        wc_buf,
+        wc_len,
+        &wc_len,
+        NULL)) {
+      free(wc_buf);
+      return failure;
+    }
+    free(wc_buf);
+    rc = bytes;
+  }
+  else
+#endif
+    rc = fwrite(buffer, sz, nmemb, outs->stream);
 
   if(bytes == rc)
     /* we added this amount of data to the output */

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -241,13 +241,12 @@ static void main_free(struct GlobalConfig *config)
 static struct TerminalSettings {
   HANDLE hStdOut;
   DWORD dwOutputMode;
-  UINT nCodepage;
 } TerminalSettings;
 
 static void configure_terminal(void)
 {
   /*
-   * If we're running Windows, enable VT output & set codepage to UTF-8.
+   * If we're running Windows, enable VT output.
    * Note: VT mode flag can be set on any version of Windows, but VT
    * processing only performed on Win10 >= Creators Update)
    */
@@ -257,10 +256,7 @@ static void configure_terminal(void)
     #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
 
-  /* Cache current codepage (will restore on exit) & set codepage to UTF-8 */
   memset(&TerminalSettings, 0, sizeof(TerminalSettings));
-  TerminalSettings.nCodepage = GetConsoleOutputCP();
-  SetConsoleOutputCP(65001);
 
   /* Enable VT output */
   TerminalSettings.hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -282,7 +278,6 @@ static void restore_terminal(void)
   /* Restore Console output mode and codepage to whatever they were
    * when Curl started */
   SetConsoleMode(TerminalSettings.hStdOut, TerminalSettings.dwOutputMode);
-  SetConsoleOutputCP(TerminalSettings.nCodepage);
 #endif
 }
 


### PR DESCRIPTION
Current implementation for output UTF-8 on Windows console doesn't restore font. Windows console set font to **suitable** possibly. And restoring code page also set **suitable** font. So font is not restored correctly. At least, this implementation doesn't work on Japanese locale on Windows. To write UTF-8 without changing console code page, it should use Wide String APIs. If output stream is not a TTY, do original behavior. Thanks.

![image](https://user-images.githubusercontent.com/10111/47864370-c20f8080-de3c-11e8-88b7-8af412017601.png)

You notice some borders in this screenshot are not displayed in correct location. This is problem of fonts not curl. If you set Raster Font for the console, it probably works well.

![image](https://user-images.githubusercontent.com/10111/47864506-1ca8dc80-de3d-11e8-8206-3e35a0d962c7.png)


Fixes #3211 
