### PR TITLE
multi: convert two timeout variables to timediff_t

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1354,8 +1354,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
   CURLMcode rc;
   CURLcode result = CURLE_OK;
   struct SingleRequest *k;
-  time_t timeout_ms;
-  time_t recv_timeout_ms;
+  timediff_t timeout_ms;
+  timediff_t recv_timeout_ms;
   timediff_t send_timeout_ms;
   int control;
 


### PR DESCRIPTION
The time_t type is unsigned on some systems and these variables are used
to hold return values from functions that return timediff_t
already. timediff_t is always a signed type.