### PR TITLE
OpenSSL: Report -fips in version if OpenSSL is built with FIPS

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3822,11 +3822,11 @@ static size_t Curl_ossl_version(char *buffer, size_t size)
       sub[0]='\0';
   }
 
+  return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s"
 #ifdef OPENSSL_FIPS
-  return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s-fips",
-#else
-  return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s",
+                   "fips"
 #endif
+                   ,
                    OSSL_PACKAGE,
                    (ssleay_value>>28)&0xf,
                    (ssleay_value>>20)&0xff,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3824,7 +3824,7 @@ static size_t Curl_ossl_version(char *buffer, size_t size)
 
   return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s"
 #ifdef OPENSSL_FIPS
-                   "fips"
+                   "-fips"
 #endif
                    ,
                    OSSL_PACKAGE,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3822,7 +3822,11 @@ static size_t Curl_ossl_version(char *buffer, size_t size)
       sub[0]='\0';
   }
 
+#ifdef OPENSSL_FIPS
+  return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s-fips",
+#else
   return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s",
+#endif
                    OSSL_PACKAGE,
                    (ssleay_value>>28)&0xf,
                    (ssleay_value>>20)&0xff,


### PR DESCRIPTION
Older versions of OpenSSL report FIPS availabilty via an OPENSSL_FIPS
define. It uses this define to determine whether to publish -fips at
the end of the version displayed. Applications that utilize the version
reported by OpenSSL will see a mismatch if they compare it to what curl
reports, as curl is not modifying the version in the same way. This
change simply adds a check to see if OPENSSL_FIPS is defined, and will
alter the reported version to match what OpenSSL itself provides. This
only appears to be applicable in versions of OpenSSL <1.1.1

Reported-by: Ricky Leverence Jr