### PR TITLE
TODO: remove CURLOPT_DNS_USE_GLOBAL_CACHE entry

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -184,9 +184,8 @@
  22.3 size_t
  22.4 remove several functions
  22.5 remove CURLOPT_FAILONERROR
- 22.6 remove CURLOPT_DNS_USE_GLOBAL_CACHE
- 22.7 remove progress meter from libcurl
- 22.8 remove 'curl_httppost' from public
+ 22.6 remove progress meter from libcurl
+ 22.7 remove 'curl_httppost' from public
 
 ==============================================================================
 
@@ -1260,13 +1259,7 @@ that doesn't exist on the server, just like --ftp-create-dirs.
  Remove support for CURLOPT_FAILONERROR, it has gotten too kludgy and weird
  internally. Let the app judge success or not for itself.
 
-22.6 remove CURLOPT_DNS_USE_GLOBAL_CACHE
-
- Remove support for a global DNS cache. Anything global is silly, and we
- already offer the share interface for the same functionality but done
- "right".
-
-22.7 remove progress meter from libcurl
+22.6 remove progress meter from libcurl
 
  The internally provided progress meter output doesn't belong in the library.
  Basically no application wants it (apart from curl) but instead applications
@@ -1276,7 +1269,7 @@ that doesn't exist on the server, just like --ftp-create-dirs.
  variable types passed to it instead of doubles so that big files work
  correctly.
 
-22.8 remove 'curl_httppost' from public
+22.7 remove 'curl_httppost' from public
 
  curl_formadd() was made to fill in a public struct, but the fact that the
  struct is public is never really used by application for their own advantage


### PR DESCRIPTION
Commit 7c5837e79280e6abb3ae143dfc49bca5e74cdd11 deprecated the option making it a manual code-edit operation to turn it back on. The removal process has thus started and is now documented in docs/DEPRECATE.md so remove from the TODO to avoid anyone looking for something to pick up spend cycles on an already in-progress entry.

Not sure what has historically been done, leave it in the TODO until finally removed or purge it when started? The latter is what makes sense to me so proposed that in this PR.