### PR TITLE
tool_help: Warn if curl and libcurl versions do not match

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -150,7 +150,6 @@
  18.4 simultaneous parallel transfers
  18.5 UTF-8 filenames in Content-Disposition
  18.6 warning when setting an option
- 18.7 warning if curl version is not in sync with libcurl version
  18.8 offer color-coded HTTP header output
  18.9 Choose the name of file in braces for complex URLs
  18.10 improve how curl works in a windows console window
@@ -1024,13 +1023,6 @@ that doesn't exist on the server, just like --ftp-create-dirs.
  Display a warning when libcurl returns an error when setting an option.
  This can be useful to tell when support for a particular feature hasn't been
  compiled into the library.
-
-18.7 warning if curl version is not in sync with libcurl version
-
- This is usually a sign of a funny, weird or unexpected install situations
- that aren't always quickly nor easily detected by users. curl and libcurl are
- always released in sync and should use the same version numbers unless very
- special situations.
 
 18.8 offer color-coded HTTP header output
 

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -596,6 +596,10 @@ void tool_version_info(void)
       printf(" %s", featp[i]);
     puts(""); /* newline */
   }
+  if(strcmp(CURL_VERSION, curlinfo->version)) {
+    printf("WARNING: curl and libcurl versions do not match. "
+           "Functionality may be affected.\n");
+  }
 }
 
 void tool_list_engines(CURL *curl)


### PR DESCRIPTION
.. because functionality may be affected if the versions differ.

This commit implements TODO 18.7 "warning if curl version is not in sync
with libcurl version".

Ref: https://github.com/curl/curl/blob/curl-7_64_1/docs/TODO#L1028-L1033

Closes #xxxx

---

For example:

~~~
curl 7.65.0-DEV (i386-pc-win32) libcurl/7.64.0-DEV Schannel WinIDN
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS Debug IDN IPv6 Kerberos Largefile NTLM SPNEGO SSL SSPI
WARNING: curl and libcurl versions do not match. Functionality may be affected.
~~~
