### PR TITLE
singlesocket: fix the 'sincebefore' placement

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2349,8 +2349,6 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
   int num;
   unsigned int curraction;
   int actions[MAX_SOCKSPEREASYHANDLE];
-  unsigned int comboaction;
-  bool sincebefore = FALSE;
 
   for(i = 0; i< MAX_SOCKSPEREASYHANDLE; i++)
     socks[i] = CURL_SOCKET_BAD;
@@ -2369,6 +2367,8 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
       i++) {
     unsigned int action = CURL_POLL_NONE;
     unsigned int prevaction = 0;
+    unsigned int comboaction;
+    bool sincebefore = FALSE;
 
     s = socks[i];
 


### PR DESCRIPTION
The variable wasn't properly reset within the loop and thus could remain
set for sockets that hadn't been set before and thus missed notifying
the app.

Detected-by: Jan Alexander Steffens (@heftig)
Fixes #3585