### PR TITLE
Use __has_declspec_attribute for shared builds

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -91,6 +91,11 @@
 #include <support/SupportDefs.h>
 #endif
 
+/* Compatibility for non-Clang compilers */
+#ifndef __has_declspec_attribute
+#  define __has_declspec_attribute(x) 0
+#endif
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -109,7 +114,9 @@ typedef void CURLSH;
 
 #ifdef CURL_STATICLIB
 #  define CURL_EXTERN
-#elif defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__)
+#elif defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__) || \
+     (__has_declspec_attribute(dllexport) && \
+      __has_declspec_attribute(dllimport))
 #  if defined(BUILDING_LIBCURL)
 #    define CURL_EXTERN  __declspec(dllexport)
 #  else


### PR DESCRIPTION
Clang compilation targets may support `__declspec` attributes. Because of that it has a `__has_declspec_attribute` [check](https://clang.llvm.org/docs/LanguageExtensions.html#has-declspec-attribute).

Currently cURL just assumes that `__declspec` is Windows only. This adds a compatibility macro and checks whether `dllimport` and `dllexport` are available.