### PR TITLE
Curl_now: figure out windows version in win32_init

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -98,7 +98,7 @@ static void win32_cleanup(void)
 
 #ifdef WIN32
 LARGE_INTEGER Curl_freq;
-int Curl_isVistaOrGreater = -1;
+bool Curl_isVistaOrGreater;
 #endif
 
 /* win32_init() performs win32 socket initialization to properly setup the
@@ -153,11 +153,11 @@ static CURLcode win32_init(void)
 #ifdef WIN32
   if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
                                  VERSION_GREATER_THAN_EQUAL)) {
-    Curl_isVistaOrGreater = 1;
+    Curl_isVistaOrGreater = TRUE;
     QueryPerformanceFrequency(&Curl_freq);
   }
   else
-    Curl_isVistaOrGreater = 0;
+    Curl_isVistaOrGreater = FALSE;
 #endif
 
   return CURLE_OK;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -95,6 +95,11 @@ static void win32_cleanup(void)
 #endif
 }
 
+#ifdef WIN32
+LARGE_INTEGER Curl_freq;
+int Curl_isVistaOrGreater = -1;
+#endif
+
 /* win32_init() performs win32 socket initialization to properly setup the
    stack to allow networking */
 static CURLcode win32_init(void)
@@ -142,6 +147,16 @@ static CURLcode win32_init(void)
     if(result)
       return result;
   }
+#endif
+
+#ifdef WIN32
+  if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
+                                 VERSION_GREATER_THAN_EQUAL)) {
+    Curl_isVistaOrGreater = 1;
+    QueryPerformanceFrequency(&Curl_freq);
+  }
+  else
+    Curl_isVistaOrGreater = 0;
 #endif
 
   return CURLE_OK;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -75,6 +75,7 @@
 #include "ssh.h"
 #include "setopt.h"
 #include "http_digest.h"
+#include "system_win32.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -25,26 +25,19 @@
 
 #if defined(WIN32) && !defined(MSDOS)
 
+/* set in win32_init() */
+extern LARGE_INTEGER Curl_freq;
+extern int Curl_isVistaOrGreater;
+
 struct curltime Curl_now(void)
 {
   struct curltime now;
-  static LARGE_INTEGER freq;
-  static int isVistaOrGreater = -1;
-  if(isVistaOrGreater == -1) {
-    if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
-                                   VERSION_GREATER_THAN_EQUAL)) {
-      isVistaOrGreater = 1;
-      QueryPerformanceFrequency(&freq);
-    }
-    else
-      isVistaOrGreater = 0;
-  }
-  if(isVistaOrGreater == 1) { /* QPC timer might have issues pre-Vista */
+  if(Curl_isVistaOrGreater) { /* QPC timer might have issues pre-Vista */
     LARGE_INTEGER count;
     QueryPerformanceCounter(&count);
-    now.tv_sec = (time_t)(count.QuadPart / freq.QuadPart);
-    now.tv_usec =
-      (int)((count.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart);
+    now.tv_sec = (time_t)(count.QuadPart / Curl_freq.QuadPart);
+    now.tv_usec = (int)((count.QuadPart % Curl_freq.QuadPart) * 1000000 /
+                        Curl_freq.QuadPart);
   }
   else {
     /* Disable /analyze warning that GetTickCount64 is preferred  */

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -26,7 +26,7 @@
 
 /* set in win32_init() */
 extern LARGE_INTEGER Curl_freq;
-extern int Curl_isVistaOrGreater;
+extern bool Curl_isVistaOrGreater;
 
 struct curltime Curl_now(void)
 {

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -21,7 +21,6 @@
  ***************************************************************************/
 
 #include "timeval.h"
-#include "system_win32.h"
 
 #if defined(WIN32) && !defined(MSDOS)
 


### PR DESCRIPTION
... and avoid use of static variables that aren't thread safe.

Fixes regression from e9ababd4f5aff042dd3b5a4f9568f22e6604d115

Reported-by: Paul Groke
Fixes #3572