### PR TITLE
snprintf: renamed and we now only use msnprintf()

### DIFF
--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -62,4 +62,4 @@ include Makefile.inc
 all: $(check_PROGRAMS)
 
 checksrc:
-	@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.c
+	@PERL@ $(top_srcdir)/lib/checksrc.pl -ASNPRINTF $(srcdir)/*.c

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -277,7 +277,7 @@ static unsigned int CURL_STDCALL getaddrinfo_thread(void *arg)
   char service[12];
   int rc;
 
-  snprintf(service, sizeof(service), "%d", tsd->port);
+  msnprintf(service, sizeof(service), "%d", tsd->port);
 
   rc = Curl_getaddrinfo_ex(tsd->hostname, service, &tsd->hints, &tsd->res);
 
@@ -679,7 +679,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
   hints.ai_family = pf;
   hints.ai_socktype = conn->socktype;
 
-  snprintf(sbuf, sizeof(sbuf), "%d", port);
+  msnprintf(sbuf, sizeof(sbuf), "%d", port);
 
   reslv->start = Curl_now();
   /* fire up a new resolver thread! */

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -233,24 +233,24 @@ static CURLcode base64_encode(const char *table64,
 
     switch(inputparts) {
     case 1: /* only one byte read */
-      snprintf(output, 5, "%c%c==",
-               table64[obuf[0]],
-               table64[obuf[1]]);
+      msnprintf(output, 5, "%c%c==",
+                table64[obuf[0]],
+                table64[obuf[1]]);
       break;
 
     case 2: /* two bytes read */
-      snprintf(output, 5, "%c%c%c=",
-               table64[obuf[0]],
-               table64[obuf[1]],
-               table64[obuf[2]]);
+      msnprintf(output, 5, "%c%c%c=",
+                table64[obuf[0]],
+                table64[obuf[1]],
+                table64[obuf[2]]);
       break;
 
     default:
-      snprintf(output, 5, "%c%c%c%c",
-               table64[obuf[0]],
-               table64[obuf[1]],
-               table64[obuf[2]],
-               table64[obuf[3]]);
+      msnprintf(output, 5, "%c%c%c%c",
+                table64[obuf[0]],
+                table64[obuf[1]],
+                table64[obuf[2]],
+                table64[obuf[3]]);
       break;
     }
     output += 4;

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -35,6 +35,7 @@ my $suppressed; # whitelisted problems
 my $file;
 my $dir=".";
 my $wlist="";
+my @alist;
 my $windows_os = $^O eq 'MSWin32' || $^O eq 'msys' || $^O eq 'cygwin';
 my $verbose;
 my %whitelist;
@@ -74,6 +75,7 @@ my %warnings = (
     'SEMINOSPACE'      => 'semicolon without following space',
     'MULTISPACE'       => 'multiple spaces used when not suitable',
     'SIZEOFNOPAREN'    => 'use of sizeof without parentheses',
+    'SNPRINTF'         => 'use of snprintf',
     );
 
 sub readwhitelist {
@@ -153,6 +155,11 @@ while(1) {
         $file = shift @ARGV;
         next;
     }
+    elsif($file =~ /-A(.*)/) {
+        push @alist, $1;
+        $file = shift @ARGV;
+        next;
+    }
     elsif($file =~ /-i([1-9])/) {
         $indent = $1 + 0;
         $file = shift @ARGV;
@@ -174,6 +181,7 @@ while(1) {
 if(!$file) {
     print "checksrc.pl [option] <file1> [file2] ...\n";
     print " Options:\n";
+    print "  -A[rule]  Accept this violation, can be used multiple times\n";
     print "  -D[DIR]   Directory to prepend file names\n";
     print "  -h        Show help output\n";
     print "  -W[file]  Whitelist the given file - ignore all its flaws\n";
@@ -197,6 +205,17 @@ do {
     $file = shift @ARGV;
 
 } while($file);
+
+sub accept_violations {
+    for my $r (@alist) {
+        if(!$warnings{$r}) {
+            print "'$r' is not a warning to accept!\n";
+            exit;
+        }
+        $ignore{$r}=999999;
+        $ignore_used{$r}=0;
+    }
+}
 
 sub checksrc_clear {
     undef %ignore;
@@ -297,6 +316,7 @@ sub scanfile {
     my $incomment=0;
     my $copyright=0;
     checksrc_clear(); # for file based ignores
+    accept_violations();
 
     while(<R>) {
         $windows_os ? $_ =~ s/\r?\n$// : chomp;
@@ -507,6 +527,13 @@ sub scanfile {
                    \s*\(
                  /x) {
             checkwarn("BANNEDFUNC",
+                      $line, length($1), $file, $ol,
+                      "use of $2 is banned");
+        }
+
+        # scan for use of snprintf for curl-internals reasons
+        if($l =~ /^(.*\W)(v?snprintf)\s*\(/x) {
+            checkwarn("SNPRINTF",
                       $line, length($1), $file, $ol,
                       "use of $2 is banned");
         }

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -175,7 +175,7 @@ static void hashkey(struct connectdata *conn, char *buf,
   DEBUGASSERT(len > 32);
 
   /* put the number first so that the hostname gets cut off if too long */
-  snprintf(buf, len, "%ld%s", conn->port, hostname);
+  msnprintf(buf, len, "%ld%s", conn->port, hostname);
 }
 
 void Curl_conncache_unlock(struct connectdata *conn)

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -655,7 +655,7 @@ bool Curl_getaddressinfo(struct sockaddr *sa, char *addr,
 #if defined(HAVE_SYS_UN_H) && defined(AF_UNIX)
     case AF_UNIX:
       su = (struct sockaddr_un*)sa;
-      snprintf(addr, MAX_IPADR_LEN, "%s", su->sun_path);
+      msnprintf(addr, MAX_IPADR_LEN, "%s", su->sun_path);
       *port = 0;
       return TRUE;
 #endif

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -97,9 +97,9 @@ static size_t display_gss_error(OM_uint32 status, int type,
                                   &msg_ctx,
                                   &status_string);
     if(GSS_LOG_BUFFER_LEN > len + status_string.length + 3) {
-      len += snprintf(buf + len, GSS_LOG_BUFFER_LEN - len,
-                      "%.*s. ", (int)status_string.length,
-                      (char *)status_string.value);
+      len += msnprintf(buf + len, GSS_LOG_BUFFER_LEN - len,
+                       "%.*s. ", (int)status_string.length,
+                       (char *)status_string.value);
     }
     gss_release_buffer(&min_stat, &status_string);
   } while(!GSS_ERROR(maj_stat) && msg_ctx != 0);

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -743,12 +743,12 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
     return CURLE_OUT_OF_MEMORY;
 
   /* Create the BLOB structure */
-  snprintf((char *)ptr + NTLM_HMAC_MD5_LEN, NTLMv2_BLOB_LEN,
-           "%c%c%c%c"   /* NTLMv2_BLOB_SIGNATURE */
-           "%c%c%c%c",  /* Reserved = 0 */
-           NTLMv2_BLOB_SIGNATURE[0], NTLMv2_BLOB_SIGNATURE[1],
-           NTLMv2_BLOB_SIGNATURE[2], NTLMv2_BLOB_SIGNATURE[3],
-           0, 0, 0, 0);
+  msnprintf((char *)ptr + NTLM_HMAC_MD5_LEN, NTLMv2_BLOB_LEN,
+            "%c%c%c%c"   /* NTLMv2_BLOB_SIGNATURE */
+            "%c%c%c%c",  /* Reserved = 0 */
+            NTLMv2_BLOB_SIGNATURE[0], NTLMv2_BLOB_SIGNATURE[1],
+            NTLMv2_BLOB_SIGNATURE[2], NTLMv2_BLOB_SIGNATURE[3],
+            0, 0, 0, 0);
 
   Curl_write64_le(tw, ptr + 24);
   memcpy(ptr + 32, challenge_client, 8);

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,7 +31,7 @@
 
 # undef printf
 # undef fprintf
-# undef snprintf
+# undef msnprintf
 # undef vprintf
 # undef vfprintf
 # undef vsnprintf
@@ -39,18 +39,10 @@
 # undef vaprintf
 # define printf curl_mprintf
 # define fprintf curl_mfprintf
-# define snprintf curl_msnprintf
+# define msnprintf curl_msnprintf
 # define vprintf curl_mvprintf
 # define vfprintf curl_mvfprintf
-# define vsnprintf curl_mvsnprintf
+# define mvsnprintf curl_mvsnprintf
 # define aprintf curl_maprintf
 # define vaprintf curl_mvaprintf
-
-/* We define away the sprintf functions unconditonally since we don't want
-   internal code to be using them, intentionally or by mistake!*/
-# undef sprintf
-# undef vsprintf
-# define sprintf sprintf_was_used
-# define vsprintf vsprintf_was_used
-
 #endif /* HEADER_CURL_PRINTF_H */

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -81,22 +81,21 @@
 # undef printf
 # undef fprintf
 # undef sprintf
-# undef snprintf
+# undef msnprintf
 # undef vprintf
 # undef vfprintf
 # undef vsprintf
-# undef vsnprintf
+# undef mvsnprintf
 # undef aprintf
 # undef vaprintf
 
 # define printf curlx_mprintf
 # define fprintf curlx_mfprintf
 # define sprintf curlx_msprintf
-# define snprintf curlx_msnprintf
+# define msnprintf curlx_msnprintf
 # define vprintf curlx_mvprintf
 # define vfprintf curlx_mvfprintf
-# define vsprintf curlx_mvsprintf
-# define vsnprintf curlx_mvsnprintf
+# define mvsnprintf curlx_mvsnprintf
 # define aprintf curlx_maprintf
 # define vaprintf curlx_mvaprintf
 #endif /* ENABLE_CURLX_PRINTF */

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -660,13 +660,13 @@ static void showdoh(struct Curl_easy *data,
       char buffer[128];
       char *ptr;
       size_t len;
-      snprintf(buffer, 128, "DOH AAAA: ");
+      msnprintf(buffer, 128, "DOH AAAA: ");
       ptr = &buffer[10];
       len = 118;
       for(j = 0; j < 16; j += 2) {
         size_t l;
-        snprintf(ptr, len, "%s%02x%02x", j?":":"", d->addr[i].ip.v6[j],
-                 d->addr[i].ip.v6[j + 1]);
+        msnprintf(ptr, len, "%s%02x%02x", j?":":"", d->addr[i].ip.v6[j],
+                  d->addr[i].ip.v6[j + 1]);
         l = strlen(ptr);
         len -= l;
         ptr += l;

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -122,7 +122,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
         return NULL;
       }
 
-      snprintf(&ns[strindex], 4, "%%%02X", in);
+      msnprintf(&ns[strindex], 4, "%%%02X", in);
 
       strindex += 3;
     }

--- a/lib/file.c
+++ b/lib/file.c
@@ -417,8 +417,9 @@ static CURLcode file_do(struct connectdata *conn, bool *done)
     struct tm buffer;
     const struct tm *tm = &buffer;
     char header[80];
-    snprintf(header, sizeof(header),
-             "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n", expected_size);
+    msnprintf(header, sizeof(header),
+              "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n",
+              expected_size);
     result = Curl_client_write(conn, CLIENTWRITE_HEADER, header, 0);
     if(result)
       return result;
@@ -434,16 +435,16 @@ static CURLcode file_do(struct connectdata *conn, bool *done)
       return result;
 
     /* format: "Tue, 15 Nov 1994 12:45:26 GMT" */
-    snprintf(header, sizeof(header),
-             "Last-Modified: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n%s",
-             Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
-             tm->tm_mday,
-             Curl_month[tm->tm_mon],
-             tm->tm_year + 1900,
-             tm->tm_hour,
-             tm->tm_min,
-             tm->tm_sec,
-             data->set.opt_no_body ? "": "\r\n");
+    msnprintf(header, sizeof(header),
+              "Last-Modified: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n%s",
+              Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
+              tm->tm_mday,
+              Curl_month[tm->tm_mon],
+              tm->tm_year + 1900,
+              tm->tm_hour,
+              tm->tm_min,
+              tm->tm_sec,
+              data->set.opt_no_body ? "": "\r\n");
     result = Curl_client_write(conn, CLIENTWRITE_HEADER, header, 0);
     if(result)
       return result;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1272,7 +1272,7 @@ static CURLcode ftp_state_use_port(struct connectdata *conn,
         source++;
       }
       *dest = 0;
-      snprintf(dest, 20, ",%d,%d", (int)(port>>8), (int)(port&0xff));
+      msnprintf(dest, 20, ",%d,%d", (int)(port>>8), (int)(port&0xff));
 
       result = Curl_pp_sendf(&ftpc->pp, "%s %s", mode[fcmd], tmp);
       if(result) {
@@ -2061,9 +2061,9 @@ static CURLcode ftp_state_mdtm_resp(struct connectdata *conn,
         char timebuf[24];
         time_t secs = time(NULL);
 
-        snprintf(timebuf, sizeof(timebuf),
-                 "%04d%02d%02d %02d:%02d:%02d GMT",
-                 year, month, day, hour, minute, second);
+        msnprintf(timebuf, sizeof(timebuf),
+                  "%04d%02d%02d %02d:%02d:%02d GMT",
+                  year, month, day, hour, minute, second);
         /* now, convert this into a time() value: */
         data->info.filetime = curl_getdate(timebuf, &secs);
       }
@@ -2086,15 +2086,15 @@ static CURLcode ftp_state_mdtm_resp(struct connectdata *conn,
           return result;
 
         /* format: "Tue, 15 Nov 1994 12:45:26" */
-        snprintf(headerbuf, sizeof(headerbuf),
-                 "Last-Modified: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n",
-                 Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
-                 tm->tm_mday,
-                 Curl_month[tm->tm_mon],
-                 tm->tm_year + 1900,
-                 tm->tm_hour,
-                 tm->tm_min,
-                 tm->tm_sec);
+        msnprintf(headerbuf, sizeof(headerbuf),
+                  "Last-Modified: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n",
+                  Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
+                  tm->tm_mday,
+                  Curl_month[tm->tm_mon],
+                  tm->tm_year + 1900,
+                  tm->tm_hour,
+                  tm->tm_min,
+                  tm->tm_sec);
         result = Curl_client_write(conn, CLIENTWRITE_BOTH, headerbuf, 0);
         if(result)
           return result;
@@ -2276,8 +2276,8 @@ static CURLcode ftp_state_size_resp(struct connectdata *conn,
 #ifdef CURL_FTP_HTTPSTYLE_HEAD
     if(-1 != filesize) {
       char clbuf[128];
-      snprintf(clbuf, sizeof(clbuf),
-               "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n", filesize);
+      msnprintf(clbuf, sizeof(clbuf),
+                "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n", filesize);
       result = Curl_client_write(conn, CLIENTWRITE_BOTH, clbuf, 0);
       if(result)
         return result;

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -145,7 +145,7 @@ Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
     hints.ai_family = PF_INET;
     hints.ai_socktype = SOCK_STREAM;
     if(port) {
-      snprintf(sbuf, sizeof(sbuf), "%d", port);
+      msnprintf(sbuf, sizeof(sbuf), "%d", port);
       sbufptr = sbuf;
     }
 

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -178,7 +178,7 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
 #endif
 
   if(port) {
-    snprintf(sbuf, sizeof(sbuf), "%d", port);
+    msnprintf(sbuf, sizeof(sbuf), "%d", port);
     sbufptr = sbuf;
   }
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1478,14 +1478,14 @@ static CURLcode add_haproxy_protocol_header(struct connectdata *conn)
     strcpy(tcp_version, "TCP4");
   }
 
-  snprintf(proxy_header,
-           sizeof(proxy_header),
-           "PROXY %s %s %s %li %li\r\n",
-           tcp_version,
-           conn->data->info.conn_local_ip,
-           conn->data->info.conn_primary_ip,
-           conn->data->info.conn_local_port,
-           conn->data->info.conn_primary_port);
+  msnprintf(proxy_header,
+            sizeof(proxy_header),
+            "PROXY %s %s %s %li %li\r\n",
+            tcp_version,
+            conn->data->info.conn_local_ip,
+            conn->data->info.conn_primary_ip,
+            conn->data->info.conn_local_port,
+            conn->data->info.conn_primary_port);
 
   req_buffer = Curl_add_buffer_init();
   if(!req_buffer)
@@ -1849,16 +1849,16 @@ CURLcode Curl_add_timecondition(struct Curl_easy *data,
    */
 
   /* format: "Tue, 15 Nov 1994 12:45:26 GMT" */
-  snprintf(datestr, sizeof(datestr),
-           "%s: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n",
-           condp,
-           Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
-           tm->tm_mday,
-           Curl_month[tm->tm_mon],
-           tm->tm_year + 1900,
-           tm->tm_hour,
-           tm->tm_min,
-           tm->tm_sec);
+  msnprintf(datestr, sizeof(datestr),
+            "%s: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n",
+            condp,
+            Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
+            tm->tm_mday,
+            Curl_month[tm->tm_mon],
+            tm->tm_year + 1900,
+            tm->tm_hour,
+            tm->tm_min,
+            tm->tm_sec);
 
   result = Curl_add_buffer(&req_buffer, datestr, strlen(datestr));
 
@@ -2292,8 +2292,8 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
           if(!*data->state.up.path && path[strlen(path) - 1] != '/') {
             *p++ = '/';
           }
-          snprintf(p, sizeof(ftp_typecode) - 1, ";type=%c",
-                   data->set.prefer_ascii ? 'a' : 'i');
+          msnprintf(p, sizeof(ftp_typecode) - 1, ";type=%c",
+                    data->set.prefer_ascii ? 'a' : 'i');
         }
       }
       if(conn->bits.user_passwd && !conn->bits.userpwd_in_url)

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -350,7 +350,7 @@ static const struct Curl_handler Curl_handler_http2_ssl = {
 int Curl_http2_ver(char *p, size_t len)
 {
   nghttp2_info *h2 = nghttp2_version(0);
-  return snprintf(p, len, " nghttp2/%s", h2->version_str);
+  return msnprintf(p, len, " nghttp2/%s", h2->version_str);
 }
 
 /* HTTP/2 error code to name based on the Error Code Registry.

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -169,7 +169,7 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
               }
 #endif
               if(scopeid)
-                snprintf(scope, sizeof(scope), "%%%u", scopeid);
+                msnprintf(scope, sizeof(scope), "%%%u", scopeid);
             }
             else
 #endif
@@ -177,7 +177,7 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
                   &((struct sockaddr_in *)(void *)iface->ifa_addr)->sin_addr;
             res = IF2IP_FOUND;
             ip = (char *) Curl_inet_ntop(af, addr, ipstr, sizeof(ipstr));
-            snprintf(buf, buf_size, "%s%s", ip, scope);
+            msnprintf(buf, buf_size, "%s%s", ip, scope);
             break;
           }
         }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1749,8 +1749,8 @@ static CURLcode imap_sendf(struct connectdata *conn, const char *fmt, ...)
   imapc->cmdid = (imapc->cmdid + 1) % 1000;
 
   /* Calculate the tag based on the connection ID and command ID */
-  snprintf(imapc->resptag, sizeof(imapc->resptag), "%c%03d",
-           'A' + curlx_sltosi(conn->connection_id % 26), imapc->cmdid);
+  msnprintf(imapc->resptag, sizeof(imapc->resptag), "%c%03d",
+            'A' + curlx_sltosi(conn->connection_id % 26), imapc->cmdid);
 
   /* Prefix the format with the tag */
   taggedfmt = aprintf("%s %s", imapc->resptag, fmt);

--- a/lib/inet_ntop.c
+++ b/lib/inet_ntop.c
@@ -55,11 +55,11 @@ static char *inet_ntop4 (const unsigned char *src, char *dst, size_t size)
   DEBUGASSERT(size >= 16);
 
   tmp[0] = '\0';
-  (void)snprintf(tmp, sizeof(tmp), "%d.%d.%d.%d",
-                 ((int)((unsigned char)src[0])) & 0xff,
-                 ((int)((unsigned char)src[1])) & 0xff,
-                 ((int)((unsigned char)src[2])) & 0xff,
-                 ((int)((unsigned char)src[3])) & 0xff);
+  (void)msnprintf(tmp, sizeof(tmp), "%d.%d.%d.%d",
+                  ((int)((unsigned char)src[0])) & 0xff,
+                  ((int)((unsigned char)src[1])) & 0xff,
+                  ((int)((unsigned char)src[2])) & 0xff,
+                  ((int)((unsigned char)src[3])) & 0xff);
 
   len = strlen(tmp);
   if(len == 0 || len >= size) {
@@ -148,7 +148,7 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
       tp += strlen(tp);
       break;
     }
-    tp += snprintf(tp, 5, "%lx", words[i]);
+    tp += msnprintf(tp, 5, "%lx", words[i]);
   }
 
   /* Was it a trailing run of 0x00's?

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -504,7 +504,7 @@ void curl_memlog(const char *format, ...)
     return;
 
   va_start(ap, format);
-  nchars = vsnprintf(buf, LOGLINE_BUFSIZE, format, ap);
+  nchars = mvsnprintf(buf, LOGLINE_BUFSIZE, format, ap);
   va_end(ap);
 
   if(nchars > LOGLINE_BUFSIZE - 1)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -634,13 +634,13 @@ static CURLcode multi_done(struct connectdata **connp,
   else {
     char buffer[256];
     /* create string before returning the connection */
-    snprintf(buffer, sizeof(buffer),
-             "Connection #%ld to host %s left intact",
-             conn->connection_id,
-             conn->bits.socksproxy ? conn->socks_proxy.host.dispname :
-             conn->bits.httpproxy ? conn->http_proxy.host.dispname :
-             conn->bits.conn_to_host ? conn->conn_to_host.dispname :
-             conn->host.dispname);
+    msnprintf(buffer, sizeof(buffer),
+              "Connection #%ld to host %s left intact",
+              conn->connection_id,
+              conn->bits.socksproxy ? conn->socks_proxy.host.dispname :
+              conn->bits.httpproxy ? conn->http_proxy.host.dispname :
+              conn->bits.conn_to_host ? conn->conn_to_host.dispname :
+              conn->host.dispname);
 
     /* the connection is no longer in use by this transfer */
     if(Curl_conncache_return_conn(conn)) {

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -220,8 +220,8 @@ static CURLcode ldap_connect(struct connectdata *conn, bool *done)
   ptr = hosturl + 4;
   if(conn->handler->flags & PROTOPT_SSL)
     *ptr++ = 's';
-  snprintf(ptr, sizeof(hosturl)-(ptr-hosturl), "://%s:%d",
-           conn->host.name, conn->remote_port);
+  msnprintf(ptr, sizeof(hosturl)-(ptr-hosturl), "://%s:%d",
+            conn->host.name, conn->remote_port);
 
 #ifdef CURL_OPENLDAP_DEBUG
   static int do_trace = 0;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -443,7 +443,7 @@ static CURLcode pop3_perform_apop(struct connectdata *conn)
 
   /* Convert the calculated 16 octet digest into a 32 byte hex string */
   for(i = 0; i < MD5_DIGEST_LEN; i++)
-    snprintf(&secret[2 * i], 3, "%02x", digest[i]);
+    msnprintf(&secret[2 * i], 3, "%02x", digest[i]);
 
   result = Curl_pp_sendf(&pop3c->pp, "APOP %s %s", conn->user, secret);
 

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -44,8 +44,8 @@ static void time2str(char *r, curl_off_t seconds)
   if(h <= CURL_OFF_T_C(99)) {
     curl_off_t m = (seconds - (h*CURL_OFF_T_C(3600))) / CURL_OFF_T_C(60);
     curl_off_t s = (seconds - (h*CURL_OFF_T_C(3600))) - (m*CURL_OFF_T_C(60));
-    snprintf(r, 9, "%2" CURL_FORMAT_CURL_OFF_T ":%02" CURL_FORMAT_CURL_OFF_T
-             ":%02" CURL_FORMAT_CURL_OFF_T, h, m, s);
+    msnprintf(r, 9, "%2" CURL_FORMAT_CURL_OFF_T ":%02" CURL_FORMAT_CURL_OFF_T
+              ":%02" CURL_FORMAT_CURL_OFF_T, h, m, s);
   }
   else {
     /* this equals to more than 99 hours, switch to a more suitable output
@@ -53,10 +53,10 @@ static void time2str(char *r, curl_off_t seconds)
     curl_off_t d = seconds / CURL_OFF_T_C(86400);
     h = (seconds - (d*CURL_OFF_T_C(86400))) / CURL_OFF_T_C(3600);
     if(d <= CURL_OFF_T_C(999))
-      snprintf(r, 9, "%3" CURL_FORMAT_CURL_OFF_T
-               "d %02" CURL_FORMAT_CURL_OFF_T "h", d, h);
+      msnprintf(r, 9, "%3" CURL_FORMAT_CURL_OFF_T
+                "d %02" CURL_FORMAT_CURL_OFF_T "h", d, h);
     else
-      snprintf(r, 9, "%7" CURL_FORMAT_CURL_OFF_T "d", d);
+      msnprintf(r, 9, "%7" CURL_FORMAT_CURL_OFF_T "d", d);
   }
 }
 
@@ -72,40 +72,40 @@ static char *max5data(curl_off_t bytes, char *max5)
 #define ONE_PETABYTE (CURL_OFF_T_C(1024) * ONE_TERABYTE)
 
   if(bytes < CURL_OFF_T_C(100000))
-    snprintf(max5, 6, "%5" CURL_FORMAT_CURL_OFF_T, bytes);
+    msnprintf(max5, 6, "%5" CURL_FORMAT_CURL_OFF_T, bytes);
 
   else if(bytes < CURL_OFF_T_C(10000) * ONE_KILOBYTE)
-    snprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "k", bytes/ONE_KILOBYTE);
+    msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "k", bytes/ONE_KILOBYTE);
 
   else if(bytes < CURL_OFF_T_C(100) * ONE_MEGABYTE)
     /* 'XX.XM' is good as long as we're less than 100 megs */
-    snprintf(max5, 6, "%2" CURL_FORMAT_CURL_OFF_T ".%0"
-             CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE,
-             (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/CURL_OFF_T_C(10)) );
+    msnprintf(max5, 6, "%2" CURL_FORMAT_CURL_OFF_T ".%0"
+              CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE,
+              (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/CURL_OFF_T_C(10)) );
 
 #if (CURL_SIZEOF_CURL_OFF_T > 4)
 
   else if(bytes < CURL_OFF_T_C(10000) * ONE_MEGABYTE)
     /* 'XXXXM' is good until we're at 10000MB or above */
-    snprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE);
+    msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE);
 
   else if(bytes < CURL_OFF_T_C(100) * ONE_GIGABYTE)
     /* 10000 MB - 100 GB, we show it as XX.XG */
-    snprintf(max5, 6, "%2" CURL_FORMAT_CURL_OFF_T ".%0"
-             CURL_FORMAT_CURL_OFF_T "G", bytes/ONE_GIGABYTE,
-             (bytes%ONE_GIGABYTE) / (ONE_GIGABYTE/CURL_OFF_T_C(10)) );
+    msnprintf(max5, 6, "%2" CURL_FORMAT_CURL_OFF_T ".%0"
+              CURL_FORMAT_CURL_OFF_T "G", bytes/ONE_GIGABYTE,
+              (bytes%ONE_GIGABYTE) / (ONE_GIGABYTE/CURL_OFF_T_C(10)) );
 
   else if(bytes < CURL_OFF_T_C(10000) * ONE_GIGABYTE)
     /* up to 10000GB, display without decimal: XXXXG */
-    snprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "G", bytes/ONE_GIGABYTE);
+    msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "G", bytes/ONE_GIGABYTE);
 
   else if(bytes < CURL_OFF_T_C(10000) * ONE_TERABYTE)
     /* up to 10000TB, display without decimal: XXXXT */
-    snprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "T", bytes/ONE_TERABYTE);
+    msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "T", bytes/ONE_TERABYTE);
 
   else
     /* up to 10000PB, display without decimal: XXXXP */
-    snprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "P", bytes/ONE_PETABYTE);
+    msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "P", bytes/ONE_PETABYTE);
 
     /* 16384 petabytes (16 exabytes) is the maximum a 64 bit unsigned number
        can hold, but our data type is signed so 8192PB will be the maximum. */
@@ -113,7 +113,7 @@ static char *max5data(curl_off_t bytes, char *max5)
 #else
 
   else
-    snprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE);
+    msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE);
 
 #endif
 

--- a/lib/security.c
+++ b/lib/security.c
@@ -10,7 +10,7 @@
  * Copyright (c) 1998, 1999, 2017 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  *
- * Copyright (C) 2001 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2001 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * All rights reserved.
  *
@@ -120,7 +120,7 @@ static int ftp_send_command(struct connectdata *conn, const char *message, ...)
   char print_buffer[50];
 
   va_start(args, message);
-  vsnprintf(print_buffer, sizeof(print_buffer), message, args);
+  mvsnprintf(print_buffer, sizeof(print_buffer), message, args);
   va_end(args);
 
   if(Curl_ftpsend(conn, print_buffer)) {

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -237,7 +237,7 @@ void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
     size_t len;
     char print_buffer[2048 + 1];
     va_start(ap, fmt);
-    len = vsnprintf(print_buffer, sizeof(print_buffer), fmt, ap);
+    len = mvsnprintf(print_buffer, sizeof(print_buffer), fmt, ap);
     /*
      * Indicate truncation of the input by replacing the last 3 characters
      * with "...", and transfer the newline over in case the format had one.
@@ -245,9 +245,9 @@ void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
     if(len >= sizeof(print_buffer)) {
       len = strlen(fmt);
       if(fmt[--len] == '\n')
-        snprintf(print_buffer + (sizeof(print_buffer) - 5), 5, "...\n");
+        msnprintf(print_buffer + (sizeof(print_buffer) - 5), 5, "...\n");
       else
-        snprintf(print_buffer + (sizeof(print_buffer) - 4), 4, "...");
+        msnprintf(print_buffer + (sizeof(print_buffer) - 4), 4, "...");
     }
     va_end(ap);
     len = strlen(print_buffer);
@@ -266,7 +266,7 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
     size_t len;
     char error[CURL_ERROR_SIZE + 2];
     va_start(ap, fmt);
-    vsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
+    mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
     len = strlen(error);
 
     if(data->set.errorbuffer && !data->state.errorbuf) {

--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2009, Markus Moeller, <markus_moeller@compuserve.com>
- * Copyright (C) 2012 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -151,8 +151,8 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
       return CURLE_OUT_OF_MEMORY;
     service.length = serviceptr_length +
       strlen(conn->socks_proxy.host.name) + 1;
-    snprintf(service.value, service.length + 1, "%s@%s",
-             serviceptr, conn->socks_proxy.host.name);
+    msnprintf(service.value, service.length + 1, "%s@%s",
+              serviceptr, conn->socks_proxy.host.name);
 
     gss_major_status = gss_import_name(&gss_minor_status, &service,
                                        GSS_C_NT_HOSTBASED_SERVICE, &server);

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  * Copyright (C) 2009, 2011, Markus Moeller, <markus_moeller@compuserve.com>
  *
  * This software is licensed as described in the file COPYING, which
@@ -107,9 +107,9 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
                           strlen(conn->socks_proxy.host.name) + 2);
     if(!service_name)
       return CURLE_OUT_OF_MEMORY;
-    snprintf(service_name, service_length +
-             strlen(conn->socks_proxy.host.name) + 2, "%s/%s",
-             service, conn->socks_proxy.host.name);
+    msnprintf(service_name, service_length +
+              strlen(conn->socks_proxy.host.name) + 2, "%s/%s",
+              service, conn->socks_proxy.host.name);
   }
 
   input_desc.cBuffers = 1;

--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -1342,8 +1342,8 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
               break;
             }
 
-            snprintf(sshc->readdir_linkPath, PATH_MAX, "%s%s", protop->path,
-                     sshc->readdir_filename);
+            msnprintf(sshc->readdir_linkPath, PATH_MAX, "%s%s", protop->path,
+                      sshc->readdir_filename);
 
             state(conn, SSH_SFTP_READDIR_LINK);
             break;
@@ -1406,12 +1406,12 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
       }
       sshc->readdir_line = new_readdir_line;
 
-      sshc->readdir_currLen += snprintf(sshc->readdir_line +
-                                        sshc->readdir_currLen,
-                                        sshc->readdir_totalLen -
-                                        sshc->readdir_currLen,
-                                        " -> %s",
-                                        sshc->readdir_filename);
+      sshc->readdir_currLen += msnprintf(sshc->readdir_line +
+                                         sshc->readdir_currLen,
+                                         sshc->readdir_totalLen -
+                                         sshc->readdir_currLen,
+                                         " -> %s",
+                                         sshc->readdir_filename);
 
       sftp_attributes_free(sshc->readdir_link_attrs);
       sshc->readdir_link_attrs = NULL;
@@ -1421,10 +1421,10 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
       state(conn, SSH_SFTP_READDIR_BOTTOM);
       /* FALLTHROUGH */
     case SSH_SFTP_READDIR_BOTTOM:
-      sshc->readdir_currLen += snprintf(sshc->readdir_line +
-                                        sshc->readdir_currLen,
-                                        sshc->readdir_totalLen -
-                                        sshc->readdir_currLen, "\n");
+      sshc->readdir_currLen += msnprintf(sshc->readdir_line +
+                                         sshc->readdir_currLen,
+                                         sshc->readdir_totalLen -
+                                         sshc->readdir_currLen, "\n");
       result = Curl_client_write(conn, CLIENTWRITE_BODY,
                                  sshc->readdir_line,
                                  sshc->readdir_currLen);

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -599,7 +599,7 @@ static CURLcode ssh_check_fingerprint(struct connectdata *conn)
   if(fingerprint) {
     /* The fingerprint points to static storage (!), don't free() it. */
     for(i = 0; i < 16; i++)
-      snprintf(&md5buffer[i*2], 3, "%02x", (unsigned char) fingerprint[i]);
+      msnprintf(&md5buffer[i*2], 3, "%02x", (unsigned char) fingerprint[i]);
     infof(data, "SSH MD5 fingerprint: %s\n", md5buffer);
   }
 
@@ -1999,8 +1999,8 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
               break;
             }
 
-            snprintf(sshc->readdir_linkPath, PATH_MAX, "%s%s", sftp_scp->path,
-                     sshc->readdir_filename);
+            msnprintf(sshc->readdir_linkPath, PATH_MAX, "%s%s", sftp_scp->path,
+                      sshc->readdir_filename);
             state(conn, SSH_SFTP_READDIR_LINK);
             break;
           }
@@ -2055,21 +2055,21 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       }
       sshc->readdir_line = new_readdir_line;
 
-      sshc->readdir_currLen += snprintf(sshc->readdir_line +
-                                        sshc->readdir_currLen,
-                                        sshc->readdir_totalLen -
-                                        sshc->readdir_currLen,
-                                        " -> %s",
-                                        sshc->readdir_filename);
+      sshc->readdir_currLen += msnprintf(sshc->readdir_line +
+                                         sshc->readdir_currLen,
+                                         sshc->readdir_totalLen -
+                                         sshc->readdir_currLen,
+                                         " -> %s",
+                                         sshc->readdir_filename);
 
       state(conn, SSH_SFTP_READDIR_BOTTOM);
       break;
 
     case SSH_SFTP_READDIR_BOTTOM:
-      sshc->readdir_currLen += snprintf(sshc->readdir_line +
-                                        sshc->readdir_currLen,
-                                        sshc->readdir_totalLen -
-                                        sshc->readdir_currLen, "\n");
+      sshc->readdir_currLen += msnprintf(sshc->readdir_line +
+                                         sshc->readdir_currLen,
+                                         sshc->readdir_totalLen -
+                                         sshc->readdir_currLen, "\n");
       result = Curl_client_write(conn, CLIENTWRITE_BODY,
                                  sshc->readdir_line,
                                  sshc->readdir_currLen);

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2004 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2004 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -681,7 +681,7 @@ const char *Curl_strerror(struct connectdata *conn, int err)
     if(!get_winsock_error(err, buf, max) &&
        !FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err,
                        LANG_NEUTRAL, buf, (DWORD)max, NULL))
-      snprintf(buf, max, "Unknown error %d (%#x)", err, err);
+      msnprintf(buf, max, "Unknown error %d (%#x)", err, err);
   }
 #endif
 
