### PR TITLE
add additional libraries to check for LDAP support

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -791,7 +791,9 @@ AC_DEFUN([CURL_CHECK_LIBS_LDAP], [
     '-lldap -llber' \
     '-llber -lldap' \
     '-lldapssl -lldapx -lldapsdk' \
-    '-lldapsdk -lldapx -lldapssl' ; do
+    '-lldapsdk -lldapx -lldapssl' \
+    '-lldap -llber -lssl -lcrypto' ; do
+
     if test "$curl_cv_ldap_LIBS" = "unknown"; then
       if test -z "$x_nlibs"; then
         LIBS="$curl_cv_save_LIBS"


### PR DESCRIPTION
A PR to resolve issue-3595.

On AIX additional libraries (-lcrypt and -lssl) must be provided for openldap to link properly

Fixes #3595 