### PR TITLE
nss: allow fifos and character devices for certificates.

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -377,7 +377,7 @@ static int is_file(const char *filename)
     return 0;
 
   if(stat(filename, &st) == 0)
-    if(S_ISREG(st.st_mode))
+    if(S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode) || S_ISCHR(st.st_mode))
       return 1;
 
   return 0;


### PR DESCRIPTION
Currently you can do things like --cert <(cat ./cert.crt) with (at least) the
openssl backend, but that doesn't work for nss because is_file rejects fifos.

I don't actually know if this is sufficient, nss might do things internally
(like seeking back) that make this not work, so actual testing is needed.