### PR TITLE
http_ntlm_wb: Fix the error handling to align with that of native/SSPI NTLM

### DIFF
--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -356,7 +356,13 @@ CURLcode Curl_input_ntlm_wb(struct connectdata *conn,
     *state = NTLMSTATE_TYPE2; /* We got a type-2 message */
   }
   else {
-    if(*state >= NTLMSTATE_TYPE1) {
+    if(*state == NTLMSTATE_TYPE3) {
+      infof(conn->data, "NTLM handshake rejected\n");
+      Curl_http_auth_cleanup_ntlm_wb(conn);
+      *state = NTLMSTATE_NONE;
+      return CURLE_REMOTE_ACCESS_DENIED;
+    }
+    else if(*state >= NTLMSTATE_TYPE1) {
       infof(conn->data, "NTLM handshake failure (internal error)\n");
       return CURLE_REMOTE_ACCESS_DENIED;
     }


### PR DESCRIPTION
The current code doesn't clean up properly on failed authentication attempts nor does it handle a 401 error properly.

These fixes were implemented in the native/SSPI NTLM code in b4d6db83, 50b87c4e and fe6049f0 but not im the winbind code. As such this patch brings the code up to date.