### PR TITLE
urlapi: strip off scope id from numerical IPv6 addresses

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -35,6 +35,7 @@
  1.16 Try to URL encode given URL
  1.17 Add support for IRIs
  1.18 try next proxy if one doesn't work
+ 1.19 add CURLUPART_SCOPEID
  1.20 SRV and URI DNS records
  1.21 Have the URL API offer IDN decoding
  1.22 CURLINFO_PAUSE_STATE
@@ -371,6 +372,11 @@
  using PACs.
 
  https://github.com/curl/curl/issues/896
+
+1.19 add CURLUPART_SCOPEID
+
+ Add support for CURLUPART_SCOPEID to curl_url_set() and curl_url_get(). It is
+ only really used when the host name is an IPv6 numerical address.
 
 1.20 SRV and URI DNS records
 

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -31,4 +31,14 @@ lib1560
 </tool>
 </client>
 
+<verify>
+<stdout>
+we got [fe80::20c:29ff:fe9c:409b]
+we got https://[::1]/hello.html
+we got https://example.com/hello.html
+we got https://[fe80::20c:29ff:fe9c:409b%25eth0]/hello.html
+we got [fe80::20c:29ff:fe9c:409b]
+success
+</stdout>
+</verify>
 </testcase>

--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -168,7 +168,7 @@ UNITTEST_START
   u = curl_url();
   if(!u)
     goto fail;
-  ipv6port = strdup("[fe80::250:56ff:fea7:da15%!25eth3]:80");
+  ipv6port = strdup("[fe80::250:56ff:fea7:da15!25eth3]:80");
   if(!ipv6port)
     goto fail;
   ret = Curl_parse_port(u, ipv6port);
@@ -184,7 +184,7 @@ UNITTEST_START
   if(!ipv6port)
     goto fail;
   ret = Curl_parse_port(u, ipv6port);
-  fail_unless(ret != CURLUE_OK, "Curl_parse_port returned non-error");
+  fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
   fail:
   free(ipv6port);
   curl_url_cleanup(u);


### PR DESCRIPTION
... to make the host name "usable". Store the scope id and put it back
when extracting a URL out of it.

Fixes #3817