### PR TITLE
cmdline-opts/gen.pl: define the correct varname

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -158,7 +158,7 @@ sub single {
             print STDERR "WARN: unrecognized line in $f, ignoring:\n:'$_';"
         }
     }
-    my @dest;
+    my @desc;
     while(<F>) {
         push @desc, $_;
     }


### PR DESCRIPTION
The variable definition had a small typo making it declare another variable than the intended.