### PR TITLE
ftp: move ftp_ccc in under featureflag

### DIFF
--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1266,8 +1266,10 @@ static int Curl_gskit_shutdown(struct connectdata *conn, int sockindex)
   if(!BACKEND->handle)
     return 0;
 
+#ifndef CURL_DISABLE_FTP
   if(data->set.ftp_ccc != CURLFTPSSL_CCC_ACTIVE)
     return 0;
+#endif
 
   close_one(connssl, conn, sockindex);
   rc = 0;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1640,6 +1640,7 @@ static int Curl_gtls_shutdown(struct connectdata *conn, int sockindex)
   int retval = 0;
   struct Curl_easy *data = conn->data;
 
+#ifndef CURL_DISABLE_FTP
   /* This has only been tested on the proftpd server, and the mod_tls code
      sends a close notify alert without waiting for a close notify alert in
      response. Thus we wait for a close notify alert from the server, but
@@ -1647,6 +1648,7 @@ static int Curl_gtls_shutdown(struct connectdata *conn, int sockindex)
 
   if(data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE)
       gnutls_bye(BACKEND->session, GNUTLS_SHUT_WR);
+#endif
 
   if(BACKEND->session) {
     ssize_t result;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1308,6 +1308,7 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
   int err;
   bool done = FALSE;
 
+#ifndef CURL_DISABLE_FTP
   /* This has only been tested on the proftpd server, and the mod_tls code
      sends a close notify alert without waiting for a close notify alert in
      response. Thus we wait for a close notify alert from the server, but
@@ -1315,6 +1316,7 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
 
   if(data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE)
       (void)SSL_shutdown(BACKEND->handle);
+#endif
 
   if(BACKEND->handle) {
     buffsize = (int)sizeof(buf);

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2963,8 +2963,10 @@ static int Curl_sectransp_shutdown(struct connectdata *conn, int sockindex)
   if(!BACKEND->ssl_ctx)
     return 0;
 
+#ifndef CURL_DISABLE_FTP
   if(data->set.ftp_ccc != CURLFTPSSL_CCC_ACTIVE)
     return 0;
+#endif
 
   Curl_sectransp_close(conn, sockindex);
 


### PR DESCRIPTION
Commit e91e48161235272ff485ff32bd048c53af731f43 moved ftp_ccc in under the FTP featureflag in the UserDefined struct, but vtls callsites were still using it unprotected.

Closes #xxxx
Fixes https://curl.haxx.se/dev/log.cgi?id=20190520044705-29865