### PR TITLE
memdebug: log pointer before freeing its data

### DIFF
--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -550,13 +550,13 @@ void
 curl_dbg_freeaddrinfo(struct addrinfo *freethis,
                       int line, const char *source)
 {
+  curl_dbg_log("ADDR %s:%d freeaddrinfo(%p)\n",
+               source, line, (void *)freethis);
 #ifdef USE_LWIPSOCK
   lwip_freeaddrinfo(freethis);
 #else
   (freeaddrinfo)(freethis);
 #endif
-  curl_dbg_log("ADDR %s:%d freeaddrinfo(%p)\n",
-               source, line, (void *)freethis);
 }
 #endif /* defined(CURLDEBUG) && defined(HAVE_FREEADDRINFO) */
 

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -463,11 +463,11 @@ int curl_dbg_fclose(FILE *file, int line, const char *source)
 
   DEBUGASSERT(file != NULL);
 
-  res = fclose(file);
-
   if(source)
     curl_dbg_log("FILE %s:%d fclose(%p)\n",
-                source, line, (void *)file);
+                 source, line, (void *)file);
+
+  res = fclose(file);
 
   return res;
 }


### PR DESCRIPTION
Coverity warned for two potentional "Use after free" cases. Both are false
positives because the memory wasn't used, it was only the actual pointer
value that was logged.

The fix still changes the order of execution to avoid the warnings.

Coverity CID 1443033 and 1443034