### PR TITLE
http_auth: Move the authentication states out of the authentication contexts

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -466,8 +466,8 @@ static CURLcode http_perhapsrewind(struct connectdata *conn)
        (data->state.authproxy.picked == CURLAUTH_NTLM_WB) ||
        (data->state.authhost.picked == CURLAUTH_NTLM_WB)) {
       if(((expectsend - bytessent) < 2000) ||
-         (conn->ntlm.state != NTLMSTATE_NONE) ||
-         (conn->proxyntlm.state != NTLMSTATE_NONE)) {
+         (conn->http_ntlm_state != NTLMSTATE_NONE) ||
+         (conn->proxy_ntlm_state != NTLMSTATE_NONE)) {
         /* The NTLM-negotiation has started *OR* there is just a little (<2K)
            data left to send, keep on sending. */
 
@@ -3422,9 +3422,9 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
 #if defined(USE_NTLM)
       if(conn->bits.close &&
          (((data->req.httpcode == 401) &&
-           (conn->ntlm.state == NTLMSTATE_TYPE2)) ||
+           (conn->http_ntlm_state == NTLMSTATE_TYPE2)) ||
           ((data->req.httpcode == 407) &&
-           (conn->proxyntlm.state == NTLMSTATE_TYPE2)))) {
+           (conn->proxy_ntlm_state == NTLMSTATE_TYPE2)))) {
         infof(data, "Connection closure while negotiating auth (HTTP 1.0?)\n");
         data->state.authproblem = TRUE;
       }

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -49,6 +49,7 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
 
   /* Point to the correct struct with this */
   struct negotiatedata *neg_ctx;
+  curlnegotiate state;
 
   if(proxy) {
     userp = conn->http_proxy.user;
@@ -57,6 +58,7 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
               data->set.str[STRING_PROXY_SERVICE_NAME] : "HTTP";
     host = conn->http_proxy.host.name;
     neg_ctx = &conn->proxyneg;
+    state = conn->proxy_negotiate_state;
   }
   else {
     userp = conn->user;
@@ -65,6 +67,7 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
               data->set.str[STRING_SERVICE_NAME] : "HTTP";
     host = conn->host.name;
     neg_ctx = &conn->negotiate;
+    state = conn->http_negotiate_state;
   }
 
   /* Not set means empty */
