### PR TITLE
http: Don't expose function definitions when components are disabled

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -961,7 +961,10 @@ void curl_easy_reset(struct Curl_easy *data)
   /* zero out authentication data: */
   memset(&data->state.authhost, 0, sizeof(struct auth));
   memset(&data->state.authproxy, 0, sizeof(struct auth));
+
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
   Curl_digest_cleanup(data);
+#endif
 }
 
 /*

--- a/lib/http_digest.h
+++ b/lib/http_digest.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,6 +23,8 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+
 /* this is for digest header input */
 CURLcode Curl_input_digest(struct connectdata *conn,
                            bool proxy, const char *header);
@@ -33,10 +35,8 @@ CURLcode Curl_output_digest(struct connectdata *conn,
                             const unsigned char *request,
                             const unsigned char *uripath);
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
 void Curl_digest_cleanup(struct Curl_easy *data);
-#else
-#define Curl_digest_cleanup(x) Curl_nop_stmt
-#endif
+
+#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_CRYPTO_AUTH */
 
 #endif /* HEADER_CURL_HTTP_DIGEST_H */

--- a/lib/http_negotiate.h
+++ b/lib/http_negotiate.h
@@ -22,7 +22,7 @@
  *
  ***************************************************************************/
 
-#ifdef USE_SPNEGO
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
 
 /* this is for Negotiate header input */
 CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
@@ -33,6 +33,6 @@ CURLcode Curl_output_negotiate(struct connectdata *conn, bool proxy);
 
 void Curl_cleanup_negotiate(struct connectdata *conn);
 
-#endif /* USE_SPNEGO */
+#endif /* !CURL_DISABLE_HTTP && USE_SPNEGO */
 
 #endif /* HEADER_CURL_HTTP_NEGOTIATE_H */

--- a/lib/url.c
+++ b/lib/url.c
@@ -379,7 +379,9 @@ CURLcode Curl_close(struct Curl_easy *data)
   Curl_altsvc_cleanup(data->asi);
   data->asi = NULL;
 #endif
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
   Curl_digest_cleanup(data);
+#endif
   Curl_safefree(data->info.contenttype);
   Curl_safefree(data->info.wouldredirect);
 


### PR DESCRIPTION
As per other header files. For example: http.h and http_ntlm.h.

There is no point in exposing the functions definitions unnecessarily when components are disabled.

This is more of a tidy up for consistency rather than to fix an actual (existing) issue. As the current code stands these header files would only cause a problem if a libcurl developer tried to a) include them in non HTTP code or b) use the HTTP negotiate functions from outside the negotiate code in http.c - prior to this commit this would cause a linker error rather than a compilation error as the function would be defined but not exist.