### PR TITLE
tests: add support to test cross-compiled via Windows Subsystem for Linux (WIP)

### DIFF
--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -68,6 +68,10 @@ use serverhelp qw(
     datasockf_logfilename
     );
 
+use sshhelp qw(
+    exe_ext
+    );
+
 #**********************************************************************
 # global vars...
 #
@@ -411,7 +415,7 @@ sub sysread_or_die {
 }
 
 sub startsf {
-    my $mainsockfcmd = "./server/sockfilt " .
+    my $mainsockfcmd = "./server/sockfilt".exe_ext('SRV')." " .
         "--ipv$ipvnum --port $port " .
         "--pidfile \"$mainsockf_pidfile\" " .
         "--logfile \"$mainsockf_logfile\"";
@@ -2401,7 +2405,7 @@ sub PASV_ftp {
     logmsg "DATA sockfilt for passive data channel starting...\n";
 
     # We fire up a new sockfilt to do the data transfer for us.
-    my $datasockfcmd = "./server/sockfilt " .
+    my $datasockfcmd = "./server/sockfilt".exe_ext('SRV')." " .
         "--ipv$ipvnum $bindonly --port 0 " .
         "--pidfile \"$datasockf_pidfile\" " .
         "--logfile \"$datasockf_logfile\"";
@@ -2620,7 +2624,7 @@ sub PORT_ftp {
     logmsg "DATA sockfilt for active data channel starting...\n";
 
     # We fire up a new sockfilt to do the data transfer for us.
-    my $datasockfcmd = "./server/sockfilt " .
+    my $datasockfcmd = "./server/sockfilt".exe_ext('SRV')." " .
         "--ipv$ipvnum --connect $port --addr \"$addr\" " .
         "--pidfile \"$datasockf_pidfile\" " .
         "--logfile \"$datasockf_logfile\"";

--- a/tests/httpserver.pl
+++ b/tests/httpserver.pl
@@ -34,6 +34,10 @@ use serverhelp qw(
     server_logfilename
     );
 
+use sshhelp qw(
+    exe_ext
+    );
+
 my $verbose = 0;     # set to 1 for debugging
 my $port = 8990;     # just a default
 my $unix_socket;     # location to place a listening Unix socket
@@ -133,7 +137,7 @@ if($ipvnum eq 'unix') {
 $flags .= "--srcdir \"$srcdir\"";
 
 if($verbose) {
-    print STDERR "RUN: server/sws $flags\n";
+    print STDERR "RUN: server/sws".exe_ext('SRV')." $flags\n";
 }
 
-exec("server/sws $flags");
+exec("server/sws".exe_ext('SRV')." $flags");

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -206,6 +206,9 @@ my $valgrind_tool;
 my $gdb = checktestcmd("gdb");
 my $httptlssrv = find_httptlssrv();
 
+my $uname_release = `uname -r`;
+my $is_wsl = $uname_release =~ /Microsoft$/;
+
 my $has_ssl;        # set if libcurl is built with SSL support
 my $has_largefile;  # set if libcurl is built with large file support
 my $has_idn;        # set if libcurl is built with IDN support
@@ -324,7 +327,12 @@ my $tortalloc;
 #
 sub logmsg {
     for(@_) {
-        print "$_";
+        my $line = $_;
+        if ($is_wsl) {
+            # use \r\n for WSL shell
+            $line =~ s/\r?\n$/\r\n/g;
+        }
+        print "$line";
     }
 }
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -150,7 +150,7 @@ my $SMBSPORT;            # SMBS server port
 my $NEGTELNETPORT;       # TELNET server port with negotiation
 
 my $srcdir = $ENV{'srcdir'} || '.';
-my $CURL="../src/curl".exe_ext(); # what curl executable to run on the tests
+my $CURL="../src/curl".exe_ext('TOOL'); # what curl executable to run on the tests
 my $VCURL=$CURL;   # what curl binary to use to verify the servers with
                    # VCURL is handy to set to the system one when the one you
                    # just built hangs or crashes and thus prevent verification
@@ -2915,7 +2915,8 @@ sub checksystem {
         # client has IPv6 support
 
         # check if the HTTP server has it!
-        my @sws = `server/sws --version`;
+        my $cmd = "server/sws".exe_ext('SRV')." --version";
+        my @sws = `$cmd`;
         if($sws[0] =~ /IPv6/) {
             # HTTP server has IPv6 support!
             $http_ipv6 = 1;
@@ -2923,7 +2924,8 @@ sub checksystem {
         }
 
         # check if the FTP server has it!
-        @sws = `server/sockfilt --version`;
+        $cmd = "server/sockfilt".exe_ext('SRV')." --version";
+        @sws = `$cmd`;
         if($sws[0] =~ /IPv6/) {
             # FTP server has IPv6 support!
             $ftp_ipv6 = 1;
@@ -2932,7 +2934,8 @@ sub checksystem {
 
     if($has_unix) {
         # client has Unix sockets support, check whether the HTTP server has it
-        my @sws = `server/sws --version`;
+        my $cmd = "server/sws".exe_ext('SRV')." --version";
+        my @sws = `$cmd`;
         $http_unix = 1 if($sws[0] =~ /unix/);
     }
 
@@ -3342,7 +3345,7 @@ sub singletest {
                 }
                 else {
                     if($var =~ /^LD_PRELOAD/) {
-                        if(exe_ext() && (exe_ext() eq '.exe')) {
+                        if(exe_ext('TOOL') && (exe_ext('TOOL') eq '.exe')) {
                             # print "Skipping LD_PRELOAD due to lack of OS support\n";
                             next;
                         }
@@ -3489,6 +3492,7 @@ sub singletest {
     if(@codepieces) {
         $tool = $codepieces[0];
         chomp $tool;
+        $tool .= exe_ext('TOOL');
     }
 
     # remove server output logfile

--- a/tests/sshhelp.pm
+++ b/tests/sshhelp.pm
@@ -106,12 +106,12 @@ use vars qw(
 #***************************************************************************
 # Global variables initialization
 #
-$sshdexe         = 'sshd'        .exe_ext(); # base name and ext of ssh daemon
-$sshexe          = 'ssh'         .exe_ext(); # base name and ext of ssh client
-$sftpsrvexe      = 'sftp-server' .exe_ext(); # base name and ext of sftp-server
-$sftpexe         = 'sftp'        .exe_ext(); # base name and ext of sftp client
-$sshkeygenexe    = 'ssh-keygen'  .exe_ext(); # base name and ext of ssh-keygen
-$httptlssrvexe   = 'gnutls-serv' .exe_ext(); # base name and ext of gnutls-serv
+$sshdexe         = 'sshd'        .exe_ext('SSH'); # base name and ext of ssh daemon
+$sshexe          = 'ssh'         .exe_ext('SSH'); # base name and ext of ssh client
+$sftpsrvexe      = 'sftp-server' .exe_ext('SSH'); # base name and ext of sftp-server
+$sftpexe         = 'sftp'        .exe_ext('SSH'); # base name and ext of sftp client
+$sshkeygenexe    = 'ssh-keygen'  .exe_ext('SSH'); # base name and ext of ssh-keygen
+$httptlssrvexe   = 'gnutls-serv' .exe_ext('SSH'); # base name and ext of gnutls-serv
 $sshdconfig      = 'curl_sshd_config';       # ssh daemon config file
 $sshconfig       = 'curl_ssh_config';        # ssh client config file
 $sftpconfig      = 'curl_sftp_config';       # sftp client config file
@@ -180,6 +180,13 @@ $clipubkeyf      = 'curl_client_key.pub';    # client public key file
 # Return file extension for executable files on this operating system
 #
 sub exe_ext {
+    my ($component, @arr) = @_;
+    if ($ENV{'CURL_TEST_EXE_EXT'}) {
+        return $ENV{'CURL_TEST_EXE_EXT'};
+    }
+    if ($ENV{'CURL_TEST_EXE_EXT_'.$component}) {
+        return $ENV{'CURL_TEST_EXE_EXT_'.$component};
+    }
     if ($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' ||
         $^O eq 'dos' || $^O eq 'os2') {
         return '.exe';
@@ -314,7 +321,7 @@ sub find_exe_file {
     my $fn = $_[0];
     shift;
     my @path = @_;
-    my $xext = exe_ext();
+    my $xext = exe_ext('SSH');
     foreach (@path) {
         my $file = File::Spec->catfile($_, $fn);
         if(-e $file && ! -d $file) {

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -371,6 +371,9 @@ if((! -e $hstprvkeyf) || (! -s $hstprvkeyf) ||
         logmsg 'Could not generate client key';
         exit 1;
     }
+    # Make sure that permissions are restricted so openssh doesn't complain
+    system "chmod 600 $hstprvkeyf";
+    system "chmod 600 $cliprvkeyf";
 }
 
 


### PR DESCRIPTION
This enables the use of Windows Subsystem for Linux to run the
testsuite against Windows binaries while using Linux servers.

This PR introduces the following environment variables:
- CURL_TEST_EXE_EXT: set the executable extension for all components
- CURL_TEST_EXE_EXT_TOOL: set it for the curl tool only
- CURL_TEST_EXE_EXT_SSH: set it for the SSH tools only
- CURL_TEST_EXE_EXT_SRV: set it for the test servers only

Later testcurl.pl could be adjusted to make use of those variables.

Example usage:

`CURL_TEST_EXE_EXT_TOOL=.exe CURL_TEST_EXE_EXT_SRV=.exe ./runtests.pl -a`

This will use .exe variants for the curl tool and the test servers, but not for OpenSSH commands and therefore enables testing Windows curl against known good Linux OpenSSH (instead of a Windows port).

This PR requires #3290 and therefore currently carries b9f8937afa936be7fbc503aa02ace28ef6c74206 with it until #3290 is merged.