### PR TITLE
doc: use meaningless port number in CURLOPT_LOCALPORT example

### DIFF
--- a/docs/libcurl/opts/CURLOPT_LOCALPORT.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORT.3
@@ -41,7 +41,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
-  curl_easy_setopt(curl, CURLOPT_LOCALPORT, 8080L);
+  curl_easy_setopt(curl, CURLOPT_LOCALPORT, 49152L);
   /* and try 20 more ports following that */
   curl_easy_setopt(curl, CURLOPT_LOCALPORTRANGE, 20L);
   ret = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
@@ -45,7 +45,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
-  curl_easy_setopt(curl, CURLOPT_LOCALPORT, 8080L);
+  curl_easy_setopt(curl, CURLOPT_LOCALPORT, 49152L);
   /* and try 20 more ports following that */
   curl_easy_setopt(curl, CURLOPT_LOCALPORTRANGE, 20L);
   ret = curl_easy_perform(curl);


### PR DESCRIPTION
A tiny documentation tweak to hopefully help avoid the next misinterpretation like on the mailing list today: [“Bug: Ignored port setting”](https://curl.haxx.se/mail/lib-2019-01/0084.html).

Use an ephemeral port number here; previously the example had 8080 which could be confusing as the common web server port number might be misinterpreted as suggesting this option affects the remote port.