### PR TITLE
md4: build correctly with openssl without MD4

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -41,6 +41,9 @@
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
 #endif
+#ifdef USE_MBEDTLS
+#include <mbedtls/config.h>
+#endif
 
 /* The NSS, OS/400, and when not included, OpenSSL and mbed TLS crypto
  * libraries do not provide the MD4 hash algorithm, so we use this

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -38,6 +38,10 @@
 
 #include "curl_setup.h"
 
+#ifdef USE_OPENSSL
+#include <openssl/opensslconf.h>
+#endif
+
 /* The NSS, OS/400, and when not included, OpenSSL and mbed TLS crypto
  * libraries do not provide the MD4 hash algorithm, so we use this
  * implementation of it */


### PR DESCRIPTION
Reported-by: elsamuko at github
Fixes #3921