### PR TITLE
gssapi: fix warnings

### DIFF
--- a/lib/curl_gssapi.h
+++ b/lib/curl_gssapi.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2011 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2011 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,19 +26,6 @@
 #include "urldata.h"
 
 #ifdef HAVE_GSSAPI
-
-#ifdef HAVE_GSSGNU
-#  include <gss.h>
-#elif defined HAVE_GSSMIT
-   /* MIT style */
-#  include <gssapi/gssapi.h>
-#  include <gssapi/gssapi_generic.h>
-#  include <gssapi/gssapi_krb5.h>
-#else
-   /* Heimdal-style */
-#  include <gssapi.h>
-#endif
-
 extern gss_OID_desc Curl_spnego_mech_oid;
 extern gss_OID_desc Curl_krb5_mech_oid;
 
@@ -71,5 +58,4 @@ void Curl_gss_log_error(struct Curl_easy *data, const char *prefix,
 #define GSSAUTH_P_PRIVACY   4
 
 #endif /* HAVE_GSSAPI */
-
 #endif /* HEADER_CURL_GSSAPI_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -129,11 +129,13 @@ typedef ssize_t (Curl_recv)(struct connectdata *conn, /* connection data */
 #ifdef HAVE_GSSAPI
 # ifdef HAVE_GSSGNU
 #  include <gss.h>
-# elif defined HAVE_GSSMIT
+# elif defined HAVE_GSSAPI_GSSAPI_H
 #  include <gssapi/gssapi.h>
-#  include <gssapi/gssapi_generic.h>
 # else
 #  include <gssapi.h>
+# endif
+# ifdef HAVE_GSSAPI_GSSAPI_GENERIC_H
+#  include <gssapi/gssapi_generic.h>
 # endif
 #endif
 

--- a/tests/libtest/stub_gssapi.c
+++ b/tests/libtest/stub_gssapi.c
@@ -44,15 +44,15 @@ enum min_err_code {
     GSS_LAST
 };
 
-const char *min_err_table[] = {
-    "stub-gss: no error",
-    "stub-gss: no memory",
-    "stub-gss: invalid arguments",
-    "stub-gss: invalid credentials",
-    "stub-gss: invalid context",
-    "stub-gss: server returned error",
-    "stub-gss: cannot find a mechanism",
-    NULL
+static const char *min_err_table[] = {
+  "stub-gss: no error",
+  "stub-gss: no memory",
+  "stub-gss: invalid arguments",
+  "stub-gss: invalid credentials",
+  "stub-gss: invalid context",
+  "stub-gss: server returned error",
+  "stub-gss: cannot find a mechanism",
+  NULL
 };
 
 struct gss_ctx_id_t_desc_struct {


### PR DESCRIPTION
Heimdal includes on FreeBSD spewed out lots of them. Less so now.