### PR TITLE
Centralise the TLS specific MD4 code away from the NTLM code

### DIFF
--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -24,13 +24,15 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
+#if defined(USE_GNUTLS_NETTLE) || defined(USE_NSS) || \
+    defined(USE_OS400CRYPTO) || \
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
 
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
-#endif /* defined(USE_NSS) || defined(USE_OS400CRYPTO) ||
+#endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_NSS) ||
+    defined(USE_OS400CRYPTO) ||
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) ||
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
 

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -25,7 +25,8 @@
 #include "curl_setup.h"
 
 #if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
-    defined(USE_OPENSSL) || defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
+    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || defined(USE_NSS) || \
+    defined(USE_OS400CRYPTO) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
 
 #define MD4_DIGEST_LENGTH 16
@@ -33,7 +34,8 @@
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
 #endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_OPENSSL) || defined(USE_NSS) || defined(USE_OS400CRYPTO) ||
+    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || defined(USE_NSS) ||
+    defined(USE_OS400CRYPTO) ||
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
 
 #endif /* HEADER_CURL_MD4_H */

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -27,17 +27,15 @@
 #if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
     defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
     defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || \
-    (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
+    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS)
 
 #define MD4_DIGEST_LENGTH 16
 
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
 #endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
-    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || \
-    (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
+    defined(USE_OPENSSL) || defined(USE_SECTRANSP) ||
+    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) ||
+    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS) */
 
 #endif /* HEADER_CURL_MD4_H */

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -25,7 +25,8 @@
 #include "curl_setup.h"
 
 #if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || defined(USE_NSS) || \
+    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
+    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
     defined(USE_OS400CRYPTO) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
 
@@ -34,8 +35,9 @@
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
 #endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || defined(USE_NSS) ||
-    defined(USE_OS400CRYPTO) ||
+    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
+    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
+    defined(USE_OS400CRYPTO) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
 
 #endif /* HEADER_CURL_MD4_H */

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -29,10 +29,12 @@
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
 
+#define MD4_DIGEST_LENGTH 16
+
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
-#endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_NSS) ||
-    defined(USE_OS400CRYPTO) ||
+#endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
+    defined(USE_NSS) || defined(USE_OS400CRYPTO) ||
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) ||
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
 

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -24,9 +24,8 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_GNUTLS_NETTLE) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || \
-    (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
+#if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
+    defined(USE_OPENSSL) || defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
 
 #define MD4_DIGEST_LENGTH 16
@@ -34,8 +33,7 @@
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
 #endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_NSS) || defined(USE_OS400CRYPTO) ||
-    (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) ||
+    defined(USE_OPENSSL) || defined(USE_NSS) || defined(USE_OS400CRYPTO) ||
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
 
 #endif /* HEADER_CURL_MD4_H */

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -24,18 +24,12 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
-    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS)
+#if !defined(CURL_DISABLE_CRYPTO_AUTH)
 
 #define MD4_DIGEST_LENGTH 16
 
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len);
 
-#endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) ||
-    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) ||
-    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS) */
+#endif /* !defined(CURL_DISABLE_CRYPTO_AUTH) */
 
 #endif /* HEADER_CURL_MD4_H */

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -103,6 +103,7 @@
 
 #  include <CommonCrypto/CommonCryptor.h>
 #  include <CommonCrypto/CommonDigest.h>
+#  include "curl_md4.h"
 
 #elif defined(USE_OS400CRYPTO)
 #  include "cipher.mih"  /* mih/cipher */
@@ -579,7 +580,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
     Curl_md4it(ntbuffer, pw, 2 * len);
 #endif
 #elif defined(USE_SECTRANSP)
-    (void)CC_MD4(pw, (CC_LONG)(2 * len), ntbuffer);
+    Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_OS400CRYPTO)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_WIN32_CRYPTO)

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -556,12 +556,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
     return result;
 
   /* Create NT hashed password. */
