### PR TITLE
Examples: fix Codacy warnings

### DIFF
--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -123,26 +123,26 @@ int main(void)
   CURL *ch;
   CURLcode rv;
 
-  rv = curl_global_init(CURL_GLOBAL_ALL);
+  curl_global_init(CURL_GLOBAL_ALL);
   ch = curl_easy_init();
-  rv = curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
-  rv = curl_easy_setopt(ch, CURLOPT_HEADER, 0L);
-  rv = curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
-  rv = curl_easy_setopt(ch, CURLOPT_NOSIGNAL, 1L);
-  rv = curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, *writefunction);
-  rv = curl_easy_setopt(ch, CURLOPT_WRITEDATA, stdout);
-  rv = curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, *writefunction);
-  rv = curl_easy_setopt(ch, CURLOPT_HEADERDATA, stderr);
-  rv = curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
-  rv = curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 1L);
-  rv = curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
+  curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
+  curl_easy_setopt(ch, CURLOPT_HEADER, 0L);
+  curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
+  curl_easy_setopt(ch, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, *writefunction);
+  curl_easy_setopt(ch, CURLOPT_WRITEDATA, stdout);
+  curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, *writefunction);
+  curl_easy_setopt(ch, CURLOPT_HEADERDATA, stderr);
+  curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
+  curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 1L);
+  curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
 
   /* Turn off the default CA locations, otherwise libcurl will load CA
    * certificates from the locations that were detected/specified at
    * build-time
    */
-  rv = curl_easy_setopt(ch, CURLOPT_CAINFO, NULL);
-  rv = curl_easy_setopt(ch, CURLOPT_CAPATH, NULL);
+  curl_easy_setopt(ch, CURLOPT_CAINFO, NULL);
+  curl_easy_setopt(ch, CURLOPT_CAPATH, NULL);
 
   /* first try: retrieve page without ca certificates -> should fail
    * unless libcurl was built --with-ca-fallback enabled at build-time
@@ -162,13 +162,13 @@ int main(void)
    * handle. normally you would set the ssl ctx function before making
    * any transfers, and not use this option.
    */
-  rv = curl_easy_setopt(ch, CURLOPT_FRESH_CONNECT, 1L);
+  curl_easy_setopt(ch, CURLOPT_FRESH_CONNECT, 1L);
 
   /* second try: retrieve page using cacerts' certificate -> will succeed
    * load the certificate by installing a function doing the necessary
    * "modifications" to the SSL CONTEXT just before link init
    */
-  rv = curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
+  curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
   rv = curl_easy_perform(ch);
   if(rv == CURLE_OK)
     printf("*** transfer succeeded ***\n");

--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -85,7 +85,6 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *parm)
 
   BIO *cbio = BIO_new_mem_buf(mypem, sizeof(mypem));
   X509_STORE  *cts = SSL_CTX_get_cert_store((SSL_CTX *)sslctx);
-  X509_INFO *itmp;
   int i;
   STACK_OF(X509_INFO) *inf;
   (void)curl;
