### PR TITLE
nss: don't set unused parameter

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1421,7 +1421,7 @@ static int Curl_nss_init(void)
 {
   /* curl_global_init() is not thread-safe so this test is ok */
   if(nss_initlock == NULL) {
-    PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 256);
+    PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
     nss_initlock = PR_NewLock();
     nss_crllock = PR_NewLock();
     nss_findslot_lock = PR_NewLock();


### PR DESCRIPTION
The value of the maxPTDs parameter to PR_Init() has since at least NSPR 2.1, which was released sometime in 1998, been marked ignored as is accordingly not used in the initialization code.  Setting it to a value when calling PR_Init() is thus benign, but indicates an intent which may be misleading. Reset the value to zero to improve clarity.