### PR TITLE
docs/examples/imap-tls.c: add 's' for secure scheme

### DIFF
--- a/docs/examples/imap-tls.c
+++ b/docs/examples/imap-tls.c
@@ -48,7 +48,7 @@ int main(void)
 
     /* This will fetch message 1 from the user's inbox */
     curl_easy_setopt(curl, CURLOPT_URL,
-                     "imap://imap.example.com/INBOX/;UID=1");
+                     "imaps://imap.example.com/INBOX/;UID=1");
 
     /* In this example, we'll start with a plain text connection, and upgrade
      * to Transport Layer Security (TLS) using the STARTTLS command. Be careful


### PR DESCRIPTION
Hello there,

Maybe this tiny fix will help to start more quickly with `imaps://` instead of `imap://` for gmail account.

Sergey.