### PR TITLE
travis: revert inconv build to default GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,6 @@ matrix:
           dist: trusty
           env:
               - T=iconv
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: osx
           compiler: gcc
           env: T=debug C=--with-libssh2


### PR DESCRIPTION
With GCC 8, it hit Travis' 50 minutes timeout.

Trying to see if it's caused by using the newer compiler.