### PR TITLE
ssh: log the libssh2 error message when ssh session startup fails

### DIFF
--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -667,7 +667,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         break;
       }
       if(rc) {
-        failf(data, "Failure establishing ssh session");
+        char *err_msg = NULL;
+        (void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+        failf(data, "Failure establishing ssh session: %d, %s", rc, err_msg);
+
         state(conn, SSH_SESSION_FREE);
         sshc->actualcode = CURLE_FAILED_INIT;
         break;


### PR DESCRIPTION
When a ssh session startup fails, it is useful to know why it has
failed. This commit changes the message from:
   "Failure establishing ssh session"
to something like this, for example:
   "Failure establishing ssh session: -5, Unable to exchange encryption keys"