### PR TITLE
connect: fix possible uninitialized memory access in getaddressinfo()

### DIFF
--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -27,7 +27,8 @@
 
 /* retrieves ip address and port from a sockaddr structure.
    note it calls Curl_inet_ntop which sets errno on fail, not SOCKERRNO. */
-bool getaddressinfo(struct sockaddr *sa, char *addr, long *port);
+bool getaddressinfo(struct sockaddr *sa, curl_socklen_t len,
+                    char *addr, long *port);
 
 #include "memdebug.h" /* LAST include file */
 
@@ -154,7 +155,7 @@ UNITTEST_START
       if(tests[i].address[j] == &skip)
         continue;
 
-      if(addr && !getaddressinfo(addr->ai_addr,
+      if(addr && !getaddressinfo(addr->ai_addr, addr->ai_addrlen,
                                  ipaddress, &port)) {
         fprintf(stderr, "%s:%d tests[%d] failed. getaddressinfo failed.\n",
                 __FILE__, __LINE__, i);

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -27,7 +27,8 @@
 
 /* retrieves ip address and port from a sockaddr structure.
    note it calls Curl_inet_ntop which sets errno on fail, not SOCKERRNO. */
-bool getaddressinfo(struct sockaddr *sa, char *addr, long *port);
+bool getaddressinfo(struct sockaddr *sa, curl_socklen_t len,
+                    char *addr, long *port);
 
 #include "memdebug.h" /* LAST include file */
 
@@ -154,7 +155,7 @@ UNITTEST_START
       if(!addr && !tests[i].address[j])
         break;
 
-      if(addr && !getaddressinfo(addr->ai_addr,
+      if(addr && !getaddressinfo(addr->ai_addr, addr->ai_addrlen,
                                  ipaddress, &port)) {
         fprintf(stderr, "%s:%d tests[%d] failed. getaddressinfo failed.\n",
                 __FILE__, __LINE__, i);


### PR DESCRIPTION
I am using libcurl over anonymous/unbound AF_LOCAL sockets via socketpair() to test-drive some HTTP server code, using CURLOPT_OPENSOCKETFUNCTION to inject the file descriptor and CURLOPT_SOCKOPTFUNCTION to prevent a furter connect().

Admitting that this is somewhat of a corner-case.

On linux, sun_path in struct sockaddr_un is not initialized by accept(), getsockaddr() or getpeername() if the socket is not bound. This can only be detected by evaluating the length of the address, as returned by any of these functions.

The current implementation of getaddressinfo() in curl does not evaluate the address length and expects a null-terminated string in sun_path and therefore may access uninitialized data. getaddressinfo() won't write more than MAX_IPADR_LEN bytes, hence I believe no buffer overflow is possible.

I am not sure if it is worth fixing, but I am submitting this for review.
