### PR TITLE
Fix Payload dropped from POST when using proxy with NTLM authentication

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2060,7 +2060,8 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
       return result;
   }
 
-  if((data->state.authhost.multipass || data->state.authproxy.multipass) &&
+  if(((data->state.authhost.multipass && !data->state.authhost.done)
+      || (data->state.authproxy.multipass && !data->state.authproxy.done)) &&
      (httpreq != HTTPREQ_GET) &&
      (httpreq != HTTPREQ_HEAD)) {
     /* Auth is required and we are not authenticated yet. Make a PUT or POST

--- a/tests/data/test1097
+++ b/tests/data/test1097
@@ -60,7 +60,7 @@ http://test.a.galaxy.far.far.away.1097:%HTTPPORT/1097 --proxy http://%HOSTIP:%HT
 <strip>
 ^User-Agent: curl/.*
 </strip>
-<protocol>
+<protocol nonewline="yes">
 CONNECT test.a.galaxy.far.far.away.1097:%HTTPPORT HTTP/1.1
 Host: test.a.galaxy.far.far.away.1097:%HTTPPORT
 Proxy-Authorization: NTLM TlRMTVNTUAABAAAABoIIAAAAAAAAAAAAAAAAAAAAAAA=
@@ -71,9 +71,10 @@ POST /1097 HTTP/1.1
 User-Agent: curl/7.19.5-CVS (i686-pc-linux-gnu) libcurl/7.19.5-CVS OpenSSL/0.9.8g zlib/1.2.3.3 c-ares/1.6.1-CVS libidn/1.12 libssh2/1.0.1_CVS
 Host: test.a.galaxy.far.far.away.1097:%HTTPPORT
 Accept: */*
-Content-Length: 0
+Content-Length: 11
 Content-Type: application/x-www-form-urlencoded
 
+dummy=value
 </protocol>
 
 </verify>


### PR DESCRIPTION
Hello,

There's an attempt to fix the bug (https://github.com/curl/curl/issues/2431) that prevents sending payload when authentication with NTLM is done before sending credentials.

I noticed that the check that prevent payload from sending in case of authentication doesn't check properly if the authentication is done or not.

They're cases where the proxy respond "200 OK" before sending authentication challenge. This change thake care of that cases. I tested it and it works in my cases.

Can you tell me what do you think about it?

Thank you