### PR TITLE
[ntlm] SSPI channel binding support

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -328,6 +328,10 @@ struct kerberos5data {
 struct ntlmdata {
   curlntlm state;
 #if defined(USE_WINDOWS_SSPI)
+/* The sslContext is used for the Schannel bindings. The
+ * api is available on the Windows 7 SDK and later.
+ * Visual Studio 2008 and older build against older SDKs.
+ */
 #if defined(_MSC_VER) && (_MSC_VER >= 1600)
   CtxtHandle *sslContext;
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -327,8 +327,10 @@ struct kerberos5data {
 #if defined(USE_NTLM)
 struct ntlmdata {
   curlntlm state;
-#ifdef USE_WINDOWS_SSPI
+#if defined(USE_WINDOWS_SSPI)
+#if defined(_MSC_VER) && (_MSC_VER >= 1600)
   CtxtHandle *sslContext;
+#endif
   CredHandle *credentials;
   CtxtHandle *context;
   SEC_WINNT_AUTH_IDENTITY identity;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -328,6 +328,7 @@ struct kerberos5data {
 struct ntlmdata {
   curlntlm state;
 #ifdef USE_WINDOWS_SSPI
+  CtxtHandle *sslContext;
   CredHandle *credentials;
   CtxtHandle *context;
   SEC_WINNT_AUTH_IDENTITY identity;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -330,9 +330,8 @@ struct ntlmdata {
 #if defined(USE_WINDOWS_SSPI)
 /* The sslContext is used for the Schannel bindings. The
  * api is available on the Windows 7 SDK and later.
- * Visual Studio 2008 and older build against older SDKs.
  */
-#if defined(_MSC_VER) && (_MSC_VER >= 1600)
+#ifdef _WIN32_WINNT_WIN7
   CtxtHandle *sslContext;
 #endif
   CredHandle *credentials;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -274,7 +274,8 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   * When extended protection is used in IIS server,
   * we have to pass a second SecBuffer to the SecBufferDesc
   * otherwise ISS will not pass the authentication (401 response)
-  * https://docs.microsoft.com/en-us/security-updates/SecurityAdvisories/2009/973811
+  * https://docs.microsoft.com/en-us/security-updates
+  * /SecurityAdvisories/2009/973811
   */
   if(ntlm->sslContext) {
     SEC_CHANNEL_BINDINGS channelBindings;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -270,10 +270,12 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   type_2_bufs[0].pvBuffer = ntlm->input_token;
   type_2_bufs[0].cbBuffer = curlx_uztoul(ntlm->input_token_len);
 
+#if defined(USE_WINDOWS_SSPI) && defined(_MSC_VER) && (_MSC_VER >= 1600)
   /* ssl context comes from schannel.
   * When extended protection is used in IIS server,
   * we have to pass a second SecBuffer to the SecBufferDesc
-  * otherwise ISS will not pass the authentication (401 response)
+  * otherwise ISS will not pass the authentication (401 response).
+  * Minimum supported version is Windows 7.
   * https://docs.microsoft.com/en-us/security-updates
   * /SecurityAdvisories/2009/973811
   */
@@ -293,7 +295,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
       type_2_bufs[1].pvBuffer = pkgBindings.Bindings;
     }
   }
-
+#endif
 
   /* Setup the type-3 "output" security buffer */
   type_3_desc.ulVersion = SECBUFFER_VERSION;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -249,7 +249,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              char **outptr, size_t *outlen)
 {
   CURLcode result = CURLE_OK;
-  SecBuffer type_2_buf;
+  SecBuffer type_2_bufs[2];
   SecBuffer type_3_buf;
   SecBufferDesc type_2_desc;
   SecBufferDesc type_3_desc;
@@ -262,11 +262,37 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
   /* Setup the type-2 "input" security buffer */
   type_2_desc.ulVersion = SECBUFFER_VERSION;
-  type_2_desc.cBuffers  = 1;
-  type_2_desc.pBuffers  = &type_2_buf;
-  type_2_buf.BufferType = SECBUFFER_TOKEN;
-  type_2_buf.pvBuffer   = ntlm->input_token;
-  type_2_buf.cbBuffer   = curlx_uztoul(ntlm->input_token_len);
+  type_2_desc.cBuffers = 1;
+  type_2_desc.pBuffers = &type_2_bufs[0];
+
+
+  type_2_bufs[0].BufferType = SECBUFFER_TOKEN;
+  type_2_bufs[0].pvBuffer = ntlm->input_token;
+  type_2_bufs[0].cbBuffer = curlx_uztoul(ntlm->input_token_len);
+
+  /* ssl context comes from schannel.
+  * When extended protection is used in IIS server,
+  * we have to pass a second SecBuffer to the SecBufferDesc
+  * otherwise ISS will not pass the authentication (401 response)
+  * https://docs.microsoft.com/en-us/security-updates/SecurityAdvisories/2009/973811
+  */
+  if(ntlm->sslContext) {
+    SEC_CHANNEL_BINDINGS channelBindings;
+    SecPkgContext_Bindings pkgBindings;
+    pkgBindings.Bindings = &channelBindings;
+    status = s_pSecFn->QueryContextAttributes(
+      ntlm->sslContext,
+      SECPKG_ATTR_ENDPOINT_BINDINGS,
+      &pkgBindings
+    );
+    if(status == SEC_E_OK) {
+      type_2_desc.cBuffers++;
+      type_2_bufs[1].BufferType = SECBUFFER_CHANNEL_BINDINGS;
+      type_2_bufs[1].cbBuffer = pkgBindings.BindingsLength;
+      type_2_bufs[1].pvBuffer = pkgBindings.Bindings;
+    }
+  }
+
 
   /* Setup the type-3 "output" security buffer */
   type_3_desc.ulVersion = SECBUFFER_VERSION;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -264,8 +264,6 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   type_2_desc.ulVersion = SECBUFFER_VERSION;
   type_2_desc.cBuffers = 1;
   type_2_desc.pBuffers = &type_2_bufs[0];
-
-
   type_2_bufs[0].BufferType = SECBUFFER_TOKEN;
   type_2_bufs[0].pvBuffer = ntlm->input_token;
   type_2_bufs[0].cbBuffer = curlx_uztoul(ntlm->input_token_len);

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -268,7 +268,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   type_2_bufs[0].pvBuffer = ntlm->input_token;
   type_2_bufs[0].cbBuffer = curlx_uztoul(ntlm->input_token_len);
 
-#if defined(USE_WINDOWS_SSPI) && defined(_MSC_VER) && (_MSC_VER >= 1600)
+#if defined(USE_WINDOWS_SSPI) && defined(_WIN32_WINNT_WIN7)
   /* ssl context comes from schannel.
   * When extended protection is used in IIS server,
   * we have to pass a second SecBuffer to the SecBufferDesc

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1414,13 +1414,15 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
     connssl->state = ssl_connection_complete;
     conn->recv[sockindex] = schannel_recv;
     conn->send[sockindex] = schannel_send;
-#if defined(USE_WINDOWS_SSPI)
+
+#if defined(USE_WINDOWS_SSPI) && defined(_MSC_VER) && (_MSC_VER > 1500)
     /* When SSPI is used in combination with scannel
      * we need the scannel context to create the channel
      * binding to pass the IIS extended protection checks.
      */
     conn->ntlm.sslContext = &BACKEND->ctxt->ctxt_handle;
 #endif
+
     *done = TRUE;
   }
   else

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1416,8 +1416,8 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
     conn->send[sockindex] = schannel_send;
 
 #if defined(USE_WINDOWS_SSPI) && defined(_MSC_VER) && (_MSC_VER > 1500)
-    /* When SSPI is used in combination with scannel
-     * we need the scannel context to create the channel
+    /* When SSPI is used in combination with Schannel
+     * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.
      */
     conn->ntlm.sslContext = &BACKEND->ctxt->ctxt_handle;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1396,7 +1396,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
      * have a valid fdset to wait on.
      */
     result = schannel_connect_step2(conn, sockindex);
-    if(result || (nonblocking &&  
+    if(result || (nonblocking &&
                   (ssl_connect_2 == connssl->connecting_state ||
                    ssl_connect_2_reading == connssl->connecting_state ||
                    ssl_connect_2_writing == connssl->connecting_state)))

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1396,7 +1396,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
      * have a valid fdset to wait on.
      */
     result = schannel_connect_step2(conn, sockindex);
-    if(result || (nonblocking &&
+    if(result || (nonblocking &&  
                   (ssl_connect_2 == connssl->connecting_state ||
                    ssl_connect_2_reading == connssl->connecting_state ||
                    ssl_connect_2_writing == connssl->connecting_state)))
@@ -1414,6 +1414,13 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
     connssl->state = ssl_connection_complete;
     conn->recv[sockindex] = schannel_recv;
     conn->send[sockindex] = schannel_send;
+#if defined(USE_WINDOWS_SSPI)
+    /* When SSPI is used in combination with scannel
+     * we need the scannel context to create the channel
+     * binding to pass the IIS extended protection checks.
+     */
+    conn->ntlm.sslContext = &BACKEND->ctxt->ctxt_handle;
+#endif
     *done = TRUE;
   }
   else
@@ -1421,7 +1428,6 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
 
   /* reset our connection state machine */
   connssl->connecting_state = ssl_connect_1;
-
   return CURLE_OK;
 }
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1415,10 +1415,11 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
     conn->recv[sockindex] = schannel_recv;
     conn->send[sockindex] = schannel_send;
 
-#if defined(USE_WINDOWS_SSPI) && defined(_MSC_VER) && (_MSC_VER > 1500)
+#if defined(USE_WINDOWS_SSPI) && defined(_WIN32_WINNT_WIN7)
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.
+     * Available on Windows 7 or later.
      */
     conn->ntlm.sslContext = &BACKEND->ctxt->ctxt_handle;
 #endif


### PR DESCRIPTION
Windows extended protection (aka ssl channel binding) is required
to login to ntlm IIS endpoint, otherwise the server return 401
responses.

[Fixes: #3280]