### PR TITLE
tool_setopt: for builds with disabled-proxy, skip all proxy setopts()

### DIFF
--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -713,4 +713,56 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *config,
   return ret;
 }
 
+#else /* CURL_DISABLE_LIBCURL_OPTION */
+
+#include "tool_cfgable.h"
+#include "tool_setopt.h"
+
 #endif /* CURL_DISABLE_LIBCURL_OPTION */
+
+CURLcode tool_real_error(CURLcode result, CURLoption tag)
+{
+#ifdef CURL_DISABLE_PROXY
+  switch(tag) {
+  case CURLOPT_HAPROXYPROTOCOL:
+  case CURLOPT_HTTPPROXYTUNNEL:
+  case CURLOPT_NOPROXY:
+  case CURLOPT_PRE_PROXY:
+  case CURLOPT_PROXY:
+  case CURLOPT_PROXYAUTH:
+  case CURLOPT_PROXY_CAINFO:
+  case CURLOPT_PROXY_CAPATH:
+  case CURLOPT_PROXY_CRLFILE:
+  case CURLOPT_PROXYHEADER:
+  case CURLOPT_PROXY_KEYPASSWD:
+  case CURLOPT_PROXYPASSWORD:
+  case CURLOPT_PROXY_PINNEDPUBLICKEY:
+  case CURLOPT_PROXYPORT:
+  case CURLOPT_PROXY_SERVICE_NAME:
+  case CURLOPT_PROXY_SSLCERT:
+  case CURLOPT_PROXY_SSLCERTTYPE:
+  case CURLOPT_PROXY_SSL_CIPHER_LIST:
+  case CURLOPT_PROXY_SSLKEY:
+  case CURLOPT_PROXY_SSLKEYTYPE:
+  case CURLOPT_PROXY_SSL_OPTIONS:
+  case CURLOPT_PROXY_SSL_VERIFYHOST:
+  case CURLOPT_PROXY_SSL_VERIFYPEER:
+  case CURLOPT_PROXY_SSLVERSION:
+  case CURLOPT_PROXY_TLS13_CIPHERS:
+  case CURLOPT_PROXY_TLSAUTH_PASSWORD:
+  case CURLOPT_PROXY_TLSAUTH_TYPE:
+  case CURLOPT_PROXY_TLSAUTH_USERNAME:
+  case CURLOPT_PROXY_TRANSFER_MODE:
+  case CURLOPT_PROXYTYPE:
+  case CURLOPT_PROXYUSERNAME:
+  case CURLOPT_PROXYUSERPWD:
+    return CURLE_OK; /* pretend it worked */
+  default:
+    break;
+  }
+#else
+  (void)tag;
+#endif
+  return result;
+}
+

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -29,11 +29,14 @@
  * Macros used in operate()
  */
 
-#define SETOPT_CHECK(v) do { \
-  result = (v); \
-  if(result) \
-    goto show_error; \
-} WHILE_FALSE
+#define SETOPT_CHECK(v,opt) do {                \
+    result = tool_real_error((v), opt);         \
+    if(result)                                  \
+      goto show_error;                          \
+  } WHILE_FALSE
+
+/* allow removed features to simulate success: */
+CURLcode tool_real_error(CURLcode result, CURLoption tag);
 
 #ifndef CURL_DISABLE_LIBCURL_OPTION
 
@@ -97,25 +100,25 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *config,
                      const char *name, CURLoption tag, ...);
 
 #define my_setopt(x,y,z) \
-  SETOPT_CHECK(tool_setopt(x, FALSE, global, #y, y, z))
+  SETOPT_CHECK(tool_setopt(x, FALSE, global, #y, y, z), y)
 
 #define my_setopt_str(x,y,z) \
-  SETOPT_CHECK(tool_setopt(x, TRUE, global, #y, y, z))
+  SETOPT_CHECK(tool_setopt(x, TRUE, global, #y, y, z), y)
 
 #define my_setopt_enum(x,y,z) \
-  SETOPT_CHECK(tool_setopt_enum(x, global, #y, y, setopt_nv_ ## y, z))
+  SETOPT_CHECK(tool_setopt_enum(x, global, #y, y, setopt_nv_ ## y, z), y)
 
 #define my_setopt_flags(x,y,z) \
-  SETOPT_CHECK(tool_setopt_flags(x, global, #y, y, setopt_nv_ ## y, z))
+  SETOPT_CHECK(tool_setopt_flags(x, global, #y, y, setopt_nv_ ## y, z), y)
 
 #define my_setopt_bitmask(x,y,z) \
-  SETOPT_CHECK(tool_setopt_bitmask(x, global, #y, y, setopt_nv_ ## y, z))
+  SETOPT_CHECK(tool_setopt_bitmask(x, global, #y, y, setopt_nv_ ## y, z), y)
 
 #define my_setopt_mimepost(x,y,z) \
-  SETOPT_CHECK(tool_setopt_mimepost(x, global, #y, y, z))
+  SETOPT_CHECK(tool_setopt_mimepost(x, global, #y, y, z), y)
 
 #define my_setopt_slist(x,y,z) \
-  SETOPT_CHECK(tool_setopt_slist(x, global, #y, y, z))
+  SETOPT_CHECK(tool_setopt_slist(x, global, #y, y, z), y)
 
 #define res_setopt(x,y,z) tool_setopt(x, FALSE, global, #y, y, z)
 
@@ -126,25 +129,25 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *config,
 /* No --libcurl, so pass options directly to library */
 
 #define my_setopt(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_str(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_enum(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_flags(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_bitmask(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_mimepost(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_slist(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z))
+  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define res_setopt(x,y,z) curl_easy_setopt(x,y,z)
 


### PR DESCRIPTION
Reported-by: Marcel Raad
Fixes #3926

@MarcelRaad, due to the excessive amount of proxy options I opted to a slightly different take on handling them when building without proxy support (to avoid a bazillion of separate #ifdefs). I hope this approach works for your case? Consider this a first shot and a discussion starter.