### PR TITLE
config.d: clarify that initial : and = might need quoting [skip ci]

### DIFF
--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -15,12 +15,12 @@ if so, the colon or equals characters can be used as separators. If the option
 is specified with one or two dashes, there can be no colon or equals character
 between the option and its parameter.
 
-If the parameter is to contain whitespace, the parameter must be enclosed
-within quotes. Within double quotes, the following escape sequences are
-available: \\\\, \\", \\t, \\n, \\r and \\v. A backslash preceding any other
-letter is ignored. If the first column of a config line is a '#' character,
-the rest of the line will be treated as a comment. Only write one option per
-physical line in the config file.
+If the parameter contains whitespace (or starts with : or =), the parameter
+must be enclosed within quotes. Within double quotes, the following escape
+sequences are available: \\\\, \\", \\t, \\n, \\r and \\v. A backslash
+preceding any other letter is ignored. If the first column of a config line is
+a '#' character, the rest of the line will be treated as a comment. Only write
+one option per physical line in the config file.
 
 Specify the filename to --config as '-' to make curl read the file from stdin.
 


### PR DESCRIPTION
Fixes #3738