### PR TITLE
use ares_set_servers_ports_csv on new enough c-ares so that CURLOPT_DNS_SERVERS honors ports

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -734,7 +734,7 @@ CURLcode Curl_set_dns_servers(struct Curl_easy *data,
     return CURLE_OK;
 
 #if (ARES_VERSION >= 0x010704)
-#if (ARES_VERSION >= 0x011100)
+#if (ARES_VERSION >= 0x010b00)
   ares_result = ares_set_servers_ports_csv(data->state.resolver, servers);
 #else
   ares_result = ares_set_servers_csv(data->state.resolver, servers);

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -734,7 +734,11 @@ CURLcode Curl_set_dns_servers(struct Curl_easy *data,
     return CURLE_OK;
 
 #if (ARES_VERSION >= 0x010704)
+#if (ARES_VERSION >= 0x011100)
+  ares_result = ares_set_servers_ports_csv(data->state.resolver, servers);
+#else
   ares_result = ares_set_servers_csv(data->state.resolver, servers);
+#endif
   switch(ares_result) {
   case ARES_SUCCESS:
     result = CURLE_OK;


### PR DESCRIPTION
Fixes #4066 