### PR TITLE
ESCape "\n" codes

### DIFF
--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
@@ -44,7 +44,7 @@ if(curl) {
     long error;
     res = curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &error);
     if(res && error) {
-      printf("Errno: %ld\n", error);
+      printf("Errno: %ld\\n", error);
     }
   }
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_CHUNK_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_DATA.3
@@ -46,20 +46,20 @@ static long file_is_coming(struct curl_fileinfo *finfo,
 
   switch(finfo->filetype) {
   case CURLFILETYPE_DIRECTORY:
-    printf(" DIR\n");
+    printf(" DIR\\n");
     break;
   case CURLFILETYPE_FILE:
     printf("FILE ");
     break;
   default:
-    printf("OTHER\n");
+    printf("OTHER\\n");
     break;
   }
 
   if(finfo->filetype == CURLFILETYPE_FILE) {
     /* do not transfer files >= 50B */
     if(finfo->size > 50) {
-      printf("SKIPPED\n");
+      printf("SKIPPED\\n");
       return CURL_CHUNK_BGN_FUNC_SKIP;
     }
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.3
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.3
@@ -39,7 +39,7 @@ All except file:
 .nf
 static int closesocket(void *clientp, curl_socket_t item)
 {
-  printf("libcurl wants to close %d now\n", (int)item);
+  printf("libcurl wants to close %d now\\n", (int)item);
   return 0;
 }
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.3
@@ -50,7 +50,7 @@ All
 .nf
 static int closesocket(void *clientp, curl_socket_t item)
 {
-  printf("libcurl wants to close %d now\n", (int)item);
+  printf("libcurl wants to close %d now\\n", (int)item);
   return 0;
 }
 


### PR DESCRIPTION
In a `.nf` section, Groff / Troff will display a:
```c
 printf("Errno: %ld\n", error);
```
as:
```
  printf("Errno: %ld0, error);
```
when a `"\n"` is not escaped. Use `"\\n"` instead.