### PR TITLE
cookie: handle dotless host name in non-PSL build

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -816,8 +816,6 @@ Curl_cookie_add(struct Curl_easy *data,
         co->domain = strdup(ptr);
         if(!co->domain)
           badcookie = TRUE;
-        else if(bad_domain(co->domain))
-          badcookie = TRUE;
         break;
       case 1:
         /* This field got its explanation on the 23rd of May 2001 by
@@ -946,20 +944,18 @@ Curl_cookie_add(struct Curl_easy *data,
   if(!noexpire)
     remove_expired(c);
 
-  if(domain && co->domain && !isip(co->domain)) {
-    int acceptable;
 #ifdef USE_LIBPSL
+  /* Check if the domain is a Public Suffix and if yes, ignore the cookie. */
+  if(domain && co->domain && !isip(co->domain)) {
     const psl_ctx_t *psl = Curl_psl_use(data);
+    int acceptable;
 
-    /* Check if the domain is a Public Suffix and if yes, ignore the cookie. */
     if(psl) {
       acceptable = psl_is_cookie_domain_acceptable(psl, domain, co->domain);
       Curl_psl_release(data);
     }
     else
-#endif
-    /* Without libpsl, do the best we can. */
-    acceptable = !bad_domain(co->domain);
+      acceptable = !bad_domain(domain);
 
     if(!acceptable) {
       infof(data, "cookie '%s' dropped, domain '%s' must not "
@@ -968,6 +964,7 @@ Curl_cookie_add(struct Curl_easy *data,
       return NULL;
     }
   }
+#endif
 
   myhash = cookiehash(co->domain);
   clist = c->cookies[myhash];

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -56,7 +56,7 @@ test289 test290 test291 test292 test293 test294 test295 test296 test297 \
 test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
-test325 test326 test327 test328 test329 test330 \
+test325 test326 test327 test328 test329 test330 test331 \
 \
 test340 \
 \

--- a/tests/data/test331
+++ b/tests/data/test331
@@ -1,0 +1,65 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+cookies
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Content-Length: 4
+Set-Cookie: moo=yes;
+
+hej
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Content-Length: 0
+Funny-head: yesyes swsclose
+
+</data2>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP with cookie using host name 'moo'
+ </name>
+ <command>
+-x http://%HOSTIP:%HTTPPORT http://moo/we/want/331 -b none http://moo/we/want/3310002
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://moo/we/want/331 HTTP/1.1
+Host: moo
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://moo/we/want/3310002 HTTP/1.1
+Host: moo
+Accept: */*
+Proxy-Connection: Keep-Alive
+Cookie: moo=yes
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test8
+++ b/tests/data/test8
@@ -46,7 +46,6 @@ Set-Cookie: trailingspace    = removed; path=/we/want;
 Set-Cookie: nocookie=yes; path=/WE;
 Set-Cookie: blexp=yesyes; domain=%HOSTIP; domain=%HOSTIP; expiry=totally bad;
 Set-Cookie: partialip=nono; domain=.0.0.1;
-Set-Cookie: chocolate=chip; domain=curl; path=/we/want;
 
 </file>
 <precheck>


### PR DESCRIPTION
Fixes #3649 