### PR TITLE
improved no-multiplexing situation

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3630,6 +3630,10 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
             if(conn->httpversion != 20)
               infof(data, "Lying server, not serving HTTP/2\n");
           }
+          if(conn->httpversion < 20) {
+            conn->bundle->multiuse = BUNDLE_NO_MULTIUSE;
+            infof(data, "Mark bundle as not supporting multiuse\n");
+          }
         }
         else if(!nc) {
           /* this is the real world, not a Nirvana

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1365,6 +1365,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         result = CURLE_OK;
         break;
       }
+      else if(data->state.previouslypending) {
+        /* this transfer comes from the pending queue so try move another */
+        infof(data, "Transfer was pending, now try another\n");
+        process_pending_handles(data->multi);
+      }
 
       if(!result) {
         if(async)
@@ -2991,6 +2996,9 @@ static void process_pending_handles(struct Curl_multi *multi)
 
     /* Make sure that the handle will be processed soonish. */
     Curl_expire(data, 0, EXPIRE_RUN_NOW);
+
+    /* mark this as having been in the pending queue */
+    data->state.previouslypending = TRUE;
   }
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2981,6 +2981,22 @@ size_t Curl_multi_max_total_connections(struct Curl_multi *multi)
   return multi ? multi->max_total_connections : 0;
 }
 
