### PR TITLE
checksrc: add COPYRIGHT year check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ scripts/_curl
 curl_fuzzer
 curl_fuzzer_seed_corpus.zip
 libstandaloneengine.a
+.checksrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -327,6 +327,9 @@ script:
                 make test-nonflaky
              fi
              if [ -n $CHECKSRC ]; then
+                echo "enable COPYRIGHTYEAR" > "lib/.checksrc"
+                echo "enable COPYRIGHTYEAR" > "src/.checksrc"
+                echo "enable COPYRIGHTYEAR" > "include/curl/.checksrc"
                 make checksrc
              fi
         fi

--- a/docs/CHECKSRC.md
+++ b/docs/CHECKSRC.md
@@ -103,6 +103,19 @@ warnings are:
 - `UNUSEDIGNORE`: a checksrc inlined warning ignore was asked for but not used,
    that's an ignore that should be removed or changed to get used.
 
+### Extended warnings
+
+Some warnings are quite computationally expensive to perform, so they are
+turned off by default. To enable these warnings, place a `.checksrc` file in
+the directory where they should be activated with commands to enable the
+warnings you are interested in. The format of the file is to enable one
+warning per line like so: `enable <EXTENDEDWARNING>`
+
+Currently there is one extended warning which can be enabled:
+
+- `COPYRIGHTYEAR`: the current changeset hasn't updated the copyright year in
+   the source file
+
 ## Ignore certain warnings
 
 Due to the nature of the source code and the flaws of the checksrc tool, there

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -1,4 +1,5 @@
 /*
+ * !checksrc! disable COPYRIGHT
  * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
  * MD4 Message-Digest Algorithm (RFC 1320).
  *


### PR DESCRIPTION
This is a patch which I had shelved deeming it too uninteresting/complicated to be useful, but when discussing the recent `snprintf()` switcheroo in #3297 the topic was brought up again. This is more of a discussion piece/show-and-tell PR than something I really think we should do, but working code is generally nicer to discuss around than handwaving so here goes.

The check for updated copyright year is currently not enforced on any file but only on files edited and/or committed locally. This is due to the amount of files which aren't updated with their correct copyright year at the time of their respective commit. If enforced for the correct year, there are hundreds of errors which is painful. We could of course just sed the list of files to the current year and be done with it, but then we could just as well bump every file in the tree and there are reasons why we don't do that.

Invoking the checking like in this patch is rather expensive, and obviously only works on cloned repos and not source tarballs (which in this day and age really isn't used for active development anyways).