-#if defined(USE_OPENSSL) || defined(USE_GNUTLS_NETTLE) || \
-  defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_MBEDTLS) || \
-  defined(USE_SECTRANSP) || defined(USE_OS400CRYPTO) || \
-  defined(USE_WIN32_CRYPTO)
   Curl_md4it(ntbuffer, pw, 2 * len);
-#endif
 
   memset(ntbuffer + 16, 0, 21 - 16);
 

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -83,9 +83,9 @@
 
 #elif defined(USE_GNUTLS)
 
+#  include "curl_md4.h"
 #  include <gcrypt.h>
 #  define MD5_DIGEST_LENGTH 16
-#  define MD4_DIGEST_LENGTH 16
 
 #elif defined(USE_NSS)
 
@@ -580,11 +580,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
 #elif defined(USE_GNUTLS_NETTLE)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_GNUTLS)
-    gcry_md_hd_t MD4pw;
-    gcry_md_open(&MD4pw, GCRY_MD_MD4, 0);
-    gcry_md_write(MD4pw, pw, 2 * len);
-    memcpy(ntbuffer, gcry_md_read(MD4pw, 0), MD4_DIGEST_LENGTH);
-    gcry_md_close(MD4pw);
+    Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_NSS)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_MBEDTLS)

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -561,28 +561,15 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
   if(result)
     return result;
 
-  {
-    /* Create NT hashed password. */
-#ifdef USE_OPENSSL
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_GNUTLS_NETTLE)
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_GNUTLS)
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_NSS)
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_MBEDTLS)
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_SECTRANSP)
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_OS400CRYPTO)
-    Curl_md4it(ntbuffer, pw, 2 * len);
-#elif defined(USE_WIN32_CRYPTO)
-    Curl_md4it(ntbuffer, pw, 2 * len);
+  /* Create NT hashed password. */
+#if defined(USE_OPENSSL) || defined(USE_GNUTLS_NETTLE) || \
+  defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_MBEDTLS) || \
+  defined(USE_SECTRANSP) || defined(USE_OS400CRYPTO) || \
+  defined(USE_WIN32_CRYPTO)
+  Curl_md4it(ntbuffer, pw, 2 * len);
 #endif
 
-    memset(ntbuffer + 16, 0, 21 - 16);
-  }
+  memset(ntbuffer + 16, 0, 21 - 16);
 
   free(pw);
 

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -70,16 +70,13 @@
 #    define DESKEYARG(x) *x
 #    define DESKEY(x) &x
 #  endif
-#  include "curl_md4.h"
 
 #elif defined(USE_GNUTLS_NETTLE)
 
 #  include <nettle/des.h>
-#  include "curl_md4.h"
 
 #elif defined(USE_GNUTLS)
 
-#  include "curl_md4.h"
 #  include <gcrypt.h>
 #  define MD5_DIGEST_LENGTH 16
 
@@ -88,7 +85,6 @@
 #  include <nss.h>
 #  include <pk11pub.h>
 #  include <hasht.h>
-#  include "curl_md4.h"
 #  define MD5_DIGEST_LENGTH MD5_LENGTH
 
 #elif defined(USE_MBEDTLS)
@@ -100,14 +96,11 @@
 
 #  include <CommonCrypto/CommonCryptor.h>
 #  include <CommonCrypto/CommonDigest.h>
-#  include "curl_md4.h"
 
 #elif defined(USE_OS400CRYPTO)
 #  include "cipher.mih"  /* mih/cipher */
-#  include "curl_md4.h"
 #elif defined(USE_WIN32_CRYPTO)
 #  include <wincrypt.h>
-#  include "curl_md4.h"
 #else
 #  error "Can't compile NTLM support without a crypto library."
 #endif
@@ -121,6 +114,7 @@
 #include "warnless.h"
 #include "curl_endian.h"
 #include "curl_des.h"
+#include "curl_md4.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -110,6 +110,7 @@
 #  include "curl_md4.h"
 #elif defined(USE_WIN32_CRYPTO)
 #  include <wincrypt.h>
