### PR TITLE
--disable-progress-meter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4115,6 +4115,24 @@ AC_HELP_STRING([--disable-netrc],[Disable netrc parsing]),
 )
 
 dnl ************************************************************
+dnl disable progress-meter
+dnl
+AC_MSG_CHECKING([whether to support progress-meter])
+AC_ARG_ENABLE(progress-meter,
+AC_HELP_STRING([--enable-progress-meter],[Enable progress-meter])
+AC_HELP_STRING([--disable-progress-meter],[Disable progress-meter]),
+[ case "$enableval" in
+  no)
+       AC_MSG_RESULT(no)
+       AC_DEFINE(CURL_DISABLE_PROGRESS_METER, 1, [disable progress-meter])
+       ;;
+  *)   AC_MSG_RESULT(yes)
+       ;;
+  esac ],
+       AC_MSG_RESULT(yes)
+)
+
+dnl ************************************************************
 dnl disable shuffle DNS support
 dnl
 AC_MSG_CHECKING([whether to support DNS shuffling])

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,6 +31,7 @@
 /* check rate limits within this many recent milliseconds, at minimum. */
 #define MIN_RATE_LIMIT_PERIOD 3000
 
+#ifndef CURL_DISABLE_PROGRESS_METER
 /* Provide a string that is 2 + 1 + 2 + 1 + 2 = 8 letters long (plus the zero
    byte) */
 static void time2str(char *r, curl_off_t seconds)
@@ -119,6 +120,7 @@ static char *max5data(curl_off_t bytes, char *max5)
 
   return max5;
 }
+#endif
 
 /*
 
@@ -362,22 +364,13 @@ void Curl_pgrsSetUploadSize(struct Curl_easy *data, curl_off_t size)
   }
 }
 
-/*
- * Curl_pgrsUpdate() returns 0 for success or the value returned by the
- * progress callback!
- */
-int Curl_pgrsUpdate(struct connectdata *conn)
+static void progress_calc(struct connectdata *conn, struct curltime now)
 {
-  struct curltime now;
   curl_off_t timespent;
   curl_off_t timespent_ms; /* milliseconds */
   struct Curl_easy *data = conn->data;
-  int nowindex = data->progress.speeder_c% CURR_TIME;
-  bool shownow = FALSE;
   curl_off_t dl = data->progress.downloaded;
   curl_off_t ul = data->progress.uploaded;
-
-  now = Curl_now(); /* what time is it */
 
   /* The time spent so far (from the start) */
   data->progress.timespent = Curl_timediff_us(now, data->progress.start);
@@ -399,8 +392,7 @@ int Curl_pgrsUpdate(struct connectdata *conn)
   /* Calculations done at most once a second, unless end is reached */
   if(data->progress.lastshow != now.tv_sec) {
     int countindex; /* amount of seconds stored in the speeder array */
-    shownow = TRUE;
-
+    int nowindex = data->progress.speeder_c% CURR_TIME;
     data->progress.lastshow = now.tv_sec;
 
     /* Let's do the "current speed" thing, with the dl + ul speeds
@@ -434,8 +426,7 @@ int Curl_pgrsUpdate(struct connectdata *conn)
         data->progress.speeder_c%CURR_TIME:0;
 
       /* Figure out the exact time for the time span */
-      span_ms = Curl_timediff(now,
-                              data->progress.speeder_time[checkindex]);
+      span_ms = Curl_timediff(now, data->progress.speeder_time[checkindex]);
       if(0 == span_ms)
         span_ms = 1; /* at least one millisecond MUST have passed */
 
@@ -461,8 +452,25 @@ int Curl_pgrsUpdate(struct connectdata *conn)
         data->progress.ulspeed + data->progress.dlspeed;
 
   } /* Calculations end */
+}
 
