### PR TITLE
Fix CURLOPT_MAXAGE_CONN time comparison

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -975,7 +975,7 @@ static bool conn_maxage(struct Curl_easy *data,
     timediff_t idletime = Curl_timediff(now, conn->lastused);
     idletime /= 1000; /* integer seconds is fine */
 
-    if(idletime/1000 > data->set.maxage_conn) {
+    if(idletime > data->set.maxage_conn) {
       infof(data, "Too old connection (%ld seconds), disconnect it\n",
             idletime);
       return TRUE;


### PR DESCRIPTION
Old connections are meant to expire from the connection cache after
CURLOPT_MAXAGE_CONN seconds. However, they actually expire after 1000x
that value. This occurs because a time value measured in milliseconds is
accidentally divided by 1M instead of by 1,000.

Test case: https://gist.github.com/cliffcrosland/bd1681f06de12e1c9489eac5632e444a