@@ -695,7 +695,7 @@ const char *Curl_strerror(struct connectdata *conn, int err)
   */
   if(0 != strerror_r(err, buf, max)) {
     if('\0' == buf[0])
-      snprintf(buf, max, "Unknown error %d", err);
+      msnprintf(buf, max, "Unknown error %d", err);
   }
 #elif defined(HAVE_STRERROR_R) && defined(HAVE_GLIBC_STRERROR_R)
  /*
@@ -709,7 +709,7 @@ const char *Curl_strerror(struct connectdata *conn, int err)
     if(msg)
       strncpy(buf, msg, max);
     else
-      snprintf(buf, max, "Unknown error %d", err);
+      msnprintf(buf, max, "Unknown error %d", err);
   }
 #elif defined(HAVE_STRERROR_R) && defined(HAVE_VXWORKS_STRERROR_R)
  /*
@@ -721,7 +721,7 @@ const char *Curl_strerror(struct connectdata *conn, int err)
     if(OK == strerror_r(err, buffer))
       strncpy(buf, buffer, max);
     else
-      snprintf(buf, max, "Unknown error %d", err);
+      msnprintf(buf, max, "Unknown error %d", err);
   }
 #else
   {
@@ -729,7 +729,7 @@ const char *Curl_strerror(struct connectdata *conn, int err)
     if(msg)
       strncpy(buf, msg, max);
     else
-      snprintf(buf, max, "Unknown error %d", err);
+      msnprintf(buf, max, "Unknown error %d", err);
   }
 #endif
 
@@ -1032,14 +1032,14 @@ const char *Curl_sspi_strerror (struct connectdata *conn, int err)
   if(err == SEC_E_OK)
     strncpy(outbuf, txt, outmax);
   else if(err == SEC_E_ILLEGAL_MESSAGE)
-    snprintf(outbuf, outmax,
-             "SEC_E_ILLEGAL_MESSAGE (0x%08X) - This error usually occurs "
-             "when a fatal SSL/TLS alert is received (e.g. handshake failed). "
-             "More detail may be available in the Windows System event log.",
-             err);
+    msnprintf(outbuf, outmax,
+              "SEC_E_ILLEGAL_MESSAGE (0x%08X) - This error usually occurs "
+              "when a fatal SSL/TLS alert is received (e.g. handshake failed)."
+              " More detail may be available in the Windows System event log.",
+              err);
   else {
     str = txtbuf;
-    snprintf(txtbuf, sizeof(txtbuf), "%s (0x%08X)", txt, err);
+    msnprintf(txtbuf, sizeof(txtbuf), "%s (0x%08X)", txt, err);
     txtbuf[sizeof(txtbuf)-1] = '\0';
 
 #ifdef _WIN32_WCE
@@ -1075,7 +1075,7 @@ const char *Curl_sspi_strerror (struct connectdata *conn, int err)
       msg = msgbuf;
     }
     if(msg)
-      snprintf(outbuf, outmax, "%s - %s", str, msg);
+      msnprintf(outbuf, outmax, "%s - %s", str, msg);
     else
       strncpy(outbuf, str, outmax);
   }

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -829,7 +829,7 @@ static CURLcode check_telnet_options(struct connectdata *conn)
   /* Add the user name as an environment variable if it
      was given on the command line */
   if(conn->bits.user_passwd) {
-    snprintf(option_arg, sizeof(option_arg), "USER,%s", conn->user);
+    msnprintf(option_arg, sizeof(option_arg), "USER,%s", conn->user);
     beg = curl_slist_append(tn->telnet_vars, option_arg);
     if(!beg) {
       curl_slist_free_all(tn->telnet_vars);
@@ -935,9 +935,9 @@ static void suboption(struct connectdata *conn)
   switch(CURL_SB_GET(tn)) {
     case CURL_TELOPT_TTYPE:
       len = strlen(tn->subopt_ttype) + 4 + 2;
-      snprintf((char *)temp, sizeof(temp),
-               "%c%c%c%c%s%c%c", CURL_IAC, CURL_SB, CURL_TELOPT_TTYPE,
-               CURL_TELQUAL_IS, tn->subopt_ttype, CURL_IAC, CURL_SE);
+      msnprintf((char *)temp, sizeof(temp),
+                "%c%c%c%c%s%c%c", CURL_IAC, CURL_SB, CURL_TELOPT_TTYPE,
+                CURL_TELQUAL_IS, tn->subopt_ttype, CURL_IAC, CURL_SE);
       bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
       if(bytes_written < 0) {
         err = SOCKERRNO;
@@ -947,9 +947,9 @@ static void suboption(struct connectdata *conn)
       break;
     case CURL_TELOPT_XDISPLOC:
       len = strlen(tn->subopt_xdisploc) + 4 + 2;
-      snprintf((char *)temp, sizeof(temp),
-               "%c%c%c%c%s%c%c", CURL_IAC, CURL_SB, CURL_TELOPT_XDISPLOC,
-               CURL_TELQUAL_IS, tn->subopt_xdisploc, CURL_IAC, CURL_SE);
+      msnprintf((char *)temp, sizeof(temp),
+                "%c%c%c%c%s%c%c", CURL_IAC, CURL_SB, CURL_TELOPT_XDISPLOC,
+                CURL_TELQUAL_IS, tn->subopt_xdisploc, CURL_IAC, CURL_SE);
       bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
       if(bytes_written < 0) {
         err = SOCKERRNO;
@@ -958,9 +958,9 @@ static void suboption(struct connectdata *conn)
       printsub(data, '>', &temp[2], len-2);
       break;
     case CURL_TELOPT_NEW_ENVIRON:
-      snprintf((char *)temp, sizeof(temp),
-               "%c%c%c%c", CURL_IAC, CURL_SB, CURL_TELOPT_NEW_ENVIRON,
-               CURL_TELQUAL_IS);
+      msnprintf((char *)temp, sizeof(temp),
+                "%c%c%c%c", CURL_IAC, CURL_SB, CURL_TELOPT_NEW_ENVIRON,
+                CURL_TELQUAL_IS);
       len = 4;
 
       for(v = tn->telnet_vars; v; v = v->next) {
@@ -968,15 +968,15 @@ static void suboption(struct connectdata *conn)
         /* Add the variable only if it fits */
         if(len + tmplen < (int)sizeof(temp)-6) {
           if(sscanf(v->data, "%127[^,],%127s", varname, varval)) {
-            snprintf((char *)&temp[len], sizeof(temp) - len,
-                     "%c%s%c%s", CURL_NEW_ENV_VAR, varname,
-                     CURL_NEW_ENV_VALUE, varval);
+            msnprintf((char *)&temp[len], sizeof(temp) - len,
+                      "%c%s%c%s", CURL_NEW_ENV_VAR, varname,
+                      CURL_NEW_ENV_VALUE, varval);
             len += tmplen;
           }
         }
       }
-      snprintf((char *)&temp[len], sizeof(temp) - len,
-               "%c%c", CURL_IAC, CURL_SE);
+      msnprintf((char *)&temp[len], sizeof(temp) - len,
+                "%c%c", CURL_IAC, CURL_SE);
       len += 2;
       bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
       if(bytes_written < 0) {

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -496,9 +496,9 @@ static CURLcode tftp_send_first(tftp_state_data_t *state, tftp_event_t event)
       return CURLE_TFTP_ILLEGAL; /* too long file name field */
     }
 
-    snprintf((char *)state->spacket.data + 2,
-             state->blksize,
-             "%s%c%s%c", filename, '\0',  mode, '\0');
+    msnprintf((char *)state->spacket.data + 2,
+              state->blksize,
+              "%s%c%s%c", filename, '\0',  mode, '\0');
     sbytes = 4 + strlen(filename) + strlen(mode);
 
     /* optional addition of TFTP options */
@@ -506,8 +506,8 @@ static CURLcode tftp_send_first(tftp_state_data_t *state, tftp_event_t event)
       char buf[64];
       /* add tsize option */
       if(data->set.upload && (data->state.infilesize != -1))
-        snprintf(buf, sizeof(buf), "%" CURL_FORMAT_CURL_OFF_T,
-                 data->state.infilesize);
+        msnprintf(buf, sizeof(buf), "%" CURL_FORMAT_CURL_OFF_T,
+                  data->state.infilesize);
       else
         strcpy(buf, "0"); /* the destination is large enough */
 
@@ -517,7 +517,7 @@ static CURLcode tftp_send_first(tftp_state_data_t *state, tftp_event_t event)
       sbytes += tftp_option_add(state, sbytes,
                                 (char *)state->spacket.data + sbytes, buf);
       /* add blksize option */
-      snprintf(buf, sizeof(buf), "%d", state->requested_blksize);
+      msnprintf(buf, sizeof(buf), "%d", state->requested_blksize);
       sbytes += tftp_option_add(state, sbytes,
                                 (char *)state->spacket.data + sbytes,
                                 TFTP_OPTION_BLKSIZE);
@@ -525,7 +525,7 @@ static CURLcode tftp_send_first(tftp_state_data_t *state, tftp_event_t event)
                                 (char *)state->spacket.data + sbytes, buf);
 
       /* add timeout option */
-      snprintf(buf, sizeof(buf), "%d", state->retry_time);
+      msnprintf(buf, sizeof(buf), "%d", state->retry_time);
       sbytes += tftp_option_add(state, sbytes,
                                 (char *)state->spacket.data + sbytes,
                                 TFTP_OPTION_INTERVAL);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -218,8 +218,8 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
       endofline_native  = "\r\n";
       endofline_network = "\x0d\x0a";
     }
-    hexlen = snprintf(hexbuffer, sizeof(hexbuffer),
-                      "%x%s", nread, endofline_native);
+    hexlen = msnprintf(hexbuffer, sizeof(hexbuffer),
+                       "%x%s", nread, endofline_native);
 
     /* move buffer pointer */
     data->req.upload_fromhere -= hexlen;

--- a/lib/url.c
+++ b/lib/url.c
@@ -2997,7 +2997,7 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
     char portbuf[16];
     CURLUcode uc;
     conn->remote_port = (unsigned short)data->set.use_port;
-    snprintf(portbuf, sizeof(portbuf), "%u", conn->remote_port);
+    msnprintf(portbuf, sizeof(portbuf), "%u", conn->remote_port);
     uc = curl_url_set(data->state.uh, CURLUPART_PORT, portbuf, 0);
     if(uc)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -203,7 +203,7 @@ void Curl_strcpy_url(char *output, const char *url, bool relative)
       /* FALLTHROUGH */
     default:
       if(urlchar_needs_escaping(*iptr)) {
-        snprintf(optr, 4, "%%%02x", *iptr);
+        msnprintf(optr, 4, "%%%02x", *iptr);
         optr += 3;
       }
       else
@@ -531,7 +531,7 @@ static CURLUcode parse_port(struct Curl_URL *u, char *hostname)
       *portptr++ = '\0'; /* cut off the name there */
       *rest = 0;
       /* generate a new to get rid of leading zeroes etc */
-      snprintf(portbuf, sizeof(portbuf), "%ld", port);
+      msnprintf(portbuf, sizeof(portbuf), "%ld", port);
       u->portnum = port;
       u->port = strdup(portbuf);
       if(!u->port)
@@ -964,7 +964,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
       const struct Curl_handler *h =
         Curl_builtin_scheme(u->scheme);
       if(h) {
-        snprintf(portbuf, sizeof(portbuf), "%ld", h->defport);
+        msnprintf(portbuf, sizeof(portbuf), "%ld", h->defport);
         ptr = portbuf;
       }
     }
@@ -1023,7 +1023,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
           /* there's no stored port number, but asked to deliver
              a default one for the scheme */
           if(h) {
-            snprintf(portbuf, sizeof(portbuf), "%ld", h->defport);
+            msnprintf(portbuf, sizeof(portbuf), "%ld", h->defport);
             port = portbuf;
           }
         }
@@ -1287,7 +1287,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
           o++;
         }
         else {
-          snprintf(o, 4, "%%%02x", *i);
+          msnprintf(o, 4, "%%%02x", *i);
           o += 3;
         }
       }

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -143,7 +143,7 @@ static void auth_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
 {
   int i;
   for(i = 0; i < 16; i++)
-    snprintf((char *) &dest[i * 2], 3, "%02x", source[i]);
+    msnprintf((char *) &dest[i * 2], 3, "%02x", source[i]);
 }
 
 /* Convert sha256 chunk to RFC7616 -suitable ascii string*/
