### PR TITLE
Remove redundant ifdef USE_OPENSSL

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -52,15 +52,15 @@
 
 #if !defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO)
 
-#  ifdef USE_OPENSSL
-#    include <openssl/des.h>
-#    ifndef OPENSSL_NO_MD4
-#      include <openssl/md4.h>
-#    endif
-#    include <openssl/md5.h>
-#    include <openssl/ssl.h>
-#    include <openssl/rand.h>
-#  endif
+#ifdef USE_OPENSSL
+#   include <openssl/des.h>
+#   ifndef OPENSSL_NO_MD4
+#     include <openssl/md4.h>
+#   endif
+#   include <openssl/md5.h>
+#   include <openssl/ssl.h>
+#   include <openssl/rand.h>
+# endif
 #  if (OPENSSL_VERSION_NUMBER < 0x00907001L)
 #    define DES_key_schedule des_key_schedule
 #    define DES_cblock des_cblock

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -52,8 +52,6 @@
 
 #if !defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO)
 
-#ifdef USE_OPENSSL
-
 #  ifdef USE_OPENSSL
 #    include <openssl/des.h>
 #    ifndef OPENSSL_NO_MD4
@@ -62,14 +60,6 @@
 #    include <openssl/md5.h>
 #    include <openssl/ssl.h>
 #    include <openssl/rand.h>
-#  else
-#    include <des.h>
-#    ifndef OPENSSL_NO_MD4
-#      include <md4.h>
-#    endif
-#    include <md5.h>
-#    include <ssl.h>
-#    include <rand.h>
 #  endif
 #  if (OPENSSL_VERSION_NUMBER < 0x00907001L)
 #    define DES_key_schedule des_key_schedule


### PR DESCRIPTION
There's code that reads as follows:
#ifdef USE_OPENSSL
#ifdef USE_OPENSSL
#else
Remove the redundant USE_OPENSSL along with #else (it's not possible to reach it anyway).