### PR TITLE
openssl: Remove SSLEAY leftovers

### DIFF
--- a/lib/Makefile.Watcom
+++ b/lib/Makefile.Watcom
@@ -157,7 +157,7 @@ CFLAGS += -DUSE_LIBSSH2 -DHAVE_LIBSSH2_H -I"$(LIBSSH2_ROOT)/include" -I"$(LIBSSH
 !endif
 
 !ifdef %use_ssl
-CFLAGS += -wcd=138 -dUSE_OPENSSL -dUSE_SSLEAY -I"$(OPENSSL_ROOT)/inc32"
+CFLAGS += -wcd=138 -dUSE_OPENSSL -I"$(OPENSSL_ROOT)/inc32"
 !endif
 
 !ifdef %use_ares

--- a/lib/Makefile.netware
+++ b/lib/Makefile.netware
@@ -632,7 +632,6 @@ ifdef WITH_ZLIB
 	@echo $(DL)#define HAVE_LIBZ 1$(DL) >> $@
 endif
 ifdef WITH_SSL
-	@echo $(DL)#define USE_SSLEAY 1$(DL) >> $@
 	@echo $(DL)#define USE_OPENSSL 1$(DL) >> $@
 	@echo $(DL)#define HAVE_OPENSSL_X509_H 1$(DL) >> $@
 	@echo $(DL)#define HAVE_OPENSSL_SSL_H 1$(DL) >> $@
@@ -645,7 +644,6 @@ ifdef WITH_SSL
 	@echo $(DL)#define HAVE_LIBCRYPTO 1$(DL) >> $@
 	@echo $(DL)#define OPENSSL_NO_KRB5 1$(DL) >> $@
 ifdef WITH_SRP
-	@echo $(DL)#define HAVE_SSLEAY_SRP 1$(DL) >> $@
 	@echo $(DL)#define USE_TLS_SRP 1$(DL) >> $@
 endif
 ifdef WITH_SPNEGO

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -96,7 +96,7 @@ CFLAGS = -g -O2 -I. -I$(TOPDIR)/include -I$(TOPDIR)/lib \
          -I$(WATT32_ROOT)/inc -Wall -DHAVE_CONFIG_H
 
 ifeq ($(USE_SSL),1)
-  CFLAGS += -DUSE_SSLEAY -DUSE_OPENSSL -I$(OPENSSL_ROOT)
+  CFLAGS += -DUSE_OPENSSL -I$(OPENSSL_ROOT)
 endif
 
 ifeq ($(USE_ZLIB),1)

--- a/packages/vms/generate_config_vms_h_curl.com
+++ b/packages/vms/generate_config_vms_h_curl.com
@@ -404,9 +404,6 @@ $!
 $   write cvh "#ifndef USE_OPENSSL"
 $   write cvh "#define USE_OPENSSL 1"
 $   write cvh "#endif"
-$   write cvh "#ifndef USE_SSLEAY"
-$   write cvh "#define USE_SSLEAY 1"
-$   write cvh "#endif"
 $   if arch_name .eqs. "VAX"
 $   then
 $       old_mes = f$enviroment("message")


### PR DESCRIPTION
Commit 709cf76f6bb7dbac deprecated `USE_SSLEAY`, as curl since long isn't compatible with the SSLeay library. This removes the few leftovers that were omitted in the less frequently used platform targets.