### PR TITLE
tool_cb_prg: Fix integer overflow in progress bar

### DIFF
--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -126,13 +126,15 @@ int tool_progress_cb(void *clientp,
   curl_off_t point;
 
   /* expected transfer size */
-  if((CURL_OFF_T_MAX - bar->initial_size) < (dltotal + ultotal))
+  if(bar->initial_size < 0 ||
+     ((CURL_OFF_T_MAX - bar->initial_size) < (dltotal + ultotal)))
     total = CURL_OFF_T_MAX;
   else
     total = dltotal + ultotal + bar->initial_size;
 
   /* we've come this far */
-  if((CURL_OFF_T_MAX - bar->initial_size) < (dlnow + ulnow))
+  if(bar->initial_size < 0 ||
+     ((CURL_OFF_T_MAX - bar->initial_size) < (dlnow + ulnow)))
     point = CURL_OFF_T_MAX;
   else
     point = dlnow + ulnow + bar->initial_size;


### PR DESCRIPTION
Commit 61faa0b420c236480bc9ef6fd52b4ecc1e0f8d17 fixed the progress bar width calculation to avoid integer overflow, but failed to account for the fact that initial_size is initialized to -1 causing another signed integer overflow.  Fix by separately checking for this case before the width calculation.

Closes #xxxx
Reported-by: Brian Carpenter (Geeknik Labs)