### PR TITLE
schannel: stop calling it "winssl"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1480,6 +1480,11 @@ AC_HELP_STRING([--with-winssl],[enable Windows native SSL/TLS])
 AC_HELP_STRING([--without-winssl], [disable Windows native SSL/TLS]),
   OPT_WINSSL=$withval)
 
+AC_ARG_WITH(schannel,dnl
+AC_HELP_STRING([--with-schannel],[enable Windows native SSL/TLS])
+AC_HELP_STRING([--without-schannel], [disable Windows native SSL/TLS]),
+  OPT_WINSSL=$withval)
+
 AC_MSG_CHECKING([whether to enable Windows native SSL/TLS (Windows native builds only)])
 if test -z "$ssl_backends" -o "x$OPT_WINSSL" != xno; then
   ssl_msg=

--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -25,9 +25,9 @@ should not be set. If the option is not set, then curl will use the
 certificates in the system and user Keychain to verify the peer, which is the
 preferred method of verifying the peer's certificate chain.
 
-(Schannel/WinSSL only) This option is supported for WinSSL in Windows 7 or
-later with libcurl 7.60 or later. This option is supported for backward
-compatibility with other SSL engines; instead it is recommended to use Windows'
-store of root certificates (the default for WinSSL).
+(Schannel only) This option is supported for Schannel in Windows 7 or later with
+libcurl 7.60 or later. This option is supported for backward compatibility
+with other SSL engines; instead it is recommended to use Windows' store of
+root certificates (the default for Schannel).
 
 If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -36,7 +36,7 @@ system or user keychain, or the path to a PKCS#12-encoded certificate and
 private key. If you want to use a file from the current directory, please
 precede it with "./" prefix, in order to avoid confusion with a nickname.
 
-(Schannel/WinSSL only) Client certificates must be specified by a path
+(Schannel only) Client certificates must be specified by a path
 expression to a certificate store. (Loading PFX is not supported; you can
 import it to a store first). You can use
 "<store location>\\<store name>\\<thumbprint>" to refer to a certificate

--- a/docs/cmdline-opts/ssl-no-revoke.d
+++ b/docs/cmdline-opts/ssl-no-revoke.d
@@ -1,7 +1,7 @@
 Long: ssl-no-revoke
-Help: Disable cert revocation checks (WinSSL)
+Help: Disable cert revocation checks (Schannel)
 Added: 7.44.0
 ---
-(WinSSL) This option tells curl to disable certificate revocation checks.
+(Schannel) This option tells curl to disable certificate revocation checks.
 WARNING: this option loosens the SSL security, and by using this flag you ask
 for exactly that.

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -170,7 +170,7 @@ libcurl was built with multiple SSL backends. For details, see
 supports HTTP Brotli content encoding using libbrotlidec (Added in 7.57.0)
 .RE
 \fIssl_version\fP is an ASCII string for the TLS library name + version
-used. If libcurl has no SSL support, this is NULL. For example "WinSSL",
+used. If libcurl has no SSL support, this is NULL. For example "Schannel",
 \&"SecureTransport" or "OpenSSL/1.1.0g".
 
 \fIssl_version_num\fP is always 0.

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -81,7 +81,7 @@ as well:
 mbedtls_ssl_context *
 .IP PolarSSL
 ssl_context *
-.IP "Secure Channel (WinSSL)"
+.IP "Secure Channel"
 CtxtHandle *
 .IP "Secure Transport (DarwinSSL)"
 SSLContext *

--- a/docs/libcurl/opts/CURLOPT_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -52,10 +52,10 @@ should not be set. If the option is not set, then curl will use the
 certificates in the system and user Keychain to verify the peer, which is the
 preferred method of verifying the peer's certificate chain.
 