@@ -103,7 +102,7 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *parm)
   }
 
   for(i = 0; i < sk_X509_INFO_num(inf); i++) {
-    itmp = sk_X509_INFO_value(inf, i);
+    X509_INFO *itmp = sk_X509_INFO_value(inf, i);
     if(itmp->x509) {
       X509_STORE_add_cert(cts, itmp->x509);
     }

--- a/docs/examples/curlgtk.c
+++ b/docs/examples/curlgtk.c
@@ -45,13 +45,12 @@ int my_progress_func(GtkWidget *bar,
 void *my_thread(void *ptr)
 {
   CURL *curl;
-  FILE *outfile;
-  gchar *url = ptr;
 
   curl = curl_easy_init();
   if(curl) {
+    gchar *url = ptr;
     const char *filename = "test.curl";
-    outfile = fopen(filename, "wb");
+    FILE *outfile = fopen(filename, "wb");
 
     curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, outfile);

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -207,8 +207,8 @@ static void event_cb(GlobalInfo *g, int fd, int revents)
   CURLMcode rc;
   struct itimerspec its;
 
-  int action = (revents & EPOLLIN ? CURL_CSELECT_IN : 0) |
-               (revents & EPOLLOUT ? CURL_CSELECT_OUT : 0);
+  int action = ((revents & EPOLLIN) ? CURL_CSELECT_IN : 0) |
+               ((revents & EPOLLOUT) ? CURL_CSELECT_OUT : 0);
 
   rc = curl_multi_socket_action(g->multi, fd, action, &g->still_running);
   mcode_or_die("event_cb: curl_multi_socket_action", rc);
@@ -273,8 +273,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
                     GlobalInfo *g)
 {
   struct epoll_event ev;
-  int kind = (act & CURL_POLL_IN ? EPOLLIN : 0) |
-             (act & CURL_POLL_OUT ? EPOLLOUT : 0);
+  int kind = ((act & CURL_POLL_IN) ? EPOLLIN : 0) |
+             ((act & CURL_POLL_OUT) ? EPOLLOUT : 0);
 
   if(f->sockfd) {
     if(epoll_ctl(g->epfd, EPOLL_CTL_DEL, f->sockfd, NULL))

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -472,8 +472,6 @@ void SignalHandler(int signo)
 int main(int argc _Unused, char **argv _Unused)
 {
   GlobalInfo g;
-  int err;
-  int idx;
   struct itimerspec its;
   struct epoll_event ev;
   struct epoll_event events[10];
@@ -518,8 +516,9 @@ int main(int argc _Unused, char **argv _Unused)
   fprintf(MSG_OUT, "Entering wait loop\n");
   fflush(MSG_OUT);
   while(!g_should_exit_) {
-    err = epoll_wait(g.epfd, events, sizeof(events)/sizeof(struct epoll_event),
-                     10000);
+    int idx;
+    int err = epoll_wait(g.epfd, events,
+                         sizeof(events)/sizeof(struct epoll_event), 10000);
     if(err == -1) {
       if(errno == EINTR) {
         fprintf(MSG_OUT, "note: wait interrupted\n");

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -203,8 +203,8 @@ static void event_cb(EV_P_ struct ev_io *w, int revents)
   GlobalInfo *g = (GlobalInfo*) w->data;
   CURLMcode rc;
 
-  int action = (revents&EV_READ?CURL_POLL_IN:0)|
-    (revents&EV_WRITE?CURL_POLL_OUT:0);
+  int action = ((revents & EV_READ) ? CURL_POLL_IN : 0) |
+    ((revents & EV_WRITE) ? CURL_POLL_OUT : 0);
   rc = curl_multi_socket_action(g->multi, w->fd, action, &g->still_running);
   mcode_or_die("event_cb: curl_multi_socket_action", rc);
   check_multi_info(g);
@@ -247,7 +247,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 {
   printf("%s  \n", __PRETTY_FUNCTION__);
 
-  int kind = (act&CURL_POLL_IN?EV_READ:0)|(act&CURL_POLL_OUT?EV_WRITE:0);
+  int kind = ((act & CURL_POLL_IN) ? EV_READ : 0) |
+             ((act & CURL_POLL_OUT) ? EV_WRITE : 0);
 
   f->sockfd = s;
   f->action = act;

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -182,8 +182,8 @@ static gboolean event_cb(GIOChannel *ch, GIOCondition condition, gpointer data)
   int fd = g_io_channel_unix_get_fd(ch);
 
   int action =
-    (condition & G_IO_IN ? CURL_CSELECT_IN : 0) |
-    (condition & G_IO_OUT ? CURL_CSELECT_OUT : 0);
+    ((condition & G_IO_IN) ? CURL_CSELECT_IN : 0) |
+    ((condition & G_IO_OUT) ? CURL_CSELECT_OUT : 0);
 
   rc = curl_multi_socket_action(g->multi, fd, action, &g->still_running);
   mcode_or_die("event_cb: curl_multi_socket_action", rc);
@@ -218,7 +218,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
                     GlobalInfo *g)
 {
   GIOCondition kind =
-    (act&CURL_POLL_IN?G_IO_IN:0)|(act&CURL_POLL_OUT?G_IO_OUT:0);
+    ((act & CURL_POLL_IN) ? G_IO_IN : 0) |
+    ((act & CURL_POLL_OUT) ? G_IO_OUT : 0);
 
   f->sockfd = s;
   f->action = act;
@@ -255,8 +256,8 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
   else {
     if(!fdp) {
       MSG_OUT("Adding data: %s%s\n",
-              what&CURL_POLL_IN?"READ":"",
-              what&CURL_POLL_OUT?"WRITE":"");
+              (what & CURL_POLL_IN) ? "READ" : "",
+              (what & CURL_POLL_OUT) ? "WRITE" : "");
       addsock(s, e, what, g);
     }
     else {

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -202,8 +202,8 @@ static void event_cb(int fd, short kind, void *userp)
   CURLMcode rc;
 
   int action =
-    (kind & EV_READ ? CURL_CSELECT_IN : 0) |
-    (kind & EV_WRITE ? CURL_CSELECT_OUT : 0);
+    ((kind & EV_READ) ? CURL_CSELECT_IN : 0) |
+    ((kind & EV_WRITE) ? CURL_CSELECT_OUT : 0);
 
   rc = curl_multi_socket_action(g->multi, fd, action, &g->still_running);
   mcode_or_die("event_cb: curl_multi_socket_action", rc);
@@ -249,7 +249,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
                     GlobalInfo *g)
 {
   int kind =
-     (act&CURL_POLL_IN?EV_READ:0)|(act&CURL_POLL_OUT?EV_WRITE:0)|EV_PERSIST;
+     ((act & CURL_POLL_IN) ? EV_READ : 0) |
+     ((act & CURL_POLL_OUT) ? EV_WRITE : 0) | EV_PERSIST;
 
   f->sockfd = s;
   f->action = act;

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -146,7 +146,6 @@ static void mcode_or_die(const char *where, CURLMcode code)
 static int multi_timer_cb(CURLM *multi _Unused, long timeout_ms, GlobalInfo *g)
 {
   struct timeval timeout;
-  CURLMcode rc;
 
   timeout.tv_sec = timeout_ms/1000;
   timeout.tv_usec = (timeout_ms%1000)*1000;

--- a/docs/examples/htmltidy.c
+++ b/docs/examples/htmltidy.c
@@ -74,13 +74,14 @@ void dumpNode(TidyDoc doc, TidyNode tnod, int indent)
 
 int main(int argc, char **argv)
 {
-  CURL *curl;
-  char curl_errbuf[CURL_ERROR_SIZE];
-  TidyDoc tdoc;
-  TidyBuffer docbuf = {0};
-  TidyBuffer tidy_errbuf = {0};
-  int err;
   if(argc == 2) {
+    CURL *curl;
+    char curl_errbuf[CURL_ERROR_SIZE];
+    TidyDoc tdoc;
+    TidyBuffer docbuf = {0};
+    TidyBuffer tidy_errbuf = {0};
+    int err;
+
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_errbuf);

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -110,7 +110,7 @@ int my_trace(CURL *handle, curl_infotype type,
 
   switch(type) {
   case CURLINFO_TEXT:
-    fprintf(stderr, "== %d Info: %s", num, data);
+    fprintf(stderr, "== %u Info: %s", num, data);
     /* FALLTHROUGH */
   default: /* in case a new one is introduced to shock us */
     return 0;

--- a/docs/examples/imap-append.c
+++ b/docs/examples/imap-append.c
@@ -85,14 +85,15 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
-  const char **p;
-  long infilesize;
-  struct upload_status upload_ctx;
-
-  upload_ctx.lines_read = 0;
 
   curl = curl_easy_init();
   if(curl) {
+    const char **p;
+    long infilesize;
+    struct upload_status upload_ctx;
+
+    upload_ctx.lines_read = 0;
+
     /* Set username and password */
     curl_easy_setopt(curl, CURLOPT_USERNAME, "user");
     curl_easy_setopt(curl, CURLOPT_PASSWORD, "secret");

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -147,11 +147,11 @@ int main(void)
   /* See how the transfers went */
   while((msg = curl_multi_info_read(multi_handle, &msgs_left))) {
     if(msg->msg == CURLMSG_DONE) {
-      int idx, found = 0;
+      int idx;
 
       /* Find out which handle this message is about */
       for(idx = 0; idx<HANDLECOUNT; idx++) {
-        found = (msg->easy_handle == handles[idx]);
+        int found = (msg->easy_handle == handles[idx]);
         if(found)
           break;
       }

--- a/docs/examples/resolve.c
+++ b/docs/examples/resolve.c
@@ -31,14 +31,14 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
-  struct curl_slist *host = NULL;
 
   /* Each single name resolve string should be written using the format
      HOST:PORT:ADDRESS where HOST is the name libcurl will try to resolve,
      PORT is the port number of the service where libcurl wants to connect to
      the HOST and ADDRESS is the numerical IP address
    */
-  host = curl_slist_append(NULL, "example.com:443:127.0.0.1");
+  struct curl_slist *host = curl_slist_append(NULL,
+                                              "example.com:443:127.0.0.1");
 
   curl = curl_easy_init();
   if(curl) {

--- a/docs/examples/sendrecv.c
+++ b/docs/examples/sendrecv.c
@@ -59,12 +59,9 @@ static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
 int main(void)
 {
   CURL *curl;
-  CURLcode res;
   /* Minimalistic http request */
   const char *request = "GET / HTTP/1.0\r\nHost: example.com\r\n\r\n";
   size_t request_len = strlen(request);
-  curl_socket_t sockfd;
-  size_t nsent_total = 0;
 
   /* A general note of caution here: if you're using curl_easy_recv() or
      curl_easy_send() to implement HTTP or _any_ other protocol libcurl
@@ -76,6 +73,10 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
+    CURLcode res;
+    curl_socket_t sockfd;
+    size_t nsent_total = 0;
+
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     /* Do not do the transfer - only connect to host */
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -49,9 +49,8 @@ static curl_off_t sftpGetRemoteFileSize(const char *i_remoteFile)
 {
   CURLcode result = CURLE_GOT_NOTHING;
   curl_off_t remoteFileSizeByte = -1;
-  CURL *curlHandlePtr = NULL;
+  CURL *curlHandlePtr = curl_easy_init();
 
-  curlHandlePtr = curl_easy_init();
   curl_easy_setopt(curlHandlePtr, CURLOPT_VERBOSE, 1L);
 
   curl_easy_setopt(curlHandlePtr, CURLOPT_URL, i_remoteFile);

--- a/docs/examples/shared-connection-cache.c
+++ b/docs/examples/shared-connection-cache.c
@@ -46,8 +46,6 @@ static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
 
 int main(void)
 {
-  CURL *curl;
-  CURLcode res;
   CURLSH *share;
   int i;
 
@@ -61,8 +59,10 @@ int main(void)
      still reuse connections since the pool is in the shared object! */
 
   for(i = 0; i < 3; i++) {
-    curl = curl_easy_init();
+    CURL *curl = curl_easy_init();
     if(curl) {
+      CURLcode res;
+
       curl_easy_setopt(curl, CURLOPT_URL, "https://curl.haxx.se/");
 
       /* use the share object */

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -67,13 +67,12 @@ size_t write_file(void *ptr, size_t size, size_t nmemb, FILE *stream)
 /* https://weather.com/weather/today/l/46214?cc=*&dayf=5&unit=i */
 void *pull_one_url(void *NaN)
 {
-  CURL *curl;
-  gchar *http;
-  FILE *outfile;
-
   /* Stop threads from entering unless j is incremented */
   pthread_mutex_lock(&lock);
   while(j < num_urls) {
+    CURL *curl;
+    gchar *http;
+
     printf("j = %d\n", j);
 
     http =
@@ -85,7 +84,7 @@ void *pull_one_url(void *NaN)
     curl = curl_easy_init();
     if(curl) {
 
-      outfile = fopen(urls[j], "wb");
+      FILE *outfile = fopen(urls[j], "wb");
 
       /* Set the URL and transfer type */
       curl_easy_setopt(curl, CURLOPT_URL, http);

--- a/docs/examples/smtp-mime.c
+++ b/docs/examples/smtp-mime.c
@@ -70,16 +70,17 @@ int main(void)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
-  struct curl_slist *headers = NULL;
-  struct curl_slist *recipients = NULL;
-  struct curl_slist *slist = NULL;
-  curl_mime *mime;
-  curl_mime *alt;
-  curl_mimepart *part;
-  const char **cpp;
 
   curl = curl_easy_init();
   if(curl) {
+    struct curl_slist *headers = NULL;
+    struct curl_slist *recipients = NULL;
+    struct curl_slist *slist = NULL;
+    curl_mime *mime;
+    curl_mime *alt;
+    curl_mimepart *part;
+    const char **cpp;
+
     /* This is the URL for your mailserver */
     curl_easy_setopt(curl, CURLOPT_URL, "smtp://mail.example.com");
 

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -257,25 +257,15 @@ int main(int argc, char *argv[])
 {
   CURL    *curl;
   conf_t  conf[1];
-  int     OptionIndex;
-  struct  tm *lt;
-  struct  tm *gmt;
-  time_t  tt;
-  time_t  tt_local;
-  time_t  tt_gmt;
-  double  tzonediffFloat;
-  int     tzonediffWord;
-  char    timeBuf[61];
-  char    tzoneBuf[16];
   int     RetValue;
 
-  OptionIndex     = 0;
   ShowAllHeader   = 0;    /* Do not show HTTP Header */
   AutoSyncTime    = 0;    /* Do not synchronise computer clock */
   RetValue        = 0;    /* Successful Exit */
   conf_init(conf);
 
   if(argc > 1) {
+    int OptionIndex = 0;
     while(OptionIndex < argc) {
       if(strncmp(argv[OptionIndex], "--server=", 9) == 0)
         snprintf(conf->timeserver, MAX_STRING, "%s", &argv[OptionIndex][9]);
@@ -308,6 +298,16 @@ int main(int argc, char *argv[])
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   if(curl) {
+    struct tm *lt;
+    struct tm *gmt;
+    time_t tt;
+    time_t tt_local;
+    time_t tt_gmt;
+    double tzonediffFloat;
+    int tzonediffWord;
+    char timeBuf[61];
+    char tzoneBuf[16];
+
     SyncTime_CURL_Init(curl, conf->http_proxy, conf->proxy_user);
 
     /* Calculating time diff between GMT and localtime */

--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -177,25 +177,25 @@ int main(void)
   CURL *ch;
   CURLcode rv;
 
-  rv = curl_global_init(CURL_GLOBAL_ALL);
+  curl_global_init(CURL_GLOBAL_ALL);
   ch = curl_easy_init();
-  rv = curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
-  rv = curl_easy_setopt(ch, CURLOPT_HEADER, 0L);
-  rv = curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
-  rv = curl_easy_setopt(ch, CURLOPT_NOSIGNAL, 1L);
-  rv = curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, writefunction);
-  rv = curl_easy_setopt(ch, CURLOPT_WRITEDATA, stdout);
-  rv = curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, writefunction);
-  rv = curl_easy_setopt(ch, CURLOPT_HEADERDATA, stderr);
-  rv = curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
+  curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
+  curl_easy_setopt(ch, CURLOPT_HEADER, 0L);
+  curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
+  curl_easy_setopt(ch, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, writefunction);
+  curl_easy_setopt(ch, CURLOPT_WRITEDATA, stdout);
+  curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, writefunction);
+  curl_easy_setopt(ch, CURLOPT_HEADERDATA, stderr);
+  curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
 
   /* both VERIFYPEER and VERIFYHOST are set to 0 in this case because there is
      no CA certificate*/
 
-  rv = curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 0L);
-  rv = curl_easy_setopt(ch, CURLOPT_SSL_VERIFYHOST, 0L);
-  rv = curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
-  rv = curl_easy_setopt(ch, CURLOPT_SSLKEYTYPE, "PEM");
+  curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 0L);
+  curl_easy_setopt(ch, CURLOPT_SSL_VERIFYHOST, 0L);
+  curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
+  curl_easy_setopt(ch, CURLOPT_SSLKEYTYPE, "PEM");
 
   /* first try: retrieve page without user certificate and key -> will fail
    */
@@ -211,7 +211,7 @@ int main(void)
    * load the certificate and key by installing a function doing the necessary
    * "modifications" to the SSL CONTEXT just before link init
    */
-  rv = curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
+  curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
   rv = curl_easy_perform(ch);
   if(rv == CURLE_OK) {
     printf("*** transfer succeeded ***\n");


### PR DESCRIPTION
- fix format specifier
- reduce variable scopes
- remove dead variable stores
- use parentheses for ?: operator
