### PR TITLE
AppVeyor: enable testing for WinSSL build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ environment:
         COMPILER_PATH: ""
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         PRJ_GEN: "Visual Studio 15 2017 Win64"
-        PRJ_CFG: Release
+        PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: ON
         HTTP_ONLY: OFF
-        TESTING: OFF
-        SHARED: ON
+        TESTING: ON
+        SHARED: OFF
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"


### PR DESCRIPTION
The only failing test is the one comparing the output of `curl --version` with `curl-config --features` mentioned in https://github.com/curl/curl/issues/3609.

There are a lot more failures in the OpenSSL job I have yet to analyze.