### PR TITLE
Use explicit include opt for perl calls.

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3865,7 +3865,7 @@ sub singletest {
     if($cmdtype eq "perl") {
         # run the command line prepended with "perl"
         $cmdargs ="$cmd";
-        $CMDLINE = "perl ";
+        $CMDLINE = "perl -I$srcdir ";
         $tool=$CMDLINE;
         $disablevalgrind=1;
     }


### PR DESCRIPTION
At the top, perl is called using with the "-Isrcdir" option, and it works:

https://github.com/curl/curl/blob/master/tests/runtests.pl#L182-L183

But on line 3868, that option is omitted. This caused problems for me, as the symbol-scan.pl script in particular, couldn't find it's dependencies properly:

https://github.com/curl/curl/blob/master/tests/runtests.pl#L3868

This patch fixes that oversight by making calls to perl sub-shells uniform.