### PR TITLE
urlapi: reduce variable scope, remove unreachable 'break'

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -574,15 +574,15 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname)
 /* scan for byte values < 31 or 127 */
 static CURLUcode junkscan(char *part)
 {
-  char badbytes[]={
-    /* */ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
-    0x7f,
-    0x00 /* zero terminate */
-  };
   if(part) {
+    static const char badbytes[]={
+      /* */ 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+      0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+      0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+      0x7f,
+      0x00 /* zero terminate */
+    };
     size_t n = strlen(part);
     size_t nfine = strcspn(part, badbytes);
     if(nfine != n)
@@ -1083,10 +1083,10 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
       return CURLUE_OUT_OF_MEMORY;
     *part = url;
     return CURLUE_OK;
-    break;
   }
   default:
     ptr = NULL;
+    break;
   }
   if(ptr) {
     *part = strdup(ptr);


### PR DESCRIPTION
Both nits pointed out by codacy.com