### PR TITLE
pretransfer: don't strlen() POSTFIELDS set for GET requests

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1526,7 +1526,8 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 
   if(data->set.httpreq == HTTPREQ_PUT)
     data->state.infilesize = data->set.filesize;
-  else {
+  else if((data->set.httpreq != HTTPREQ_GET) &&
+          (data->set.httpreq != HTTPREQ_HEAD)) {
     data->state.infilesize = data->set.postfieldsize;
     if(data->set.postfields && (data->state.infilesize == -1))
       data->state.infilesize = (curl_off_t)strlen(data->set.postfields);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1532,6 +1532,8 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     if(data->set.postfields && (data->state.infilesize == -1))
       data->state.infilesize = (curl_off_t)strlen(data->set.postfields);
   }
+  else
+    data->state.infilesize = 0;
 
   /* If there is a list of cookie files to read, do it now! */
   if(data->change.cookielist)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1150,7 +1150,6 @@ typedef enum {
   HTTPREQ_PUT,
   HTTPREQ_HEAD,
   HTTPREQ_OPTIONS,
-  HTTPREQ_CUSTOM,
   HTTPREQ_LAST /* last in list */
 } Curl_HttpReq;
 


### PR DESCRIPTION
... since that data won't be used in the request anyway.

Fixes #3548
Reported-by: Renaud Allard