### PR TITLE
AppVeyor: update to Visual Studio 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
         TESTING: OFF
         SHARED: ON
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
-        PRJ_GEN: "Visual Studio 14 2015 Win64"
+        PRJ_GEN: "Visual Studio 15 2017 Win64"
         PRJ_CFG: Release
         OPENSSL: OFF
         WINSSL: ON
@@ -19,7 +19,7 @@ environment:
         TESTING: OFF
         SHARED: ON
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
-        PRJ_GEN: "Visual Studio 14 2015 Win64"
+        PRJ_GEN: "Visual Studio 15 2017 Win64"
         PRJ_CFG: Release
         OPENSSL: ON
         WINSSL: OFF
@@ -35,7 +35,7 @@ environment:
         TESTING: ON
         SHARED: OFF
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
-        PRJ_GEN: "Visual Studio 14 2015 Win64"
+        PRJ_GEN: "Visual Studio 15 2017 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF
@@ -43,7 +43,7 @@ environment:
         TESTING: ON
         SHARED: OFF
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
-        PRJ_GEN: "Visual Studio 14 2015 Win64"
+        PRJ_GEN: "Visual Studio 15 2017 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,42 +2,48 @@ version: 7.50.0.{build}
 
 environment:
     matrix:
-      - PRJ_GEN: "Visual Studio 9 2008"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+        PRJ_GEN: "Visual Studio 9 2008"
         PRJ_CFG: Release
         OPENSSL: OFF
         WINSSL: ON
         HTTP_ONLY: OFF
         TESTING: OFF
         SHARED: ON
-      - PRJ_GEN: "Visual Studio 14 2015 Win64"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+        PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Release
         OPENSSL: OFF
         WINSSL: ON
         HTTP_ONLY: OFF
         TESTING: OFF
         SHARED: ON
-      - PRJ_GEN: "Visual Studio 14 2015 Win64"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+        PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Release
         OPENSSL: ON
         WINSSL: OFF
         HTTP_ONLY: OFF
         TESTING: OFF
         SHARED: ON
-      - PRJ_GEN: "Visual Studio 10 2010 Win64"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+        PRJ_GEN: "Visual Studio 10 2010 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF
         HTTP_ONLY: OFF
         TESTING: ON
         SHARED: OFF
-      - PRJ_GEN: "Visual Studio 14 2015 Win64"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+        PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF
         HTTP_ONLY: OFF
         TESTING: ON
         SHARED: OFF
-      - PRJ_GEN: "Visual Studio 14 2015 Win64"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+        PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
         HTTP_ONLY: OFF
         TESTING: OFF
         SHARED: ON
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Release
         OPENSSL: OFF
@@ -18,7 +18,7 @@ environment:
         HTTP_ONLY: OFF
         TESTING: OFF
         SHARED: ON
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Release
         OPENSSL: ON
@@ -34,7 +34,7 @@ environment:
         HTTP_ONLY: OFF
         TESTING: ON
         SHARED: OFF
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF
@@ -42,7 +42,7 @@ environment:
         HTTP_ONLY: OFF
         TESTING: ON
         SHARED: OFF
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF


### PR DESCRIPTION
The last major update to Visual Studio 2017 has been released and is available on AppVeyor. It requires the non-default Visual Studio 2017 worker Image, which can also be used for Visual Studio 2015 and comes with more modern, but less software.