### PR TITLE
os400: make vsetopt() non-static as Curl_vsetopt() for os400 support.

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -119,8 +119,11 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
 #define C_SSLVERSION_VALUE(x) (x & 0xffff)
 #define C_SSLVERSION_MAX_VALUE(x) (x & 0xffff0000)
 
-static CURLcode vsetopt(struct Curl_easy *data, CURLoption option,
-                        va_list param)
+/*
+ * Do not make Curl_vsetopt() static: it is called from
+ * packages/OS400/ccsidcurl.c.
+ */
+CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 {
   char *argptr;
   CURLcode result = CURLE_OK;
@@ -2770,7 +2773,7 @@ CURLcode curl_easy_setopt(struct Curl_easy *data, CURLoption tag, ...)
 
   va_start(arg, tag);
 
-  result = vsetopt(data, tag, arg);
+  result = Curl_vsetopt(data, tag, arg);
 
   va_end(arg);
   return result;

--- a/lib/setopt.h
+++ b/lib/setopt.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 CURLcode Curl_setstropt(char **charp, const char *s);
-CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
-                      va_list arg);
+CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list arg);
 
 #endif /* HEADER_CURL_SETOPT_H */

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1314,11 +1314,8 @@ curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
 
   case CURLOPT_ERRORBUFFER:                     /* This is an output buffer. */
   default:
-  {
-    long val = va_arg(arg, long);
-    result = curl_easy_setopt(curl, tag, val);
+    result = Curl_vsetopt(curl, tag, arg);
     break;
-  }
   }
 
   va_end(arg);


### PR DESCRIPTION
Use it in curl_easy_setopt_ccsid()

Reported-by: jonrumsey on github
Fixes #3833