### PR TITLE
global_init: Make it thread-safe when possible

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -59,7 +59,7 @@ LIB_CFILES = file.c timeval.c base64.c hostip.c progress.c formdata.c   \
   curl_multibyte.c hostcheck.c conncache.c dotdot.c                     \
   x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c      \
   mime.c sha256.c setopt.c curl_path.c curl_ctype.c curl_range.c psl.c  \
-  doh.c urlapi.c curl_get_line.c altsvc.c
+  doh.c urlapi.c curl_get_line.c altsvc.c lazylock.c
 
 LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
   formdata.h cookie.h http.h sendf.h ftp.h url.h dict.h if2ip.h         \
@@ -80,7 +80,7 @@ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
   x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h           \
   curl_printf.h system_win32.h rand.h mime.h curl_sha256.h setopt.h     \
   curl_path.h curl_ctype.h curl_range.h psl.h doh.h urlapi-int.h        \
-  curl_get_line.h altsvc.h quic.h
+  curl_get_line.h altsvc.h quic.h lazylock.h
 
 LIB_RCFILES = libcurl.rc
 

--- a/lib/lazylock.c
+++ b/lib/lazylock.c
@@ -1,0 +1,114 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include "lazylock.h"
+#include <curl/curl.h>
+#include "select.h"
+#include "system_win32.h"
+#include "warnless.h"
+
+/* The last #include files should be: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
+/*
+ * Lazy locking for thread synchronization.
+ *
+ * This is a type of lock that needs no allocated resources, to avoid the
+ * chicken-and-egg problem we'd have with thread-safe init/deinit of the lock
+ * itself during global init/deinit.
+ *
+ * The lock is an atomic compare-and-swap with a full memory barrier. Rather
+ * than aggressive spin to acquire the lock or efficiently wait in a queue it
+ * will wait to lock by sleeping instead. Acquisition is not ordered.
+ *
+ * The lock is not re-entrant since for our purposes locking global init/deinit
+ * that is not needed. Re-entrancy could be implemented but it would limit
+ * support to builds that have thread support or some system function to get
+ * the current thread id.
+ *
+ * The implementation of this lock does not (and should not) require libcurl to
+ * be built with any threading support.
+ */
+
+#ifdef HAVE_LAZYLOCK
+
+typedef enum {
+  LAZYLOCK_UNLOCKED,
+  /* LAZYLOCK_TRANSIENT, */
+  LAZYLOCK_LOCKED
+} lockstate;
+
+curl_lazylock_obj curl_initlock;
+
+/* atomic compare-and-swap with full memory barrier */
+static long compare_and_swap(LAZYLOCK_ATOMIC_TYPENAME long *target,
+                             long oldval, long newval)
+{
+#ifdef WIN32
+  return InterlockedCompareExchange(target, newval, oldval);
+#elif defined(__clang__)
+  /* C11's atomic_compare_exchange_strong with memory_order_seq_cst */
+  __c11_atomic_compare_exchange_strong(target, &oldval, newval,
+                                       __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+  return oldval;
+#elif defined(__GNUC__)
+  /* gcc says intel is unclear on whether or not __sync_val_compare_and_swap
+     gives a full memory barrier so play it safe and call __sync_synchronize.
+     https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html */
+  __sync_synchronize();
+  return __sync_val_compare_and_swap(target, oldval, newval);
+#else
+#error "compare-and-swap function not implemented"
+#endif
+}
+
+void Curl_lazylock_lock(curl_lazylock_obj *lock)
+{
+  int milliseconds = 1;
+
+  for(;;) {
+    long prev = compare_and_swap(lock, LAZYLOCK_UNLOCKED, LAZYLOCK_LOCKED);
+
+    /* if the previous state was UNLOCKED then we own LOCKED */
+    if(prev == LAZYLOCK_UNLOCKED)
+      return;
+
+    Curl_wait_ms(milliseconds);
+
+    if(milliseconds < 1024)
+      milliseconds *= 2;
+  }
+}
+
+void Curl_lazylock_unlock(curl_lazylock_obj *lock)
+{
+  long prev = compare_and_swap(lock, LAZYLOCK_LOCKED, LAZYLOCK_UNLOCKED);
+  /* the previous state should always be LOCKED */
+  DEBUGASSERT(prev == LAZYLOCK_LOCKED);
+  (void)prev;
+  return;
+}
+
+#endif /* HAVE_LAZYLOCK */

--- a/lib/lazylock.h
+++ b/lib/lazylock.h
@@ -1,0 +1,56 @@
+#ifndef HEADER_LAZYLOCK_H
+#define HEADER_LAZYLOCK_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#if defined(WIN32) || defined(__clang__) || defined(__GNUC__)
+#define HAVE_LAZYLOCK
+#endif
+
+#ifdef HAVE_LAZYLOCK
+
+/* lazylock object is just the state. type long due to Windows CAS type. */
+#ifdef __clang__
+#define LAZYLOCK_ATOMIC_TYPENAME _Atomic
+#else
+#define LAZYLOCK_ATOMIC_TYPENAME
+#endif
+
+typedef LAZYLOCK_ATOMIC_TYPENAME long curl_lazylock_obj;
+
+extern curl_lazylock_obj curl_initlock;
+
+/* lazylock is not re-entrant */
+void Curl_lazylock_lock(curl_lazylock_obj *lock);
+void Curl_lazylock_unlock(curl_lazylock_obj *lock);
+
+#define LOCK_GLOBAL_INIT() Curl_lazylock_lock(&curl_initlock)
+#define UNLOCK_GLOBAL_INIT() Curl_lazylock_unlock(&curl_initlock)
+
+#else
+#define LOCK_GLOBAL_INIT()
+#define UNLOCK_GLOBAL_INIT()
+#endif /* HAVE_LAZYLOCK */
+
+#endif /* HEADER_LAZYLOCK_H */


### PR DESCRIPTION
- Use compare-and-swap with a full memory barrier to synchronize
  calls to curl_global_init, curl_global_init_mem, curl_global_cleanup
  and curl_global_sslset.

This is a locking method that does not require libcurl to be built with
a threading library. If compare-and-swap with a full memory barrier is
supported by the compiler (gcc, clang) or the OS (Windows) then libcurl
init/cleanup will be locked.

As discused in #3990 curl_global_ functions are not thread-safe which is
a problem for some users of libcurl that are themselves libraries. The
curl_global_ function requirements may be impossible to meet, eg:

"You must not call it when any other thread in the program (i.e. a
thread sharing the same memory) is running. This doesn't just mean no
other thread that is using libcurl. Because curl_global_init calls
functions of other libraries that are similarly thread unsafe, it could
conflict with any other thread that uses these other libraries."

Even if the user builds libcurl to depend only on libraries that offer
documented thread-safe init/cleanup, there is still libcurl's own
init/cleanup where we have a chicken-and-egg problem of how to
initialize and clean up our lock on many platforms. To solve that I've
implemented a lock that has only its state using compare-and-swap and
does not require any initialization or clean up.

We still cannot guarantee curl_global_ functions are thread-safe, but
this change should make it safer for the user.

Ref: https://github.com/curl/curl/issues/3990
Ref: https://curl.haxx.se/libcurl/c/curl_global_init.html
Ref: ??? probably this has come up before elsewhere

Closes #xxxx

---

/cc @nicowilliams @kdudka 