### PR TITLE
cmake: updated check for HAVE_POLL_FINE to match autotools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -70,7 +70,6 @@ message(STATUS "curl version=[${CURL_VERSION}]")
 set(OPERATING_SYSTEM "${CMAKE_SYSTEM_NAME}")
 set(OS "\"${CMAKE_SYSTEM_NAME}\"")
 
-include_directories(${PROJECT_BINARY_DIR}/include/curl)
 include_directories(${CURL_SOURCE_DIR}/include)
 
 option(CURL_WERROR "Turn compiler warnings into errors" OFF)
@@ -828,12 +827,8 @@ endif()
 
 check_symbol_exists(basename      "${CURL_INCLUDES}" HAVE_BASENAME)
 check_symbol_exists(socket        "${CURL_INCLUDES}" HAVE_SOCKET)
-# poll on macOS is unreliable, it first did not exist, then was broken until
-# fixed in 10.9 only to break again in 10.12.
-if(NOT APPLE)
-  check_symbol_exists(poll        "${CURL_INCLUDES}" HAVE_POLL)
-endif()
 check_symbol_exists(select        "${CURL_INCLUDES}" HAVE_SELECT)
+check_symbol_exists(poll          "${CURL_INCLUDES}" HAVE_POLL)
 check_symbol_exists(strdup        "${CURL_INCLUDES}" HAVE_STRDUP)
 check_symbol_exists(strstr        "${CURL_INCLUDES}" HAVE_STRSTR)
 check_symbol_exists(strtok_r      "${CURL_INCLUDES}" HAVE_STRTOK_R)

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -384,9 +384,6 @@ problems may have been fixed or changed somewhat since this was written!
 
   - no nghttp2 check
 
-  - no check for what variadic macros that are supported. See
-    https://github.com/curl/curl/pull/3452
-
   - unusable tool_hugehelp.c with MinGW, see
     https://github.com/curl/curl/issues/3125
 


### PR DESCRIPTION
Fixed checks for HAVE_POLL_FINE to be the same as in autotools (ref: [here](https://github.com/curl/curl/blob/5616c1df285bef32e879f5e29fdf28c062e6506d/m4/curl-functions.m4#L4802))
Also updated KNOWN_BUGS and years.

Fixes: #3292 