### PR TITLE
tool_help: include <strings.h> for strcasecmp

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -20,6 +20,9 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
+#ifdef HAVE_STRCASECMP
+#include <strings.h>
+#endif
 
 #include "tool_panykey.h"
 #include "tool_help.h"


### PR DESCRIPTION
Reported-by: Wyatt O'Day
Fixes #3715