### PR TITLE
Build docker container for master

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git*
+projects/
+winbuild/

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ addons:
 
 matrix:
     include:
+        - os: docker
+          env:
+            - T=normal
+          services:
+            - docker
+
         - os: linux
           compiler: gcc
           dist: trusty
@@ -472,6 +478,11 @@ script:
              scan-build ./configure --enable-debug --enable-werror $C
              scan-build --status-bugs make && scan-build --status-bugs make examples
         fi
+     - |
+        if [ "$T" = "normal" ] && [ $TRAVIS_OS_NAME = linux ]; then
+             docker build --no-cache --rm -t "curl:latest" .
+        fi
+
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)
 branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2019 Olliver Schinagl <oliver@schinagl.nl>
+#
+# SPDX-License-Identifier: BSD-4-Clause
+
+# For Alpine, latest is actually the latest stable
+# hadolint ignore=DL3007
+FROM registry.hub.docker.com/library/alpine:latest AS builder
+
+LABEL Maintainer="Olliver Schinagl <oliver@schinagl.nl>"
+
+WORKDIR /build
+
+# We want the latest stable version from the repo
+# hadolint ignore=DL3018
+RUN \
+    apk add --no-cache \
+       autoconf \
+       automake \
+       build-base \
+       curl-dev \
+       groff \
+       libtool \
+    && \
+    rm -rf "/var/cache/apk/"*
+
+COPY . "/build"
+
+RUN \
+    autoreconf -vif && \
+    ./configure \
+        --disable-ldap \
+        --enable-ipv6 \
+        --enable-unix-sockets \
+        --prefix=/usr \
+        --with-libssh2 \
+        --with-nghttp2 \
+        --with-pic \
+        --with-ssl \
+        --without-libidn \
+        --without-libidn2 \
+    && \
+    make && \
+    make DESTDIR="/alpine/" install
+
+# For Alpine, latest is actually the latest stable
+# hadolint ignore=DL3007
+FROM registry.hub.docker.com/library/alpine:latest
+
+RUN \
+    apk add --no-cache \
+        curl \
+    && \
+    rm -rf "/var/cache/apk/"* && \
+    for curlfile in $(apk info -L curl libcurl); do \
+        if [ -f "/${curlfile}" ]; then \
+            rm "/${curlfile:?}"; \
+        fi \
+    done
+
+COPY --from=builder "/alpine/usr/lib/libcurl.so.4.5.0" "/usr/lib/libcurl.so.4.5.0"
+COPY --from=builder "/alpine/usr/lib/libcurl.so.4" "/usr/lib/libcurl.so.4"
+COPY --from=builder "/alpine/usr/lib/libcurl.so" "/usr/lib/libcurl.so"
+COPY --from=builder "/alpine/usr/bin/curl" "/usr/bin/curl"
+
+COPY "scripts/docker-entrypoint.sh" "/docker-entrypoint.sh"
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (C) 2019 Olliver Schinagl <oliver@schinagl.nl>
+#
+# SPDX-License-Identifier: BSD-4-Clause
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt "0" ] && \
+   [ "${1#-}" = "${1}" ] && \
+   command -v "${1}"; then
+    exec "${@}"
+else
+    # else default to run command with curl
+    exec curl "${@}"
+fi


### PR DESCRIPTION
This patch adds support for building alpine docker images. These can
then be used to be pushed to the dockerhub, yielding in the future an
official docker image.

Travis's purpose for now is only to test if the container can actually
be built.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>