### PR TITLE
http_ntlm: Remove duplicate NSS initialisation

### DIFF
--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -44,9 +44,7 @@
 
 /* SSL backend-specific #if branches in this file must be kept in the order
    documented in curl_ntlm_core. */
-#if defined(NTLM_NEEDS_NSS_INIT)
-#include "vtls/nssg.h"
-#elif defined(USE_WINDOWS_SSPI)
+#if defined(USE_WINDOWS_SSPI)
 #include "curl_sspi.h"
 #endif
 
@@ -136,11 +134,6 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
 
   DEBUGASSERT(conn);
   DEBUGASSERT(conn->data);
-
-#if defined(NTLM_NEEDS_NSS_INIT)
-  if(CURLE_OK != Curl_nss_force_init(conn->data))
-    return CURLE_OUT_OF_MEMORY;
-#endif
 
   if(proxy) {
     allocuserpwd = &conn->allocptr.proxyuserpwd;


### PR DESCRIPTION
Given that this is performed by the NTLM code there is no need to
perform the initialisation in the HTTP layer. This also keeps the
initialisation the same as the SASL based protocols and also fixes a
possible compilation issue if both NSS and SSPI were to be used as
multiple SSL backends.