-  if(!(data->progress.flags & PGRS_HIDE)) {
+#ifndef CURL_DISABLE_PROGRESS_METER
+static void progress_meter(struct connectdata *conn,
+                           struct curltime now)
+{
+  struct Curl_easy *data = conn->data;
+  bool shownow = FALSE;
+  if(data->progress.lastshow != now.tv_sec) {
+    if(!(data->progress.flags & PGRS_HIDE))
+      shownow = TRUE;
+  }
+
+  if(!shownow)
+    /* only show the internal progress meter once per second */
+    return;
+  else {
+    /* If there's no external callback set, use internal code to show
+       progress */
     /* progress meter has not been shut off */
     char max5[6][10];
     curl_off_t dlpercen = 0;
@@ -476,42 +484,8 @@ int Curl_pgrsUpdate(struct connectdata *conn)
     curl_off_t ulestimate = 0;
     curl_off_t dlestimate = 0;
     curl_off_t total_estimate;
-
-    if(data->set.fxferinfo) {
-      int result;
-      /* There's a callback set, call that */
-      Curl_set_in_callback(data, true);
-      result = data->set.fxferinfo(data->set.progress_client,
-                                   data->progress.size_dl,
-                                   data->progress.downloaded,
-                                   data->progress.size_ul,
-                                   data->progress.uploaded);
-      Curl_set_in_callback(data, false);
-      if(result)
-        failf(data, "Callback aborted");
-      return result;
-    }
-    if(data->set.fprogress) {
-      int result;
-      /* The older deprecated callback is set, call that */
-      Curl_set_in_callback(data, true);
-      result = data->set.fprogress(data->set.progress_client,
-                                   (double)data->progress.size_dl,
-                                   (double)data->progress.downloaded,
-                                   (double)data->progress.size_ul,
-                                   (double)data->progress.uploaded);
-      Curl_set_in_callback(data, false);
-      if(result)
-        failf(data, "Callback aborted");
-      return result;
-    }
-
-    if(!shownow)
-      /* only show the internal progress meter once per second */
-      return 0;
-
-    /* If there's no external callback set, use internal code to show
-       progress */
+    curl_off_t timespent =
+      (curl_off_t)data->progress.timespent/1000000; /* seconds */
 
     if(!(data->progress.flags & PGRS_HEADERS_OUT)) {
       if(data->state.resume_from) {
@@ -595,13 +569,60 @@ int Curl_pgrsUpdate(struct connectdata *conn)
             time_total,    /* 8 letters */                /* total time */
             time_spent,    /* 8 letters */                /* time spent */
             time_left,     /* 8 letters */                /* time left */
-            max5data(data->progress.current_speed, max5[5]) /* current speed */
-            );
+            max5data(data->progress.current_speed, max5[5])
+      );
 
     /* we flush the output stream to make it appear as soon as possible */
     fflush(data->set.err);
+  } /* don't show now */
+}
+#else
+ /* progress bar disabled */
+#define progress_meter(x,y)
+#endif
 
-  } /* !(data->progress.flags & PGRS_HIDE) */
+
+/*
+ * Curl_pgrsUpdate() returns 0 for success or the value returned by the
+ * progress callback!
+ */
+int Curl_pgrsUpdate(struct connectdata *conn)
+{
+  struct Curl_easy *data = conn->data;
+  struct curltime now = Curl_now(); /* what time is it */
+
+  progress_calc(conn, now);
+  if(!(data->progress.flags & PGRS_HIDE)) {
+    if(data->set.fxferinfo) {
+      int result;
+      /* There's a callback set, call that */
+      Curl_set_in_callback(data, true);
+      result = data->set.fxferinfo(data->set.progress_client,
+                                   data->progress.size_dl,
+                                   data->progress.downloaded,
+                                   data->progress.size_ul,
+                                   data->progress.uploaded);
+      Curl_set_in_callback(data, false);
+      if(result)
+        failf(data, "Callback aborted");
+      return result;
+    }
+    if(data->set.fprogress) {
+      int result;
+      /* The older deprecated callback is set, call that */
+      Curl_set_in_callback(data, true);
+      result = data->set.fprogress(data->set.progress_client,
+                                   (double)data->progress.size_dl,
+                                   (double)data->progress.downloaded,
+                                   (double)data->progress.size_ul,
+                                   (double)data->progress.uploaded);
+      Curl_set_in_callback(data, false);
+      if(result)
+        failf(data, "Callback aborted");
+      return result;
+    }
+  }
+  progress_meter(conn, now);
 
   return 0;
 }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -169,7 +169,7 @@ test1444 test1445 test1446 test1447 test1448 test1449 test1450 test1451 \
 test1452 test1453 test1454 test1455 test1456 test1457 test1458\
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
-test1516 test1517 test1518 test1519 test1520 test1521 test1522 \
+test1516 test1517 test1518 test1519 test1520 test1521 test1522 test1523 \
 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \

