### PR TITLE
PolarSSL: deprecate support step 1. Removed from configure.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,7 +155,7 @@ AC_SUBST(PKGADD_VENDOR)
 
 dnl
 dnl initialize all the info variables
-    curl_ssl_msg="no      (--with-{ssl,gnutls,nss,polarssl,mbedtls,cyassl,schannel,secure-transport,mesalink,amissl} )"
+    curl_ssl_msg="no      (--with-{ssl,gnutls,nss,mbedtls,cyassl,schannel,secure-transport,mesalink,amissl} )"
     curl_ssh_msg="no      (--with-libssh2)"
    curl_zlib_msg="no      (--with-zlib)"
  curl_brotli_msg="no      (--with-brotli)"
@@ -2119,98 +2119,6 @@ if test "$GNUTLS_ENABLED" = "1"; then
 fi
 
 dnl ----------------------------------------------------
-dnl check for PolarSSL
-dnl ----------------------------------------------------
-
-dnl Default to compiler & linker defaults for PolarSSL files & libraries.
-OPT_POLARSSL=no
-
-_cppflags=$CPPFLAGS
-_ldflags=$LDFLAGS
-AC_ARG_WITH(polarssl,dnl
-AC_HELP_STRING([--with-polarssl=PATH],[where to look for PolarSSL, PATH points to the installation root])
-AC_HELP_STRING([--without-polarssl], [disable PolarSSL detection]),
-  OPT_POLARSSL=$withval)
-
-if test -z "$ssl_backends" -o "x$OPT_POLARSSL" != xno; then
-  ssl_msg=
-
-  if test X"$OPT_POLARSSL" != Xno; then
-
-    if test "$OPT_POLARSSL" = "yes"; then
-      OPT_POLARSSL=""
-    fi
-
-    if test -z "$OPT_POLARSSL" ; then
-      dnl check for lib first without setting any new path
-
-      AC_CHECK_LIB(polarssl, havege_init,
-      dnl libpolarssl found, set the variable
-       [
-         AC_DEFINE(USE_POLARSSL, 1, [if PolarSSL is enabled])
-         AC_SUBST(USE_POLARSSL, [1])
-         POLARSSL_ENABLED=1
-         USE_POLARSSL="yes"
-         ssl_msg="PolarSSL"
-	 test polarssl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-        ])
-    fi
-
-    addld=""
-    addlib=""
-    addcflags=""
-    polarssllib=""
-
-    if test "x$USE_POLARSSL" != "xyes"; then
-      dnl add the path and test again
-      addld=-L$OPT_POLARSSL/lib$libsuff
-      addcflags=-I$OPT_POLARSSL/include
-      polarssllib=$OPT_POLARSSL/lib$libsuff
-
-      LDFLAGS="$LDFLAGS $addld"
-      if test "$addcflags" != "-I/usr/include"; then
-         CPPFLAGS="$CPPFLAGS $addcflags"
-      fi
-
-      AC_CHECK_LIB(polarssl, ssl_init,
-       [
-       AC_DEFINE(USE_POLARSSL, 1, [if PolarSSL is enabled])
-       AC_SUBST(USE_POLARSSL, [1])
-       POLARSSL_ENABLED=1
-       USE_POLARSSL="yes"
-       ssl_msg="PolarSSL"
-       test polarssl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-       ],
-       [
-         CPPFLAGS=$_cppflags
-         LDFLAGS=$_ldflags
-       ])
-    fi
-
-    if test "x$USE_POLARSSL" = "xyes"; then
-      AC_MSG_NOTICE([detected PolarSSL])
-      check_for_ca_bundle=1
-      LIBS="-lpolarssl $LIBS"
-
-      if test -n "$polarssllib"; then
-        dnl when shared libs were found in a path that the run-time
-        dnl linker doesn't search through, we need to add it to
-        dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
-        dnl due to this
-        if test "x$cross_compiling" != "xyes"; then
-          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$polarssllib"
-          export CURL_LIBRARY_PATH
-          AC_MSG_NOTICE([Added $polarssllib to CURL_LIBRARY_PATH])
-        fi
-      fi
-    fi
-
-  fi dnl PolarSSL not disabled
-
-  test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi
-
-dnl ----------------------------------------------------
 dnl check for mbedTLS
 dnl ----------------------------------------------------
 
