### PR TITLE
Adds support for channel binding for http-SSPI-Negotiate.

### DIFF
--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -89,6 +89,11 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
     }
   }
 
+  /* Supports SSL channel binding for Windows ISS extended protection */
+#if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
+  neg_ctx->sslContext = conn->sslContext;
+#endif
+
   /* Initialize the security context and decode our challenge */
   result = Curl_auth_decode_spnego_message(data, userp, passwdp, service,
                                            host, header, neg_ctx);

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -175,6 +175,9 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
     if(s_hSecDll == NULL)
       return err;
   }
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  ntlm->sslContext = conn->sslContext;
+#endif
 #endif
 
   switch(ntlm->state) {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -983,7 +983,7 @@ struct connectdata {
   void *seek_client;            /* pointer to pass to the seek() above */
 
   /*************** Request - specific items ************/
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+#if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
   CtxtHandle *sslContext;
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -364,6 +364,9 @@ struct negotiatedata {
   gss_buffer_desc output_token;
 #else
 #ifdef USE_WINDOWS_SSPI
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  CtxtHandle *sslContext;
+#endif
   DWORD status;
   CredHandle *credentials;
   CtxtHandle *context;
@@ -980,6 +983,9 @@ struct connectdata {
   void *seek_client;            /* pointer to pass to the seek() above */
 
   /*************** Request - specific items ************/
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  CtxtHandle *sslContext;
+#endif
 
 #if defined(USE_NTLM)
   struct ntlmdata ntlm;     /* NTLM differs from other authentication schemes

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1428,7 +1428,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
      * binding to pass the IIS extended protection checks.
      * Available on Windows 7 or later.
      */
-    conn->ntlm.sslContext = &BACKEND->ctxt->ctxt_handle;
+    conn->sslContext = &BACKEND->ctxt->ctxt_handle;
 #endif
 
     *done = TRUE;


### PR DESCRIPTION
Attempt to add support for Secure Channel binding when negotiate authentication is used. The problem to solve is that by default IIS accepts channel binding and curl doesn't utilise them. The result was a 401 response. Scope affects only the Schannel(winssl)-SSPI combination.