### PR TITLE
slist: retain list on allocation failure

### DIFF
--- a/lib/slist.c
+++ b/lib/slist.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -89,16 +89,17 @@ struct curl_slist *Curl_slist_append_nodup(struct curl_slist *list, char *data)
 struct curl_slist *curl_slist_append(struct curl_slist *list,
                                      const char *data)
 {
+  struct curl_slist *nl;
   char *dupdata = strdup(data);
 
   if(!dupdata)
     return NULL;
 
-  list = Curl_slist_append_nodup(list, dupdata);
-  if(!list)
+  nl = Curl_slist_append_nodup(list, dupdata);
+  if(!nl)
     free(dupdata);
 
-  return list;
+  return nl;
 }
 
 /*


### PR DESCRIPTION
In case `Curl_slist_append_nodup()` fails to allocate enough memory to hold the new item for the list, it will return NULL leaving the list which was passed intact. `curl_slist_append()` use `_nodup()` internally and advertise the same API. This allows for the caller to handle the items on the list in whichever way the application see fit, knowing that the new item didn't get appended (typically freeing the list in a controlled manner and returning with an error). The documented API for appending to a list is to use a temporary pointer like below:
```C
  struct curl_slist *nl = curl_slist_append(list, "new item");

  if(!nl) {
    curl_slist_free_all(list);
    return -1;
  }
  list = nl;
```
The call to `Curl_slist_append_nodup()` was however using the passed slist pointer for its return value as well, thus overwriting the existing list on allocation failure. Fix by using a temporary slist pointer internally instead of the passed list pointer.