### PR TITLE
Fix more Codacy warnings

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -125,6 +125,7 @@ int main(void)
 #if   defined(HAVE_GETHOSTBYADDR_R_5) || \
       defined(HAVE_GETHOSTBYADDR_R_5_REENTRANT)
   rc = gethostbyaddr_r(address, length, type, &h, &hdata);
+  (void)rc;
 #elif defined(HAVE_GETHOSTBYADDR_R_7) || \
       defined(HAVE_GETHOSTBYADDR_R_7_REENTRANT)
   hp = gethostbyaddr_r(address, length, type, &h, buffer, 8192, &h_errnop);
@@ -132,6 +133,7 @@ int main(void)
 #elif defined(HAVE_GETHOSTBYADDR_R_8) || \
       defined(HAVE_GETHOSTBYADDR_R_8_REENTRANT)
   rc = gethostbyaddr_r(address, length, type, &h, buffer, 8192, &hp, &h_errnop);
+  (void)rc;
 #endif
 
 #if   defined(HAVE_GETHOSTBYNAME_R_3) || \

--- a/docs/examples/fopen.c
+++ b/docs/examples/fopen.c
@@ -211,7 +211,7 @@ static int fill_buffer(URL_FILE *file, size_t want)
 static int use_buffer(URL_FILE *file, size_t want)
 {
   /* sort out buffer */
-  if((file->buffer_pos - want) <= 0) {
+  if(file->buffer_pos <= want) {
     /* ditch buffer - write will recreate */
     free(file->buffer);
     file->buffer = NULL;

--- a/docs/examples/ftp-wildcard.c
+++ b/docs/examples/ftp-wildcard.c
@@ -41,8 +41,6 @@ static size_t write_it(char *buff, size_t size, size_t nmemb,
 
 int main(int argc, char **argv)
 {
-  int rc = CURLE_OK;
-
   /* curl easy handle */
   CURL *handle;
 
@@ -50,7 +48,7 @@ int main(int argc, char **argv)
   struct callback_data data = { 0 };
 
   /* global initialization */
-  rc = curl_global_init(CURL_GLOBAL_ALL);
+  int rc = curl_global_init(CURL_GLOBAL_ALL);
   if(rc)
     return rc;
 

--- a/docs/examples/htmltitle.cpp
+++ b/docs/examples/htmltitle.cpp
@@ -136,9 +136,9 @@ static void StartElement(void *voidContext,
                          const xmlChar *name,
                          const xmlChar **attributes)
 {
-  Context *context = (Context *)voidContext;
+  Context *context = static_cast<Context *>(voidContext);
 
-  if(COMPARE((char *)name, "TITLE")) {
+  if(COMPARE(reinterpret_cast<char *>(name), "TITLE")) {
     context->title = "";
     context->addTitle = true;
   }
@@ -152,9 +152,9 @@ static void StartElement(void *voidContext,
 static void EndElement(void *voidContext,
                        const xmlChar *name)
 {
-  Context *context = (Context *)voidContext;
+  Context *context = static_cast<Context *>(voidContext);
 
-  if(COMPARE((char *)name, "TITLE"))
+  if(COMPARE(reinterpret_cast<char *>(name), "TITLE"))
     context->addTitle = false;
 }
 
@@ -167,7 +167,7 @@ static void handleCharacters(Context *context,
                              int length)
 {
   if(context->addTitle)
-    context->title.append((char *)chars, length);
+    context->title.append(reinterpret_cast<char *>(chars), length);
 }
 
 //
@@ -178,7 +178,7 @@ static void Characters(void *voidContext,
                        const xmlChar *chars,
                        int length)
 {
-  Context *context = (Context *)voidContext;
+  Context *context = static_cast<Context *>(voidContext);
 
   handleCharacters(context, chars, length);
 }
@@ -191,7 +191,7 @@ static void cdata(void *voidContext,
                   const xmlChar *chars,
                   int length)
 {
-  Context *context = (Context *)voidContext;
+  Context *context = static_cast<Context *>(voidContext);
 
   handleCharacters(context, chars, length);
 }

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -137,7 +137,6 @@ size_t SyncTime_CURL_WriteOutput(void *ptr, size_t size, size_t nmemb,
 size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
                                  void *stream)
 {
-  int   i, RetVal;
   char  TmpStr1[26], TmpStr2[26];
 
   (void)stream;
@@ -156,11 +155,13 @@ size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
                                          TmpStr1 & 2? */
         AutoSyncTime = 0;
       else {
-        RetVal = sscanf((char *)(ptr), "Date: %s %hu %s %hu %hu:%hu:%hu",
-                        TmpStr1, &SYSTime.wDay, TmpStr2, &SYSTime.wYear,
-                        &SYSTime.wHour, &SYSTime.wMinute, &SYSTime.wSecond);
+        int RetVal = sscanf((char *)(ptr), "Date: %s %hu %s %hu %hu:%hu:%hu",
+                            TmpStr1, &SYSTime.wDay, TmpStr2, &SYSTime.wYear,
+                            &SYSTime.wHour, &SYSTime.wMinute,
+                            &SYSTime.wSecond);
 
         if(RetVal == 7) {
+          int i;
           SYSTime.wMilliseconds = 500;    /* adjust to midpoint, 0.5 sec */
           for(i = 0; i<12; i++) {
             if(strcmp(MthStr[i], TmpStr2) == 0) {

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -218,7 +218,6 @@ static bool encrypt_des(const unsigned char *in, unsigned char *out,
                         const unsigned char *key_56)
 {
   const CK_MECHANISM_TYPE mech = CKM_DES_ECB; /* DES cipher in ECB mode */
-  PK11SlotInfo *slot = NULL;
   char key[8];                                /* expanded 64 bit key */
   SECItem key_item;
   PK11SymKey *symkey = NULL;
@@ -228,7 +227,7 @@ static bool encrypt_des(const unsigned char *in, unsigned char *out,
   bool rv = FALSE;
 
   /* use internal slot for DES encryption (requires NSS to be initialized) */
-  slot = PK11_GetInternalKeySlot();
+  PK11SlotInfo *slot = PK11_GetInternalKeySlot();
   if(!slot)
     return FALSE;
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -565,10 +565,8 @@ static CURLcode ftp_readresp(curl_socket_t sockfd,
 #ifdef HAVE_GSSAPI
   char * const buf = data->state.buffer;
 #endif
-  CURLcode result = CURLE_OK;
   int code;
-
-  result = Curl_pp_readresp(sockfd, pp, &code, size);
+  CURLcode result = Curl_pp_readresp(sockfd, pp, &code, size);
 
 #if defined(HAVE_GSSAPI)
   /* handle the security-oriented responses 6xx ***/
@@ -1499,24 +1497,14 @@ static CURLcode ftp_state_list(struct connectdata *conn)
 
 static CURLcode ftp_state_retr_prequote(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* We've sent the TYPE, now we must send the list of prequote strings */
-
-  result = ftp_state_quote(conn, TRUE, FTP_RETR_PREQUOTE);
-
-  return result;
+  return ftp_state_quote(conn, TRUE, FTP_RETR_PREQUOTE);
 }
 
 static CURLcode ftp_state_stor_prequote(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* We've sent the TYPE, now we must send the list of prequote strings */
-
-  result = ftp_state_quote(conn, TRUE, FTP_STOR_PREQUOTE);
-
-  return result;
+  return ftp_state_quote(conn, TRUE, FTP_STOR_PREQUOTE);
 }
 
 static CURLcode ftp_state_type(struct connectdata *conn)

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -444,10 +444,8 @@ static CURLcode imap_perform_capability(struct connectdata *conn)
  */
 static CURLcode imap_perform_starttls(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* Send the STARTTLS command */
-  result = imap_sendf(conn, "STARTTLS");
+  CURLcode result = imap_sendf(conn, "STARTTLS");
 
   if(!result)
     state(conn, IMAP_STARTTLS);
@@ -463,11 +461,10 @@ static CURLcode imap_perform_starttls(struct connectdata *conn)
  */
 static CURLcode imap_perform_upgrade_tls(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-  struct imap_conn *imapc = &conn->proto.imapc;
-
   /* Start the SSL connection */
-  result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &imapc->ssldone);
+  struct imap_conn *imapc = &conn->proto.imapc;
+  CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+                                                 &imapc->ssldone);
 
   if(!result) {
     if(imapc->state != IMAP_UPGRADETLS)
@@ -826,10 +823,8 @@ static CURLcode imap_perform_search(struct connectdata *conn)
  */
 static CURLcode imap_perform_logout(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* Send the LOGOUT command */
-  result = imap_sendf(conn, "LOGOUT");
+  CURLcode result = imap_sendf(conn, "LOGOUT");
 
   if(!result)
     state(conn, IMAP_LOGOUT);

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -339,10 +339,8 @@ static CURLcode pop3_perform_capa(struct connectdata *conn)
  */
 static CURLcode pop3_perform_starttls(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* Send the STLS command */
-  result = Curl_pp_sendf(&conn->proto.pop3c.pp, "%s", "STLS");
+  CURLcode result = Curl_pp_sendf(&conn->proto.pop3c.pp, "%s", "STLS");
 
   if(!result)
     state(conn, POP3_STARTTLS);
@@ -358,11 +356,10 @@ static CURLcode pop3_perform_starttls(struct connectdata *conn)
  */
 static CURLcode pop3_perform_upgrade_tls(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-  struct pop3_conn *pop3c = &conn->proto.pop3c;
-
   /* Start the SSL connection */
-  result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &pop3c->ssldone);
+  struct pop3_conn *pop3c = &conn->proto.pop3c;
+  CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+                                                 &pop3c->ssldone);
 
   if(!result) {
     if(pop3c->state != POP3_UPGRADETLS)
@@ -593,10 +590,8 @@ static CURLcode pop3_perform_command(struct connectdata *conn)
  */
 static CURLcode pop3_perform_quit(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* Send the QUIT command */
-  result = Curl_pp_sendf(&conn->proto.pop3c.pp, "%s", "QUIT");
+  CURLcode result = Curl_pp_sendf(&conn->proto.pop3c.pp, "%s", "QUIT");
 
   if(!result)
     state(conn, POP3_QUIT);

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -957,7 +957,6 @@ static CURLcode smb_do(struct connectdata *conn, bool *done)
 
 static CURLcode smb_parse_url_path(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
   struct smb_request *req = data->req.protop;
   struct smb_conn *smbc = &conn->proto.smbc;
@@ -965,7 +964,8 @@ static CURLcode smb_parse_url_path(struct connectdata *conn)
   char *slash;
 
   /* URL decode the path */
-  result = Curl_urldecode(data, data->state.up.path, 0, &path, NULL, TRUE);
+  CURLcode result = Curl_urldecode(data, data->state.up.path, 0, &path, NULL,
+                                   TRUE);
   if(result)
     return result;
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -359,10 +359,8 @@ static CURLcode smtp_perform_helo(struct connectdata *conn)
  */
 static CURLcode smtp_perform_starttls(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* Send the STARTTLS command */
-  result = Curl_pp_sendf(&conn->proto.smtpc.pp, "%s", "STARTTLS");
+  CURLcode result = Curl_pp_sendf(&conn->proto.smtpc.pp, "%s", "STARTTLS");
 
   if(!result)
     state(conn, SMTP_STARTTLS);
@@ -378,11 +376,10 @@ static CURLcode smtp_perform_starttls(struct connectdata *conn)
  */
 static CURLcode smtp_perform_upgrade_tls(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-  struct smtp_conn *smtpc = &conn->proto.smtpc;
-
   /* Start the SSL connection */
-  result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &smtpc->ssldone);
+  struct smtp_conn *smtpc = &conn->proto.smtpc;
+  CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+                                                 &smtpc->ssldone);
 
   if(!result) {
     if(smtpc->state != SMTP_UPGRADETLS)
@@ -645,10 +642,8 @@ static CURLcode smtp_perform_rcpt_to(struct connectdata *conn)
  */
 static CURLcode smtp_perform_quit(struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-
   /* Send the QUIT command */
-  result = Curl_pp_sendf(&conn->proto.smtpc.pp, "%s", "QUIT");
+  CURLcode result = Curl_pp_sendf(&conn->proto.smtpc.pp, "%s", "QUIT");
 
   if(!result)
     state(conn, SMTP_QUIT);

--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -1968,11 +1968,10 @@ static CURLcode myssh_multi_statemach(struct connectdata *conn,
                                       bool *done)
 {
   struct ssh_conn *sshc = &conn->proto.sshc;
-  CURLcode result = CURLE_OK;
   bool block;    /* we store the status and use that to provide a ssh_getsock()
                     implementation */
+  CURLcode result = myssh_statemach_act(conn, &block);
 
-  result = myssh_statemach_act(conn, &block);
   *done = (sshc->state == SSH_STOP) ? TRUE : FALSE;
   myssh_block2waitfor(conn, block);
 

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -357,7 +357,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                                              const char *service,
                                              char **outptr, size_t *outlen)
 {
-  CURLcode result = CURLE_OK;
   size_t i;
   MD5_context *ctxt;
   char *response = NULL;
@@ -377,10 +376,12 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   char *spn         = NULL;
 
   /* Decode the challenge message */
-  result = auth_decode_digest_md5_message(chlg64, nonce, sizeof(nonce),
-                                          realm, sizeof(realm),
-                                          algorithm, sizeof(algorithm),
-                                          qop_options, sizeof(qop_options));
+  CURLcode result = auth_decode_digest_md5_message(chlg64, nonce,
+                                                   sizeof(nonce), realm,
+                                                   sizeof(realm), algorithm,
+                                                   sizeof(algorithm),
+                                                   qop_options,
+                                                   sizeof(qop_options));
   if(result)
     return result;
 

--- a/lib/vtls/cyassl.c
+++ b/lib/vtls/cyassl.c
@@ -357,9 +357,8 @@ cyassl_connect_step1(struct connectdata *conn,
 
   /* give application a chance to interfere with SSL set up. */
   if(data->set.ssl.fsslctx) {
-    CURLcode result = CURLE_OK;
-    result = (*data->set.ssl.fsslctx)(data, BACKEND->ctx,
-                                      data->set.ssl.fsslctxp);
+    CURLcode result = (*data->set.ssl.fsslctx)(data, BACKEND->ctx,
+                                               data->set.ssl.fsslctxp);
     if(result) {
       failf(data, "error signaled by ssl ctx callback");
       return result;

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -265,7 +265,6 @@ mesalink_connect_step2(struct connectdata *conn, int sockindex)
 
   ret = SSL_connect(BACKEND->handle);
   if(ret != SSL_SUCCESS) {
-    char error_buffer[MESALINK_MAX_ERROR_SZ];
     int detail = SSL_get_error(BACKEND->handle, ret);
 
     if(SSL_ERROR_WANT_CONNECT == detail || SSL_ERROR_WANT_READ == detail) {
@@ -273,6 +272,7 @@ mesalink_connect_step2(struct connectdata *conn, int sockindex)
       return CURLE_OK;
     }
     else {
+      char error_buffer[MESALINK_MAX_ERROR_SZ];
       failf(data,
             "SSL_connect failed with error %d: %s",
             detail,

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -620,12 +620,7 @@ curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
   va_list arg;
   void *paramp;
   CURLcode ret;
-  unsigned int ccsid;
-  char * * cpp;
   struct Curl_easy * data;
-  struct curl_slist * * slp;
-  struct curl_certinfo * cipf;
-  struct curl_certinfo * cipt;
 
   /* WARNING: unlike curl_easy_getinfo(), the strings returned by this
      procedure have to be free'ed. */
@@ -635,7 +630,13 @@ curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
   paramp = va_arg(arg, void *);
   ret = Curl_getinfo(data, info, paramp);
 
-  if(ret == CURLE_OK)
+  if(ret == CURLE_OK) {
+    unsigned int ccsid;
+    char **cpp;
+    struct curl_slist **slp;
+    struct curl_certinfo *cipf;
+    struct curl_certinfo *cipt;
+
     switch((int) info & CURLINFO_TYPEMASK) {
 
     case CURLINFO_STRING:
@@ -706,6 +707,7 @@ curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
         break;
       }
     }
+  }
 
   va_end(arg);
   return ret;
@@ -1355,13 +1357,12 @@ curl_pushheader_byname_ccsid(struct curl_pushheaders *h, const char *header,
 
 {
   char *d = (char *) NULL;
-  char *s;
 
   if(header) {
     header = dynconvert(ASCII_CCSID, header, -1, ccsidin);
 
     if(header) {
-      s = curl_pushheader_byname(h, header);
+      char *s = curl_pushheader_byname(h, header);
       free((char *) header);
 
       if(s)

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -268,13 +268,9 @@ Curl_getnameinfo_a(const struct sockaddr * sa, curl_socklen_t salen,
               int flags)
 
 {
-  char * enodename;
-  char * eservname;
+  char *enodename = NULL;
+  char *eservname = NULL;
   int status;
-  int i;
-
-  enodename = (char *) NULL;
-  eservname = (char *) NULL;
 
   if(nodename && nodenamelen) {
     enodename = malloc(nodenamelen);
@@ -294,6 +290,7 @@ Curl_getnameinfo_a(const struct sockaddr * sa, curl_socklen_t salen,
                        eservname, servnamelen, flags);
 
   if(!status) {
+    int i;
     if(enodename) {
       i = QadrtConvertE2A(nodename, enodename,
         nodenamelen - 1, strlen(enodename));
@@ -766,16 +763,13 @@ static int
 Curl_gss_convert_in_place(OM_uint32 * minor_status, gss_buffer_t buf)
 
 {
-  unsigned int i;
-  char * t;
+  unsigned int i = buf->length;
 
   /* Convert `buf' in place, from EBCDIC to ASCII.
      If error, release the buffer and return -1. Else return 0. */
 
-  i = buf->length;
-
   if(i) {
-    t = malloc(i);
+    char *t = malloc(i);
     if(!t) {
       gss_release_buffer(minor_status, buf);
 
@@ -865,7 +859,6 @@ Curl_gss_init_sec_context_a(OM_uint32 * minor_status,
 
 {
   int rc;
-  unsigned int i;
   gss_buffer_desc in;
   gss_buffer_t inp;
 
@@ -874,7 +867,7 @@ Curl_gss_init_sec_context_a(OM_uint32 * minor_status,
 
   if(inp) {
     if(inp->length && inp->value) {
-      i = inp->length;
+      unsigned int i = inp->length;
 
       in.value = malloc(i + 1);
       if(!in.value) {

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -93,7 +93,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
     if((sts & 1) && (iosb.iosb$w_status & 1))
       buffer[iosb.iosb$w_bcnt] = '\0';
 
-    sts = sys$dassgn(chan);
+    sys$dassgn(chan);
   }
   return buffer; /* we always return success */
 }

--- a/tests/libtest/lib1541.c
+++ b/tests/libtest/lib1541.c
@@ -104,7 +104,6 @@ int test(char *URL)
 {
   pthread_t tid[NUM_THREADS];
   int i;
-  int error;
   CURLSH *share;
   struct initurl url[NUM_THREADS];
 
@@ -119,6 +118,7 @@ int test(char *URL)
   init_locks();
 
   for(i = 0; i< NUM_THREADS; i++) {
+    int error;
     url[i].url = URL;
     url[i].share = share;
     url[i].threadno = i;
@@ -131,7 +131,7 @@ int test(char *URL)
 
   /* now wait for all threads to terminate */
   for(i = 0; i< NUM_THREADS; i++) {
-    error = pthread_join(tid[i], NULL);
+    pthread_join(tid[i], NULL);
     fprintf(stderr, "Thread %d terminated\n", i);
   }
 

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -645,13 +645,11 @@ static struct redircase set_url_list[] = {
 static int set_url(void)
 {
   int i;
-  CURLUcode rc;
-  CURLU *urlp;
   int error = 0;
 
   for(i = 0; set_url_list[i].in && !error; i++) {
-    char *url = NULL;
-    urlp = curl_url();
+    CURLUcode rc;
+    CURLU *urlp = curl_url();
     if(!urlp)
       break;
     rc = curl_url_set(urlp, CURLUPART_URL, set_url_list[i].in,
@@ -666,6 +664,7 @@ static int set_url(void)
         error++;
       }
       else {
+        char *url = NULL;
         rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
         if(rc) {
           fprintf(stderr, "%s:%d Get URL returned %d\n",
@@ -677,8 +676,8 @@ static int set_url(void)
             error++;
           }
         }
+        curl_free(url);
       }
-      curl_free(url);
     }
     else if(rc != set_url_list[i].ucode) {
       fprintf(stderr, "Set URL\nin: %s\nreturned %d (expected %d)\n",
@@ -693,11 +692,10 @@ static int set_url(void)
 static int set_parts(void)
 {
   int i;
-  CURLUcode rc;
   int error = 0;
 
   for(i = 0; set_parts_list[i].set && !error; i++) {
-    char *url = NULL;
+    CURLUcode rc;
     CURLU *urlp = curl_url();
     if(!urlp) {
       error++;
@@ -709,6 +707,7 @@ static int set_parts(void)
     else
       rc = CURLUE_OK;
     if(!rc) {
+      char *url = NULL;
       CURLUcode uc = updateurl(urlp, set_parts_list[i].set,
                                set_parts_list[i].setflags);
 
@@ -728,13 +727,13 @@ static int set_parts(void)
       else if(checkurl(url, set_parts_list[i].out)) {
         error++;
       }
+      curl_free(url);
     }
     else if(rc != set_parts_list[i].ucode) {
       fprintf(stderr, "Set parts\nin: %s\nreturned %d (expected %d)\n",
               set_parts_list[i].in, (int)rc, set_parts_list[i].ucode);
       error++;
     }
-    curl_free(url);
     curl_url_cleanup(urlp);
   }
   return error;
@@ -743,10 +742,9 @@ static int set_parts(void)
 static int get_url(void)
 {
   int i;
-  CURLUcode rc;
   int error = 0;
   for(i = 0; get_url_list[i].in && !error; i++) {
-    char *url = NULL;
+    CURLUcode rc;
     CURLU *urlp = curl_url();
     if(!urlp) {
       error++;
@@ -755,6 +753,7 @@ static int get_url(void)
     rc = curl_url_set(urlp, CURLUPART_URL, get_url_list[i].in,
                       get_url_list[i].urlflags);
     if(!rc) {
+      char *url = NULL;
       rc = curl_url_get(urlp, CURLUPART_URL, &url, get_url_list[i].getflags);
 
       if(rc) {
@@ -767,13 +766,13 @@ static int get_url(void)
           error++;
         }
       }
+      curl_free(url);
     }
     else if(rc != get_url_list[i].ucode) {
       fprintf(stderr, "Get URL\nin: %s\nreturned %d (expected %d)\n",
               get_url_list[i].in, (int)rc, get_url_list[i].ucode);
       error++;
     }
-    curl_free(url);
     curl_url_cleanup(urlp);
   }
   return error;
@@ -782,11 +781,10 @@ static int get_url(void)
 static int get_parts(void)
 {
   int i;
-  CURLUcode rc;
-  CURLU *urlp;
   int error = 0;
   for(i = 0; get_parts_list[i].in && !error; i++) {
-    urlp = curl_url();
+    CURLUcode rc;
+    CURLU *urlp = curl_url();
     if(!urlp) {
       error++;
       break;
@@ -831,11 +829,10 @@ static struct querycase append_list[] = {
 static int append(void)
 {
   int i;
-  CURLUcode rc;
-  CURLU *urlp;
   int error = 0;
   for(i = 0; append_list[i].in && !error; i++) {
-    urlp = curl_url();
+    CURLUcode rc;
+    CURLU *urlp = curl_url();
     if(!urlp) {
       error++;
       break;
@@ -881,12 +878,11 @@ static int append(void)
 
 static int scopeid(void)
 {
-  CURLU *u;
+  CURLU *u = curl_url();
   int error = 0;
   CURLUcode rc;
   char *url;
 
-  u = curl_url();
   rc = curl_url_set(u, CURLUPART_URL,
                     "https://[fe80::20c:29ff:fe9c:409b%25eth0]/hello.html", 0);
   if(rc != CURLUE_OK) {

--- a/tests/libtest/lib1905.c
+++ b/tests/libtest/lib1905.c
@@ -27,12 +27,11 @@
 
 int test(char *URL)
 {
-  CURLM *cm = NULL;
   CURLSH *sh = NULL;
   CURL *ch = NULL;
   int unfinished;
 
-  cm = curl_multi_init();
+  CURLM *cm = curl_multi_init();
   if(!cm)
     return 1;
   sh = curl_share_init();

--- a/tests/libtest/lib541.c
+++ b/tests/libtest/lib541.c
@@ -97,7 +97,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_READDATA, hd_src);
 
   /* Now run off and do what you've been told! */
-  res = curl_easy_perform(curl);
+  curl_easy_perform(curl);
 
   /* and now upload the exact same again, but without rewinding so it already
      is at end of file */

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -39,9 +39,8 @@ int test(char *URL)
   char *rtsp_session_id;
   int request = 1;
   int i;
-  FILE *idfile = NULL;
 
-  idfile = fopen(libtest_arg2, "wb");
+  FILE *idfile = fopen(libtest_arg2, "wb");
   if(idfile == NULL) {
     fprintf(stderr, "couldn't open the Session ID File\n");
     return TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -104,9 +104,8 @@ int test(char *URL)
   CURL *curl;
   char *stream_uri = NULL;
   int request = 1;
-  FILE *protofile = NULL;
 
-  protofile = fopen(libtest_arg2, "wb");
+  FILE *protofile = fopen(libtest_arg2, "wb");
   if(protofile == NULL) {
     fprintf(stderr, "Couldn't open the protocol dump file\n");
     return TEST_ERR_MAJOR_BAD;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -749,10 +749,6 @@ static bool incoming(curl_socket_t listenfd)
   fd_set fds_read;
   fd_set fds_write;
   fd_set fds_err;
-  curl_socket_t sockfd = CURL_SOCKET_BAD;
-  int maxfd = -99;
-  ssize_t rc;
-  int error = 0;
   int clients = 0; /* connected clients */
   struct perclient c[2];
 
@@ -772,15 +768,17 @@ static bool incoming(curl_socket_t listenfd)
 
   do {
     int i;
+    ssize_t rc;
+    int error = 0;
+    curl_socket_t sockfd = listenfd;
+    int maxfd = (int)sockfd;
 
     FD_ZERO(&fds_read);
     FD_ZERO(&fds_write);
     FD_ZERO(&fds_err);
 
-    sockfd = listenfd;
     /* there's always a socket to wait for */
     FD_SET(sockfd, &fds_read);
-    maxfd = (int)sockfd;
 
     for(i = 0; i < 2; i++) {
       if(c[i].used) {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -952,28 +952,19 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
   ssize_t got = 0;
   int overflow = 0;
 
-  char *pipereq = NULL;
-  size_t pipereq_length = 0;
-
   if(req->offset >= REQBUFSIZ-1) {
     /* buffer is already full; do nothing */
     overflow = 1;
   }
   else {
-    if(pipereq_length && pipereq) {
-      memmove(reqbuf, pipereq, pipereq_length);
-      got = curlx_uztosz(pipereq_length);
-      pipereq_length = 0;
-    }
-    else {
-      if(req->skip)
-        /* we are instructed to not read the entire thing, so we make sure to
-           only read what we're supposed to and NOT read the enire thing the
-           client wants to send! */
-        got = sread(sock, reqbuf + req->offset, req->cl);
-      else
-        got = sread(sock, reqbuf + req->offset, REQBUFSIZ-1 - req->offset);
-    }
+    if(req->skip)
+      /* we are instructed to not read the entire thing, so we make sure to
+         only read what we're supposed to and NOT read the enire thing the
+         client wants to send! */
+      got = sread(sock, reqbuf + req->offset, req->cl);
+    else
+      got = sread(sock, reqbuf + req->offset, REQBUFSIZ-1 - req->offset);
+
     if(got_exit_signal)
       return -1;
     if(got == 0) {


### PR DESCRIPTION
This brings the "code style" C warnings in Codacy down to 57, most of which are either false positives or dead stores with the variable overriden after being initialized to a default value.

I'm not going to merge this before the 7.65.1 release. Just opening the PR because I had already forgotten about that branch.

- remove unused code
- remove dead variable stores
- reduce variable scopes
- use C++ casts in C++ code
- fix check if result of unsigned integer expression is negative