### PR TITLE
version: make ssl_version buffer match for multi_ssl

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -394,7 +394,11 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
   static char ssh_buffer[80];
 #endif
 #ifdef USE_SSL
+#ifdef CURL_WITH_MULTI_SSL
+  static char ssl_buffer[200];
+#else
   static char ssl_buffer[80];
+#endif
 #endif
 #ifdef HAVE_BROTLI
   static char brotli_buffer[80];


### PR DESCRIPTION
When running a multi TLS backend build the version string needs more buffer space. Make the internal `ssl_buffer` stack buffer match the one in `Curl_multissl_version()` to allow for the longer string. For single TLS backend builds there is no use in extended to buffer. This is a fallout from #3863 which fixes up the multi_ssl string generation to avoid a buffer overflow when the buffer is too small.