### PR TITLE
Curl_follow: extract the Location: header field unvalidated

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -169,7 +169,7 @@ test1444 test1445 test1446 test1447 test1448 test1449 test1450 test1451 \
 test1452 test1453 test1454 test1455 test1456 test1457 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
-test1516 test1517 \
+test1516 test1517 test1518 \
 \
 test1520 test1521 test1522 \
 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -169,9 +169,7 @@ test1444 test1445 test1446 test1447 test1448 test1449 test1450 test1451 \
 test1452 test1453 test1454 test1455 test1456 test1457 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
-test1516 test1517 test1518 \
-\
-test1520 test1521 test1522 \
+test1516 test1517 test1518 test1519 test1520 test1521 test1522 \
 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \

--- a/tests/data/test1518
+++ b/tests/data/test1518
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+</keywords>
+</info>
+#
+# This reproduces issue #3340
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 302 redirect to broken URL
+Date: Thu, 17 Mar 2016 14:41:00 GMT
+Server: test-server/fake
+Content-Type: text/plain; charset=US-ASCII
+X-Special: swsclose
+Location: http://1.2 .4.5/test
+Content-Length: 0
+Connection: close
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib1518
+</tool>
+
+ <name>
+Extract Location: with broken URL
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/1518
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strippart>
+
+</strippart>
+<protocol>
+</protocol>
+<stdout>
+res: 0
+status: 302
+redirects: 0
+effectiveurl: http://%HOSTIP:%HTTPPORT/1518
+redirecturl: http://1.2 .4.5/test
+</stdout>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1519
+++ b/tests/data/test1519
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+</keywords>
+</info>
+#
+# This reproduces issue #3340
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 302 redirect to broken URL
+Date: Thu, 17 Mar 2016 14:41:00 GMT
+Server: test-server/fake
+Content-Type: text/plain; charset=US-ASCII
+X-Special: swsclose
+Location: h ttp://1.2.4.5/test
+Content-Length: 0
+Connection: close
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib1518
+</tool>
+
+ <name>
+Extract Location: with broken absolute URL
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/1519
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strippart>
+
+</strippart>
+<protocol>
+</protocol>
+<stdout>
+res: 0
+status: 302
+redirects: 0
+effectiveurl: http://%HOSTIP:%HTTPPORT/1519
+redirecturl: http://127.0.0.1:8990/h%20ttp://1.2.4.5/test
+</stdout>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -25,7 +25,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1156 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
- lib1520 lib1521 lib1522 \
+ lib1518         lib1520 lib1521 lib1522 \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 \
@@ -413,6 +413,9 @@ lib1515_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1515
 
 lib1517_SOURCES = lib1517.c $(SUPPORTFILES)
 lib1517_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1517
+
+lib1518_SOURCES = lib1518.c $(SUPPORTFILES)
+lib1518_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1520_SOURCES = lib1520.c $(SUPPORTFILES)
 lib1520_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1520

--- a/tests/libtest/lib1518.c
+++ b/tests/libtest/lib1518.c
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "memdebug.h"
+
+/* Test inspired by github issue 3340 */
+
+int test(char *URL)
+{
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+  long curlResponseCode;
+  long curlRedirectCount;
+  char *effectiveUrl = NULL;
+  char *redirectUrl = NULL;
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  test_setopt(curl, CURLOPT_URL, URL);
+  /* just to make it explicit and visible in this test: */
+  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+
+  /* Perform the request, res will get the return code */
+  res = curl_easy_perform(curl);
+
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &curlResponseCode);
+  curl_easy_getinfo(curl, CURLINFO_REDIRECT_COUNT, &curlRedirectCount);
+  curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effectiveUrl);
+  curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirectUrl);
+
+  printf("res: %d\n"
+         "status: %d\n"
+         "redirects: %d\n"
+         "effectiveurl: %s\n"
+         "redirecturl: %s\n",
+         (int)res,
+         (int)curlResponseCode,
+         (int)curlRedirectCount,
+         effectiveUrl,
+         redirectUrl);
+
+test_cleanup:
+
+  /* always cleanup */
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return res;
+}


### PR DESCRIPTION
... when not actually following the redirect. Otherwise we return error
for this and an application can't extract the value.

Test 1518 added to verify.

Reported-by: Pavel Pavlov
Fixes #3340 