### PR TITLE
http: Ignore HTTP/2 prior knowledge setting for HTTP proxies

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1970,6 +1970,13 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
 #ifdef USE_NGHTTP2
       if(conn->data->set.httpversion ==
          CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE) {
+        if(conn->bits.httpproxy && !conn->bits.tunnel_proxy) {
+          /* We don't support HTTP/2 proxies yet. Also it's debatable whether
+             or not this setting should apply to HTTP/2 proxies. */
+          infof(data, "Ignoring HTTP/2 prior knowledge due to proxy\n");
+          break;
+        }
+
         DEBUGF(infof(data, "HTTP/2 over clean TCP\n"));
         conn->httpversion = 20;
 


### PR DESCRIPTION
- Do not switch to HTTP/2 for an HTTP proxy that is not tunnelling to
  the destination host.

We already do something similar for HTTPS proxies by not sending h2. [1]

Prior to this change setting CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE would
incorrectly use HTTP/2 to talk to the proxy, which is not something we
support (yet?). Also it's debatable whether or not that setting should
apply to HTTP/2 proxies.

[1]: https://github.com/curl/curl/commit/17c5d05

Bug: https://github.com/curl/curl/issues/3570
Bug: https://github.com/curl/curl/issues/3832

Closes #xxxx