### PR TITLE
[WIP] tool_parsecfg: Support .netrc and .curlrc on Windows

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -37,6 +37,8 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#define NETRC DOT_CHAR "netrc"
+
 /* Get user and password from .netrc when given a machine name */
 
 enum host_lookup_state {
@@ -72,8 +74,6 @@ int Curl_parsenetrc(const char *host,
   char state_password = 0;   /* Found a password keyword */
   int state_our_login = FALSE;  /* With specific_login, found *our* login
                                    name */
-
-#define NETRC DOT_CHAR "netrc"
 
   if(!netrcfile) {
     bool home_alloc = FALSE;

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -75,6 +75,7 @@ int Curl_parsenetrc(const char *host,
                                    name */
 
   if(!netrcfile) {
+    const char *filename = NETRC;     /* sensible default */
     char *home = curl_getenv("HOME"); /* portable environment reader */
     if(home) {
 #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
@@ -102,7 +103,7 @@ int Curl_parsenetrc(const char *host,
     if(!home)
       return retcode; /* no home directory found (or possibly out of memory) */
 
-    netrcfile = curl_maprintf("%s%s%s", home, DIR_CHAR, NETRC);
+    netrcfile = curl_maprintf("%s%s%s", home, DIR_CHAR, filename);
     free(home);
     if(!netrcfile) {
       return -1;

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -67,7 +67,6 @@ int Curl_parsenetrc(const char *host,
   bool specific_login = (login && *login != 0);
   bool login_alloc = FALSE;
   bool password_alloc = FALSE;
-  bool netrc_alloc = FALSE;
   enum host_lookup_state state = NOTHING;
 
   char state_login = 0;      /* Found a login keyword */
@@ -76,10 +75,8 @@ int Curl_parsenetrc(const char *host,
                                    name */
 
   if(!netrcfile) {
-    bool home_alloc = FALSE;
     char *home = curl_getenv("HOME"); /* portable environment reader */
     if(home) {
-      home_alloc = TRUE;
 #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
     }
     else {
@@ -90,7 +87,6 @@ int Curl_parsenetrc(const char *host,
         home = strdup(pw.pw_dir);
         if(!home)
           return -1;
-        home_alloc = TRUE;
       }
 #elif defined(HAVE_GETPWUID) && defined(HAVE_GETEUID)
     }
@@ -107,17 +103,14 @@ int Curl_parsenetrc(const char *host,
       return retcode; /* no home directory found (or possibly out of memory) */
 
     netrcfile = curl_maprintf("%s%s%s", home, DIR_CHAR, NETRC);
-    if(home_alloc)
-      free(home);
+    free(home);
     if(!netrcfile) {
       return -1;
     }
-    netrc_alloc = TRUE;
   }
 
   file = fopen(netrcfile, FOPEN_READTEXT);
-  if(netrc_alloc)
-    free(netrcfile);
+  free(netrcfile);
   if(file) {
     char *tok;
     char *tok_buf;

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -59,9 +59,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     char *home = homedir();    /* portable homedir finder */
     filename = CURLRC;   /* sensible default */
     if(home) {
-      if(strlen(home) < (sizeof(filebuffer) - strlen(CURLRC))) {
+      if(strlen(home) < (sizeof(filebuffer) - strlen(filename))) {
         msnprintf(filebuffer, sizeof(filebuffer),
-                  "%s%s%s", home, DIR_CHAR, CURLRC);
+                  "%s%s%s", home, DIR_CHAR, filename);
 
 #ifdef WIN32
         /* Check if the file exists - if not, try CURLRC in the same
@@ -86,9 +86,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
               *lastdirchar = 0;
               /* If we have enough space, build the RC filename */
               remaining = sizeof(filebuffer) - strlen(filebuffer);
-              if(strlen(CURLRC) < remaining - 1) {
+              if(strlen(filename) < remaining - 1) {
                 msnprintf(lastdirchar, remaining,
-                          "%s%s", DIR_CHAR, CURLRC);
+                          "%s%s", DIR_CHAR, filename);
                 /* Don't bother checking if it exists - we do that later */
                 filename = filebuffer;
               }


### PR DESCRIPTION
Support and prefer .curlrc over _curlrc in Windows. Other OSes are unaffected by this change; so _curlrc on DOS and .curlrc on all others.

I know .curlrc on Windows has been discussed before and without checking the mailing lists I can't remember the last time it was. However this is my take on trying to support .curlrc on Windows as well as maintaining support for _curlrc (as Windows doesn't have the same limitation as DOS).

**Note: I haven't worried about supporting older versions of Windows that don't support long file names - ie versions prior to Windows 95 that are not Windows NT based.**

In summary it performs the check for the CURLRC file in both the 'home' folder and the current executable directory as per the current behaviour, but loops round this code twice. The first time looking for .curlrc and then if that fails looking for _curlrc the second time.

It fixes a long known "git for windows" bug bear (as it's been in their release notes since I have been involved with curl - and using git).

If the general consensus is that we should proceed with 'fixing' this then I would propose something similar for _netrc too.

I would appreciate feedback and comments.

Many thanks