### PR TITLE
CURLOPT_ADDRESS_SCOPE: fix range check and more

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.3
+++ b/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2014, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -22,14 +22,13 @@
 .\"
 .TH CURLOPT_ADDRESS_SCOPE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
 .SH NAME
-CURLOPT_ADDRESS_SCOPE \- set scope for local IPv6 addresses
+CURLOPT_ADDRESS_SCOPE \- set scope id for IPv6 addresses
 .SH SYNOPSIS
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ADDRESS_SCOPE, long scope);
 .SH DESCRIPTION
-Pass a long specifying the scope_id value to use when connecting to IPv6
-link-local or site-local addresses.
+Pass a long specifying the scope id value to use when connecting to IPv6 addresses.
 .SH DEFAULT
 0
 .SH PROTOCOLS
@@ -39,12 +38,10 @@ All, when using IPv6
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode ret;
+  long my_scope_id;
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-  /* 0x2 link-local
-     0x5 site-local
-     0x8 organization-local
-     0xe global ... */
-  curl_easy_setopt(curl, CURLOPT_ADDRESS_SCOPE, 0xEL);
+  my_scope_id = if_nametoindex("eth0");
+  curl_easy_setopt(curl, CURLOPT_ADDRESS_SCOPE, my_scope_id);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }
@@ -53,5 +50,6 @@ if(curl) {
 Added in 7.19.0
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+Returns CURLE_BAD_FUNCTION_ARGUMENT if set to a negative value.
 .SH "SEE ALSO"
 .BR CURLOPT_STDERR "(3), " CURLOPT_DEBUGFUNCTION "(3), "

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -97,7 +97,7 @@ unsigned int Curl_ipv6_scope(const struct sockaddr *sa)
 #if defined(HAVE_GETIFADDRS)
 
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
-                          unsigned int remote_scope_id, const char *interf,
+                          unsigned int local_scope_id, const char *interf,
                           char *buf, int buf_size)
 {
   struct ifaddrs *iface, *head;
@@ -109,7 +109,7 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
 
 #if !defined(HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID) || \
     !defined(ENABLE_IPV6)
-  (void) remote_scope_id;
+  (void) local_scope_id;
 #endif
 
   if(getifaddrs(&head) >= 0) {
@@ -145,7 +145,7 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
                             ->sin6_scope_id;
 
               /* If given, scope id should match. */
-              if(remote_scope_id && scopeid != remote_scope_id) {
+              if(local_scope_id && scopeid != local_scope_id) {
                 if(res == IF2IP_NOT_FOUND)
                   res = IF2IP_AF_NOT_SUPPORTED;
 
@@ -182,7 +182,7 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
 #elif defined(HAVE_IOCTL_SIOCGIFADDR)
 
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
-                          unsigned int remote_scope_id, const char *interf,
+                          unsigned int local_scope_id, const char *interf,
                           char *buf, int buf_size)
 {
   struct ifreq req;
@@ -192,7 +192,7 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
   size_t len;
 
   (void)remote_scope;
-  (void)remote_scope_id;
+  (void)local_scope_id;
 
   if(!interf || (af != AF_INET))
     return IF2IP_NOT_FOUND;
@@ -228,12 +228,12 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
 #else
 
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
-                          unsigned int remote_scope_id, const char *interf,
+                          unsigned int local_scope_id, const char *interf,
                           char *buf, int buf_size)
 {
     (void) af;
     (void) remote_scope;
-    (void) remote_scope_id;
+    (void) local_scope_id;
     (void) interf;
     (void) buf;
     (void) buf_size;

--- a/lib/if2ip.h
+++ b/lib/if2ip.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -39,7 +39,7 @@ typedef enum {
 } if2ip_result_t;
 
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
-                          unsigned int remote_scope_id, const char *interf,
+                          unsigned int local_scope_id, const char *interf,
                           char *buf, int buf_size);
 
 #ifdef __INTERIX

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -118,6 +118,7 @@ static CURLcode vsetopt(struct Curl_easy *data, CURLoption option,
   char *argptr;
   CURLcode result = CURLE_OK;
   long arg;
+  unsigned long uarg;
   curl_off_t bigsize;
 
   switch(option) {
@@ -2297,14 +2298,16 @@ static CURLcode vsetopt(struct Curl_easy *data, CURLoption option,
 
   case CURLOPT_ADDRESS_SCOPE:
     /*
-     * We always get longs when passed plain numericals, but for this value we
-     * know that an unsigned int will always hold the value so we blindly
-     * typecast to this type
+     * Use this scope id when using IPv6
+     * We always get longs when passed plain numericals so we should check
+     * that the value fits into an unsigned 32 bit integer.
      */
-    arg = va_arg(param, long);
-    if((arg < 0) || (arg > 0xf))
+    uarg = va_arg(param, unsigned long);
+#if SIZEOF_LONG > 4
+    if(uarg > UINT_MAX)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.scope_id = curlx_sltoui(arg);
+#endif
+    data->set.scope_id = (unsigned int)uarg;
     break;
 
   case CURLOPT_PROTOCOLS:


### PR DESCRIPTION
Commit 9081014 fixed most of the confusing issues between scope id and scope however 844896d added bad limits checking assuming that the scope is being set and not the scope id.

I have fixed the documentation so it all refers to scope ids.

In addition Curl_if2ip referred to the scope id as remote_scope_id which is incorrect, so I renamed it to local_scope_id.

Closes #3655

(I took that PR, squashed it and fixed some nits and push it here to make sure the CI likes it)