### PR TITLE
ssl: fix compilation with OpenSSL 0.9.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1772,7 +1772,6 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
     dnl as it's a macro that needs the header files be included)
 
     AC_CHECK_FUNCS( RAND_egd \
-                    ENGINE_cleanup \
                     SSL_get_shutdown \
                     SSLv2_client_method )
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -69,7 +69,7 @@
 #include <openssl/ocsp.h>
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL) && /* 0.9.8 or later */     \
+#if (OPENSSL_VERSION_NUMBER >= 0x0090700fL) && /* 0.9.7 or later */     \
   !defined(OPENSSL_NO_ENGINE)
 #define USE_OPENSSL_ENGINE
 #include <openssl/engine.h>
@@ -1049,7 +1049,7 @@ static void Curl_ossl_cleanup(void)
   /* Free ciphers and digests lists */
   EVP_cleanup();
 
-#ifdef HAVE_ENGINE_CLEANUP
+#ifdef USE_OPENSSL_ENGINE
   /* Free engine list */
   ENGINE_cleanup();
 #endif


### PR DESCRIPTION
- ENGINE_cleanup() was used without including "openssl/engine.h"
- enable engine support for OpenSSL 0.9.7

OpenSSL 0.9.7 was the first version that shipped with engine support. See [README.ENGINE](https://www.github.com/openssl/openssl/blob/OpenSSL_0_9_7-stable/README.ENGINE)

Follow-up to #2983