@@ -152,7 +152,7 @@ static void auth_digest_sha256_to_ascii(unsigned char *source, /* 32 bytes */
 {
   int i;
   for(i = 0; i < 32; i++)
-    snprintf((char *) &dest[i * 2], 3, "%02x", source[i]);
+    msnprintf((char *) &dest[i * 2], 3, "%02x", source[i]);
 }
 
 /* Perform quoted-string escaping as described in RFC2616 and its errata */
@@ -432,7 +432,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 
   /* Convert calculated 16 octet hex into 32 bytes string */
   for(i = 0; i < MD5_DIGEST_LEN; i++)
-    snprintf(&HA1_hex[2 * i], 3, "%02x", digest[i]);
+    msnprintf(&HA1_hex[2 * i], 3, "%02x", digest[i]);
 
   /* Generate our SPN */
   spn = Curl_auth_build_spn(service, realm, NULL);
@@ -455,7 +455,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   Curl_MD5_final(ctxt, digest);
 
   for(i = 0; i < MD5_DIGEST_LEN; i++)
-    snprintf(&HA2_hex[2 * i], 3, "%02x", digest[i]);
+    msnprintf(&HA2_hex[2 * i], 3, "%02x", digest[i]);
 
   /* Now calculate the response hash */
   ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
@@ -485,7 +485,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   Curl_MD5_final(ctxt, digest);
 
   for(i = 0; i < MD5_DIGEST_LEN; i++)
-    snprintf(&resp_hash_hex[2 * i], 3, "%02x", digest[i]);
+    msnprintf(&resp_hash_hex[2 * i], 3, "%02x", digest[i]);
 
   /* Generate the response */
   response = aprintf("username=\"%s\",realm=\"%s\",nonce=\"%s\","

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -409,38 +409,38 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 #else
 #define NTLM2FLAG 0
 #endif
-  snprintf((char *)ntlmbuf, NTLM_BUFSIZE,
-           NTLMSSP_SIGNATURE "%c"
-           "\x01%c%c%c" /* 32-bit type = 1 */
-           "%c%c%c%c"   /* 32-bit NTLM flag field */
-           "%c%c"       /* domain length */
-           "%c%c"       /* domain allocated space */
-           "%c%c"       /* domain name offset */
-           "%c%c"       /* 2 zeroes */
-           "%c%c"       /* host length */
-           "%c%c"       /* host allocated space */
-           "%c%c"       /* host name offset */
-           "%c%c"       /* 2 zeroes */
-           "%s"         /* host name */
-           "%s",        /* domain string */
-           0,           /* trailing zero */
-           0, 0, 0,     /* part of type-1 long */
+  msnprintf((char *)ntlmbuf, NTLM_BUFSIZE,
+            NTLMSSP_SIGNATURE "%c"
+            "\x01%c%c%c" /* 32-bit type = 1 */
+            "%c%c%c%c"   /* 32-bit NTLM flag field */
+            "%c%c"       /* domain length */
+            "%c%c"       /* domain allocated space */
+            "%c%c"       /* domain name offset */
+            "%c%c"       /* 2 zeroes */
+            "%c%c"       /* host length */
+            "%c%c"       /* host allocated space */
+            "%c%c"       /* host name offset */
+            "%c%c"       /* 2 zeroes */
+            "%s"         /* host name */
+            "%s",        /* domain string */
+            0,           /* trailing zero */
+            0, 0, 0,     /* part of type-1 long */
 
-           LONGQUARTET(NTLMFLAG_NEGOTIATE_OEM |
-                       NTLMFLAG_REQUEST_TARGET |
-                       NTLMFLAG_NEGOTIATE_NTLM_KEY |
-                       NTLM2FLAG |
-                       NTLMFLAG_NEGOTIATE_ALWAYS_SIGN),
-           SHORTPAIR(domlen),
-           SHORTPAIR(domlen),
-           SHORTPAIR(domoff),
-           0, 0,
-           SHORTPAIR(hostlen),
-           SHORTPAIR(hostlen),
-           SHORTPAIR(hostoff),
-           0, 0,
-           host,  /* this is empty */
-           domain /* this is empty */);
+            LONGQUARTET(NTLMFLAG_NEGOTIATE_OEM |
+                        NTLMFLAG_REQUEST_TARGET |
+                        NTLMFLAG_NEGOTIATE_NTLM_KEY |
+                        NTLM2FLAG |
+                        NTLMFLAG_NEGOTIATE_ALWAYS_SIGN),
+            SHORTPAIR(domlen),
+            SHORTPAIR(domlen),
+            SHORTPAIR(domoff),
+            0, 0,
+            SHORTPAIR(hostlen),
+            SHORTPAIR(hostlen),
+            SHORTPAIR(hostoff),
+            0, 0,
+            host,  /* this is empty */
+            domain /* this is empty */);
 
   /* Initial packet length */
   size = 32 + hostlen + domlen;
@@ -678,88 +678,88 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   hostoff = useroff + userlen;
 
   /* Create the big type-3 message binary blob */
-  size = snprintf((char *)ntlmbuf, NTLM_BUFSIZE,
-                  NTLMSSP_SIGNATURE "%c"
-                  "\x03%c%c%c"  /* 32-bit type = 3 */
+  size = msnprintf((char *)ntlmbuf, NTLM_BUFSIZE,
+                   NTLMSSP_SIGNATURE "%c"
+                   "\x03%c%c%c"  /* 32-bit type = 3 */
 
-                  "%c%c"  /* LanManager length */
-                  "%c%c"  /* LanManager allocated space */
-                  "%c%c"  /* LanManager offset */
-                  "%c%c"  /* 2 zeroes */
+                   "%c%c"  /* LanManager length */
+                   "%c%c"  /* LanManager allocated space */
+                   "%c%c"  /* LanManager offset */
+                   "%c%c"  /* 2 zeroes */
 
-                  "%c%c"  /* NT-response length */
-                  "%c%c"  /* NT-response allocated space */
-                  "%c%c"  /* NT-response offset */
-                  "%c%c"  /* 2 zeroes */
+                   "%c%c"  /* NT-response length */
+                   "%c%c"  /* NT-response allocated space */
+                   "%c%c"  /* NT-response offset */
+                   "%c%c"  /* 2 zeroes */
 
-                  "%c%c"  /* domain length */
-                  "%c%c"  /* domain allocated space */
-                  "%c%c"  /* domain name offset */
-                  "%c%c"  /* 2 zeroes */
+                   "%c%c"  /* domain length */
+                   "%c%c"  /* domain allocated space */
+                   "%c%c"  /* domain name offset */
+                   "%c%c"  /* 2 zeroes */
 
-                  "%c%c"  /* user length */
-                  "%c%c"  /* user allocated space */
-                  "%c%c"  /* user offset */
-                  "%c%c"  /* 2 zeroes */
+                   "%c%c"  /* user length */
+                   "%c%c"  /* user allocated space */
+                   "%c%c"  /* user offset */
+                   "%c%c"  /* 2 zeroes */
 
-                  "%c%c"  /* host length */
-                  "%c%c"  /* host allocated space */
-                  "%c%c"  /* host offset */
-                  "%c%c"  /* 2 zeroes */
+                   "%c%c"  /* host length */
+                   "%c%c"  /* host allocated space */
+                   "%c%c"  /* host offset */
+                   "%c%c"  /* 2 zeroes */
 
-                  "%c%c"  /* session key length (unknown purpose) */
-                  "%c%c"  /* session key allocated space (unknown purpose) */
-                  "%c%c"  /* session key offset (unknown purpose) */
-                  "%c%c"  /* 2 zeroes */
+                   "%c%c"  /* session key length (unknown purpose) */
+                   "%c%c"  /* session key allocated space (unknown purpose) */
+                   "%c%c"  /* session key offset (unknown purpose) */
+                   "%c%c"  /* 2 zeroes */
 
-                  "%c%c%c%c",  /* flags */
+                   "%c%c%c%c",  /* flags */
 
-                  /* domain string */
-                  /* user string */
-                  /* host string */
-                  /* LanManager response */
-                  /* NT response */
+                   /* domain string */
+                   /* user string */
+                   /* host string */
+                   /* LanManager response */
+                   /* NT response */
 
-                  0,                /* zero termination */
-                  0, 0, 0,          /* type-3 long, the 24 upper bits */
+                   0,                /* zero termination */
+                   0, 0, 0,          /* type-3 long, the 24 upper bits */
 
-                  SHORTPAIR(0x18),  /* LanManager response length, twice */
-                  SHORTPAIR(0x18),
-                  SHORTPAIR(lmrespoff),
-                  0x0, 0x0,
+                   SHORTPAIR(0x18),  /* LanManager response length, twice */
+                   SHORTPAIR(0x18),
+                   SHORTPAIR(lmrespoff),
+                   0x0, 0x0,
 
 #ifdef USE_NTRESPONSES
-                  SHORTPAIR(ntresplen),  /* NT-response length, twice */
-                  SHORTPAIR(ntresplen),
-                  SHORTPAIR(ntrespoff),
-                  0x0, 0x0,
+                   SHORTPAIR(ntresplen),  /* NT-response length, twice */
+                   SHORTPAIR(ntresplen),
+                   SHORTPAIR(ntrespoff),
+                   0x0, 0x0,
 #else
-                  0x0, 0x0,
-                  0x0, 0x0,
-                  0x0, 0x0,
-                  0x0, 0x0,
+                   0x0, 0x0,
+                   0x0, 0x0,
+                   0x0, 0x0,
+                   0x0, 0x0,
 #endif
-                  SHORTPAIR(domlen),
-                  SHORTPAIR(domlen),
-                  SHORTPAIR(domoff),
-                  0x0, 0x0,
+                   SHORTPAIR(domlen),
+                   SHORTPAIR(domlen),
+                   SHORTPAIR(domoff),
+                   0x0, 0x0,
 
-                  SHORTPAIR(userlen),
-                  SHORTPAIR(userlen),
-                  SHORTPAIR(useroff),
-                  0x0, 0x0,
+                   SHORTPAIR(userlen),
+                   SHORTPAIR(userlen),
+                   SHORTPAIR(useroff),
+                   0x0, 0x0,
 
-                  SHORTPAIR(hostlen),
-                  SHORTPAIR(hostlen),
-                  SHORTPAIR(hostoff),
-                  0x0, 0x0,
+                   SHORTPAIR(hostlen),
+                   SHORTPAIR(hostlen),
+                   SHORTPAIR(hostoff),
+                   0x0, 0x0,
 
-                  0x0, 0x0,
-                  0x0, 0x0,
-                  0x0, 0x0,
-                  0x0, 0x0,
+                   0x0, 0x0,
+                   0x0, 0x0,
+                   0x0, 0x0,
+                   0x0, 0x0,
 
-                  LONGQUARTET(ntlm->flags));
+                   LONGQUARTET(ntlm->flags));
 
   DEBUGASSERT(size == 64);
   DEBUGASSERT(size == (size_t)lmrespoff);

--- a/lib/version.c
+++ b/lib/version.c
@@ -95,7 +95,7 @@ static size_t brotli_version(char *buf, size_t bufsz)
   unsigned int minor = (brotli_version & 0x00FFFFFF) >> 12;
   unsigned int patch = brotli_version & 0x00000FFF;
 
-  return snprintf(buf, bufsz, "%u.%u.%u", major, minor, patch);
+  return msnprintf(buf, bufsz, "%u.%u.%u", major, minor, patch);
 }
 #endif
 
@@ -126,12 +126,12 @@ char *curl_version(void)
   }
 
 #ifdef HAVE_LIBZ
