### PR TITLE
Always include typecheck header

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2851,22 +2851,5 @@ CURL_EXTERN CURLcode curl_easy_pause(CURL *handle, int bitmask);
 #include "easy.h" /* nothing in curl is fun without the easy stuff */
 #include "multi.h"
 #include "urlapi.h"
-
-/* the typechecker doesn't work in C++ (yet) */
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && \
-    ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)) && \
-    !defined(__cplusplus) && !defined(CURL_DISABLE_TYPECHECK)
 #include "typecheck-gcc.h"
-#else
-#if defined(__STDC__) && (__STDC__ >= 1)
-/* This preprocessor magic that replaces a call with the exact same call is
-   only done to make sure application authors pass exactly three arguments
-   to these functions. */
-#define curl_easy_setopt(handle,opt,param) curl_easy_setopt(handle,opt,param)
-#define curl_easy_getinfo(handle,info,arg) curl_easy_getinfo(handle,info,arg)
-#define curl_share_setopt(share,opt,param) curl_share_setopt(share,opt,param)
-#define curl_multi_setopt(handle,opt,param) curl_multi_setopt(handle,opt,param)
-#endif /* __STDC__ >= 1 */
-#endif /* gcc >= 4.3 && !__cplusplus */
-
 #endif /* __CURL_CURL_H */

--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -38,6 +38,12 @@
  * To add an option that uses the same type as an existing option, you'll just
  * need to extend the appropriate _curl_*_option macro
  */
+
+/* the typechecker doesn't work in C++ (yet) */
+#if defined(__GNUC__) && defined(__GNUC_MINOR__) && \
+    ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)) && \
+    !defined(__cplusplus) && !defined(CURL_DISABLE_TYPECHECK)
+
 #define curl_easy_setopt(handle, option, value)                               \
 __extension__ ({                                                              \
   __typeof__(option) _curl_opt = option;                                     \
@@ -234,6 +240,17 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_socket,
   "curl_easy_getinfo expects a pointer to curl_socket_t for this info")
 _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
   "curl_easy_getinfo expects a pointer to curl_off_t for this info")
+#else
+#if defined(__STDC__) && (__STDC__ >= 1)
+/* This preprocessor magic that replaces a call with the exact same call is
+   only done to make sure application authors pass exactly three arguments
+   to these functions. */
+#define curl_easy_setopt(handle,opt,param) curl_easy_setopt(handle,opt,param)
+#define curl_easy_getinfo(handle,info,arg) curl_easy_getinfo(handle,info,arg)
+#define curl_share_setopt(share,opt,param) curl_share_setopt(share,opt,param)
+#define curl_multi_setopt(handle,opt,param) curl_multi_setopt(handle,opt,param)
+#endif /* __STDC__ >= 1 */
+#endif /* gcc >= 4.3 && !__cplusplus */
 
 /* groups of curl_easy_setops options that take the same type of argument */
 

--- a/tests/data/test1459
+++ b/tests/data/test1459
@@ -1,0 +1,26 @@
+<testcase>
+<info>
+<keywords>
+unittest
+typecheck
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+typecheck unit tests
+ </name>
+<tool>
+unit1459
+</tool>
+</client>
+
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -9,6 +9,7 @@ UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307 \
  unit1308 unit1309 unit1323 \
  unit1330 unit1394 unit1395 unit1396 unit1397 unit1398 \
  unit1399 \
+ unit1459 \
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
  unit1608 unit1609 unit1620 unit1621 \
  unit1650 unit1651 unit1652 unit1653 unit1654
@@ -66,6 +67,9 @@ unit1398_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1399_SOURCES = unit1399.c $(UNITFILES)
 unit1399_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1459_SOURCES = unit1459.c $(UNITFILES)
+unit1459_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1600_SOURCES = unit1600.c $(UNITFILES)
 unit1600_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1459.c
+++ b/tests/unit/unit1459.c
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include <curl/curl.h>
+
+UNITTEST_START
+
+int rc;
+
+rc = _curl_is_slist_option(CURLOPT_HTTPHEADER);
+fail_unless(rc != 0, "CURLOPT_HTTPHEADER is an slist option");
+
+rc = _curl_is_string_option(CURLOPT_COOKIE);
+fail_unless(rc != 0, "CURLOPT_COOKIE is a string option");
+
+rc = _curl_is_long_option(CURLOPT_TIMEOUT);
+fail_unless(rc != 0, "CURLOPT_TIMEOUT is a long option");
+
+rc = _curl_is_off_t_option(CURLOPT_MAX_SEND_SPEED_LARGE);
+fail_unless(rc != 0, "CURLOPT_MAX_SEND_SPEED_LARGE is an off_t option");
+
+UNITTEST_STOP

--- a/tests/unit/unit1459.c
+++ b/tests/unit/unit1459.c
@@ -23,6 +23,9 @@
 
 #include <curl/curl.h>
 
+static CURLcode unit_setup(void) {return CURLE_OK;}
+static void unit_stop(void) {}
+
 UNITTEST_START
 
 int rc;


### PR DESCRIPTION
Consistently include the `typecheck-gcc.h` header such that the same macros are available on all compilers:

```
_curl_is_long_option()
_curl_is_off_t_option()
_curl_is_string_option()
_curl_is_postfields_option()
_curl_is_slist_option()
``` 

On compilers other than GCC the `__warning__` attribute is not available, but at least bindings can use the type type checking macros on all systems. See also https://github.com/curl/curl/issues/4038.
