### PR TITLE
Support non-localhost HOSTIP for dict/smb servers

### DIFF
--- a/tests/dictserver.py
+++ b/tests/dictserver.py
@@ -33,7 +33,7 @@ def dictserver(options):
         with open(options.pidfile, "w") as f:
             f.write("{0}".format(pid))
 
-    local_bind = (HOST, options.port)
+    local_bind = (options.host, options.port)
     log.info("[DICT] Listening on %s", local_bind)
 
     # Need to set the allow_reuse on the class, not on the instance.
@@ -83,6 +83,8 @@ def get_options():
 
     parser.add_argument("--port", action="store", default=9016,
                         type=int, help="port to listen on")
+    parser.add_argument("--host", action="store", default=HOST,
+                        help="host to listen on")
     parser.add_argument("--verbose", action="store", type=int, default=0,
                         help="verbose output")
     parser.add_argument("--pidfile", action="store",

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2203,7 +2203,8 @@ sub rundictserver {
     $flags .= "--verbose 1 " if($debugprotocol);
     $flags .= "--pidfile \"$pidfile\" --logfile \"$logfile\" ";
     $flags .= "--id $idnum " if($idnum > 1);
-    $flags .= "--port $port --srcdir \"$srcdir\"";
+    $flags .= "--port $port --srcdir \"$srcdir\" ";
+    $flags .= "--host $HOSTIP";
 
     my $cmd = "$srcdir/dictserver.py $flags";
     my ($dictpid, $pid2) = startnew($cmd, $pidfile, 15, 0);
@@ -2279,7 +2280,8 @@ sub runsmbserver {
     $flags .= "--verbose 1 " if($debugprotocol);
     $flags .= "--pidfile \"$pidfile\" --logfile \"$logfile\" ";
     $flags .= "--id $idnum " if($idnum > 1);
-    $flags .= "--port $port --srcdir \"$srcdir\"";
+    $flags .= "--port $port --srcdir \"$srcdir\" ";
+    $flags .= "--host $HOSTIP";
 
     my $cmd = "$srcdir/smbserver.py $flags";
     my ($smbpid, $pid2) = startnew($cmd, $pidfile, 15, 0);

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -86,7 +86,7 @@ def smbserver(options):
 
     test_data_dir = os.path.join(options.srcdir, "data")
 
-    smb_server = TestSmbServer(("127.0.0.1", options.port),
+    smb_server = TestSmbServer((options.host, options.port),
                                config_parser=smb_config,
                                test_data_directory=test_data_dir)
     log.info("[SMB] setting up SMB server on port %s", options.port)
@@ -312,6 +312,8 @@ def get_options():
 
     parser.add_argument("--port", action="store", default=9017,
                       type=int, help="port to listen on")
+    parser.add_argument("--host", action="store", default="127.0.0.1",
+                      help="host to listen on")
     parser.add_argument("--verbose", action="store", type=int, default=0,
                         help="verbose output")
     parser.add_argument("--pidfile", action="store",


### PR DESCRIPTION
smbserver.py/dictserver.py were explicitly using localhost/127.0.0.1
for binding the server which when we were running the tests with
a separate HOSTIP and CLIENTIP had failures verifying the server
from the device we were testing.

This changes them to take the address on the command line from
runtests.py and default to localhost/127.0.0.1 if none is given.