### PR TITLE
impacket: add LICENSE

### DIFF
--- a/tests/python_dependencies/impacket/LICENSE
+++ b/tests/python_dependencies/impacket/LICENSE
@@ -1,0 +1,84 @@
+Licencing
+---------
+
+We provide this software under a slightly modified version of the
+Apache Software License. The only changes to the document were the
+replacement of "Apache" with "Impacket" and "Apache Software Foundation"
+with "SecureAuth Corporation". Feel free to compare the resulting
+document to the official Apache license.
+
+The `Apache Software License' is an Open Source Initiative Approved
+License.
+
+
+The Apache Software License, Version 1.1
+Modifications by SecureAuth Corporation (see above)
+
+Copyright (c) 2000 The Apache Software Foundation.  All rights
+reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:
+      "This product includes software developed by
+       SecureAuth Corporation (http://www.secureauth.com/)."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "Impacket", "SecureAuth Corporation" and "CORE Security Technologies" must
+   not be used to endorse or promote products derived from this
+   software without prior written permission. For written
+   permission, please contact oss@coresecurity.com.
+
+5. Products derived from this software may not be called "Impacket",
+   nor may "Impacket" appear in their name, without prior written
+   permission of SecureAuth Corporation.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+
+
+Smb.py and nmb.py are based on Pysmb by Michael Teo
+(http://miketeo.net/projects/pysmb/), and are distributed under the
+following license:
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the author be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+   not claim that you wrote the original software. If you use this
+   software in a product, an acknowledgment in the product
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must
+   not be misrepresented as being the original software.
+
+3. This notice cannot be removed or altered from any source
+   distribution.


### PR DESCRIPTION
The license for the impacket package was not in our tree.

Imported now from upstream's
https://github.com/SecureAuthCorp/impacket/blob/master/LICENSE

Reported-by: infinnovation-dev on github
Fixes #3276