### PR TITLE
http_ntlm: No need to skip spaces when processing messages for winbind

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -895,8 +895,6 @@ CURLcode Curl_http_input_auth(struct connectdata *conn, bool proxy,
 
                 /* Get the challenge-message which will be passed to
                  * ntlm_auth for generating the type 3 message later */
-                while(*auth && ISSPACE(*auth))
-                  auth++;
                 if(checkprefix("NTLM", auth)) {
                   auth += strlen("NTLM");
                   while(*auth && ISSPACE(*auth))


### PR DESCRIPTION
...as this is already performed by the outer loop. Missed in cdccb422.