### PR TITLE
http_negotiate: do not close connection until negotiation is completed

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -610,7 +610,6 @@ output_auth_headers(struct connectdata *conn,
     result = Curl_output_negotiate(conn, proxy);
     if(result)
       return result;
-    authstatus->done = TRUE;
     negdata->state = GSS_AUTHSENT;
   }
   else


### PR DESCRIPTION
Aim of this PR is to fix the HTTP POST using CURLAUTH_NEGOTIATE.

When connecting to an HTTP URL through a proxy that accepts Negotiation based authorization, libcURL fails to login to the proxy. The Negotiate protocol requires two round trips with the proxy. During the first one the client provides the Negotiate flags and the proxy answers with a Negotiate challenge, returning also HTTP 407. In the second round trip, the client provides the answer to the challenge and, if the proxy accepts it, it returns HTTP 200.
By setting authstatus->done always to true after emitting the Negotiate authorization header, so even after just emitting the header for the first request, libcURL closes the connection after the first round trip. Then it reopens it and executes the second roundtrip, thus answering to the challenge: the proxy, receiving a new connection, loses the context and is unable to associate the challenge response to the original challenge. For this reason it returns again 407.
 
The change is aimed at setting authstatus->done to true only if the client thinks it is at the last stage of its negotiation, to prevent libcURL from closing the socket while the negotiation is still ongoing. The negotiation can be considered as complete when the final status of the SPNEGO decoding is a completion status (GSS_S_COMPLETE for GSSAPI and SEC_E_OK for SSPI).

Please review.