### PR TITLE
CURLOPT_CAINFO.3: polished wording

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.3
@@ -46,22 +46,20 @@ libnssckbi.so, which contains a more comprehensive set of trust information
 than supported by nss-pem, because libnssckbi.so also includes information
 about distrusted certificates.
 
-(iOS and macOS) If curl is built against Secure Transport, then this
-option is supported for backward compatibility with other SSL engines, but it
-should not be set. If the option is not set, then curl will use the
-certificates in the system and user Keychain to verify the peer, which is the
-preferred method of verifying the peer's certificate chain.
+(iOS and macOS) When curl uses Secure Transport this option is supported. If
+the option is not set, then curl will use the certificates in the system and
+user Keychain to verify the peer.
 
 (Schannel) This option is supported for Schannel in Windows 7 or later but we
 recommend not using it until Windows 8 since it works better starting then.
-Added in libcurl 7.60. This option is supported for backward compatibility
-with other SSL engines; instead it is recommended to use Windows' store of
-root certificates (the default for Schannel).
+If the option is not set, then curl will use the certificates in the Windows'
+store of root certificates (the default for Schannel).
 
 The application does not have to keep the string around after setting this
 option.
 .SH DEFAULT
-Built-in system specific
+Built-in system specific. When curl is built with Secure Transport or
+Schannel, this option is not set by default.
 .SH PROTOCOLS
 All TLS based protocols: HTTPS, FTPS, IMAPS, POP3S, SMTPS etc.
 .SH EXAMPLE
@@ -75,8 +73,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-For SSL engines that don't support certificate files the CURLOPT_CAINFO option
-is ignored. Refer to https://curl.haxx.se/docs/ssl-compared.html
+For the SSL engines that don't support certificate files the CURLOPT_CAINFO
+option is ignored. Schannel support added in libcurl 7.60.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.


### PR DESCRIPTION
Clarify the functionality when built to use Schannel and Secure
Transport and stop calling it the "recommended" or "preferred" way and
instead rather call it the default.

Removed the reference to the ssl comparison table as it isn't necessary.

Reported-by: Richard Alcock
Bug: https://curl.haxx.se/mail/lib-2019-06/0019.html