### PR TITLE
configure: fix recv/send/select detection on Android

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1083,9 +1083,6 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #define RECVCALLCONV
 #endif
                       extern $recv_retv RECVCALLCONV
-#ifdef __ANDROID__
-__attribute__((overloadable))
-#endif
                       recv($recv_arg1, $recv_arg2, $recv_arg3, $recv_arg4);
                     ]],[[
                       $recv_arg1 s=0;
@@ -1220,9 +1217,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #define SENDCALLCONV
 #endif
                       extern $send_retv SENDCALLCONV
-#ifdef __ANDROID__
-__attribute__((overloadable))
-#endif
                       send($send_arg1, $send_arg2, $send_arg3, $send_arg4);
                     ]],[[
                       $send_arg1 s=0;
@@ -1931,10 +1925,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
                     };
 #endif
                     extern $sel_retv SELECTCALLCONV
-#ifdef __ANDROID__
-__attribute__((overloadable))
-#endif
-			select($sel_arg1,
+				select($sel_arg1,
 					$sel_arg234,
 					$sel_arg234,
 					$sel_arg234,


### PR DESCRIPTION
This reverts commit d4f25201fb7da03fc88f90d51101beb3d0026db9.

The overloadable attribute was removed starting NDK17. Actually they only exist in two NDK versions (15 and 16). With overloadable, the first condition tried will succeed. Results in wrong detection result.