### PR TITLE
cookie: Guard against possible NULL ptr deref

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -874,11 +874,13 @@ Curl_cookie_add(struct Curl_easy *data,
         co->name = strdup(ptr);
         if(!co->name)
           badcookie = TRUE;
-        /* For Netscape file format cookies we check prefix on the name */
-        if(strncasecompare("__Secure-", co->name, 9))
-          co->prefix |= COOKIE_PREFIX__SECURE;
-        else if(strncasecompare("__Host-", co->name, 7))
-          co->prefix |= COOKIE_PREFIX__HOST;
+        else {
+          /* For Netscape file format cookies we check prefix on the name */
+          if(strncasecompare("__Secure-", co->name, 9))
+            co->prefix |= COOKIE_PREFIX__SECURE;
+          else if(strncasecompare("__Host-", co->name, 7))
+            co->prefix |= COOKIE_PREFIX__HOST;
+        }
         break;
       case 6:
         co->value = strdup(ptr);


### PR DESCRIPTION
In case the name pointer isn't set (due to memory pressure most likely) we need to skip the prefix matching and reject with a badcookie to avoid a possible NULL pointer dereference.

Closes #3820
Reported-by: Jonathan Moerman