### PR TITLE
Nmake install prefix

### DIFF
--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -39,9 +39,13 @@ CFGSET=true
 !MESSAGE where <options> is one or many of:
 !MESSAGE   VC=<6,7,8,9,10,11,12,14,15>    - VC versions
 !MESSAGE   WITH_DEVEL=<path>              - Paths for the development files (SSL, zlib, etc.)
-!MESSAGE                                    Defaults to sibbling directory deps: ../deps
+!MESSAGE                                    Defaults to curl's sibling directory deps: ../deps
 !MESSAGE                                    Libraries can be fetched at https://windows.php.net/downloads/php-sdk/deps/
 !MESSAGE                                    Uncompress them into the deps folder.
+!MESSAGE   WITH_PREFIX=<path>             - Installation directory path
+!MESSAGE                                    Defaults to a configuration dependent (SSL, zlib, etc.)
+!MESSAGE                                    directory inside curl's subdirectory builds: ./builds
+!MESSAGE                                    Use backslashes as path separator
 !MESSAGE   WITH_SSL=<dll or static>       - Enable OpenSSL support, DLL or static
 !MESSAGE   WITH_NGHTTP2=<dll or static>   - Enable HTTP/2 support, DLL or static
 !MESSAGE   WITH_CARES=<dll or static>     - Enable c-ares support, DLL or static

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -487,7 +487,12 @@ CFLAGS = $(CFLAGS) /DCURL_WITH_MULTI_SSL
 
 LIB_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-lib
 CURL_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-curl
+
+!IFDEF WITH_PREFIX
+DIRDIST = $(WITH_PREFIX)
+!ELSE
 DIRDIST = ..\builds\$(CONFIG_NAME_LIB)\
+!ENDIF
 
 #
 # curl.exe


### PR DESCRIPTION
Add WITH_PREFIX flag to the nmake based build to allow for a custom install directory.
Please add rdw@steadingsoftware.com as reviewer.

Thanks,
Thomas