### PR TITLE
Schannel CALG_ECDH_EPHEM algorithm support on Windows.

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -496,3 +496,4 @@ WinSSL allows the enabling and disabling of encryption algorithms, but not speci
 `CALG_ECDH`,
 `CALG_ECMQV`,
 `CALG_ECDSA`,
+`CALG_ECDH_EPHEM`,

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -324,6 +324,9 @@ get_alg_id_by_name(char *name)
 #ifdef CALG_ECDSA
   CIPHEROPTION(CALG_ECDSA);
 #endif
+#ifdef CALG_ECDH_EPHEM
+  CIPHEROPTION(CALG_ECDH_EPHEM);
+#endif
   return 0;
 }
 


### PR DESCRIPTION
Added support Ephemeral elliptic curve Diffie-Hellman key exchange algorithm option when selecting ciphers. This became available on the Win10 SDK.