### PR TITLE
FAQ: remove mention of sourceforge for github

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -253,11 +253,10 @@ FAQ
   any way by the project.
 
   We still get help from companies. Haxx provides web site, bandwidth, mailing
-  lists etc, sourceforge.net hosts project services we take advantage from,
-  like the bug tracker, and GitHub hosts the primary git repository at
-  https://github.com/curl/curl. Also again, some companies have sponsored
-  certain parts of the development in the past and I hope some will continue to
-  do so in the future.
+  lists etc, GitHub hosts the primary git repository and other services like
+  the bug tracker at https://github.com/curl/curl. Also again, some companies
+  have sponsored certain parts of the development in the past and I hope some
+  will continue to do so in the future.
 
   If you want to support our project, consider a donation or a banner-program
   or even better: by helping us with coding, documenting or testing etc.


### PR DESCRIPTION
The project bug tracker is no longer hosted at sourceforge but is now hosted on the curl Github page. Update the FAQ to reflect.

Closes #xxxx