### PR TITLE
url: a short host name + port is not a scheme

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -238,7 +238,7 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
 #endif
   for(i = 0; i < buflen && url[i]; ++i) {
     char s = url[i];
-    if(s == ':') {
+    if((s == ':') && (url[i + 1] == '/')) {
       if(buf)
         buf[i] = 0;
       return TRUE;

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -128,6 +128,9 @@ struct querycase {
 };
 
 static struct testcase get_parts_list[] ={
+  {"boing:80",
+   "https | [11] | [12] | [13] | boing | 80 | / | [16] | [17]",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
   {"http://[fd00:a41::50]:8080",
    "http | [11] | [12] | [13] | [fd00:a41::50] | 8080 | / | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},


### PR DESCRIPTION
The function identifying a leading "scheme" part of the URL considered a few
letters ending with a colon to be a scheme, making something like "short:80"
to become an unknown scheme instead of a short host name and a port number.

Extended test 1560 to verify.

Reported-by: Hagai Auro
Fixes #3220