### PR TITLE
examples: remove recursive calls to curl_multi_socket_action

### DIFF
--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -119,13 +119,12 @@ static int multi_timer_cb(CURLM *multi, long timeout_ms, GlobalInfo *g)
 {
   DPRINT("%s %li\n", __PRETTY_FUNCTION__,  timeout_ms);
   ev_timer_stop(g->loop, &g->timer_event);
-  if(timeout_ms > 0) {
+  if(timeout_ms >= 0) {
+    /* -1 means delete, other values are timeout times in milliseconds */
     double  t = timeout_ms / 1000;
     ev_timer_init(&g->timer_event, timer_cb, t, 0.);
     ev_timer_start(g->loop, &g->timer_event);
   }
-  else if(timeout_ms == 0)
-    timer_cb(g->loop, &g->timer_event, 0);
   return 0;
 }
 

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -163,16 +163,14 @@ static int update_timeout_cb(CURLM *multi, long timeout_ms, void *userp)
   MSG_OUT("*** update_timeout_cb %ld => %ld:%ld ***\n",
           timeout_ms, timeout.tv_sec, timeout.tv_usec);
 
-  /* TODO
-   *
-   * if timeout_ms is 0, call curl_multi_socket_action() at once!
-   *
+  /*
    * if timeout_ms is -1, just delete the timer
    *
-   * for all other values of timeout_ms, this should set or *update*
-   * the timer to the new value
+   * For other values of timeout_ms, this should set or *update* the timer to
+   * the new value
    */
-  g->timer_event = g_timeout_add(timeout_ms, timer_cb, g);
+  if(timeout_ms >= 0)
+    g->timer_event = g_timeout_add(timeout_ms, timer_cb, g);
   return 0;
 }
 

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -152,23 +152,15 @@ static int multi_timer_cb(CURLM *multi _Unused, long timeout_ms, GlobalInfo *g)
   timeout.tv_usec = (timeout_ms%1000)*1000;
   fprintf(MSG_OUT, "multi_timer_cb: Setting timeout to %ld ms\n", timeout_ms);
 
-  /* TODO
-   *
-   * if timeout_ms is 0, call curl_multi_socket_action() at once!
-   *
+  /*
    * if timeout_ms is -1, just delete the timer
    *
-   * for all other values of timeout_ms, this should set or *update*
-   * the timer to the new value
+   * For all other values of timeout_ms, this should set or *update* the timer
+   * to the new value
    */
-  if(timeout_ms == 0) {
-    rc = curl_multi_socket_action(g->multi,
-                                  CURL_SOCKET_TIMEOUT, 0, &g->still_running);
-    mcode_or_die("multi_timer_cb: curl_multi_socket_action", rc);
-  }
-  else if(timeout_ms == -1)
+  if(timeout_ms == -1)
     evtimer_del(&g->timer_event);
-  else
+  else /* includes timeout zero */
     evtimer_add(&g->timer_event, &timeout);
   return 0;
 }

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -28,7 +28,7 @@ CURLMOPT_TIMERFUNCTION \- set callback to receive timeout values
 #include <curl/curl.h>
 
 int timer_callback(CURLM *multi,    /* multi handle */
-                   long timeout_ms, /* see above */
+                   long timeout_ms, /* timeout in number of ms */
                    void *userp);    /* private callback pointer */
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_TIMERFUNCTION, timer_callback);
@@ -40,17 +40,15 @@ Certain features, such as timeouts and retries, require you to call libcurl
 even when there is no activity on the file descriptors.
 
 Your callback function \fBtimer_callback\fP should install a non-repeating
-timer with an interval of \fBtimeout_ms\fP. Each time that timer fires, call
+timer with an interval of \fBtimeout_ms\fP. When time that timer fires, call
 either \fIcurl_multi_socket_action(3)\fP or \fIcurl_multi_perform(3)\fP,
 depending on which interface you use.
 
-A \fBtimeout_ms\fP value of -1 means you should delete your timer.
+A \fBtimeout_ms\fP value of -1 passed to this callback means you should delete
+the timer. All other values are valid expire times in number of milliseconds.
 
-A \fBtimeout_ms\fP value of 0 means you should call
-\fIcurl_multi_socket_action(3)\fP or \fIcurl_multi_perform(3)\fP (once) as soon
-as possible.
-
-\fBtimer_callback\fP will only be called when the \fBtimeout_ms\fP changes.
+The \fBtimer_callback\fP will only be called when the timeout expire time is
+changed.
 
 The \fBuserp\fP pointer is set with \fICURLMOPT_TIMERDATA(3)\fP.
 


### PR DESCRIPTION
From within the timer callbacks. Recursive is problematic for several
reasons.

Discussed in #3537