### PR TITLE
travis: run more tests with coverage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -459,7 +459,7 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "coverage" ]; then
-             ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --with-libssh2
+             ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --enable-alt-svc --with-libssh2
              make
              make TFLAGS=-n test-nonflaky
              make "TFLAGS=-n -e" test-nonflaky

--- a/.travis.yml
+++ b/.travis.yml
@@ -300,6 +300,7 @@ matrix:
                       - lcov
                       - libpsl-dev
                       - libbrotli-dev
+                      - libssh2-1-dev
         - os: linux
           compiler: gcc
           dist: xenial
@@ -458,11 +459,11 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "coverage" ]; then
-             ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror
+             ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --with-libssh2
              make
              make TFLAGS=-n test-nonflaky
              make "TFLAGS=-n -e" test-nonflaky
-             tests="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 200 201 202 300 301 302 500 501 502 503 504 506 507 508 509 510 511 512 513 514 515 516 517 518 519 600 601 700 701 702 800 801 802 803 900 901 902 903 1000 1001 1002 1004 1100 1101 1200 1201 1302 1303 1304 1305 1306 1308 1400 1401 1402 1404 1450 1451 1452 1502 1507 1508 1600 1602 1603 1605 1650 1651 1652 1653 1654 2001 2100 3000"
+             tests="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 200 201 202 300 301 302 500 501 502 503 504 506 507 508 509 510 511 512 513 514 515 516 517 518 519 700 701 702 800 801 802 803 900 901 902 903 1000 1001 1002 1004 1100 1101 1200 1201 1302 1303 1304 1305 1306 1308 1400 1401 1402 1404 1450 1451 1452 1502 1507 1508 1600 1602 1603 1605 1650 1651 1652 1653 1654 2001 2100 3000"
              make "TFLAGS=-n -t $tests" test-nonflaky
              coveralls --gcov /usr/bin/gcov-8 --gcov-options '\-lp' -i src -e lib -e tests -e docs -b $PWD/src
              coveralls --gcov /usr/bin/gcov-8 --gcov-options '\-lp' -e src -i lib -e tests -e docs -b $PWD/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -458,7 +458,7 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "coverage" ]; then
-             ./configure --enable-debug --disable-shared --enable-code-coverage --enable-werror
+             ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror
              make
              make TFLAGS=-n test-nonflaky
              make "TFLAGS=-n -e" test-nonflaky

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,12 +82,7 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
-        - os: linux
-          compiler: gcc
-          dist: trusty
-          env:
-              - T=normal BROTLI=yes
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+                      - libbrotli-dev
         - os: linux
           compiler: gcc
           dist: xenial
@@ -101,6 +96,7 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: gcc
           dist: xenial
@@ -114,12 +110,21 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: gcc
           dist: xenial
           env:
               - T=debug-mesalink C="--with-mesalink --without-ssl"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+          addons:
+              apt:
+                  sources:
+                      - *common_sources
+                  packages:
+                      - *common_packages
+                      - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -135,6 +140,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -150,6 +156,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -165,6 +172,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
                       - libmbedtls-dev
         - os: linux
           compiler: clang
@@ -182,6 +190,7 @@ matrix:
                       - clang-7
                       - libgnutls28-dev
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -197,6 +206,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -213,6 +223,7 @@ matrix:
                       - clang-7
                       - libnss3-dev
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: gcc
           dist: trusty
@@ -257,6 +268,7 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -272,6 +284,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: gcc
           dist: xenial
@@ -286,6 +299,7 @@ matrix:
                       - *common_packages
                       - lcov
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: gcc
           dist: xenial
@@ -299,6 +313,7 @@ matrix:
                   packages:
                       - *common_packages
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -314,6 +329,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -330,6 +346,7 @@ matrix:
                       - clang-7
                       - clang-tidy-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -345,6 +362,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
         - os: linux
           compiler: clang
           dist: xenial
@@ -360,6 +378,7 @@ matrix:
                       - *common_packages
                       - clang-7
                       - libpsl-dev
+                      - libbrotli-dev
 
 before_install:
     - eval "${OVERRIDE_CC}"
@@ -373,20 +392,6 @@ install:
 
 before_script:
     - ./buildconf
-    - |
-      # No brotli package available for Trusty. Download & compile from source.
-      # Cannot be done in the install script because cmake is needed.
-          if [ "$TRAVIS_OS_NAME" = linux -a "$BROTLI" ]; then
-          curl -L https://github.com/google/brotli/archive/v1.0.1.tar.gz |
-              tar xzf - &&
-              (
-                  cd brotli-1.0.1 &&
-                  cmake . -DCMAKE_INSTALL_PREFIX=/usr \
-                          -DCMAKE_INSTALL_LIBDIR=/usr/lib &&
-                  make &&
-                  sudo make install
-              )
-          fi
     - |
       if [ "$TRAVIS_OS_NAME" = linux -a "$BORINGSSL" ]; then
         (cd $HOME &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -453,7 +453,7 @@ script:
     - |
         set -eo pipefail
         if [ "$T" = "coverage" ]; then
-             ./configure --enable-debug --disable-shared --enable-code-coverage
+             ./configure --enable-debug --disable-shared --enable-code-coverage --enable-werror
              make
              make TFLAGS=-n test-nonflaky
              make "TFLAGS=-n -e" test-nonflaky


### PR DESCRIPTION
This enables the following features and tests for the coverage build:
- brotli
- synchronous resolver / TrackMemory
- libssh2
- alt-svc