### PR TITLE
extract_if_dead: follow-up to 54b201b48c90a

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -965,9 +965,7 @@ static bool extract_if_dead(struct connectdata *conn,
       /* The protocol has a special method for checking the state of the
          connection. Use it to check if the connection is dead. */
       unsigned int state;
-      conn->data = data; /* temporary transfer for this connection to use */
       state = conn->handler->connection_check(conn, CONNCHECK_ISDEAD);
-      conn->data = NULL; /* clear transfer again */
       dead = (state & CONNRESULT_DEAD);
     }
     else {
@@ -996,6 +994,7 @@ struct prunedead {
 static int call_extract_if_dead(struct connectdata *conn, void *param)
 {
   struct prunedead *p = (struct prunedead *)param;
+  conn->data = p->data; /* transfer to use for this check */
   if(extract_if_dead(conn, p->data)) {
     /* stop the iteration here, pass back the connection that was extracted */
     p->extracted = conn;


### PR DESCRIPTION
extract_if_dead() dead is called from two functions, and only one of
them should get conn->data updated and now neither clear it.

scan-build found a case where conn->data would be NULL dereferenced in
ConnectionExists() otherwise.