### PR TITLE
socket handling and WIN32 WSACleanup fixes

### DIFF
--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -124,8 +124,10 @@ int main(void)
     servaddr.sin_port   = htons(PORTNUM);
 
     servaddr.sin_addr.s_addr = inet_addr(IPADDR);
-    if(INADDR_NONE == servaddr.sin_addr.s_addr)
+    if(INADDR_NONE == servaddr.sin_addr.s_addr) {
+      close(sockfd);
       return 2;
+    }
 
     if(connect(sockfd, (struct sockaddr *) &servaddr, sizeof(servaddr)) ==
        -1) {

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -160,7 +160,7 @@ int main(void)
     curl_easy_cleanup(curl);
 
     close(sockfd);
-    
+
     if(res) {
       printf("libcurl error: %d\n", res);
       return 4;

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -159,10 +159,16 @@ int main(void)
 
     curl_easy_cleanup(curl);
 
+    close(sockfd);
+    
     if(res) {
       printf("libcurl error: %d\n", res);
       return 4;
     }
   }
+
+#ifdef WIN32
+  WSACleanup();
+#endif
   return 0;
 }


### PR DESCRIPTION
Just a couple of nitpicks in docs/examples/externalsocket.c:

In the event that servaddr.sin_addr.s_addr is INADDR_NONE, the example code leaks sockfd. This would matter if someone copied the code into a function that wasn't main()... ;-)

Microsoft's Winsock documentation states that a matching call to WSACleanup() should be called for every WSAStartup() call performed.