### PR TITLE
travis: update to clang 7 and actually use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ addons:
             retries: true
         sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-trusty-7
         packages:
             - cmake
             - gcc-7
             - gcc-8
             - lcov
-            - clang-6.0
+            - clang-7
             - valgrind
             - libev-dev
             - libc-ares-dev
@@ -41,7 +41,7 @@ addons:
             - libnss3-dev
             - gnutls-bin
             - libgnutls28-dev
-            - clang-tidy-6.0
+            - clang-tidy-7
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
             - llvm-toolchain-trusty-7
         packages:
             - cmake
-            - gcc-7
             - gcc-8
             - lcov
             - clang-7
@@ -48,67 +47,99 @@ matrix:
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=normal C="--with-gssapi --with-libssh2" CHECKSRC=1
+          env:
+              - T=normal C="--with-gssapi --with-libssh2" CHECKSRC=1
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=normal C=--with-libssh
+          env:
+              - T=normal C=--with-libssh
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=normal C="--disable-http --disable-smtp --disable-imap"
+          env:
+              - T=normal C="--disable-http --disable-smtp --disable-imap"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=normal C="--enable-ares"
+          env:
+              - T=normal C="--enable-ares"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=normal C="--disable-verbose" CPPFLAGS="-Wno-variadic-macros" NOTESTS=1
+          env:
+              - T=normal C="--disable-verbose" CPPFLAGS="-Wno-variadic-macros" NOTESTS=1
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=normal BROTLI=yes
+          env:
+              - T=normal BROTLI=yes
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=novalgrind BORINGSSL=yes C="--with-ssl=$HOME/boringssl" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
+          env:
+              - T=novalgrind BORINGSSL=yes C="--with-ssl=$HOME/boringssl" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=debug-wolfssl C="--with-wolfssl --without-ssl"
+          env:
+              - T=debug-wolfssl C="--with-wolfssl --without-ssl"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=debug-mesalink C="--with-mesalink --without-ssl"
+          env:
+              - T=debug-mesalink C="--with-mesalink --without-ssl"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug
+          env:
+              - T=debug
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug C="--enable-alt-svc"
+          env:
+              - T=debug C="--enable-alt-svc"
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug C="--with-mbedtls --without-ssl"
+          env:
+              - T=debug C="--with-mbedtls --without-ssl"
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug C="--with-gnutls --without-ssl"
+          env:
+              - T=debug C="--with-gnutls --without-ssl"
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug C="--disable-threaded-resolver"
+          env:
+              - T=debug C="--disable-threaded-resolver"
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug C="--with-nss --without-ssl" NOTESTS=1 CPPFLAGS="-isystem /usr/include/nss"
+          env:
+              - T=debug C="--with-nss --without-ssl" NOTESTS=1 CPPFLAGS="-isystem /usr/include/nss"
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=iconv
+          env:
+              - T=iconv
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: osx
           compiler: gcc
           env: T=debug C=--with-libssh2
@@ -134,35 +165,55 @@ matrix:
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=cmake
+          env:
+              - T=cmake
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=cmake
+          env:
+              - T=cmake
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=coverage
+          env:
+              - T=coverage
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc
           dist: trusty
-          env: T=distcheck
+          env:
+              - T=distcheck
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=fuzzer
+          env:
+              - T=fuzzer
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=tidy
+          env:
+              - T=tidy
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=scan-build
+          env:
+              - T=scan-build
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
         - os: linux
           compiler: clang
           dist: trusty
-          env: T=debug CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g" LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer" LIBS="-ldl -lubsan"
+          env:
+              - T=debug CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g" LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer" LIBS="-ldl -lubsan"
+              - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+
+before_install:
+    - eval "${OVERRIDE_CC}"
+    - eval "${OVERRIDE_CXX}"
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi
@@ -193,7 +244,7 @@ before_script:
         cd boringssl &&
         mkdir build &&
         cd build &&
-        cmake -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=1 .. &&
+        CXX="g++" CC="gcc" cmake -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=1 .. &&
         make &&
         cd .. &&
         mkdir lib &&
@@ -289,15 +340,14 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "coverage" ]; then
-             export CC="gcc-7"
              ./configure --enable-debug --disable-shared --enable-code-coverage
              make
              make TFLAGS=-n test-nonflaky
              make "TFLAGS=-n -e" test-nonflaky
              tests="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 200 201 202 300 301 302 500 501 502 503 504 506 507 508 509 510 511 512 513 514 515 516 517 518 519 600 601 700 701 702 800 801 802 803 900 901 902 903 1000 1001 1002 1004 1100 1101 1200 1201 1302 1303 1304 1305 1306 1308 1400 1401 1402 1404 1450 1451 1452 1502 1507 1508 1600 1602 1603 1605 1650 1651 1652 1653 1654 2001 2100 3000"
              make "TFLAGS=-n -t $tests" test-nonflaky
-             coveralls --gcov /usr/bin/gcov-7 --gcov-options '\-lp' -i src -e lib -e tests -e docs -b $PWD/src
-             coveralls --gcov /usr/bin/gcov-7 --gcov-options '\-lp' -e src -i lib -e tests -e docs -b $PWD/lib
+             coveralls --gcov /usr/bin/gcov-8 --gcov-options '\-lp' -i src -e lib -e tests -e docs -b $PWD/src
+             coveralls --gcov /usr/bin/gcov-8 --gcov-options '\-lp' -e src -i lib -e tests -e docs -b $PWD/lib
         fi
     - |
         set -eo pipefail


### PR DESCRIPTION
For the Linux builds, GCC 8 and 7 and clang 7 were installed, but the
new GCC versions were only used for the coverage build and for building
nghttp2, while the new clang version was not used at all.

BoringSSL needs to use the default GCC as it respects CC, but not CXX,
so it would otherwise pass gcc 8 options to g++ 4.8 and fail.

Also remove GCC 7, it's not needed anymore.

Ref: https://docs.travis-ci.com/user/languages/c/#c11c11-and-beyond-and-toolchain-versioning