### PR TITLE
Curl_udpateconninfo: mark variable unused when compiled without features

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -726,6 +726,8 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
     }
 #endif
   }
+#else /* !HAVE_GETSOCKNAME && !HAVE_GETPEERNAME */
+  (void)sockfd; /* unused */
 #endif
 
   /* persist connection info in session handle */


### PR DESCRIPTION
When compiling without `getpeername()` or `getsockname()`, the `sockfd` parameter to `Curl_udpateconninfo()` became unused after commit e91e481612 added ifdef guards.

Reported in autobuild https://curl.haxx.se/dev/log.cgi?id=20190520172441-32196