### PR TITLE
tool_doswin: Fix uninitialized field warning

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -678,8 +678,10 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 struct curl_slist *GetLoadedModulePaths(void)
 {
   HANDLE hnd = INVALID_HANDLE_VALUE;
-  MODULEENTRY32 mod = { sizeof(mod), };
+  MODULEENTRY32 mod = {0};
   struct curl_slist *slist = NULL;
+
+  mod.dwSize = sizeof(MODULEENTRY32);
 
   do {
     hnd = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0);


### PR DESCRIPTION
The partial struct initialization in 397664a065abffb7c3445ca9 caused a [warning](https://curl.haxx.se/dev/log.cgi?id=20181109070801-27852#prob2) in the buildfarm on uninitialized `MODULEENTRY32` struct members:
```
  /src/tool_doswin.c:681:3: warning: missing initializer for field 'th32ModuleID' of 'MODULEENTRY32 {aka struct tagMODULEENTRY32}' [-Wmissing-field-initializers]
```
This is sort of a bogus warning as the remaining members will be set to zero by the compiler, as all omitted members are. Nevertheless, remove the warning by omitting all members and setting the `dwSize` member explicitly. (Setting `th32ModuleID` to 1 as it's documented value is will only shift the warning to complain about the next field, so we need to do all or nothing.)

@jay does this seem reasonable to you?