### PR TITLE
xattr: skip unittest on unsupported platforms

### DIFF
--- a/tests/unit/unit1621.c
+++ b/tests/unit/unit1621.c
@@ -35,7 +35,9 @@ static void unit_stop(void)
 {
 }
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__)  || \
+  (!defined(HAVE_FSETXATTR) && \
+  (!defined(__FreeBSD_version) || (__FreeBSD_version < 500000)))
 UNITTEST_START
 {
   return 0;


### PR DESCRIPTION
The `stripcredentials()` unittest fails to compile on platforms without xattr support, for example the [Solaris member in the buildfarm](https://curl.haxx.se/dev/log.cgi?id=20190410182614-3170#prob1) which fails with the following:
```
  CC unit1621-unit1621.o
  CC ../libtest/unit1621-first.o
  CCLD unit1621
  Undefined first referenced
  symbol in file
  stripcredentials unit1621-unit1621.o
  goto problem 2
  ld: fatal: symbol referencing errors. No output written to .libs/unit1621
  collect2: error: ld returned 1 exit status
  gmake[2]: *** [Makefile:996: unit1621] Error 1
```
Fix by excluding the test on such platforms by using the reverse logic from where `stripcredentials()` is defined.