### PR TITLE
travis: remove mesalink builds (temporarily?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
         - $HOME/mbedtls-mbedtls-2.8.0
         - $HOME/libidn2-2.0.4
         - $HOME/wolfssl-4.0.0-stable
-        - $HOME/mesalink-0.7.1
         - $HOME/nghttp2-1.34.0
 
 env:
@@ -97,12 +96,6 @@ matrix:
           dist: trusty
           env:
               - T=debug-wolfssl C="--with-wolfssl --without-ssl"
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-        - os: linux
-          compiler: gcc
-          dist: trusty
-          env:
-              - T=debug-mesalink C="--with-mesalink --without-ssl"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: clang
@@ -407,20 +400,6 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
-        if [ ! -e $HOME/mesalink-0.7.1/Makefile ]; then
-          (cd $HOME && \
-          curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-          source $HOME/.cargo/env && \
-          curl -LO https://github.com/mesalock-linux/mesalink/archive/v0.7.1.tar.gz && \
-          tar -xzf v0.7.1.tar.gz && \
-          cd mesalink-0.7.1 && \
-          ./autogen.sh && \
-          ./configure --enable-tls13  && \
-          make)
-        fi
-      fi
-    - |
-      if [ $TRAVIS_OS_NAME = linux ]; then
         if [ ! -e $HOME/nghttp2-1.34.0/Makefile ]; then
           (cd $HOME && \
           curl -L https://github.com/nghttp2/nghttp2/releases/download/v1.34.0/nghttp2-1.34.0.tar.gz |
@@ -436,7 +415,6 @@ before_script:
         (cd $HOME/libpsl-0.20.1 && sudo make install)
         (cd $HOME/mbedtls-mbedtls-2.8.0 && sudo make install)
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
-        (cd $HOME/mesalink-0.7.1 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
       fi
 
@@ -465,13 +443,6 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "debug-wolfssl" ]; then
-             ./configure --enable-debug --enable-werror $C
-             make
-             make "TFLAGS=-n !313" test-nonflaky
-        fi
-    - |
-        set -eo pipefail
-        if [ "$T" = "debug-mesalink" ]; then
              ./configure --enable-debug --enable-werror $C
              make
              make "TFLAGS=-n !313" test-nonflaky


### PR DESCRIPTION
Since the mesalink build started to fail on travis, even though we build
a fixed release version, we disable it to prevent it from blocking
progress.