### PR TITLE
travis: only install required apt packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ addons:
             - libidn2-0-dev
             - libssh2-1-dev
             - libssh-dev
-            - krb5-user
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
             - libunistring-dev # for libidn2 needed by libpsl
             - libnss3-dev
@@ -46,6 +45,13 @@ matrix:
           env:
               - T=normal C="--with-gssapi --with-libssh2" CHECKSRC=1
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - krb5-user
         - os: linux
           compiler: gcc
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
         packages: &common_packages
             - cmake
             - gcc-8
-            - lcov
             - valgrind
             - libev-dev
             - libc-ares-dev
@@ -233,6 +232,13 @@ matrix:
           env:
               - T=coverage
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - lcov
         - os: linux
           compiler: gcc
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ addons:
             - libidn2-0-dev
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
             - libunistring-dev # for libidn2 needed by libpsl
-            - libnss3-dev
             - gnutls-bin
             - libgnutls28-dev
 
@@ -190,6 +189,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libnss3-dev
         - os: linux
           compiler: gcc
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ addons:
             - stunnel4
             - libidn2-0-dev
             - libssh2-1-dev
-            - libssh-dev
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
             - libunistring-dev # for libidn2 needed by libpsl
             - libnss3-dev
@@ -58,6 +57,13 @@ matrix:
           env:
               - T=normal C=--with-libssh
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libssh-dev
         - os: linux
           compiler: gcc
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
             - libunistring-dev # for libidn2 needed by libpsl
             - gnutls-bin
-            - libgnutls28-dev
 
 matrix:
     include:
@@ -161,6 +160,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libgnutls28-dev
         - os: linux
           compiler: clang
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
             - libstdc++-8-dev
             - stunnel4
             - libidn2-0-dev
-            - libssh2-1-dev
             - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
             - libunistring-dev # for libidn2 needed by libpsl
             - libnss3-dev
@@ -51,6 +50,7 @@ matrix:
                   packages:
                       - *common_packages
                       - krb5-user
+                      - libssh2-1-dev
         - os: linux
           compiler: gcc
           dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,12 @@ addons:
     apt:
         config:
             retries: true
-        sources:
+        sources: &common_sources
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
-        packages:
+        packages: &common_packages
             - cmake
             - gcc-8
             - lcov
-            - clang-7
             - valgrind
             - libev-dev
             - libc-ares-dev
@@ -40,7 +38,6 @@ addons:
             - libnss3-dev
             - gnutls-bin
             - libgnutls28-dev
-            - clang-tidy-7
 
 matrix:
     include:
@@ -104,36 +101,84 @@ matrix:
           env:
               - T=debug
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=debug C="--enable-alt-svc"
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=debug C="--with-mbedtls --without-ssl"
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=debug C="--with-gnutls --without-ssl"
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=debug C="--disable-threaded-resolver"
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=debug C="--with-nss --without-ssl" NOTESTS=1 CPPFLAGS="-isystem /usr/include/nss"
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: gcc
           dist: trusty
@@ -174,6 +219,14 @@ matrix:
           env:
               - T=cmake
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: gcc
           dist: trusty
@@ -192,24 +245,57 @@ matrix:
           env:
               - T=fuzzer
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=tidy
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
+                      - clang-tidy-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=scan-build
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
         - os: linux
           compiler: clang
           dist: trusty
           env:
               - T=debug CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g" LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer" LIBS="-ldl -lubsan"
               - OVERRIDE_CC="CC=clang-7" OVERRIDE_CXX="CXX=clang++-7"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                      - llvm-toolchain-trusty-7
+                  packages:
+                      - *common_packages
+                      - clang-7
 
 before_install:
     - eval "${OVERRIDE_CC}"


### PR DESCRIPTION
This allows to selectively update some clang jobs to xenial as the LLVM repository name is different for xenial than for trusty. Also, it saves a little time for most Linux jobs.