### PR TITLE
sigpipe: if MBEDTLS is used, force curl to ignore sigpipe.

### DIFF
--- a/lib/sigpipe.h
+++ b/lib/sigpipe.h
@@ -23,7 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(HAVE_SIGNAL_H) && defined(HAVE_SIGACTION) && defined(USE_OPENSSL)
+#if defined(HAVE_SIGNAL_H) && defined(HAVE_SIGACTION) && (defined(USE_OPENSSL) || defined(USE_MBEDTLS))
 #include <signal.h>
 
 struct sigpipe_ignore {


### PR DESCRIPTION
mbedtls doesn't have a sigpipe management.
If a write/read occurs when the remote closes the socket, the signal is raised and kills the application.
Use the curl mecanisms fix this behavior.

Signed-off-by: Jeremie Rapin <j.rapin@overkiz.com>