### PR TITLE
dump-header.d: spell out that no headers == empty file [ci skip]

### DIFF
--- a/docs/cmdline-opts/dump-header.d
+++ b/docs/cmdline-opts/dump-header.d
@@ -12,6 +12,8 @@ site sends to you. Cookies from the headers could then be read in a second
 curl invocation by using the --cookie option! The --cookie-jar option is a
 better way to store cookies.
 
+If no headers are received, the use of this option will create an empty file.
+
 When used in FTP, the FTP server response lines are considered being "headers"
 and thus are saved there.
 


### PR DESCRIPTION
Reported-by: wesinator at github
Fixes #3964