+#  include "curl_md4.h"
 #else
 #  error "Can't compile NTLM support without a crypto library."
 #endif
@@ -584,18 +585,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
 #elif defined(USE_OS400CRYPTO)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_WIN32_CRYPTO)
-    HCRYPTPROV hprov;
-    if(CryptAcquireContext(&hprov, NULL, NULL, PROV_RSA_FULL,
-                           CRYPT_VERIFYCONTEXT)) {
-      HCRYPTHASH hhash;
-      if(CryptCreateHash(hprov, CALG_MD4, 0, 0, &hhash)) {
-        DWORD length = 16;
-        CryptHashData(hhash, pw, (unsigned int)len * 2, 0);
-        CryptGetHashParam(hhash, HP_HASHVAL, ntbuffer, &length, 0);
-        CryptDestroyHash(hhash);
-      }
-      CryptReleaseContext(hprov, 0);
-    }
+    Curl_md4it(ntbuffer, pw, 2 * len);
 #endif
 
     memset(ntbuffer + 16, 0, 21 - 16);

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -79,7 +79,7 @@
 #elif defined(USE_GNUTLS_NETTLE)
 
 #  include <nettle/des.h>
-#  include <nettle/md4.h>
+#  include "curl_md4.h"
 
 #elif defined(USE_GNUTLS)
 
@@ -578,10 +578,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
     Curl_md4it(ntbuffer, pw, 2 * len);
 #endif
 #elif defined(USE_GNUTLS_NETTLE)
-    struct md4_ctx MD4pw;
-    md4_init(&MD4pw);
-    md4_update(&MD4pw, (unsigned int)(2 * len), pw);
-    md4_digest(&MD4pw, MD4_DIGEST_SIZE, ntbuffer);
+    Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_GNUTLS)
     gcry_md_hd_t MD4pw;
     gcry_md_open(&MD4pw, GCRY_MD_MD4, 0);

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -55,11 +55,6 @@
 #ifdef USE_OPENSSL
 
 #  include <openssl/des.h>
-#  ifndef OPENSSL_NO_MD4
-#    include <openssl/md4.h>
-#  else
-#    include "curl_md4.h"
-#  endif
 #  include <openssl/md5.h>
 #  include <openssl/ssl.h>
 #  include <openssl/rand.h>
@@ -75,6 +70,7 @@
 #    define DESKEYARG(x) *x
 #    define DESKEY(x) &x
 #  endif
+#  include "curl_md4.h"
 
 #elif defined(USE_GNUTLS_NETTLE)
 
@@ -569,14 +565,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
   {
     /* Create NT hashed password. */
 #ifdef USE_OPENSSL
-#if !defined(OPENSSL_NO_MD4)
-    MD4_CTX MD4pw;
-    MD4_Init(&MD4pw);
-    MD4_Update(&MD4pw, pw, 2 * len);
-    MD4_Final(ntbuffer, &MD4pw);
-#else
     Curl_md4it(ntbuffer, pw, 2 * len);
-#endif
 #elif defined(USE_GNUTLS_NETTLE)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_GNUTLS)

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -94,10 +94,7 @@
 #elif defined(USE_MBEDTLS)
 
 #  include <mbedtls/des.h>
-#  include <mbedtls/md4.h>
-#  if !defined(MBEDTLS_MD4_C)
-#    include "curl_md4.h"
-#  endif
+#  include "curl_md4.h"
 
 #elif defined(USE_SECTRANSP)
 
@@ -575,11 +572,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(struct Curl_easy *data,
 #elif defined(USE_NSS)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_MBEDTLS)
-#if defined(MBEDTLS_MD4_C)
-    mbedtls_md4(pw, 2 * len, ntbuffer);
-#else
     Curl_md4it(ntbuffer, pw, 2 * len);
-#endif
 #elif defined(USE_SECTRANSP)
     Curl_md4it(ntbuffer, pw, 2 * len);
 #elif defined(USE_OS400CRYPTO)

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -22,6 +22,11 @@
 
 #include "curl_setup.h"
 
+#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+
+#include "curl_md4.h"
+#include "warnless.h"
+
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
 #endif
@@ -33,8 +38,6 @@
 
 #include <nettle/md4.h>
 
-#include "curl_md4.h"
-#include "warnless.h"
 #include "curl_memory.h"
 
 /* The last #include file should be: */
@@ -61,8 +64,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include <gcrypt.h>
 
-#include "curl_md4.h"
-#include "warnless.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"
@@ -89,15 +90,10 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 /* When OpenSSL is available we use the MD4-functions from OpenSSL */
 #include <openssl/md4.h>
 
-#include "curl_md4.h"
-#include "warnless.h"
-
 #elif defined(USE_SECTRANSP)
 
 #include <CommonCrypto/CommonDigest.h>
 
-#include "curl_md4.h"
-#include "warnless.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"
@@ -138,8 +134,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include <wincrypt.h>
 
-#include "curl_md4.h"
-#include "warnless.h"
 #include "curl_memory.h"
  /* The last #include file should be: */
 #include "memdebug.h"
@@ -184,8 +178,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include <mbedtls/md4.h>
 
-#include "curl_md4.h"
-#include "warnless.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"
@@ -222,12 +214,9 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
   }
 }
 
