### PR TITLE
unpause: trigger a timeout for event-based transfers

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1038,8 +1038,11 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
      to have this handle checked soon */
   if(!result &&
      ((newstate&(KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) !=
-      (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) )
+      (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) ) {
     Curl_expire(data, 0, EXPIRE_RUN_NOW); /* get this handle going again */
+    if(data->multi)
+      Curl_update_timer(data->multi);
+  }
 
   /* This transfer may have been moved in or out of the bundle, update
      the corresponding socket callback, if used */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -30,6 +30,7 @@ void Curl_updatesocket(struct Curl_easy *data);
 void Curl_expire(struct Curl_easy *data, time_t milli, expire_id);
 void Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
+void Curl_update_timer(struct Curl_multi *multi);
 void Curl_detach_connnection(struct Curl_easy *data);
 void Curl_attach_connnection(struct Curl_easy *data,
                              struct connectdata *conn);


### PR DESCRIPTION
... so that timeouts or other state machine actions get going again
after a changing pause state. For example, if the last delivery was
paused there's no pending socket activity.

Reported-by: sstruchtrup on github
Fixes #3994