### PR TITLE
use c-ares callback for socket close

### DIFF
--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -257,7 +257,9 @@ static void remsock(SockInfo *f, GlobalInfo* g)
 {
   if(f) {
     if(f->sockfd) {
-      epoll_ctl(g->epfd, EPOLL_CTL_DEL, f->sockfd, NULL);
+      if(epoll_ctl(g->epfd, EPOLL_CTL_DEL, f->sockfd, NULL))
+        fprintf(stderr, "EPOLL_CTL_DEL failed for fd: %d : %s\n",
+                f->sockfd, strerror(errno));
     }
     free(f);
   }
@@ -274,7 +276,9 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
              (act & CURL_POLL_OUT ? EPOLLOUT : 0);
 
   if(f->sockfd) {
-    epoll_ctl(g->epfd, EPOLL_CTL_DEL, f->sockfd, NULL);
+    if(epoll_ctl(g->epfd, EPOLL_CTL_DEL, f->sockfd, NULL))
+      fprintf(stderr, "EPOLL_CTL_DEL failed for fd: %d : %s\n",
+              f->sockfd, strerror(errno));
   }
 
   f->sockfd = s;
@@ -283,7 +287,9 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 
   ev.events = kind;
   ev.data.fd = s;
-  epoll_ctl(g->epfd, EPOLL_CTL_ADD, s, &ev);
+  if(epoll_ctl(g->epfd, EPOLL_CTL_ADD, s, &ev))
+    fprintf(stderr, "EPOLL_CTL_ADD failed for fd: %d : %s\n",
+            s, strerror(errno));
 }
 
 

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -119,6 +119,21 @@ void Curl_resolver_global_cleanup(void)
 #endif
 }
 
+
+static void Curl_ares_sock_state_cb(void *data, ares_socket_t socket_fd,
+                                    int readable, int writable)
+{
+  struct Curl_easy *easy = data;
+  if(!readable && !writable) {
+    if(easy->easy_conn) {
+      Curl_multi_closed(easy->easy_conn, socket_fd);
+    }
+    else {
+      DEBUGASSERT(easy->easy_conn);
+    }
+  }
+}
+
 /*
  * Curl_resolver_init()
  *
@@ -126,9 +141,14 @@ void Curl_resolver_global_cleanup(void)
  * URL-state specific environment ('resolver' member of the UrlState
  * structure).  Fills the passed pointer by the initialized ares_channel.
  */
