### PR TITLE
openssl: fix unused variable compiler warning with old openssl

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2167,6 +2167,7 @@ set_ssl_version_min_max(long *ctx_options, struct connectdata *conn,
     }
 #else
       (void)sockindex;
+      (void)ctx_options;
       failf(data, OSSL_PACKAGE " was built without TLS 1.3 support");
       return CURLE_NOT_BUILT_IN;
 #endif


### PR DESCRIPTION
URL: https://curl.haxx.se/mail/lib-2018-11/0055.html