### PR TITLE
unittest: make 1652 stable across collations

### DIFF
--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -85,8 +85,8 @@ Curl_infof(data, "%s", input);
 fail_unless(strcmp(result, input) == 0, "Simple string test");
 
 /* Injecting a few different variables with a format */
-Curl_infof(data, "%s %u testing %.1f\n", input, 42, 43.0123324);
-fail_unless(strcmp(result, "Simple Test 42 testing 43.0\n") == 0,
+Curl_infof(data, "%s %u testing %lu\n", input, 42, 43L);
+fail_unless(strcmp(result, "Simple Test 42 testing 43\n") == 0,
             "Format string");
 
 /* Variations of empty strings */


### PR DESCRIPTION
The previous coding used a format string whose output depended on the current locale of the environment running the test. Since the gist of the test is to have a format string, with the actual formatting being less important, switch to a more stable formatstring with decimals.

Reported by Marcel Raad