### PR TITLE
lgtm: Exclude FIXME comments from alerts

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,5 @@
+queries:
+  - exclude: cpp/fixme-comment
 extraction:
   cpp:
     prepare:


### PR DESCRIPTION
LGTM triggers on FIXME comments issuing alerts for them, which is a bit overzealous as they clutter up the alert list and risk hiding more interesting things from alert-fatigue. Fix by hiding the fixme alerts to let us focus on the more interesting ones.

I don't really know if this does what it says on the tin, since I don't know LGTM at all, but the documentation at least implies that it will.