### PR TITLE
tool_operate: fix typecheck warning

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1006,7 +1006,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
           if(config->tr_encoding)
             my_setopt(curl, CURLOPT_TRANSFER_ENCODING, 1L);
           /* new in libcurl 7.64.0 */
-          my_setopt(curl, CURLOPT_HTTP09_ALLOWED, config->http09_allowed);
+          my_setopt(curl, CURLOPT_HTTP09_ALLOWED,
+                    config->http09_allowed ? 1L : 0L);
 
         } /* (built_in_protos & CURLPROTO_HTTP) */
 


### PR DESCRIPTION
Use `long` for `CURLOPT_HTTP09_ALLOWED` to fix the following warning:
> tool_operate.c: In function 'operate_do':
../include/curl/typecheck-gcc.h:47:9: error: call to
'_curl_easy_setopt_err_long' declared with attribute warning:
curl_easy_setopt expects a long argument for this option [-Werror]