### PR TITLE
URL: fix IPv6 numeral address parser

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -499,8 +499,12 @@ static CURLUcode parse_port(struct Curl_URL *u, char *hostname)
      (']' == endbracket)) {
     /* this is a RFC2732-style specified IP-address */
     portptr = &hostname[len];
-    if (*portptr != ':')
-      return CURLUE_MALFORMED_INPUT;
+    if(*portptr) {
+      if(*portptr != ':')
+        return CURLUE_MALFORMED_INPUT;
+    }
+    else
+      portptr = NULL;
   }
   else
     portptr = strchr(hostname, ':');

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -128,6 +128,15 @@ struct querycase {
 };
 
 static struct testcase get_parts_list[] ={
+  {"http://[fd00:a41::50]:8080",
+   "http | [11] | [12] | [13] | [fd00:a41::50] | 8080 | / | [16] | [17]",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
+  {"http://[fd00:a41::50]/",
+   "http | [11] | [12] | [13] | [fd00:a41::50] | [15] | / | [16] | [17]",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
+  {"http://[fd00:a41::50]",
+   "http | [11] | [12] | [13] | [fd00:a41::50] | [15] | / | [16] | [17]",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
   {"https://[::1%252]:1234",
    "https | [11] | [12] | [13] | [::1%252] | 1234 | / | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},


### PR DESCRIPTION
Regression from 46e164069d1a52. Extended test 1560 to verify.

Reported-by: tpaukrt on github
Fixes #3218