### PR TITLE
multi: track users of a socket better

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1778,6 +1778,7 @@ struct Curl_easy {
   struct connectdata *conn;
   struct curl_llist_element connect_queue;
   struct curl_llist_element sh_queue; /* list per Curl_sh_entry */
+  struct Curl_sh_entry *sh_entry; /* the socket hash this was added to */
   struct curl_llist_element conn_queue; /* list per connectdata */
 
   CURLMstate mstate;  /* the handle's state */


### PR DESCRIPTION
They need to be removed from the socket hash linked list with more care.

When sh_delentry() is called to remove a sockethash entry, remove all
individual transfers from the list first. To enable this, each Curl_easy struct
now stores a pointer to the sockethash entry to know how to remove itself.

Reported-by: Tom van der Woerdt and Kunal Ekawde

Fixes #3952
Fixes #3904