### PR TITLE
gopher: remove check for path == NULL

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -79,7 +79,6 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   struct Curl_easy *data = conn->data;
   curl_socket_t sockfd = conn->sock[FIRSTSOCKET];
   char *gopherpath;
-  /* path is guaranteed non-NULL */
   char *path = data->state.up.path;
   char *query = data->state.up.query;
   char *sel = NULL;
@@ -88,6 +87,9 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   size_t len;
 
   *done = TRUE; /* unconditionally */
+
+  /* path is guaranteed non-NULL */
+  DEBUGASSERT(path);
 
   if(query)
     gopherpath = aprintf("%s?%s", path, query);

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -79,6 +79,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
   struct Curl_easy *data = conn->data;
   curl_socket_t sockfd = conn->sock[FIRSTSOCKET];
   char *gopherpath;
+  /* path is guaranteed non-NULL */
   char *path = data->state.up.path;
   char *query = data->state.up.query;
   char *sel = NULL;
@@ -88,7 +89,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
 
   *done = TRUE; /* unconditionally */
 
-  if(path && query)
+  if(query)
     gopherpath = aprintf("%s?%s", path, query);
   else
     gopherpath = strdup(path);


### PR DESCRIPTION
Since it can't be NULL and it makes Coverity believe we lack proper NULL
checks. Verified by test 659 coming separately in PR #3641.

Pointed out by Coverity CID 1442746.

Fixes #3617