### PR TITLE
cleanup: remove FIXME and TODO comments

### DIFF
--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -518,9 +518,6 @@ int main(int argc _Unused, char **argv _Unused)
   fprintf(MSG_OUT, "Entering wait loop\n");
   fflush(MSG_OUT);
   while(!g_should_exit_) {
-    /* TODO(josh): use epoll_pwait to avoid a race on the signal. Mask the
-     * signal before the while loop, and then re-enable the signal during
-     * epoll wait. Mask at the end of the loop. */
     err = epoll_wait(g.epfd, events, sizeof(events)/sizeof(struct epoll_event),
                      10000);
     if(err == -1) {

--- a/docs/examples/ftpgetinfo.c
+++ b/docs/examples/ftpgetinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -56,7 +56,6 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
     /* Ask for filetime */
     curl_easy_setopt(curl, CURLOPT_FILETIME, 1L);
-    /* No header output: TODO 14.1 http-style HEAD output for ftp */
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, throw_away);
     curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
     /* Switch on full protocol/debug output */

--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -113,7 +113,6 @@ __extension__ ({                                                              \
 })
 
 /* wraps curl_easy_getinfo() with typechecking */
-/* FIXME: don't allow const pointers */
 #define curl_easy_getinfo(handle, info, arg)                                  \
 __extension__ ({                                                              \
   __typeof__(info) _curl_info = info;                                         \
@@ -146,9 +145,8 @@ __extension__ ({                                                              \
   curl_easy_getinfo(handle, _curl_info, arg);                                 \
 })
 
-/* TODO: typechecking for curl_share_setopt() and curl_multi_setopt(),
- * for now just make sure that the functions are called with three
- * arguments
+/*
+ * For now, just make sure that the functions are called with three arguments
  */
 #define curl_share_setopt(share,opt,param) curl_share_setopt(share,opt,param)
 #define curl_multi_setopt(handle,opt,param) curl_multi_setopt(handle,opt,param)
@@ -506,10 +504,6 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
    _curl_is_arr((expr), char) ||                                              \
    _curl_is_arr((expr), unsigned char))
 
-/* FIXME: the whole callback checking is messy...
- * The idea is to tolerate char vs. void and const vs. not const
- * pointers in arguments at least
- */
 /* helper: __builtin_types_compatible_p distinguishes between functions and
  * function pointers, hide it */
 #define _curl_callback_compatible(func, type)                                 \

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -253,7 +253,6 @@ struct altsvcinfo *Curl_altsvc_init(void)
     | CURLALTSVC_H2
 #endif
 #ifdef USE_HTTP3
-    /* TODO: adjust when known */
     | CURLALTSVC_H3
 #endif
     ;
@@ -349,7 +348,7 @@ static CURLcode getalnum(const char **ptr, char *alpnbuf, size_t buflen)
   len = p - protop;
 
   if(!len || (len >= buflen))
-    return CURLE_BAD_FUNCTION_ARGUMENT; /* TODO: improve error code */
+    return CURLE_BAD_FUNCTION_ARGUMENT;
   memcpy(alpnbuf, protop, len);
   alpnbuf[len] = 0;
   *ptr = p;
@@ -425,7 +424,6 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
 
   /* "clear" is a magic keyword */
   if(strcasecompare(alpnbuf, "clear")) {
-    /* TODO: clear whatever it is it should clear */
     return CURLE_OK;
   }
 
@@ -478,7 +476,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
             p++;
           len = p - hostp;
           if(!len || (len >= MAX_ALTSVC_HOSTLEN))
-            return CURLE_BAD_FUNCTION_ARGUMENT; /* TODO: improve error code */
+            return CURLE_BAD_FUNCTION_ARGUMENT;
           memcpy(namebuf, hostp, len);
           namebuf[len] = 0;
           dsthost = namebuf;
@@ -504,8 +502,8 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
                              srcalpnid, dstalpnid,
                              srcport, dstport);
         if(as) {
-          /* TODO: the expires time also needs to take the Age: value (if any)
-             into account. [See RFC 7838 section 3.1] */
+          /* The expires time also needs to take the Age: value (if any) into
+             account. [See RFC 7838 section 3.1] */
           as->expires = maxage + time(NULL);
           as->persist = persist;
           Curl_llist_insert_next(&asi->list, asi->list.tail, as, &as->node);

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -490,9 +490,7 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
 
   if(result)
     /* close the connection, since we can't return failure here without
-       cleaning up this connection properly.
-       TODO: remove this action from here, it is not a name resolver decision.
-    */
+       cleaning up this connection properly. */
     connclose(conn, "c-ares resolve failed");
 
   return result;

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -32,15 +32,6 @@
 
 #ifndef HAVE_FNMATCH
 
-/*
- * TODO:
- *
- * Make this function match POSIX. Test 1307 includes a set of test patterns
- * that returns different results with a POSIX fnmatch() than with this
- * implementation and this is considered a bug where POSIX is the guiding
- * light.
- */
-
 #define CURLFNM_CHARSET_LEN (sizeof(char) * 256)
 #define CURLFNM_CHSET_SIZE (CURLFNM_CHARSET_LEN + 15)
 

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -39,7 +39,7 @@
  *
  * File lib/strdup.c is an exception, given that it provides a strdup
  * clone implementation while using malloc. Extra care needed inside
- * this one. TODO: revisit this paragraph and related code.
+ * this one.
  *
  * The need for curl_memory.h inclusion is due to libcurl's feature
  * of allowing library user to provide memory replacement functions,

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -293,7 +293,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct connectdata *conn,
 #if defined(USE_KERBEROS5)
     if((enabledmechs & SASL_MECH_GSSAPI) && Curl_auth_is_gssapi_supported() &&
        Curl_auth_user_contains_domain(conn->user)) {
-      sasl->mutual_auth = FALSE; /* TODO: Calculate mutual authentication */
+      sasl->mutual_auth = FALSE;
       mech = SASL_MECH_STRING_GSSAPI;
       state1 = SASL_GSSAPI;
       state2 = SASL_GSSAPI_TOKEN;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -559,7 +559,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
       return CURLE_RECV_ERROR;
 
     if(mcode)
-      return CURLE_URL_MALFORMAT; /* TODO: return a proper error! */
+      return CURLE_URL_MALFORMAT;
 
     /* we don't really care about the "msgs_in_queue" value returned in the
        second argument */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -572,7 +572,6 @@ static CURLcode ftp_readresp(curl_socket_t sockfd,
 
 #if defined(HAVE_GSSAPI)
   /* handle the security-oriented responses 6xx ***/
-  /* FIXME: some errorchecking perhaps... ***/
   switch(code) {
   case 631:
     code = Curl_sec_read_msg(conn, buf, PROT_SAFE);
@@ -3490,7 +3489,7 @@ static CURLcode ftp_do_more(struct connectdata *conn, int *completep)
   if(!conn->bits.tcpconnect[SECONDARYSOCKET]) {
     if(Curl_connect_ongoing(conn)) {
       /* As we're in TUNNEL_CONNECT state now, we know the proxy name and port
-         aren't used so we blank their arguments. TODO: make this nicer */
+         aren't used so we blank their arguments. */
       result = Curl_proxyCONNECT(conn, SECONDARYSOCKET, NULL, 0);
 
       return result;

--- a/lib/http.c
+++ b/lib/http.c
@@ -1717,8 +1717,6 @@ CURLcode Curl_http_compile_trailers(struct curl_slist *trailers,
   const char *endofline_native = NULL;
   const char *endofline_network = NULL;
 
-  /* TODO: Maybe split Curl_add_custom_headers to make it reusable here */
-
   if(
 #ifdef CURL_DO_LINEEND_CONV
      (handle->set.prefer_ascii) ||
@@ -3723,7 +3721,6 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
           conn->httpversion = 11; /* For us, RTSP acts like HTTP 1.1 */
         }
         else {
-          /* TODO: do we care about the other cases here? */
           nc = 0;
         }
       }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -111,8 +111,6 @@ static int http2_perform_getsock(const struct connectdata *conn,
   int bitmap = GETSOCK_BLANK;
   (void)numsocks;
 
-  /* TODO We should check underlying socket state if it is SSL socket
-     because of renegotiation. */
   sock[0] = conn->sock[FIRSTSOCKET];
 
   /* in a HTTP/2 connection we can basically always get a frame so we should
@@ -1847,9 +1845,9 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
                           const void *mem, size_t len, CURLcode *err)
 {
   /*
-   * BIG TODO: Currently, we send request in this function, but this
-   * function is also used to send request body. It would be nice to
-   * add dedicated function for request.
+   * Currently, we send request in this function, but this function is also
+   * used to send request body. It would be nice to add dedicated function for
+   * request.
    */
   int rv;
   struct http_conn *httpc = &conn->proto.httpc;

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1043,7 +1043,7 @@ static CURLcode imap_state_listsearch_resp(struct connectdata *conn,
     line[len] = '\0';
   }
   else if(imapcode != IMAP_RESP_OK)
-    result = CURLE_QUOTE_ERROR; /* TODO: Fix error code */
+    result = CURLE_QUOTE_ERROR;
   else
     /* End of DO phase */
     state(conn, IMAP_STOP);
@@ -1115,7 +1115,7 @@ static CURLcode imap_state_fetch_resp(struct connectdata *conn, int imapcode,
   if(imapcode != '*') {
     Curl_pgrsSetDownloadSize(data, -1);
     state(conn, IMAP_STOP);
-    return CURLE_REMOTE_FILE_NOT_FOUND; /* TODO: Fix error code */
+    return CURLE_REMOTE_FILE_NOT_FOUND;
   }
 
   /* Something like this is received "* 1 FETCH (BODY[TEXT] {2021}\r" so parse
@@ -1492,12 +1492,7 @@ static CURLcode imap_done(struct connectdata *conn, CURLcode status,
         state(conn, IMAP_APPEND_FINAL);
     }
 
-    /* Run the state-machine
-
-       TODO: when the multi interface is used, this _really_ should be using
-       the imap_multi_statemach function but we have no general support for
-       non-blocking DONE operations!
-    */
+    /* Run the state-machine */
     if(!result)
       result = imap_block_statemach(conn, FALSE);
   }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1206,8 +1206,6 @@ static CURLcode multi_do(struct Curl_easy *data, bool *done)
  * second stage DO state which (wrongly) was introduced to support FTP's
  * second connection.
  *
- * TODO: A future libcurl should be able to work away this state.
- *
  * 'complete' can return 0 for incomplete, 1 for done and -1 for go back to
  * DOING state there's more work to do!
  */

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -196,9 +196,6 @@ static CURLcode ldap_setup_connection(struct connectdata *conn)
   li->proto = proto;
   conn->proto.generic = li;
   connkeep(conn, "OpenLDAP default");
-  /* TODO:
-   * - provide option to choose SASL Binds instead of Simple
-   */
   return CURLE_OK;
 }
 
@@ -510,8 +507,6 @@ static ssize_t ldap_recv(struct connectdata *conn, int sockindex, char *buf,
     lr->nument++;
     rc = ldap_get_dn_ber(li->ld, ent, &ber, &bv);
     if(rc < 0) {
-      /* TODO: verify that this is really how this return code should be
-         handled */
       *err = CURLE_RECV_ERROR;
       return -1;
     }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -42,15 +42,6 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-/*
- * TODO (general)
- *  -incoming server requests
- *      -server CSeq counter
- *  -digest authentication
- *  -connect through proxy
- */
-
-
 #define RTP_PKT_CHANNEL(p)   ((int)((unsigned char)((p)[1])))
 
 #define RTP_PKT_LENGTH(p)  ((((int)((unsigned char)((p)[2]))) << 8) | \
@@ -235,7 +226,6 @@ static CURLcode rtsp_done(struct connectdata *conn,
     if(data->set.rtspreq == RTSPREQ_RECEIVE &&
             (conn->proto.rtspc.rtp_channel == -1)) {
       infof(data, "Got an RTP Receive with a CSeq of %ld\n", CSeq_recv);
-      /* TODO CPC: Server -> Client logic here */
     }
   }
 
@@ -334,8 +324,6 @@ static CURLcode rtsp_do(struct connectdata *conn, bool *done)
           p_request);
     return CURLE_BAD_FUNCTION_ARGUMENT;
   }
-
-  /* TODO: proxy? */
 
   /* Stream URI. Default to server '*' if not specified */
   if(data->set.str[STRING_RTSP_STREAM_URI]) {

--- a/lib/security.c
+++ b/lib/security.c
@@ -151,7 +151,6 @@ socket_read(curl_socket_t fd, void *to, size_t len)
       to_p += nread;
     }
     else {
-      /* FIXME: We are doing a busy wait */
       if(result == CURLE_AGAIN)
         continue;
       return result;
@@ -179,7 +178,6 @@ socket_write(struct connectdata *conn, curl_socket_t fd, const void *to,
       to_p += written;
     }
     else {
-      /* FIXME: We are doing a busy wait */
       if(result == CURLE_AGAIN)
         continue;
       return result;
@@ -265,13 +263,11 @@ static ssize_t sec_recv(struct connectdata *conn, int sockindex,
     total_read += bytes_read;
     buffer += bytes_read;
   }
-  /* FIXME: Check for overflow */
   return total_read;
 }
 
 /* Send |length| bytes from |from| to the |fd| socket taking care of encoding
    and negociating with the server. |from| can be NULL. */
-/* FIXME: We don't check for errors nor report any! */
 static void do_sec_send(struct connectdata *conn, curl_socket_t fd,
                         const char *from, int length)
 {
@@ -406,13 +402,11 @@ int Curl_sec_read_msg(struct connectdata *conn, char *buffer,
 
   if(buf[decoded_len - 1] == '\n')
     buf[decoded_len - 1] = '\0';
-  /* FIXME: Is |buffer| length always greater than |decoded_len|? */
   strcpy(buffer, buf);
   free(buf);
   return ret_code;
 }
 
-/* FIXME: The error code returned here is never checked. */
 static int sec_set_protection_level(struct connectdata *conn)
 {
   int code;
@@ -508,7 +502,6 @@ static CURLcode choose_mech(struct connectdata *conn)
   infof(data, "Trying mechanism %s...\n", mech->name);
   ret = ftp_send_command(conn, "AUTH %s", mech->name);
   if(ret < 0)
-    /* FIXME: This error is too generic but it is OK for now. */
     return CURLE_COULDNT_CONNECT;
 
   if(ret/100 != 3) {
@@ -575,7 +568,6 @@ Curl_sec_end(struct connectdata *conn)
     conn->in_buffer.data = NULL;
     conn->in_buffer.size = 0;
     conn->in_buffer.index = 0;
-    /* FIXME: Is this really needed? */
     conn->in_buffer.eof_flag = 0;
   }
   conn->sec_complete = 0;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1253,12 +1253,7 @@ static CURLcode smtp_done(struct connectdata *conn, CURLcode status,
 
     state(conn, SMTP_POSTDATA);
 
-    /* Run the state-machine
-
-       TODO: when the multi interface is used, this _really_ should be using
-       the smtp_multi_statemach function but we have no general support for
-       non-blocking DONE operations!
-    */
+    /* Run the state-machine */
     result = smtp_block_statemach(conn, FALSE);
   }
 

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1997 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1997 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -198,7 +198,7 @@ struct Curl_tree *Curl_splaygetbest(struct curltime i,
 /* Deletes the very node we point out from the tree if it's there. Stores a
  * pointer to the new resulting tree in 'newroot'.
  *
- * Returns zero on success and non-zero on errors! TODO: document error codes.
+ * Returns zero on success and non-zero on errors!
  * When returning error, it does not touch the 'newroot' pointer.
  *
  * NOTE: when the last node of the tree is removed, there's no tree left so

--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -2227,12 +2227,7 @@ static CURLcode myssh_done(struct connectdata *conn, CURLcode status)
   struct SSHPROTO *protop = conn->data->req.protop;
 
   if(!status) {
-    /* run the state-machine
-
-       TODO: when the multi interface is used, this _really_ should be using
-       the ssh_multi_statemach function but we have no general support for
-       non-blocking DONE operations!
-     */
+    /* run the state-machine */
     result = myssh_block_statemach(conn, FALSE);
   }
   else

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -290,10 +290,6 @@ static CURLcode libssh2_session_error_to_CURLE(int err)
       return CURLE_AGAIN;
   }
 
-  /* TODO: map some more of the libssh2 errors to the more appropriate CURLcode
-     error code, and possibly add a few new SSH-related one. We must however
-     not return or even depend on libssh2 errors in the public libcurl API */
-
   return CURLE_SSH;
 }
 
@@ -3065,12 +3061,7 @@ static CURLcode ssh_done(struct connectdata *conn, CURLcode status)
   struct SSHPROTO *sftp_scp = conn->data->req.protop;
 
   if(!status) {
-    /* run the state-machine
-
-       TODO: when the multi interface is used, this _really_ should be using
-       the ssh_multi_statemach function but we have no general support for
-       non-blocking DONE operations!
-    */
+    /* run the state-machine */
     result = ssh_block_statemach(conn, FALSE);
   }
   else

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -463,7 +463,6 @@ CURLcode Curl_readrewind(struct connectdata *conn)
       infof(data, "the ioctl callback returned %d\n", (int)err);
 
       if(err) {
-        /* FIXME: convert to a human readable error message */
         failf(data, "ioctl callback returned error %d", (int)err);
         return CURLE_SEND_FAIL_REWIND;
       }

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -785,8 +785,7 @@ static CURLcode _Curl_auth_create_digest_http_message(
     return CURLE_OUT_OF_MEMORY;
 
   if(digest->qop && strcasecompare(digest->qop, "auth-int")) {
-    /* We don't support auth-int for PUT or POST at the moment.
-       TODO: replace hash of empty string with entity-body for PUT/POST */
+    /* We don't support auth-int for PUT or POST */
     char hashed[65];
     unsigned char *hashthis2;
 

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1762,12 +1762,6 @@ static int Curl_gtls_seed(struct Curl_easy *data)
 
   if(!ssl_seeded || data->set.str[STRING_SSL_RANDOM_FILE] ||
      data->set.str[STRING_SSL_EGDSOCKET]) {
-
-    /* TODO: to a good job seeding the RNG
-       This may involve the gcry_control function and these options:
-       GCRYCTL_SET_RANDOM_SEED_FILE
-       GCRYCTL_SET_RNDEGD_SOCKET
-    */
     ssl_seeded = TRUE;
   }
   return 0;

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1831,7 +1831,6 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
   /* list of all NSS objects we need to destroy in Curl_nss_close() */
   Curl_llist_init(&BACKEND->obj_list, nss_destroy_object);
 
-  /* FIXME. NSS doesn't support multiple databases open at the same time. */
   PR_Lock(nss_initlock);
   result = nss_init(conn->data);
   if(result) {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3227,11 +3227,6 @@ static CURLcode get_cert_chain(struct connectdata *conn,
 #endif
         break;
       }
-#if 0
-      case EVP_PKEY_EC: /* symbol not present in OpenSSL 0.9.6 */
-        /* left TODO */
-        break;
-#endif
       }
       EVP_PKEY_free(pubkey);
     }

--- a/lib/vtls/polarssl.c
+++ b/lib/vtls/polarssl.c
@@ -911,9 +911,7 @@ const struct Curl_ssl Curl_ssl_polarssl = {
   Curl_none_check_cxn,               /* check_cxn */
   Curl_none_shutdown,                /* shutdown */
   Curl_polarssl_data_pending,        /* data_pending */
-  /* This might cause libcurl to use a weeker random!
-   * TODO: use Polarssl's CTR-DRBG or HMAC-DRBG
-  */
+  /* This might cause libcurl to use a weeker random! */
   Curl_none_random,                  /* random */
   Curl_none_cert_status_request,     /* cert_status_request */
   Curl_polarssl_connect,             /* connect */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -523,7 +523,6 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
 #endif
         schannel_cred.dwFlags = SCH_CRED_AUTO_CRED_VALIDATION;
 
-      /* TODO s/data->set.ssl.no_revoke/SSL_SET_OPTION(no_revoke)/g */
       if(data->set.ssl.no_revoke) {
         schannel_cred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
           SCH_CRED_IGNORE_REVOCATION_OFFLINE;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1903,7 +1903,6 @@ static CURLcode sectransp_connect_step1(struct connectdata *conn,
   /* We want to enable 1/n-1 when using a CBC cipher unless the user
      specifically doesn't want us doing that: */
   if(SSLSetSessionOption != NULL) {
-    /* TODO s/data->set.ssl.enable_beast/SSL_SET_OPTION(enable_beast)/g */
     SSLSetSessionOption(BACKEND->ssl_ctx, kSSLSessionOptionSendOneByteRecord,
                       !data->set.ssl.enable_beast);
     SSLSetSessionOption(BACKEND->ssl_ctx, kSSLSessionOptionFalseStart,

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -1056,8 +1056,6 @@ CURLcode Curl_extract_certinfo(struct connectdata *conn,
   do_pubkey(data, certnum, ccp, &param, &cert.subjectPublicKey);
   free((char *) ccp);
 
-/* TODO: extensions. */
-
   /* Signature. */
   ccp = ASN1tostr(&cert.signature, 0);
   if(!ccp)

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -34,11 +34,11 @@ void config_init(struct OperationConfig* config)
   config->use_httpget = FALSE;
   config->create_dirs = FALSE;
   config->maxredirs = DEFAULT_MAXREDIRS;
-  config->proto = CURLPROTO_ALL; /* FIXME: better to read from library */
+  config->proto = CURLPROTO_ALL;
   config->proto_present = FALSE;
   config->proto_redir = CURLPROTO_ALL & /* All except FILE, SCP and SMB */
-                        ~(CURLPROTO_FILE | CURLPROTO_SCP | CURLPROTO_SMB |
-                          CURLPROTO_SMBS);
+    ~(CURLPROTO_FILE | CURLPROTO_SCP | CURLPROTO_SMB |
+      CURLPROTO_SMBS);
   config->proto_redir_present = FALSE;
   config->proto_default = NULL;
   config->tcp_nodelay = TRUE; /* enabled by default */

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -568,7 +568,6 @@ static int get_param_part(struct OperationConfig *config, char endchar,
             endpos--;
         sep = *p;
         *endpos = '\0';
-        /* TODO: maybe special fopen for VMS? */
         fp = fopen(hdrfile, FOPEN_READTEXT);
         if(!fp)
           warnf(config->global, "Cannot read from %s: %s\n", hdrfile,

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -101,7 +101,6 @@ CURLcode curl_easy_perform_ev(CURL *easy);
 static bool is_fatal_error(CURLcode code)
 {
   switch(code) {
-  /* TODO: Should CURLE_PEER_FAILED_VERIFICATION be a critical error? */
   case CURLE_FAILED_INIT:
   case CURLE_OUT_OF_MEMORY:
   case CURLE_UNKNOWN_OPTION:
@@ -876,8 +875,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
 
 #if !defined(CURL_DISABLE_PROXY)
         {
-          /* TODO: Make this a run-time check instead of compile-time one. */
-
           my_setopt_str(curl, CURLOPT_PROXY, config->proxy);
           /* new in libcurl 7.5 */
           if(config->proxy)
@@ -1660,10 +1657,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
                    * file (or terminal). If we write to a file, we must rewind
                    * or close/re-open the file so that the next attempt starts
                    * over from the beginning.
-                   *
-                   * TODO: similar action for the upload case. We might need
-                   * to start over reading from a previous point if we have
-                   * uploaded something when this was returned.
                    */
                   break;
                 }
@@ -1754,8 +1747,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
                download was not successful. */
             long response;
             if(CURLE_OK == result) {
-              /* TODO We want to try next resource when download was
-                 not successful. How to know that? */
               char *effective_url = NULL;
               curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effective_url);
               if(effective_url &&
@@ -1929,9 +1920,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
             break;
           mlres = mlres->next;
           if(mlres == NULL)
-            /* TODO If metalink_next_res is 1 and mlres is NULL,
-             * set res to error code
-             */
             break;
         }
         else if(urlnum > 1) {

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -553,8 +553,7 @@ CURLcode glob_next_url(char **globbed, URLGlob *glob)
       }
     }
     if(carry) {         /* first pattern ptr has run into overflow, done! */
-      /* TODO: verify if this should actually return CURLE_OK. */
-      return CURLE_OK; /* CURLE_OK to match previous behavior */
+      return CURLE_OK;
     }
   }
 

--- a/tests/unit/unit1304.c
+++ b/tests/unit/unit1304.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -207,8 +207,4 @@ UNITTEST_START
   fail_unless(strncmp(login, "none", 4) == 0, "login should be 'none'");
   fail_unless(!login_changed, "login should not have been changed");
 
-  /* TODO:
-   * Test over the size limit password / login!
-   * Test files with a bad format
-   */
 UNITTEST_STOP

--- a/tests/unit/unit1398.c
+++ b/tests/unit/unit1398.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -74,7 +74,6 @@ fail_unless(!strcmp(output, "     bu"), "wrong output");
 
 /* output a number in a limited output */
 rc = curl_msnprintf(output, 4, "%d", 10240);
-/* TODO: this should return 5 to be POSIX/msnprintf compliant! */
 fail_unless(rc == 4, "return code should be 4");
 fail_unless(!strcmp(output, "102"), "wrong output");
 


### PR DESCRIPTION
They serve very little purpose and mostly just add noise. Most of them
have been around for a very long time. I read them all before removing
or rephrasing them.

Ref: #3876