### PR TITLE
configure: error out if OpenSSL wasn't detected when asked for

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1889,6 +1889,13 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 fi
 
+if test X"$OPT_SSL" != Xoff &&
+  test "$OPENSSL_ENABLED" != "1"; then
+  AC_MSG_ERROR([--with-ssl was given but OpenSSL could not be detected])
+  AC_MSG_ERROR([OPT_SSL: $OPT_SSL])
+  AC_MSG_ERROR([OPENSSL_ENABLED: $OPENSSL_ENABLED])
+fi
+
 dnl **********************************************************************
 dnl Check for the random seed preferences
 dnl **********************************************************************

--- a/configure.ac
+++ b/configure.ac
@@ -1890,10 +1890,11 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
 fi
 
 if test X"$OPT_SSL" != Xoff &&
+  test X"$OPT_SSL" != Xno &&
   test "$OPENSSL_ENABLED" != "1"; then
+  AC_MSG_NOTICE([OPT_SSL: $OPT_SSL])
+  AC_MSG_NOTICE([OPENSSL_ENABLED: $OPENSSL_ENABLED])
   AC_MSG_ERROR([--with-ssl was given but OpenSSL could not be detected])
-  AC_MSG_ERROR([OPT_SSL: $OPT_SSL])
-  AC_MSG_ERROR([OPENSSL_ENABLED: $OPENSSL_ENABLED])
 fi
 
 dnl **********************************************************************


### PR DESCRIPTION
If --with-ssl is used and configure still couldn't enable SSL this
creates an error instead of just silently ignoring the fact.

Suggested-by: Isaiah Norton
Fixes #3824