### PR TITLE
http: fix HTTP auth to include query in URI

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -702,7 +702,7 @@ output_auth_headers(struct connectdata *conn,
  *
  * @param conn all information about the current connection
  * @param request pointer to the request keyword
- * @param path pointer to the requested path
+ * @param path pointer to the requested path; should include query part
  * @param proxytunnel boolean if this is the request setting up a "proxy
  * tunnel"
  *
@@ -2000,9 +2000,18 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
   }
 
   /* setup the authentication headers */
-  result = Curl_http_output_auth(conn, request, path, FALSE);
-  if(result)
-    return result;
+  {
+    char *pq = NULL;
+    if(query && *query) {
+      pq = aprintf("%s?%s", path, query);
+      if(!pq)
+        return CURLE_OUT_OF_MEMORY;
+    }
+    result = Curl_http_output_auth(conn, request, (pq ? pq : path), FALSE);
+    free(pq);
+    if(result)
+      return result;
+  }
 
   if((data->state.authhost.multipass || data->state.authproxy.multipass) &&
      (httpreq != HTTPREQ_GET) &&

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -201,7 +201,7 @@ test2040 test2041 test2042 test2043 test2044 test2045 test2046 test2047 \
 test2048 test2049 test2050 test2051 test2052 test2053 test2054 test2055 \
 test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 \
-         test2071 test2072 test2073 test2074 test2075 \
+         test2071 test2072 test2073 test2074 test2075 test2076 \
 test2080 \
 test2100 \
 \

--- a/tests/data/test2076
+++ b/tests/data/test2076
@@ -1,0 +1,75 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Digest auth
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 401 Authorization Required swsclose
+WWW-Authenticate: Digest realm="testrealm", nonce="1"
+Content-Length: 26
+
+This is not the real page
+</data>
+
+# This is supposed to be returned when the server gets a
+# Authorization: Digest line passed-in from the client
+<data1000>
+HTTP/1.1 200 OK swsclose
+Content-Length: 23
+
+This IS the real page!
+</data1000>
+
+<datacheck>
+HTTP/1.1 401 Authorization Required swsclose
+WWW-Authenticate: Digest realm="testrealm", nonce="1"
+Content-Length: 26
+
+HTTP/1.1 200 OK swsclose
+Content-Length: 23
+
+This IS the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+!SSPI
+crypto
+</features>
+<name>
+HTTP with digest auth and URI contains query
+</name>
+<command>
+"http://%HOSTIP:%HTTPPORT/2076?query" -u testuser:testpass --digest
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /2076?query HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /2076?query HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="1", uri="/2076?query", response="5758bd3bbde7f33236e6ccd278eb59af"
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
- Include query in the path passed to generate HTTP auth.

Recent changes to use the URL API internally (46e1640) inadvertently
broke authentication URIs by omitting the query.

Fixes https://github.com/curl/curl/issues/3353
Closes #xxxx