### PR TITLE
openssl: support BoringSSL TLS renegotiation

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2610,6 +2610,10 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     SSL_set_tlsext_status_type(BACKEND->handle, TLSEXT_STATUSTYPE_ocsp);
 #endif
 
+#ifdef OPENSSL_IS_BORINGSSL
+  SSL_set_renegotiate_mode(BACKEND->handle, ssl_renegotiate_freely);
+#endif
+
   SSL_set_connect_state(BACKEND->handle);
 
   BACKEND->server_cert = 0x0;


### PR DESCRIPTION
As per BoringSSL porting documentation [1], BoringSSL rejects peer
renegotiations by default.

curl fails when trying to authenticate to server through client
certificate if it is requested by server after the initial TLS
handshake.

Enable renegotiation by default with BoringSSL to get same behavior as
with OpenSSL. This is done by calling SSL_set_renegotiate_mode [2]
which was introduced in commit 1d5ef3bb1eb9 [3].

1 - https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md#tls-renegotiation
2 - https://boringssl.googlesource.com/boringssl/+/master/include/openssl/ssl.h#3482
3 - https://boringssl.googlesource.com/boringssl/+/1d5ef3bb1eb97848617db5e7d633d735a401df86

Closes #3258 

Signed-off-by: Jérémy Rocher <rocher.jeremy@gmail.com>