### PR TITLE
system_win32: move win32_init here from easy.c

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -89,94 +89,6 @@ static unsigned int  initialized;
 static long          init_flags;
 
 /*
- * win32 init and cleanup functions
- */
-#ifdef WIN32
-
-/* win32_cleanup() is the opposite of win32_init() */
-static void win32_cleanup(void)
-{
-#ifdef USE_WINDOWS_SSPI
-  Curl_sspi_global_cleanup();
-#endif
-
-  if(init_flags & CURL_GLOBAL_WIN32) {
-#ifdef USE_WINSOCK
-    WSACleanup();
-#endif
-  }
-}
-
-LARGE_INTEGER Curl_freq;
-bool Curl_isVistaOrGreater;
-
-/* win32_init() performs win32 global initialization */
-static CURLcode win32_init(long flags)
-{
-  /* CURL_GLOBAL_WIN32 controls the *optional* part of the initialization which
-     is just for Winsock at the moment. Any required win32 initialization
-     should take place after this block. */
-  if(flags & CURL_GLOBAL_WIN32) {
-#ifdef USE_WINSOCK
-    WORD wVersionRequested;
-    WSADATA wsaData;
-    int res;
-
-#if defined(ENABLE_IPV6) && (USE_WINSOCK < 2)
-#error IPV6_requires_winsock2
-#endif
-
-    wVersionRequested = MAKEWORD(USE_WINSOCK, USE_WINSOCK);
-
-    res = WSAStartup(wVersionRequested, &wsaData);
-
-    if(res != 0)
-      /* Tell the user that we couldn't find a usable */
-      /* winsock.dll.     */
-      return CURLE_FAILED_INIT;
-
-    /* Confirm that the Windows Sockets DLL supports what we need.*/
-    /* Note that if the DLL supports versions greater */
-    /* than wVersionRequested, it will still return */
-    /* wVersionRequested in wVersion. wHighVersion contains the */
-    /* highest supported version. */
-
-    if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
-       HIBYTE(wsaData.wVersion) != HIBYTE(wVersionRequested) ) {
-      /* Tell the user that we couldn't find a usable */
-
-      /* winsock.dll. */
-      WSACleanup();
-      return CURLE_FAILED_INIT;
-    }
-    /* The Windows Sockets DLL is acceptable. Proceed. */
-  #elif defined(USE_LWIPSOCK)
-    lwip_init();
-  #endif
-  } /* CURL_GLOBAL_WIN32 */
-
-#ifdef USE_WINDOWS_SSPI
-  {
-    CURLcode result = Curl_sspi_global_init();
-    if(result)
-      return result;
-  }
-#endif
-
-  if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
-                                 VERSION_GREATER_THAN_EQUAL)) {
-    Curl_isVistaOrGreater = TRUE;
-    QueryPerformanceFrequency(&Curl_freq);
-  }
-  else
-    Curl_isVistaOrGreater = FALSE;
-
-  return CURLE_OK;
-}
-
-#endif /* WIN32 */
-
-/*
  * strdup (and other memory functions) is redefined in complicated
  * ways, but at this point it must be defined as the system-supplied strdup
  * so the callback pointer is initialized correctly.
@@ -249,7 +161,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
   }
 
 #ifdef WIN32
-  if(win32_init(flags)) {
+  if(Curl_win32_init(flags)) {
     DEBUGF(fprintf(stderr, "Error: win32_init failed\n"));
     return CURLE_FAILED_INIT;
   }
@@ -358,7 +270,7 @@ void curl_global_cleanup(void)
   Curl_resolver_global_cleanup();
 
 #ifdef WIN32
-  win32_cleanup();
+  Curl_win32_cleanup(init_flags);
 #endif
 
   Curl_amiga_cleanup();

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -32,6 +32,87 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+LARGE_INTEGER Curl_freq;
+bool Curl_isVistaOrGreater;
+
+/* Curl_win32_init() performs win32 global initialization */
+CURLcode Curl_win32_init(long flags)
+{
+  /* CURL_GLOBAL_WIN32 controls the *optional* part of the initialization which
+     is just for Winsock at the moment. Any required win32 initialization
+     should take place after this block. */
+  if(flags & CURL_GLOBAL_WIN32) {
+#ifdef USE_WINSOCK
+    WORD wVersionRequested;
+    WSADATA wsaData;
+    int res;
+
+#if defined(ENABLE_IPV6) && (USE_WINSOCK < 2)
+#error IPV6_requires_winsock2
+#endif
+
+    wVersionRequested = MAKEWORD(USE_WINSOCK, USE_WINSOCK);
+
+    res = WSAStartup(wVersionRequested, &wsaData);
+
+    if(res != 0)
+      /* Tell the user that we couldn't find a usable */
+      /* winsock.dll.     */
+      return CURLE_FAILED_INIT;
+
+    /* Confirm that the Windows Sockets DLL supports what we need.*/
+    /* Note that if the DLL supports versions greater */
+    /* than wVersionRequested, it will still return */
+    /* wVersionRequested in wVersion. wHighVersion contains the */
+    /* highest supported version. */
+
+    if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
+       HIBYTE(wsaData.wVersion) != HIBYTE(wVersionRequested) ) {
+      /* Tell the user that we couldn't find a usable */
+
+      /* winsock.dll. */
+      WSACleanup();
+      return CURLE_FAILED_INIT;
+    }
+    /* The Windows Sockets DLL is acceptable. Proceed. */
+  #elif defined(USE_LWIPSOCK)
+    lwip_init();
+  #endif
+  } /* CURL_GLOBAL_WIN32 */
+
+#ifdef USE_WINDOWS_SSPI
+  {
+    CURLcode result = Curl_sspi_global_init();
+    if(result)
+      return result;
+  }
+#endif
+
+  if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
+                                 VERSION_GREATER_THAN_EQUAL)) {
+    Curl_isVistaOrGreater = TRUE;
+    QueryPerformanceFrequency(&Curl_freq);
+  }
+  else
+    Curl_isVistaOrGreater = FALSE;
+
+  return CURLE_OK;
+}
+
+/* Curl_win32_cleanup() is the opposite of Curl_win32_init() */
+void Curl_win32_cleanup(long init_flags)
+{
+#ifdef USE_WINDOWS_SSPI
+  Curl_sspi_global_cleanup();
+#endif
+
+  if(init_flags & CURL_GLOBAL_WIN32) {
+#ifdef USE_WINSOCK
+    WSACleanup();
+#endif
+  }
+}
+
 #if defined(USE_WINDOWS_SSPI) || (!defined(CURL_DISABLE_TELNET) && \
                                   defined(USE_WINSOCK))
 

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -26,6 +26,7 @@
 
 #include <curl/curl.h>
 #include "system_win32.h"
+#include "curl_sspi.h"
 #include "warnless.h"
 
 /* The last #include files should be: */

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -26,6 +26,12 @@
 
 #if defined(WIN32)
 
+extern LARGE_INTEGER Curl_freq;
+extern bool Curl_isVistaOrGreater;
+
+CURLcode Curl_win32_init(long flags);
+void Curl_win32_cleanup(long init_flags);
+
 /* Version condition */
 typedef enum {
   VERSION_LESS_THAN,


### PR DESCRIPTION
.. since system_win32 is a more appropriate location for the functions
and to extern the globals.

Ref: https://github.com/curl/curl/commit/ca597ad#r32446578
Reported-by: Gisle Vanem

Closes #xxxx

---

/cc @gvanem 