### PR TITLE
Curl_disconnect: treat all CONNECT_ONLY connections as "dead"

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -809,6 +809,10 @@ CURLcode Curl_disconnect(struct Curl_easy *data,
      for the connection! */
   conn->data = data;
 
+  if(conn->bits.connect_only)
+    /* treat the connection as dead in CONNECT_ONLY situations */
+    dead_connection = TRUE;
+
   if(conn->handler->disconnect)
     /* This is set if protocol-specific cleanups should be made */
     conn->handler->disconnect(conn, dead_connection);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -83,7 +83,7 @@ test617 test618 test619 test620 test621 test622 test623 test624 test625 \
 test626 test627 test628 test629 test630 test631 test632 test633 test634 \
 test635 test636 test637 test638 test639 test640 test641 test642 \
 test643 test644 test645 test646 test647 test648 test649 test650 test651 \
-test652 test653 test654 test655 test656 test658 test659 \
+test652 test653 test654 test655 test656 test658 test659 test660 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test660
+++ b/tests/data/test660
@@ -1,0 +1,34 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+CONNECT_ONLY
+</keywords>
+</info>
+
+# Client-side
+<client>
+<server>
+imap
+</server>
+<tool>
+lib597
+</tool>
+ <name>
+IMAP CONNECT_ONLY option
+ </name>
+
+<command>
+imap://%HOSTIP:%IMAPPORT/660
+</command>
+
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+A001 CAPABILITY
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Since the connection has been used by the "outside" we don't know the
state of it anymore and curl should not use it anymore.

Bug: https://curl.haxx.se/mail/lib-2019-04/0052.html