### PR TITLE
url: fix bad #ifdef

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -439,7 +439,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   set->httpreq = HTTPREQ_GET; /* Default HTTP request */
   set->rtspreq = RTSPREQ_OPTIONS; /* Default RTSP request */
-#ifndef CURL_DISABLE_FILE
+#ifndef CURL_DISABLE_FTP
   set->ftp_use_epsv = TRUE;   /* FTP defaults to EPSV operations */
   set->ftp_use_eprt = TRUE;   /* FTP defaults to EPRT operations */
   set->ftp_use_pret = FALSE;  /* mainly useful for drftpd servers */


### PR DESCRIPTION
Regression since e91e48161235272ff485.

Reported-by: Tom Greenslade
Fixes #3924