### PR TITLE
winssl: be consistent in Schannel capitalization

### DIFF
--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -7,7 +7,7 @@ HTTP/2 with curl
 Build prerequisites
 -------------------
   - nghttp2
-  - OpenSSL, libressl, BoringSSL, NSS, GnutTLS, mbedTLS, wolfSSL or SChannel
+  - OpenSSL, libressl, BoringSSL, NSS, GnutTLS, mbedTLS, wolfSSL or Schannel
     with a new enough version.
 
 [nghttp2](https://nghttp2.org/)
@@ -61,7 +61,7 @@ the necessary TLS features. Right now we support:
   - NSS:              ALPN and NPN
   - GnuTLS:           ALPN
   - mbedTLS:          ALPN
-  - SChannel:         ALPN
+  - Schannel:         ALPN
   - wolfSSL:          ALPN
   - Secure Transport: ALPN
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -248,7 +248,7 @@ look for dynamic import symbols.
 
 ## Legacy Windows and SSL
 
-WinSSL (specifically SChannel from Windows SSPI), is the native SSL library in
+WinSSL (specifically Schannel from Windows SSPI), is the native SSL library in
 Windows. However, WinSSL in Windows <= XP is unable to connect to servers that
 no longer support the legacy handshakes and algorithms used by those
 versions. If you will be using curl in one of those earlier versions of

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -411,12 +411,12 @@ problems may have been fixed or changed somewhat since this was written!
 6.1 NTLM authentication and unicode
 
  NTLM authentication involving unicode user name or password only works
- properly if built with UNICODE defined together with the WinSSL/schannel
+ properly if built with UNICODE defined together with the WinSSL/Schannel
  backend. The original problem was mentioned in:
  https://curl.haxx.se/mail/lib-2009-10/0024.html
  https://curl.haxx.se/bug/view.cgi?id=896
 
- The WinSSL/schannel version verified to work as mentioned in
+ The WinSSL/Schannel version verified to work as mentioned in
  https://curl.haxx.se/mail/lib-2012-07/0073.html
 
 6.2 MIT Kerberos for Windows build

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.3
@@ -71,8 +71,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-This option is only working in libcurl built with OpenSSL, NSS, schannel or
-GSKit support. schannel support added in 7.50.0
+This option is only working in libcurl built with OpenSSL, NSS, Schannel or
+GSKit support. Schannel support added in 7.50.0
 
 Added in 7.19.1
 .SH RETURN VALUE

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -23,9 +23,8 @@
  ***************************************************************************/
 
 /*
- * Source file for all SChannel-specific code for the TLS/SSL layer. No code
+ * Source file for all Schannel-specific code for the TLS/SSL layer. No code
  * but vtls.c should ever call or use these functions.
- *
  */
 
 /*
@@ -196,7 +195,7 @@ set_ssl_version_min_max(SCHANNEL_CRED *schannel_cred, struct connectdata *conn)
         schannel_cred->grbitEnabledProtocols |= SP_PROT_TLS1_2_CLIENT;
         break;
       case CURL_SSLVERSION_TLSv1_3:
-        failf(data, "Schannel: TLS 1.3 is not yet supported");
+        failf(data, "schannel: TLS 1.3 is not yet supported");
         return CURLE_SSL_CONNECT_ERROR;
     }
   }
@@ -434,7 +433,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
 
   if(Curl_verify_windows_version(5, 1, PLATFORM_WINNT,
                                  VERSION_LESS_THAN_EQUAL)) {
-     /* SChannel in Windows XP (OS version 5.1) uses legacy handshakes and
+     /* Schannel in Windows XP (OS version 5.1) uses legacy handshakes and
         algorithms that may not be supported by all servers. */
      infof(data, "schannel: WinSSL version is old and may not be able to "
            "connect to some servers due to lack of SNI, algorithms, etc.\n");

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 
 /*
- * Source file for SChannel-specific certificate verification. This code should
+ * Source file for Schannel-specific certificate verification. This code should
  * only be invoked by code in schannel.c.
  */
 

--- a/projects/README
+++ b/projects/README
@@ -152,7 +152,7 @@ Legacy Windows and SSL
 ======================
 
    Some of the project configurations allow the use of WinSSL (specifically
-   SChannel from Windows SSPI), the native SSL library in Windows. However,
+   Schannel from Windows SSPI), the native SSL library in Windows. However,
    WinSSL in Windows <= XP is unable to connect to servers that no longer
    support the legacy handshakes and algorithms used by those versions. If
    you will be using curl in one of those earlier versions of Windows you


### PR DESCRIPTION
The productname from Microsoft is "Schannel", but in infof/failf reporting we use "schannel". This removes different versions from userfacing documentation/output.