### PR TITLE
Curl_easy: remove req.maxfd - never used!

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1253,8 +1253,6 @@ static CURLcode multi_reconnect_request(struct Curl_easy *data)
 static void do_complete(struct connectdata *conn)
 {
   conn->data->req.chunk = FALSE;
-  conn->data->req.maxfd = (conn->sockfd>conn->writesockfd?
-                           conn->sockfd:conn->writesockfd) + 1;
   Curl_pgrsTime(conn->data, TIMER_PRETRANSFER);
 }
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -584,7 +584,6 @@ struct SingleRequest {
   time_t timeofdoc;
   long bodywrites;
   char *buf;
-  curl_socket_t maxfd;
   int keepon;
   char *location;   /* This points to an allocated version of the Location:
                        header data */


### PR DESCRIPTION
Introduced in 8b6314ccfb, but not used anymore in current code. Unclear
since when.