### PR TITLE
curl: --local-port range was not "including"

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -958,7 +958,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           err = str2unum(&config->localportrange, lrange);
           if(err || (config->localportrange > 65535))
             return PARAM_BAD_USE;
-          config->localportrange -= config->localport;
+          config->localportrange -= (config->localport-1);
           if(config->localportrange < 1)
             return PARAM_BAD_USE;
         }


### PR DESCRIPTION
The end port number in a given range was not included in the range used,
as it is documented to be.

Reported-by: infinnovation-dev on github
Fixes #3251