### PR TITLE
EBADIOCTL doesn't exist on more recent Minix.

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -522,7 +522,7 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
     err = 0;
   }
 #endif
-#ifdef __minix
+#if defined EBADIOCTL && defined __minix
   /* Minix 3.1.x doesn't support getsockopt on UDP sockets */
   if(EBADIOCTL == err) {
     SET_SOCKERRNO(0);


### PR DESCRIPTION
There have also been substantial changes to the network stack.
Fixes build on Minix 3.4rc