@@ -2698,10 +2606,10 @@ if test -z "$ssl_backends" -o "x$OPT_NSS" != xno; then
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 fi
 
-case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$POLARSSL_ENABLED$MBEDTLS_ENABLED$CYASSL_ENABLED$WINSSL_ENABLED$SECURETRANSPORT_ENABLED$MESALINK_ENABLED$AMISSL_ENABLED" in
+case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$CYASSL_ENABLED$WINSSL_ENABLED$SECURETRANSPORT_ENABLED$MESALINK_ENABLED$AMISSL_ENABLED" in
 x)
   AC_MSG_WARN([SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.])
-  AC_MSG_WARN([Use --with-ssl, --with-gnutls, --with-polarssl, --with-cyassl, --with-nss, --with-schannel, --with-secure-transport, --with-mesalink or --with-amissl to address this.])
+  AC_MSG_WARN([Use --with-ssl, --with-gnutls, --with-cyassl, --with-nss, --with-schannel, --with-secure-transport, --with-mesalink or --with-amissl to address this.])
   ;;
 x1)
   # one SSL backend is enabled
@@ -3125,8 +3033,6 @@ AC_HELP_STRING([--disable-versioned-symbols], [Disable versioned symbols in shar
           versioned_symbols_flavour="GNUTLS_"
         elif test "x$NSS_ENABLED" = "x1"; then
           versioned_symbols_flavour="NSS_"
-        elif test "x$POLARSSL_ENABLED" = "x1"; then
-          versioned_symbols_flavour="POLARSSL_"
         elif test "x$CYASSL_ENABLED" = "x1"; then
           versioned_symbols_flavour="CYASSL_"
         elif test "x$WINSSL_ENABLED" = "x1"; then

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -19,3 +19,32 @@ version. The default remains supported for now.
 
 The support for HTTP/0.9 will be switched to disabled by default in 6 months,
 in the September 2019 release (possibly called curl 7.68.0).
+
+## PolarSSL
+
+The polarssl TLS library has not had an update in over three years. The last
+release was done on [January 7
+2016](https://tls.mbed.org/tech-updates/releases). This library has been
+superceded by the mbedTLS library, which is the current incarnation of
+PolarSSL. curl has supported mbedTLS since 2015.
+
+It seems unlikely that this library is a good choice for users to get proper
+TLS security and support today and at the same time there are plenty of good
+and updated alternatives.
+
+I consider it likely that the existing users of curl + polarssl out there are
+stuck on old curl versions and when they eventually manage to update curl they
+should also be able to update their TLS library.
+
+### State
+
+In the curl 7.66.0 release (July 17, 2019) the ability to build with this TLS
+backend is removed from the configure script. The code remains and can be
+built and used going forward, but it has to be manually enabled in a build (or
+the configure removal reverted).
+
+### Removal
+
+The support for PolarSSL and all code for it will be completely removed from
+the curl code base six months after it ships disabled in configure in a
+release. In the release on or near February 27, 2020. (Named 7.70.0?)

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -17,11 +17,9 @@ PEM/DER support:
   7.39.0: OpenSSL, GnuTLS and GSKit
   7.43.0: NSS and wolfSSL/CyaSSL
   7.47.0: mbedtls
-  7.49.0: PolarSSL
 sha256 support:
   7.44.0: OpenSSL, GnuTLS, NSS and wolfSSL/CyaSSL.
   7.47.0: mbedtls
-  7.49.0: PolarSSL
 Other SSL backends not supported.
 
 If this option is used several times, the last one will be used.

--- a/docs/libcurl/libcurl-thread.3
+++ b/docs/libcurl/libcurl-thread.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2015 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2015 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -56,10 +56,6 @@ https://curl.haxx.se/libcurl/c/opensslthreadlock.html
 https://gnutls.org/manual/html_node/Thread-safety.html
 .IP NSS
 thread-safe already without anything required.
-.IP PolarSSL
-Required actions unknown.
-.IP yassl
-Required actions unknown.
 .IP Secure-Transport
 The engine is used by libcurl in a way that is fully thread-safe.
 .IP WinSSL

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -99,13 +99,11 @@ PEM/DER support:
 
   7.39.0-7.48.0,7.58.1+: GSKit
 
-  7.43.0: NSS and wolfSSL/CyaSSL
+  7.43.0: NSS and wolfSSL
 
   7.47.0: mbedtls
 
-  7.49.0: PolarSSL
-
-  7.54.1: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
+  7.54.1: SecureTransport on macOS 10.7+/iOS 10+
 
   7.58.1: SChannel
 
@@ -115,9 +113,7 @@ sha256 support:
 
   7.47.0: mbedtls
 
-  7.49.0: PolarSSL
-
-  7.54.1: SecureTransport/DarwinSSL on macOS 10.7+/iOS 10+
+  7.54.1: SecureTransport on macOS 10.7+/iOS 10+
 
   7.58.1: SChannel Windows XP SP3+
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -55,9 +55,8 @@ if(curl) {
 .SH AVAILABILITY
 Added in 7.52.0
 
-This option is supported by the OpenSSL, GnuTLS, PolarSSL and mbedTLS
-(since 7.56.0) backends. The NSS backend provides the option only for
-backward compatibility.
+This option is supported by the OpenSSL, GnuTLS, and mbedTLS (since 7.56.0)
+backends. The NSS backend provides the option only for backward compatibility.
 .SH RETURN VALUE
 CURLE_OK if supported; or an error such as:
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -94,11 +94,11 @@ footer:
 .SH AVAILABILITY
 PEM/DER support:
 
-  7.52.0: GSKit, GnuTLS, NSS, OpenSSL, PolarSSL, mbedtls, wolfSSL/CyaSSL
+  7.52.0: GSKit, GnuTLS, NSS, OpenSSL, mbedtls, wolfSSL
 
 sha256 support:
 
-  7.52.0: GnuTLS, NSS, OpenSSL, PolarSSL, mbedtls, wolfSSL/CyaSSL
+  7.52.0: GnuTLS, NSS, OpenSSL, mbedtls, wolfSSL
 
 Other SSL backends not supported.
 .SH RETURN VALUE

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -647,7 +647,7 @@ int netware_init(void);
 #define LIBIDN_REQUIRED_VERSION "0.4.1"
 
 #if defined(USE_GNUTLS) || defined(USE_OPENSSL) || defined(USE_NSS) || \
-    defined(USE_POLARSSL) || defined(USE_MBEDTLS) || \
+    defined(USE_MBEDTLS) || \
     defined(USE_CYASSL) || defined(USE_SCHANNEL) || \
     defined(USE_SECTRANSP) || defined(USE_GSKIT) || defined(USE_MESALINK)
 #define USE_SSL    /* SSL support has been enabled */

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -106,8 +106,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
  * 'rndptr' points to.
  *
  * If libcurl is built without TLS support or with a TLS backend that lacks a
- * proper random API (Gskit, PolarSSL or mbedTLS), this function will use
- * "weak" random.
+ * proper random API (Gskit or mbedTLS), this function will use "weak" random.
  *
  * When built *with* TLS support and a backend that offers strong random, it
  * will return error if it cannot provide strong random values.

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,8 +27,7 @@
  * 'rnd' points to.
  *
  * If libcurl is built without TLS support or with a TLS backend that lacks a
- * proper random API (Gskit, PolarSSL or mbedTLS), this function will use
- * "weak" random.
+ * proper random API (Gskit or mbedTLS), this function will use "weak" random.
  *
  * When built *with* TLS support and a backend that offers strong random, it
  * will return error if it cannot provide strong random values.


### PR DESCRIPTION
Also removed mentions from most docs.

Discussed: https://curl.haxx.se/mail/lib-2019-05/0045.html