-  len = snprintf(ptr, left, " zlib/%s", zlibVersion());
+  len = msnprintf(ptr, left, " zlib/%s", zlibVersion());
   left -= len;
   ptr += len;
 #endif
 #ifdef HAVE_BROTLI
-  len = snprintf(ptr, left, "%s", " brotli/");
+  len = msnprintf(ptr, left, "%s", " brotli/");
   left -= len;
   ptr += len;
   len = brotli_version(ptr, left);
@@ -140,45 +140,45 @@ char *curl_version(void)
 #endif
 #ifdef USE_ARES
   /* this function is only present in c-ares, not in the original ares */
-  len = snprintf(ptr, left, " c-ares/%s", ares_version(NULL));
+  len = msnprintf(ptr, left, " c-ares/%s", ares_version(NULL));
   left -= len;
   ptr += len;
 #endif
 #ifdef USE_LIBIDN2
   if(idn2_check_version(IDN2_VERSION)) {
-    len = snprintf(ptr, left, " libidn2/%s", idn2_check_version(NULL));
+    len = msnprintf(ptr, left, " libidn2/%s", idn2_check_version(NULL));
     left -= len;
     ptr += len;
   }
 #endif
 #ifdef USE_LIBPSL
-  len = snprintf(ptr, left, " libpsl/%s", psl_get_version());
+  len = msnprintf(ptr, left, " libpsl/%s", psl_get_version());
   left -= len;
   ptr += len;
 #endif
 #ifdef USE_WIN32_IDN
-  len = snprintf(ptr, left, " WinIDN");
+  len = msnprintf(ptr, left, " WinIDN");
   left -= len;
   ptr += len;
 #endif
 #if defined(HAVE_ICONV) && defined(CURL_DOES_CONVERSIONS)
 #ifdef _LIBICONV_VERSION
-  len = snprintf(ptr, left, " iconv/%d.%d",
-                 _LIBICONV_VERSION >> 8, _LIBICONV_VERSION & 255);
+  len = msnprintf(ptr, left, " iconv/%d.%d",
+                  _LIBICONV_VERSION >> 8, _LIBICONV_VERSION & 255);
 #else
   /* version unknown */
-  len = snprintf(ptr, left, " iconv");
+  len = msnprintf(ptr, left, " iconv");
 #endif /* _LIBICONV_VERSION */
   left -= len;
   ptr += len;
 #endif
 #ifdef USE_LIBSSH2
-  len = snprintf(ptr, left, " libssh2/%s", CURL_LIBSSH2_VERSION);
+  len = msnprintf(ptr, left, " libssh2/%s", CURL_LIBSSH2_VERSION);
   left -= len;
   ptr += len;
 #endif
 #ifdef USE_LIBSSH
-  len = snprintf(ptr, left, " libssh/%s", CURL_LIBSSH_VERSION);
+  len = msnprintf(ptr, left, " libssh/%s", CURL_LIBSSH_VERSION);
   left -= len;
   ptr += len;
 #endif
@@ -197,14 +197,14 @@ char *curl_version(void)
     else
       suff[0] = '\0';
 
-    snprintf(ptr, left, " librtmp/%d.%d%s",
-             RTMP_LIB_VERSION >> 16, (RTMP_LIB_VERSION >> 8) & 0xff,
-             suff);
+    msnprintf(ptr, left, " librtmp/%d.%d%s",
+              RTMP_LIB_VERSION >> 16, (RTMP_LIB_VERSION >> 8) & 0xff,
+              suff);
 /*
   If another lib version is added below this one, this code would
   also have to do:
 
-    len = what snprintf() returned
+    len = what msnprintf() returned
 
     left -= len;
     ptr += len;
@@ -436,10 +436,10 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
 #endif
 
 #if defined(USE_LIBSSH2)
-  snprintf(ssh_buffer, sizeof(ssh_buffer), "libssh2/%s", LIBSSH2_VERSION);
+  msnprintf(ssh_buffer, sizeof(ssh_buffer), "libssh2/%s", LIBSSH2_VERSION);
   version_info.libssh_version = ssh_buffer;
 #elif defined(USE_LIBSSH)
-  snprintf(ssh_buffer, sizeof(ssh_buffer), "libssh/%s", CURL_LIBSSH_VERSION);
+  msnprintf(ssh_buffer, sizeof(ssh_buffer), "libssh/%s", CURL_LIBSSH_VERSION);
   version_info.libssh_version = ssh_buffer;
 #endif
 

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -777,13 +777,13 @@ static void Curl_cyassl_session_free(void *ptr)
 static size_t Curl_cyassl_version(char *buffer, size_t size)
 {
 #if LIBCYASSL_VERSION_HEX >= 0x03006000
-  return snprintf(buffer, size, "wolfSSL/%s", wolfSSL_lib_version());
+  return msnprintf(buffer, size, "wolfSSL/%s", wolfSSL_lib_version());
 #elif defined(WOLFSSL_VERSION)
-  return snprintf(buffer, size, "wolfSSL/%s", WOLFSSL_VERSION);
+  return msnprintf(buffer, size, "wolfSSL/%s", WOLFSSL_VERSION);
 #elif defined(CYASSL_VERSION)
-  return snprintf(buffer, size, "CyaSSL/%s", CYASSL_VERSION);
+  return msnprintf(buffer, size, "CyaSSL/%s", CYASSL_VERSION);
 #else
-  return snprintf(buffer, size, "CyaSSL/%s", "<1.8.8");
+  return msnprintf(buffer, size, "CyaSSL/%s", "<1.8.8");
 #endif
 }
 

--- a/lib/vtls/darwinssl.c
+++ b/lib/vtls/darwinssl.c
@@ -3015,7 +3015,7 @@ static void Curl_darwinssl_session_free(void *ptr)
 
 static size_t Curl_darwinssl_version(char *buffer, size_t size)
 {
-  return snprintf(buffer, size, "SecureTransport");
+  return msnprintf(buffer, size, "SecureTransport");
 }
 
 /*

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1314,7 +1314,7 @@ static int Curl_gskit_shutdown(struct connectdata *conn, int sockindex)
 
 static size_t Curl_gskit_version(char *buffer, size_t size)
 {
-  return snprintf(buffer, size, "GSKit");
+  return msnprintf(buffer, size, "GSKit");
 }
 
 

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -227,17 +227,17 @@ static void showtime(struct Curl_easy *data,
   if(result)
     return;
 
-  snprintf(str,
-           sizeof(str),
-           "\t %s: %s, %02d %s %4d %02d:%02d:%02d GMT",
-           text,
-           Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
-           tm->tm_mday,
-           Curl_month[tm->tm_mon],
-           tm->tm_year + 1900,
-           tm->tm_hour,
-           tm->tm_min,
-           tm->tm_sec);
+  msnprintf(str,
+            sizeof(str),
+            "\t %s: %s, %02d %s %4d %02d:%02d:%02d GMT",
+            text,
+            Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
+            tm->tm_mday,
+            Curl_month[tm->tm_mon],
+            tm->tm_year + 1900,
+            tm->tm_hour,
+            tm->tm_min,
+            tm->tm_sec);
   infof(data, "%s\n", str);
 }
 #endif
@@ -1748,7 +1748,7 @@ static void Curl_gtls_session_free(void *ptr)
 
 static size_t Curl_gtls_version(char *buffer, size_t size)
 {
-  return snprintf(buffer, size, "GnuTLS/%s", gnutls_check_version(NULL));
+  return msnprintf(buffer, size, "GnuTLS/%s", gnutls_check_version(NULL));
 }
 
 #ifndef USE_GNUTLS_NETTLE

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -812,8 +812,8 @@ static void Curl_mbedtls_session_free(void *ptr)
 static size_t Curl_mbedtls_version(char *buffer, size_t size)
 {
   unsigned int version = mbedtls_version_get_number();
-  return snprintf(buffer, size, "mbedTLS/%u.%u.%u", version>>24,
-                  (version>>16)&0xff, (version>>8)&0xff);
+  return msnprintf(buffer, size, "mbedTLS/%u.%u.%u", version>>24,
+                   (version>>16)&0xff, (version>>8)&0xff);
 }
 
 static CURLcode Curl_mbedtls_random(struct Curl_easy *data,

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -5,8 +5,8 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2017-2018, Yiming Jing, <jingyiming@baidu.com>
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2017 - 2018, Yiming Jing, <jingyiming@baidu.com>
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -424,7 +424,7 @@ mesalink_recv(struct connectdata *conn, int num, char *buf, size_t buffersize,
 static size_t
 Curl_mesalink_version(char *buffer, size_t size)
 {
-  return snprintf(buffer, size, "MesaLink/%s", MESALINK_VERSION_STRING);
+  return msnprintf(buffer, size, "MesaLink/%s", MESALINK_VERSION_STRING);
 }
 
 static int

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2270,7 +2270,7 @@ static ssize_t nss_recv(struct connectdata *conn,  /* connection data */
 
 static size_t Curl_nss_version(char *buffer, size_t size)
 {
-  return snprintf(buffer, size, "NSS/%s", NSS_VERSION);
+  return msnprintf(buffer, size, "NSS/%s", NSS_VERSION);
 }
 
 /* data might be NULL */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1974,7 +1974,7 @@ static void ssl_tls_trace(int direction, int ssl_ver, int content_type,
   case 0:
     break;
   default:
-    snprintf(unknown, sizeof(unknown), "(%x)", ssl_ver);
+    msnprintf(unknown, sizeof(unknown), "(%x)", ssl_ver);
     verstr = unknown;
     break;
   }