-#elif defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
-    (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
-    (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
-/* The NSS, OS/400, and when not included, OpenSSL and mbed TLS crypto
- * libraries do not provide the MD4 hash algorithm, so we use this
- * implementation of it
+#else
+/* When no other crypto library is available, or the crypto library doesn't
+ * support MD4, we use this code segment this implementation of it
  *
  * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
  * MD4 Message-Digest Algorithm (RFC 1320).
@@ -265,8 +254,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
  * compile-time configuration.
  */
 
-#include "curl_md4.h"
-#include "warnless.h"
 
 #include <string.h>
 
@@ -518,11 +505,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #endif /* CRYPTO LIBS */
 
-#if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
-    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS)
-
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len)
 {
   MD4_CTX ctx;
@@ -531,7 +513,4 @@ void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len)
   MD4_Final(output, &ctx);
 }
 
-#endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) ||
-    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) ||
-    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS) */
+#endif /* CURL_DISABLE_CRYPTO_AUTH */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -85,6 +85,13 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
   gcry_md_close(ctx);
 }
 
+#elif defined(USE_OPENSSL) && !defined(OPENSSL_NO_MD4)
+/* When OpenSSL is available we use the MD4-functions from OpenSSL */
+#include <openssl/md4.h>
+
+#include "curl_md4.h"
+#include "warnless.h"
+
 #elif defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
@@ -130,8 +137,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include "curl_md4.h"
 #include "warnless.h"
-
-#ifndef HAVE_OPENSSL
 
 #include <string.h>
 
@@ -381,13 +386,10 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
   memset(ctx, 0, sizeof(*ctx));
 }
 
-#endif
-
 #endif /* CRYPTO LIBS */
 
 #if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
-    defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
-    (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
+    defined(USE_OPENSSL) || defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
 
@@ -400,7 +402,5 @@ void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len)
 }
 
 #endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_NSS) || defined(USE_OS400CRYPTO) ||
-    defined(USE_OS400CRYPTO) ||
-    (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) ||
+    defined(USE_OPENSSL) || defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -180,6 +180,48 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
     CryptReleaseContext(ctx->hCryptProv, 0);
 }
 
