### PR TITLE
Apply speed limits when network connectivity is lost

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1797,7 +1797,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
       /* check if under send speed */
       result = Curl_speedcheck(data, now);
-      if (result) {
+      if(result) {
           break;
       }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1795,6 +1795,12 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       bool retry = FALSE;
       bool comeback = FALSE;
 
+      /* check if under send speed */
+      result = Curl_speedcheck(data, now);
+      if (result) {
+          break;
+      }
+
       /* check if over send speed */
       send_timeout_ms = 0;
       if(data->set.max_send_speed > 0)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1798,7 +1798,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /* check if under send speed */
       result = Curl_speedcheck(data, now);
       if(result) {
-          break;
+        break;
       }
 
       /* check if over send speed */


### PR DESCRIPTION
After a successful connection, if the machine loses connectivity, it
should timeout the transfer according to the limits set by
CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME