### PR TITLE
curl/urlapi.h: include "curl.h" first

### DIFF
--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -21,6 +21,8 @@
  * KIND, either express or implied.
  *
  ***************************************************************************/
+
+#include "curl.h"
 
 #ifdef  __cplusplus
 extern "C" {


### PR DESCRIPTION
This allows programs to include curl/urlapi.h directly.

Reported-by: Ben Kohler
Fixes #3438