### PR TITLE
Avoid unportable `==' test(1) operator in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1569,7 +1569,7 @@ AC_HELP_STRING([--without-amissl], [disable Amiga native SSL/TLS (AmiSSL)]),
   OPT_AMISSL=$withval)
 
 AC_MSG_CHECKING([whether to enable Amiga native SSL/TLS (AmiSSL)])
-if test "$HAVE_PROTO_BSDSOCKET_H" == "1"; then
+if test "$HAVE_PROTO_BSDSOCKET_H" = "1"; then
   if test -z "$ssl_backends" -o "x$OPT_AMISSL" != xno; then
     ssl_msg=
     if test "x$OPT_AMISSL" != "xno"; then


### PR DESCRIPTION
When updating www/curl package in pkgsrc the pkgsrc checks spotted
the non-portable `==` operator (`=` can be used instead).