### PR TITLE
CURLOPT_DNS_USE_GLOBAL_CACHE: remove

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -5,26 +5,6 @@ email the curl-library mailing list as soon as possible and explain to us why
 this is a problem for you and how your use case can't be satisfied properly
 using a work around.
 
-## `CURLOPT_DNS_USE_GLOBAL_CACHE`
-
-This option makes libcurl use a global non-thread-safe cache for DNS if
-enabled. The option has been marked as "obsolete" in the header file and in
-documentation for several years already.
-
-There's proper and safe method alternative provided since many years: the
-share API.
-
-### State
-
-In curl 7.62.0 setting this option to TRUE will not have any effect. The
-global cache will not be enabled. The code still remains so it is easy to
-revert if need be.
-
-### Removal
-
-Remove all global-cache related code from curl around April 2019 (might be
-7.66.0).
-
 ## HTTP/0.9
 
 Supporting this is non-obvious and might even come as a surprise to some

--- a/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -29,6 +29,8 @@ CURLOPT_DNS_USE_GLOBAL_CACHE \- enable/disable global DNS cache
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_USE_GLOBAL_CACHE,
                           long enable);
 .SH DESCRIPTION
+Has no function since 7.62.0. Do note use!
+
 Pass a long. If the \fIenable\fP value is 1, it tells curl to use a global DNS
 cache that will survive between easy handle creations and deletions. This is
 not thread-safe and this will use a global variable.
@@ -53,7 +55,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Subject for removal in the future. Do not use!
+Deprecated since 7.62.0. Has no function.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -265,7 +265,6 @@ void curl_global_cleanup(void)
   if(--initialized)
     return;
 
-  Curl_global_host_cache_dtor();
   Curl_ssl_cleanup();
   Curl_resolver_global_cleanup();
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -114,41 +114,7 @@
  * CURLRES_* defines based on the config*.h and curl_setup.h defines.
  */
 
-/* These two symbols are for the global DNS cache */
-static struct curl_hash hostname_cache;
-static int host_cache_initialized;
-
 static void freednsentry(void *freethis);
-
-/*
- * Curl_global_host_cache_init() initializes and sets up a global DNS cache.
- * Global DNS cache is general badness. Do not use. This will be removed in
- * a future version. Use the share interface instead!
- *
- * Returns a struct curl_hash pointer on success, NULL on failure.
- */
-struct curl_hash *Curl_global_host_cache_init(void)
-{
-  int rc = 0;
-  if(!host_cache_initialized) {
-    rc = Curl_hash_init(&hostname_cache, 7, Curl_hash_str,
-                        Curl_str_key_compare, freednsentry);
-    if(!rc)
-      host_cache_initialized = 1;
-  }
-  return rc?NULL:&hostname_cache;
-}
-
-/*
- * Destroy and cleanup the global DNS cache
- */
-void Curl_global_host_cache_dtor(void)
-{
-  if(host_cache_initialized) {
-    Curl_hash_destroy(&hostname_cache);
-    host_cache_initialized = 0;
-  }
-}
 
 /*
  * Return # of addresses in a Curl_addrinfo struct

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -402,19 +402,9 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
   /* set the easy handle */
   multistate(data, CURLM_STATE_INIT);
 
-  if((data->set.global_dns_cache) &&
-     (data->dns.hostcachetype != HCACHE_GLOBAL)) {
-    /* global dns cache was requested but still isn't */
-    struct curl_hash *global = Curl_global_host_cache_init();
-    if(global) {
-      /* only do this if the global cache init works */
-      data->dns.hostcache = global;
-      data->dns.hostcachetype = HCACHE_GLOBAL;
-    }
-  }
   /* for multi interface connections, we share DNS cache automatically if the
      easy handle's one is currently not set. */
