### PR TITLE
multi: call multi_done on connect timeouts

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1606,7 +1606,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       }
       else if(result) {
         /* failure detected */
-        /* Just break, the cleaning up is handled all in one place */
+        Curl_posttransfer(data);
+        multi_done(data, result, TRUE);
         stream_error = TRUE;
         break;
       }


### PR DESCRIPTION
Failing to do so would make the CURLINFO_TOTAL_TIME timeout to not get updated correctly and could end up getting reported to the application completely wrong (way too small).


Reported-by: accountantM on github
Fixes #3602