### PR TITLE
travis: allow builds on branches named "ci"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -477,6 +477,7 @@ script:
 branches:
     only:
         - master
+        - /\/ci$/
 
 notifications:
   email: false


### PR DESCRIPTION
This allows a way to test changes when the overhead of a PR isn't warranted but when the results of the CI builds is still useful.