### PR TITLE
cmake: restore C89 compatibility of CurlTests.c

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -584,8 +584,8 @@ int fun2(int arg1, int arg2) {
 int
 main() {
   int res3 = c99_vmacro3(1, 2, 3);
-  (void)res3;
   int res2 = c99_vmacro2(1, 2);
+  (void)res3;
   (void)res2;
   return 0;
 }
@@ -607,8 +607,8 @@ int fun2(int arg1, int arg2) {
 int
 main() {
   int res3 = gcc_vmacro3(1, 2, 3);
-  (void)res3;
   int res2 = gcc_vmacro2(1, 2);
+  (void)res3;
   (void)res2;
   return 0;
 }


### PR DESCRIPTION
I broke it in d1b5cf830bfe169745721b21245d2217d2c2453e and
97de97daefc2ed084c91eff34af2426f2e55e134.

Reported-by: Viktor Szakats
Ref: https://github.com/curl/curl/commit/97de97daefc2ed084c91eff34af2426f2e55e134#commitcomment-33499044
Closes