### PR TITLE
[WIP] ntlm: Separate the winbind implementation from the HTTP protocol

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -59,7 +59,7 @@ LIB_CFILES = file.c timeval.c base64.c hostip.c progress.c formdata.c   \
   pingpong.c rtsp.c curl_threads.c warnless.c hmac.c curl_rtmp.c        \
   openldap.c curl_gethostname.c gopher.c idn_win32.c                    \
   http_proxy.c non-ascii.c asyn-ares.c asyn-thread.c curl_gssapi.c      \
-  http_ntlm.c curl_ntlm_wb.c curl_ntlm_core.c curl_sasl.c rand.c        \
+  http_ntlm.c http_ntlm_wb.c curl_ntlm_core.c curl_sasl.c rand.c        \
   curl_multibyte.c hostcheck.c conncache.c dotdot.c                     \
   x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c      \
   mime.c sha256.c setopt.c curl_path.c curl_ctype.c curl_range.c psl.c  \
@@ -78,7 +78,7 @@ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
   slist.h nonblock.h curl_memrchr.h imap.h pop3.h smtp.h pingpong.h     \
   rtsp.h curl_threads.h warnless.h curl_hmac.h curl_rtmp.h              \
   curl_gethostname.h gopher.h http_proxy.h non-ascii.h asyn.h           \
-  http_ntlm.h curl_gssapi.h curl_ntlm_wb.h curl_ntlm_core.h             \
+  http_ntlm.h curl_gssapi.h http_ntlm_wb.h curl_ntlm_core.h             \
   curl_sasl.h curl_multibyte.h hostcheck.h conncache.h                  \
   curl_setup_once.h multihandle.h setup-vms.h dotdot.h                  \
   x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h           \

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -22,8 +22,8 @@
 
 LIB_VAUTH_CFILES = vauth/vauth.c vauth/cleartext.c vauth/cram.c         \
   vauth/digest.c vauth/digest_sspi.c vauth/krb5_gssapi.c                \
-  vauth/krb5_sspi.c vauth/ntlm.c vauth/ntlm_sspi.c vauth/oauth2.c       \
-  vauth/spnego_gssapi.c vauth/spnego_sspi.c
+  vauth/krb5_sspi.c vauth/ntlm.c vauth/ntlm_sspi.c vauth/ntlm_wb.c      \
+  vauth/oauth2.c vauth/spnego_gssapi.c vauth/spnego_sspi.c
 
 LIB_VAUTH_HFILES = vauth/vauth.h vauth/digest.h vauth/ntlm.h
 

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -25,35 +25,13 @@
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM) && \
     defined(NTLM_WB_ENABLED)
 
-/*
- * NTLM details:
- *
- * https://davenport.sourceforge.io/ntlm.html
- * https://www.innovation.ch/java/ntlm.html
- */
-
 #define DEBUG_ME 0
-
-#ifdef HAVE_SYS_WAIT_H
-#include <sys/wait.h>
-#endif
-#ifdef HAVE_SIGNAL_H
-#include <signal.h>
-#endif
-#ifdef HAVE_PWD_H
-#include <pwd.h>
-#endif
 
 #include "urldata.h"
 #include "sendf.h"
-#include "select.h"
-#include "vauth/ntlm.h"
-#include "curl_ntlm_core.h"
 #include "curl_ntlm_wb.h"
-#include "url.h"
-#include "strerror.h"
-#include "strdup.h"
 #include "strcase.h"
+#include "vauth/vauth.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -65,282 +43,6 @@
 #else
 # define DEBUG_OUT(x) Curl_nop_stmt
 #endif
