### PR TITLE
Fixes for ZSH completion script

### DIFF
--- a/scripts/zsh.pl
+++ b/scripts/zsh.pl
@@ -7,7 +7,7 @@ use warnings;
 
 my $curl = $ARGV[0] || 'curl';
 
-my $regex = '\s+(?:(-[^\s]+),\s)?(--[^\s]+)\s([^\s.]+)?\s+(.*)';
+my $regex = '\s+(?:(-[^\s]+),\s)?(--[^\s]+)\s*(\<.+?\>)?\s+(.*)';
 my @opts = parse_main_opts('--help', $regex);
 
 my $opts_str;

--- a/scripts/zsh.pl
+++ b/scripts/zsh.pl
@@ -45,9 +45,12 @@ sub parse_main_opts {
 
         my $option = '';
 
+        $arg =~ s/\:/\\\:/g if defined $arg;
+
         $desc =~ s/'/'\\''/g if defined $desc;
         $desc =~ s/\[/\\\[/g if defined $desc;
         $desc =~ s/\]/\\\]/g if defined $desc;
+        $desc =~ s/\:/\\\:/g if defined $desc;
 
         $option .= '{' . trim($short) . ',' if defined $short;
         $option .= trim($long)  if defined $long;


### PR DESCRIPTION
A couple of fixes for the script that generates ZSH completion.

One of the fixes is for https://bugs.debian.org/921452.