### PR TITLE
OS400: handle memory error in list conversion

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -219,13 +219,20 @@ slist_convert(int dccsid, struct curl_slist * from, int sccsid)
   struct curl_slist * to = (struct curl_slist *) NULL;
 
   for(; from; from = from->next) {
+    struct curl_slist *nl;
     char * cp = dynconvert(dccsid, from->data, -1, sccsid);
 
     if(!cp) {
       curl_slist_free_all(to);
       return (struct curl_slist *) NULL;
     }
-    to = Curl_slist_append_nodup(to, cp);
+    nl = Curl_slist_append_nodup(to, cp);
+    if(!nl) {
+      curl_slist_free_all(to);
+      free(cp);
+      return NULL;
+    }
+    to = nl;
   }
   return to;
 }


### PR DESCRIPTION
`Curl_slist_append_nodup()` returns NULL when it fails to create a new item for the specified list, and since the coding here reassigned the new list on top of the old list it would result in a dangling pointer
and lost memory. Also, in case we hit an allocation failure at some point during the conversion, with allocation succeeding again on the subsequent call(s) we will return a truncated list around the malloc
failure point.

Fix by assigning to a temporary list pointer, which can be checked (which is the common pattern for slist appending), and free all the resources on allocation failure.

*Disclaimer:* I have not tested this since I have no access to an OS400 environment.