### PR TITLE
multi: enable multiplexing by default (again)

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -363,6 +363,8 @@ struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
   Curl_llist_init(&multi->msglist, NULL);
   Curl_llist_init(&multi->pending, NULL);
 
+  multi->multiplexing = CURLPIPE_MULTIPLEX;
+
   /* -1 means it not set by user, use the default value */
   multi->maxconnects = -1;
   return multi;


### PR DESCRIPTION
It was originally made default in d7c4213bd0c (7.62.0) but mistakenly reverted
in commit 2f44e94efb3d (7.65.0).

Now enabled again.