### PR TITLE
curl: make code work with protocol-disabled libcurl

### DIFF
--- a/tests/data/test1406
+++ b/tests/data/test1406
@@ -89,7 +89,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer
@@ -117,12 +116,14 @@ int main(int argc, char *argv[])
 </file>
 <stripfile>
 # These options vary with configurations - just ignore them
+# CURLOPT_INTERLEAVEDATA requires RTSP (HTTP) protocol
 $_ = '' if /CURLOPT_USERAGENT/
 $_ = '' if /CURLOPT_MAXREDIRS/
 $_ = '' if /CURLOPT_SSL_VERIFYPEER/
 $_ = '' if /CURLOPT_SSH_KNOWNHOSTS/
 $_ = '' if /CURLOPT_HTTP_VERSION/
 $_ = '' if /CURLOPT_HTTP09_ALLOWED/
+$_ = '' if /CURLOPT_INTERLEAVEDATA/
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
      them yourself.
 
   CURLOPT_WRITEDATA set to a objectpointer
-  CURLOPT_INTERLEAVEDATA set to a objectpointer
   CURLOPT_WRITEFUNCTION set to a functionpointer
   CURLOPT_READDATA set to a objectpointer
   CURLOPT_READFUNCTION set to a functionpointer
@@ -101,11 +100,13 @@ int main(int argc, char *argv[])
 </file>
 <stripfile>
 # These options vary with configurations - just ignore them
+# CURLOPT_INTERLEAVEDATA requires RTSP (HTTP) protocol
 $_ = '' if /CURLOPT_USERAGENT/
 $_ = '' if /CURLOPT_MAXREDIRS/
 $_ = '' if /CURLOPT_SSL_VERIFYPEER/
 $_ = '' if /CURLOPT_SSH_KNOWNHOSTS/
 $_ = '' if /CURLOPT_HTTP_VERSION/
+$_ = '' if /CURLOPT_INTERLEAVEDATA/
 </stripfile>
 </verify>
 </testcase>


### PR DESCRIPTION
Hello.
I noticed that tests 1406 and 1420 fail for cURL built with _--disable-rtsp_. The reason is a missing option CURLOPT_INTERLEAVEDATA, that is available only with enabled RTSP support.
I changed the corresponding test files in a way similar to the changes from 697b1f911b6fee51ff2b271a292488fd7f9cdcda to suppress the testing errors.