### PR TITLE
curl-win32.h: Enable Unix Domain Sockets based on the Window SDK version

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -727,8 +727,12 @@ Vista
 #define USE_WIN32_CRYPTO
 
 /* Define to use Unix sockets. */
-#if defined(_MSC_VER) && _MSC_VER >= 1900
-/* #define USE_UNIX_SOCKETS */
+#if defined(_MSC_VER) && (_MSC_VER >= 1500)
+/* sdkddkver.h first shipped with Platform SDK v6.0A included with VS2008 */
+#include <sdkddkver.h>
+#if defined(NTDDI_WIN10_RS4)
+#define USE_UNIX_SOCKETS
+#endif
 #endif
 
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
Microsoft added support for Unix Domain Sockets in Windows 10 1803 (RS4).

Rather than expect the user to enable Unix Domain Sockets by uncommenting the #define that was added in 0fd6221f we use the RS4 pre-processor variable that is present in newer versions of the Windows SDK.