### PR TITLE
AppVeyor: remove redundant builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,20 +30,6 @@ environment:
         HTTP_ONLY: OFF
         TESTING: ON
         SHARED: OFF
-      - PRJ_GEN: "Visual Studio 11 2012 Win64"
-        PRJ_CFG: Debug
-        OPENSSL: OFF
-        WINSSL: OFF
-        HTTP_ONLY: OFF
-        TESTING: ON
-        SHARED: OFF
-      - PRJ_GEN: "Visual Studio 12 2013 Win64"
-        PRJ_CFG: Debug
-        OPENSSL: OFF
-        WINSSL: OFF
-        HTTP_ONLY: OFF
-        TESTING: ON
-        SHARED: OFF
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         PRJ_CFG: Debug
         OPENSSL: OFF


### PR DESCRIPTION
Remove the Visual Studio 2012 and 2013 builds as they add little value.

Ref: https://github.com/curl/curl/pull/3606