### PR TITLE
Fix Codacy warnings

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -240,6 +240,7 @@ int main()
 #ifndef inet_ntoa_r
   func_type func;
   func = (func_type)inet_ntoa_r;
+  (void)func;
 #endif
   return 0;
 }
@@ -255,6 +256,7 @@ int main()
 #ifndef inet_ntoa_r
   func_type func;
   func = (func_type)&inet_ntoa_r;
+  (void)func;
 #endif
   return 0;
 }
@@ -582,7 +584,9 @@ int fun2(int arg1, int arg2) {
 int
 main() {
   int res3 = c99_vmacro3(1, 2, 3);
+  (void)res3;
   int res2 = c99_vmacro2(1, 2);
+  (void)res2;
   return 0;
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 <a href="https://opencollective.com/curl#backers" target="_blank"><img src="https://opencollective.com/curl/backers.svg?width=890"></a>
 
-
 ## Sponsors
 
 Support this project by becoming a sponsor. Your logo will show up here with a

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -114,7 +114,7 @@ typedef void CURLSH;
 
 #ifdef CURL_STATICLIB
 #  define CURL_EXTERN
-#elif defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__) || \
+#elif defined(WIN32) || defined(__SYMBIAN32__) || \
      (__has_declspec_attribute(dllexport) && \
       __has_declspec_attribute(dllimport))
 #  if defined(BUILDING_LIBCURL)

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -68,7 +68,7 @@
 #include "progress.h"
 
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) && \
-     (defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__))
+     (defined(WIN32) || defined(__SYMBIAN32__))
 #    define CARES_STATICLIB
 #  endif
 #  include <ares.h>

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -123,7 +123,9 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
             char ipstr[64];
 #ifdef ENABLE_IPV6
             if(af == AF_INET6) {
+#ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
               unsigned int scopeid = 0;
+#endif
               unsigned int ifscope = Curl_ipv6_scope(iface->ifa_addr);
 
               if(ifscope != remote_scope) {
@@ -149,9 +151,10 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
 
                 continue;
               }
-#endif
+
               if(scopeid)
-                msnprintf(scope, sizeof(scope), "%%%u", scopeid);
+                  msnprintf(scope, sizeof(scope), "%%%u", scopeid);
+#endif
             }
             else
 #endif

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -124,7 +124,7 @@ static void MD5_Final(unsigned char digest[16], MD5_CTX *ctx)
   CC_MD5_Final(digest, ctx);
 }
 
-#elif defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#elif defined(WIN32) && !defined(CURL_WINDOWS_APP)
 
 #include <wincrypt.h>
 #include "curl_memory.h"

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -66,7 +66,9 @@ struct curltime Curl_now(void)
   ** in any case the time starting point does not change once that the
   ** system has started up.
   */
+#ifdef HAVE_GETTIMEOFDAY
   struct timeval now;
+#endif
   struct curltime cnow;
   struct timespec tsnow;
 

--- a/lib/version.c
+++ b/lib/version.c
@@ -31,7 +31,7 @@
 
 #ifdef USE_ARES
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) && \
-     (defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__))
+     (defined(WIN32) || defined(__SYMBIAN32__))
 #    define CARES_STATICLIB
 #  endif
 #  include <ares.h>

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1160,7 +1160,6 @@ static CURLcode gskit_connect_common(struct connectdata *conn, int sockindex,
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   long timeout_ms;
-  Qso_OverlappedIO_t cstat;
   CURLcode result = CURLE_OK;
 
   *done = connssl->state == ssl_connection_complete;

--- a/lib/vtls/polarssl_threadlock.h
+++ b/lib/vtls/polarssl_threadlock.h
@@ -26,13 +26,8 @@
 
 #if (defined USE_POLARSSL) || (defined USE_MBEDTLS)
 
-#if defined(USE_THREADS_POSIX)
-#  define POLARSSL_MUTEX_T       pthread_mutex_t
-#elif defined(USE_THREADS_WIN32)
-#  define POLARSSL_MUTEX_T       HANDLE
-#endif
-
-#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+#if (defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)) || \
+    (defined(USE_THREADS_WIN32) && defined(HAVE_PROCESS_H))
 
 int Curl_polarsslthreadlock_thread_setup(void);
 int Curl_polarsslthreadlock_thread_cleanup(void);

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -389,7 +389,6 @@ Curl_gsk_environment_open(gsk_handle * my_env_handle)
 
 {
   struct Curl_gsk_descriptor * p;
-  gsk_handle h;
   int rc;
 
   if(!my_env_handle)

--- a/packages/vms/curl_crtl_init.c
+++ b/packages/vms/curl_crtl_init.c
@@ -183,7 +183,6 @@ static void set_features(void)
     status = sys_trnlnm("GNV$UNIX_SHELL",
                         unix_shell_name, sizeof unix_shell_name -1);
     if (!$VMS_STATUS_SUCCESS(status)) {
-        unix_shell_name[0] = 0;
         use_unix_settings = 0;
     }
 

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -221,7 +221,7 @@ void progressbarinit(struct ProgressData *bar,
     struct winsize ts;
     if(!ioctl(STDIN_FILENO, TIOCGWINSZ, &ts))
       cols = ts.ws_col;
-#elif defined(_WIN32)
+#elif defined(WIN32)
     {
       HANDLE  stderr_hnd = GetStdHandle(STD_ERROR_HANDLE);
       CONSOLE_SCREEN_BUFFER_INFO console_info;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -159,7 +159,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     }
   }
 
-#ifdef _WIN32
+#ifdef WIN32
   fhnd = _get_osfhandle(fileno(outs->stream));
   if(isatty(fileno(outs->stream)) &&
      GetConsoleScreenBufferInfo((HANDLE)fhnd, &console_info)) {

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -599,7 +599,6 @@ SANITIZEcode rename_if_reserved_dos_device_name(char **const sanitized,
       }
       memmove(base + 1, base, blen + 1);
       base[0] = '_';
-      ++blen;
     }
   }
 #endif

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -237,7 +237,7 @@ static void main_free(struct GlobalConfig *config)
   config->last = NULL;
 }
 