+/*
+ * When information about a connection has appeared, call this!
+ */
+
+void Curl_multiuse_state(struct connectdata *conn,
+                         int bundlestate) /* use BUNDLE_* defines */
+{
+  DEBUGASSERT(conn);
+  DEBUGASSERT(conn->bundle);
+  DEBUGASSERT(conn->data);
+  DEBUGASSERT(conn->data->multi);
+
+  conn->bundle->multiuse = bundlestate;
+  process_pending_handles(conn->data->multi);
+}
+
 static void process_pending_handles(struct Curl_multi *multi)
 {
   struct curl_llist_element *e = multi->pending.head;

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -82,6 +82,9 @@ size_t Curl_multi_max_total_connections(struct Curl_multi *multi);
 
 void Curl_multi_connchanged(struct Curl_multi *multi);
 
+void Curl_multiuse_state(struct connectdata *conn,
+                         int bundlestate); /* use BUNDLE_* defines */
+
 /*
  * Curl_multi_closed()
  *

--- a/lib/url.c
+++ b/lib/url.c
@@ -1031,7 +1031,7 @@ ConnectionExists(struct Curl_easy *data,
 
     /* We can't multiplex if we don't know anything about the server */
     if(canmultiplex) {
-      if(bundle->multiuse <= BUNDLE_UNKNOWN) {
+      if(bundle->multiuse == BUNDLE_UNKNOWN) {
         if((bundle->multiuse == BUNDLE_UNKNOWN) && data->set.pipewait) {
           infof(data, "Server doesn't support multiplex yet, wait\n");
           *waitpipe = TRUE;
@@ -1045,6 +1045,10 @@ ConnectionExists(struct Curl_easy *data,
       if((bundle->multiuse == BUNDLE_MULTIPLEX) &&
          !Curl_multiplex_wanted(data->multi)) {
         infof(data, "Could multiplex, but not asked to!\n");
+        canmultiplex = FALSE;
+      }
+      if(bundle->multiuse == BUNDLE_NO_MULTIUSE) {
+        infof(data, "Can not multiplex, even if we wanted to!\n");
         canmultiplex = FALSE;
       }
     }
@@ -1071,7 +1075,8 @@ ConnectionExists(struct Curl_easy *data,
         continue;
       }
 
-      multiplexed = CONN_INUSE(check);
+      multiplexed = CONN_INUSE(check) &&
+        (bundle->multiuse == BUNDLE_MULTIPLEX);
 
       if(canmultiplex) {
         if(check->bits.protoconnstart && check->bits.close)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1363,6 +1363,7 @@ struct UrlState {
                   when multi_done() is called, to prevent multi_done() to get
                   invoked twice when the multi interface is used. */
   bit stream_depends_e:1; /* set or don't set the Exclusive bit */
+  bit previouslypending:1; /* this transfer WAS in the multi->pending queue */
 };
 
 

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -79,6 +79,7 @@ and that's a problem since options.h hasn't been included yet. */
 #include "strcase.h"
 #include "x509asn1.h"
 #include "curl_printf.h"
+#include "multiif.h"
 
 #include <cyassl/openssl/ssl.h>
 #include <cyassl/ssl.h>
@@ -599,6 +600,8 @@ cyassl_connect_step2(struct connectdata *conn,
       else
         infof(data, "ALPN, unrecognized protocol %.*s\n", protocol_len,
               protocol);
+      Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
     }
     else if(rc == SSL_ALPN_NOT_FOUND)
       infof(data, "ALPN, server did not agree to a protocol\n");

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -55,6 +55,7 @@
 #include "strcase.h"
 #include "warnless.h"
 #include "x509asn1.h"
+#include "multiif.h"
 #include "curl_printf.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
@@ -1449,6 +1450,9 @@ gtls_connect_step3(struct connectdata *conn,
     }
     else
       infof(data, "ALPN, server did not agree to a protocol\n");
+
+    Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 #endif
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -54,6 +54,7 @@
 #include "parsedate.h"
 #include "connect.h" /* for the connect timeout */
 #include "select.h"
+#include "multiif.h"
 #include "polarssl_threadlock.h"
 
 /* The last 3 #include files should be in this order */
@@ -684,6 +685,8 @@ mbed_connect_step2(struct connectdata *conn,
     else {
       infof(data, "ALPN, server did not agree to a protocol\n");
     }
+    Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 #endif
 

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -38,6 +38,7 @@
 #include "select.h"
 #include "vtls.h"
 #include "llist.h"
+#include "multiif.h"
 #include "curl_printf.h"
 #include "nssg.h"
 #include <nspr.h>
@@ -843,6 +844,8 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
        !memcmp(ALPN_HTTP_1_1, buf, ALPN_HTTP_1_1_LENGTH)) {
       conn->negnpn = CURL_HTTP_VERSION_1_1;
     }
+    Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 }
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -48,6 +48,7 @@
 #include "vtls.h"
 #include "strcase.h"
 #include "hostcheck.h"
+#include "multiif.h"
 #include "curl_printf.h"
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
@@ -2917,6 +2918,9 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
       }
       else
         infof(data, "ALPN, server did not agree to a protocol\n");
+
+      Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
     }
 #endif
 

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  * Copyright (C) 2010 - 2011, Hoi-Ho Chan, <hoiho.chan@gmail.com>
  *
  * This software is licensed as described in the file COPYING, which
@@ -55,6 +55,7 @@
 #include "select.h"
 #include "strcase.h"
 #include "polarssl_threadlock.h"
+#include "multiif.h"
 #include "curl_printf.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
@@ -593,6 +594,8 @@ polarssl_connect_step2(struct connectdata *conn,
     }
     else
       infof(data, "ALPN, server did not agree to a protocol\n");
+    Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 #endif
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -58,6 +58,7 @@
 #include "warnless.h"
 #include "x509asn1.h"
 #include "curl_printf.h"
+#include "multiif.h"
 #include "system_win32.h"
 
  /* The last #include file should be: */
@@ -1269,6 +1270,8 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
     }
     else
       infof(data, "ALPN, server did not agree to a protocol\n");
+    Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 #endif
 

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -31,6 +31,7 @@
 #include "urldata.h" /* for the Curl_easy definition */
 #include "curl_base64.h"
 #include "strtok.h"
+#include "multiif.h"
 
 #ifdef USE_SECTRANSP
 
@@ -2650,6 +2651,9 @@ sectransp_connect_step2(struct connectdata *conn, int sockindex)
         }
         else
           infof(data, "ALPN, server did not agree to a protocol\n");
+
+        Curl_multiuse_state(conn, conn->negnpn == CURL_HTTP_VERSION_2 ?
+                            BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
 
         /* chosenProtocol is a reference to the string within alpnArr
            and doesn't need to be freed separately */


### PR DESCRIPTION
1. **http: mark bundle as not for multiuse on < HTTP/2 response** - make it known that the "bundle" doesn't support multiplexing as soon as we get a HTTP/1 response confirmed.
2. **process_pending_handles: mark queued transfers as previously pending** - with transfers being queued up, we only move one at a a time back to the CONNECT state but now we mark moved transfers so that when a moved transfer is confirmed "successful" (it connected) it will trigger the move of another pending transfer. Previously, it would otherwise wait until the transfer was done. This makes pending transfers get processed faster.
3. **multi: provide Curl_multiuse_state to update information** - as soon as a TLS backend gets ALPN conformation about the specific HTTP version it can now set the multiplex situation for the "bundle" and trigger moving potentially queued transfers to the CONNECT state.
4. **ConnectionExists: improve non-multiplexing use case** - improve the log output when finding a bundle with no multiplexing ability.

Debugging of this issue and work on this PR, done in Daniel's [curl dev video 13](https://youtu.be/NeCihFR6rus).

Fixes #3813 