### PR TITLE
travis: add scan-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,6 +149,10 @@ matrix:
         - os: linux
           compiler: clang
           dist: trusty
+          env: T=scan-build
+        - os: linux
+          compiler: clang
+          dist: trusty
           env: T=debug CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g" LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer" LIBS="-ldl -lubsan"
 
 install:
@@ -403,6 +407,11 @@ script:
           pushd /tmp/curl_fuzzer
           ./mainline.sh ${CURLSRC}
           popd
+        fi
+    - |
+        if [ "$T" = "scan-build" ]; then
+             scan-build ./configure --enable-debug --enable-werror $C
+             scan-build --status-bugs make && scan-build --status-bugs make examples
         fi
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)

--- a/docs/examples/ftpget.c
+++ b/docs/examples/ftpget.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -36,7 +36,7 @@ struct FtpFile {
 static size_t my_fwrite(void *buffer, size_t size, size_t nmemb, void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
-  if(out && !out->stream) {
+  if(!out->stream) {
     /* open file for writing */
     out->stream = fopen(out->filename, "wb");
     if(!out->stream)

--- a/docs/examples/ftpsget.c
+++ b/docs/examples/ftpsget.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -38,7 +38,7 @@ static size_t my_fwrite(void *buffer, size_t size, size_t nmemb,
                         void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
-  if(out && !out->stream) {
+  if(!out->stream) {
     /* open file for writing */
     out->stream = fopen(out->filename, "wb");
     if(!out->stream)

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -41,22 +41,13 @@
 #define CURLPIPE_MULTIPLEX 0
 #endif
 
+struct transfer {
+  CURL *easy;
+  unsigned int num;
+  FILE *out;
+};
+
 #define NUM_HANDLES 1000
-
-static void *curl_hnd[NUM_HANDLES];
-static int num_transfers;
-
-/* a handle to number lookup, highly ineffective when we do many
-   transfers... */
-static int hnd2num(CURL *hnd)
-{
-  int i;
-  for(i = 0; i< num_transfers; i++) {
-    if(curl_hnd[i] == hnd)
-      return i;
-  }
-  return 0; /* weird, but just a fail-safe */
-}
 
 static
 void dump(const char *text, int num, unsigned char *ptr, size_t size,
@@ -113,9 +104,10 @@ int my_trace(CURL *handle, curl_infotype type,
              void *userp)
 {
   const char *text;
-  int num = hnd2num(handle);
+  struct transfer *t = (struct transfer *)userp;
+  unsigned int num = t->num;
   (void)handle; /* prevent compiler warning */
-  (void)userp;
+
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== %d Info: %s", num, data);
@@ -147,17 +139,19 @@ int my_trace(CURL *handle, curl_infotype type,
   return 0;
 }
 
-static void setup(CURL *hnd, int num)
+static void setup(struct transfer *t, int num)
 {
-  FILE *out;
   char filename[128];
+  CURL *hnd;
+
+  hnd = t->easy = curl_easy_init();
 
   snprintf(filename, 128, "dl-%d", num);
 
-  out = fopen(filename, "wb");
+  t->out = fopen(filename, "wb");
 
   /* write to this file */
-  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, out);
+  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, t->out);
 
   /* set the same URL */
   curl_easy_setopt(hnd, CURLOPT_URL, "https://localhost:8443/index.html");
@@ -165,6 +159,7 @@ static void setup(CURL *hnd, int num)
   /* please be verbose */
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_DEBUGFUNCTION, my_trace);
+  curl_easy_setopt(hnd, CURLOPT_DEBUGDATA, t);
 
   /* HTTP/2 please */
   curl_easy_setopt(hnd, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
@@ -177,37 +172,35 @@ static void setup(CURL *hnd, int num)
   /* wait for pipe connection to confirm */
   curl_easy_setopt(hnd, CURLOPT_PIPEWAIT, 1L);
 #endif
-
-  curl_hnd[num] = hnd;
 }
 
 /*
- * Simply download two files over HTTP/2, using the same physical connection!
+ * Download many transfers over HTTP/2, using the same connection!
  */
 int main(int argc, char **argv)
 {
-  CURL *easy[NUM_HANDLES];
+  struct transfer trans[NUM_HANDLES];
   CURLM *multi_handle;
   int i;
   int still_running = 0; /* keep number of running handles */
-
-  if(argc > 1)
+  int num_transfers;
+  if(argc > 1) {
     /* if given a number, do that many transfers */
     num_transfers = atoi(argv[1]);
-
-  if(!num_transfers || (num_transfers > NUM_HANDLES))
-    num_transfers = 3; /* a suitable low default */
+    if((num_transfers < 1) || (num_transfers > NUM_HANDLES))
+      num_transfers = 3; /* a suitable low default */
+  }
+  else
+    num_transfers = 3; /* suitable default */
 
   /* init a multi stack */
   multi_handle = curl_multi_init();
 
-  for(i = 0; i<num_transfers; i++) {
-    easy[i] = curl_easy_init();
-    /* set options */
-    setup(easy[i], i);
+  for(i = 0; i < num_transfers; i++) {
+    setup(&trans[i], i);
 
     /* add the individual transfer */
-    curl_multi_add_handle(multi_handle, easy[i]);
+    curl_multi_add_handle(multi_handle, trans[i].easy);
   }
 
   curl_multi_setopt(multi_handle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
@@ -286,10 +279,12 @@ int main(int argc, char **argv)
     }
   }
 
-  curl_multi_cleanup(multi_handle);
+  for(i = 0; i < num_transfers; i++) {
+    curl_multi_remove_handle(multi_handle, trans[i].easy);
+    curl_easy_cleanup(trans[i].easy);
+  }
 
-  for(i = 0; i<num_transfers; i++)
-    curl_easy_cleanup(easy[i]);
+  curl_multi_cleanup(multi_handle);
 
   return 0;
 }

--- a/docs/examples/httpcustomheader.c
+++ b/docs/examples/httpcustomheader.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,7 +49,7 @@ int main(void)
     chunk = curl_slist_append(chunk, "X-silly-header;");
 
     /* set our custom set of headers */
-    res = curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
 
     curl_easy_setopt(curl, CURLOPT_URL, "localhost");
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -67,7 +67,6 @@ int main(void)
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   if(curl) {
-
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.org/");
 
     /* send all data to this function  */
@@ -106,10 +105,9 @@ int main(void)
     /* always cleanup */
     curl_easy_cleanup(curl);
 
-    free(chunk.memory);
-
     /* we're done with libcurl, so clean it up */
     curl_global_cleanup();
   }
+  free(chunk.memory);
   return 0;
 }

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -47,7 +47,7 @@ static size_t my_fwrite(void *buffer, size_t size, size_t nmemb,
                         void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
-  if(out && !out->stream) {
+  if(!out->stream) {
     /* open file for writing */
     out->stream = fopen(out->filename, "wb");
     if(!out->stream)

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -65,6 +65,8 @@ static curl_off_t sftpGetRemoteFileSize(const char *i_remoteFile)
     result = curl_easy_getinfo(curlHandlePtr,
                                CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                                &remoteFileSizeByte);
+    if(result)
+      return -1;
     printf("filesize: %" CURL_FORMAT_CURL_OFF_T "\n", remoteFileSizeByte);
   }
   curl_easy_cleanup(curlHandlePtr);

--- a/lib/url.c
+++ b/lib/url.c
@@ -1685,6 +1685,8 @@ static bool is_ASCII_name(const char *hostname)
 static void strip_trailing_dot(struct hostname *host)
 {
   size_t len;
+  if(!host || !host->name)
+    return;
   len = strlen(host->name);
   if(len && (host->name[len-1] == '.'))
     host->name[len-1] = 0;


### PR DESCRIPTION
Here's a new take at adding a scan-build run to travis. scan-build generally have the downside that it is very annoying when it happens to trigger false positives. But it does point out flaws every now and then and clearly the tidy target is not as picky.