### PR TITLE
travis: use system packages for libpsl and mbedtls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 sudo: required
 cache:
     directories:
-        - $HOME/mbedtls-mbedtls-2.8.0
         - $HOME/wolfssl-4.0.0-stable
         - $HOME/nghttp2-1.34.0
 
@@ -159,6 +158,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libmbedtls-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -395,17 +395,6 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
-        if [ ! -e $HOME/mbedtls-mbedtls-2.8.0/library/libmbedtls.a ]; then
-          (cd $HOME && \
-          curl -LO https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.8.0.tar.gz && \
-          tar -xzf mbedtls-2.8.0.tar.gz && \
-          cd mbedtls-mbedtls-2.8.0 && \
-          cmake . -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_C_FLAGS=-fPIC && \
-          make)
-        fi
-      fi
-    - |
-      if [ $TRAVIS_OS_NAME = linux ]; then
         if [ ! -e $HOME/wolfssl-4.0.0-stable/Makefile ]; then
           (cd $HOME && \
           curl -LO https://github.com/wolfSSL/wolfssl/archive/v4.0.0-stable.tar.gz && \
@@ -430,7 +419,6 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
-        (cd $HOME/mbedtls-mbedtls-2.8.0 && sudo make install)
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: c
 sudo: required
 cache:
     directories:
-        - $HOME/libpsl-0.20.1
         - $HOME/mbedtls-mbedtls-2.8.0
-        - $HOME/libidn2-2.0.4
         - $HOME/wolfssl-4.0.0-stable
         - $HOME/nghttp2-1.34.0
 
@@ -28,8 +26,6 @@ addons:
             - libstdc++-8-dev
             - stunnel4
             - libidn2-0-dev
-            - autopoint  # for libpsl that needs autoreconf that uses gettext that needs it
-            - libunistring-dev # for libidn2 needed by libpsl
             - gnutls-bin
 
 matrix:
@@ -79,6 +75,13 @@ matrix:
           env:
               - T=normal C="--disable-verbose" CPPFLAGS="-Wno-variadic-macros" NOTESTS=1
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libpsl-dev
         - os: linux
           compiler: gcc
           dist: trusty
@@ -91,12 +94,26 @@ matrix:
           env:
               - T=novalgrind BORINGSSL=yes C="--with-ssl=$HOME/boringssl" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libpsl-dev
         - os: linux
           compiler: gcc
           dist: xenial
           env:
               - T=debug-wolfssl C="--with-wolfssl --without-ssl"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -111,6 +128,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -125,6 +143,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -139,6 +158,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -154,6 +174,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libgnutls28-dev
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -168,6 +189,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -183,6 +205,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libnss3-dev
+                      - libpsl-dev
         - os: linux
           compiler: gcc
           dist: trusty
@@ -217,6 +240,13 @@ matrix:
           env:
               - T=cmake
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -231,6 +261,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
         - os: linux
           compiler: gcc
           dist: xenial
@@ -244,12 +275,20 @@ matrix:
                   packages:
                       - *common_packages
                       - lcov
+                      - libpsl-dev
         - os: linux
           compiler: gcc
           dist: xenial
           env:
               - T=distcheck
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -264,6 +303,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -279,6 +319,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - clang-tidy-7
+                      - libpsl-dev
         - os: linux
           compiler: clang
           dist: trusty
@@ -307,6 +348,7 @@ matrix:
                   packages:
                       - *common_packages
                       - clang-7
+                      - libpsl-dev
 
 before_install:
     - eval "${OVERRIDE_CC}"
@@ -353,29 +395,6 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
-        if [ ! -e $HOME/libidn2-2.0.4/Makefile ]; then
-          (cd $HOME && \
-          curl -LO https://ftp.gnu.org/gnu/libidn/libidn2-2.0.4.tar.gz && \
-          tar -xzf libidn2-2.0.4.tar.gz && \
-          cd libidn2-2.0.4 && \
-          ./configure && \
-          make)
-        fi
-      fi
-    - |
-      if [ $TRAVIS_OS_NAME = linux ]; then
-        if [ ! -e $HOME/libpsl-0.20.1/Makefile ]; then
-          (cd $HOME && \
-          curl -LO https://github.com/rockdaboot/libpsl/releases/download/libpsl-0.20.1/libpsl-0.20.1.tar.gz && \
-          tar -xzf libpsl-0.20.1.tar.gz && \
-          cd libpsl-0.20.1 && \
-          autoreconf -i && \
-          ./configure && \
-          make)
-        fi
-      fi
-    - |
-      if [ $TRAVIS_OS_NAME = linux ]; then
         if [ ! -e $HOME/mbedtls-mbedtls-2.8.0/library/libmbedtls.a ]; then
           (cd $HOME && \
           curl -LO https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.8.0.tar.gz && \
@@ -411,8 +430,6 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
-        (cd $HOME/libidn2-2.0.4 && sudo make install)
-        (cd $HOME/libpsl-0.20.1 && sudo make install)
         (cd $HOME/mbedtls-mbedtls-2.8.0 && sudo make install)
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)


### PR DESCRIPTION
Building libpsl required building libidn2 from source plus installing the autopoint and libunistring-dev packages. Using the Xenial package for libpsl should also fix the build for https://github.com/curl/curl/pull/3755.

mbedtls is only used in one build, so it doesn't need to be cached.