### PR TITLE
wolfssl: stop custom-adding curves

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2384,7 +2384,6 @@ if test -z "$ssl_backends" -o "x$OPT_CYASSL" != xno; then
         dnl Recent WolfSSL versions build without SSLv3 by default
         dnl WolfSSL needs configure --enable-opensslextra to have *get_peer*
         AC_CHECK_FUNCS(wolfSSLv3_client_method \
-                       wolfSSL_CTX_UseSupportedCurve \
                        wolfSSL_get_peer_certificate \
                        wolfSSL_UseALPN)
       else

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -64,15 +64,6 @@ and that's a problem since options.h hasn't been included yet. */
 #if (LIBCYASSL_VERSION_HEX < 0x03006006) || \
     defined(HAVE_WOLFSSLV3_CLIENT_METHOD)
 #define WOLFSSL_ALLOW_SSLV3
-#endif
-#endif
-
-/* HAVE_SUPPORTED_CURVES is wolfSSL's build time symbol for enabling the ECC
-   supported curve extension in options.h. Note ECC is enabled separately. */
-#ifndef HAVE_SUPPORTED_CURVES
-#if defined(HAVE_CYASSL_CTX_USESUPPORTEDCURVE) || \
-    defined(HAVE_WOLFSSL_CTX_USESUPPORTEDCURVE)
-#define HAVE_SUPPORTED_CURVES
 #endif
 #endif
 
@@ -362,16 +353,6 @@ cyassl_connect_step1(struct connectdata *conn,
             "TLS extension\n");
     }
   }
-#endif
-
-#ifdef HAVE_SUPPORTED_CURVES
-  /* CyaSSL/wolfSSL does not send the supported ECC curves ext automatically:
-     https://github.com/wolfSSL/wolfssl/issues/366
-     The supported curves below are those also supported by OpenSSL 1.0.2 and
-     in the same order. */
-  CyaSSL_CTX_UseSupportedCurve(BACKEND->ctx, 0x17); /* secp256r1 */
-  CyaSSL_CTX_UseSupportedCurve(BACKEND->ctx, 0x19); /* secp521r1 */
-  CyaSSL_CTX_UseSupportedCurve(BACKEND->ctx, 0x18); /* secp384r1 */
 #endif
 
   /* give application a chance to interfere with SSL set up. */


### PR DESCRIPTION
since wolfSSL PR https://github.com/wolfSSL/wolfssl/pull/717 (shipped in
wolfSSL 3.10.2 and later) it sends these curves by default already.

Pointed-out-by: David Garske (@dgarske)