### PR TITLE
CURL_MAX_INPUT_LENGTH: largest acceptable string input size

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -61,6 +61,13 @@ CURLcode Curl_setstropt(char **charp, const char *s)
   if(s) {
     char *str = strdup(s);
 
+    if(str) {
+      size_t len = strlen(str);
+      if(len > CURL_MAX_INPUT_LENGTH) {
+        free(str);
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+      }
+    }
     if(!str)
       return CURLE_OUT_OF_MEMORY;
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -642,6 +642,10 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
    ************************************************************/
   /* allocate scratch area */
   urllen = strlen(url);
+  if(urllen > CURL_MAX_INPUT_LENGTH)
+    /* excessive input length */
+    return CURLUE_MALFORMED_INPUT;
+
   path = u->scratch = malloc(urllen * 2 + 2);
   if(!path)
     return CURLUE_OUT_OF_MEMORY;
@@ -1278,6 +1282,10 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
   if(storep) {
     const char *newp = part;
     size_t nalloc = strlen(part);
+
+    if(nalloc > CURL_MAX_INPUT_LENGTH)
+      /* excessive input length */
+      return CURLUE_MALFORMED_INPUT;
 
     if(urlencode) {
       const unsigned char *i;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -79,6 +79,10 @@
 */
 #define RESP_TIMEOUT (120*1000)
 
+/* Max string intput length is a precaution against abuse and to detect junk
+   input easier and better. */
+#define CURL_MAX_INPUT_LENGTH 1000000
+
 #include "cookie.h"
 #include "psl.h"
 #include "formdata.h"

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -176,7 +176,7 @@ test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 test1541 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
-test1558          test1560 test1561 test1562 \
+test1558 test1559 test1560 test1561 test1562 \
 \
 test1590 test1591 test1592 \
 \

--- a/tests/data/test1559
+++ b/tests/data/test1559
@@ -1,0 +1,39 @@
+<testcase>
+<info>
+<keywords>
+CURLOPT_URL
+</keywords>
+</info>
+
+<reply>
+</reply>
+
+<client>
+<server>
+none
+</server>
+<tool>
+lib1559
+</tool>
+
+<name>
+Set excessive URL lengths
+</name>
+</client>
+
+#
+# Verify that the test runs to completion without crashing
+<verify>
+<errorcode>
+0
+</errorcode>
+<stdout>
+CURLOPT_URL 10000000 bytes URL == 43
+CURLOPT_POSTFIELDS 10000000 bytes data == 0
+CURLUPART_URL 10000000 bytes URL == 3
+CURLUPART_SCHEME 10000000 bytes scheme == 3
+CURLUPART_USER 10000000 bytes user == 3
+</stdout>
+</verify>
+
+</testcase>

--- a/tests/data/test1559
+++ b/tests/data/test1559
@@ -12,6 +12,11 @@ CURLOPT_URL
 <server>
 none
 </server>
+
+# require HTTP so that CURLOPT_POSTFIELDS works as assumed
+<features>
+http
+</features>
 <tool>
 lib1559
 </tool>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -31,8 +31,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 lib1541 \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
- lib1558 \
- lib1560 \
+ lib1558 lib1559 lib1560 \
  lib1591 lib1592 \
  lib1900 lib1905 lib1906 \
  lib2033
@@ -524,6 +523,9 @@ lib1557_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1557
 
 lib1558_SOURCES = lib1558.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1558_LDADD = $(TESTUTIL_LIBS)
+
+lib1559_SOURCES = lib1559.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1559_LDADD = $(TESTUTIL_LIBS)
 
 lib1560_SOURCES = lib1560.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1560_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1559.c
+++ b/tests/libtest/lib1559.c
@@ -1,0 +1,78 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+#define EXCESSIVE 10*1000*1000
+int test(char *URL)
+{
+  CURLcode res = 0;
+  CURL *curl = NULL;
+  char *longurl = malloc(EXCESSIVE);
+  CURLU *u;
+  (void)URL;
+
+  memset(longurl, 'a', EXCESSIVE);
+  longurl[EXCESSIVE-1] = 0;
+
+  global_init(CURL_GLOBAL_ALL);
+  easy_init(curl);
+
+  res = curl_easy_setopt(curl, CURLOPT_URL, longurl);
+  printf("CURLOPT_URL %d bytes URL == %d\n",
+         EXCESSIVE, (int)res);
+
+  res = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, longurl);
+  printf("CURLOPT_POSTFIELDS %d bytes data == %d\n",
+         EXCESSIVE, (int)res);
+
+  u = curl_url();
+  if(u) {
+    CURLUcode uc = curl_url_set(u, CURLUPART_URL, longurl, 0);
+    printf("CURLUPART_URL %d bytes URL == %d\n",
+           EXCESSIVE, (int)uc);
+    uc = curl_url_set(u, CURLUPART_SCHEME, longurl, CURLU_NON_SUPPORT_SCHEME);
+    printf("CURLUPART_SCHEME %d bytes scheme == %d\n",
+           EXCESSIVE, (int)uc);
+    uc = curl_url_set(u, CURLUPART_USER, longurl, 0);
+    printf("CURLUPART_USER %d bytes user == %d\n",
+           EXCESSIVE, (int)uc);
+    curl_url_cleanup(u);
+  }
+
+  free(longurl);
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return 0;
+
+test_cleanup:
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return res; /* return the final return code */
+}


### PR DESCRIPTION
This limits all accepted input strings passed to libcurl to be less than
CURL_MAX_INPUT_LENGTH (1000000) bytes, for these API calls:
curl_easy_setopt() and curl_url_set().

The 1000000 number is arbitrary picked and is meant to detect mistakes
or abuse, not to limit actual practical use cases. By limiting the
acceptable string lengths we also reduce the risk of integer overflows
all over.

NOTE_ This does not apply to `CURLOPT_POSTFIELDS`.

Adds test 1559 that verifies the functionality.