### PR TITLE
AmiSSL support

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1031,6 +1031,10 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #endif
 #endif
 #else
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1076,6 +1080,10 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #endif
 #define RECVCALLCONV PASCAL
 #else
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1084,8 +1092,10 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #endif
 #define RECVCALLCONV
 #endif
+#ifndef HAVE_PROTO_BSDSOCKET_H
                       extern $recv_retv RECVCALLCONV
                       recv($recv_arg1, $recv_arg2, $recv_arg3, $recv_arg4);
+#endif
                     ]],[[
                       $recv_arg1 s=0;
                       $recv_arg2 buf=0;
@@ -1165,6 +1175,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #endif
 #endif
 #else
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1210,6 +1224,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #endif
 #define SENDCALLCONV PASCAL
 #else
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1218,8 +1236,10 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #endif
 #define SENDCALLCONV
 #endif
+#ifndef HAVE_PROTO_BSDSOCKET_H
                       extern $send_retv SENDCALLCONV
                       send($send_arg1, $send_arg2, $send_arg3, $send_arg4);
+#endif
                     ]],[[
                       $send_arg1 s=0;
                       $send_arg3 len=0;
@@ -1321,6 +1341,10 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
 #endif
 #endif
 #else
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1714,6 +1738,7 @@ dnl using current libraries or if another one is required.
 
 AC_DEFUN([CURL_CHECK_LIBS_CONNECT], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
+  AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   AC_MSG_CHECKING([for connect in libraries])
   tst_connect_save_LIBS="$LIBS"
   tst_connect_need_LIBS="unknown"
@@ -1723,7 +1748,8 @@ AC_DEFUN([CURL_CHECK_LIBS_CONNECT], [
       AC_LINK_IFELSE([
         AC_LANG_PROGRAM([[
           $curl_includes_winsock2
-          #ifndef HAVE_WINDOWS_H
+          $curl_includes_bsdsocket
+          #if !defined(HAVE_WINDOWS_H) && !defined(HAVE_PROTO_BSDSOCKET_H)
             int connect(int, void*, int);
           #endif
         ]],[[
@@ -1854,6 +1880,11 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
 #endif
 #endif
 #ifndef HAVE_WINDOWS_H
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
+#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
@@ -1912,6 +1943,11 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
 #endif
 #endif
 #ifndef HAVE_WINDOWS_H
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
+#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
@@ -1926,12 +1962,14 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
                       long tv_usec;
                     };
 #endif
+#ifndef HAVE_PROTO_BSDSOCKET_H
                     extern $sel_retv SELECTCALLCONV
 				select($sel_arg1,
 					$sel_arg234,
 					$sel_arg234,
 					$sel_arg234,
 					$sel_arg5);
+#endif
                   ]],[[
                     $sel_arg1   nfds=0;
                     $sel_arg234 rfds=0;

--- a/configure.ac
+++ b/configure.ac
@@ -1554,6 +1554,7 @@ if test -z "$ssl_backends" -o "x$OPT_AMISSL" != xno; then
     test amissl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
     AMISSL_ENABLED=1
     LIBS="-lamisslauto $LIBS"
+    AC_DEFINE(USE_AMISSL, 1, [if AmiSSL is in use])
     AC_DEFINE(USE_OPENSSL, 1, [if OpenSSL is in use])
   else
     AC_MSG_RESULT(no)

--- a/configure.ac
+++ b/configure.ac
@@ -1553,7 +1553,7 @@ if test -z "$ssl_backends" -o "x$OPT_AMISSL" != xno; then
     ssl_msg="AmiSSL"
     test amissl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
     AMISSL_ENABLED=1
-    CURL_NETWORK_LIBS="-lamisslauto $CURL_NETWORK_LIBS"
+    LIBS="-lamisslauto $LIBS"
     AC_DEFINE(USE_OPENSSL, 1, [if OpenSSL is in use])
   else
     AC_MSG_RESULT(no)

--- a/configure.ac
+++ b/configure.ac
@@ -366,17 +366,6 @@ CURL_MAC_CFLAGS
 CURL_SUPPORTS_BUILTIN_AVAILABLE
 
 
-dnl Check for Amiga bsdsocket.library headers
-AC_CHECK_HEADERS([proto/bsdsocket.h],
-  [
-  HAVE_PROTO_BSDSOCKET_H=1
-  AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
-  AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])],
-  [],
-  []
-)
-
-
 dnl ************************************************************
 dnl switch off particular protocols
 dnl
@@ -855,16 +844,17 @@ then
   AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
-#ifdef HAVE_PROTO_BSDSOCKET_H
 #include <proto/bsdsocket.h>
 struct Library *SocketBase = NULL;
-#endif
     ]],[[
       gethostbyname("www.dummysite.com");
     ]])
   ],[
     AC_MSG_RESULT([yes])
     HAVE_GETHOSTBYNAME="1"
+    HAVE_PROTO_BSDSOCKET_H="1"
+    AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
+    AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])
   ],[
     AC_MSG_RESULT([no])
   ])