@@ -2018,9 +2018,9 @@ static void ssl_tls_trace(int direction, int ssl_ver, int content_type,
       msg_name = ssl_msg_type(ssl_ver, msg_type);
     }
 
-    txt_len = snprintf(ssl_buf, sizeof(ssl_buf), "%s (%s), %s, %s (%d):\n",
-                       verstr, direction?"OUT":"IN",
-                       tls_rt_name, msg_name, msg_type);
+    txt_len = msnprintf(ssl_buf, sizeof(ssl_buf), "%s (%s), %s, %s (%d):\n",
+                        verstr, direction?"OUT":"IN",
+                        tls_rt_name, msg_name, msg_type);
     if(0 <= txt_len && (unsigned)txt_len < sizeof(ssl_buf)) {
       Curl_debug(data, CURLINFO_TEXT, ssl_buf, (size_t)txt_len);
     }
@@ -2833,9 +2833,9 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
         lerr = SSL_get_verify_result(BACKEND->handle);
         if(lerr != X509_V_OK) {
           *certverifyresult = lerr;
-          snprintf(error_buffer, sizeof(error_buffer),
-                   "SSL certificate problem: %s",
-                   X509_verify_cert_error_string(lerr));
+          msnprintf(error_buffer, sizeof(error_buffer),
+                    "SSL certificate problem: %s",
+                    X509_verify_cert_error_string(lerr));
         }
         else
           /* strcpy() is fine here as long as the string fits within
@@ -2946,7 +2946,7 @@ static void pubkey_show(struct Curl_easy *data,
   char *ptr;
   char namebuf[32];
 
-  snprintf(namebuf, sizeof(namebuf), "%s(%s)", type, name);
+  msnprintf(namebuf, sizeof(namebuf), "%s(%s)", type, name);
 
   if(bn)
     BN_print(mem, bn);
@@ -3007,8 +3007,8 @@ static int X509V3_ext(struct Curl_easy *data,
       while((j<(size_t)biomem->length) && (biomem->data[j] == ' '))
         j++;
       if(j<(size_t)biomem->length)
-        ptr += snprintf(ptr, sizeof(buf)-(ptr-buf), "%s%c", sep,
-                        biomem->data[j]);
+        ptr += msnprintf(ptr, sizeof(buf)-(ptr-buf), "%s%c", sep,
+                         biomem->data[j]);
     }
 
     Curl_ssl_push_certinfo(data, certnum, namebuf, buf);
@@ -3774,7 +3774,7 @@ static ssize_t ossl_recv(struct connectdata *conn, /* connection data */
 static size_t Curl_ossl_version(char *buffer, size_t size)
 {
 #ifdef OPENSSL_IS_BORINGSSL
-  return snprintf(buffer, size, OSSL_PACKAGE);
+  return msnprintf(buffer, size, OSSL_PACKAGE);
 #else /* OPENSSL_IS_BORINGSSL */
   char sub[3];
   unsigned long ssleay_value;
@@ -3801,12 +3801,12 @@ static size_t Curl_ossl_version(char *buffer, size_t size)
       sub[0]='\0';
   }
 
-  return snprintf(buffer, size, "%s/%lx.%lx.%lx%s",
-                  OSSL_PACKAGE,
-                  (ssleay_value>>28)&0xf,
-                  (ssleay_value>>20)&0xff,
-                  (ssleay_value>>12)&0xff,
-                  sub);
+  return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s",
+                   OSSL_PACKAGE,
+                   (ssleay_value>>28)&0xf,
+                   (ssleay_value>>20)&0xff,
+                   (ssleay_value>>12)&0xff,
+                   sub);
 #endif /* OPENSSL_IS_BORINGSSL */
 }
 

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -716,9 +716,9 @@ static void Curl_polarssl_session_free(void *ptr)
 static size_t Curl_polarssl_version(char *buffer, size_t size)
 {
   unsigned int version = version_get_number();
-  return snprintf(buffer, size, "%s/%d.%d.%d",
-                  version >= 0x01030A00?"mbedTLS":"PolarSSL",
-                  version>>24, (version>>16)&0xff, (version>>8)&0xff);
+  return msnprintf(buffer, size, "%s/%d.%d.%d",
+                   version >= 0x01030A00?"mbedTLS":"PolarSSL",
+                   version>>24, (version>>16)&0xff, (version>>8)&0xff);
 }
 
 static CURLcode

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2049,7 +2049,7 @@ static void Curl_schannel_cleanup(void)
 
 static size_t Curl_schannel_version(char *buffer, size_t size)
 {
-  size = snprintf(buffer, size, "WinSSL");
+  size = msnprintf(buffer, size, "WinSSL");
 
   return size;
 }

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -700,7 +700,7 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   /* sprintf the label and colon */
-  snprintf(output, outlen, "%s:", label);
+  msnprintf(output, outlen, "%s:", label);
 
   /* memcpy the value (it might not be zero terminated) */
   memcpy(&output[labellen + 1], value, valuelen);

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -209,7 +209,7 @@ static const char *octet2str(const char *beg, const char *end)
     buf = malloc(3 * n + 1);
     if(buf)
       for(n = 0; beg < end; n += 3)
-        snprintf(buf + n, 4, "%02x:", *(const unsigned char *) beg++);
+        msnprintf(buf + n, 4, "%02x:", *(const unsigned char *) beg++);
   }
   return buf;
 }

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -66,8 +66,8 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
     }
     secs = epoch_offset + tv.tv_sec;
     now = localtime(&secs);  /* not thread safe but we don't care */
-    snprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
-             now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);
+    msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
+              now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);
   }
   else
     timebuf[0] = 0;

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -274,7 +274,7 @@ static char *parse_filename(const char *ptr, size_t len)
     char *tdir = curlx_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
-      snprintf(buffer, sizeof(buffer), "%s/%s", tdir, copy);
+      msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, copy);
       Curl_safefree(copy);
       copy = strdup(buffer); /* clone the buffer, we don't use the libcurl
                                 aprintf() or similar since we want to use the

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -72,7 +72,7 @@ static void fly(struct ProgressData *bar, bool moved)
   int pos;
   int check = bar->width - 2;
 
-  snprintf(buf, sizeof(buf), "%*s\r", bar->width-1, " ");
+  msnprintf(buf, sizeof(buf), "%*s\r", bar->width-1, " ");
   memcpy(&buf[bar->bar], "-=O=-", 5);
 
   pos = sinus[bar->tick%200] / (10000 / check);
@@ -166,7 +166,7 @@ int tool_progress_cb(void *clientp,
       num = MAX_BARLENGTH;
     memset(line, '#', num);
     line[num] = '\0';
-    snprintf(format, sizeof(format), "\r%%-%ds %%5.1f%%%%", barwidth);
+    msnprintf(format, sizeof(format), "\r%%-%ds %%5.1f%%%%", barwidth);
     fprintf(bar->out, format, line, percent);
   }
   fflush(bar->out);

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -131,13 +131,13 @@ CURLcode create_dir_hierarchy(const char *outfile, FILE *errors)
     if(tempdir2 != NULL) {
       size_t dlen = strlen(dirbuildup);
       if(dlen)
-        snprintf(&dirbuildup[dlen], outlen - dlen, "%s%s", DIR_CHAR, tempdir);
+        msnprintf(&dirbuildup[dlen], outlen - dlen, "%s%s", DIR_CHAR, tempdir);
       else {
         if(outdup == tempdir)
           /* the output string doesn't start with a separator */
           strcpy(dirbuildup, tempdir);
         else
-          snprintf(dirbuildup, outlen, "%s%s", DIR_CHAR, tempdir);
+          msnprintf(dirbuildup, outlen, "%s%s", DIR_CHAR, tempdir);
       }
       if((-1 == mkdir(dirbuildup, (mode_t)0000750)) && (errno != EEXIST)) {
         show_dir_errno(errors, dirbuildup);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1351,7 +1351,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
               return PARAM_NO_MEM;
             }
             if(nlen > 0) { /* only append '=' if we have a name */
-              snprintf(n, outlen, "%.*s=%s", nlen, nextarg, enc);
+              msnprintf(n, outlen, "%.*s=%s", nlen, nextarg, enc);
               size = outlen-1;
             }
             else {
@@ -1935,7 +1935,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         warnf(global,
               "A specified range MUST include at least one dash (-). "
               "Appending one for you!\n");
-        snprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-", off);
+        msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-", off);
         Curl_safefree(config->range);
         config->range = strdup(buffer);
         if(!config->range)

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -176,7 +176,7 @@ CURLcode get_url_file_name(char **filename, const char *url)
     char *tdir = curlx_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
-      snprintf(buffer, sizeof(buffer), "%s/%s", tdir, *filename);
+      msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, *filename);
       Curl_safefree(*filename);
       *filename = strdup(buffer); /* clone the buffer */
       curl_free(tdir);

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -60,8 +60,8 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     filename = CURLRC;   /* sensible default */
     if(home) {
       if(strlen(home) < (sizeof(filebuffer) - strlen(CURLRC))) {
-        snprintf(filebuffer, sizeof(filebuffer),
-                 "%s%s%s", home, DIR_CHAR, CURLRC);
+        msnprintf(filebuffer, sizeof(filebuffer),
+                  "%s%s%s", home, DIR_CHAR, CURLRC);
 
 #ifdef WIN32
         /* Check if the file exists - if not, try CURLRC in the same
@@ -87,11 +87,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
               /* If we have enough space, build the RC filename */
               remaining = sizeof(filebuffer) - strlen(filebuffer);
               if(strlen(CURLRC) < remaining - 1) {
-                snprintf(lastdirchar, remaining,
-                         "%s%s", DIR_CHAR, CURLRC);
-                /* Don't bother checking if it exists - we do
-                 * that later
-                 */
+                msnprintf(lastdirchar, remaining,
+                          "%s%s", DIR_CHAR, CURLRC);
+                /* Don't bother checking if it exists - we do that later */
                 filename = filebuffer;
               }
             }

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -251,7 +251,7 @@ static char *c_escape(const char *str, size_t len)
       e += 2;
     }
     else if(! isprint(c)) {
-      snprintf(e, 5, "\\%03o", (unsigned)c);
+      msnprintf(e, 5, "\\%03o", (unsigned)c);
       e += 4;
     }
     else
@@ -311,8 +311,8 @@ CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
     char preamble[80];          /* should accommodate any symbol name */
     long rest = lval;           /* bits not handled yet */
     const NameValue *nv = NULL;
-    snprintf(preamble, sizeof(preamble),
-             "curl_easy_setopt(hnd, %s, ", name);
+    msnprintf(preamble, sizeof(preamble),
+              "curl_easy_setopt(hnd, %s, ", name);
     for(nv = nvlist; nv->name; nv++) {
       if((nv->value & ~ rest) == 0) {
         /* all value flags contained in rest */
@@ -322,7 +322,7 @@ CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
         if(!rest)
           break;                /* handled them all */
         /* replace with all spaces for continuation line */
-        snprintf(preamble, sizeof(preamble), "%*s", strlen(preamble), "");
+        msnprintf(preamble, sizeof(preamble), "%*s", strlen(preamble), "");
       }
     }
     /* If any bits have no definition, output an explicit value.
@@ -354,8 +354,8 @@ CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
     char preamble[80];
     unsigned long rest = (unsigned long)lval;
     const NameValueUnsigned *nv = NULL;
-    snprintf(preamble, sizeof(preamble),
-             "curl_easy_setopt(hnd, %s, ", name);
+    msnprintf(preamble, sizeof(preamble),
+              "curl_easy_setopt(hnd, %s, ", name);
     for(nv = nvlist; nv->name; nv++) {
       if((nv->value & ~ rest) == 0) {
         /* all value flags contained in rest */
@@ -365,7 +365,7 @@ CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
         if(!rest)
           break;                /* handled them all */
         /* replace with all spaces for continuation line */
-        snprintf(preamble, sizeof(preamble), "%*s", strlen(preamble), "");
+        msnprintf(preamble, sizeof(preamble), "%*s", strlen(preamble), "");
       }
     }
     /* If any bits have no definition, output an explicit value.
@@ -629,7 +629,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *config,
       }
     }
 
-    snprintf(buf, sizeof(buf), "%ldL", lval);
+    msnprintf(buf, sizeof(buf), "%ldL", lval);
     value = buf;
     ret = curl_easy_setopt(curl, tag, lval);
     if(lval == defval)
@@ -666,8 +666,8 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *config,
   else {
     /* Value is expected to be curl_off_t */
     curl_off_t oval = va_arg(arg, curl_off_t);
