### PR TITLE
url: Load if_nametoindex() dynamically from iphlpapi.dll on Windows

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -154,11 +154,6 @@
 #define HAVE_WS2TCPIP_H 1
 #endif
 
-/* Define if you have the <Iphlpapi.h> header file. */
-#ifndef __SALFORDC__
-#define HAVE_IPHLPAPI_H 1
-#endif
-
 /* ---------------------------------------------------------------- */
 /*                        OTHER HEADER INFO                         */
 /* ---------------------------------------------------------------- */
@@ -610,11 +605,6 @@ Vista
 #    define HAVE_GETADDRINFO_THREADSAFE 1
 #    define HAVE_GETNAMEINFO            1
 #  endif
-#endif
-#if defined(HAVE_IPHLPAPI_H)
-  #if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600)
-    #define HAVE_IF_NAMETOINDEX 1
-  #endif
 #endif
 
 #if defined(__POCC__)

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2016 - 2017, Steve Holme, <steve_holme@hotmail.com>.
+ * Copyright (C) 2016 - 2019, Steve Holme, <steve_holme@hotmail.com>.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -35,6 +35,12 @@
 
 LARGE_INTEGER Curl_freq;
 bool Curl_isVistaOrGreater;
+
+/* Handle of iphlpapp.dll */
+static HMODULE s_hIpHlpApiDll = NULL;
+
+/* Pointer to the if_nametoindex function */
+IF_NAMETOINDEX_FN Curl_if_nametoindex = NULL;
 
 /* Curl_win32_init() performs win32 global initialization */
 CURLcode Curl_win32_init(long flags)
@@ -89,6 +95,17 @@ CURLcode Curl_win32_init(long flags)
   }
 #endif
 
+  s_hIpHlpApiDll = Curl_load_library(TEXT("iphlpapi.dll"));
+  if(s_hIpHlpApiDll) {
+    /* Get the address of the if_nametoindex function */
+    IF_NAMETOINDEX_FN pIfNameToIndex =
+      CURLX_FUNCTION_CAST(IF_NAMETOINDEX_FN,
+                          (GetProcAddress(s_hIpHlpApiDll, "if_nametoindex")));
+
+    if(pIfNameToIndex)
+      Curl_if_nametoindex = pIfNameToIndex;
+  }
+
   if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
                                  VERSION_GREATER_THAN_EQUAL)) {
     Curl_isVistaOrGreater = TRUE;
@@ -103,6 +120,12 @@ CURLcode Curl_win32_init(long flags)
 /* Curl_win32_cleanup() is the opposite of Curl_win32_init() */
 void Curl_win32_cleanup(long init_flags)
 {
+  if(s_hIpHlpApiDll) {
+    FreeLibrary(s_hIpHlpApiDll);
+    s_hIpHlpApiDll = NULL;
+    Curl_if_nametoindex = NULL;
+  }
+
 #ifdef USE_WINDOWS_SSPI
   Curl_sspi_global_cleanup();
 #endif
@@ -113,10 +136,6 @@ void Curl_win32_cleanup(long init_flags)
 #endif
   }
 }
-
-#if defined(USE_WINDOWS_SSPI) || (!defined(CURL_DISABLE_TELNET) && \
-                                  defined(USE_WINSOCK))
-
 
 #if !defined(LOAD_WITH_ALTERED_SEARCH_PATH)
 #define LOAD_WITH_ALTERED_SEARCH_PATH  0x00000008
@@ -139,8 +158,6 @@ typedef HMODULE (APIENTRY *LOADLIBRARYEX_FN)(LPCTSTR, HANDLE, DWORD);
 #else
 #  define LOADLIBARYEX    "LoadLibraryExA"
 #endif
-
-#endif /* USE_WINDOWS_SSPI || (!CURL_DISABLE_TELNET && USE_WINSOCK) */
 
 /*
  * Curl_verify_windows_version()
@@ -334,9 +351,6 @@ bool Curl_verify_windows_version(const unsigned int majorVersion,
   return matched;
 }
 
-#if defined(USE_WINDOWS_SSPI) || (!defined(CURL_DISABLE_TELNET) && \
-                                  defined(USE_WINSOCK))
-
 /*
  * Curl_load_library()
  *
@@ -410,7 +424,5 @@ HMODULE Curl_load_library(LPCTSTR filename)
 
   return hModule;
 }
-
-#endif /* USE_WINDOWS_SSPI || (!CURL_DISABLE_TELNET && USE_WINSOCK) */
 
 #endif /* WIN32 */

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2016, Steve Holme, <steve_holme@hotmail.com>.
+ * Copyright (C) 2016 - 2019, Steve Holme, <steve_holme@hotmail.com>.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -48,19 +48,20 @@ typedef enum {
   PLATFORM_WINNT
 } PlatformIdentifier;
 
+/* We use our own typedef here since some headers might lack this */
+typedef unsigned int(WINAPI *IF_NAMETOINDEX_FN)(char *);
+
+/* This is used instread of if_nametoindex if available on Windows */
+IF_NAMETOINDEX_FN Curl_if_nametoindex;
+
 /* This is used to verify if we are running on a specific windows version */
 bool Curl_verify_windows_version(const unsigned int majorVersion,
                                  const unsigned int minorVersion,
                                  const PlatformIdentifier platform,
                                  const VersionCondition condition);
 
-#if defined(USE_WINDOWS_SSPI) || (!defined(CURL_DISABLE_TELNET) && \
-                                  defined(USE_WINSOCK))
-
 /* This is used to dynamically load DLLs */
 HMODULE Curl_load_library(LPCTSTR filename);
-
-#endif /* USE_WINDOWS_SSPI || (!CURL_DISABLE_TELNET && USE_WINSOCK) */
 
 #endif /* WIN32 */
 


### PR DESCRIPTION
This fixes the static dependency on iphlpapi.lib and allows curl to build for for targets prior to Windows Vista.

This partially reverts 170bd047.

Related to #3934 and #3943.