### PR TITLE
travis: added cmake build for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,9 @@ matrix:
         - os: osx
           compiler: clang
           env: T=normal
+        - os: osx
+          compiler: clang
+          env: T=cmake
         - os: linux
           compiler: gcc
           dist: trusty
@@ -347,10 +350,11 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "cmake" ]; then
-             mkdir build
-             cd build
-             cmake .. -DCURL_WERROR=ON
-             make
+             if [ $TRAVIS_OS_NAME = linux ]; then
+                cmake -H. -Bbuild -DCURL_WERROR=ON && cmake --build build
+             else
+                cmake -H. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON && cmake --build build
+             fi
         fi
     - |
         set -eo pipefail


### PR DESCRIPTION
Added preliminary support to build curl on OSX image.

- LDAP is disabled, due deprecation issues (need support for OpenDirectory Framework)

Fixes: #3467

