### PR TITLE
openssl: disable engine if OPENSSL_NO_UI_CONSOLE is defined

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -75,7 +75,7 @@
 #endif
 
 #if (OPENSSL_VERSION_NUMBER >= 0x0090700fL) && /* 0.9.7 or later */     \
-  !defined(OPENSSL_NO_ENGINE)
+  !defined(OPENSSL_NO_ENGINE) && !defined(OPENSSL_NO_UI_CONSOLE)
 #define USE_OPENSSL_ENGINE
 #include <openssl/engine.h>
 #endif


### PR DESCRIPTION
... since that needs UI_OpenSSL() which isn't provided when OpenSSL is
built with OPENSSL_NO_UI_CONSOLE which happens when OpenSSL is built for
UWP (with "VC-WIN32-UWP").

Reported-by: Vasily Lobaskin
Fixes #4073