### PR TITLE
unit1307: require FTP support

### DIFF
--- a/tests/data/test1307
+++ b/tests/data/test1307
@@ -15,6 +15,7 @@ none
 </server>
 <features>
 unittest
+ftp
 </features>
  <name>
 internal Curl_fnmatch() testing


### PR DESCRIPTION
This test doesn't link after fc7ab4835b5fd09d0a6f57000633bb6bb6edfda1,
which made Curl_fnmatch unavailable without FTP support.