### PR TITLE
cookies: allow secure override when done over HTTPS

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -951,7 +951,7 @@ Curl_cookie_add(struct Curl_easy *data,
         /* the domains were identical */
 
         if(clist->spath && co->spath) {
-          if(clist->secure && !co->secure) {
+          if(clist->secure && !co->secure && !secure) {
             size_t cllen;
             const char *sep;
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -177,7 +177,7 @@ test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 \
-test1560 test1561 \
+test1560 test1561 test1562 \
 \
 test1590 test1591 test1592 \
 \

--- a/tests/data/test1562
+++ b/tests/data/test1562
@@ -1,0 +1,73 @@
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP
+HTTP GET
+cookies
+cookiejar
+HTTP replaced headers
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data1>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Set-Cookie: foo=123; path=/; secure;
+Content-Length: 7
+
+nomnom
+</data1>
+<data2>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Set-Cookie: foo=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/
+Content-Length: 7
+
+nomnom
+</data2>
+</reply>
+
+# Client-side
+<client>
+<features>
+SSL
+</features>
+<server>
+http
+https
+</server>
+<name>
+Expire secure cookies over HTTPS
+</name>
+<command>
+-k https://%HOSTIP:%HTTPSPORT/15620001 -H "Host: www.example.com" https://%HOSTIP:%HTTPSPORT/15620002 -b "non-existing" https://%HOSTIP:%HTTPSPORT/15620001
+</command>
+</client>
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /15620001 HTTP/1.1
+Host: www.example.com
+Accept: */*
+
+GET /15620002 HTTP/1.1
+Host: www.example.com
+Accept: */*
+Cookie: foo=123
+
+GET /15620001 HTTP/1.1
+Host: www.example.com
+Accept: */*
+
+</protocol>
+
+</verify>
+
+</testcase>


### PR DESCRIPTION
Added test 1562 to verify.

Reported-by: Jeroen Ooms
Fixes #3445