### PR TITLE
Don't parse body-related headers for status codes 1xx, 204 or 304

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3734,6 +3734,8 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
           }
         }
 
+        k->httpcode_1xx = k->httpcode >= 100 && k->httpcode < 200;
+
         switch(k->httpcode) {
         case 304:
           /* (quote from RFC2616, section 10.3.5): The 304 response
@@ -3751,7 +3753,6 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
            * empty line after the header fields. */
           k->size = 0;
           k->maxdownload = 0;
-          k->ignorecl = TRUE; /* ignore Content-Length headers */
           break;
         default:
           /* nothing */
@@ -3770,8 +3771,8 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
       return result;
 
     /* Check for Content-Length: header lines to get size */
-    if(!k->ignorecl && !data->set.ignorecl &&
-       checkprefix("Content-Length:", k->p)) {
+    if(!k->httpcode_1xx && k->httpcode != 204 && k->httpcode != 304 &&
+       !data->set.ignorecl && checkprefix("Content-Length:", k->p)) {
       curl_off_t contentlength;
       CURLofft offt = curlx_strtoofft(k->p + 15, NULL, 10, &contentlength);
 
@@ -3873,7 +3874,8 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
        */
       streamclose(conn, "Connection: close used");
     }
-    else if(checkprefix("Transfer-Encoding:", k->p)) {
+    else if(!k->httpcode_1xx && k->httpcode != 204 && k->httpcode != 304 &&
+            checkprefix("Transfer-Encoding:", k->p)) {
       /* One or more encodings. We check for chunked and/or a compression
          algorithm. */
       /*
@@ -3889,7 +3891,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
       if(result)
         return result;
     }
-    else if(checkprefix("Content-Encoding:", k->p) &&
+    else if(!k->httpcode_1xx && checkprefix("Content-Encoding:", k->p) &&
             data->set.str[STRING_ENCODING]) {
       /*
        * Process Content-Encoding. Look for the values: identity,
@@ -3902,7 +3904,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
       if(result)
         return result;
     }
-    else if(checkprefix("Content-Range:", k->p)) {
+    else if(!k->httpcode_1xx && checkprefix("Content-Range:", k->p)) {
       /* Content-Range: bytes [num]-
          Content-Range: bytes: [num]-
          Content-Range: [num]-
@@ -3948,7 +3950,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
       Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
     }
 #endif
-    else if(checkprefix("Last-Modified:", k->p) &&
+    else if(!k->httpcode_1xx && checkprefix("Last-Modified:", k->p) &&
             (data->set.timecondition || data->set.get_filetime) ) {
       time_t secs = time(NULL);
       k->timeofdoc = curl_getdate(k->p + strlen("Last-Modified:"),

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -610,8 +610,7 @@ struct SingleRequest {
   bit upload_done:1;  /* set to TRUE when doing chunked transfer-encoding
                          upload and we're uploading the last chunk */
   bit ignorebody:1;   /* we read a response-body but we ignore it! */
-  bit ignorecl:1;     /* This HTTP response has no body so we ignore the
-                         Content-Length: header */
+  bit httpcode_1xx:1; /* HTTP response status code is between 100 and 199 */
   bit chunk:1; /* if set, this is a chunked transfer-encoding */
   bit upload_chunky:1; /* set TRUE if we are doing chunked transfer-encoding
                           on upload */

--- a/tests/data/test1429
+++ b/tests/data/test1429
@@ -9,7 +9,7 @@ HTTP/0.9
 
 <reply>
 <data nocheck="yes">
-HTTP/1.1 1234 OK
+HTTP/1.1 2345 OK
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
 Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
@@ -43,7 +43,7 @@ http://%HOSTIP:%HTTPPORT/1429 --write-out '%{response_code}' --http0.9
 # Verify data after the test has been "shot"
 <verify>
 <stdout nonewline="yes">
-HTTP/1.1 1234 OK
+HTTP/1.1 2345 OK
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
 Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
@@ -55,7 +55,7 @@ Content-Type: text/html
 Funny-head: yesyes
 
 -foo-
-123
+234
 </stdout>
 <strip>
 ^User-Agent:.*


### PR DESCRIPTION
Responses with status codes 1xx, 204 or 304 don't have a response body.

For status codes 1xx, don't parse these headers:
- Content-Encoding
- Content-Length
- Content-Range
- Last-Modified
- Transfer-Encoding

For status codes 204 and 304, don't parse the "Transfer-Encoding"
header.

This change ensures that HTTP/2 upgrades work even if a
"Content-Length: 0" or a "Transfer-Encoding: chunked" header is present.