@@ -82,11 +85,11 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
   len = strlen(header);
   neg_ctx->havenegdata = len != 0;
   if(!len) {
-    if(neg_ctx->state == GSS_AUTHSUCC) {
+    if(state == GSS_AUTHSUCC) {
       infof(conn->data, "Negotiate auth restarted\n");
       Curl_http_auth_cleanup_negotiate(conn);
     }
-    else if(neg_ctx->state != GSS_AUTHNONE) {
+    else if(state != GSS_AUTHNONE) {
       /* The server rejected our authentication and hasn't supplied any more
       negotiation mechanisms */
       Curl_http_auth_cleanup_negotiate(conn);
@@ -104,7 +107,7 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
                                            host, header, neg_ctx);
 
   if(result)
-    Curl_auth_cleanup_spnego(neg_ctx);
+    Curl_http_auth_cleanup_negotiate(conn);
 
   return result;
 }
@@ -115,6 +118,8 @@ CURLcode Curl_output_negotiate(struct connectdata *conn, bool proxy)
     &conn->negotiate;
   struct auth *authp = proxy ? &conn->data->state.authproxy :
     &conn->data->state.authhost;
+  curlnegotiate *state = proxy ? &conn->proxy_negotiate_state :
+                                 &conn->http_negotiate_state;
   char *base64 = NULL;
   size_t len = 0;
   char *userp;
@@ -122,24 +127,24 @@ CURLcode Curl_output_negotiate(struct connectdata *conn, bool proxy)
 
   authp->done = FALSE;
 
-  if(neg_ctx->state == GSS_AUTHRECV) {
+  if(*state == GSS_AUTHRECV) {
     if(neg_ctx->havenegdata) {
       neg_ctx->havemultiplerequests = TRUE;
     }
   }
-  else if(neg_ctx->state == GSS_AUTHSUCC) {
+  else if(*state == GSS_AUTHSUCC) {
     if(!neg_ctx->havenoauthpersist) {
       neg_ctx->noauthpersist = !neg_ctx->havemultiplerequests;
     }
   }
 
   if(neg_ctx->noauthpersist ||
-    (neg_ctx->state != GSS_AUTHDONE && neg_ctx->state != GSS_AUTHSUCC)) {
+    (*state != GSS_AUTHDONE && *state != GSS_AUTHSUCC)) {
 
-    if(neg_ctx->noauthpersist && neg_ctx->state == GSS_AUTHSUCC) {
+    if(neg_ctx->noauthpersist && *state == GSS_AUTHSUCC) {
       infof(conn->data, "Curl_output_negotiate, "
        "no persistent authentication: cleanup existing context");
-      Curl_auth_cleanup_spnego(neg_ctx);
+      Curl_http_auth_cleanup_negotiate(conn);
     }
     if(!neg_ctx->context) {
       result = Curl_input_negotiate(conn, proxy, "Negotiate");
@@ -176,23 +181,23 @@ CURLcode Curl_output_negotiate(struct connectdata *conn, bool proxy)
       return CURLE_OUT_OF_MEMORY;
     }
 
-    neg_ctx->state = GSS_AUTHSENT;
+    *state = GSS_AUTHSENT;
   #ifdef HAVE_GSSAPI
     if(neg_ctx->status == GSS_S_COMPLETE ||
        neg_ctx->status == GSS_S_CONTINUE_NEEDED) {
-      neg_ctx->state = GSS_AUTHDONE;
+      *state = GSS_AUTHDONE;
     }
   #else
   #ifdef USE_WINDOWS_SSPI
     if(neg_ctx->status == SEC_E_OK ||
        neg_ctx->status == SEC_I_CONTINUE_NEEDED) {
-      neg_ctx->state = GSS_AUTHDONE;
+      *state = GSS_AUTHDONE;
     }
   #endif
   #endif
   }
 
-  if(neg_ctx->state == GSS_AUTHDONE || neg_ctx->state == GSS_AUTHSUCC) {
+  if(*state == GSS_AUTHDONE || *state == GSS_AUTHSUCC) {
     /* connection is already authenticated,
      * don't send a header in future requests */
     authp->done = TRUE;
@@ -205,6 +210,9 @@ CURLcode Curl_output_negotiate(struct connectdata *conn, bool proxy)
 
 void Curl_http_auth_cleanup_negotiate(struct connectdata *conn)
 {
+  conn->http_negotiate_state = GSS_AUTHNONE;
+  conn->proxy_negotiate_state = GSS_AUTHNONE;
+
   Curl_auth_cleanup_spnego(&conn->negotiate);
   Curl_auth_cleanup_spnego(&conn->proxyneg);
 }

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -68,9 +68,11 @@ CURLcode Curl_input_ntlm(struct connectdata *conn,
 {
   /* point to the correct struct with this */
   struct ntlmdata *ntlm;
+  curlntlm *state;
   CURLcode result = CURLE_OK;
 
   ntlm = proxy ? &conn->proxyntlm : &conn->ntlm;
+  state = proxy ? &conn->proxy_ntlm_state : &conn->http_ntlm_state;
 
   if(checkprefix("NTLM", header)) {
     header += strlen("NTLM");
@@ -83,25 +85,25 @@ CURLcode Curl_input_ntlm(struct connectdata *conn,
       if(result)
         return result;
 
-      ntlm->state = NTLMSTATE_TYPE2; /* We got a type-2 message */
+      *state = NTLMSTATE_TYPE2; /* We got a type-2 message */
     }
     else {
-      if(ntlm->state == NTLMSTATE_LAST) {
+      if(*state == NTLMSTATE_LAST) {
         infof(conn->data, "NTLM auth restarted\n");
         Curl_http_auth_cleanup_ntlm(conn);
       }
-      else if(ntlm->state == NTLMSTATE_TYPE3) {
+      else if(*state == NTLMSTATE_TYPE3) {
         infof(conn->data, "NTLM handshake rejected\n");
         Curl_http_auth_cleanup_ntlm(conn);
-        ntlm->state = NTLMSTATE_NONE;
+        *state = NTLMSTATE_NONE;
         return CURLE_REMOTE_ACCESS_DENIED;
       }
-      else if(ntlm->state >= NTLMSTATE_TYPE1) {
+      else if(*state >= NTLMSTATE_TYPE1) {
         infof(conn->data, "NTLM handshake failure (internal error)\n");
         return CURLE_REMOTE_ACCESS_DENIED;
       }
 
-      ntlm->state = NTLMSTATE_TYPE1; /* We should send away a type-1 */
+      *state = NTLMSTATE_TYPE1; /* We should send away a type-1 */
     }
   }
 
@@ -129,6 +131,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
 
   /* point to the correct struct with this */
   struct ntlmdata *ntlm;
+  curlntlm *state;
   struct auth *authp;
 
   DEBUGASSERT(conn);
@@ -147,6 +150,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
               conn->data->set.str[STRING_PROXY_SERVICE_NAME] : "HTTP";
     hostname = conn->http_proxy.host.name;
     ntlm = &conn->proxyntlm;
+    state = &conn->proxy_ntlm_state;
     authp = &conn->data->state.authproxy;
   }
   else {
@@ -157,6 +161,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
               conn->data->set.str[STRING_SERVICE_NAME] : "HTTP";
     hostname = conn->host.name;
     ntlm = &conn->ntlm;
+    state = &conn->http_ntlm_state;
     authp = &conn->data->state.authhost;
   }
   authp->done = FALSE;
@@ -180,7 +185,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
 #endif
 #endif
 
-  switch(ntlm->state) {
+  switch(*state) {
   case NTLMSTATE_TYPE1:
   default: /* for the weird cases we (re)start here */
     /* Create a type-1 message */
@@ -222,7 +227,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
 
       DEBUG_OUT(fprintf(stderr, "**** %s\n ", *allocuserpwd));
 
-      ntlm->state = NTLMSTATE_TYPE3; /* we send a type-3 */
+      *state = NTLMSTATE_TYPE3; /* we send a type-3 */
       authp->done = TRUE;
     }
     break;
@@ -230,7 +235,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
   case NTLMSTATE_TYPE3:
     /* connection is already authenticated,
      * don't send a header in future requests */
-    ntlm->state = NTLMSTATE_LAST;
+    *state = NTLMSTATE_LAST;
     /* FALLTHROUGH */
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -592,8 +592,8 @@ static CURLcode multi_done(struct Curl_easy *data,
            conn->proxy_ntlm_state == NTLMSTATE_TYPE2)
 #endif
 #if defined(USE_SPNEGO)
-      && !(conn->negotiate.state == GSS_AUTHRECV ||
-           conn->proxyneg.state == GSS_AUTHRECV)
+      && !(conn->http_negotiate_state == GSS_AUTHRECV ||
+           conn->proxy_negotiate_state == GSS_AUTHRECV)
 #endif
      ) || conn->bits.close
        || (premature && !(conn->handler->flags & PROTOPT_STREAM))) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -588,8 +588,8 @@ static CURLcode multi_done(struct Curl_easy *data,
 
   if((data->set.reuse_forbid
 #if defined(USE_NTLM)
-      && !(conn->ntlm.state == NTLMSTATE_TYPE2 ||
-           conn->proxyntlm.state == NTLMSTATE_TYPE2)
+      && !(conn->http_ntlm_state == NTLMSTATE_TYPE2 ||
+           conn->proxy_ntlm_state == NTLMSTATE_TYPE2)
 #endif
 #if defined(USE_SPNEGO)
       && !(conn->negotiate.state == GSS_AUTHRECV ||

--- a/lib/url.c
+++ b/lib/url.c
@@ -1284,7 +1284,7 @@ ConnectionExists(struct Curl_easy *data,
              strcmp(needle->passwd, check->passwd))
             continue;
         }
-        else if(check->ntlm.state != NTLMSTATE_NONE) {
+        else if(check->http_ntlm_state != NTLMSTATE_NONE) {
           /* Connection is using NTLM auth but we don't want NTLM */
           continue;
         }
@@ -1300,7 +1300,7 @@ ConnectionExists(struct Curl_easy *data,
              strcmp(needle->http_proxy.passwd, check->http_proxy.passwd))
             continue;
         }
-        else if(check->proxyntlm.state != NTLMSTATE_NONE) {
+        else if(check->proxy_ntlm_state != NTLMSTATE_NONE) {
           /* Proxy connection is using NTLM auth but we don't want NTLM */
           continue;
         }
@@ -1310,9 +1310,9 @@ ConnectionExists(struct Curl_easy *data,
           chosen = check;
 
           if((wantNTLMhttp &&
-             (check->ntlm.state != NTLMSTATE_NONE)) ||
+             (check->http_ntlm_state != NTLMSTATE_NONE)) ||
               (wantProxyNTLMhttp &&
-               (check->proxyntlm.state != NTLMSTATE_NONE))) {
+               (check->proxy_ntlm_state != NTLMSTATE_NONE))) {
             /* We must use this connection, no other */
             *force_reuse = TRUE;
             break;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -336,7 +336,6 @@ struct kerberos5data {
 /* Struct used for NTLM challenge-response authentication */
 #if defined(USE_NTLM)
 struct ntlmdata {
-  curlntlm state;
 #ifdef USE_WINDOWS_SSPI
 /* The sslContext is used for the Schannel bindings. The
  * api is available on the Windows 7 SDK and later.
@@ -968,6 +967,9 @@ struct connectdata {
 #endif
 
 #if defined(USE_NTLM)
+  curlntlm http_ntlm_state;
+  curlntlm proxy_ntlm_state;
+
   struct ntlmdata ntlm;     /* NTLM differs from other authentication schemes
                                because it authenticates connections, not
                                single requests! */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -361,11 +361,9 @@ struct ntlmdata {
 };
 #endif
 
+/* Struct used for Negotiate (SPNEGO) authentication */
 #ifdef USE_SPNEGO
 struct negotiatedata {
-  /* When doing Negotiate (SPNEGO) auth, we first need to send a token
-     and then validate the received one. */
-  curlnegotiate state;
 #ifdef HAVE_GSSAPI
   OM_uint32 status;
   gss_ctx_id_t context;
@@ -985,6 +983,9 @@ struct connectdata {
 #endif
 
 #ifdef USE_SPNEGO
+  curlnegotiate http_negotiate_state;
+  curlnegotiate proxy_negotiate_state;
+
   struct negotiatedata negotiate; /* state data for host Negotiate auth */
   struct negotiatedata proxyneg; /* state data for proxy Negotiate auth */
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -303,6 +303,14 @@ typedef enum {
   NTLMSTATE_LAST
 } curlntlm;
 
+typedef enum {
+  GSS_AUTHNONE,
+  GSS_AUTHRECV,
+  GSS_AUTHSENT,
+  GSS_AUTHDONE,
+  GSS_AUTHSUCC
+} curlnegotiate;
+
 #if defined(CURL_DOES_CONVERSIONS) && defined(HAVE_ICONV)
 #include <iconv.h>
 #endif
@@ -358,9 +366,7 @@ struct ntlmdata {
 struct negotiatedata {
   /* When doing Negotiate (SPNEGO) auth, we first need to send a token
      and then validate the received one. */
-  enum {
-    GSS_AUTHNONE, GSS_AUTHRECV, GSS_AUTHSENT, GSS_AUTHDONE, GSS_AUTHSUCC
-  } state;
+  curlnegotiate state;
 #ifdef HAVE_GSSAPI
   OM_uint32 status;
   gss_ctx_id_t context;

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -273,7 +273,6 @@ void Curl_auth_cleanup_spnego(struct negotiatedata *nego)
 
   /* Reset any variables */
   nego->status = 0;
-  nego->state = GSS_AUTHNONE;
   nego->noauthpersist = FALSE;
   nego->havenoauthpersist = FALSE;
   nego->havenegdata = FALSE;

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -343,7 +343,6 @@ void Curl_auth_cleanup_spnego(struct negotiatedata *nego)
   /* Reset any variables */
   nego->status = 0;
   nego->token_max = 0;
-  nego->state = GSS_AUTHNONE;
   nego->noauthpersist = FALSE;
   nego->havenoauthpersist = FALSE;
   nego->havenegdata = FALSE;


### PR DESCRIPTION
As these context structures are used to store context handles and message data which is not specific to any one protocol should not be storing HTTP and HTTP proxy state information in them.

In addition to this it may also be possible to remove the proxy data structures as I believe these may no longer be required - we should be able to use one structure for both proxy and none-proxy (just like the current NTLM winbind code does). However this is still to be investigated and isn't something I would recommend rushing as part of 7.65.