### PR TITLE
docs: mention ./buildconf in unix installation

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -18,6 +18,7 @@ proceed.
 A normal Unix installation is made in three or four steps (after you've
 unpacked the source archive):
 
+    ./buildconf
     ./configure
     make
     make test (optional)


### PR DESCRIPTION
Took me longer than I'd like to admit to build curl because I'm not used to this workflow. Was confussed by missing `./configure` :)