### PR TITLE
HAProxy tests: add keywords

### DIFF
--- a/tests/data/test1455
+++ b/tests/data/test1455
@@ -3,6 +3,8 @@
 <keywords>
 HTTP
 HTTP GET
+proxy
+haproxy
 </keywords>
 </info>
 

--- a/tests/data/test1456
+++ b/tests/data/test1456
@@ -3,6 +3,8 @@
 <keywords>
 HTTP
 HTTP GET
+proxy
+haproxy
 IPv6
 </keywords>
 </info>


### PR DESCRIPTION
Add the proxy and haproxy keywords in order to be able to exclude or
run these specific tests.