### PR TITLE
connection: never reuse CONNECT_ONLY conections

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -37,6 +37,9 @@ useful when used with the \fICURLINFO_ACTIVESOCKET(3)\fP option to
 \fIcurl_easy_getinfo(3)\fP as the library can set up the connection and then
 the application can obtain the most recently used socket for special data
 transfers.
+
+Transfers marked connect only will not reuse any existing connections and
+connections marked connect only will not be allowed to get reused.
 .SH DEFAULT
 0
 .SH PROTOCOLS

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -452,6 +452,7 @@ struct ConnectBits {
   bool proxy_ssl_connected[2]; /* TRUE when SSL initialization for HTTPS proxy
                                   is complete */
   bool socksproxy_connecting; /* connecting through a socks proxy */
+  bool connect_only;
 };
 
 struct hostname {

--- a/tests/data/test597
+++ b/tests/data/test597
@@ -31,7 +31,6 @@ ftp://%HOSTIP:%FTPPORT
 USER anonymous
 PASS ftp@example.com
 PWD
-QUIT
 </protocol>
 </verify>
 </testcase>

--- a/tests/libtest/lib597.c
+++ b/tests/libtest/lib597.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -32,19 +32,11 @@
 /*
  * Test case for below scenario:
  *   - Connect to an FTP server using CONNECT_ONLY option
- *   - transfer some files with re-using the connection (omitted in test case)
- *   - Disconnect from FTP server with sending QUIT command
  *
  * The test case originated for verifying CONNECT_ONLY option shall not
  * block after protocol connect is done, but it returns the message
  * with function curl_multi_info_read().
  */
-
-enum {
-  CONNECT_ONLY_PHASE = 0,
-  QUIT_PHASE,
-  LAST_PHASE
-};
 
 int test(char *URL)
 {
@@ -53,7 +45,6 @@ int test(char *URL)
   int res = 0;
   int running;
   int msgs_left;
-  int phase;
   CURLMsg *msg;
 
   start_test_timing();
@@ -64,75 +55,64 @@ int test(char *URL)
 
   multi_init(multi);
 
-  for(phase = CONNECT_ONLY_PHASE; phase < LAST_PHASE; ++phase) {
-    /* go verbose */
-    easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+  /* go verbose */
+  easy_setopt(easy, CURLOPT_VERBOSE, 1L);
 
-    /* specify target */
-    easy_setopt(easy, CURLOPT_URL, URL);
+  /* specify target */
+  easy_setopt(easy, CURLOPT_URL, URL);
 
-    /* enable 'CONNECT_ONLY' option when in connect phase */
-    if(phase == CONNECT_ONLY_PHASE)
-      easy_setopt(easy, CURLOPT_CONNECT_ONLY, 1L);
+  easy_setopt(easy, CURLOPT_CONNECT_ONLY, 1L);
 
-    /* enable 'NOBODY' option to send 'QUIT' command in quit phase */
-    if(phase == QUIT_PHASE) {
-      easy_setopt(easy, CURLOPT_CONNECT_ONLY, 0L);
-      easy_setopt(easy, CURLOPT_NOBODY, 1L);
-      easy_setopt(easy, CURLOPT_FORBID_REUSE, 1L);
+  multi_add_handle(multi, easy);
+
+  for(;;) {
+    struct timeval interval;
+    fd_set fdread;
+    fd_set fdwrite;
+    fd_set fdexcep;
+    long timeout = -99;
+    int maxfd = -99;
+
+    multi_perform(multi, &running);
+
+    abort_on_test_timeout();
+
+    if(!running)
+      break; /* done */
+
+    FD_ZERO(&fdread);
+    FD_ZERO(&fdwrite);
+    FD_ZERO(&fdexcep);
+
+    multi_fdset(multi, &fdread, &fdwrite, &fdexcep, &maxfd);
+
+    /* At this point, maxfd is guaranteed to be greater or equal than -1. */
+
+    multi_timeout(multi, &timeout);
+
+    /* At this point, timeout is guaranteed to be greater or equal than
+       -1. */
+
+    if(timeout != -1L) {
+      int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+      interval.tv_sec = itimeout/1000;
+      interval.tv_usec = (itimeout%1000)*1000;
+    }
+    else {
+      interval.tv_sec = TEST_HANG_TIMEOUT/1000 + 1;
+      interval.tv_usec = 0;
     }
 
-    multi_add_handle(multi, easy);
+    select_test(maxfd + 1, &fdread, &fdwrite, &fdexcep, &interval);
 
-    for(;;) {
-      struct timeval interval;
-      fd_set fdread;
-      fd_set fdwrite;
-      fd_set fdexcep;
-      long timeout = -99;
-      int maxfd = -99;
-
-      multi_perform(multi, &running);
-
-      abort_on_test_timeout();
-
-      if(!running)
-        break; /* done */
-
-      FD_ZERO(&fdread);
-      FD_ZERO(&fdwrite);
-      FD_ZERO(&fdexcep);
-
-      multi_fdset(multi, &fdread, &fdwrite, &fdexcep, &maxfd);
-
-      /* At this point, maxfd is guaranteed to be greater or equal than -1. */
-
-      multi_timeout(multi, &timeout);
-
-      /* At this point, timeout is guaranteed to be greater or equal than
-         -1. */
-
-      if(timeout != -1L) {
-        int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
-        interval.tv_sec = itimeout/1000;
-        interval.tv_usec = (itimeout%1000)*1000;
-      }
-      else {
-        interval.tv_sec = TEST_HANG_TIMEOUT/1000 + 1;
-        interval.tv_usec = 0;
-      }
-
-      select_test(maxfd + 1, &fdread, &fdwrite, &fdexcep, &interval);
-
-      abort_on_test_timeout();
-    }
-
-    msg = curl_multi_info_read(multi, &msgs_left);
-    if(msg)
-      res = msg->data.result;
-
-    multi_remove_handle(multi, easy);
+    abort_on_test_timeout();
   }
+
+  msg = curl_multi_info_read(multi, &msgs_left);
+  if(msg)
+    res = msg->data.result;
+
+  multi_remove_handle(multi, easy);
 
 test_cleanup:
 


### PR DESCRIPTION
and make CONNECT_ONLY conections never reuse any existing ones either.

Reported-by: Pavel Löbl
Bug: https://curl.haxx.se/mail/lib-2019-02/0064.html