-CURLcode Curl_resolver_init(void **resolver)
+CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver)
 {
-  int status = ares_init((ares_channel*)resolver);
+  int status;
+  struct ares_options options;
+  int optmask = ARES_OPT_SOCK_STATE_CB;
+  options.sock_state_cb = Curl_ares_sock_state_cb;
+  options.sock_state_cb_data = easy;
+  status = ares_init_options((ares_channel*)resolver, &options, optmask);
   if(status != ARES_SUCCESS) {
     if(status == ARES_ENOMEM)
       return CURLE_OUT_OF_MEMORY;
@@ -159,12 +179,15 @@ void Curl_resolver_cleanup(void *resolver)
  * environment ('resolver' member of the UrlState structure).  Duplicates the
  * 'from' ares channel and passes the resulting channel to the 'to' pointer.
  */
-int Curl_resolver_duphandle(void **to, void *from)
+CURLcode Curl_resolver_duphandle(struct Curl_easy *easy, void **to, void *from)
 {
-  /* Clone the ares channel for the new handle */
-  if(ARES_SUCCESS != ares_dup((ares_channel*)to, (ares_channel)from))
-    return CURLE_FAILED_INIT;
-  return CURLE_OK;
+  (void)from;
+  /*
+   * it would be better to call ares_dup instead, but right now
+   * it is not possible to set 'sock_state_cb_data' outside of
+   * ares_init_options
+   */
+  return Curl_resolver_init(easy, to);
 }
 
 static void destroy_async_data(struct Curl_async *async);

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -125,12 +125,8 @@ static void Curl_ares_sock_state_cb(void *data, ares_socket_t socket_fd,
 {
   struct Curl_easy *easy = data;
   if(!readable && !writable) {
-    if(easy->easy_conn) {
-      Curl_multi_closed(easy->easy_conn, socket_fd);
-    }
-    else {
-      DEBUGASSERT(easy->easy_conn);
-    }
+    DEBUGASSERT(easy);
+    Curl_multi_closed(easy, socket_fd);
   }
 }
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -108,8 +108,9 @@ void Curl_resolver_global_cleanup(void)
  * URL-state specific environment ('resolver' member of the UrlState
  * structure).
  */
-CURLcode Curl_resolver_init(void **resolver)
+CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver)
 {
+  (void)easy;
   *resolver = calloc(1, sizeof(struct resdata));
   if(!*resolver)
     return CURLE_OUT_OF_MEMORY;
@@ -132,10 +133,10 @@ void Curl_resolver_cleanup(void *resolver)
  * Called from curl_easy_duphandle() to duplicate resolver URL state-specific
  * environment ('resolver' member of the UrlState structure).
  */
-int Curl_resolver_duphandle(void **to, void *from)
+CURLcode Curl_resolver_duphandle(struct Curl_easy *easy, void **to, void *from)
 {
   (void)from;
-  return Curl_resolver_init(to);
+  return Curl_resolver_init(easy, to);
 }
 
 static void destroy_async_data(struct Curl_async *);

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -60,7 +60,7 @@ void Curl_resolver_global_cleanup(void);
  * Returning anything else than CURLE_OK fails curl_easy_init() with the
  * correspondent code.
  */
-CURLcode Curl_resolver_init(void **resolver);
+CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver);
 
 /*
  * Curl_resolver_cleanup()
@@ -79,7 +79,8 @@ void Curl_resolver_cleanup(void *resolver);
  * pointer.  Returning anything else than CURLE_OK causes failed
  * curl_easy_duphandle() call.
  */
-int Curl_resolver_duphandle(void **to, void *from);
+CURLcode Curl_resolver_duphandle(struct Curl_easy *easy, void **to,
+                                 void *from);
 
 /*
  * Curl_resolver_cancel().
@@ -150,8 +151,8 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 #define Curl_resolver_is_resolved(x,y) CURLE_COULDNT_RESOLVE_HOST
 #define Curl_resolver_wait_resolv(x,y) CURLE_COULDNT_RESOLVE_HOST
 #define Curl_resolver_getsock(x,y,z) 0
-#define Curl_resolver_duphandle(x,y) CURLE_OK
-#define Curl_resolver_init(x) CURLE_OK
+#define Curl_resolver_duphandle(x,y,z) CURLE_OK
+#define Curl_resolver_init(x,y) CURLE_OK
 #define Curl_resolver_global_init() CURLE_OK
 #define Curl_resolver_global_cleanup() Curl_nop_stmt
 #define Curl_resolver_cleanup(x) Curl_nop_stmt

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1314,7 +1314,7 @@ int Curl_closesocket(struct connectdata *conn,
       conn->sock_accepted[SECONDARYSOCKET] = FALSE;
     else {
       int rc;
-      Curl_multi_closed(conn, sock);
+      Curl_multi_closed(conn->data, sock);
       Curl_set_in_callback(conn->data, true);
       rc = conn->fclosesocket(conn->closesocket_client, sock);
       Curl_set_in_callback(conn->data, false);
@@ -1324,7 +1324,7 @@ int Curl_closesocket(struct connectdata *conn,
 
   if(conn)
     /* tell the multi-socket code about this */
-    Curl_multi_closed(conn, sock);
+    Curl_multi_closed(conn->data, sock);
 
   sclose(sock);
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -966,7 +966,8 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   }
 
   /* Clone the resolver handle, if present, for the new handle */
-  if(Curl_resolver_duphandle(&outcurl->state.resolver,
+  if(Curl_resolver_duphandle(outcurl,
+                             &outcurl->state.resolver,
                              data->state.resolver))
     goto fail;
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2466,11 +2466,11 @@ void Curl_updatesocket(struct Curl_easy *data)
  * socket again and it gets the same file descriptor number.
  */
 
-void Curl_multi_closed(struct connectdata *conn, curl_socket_t s)
+void Curl_multi_closed(struct Curl_easy *data, curl_socket_t s)
 {
-  if(conn->data) {
+  if(data) {
     /* if there's still an easy handle associated with this connection */
-    struct Curl_multi *multi = conn->data->multi;
+    struct Curl_multi *multi = data->multi;
     if(multi) {
       /* this is set if this connection is part of a handle that is added to
          a multi handle, and only then this is necessary */
@@ -2478,7 +2478,7 @@ void Curl_multi_closed(struct connectdata *conn, curl_socket_t s)
 
       if(entry) {
         if(multi->socket_cb)
-          multi->socket_cb(conn->data, s, CURL_POLL_REMOVE,
+          multi->socket_cb(data, s, CURL_POLL_REMOVE,
                            multi->socket_userp,
                            entry->socketp);
 

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -89,7 +89,7 @@ void Curl_multi_connchanged(struct Curl_multi *multi);
  * socket again and it gets the same file descriptor number.
  */
 
-void Curl_multi_closed(struct connectdata *conn, curl_socket_t s);
+void Curl_multi_closed(struct Curl_easy *data, curl_socket_t s);
 
 /*
  * Add a handle and move it into PERFORM state at once. For pushed streams.

--- a/lib/url.c
+++ b/lib/url.c
@@ -570,7 +570,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
   data->magic = CURLEASY_MAGIC_NUMBER;
 
-  result = Curl_resolver_init(&data->state.resolver);
+  result = Curl_resolver_init(data, &data->state.resolver);
   if(result) {
     DEBUGF(fprintf(stderr, "Error: resolver_init failed\n"));
     free(data);


### PR DESCRIPTION
When using c-ares for asyn dns, the dns socket fd was silently closed by c-ares without curl being aware. curl would then 'realize' the fd has been removed at next call of `Curl_resolver_getsock`, and only then notify the `CURLMOPT_SOCKETFUNCTION` to remove fd from its poll set with `CURL_POLL_REMOVE`. At this point the fd is already closed.

Using the `ephiperfifo.c` example with the updated patch displaying `epoll_ctl` errors allow reproducing the issue:

```Adding easy 0x2345bf8 to multi 0x230a108 (https://r0ro.fr/)
* STATE: INIT => CONNECT handle 0x2345bf8; line 1428 (connection #-5000)
* Added connection 0. The cache now contains 1 members
* STATE: CONNECT => WAITRESOLVE handle 0x2345bf8; line 1464 (connection #0)
Progress: https://r0ro.fr/ (0/0)
socket callback: s=7 e=0x2345bf8 what=IN Adding data: IN
socket callback: s=7 e=0x2345bf8 what=REMOVE 
EPOLL_CTL_DEL failed for fd: 7 : Bad file descriptor   <======== fd already closed here
*   Trying 2001:bc8:33d1::1...
* TCP_NODELAY set
* STATE: WAITRESOLVE => WAITCONNECT handle 0x2345bf8; line 1545 (connection #0)
```

Note that it only affect builds with ares enabled:

``./configure --enable-ares --enable-debug ``