-
-/* Portable 'sclose_nolog' used only in child process instead of 'sclose'
-   to avoid fooling the socket leak detector */
-#if defined(HAVE_CLOSESOCKET)
-#  define sclose_nolog(x)  closesocket((x))
-#elif defined(HAVE_CLOSESOCKET_CAMEL)
-#  define sclose_nolog(x)  CloseSocket((x))
-#else
-#  define sclose_nolog(x)  close((x))
-#endif
-
-static void ntlm_wb_cleanup(struct ntlmdata *ntlm)
-{
-  if(ntlm->ntlm_auth_hlpr_socket != CURL_SOCKET_BAD) {
-    sclose(ntlm->ntlm_auth_hlpr_socket);
-    ntlm->ntlm_auth_hlpr_socket = CURL_SOCKET_BAD;
-  }
-
-  if(ntlm->ntlm_auth_hlpr_pid) {
-    int i;
-    for(i = 0; i < 4; i++) {
-      pid_t ret = waitpid(ntlm->ntlm_auth_hlpr_pid, NULL, WNOHANG);
-      if(ret == ntlm->ntlm_auth_hlpr_pid || errno == ECHILD)
-        break;
-      switch(i) {
-      case 0:
-        kill(ntlm->ntlm_auth_hlpr_pid, SIGTERM);
-        break;
-      case 1:
-        /* Give the process another moment to shut down cleanly before
-           bringing down the axe */
-        Curl_wait_ms(1);
-        break;
-      case 2:
-        kill(ntlm->ntlm_auth_hlpr_pid, SIGKILL);
-        break;
-      case 3:
-        break;
-      }
-    }
-    ntlm->ntlm_auth_hlpr_pid = 0;
-  }
-
-  Curl_safefree(ntlm->challenge);
-  Curl_safefree(ntlm->response);
-}
-
-static CURLcode ntlm_wb_init(struct Curl_easy *data, struct ntlmdata *ntlm,
-                             const char *userp)
-{
-  curl_socket_t sockfds[2];
-  pid_t child_pid;
-  const char *username;
-  char *slash, *domain = NULL;
-  const char *ntlm_auth = NULL;
-  char *ntlm_auth_alloc = NULL;
-#if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
-  struct passwd pw, *pw_res;
-  char pwbuf[1024];
-#endif
-  char buffer[STRERROR_LEN];
-
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
-  (void) data;
-#endif
-
-  /* Return if communication with ntlm_auth already set up */
-  if(ntlm->ntlm_auth_hlpr_socket != CURL_SOCKET_BAD ||
-     ntlm->ntlm_auth_hlpr_pid)
-    return CURLE_OK;
-
-  username = userp;
-  /* The real ntlm_auth really doesn't like being invoked with an
-     empty username. It won't make inferences for itself, and expects
-     the client to do so (mostly because it's really designed for
-     servers like squid to use for auth, and client support is an
-     afterthought for it). So try hard to provide a suitable username
-     if we don't already have one. But if we can't, provide the
-     empty one anyway. Perhaps they have an implementation of the
-     ntlm_auth helper which *doesn't* need it so we might as well try */
-  if(!username || !username[0]) {
-    username = getenv("NTLMUSER");
-    if(!username || !username[0])
-      username = getenv("LOGNAME");
-    if(!username || !username[0])
-      username = getenv("USER");
-#if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
-    if((!username || !username[0]) &&
-       !getpwuid_r(geteuid(), &pw, pwbuf, sizeof(pwbuf), &pw_res) &&
-       pw_res) {
-      username = pw.pw_name;
-    }
-#endif
-    if(!username || !username[0])
-      username = userp;
-  }
-  slash = strpbrk(username, "\\/");
-  if(slash) {
-    domain = strdup(username);
-    if(!domain)
-      return CURLE_OUT_OF_MEMORY;
-    slash = domain + (slash - username);
-    *slash = '\0';
-    username = username + (slash - domain) + 1;
-  }
-
-  /* For testing purposes, when DEBUGBUILD is defined and environment
-     variable CURL_NTLM_WB_FILE is set a fake_ntlm is used to perform
-     NTLM challenge/response which only accepts commands and output
-     strings pre-written in test case definitions */
-#ifdef DEBUGBUILD
-  ntlm_auth_alloc = curl_getenv("CURL_NTLM_WB_FILE");
-  if(ntlm_auth_alloc)
-    ntlm_auth = ntlm_auth_alloc;
-  else
-#endif
-    ntlm_auth = NTLM_WB_FILE;
-
-  if(access(ntlm_auth, X_OK) != 0) {
-    failf(data, "Could not access ntlm_auth: %s errno %d: %s",
-          ntlm_auth, errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-    goto done;
-  }
-
-  if(Curl_socketpair(AF_UNIX, SOCK_STREAM, 0, sockfds)) {
-    failf(data, "Could not open socket pair. errno %d: %s",
-          errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-    goto done;
-  }
-
-  child_pid = fork();
-  if(child_pid == -1) {
-    sclose(sockfds[0]);
-    sclose(sockfds[1]);
-    failf(data, "Could not fork. errno %d: %s",
-          errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-    goto done;
-  }
-  else if(!child_pid) {
-    /*
-     * child process
-     */
-
-    /* Don't use sclose in the child since it fools the socket leak detector */
-    sclose_nolog(sockfds[0]);
-    if(dup2(sockfds[1], STDIN_FILENO) == -1) {
-      failf(data, "Could not redirect child stdin. errno %d: %s",
-            errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-      exit(1);
-    }
-
-    if(dup2(sockfds[1], STDOUT_FILENO) == -1) {
-      failf(data, "Could not redirect child stdout. errno %d: %s",
-            errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-      exit(1);
-    }
-
-    if(domain)
-      execl(ntlm_auth, ntlm_auth,
-            "--helper-protocol", "ntlmssp-client-1",
-            "--use-cached-creds",
-            "--username", username,
-            "--domain", domain,
-            NULL);
-    else
-      execl(ntlm_auth, ntlm_auth,
-            "--helper-protocol", "ntlmssp-client-1",
-            "--use-cached-creds",
-            "--username", username,
-            NULL);
-
-    sclose_nolog(sockfds[1]);
-    failf(data, "Could not execl(). errno %d: %s",
-          errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-    exit(1);
-  }
-
-  sclose(sockfds[1]);
-  ntlm->ntlm_auth_hlpr_socket = sockfds[0];
-  ntlm->ntlm_auth_hlpr_pid = child_pid;
-  free(domain);
-  free(ntlm_auth_alloc);
-  return CURLE_OK;
-
-done:
-  free(domain);
-  free(ntlm_auth_alloc);
-  return CURLE_REMOTE_ACCESS_DENIED;
-}
-
-/* if larger than this, something is seriously wrong */
-#define MAX_NTLM_WB_RESPONSE 100000
-
-static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
-                                 const char *input, curlntlm state)
-{
-  char *buf = malloc(NTLM_BUFSIZE);
-  size_t len_in = strlen(input), len_out = 0;
-
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
-  (void) data;
-#endif
-
-  if(!buf)
-    return CURLE_OUT_OF_MEMORY;
-
-  while(len_in > 0) {
-    ssize_t written = swrite(ntlm->ntlm_auth_hlpr_socket, input, len_in);
-    if(written == -1) {
-      /* Interrupted by a signal, retry it */
-      if(errno == EINTR)
-        continue;
-      /* write failed if other errors happen */
-      goto done;
-    }
-    input += written;
-    len_in -= written;
-  }
-  /* Read one line */
-  while(1) {
-    ssize_t size;
-    char *newbuf;
-
-    size = sread(ntlm->ntlm_auth_hlpr_socket, buf + len_out, NTLM_BUFSIZE);
-    if(size == -1) {
-      if(errno == EINTR)
-        continue;
-      goto done;
-    }
-    else if(size == 0)
-      goto done;
-
-    len_out += size;
-    if(buf[len_out - 1] == '\n') {
-      buf[len_out - 1] = '\0';
-      break;
-    }
-
-    if(len_out > MAX_NTLM_WB_RESPONSE) {
-      failf(data, "too large ntlm_wb response!");
-      free(buf);
-      return CURLE_OUT_OF_MEMORY;
-    }
-
-    newbuf = Curl_saferealloc(buf, len_out + NTLM_BUFSIZE);
-    if(!newbuf)
-      return CURLE_OUT_OF_MEMORY;
-
-    buf = newbuf;
-  }
-
-  /* Samba/winbind installed but not configured */
-  if(state == NTLMSTATE_TYPE1 &&
-     len_out == 3 &&
-     buf[0] == 'P' && buf[1] == 'W')
-    goto done;
-  /* invalid response */
-  if(len_out < 4)
-    goto done;
-  if(state == NTLMSTATE_TYPE1 &&
-     (buf[0]!='Y' || buf[1]!='R' || buf[2]!=' '))
-    goto done;
-  if(state == NTLMSTATE_TYPE2 &&
-     (buf[0]!='K' || buf[1]!='K' || buf[2]!=' ') &&
-     (buf[0]!='A' || buf[1]!='F' || buf[2]!=' '))
-    goto done;
-
-  ntlm->response = aprintf("%.*s", len_out - 4, buf + 3);
-  free(buf);
-  if(!ntlm->response)
-    return CURLE_OUT_OF_MEMORY;
-  return CURLE_OK;
-done:
-  free(buf);
-  return CURLE_REMOTE_ACCESS_DENIED;
-}
 
 CURLcode Curl_input_ntlm_wb(struct connectdata *conn,
                             bool proxy,
@@ -395,7 +97,7 @@ CURLcode Curl_output_ntlm_wb(struct connectdata *conn,
   /* point to the address of the pointer that holds the string to send to the
      server, which is for a plain host or for a HTTP proxy */
   char **allocuserpwd;
-  /* point to the name and password for this */
+  /* point to the name and password */
   const char *userp;
   struct ntlmdata *ntlm;
   curlntlm *state;
@@ -496,8 +198,8 @@ CURLcode Curl_output_ntlm_wb(struct connectdata *conn,
 
 void Curl_http_auth_cleanup_ntlm_wb(struct connectdata *conn)
 {
-  ntlm_wb_cleanup(&conn->ntlm);
-  ntlm_wb_cleanup(&conn->proxyntlm);
+  Curl_auth_cleanup_ntlm_wb(&conn->ntlm);
+  Curl_auth_cleanup_ntlm_wb(&conn->proxyntlm);
 }
 
 #endif /* !CURL_DISABLE_HTTP && USE_NTLM && NTLM_WB_ENABLED */

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -59,9 +59,9 @@ CURLcode Curl_input_ntlm_wb(struct connectdata *conn,
     header++;
 
   if(*header) {
-    ntlm->challenge = strdup(header);
-    if(!ntlm->challenge)
-      return CURLE_OUT_OF_MEMORY;
+    CURLcode result = Curl_auth_decode_ntlm_wb_type2_message(header, ntlm);
+    if(result)
+      return result;
 
     *state = NTLMSTATE_TYPE2; /* We got a type-2 message */
   }

--- a/lib/http.c
+++ b/lib/http.c
@@ -58,7 +58,7 @@
 #include "vtls/vtls.h"
 #include "http_digest.h"
 #include "http_ntlm.h"
-#include "curl_ntlm_wb.h"
+#include "http_ntlm_wb.h"
 #include "http_negotiate.h"
 #include "url.h"
 #include "share.h"

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -37,8 +37,6 @@
 #include "sendf.h"
 #include "strcase.h"
 #include "http_ntlm.h"
-#include "curl_ntlm_core.h"
-#include "curl_ntlm_wb.h"
 #include "vauth/vauth.h"
 #include "url.h"
 
@@ -243,10 +241,6 @@ void Curl_http_auth_cleanup_ntlm(struct connectdata *conn)
 {
   Curl_auth_cleanup_ntlm(&conn->ntlm);
   Curl_auth_cleanup_ntlm(&conn->proxyntlm);
-
-#if defined(NTLM_WB_ENABLED)
-  Curl_http_auth_cleanup_ntlm_wb(conn);
-#endif
 }
 
 #endif /* !CURL_DISABLE_HTTP && USE_NTLM */

--- a/lib/http_ntlm_wb.c
+++ b/lib/http_ntlm_wb.c
@@ -28,8 +28,8 @@
 #define DEBUG_ME 0
 
 #include "urldata.h"
+#include "http_ntlm_wb.h"
 #include "sendf.h"
-#include "curl_ntlm_wb.h"
 #include "strcase.h"
 #include "vauth/vauth.h"
 

--- a/lib/http_ntlm_wb.h
+++ b/lib/http_ntlm_wb.h
@@ -1,5 +1,5 @@
-#ifndef HEADER_CURL_NTLM_WB_H
-#define HEADER_CURL_NTLM_WB_H
+#ifndef HEADER_CURL_HTTP_NTLM_WB_H
+#define HEADER_CURL_HTTP_NTLM_WB_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -38,4 +38,4 @@ void Curl_http_auth_cleanup_ntlm_wb(struct connectdata *conn);
 
 #endif /* !CURL_DISABLE_HTTP && USE_NTLM && NTLM_WB_ENABLED */
 
-#endif /* HEADER_CURL_NTLM_WB_H */
+#endif /* HEADER_CURL_HTTP_NTLM_WB_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -373,7 +373,6 @@ struct ntlmdata {
   curl_socket_t ntlm_auth_hlpr_socket;
   pid_t ntlm_auth_hlpr_pid;
   char *challenge; /* The received base64 encoded ntlm type-2 message */
-  char *response;  /* The generated base64 ntlm type-1/type-3 message */
 #endif
 #endif
 };

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -867,6 +867,10 @@ void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm)
 
   /* Reset any variables */
   ntlm->target_info_len = 0;
+
+#if defined(NTLM_WB_ENABLED)
+  Curl_auth_cleanup_ntlm_wb(ntlm);
+#endif
 }
 
 #endif /* USE_NTLM && !USE_WINDOWS_SSPI */

--- a/lib/vauth/ntlm_wb.c
+++ b/lib/vauth/ntlm_wb.c
@@ -1,0 +1,351 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#if defined(USE_NTLM) && defined(NTLM_WB_ENABLED)
+
+/* Use Samba's 'winbind' daemon to support NTLM authentication,
+ * by delegating the NTLM challenge/response protocol to a helper
+ * in ntlm_auth.
+ * http://devel.squid-cache.org/ntlm/squid_helper_protocol.html
+ * https://www.samba.org/samba/docs/man/manpages-3/winbindd.8.html
+ * https://www.samba.org/samba/docs/man/manpages-3/ntlm_auth.1.html
+ * Preprocessor symbol 'NTLM_WB_ENABLED' is defined when this
+ * feature is enabled and 'NTLM_WB_FILE' symbol holds absolute
+ * filename of ntlm_auth helper.
+ * If NTLM authentication using winbind fails, go back to original
+ * request handling process.
+ */
+
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
+#ifdef HAVE_PWD_H
+#include <pwd.h>
+#endif
+
+#include "urldata.h"
+#include "sendf.h"
+#include "select.h"
+#include "strerror.h"
+#include "strdup.h"
+#include "vauth/vauth.h"
+#include "vauth/ntlm.h"
+
+/* The last #include files should be: */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
+
+/* If the response is larger than this then something is seriously wrong */
+#define MAX_NTLM_WB_RESPONSE 100000
+
+/* Portable 'sclose_nolog' used only in child process instead of 'sclose'
+   to avoid fooling the socket leak detector */
+#if defined(HAVE_CLOSESOCKET)
+#define sclose_nolog(x)  closesocket((x))
+#elif defined(HAVE_CLOSESOCKET_CAMEL)
+#define sclose_nolog(x)  CloseSocket((x))
+#else
+#define sclose_nolog(x)  close((x))
+#endif
+
+CURLcode ntlm_wb_init(struct Curl_easy *data, struct ntlmdata *ntlm,
+                      const char *userp)
+{
+  curl_socket_t sockfds[2];
+  pid_t child_pid;
+  const char *username;
+  char *slash, *domain = NULL;
+  const char *ntlm_auth = NULL;
+  char *ntlm_auth_alloc = NULL;
+#if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
+  struct passwd pw, *pw_res;
+  char pwbuf[1024];
+#endif
+  char buffer[STRERROR_LEN];
+
+#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+  (void) data;
+#endif
+
+  /* Return if communication with ntlm_auth already set up */
+  if(ntlm->ntlm_auth_hlpr_socket != CURL_SOCKET_BAD ||
+    ntlm->ntlm_auth_hlpr_pid)
+    return CURLE_OK;
+
+  username = userp;
+  /* The real ntlm_auth really doesn't like being invoked with an
+     empty username. It won't make inferences for itself, and expects
+     the client to do so (mostly because it's really designed for
+     servers like squid to use for auth, and client support is an
+     afterthought for it). So try hard to provide a suitable username
+     if we don't already have one. But if we can't, provide the
+     empty one anyway. Perhaps they have an implementation of the
+     ntlm_auth helper which *doesn't* need it so we might as well try */
+  if(!username || !username[0]) {
+    username = getenv("NTLMUSER");
+    if(!username || !username[0])
+      username = getenv("LOGNAME");
+    if(!username || !username[0])
+      username = getenv("USER");
+#if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
+    if((!username || !username[0]) &&
+      !getpwuid_r(geteuid(), &pw, pwbuf, sizeof(pwbuf), &pw_res) &&
+      pw_res) {
+      username = pw.pw_name;
+    }
+#endif
+    if(!username || !username[0])
+      username = userp;
+  }
+  slash = strpbrk(username, "\\/");
+  if(slash) {
+    domain = strdup(username);
+    if(!domain)
+      return CURLE_OUT_OF_MEMORY;
+    slash = domain + (slash - username);
+    *slash = '\0';
+    username = username + (slash - domain) + 1;
+  }
+
+  /* For testing purposes, when DEBUGBUILD is defined and environment
+     variable CURL_NTLM_WB_FILE is set a fake_ntlm is used to perform
+     NTLM challenge/response which only accepts commands and output
+     strings pre-written in test case definitions */
+#ifdef DEBUGBUILD
+  ntlm_auth_alloc = curl_getenv("CURL_NTLM_WB_FILE");
+  if(ntlm_auth_alloc)
+    ntlm_auth = ntlm_auth_alloc;
+  else
+#endif
+    ntlm_auth = NTLM_WB_FILE;
+
+  if(access(ntlm_auth, X_OK) != 0) {
+    failf(data, "Could not access ntlm_auth: %s errno %d: %s",
+      ntlm_auth, errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+    goto done;
+  }
+
+  if(Curl_socketpair(AF_UNIX, SOCK_STREAM, 0, sockfds)) {
+    failf(data, "Could not open socket pair. errno %d: %s",
+      errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+    goto done;
+  }
+
+  child_pid = fork();
+  if(child_pid == -1) {
+    sclose(sockfds[0]);
+    sclose(sockfds[1]);
+    failf(data, "Could not fork. errno %d: %s",
+      errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+    goto done;
+  }
+  else if(!child_pid) {
+    /*
+     * child process
+     */
+
+    /* Don't use sclose in the child since it fools the socket leak detector */
+    sclose_nolog(sockfds[0]);
+    if(dup2(sockfds[1], STDIN_FILENO) == -1) {
+      failf(data, "Could not redirect child stdin. errno %d: %s",
+        errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+      exit(1);
+    }
+
+    if(dup2(sockfds[1], STDOUT_FILENO) == -1) {
+      failf(data, "Could not redirect child stdout. errno %d: %s",
+        errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+      exit(1);
+    }
+
+    if(domain)
+      execl(ntlm_auth, ntlm_auth,
+        "--helper-protocol", "ntlmssp-client-1",
+        "--use-cached-creds",
+        "--username", username,
+        "--domain", domain,
+        NULL);
+    else
+      execl(ntlm_auth, ntlm_auth,
+        "--helper-protocol", "ntlmssp-client-1",
+        "--use-cached-creds",
+        "--username", username,
+        NULL);
+
+    sclose_nolog(sockfds[1]);
+    failf(data, "Could not execl(). errno %d: %s",
+      errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+    exit(1);
+  }
+
+  sclose(sockfds[1]);
+  ntlm->ntlm_auth_hlpr_socket = sockfds[0];
+  ntlm->ntlm_auth_hlpr_pid = child_pid;
+  free(domain);
+  free(ntlm_auth_alloc);
+  return CURLE_OK;
+
+done:
+  free(domain);
+  free(ntlm_auth_alloc);
+  return CURLE_REMOTE_ACCESS_DENIED;
+}
+
+CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
+                          const char *input, curlntlm state)
+{
+  char *buf = malloc(NTLM_BUFSIZE);
+  size_t len_in = strlen(input), len_out = 0;
+
+#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+  (void) data;
+#endif
+
+  if(!buf)
+    return CURLE_OUT_OF_MEMORY;
+
+  while(len_in > 0) {
+    ssize_t written = swrite(ntlm->ntlm_auth_hlpr_socket, input, len_in);
+    if(written == -1) {
+      /* Interrupted by a signal, retry it */
+      if(errno == EINTR)
+        continue;
+      /* write failed if other errors happen */
+      goto done;
+    }
+    input += written;
+    len_in -= written;
+  }
+
+  /* Read one line */
+  while(1) {
+    ssize_t size;
+    char *newbuf;
+
+    size = sread(ntlm->ntlm_auth_hlpr_socket, buf + len_out, NTLM_BUFSIZE);
+    if(size == -1) {
+      if(errno == EINTR)
+        continue;
+      goto done;
+    }
+    else if(size == 0)
+      goto done;
+
+    len_out += size;
+    if(buf[len_out - 1] == '\n') {
+      buf[len_out - 1] = '\0';
+      break;
+    }
+
+    if(len_out > MAX_NTLM_WB_RESPONSE) {
+      failf(data, "too large ntlm_wb response!");
+      free(buf);
+      return CURLE_OUT_OF_MEMORY;
+    }
+
+    newbuf = Curl_saferealloc(buf, len_out + NTLM_BUFSIZE);
+    if(!newbuf)
+      return CURLE_OUT_OF_MEMORY;
+
+    buf = newbuf;
+  }
+
+  /* Samba/winbind installed but not configured */
+  if(state == NTLMSTATE_TYPE1 &&
+     len_out == 3 &&
+     buf[0] == 'P' && buf[1] == 'W')
+    goto done;
+  /* invalid response */
+  if(len_out < 4)
+    goto done;
+  if(state == NTLMSTATE_TYPE1 &&
+     (buf[0] != 'Y' || buf[1] != 'R' || buf[2] != ' '))
+    goto done;
+  if(state == NTLMSTATE_TYPE2 &&
+     (buf[0] != 'K' || buf[1] != 'K' || buf[2] != ' ') &&
+     (buf[0] != 'A' || buf[1] != 'F' || buf[2] != ' '))
+    goto done;
+
+  ntlm->response = aprintf("%.*s", len_out - 4, buf + 3);
+  free(buf);
+  if(!ntlm->response)
+    return CURLE_OUT_OF_MEMORY;
+  return CURLE_OK;
+
+done:
+  free(buf);
+  return CURLE_REMOTE_ACCESS_DENIED;
+}
+
+/*
+ * Curl_auth_cleanup_ntlm_wb()
+ *
+ * This is used to clean up the NTLM specific data.
+ *
+ * Parameters:
+ *
+ * ntlm    [in/out] - The NTLM data struct being cleaned up.
+ *
+ */
+void Curl_auth_cleanup_ntlm_wb(struct ntlmdata *ntlm)
+{
+  if(ntlm->ntlm_auth_hlpr_socket != CURL_SOCKET_BAD) {
+    sclose(ntlm->ntlm_auth_hlpr_socket);
+    ntlm->ntlm_auth_hlpr_socket = CURL_SOCKET_BAD;
+  }
+
+  if(ntlm->ntlm_auth_hlpr_pid) {
+    int i;
+    for(i = 0; i < 4; i++) {
+      pid_t ret = waitpid(ntlm->ntlm_auth_hlpr_pid, NULL, WNOHANG);
+      if(ret == ntlm->ntlm_auth_hlpr_pid || errno == ECHILD)
+        break;
+      switch(i) {
+      case 0:
+        kill(ntlm->ntlm_auth_hlpr_pid, SIGTERM);
+        break;
+      case 1:
+        /* Give the process another moment to shut down cleanly before
+           bringing down the axe */
+        Curl_wait_ms(1);
+        break;
+      case 2:
+        kill(ntlm->ntlm_auth_hlpr_pid, SIGKILL);
+        break;
+      case 3:
+        break;
+      }
+    }
+    ntlm->ntlm_auth_hlpr_pid = 0;
+  }
+
+  Curl_safefree(ntlm->challenge);
+  Curl_safefree(ntlm->response);
+}
+
+#endif /* USE_NTLM && NTLM_WB_ENABLED */

--- a/lib/vauth/ntlm_wb.c
+++ b/lib/vauth/ntlm_wb.c
@@ -351,6 +351,34 @@ CURLcode Curl_auth_create_ntlm_wb_type1_message(struct Curl_easy *data,
 }
 
 /*
+ * Curl_auth_decode_ntlm_wb_type2_message()
+ *
+ * This is used to decode an already encoded NTLM type-2 message. The message
+ * is first decoded from a base64 string into a raw NTLM message and checked
+ * for validity before the appropriate data for creating a type-3 message is
+ * written to the given NTLM data structure.
+ *
+ * Parameters:
+ *
+ * type2msg [in]     - The base64 encoded type-2 message.
+ * ntlm     [in/out] - The NTLM data struct being used and modified.
+ *
+ * Returns CURLE_OK on success.
+ */
+CURLcode Curl_auth_decode_ntlm_wb_type2_message(const char *type2msg,
+                                                struct ntlmdata *ntlm)
+{
+  CURLcode result = CURLE_OK;
+
+  /* Extract the challage and store for when we generate the type-3 message */
+  ntlm->challenge = strdup(type2msg);
+  if(!ntlm->challenge)
+    result = CURLE_OUT_OF_MEMORY;
+
+  return result;
+}
+
+/*
  * Curl_auth_cleanup_ntlm_wb()
  *
  * This is used to clean up the NTLM specific data.

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -123,7 +123,8 @@ void Curl_auth_digest_cleanup(struct digestdata *digest);
 CURLcode ntlm_wb_init(struct Curl_easy *data, struct ntlmdata *ntlm,
                       const char *userp);
 CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
-                          const char *input, curlntlm state);
+                          const char *input, char **outptr, size_t *outlen,
+                          curlntlm state);
 #endif
 
 /* This is used to evaluate if NTLM is supported */
@@ -138,6 +139,14 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                              struct ntlmdata *ntlm,
                                              char **outptr,
                                              size_t *outlen);
+
+#if defined(NTLM_WB_ENABLED)
+CURLcode Curl_auth_create_ntlm_wb_type1_message(struct Curl_easy *data,
+                                                const char *userp,
+                                                struct ntlmdata *ntlm,
+                                                char **outptr,
+                                                size_t *outlen);
+#endif
 
 /* This is used to decode a base64 encoded NTLM type-2 message */
 CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -152,6 +152,10 @@ CURLcode Curl_auth_create_ntlm_wb_type1_message(struct Curl_easy *data,
 CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
                                              const char *type2msg,
                                              struct ntlmdata *ntlm);
+#if defined(NTLM_WB_ENABLED)
+CURLcode Curl_auth_decode_ntlm_wb_type2_message(const char *type2msg,
+                                                struct ntlmdata *ntlm);
+#endif
 
 /* This is used to generate a base64 encoded NTLM type-3 message */
 CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include <curl/curl.h>
-#include "urldata.h"
 
 struct Curl_easy;
 
@@ -118,15 +117,6 @@ void Curl_auth_digest_cleanup(struct digestdata *digest);
 
 #if defined(USE_NTLM)
 
-#if defined(NTLM_WB_ENABLED)
-/* Don't give these functions public names as this is only temporary */
-CURLcode ntlm_wb_init(struct Curl_easy *data, struct ntlmdata *ntlm,
-                      const char *userp);
-CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
-                          const char *input, char **outptr, size_t *outlen,
-                          curlntlm state);
-#endif
-
 /* This is used to evaluate if NTLM is supported */
 bool Curl_auth_is_ntlm_supported(void);
 
@@ -163,6 +153,11 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *passwdp,
                                              struct ntlmdata *ntlm,
                                              char **outptr, size_t *outlen);
+#if defined(NTLM_WB_ENABLED)
+CURLcode Curl_auth_create_ntlm_wb_type3_message(struct Curl_easy *data,
+                                                struct ntlmdata *ntlm,
+                                                char **outptr, size_t *outlen);
+#endif
 
 /* This is used to clean up the NTLM specific data */
 void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2014 - 2019, Steve Holme, <steve_holme@hotmail.com>.
+ * Copyright (C) 2014 - 2020, Steve Holme, <steve_holme@hotmail.com>.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <curl/curl.h>
+#include "urldata.h"
 
 struct Curl_easy;
 
@@ -116,6 +117,15 @@ void Curl_auth_digest_cleanup(struct digestdata *digest);
 #endif /* !CURL_DISABLE_CRYPTO_AUTH */
 
 #if defined(USE_NTLM)
+
+#if defined(NTLM_WB_ENABLED)
+/* Don't give these functions public names as this is only temporary */
+CURLcode ntlm_wb_init(struct Curl_easy *data, struct ntlmdata *ntlm,
+                      const char *userp);
+CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
+                          const char *input, curlntlm state);
+#endif
+
 /* This is used to evaluate if NTLM is supported */
 bool Curl_auth_is_ntlm_supported(void);
 
@@ -143,6 +153,9 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
 /* This is used to clean up the NTLM specific data */
 void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm);
+#if defined(NTLM_WB_ENABLED)
+void Curl_auth_cleanup_ntlm_wb(struct ntlmdata *ntlm);
+#endif
 #endif /* USE_NTLM */
 
 /* This is used to generate a base64 encoded OAuth 2.0 message */


### PR DESCRIPTION
This is the start of adding support for NTLM using the winbind ntlm_auth helper to the SASL based protocols.

The steps to achieving this are:

1. Separate the winbind implementation from the HTTP protocol (This patch set)
2. Rework the HTTP implementation to see if we really need separate native and winbind input and output functions as the code is virtually identical now.
2. Add SASL functions for supporting winbind (and new test cases for IMAP, POP3 and SMTP).