### PR TITLE
Some fixes for `curl_global_sslset()` when built with a single SSL backend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ configure.ac eol=lf
 *.in eol=lf
 *.am eol=lf
 *.sh eol=lf
+*.[ch] whitespace=tab-in-indent

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1315,7 +1315,12 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
   if(Curl_ssl != &Curl_ssl_multi)
     return id == Curl_ssl->info.id ||
            (name && strcasecompare(name, Curl_ssl->info.name)) ?
-           CURLSSLSET_OK : CURLSSLSET_TOO_LATE;
+           CURLSSLSET_OK :
+#if defined(CURL_WITH_MULTI_SSL)
+           CURLSSLSET_TOO_LATE;
+#else
+           CURLSSLSET_UNKNOWN_BACKEND;
+#endif
 
   for(i = 0; available_backends[i]; i++) {
     if(available_backends[i]->info.id == id ||

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1313,7 +1313,9 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
     *avail = (const curl_ssl_backend **)&available_backends;
 
   if(Curl_ssl != &Curl_ssl_multi)
-    return id == Curl_ssl->info.id ? CURLSSLSET_OK : CURLSSLSET_TOO_LATE;
+    return id == Curl_ssl->info.id ||
+           (name && strcasecompare(name, Curl_ssl->info.name)) ?
+           CURLSSLSET_OK : CURLSSLSET_TOO_LATE;
 
   for(i = 0; available_backends[i]; i++) {
     if(available_backends[i]->info.id == id ||


### PR DESCRIPTION
While working on https://github.com/curl/curl/pull/3345, I realized that there were a couple of issues with the `curl_global_sslset()` when built with a single SSL backend, resulting in an incorrect error messages in one case, and in another case an error when we should have succeeded.

This PR fixes both issues.