### PR TITLE
tool_parsecfg: Use correct return type for GetModuleFileName()

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -76,8 +76,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
            * already declared via inclusions done in setup header file.
            * We assume that we are using the ASCII version here.
            */
-          int n = GetModuleFileNameA(0, filebuffer, sizeof(filebuffer));
-          if(n > 0 && n < (int)sizeof(filebuffer)) {
+          unsigned long len = GetModuleFileNameA(0, filebuffer,
+                                                 sizeof(filebuffer));
+          if(len > 0 && len < sizeof(filebuffer)) {
             /* We got a valid filename - get the directory part */
             char *lastdirchar = strrchr(filebuffer, '\\');
             if(lastdirchar) {


### PR DESCRIPTION
GetModuleFileName() returns a DWORD which is a typedef of an unsigned
long and not an int.

Unfortunately we still need the cast in the if statement for Win64 :(