### PR TITLE
Fix a gcc -Werror=maybe-uninitialized warning in LTO mode.

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -543,7 +543,7 @@ int Curl_resolv(struct connectdata *conn,
     /* The entry was not in the cache. Resolve it to IP address */
 
     Curl_addrinfo *addr;
-    int respwait;
+    int respwait = 0;
 
     /* Check what IP specifics the app has requested and if we can provide it.
      * If not, bail out. */


### PR DESCRIPTION
Hi,

We have a gcc warning (error in our case since we use -Werror) when building some of our own code in LTO (link time optimisation) mode + statically linking curl which was also built with LTO mode. In practice, gcc will try at link time to optimize the whole program (so our own code + the curl code) in one go.

When doing that, with flags -Werror -Wall -Wextra, we get this warning (error):
```
hostip.c: In function ‘Curl_resolv’:
hostip.c:585:9: error: ‘respwait’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
hostip.c:551:9: note: ‘respwait’ was declared here
```

I checked the code, and this definitely looks like a false positive (gcc generates quite often false positives with -Wmaybe-uninitialized which is implied by -Wall/-Wextra). I propose to silence the false positive by actually initializing the value even if it's useless. If that does not fly for you, we might consider another fix which is adding a pragma diagnostic to actually ignore this warning, that's up to you.

Cheers,
Romain