### PR TITLE
vauth/cleartext: Update the PLAIN login function signature to match RFC 4616

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -367,8 +367,8 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct connectdata *conn,
       sasl->authused = SASL_MECH_PLAIN;
 
       if(force_ir || data->set.sasl_ir)
-        result = Curl_auth_create_plain_message(data, conn->user, conn->passwd,
-                                                &resp, &len);
+        result = Curl_auth_create_plain_message(data, conn->user, conn->user,
+                                                conn->passwd, &resp, &len);
     }
     else if(enabledmechs & SASL_MECH_LOGIN) {
       mech = SASL_MECH_STRING_LOGIN;
@@ -450,9 +450,8 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct connectdata *conn,
     *progress = SASL_DONE;
     return result;
   case SASL_PLAIN:
-    result = Curl_auth_create_plain_message(data, conn->user, conn->passwd,
-                                            &resp,
-                                            &len);
+    result = Curl_auth_create_plain_message(data, conn->user, conn->user,
+                                            conn->passwd, &resp, &len);
     break;
   case SASL_LOGIN:
     result = Curl_auth_create_login_message(data, conn->user, &resp, &len);

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,8 +49,9 @@
  * Parameters:
  *
  * data    [in]     - The session handle.
- * userp   [in]     - The user name.
- * passwdp [in]     - The user's password.
+ * authzid [in]     - The authorization identity.
+ * authcid [in]     - The authentication identity.
+ * passwd  [in]     - The password.
  * outptr  [in/out] - The address where a pointer to newly allocated memory
  *                    holding the result will be stored upon completion.
  * outlen  [out]    - The length of the output message.
@@ -58,36 +59,39 @@
  * Returns CURLE_OK on success.
  */
 CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
-                                        const char *userp,
-                                        const char *passwdp,
+                                        const char *authzid,
+                                        const char *authcid,
+                                        const char *passwd,
                                         char **outptr, size_t *outlen)
 {
   CURLcode result;
   char *plainauth;
-  size_t ulen;
+  size_t zlen;
+  size_t clen;
   size_t plen;
   size_t plainlen;
 
   *outlen = 0;
   *outptr = NULL;
-  ulen = strlen(userp);
-  plen = strlen(passwdp);
+  zlen = strlen(authzid);
+  clen = strlen(authcid);
+  plen = strlen(passwd);
 
   /* Compute binary message length. Check for overflows. */
-  if((ulen > SIZE_T_MAX/4) || (plen > (SIZE_T_MAX/2 - 2)))
+  if(((zlen + clen) > SIZE_T_MAX/4) || (plen > (SIZE_T_MAX/2 - 2)))
     return CURLE_OUT_OF_MEMORY;
-  plainlen = 2 * ulen + plen + 2;
+  plainlen = zlen + clen + plen + 2;
 
   plainauth = malloc(plainlen);
   if(!plainauth)
     return CURLE_OUT_OF_MEMORY;
 
   /* Calculate the reply */
-  memcpy(plainauth, userp, ulen);
-  plainauth[ulen] = '\0';
-  memcpy(plainauth + ulen + 1, userp, ulen);
-  plainauth[2 * ulen + 1] = '\0';
-  memcpy(plainauth + 2 * ulen + 2, passwdp, plen);
+  memcpy(plainauth, authzid, zlen);
+  plainauth[zlen] = '\0';
+  memcpy(plainauth + zlen + 1, authcid, clen);
+  plainauth[zlen + clen + 1] = '\0';
+  memcpy(plainauth + zlen + clen + 2, passwd, plen);
 
   /* Base64 encode the reply */
   result = Curl_base64_encode(data, plainauth, plainlen, outptr, outlen);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2014 - 2017, Steve Holme, <steve_holme@hotmail.com>.
+ * Copyright (C) 2014 - 2019, Steve Holme, <steve_holme@hotmail.com>.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -60,8 +60,9 @@ bool Curl_auth_user_contains_domain(const char *user);
 
 /* This is used to generate a base64 encoded PLAIN cleartext message */
 CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
-                                        const char *userp,
-                                        const char *passwdp,
+                                        const char *authzid,
+                                        const char *authcid,
+                                        const char *passwd,
                                         char **outptr, size_t *outlen);
 
 /* This is used to generate a base64 encoded LOGIN cleartext message */


### PR DESCRIPTION
Functionally this doesn't change anything as we still use the username
for both the authorisation identity and the authentication identity.