### PR TITLE
unit1307: just fail without FTP support

### DIFF
--- a/tests/unit/unit1307.c
+++ b/tests/unit/unit1307.c
@@ -23,6 +23,17 @@
 
 #include "curl_fnmatch.h"
 
+static CURLcode unit_setup(void)
+{
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+}
+
+#ifndef CURL_DISABLE_FTP
+
 /*
    CURL_FNMATCH_MATCH    0
    CURL_FNMATCH_NOMATCH  1
@@ -239,15 +250,6 @@ static const struct testcase tests[] = {
                                 "a",                      NOMATCH|LINUX_FAIL}
 };
 
-static CURLcode unit_setup(void)
-{
-  return CURLE_OK;
-}
-
-static void unit_stop(void)
-{
-}
-
 static const char *ret2name(int i)
 {
   switch(i) {
@@ -308,3 +310,14 @@ UNITTEST_START
   }
 }
 UNITTEST_STOP
+
+#else
+
+UNITTEST_START
+{
+  /* nothing to do, just fail */
+  return 1;
+}
+UNITTEST_STOP
+
+#endif


### PR DESCRIPTION
I missed to check this in with commit
71786c0505926aaf7e9b2477b2fb7ee16a915ec6, which only disabled the test.
This fixes the actual linker error.