### PR TITLE
tool_cb_wrt: fix bad-function-cast warning

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -81,6 +81,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   bool is_tty = config->global->isatty;
 #ifdef WIN32
   CONSOLE_SCREEN_BUFFER_INFO console_info;
+  intptr_t fhnd;
 #endif
 
   /*
@@ -159,13 +160,12 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   }
 
 #ifdef _WIN32
+  fhnd = _get_osfhandle(fileno(outs->stream));
   if(isatty(fileno(outs->stream)) &&
-     GetConsoleScreenBufferInfo(
-       (HANDLE)_get_osfhandle(fileno(outs->stream)), &console_info)) {
+     GetConsoleScreenBufferInfo((HANDLE)fhnd, &console_info)) {
     DWORD in_len = (DWORD)(sz * nmemb);
     wchar_t* wc_buf;
     DWORD wc_len;
-    intptr_t fhnd;
 
     /* calculate buffer size for wide characters */
     wc_len = MultiByteToWideChar(CP_UTF8, 0, buffer, in_len,  NULL, 0);
@@ -179,8 +179,6 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       free(wc_buf);
       return failure;
     }
-
-    fhnd = _get_osfhandle(fileno(outs->stream));
 
     if(!WriteConsoleW(
         (HANDLE) fhnd,


### PR DESCRIPTION
Commit f5bc578f4cdfdc6c708211dfc2962a0e9d79352d reintroduced the
warning fixed in commit 2f5f31bb57d68b54e03bffcd9648aece1fe564f8.
Extend `fhnd`'s scope and reuse that variable instead of calling
`_get_osfhandle` a second time to fix the warning again.

Closes