### PR TITLE
urlapi: add CURLUPART_ZONEID to set and get

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -35,7 +35,6 @@
  1.16 Try to URL encode given URL
  1.17 Add support for IRIs
  1.18 try next proxy if one doesn't work
- 1.19 add CURLUPART_SCOPEID
  1.20 SRV and URI DNS records
  1.21 Have the URL API offer IDN decoding
  1.22 CURLINFO_PAUSE_STATE
@@ -372,11 +371,6 @@
  using PACs.
 
  https://github.com/curl/curl/issues/896
-
-1.19 add CURLUPART_SCOPEID
-
- Add support for CURLUPART_SCOPEID to curl_url_set() and curl_url_get(). It is
- only really used when the host name is an IPv6 numerical address.
 
 1.20 SRV and URI DNS records
 

--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -76,6 +76,10 @@ Scheme cannot be URL decoded on get.
 .IP CURLUPART_PASSWORD
 .IP CURLUPART_OPTIONS
 .IP CURLUPART_HOST
+If the host part is an IPv6 numeric address, the zoneid will not be part of
+the extracted host but is provided separately in \fICURLUPART_ZONEID\fP.
+.IP CURLUPART_ZONEID
+If the host name is a numeric IPv6 address, this field might also be set.
 .IP CURLUPART_PORT
 Port cannot be URL decoded on get.
 .IP CURLUPART_PATH
@@ -104,7 +108,7 @@ If this function returns an error, no URL part is returned.
   }
 .fi
 .SH AVAILABILITY
-Added in curl 7.62.0
+Added in curl 7.62.0. CURLUPART_ZONEID was added in 7.65.0.
 .SH "SEE ALSO"
 .BR curl_url_cleanup "(3), " curl_url "(3), " curl_url_set "(3), "
 .BR curl_url_dup "(3), "

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -62,6 +62,8 @@ Scheme cannot be URL decoded on set.
 .IP CURLUPART_HOST
 The host name can use IDNA. The string must then be encoded as your locale
 says or UTF-8 (when winidn is used).
+.IP CURLUPART_ZONEID
+If the host name is a numeric IPv6 address, this field can also be set.
 .IP CURLUPART_PORT
 Port cannot be URL encoded on set. The given port number is provided as a
 string and the decimal number must be between 1 and 65535. Anything else will
@@ -127,7 +129,7 @@ If this function returns an error, no URL part is returned.
   curl_url_cleanup(url);
 .fi
 .SH AVAILABILITY
-Added in curl 7.62.0
+Added in curl 7.62.0. CURLUPART_ZONEID was added in 7.65.0.
 .SH "SEE ALSO"
 .BR curl_url_cleanup "(3), " curl_url "(3), " curl_url_get "(3), "
 .BR curl_url_dup "(3), "

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -764,6 +764,7 @@ CURLUPART_QUERY                 7.62.0
 CURLUPART_SCHEME                7.62.0
 CURLUPART_URL                   7.62.0
 CURLUPART_USER                  7.62.0
+CURLUPART_ZONEID                7.65.0
 CURLUSESSL_ALL                  7.17.0
 CURLUSESSL_CONTROL              7.17.0
 CURLUSESSL_NONE                 7.17.0

--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -60,7 +60,8 @@ typedef enum {
   CURLUPART_PORT,
   CURLUPART_PATH,
   CURLUPART_QUERY,
-  CURLUPART_FRAGMENT
+  CURLUPART_FRAGMENT,
+  CURLUPART_ZONEID /* added in 7.65.0 */
 } CURLUPart;
 
 #define CURLU_DEFAULT_PORT (1<<0)       /* return default port number */

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -38,6 +38,8 @@ we got https://[::1]/hello.html
 we got https://example.com/hello.html
 we got https://[fe80::20c:29ff:fe9c:409b%25eth0]/hello.html
 we got [fe80::20c:29ff:fe9c:409b]
+we got eth0
+we got https://[fe80::20c:29ff:fe9c:409b%25clown]/hello.html
 success
 </stdout>
 </verify>

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -577,7 +577,7 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
         /* for debugging this */
         fprintf(stderr, "%s = %s [%d]\n", part, value, (int)what);
 #endif
-        if(what == 9999)
+        if(what > CURLUPART_ZONEID)
           fprintf(stderr, "UNKNOWN part '%s'\n", part);
 
         if(!strcmp("NULL", value))

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -414,6 +414,10 @@ static int checkurl(const char *url, const char *out)
 
 /* !checksrc! disable SPACEBEFORECOMMA 1 */
 static struct setcase set_parts_list[] = {
+  {"https://[::1%25fake]:1234/",
+   "zoneid=NULL,",
+   "https://[::1]:1234/",
+   0, 0, CURLUE_OK, CURLUE_OK},
   {"https://host:1234/",
    "port=NULL,",
    "https://host/",
@@ -547,6 +551,8 @@ static CURLUPart part2id(char *part)
     return CURLUPART_QUERY;
   if(!strcmp("fragment", part))
     return CURLUPART_FRAGMENT;
+  if(!strcmp("zoneid", part))
+    return CURLUPART_ZONEID;
   return 9999; /* bad input => bad output */
 }
 
@@ -571,6 +577,9 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
         /* for debugging this */
         fprintf(stderr, "%s = %s [%d]\n", part, value, (int)what);
 #endif
+        if(what == 9999)
+          fprintf(stderr, "UNKNOWN part '%s'\n", part);
+
         if(!strcmp("NULL", value))
           uc = curl_url_set(u, what, NULL, setflags);
         else if(!strcmp("\"\"", value))
@@ -934,6 +943,35 @@ static int scopeid(void)
   rc = curl_url_get(u, CURLUPART_HOST, &url, 0);
   if(rc != CURLUE_OK) {
     fprintf(stderr, "%s:%d curl_url_get CURLUPART_HOST returned %d\n",
+            __FILE__, __LINE__, (int)rc);
+    error++;
+  }
+  else {
+    printf("we got %s\n", url);
+    curl_free(url);
+  }
+
+  rc = curl_url_get(u, CURLUPART_ZONEID, &url, 0);
+  if(rc != CURLUE_OK) {
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_ZONEID returned %d\n",
+            __FILE__, __LINE__, (int)rc);
+    error++;
+  }
+  else {
+    printf("we got %s\n", url);
+    curl_free(url);
+  }
+
+  rc = curl_url_set(u, CURLUPART_ZONEID, "clown", 0);
+  if(rc != CURLUE_OK) {
+    fprintf(stderr, "%s:%d curl_url_set CURLUPART_ZONEID returned %d\n",
+            __FILE__, __LINE__, (int)rc);
+    error++;
+  }
+
+  rc = curl_url_get(u, CURLUPART_URL, &url, 0);
+  if(rc != CURLUE_OK) {
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d\n",
             __FILE__, __LINE__, (int)rc);
     error++;
   }


### PR DESCRIPTION
The zoneid can be used with IPv6 numerical addresses.

Updated test 1560 to verify.