### PR TITLE
urlapi: Fix port parsing of eol colon

### DIFF
--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -103,6 +103,15 @@ UNITTEST_START
   free(ipv6port);
   curl_url_cleanup(u);
 
+  /* Valid IPv6 with no port after the colon, should use default */
+  u = curl_url();
+  ipv6port = strdup("[fe80::250:56ff:fea7:da15]:");
+  ret = Curl_parse_port(u, ipv6port);
+  fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
+  free(ipv6port);
+  curl_url_cleanup(u);
+
+  /* Valid IPv6 */
   u = curl_url();
   ipv6port = strdup("[fe80::250:56ff:fea7:da15]80");
   ret = Curl_parse_port(u, ipv6port);


### PR DESCRIPTION
A URL with a single colon without a portnumber should use th default
port, discarding the colon. Fix and also do comment wordsmithing.