### PR TITLE
curl: follow-up to 3f16990ec84

### DIFF
--- a/src/tool_xattr.c
+++ b/src/tool_xattr.c
@@ -116,7 +116,7 @@ int fwrite_xattr(CURL *curl, int fd)
                                       mappings[i].attr, value, strlen(value));
           /* FreeBSD's extattr_set_fd returns the length of the extended
              attribute */
-          err = (rc < 0 : -1 : 0);
+          err = (rc < 0 ? -1 : 0);
         }
 #endif
         if(freeptr)


### PR DESCRIPTION
Commit 3f16990ec84cc4b followed-up a bug in b49652ac66cc0 but was inadvertently introducing a new bug in the ternary expression.