### PR TITLE
Assign conn->data for disconnect

### DIFF
--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -554,19 +554,14 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
 {
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
-  struct SSHPROTO *protop;
+  struct SSHPROTO *protop = data->req.protop;
   struct ssh_conn *sshc = &conn->proto.sshc;
   int rc = SSH_NO_ERROR, err;
   char *new_readdir_line;
   int seekerr = CURL_SEEKFUNC_OK;
   const char *err_msg;
   *block = 0;                   /* we're not blocking by default */
-  if(!data) {
-    state(conn, SSH_STOP);
-    return CURLE_OK;
-  }
 
-  protop = data->req.protop;
   do {
 
     switch(sshc->state) {
@@ -1993,10 +1988,6 @@ static CURLcode myssh_block_statemach(struct connectdata *conn,
   struct ssh_conn *sshc = &conn->proto.sshc;
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
-  if(!data) {
-    state(conn, SSH_STOP);
-    return CURLE_OK;
-  }
 
   while((sshc->state != SSH_STOP) && !result) {
     bool block;

--- a/lib/url.c
+++ b/lib/url.c
@@ -781,6 +781,9 @@ CURLcode Curl_disconnect(struct Curl_easy *data,
   Curl_http_ntlm_cleanup(conn);
 #endif
 
+  /* the protocol specific disconnect handler needs a transfer for its
+     connection! */
+  conn->data = data;
   if(conn->handler->disconnect)
     /* This is set if protocol-specific cleanups should be made */
     conn->handler->disconnect(conn, dead_connection);


### PR DESCRIPTION
The previous cleanup was a little too aggressive and [OSS-Fuzz found out](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12173) (that issue is hidden for the public for another 90 days).

Instead of making the protocols handle disconnect without a transfer, we make sure to assign the easy pointer just before calling the disconnect and while still "owning" the connection.