### PR TITLE
build: fix "clarify calculation precedence" warnings

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -331,9 +331,9 @@ static int waitperform(struct connectdata *conn, int timeout_ms)
     /* move through the descriptors and ask for processing on them */
     for(i = 0; i < num; i++)
       ares_process_fd((ares_channel)data->state.resolver,
-                      pfd[i].revents & (POLLRDNORM|POLLIN)?
+                      (pfd[i].revents & (POLLRDNORM|POLLIN))?
                       pfd[i].fd:ARES_SOCKET_BAD,
-                      pfd[i].revents & (POLLWRNORM|POLLOUT)?
+                      (pfd[i].revents & (POLLWRNORM|POLLOUT))?
                       pfd[i].fd:ARES_SOCKET_BAD);
   }
   return nfds;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -451,8 +451,8 @@ static int events_socket(struct Curl_easy *easy,      /* easy handle */
         m->socket.revents = 0;
         ev->list = m;
         infof(easy, "socket cb: socket %d ADDED as %s%s\n", s,
-              what&CURL_POLL_IN?"IN":"",
-              what&CURL_POLL_OUT?"OUT":"");
+              (what&CURL_POLL_IN)?"IN":"",
+              (what&CURL_POLL_OUT)?"OUT":"");
       }
       else
         return CURLE_OUT_OF_MEMORY;

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -569,7 +569,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
       if(((form->flags & HTTPPOST_FILENAME) ||
           (form->flags & HTTPPOST_BUFFER)) &&
          !form->contenttype) {
-        char *f = form->flags & HTTPPOST_BUFFER?
+        char *f = (form->flags & HTTPPOST_BUFFER)?
           form->showfilename : form->value;
         char const *type;
         type = Curl_mime_contenttype(f);

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -821,8 +821,10 @@ static size_t readback_part(curl_mimepart *part,
     struct curl_slist *hdr = (struct curl_slist *) part->state.ptr;
     switch(part->state.state) {
     case MIMESTATE_BEGIN:
-      mimesetstate(&part->state, part->flags & MIME_BODY_ONLY? MIMESTATE_BODY:
-                                 MIMESTATE_CURLHEADERS, part->curlheaders);
+      mimesetstate(&part->state,
+                   (part->flags & MIME_BODY_ONLY)?
+                     MIMESTATE_BODY: MIMESTATE_CURLHEADERS,
+                   part->curlheaders);
       break;
     case MIMESTATE_USERHEADERS:
       if(!hdr) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3056,8 +3056,8 @@ void Curl_multi_dump(struct Curl_multi *multi)
           continue;
         }
         fprintf(stderr, "[%s %s] ",
-                entry->action&CURL_POLL_IN?"RECVING":"",
-                entry->action&CURL_POLL_OUT?"SENDING":"");
+                (entry->action&CURL_POLL_IN)?"RECVING":"",
+                (entry->action&CURL_POLL_OUT)?"SENDING":"");
       }
       if(data->numsocks)
         fprintf(stderr, "\n");

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -564,9 +564,9 @@ int Curl_pgrsUpdate(struct connectdata *conn)
 
     /* Get the total amount of data expected to get transferred */
     total_expected_transfer =
-      (data->progress.flags & PGRS_UL_SIZE_KNOWN?
+      ((data->progress.flags & PGRS_UL_SIZE_KNOWN)?
        data->progress.size_ul:data->progress.uploaded)+
-      (data->progress.flags & PGRS_DL_SIZE_KNOWN?
+      ((data->progress.flags & PGRS_DL_SIZE_KNOWN)?
        data->progress.size_dl:data->progress.downloaded);
 
     /* We have transferred this much so far */

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -88,7 +88,7 @@ static int onetest(CURL *curl, const char *url, const testparams *p)
   unsigned int replyselector;
   char urlbuf[256];
 
-  replyselector = p->flags & F_CONTENTRANGE? 1: 0;
+  replyselector = (p->flags & F_CONTENTRANGE)? 1: 0;
   if(p->flags & F_HTTP416)
     replyselector += 2;
   msnprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
@@ -96,7 +96,7 @@ static int onetest(CURL *curl, const char *url, const testparams *p)
   test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME)? 3: 0);
   test_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME)?
                                    "3-1000000": (char *) NULL);
-  test_setopt(curl, CURLOPT_FAILONERROR, p->flags & F_FAIL? 1: 0);
+  test_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL)? 1: 0);
   hasbody = 0;
   res = curl_easy_perform(curl);
   if(res != p->result) {


### PR DESCRIPTION
Codacy/CppCheck warns about this. Consistently use parentheses as we
already do in some places to silence the warning.