--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,18 @@ CURL_CHECK_WIN32_LARGEFILE
 CURL_MAC_CFLAGS
 CURL_SUPPORTS_BUILTIN_AVAILABLE
 
+
+dnl Check for Amiga bsdsocket.library headers
+AC_CHECK_HEADERS([proto/bsdsocket.h],
+  [
+  HAVE_PROTO_BSDSOCKET_H=1
+  AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
+  AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])],
+  [],
+  []
+)
+
+
 dnl ************************************************************
 dnl switch off particular protocols
 dnl
@@ -826,6 +838,27 @@ then
     AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <netdb.h>
+    ]],[[
+      gethostbyname("www.dummysite.com");
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    HAVE_GETHOSTBYNAME="1"
+  ],[
+    AC_MSG_RESULT([no])
+  ])
+fi
+
+if test "$HAVE_GETHOSTBYNAME" != "1"
+then
+  dnl This is for AmigaOS with bsdsocket.library - needs testing before -lnet
+  AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#endif
     ]],[[
       gethostbyname("www.dummysite.com");
     ]])
@@ -1546,20 +1579,24 @@ AC_HELP_STRING([--without-amissl], [disable Amiga native SSL/TLS (AmiSSL)]),
   OPT_AMISSL=$withval)
 
 AC_MSG_CHECKING([whether to enable Amiga native SSL/TLS (AmiSSL)])
-if test -z "$ssl_backends" -o "x$OPT_AMISSL" != xno; then
-  ssl_msg=
-  if test "x$OPT_AMISSL" != "xno"; then
-    AC_MSG_RESULT(yes)
-    ssl_msg="AmiSSL"
-    test amissl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-    AMISSL_ENABLED=1
-    LIBS="-lamisslauto $LIBS"
-    AC_DEFINE(USE_AMISSL, 1, [if AmiSSL is in use])
-    AC_DEFINE(USE_OPENSSL, 1, [if OpenSSL is in use])
+if test "$HAVE_PROTO_BSDSOCKET_H" == "1"; then
+  if test -z "$ssl_backends" -o "x$OPT_AMISSL" != xno; then
+    ssl_msg=
+    if test "x$OPT_AMISSL" != "xno"; then
+      AC_MSG_RESULT(yes)
+      ssl_msg="AmiSSL"
+      test amissl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+      AMISSL_ENABLED=1
+      LIBS="-lamisslauto $LIBS"
+      AC_DEFINE(USE_AMISSL, 1, [if AmiSSL is in use])
+      AC_DEFINE(USE_OPENSSL, 1, [if OpenSSL is in use])
+    else
+      AC_MSG_RESULT(no)
+    fi
+    test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
   else
     AC_MSG_RESULT(no)
   fi
-  test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 else
   AC_MSG_RESULT(no)
 fi
@@ -3546,6 +3583,7 @@ dnl default includes
 #endif
 ]
 )
