### PR TITLE
prevent stripping trailing dot for resolving

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -167,7 +167,8 @@ problems may have been fixed or changed somewhat since this was written!
  When given a URL with a trailing dot for the host name part:
  "https://example.com./", libcurl will strip off the dot and use the name
  without a dot internally and send it dot-less in HTTP Host: headers and in
- the TLS SNI field.
+ the TLS SNI field. For the purpose of resolving the name to an address
+ the hostname is used as is without any change.
 
  The HTTP part violates RFC 7230 section 5.4 but the SNI part is accordance
  with RFC 6066 section 3.
@@ -186,10 +187,10 @@ problems may have been fixed or changed somewhat since this was written!
  Our current approach allows a knowing client to send a custom HTTP header
  with the dot added.
 
- It can also be noted that while adding a trailing dot to the host name in
- most (all?) cases will make the name resolve to the same set of IP addresses,
- many HTTP servers will not happily accept the trailing dot there unless that
- has been specifically configured to be a fine virtual host.
+ In a few cases there is a difference in name resolving to IP addresses with
+ a trailing dot, but it can be noted that many HTTP servers will not happily
+ accept the trailing dot there unless that has been specifically configured
+ to be a fine virtual host.
 
  If URLs with trailing dots for host names become more popular or even just
  used more than for just plain fun experiments, I'm sure we will have reason

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -828,6 +828,7 @@ struct connectdata {
   int socktype;  /* SOCK_STREAM or SOCK_DGRAM */
 
   struct hostname host;
+  char *hostname_resolve; /* host name to resolve to address, allocated */
   char *secondaryhostname; /* secondary socket host name (ftp) */
   struct hostname conn_to_host; /* the host to connect to. valid only if
                                    bits.conn_to_host is set */

--- a/tests/data/test1322
+++ b/tests/data/test1322
@@ -37,7 +37,7 @@ http
 HTTP with --resolve and hostname with trailing dot
 </name>
 <command>
---resolve example.com:%HTTPPORT:%HOSTIP http://example.com.:%HTTPPORT/1322
+--ipv4 --resolve example.com.:%HTTPPORT:%HOSTIP http://example.com.:%HTTPPORT/1322
 </command>
 </client>
 

--- a/tests/data/test20
+++ b/tests/data/test20
@@ -25,7 +25,7 @@ http
 attempt connect to non-existing host name
  </name>
  <command>
-non-existing-host.haxx.se.
+--ipv4 non-existing-host.haxx.se.
 </command>
 </client>
 


### PR DESCRIPTION
This change removes the stripping of trailing dots in hostnames for the aspect of name resolving.
It does not change hostnames for SNI or http Host header.

This allows using a trailing dot to denote a fully qualified name with DNS.

Fixes: #3022