### PR TITLE
urlapi: require a non-zero host name length when parsing URL

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -636,6 +636,8 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname)
       /* hostname with bad content */
       return CURLUE_MALFORMED_INPUT;
   }
+  if(!hostname[0])
+    return CURLUE_NO_HOST;
   return CURLUE_OK;
 }
 

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -140,6 +140,9 @@ static struct testcase get_parts_list[] ={
    "file | [11] | [12] | [13] | [14] | [15] | C:\\programs\\foo | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
 #endif
+  /* URL without host name */
+  {"http://a:b@/x", "",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_NO_HOST},
   {"boing:80",
    "https | [11] | [12] | [13] | boing | 80 | / | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},


### PR DESCRIPTION
Updated test 1560 to verify.