### PR TITLE
Clear Cookie header when redirect to cross-site

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
@@ -87,6 +87,10 @@ those servers will get all the contents of your custom headers too.
 Starting in 7.58.0, libcurl will specifically prevent "Authorization:" headers
 from being sent to other hosts than the first used one, unless specifically
 permitted with the \fICURLOPT_UNRESTRICTED_AUTH(3)\fP option.
+
+Starting in 7.64.0, libcurl will specifically prevent "Cookie:" headers
+from being sent to other hosts than the first used one, unless specifically
+permitted with the \fBCURLOPT_UNRESTRICTED_AUTH(3)\fP option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
@@ -90,7 +90,7 @@ permitted with the \fICURLOPT_UNRESTRICTED_AUTH(3)\fP option.
 
 Starting in 7.64.0, libcurl will specifically prevent "Cookie:" headers
 from being sent to other hosts than the first used one, unless specifically
-permitted with the \fBCURLOPT_UNRESTRICTED_AUTH(3)\fP option.
+permitted with the \fICURLOPT_UNRESTRICTED_AUTH(3)\fP option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/lib/http.c
+++ b/lib/http.c
@@ -1834,7 +1834,8 @@ CURLcode Curl_add_custom_headers(struct connectdata *conn,
                   checkprefix("Transfer-Encoding:", headers->data))
             /* HTTP/2 doesn't support chunked requests */
             ;
-          else if(checkprefix("Authorization:", headers->data) &&
+          else if((checkprefix("Authorization:", headers->data) ||
+                   checkprefix("Cookie:", headers->data)) &&
                   /* be careful of sending this potentially sensitive header to
                      other hosts */
                   (data->state.this_is_a_follow &&

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -56,7 +56,7 @@ test289 test290 test291 test292 test293 test294 test295 test296 test297 \
 test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
-test325 test326 test327 test328 test329 \
+test325 test326 test327 test328 test329 test330 \
 \
 test340 \
 \

--- a/tests/data/test330
+++ b/tests/data/test330
@@ -3,6 +3,7 @@
 <keywords>
 HTTP
 followlocation
+cookies
 </keywords>
 </info>
 #

--- a/tests/data/test330
+++ b/tests/data/test330
@@ -1,0 +1,89 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+followlocation
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/3170002
+Content-Length: 8
+Connection: close
+
+contents
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data2>
+
+<datacheck>
+HTTP/1.1 302 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/3170002
+Content-Length: 8
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP with custom Cookie: and redirect to new host
+ </name>
+ <command>
+http://first.host.it.is/we/want/that/page/317 -x %HOSTIP:%HTTPPORT -H "Cookie: test=yes" --location
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://first.host.it.is/we/want/that/page/317 HTTP/1.1
+Host: first.host.it.is
+Accept: */*
+Proxy-Connection: Keep-Alive
+Cookie: test=yes
+
+GET http://goto.second.host.now/3170002 HTTP/1.1
+Host: goto.second.host.now
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
After version 7.58.0, Authorization header isn't forward to cross-site when redirect.

Cookie header with confidential data should also be supported.