### PR TITLE
Fix clang string-plus-int warning

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1218,7 +1218,7 @@ static CURLcode smtp_done(struct connectdata *conn, CURLcode status,
        returned CURLE_AGAIN, we duplicate the EOB now rather than when the
        bytes written doesn't equal len. */
     if(smtp->trailing_crlf || !conn->data->state.infilesize) {
-      eob = strdup(SMTP_EOB + 2);
+      eob = strdup(&SMTP_EOB[2]);
       len = SMTP_EOB_LEN - 2;
     }
     else {


### PR DESCRIPTION
Clang 8 warns about adding a string to an int does not append to the
string. Indeed it doesn't, but that was not the intention either. Use
array indexing as suggested to silence the warning. There should be no
functional changes.

The full warning message was:

    smtp.c:1221:29: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
          eob = strdup(SMTP_EOB + 2);
                ~~~~~~~~~~~~~~~~^~~~
    ../lib/memdebug.h:88:37: note: expanded from macro 'strdup'
    #define strdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
                                        ^~~
    smtp.c:1221:29: note: use array indexing to silence this warning
          eob = strdup(SMTP_EOB + 2);
                                ^
                       &        [
    ../lib/memdebug.h:88:37: note: expanded from macro 'strdup'