### PR TITLE
OpenSSL: Add support for TLS ASYNC state.

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2808,6 +2808,12 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
       connssl->connecting_state = ssl_connect_2_writing;
       return CURLE_OK;
     }
+#if defined(SSL_ERROR_WANT_ASYNC)
+    if(SSL_ERROR_WANT_ASYNC == detail) {
+      connssl->connecting_state = ssl_connect_2;
+      return CURLE_OK;
+    }
+#endif
     else {
       /* untreated error */
       unsigned long errdetail;


### PR DESCRIPTION
In case that the TLS connection is paused using openssl ASYNC_pause_job()
current implementation of libcurl handles it as a connection error.

The proposed change adds support in case the TLS connections is paused that way.