### PR TITLE
Permit to semantically distinguish URL with empty query (closes #3369)

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -31,9 +31,11 @@
 #include "progress.h"
 #include "gopher.h"
 #include "select.h"
+#include "strdup.h"
 #include "url.h"
 #include "escape.h"
 #include "warnless.h"
+#include "curl_printf.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"
@@ -78,7 +80,9 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   curl_socket_t sockfd = conn->sock[FIRSTSOCKET];
 
   curl_off_t *bytecount = &data->req.bytecount;
+  char *gopherpath;
   char *path = data->state.up.path;
+  char *query = data->state.up.query;
   char *sel = NULL;
   char *sel_org = NULL;
   ssize_t amount, k;
@@ -86,8 +90,16 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
 
   *done = TRUE; /* unconditionally */
 
+  if(path && query)
+    gopherpath = aprintf("%s?%s", path, query);
+  else
+    gopherpath = strdup(path);
+
+  if(!gopherpath)
+    return CURLE_OUT_OF_MEMORY;
+
   /* Create selector. Degenerate cases: / and /1 => convert to "" */
-  if(strlen(path) <= 2) {
+  if(strlen(gopherpath) <= 2) {
     sel = (char *)"";
     len = strlen(sel);
   }
@@ -95,11 +107,12 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
     char *newp;
 
     /* Otherwise, drop / and the first character (i.e., item type) ... */
-    newp = path;
+    newp = gopherpath;
     newp += 2;
 
     /* ... and finally unescape */
     result = Curl_urldecode(data, newp, 0, &sel, &len, FALSE);
+    free(gopherpath);
     if(result)
       return result;
     sel_org = sel;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -864,7 +864,7 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
       return CURLUE_OUT_OF_MEMORY;
   }
 
-  if(query && query[0]) {
+  if(query) {
     u->query = strdup(query);
     if(!u->query)
       return CURLUE_OUT_OF_MEMORY;
@@ -1071,8 +1071,8 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
                     port ? port : "",
                     (u->path && (u->path[0] != '/')) ? "/": "",
                     u->path ? u->path : "/",
-                    u->query? "?": "",
-                    u->query? u->query : "",
+                    (u->query && u->query[0]) ? "?": "",
+                    (u->query && u->query[0]) ? u->query : "",
                     u->fragment? "#": "",
                     u->fragment? u->fragment : "");
     }

--- a/tests/data/test1201
+++ b/tests/data/test1201
@@ -25,7 +25,7 @@ gopher
 Gopher selector
  </name>
  <command>
-gopher://%HOSTIP:%GOPHERPORT/1/selector/SELECTOR/1201
+gopher://%HOSTIP:%GOPHERPORT/1/selector/SELECTOR/1201?
 </command>
 </client>
 
@@ -33,7 +33,7 @@ gopher://%HOSTIP:%GOPHERPORT/1/selector/SELECTOR/1201
 # Verify data after the test has been "shot"
 <verify>
 <protocol>
-/selector/SELECTOR/1201
+/selector/SELECTOR/1201?
 </protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
In the URL API there is no way to distinguish URL with possible
trailing `?' (empty query).

This is needed for e.g. in the gopher:// scheme where
<gopher://host/1/foo> and <gopher://host/1/foo?>.
can be two different URLs.

Adjust gopher too in order to not ignore the "query" part and modify
the selector in the gopher selector test (`test1201`) to test for
that.

Closes #3369