### PR TITLE
formparse: remove access to private data

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,9 +22,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
 #include "tool_sdecls.h"
-
 #include "tool_metalink.h"
 
 typedef enum {
@@ -34,6 +32,12 @@ typedef enum {
 } curl_error;
 
 struct GlobalConfig;
+
+#define MAX_PARENTS 5
+struct mimeparent {
+  curl_mime *p[MAX_PARENTS];
+  int numparents; /* number of parents stored */
+};
 
 struct OperationConfig {
   CURL *easy;               /* A copy of the handle from GlobalConfig */
@@ -178,6 +182,7 @@ struct OperationConfig {
   struct curl_slist *proxyheaders;
   curl_mime *mimepost;
   curl_mime *mimecurrent;
+  struct mimeparent mimeparent; /* for remembering parents */
   struct curl_slist *telnet_options;
   struct curl_slist *resolve;
   struct curl_slist *connect_to;

--- a/src/tool_formparse.h
+++ b/src/tool_formparse.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,6 +27,7 @@ int formparse(struct OperationConfig *config,
               const char *input,
               curl_mime **mimepost,
               curl_mime **mimecurrent,
+              struct mimeparent *parent,
               bool literal_value);
 
 #endif /* HEADER_CURL_TOOL_FORMPARSE_H */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1693,6 +1693,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                    nextarg,
                    &config->mimepost,
                    &config->mimecurrent,
+                   &config->mimeparent,
                    (subletter == 's')?TRUE:FALSE)) /* 's' is literal string */
         return PARAM_BAD_USE;
       if(SetHTTPrequest(config, HTTPREQ_MIMEPOST, &config->httpreq))


### PR DESCRIPTION
The mime.h (and strcase.h) include files are not meant to be included by
the command line tool.

Fixes #3532