### PR TITLE
examples: only include <curl/curl.h>

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -30,7 +30,7 @@
 #ifndef WIN32
 #  include <unistd.h>
 #endif
-#include <curl/multi.h>
+#include <curl/curl.h>
 
 static const char *urls[] = {
   "https://www.microsoft.com",

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -72,7 +72,6 @@ callback.
 #include <unistd.h>
 
 #include <curl/curl.h>
-#include <curl/multi.h>
 
 #ifdef __GNUC__
 #define _Unused __attribute__((unused))


### PR DESCRIPTION
That's the only public curl header we should encourage use of.