-(Schannel/WinSSL only) This option is supported for WinSSL in Windows 7 or
-later with libcurl 7.60 or later. This option is supported for backward
-compatibility with other SSL engines; instead it is recommended to use Windows'
-store of root certificates (the default for WinSSL).
+(Schannel only) This option is supported for Schannel in Windows 7 or later
+with libcurl 7.60 or later. This option is supported for backward
+compatibility with other SSL engines; instead it is recommended to use
+Windows' store of root certificates (the default for Schannel).
 
 The application does not have to keep the string around after setting this
 option.

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -70,7 +70,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-This option is supported by the OpenSSL, GnuTLS, WinSSL, NSS and GSKit backends.
+This option is supported by the OpenSSL, GnuTLS, Schannel, NSS and GSKit
+backends.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -107,7 +107,7 @@ PEM/DER support:
 
   7.54.1: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
 
-  7.58.1: SChannel/WinSSL
+  7.58.1: SChannel
 
 sha256 support:
 
@@ -119,7 +119,7 @@ sha256 support:
 
   7.54.1: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
 
-  7.58.1: SChannel/WinSSL Windows XP SP3+
+  7.58.1: SChannel Windows XP SP3+
 
 Other SSL backends not supported.
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -40,7 +40,7 @@ that.  This option is only supported for DarwinSSL, NSS and OpenSSL.
 
 \fICURLSSLOPT_NO_REVOKE\fP tells libcurl to disable certificate revocation
 checks for those SSL backends where such behavior is present. \fBCurrently
-this option is only supported for WinSSL (the native Windows SSL library),
+this option is only supported for Schannel (the native Windows SSL library),
 with an exception in the case of Windows' Untrusted Publishers blacklist which
 it seems can't be bypassed.\fP This option may have broader support to
 accommodate other SSL backends in the future.

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -38,11 +38,10 @@ you wish to authenticate with as it is named in the security database. If you
 want to use a file from the current directory, please precede it with "./"
 prefix, in order to avoid confusion with a nickname.
 
-(Schannel/WinSSL only) Client certificates must be specified by a path
-expression to a certificate store. (Loading PFX is not supported; you can
-import it to a store first). You can use
-"<store location>\\<store name>\\<thumbprint>" to refer to a certificate
-in the system certificates store, for example,
+(Schannel only) Client certificates must be specified by a path expression to
+a certificate store. (Loading PFX is not supported; you can import it to a
+store first). You can use "<store location>\\<store name>\\<thumbprint>" to
+refer to a certificate in the system certificates store, for example,
 "CurrentUser\\MY\\934a7ac6f8a5d579285a74fa61e19f23ddfe8d7a". Thumbprint is
 usually a SHA-1 hex string which you can see in certificate details. Following
 store locations are supported: CurrentUser, LocalMachine, CurrentService,

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -42,7 +42,7 @@ Added in 7.44.0:
 
 \fICURLSSLOPT_NO_REVOKE\fP tells libcurl to disable certificate revocation
 checks for those SSL backends where such behavior is present. \fBCurrently this
-option is only supported for WinSSL (the native Windows SSL library), with an
+option is only supported for Schannel (the native Windows SSL library), with an
 exception in the case of Windows' Untrusted Publishers blacklist which it seems
 can't be bypassed.\fP This option may have broader support to accommodate other
 SSL backends in the future.

