### PR TITLE
Avoid two unsigned int overflows in FTP listing parser

### DIFF
--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -405,7 +405,7 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
             parser->state.UNIX.main = PL_UNIX_FILETYPE;
             /* start FSM again not considering size of directory */
             finfo->b_used = 0;
-            i--;
+            continue;
           }
           break;
         case PL_UNIX_TOTALSIZE_READING:


### PR DESCRIPTION
Curl_ftp_parselist: avoid unsigned integer overflows detected by clang

The overflow has no real world impact.
Just avoid it for "best practice".

**Details**
ftplistparser.c:

With any input and first char no being a digit (0-9), the execution
goes straight to L408. This results in the 'unsigned int overflow'.

Then the execution goes straight to L1007 which causes the second
'unsigned int overflow'.

A simple 'continue' in L408 instead of 'i--' avoids both warnings.

```
ftplistparser.c:408:14: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned long'
    #0 0x892d3d in Curl_ftp_parselist /home/tim/src/curl/lib/ftplistparser.c:408:14
    #1 0x667134 in chop_write /home/tim/src/curl/lib/sendf.c:585:22
    #2 0x6f73e3 in readwrite_data /home/tim/src/curl/lib/transfer.c:806:26
    #3 0x6f055a in Curl_readwrite /home/tim/src/curl/lib/transfer.c:1163:14
    #4 0x5581c8 in multi_runsingle /home/tim/src/curl/lib/multi.c:1912:16
    #5 0x54e98b in curl_multi_perform /home/tim/src/curl/lib/multi.c:2178:14
    #6 0x52997b in easy_transfer /home/tim/src/curl/lib/easy.c:686:15
    #7 0x521d0a in easy_perform /home/tim/src/curl/lib/easy.c:779:42

ftplistparser.c:1007:6: runtime error: unsigned integer overflow: 18446744073709551615 + 1 cannot be represented in type 'unsigned long'
    #0 0x88ead4 in Curl_ftp_parselist /home/tim/src/curl/lib/ftplistparser.c:1007:6
    #1 0x667134 in chop_write /home/tim/src/curl/lib/sendf.c:585:22
    #2 0x6f73e3 in readwrite_data /home/tim/src/curl/lib/transfer.c:806:26
    #3 0x6f055a in Curl_readwrite /home/tim/src/curl/lib/transfer.c:1163:14
    #4 0x5581c8 in multi_runsingle /home/tim/src/curl/lib/multi.c:1912:16
    #5 0x54e98b in curl_multi_perform /home/tim/src/curl/lib/multi.c:2178:14
    #6 0x52997b in easy_transfer /home/tim/src/curl/lib/easy.c:686:15
    #7 0x521d0a in easy_perform /home/tim/src/curl/lib/easy.c:779:42
```
