### PR TITLE
ROADMAP: remove already performed item

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,11 +13,8 @@ QUIC
 HTTP cookies
 ------------
 
-Two cookie drafts have been adopted by the httpwg in IETF and we should
-support them as the popular browsers will as well:
-
-[Deprecate modification of 'secure' cookies from non-secure
-origins](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-alone-00)
+On top of what we already support, the prefix cookie draft has been adopted by
+the httpwg in IETF and we should support it as the popular browsers will:
 
 [Cookie Prefixes](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00)
 


### PR DESCRIPTION
Commit 7a09b52c98ac8d840a8a9907b1a1d9a9e684bcf5 introduced support for the draft-ietf-httpbis-cookie-alone-01 cookie draft, and while the entry was removed from the TODO it was mistakenly left here. Fix by removing and rewording the entry slightly.

Closes #xxxx

@bagder if you agree with the wording, this should probably go in before we cut 7.64 as the roadmap will otherwise be out of sync with the code.