### PR TITLE
curl_easy_perform: fix timeout handling

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -664,12 +664,12 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
 
   while(!done && !mcode) {
     int still_running = 0;
-    int rc;
+    bool gotsocket = FALSE;
 
-    mcode = curl_multi_wait(multi, NULL, 0, 1000, &rc);
+    mcode = Curl_multi_wait(multi, NULL, 0, 1000, NULL, &gotsocket);
 
     if(!mcode) {
-      if(!rc) {
+      if(!gotsocket) {
         long sleep_ms;
 
         /* If it returns without any filedescriptor instantly, we need to
@@ -688,6 +688,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
 
     /* only read 'still_running' if curl_multi_perform() return OK */
     if(!mcode && !still_running) {
+      int rc;
       CURLMsg *msg = curl_multi_info_read(multi, &rc);
       if(msg) {
         result = msg->data.result;

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -97,4 +97,12 @@ void Curl_multi_closed(struct Curl_easy *data, curl_socket_t s);
 CURLMcode Curl_multi_add_perform(struct Curl_multi *multi,
                                  struct Curl_easy *data,
                                  struct connectdata *conn);
+
+CURLMcode Curl_multi_wait(struct Curl_multi *multi,
+                          struct curl_waitfd extra_fds[],
+                          unsigned int extra_nfds,
+                          int timeout_ms,
+                          int *ret,
+                          bool *gotsocket); /* if any socket was checked */
+
 #endif /* HEADER_CURL_MULTIIF_H */


### PR DESCRIPTION
curl_multi_wait() was erroneously used from within
curl_easy_perform(). It could lead to it believing there was no socket
to wait for and then instead sleep for a while instead of monitoring the
socket and then miss acting on that activity as swiftly as it should
(causing an up to 1000 ms delay).

Reported-by: Antoni Villalonga
Fixes #3305
Closes #3306