-#ifdef _WIN32
+#ifdef WIN32
 /* TerminalSettings for Windows */
 static struct TerminalSettings {
   HANDLE hStdOut;
@@ -275,7 +275,7 @@ static void configure_terminal(void)
 
 static void restore_terminal(void)
 {
-#ifdef _WIN32
+#ifdef WIN32
   /* Restore Console output mode and codepage to whatever they were
    * when Curl started */
   SetConsoleMode(TerminalSettings.hStdOut, TerminalSettings.dwOutputMode);

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -73,7 +73,7 @@
    and later. If you're building for an older cat, well, sorry. */
 #  define COMMON_DIGEST_FOR_OPENSSL
 #  include <CommonCrypto/CommonDigest.h>
-#elif defined(_WIN32)
+#elif defined(WIN32)
 /* For Windows: If no other crypto library is provided, we fallback
    to the hash functions provided within the Microsoft Windows CryptoAPI */
 #  include <wincrypt.h>
@@ -380,7 +380,7 @@ static void SHA256_Final(unsigned char digest[32], SHA256_CTX *ctx)
   sha256_finish(ctx, digest);
 }
 
-#elif defined(_WIN32)
+#elif defined(WIN32)
 
 static void win32_crypto_final(struct win32_crypto_hash *ctx,
                                unsigned char *digest,

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -32,14 +32,16 @@ static char g_Data[40 * 1024]; /* POST 40KB */
 static int sockopt_callback(void *clientp, curl_socket_t curlfd,
                             curlsocktype purpose)
 {
+#if defined(SOL_SOCKET) && defined(SO_SNDBUF)
   int sndbufsize = 4 * 1024; /* 4KB send buffer */
   (void) clientp;
   (void) purpose;
-#if defined(SOL_SOCKET) && defined(SO_SNDBUF)
   setsockopt(curlfd, SOL_SOCKET, SO_SNDBUF,
              (const char *)&sndbufsize, sizeof(sndbufsize));
 #else
+  (void)clientp;
   (void)curlfd;
+  (void)purpose;
 #endif
   return CURL_SOCKOPT_OK;
 }

--- a/tests/libtest/lib509.c
+++ b/tests/libtest/lib509.c
@@ -21,6 +21,8 @@
  ***************************************************************************/
 #include "test.h"
 
+#include <string.h>
+
 /*
  * This test uses these funny custom memory callbacks for the only purpose
  * of verifying that curl_global_init_mem() functionality is present in

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -122,7 +122,7 @@ static struct curloff_st  co_test[COFFT_TESTS_ARRSZ];
 static int test_unsigned_short_formatting(void)
 {
   int i, j;
-  int num_ushort_tests;
+  int num_ushort_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_SHORT == 1)
@@ -229,7 +229,7 @@ static int test_unsigned_short_formatting(void)
 static int test_signed_short_formatting(void)
 {
   int i, j;
-  int num_sshort_tests;
+  int num_sshort_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_SHORT == 1)
@@ -399,7 +399,7 @@ static int test_signed_short_formatting(void)
 static int test_unsigned_int_formatting(void)
 {
   int i, j;
-  int num_uint_tests;
+  int num_uint_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_INT == 2)
@@ -549,7 +549,7 @@ static int test_unsigned_int_formatting(void)
 static int test_signed_int_formatting(void)
 {
   int i, j;
-  int num_sint_tests;
+  int num_sint_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_INT == 2)
@@ -777,7 +777,7 @@ static int test_signed_int_formatting(void)
 static int test_unsigned_long_formatting(void)
 {
   int i, j;
-  int num_ulong_tests;
+  int num_ulong_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_LONG == 2)
@@ -926,7 +926,7 @@ static int test_unsigned_long_formatting(void)
 static int test_signed_long_formatting(void)
 {
   int i, j;
-  int num_slong_tests;
+  int num_slong_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_LONG == 2)
@@ -1154,7 +1154,7 @@ static int test_signed_long_formatting(void)
 static int test_curl_off_t_formatting(void)
 {
   int i, j;
-  int num_cofft_tests;
+  int num_cofft_tests = 0;
   int failed = 0;
 
 #if (SIZEOF_CURL_OFF_T == 2)


### PR DESCRIPTION
Mostly from CppCheck. Some fixes for unused local variable warnings would have been nicer with C99, being able to declare them in the right preprocessor condition block.