### PR TITLE
curl: remove MANUAL from -M output

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -65,7 +65,6 @@ EXTRA_DIST =                                    \
  KNOWN_BUGS                                     \
  LICENSE-MIXING.md                              \
  MAIL-ETIQUETTE                                 \
- MANUAL                                         \
  README.cmake                                   \
  README.md                                      \
  README.netware                                 \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,16 +9,13 @@ if(USE_MANUAL)
     COMMAND ${CMAKE_COMMAND} -E echo "#ifndef HAVE_LIBZ" >> tool_hugehelp.c
     COMMAND env LC_ALL=C "${NROFF}" ${NROFF_MANOPT}
             "${CURL_BINARY_DIR}/docs/curl.1" |
-            "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
-            "${CURL_SOURCE_DIR}/docs/MANUAL" >> tool_hugehelp.c
+            "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" >> tool_hugehelp.c
     COMMAND ${CMAKE_COMMAND} -E echo "#else" >> tool_hugehelp.c
     COMMAND env LC_ALL=C "${NROFF}" ${NROFF_MANOPT}
             "${CURL_BINARY_DIR}/docs/curl.1" |
-            "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c
-            "${CURL_SOURCE_DIR}/docs/MANUAL" >> tool_hugehelp.c
+            "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c >> tool_hugehelp.c
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> tool_hugehelp.c
     DEPENDS
-      "${CURL_SOURCE_DIR}/docs/MANUAL"
       generate-curl.1
       "${CURL_BINARY_DIR}/docs/curl.1"
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,7 +91,6 @@ EXTRA_DIST = mkhelp.pl makefile.dj                                     \
 
 # Use absolute directory to disable VPATH
 MANPAGE=$(abs_top_builddir)/docs/curl.1
-README=$(top_srcdir)/docs/MANUAL
 MKHELP=$(top_srcdir)/src/mkhelp.pl
 HUGE=tool_hugehelp.c
 
@@ -104,18 +103,18 @@ $(MANPAGE):
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and
 # compressed formats.
-$(HUGE): $(MANPAGE) $(README) $(MKHELP)
+$(HUGE): $(MANPAGE) $(MKHELP)
 	echo '#include "tool_setup.h"' > $(HUGE)
 	echo '#ifndef HAVE_LIBZ' >> $(HUGE)
-	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) >> $(HUGE)
 	echo '#else' >> $(HUGE)
-	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) -c $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) -c >> $(HUGE)
 	echo '#endif /* HAVE_LIBZ */' >> $(HUGE)
 else # HAVE_LIBZ
 # This generates the tool_hugehelp.c file uncompressed only
-$(HUGE): $(MANPAGE) $(README) $(MKHELP)
+$(HUGE): $(MANPAGE) $(MKHELP)
 	echo '#include "tool_setup.h"' > $(HUGE)
-	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) $(README) >> $(HUGE)
+	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) >> $(HUGE)
 endif
 
 else # USE_MANUAL

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -32,14 +32,6 @@ if($ARGV[0] eq "-c") {
     $c=1;
     shift @ARGV;
 }
-
-my $README = $ARGV[0];
-
-if($README eq "") {
-    print "usage: mkhelp.pl [-c] <README> < manpage\n";
-    exit;
-}
-
 
 push @out, "                                  _   _ ____  _\n";
 push @out, "  Project                     ___| | | |  _ \\| |\n";
@@ -88,19 +80,6 @@ while (<STDIN>) {
     push @out, $line;
 }
 push @out, "\n"; # just an extra newline
-
-open(READ, "<$README") ||
-    die "couldn't read the README infile $README";
-
-while(<READ>) {
-    my $line = $_;
-
-    # remove trailing CR from line. msysgit checks out files as line+CRLF
-    $line =~ s/\r$//;
-
-    push @out, $line;
-}
-close(READ);
 
 print <<HEAD
 /*

--- a/tests/data/test1026
+++ b/tests/data/test1026
@@ -28,7 +28,7 @@ curl --manual
 # Search for these two sentinel lines in the manual output; if they are found,
 # then chances are good the entire manual is there.
 <postcheck>
-perl -e 'open(IN,$ARGV[0]); my $lines=grep(/(a\s*tool\s*to\s*transfer\s*data)|(mailing\s*lists\s*to\s*discuss\s*curl)/, <IN>); exit ($lines != 2); # Let this file pass an XML syntax check: </IN>' log/stdout1026
+perl -e 'open(IN,$ARGV[0]); my $lines=grep(/(curl\s*-\s*transfer\sa\s*URL)|(CONTRIBUTORS)/, <IN>); exit ($lines != 2); # Let this file pass an XML syntax check: </IN>' log/stdout1026
 </postcheck>
 </client>
 


### PR DESCRIPTION
... and remove it from the dist tarball. It has served its time, it
barely gets updated anymore and "everything curl" is now convering all
this document once tried to include, and does it more and better.

In the compressed scenario, this removes ~15K data from the binary,
which is 25% of the -M output.

It remains in the git repo for now for as long as the web site builds a
page using that as source. It renders poorly on the site (especially for
mobile users) so its not even good there.