### PR TITLE
multi: support verbose and err stream for conncache closure handle

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -497,6 +497,8 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
     data->set.server_response_timeout;
   data->state.conn_cache->closure_handle->set.no_signal =
     data->set.no_signal;
+  data->state.conn_cache->closure_handle->set.verbose =
+    data->set.verbose;
 
   update_timer(multi);
   return CURLM_OK;

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -94,7 +94,7 @@ Accept: */*
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))
-s/^(\* Closing connection) [123]$/$1/
+s/^(\* Closing connection) [123](?=\r?\n)/$1/
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -81,6 +81,7 @@ Accept: */*
 </protocol>
 <strip>
 ^Host:.*
+^\* Closing connection (?:1|2|3)$
 </strip>
 <file name="log/stderr1506" mode="text">
 * Connection #0 to host server1.example.com left intact

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -81,7 +81,6 @@ Accept: */*
 </protocol>
 <strip>
 ^Host:.*
-^\* Closing connection (?:1|2|3)$
 </strip>
 <file name="log/stderr1506" mode="text">
 * Connection #0 to host server1.example.com left intact
@@ -89,9 +88,13 @@ Accept: */*
 * Connection #2 to host server3.example.com left intact
 * Closing connection 0
 * Connection #3 to host server4.example.com left intact
+* Closing connection
+* Closing connection
+* Closing connection
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+s/^(\* Closing connection) [123]$/$1/
 </stripfile>
 </verify>
 </testcase>


### PR DESCRIPTION
- Change closure handle to receive verbose and error stream settings
  from the easy handle most recently added via curl_multi_add_handle.

The closure handle is a special easy handle used for closing cached
connections. It receives limited settings from the easy handle most
recently added to the multi handle. Prior to this change that did not
include verbose and the error stream which was a problem because on
connection shutdown verbose mode was not acknowledged.

Ref: https://github.com/curl/curl/pull/3598

Closes #xxxx