### PR TITLE
CURLU: fix NULL dereference when used over proxy

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -304,7 +304,8 @@ static void up_free(struct Curl_easy *data)
   Curl_safefree(up->options);
   Curl_safefree(up->path);
   Curl_safefree(up->query);
-  curl_url_cleanup(data->state.uh);
+  if(data->set.uh != data->state.uh)
+    curl_url_cleanup(data->state.uh);
   data->state.uh = NULL;
 }
 
@@ -2046,7 +2047,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
 
   /* parse the URL */
   if(data->set.uh) {
-    uh = data->set.uh;
+    uh = data->state.uh = data->set.uh;
   }
   else {
     uh = data->state.uh = curl_url();

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -83,7 +83,7 @@ test617 test618 test619 test620 test621 test622 test623 test624 test625 \
 test626 test627 test628 test629 test630 test631 test632 test633 test634 \
 test635 test636 test637 test638 test639 test640 test641 test642 \
 test643 test644 test645 test646 test647 test648 test649 test650 test651 \
-test652 test653 test654 test655 test656 test658 \
+test652 test653 test654 test655 test656 test658 test659 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 \

--- a/tests/data/test659
+++ b/tests/data/test659
@@ -4,6 +4,7 @@
 HTTP
 HTTP GET
 CURLOPT_CURLU
+proxy
 </keywords>
 </info>
 <reply>
@@ -27,13 +28,13 @@ Funny-head: yesyes
 http
 </server>
 <tool>
-lib658
+lib659
 </tool>
 <name>
-Pass URL to libcurl with CURLOPT_CURLU
+CURLOPT_CURLU without the path set - over proxy
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/658
+http://%HOSTIP:%HTTPPORT
 </command>
 </client>
 
@@ -42,9 +43,10 @@ http://%HOSTIP:%HTTPPORT/658
 ^User-Agent:.*
 </strip>
 <protocol>
-GET /658 HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
+GET http://www.example.com:80/ HTTP/1.1
+Host: www.example.com
 Accept: */*
+Proxy-Connection: Keep-Alive
 
 </protocol>
 </verify>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -22,6 +22,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib571 lib572 lib573 lib574 lib575 lib576        lib578 lib579 lib582   \
  lib583 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598 lib599   \
  lib643 lib644 lib645 lib650 lib651 lib652 lib653 lib654 lib655 lib658   \
+ lib659 \
  lib1156 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
@@ -344,6 +345,10 @@ lib655_CPPFLAGS = $(AM_CPPFLAGS)
 lib658_SOURCES = lib658.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib658_LDADD = $(TESTUTIL_LIBS)
 lib658_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib659_SOURCES = lib659.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib659_LDADD = $(TESTUTIL_LIBS)
+lib659_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1500_SOURCES = lib1500.c $(SUPPORTFILES) $(TESTUTIL)
 lib1500_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib659.c
+++ b/tests/libtest/lib659.c
@@ -1,0 +1,75 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+/*
+ * Get a single URL without select().
+ */
+
+int test(char *URL)
+{
+  CURL *handle = NULL;
+  CURLcode res = 0;
+  CURLU *urlp = NULL;
+
+  global_init(CURL_GLOBAL_ALL);
+  easy_init(handle);
+
+  urlp = curl_url();
+
+  if(!urlp) {
+    fprintf(stderr, "problem init URL api.");
+    goto test_cleanup;
+  }
+
+  /* this doesn't set the PATH part */
+  if(curl_url_set(urlp, CURLUPART_HOST, "www.example.com", 0) ||
+     curl_url_set(urlp, CURLUPART_SCHEME, "http", 0) ||
+     curl_url_set(urlp, CURLUPART_PORT, "80", 0)) {
+    fprintf(stderr, "problem setting CURLUPART");
+    goto test_cleanup;
+  }
+
+  easy_setopt(handle, CURLOPT_CURLU, urlp);
+  easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+  easy_setopt(handle, CURLOPT_PROXY, URL);
+
+  res = curl_easy_perform(handle);
+
+  if(res) {
+    fprintf(stderr, "%s:%d curl_easy_perform() failed with code %d (%s)\n",
+            __FILE__, __LINE__, res, curl_easy_strerror(res));
+    goto test_cleanup;
+  }
+
+test_cleanup:
+
+  curl_url_cleanup(urlp);
+  curl_easy_cleanup(handle);
+  curl_global_cleanup();
+
+  return res;
+}


### PR DESCRIPTION
Test 659 verifies

Also fixed the test 658 name