### PR TITLE
os400: Disable Alt-Svc by default since it's experimental

### DIFF
--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -425,8 +425,8 @@
 /* Define if you can safely include both <sys/time.h> and <time.h>. */
 #define TIME_WITH_SYS_TIME
 
-/* to enable alt-svc */
-#define USE_ALTSVC 1
+/* Define to enable alt-svc support (experimental) */
+#undef USE_ALTSVC
 
 /* Version number of package */
 #undef VERSION

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1132,7 +1132,12 @@ curl_easy_setopt_ccsid(CURL * curl, CURLoption tag, ...)
   if(testwarn) {
     testwarn = 0;
 
-    if((int) STRING_LASTZEROTERMINATED != (int) STRING_ALTSVC + 1 ||
+    if(
+#ifdef USE_ALTSVC
+       (int) STRING_LASTZEROTERMINATED != (int) STRING_ALTSVC + 1 ||
+#else
+       (int) STRING_LASTZEROTERMINATED != (int) STRING_DOH + 1 ||
+#endif
        (int) STRING_LAST != (int) STRING_COPYPOSTFIELDS + 1)
       curl_mfprintf(stderr,
        "*** WARNING: curl_easy_setopt_ccsid() should be reworked ***\n");


### PR DESCRIPTION
Follow-up to 520f0b4 which added Alt-Svc support and enabled it by
default for OS400. Since the feature is experimental, it should be
disabled by default.

Ref: https://github.com/curl/curl/commit/520f0b4#commitcomment-32792332
Ref: https://curl.haxx.se/mail/lib-2019-02/0008.html

Closes #xxxx

---

By keeping Alt-Svc enabled by default in OS400 we're breaking the [assertion](https://github.com/curl/curl/blob/master/docs/ALTSVC.md#experimental) that experimental features will not be enabled by default. @monnerat has a good point about the testing since we don't get these things exercised when they're disabled by default, but in my opinion we need to only ship stability unless otherwise asked for.