### PR TITLE
ntlm: Fix misaligned function comments for Curl_auth_ntlm_cleanup()

### DIFF
--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -850,15 +850,15 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 }
 
 /*
-* Curl_auth_ntlm_cleanup()
-*
-* This is used to clean up the NTLM specific data.
-*
-* Parameters:
-*
-* ntlm    [in/out] - The NTLM data struct being cleaned up.
-*
-*/
+ * Curl_auth_ntlm_cleanup()
+ *
+ * This is used to clean up the NTLM specific data.
+ *
+ * Parameters:
+ *
+ * ntlm    [in/out] - The NTLM data struct being cleaned up.
+ *
+ */
 void Curl_auth_ntlm_cleanup(struct ntlmdata *ntlm)
 {
   /* Free the target info */


### PR DESCRIPTION
From 6012fa5a.