--- a/lib/url.c
+++ b/lib/url.c
@@ -492,9 +492,9 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   /* Set the default CA cert bundle/path detected/specified at build time.
    *
-   * If Schannel (WinSSL) is the selected SSL backend then these locations
-   * are ignored. We allow setting CA location for schannel only when
-   * explicitly specified by the user via CURLOPT_CAINFO / --cacert.
+   * If Schannel is the selected SSL backend then these locations are
+   * ignored. We allow setting CA location for schannel only when explicitly
+   * specified by the user via CURLOPT_CAINFO / --cacert.
    */
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(CURL_CA_BUNDLE)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -440,7 +440,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
                                  VERSION_LESS_THAN_EQUAL)) {
      /* Schannel in Windows XP (OS version 5.1) uses legacy handshakes and
         algorithms that may not be supported by all servers. */
-     infof(data, "schannel: WinSSL version is old and may not be able to "
+     infof(data, "schannel: Windows version is old and may not be able to "
            "connect to some servers due to lack of SNI, algorithms, etc.\n");
   }
 
@@ -2073,7 +2073,7 @@ static void Curl_schannel_cleanup(void)
 
 static size_t Curl_schannel_version(char *buffer, size_t size)
 {
-  size = msnprintf(buffer, size, "WinSSL");
+  size = msnprintf(buffer, size, "Schannel");
 
   return size;
 }
@@ -2161,11 +2161,11 @@ static CURLcode pkp_pin_peer_pubkey(struct connectdata *conn, int sockindex,
 }
 
 static void Curl_schannel_checksum(const unsigned char *input,
-                      size_t inputlen,
-                      unsigned char *checksum,
-                      size_t checksumlen,
-                      DWORD provType,
-                      const unsigned int algId)
+                                   size_t inputlen,
+                                   unsigned char *checksum,
+                                   size_t checksumlen,
+                                   DWORD provType,
+                                   const unsigned int algId)
 {
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
@@ -2215,9 +2215,9 @@ static CURLcode Curl_schannel_md5sum(unsigned char *input,
                                      unsigned char *md5sum,
                                      size_t md5len)
 {
-    Curl_schannel_checksum(input, inputlen, md5sum, md5len,
-                           PROV_RSA_FULL, CALG_MD5);
-    return CURLE_OK;
+  Curl_schannel_checksum(input, inputlen, md5sum, md5len,
+                         PROV_RSA_FULL, CALG_MD5);
+  return CURLE_OK;
 }
 
 static CURLcode Curl_schannel_sha256sum(const unsigned char *input,
@@ -2225,9 +2225,9 @@ static CURLcode Curl_schannel_sha256sum(const unsigned char *input,
                                     unsigned char *sha256sum,
                                     size_t sha256len)
 {
-    Curl_schannel_checksum(input, inputlen, sha256sum, sha256len,
-                           PROV_RSA_AES, CALG_SHA_256);
-    return CURLE_OK;
+  Curl_schannel_checksum(input, inputlen, sha256sum, sha256len,
+                         PROV_RSA_AES, CALG_SHA_256);
+  return CURLE_OK;
 }
 
 static void *Curl_schannel_get_internals(struct ssl_connect_data *connssl,

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -646,9 +646,9 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 
   /* Search and set cert file only if libcurl supports SSL.
    *
-   * If Schannel (WinSSL) is the selected SSL backend then these locations
-   * are ignored. We allow setting CA location for schannel only when
-   * explicitly specified by the user via CURLOPT_CAINFO / --cacert.
+   * If Schannel is the selected SSL backend then these locations are
+   * ignored. We allow setting CA location for schannel only when explicitly
+   * specified by the user via CURLOPT_CAINFO / --cacert.
    */
   if((curlinfo->features & CURL_VERSION_SSL) &&
      backend != CURLSSLBACKEND_SCHANNEL) {

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -413,7 +413,7 @@ static const struct helptxt helptext[] = {
   {"    --ssl-allow-beast",
    "Allow security flaw to improve interop"},
   {"    --ssl-no-revoke",
-   "Disable cert revocation checks (WinSSL)"},
+   "Disable cert revocation checks (Schannel)"},
   {"    --ssl-reqd",
    "Require SSL/TLS"},
   {"-2, --sslv2",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -258,9 +258,9 @@ static CURLcode operate_do(struct GlobalConfig *global,
      * no environment-specified filename is found then check for CA bundle
      * default filename curl-ca-bundle.crt in the user's PATH.
      *
-     * If Schannel (WinSSL) is the selected SSL backend then these locations
-     * are ignored. We allow setting CA location for schannel only when
-     * explicitly specified by the user via CURLOPT_CAINFO / --cacert.
+     * If Schannel is the selected SSL backend then these locations are
+     * ignored. We allow setting CA location for schannel only when explicitly
+     * specified by the user via CURLOPT_CAINFO / --cacert.
      */
     if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL) {
       char *env;


### PR DESCRIPTION
Stick to "Schannel" everywhere. The configure option --with-winssl is
kept to allow existing builds to work but a new --enable-schannel is
added as an alias.