### PR TITLE
Increase scheme length

### DIFF
--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -22,9 +22,9 @@
  *
  ***************************************************************************/
 #include "curl_setup.h"
-/* scheme is not URL encoded, the longest libcurl supported ones are 6
+/* scheme is not URL encoded, the longest libcurl supported ones are 256
    letters */
-#define MAX_SCHEME_LEN 8
+#define MAX_SCHEME_LEN 256
 
 bool Curl_is_absolute_url(const char *url, char *scheme, size_t buflen);
 char *Curl_concat_url(const char *base, const char *relurl);


### PR DESCRIPTION
The current scheme length is arbitrarily set to 8. With the new URL parsing support tools in CURL, its generally useful to parse schemes that may not be supported (ie. requiring CURLU_NON_SUPPORT_SCHEME flag). The current cap is unreasonably small.  Bumps to 256.