### PR TITLE
http: set state.infilesize when sending formposts

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2733,7 +2733,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
       break;
     }
 
-    postsize = http->postsize;
+    data->state.infilesize = postsize = http->postsize;
 
     /* We only set Content-Length and allow a custom Content-Length if
        we don't upload data chunked, as RFC2616 forbids us to set both


### PR DESCRIPTION
Without it set, we would unwillingly triger the "HTTP error before end
of send, stop sending" condition even if the entire POST body had been
sent (since it wouldn't know the expected size) which would
unnecessarily log that message and close the connection when it didn't
have to.

Reported-by: Matt McClure
Bug: https://curl.haxx.se/mail/archive-2019-02/0023.html