### PR TITLE
NTLM: force the connection to HTTP/1.1

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -526,6 +526,12 @@ CURLcode Curl_http_auth_act(struct connectdata *conn)
     pickhost = pickoneauth(&data->state.authhost, authmask);
     if(!pickhost)
       data->state.authproblem = TRUE;
+    if(data->state.authhost.picked == CURLAUTH_NTLM &&
+       conn->httpversion > 11) {
+      infof(data, "Forcing HTTP/1.1 for NTLM");
+      connclose(conn, "Force HTTP/1.1 connection");
+      conn->data->set.httpversion = CURL_HTTP_VERSION_1_1;
+    }
   }
   if(conn->bits.proxy_user_passwd &&
      ((data->req.httpcode == 407) ||


### PR DESCRIPTION
This addresses https://github.com/curl/curl/issues/3341.

I took a slightly different approach than suggested in that ticket: instead of trying NTLM via HTTP/2 and then imitating a HTTP redirect when we get `HTTP_1_1_REQUIRED`, this PR introduces the change where we detect that situation preemptively, i.e. before trying NTLM we already ensure that we're on HTTP/1.1.