### PR TITLE
tests: add support to test against OpenSSH for Windows

### DIFF
--- a/tests/sshhelp.pm
+++ b/tests/sshhelp.pm
@@ -430,6 +430,16 @@ sub sshversioninfo {
                 $error = undef;
                 last;
             }
+            if($tmpstr =~ /OpenSSH[_-]for[_-]Windows[_-](\d+)\.(\d+)(\.(\d+))*/i) {
+                $major = $1;
+                $minor = $2;
+                $patch = $4?$4:0;
+                $sshid = 'OpenSSH-Windows';
+                $versnum = (100*$major) + (10*$minor) + $patch;
+                $versstr = "$sshid $major.$minor.$patch";
+                $error = undef;
+                last;
+            }
             if($tmpstr =~ /Sun[_-]SSH[_-](\d+)\.(\d+)(\.(\d+))*/i) {
                 $major = $1;
                 $minor = $2;


### PR DESCRIPTION
This a work-in-process pull-request to get the testsuite work with OpenSSH for Windows.

This pull-request is not complete and only open to trigger the CI tests.