-    snprintf(buf, sizeof(buf),
-             "(curl_off_t)%" CURL_FORMAT_CURL_OFF_T, oval);
+    msnprintf(buf, sizeof(buf),
+              "(curl_off_t)%" CURL_FORMAT_CURL_OFF_T, oval);
     value = buf;
     ret = curl_easy_setopt(curl, tag, oval);
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -462,9 +462,9 @@ CURLcode glob_url(URLGlob **glob, char *url, unsigned long *urlnum,
       char text[512];
       const char *t;
       if(glob_expand->pos) {
-        snprintf(text, sizeof(text), "%s in URL position %zu:\n%s\n%*s^",
-                 glob_expand->error,
-                 glob_expand->pos, url, glob_expand->pos - 1, " ");
+        msnprintf(text, sizeof(text), "%s in URL position %zu:\n%s\n%*s^",
+                  glob_expand->error,
+                  glob_expand->pos, url, glob_expand->pos - 1, " ");
         t = text;
       }
       else
@@ -563,8 +563,8 @@ CURLcode glob_next_url(char **globbed, URLGlob *glob)
     switch(pat->type) {
     case UPTSet:
       if(pat->content.Set.elements) {
-        snprintf(buf, buflen, "%s",
-                 pat->content.Set.elements[pat->content.Set.ptr_s]);
+        msnprintf(buf, buflen, "%s",
+                  pat->content.Set.elements[pat->content.Set.ptr_s]);
         len = strlen(buf);
         buf += len;
         buflen -= len;
@@ -578,9 +578,9 @@ CURLcode glob_next_url(char **globbed, URLGlob *glob)
       }
       break;
     case UPTNumRange:
-      snprintf(buf, buflen, "%0*lu",
-               pat->content.NumRange.padlength,
-               pat->content.NumRange.ptr_n);
+      msnprintf(buf, buflen, "%0*lu",
+                pat->content.NumRange.padlength,
+                pat->content.NumRange.ptr_n);
       len = strlen(buf);
       buf += len;
       buflen -= len;
@@ -653,9 +653,9 @@ CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
           appendlen = 1;
           break;
         case UPTNumRange:
-          snprintf(numbuf, sizeof(numbuf), "%0*lu",
-                   pat->content.NumRange.padlength,
-                   pat->content.NumRange.ptr_n);
+          msnprintf(numbuf, sizeof(numbuf), "%0*lu",
+                    pat->content.NumRange.padlength,
+                    pat->content.NumRange.ptr_n);
           appendthis = numbuf;
           appendlen = strlen(numbuf);
           break;

--- a/tests/libtest/chkdecimalpoint.c
+++ b/tests/libtest/chkdecimalpoint.c
@@ -33,7 +33,7 @@ int main(void)
   int chars;
 
   setlocale(LC_NUMERIC, "");
-  chars = snprintf(zero, TOTAL_STR_LEN, "%.1f", 0.0);
+  chars = msnprintf(zero, TOTAL_STR_LEN, "%.1f", 0.0);
   if((chars == (TOTAL_STR_LEN - 1)) && (strcmp(zero, "0.0") == 0))
     return 0;
   else

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -124,7 +124,7 @@ char *hexdump(const unsigned char *buffer, size_t len)
   if(len > 200)
     return NULL;
   for(i = 0; i<len; i++, p += 3)
-    snprintf(p, 4, "%02x ", buffer[i]);
+    msnprintf(p, 4, "%02x ", buffer[i]);
   return dump;
 }
 

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -91,7 +91,7 @@ static int onetest(CURL *curl, const char *url, const testparams *p)
   replyselector = p->flags & F_CONTENTRANGE? 1: 0;
   if(p->flags & F_HTTP416)
     replyselector += 2;
-  snprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
+  msnprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
   test_setopt(curl, CURLOPT_URL, urlbuf);
   test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME)? 3: 0);
   test_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME)?

--- a/tests/libtest/lib1502.c
+++ b/tests/libtest/lib1502.c
@@ -50,8 +50,8 @@ int test(char *URL)
   /* DNS cache injection */
   struct curl_slist *dns_cache_list;
 
-  snprintf(redirect, sizeof(redirect), "google.com:%s:%s", libtest_arg2,
-           libtest_arg3);
+  msnprintf(redirect, sizeof(redirect), "google.com:%s:%s", libtest_arg2,
+            libtest_arg3);
 
   start_test_timing();
 

