### PR TITLE
Curl_follow: accept non-supported schemes for "fake" redirects

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1514,7 +1514,8 @@ CURLcode Curl_follow(struct Curl_easy *data,
     disallowport = TRUE;
 
   DEBUGASSERT(data->state.uh);
-  uc = curl_url_set(data->state.uh, CURLUPART_URL, newurl, 0);
+  uc = curl_url_set(data->state.uh, CURLUPART_URL, newurl,
+                    (type == FOLLOW_FAKE) ? CURLU_NON_SUPPORT_SCHEME : 0);
   if(uc)
     return Curl_uc_to_curlcode(uc);
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -127,7 +127,7 @@ test1120 test1121 test1122 test1123 test1124 test1125 test1126 test1127 \
 test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
-test1152 test1153 test1154 test1155 test1156 test1157 test1158 \
+test1152 test1153 test1154 test1155 test1156 test1157 test1158 test1159 \
 \
 test1160 test1161 test1162 test1163 test1164 \
 test1170 test1171 \

--- a/tests/data/test1159
+++ b/tests/data/test1159
@@ -1,0 +1,58 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+redirect_url
+followlocation
+--write-out
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 301 This is a weirdo text message swsclose
+Location: ht3p://localhost/
+Content-Length: 62
+Connection: close
+
+This server reply is for testing a simple Location: following
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP Location: and 'redirect_url' with non-supported scheme
+ </name>
+<command>
+http://%HOSTIP:%HTTPPORT/we/want/our/1159 -w '%{redirect_url}\n'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /we/want/our/1159 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+<stdout>
+HTTP/1.1 301 This is a weirdo text message swsclose
+Location: ht3p://localhost/
+Content-Length: 62
+Connection: close
+
+This server reply is for testing a simple Location: following
+ht3p://localhost/
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
When not actually following the redirect and the target URL is only
stored for later retrieval, curl always accepted "non-supported"
schemes. This was a regression from 46e164069d1a5230.

Reported-by: Brad King
Fixes #3210