### PR TITLE
url: close TLS before removing conn from cache

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -788,18 +788,17 @@ CURLcode Curl_disconnect(struct Curl_easy *data,
     /* This is set if protocol-specific cleanups should be made */
     conn->handler->disconnect(conn, dead_connection);
 
-    /* unlink ourselves! */
   infof(data, "Closing connection %ld\n", conn->connection_id);
+  Curl_ssl_close(conn, FIRSTSOCKET);
+  Curl_ssl_close(conn, SECONDARYSOCKET);
+
+  /* unlink ourselves! */
   Curl_conncache_remove_conn(data, conn, TRUE);
 
   free_idnconverted_hostname(&conn->host);
   free_idnconverted_hostname(&conn->conn_to_host);
   free_idnconverted_hostname(&conn->http_proxy.host);
   free_idnconverted_hostname(&conn->socks_proxy.host);
-
-  /* this assumes that the pointer is still there after the connection was
-     detected from the cache */
-  Curl_ssl_close(conn, FIRSTSOCKET);
 
   conn_free(conn);
   return CURLE_OK;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2035,11 +2035,9 @@ static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
      * might not have an associated transfer so the check for conn->data is
      * necessary.
      */
-    if(conn->data)
-      Curl_ssl_sessionid_lock(conn);
+    Curl_ssl_sessionid_lock(conn);
     Curl_schannel_session_free(BACKEND->cred);
-    if(conn->data)
-      Curl_ssl_sessionid_unlock(conn);
+    Curl_ssl_sessionid_unlock(conn);
     BACKEND->cred = NULL;
   }
 


### PR DESCRIPTION
Fixes: #3412 #3505

Ensures any TLS shutdown messages are sent before removing the association between the connection and the easy handle. Reverts @bagder's previous partial fix for #3412.

Note that `conn_free` also calls `Curl_ssl_close` on `PRIMARYSOCKET` and `SECONDARYSOCKET`, but that was the case before https://github.com/curl/curl/commit/fb445a1e18d12f577964c9347bc5bca74b37cd08.