### PR TITLE
doh: inherit more SSL options from easy handle

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -251,7 +251,8 @@ static CURLcode dohprobe(struct Curl_easy *data,
     if(data->set.no_signal)
       ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
 
-    /* Inherit most SSL options */
+    /* Inherit *some* SSL options. Options likely specific to the user's
+       transfer are not inherited. Refer to discussion in #3661. */
     if(data->set.ssl_enable_alpn)
       ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_ALPN, 1L);
     if(data->set.ssl_enable_npn)
@@ -275,10 +276,6 @@ static CURLcode dohprobe(struct Curl_easy *data,
     if(data->set.str[STRING_SSL_CAFILE_PROXY]) {
       ERROR_CHECK_SETOPT(CURLOPT_PROXY_CAINFO,
         data->set.str[STRING_SSL_CAFILE_PROXY]);
-    }
-    if(data->set.str[STRING_SSL_ISSUERCERT_ORIG]) {
-      ERROR_CHECK_SETOPT(CURLOPT_ISSUERCERT,
-        data->set.str[STRING_SSL_ISSUERCERT_ORIG]);
     }
     if(data->set.str[STRING_SSL_CAPATH_ORIG]) {
       ERROR_CHECK_SETOPT(CURLOPT_CAPATH,

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -173,8 +173,12 @@ static int Curl_doh_done(struct Curl_easy *doh, CURLcode result)
   return 0;
 }
 
-#define ERROR_CHECK_SETOPT(x,y) result = curl_easy_setopt(doh, x, y);   \
-  if(result) goto error
+#define ERROR_CHECK_SETOPT(x,y) \
+do {                                      \
+  result = curl_easy_setopt(doh, x, y);   \
+  if(result)                              \
+    goto error;                           \
+} WHILE_FALSE
 
 static CURLcode dohprobe(struct Curl_easy *data,
                          struct dnsprobe *p, DNStype dnstype,

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -238,9 +238,8 @@ static CURLcode dohprobe(struct Curl_easy *data,
       ERROR_CHECK_SETOPT(CURLOPT_POSTFIELDSIZE, (long)p->dohlen);
     }
     ERROR_CHECK_SETOPT(CURLOPT_HTTPHEADER, headers);
-#ifdef USE_NGHTTP2
-    ERROR_CHECK_SETOPT(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
-#endif
+    if(data->set.httpversion != CURL_HTTP_VERSION_NONE)
+      ERROR_CHECK_SETOPT(CURLOPT_HTTP_VERSION, (long)data->set.httpversion);
 #ifndef CURLDEBUG
     /* enforce HTTPS if not debug */
     ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
@@ -252,8 +251,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
       ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
 
     /* Inherit *some* SSL options from the user's transfer. This is a
-       best-guess approach as to which options the user would've intended to
-       apply to the doh transfers. #3661 */
+       best-guess as to which options are needed for compatibility. #3661 */
     ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_ALPN,
                        (data->set.ssl_enable_alpn ? 1L : 0L));
     ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_NPN,

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -294,14 +294,6 @@ static CURLcode dohprobe(struct Curl_easy *data,
     }
     if(data->set.ssl.certinfo)
       ERROR_CHECK_SETOPT(CURLOPT_CERTINFO, 1L);
-    if(data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG]) {
-      ERROR_CHECK_SETOPT(CURLOPT_PINNEDPUBLICKEY,
-        data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG]);
-    }
-    if(data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY]) {
-      ERROR_CHECK_SETOPT(CURLOPT_PROXY_PINNEDPUBLICKEY,
-        data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY]);
-    }
     if(data->set.str[STRING_SSL_RANDOM_FILE]) {
       ERROR_CHECK_SETOPT(CURLOPT_RANDOM_FILE,
         data->set.str[STRING_SSL_RANDOM_FILE]);

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -242,7 +242,83 @@ static CURLcode dohprobe(struct Curl_easy *data,
     ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
 #endif
     ERROR_CHECK_SETOPT(CURLOPT_TIMEOUT_MS, (long)timeout_ms);
-    ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, 1L);
+    if(data->set.verbose)
+      ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, 1L);
+    if(data->set.no_signal)
+      ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
+
+    /* Inherit most SSL options */
+    if(data->set.ssl_enable_alpn)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_ALPN, 1L);
+    if(data->set.ssl_enable_npn)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_NPN, 1L);
+    if(data->set.ssl.falsestart)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_FALSESTART, 1L);
+    if(data->set.ssl.primary.verifyhost)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYHOST, 2L);
+    if(data->set.proxy_ssl.primary.verifyhost)
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYHOST, 2L);
+    if(data->set.ssl.primary.verifypeer)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYPEER, 1L);
+    if(data->set.proxy_ssl.primary.verifypeer)
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYPEER, 1L);
+    if(data->set.ssl.primary.verifystatus)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYSTATUS, 1L);
+    if(data->set.str[STRING_SSL_CAFILE_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_CAINFO,
+        data->set.str[STRING_SSL_CAFILE_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CAFILE_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_CAINFO,
+        data->set.str[STRING_SSL_CAFILE_PROXY]);
+    }
+    if(data->set.str[STRING_SSL_ISSUERCERT_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_ISSUERCERT,
+        data->set.str[STRING_SSL_ISSUERCERT_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CAPATH_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_CAPATH,
+        data->set.str[STRING_SSL_CAPATH_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CAPATH_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_CAPATH,
+        data->set.str[STRING_SSL_CAPATH_PROXY]);
+    }
+    if(data->set.str[STRING_SSL_CRLFILE_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_CRLFILE,
+        data->set.str[STRING_SSL_CRLFILE_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CRLFILE_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_CRLFILE,
+        data->set.str[STRING_SSL_CRLFILE_PROXY]);
+    }
+    if(data->set.ssl.certinfo)
+      ERROR_CHECK_SETOPT(CURLOPT_CERTINFO, 1L);
+    if(data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PINNEDPUBLICKEY,
+        data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_PINNEDPUBLICKEY,
+        data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY]);
+    }
+    if(data->set.str[STRING_SSL_RANDOM_FILE]) {
+      ERROR_CHECK_SETOPT(CURLOPT_RANDOM_FILE,
+        data->set.str[STRING_SSL_RANDOM_FILE]);
+    }
+    if(data->set.str[STRING_SSL_EGDSOCKET]) {
+      ERROR_CHECK_SETOPT(CURLOPT_EGDSOCKET,
+        data->set.str[STRING_SSL_EGDSOCKET]);
+    }
+    if(data->set.ssl.no_revoke)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
+    if(data->set.proxy_ssl.no_revoke)
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
+    if(data->set.ssl.fsslctx)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_FUNCTION, data->set.ssl.fsslctx);
+    if(data->set.ssl.fsslctxp)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_DATA, data->set.ssl.fsslctxp);
+
     doh->set.fmultidone = Curl_doh_done;
     doh->set.dohfor = data; /* identify for which transfer this is done */
     p->easy = doh;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -251,12 +251,13 @@ static CURLcode dohprobe(struct Curl_easy *data,
     if(data->set.no_signal)
       ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
 
-    /* Inherit *some* SSL options. Options likely specific to the user's
-       transfer are not inherited. Refer to discussion in #3661. */
-    if(data->set.ssl_enable_alpn)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_ALPN, 1L);
-    if(data->set.ssl_enable_npn)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_NPN, 1L);
+    /* Inherit *some* SSL options from the user's transfer. This is a
+       best-guess approach as to which options the user would've intended to
+       apply to the doh transfers. #3661 */
+    ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_ALPN,
+                       (data->set.ssl_enable_alpn ? 1L : 0L));
+    ERROR_CHECK_SETOPT(CURLOPT_SSL_ENABLE_NPN,
+                       (data->set.ssl_enable_npn ? 1L : 0L));
     if(data->set.ssl.falsestart)
       ERROR_CHECK_SETOPT(CURLOPT_SSL_FALSESTART, 1L);
     if(data->set.ssl.primary.verifyhost)


### PR DESCRIPTION
- Inherit most SSL options for the doh handle but not SSL client certs,
  SSL engine, SSL version, SSL ciphers, SSL id cache setting,
  SSL kerberos or SSL gss-api settings.

My thinking for the options not inherited is they are most likely not
intended by the user for the DOH transfer. I did inherit insecure
because I think that should still be in control of the user.

Prior to this change doh did not work for me because CAINFO was not
inherited. Also verbose was set always which AFAICT was a bug (#3660).

Fixes https://github.com/curl/curl/issues/3660
Closes #xxxx