### PR TITLE
install: fix default location for fish completions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3479,7 +3479,12 @@ case "$OPT_FISH_FPATH" in
     ;;
   default|yes)
     dnl --with-fish-functions-dir option used without path
-    FISH_FUNCTIONS_DIR="$datarootdir/fish/completions"
+    CURL_CHECK_PKGCONFIG(fish)
+    if test "$PKGCONFIG" != "no" ; then
+      FISH_FUNCTIONS_DIR="$($PKGCONFIG --variable completionsdir fish)"
+    else
+      FISH_FUNCTIONS_DIR="$datarootdir/fish/vendor_completions.d"
+    fi
     AC_SUBST(FISH_FUNCTIONS_DIR)
     ;;
   *)


### PR DESCRIPTION
Fish defines a vendor completions directory for completions that are not installed as part of the fish project itself, and the vendor completions are preferred if they exist. This prevents trying to overwrite the builtin curl.fish completion (or creating file conflicts in distro packaging).

Prefer the pkg-config defined location exported by fish, if it can be found, and fall back to the correct directory defined by most systems.