### PR TITLE
curl-compilers.m4: check for __ibmxl__ to detect xlclang

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -84,8 +84,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
   if test "$curl_cv_have_def___clang__" = "yes"; then
     AC_MSG_RESULT([yes])
     AC_MSG_CHECKING([if compiler is xlclang])
-    CURL_CHECK_DEF([__xlc__], [], [silent])
-    if test "$curl_cv_have_def___xlc__" = "yes" ; then
+    CURL_CHECK_DEF([__ibmxl__], [], [silent])
+    if test "$curl_cv_have_def___ibmxl__" = "yes" ; then
       dnl IBM's almost-compatible clang version
       AC_MSG_RESULT([yes])
       compiler_id="XLCLANG"


### PR DESCRIPTION
Follow-up to 2fa0d57e2e3. The __xlc__ symbol is only defined there if a
particular flag is used for legacy macros.

Fixes #3474