### PR TITLE
RFC: silence benign warning with pragma

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -172,7 +172,14 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len, wc_buf, wc_len);
 
     if(!WriteConsoleW(
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbad-function-cast"
+#endif
         (HANDLE) _get_osfhandle(fileno(outs->stream)),
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
         wc_buf,
         wc_len,
         &wc_len,

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -161,6 +161,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     DWORD in_len = (DWORD)(sz * nmemb);
     wchar_t* wc_buf;
     DWORD wc_len;
+    intptr_t fhnd;
 
     /* calculate buffer size for wide characters */
     wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len,  NULL, 0);
@@ -170,16 +171,15 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 
     /* calculate buffer size for multi-byte characters */
     wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len, wc_buf, wc_len);
+    if(!wc_len) {
+      free(wc_buf);
+      return failure;
+    }
+
+    fhnd = _get_osfhandle(fileno(outs->stream));
 
     if(!WriteConsoleW(
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wbad-function-cast"
-#endif
-        (HANDLE) _get_osfhandle(fileno(outs->stream)),
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+        (HANDLE) fhnd,
         wc_buf,
         wc_len,
         &wc_len,


### PR DESCRIPTION
Disclaimer: I don't have a system to reproduce the warning, and test the fix, on so this is perhaps more of a discussion piece than a patch. Anyways, here goes.

Commit 5bfaa86ceb3c2a9ac474a928e748c4a86a703b33 introduced a new compiler warning on Windows cross compilation with GCC. The coding is however a documented pattern for acquiring a handle to write to, so rather than changing working code this wraps the offending cast in a GCC diagnostic pragma to silence the warning. See below for an example of the warning from the autobuild logs:
```
/src/tool_cb_wrt.c:175:9: warning: cast from function call of type 'intptr_t {aka long long int}' to non-matching type 'void *' [-Wbad-function-cast]
(HANDLE) _get_osfhandle(fileno(outs->stream)),
^
```
An example failing build can be found here: https://curl.haxx.se/dev/log.cgi?id=20181111190642-17820#prob1