-  else if(!data->dns.hostcache ||
+  if(!data->dns.hostcache ||
      (data->dns.hostcachetype == HCACHE_NONE)) {
     data->dns.hostcache = &multi->hostcache;
     data->dns.hostcachetype = HCACHE_MULTI;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -128,11 +128,7 @@ static CURLcode vsetopt(struct Curl_easy *data, CURLoption option,
     data->set.dns_cache_timeout = arg;
     break;
   case CURLOPT_DNS_USE_GLOBAL_CACHE:
-#if 0 /* deprecated */
-    /* remember we want this enabled */
-    arg = va_arg(param, long);
-    data->set.global_dns_cache = (0 != arg) ? TRUE : FALSE;
-#endif
+    /* deprecated */
     break;
   case CURLOPT_SSL_CIPHER_LIST:
     /* set a list of cipher we want to use in the SSL connection */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1691,7 +1691,6 @@ struct UserDefined {
   bit ftp_use_pret:1;   /* if PRET is to be used before PASV or not */
 
   bit no_signal:1;      /* do not use any signal/alarm handler */
-  bit global_dns_cache:1; /* subject for future removal */
   bit tcp_nodelay:1;    /* whether to enable TCP_NODELAY or not */
   bit ignorecl:1;       /* ignore content length */
   bit ftp_skip_ip:1;    /* skip the IP address the FTP server passes on to
@@ -1732,7 +1731,6 @@ struct Names {
   struct curl_hash *hostcache;
   enum {
     HCACHE_NONE,    /* not pointing to anything */
-    HCACHE_GLOBAL,  /* points to the (shrug) global one */
     HCACHE_MULTI,   /* points to a shared one in the multi handle */
     HCACHE_SHARED   /* points to a shared one in a shared object */
   } hostcachetype;

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -31,12 +31,8 @@ bool getaddressinfo(struct sockaddr *sa, char *addr, long *port);
 
 #include "memdebug.h" /* LAST include file */
 
-static struct Curl_easy *easy;
-static struct curl_hash *hostcache;
-
 static void unit_stop(void)
 {
-  curl_easy_cleanup(easy);
   curl_global_cleanup();
 }
 
@@ -45,18 +41,6 @@ static CURLcode unit_setup(void)
   int res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
-
-  easy = curl_easy_init();
-  if(!easy) {
-    curl_global_cleanup();
-    return CURLE_OUT_OF_MEMORY;
-  }
-
-  hostcache = Curl_global_host_cache_init();
-  if(!hostcache) {
-    unit_stop();
-    return CURLE_OUT_OF_MEMORY;
-  }
 
   return res;
 }
@@ -122,7 +106,7 @@ UNITTEST_START
   int i;
   int testnum = sizeof(tests) / sizeof(struct testcase);
 
-  for(i = 0; i < testnum; ++i, curl_easy_reset(easy)) {
+  for(i = 0; i < testnum; ++i) {
     int j;
     int addressnum = sizeof(tests[i].address) / sizeof(*tests[i].address);
     struct Curl_addrinfo *addr;
@@ -130,10 +114,17 @@ UNITTEST_START
     struct curl_slist *list;
     void *entry_id;
     bool problem = false;
+    struct Curl_multi *multi;
+    struct Curl_easy *easy = curl_easy_init();
+    if(!easy) {
+      curl_global_cleanup();
+      return CURLE_OUT_OF_MEMORY;
+    }
 
-    Curl_hostcache_clean(easy, hostcache);
-    easy->dns.hostcache = hostcache;
-    easy->dns.hostcachetype = HCACHE_GLOBAL;
+    /* create a multi handle and add the easy handle to it so that the
+       hostcache is setup */
+    multi = curl_multi_init();
+    curl_multi_add_handle(multi, easy);
 
     list = curl_slist_append(NULL, tests[i].optval);
     if(!list)
@@ -214,7 +205,8 @@ UNITTEST_START
       addr = addr->ai_next;
     }
 
-    Curl_hostcache_clean(easy, easy->dns.hostcache);
+    curl_easy_cleanup(easy);
+    curl_multi_cleanup(multi);
     curl_slist_free_all(list);
 
     if(problem) {


### PR DESCRIPTION
Remove the code too. The functionality has been disabled in code since 7.62.0. Setting this option will from now on simply be ignored and have no function.