### PR TITLE
openvms: fix example name

### DIFF
--- a/packages/vms/gnv_link_curl.com
+++ b/packages/vms/gnv_link_curl.com
@@ -740,7 +740,7 @@ gnv$libcurl/share
 $endif
 $!
 $!
-$target = "persistant"
+$target = "persistent"
 $if f$search("[.docs.examples]''target'.exe") .eqs. ""
 $then
 $   define/user gnv$libcurl 'gnv_libcurl_share'

--- a/packages/vms/setup_gnv_curl_build.com
+++ b/packages/vms/setup_gnv_curl_build.com
@@ -207,7 +207,7 @@ $   example_apps = example_apps + ",ftpupload,getinfo,getinmemory"
 $   example_apps = example_apps + ",http-post,httpcustomheader,httpput"
 $   example_apps = example_apps + ",https,multi-app,multi-debugcallback"
 $   example_apps = example_apps + ",multi-double,multi-post,multi-single"
-$   example_apps = example_apps + ",persistant,post-callback,postit2"
+$   example_apps = example_apps + ",persistent,post-callback,postit2"
 $   example_apps = example_apps + ",sendrecv,sepheaders,simple,simplepost"
 $   example_apps = example_apps + ",simplessl"
 $!


### PR DESCRIPTION
Commit efc696a2e09225bfeab4 renamed persistant.c to persistent.c to fix the typo in the name, but missed to update the OpenVMS package files which still used the old name.