### PR TITLE
tests/server/util: fix Windows Unicode build

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -150,8 +150,8 @@ void win32_perror(const char *msg)
   char buf[512];
   DWORD err = SOCKERRNO;
 
-  if(!FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err,
-                    LANG_NEUTRAL, buf, sizeof(buf), NULL))
+  if(!FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err,
+                     LANG_NEUTRAL, buf, sizeof(buf), NULL))
     msnprintf(buf, sizeof(buf), "Unknown error %lu (%#lx)", err, err);
   if(msg)
     fprintf(stderr, "%s: ", msg);


### PR DESCRIPTION
Always use the ANSI version of FormatMessage as we don't have the
curl_multibyte gear available here.