### PR TITLE
krb5: fix compiler warning

### DIFF
--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -320,10 +320,8 @@ static void krb5_end(void *app_data)
     OM_uint32 min;
     gss_ctx_id_t *context = app_data;
     if(*context != GSS_C_NO_CONTEXT) {
-#ifdef DEBUGBUILD
-      OM_uint32 maj =
-#endif
-      gss_delete_sec_context(&min, context, GSS_C_NO_BUFFER);
+      OM_uint32 maj = gss_delete_sec_context(&min, context, GSS_C_NO_BUFFER);
+      (void)maj;
       DEBUGASSERT(maj == GSS_S_COMPLETE);
     }
 }


### PR DESCRIPTION
Even though the variable was used in a `DEBUGASSERT`, GCC 8 warned in
debug mode:
```
krb5.c:324:17: error: unused variable 'maj' [-Werror=unused-variable]
```

Just suppress the warning and declare the variable unconditionally
instead of only for `DEBUGBUILD` (which also missed the check for
`HAVE_ASSERT_H`).