### PR TITLE
openvms: fix OpenSSL discovery on VAX

### DIFF
--- a/packages/vms/generate_config_vms_h_curl.com
+++ b/packages/vms/generate_config_vms_h_curl.com
@@ -406,7 +406,7 @@ $   write cvh "#define USE_OPENSSL 1"
 $   write cvh "#endif"
 $   if arch_name .eqs. "VAX"
 $   then
-$       old_mes = f$enviroment("message")
+$       old_mes = f$environment("message")
 $       set message/notext/nofaci/noseve/noident
 $       search/output=nla0: ssl$include:*.h CONF_MFLAGS_IGNORE_MISSING_FILE
 $       status = $severity


### PR DESCRIPTION
The DCL code had a typo in one of the commands which would make the OpenSSL discovery on VAX fail. The correct syntax is F$ENVIRONMENT.

I have no way of testing this, but the relevant documentation for this change can be found in the [OpenVMS DCL Dictionary](http://h30266.www3.hpe.com/odl/vax/opsys/vmsos73/vmsos73/9996/9996pro_026.html#index_x_738) for OpenVMS VAX Version 7.3.

