### PR TITLE
vtls: upgrade the MesaLink TLS backend to v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 cache:
     directories:
         - $HOME/wolfssl-4.0.0-stable
+        - $HOME/mesalink-1.0.0
         - $HOME/nghttp2-1.34.0
 
 env:
@@ -113,6 +114,12 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
+        - os: linux
+          compiler: gcc
+          dist: trusty
+          env:
+              - T=debug-mesalink C="--with-mesalink --without-ssl"
+              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: clang
           dist: xenial
@@ -408,6 +415,20 @@ before_script:
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
+        if [ ! -e $HOME/mesalink-1.0.0/Makefile ]; then
+          (cd $HOME && \
+          curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+          source $HOME/.cargo/env && \
+          curl -LO https://github.com/mesalock-linux/mesalink/archive/v1.0.0.tar.gz && \
+          tar -xzf v1.0.0.tar.gz && \
+          cd mesalink-1.0.0 && \
+          ./autogen.sh && \
+          ./configure --enable-tls13  && \
+          make)
+        fi
+      fi
+    - |
+      if [ $TRAVIS_OS_NAME = linux ]; then
         if [ ! -e $HOME/nghttp2-1.34.0/Makefile ]; then
           (cd $HOME && \
           curl -L https://github.com/nghttp2/nghttp2/releases/download/v1.34.0/nghttp2-1.34.0.tar.gz |
@@ -420,6 +441,7 @@ before_script:
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then
         (cd $HOME/wolfssl-4.0.0-stable && sudo make install)
+        (cd $HOME/mesalink-1.0.0 && sudo make install)
         (cd $HOME/nghttp2-1.34.0 && sudo make install)
       fi
 
@@ -448,6 +470,13 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "debug-wolfssl" ]; then
+             ./configure --enable-debug --enable-werror $C
+             make
+             make "TFLAGS=-n !313" test-nonflaky
+        fi
+    - |
+        set -eo pipefail
+        if [ "$T" = "debug-mesalink" ]; then
              ./configure --enable-debug --enable-werror $C
              make
              make "TFLAGS=-n !313" test-nonflaky

--- a/.travis.yml
+++ b/.travis.yml
@@ -479,7 +479,7 @@ script:
         if [ "$T" = "debug-mesalink" ]; then
              ./configure --enable-debug --enable-werror $C
              make
-             make "TFLAGS=-n !313" test-nonflaky
+             make "TFLAGS=-n !313 !3001" test-nonflaky
         fi
     - |
         set -eo pipefail

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -268,7 +268,7 @@ mesalink_connect_step2(struct connectdata *conn, int sockindex)
     char error_buffer[MESALINK_MAX_ERROR_SZ];
     int detail = SSL_get_error(BACKEND->handle, ret);
 
-    if(SSL_ERROR_WANT_CONNECT == detail) {
+    if(SSL_ERROR_WANT_CONNECT == detail || SSL_ERROR_WANT_READ == detail) {
       connssl->connecting_state = ssl_connect_2_reading;
       return CURLE_OK;
     }


### PR DESCRIPTION
This attempts to solve #3776 and brings in MesaLink 1.0.0.