### PR TITLE
travis: bump the used wolfSSL version to 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
         - $HOME/libpsl-0.20.1
         - $HOME/mbedtls-mbedtls-2.8.0
         - $HOME/libidn2-2.0.4
-        - $HOME/wolfssl-3.14.0-stable
+        - $HOME/wolfssl-4.0.0-stable
         - $HOME/mesalink-0.7.1
         - $HOME/nghttp2-1.34.0
 
@@ -290,11 +290,11 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
-        if [ ! -e $HOME/wolfssl-3.14.0-stable/Makefile ]; then
+        if [ ! -e $HOME/wolfssl-4.0.0-stable/Makefile ]; then
           (cd $HOME && \
-          curl -LO https://github.com/wolfSSL/wolfssl/archive/v3.14.0-stable.tar.gz && \
-          tar -xzf v3.14.0-stable.tar.gz && \
-          cd wolfssl-3.14.0-stable && \
+          curl -LO https://github.com/wolfSSL/wolfssl/archive/v4.0.0-stable.tar.gz && \
+          tar -xzf v4.0.0-stable.tar.gz && \
+          cd wolfssl-4.0.0-stable && \
           ./autogen.sh && \
           ./configure --enable-tls13 --enable-all && \
           touch wolfssl/wolfcrypt/fips.h && \
@@ -331,7 +331,7 @@ before_script:
         (cd $HOME/libidn2-2.0.4 && sudo make install)
         (cd $HOME/libpsl-0.20.1 && sudo make install)
         (cd $HOME/mbedtls-mbedtls-2.8.0 && sudo make install)
-        (cd $HOME/wolfssl-3.14.0-stable && sudo make install)
+        (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
         (cd $HOME/mesalink-0.7.1 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
       fi
@@ -363,7 +363,7 @@ script:
         if [ "$T" = "debug-wolfssl" ]; then
              ./configure --enable-debug --enable-werror $C
              make
-             make "TFLAGS=-n !311 !313" test-nonflaky
+             make "TFLAGS=-n !313" test-nonflaky
         fi
     - |
         set -eo pipefail


### PR DESCRIPTION
Test 311 is now fine, leaving only 313 (CRL) disabled.

Test 313 details can be found here:
https://github.com/wolfSSL/wolfssl/issues/1546