### PR TITLE
travis: use libssh2 from git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ matrix:
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: osx
           compiler: gcc
-          env: T=debug C=--with-libssh2
+          env: T=debug C=--with-libssh2=/usr/local
         - os: osx
           compiler: gcc
           env: T=debug C=--enable-ares

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
             - libstdc++-8-dev
             - stunnel4
             - libidn2-0-dev
-            - libssh2-1-dev
             - libssh-dev
             - krb5-user
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
@@ -219,7 +218,7 @@ install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update > /dev/null; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew reinstall libtool > /dev/null; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install rtmpdump libssh2 c-ares libmetalink libressl nghttp2 libmetalink; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install rtmpdump c-ares libmetalink libressl nghttp2 libmetalink; fi
 
 before_script:
     - ./buildconf
@@ -253,6 +252,12 @@ before_script:
         ln -s ../build/ssl/libssl.so . &&
         echo "BoringSSL lib dir: "`pwd` &&
         export LIBS=-lpthread )
+      fi
+    - |
+      if [ ! -e "$HOME/libssh2/Makefile" ]; then
+        (cd $HOME &&
+        git clone --depth=1 https://github.com/libssh2/libssh2.git &&
+        cd libssh2 && ./buildconf && ./configure && make)
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
@@ -334,6 +339,7 @@ before_script:
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
         (cd $HOME/mesalink-0.7.1 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
+        (cd $HOME/libssh2 && sudo make install)
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
           env:
               - T=normal C="--with-gssapi --with-libssh2" CHECKSRC=1
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+              - LIBSSH2=1
         - os: linux
           compiler: gcc
           dist: trusty
@@ -142,7 +143,9 @@ matrix:
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: osx
           compiler: gcc
-          env: T=debug C=--with-libssh2=/usr/local
+          env:
+              - T=debug C=--with-libssh2=/usr/local
+              - LIBSSH2=1
         - os: osx
           compiler: gcc
           env: T=debug C=--enable-ares
@@ -258,7 +261,7 @@ before_script:
       if [ ! -e "$HOME/libssh2/Makefile" ]; then
         (cd $HOME &&
         git clone --depth=1 https://github.com/libssh2/libssh2.git &&
-        cd libssh2 && ./buildconf && ./configure && make)
+        cd libssh2 && ./buildconf && ./configure --disable-examples-build && make)
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
@@ -341,7 +344,9 @@ before_script:
         (cd $HOME/mesalink-0.7.1 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
       fi
-      cd $HOME/libssh2 && sudo make install
+      if [ $LIBSSH2 = 1 ]; then
+        cd $HOME/libssh2 && sudo make install
+      fi
 
 script:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
         - $HOME/wolfssl-4.0.0-stable
         - $HOME/mesalink-0.7.1
         - $HOME/nghttp2-1.34.0
+        - $HOME/libssh2
 
 env:
     global:
@@ -339,8 +340,8 @@ before_script:
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
         (cd $HOME/mesalink-0.7.1 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
-        (cd $HOME/libssh2 && sudo make install)
       fi
+      cd $HOME/libssh2 && sudo make install
 
 script:
     - |


### PR DESCRIPTION
When this works, it proves that the other current libssh2 test failures are due to the old libssh2 installs in the travis images that fails due to upgraded SSH servers that the tests run against and the old libssh2 version not working against that while libssh2 from git works fine.