### PR TITLE
Use lgtm to find Python syntax errors

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,3 +8,14 @@ extraction:
       - ./buildconf
     configure: # enable as many optional features as possible
       command: ./configure --enable-ares --with-libssh2 --with-gssapi --with-librtmp --with-libmetalink --with-libmetalink
+  python:
+    python_setup:
+      version: 3
+    after_prepare:
+      - python3 -m pip install --upgrade --user flake8
+    before_index:
+      - python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
+      # stop the build if there are Python syntax errors or undefined names
+      - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+      - python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
Python is just 11.8% of the curl codebase but it is still good to spot the anachronisms in the impacket code.

[flake8](http://flake8.pycqa.org) testing of https://github.com/curl/curl on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/python_dependencies/impacket/spnego.py:77:6: E999 TabError: inconsistent use of tabs and spaces in indentation
	else:
     ^
./tests/python_dependencies/impacket/structure.py:100:40: E999 SyntaxError: invalid syntax
            print "packField( %s | %s )" % (fieldName, format)
                                       ^
./tests/python_dependencies/impacket/smb.py:632:27: E999 SyntaxError: invalid syntax
        y = t & 0xffffffffL
                          ^
./tests/python_dependencies/impacket/ntlm.py:239:28: E999 SyntaxError: invalid syntax
            print "%s: {%r}" % (i,self[i])
                           ^
./tests/python_dependencies/impacket/smb3.py:234:26: E999 SyntaxError: invalid syntax
        print "CONNECTION"
                         ^
./tests/python_dependencies/impacket/uuid.py:22:13: E999 SyntaxError: invalid syntax
    top = (1L<<31)-1
            ^
./tests/python_dependencies/impacket/nmb.py:457:31: E999 SyntaxError: invalid syntax
            raise NetBIOSError, ( 'Cannot bind to a good UDP port', ERRCLASS_OS, errno.EAGAIN )
                              ^
./tests/python_dependencies/impacket/smbserver.py:83:25: E999 SyntaxError: invalid syntax
        except Exception, e:
                        ^
8     E999 SyntaxError: invalid syntax
8
```