### PR TITLE
cmake: define HAVE_VARIADIC_MACROS_C99

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -1071,6 +1071,10 @@ if(RETSIGTYPE_TEST)
 else()
   set(RETSIGTYPE int)
 endif()
+
+# TODO: this should *check* which variadic macros that work and set the
+# appropriate define.
+set(HAVE_VARIADIC_MACROS_C99 1)
 
 if(CMAKE_COMPILER_IS_GNUCC AND APPLE)
   include(CheckCCompilerFlag)


### PR DESCRIPTION
This should ideally *check* what variadic macros that actually
work. This is mostlu to improve the current situation where no define at
all is set for this.

Fixes #3142