--- a/tests/data/test1523
+++ b/tests/data/test1523
@@ -1,0 +1,46 @@
+<testcase>
+<info>
+<keywords>
+CURLINFO_LOW_SPEED_LIMIT
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Content-Length: 3
+Connection: close
+Funny-head: yesyes
+
+AA
+</data>
+<servercmd>
+writedelay: 1
+</servercmd>
+</reply>
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+lib1523
+</tool>
+
+<name>
+CURLINFO_LOW_SPEED_LIMIT
+</name>
+
+<command>
+http://%HOSTIP:%HTTPPORT/1523
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/data/test1523
+++ b/tests/data/test1523
@@ -37,6 +37,9 @@ CURLINFO_LOW_SPEED_LIMIT
 <command>
 http://%HOSTIP:%HTTPPORT/1523
 </command>
+<killserver>
+http
+</killserver>
 </client>
 
 #

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -26,7 +26,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1156 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
- lib1518         lib1520 lib1521 lib1522 \
+ lib1518         lib1520 lib1521 lib1522 lib1523 \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
  lib1534 lib1535 lib1536 lib1537 lib1538 \
  lib1540 lib1541 \
@@ -427,6 +427,9 @@ lib1521_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)
 
 lib1522_SOURCES = lib1522.c $(SUPPORTFILES)
 lib1522_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1523_SOURCES = lib1523.c $(SUPPORTFILES)
+lib1523_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1525_SOURCES = lib1525.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1525_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1523.c
+++ b/tests/libtest/lib1523.c
@@ -1,0 +1,82 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+/* test case and code based on https://github.com/curl/curl/issues/3927 */
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+static int dload_progress_cb(void *a, curl_off_t b, curl_off_t c,
+                             curl_off_t d, curl_off_t e)
+{
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  (void)e;
+  return 0;
+}
+
+static size_t write_cb(char *d, size_t n, size_t l, void *p)
+{
+  /* take care of the data here, ignored in this example */
+  (void)d;
+  (void)p;
+  return n*l;
+}
+
+static CURLcode run(CURL *hnd, long limit, long time)
+{
+  curl_easy_setopt(hnd, CURLOPT_LOW_SPEED_LIMIT, limit);
+  curl_easy_setopt(hnd, CURLOPT_LOW_SPEED_TIME, time);
+  return curl_easy_perform(hnd);
+}
+
+int test(char *URL)
+{
+  CURLcode ret;
+  CURL *hnd = curl_easy_init();
+  char buffer[CURL_ERROR_SIZE];
+  curl_easy_setopt(hnd, CURLOPT_URL, URL);
+  curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, write_cb);
+  curl_easy_setopt(hnd, CURLOPT_ERRORBUFFER, buffer);
+  curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 0L);
+  curl_easy_setopt(hnd, CURLOPT_XFERINFOFUNCTION, dload_progress_cb);
+
+  printf("Start: %d\n", time(NULL));
+  ret = run(hnd, 1, 2);
+  if(ret)
+    fprintf(stderr, "error %d: %s\n", ret, buffer);
+
+  ret = run(hnd, 12000, 1);
+  if(ret != CURLE_OPERATION_TIMEDOUT)
+    fprintf(stderr, "error %d: %s\n", ret, buffer);
+  else
+    ret = 0;
+
+  printf("End: %d\n", time(NULL));
+  curl_easy_cleanup(hnd);
+
+  return (int)ret;
+}


### PR DESCRIPTION
Here's a new take at allowing a build to disable the progress meter. The previous attempt was reverted in #3928 due to regressions.

My plan is to take the bug report from #3927 and make a test case out of it to verify that this PR doesn't break existing functionality (in the same way) before I merge.