+
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/configure.ac
+++ b/configure.ac
@@ -155,7 +155,7 @@ AC_SUBST(PKGADD_VENDOR)
 
 dnl
 dnl initialize all the info variables
-    curl_ssl_msg="no      (--with-{ssl,gnutls,nss,polarssl,mbedtls,cyassl,schannel,secure-transport,mesalink} )"
+    curl_ssl_msg="no      (--with-{ssl,gnutls,nss,polarssl,mbedtls,cyassl,schannel,secure-transport,mesalink,amissl} )"
     curl_ssh_msg="no      (--with-libssh2)"
    curl_zlib_msg="no      (--with-zlib)"
  curl_brotli_msg="no      (--with-brotli)"
@@ -1539,6 +1539,30 @@ else
   AC_MSG_RESULT(no)
 fi
 
+OPT_AMISSL=no
+AC_ARG_WITH(amissl,dnl
+AC_HELP_STRING([--with-amissl],[enable Amiga native SSL/TLS (AmiSSL)])
+AC_HELP_STRING([--without-amissl], [disable Amiga native SSL/TLS (AmiSSL)]),
+  OPT_AMISSL=$withval)
+
+AC_MSG_CHECKING([whether to enable Amiga native SSL/TLS (AmiSSL)])
+if test -z "$ssl_backends" -o "x$OPT_AMISSL" != xno; then
+  ssl_msg=
+  if test "x$OPT_AMISSL" != "xno"; then
+    AC_MSG_RESULT(yes)
+    ssl_msg="AmiSSL"
+    test amissl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+    AMISSL_ENABLED=1
+    CURL_NETWORK_LIBS="-lamisslauto $CURL_NETWORK_LIBS"
+    AC_DEFINE(USE_OPENSSL, 1, [if OpenSSL is in use])
+  else
+    AC_MSG_RESULT(no)
+  fi
+  test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl **********************************************************************
 dnl Check for the presence of SSL libraries and headers
 dnl **********************************************************************
@@ -2638,10 +2662,10 @@ if test -z "$ssl_backends" -o "x$OPT_NSS" != xno; then
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 fi
 
-case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$POLARSSL_ENABLED$MBEDTLS_ENABLED$CYASSL_ENABLED$WINSSL_ENABLED$SECURETRANSPORT_ENABLED$MESALINK_ENABLED" in
+case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$POLARSSL_ENABLED$MBEDTLS_ENABLED$CYASSL_ENABLED$WINSSL_ENABLED$SECURETRANSPORT_ENABLED$MESALINK_ENABLED$AMISSL_ENABLED" in
 x)
   AC_MSG_WARN([SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.])
-  AC_MSG_WARN([Use --with-ssl, --with-gnutls, --with-polarssl, --with-cyassl, --with-nss, --with-schannel, --with-secure-transport, or --with-mesalink to address this.])
+  AC_MSG_WARN([Use --with-ssl, --with-gnutls, --with-polarssl, --with-cyassl, --with-nss, --with-schannel, --with-secure-transport, --with-mesalink or --with-amissl to address this.])
   ;;
 x1)
   # one SSL backend is enabled

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -88,7 +88,7 @@ ADD2EXIT(Curl_amiga_cleanup, -50);
 #ifdef USE_AMISSL
 void Curl_amiga_X509_free(X509 *a)
 {
-	X509_free(a);
+  X509_free(a);
 }
 #endif /* USE_AMISSL */
 #endif /* __AMIGA__ */

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -25,7 +25,7 @@
 #ifdef __AMIGA__
 #include "amigaos.h"
 
-#ifndef USE_AMISSL
+#if defined(HAVE_PROTO_BSDSOCKET_H) && !defined(USE_AMISSL)
 #include <amitcp/socketbasetags.h>
 
 struct Library *SocketBase = NULL;
@@ -74,7 +74,9 @@ bool Curl_amiga_init()
 ADD2EXIT(Curl_amiga_cleanup, -50);
 #endif
 
