### PR TITLE
Revert "travis: remove mesalink builds (temporarily?)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 cache:
     directories:
         - $HOME/wolfssl-4.0.0-stable
+        - $HOME/mesalink-0.7.1
         - $HOME/nghttp2-1.34.0
 
 env:
@@ -113,6 +114,12 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
+        - os: linux
+          compiler: gcc
+          dist: trusty
+          env:
+              - T=debug-mesalink C="--with-mesalink --without-ssl"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: clang
           dist: xenial
@@ -408,6 +415,20 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
+        if [ ! -e $HOME/mesalink-0.7.1/Makefile ]; then
+          (cd $HOME && \
+          curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+          source $HOME/.cargo/env && \
+          curl -LO https://github.com/mesalock-linux/mesalink/archive/v0.7.1.tar.gz && \
+          tar -xzf v0.7.1.tar.gz && \
+          cd mesalink-0.7.1 && \
+          ./autogen.sh && \
+          ./configure --enable-tls13  && \
+          make)
+        fi
+      fi
+    - |
+      if [ $TRAVIS_OS_NAME = linux ]; then
         if [ ! -e $HOME/nghttp2-1.34.0/Makefile ]; then
           (cd $HOME && \
           curl -L https://github.com/nghttp2/nghttp2/releases/download/v1.34.0/nghttp2-1.34.0.tar.gz |
@@ -420,6 +441,7 @@ before_script:
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
+        (cd $HOME/mesalink-0.7.1 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
       fi
 
@@ -448,6 +470,13 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "debug-wolfssl" ]; then
+             ./configure --enable-debug --enable-werror $C
+             make
+             make "TFLAGS=-n !313" test-nonflaky
+        fi
+    - |
+        set -eo pipefail
+        if [ "$T" = "debug-mesalink" ]; then
              ./configure --enable-debug --enable-werror $C
              make
              make "TFLAGS=-n !313" test-nonflaky


### PR DESCRIPTION
This reverts commit 60034228255894fcea57950b3b39bfe6f5fca580.

The mesalink build was removed from the travis set due to constant build
failures. Things change brings the build back once functional again.