### PR TITLE
curl_easy_duphandle.3: clarify that a duped handle has no shares

### DIFF
--- a/docs/libcurl/curl_easy_duphandle.3
+++ b/docs/libcurl/curl_easy_duphandle.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -39,10 +39,12 @@ will be pointed to by the new handle as well. You must therefore make sure to
 keep the data around until both handles have been cleaned up.
 
 The new handle will \fBnot\fP inherit any state information, no connections,
-no SSL sessions and no cookies.
+no SSL sessions and no cookies. It also will not inherit any share object
+states or options (it will be made as if \fICURLOPT_SHARE(3)\fP was set to
+NULL).
 
-\fBNote\fP that even in multi-threaded programs, this function must be called
-in a synchronous way, the input handle may not be in use when cloned.
+In multi-threaded programs, this function must be called in a synchronous way,
+the input handle may not be in use when cloned.
 .SH RETURN VALUE
 If this function returns NULL, something went wrong and no valid handle was
 returned.


### PR DESCRIPTION
Reported-by: Sara Golemon

Fixes #3592