### PR TITLE
netrc: Return the correct error code when out of memory

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -89,7 +89,7 @@ int Curl_parsenetrc(const char *host,
          && pw_res) {
         home = strdup(pw.pw_dir);
         if(!home)
-          return CURLE_OUT_OF_MEMORY;
+          return -1;
         home_alloc = TRUE;
       }
 #elif defined(HAVE_GETPWUID) && defined(HAVE_GETEUID)


### PR DESCRIPTION
Prior to this change `Curl_parsenetrc()` would return 27 if the `strdup()` of `pwdir` failed even though a) the function is declared to return an `int` and `CURLE_OUT_OF_MEMORY` is an `enum`, and b) the description in the header file is the function "returns -1 on failure, 0 if the host is found, 1 is the host isn't found"

The knock on effect is that libcurl would attempt to info "Couldn't find host www.example.com in the .netrc file; using defaults" and continue running rather than erroring with a `CURLE_OUT_OF_MEMORY` code straight away.

However, the chances that curl or any application developed with libcurl continuing after a memory allocation failure is very low and would presumably return the correct error code on the next allocation failure.