### PR TITLE
static function overhaul

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -392,8 +392,8 @@ bool Curl_conncache_foreach(struct Curl_easy *data,
    NOTE: no locking is done here as this is presumably only done when cleaning
    up a cache!
 */
-struct connectdata *
-Curl_conncache_find_first_connection(struct conncache *connc)
+static struct connectdata *
+conncache_find_first_connection(struct conncache *connc)
 {
   struct curl_hash_iterator iter;
   struct curl_hash_element *he;
@@ -566,7 +566,7 @@ void Curl_conncache_close_all_connections(struct conncache *connc)
 {
   struct connectdata *conn;
 
-  conn = Curl_conncache_find_first_connection(connc);
+  conn = conncache_find_first_connection(connc);
   while(conn) {
     SIGPIPE_VARIABLE(pipe_st);
     conn->data = connc->closure_handle;
@@ -577,7 +577,7 @@ void Curl_conncache_close_all_connections(struct conncache *connc)
     (void)Curl_disconnect(connc->closure_handle, conn, FALSE);
     sigpipe_restore(&pipe_st);
 
-    conn = Curl_conncache_find_first_connection(connc);
+    conn = conncache_find_first_connection(connc);
   }
 
   if(connc->closure_handle) {

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -76,11 +76,6 @@ void Curl_persistconninfo(struct connectdata *conn);
 int Curl_closesocket(struct connectdata *conn, curl_socket_t sock);
 
 /*
- * Get presentation format IP address and port from a sockaddr.
- */
-bool Curl_getaddressinfo(struct sockaddr *sa, char *addr, long *port);
-
-/*
  * The Curl_sockaddr_ex structure is basically libcurl's external API
  * curl_sockaddr structure with enough space available to directly hold any
  * protocol-specific address structures. The variable declared here will be
@@ -110,8 +105,6 @@ CURLcode Curl_socket(struct connectdata *conn,
                      const Curl_addrinfo *ai,
                      struct Curl_sockaddr_ex *addr,
                      curl_socket_t *sockfd);
-
-void Curl_tcpnodelay(struct connectdata *conn, curl_socket_t sockfd);
 
 /*
  * Curl_conncontrol() marks the end of a connection/stream. The 'closeit'

--- a/lib/curl_endian.c
+++ b/lib/curl_endian.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -82,7 +82,7 @@ unsigned short Curl_read16_be(const unsigned char *buf)
 }
 
 /*
- * Curl_write32_le()
+ * write32_le()
  *
  * This function converts a 32-bit integer from the native endian format,
  * to little endian format ready for sending down the wire.
@@ -92,7 +92,7 @@ unsigned short Curl_read16_be(const unsigned char *buf)
  * value    [in]     - The 32-bit integer value.
  * buffer   [in]     - A pointer to the output buffer.
  */
-void Curl_write32_le(const int value, unsigned char *buffer)
+static void write32_le(const int value, unsigned char *buffer)
 {
   buffer[0] = (char)(value & 0x000000FF);
   buffer[1] = (char)((value & 0x0000FF00) >> 8);
@@ -118,7 +118,7 @@ void Curl_write64_le(const long long value, unsigned char *buffer)
 void Curl_write64_le(const __int64 value, unsigned char *buffer)
 #endif
 {
-  Curl_write32_le((int)value, buffer);
-  Curl_write32_le((int)(value >> 32), buffer + 4);
+  write32_le((int)value, buffer);
+  write32_le((int)(value >> 32), buffer + 4);
 }
 #endif /* CURL_SIZEOF_CURL_OFF_T > 4 */

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -621,9 +621,9 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
 #if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
 
 /* This returns the HMAC MD5 digest */
-CURLcode Curl_hmac_md5(const unsigned char *key, unsigned int keylen,
-                       const unsigned char *data, unsigned int datalen,
-                       unsigned char *output)
+static CURLcode hmac_md5(const unsigned char *key, unsigned int keylen,
+                         const unsigned char *data, unsigned int datalen,
+                         unsigned char *output)
 {
   HMAC_context *ctxt = Curl_HMAC_init(Curl_HMAC_MD5, key, keylen);
 
@@ -668,9 +668,8 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_hash(const char *user, size_t userlen,
   ascii_uppercase_to_unicode_le(identity, user, userlen);
   ascii_to_unicode_le(identity + (userlen << 1), domain, domlen);
 
-  result = Curl_hmac_md5(ntlmhash, 16, identity, curlx_uztoui(identity_len),
-                         ntlmv2hash);
-
+  result = hmac_md5(ntlmhash, 16, identity, curlx_uztoui(identity_len),
+                    ntlmv2hash);
   free(identity);
 
   return result;
@@ -756,8 +755,8 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
 
   /* Concatenate the Type 2 challenge with the BLOB and do HMAC MD5 */
   memcpy(ptr + 8, &ntlm->nonce[0], 8);
-  result = Curl_hmac_md5(ntlmv2hash, NTLM_HMAC_MD5_LEN, ptr + 8,
-                         NTLMv2_BLOB_LEN + 8, hmac_output);
+  result = hmac_md5(ntlmv2hash, NTLM_HMAC_MD5_LEN, ptr + 8,
+                    NTLMv2_BLOB_LEN + 8, hmac_output);
   if(result) {
     free(ptr);
     return result;
@@ -799,7 +798,7 @@ CURLcode  Curl_ntlm_core_mk_lmv2_resp(unsigned char *ntlmv2hash,
   memcpy(&data[0], challenge_server, 8);
   memcpy(&data[8], challenge_client, 8);
 
-  result = Curl_hmac_md5(ntlmv2hash, 16, &data[0], 16, hmac_output);
+  result = hmac_md5(ntlmv2hash, 16, &data[0], 16, hmac_output);
   if(result)
     return result;
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -814,6 +814,12 @@ endings either CRLF or LF so 't' is appropriate.
 struct passwd;
 int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
                size_t buflen, struct passwd **result);
+#endif
+
+#ifdef DEBUGBUILD
+#define UNITTEST
+#else
+#define UNITTEST static
 #endif
 
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -388,6 +388,9 @@ Curl_fetch_addr(struct connectdata *conn,
   return dns;
 }
 
+UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
+                                    Curl_addrinfo **addr);
+
 /*
  * Curl_shuffle_addr() shuffles the order of addresses in a 'Curl_addrinfo'
  * struct by re-linking its linked list.
@@ -400,7 +403,8 @@ Curl_fetch_addr(struct connectdata *conn,
  *
  * @unittest: 1608
  */
-CURLcode Curl_shuffle_addr(struct Curl_easy *data, Curl_addrinfo **addr)
+UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
+                                    Curl_addrinfo **addr)
 {
   CURLcode result = CURLE_OK;
   const int num_addrs = Curl_num_addresses(*addr);

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -177,16 +177,6 @@ struct Curl_dns_entry *
 Curl_fetch_addr(struct connectdata *conn,
                 const char *hostname,
                 int port);
-
-/*
- * Curl_shuffle_addr() shuffles the order of addresses in a 'Curl_addrinfo'
- * struct by re-linking its linked list.
- *
- * The addr argument should be the address of a pointer to the head node of a
- * `Curl_addrinfo` list and it will be modified to point to the new head after
- * shuffling.
- */
-CURLcode Curl_shuffle_addr(struct Curl_easy *data, Curl_addrinfo **addr);
 
 /*
  * Curl_cache_addr() stores a 'Curl_addrinfo' struct in the DNS cache.

--- a/lib/http.c
+++ b/lib/http.c
@@ -102,13 +102,14 @@ static int https_getsock(struct connectdata *conn,
 #else
 #define https_connecting(x,y) CURLE_COULDNT_CONNECT
 #endif
+static CURLcode http_setup_conn(struct connectdata *conn);
 
 /*
  * HTTP handler interface.
  */
 const struct Curl_handler Curl_handler_http = {
   "HTTP",                               /* scheme */
-  Curl_http_setup_conn,                 /* setup_connection */
+  http_setup_conn,                      /* setup_connection */
   Curl_http,                            /* do_it */
   Curl_http_done,                       /* done */
   ZERO_NULL,                            /* do_more */
@@ -133,7 +134,7 @@ const struct Curl_handler Curl_handler_http = {
  */
 const struct Curl_handler Curl_handler_https = {
   "HTTPS",                              /* scheme */
-  Curl_http_setup_conn,                 /* setup_connection */
+  http_setup_conn,                      /* setup_connection */
   Curl_http,                            /* do_it */
   Curl_http_done,                       /* done */
   ZERO_NULL,                            /* do_more */
@@ -153,7 +154,7 @@ const struct Curl_handler Curl_handler_https = {
 };
 #endif
 
-CURLcode Curl_http_setup_conn(struct connectdata *conn)
+static CURLcode http_setup_conn(struct connectdata *conn)
 {
   /* allocate the HTTP-specific struct for the Curl_easy, only to survive
      during this request */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -357,7 +357,7 @@ int Curl_http2_ver(char *p, size_t len)
 https://tools.ietf.org/html/rfc7540#page-77
 nghttp2_error_code enums are identical.
 */
-const char *Curl_http2_strerror(uint32_t err)
+static const char *http2_strerror(uint32_t err)
 {
 #ifndef NGHTTP2_HAS_HTTP2_STRERROR
   const char *str[] = {
@@ -837,7 +837,7 @@ static int on_stream_close(nghttp2_session *session, int32_t stream_id,
       return 0;
     }
     H2BUGF(infof(data_s, "on_stream_close(), %s (err %d), stream %u\n",
-                 Curl_http2_strerror(error_code), error_code, stream_id));
+                 http2_strerror(error_code), error_code, stream_id));
     stream = data_s->req.protop;
     if(!stream)
       return NGHTTP2_ERR_CALLBACK_FAILURE;
@@ -1197,7 +1197,7 @@ void Curl_http2_done(struct connectdata *conn, bool premature)
 /*
  * Initialize nghttp2 for a Curl connection
  */
-CURLcode Curl_http2_init(struct connectdata *conn)
+static CURLcode http2_init(struct connectdata *conn)
 {
   if(!conn->proto.httpc.h2) {
     int rc;
@@ -1431,7 +1431,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
   }
   else if(httpc->error_code != NGHTTP2_NO_ERROR) {
     failf(data, "HTTP/2 stream %d was not closed cleanly: %s (err %u)",
-          stream->stream_id, Curl_http2_strerror(httpc->error_code),
+          stream->stream_id, http2_strerror(httpc->error_code),
           httpc->error_code);
     *err = CURLE_HTTP2_STREAM;
     return -1;
@@ -2141,7 +2141,7 @@ CURLcode Curl_http2_setup(struct connectdata *conn)
   else
     conn->handler = &Curl_handler_http2;
 
-  result = Curl_http2_init(conn);
+  result = http2_init(conn);
   if(result) {
     Curl_add_buffer_free(&stream->header_recvbuf);
     return result;

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -63,7 +63,6 @@ void Curl_http2_cleanup_dependencies(struct Curl_easy *data);
 /* returns true if the HTTP/2 stream error was HTTP_1_1_REQUIRED */
 bool Curl_h2_http_1_1_error(struct connectdata *conn);
 #else /* USE_NGHTTP2 */
-#define Curl_http2_init(x) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_send_request(x) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_request_upgrade(x,y) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_setup(x) CURLE_UNSUPPORTED_PROTOCOL

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -426,7 +426,7 @@ curl_socket_t curl_accept(curl_socket_t s, void *saddr, void *saddrlen,
 }
 
 /* separate function to allow libcurl to mark a "faked" close */
-void curl_mark_sclose(curl_socket_t sockfd, int line, const char *source)
+static void mark_sclose(curl_socket_t sockfd, int line, const char *source)
 {
   const char *fmt = (sizeof(curl_socket_t) == sizeof(int)) ?
     "FD %s:%d sclose(%d)\n":
@@ -442,7 +442,7 @@ void curl_mark_sclose(curl_socket_t sockfd, int line, const char *source)
 int curl_sclose(curl_socket_t sockfd, int line, const char *source)
 {
   int res = sclose(sockfd);
-  curl_mark_sclose(sockfd, line, source);
+  mark_sclose(sockfd, line, source);
   return res;
 }
 
@@ -457,20 +457,6 @@ FILE *curl_fopen(const char *file, const char *mode,
 
   return res;
 }
-
-#ifdef HAVE_FDOPEN
-FILE *curl_fdopen(int filedes, const char *mode,
-                  int line, const char *source)
-{
-  FILE *res = fdopen(filedes, mode);
-
-  if(source)
-    curl_memlog("FILE %s:%d fdopen(\"%d\",\"%s\") = %p\n",
-                source, line, filedes, mode, (void *)res);
-
-  return res;
-}
-#endif
 
 int curl_fclose(FILE *file, int line, const char *source)
 {

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -80,8 +80,6 @@ static CURLcode rtsp_rtp_readwrite(struct Curl_easy *data,
                                    bool *readmore);
 
 static CURLcode rtsp_setup_connection(struct connectdata *conn);
-
-bool rtsp_connisdead(struct connectdata *check);
 static unsigned int rtsp_conncheck(struct connectdata *check,
                                    unsigned int checks_to_perform);
 
@@ -147,7 +145,7 @@ static CURLcode rtsp_setup_connection(struct connectdata *conn)
  * Instead, if it is readable, run Curl_connalive() to peek at the socket
  * and distinguish between closed and data.
  */
-bool rtsp_connisdead(struct connectdata *check)
+static bool rtsp_connisdead(struct connectdata *check)
 {
   int sval;
   bool ret_val = TRUE;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -111,8 +111,8 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
 #define C_SSLVERSION_VALUE(x) (x & 0xffff)
 #define C_SSLVERSION_MAX_VALUE(x) (x & 0xffff0000)
 
-CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
-                      va_list param)
+static CURLcode vsetopt(struct Curl_easy *data, CURLoption option,
+                        va_list param)
 {
   char *argptr;
   CURLcode result = CURLE_OK;
@@ -2679,7 +2679,7 @@ CURLcode curl_easy_setopt(struct Curl_easy *data, CURLoption tag, ...)
 
   va_start(arg, tag);
 
-  result = Curl_vsetopt(data, tag, arg);
+  result = vsetopt(data, tag, arg);
 
   va_end(arg);
   return result;

--- a/lib/url.c
+++ b/lib/url.c
@@ -292,7 +292,7 @@ void Curl_freeset(struct Curl_easy *data)
 }
 
 /* free the URL pieces */
-void Curl_up_free(struct Curl_easy *data)
+static void up_free(struct Curl_easy *data)
 {
   struct urlpieces *up = &data->state.up;
   Curl_safefree(up->scheme);
@@ -369,7 +369,7 @@ CURLcode Curl_close(struct Curl_easy *data)
   }
   data->change.referer = NULL;
 
-  Curl_up_free(data);
+  up_free(data);
   Curl_safefree(data->state.buffer);
   Curl_safefree(data->state.headerbuff);
   Curl_safefree(data->state.ulbuf);
@@ -2019,7 +2019,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   CURLUcode uc;
   char *hostname;
 
-  Curl_up_free(data); /* cleanup previous leftovers first */
+  up_free(data); /* cleanup previous leftovers first */
 
   /* parse the URL */
   if(data->set.uh) {

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -67,12 +67,6 @@ struct Curl_URL {
 
 #define DEFAULT_SCHEME "https"
 
-#ifdef DEBUGBUILD
-#define UNITTEST
-#else
-#define UNITTEST static
-#endif
-
 static void free_urlhandle(struct Curl_URL *u)
 {
   free(u->scheme);
@@ -141,7 +135,7 @@ static bool urlchar_needs_escaping(int c)
  * URL encoding should be skipped for host names, otherwise IDN resolution
  * will fail.
  */
-size_t Curl_strlen_url(const char *url, bool relative)
+static size_t strlen_url(const char *url, bool relative)
 {
   const unsigned char *ptr;
   size_t newlen = 0;
@@ -183,7 +177,7 @@ size_t Curl_strlen_url(const char *url, bool relative)
  * URL encoding should be skipped for host names, otherwise IDN resolution
  * will fail.
  */
-void Curl_strcpy_url(char *output, const char *url, bool relative)
+static void strcpy_url(char *output, const char *url, bool relative)
 {
   /* we must add this with whitespace-replacing */
   bool left = TRUE;
@@ -268,7 +262,7 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
  * The returned pointer must be freed by the caller unless NULL
  * (returns NULL on out of memory).
  */
-char *Curl_concat_url(const char *base, const char *relurl)
+static char *concat_url(const char *base, const char *relurl)
 {
   /***
    TRY to append this new path to the old URL
@@ -392,7 +386,7 @@ char *Curl_concat_url(const char *base, const char *relurl)
      letter we replace each space with %20 while it is replaced with '+'
      on the right side of the '?' letter.
   */
-  newlen = Curl_strlen_url(useurl, !host_changed);
+  newlen = strlen_url(useurl, !host_changed);
 
   urllen = strlen(url_clone);
 
@@ -414,7 +408,7 @@ char *Curl_concat_url(const char *base, const char *relurl)
     newest[urllen++]='/';
 
   /* then append the new piece on the right side */
-  Curl_strcpy_url(&newest[urllen], useurl, !host_changed);
+  strcpy_url(&newest[urllen], useurl, !host_changed);
 
   free(url_clone);
 
@@ -1252,7 +1246,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     }
 
     /* apply the relative part to create a new URL */
-    redired_url = Curl_concat_url(oldurl, part);
+    redired_url = concat_url(oldurl, part);
     free(oldurl);
     if(!redired_url)
       return CURLUE_OUT_OF_MEMORY;

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -394,44 +394,6 @@ unsigned short curlx_uitous(unsigned int uinum)
 
   DEBUGASSERT(uinum <= (unsigned int) CURL_MASK_USHORT);
   return (unsigned short) (uinum & (unsigned int) CURL_MASK_USHORT);
-
-#ifdef __INTEL_COMPILER
-#  pragma warning(pop)
-#endif
-}
-
-/*
-** unsigned int to unsigned char
-*/
-
-unsigned char curlx_uitouc(unsigned int uinum)
-{
-#ifdef __INTEL_COMPILER
-#  pragma warning(push)
-#  pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
-  DEBUGASSERT(uinum <= (unsigned int) CURL_MASK_UCHAR);
-  return (unsigned char) (uinum & (unsigned int) CURL_MASK_UCHAR);
-
-#ifdef __INTEL_COMPILER
-#  pragma warning(pop)
-#endif
-}
-
-/*
-** unsigned int to signed int
-*/
-
-int curlx_uitosi(unsigned int uinum)
-{
-#ifdef __INTEL_COMPILER
-#  pragma warning(push)
-#  pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
-  DEBUGASSERT(uinum <= (unsigned int) CURL_MASK_SINT);
-  return (int) (uinum & (unsigned int) CURL_MASK_SINT);
 
 #ifdef __INTEL_COMPILER
 #  pragma warning(pop)

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -56,10 +56,6 @@ size_t curlx_sotouz(curl_off_t sonum);
 int curlx_sztosi(ssize_t sznum);
 
 unsigned short curlx_uitous(unsigned int uinum);
-
-unsigned char curlx_uitouc(unsigned int uinum);
-
-int curlx_uitosi(unsigned int uinum);
 
 size_t curlx_sitouz(int sinum);
 

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -1,0 +1,223 @@
+#!/usr/bin/perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.haxx.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+###########################################################################
+#
+# This script is aimed to help scan for and detect globally declared functions
+# that are not used from other source files.
+#
+# Use it like this:
+#
+# $ ./scripts/singleuse.pl lib/.libs/libcurl.a
+#
+# Be aware that it might cause false positives due to various build options.
+#
+
+my $file = $ARGV[0];
+
+my %wl = (
+    'Curl_none_cert_status_request' => 'multiple TLS backends',
+    'Curl_none_check_cxn' => 'multiple TLS backends',
+    'Curl_none_cleanup' => 'multiple TLS backends',
+    'Curl_none_close_all' => 'multiple TLS backends',
+    'Curl_none_data_pending' => 'multiple TLS backends',
+    'Curl_none_engines_list' => 'multiple TLS backends',
+    'Curl_none_init' => 'multiple TLS backends',
+    'Curl_none_md5sum' => 'multiple TLS backends',
+    'Curl_none_random' => 'multiple TLS backends',
+    'Curl_none_session_free' => 'multiple TLS backends',
+    'Curl_none_set_engine' => 'multiple TLS backends',
+    'Curl_none_set_engine_default' => 'multiple TLS backends',
+    'Curl_none_shutdown' => 'multiple TLS backends',
+    'Curl_multi_dump' => 'debug build only',
+    'Curl_parse_port' => 'UNITTEST',
+    'Curl_shuffle_addr' => 'UNITTEST',
+    'de_cleanup' => 'UNITTEST',
+    'doh_decode' => 'UNITTEST',
+    'doh_encode' => 'UNITTEST',
+    'Curl_auth_digest_get_pair' => 'by digest_sspi',
+    'curlx_uztoso' => 'cmdline tool use',
+    'curlx_uztoul' => 'by krb5_sspi',
+    'curlx_uitous' => 'by schannel',
+    'Curl_islower' => 'by curl_fnmatch',
+    'getaddressinfo' => 'UNITTEST',
+    );
+
+my %api = (
+    'curl_easy_cleanup' => 'API',
+    'curl_easy_duphandle' => 'API',
+    'curl_easy_escape' => 'API',
+    'curl_easy_getinfo' => 'API',
+    'curl_easy_init' => 'API',
+    'curl_easy_pause' => 'API',
+    'curl_easy_perform' => 'API',
+    'curl_easy_recv' => 'API',
+    'curl_easy_reset' => 'API',
+    'curl_easy_send' => 'API',
+    'curl_easy_setopt' => 'API',
+    'curl_easy_strerror' => 'API',
+    'curl_easy_unescape' => 'API',
+    'curl_easy_upkeep' => 'API',
+    'curl_escape' => 'API',
+    'curl_formadd' => 'API',
+    'curl_formfree' => 'API',
+    'curl_formget' => 'API',
+    'curl_free' => 'API',
+    'curl_getdate' => 'API',
+    'curl_getenv' => 'API',
+    'curl_global_cleanup' => 'API',
+    'curl_global_init' => 'API',
+    'curl_global_init_mem' => 'API',
+    'curl_global_sslset' => 'API',
+    'curl_maprintf' => 'API',
+    'curl_mfprintf' => 'API',
+    'curl_mime_addpart' => 'API',
+    'curl_mime_data' => 'API',
+    'curl_mime_data_cb' => 'API',
+    'curl_mime_encoder' => 'API',
+    'curl_mime_filedata' => 'API',
+    'curl_mime_filename' => 'API',
+    'curl_mime_free' => 'API',
+    'curl_mime_headers' => 'API',
+    'curl_mime_init' => 'API',
+    'curl_mime_name' => 'API',
+    'curl_mime_subparts' => 'API',
+    'curl_mime_type' => 'API',
+    'curl_mprintf' => 'API',
+    'curl_msnprintf' => 'API',
+    'curl_msprintf' => 'API',
+    'curl_multi_add_handle' => 'API',
+    'curl_multi_assign' => 'API',
+    'curl_multi_cleanup' => 'API',
+    'curl_multi_fdset' => 'API',
+    'curl_multi_info_read' => 'API',
+    'curl_multi_init' => 'API',
+    'curl_multi_perform' => 'API',
+    'curl_multi_remove_handle' => 'API',
+    'curl_multi_setopt' => 'API',
+    'curl_multi_socket' => 'API',
+    'curl_multi_socket_action' => 'API',
+    'curl_multi_socket_all' => 'API',
+    'curl_multi_strerror' => 'API',
+    'curl_multi_timeout' => 'API',
+    'curl_multi_wait' => 'API',
+    'curl_mvaprintf' => 'API',
+    'curl_mvfprintf' => 'API',
+    'curl_mvprintf' => 'API',
+    'curl_mvsnprintf' => 'API',
+    'curl_mvsprintf' => 'API',
+    'curl_pushheader_byname' => 'API',
+    'curl_pushheader_bynum' => 'API',
+    'curl_share_cleanup' => 'API',
+    'curl_share_init' => 'API',
+    'curl_share_setopt' => 'API',
+    'curl_share_strerror' => 'API',
+    'curl_slist_append' => 'API',
+    'curl_slist_free_all' => 'API',
+    'curl_strequal' => 'API',
+    'curl_strnequal' => 'API',
+    'curl_unescape' => 'API',
+    'curl_url' => 'API',
+    'curl_url_cleanup' => 'API',
+    'curl_url_dup' => 'API',
+    'curl_url_get' => 'API',
+    'curl_url_set' => 'API',
+    'curl_version' => 'API',
+    'curl_version_info' => 'API',
+
+    # the following funcions are provided globally in debug builds
+    'curl_easy_perform_ev' => 'debug-build',
+    'curl_memdebug' => 'debug-build',
+    'curl_memlimit' => 'debug-build',
+    'curl_memlog' => 'debug-build',
+    'curl_accept' => 'debug-build',
+    'curl_docalloc' => 'debug-build',
+    'curl_dofree' => 'debug-build',
+    'curl_domalloc' => 'debug-build',
+    'curl_dorealloc' => 'debug-build',
+    'curl_dorecv' => 'debug-build',
+    'curl_dosend' => 'debug-build',
+    'curl_dostrdup' => 'debug-build',
+    'curl_fclose' => 'debug-build',
+    'curl_fopen' => 'debug-build',
+    'curl_sclose' => 'debug-build',
+    'curl_socket' => 'debug-build',
+    'curl_socketpair' => 'debug-build',
+    );
+
+open(N, "nm $file|") ||
+    die;
+
+my %exist;
+my %uses;
+my $file;
+while (<N>) {
+    my $l = $_;
+    chomp $l;
+
+    if($l =~ /^([0-9a-z_-]+)\.o:/) {
+        $file = $1;
+    }
+    if($l =~ /^([0-9a-f]+) T (.*)/) {
+        my ($name)=($2);
+        #print "Define $name in $file\n";
+        $file =~ s/^libcurl_la-//;
+        $exist{$name} = $file;
+    }
+    elsif($l =~ /^                 U (.*)/) {
+        my ($name)=($1);
+        #print "Uses $name in $file\n";
+        $uses{$name} .= "$file, ";
+    }
+}
+close(N);
+
+my $err;
+for(sort keys %exist) {
+    #printf "%s is defined in %s, used by: %s\n", $_, $exist{$_}, $uses{$_};
+    if(!$uses{$_}) {
+        # this is a symbol with no "global" user
+        if($_ =~ /^curl_/) {
+            if(!$api{$_}) {
+                # not present in the API, or for debug-builds
+                print STDERR "Bad curl-prefix: $_\n";
+                $err++;
+            }
+        }
+        elsif($wl{$_}) {
+            #print "$_ is WL\n";
+        }
+        else {
+            printf "%s is defined in %s, but not used outside\n", $_, $exist{$_};
+            $err++;
+        }
+    }
+    elsif($_ =~ /^curl_/) {
+        # global prefix, make sure it is "blessed"
+        if(!$api{$_}) {
+            # not present in the API, or for debug-builds
+            print STDERR "Bad curl-prefix $_\n";
+            $err++;
+        }
+    }
+}
+
+exit $err;

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -24,6 +24,10 @@
 #include "urldata.h"
 #include "connect.h"
 #include "share.h"
+
+/* retrieves ip address and port from a sockaddr structure.
+   note it calls Curl_inet_ntop which sets errno on fail, not SOCKERRNO. */
+bool getaddressinfo(struct sockaddr *sa, char *addr, long *port);
 
 #include "memdebug.h" /* LAST include file */
 
@@ -159,8 +163,8 @@ UNITTEST_START
       if(tests[i].address[j] == &skip)
         continue;
 
-      if(addr && !Curl_getaddressinfo(addr->ai_addr,
-                                      ipaddress, &port)) {
+      if(addr && !getaddressinfo(addr->ai_addr,
+                                 ipaddress, &port)) {
         fprintf(stderr, "%s:%d tests[%d] failed. getaddressinfo failed.\n",
                 __FILE__, __LINE__, i);
         problem = true;

--- a/tests/unit/unit1608.c
+++ b/tests/unit/unit1608.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,6 +22,9 @@
 #include "curlcheck.h"
 
 #include "hostip.h"
+
+CURLcode Curl_shuffle_addr(struct Curl_easy *data,
+                           Curl_addrinfo **addr);
 
 #define NUM_ADDRS 8
 static struct Curl_addrinfo addrs[NUM_ADDRS];

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -24,6 +24,10 @@
 #include "urldata.h"
 #include "connect.h"
 #include "share.h"
+
+/* retrieves ip address and port from a sockaddr structure.
+   note it calls Curl_inet_ntop which sets errno on fail, not SOCKERRNO. */
+bool getaddressinfo(struct sockaddr *sa, char *addr, long *port);
 
 #include "memdebug.h" /* LAST include file */
 
@@ -158,8 +162,8 @@ UNITTEST_START
       if(!addr && !tests[i].address[j])
         break;
 
-      if(addr && !Curl_getaddressinfo(addr->ai_addr,
-                                      ipaddress, &port)) {
+      if(addr && !getaddressinfo(addr->ai_addr,
+                                 ipaddress, &port)) {
         fprintf(stderr, "%s:%d tests[%d] failed. getaddressinfo failed.\n",
                 __FILE__, __LINE__, i);
         problem = true;


### PR DESCRIPTION
Here's a script to

1. detect global functions within the library that are not used outside the single function where it is defined and
2. detect functions using the `curl_` - prefix without being part of the public API

... and the associated changes to a bunch of files to cleanup all issues the script detected. I'll subsequently have a go and see if I can add the script to one or more of the travis builds to make sure we detect these mistakes/optimizations before they land.

(I intend so squash all these into a single commit for the changes and one for the script before merging)