### PR TITLE
unit1654: cleanup on memory failure

### DIFF
--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -53,8 +53,10 @@ UNITTEST_START
   if(!asi)
     return 1;
   result = Curl_altsvc_load(asi, arg);
-  if(result)
+  if(result) {
+    Curl_altsvc_cleanup(asi);
     return result;
+  }
   curl = curl_easy_init();
   if(!curl)
     goto fail;


### PR DESCRIPTION
... to make it handle torture tests properly.

Reported-by: Marcel Raad
Fixes #4021