### PR TITLE
openssl: remove outdated comment

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1022,14 +1022,8 @@ static int Curl_ossl_init(void)
   ENGINE_load_builtin_engines();
 #endif
 
-  /* OPENSSL_config(NULL); is "strongly recommended" to use but unfortunately
-     that function makes an exit() call on wrongly formatted config files
-     which makes it hard to use in some situations. OPENSSL_config() itself
-     calls CONF_modules_load_file() and we use that instead and we ignore
-     its return code! */
-
-  /* CONF_MFLAGS_DEFAULT_SECTION introduced some time between 0.9.8b and
-     0.9.8e */
+/* CONF_MFLAGS_DEFAULT_SECTION was introduced some time between 0.9.8b and
+   0.9.8e */
 #ifndef CONF_MFLAGS_DEFAULT_SECTION
 #define CONF_MFLAGS_DEFAULT_SECTION 0x0
 #endif


### PR DESCRIPTION
OpenSSL used to call exit(1) on syntax errors in `OPENSSL_config()`, which is why we switched to `CONF_modules_load_file()` and introduced a comment stating why. This behavior was however changed in OpenSSL commit abdd677125f3a9e3082f8c5692203590fdb9b860, so remove the now outdated and incorrect comment. The mentioned commit also declares `OPENSSL_config()` deprecated so keep the current coding.

Also re-indent an adjacent comment to something which seems saner.