### PR TITLE
Revert "multi: support verbose conncache closure handle"

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -474,8 +474,6 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
     data->set.server_response_timeout;
   data->state.conn_cache->closure_handle->set.no_signal =
     data->set.no_signal;
-  data->state.conn_cache->closure_handle->set.verbose =
-    data->set.verbose;
 
   update_timer(multi);
   return CURLM_OK;

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -88,13 +88,9 @@ Accept: */*
 * Connection #2 to host server3.example.com left intact
 * Closing connection 0
 * Connection #3 to host server4.example.com left intact
-* Closing connection
-* Closing connection
-* Closing connection
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))
-s/^(\* Closing connection) [123](?=\r?\n)/$1/
 </stripfile>
 </verify>
 </testcase>


### PR DESCRIPTION
This reverts commit b0972bc.

- No longer show verbose output for the conncache closure handle.

The offending commit was added so that the conncache closure handle
would inherit verbose mode from the user's easy handle. (Note there is
no way for the user to set options for the closure handle which is why
that was necessary.) Other debug settings such as the debug function
were not also inherited since we determined that could lead to crashes
if the user's per-handle private data was used on an unexpected handle.

The reporter here says he has a debug function to capture the verbose
output, and does not expect or want any output to stderr; however
because the conncache closure handle does not inherit the debug function
the verbose output for that handle does go to stderr.

There are other plausible scenarios as well such as the user redirects
stderr on their handle, which is also not inherited since it could lead
to crashes when used on an unexpected handle.

Short of allowing the user to set options for the conncache closure
handle I don't think there's much we can safely do except no longer
inherit the verbose setting.

Bug: https://curl.haxx.se/mail/lib-2019-05/0021.html
Reported-by: Kristoffer Gleditsch

Ref: https://github.com/curl/curl/pull/3598
Ref: https://github.com/curl/curl/pull/3618

Closes #xxxx