### PR TITLE
curl_multi_wait.3: escape backslash in example

### DIFF
--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -91,7 +91,7 @@ do {
   }
 
   if(mc != CURLM_OK) {
-    fprintf(stderr, "curl_multi failed, code %d.\n", mc);
+    fprintf(stderr, "curl_multi failed, code %d.\\n", mc);
     break;
   }
 


### PR DESCRIPTION
The backslash in the character Line Feed must be escaped.

The current man-page outputs the code as following:

	fprintf(stderr, "curl_multi failed, code %d.0, mc);

The commit fixes it as follow:

	fprintf(stderr, "curl_multi failed, code %d\n", mc);