+#elif(defined(USE_MBEDTLS) && defined(MBEDTLS_MD4_C))
+
+#include <mbedtls/md4.h>
+
+#include "curl_md4.h"
+#include "warnless.h"
+#include "curl_memory.h"
+/* The last #include file should be: */
+#include "memdebug.h"
+
+typedef struct {
+  void *data;
+  unsigned long size;
+} MD4_CTX;
+
+static void MD4_Init(MD4_CTX *ctx)
+{
+  ctx->data = NULL;
+  ctx->size = 0;
+}
+
+static void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size)
+{
+  if(ctx->data == NULL) {
+    ctx->data = malloc(size);
+    if(ctx->data != NULL) {
+      memcpy(ctx->data, data, size);
+      ctx->size = size;
+    }
+  }
+}
+
+static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
+{
+  if(ctx->data != NULL) {
+    mbedtls_md4(ctx->data, ctx->size, result);
+
+    Curl_safefree(ctx->data);
+    ctx->size = 0;
+  }
+}
+
 #elif defined(USE_NSS) || defined(USE_OS400CRYPTO) || \
     (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
     (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
@@ -479,9 +521,7 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 #if defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) || \
     defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
     defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || \
-    (defined(USE_OPENSSL) && defined(OPENSSL_NO_MD4)) || \
-    (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C))
+    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS)
 
 void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len)
 {
@@ -492,7 +532,6 @@ void Curl_md4it(unsigned char *output, const unsigned char *input, size_t len)
 }
 
 #endif /* defined(USE_GNUTLS_NETTLE) || defined(USE_GNUTLS) ||
-    defined(USE_OPENSSL) || defined(USE_SECTRANSP) || \
-    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) || \
-    defined(USE_OS400CRYPTO) || \
-    (defined(USE_MBEDTLS) && !defined(MBEDTLS_MD4_C)) */
+    defined(USE_OPENSSL) || defined(USE_SECTRANSP) ||
+    defined(USE_WIN32_CRYPTO) || defined(USE_NSS) ||
+    defined(USE_OS400CRYPTO) || defined(USE_MBEDTLS) */


### PR DESCRIPTION
Following curl://up 2019 I've finally started the task of making the NTLM code TLS backend agnostic. As this is a fairly chunky piece of work I have split it up into the following sub tasks:

* Move the TLS specific MD4 code out of curl_ntlm_core.c
* Move the TLS specific MD5 code out of curl_ntlm_core.c
* Move the TLS specific DES implementation out of curl_ntlm_core.c
* Add our own DES implementation

As you will appreciate, this will probably (more than likely) be spanned across several releases - especially as it has taken me 4 years and several discussion with folk on the curl://team to actually start this :-P

In summary this patch set centralises the MD4 code for the TLS libraries into md4.c but it also:

* Adds support for MD4, by calling our local implementation, when OpenSSL does not support it
* Adds support for MD4 in the NTLM code when no crypto libraries are used (No effect yet, given that we still rely on these libraries for MD5 and DES)
* Allows the NTLM type-3 response message to always include the extended (and more secure) NT response as opposed to just the LM response.
* Simplifies the MD4 code in curl_ntlm_core.cpp as it replaces the complex pre-processor block with one line of code.
* Maintains similar code between md4.c and md5.c.

The downsides:

Two TLS backends (SecureTransport and mbed TLS) support a single line function call when creating the MD4 hash. As the Curl_md4it() function implements an OpenSSL style API (calling multiple functions) we have to store the data to be encrypted and as such store that in a temporary buffer. The buffer is malloc'ed and as such will be slower for these two backend libraries.

Concerns:

md4.c and md5.c are a little different, from my point of view, in two areas:

* The SecureTransport pre-processor directives are different. md4.c (now) uses the USE_SECTRANSP directive, as that is what was used in the NTLM code which has now moved to md4.c. md5.c, on the other hand, uses a few Mac and IOS specific directives. @nickzman 
* The MD5 code, when using OpenSSL, has an Amiga OS specific pre-processor directive present (USE_AMISSL) from #3677. Do we need one in the MD4 code as well? The original NTLM code didn't have this so I'm not sure. @chris-y 

Notes:

Whilst I have compiled this on Windows using both OpenSSL and Schannel I cannot compile it for the other TLS, non OpenSSL style, backends (GNU TLS, mbed, SecureTransport, NSS, OS/400). As such I am relying on the automated build system and tests, as well as AppVeyor and Travis CI to let me know if there are any problems. I will of course update this patch set if and when they fail. 