--- a/tests/libtest/lib1506.c
+++ b/tests/libtest/lib1506.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2013, 2017, Linus Nielsen Feltzing <linus@haxx.se>
+ * Copyright (C) 2013 - 2018, Linus Nielsen Feltzing <linus@haxx.se>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -46,8 +46,8 @@ int test(char *URL)
 
   /* Create fake DNS entries for serverX.example.com for all handles */
   for(i = 0; i < NUM_HANDLES; i++) {
-    snprintf(dnsentry, sizeof(dnsentry), "server%d.example.com:%s:%s",
-             i + 1, port, address);
+    msnprintf(dnsentry, sizeof(dnsentry), "server%d.example.com:%s:%s",
+              i + 1, port, address);
     printf("%s\n", dnsentry);
     slist2 = curl_slist_append(slist, dnsentry);
     if(!slist2) {
@@ -70,9 +70,9 @@ int test(char *URL)
     /* get an easy handle */
     easy_init(curl[i]);
     /* specify target */
-    snprintf(target_url, sizeof(target_url),
-             "http://server%d.example.com:%s/path/1506%04i",
-             i + 1, port, i + 1);
+    msnprintf(target_url, sizeof(target_url),
+              "http://server%d.example.com:%s/path/1506%04i",
+              i + 1, port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go verbose */

--- a/tests/libtest/lib1510.c
+++ b/tests/libtest/lib1510.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2013, 2017, Linus Nielsen Feltzing <linus@haxx.se>
+ * Copyright (C) 2013 - 2018, Linus Nielsen Feltzing <linus@haxx.se>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -44,8 +44,8 @@ int test(char *URL)
 
   /* Create fake DNS entries for serverX.example.com for all handles */
   for(i = 0; i < NUM_URLS; i++) {
-    snprintf(dnsentry, sizeof(dnsentry), "server%d.example.com:%s:%s", i + 1,
-             port, address);
+    msnprintf(dnsentry, sizeof(dnsentry), "server%d.example.com:%s:%s", i + 1,
+              port, address);
     printf("%s\n", dnsentry);
     slist2 = curl_slist_append(slist, dnsentry);
     if(!slist2) {
@@ -74,9 +74,9 @@ int test(char *URL)
   /* get NUM_HANDLES easy handles */
   for(i = 0; i < NUM_URLS; i++) {
     /* specify target */
-    snprintf(target_url, sizeof(target_url),
-             "http://server%d.example.com:%s/path/1510%04i",
-             i + 1, port, i + 1);
+    msnprintf(target_url, sizeof(target_url),
+              "http://server%d.example.com:%s/path/1510%04i",
+              i + 1, port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl, CURLOPT_URL, target_url);
 

--- a/tests/libtest/lib1512.c
+++ b/tests/libtest/lib1512.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2013 - 2017, Linus Nielsen Feltzing <linus@haxx.se>
+ * Copyright (C) 2013 - 2018, Linus Nielsen Feltzing <linus@haxx.se>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,8 +49,8 @@ int test(char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  snprintf(dnsentry, sizeof(dnsentry), "server.example.curl:%s:%s",
-           port, address);
+  msnprintf(dnsentry, sizeof(dnsentry), "server.example.curl:%s:%s",
+            port, address);
   printf("%s\n", dnsentry);
   slist = curl_slist_append(slist, dnsentry);
 
@@ -59,9 +59,9 @@ int test(char *URL)
     /* get an easy handle */
     easy_init(curl[i]);
     /* specify target */
-    snprintf(target_url, sizeof(target_url),
-             "http://server.example.curl:%s/path/1512%04i",
-             port, i + 1);
+    msnprintf(target_url, sizeof(target_url),
+              "http://server.example.curl:%s/path/1512%04i",
+              port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go verbose */

--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -123,8 +123,8 @@ int test(char *URL)
   int i;
   int count = 2;
 
-  snprintf(dns_entry, sizeof(dns_entry), "testserver.example.com:%s:%s",
-           port, address);
+  msnprintf(dns_entry, sizeof(dns_entry), "testserver.example.com:%s:%s",
+            port, address);
 
   start_test_timing();
 
@@ -133,8 +133,8 @@ int test(char *URL)
 
   for(i = 1; i <= count; i++) {
     char target_url[256];
-    snprintf(target_url, sizeof(target_url),
-             "http://testserver.example.com:%s/%s%04d", port, path, i);
+    msnprintf(target_url, sizeof(target_url),
+              "http://testserver.example.com:%s/%s%04d", port, path, i);
 
     /* second request must succeed like the first one */
     res = do_one_request(multi, target_url, dns_entry);

--- a/tests/libtest/lib1529.c
+++ b/tests/libtest/lib1529.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -29,7 +29,8 @@ int test(char *URL)
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
   char bURL[512];
-  snprintf(bURL, sizeof(bURL), "%s HTTP/1.1\r\nGET http://1529.com/1529", URL);
+  msnprintf(bURL, sizeof(bURL),
+            "%s HTTP/1.1\r\nGET http://1529.com/1529", URL);
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -67,10 +67,10 @@ static int checkparts(CURLU *u, const char *in, const char *wanted,
     size_t n;
     rc = curl_url_get(u, parts[i].part, &p, getflags);
     if(!rc && p) {
-      snprintf(bufp, len, "%s%s", buf[0]?" | ":"", p);
+      msnprintf(bufp, len, "%s%s", buf[0]?" | ":"", p);
     }
     else
-      snprintf(bufp, len, "%s[%d]", buf[0]?" | ":"", (int)rc);
+      msnprintf(bufp, len, "%s[%d]", buf[0]?" | ":"", (int)rc);
 
     n = strlen(bufp);
     bufp += n;

--- a/tests/libtest/lib1900.c
+++ b/tests/libtest/lib1900.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2013 - 2017, Linus Nielsen Feltzing, <linus@haxx.se>
+ * Copyright (C) 2013 - 2018, Linus Nielsen Feltzing, <linus@haxx.se>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -113,7 +113,7 @@ static void setup_handle(char *base_url, CURLM *m, int handlenum)
 {
   char urlbuf[256];
 
-  snprintf(urlbuf, sizeof(urlbuf), "%s%s", base_url, urlstring[handlenum]);
+  msnprintf(urlbuf, sizeof(urlbuf), "%s%s", base_url, urlstring[handlenum]);
   curl_easy_setopt(handles[handlenum], CURLOPT_URL, urlbuf);
   curl_easy_setopt(handles[handlenum], CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(handles[handlenum], CURLOPT_FAILONERROR, 1L);

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -55,10 +55,10 @@ static char msgbuff[256];
 static void store_errmsg(const char *msg, int err)
 {
   if(!err)
-    snprintf(msgbuff, sizeof(msgbuff), "%s", msg);
+    msnprintf(msgbuff, sizeof(msgbuff), "%s", msg);
   else
-    snprintf(msgbuff, sizeof(msgbuff), "%s, errno %d, %s", msg,
-             err, strerror(err));
+    msnprintf(msgbuff, sizeof(msgbuff), "%s, errno %d, %s", msg,
+              err, strerror(err));
 }
 
 static void close_file_descriptors(void)
@@ -132,7 +132,7 @@ static int rlimit(int keep_open)
     strcpy(strbuff, "INFINITY");
   else
 #endif
-    snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
+    msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
   fprintf(stderr, "initial soft limit: %s\n", strbuff);
 
 #ifdef RLIM_INFINITY
@@ -140,7 +140,7 @@ static int rlimit(int keep_open)
     strcpy(strbuff, "INFINITY");
   else
 #endif
-    snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
   fprintf(stderr, "initial hard limit: %s\n", strbuff);
 
   /* show our constants */
@@ -198,7 +198,7 @@ static int rlimit(int keep_open)
       strcpy(strbuff, "INFINITY");
     else
 #endif
-      snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
     fprintf(stderr, "current soft limit: %s\n", strbuff);
 
 #ifdef RLIM_INFINITY
@@ -206,7 +206,7 @@ static int rlimit(int keep_open)
       strcpy(strbuff, "INFINITY");
     else
 #endif
-      snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
+      msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
     fprintf(stderr, "current hard limit: %s\n", strbuff);
 
   } /* (rl.rlim_cur != rl.rlim_max) */
@@ -233,10 +233,10 @@ static int rlimit(int keep_open)
      (rl.rlim_cur != RLIM_INFINITY) &&
 #endif
      (rl.rlim_cur <= num_open.rlim_cur)) {
-    snprintf(strbuff2, sizeof(strbuff2), fmt, rl.rlim_cur);
-    snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
-    snprintf(strbuff, sizeof(strbuff), "fds needed %s > system limit %s",
-             strbuff1, strbuff2);
+    msnprintf(strbuff2, sizeof(strbuff2), fmt, rl.rlim_cur);
+    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+    msnprintf(strbuff, sizeof(strbuff), "fds needed %s > system limit %s",
+              strbuff1, strbuff2);
     store_errmsg(strbuff, 0);
     fprintf(stderr, "%s\n", msgbuff);
     return -4;
@@ -257,7 +257,7 @@ static int rlimit(int keep_open)
     nitems = 0x40000;
   do {
     num_open.rlim_max = sizeof(*memchunk) * (size_t)nitems;
-    snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
     fprintf(stderr, "allocating memchunk %s byte array\n", strbuff);
     memchunk = malloc(sizeof(*memchunk) * (size_t)nitems);
     if(!memchunk) {
@@ -285,9 +285,9 @@ static int rlimit(int keep_open)
   /* verify that we won't overflow size_t in malloc() */
 
   if((size_t)(num_open.rlim_max) > ((size_t)-1) / sizeof(*fd)) {
-    snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
-    snprintf(strbuff, sizeof(strbuff), "unable to allocate an array for %s "
-             "file descriptors, would overflow size_t", strbuff1);
+    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), "unable to allocate an array for %s "
+              "file descriptors, would overflow size_t", strbuff1);
     store_errmsg(strbuff, 0);
     fprintf(stderr, "%s\n", msgbuff);
     free(memchunk);
@@ -296,7 +296,7 @@ static int rlimit(int keep_open)
 
   /* allocate array for file descriptors */
 
-  snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
   fprintf(stderr, "allocating array for %s file descriptors\n", strbuff);
 
   fd = malloc(sizeof(*fd) * (size_t)(num_open.rlim_max));
@@ -316,14 +316,14 @@ static int rlimit(int keep_open)
       num_open.rlim_cur++)
     fd[num_open.rlim_cur] = -1;
 
-  snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
   fprintf(stderr, "trying to open %s file descriptors\n", strbuff);
 
   /* open a dummy descriptor */
 
   fd[0] = open(DEV_NULL, O_RDONLY);
   if(fd[0] < 0) {
-    snprintf(strbuff, sizeof(strbuff), "opening of %s failed", DEV_NULL);
+    msnprintf(strbuff, sizeof(strbuff), "opening of %s failed", DEV_NULL);
     store_errmsg(strbuff, errno);
     fprintf(stderr, "%s\n", msgbuff);
     free(fd);
@@ -344,20 +344,20 @@ static int rlimit(int keep_open)
 
       fd[num_open.rlim_cur] = -1;
 
-      snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
-      snprintf(strbuff, sizeof(strbuff), "dup() attempt %s failed", strbuff1);
+      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), "dup() attempt %s failed", strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
-      snprintf(strbuff1, sizeof(strbuff), fmt, num_open.rlim_cur);
-      snprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
+      msnprintf(strbuff1, sizeof(strbuff), fmt, num_open.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
                strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
       num_open.rlim_max = NUM_NEEDED;
 
-      snprintf(strbuff2, sizeof(strbuff2), fmt, num_open.rlim_max);
-      snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
-      snprintf(strbuff, sizeof(strbuff), "fds needed %s > system limit %s",
+      msnprintf(strbuff2, sizeof(strbuff2), fmt, num_open.rlim_max);
+      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), "fds needed %s > system limit %s",
                strbuff2, strbuff1);
       store_errmsg(strbuff, 0);
       fprintf(stderr, "%s\n", msgbuff);
@@ -375,7 +375,7 @@ static int rlimit(int keep_open)
 
   }
 
-  snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
   fprintf(stderr, "%s file descriptors open\n", strbuff);
 
 #if !defined(HAVE_POLL_FINE)    && \
@@ -395,7 +395,7 @@ static int rlimit(int keep_open)
 
   num_open.rlim_cur = FD_SETSIZE - SAFETY_MARGIN;
   if(num_open.rlim_max > num_open.rlim_cur) {
-    snprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
+    msnprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
              FD_SETSIZE);
     store_errmsg(strbuff, 0);
     fprintf(stderr, "%s\n", msgbuff);
@@ -410,7 +410,7 @@ static int rlimit(int keep_open)
       rl.rlim_cur++) {
     if((fd[rl.rlim_cur] > 0) &&
        ((unsigned int)fd[rl.rlim_cur] > num_open.rlim_cur)) {
-      snprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
+      msnprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
                FD_SETSIZE);
       store_errmsg(strbuff, 0);
       fprintf(stderr, "%s\n", msgbuff);
@@ -432,12 +432,12 @@ static int rlimit(int keep_open)
    */
 
   if(!fopen_works()) {
-    snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
-    snprintf(strbuff, sizeof(strbuff),
+    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff),
              "fopen fails with %s fds open()",
              strbuff1);
     fprintf(stderr, "%s\n", msgbuff);
-    snprintf(strbuff, sizeof(strbuff),
+    msnprintf(strbuff, sizeof(strbuff),
              "fopen fails with lots of fds open()");
     store_errmsg(strbuff, 0);
     close_file_descriptors();

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -53,7 +53,7 @@ int test(char *URL)
     /* get an easy handle */
     easy_init(curl[i]);
     /* specify target */
-    snprintf(target_url, sizeof(target_url), "%s%04i", URL, i + 1);
+    msnprintf(target_url, sizeof(target_url), "%s%04i", URL, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go verbose */

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -56,10 +56,10 @@ static char msgbuff[256];
 static void store_errmsg(const char *msg, int err)
 {
   if(!err)
-    snprintf(msgbuff, sizeof(msgbuff), "%s", msg);
+    msnprintf(msgbuff, sizeof(msgbuff), "%s", msg);
   else
-    snprintf(msgbuff, sizeof(msgbuff), "%s, errno %d, %s", msg, err,
-             strerror(err));
+    msnprintf(msgbuff, sizeof(msgbuff), "%s, errno %d, %s", msg, err,
+              strerror(err));
 }
 
 static void close_file_descriptors(void)
@@ -133,7 +133,7 @@ static int rlimit(int keep_open)
     strcpy(strbuff, "INFINITY");
   else
 #endif
-    snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
+    msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
   fprintf(stderr, "initial soft limit: %s\n", strbuff);
 
 #ifdef RLIM_INFINITY
@@ -141,7 +141,7 @@ static int rlimit(int keep_open)
     strcpy(strbuff, "INFINITY");
   else
 #endif
-    snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
   fprintf(stderr, "initial hard limit: %s\n", strbuff);
 
   /*
@@ -193,7 +193,7 @@ static int rlimit(int keep_open)
       strcpy(strbuff, "INFINITY");
     else
 #endif
-      snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
     fprintf(stderr, "current soft limit: %s\n", strbuff);
 
 #ifdef RLIM_INFINITY
@@ -201,7 +201,7 @@ static int rlimit(int keep_open)
       strcpy(strbuff, "INFINITY");
     else
 #endif
-      snprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
+      msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
     fprintf(stderr, "current hard limit: %s\n", strbuff);
 
   } /* (rl.rlim_cur != rl.rlim_max) */
@@ -231,7 +231,7 @@ static int rlimit(int keep_open)
     nitems = 0x40000;
   do {
     num_open.rlim_max = sizeof(*memchunk) * nitems;
-    snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
     fprintf(stderr, "allocating memchunk %s byte array\n", strbuff);
     memchunk = malloc(sizeof(*memchunk) * (size_t)nitems);
     if(!memchunk) {
@@ -274,9 +274,9 @@ static int rlimit(int keep_open)
   /* verify that we won't overflow size_t in malloc() */
 
   if((size_t)(num_open.rlim_max) > ((size_t)-1) / sizeof(*fd)) {
-    snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
-    snprintf(strbuff, sizeof(strbuff), "unable to allocate an array for %s "
-             "file descriptors, would overflow size_t", strbuff1);
+    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), "unable to allocate an array for %s "
+              "file descriptors, would overflow size_t", strbuff1);
     store_errmsg(strbuff, 0);
     fprintf(stderr, "%s\n", msgbuff);
     free(memchunk);
@@ -286,7 +286,7 @@ static int rlimit(int keep_open)
   /* allocate array for file descriptors */
 
   do {
-    snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
     fprintf(stderr, "allocating array for %s file descriptors\n", strbuff);
     fd = malloc(sizeof(*fd) * (size_t)(num_open.rlim_max));
     if(!fd) {
@@ -310,14 +310,14 @@ static int rlimit(int keep_open)
       num_open.rlim_cur++)
     fd[num_open.rlim_cur] = -1;
 
-  snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
   fprintf(stderr, "trying to open %s file descriptors\n", strbuff);
 
   /* open a dummy descriptor */
 
   fd[0] = open(DEV_NULL, O_RDONLY);
   if(fd[0] < 0) {
-    snprintf(strbuff, sizeof(strbuff), "opening of %s failed", DEV_NULL);
+    msnprintf(strbuff, sizeof(strbuff), "opening of %s failed", DEV_NULL);
     store_errmsg(strbuff, errno);
     fprintf(stderr, "%s\n", msgbuff);
     free(fd);
@@ -338,21 +338,21 @@ static int rlimit(int keep_open)
 
       fd[num_open.rlim_cur] = -1;
 
-      snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
-      snprintf(strbuff, sizeof(strbuff), "dup() attempt %s failed", strbuff1);
+      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), "dup() attempt %s failed", strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
-      snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
-      snprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
-               strbuff1);
+      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
+                strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
       num_open.rlim_max = num_open.rlim_cur - SAFETY_MARGIN;
 
       num_open.rlim_cur -= num_open.rlim_max;
-      snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
-      snprintf(strbuff, sizeof(strbuff), "closing %s file descriptors",
-               strbuff1);
+      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      msnprintf(strbuff, sizeof(strbuff), "closing %s file descriptors",
+                strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
       for(num_open.rlim_cur = num_open.rlim_max;
@@ -362,7 +362,7 @@ static int rlimit(int keep_open)
         fd[num_open.rlim_cur] = -1;
       }
 
-      snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+      msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
       fprintf(stderr, "shrinking array for %s file descriptors\n", strbuff);
 
       /* we don't care if we can't shrink it */
@@ -379,7 +379,7 @@ static int rlimit(int keep_open)
 
   }
 
-  snprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
   fprintf(stderr, "%s file descriptors open\n", strbuff);
 
 #if !defined(HAVE_POLL_FINE)    && \
@@ -399,8 +399,8 @@ static int rlimit(int keep_open)
 
   num_open.rlim_cur = FD_SETSIZE - SAFETY_MARGIN;
   if(num_open.rlim_max > num_open.rlim_cur) {
-    snprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
-             FD_SETSIZE);
+    msnprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
+              FD_SETSIZE);
     store_errmsg(strbuff, 0);
     fprintf(stderr, "%s\n", msgbuff);
     close_file_descriptors();
@@ -414,8 +414,8 @@ static int rlimit(int keep_open)
       rl.rlim_cur++) {
     if((fd[rl.rlim_cur] > 0) &&
        ((unsigned int)fd[rl.rlim_cur] > num_open.rlim_cur)) {
-      snprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
-               FD_SETSIZE);
+      msnprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
+                FD_SETSIZE);
       store_errmsg(strbuff, 0);
       fprintf(stderr, "%s\n", msgbuff);
       close_file_descriptors();
@@ -436,11 +436,11 @@ static int rlimit(int keep_open)
    */
 
   if(!fopen_works()) {
-    snprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
-    snprintf(strbuff, sizeof(strbuff), "fopen fails with %s fds open",
-            strbuff1);
+    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
+    msnprintf(strbuff, sizeof(strbuff), "fopen fails with %s fds open",
+              strbuff1);
     fprintf(stderr, "%s\n", msgbuff);
-    snprintf(strbuff, sizeof(strbuff), "fopen fails with lots of fds open");
+    msnprintf(strbuff, sizeof(strbuff), "fopen fails with lots of fds open");
     store_errmsg(strbuff, 0);
     close_file_descriptors();
     free(memchunk);

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -198,7 +198,7 @@ int test(char *URL)
   if(test_argc < 4)
     return 99;
 
-  snprintf(buffer, sizeof(buffer), "Host: %s", HOST);
+  msnprintf(buffer, sizeof(buffer), "Host: %s", HOST);
 
   /* now add a custom Host: header */
   headers = curl_slist_append(headers, buffer);

--- a/tests/libtest/lib553.c
+++ b/tests/libtest/lib553.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -75,7 +75,7 @@ int test(char *URL)
   }
 
   for(i = 0; i < NUM_HEADERS; i++) {
-    int len = snprintf(buf, sizeof(buf), "Header%d: ", i);
+    int len = msnprintf(buf, sizeof(buf), "Header%d: ", i);
     memset(&buf[len], 'A', SIZE_HEADERS);
     buf[len + SIZE_HEADERS] = 0; /* zero terminate */
     hl = curl_slist_append(headerlist,  buf);

--- a/tests/libtest/libauthretry.c
+++ b/tests/libtest/libauthretry.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -38,7 +38,7 @@ static CURLcode send_request(CURL *curl, const char *url, int seq,
     return CURLE_OUT_OF_MEMORY;
   }
 
-  snprintf(full_url, len, "%s%04d", url, seq);
+  msnprintf(full_url, len, "%s%04d", url, seq);
   fprintf(stderr, "Sending new request %d to %s with credential %s "
           "(auth %ld)\n", seq, full_url, userpwd, auth_scheme);
   test_setopt(curl, CURLOPT_URL, full_url);

--- a/tests/libtest/libntlmconnect.c
+++ b/tests/libtest/libntlmconnect.c
@@ -135,11 +135,11 @@ int test(char *url)
       easy_init(easy[num_handles]);
 
       if(num_handles % 3 == 2) {
-        snprintf(full_url, urllen, "%s0200", url);
+        msnprintf(full_url, urllen, "%s0200", url);
         easy_setopt(easy[num_handles], CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
       }
       else {
-        snprintf(full_url, urllen, "%s0100", url);
+        msnprintf(full_url, urllen, "%s0100", url);
         easy_setopt(easy[num_handles], CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
       }
       easy_setopt(easy[num_handles], CURLOPT_FRESH_CONNECT, 1L);

--- a/tests/libtest/stub_gssapi.c
+++ b/tests/libtest/stub_gssapi.c
@@ -28,6 +28,11 @@
 
 #include "stub_gssapi.h"
 
+#define ENABLE_CURLX_PRINTF
+/* make the curlx header define all printf() functions to use the curlx_*
+   versions instead */
+#include "curlx.h" /* from the private lib dir */
+
 #define MAX_CREDS_LENGTH 250
 #define APPROX_TOKEN_LEN 250
 
@@ -202,8 +207,8 @@ OM_uint32 gss_init_sec_context(OM_uint32 *min,
   }
 
   /* Token format: creds:target:type:padding */
-  used = snprintf(token, length, "%s:%s:%d:", creds,
-                  (char *) target_name, ctx->sent);
+  used = msnprintf(token, length, "%s:%s:%d:", creds,
+                   (char *) target_name, ctx->sent);
 
   if(used >= length) {
     free(token);

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -108,8 +108,8 @@ int libtest_debug_cb(CURL *handle, curl_infotype type,
     }
     secs = epoch_offset + tv.tv_sec;
     now = localtime(&secs);  /* not thread safe but we don't care */
-    snprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
-             now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);
+    msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
+              now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);
   }
 
   switch(type) {

--- a/tests/server/fake_ntlm.c
+++ b/tests/server/fake_ntlm.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2010, Mandy Wu, <mandy.wu@intel.com>
- * Copyright (C) 2011 - 2013, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2011 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -75,7 +75,7 @@ static char *printable(char *inbuf, size_t inlength)
     return NULL;
 
   if(!inlength) {
-    snprintf(&outbuf[0], outsize, "%s", NOTHING_STR);
+    msnprintf(&outbuf[0], outsize, "%s", NOTHING_STR);
     return outbuf;
   }
 
@@ -97,7 +97,7 @@ static char *printable(char *inbuf, size_t inlength)
       o++;
     }
     else {
-      snprintf(&outbuf[o], outsize - o, HEX_FMT_STR, inbuf[i]);
+      msnprintf(&outbuf[o], outsize - o, HEX_FMT_STR, inbuf[i]);
       o += HEX_STR_LEN;
     }
 
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
   }
 
   /* logmsg cannot be used until this file name is set */
-  snprintf(logfilename, sizeof(logfilename), LOGFILE, testnum);
+  msnprintf(logfilename, sizeof(logfilename), LOGFILE, testnum);
   serverlogfile = logfilename;
 
   logmsg("fake_ntlm (user: %s) (proto: %s) (domain: %s) (cached creds: %s)",

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -382,11 +382,11 @@ static int ProcessRequest(struct httprequest *req)
       char *filename;
 
       if((strlen(doc) + strlen(request)) < 200)
-        snprintf(logbuf, sizeof(logbuf), "Got request: %s %s %s/%d.%d",
-                 request, doc, prot_str, prot_major, prot_minor);
+        msnprintf(logbuf, sizeof(logbuf), "Got request: %s %s %s/%d.%d",
+                  request, doc, prot_str, prot_major, prot_minor);
       else
-        snprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request %s/%d.%d",
-                prot_str, prot_major, prot_minor);
+        msnprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request %s/%d.%d",
+                  prot_str, prot_major, prot_minor);
       logmsg("%s", logbuf);
 
       if(!strncmp("/verifiedserver", ptr, 15)) {
@@ -416,8 +416,8 @@ static int ProcessRequest(struct httprequest *req)
       else
         req->partno = 0;
 
-      snprintf(logbuf, sizeof(logbuf), "Requested test number %ld part %ld",
-               req->testno, req->partno);
+      msnprintf(logbuf, sizeof(logbuf), "Requested test number %ld part %ld",
+                req->testno, req->partno);
       logmsg("%s", logbuf);
 
       filename = test2file(req->testno);
@@ -540,9 +540,9 @@ static int ProcessRequest(struct httprequest *req)
     else {
       if(sscanf(req->reqbuf, "CONNECT %" MAXDOCNAMELEN_TXT "s HTTP/%d.%d",
                 doc, &prot_major, &prot_minor) == 3) {
-        snprintf(logbuf, sizeof(logbuf),
-                 "Received a CONNECT %s HTTP/%d.%d request",
-                 doc, prot_major, prot_minor);
+        msnprintf(logbuf, sizeof(logbuf),
+                  "Received a CONNECT %s HTTP/%d.%d request",
+                  doc, prot_major, prot_minor);
         logmsg("%s", logbuf);
 
         if(req->prot_version == 10)
@@ -947,12 +947,12 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */
       logmsg("Identifying ourselves as friends");
-      snprintf(msgbuf, sizeof(msgbuf), "RTSP_SERVER WE ROOLZ: %ld\r\n",
-               (long)getpid());
+      msnprintf(msgbuf, sizeof(msgbuf), "RTSP_SERVER WE ROOLZ: %ld\r\n",
+                (long)getpid());
       msglen = strlen(msgbuf);
-      snprintf(weare, sizeof(weare),
-               "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
-               msglen, msgbuf);
+      msnprintf(weare, sizeof(weare),
+                "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
+                msglen, msgbuf);
       buffer = weare;
       break;
     case DOCNUMBER_INTERNAL:
@@ -985,7 +985,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     char partbuf[80]="data";
     FILE *stream;
     if(0 != req->partno)
-      snprintf(partbuf, sizeof(partbuf), "data%ld", req->partno);
+      msnprintf(partbuf, sizeof(partbuf), "data%ld", req->partno);
 
     stream = fopen(filename, "rb");
     if(!stream) {

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -486,20 +486,20 @@ static void lograw(unsigned char *buffer, ssize_t len)
   for(i = 0; i<len; i++) {
     switch(ptr[i]) {
     case '\n':
-      snprintf(optr, left, "\\n");
+      msnprintf(optr, left, "\\n");
       width += 2;
       optr += 2;
       left -= 2;
       break;
     case '\r':
-      snprintf(optr, left, "\\r");
+      msnprintf(optr, left, "\\r");
       width += 2;
       optr += 2;
       left -= 2;
       break;
     default:
-      snprintf(optr, left, "%c", (ISGRAPH(ptr[i]) ||
-                                  ptr[i] == 0x20) ?ptr[i]:'.');
+      msnprintf(optr, left, "%c", (ISGRAPH(ptr[i]) ||
+                                   ptr[i] == 0x20) ?ptr[i]:'.');
       width++;
       optr++;
       left--;
@@ -1062,9 +1062,9 @@ static bool juggle(curl_socket_t *sockfdp,
     else if(!memcmp("PORT", buffer, 4)) {
       /* Question asking us what PORT number we are listening to.
          Replies to PORT with "IPv[num]/[port]" */
-      snprintf((char *)buffer, sizeof(buffer), "%s/%hu\n", ipv_inuse, port);
+      msnprintf((char *)buffer, sizeof(buffer), "%s/%hu\n", ipv_inuse, port);
       buffer_len = (ssize_t)strlen((char *)buffer);
-      snprintf(data, sizeof(data), "PORT\n%04zx\n", buffer_len);
+      msnprintf(data, sizeof(data), "PORT\n%04zx\n", buffer_len);
       if(!write_stdout(data, 10))
         return FALSE;
       if(!write_stdout(buffer, buffer_len))
@@ -1155,7 +1155,7 @@ static bool juggle(curl_socket_t *sockfdp,
     nread_socket = sread(sockfd, buffer, sizeof(buffer));
 
     if(nread_socket > 0) {
-      snprintf(data, sizeof(data), "DATA\n%04zx\n", nread_socket);
+      msnprintf(data, sizeof(data), "DATA\n%04zx\n", nread_socket);
       if(!write_stdout(data, 10))
         return FALSE;
       if(!write_stdout(buffer, nread_socket))

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -509,11 +509,11 @@ static int ProcessRequest(struct httprequest *req)
     /* get the number after it */
     if(ptr) {
       if((strlen(doc) + strlen(request)) < 400)
-        snprintf(logbuf, sizeof(logbuf), "Got request: %s %s HTTP/%d.%d",
-                 request, doc, prot_major, prot_minor);
+        msnprintf(logbuf, sizeof(logbuf), "Got request: %s %s HTTP/%d.%d",
+                  request, doc, prot_major, prot_minor);
       else
-        snprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request HTTP/%d.%d",
-                 prot_major, prot_minor);
+        msnprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request HTTP/%d.%d",
+                  prot_major, prot_minor);
       logmsg("%s", logbuf);
 
       if(!strncmp("/verifiedserver", ptr, 15)) {
@@ -545,8 +545,8 @@ static int ProcessRequest(struct httprequest *req)
 
       if(req->testno) {
 
-        snprintf(logbuf, sizeof(logbuf), "Requested test number %ld part %ld",
-                 req->testno, req->partno);
+        msnprintf(logbuf, sizeof(logbuf), "Requested test number %ld part %ld",
+                  req->testno, req->partno);
         logmsg("%s", logbuf);
 
         /* find and parse <servercmd> for this test */
@@ -565,9 +565,9 @@ static int ProcessRequest(struct httprequest *req)
                 doc, &prot_major, &prot_minor) == 3) {
         char *portp = NULL;
 
-        snprintf(logbuf, sizeof(logbuf),
-                 "Received a CONNECT %s HTTP/%d.%d request",
-                 doc, prot_major, prot_minor);
+        msnprintf(logbuf, sizeof(logbuf),
+                  "Received a CONNECT %s HTTP/%d.%d request",
+                  doc, prot_major, prot_minor);
         logmsg("%s", logbuf);
 
         req->connect_request = TRUE;
@@ -645,9 +645,9 @@ static int ProcessRequest(struct httprequest *req)
         else
           req->partno = 0;
 
-        snprintf(logbuf, sizeof(logbuf),
-                 "Requested test number %ld part %ld (from host name)",
-                 req->testno, req->partno);
+        msnprintf(logbuf, sizeof(logbuf),
+                  "Requested test number %ld part %ld (from host name)",
+                  req->testno, req->partno);
         logmsg("%s", logbuf);
 
       }
@@ -696,9 +696,9 @@ static int ProcessRequest(struct httprequest *req)
       else
         req->partno = 0;
 
-      snprintf(logbuf, sizeof(logbuf),
-               "Requested GOPHER test number %ld part %ld",
-               req->testno, req->partno);
+      msnprintf(logbuf, sizeof(logbuf),
+                "Requested GOPHER test number %ld part %ld",
+                req->testno, req->partno);
       logmsg("%s", logbuf);
     }
   }
@@ -1117,14 +1117,14 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */
       logmsg("Identifying ourselves as friends");
-      snprintf(msgbuf, sizeof(msgbuf), "WE ROOLZ: %ld\r\n", (long)getpid());
+      msnprintf(msgbuf, sizeof(msgbuf), "WE ROOLZ: %ld\r\n", (long)getpid());
       msglen = strlen(msgbuf);
       if(use_gopher)
-        snprintf(weare, sizeof(weare), "%s", msgbuf);
+        msnprintf(weare, sizeof(weare), "%s", msgbuf);
       else
-        snprintf(weare, sizeof(weare),
-                 "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
-                 msglen, msgbuf);
+        msnprintf(weare, sizeof(weare),
+                  "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
+                  msglen, msgbuf);
       buffer = weare;
       break;
     case DOCNUMBER_404:
@@ -1145,9 +1145,9 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     const char *section = req->connect_request?"connect":"data";
 
     if(req->partno)
-      snprintf(partbuf, sizeof(partbuf), "%s%ld", section, req->partno);
+      msnprintf(partbuf, sizeof(partbuf), "%s%ld", section, req->partno);
     else
-      snprintf(partbuf, sizeof(partbuf), "%s", section);
+      msnprintf(partbuf, sizeof(partbuf), "%s", section);
 
     logmsg("Send response test%ld section <%s>", req->testno, partbuf);
 
@@ -2118,7 +2118,7 @@ int main(int argc, char *argv[])
     }
   }
 
-  snprintf(port_str, sizeof(port_str), "port %hu", port);
+  msnprintf(port_str, sizeof(port_str), "port %hu", port);
 
 #ifdef WIN32
   win32_init();

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (c) 1983, 2016 Regents of the University of California.
+ * Copyright (c) 1983 Regents of the University of California.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -569,7 +569,7 @@ static ssize_t write_behind(struct testcase *test, int convert)
 
   if(!test->ofile) {
     char outfile[256];
-    snprintf(outfile, sizeof(outfile), "log/upload.%ld", test->testno);
+    msnprintf(outfile, sizeof(outfile), "log/upload.%ld", test->testno);
 #ifdef WIN32
     test->ofile = open(outfile, O_CREAT|O_RDWR|O_BINARY, 0777);
 #else
@@ -1141,8 +1141,8 @@ static int validate_access(struct testcase *test,
 
   if(!strncmp("verifiedserver", filename, 14)) {
     char weare[128];
-    size_t count = snprintf(weare, sizeof(weare),
-                            "WE ROOLZ: %ld\r\n", (long)getpid());
+    size_t count = msnprintf(weare, sizeof(weare),
+                             "WE ROOLZ: %ld\r\n", (long)getpid());
 
     logmsg("Are-we-friendly question received");
     test->buffer = strdup(weare);
@@ -1187,7 +1187,7 @@ static int validate_access(struct testcase *test,
     file = test2file(testno);
 
     if(0 != partno)
-      snprintf(partbuf, sizeof(partbuf), "data%ld", partno);
+      msnprintf(partbuf, sizeof(partbuf), "data%ld", partno);
 
     if(file) {
       FILE *stream = fopen(file, "rb");

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -87,7 +87,7 @@ char *data_to_hex(char *data, size_t len)
     if((data[i] >= 0x20) && (data[i] < 0x7f))
       *optr++ = *iptr++;
     else {
-      snprintf(optr, 4, "%%%02x", *iptr++);
+      msnprintf(optr, 4, "%%%02x", *iptr++);
       optr += 3;
     }
   }
@@ -121,11 +121,12 @@ void logmsg(const char *msg, ...)
   sec = epoch_offset + tv.tv_sec;
   now = localtime(&sec); /* not thread safe but we don't care */
 
-  snprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld",
-    (int)now->tm_hour, (int)now->tm_min, (int)now->tm_sec, (long)tv.tv_usec);
+  msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld",
+            (int)now->tm_hour, (int)now->tm_min, (int)now->tm_sec,
+            (long)tv.tv_usec);
 
   va_start(ap, msg);
-  vsnprintf(buffer, sizeof(buffer), msg, ap);
+  mvsnprintf(buffer, sizeof(buffer), msg, ap);
   va_end(ap);
 
   logfp = fopen(serverlogfile, "ab");
@@ -151,7 +152,7 @@ void win32_perror(const char *msg)
 
   if(!FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err,
                     LANG_NEUTRAL, buf, sizeof(buf), NULL))
-     snprintf(buf, sizeof(buf), "Unknown error %lu (%#lx)", err, err);
+    msnprintf(buf, sizeof(buf), "Unknown error %lu (%#lx)", err, err);
   if(msg)
     fprintf(stderr, "%s: ", msg);
   fprintf(stderr, "%s\n", buf);
@@ -195,7 +196,7 @@ const char *path = ".";
 char *test2file(long testno)
 {
   static char filename[256];
-  snprintf(filename, sizeof(filename), TEST_DATA_PATH, path, testno);
+  msnprintf(filename, sizeof(filename), TEST_DATA_PATH, path, testno);
   return filename;
 }
 

--- a/tests/unit/unit1398.c
+++ b/tests/unit/unit1398.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -74,7 +74,7 @@ fail_unless(!strcmp(output, "     bu"), "wrong output");
 
 /* output a number in a limited output */
 rc = curl_msnprintf(output, 4, "%d", 10240);
-/* TODO: this should return 5 to be POSIX/snprintf compliant! */
+/* TODO: this should return 5 to be POSIX/msnprintf compliant! */
 fail_unless(rc == 4, "return code should be 4");
 fail_unless(!strcmp(output, "102"), "wrong output");
 

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -63,7 +63,7 @@ static bool usec_matches_seconds(time_t time_usec, int expected_seconds)
 static void expect_timer_seconds(struct Curl_easy *data, int seconds)
 {
   char msg[64];
-  snprintf(msg, sizeof(msg), "about %d seconds should have passed", seconds);
+  msnprintf(msg, sizeof(msg), "about %d seconds should have passed", seconds);
   fail_unless(usec_matches_seconds(data->progress.t_nslookup, seconds), msg);
   fail_unless(usec_matches_seconds(data->progress.t_connect, seconds), msg);
   fail_unless(usec_matches_seconds(data->progress.t_appconnect, seconds), msg);

--- a/tests/unit/unit1604.c
+++ b/tests/unit/unit1604.c
@@ -47,10 +47,14 @@ static char *getflagstr(int flags)
   char *buf = malloc(256);
   if(buf) {
     msnprintf(buf, 256, "%s,%s,%s,%s",
-              ((flags & SANITIZE_ALLOW_COLONS) ? "SANITIZE_ALLOW_COLONS" : ""),
-              ((flags & SANITIZE_ALLOW_PATH) ? "SANITIZE_ALLOW_PATH" : ""),
-              ((flags & SANITIZE_ALLOW_RESERVED) ? "SANITIZE_ALLOW_RESERVED" : ""),
-              ((flags & SANITIZE_ALLOW_TRUNCATE) ? "SANITIZE_ALLOW_TRUNCATE" : ""));
+              ((flags & SANITIZE_ALLOW_COLONS) ?
+               "SANITIZE_ALLOW_COLONS" : ""),
+              ((flags & SANITIZE_ALLOW_PATH) ?
+               "SANITIZE_ALLOW_PATH" : ""),
+              ((flags & SANITIZE_ALLOW_RESERVED) ?
+               "SANITIZE_ALLOW_RESERVED" : ""),
+              ((flags & SANITIZE_ALLOW_TRUNCATE) ?
+               "SANITIZE_ALLOW_TRUNCATE" : ""));
   }
   return buf;
 }
@@ -63,7 +67,7 @@ static char *getcurlcodestr(int cc)
               (cc == SANITIZE_ERR_OK ? "SANITIZE_ERR_OK" :
                cc == SANITIZE_ERR_BAD_ARGUMENT ? "SANITIZE_ERR_BAD_ARGUMENT" :
                cc == SANITIZE_ERR_INVALID_PATH ? "SANITIZE_ERR_INVALID_PATH" :
-               cc == SANITIZE_ERR_OUT_OF_MEMORY ? "SANITIZE_ERR_OUT_OF_MEMORY" :
+               cc == SANITIZE_ERR_OUT_OF_MEMORY ? "SANITIZE_ERR_OUT_OF_MEMORY":
                "unexpected error code - add name"),
               cc);
   }

--- a/tests/unit/unit1604.c
+++ b/tests/unit/unit1604.c
@@ -46,11 +46,11 @@ static char *getflagstr(int flags)
 {
   char *buf = malloc(256);
   if(buf) {
-    snprintf(buf, 256, "%s,%s,%s,%s",
-      ((flags & SANITIZE_ALLOW_COLONS) ? "SANITIZE_ALLOW_COLONS" : ""),
-      ((flags & SANITIZE_ALLOW_PATH) ? "SANITIZE_ALLOW_PATH" : ""),
-      ((flags & SANITIZE_ALLOW_RESERVED) ? "SANITIZE_ALLOW_RESERVED" : ""),
-      ((flags & SANITIZE_ALLOW_TRUNCATE) ? "SANITIZE_ALLOW_TRUNCATE" : ""));
+    msnprintf(buf, 256, "%s,%s,%s,%s",
+              ((flags & SANITIZE_ALLOW_COLONS) ? "SANITIZE_ALLOW_COLONS" : ""),
+              ((flags & SANITIZE_ALLOW_PATH) ? "SANITIZE_ALLOW_PATH" : ""),
+              ((flags & SANITIZE_ALLOW_RESERVED) ? "SANITIZE_ALLOW_RESERVED" : ""),
+              ((flags & SANITIZE_ALLOW_TRUNCATE) ? "SANITIZE_ALLOW_TRUNCATE" : ""));
   }
   return buf;
 }
@@ -59,13 +59,13 @@ static char *getcurlcodestr(int cc)
 {
   char *buf = malloc(256);
   if(buf) {
-    snprintf(buf, 256, "%s (%d)",
-      (cc == SANITIZE_ERR_OK ? "SANITIZE_ERR_OK" :
-       cc == SANITIZE_ERR_BAD_ARGUMENT ? "SANITIZE_ERR_BAD_ARGUMENT" :
-       cc == SANITIZE_ERR_INVALID_PATH ? "SANITIZE_ERR_INVALID_PATH" :
-       cc == SANITIZE_ERR_OUT_OF_MEMORY ? "SANITIZE_ERR_OUT_OF_MEMORY" :
-       "unexpected error code - add name"),
-      cc);
+    msnprintf(buf, 256, "%s (%d)",
+              (cc == SANITIZE_ERR_OK ? "SANITIZE_ERR_OK" :
+               cc == SANITIZE_ERR_BAD_ARGUMENT ? "SANITIZE_ERR_BAD_ARGUMENT" :
+               cc == SANITIZE_ERR_INVALID_PATH ? "SANITIZE_ERR_INVALID_PATH" :
+               cc == SANITIZE_ERR_OUT_OF_MEMORY ? "SANITIZE_ERR_OUT_OF_MEMORY" :
+               "unexpected error code - add name"),
+              cc);
   }
   return buf;
 }

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -200,7 +200,7 @@ UNITTEST_START
       a = &d.addr[u];
       if(resp[i].type == DNS_TYPE_A) {
         p = &a->ip.v4[0];
-        snprintf(ptr, len, "%u.%u.%u.%u ", p[0], p[1], p[2], p[3]);
+        msnprintf(ptr, len, "%u.%u.%u.%u ", p[0], p[1], p[2], p[3]);
         o = strlen(ptr);
         len -= o;
         ptr += o;
@@ -209,20 +209,20 @@ UNITTEST_START
         int j;
         for(j = 0; j < 16; j += 2) {
           size_t l;
-          snprintf(ptr, len, "%s%02x%02x", j?":":"", a->ip.v6[j],
+          msnprintf(ptr, len, "%s%02x%02x", j?":":"", a->ip.v6[j],
                    a->ip.v6[j + 1]);
           l = strlen(ptr);
           len -= l;
           ptr += l;
         }
-        snprintf(ptr, len, " ");
+        msnprintf(ptr, len, " ");
         len--;
         ptr++;
       }
     }
     for(u = 0; u < d.numcname; u++) {
       size_t o;
-      snprintf(ptr, len, "%s ", d.cname[u].alloc);
+      msnprintf(ptr, len, "%s ", d.cname[u].alloc);
       o = strlen(ptr);
       len -= o;
       ptr += o;
@@ -271,8 +271,8 @@ UNITTEST_START
       fail_if(d.numaddr != 1, "missing address");
       a = &d.addr[0];
       p = &a->ip.v4[0];
-      snprintf((char *)buffer, sizeof(buffer),
-               "%u.%u.%u.%u", p[0], p[1], p[2], p[3]);
+      msnprintf((char *)buffer, sizeof(buffer),
+                "%u.%u.%u.%u", p[0], p[1], p[2], p[3]);
       if(rc || strcmp((char *)buffer, "127.0.0.1")) {
         fprintf(stderr, "bad address decoded: %s, rc == %d\n", buffer, rc);
         return 7;

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -80,7 +80,7 @@ unit_stop(void)
 UNITTEST_START
 
 /* Injecting a simple short string via a format */
-snprintf(input, sizeof(input), "Simple Test");
+msnprintf(input, sizeof(input), "Simple Test");
 Curl_infof(data, "%s", input);
 fail_unless(strcmp(result, input) == 0, "Simple string test");
 


### PR DESCRIPTION
The function does not return the same value as snprintf() normally does,
so readers may be mislead into thinking the code works differently than
it actually does. A different function name makes this easier to detect.

This also adds snprintf() and vsnprintf() as "banned" functions in
checksrc to make us not mistakenly use them going forward.

Reported-by: Tomas Hoger
Assisted-by: Daniel Gustafsson
Fixes #3296