### PR TITLE
content_encoding: accept up to 23 unknown bytes after stream

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -60,7 +60,7 @@ test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 \
 test340 \
 \
-test350 test351 test352 test353 test354 test355 test356 \
+test350 test351 test352 test353 test354 test355 test356 test357 \
 test393 test394 test395 \
 \
 test400 test401 test402 test403 test404 test405 test406 test407 test408 \

--- a/tests/data/test357
+++ b/tests/data/test357
@@ -1,0 +1,67 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+compressed
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+# The content is two streams concatenated together, "foo" and (empty)
+# 1F 8B 08 00 00 00 00 00 02 0A 4B CB CF 07 00 21 65 73 8C 03 00 00 00
+# 1F 8B 08 00 00 00 00 00 00 FF 01 00 00 FF FF 00 00 00 00 00 00 00 00
+<data base64="yes">
+SFRUUC8xLjEgMjAwIE9LDQpDb250ZW50LUVuY29kaW5nOiBHWklQDQpDb250ZW50LUxlbmd0
+aDogNDYNCg0KH4sIAAAAAAACCkvLzwcAIWVzjAMAAAAfiwgAAAAAAAD/AQAA//8AAAAAAAAA
+AA==
+</data>
+
+<datacheck nonewline="yes">
+HTTP/1.1 200 OK
+Content-Encoding: GZIP
+Content-Length: 46
+
+foo
+</datacheck>
+
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+libz
+</features>
+<server>
+http
+</server>
+# Test support for an errant extra stream that may be empty (23 bytes or less)
+# https://github.com/curl/curl/issues/3796
+ <name>
+HTTP GET gzip compressed content with errant extra stream
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/357 --compressed
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<strippart>
+s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+</strippart>
+<protocol>
+GET /357 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Accept-Encoding: xxx
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
- Increase the number of ignored unknown bytes from 4 to 23 so that a
  concatenated null stream will not cause an error.

There's a server in the wild returning a null gzip stream concatenated
to the main gzip stream so this is a workaround for that. null gzip
streams (streams with <= 1 compressed block and no data) should not take
more than 23 bytes.

Reported-by: Dmitri Trembovetski

Fixes https://github.com/curl/curl/issues/3796
Closes #xxxx