### PR TITLE
KNOWN_BUGS: add --proxy-any connection issue

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -56,6 +56,7 @@ problems may have been fixed or changed somewhat since this was written!
  6.3 NTLM in system context uses wrong name
  6.4 Negotiate and Kerberos V5 need a fake user name
  6.5 NTLM doesn't support password with § character
+ 6.6 libcurl can fail to try alternatives with --proxy-any
 
  7. FTP
  7.1 FTP without or slow 220 response
@@ -446,6 +447,17 @@ problems may have been fixed or changed somewhat since this was written!
 6.5 NTLM doesn't support password with § character
 
  https://github.com/curl/curl/issues/2120
+
+6.6 libcurl can fail to try alternatives with --proxy-any
+
+ When connecting via a proxy using --proxy-any, a failure to establish an
+ authentication will cause libcurl to abort trying other options if the
+ failed method has a higher preference than the alternatives. As an example,
+ --proxy-any against a proxy which advertise Negotiate and NTLM, but which
+ fails to set up Kerberos authentication won't proceed to try authentication
+ using NTLM.
+
+ https://github.com/curl/curl/issues/876
 
 7. FTP
 


### PR DESCRIPTION
Add the identified issue with --proxy-any and proxy servers which advertise authentication schemes other than the supported one.

Closes #876
Reported-by: NTMan on Github