-#else /* USE_AMISSL */
+#endif /* HAVE_PROTO_BSDSOCKET_H */
+
+#ifdef USE_AMISSL
 void Curl_amiga_X509_free(X509 *a)
 {
 	X509_free(a);

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -26,7 +26,6 @@
 #include "amigaos.h"
 
 #ifndef USE_AMISSL
-#ifndef __ixemul__
 #include <amitcp/socketbasetags.h>
 
 struct Library *SocketBase = NULL;
@@ -74,8 +73,6 @@ bool Curl_amiga_init()
 #ifdef __libnix__
 ADD2EXIT(Curl_amiga_cleanup, -50);
 #endif
-
-#endif /* ! __ixemul__ */
 
 #else /* USE_AMISSL */
 void Curl_amiga_X509_free(X509 *a)

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -22,11 +22,11 @@
 
 #include "curl_setup.h"
 
-#if defined(__AMIGA__) && !defined(__ixemul__)
-
-#include <amitcp/socketbasetags.h>
-
+#ifdef __AMIGA__
 #include "amigaos.h"
+
+#ifndef __ixemul__
+#include <amitcp/socketbasetags.h>
 
 struct Library *SocketBase = NULL;
 extern int errno, h_errno;
@@ -74,4 +74,13 @@ bool Curl_amiga_init()
 ADD2EXIT(Curl_amiga_cleanup, -50);
 #endif
 
-#endif /* __AMIGA__ && ! __ixemul__ */
+#endif /* ! __ixemul__ */
+
+#ifdef USE_OPENSSL
+void Curl_amiga_X509_free(X509 *a)
+{
+	X509_free(a);
+}
+#endif /* USE_OPENSSL */
+#endif /* __AMIGA__ */
+

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -23,16 +23,25 @@
 #include "curl_setup.h"
 
 #ifdef __AMIGA__
-#include "amigaos.h"
+#  include "amigaos.h"
+#  if defined(HAVE_PROTO_BSDSOCKET_H) && !defined(USE_AMISSL)
+#    include <amitcp/socketbasetags.h>
+#  endif
+#  ifdef __libnix__
+#    include <stabs.h>
+#  endif
+#endif
 
+/* The last #include files should be: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
+#ifdef __AMIGA__
 #if defined(HAVE_PROTO_BSDSOCKET_H) && !defined(USE_AMISSL)
-#include <amitcp/socketbasetags.h>
-
 struct Library *SocketBase = NULL;
 extern int errno, h_errno;
 
 #ifdef __libnix__
-#include <stabs.h>
 void __request(const char *msg);
 #else
 # define __request(msg)       Printf(msg "\n\a")

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -25,6 +25,7 @@
 #ifdef __AMIGA__
 #include "amigaos.h"
 
+#ifndef USE_AMISSL
 #ifndef __ixemul__
 #include <amitcp/socketbasetags.h>
 
@@ -76,11 +77,11 @@ ADD2EXIT(Curl_amiga_cleanup, -50);
 
 #endif /* ! __ixemul__ */
 
-#ifdef USE_OPENSSL
+#else /* USE_AMISSL */
 void Curl_amiga_X509_free(X509 *a)
 {
 	X509_free(a);
 }
-#endif /* USE_OPENSSL */
+#endif /* USE_AMISSL */
 #endif /* __AMIGA__ */
 

--- a/lib/amigaos.h
+++ b/lib/amigaos.h
@@ -23,7 +23,9 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(__AMIGA__) && !defined(__ixemul__)
+#ifdef __AMIGA__
+
+#if !defined(__ixemul__) && !defined(USE_AMISSL)
 
 bool Curl_amiga_init();
 void Curl_amiga_cleanup();
@@ -35,9 +37,11 @@ void Curl_amiga_cleanup();
 
 #endif
 
-#if defined(__AMIGA__) && defined(USE_OPENSSL)
+#ifdef USE_AMISSL
 #include <openssl/x509v3.h>
 void Curl_amiga_X509_free(X509 *a);
 #endif
 
+#endif /* __AMIGA__ */
 #endif /* HEADER_CURL_AMIGAOS_H */
+

--- a/lib/amigaos.h
+++ b/lib/amigaos.h
@@ -25,7 +25,7 @@
 
 #ifdef __AMIGA__
 
-#if !defined(__ixemul__) && !defined(USE_AMISSL)
+#ifndef USE_AMISSL
 
 bool Curl_amiga_init();
 void Curl_amiga_cleanup();
@@ -35,12 +35,9 @@ void Curl_amiga_cleanup();
 #define Curl_amiga_init() 1
 #define Curl_amiga_cleanup() Curl_nop_stmt
 
-#endif
-
-#ifdef USE_AMISSL
 #include <openssl/x509v3.h>
 void Curl_amiga_X509_free(X509 *a);
-#endif
+#endif /* USE_AMISSL */
 
 #endif /* __AMIGA__ */
 #endif /* HEADER_CURL_AMIGAOS_H */

--- a/lib/amigaos.h
+++ b/lib/amigaos.h
@@ -35,4 +35,9 @@ void Curl_amiga_cleanup();
 
 #endif
 
+#if defined(__AMIGA__) && defined(USE_OPENSSL)
+#include <openssl/x509v3.h>
+void Curl_amiga_X509_free(X509 *a);
+#endif
+
 #endif /* HEADER_CURL_AMIGAOS_H */

--- a/lib/amigaos.h
+++ b/lib/amigaos.h
@@ -23,9 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#ifdef __AMIGA__
-
-#ifndef USE_AMISSL
+#if defined(__AMIGA__) && defined(HAVE_BSDSOCKET_H) && !defined(USE_AMISSL)
 
 bool Curl_amiga_init();
 void Curl_amiga_cleanup();
@@ -35,10 +33,12 @@ void Curl_amiga_cleanup();
 #define Curl_amiga_init() 1
 #define Curl_amiga_cleanup() Curl_nop_stmt
 
+#endif
+
+#ifdef USE_AMISSL
 #include <openssl/x509v3.h>
 void Curl_amiga_X509_free(X509 *a);
 #endif /* USE_AMISSL */
 
-#endif /* __AMIGA__ */
 #endif /* HEADER_CURL_AMIGAOS_H */
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -314,7 +314,7 @@
 #  include <exec/execbase.h>
 #  include <proto/exec.h>
 #  include <proto/dos.h>
-#  ifdef USE_AMISSL
+#  ifdef HAVE_PROTO_BSDSOCKET_H
 #    include <proto/bsdsocket.h> /* ensure we're using bsdsocket.library functions */
 #    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
 #  endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -315,7 +315,7 @@
 #  include <proto/exec.h>
 #  include <proto/dos.h>
 #  ifdef HAVE_PROTO_BSDSOCKET_H
-#    include <proto/bsdsocket.h> /* ensure we're using bsdsocket.library functions */
+#    include <proto/bsdsocket.h> /* ensure bsdsocket.library use */
 #    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
 #  endif
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -315,7 +315,9 @@
 #    include <exec/execbase.h>
 #    include <proto/exec.h>
 #    include <proto/dos.h>
-#    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
+#    ifndef USE_AMISSL
+#      define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
+#    endif
 #  endif
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -310,14 +310,13 @@
 #endif
 
 #ifdef __AMIGA__
-#  ifndef __ixemul__
-#    include <exec/types.h>
-#    include <exec/execbase.h>
-#    include <proto/exec.h>
-#    include <proto/dos.h>
-#    ifndef USE_AMISSL
-#      define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
-#    endif
+#  include <exec/types.h>
+#  include <exec/execbase.h>
+#  include <proto/exec.h>
+#  include <proto/dos.h>
+#  ifdef USE_AMISSL
+#    include <proto/bsdsocket.h> /* ensure we're using bsdsocket.library functions */
+#    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
 #  endif
 #endif
 

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -83,7 +83,7 @@ static void MD5_Final(unsigned char digest[16], MD5_CTX * ctx)
   gcry_md_close(*ctx);
 }
 
