### PR TITLE
Fix some Codacy warnings about redundant assignment

### DIFF
--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -2012,9 +2012,7 @@ static CURLcode myssh_block_statemach(struct connectdata *conn,
     }
 
     if(!result && block) {
-      curl_socket_t sock = conn->sock[FIRSTSOCKET];
-      curl_socket_t fd_read = CURL_SOCKET_BAD;
-      fd_read = sock;
+      curl_socket_t fd_read = conn->sock[FIRSTSOCKET];
       /* wait for the socket to become ready */
       (void) Curl_socket_check(fd_read, CURL_SOCKET_BAD,
                                CURL_SOCKET_BAD, left > 1000 ? 1000 : left);

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -733,18 +733,17 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
       if((data->set.ssh_auth_types & CURLSSH_AUTH_PUBLICKEY) &&
          (strstr(sshc->authlist, "publickey") != NULL)) {
-        char *home = NULL;
         bool out_of_memory = FALSE;
 
         sshc->rsa_pub = sshc->rsa = NULL;
 
-        /* To ponder about: should really the lib be messing about with the
-           HOME environment variable etc? */
-        home = curl_getenv("HOME");
-
         if(data->set.str[STRING_SSH_PRIVATE_KEY])
           sshc->rsa = strdup(data->set.str[STRING_SSH_PRIVATE_KEY]);
         else {
+          /* To ponder about: should really the lib be messing about with the
+             HOME environment variable etc? */
+          char *home = curl_getenv("HOME");
+
           /* If no private key file is specified, try some common paths. */
           if(home) {
             /* Try ~/.ssh first. */
@@ -760,6 +759,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
                 Curl_safefree(sshc->rsa);
               }
             }
+            free(home);
           }
           if(!out_of_memory && !sshc->rsa) {
             /* Nothing found; try the current dir. */
@@ -791,7 +791,6 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         }
 
         if(out_of_memory || sshc->rsa == NULL) {
-          free(home);
           Curl_safefree(sshc->rsa);
           Curl_safefree(sshc->rsa_pub);
           state(conn, SSH_SESSION_FREE);
@@ -802,8 +801,6 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         sshc->passphrase = data->set.ssl.key_passwd;
         if(!sshc->passphrase)
           sshc->passphrase = "";
-
-        free(home);
 
         if(sshc->rsa_pub)
           infof(data, "Using SSH public key file '%s'\n", sshc->rsa_pub);

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -347,12 +347,11 @@ CURLcode tool2curlmime(CURL *curl, tool_mime *m, curl_mime **mime)
 static char *get_param_word(char **str, char **end_pos, char endchar)
 {
   char *ptr = *str;
-  char *word_begin = NULL;
+  /* the first non-space char is here */
+  char *word_begin = ptr;
   char *ptr2;
   char *escape = NULL;
 
-  /* the first non-space char is here */
-  word_begin = ptr;
   if(*ptr == '"') {
     ++ptr;
     while(*ptr) {


### PR DESCRIPTION
Remove a useless variable, narrow a variable scope, and initialize a variable with the correct value to fix them.