### PR TITLE
multi_runsingle(): fix use-after-free

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1448,7 +1448,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         if(result)
           /* if Curl_once_resolved() returns failure, the connection struct
              is already freed and gone */
-          detach_connnection(data); /* no more connection */
+          data->conn = NULL; /* no more connection */
         else {
           /* call again please so that we get the next socket setup */
           rc = CURLM_CALL_MULTI_PERFORM;


### PR DESCRIPTION
Fixes #3745

The following snippet
```

int main()
{
    CURL* hCurlHandle = curl_easy_init();
    curl_easy_setopt(hCurlHandle, CURLOPT_URL, "http://example.com");
    curl_easy_setopt(hCurlHandle, CURLOPT_PROXY, "1");
    curl_easy_perform(hCurlHandle);
    curl_easy_cleanup(hCurlHandle);
    return 0;
}
```
triggers the following Valgrind warning

```
==4125== Invalid read of size 8
==4125==    at 0x4E7D1EE: Curl_llist_remove (llist.c:97)
==4125==    by 0x4E7EF5C: detach_connnection (multi.c:798)
==4125==    by 0x4E80545: multi_runsingle (multi.c:1451)
==4125==    by 0x4E8197C: curl_multi_perform (multi.c:2072)
==4125==    by 0x4E766A0: easy_transfer (easy.c:625)
==4125==    by 0x4E76915: easy_perform (easy.c:719)
==4125==    by 0x4E7697C: curl_easy_perform (easy.c:738)
==4125==    by 0x4008BE: main (in /home/even/curl/test)
==4125==  Address 0x9b3d1d0 is 1,120 bytes inside a block of size 1,600 free'd
==4125==    at 0x4C2ECF0: free (vg_replace_malloc.c:530)
==4125==    by 0x4E62C36: conn_free (url.c:756)
==4125==    by 0x4E62D34: Curl_disconnect (url.c:818)
==4125==    by 0x4E48DF9: Curl_once_resolved (hostip.c:1097)
==4125==    by 0x4E8052D: multi_runsingle (multi.c:1446)
==4125==    by 0x4E8197C: curl_multi_perform (multi.c:2072)
==4125==    by 0x4E766A0: easy_transfer (easy.c:625)
==4125==    by 0x4E76915: easy_perform (easy.c:719)
==4125==    by 0x4E7697C: curl_easy_perform (easy.c:738)
==4125==    by 0x4008BE: main (in /home/even/curl/test)
==4125==  Block was alloc'd at
==4125==    at 0x4C2F988: calloc (vg_replace_malloc.c:711)
==4125==    by 0x4E6438E: allocate_conn (url.c:1654)
==4125==    by 0x4E685B4: create_conn (url.c:3496)
==4125==    by 0x4E6968F: Curl_connect (url.c:4023)
==4125==    by 0x4E802E7: multi_runsingle (multi.c:1368)
==4125==    by 0x4E8197C: curl_multi_perform (multi.c:2072)
==4125==    by 0x4E766A0: easy_transfer (easy.c:625)
==4125==    by 0x4E76915: easy_perform (easy.c:719)
==4125==    by 0x4E7697C: curl_easy_perform (easy.c:738)
==4125==    by 0x4008BE: main (in /home/even/curl/test)
```

This has been bisected to commit 2f44e94

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=14109
Credit to OSS Fuzz