-#elif defined(USE_OPENSSL)
+#elif defined(USE_OPENSSL) && !defined(USE_AMISSL)
 /* When OpenSSL is available we use the MD5-function from OpenSSL */
 #include <openssl/md5.h>
 #include "curl_memory.h"

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -65,7 +65,7 @@
 #include <openssl/buffer.h>
 #include <openssl/pkcs12.h>
 
-#ifdef __AMIGA__
+#ifdef USE_AMISSL
 #include "amigaos.h"
 #endif
 
@@ -824,7 +824,7 @@ int cert_stuff(struct connectdata *conn,
   fail:
       EVP_PKEY_free(pri);
       X509_free(x509);
-#ifdef __AMIGA__
+#ifdef USE_AMISSL
       sk_X509_pop_free(ca, Curl_amiga_X509_free);
 #else
       sk_X509_pop_free(ca, X509_free);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -65,6 +65,10 @@
 #include <openssl/buffer.h>
 #include <openssl/pkcs12.h>
 
+#ifdef __AMIGA__
+#include "amigaos.h"
+#endif
+
 #if (OPENSSL_VERSION_NUMBER >= 0x0090808fL) && !defined(OPENSSL_NO_OCSP)
 #include <openssl/ocsp.h>
 #endif
@@ -820,8 +824,11 @@ int cert_stuff(struct connectdata *conn,
   fail:
       EVP_PKEY_free(pri);
       X509_free(x509);
+#ifdef __AMIGA__
+      sk_X509_pop_free(ca, Curl_amiga_X509_free);
+#else
       sk_X509_pop_free(ca, X509_free);
-
+#endif
       if(!cert_done)
         return 0; /* failure! */
       break;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -248,7 +248,7 @@ Curl_ssl_connect(struct connectdata *conn, int sockindex)
   conn->ssl[sockindex].use = TRUE;
   conn->ssl[sockindex].state = ssl_connection_negotiating;
 
-  result = Curl_ssl->connect(conn, sockindex);
+  result = Curl_ssl->connect_blocking(conn, sockindex);
 
   if(!result)
     Curl_pgrsTime(conn->data, TIMER_APPCONNECT); /* SSL is connected */
@@ -557,7 +557,7 @@ void Curl_ssl_close(struct connectdata *conn, int sockindex)
 
 CURLcode Curl_ssl_shutdown(struct connectdata *conn, int sockindex)
 {
-  if(Curl_ssl->shutdown(conn, sockindex))
+  if(Curl_ssl->shut_down(conn, sockindex))
     return CURLE_SSL_SHUTDOWN_FAILED;
 
   conn->ssl[sockindex].use = FALSE; /* get back to ordinary socket usage */
@@ -1114,7 +1114,7 @@ static CURLcode Curl_multissl_connect(struct connectdata *conn, int sockindex)
 {
   if(multissl_init(NULL))
     return CURLE_FAILED_INIT;
-  return Curl_ssl->connect(conn, sockindex);
+  return Curl_ssl->connect_blocking(conn, sockindex);
 }
 
 static CURLcode Curl_multissl_connect_nonblocking(struct connectdata *conn,

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -47,7 +47,7 @@ struct Curl_ssl {
 
   size_t (*version)(char *buffer, size_t size);
   int (*check_cxn)(struct connectdata *cxn);
-  int (*shutdown)(struct connectdata *conn, int sockindex);
+  int (*shut_down)(struct connectdata *conn, int sockindex);
   bool (*data_pending)(const struct connectdata *conn,
                        int connindex);
 
@@ -56,7 +56,7 @@ struct Curl_ssl {
                      size_t length);
   bool (*cert_status_request)(void);
 
-  CURLcode (*connect)(struct connectdata *conn, int sockindex);
+  CURLcode (*connect_blocking)(struct connectdata *conn, int sockindex);
   CURLcode (*connect_nonblocking)(struct connectdata *conn, int sockindex,
                                   bool *done);
   void *(*get_internals)(struct ssl_connect_data *connssl, CURLINFO info);

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -545,6 +545,25 @@ curl_includes_ws2tcpip="\
 ])
 
 
+dnl CURL_INCLUDES_BSDSOCKET
+dnl -------------------------------------------------
+dnl Set up variable with list of headers that must be
+dnl included when bsdsocket.h is to be included.
+
+AC_DEFUN([CURL_INCLUDES_BSDSOCKET], [
+curl_includes_bsdsocket="\
+/* includes start */
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#  include <proto/bsdsocket.h>
+  struct Library *SocketBase = NULL;
+#endif
+/* includes end */"
+  AC_CHECK_HEADERS(
+    proto/bsdsocket.h,
+    [], [], [      $curl_includes_bsdsocket])
+])
+
+
 dnl CURL_PREPROCESS_CALLCONV
 dnl -------------------------------------------------
 dnl Set up variable with a preprocessor block which
@@ -759,6 +778,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_socket
     ]],[[
       if(0 != closesocket(0))
@@ -776,6 +796,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
     AC_MSG_CHECKING([if closesocket is prototyped])
     AC_EGREP_CPP([closesocket],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_socket
     ],[
       AC_MSG_RESULT([yes])
@@ -791,6 +812,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_socket
       ]],[[
         if(0 != closesocket(0))
@@ -944,6 +966,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CONNECT], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_sys_socket
       $curl_includes_socket
     ]],[[
@@ -962,6 +985,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CONNECT], [
     AC_MSG_CHECKING([if connect is prototyped])
     AC_EGREP_CPP([connect],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_sys_socket
       $curl_includes_socket
     ],[
@@ -978,6 +1002,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CONNECT], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_sys_socket
         $curl_includes_socket
       ]],[[
@@ -2206,6 +2231,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYADDR], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_netdb
     ]],[[
       if(0 != gethostbyaddr(0, 0, 0))
@@ -2223,6 +2249,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYADDR], [
     AC_MSG_CHECKING([if gethostbyaddr is prototyped])
     AC_EGREP_CPP([gethostbyaddr],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_netdb
     ],[
       AC_MSG_RESULT([yes])
@@ -2238,6 +2265,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYADDR], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_netdb
       ]],[[
         if(0 != gethostbyaddr(0, 0, 0))
@@ -2299,6 +2327,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GAI_STRERROR], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_netdb
     ]],[[
       if(0 != gai_strerror(0))
@@ -2316,6 +2345,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GAI_STRERROR], [
     AC_MSG_CHECKING([if gai_strerror is prototyped])
     AC_EGREP_CPP([gai_strerror],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_netdb
     ],[
       AC_MSG_RESULT([yes])
@@ -2331,6 +2361,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GAI_STRERROR], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_netdb
       ]],[[
         if(0 != gai_strerror(0))
@@ -2535,6 +2566,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_netdb
     ]],[[
       if(0 != gethostbyname(0))
@@ -2552,6 +2584,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME], [
     AC_MSG_CHECKING([if gethostbyname is prototyped])
     AC_EGREP_CPP([gethostbyname],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_netdb
     ],[
       AC_MSG_RESULT([yes])
@@ -2567,6 +2600,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_netdb
       ]],[[
         if(0 != gethostbyname(0))
@@ -2762,6 +2796,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
   AC_REQUIRE([CURL_INCLUDES_UNISTD])dnl
   AC_REQUIRE([CURL_PREPROCESS_CALLCONV])dnl
+  AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   #
   tst_links_gethostname="unknown"
   tst_proto_gethostname="unknown"
@@ -2772,6 +2807,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_unistd
     ]],[[
       if(0 != gethostname(0, 0))
@@ -2789,6 +2825,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
     AC_MSG_CHECKING([if gethostname is prototyped])
     AC_EGREP_CPP([gethostname],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_unistd
     ],[
       AC_MSG_RESULT([yes])
@@ -2804,6 +2841,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_unistd
       ]],[[
         if(0 != gethostname(0, 0))
@@ -2827,6 +2865,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
           AC_COMPILE_IFELSE([
             AC_LANG_PROGRAM([[
               $curl_includes_winsock2
+      $curl_includes_bsdsocket
               $curl_includes_unistd
               $curl_preprocess_callconv
               extern int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
@@ -4023,6 +4062,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
     ]],[[
       if(0 != ioctlsocket(0, 0, 0))
         return 1;
@@ -4039,6 +4079,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
     AC_MSG_CHECKING([if ioctlsocket is prototyped])
     AC_EGREP_CPP([ioctlsocket],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
     ],[
       AC_MSG_RESULT([yes])
       tst_proto_ioctlsocket="yes"
@@ -4053,6 +4094,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
       ]],[[
         if(0 != ioctlsocket(0, 0, 0))
           return 1;
@@ -4111,6 +4153,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_FIONBIO], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
       ]],[[
         int flags = 0;
         if(0 != ioctlsocket(0, FIONBIO, &flags))
@@ -4925,6 +4968,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_sys_socket
     ]],[[
       if(0 != setsockopt(0, 0, 0, 0, 0))
@@ -4942,6 +4986,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT], [
     AC_MSG_CHECKING([if setsockopt is prototyped])
     AC_EGREP_CPP([setsockopt],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_sys_socket
     ],[
       AC_MSG_RESULT([yes])
@@ -4957,6 +5002,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_sys_socket
       ]],[[
         if(0 != setsockopt(0, 0, 0, 0, 0))
@@ -5016,6 +5062,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SETSOCKOPT_SO_NONBLOCK], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_sys_socket
       ]],[[
         if(0 != setsockopt(0, SOL_SOCKET, SO_NONBLOCK, 0, 0))
@@ -5561,6 +5608,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_sys_socket
       $curl_includes_socket
     ]],[[
@@ -5579,6 +5627,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
     AC_MSG_CHECKING([if socket is prototyped])
     AC_EGREP_CPP([socket],[
       $curl_includes_winsock2
+      $curl_includes_bsdsocket
       $curl_includes_sys_socket
       $curl_includes_socket
     ],[
@@ -5595,6 +5644,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
+      $curl_includes_bsdsocket
         $curl_includes_sys_socket
         $curl_includes_socket
       ]],[[

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -21,6 +21,10 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
+#if defined(__AMIGA__) && !defined(__amigaos4__)
+#  undef HAVE_TERMIOS_H
+#endif
+
 #ifndef HAVE_GETPASS_R
 /* this file is only for systems without getpass_r() */
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -33,6 +33,10 @@
 #  include <fabdef.h>
 #endif
 
+#ifdef __AMIGA__
+#  include <proto/dos.h>
+#endif
+
 #include "strcase.h"
 
 #define ENABLE_CURLX_PRINTF
@@ -1866,9 +1870,9 @@ static CURLcode operate_do(struct GlobalConfig *global,
 #ifdef __AMIGA__
         if(!result && outs.s_isreg && outs.filename) {
           /* Set the url (up to 80 chars) as comment for the file */
-          if(strlen(url) > 78)
-            url[79] = '\0';
-          SetComment(outs.filename, url);
+          if(strlen(urlnode->url) > 78)
+            urlnode->url[79] = '\0';
+          SetComment(outs.filename, urlnode->url);
         }
 #endif
 


### PR DESCRIPTION
This adds a configure option --with-amissl which selects AmiSSL as the SSL engine.
AmiSSL is an Amiga native library which provides a wrapper over OpenSSL.
It also requires all programs using it to use bsdsocket.library directly, rather than accessing socket functions through clib, which libcurl was not necessarily doing previously.  Configure will now check for the headers and ensure they are included if found.
