### PR TITLE
urlapi: fix parsing ipv6 with zone index

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -510,8 +510,11 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname)
       portptr = &hostname[len];
     else if('%' == endbracket) {
       int zonelen = len;
-      if(1 == sscanf(hostname + zonelen, "25%*[^]]]%c%n", &endbracket, &len))
-        portptr = &hostname[--zonelen + len];
+      if(1 == sscanf(hostname + zonelen, "25%*[^]]%c%n", &endbracket, &len)) {
+        if(']' != endbracket)
+          return CURLUE_MALFORMED_INPUT;
+        portptr = &hostname[--zonelen + len + 1];
+      }
       else
         return CURLUE_MALFORMED_INPUT;
     }

--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -83,6 +83,14 @@ UNITTEST_START
   free(ipv6port);
   curl_url_cleanup(u);
 
+  /* Valid IPv6 with zone index without port number */
+  u = curl_url();
+  ipv6port = strdup("[fe80::250:56ff:fea7:da15%25eth3]");
+  ret = Curl_parse_port(u, ipv6port);
+  fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
+  free(ipv6port);
+  curl_url_cleanup(u);
+
   /* Valid IPv6 with port number */
   u = curl_url();
   ipv6port = strdup("[fe80::250:56ff:fea7:da15]:81");


### PR DESCRIPTION
The previous fix for parsing IPv6 URLs with a zone index was a paddle short for URLs without an explicit port. Fix for this case and add a unit test case.

This bug was highlighted by issue #3408, and while it's not the full fix for the problem there it is an isolated bug that should be fixed.