### PR TITLE
tests: Run global cleanup at end of tests

### DIFF
--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -84,6 +84,7 @@ int test(char *URL)
 
   curl_slist_free_all(pHeaderList);
   curl_easy_cleanup(pCurl);
+  curl_global_cleanup();
 
   return 0;
 }

--- a/tests/libtest/lib1905.c
+++ b/tests/libtest/lib1905.c
@@ -88,6 +88,7 @@ int test(char *URL)
   curl_easy_cleanup(ch);
   curl_share_cleanup(sh);
   curl_multi_cleanup(cm);
+  curl_global_cleanup();
 
   return 0;
 }

--- a/tests/libtest/lib1906.c
+++ b/tests/libtest/lib1906.c
@@ -66,6 +66,7 @@ int test(char *URL)
 
   curl_easy_cleanup(curl);
   curl_url_cleanup(curlu);
+  curl_global_cleanup();
 
   return 0;
 }

--- a/tests/unit/unit1608.c
+++ b/tests/unit/unit1608.c
@@ -65,6 +65,7 @@ UNITTEST_START
   }
 
   curl_easy_cleanup(easy);
+  curl_global_cleanup();
 
   abort_unless(addrhead != addrs, "addresses are not being reordered");
 


### PR DESCRIPTION
Make sure to run `curl_global_cleanup()` when shutting down the test suite to release any resources allocated in the SSL setup. This is clearly visible when running tests with PolarSSL where the thread lock `calloc()` memory which isn't released when not running cleanup. Below is an excerpt from the autobuild logs:
```
  ==12368== 96 bytes in 1 blocks are possibly lost in loss record 1 of 2
  ==12368== at 0x4837B65: calloc (vg_replace_malloc.c:752)
  ==12368== by 0x11A76E: curl_dbg_calloc (memdebug.c:205)
  ==12368== by 0x145CDF: Curl_polarsslthreadlock_thread_setup (polarssl_threadlock.c:54)
  ==12368== by 0x145B37: Curl_polarssl_init (polarssl.c:865)
  ==12368== by 0x14129D: Curl_ssl_init (vtls.c:171)
  ==12368== by 0x118B4C: global_init (easy.c:158)
  ==12368== by 0x118BF5: curl_global_init (easy.c:221)
  ==12368== by 0x118D0B: curl_easy_init (easy.c:299)
  ==12368== by 0x114E96: test (lib1906.c:32)
  ==12368== by 0x115495: main (first.c:174)
```