### PR TITLE
add CURLOPT_GSS_DELEGCRED option to support cred passthrough on linux

### DIFF
--- a/docs/libcurl/opts/CURLOPT_GSS_DELEGCRED.3
+++ b/docs/libcurl/opts/CURLOPT_GSS_DELEGCRED.3
@@ -1,0 +1,60 @@
+.\" **************************************************************************
+.\" *                                  _   _ ____  _
+.\" *  Project                     ___| | | |  _ \| |
+.\" *                             / __| | | | |_) | |
+.\" *                            | (__| |_| |  _ <| |___
+.\" *                             \___|\___/|_| \_\_____|
+.\" *
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" *
+.\" * This software is licensed as described in the file COPYING, which
+.\" * you should have received as part of this distribution. The terms
+.\" * are also available at https://curl.haxx.se/docs/copyright.html.
+.\" *
+.\" * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+.\" * copies of the Software, and permit persons to whom the Software is
+.\" * furnished to do so, under the terms of the COPYING file.
+.\" *
+.\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+.\" * KIND, either express or implied.
+.\" *
+.\" **************************************************************************
+.\"
+.TH CURLOPT_GSS_DELEGCRED 3 "27 Jun 2019" "libcurl 7.66.0" "curl_easy_setopt options"
+.SH NAME
+CURLOPT_GSS_DELEGCRED \- set the credentials to init the security context, which is used for Kerberos credential delegated situation.
+.SH SYNOPSIS
+#include <curl/curl.h>
+
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_GSS_DELEGCRED, void* cred);
+.SH DESCRIPTION
+pass the delegated credentials through cred to libcurl, so that the libcurl could impersonate the original client to retrieve remote resource.
+
+.SH DEFAULT
+By default, the cred is NULL, that means default security context would be used(GSS_C_NO_CREDENTIAL is acting as a default initiator principal).
+.SH PROTOCOLS
+HTTP
+.SH EXAMPLE
+.nf
+CURL *curl = curl_easy_init();
+if(curl) {
+  CURLcode ret;
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+  /* accept and acquire delegated cred passed from original client*/
+  gss_cred_id_t cred = GSS_C_NO_CREDENTIAL; 
+  ...
+  gss_accept_sec_context(..., &cred);
+  ... 
+  /* pass the cred to libcurl */
+  curl_easy_setopt(curl, CURLOPT_GSS_DELEGCRED,
+                         cred);
+  ret = curl_easy_perform(curl);
+}
+.fi
+
+.SH AVAILABILITY
+Added in 7.66.0
+.SH RETURN VALUE
+Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+.SH "SEE ALSO"
+.BR CURLOPT_HTTPAUTH "(3), " CURLOPT_PROXYAUTH "(3), "

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -12,6 +12,7 @@
 
  Name                           Introduced  Deprecated  Removed
 
+CURLOPT_GSS_DELEGCRED           7.66.0
 CURLALTSVC_ALTUSED              7.64.1
 CURLALTSVC_H1                   7.64.1
 CURLALTSVC_H2                   7.64.1

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1926,7 +1926,7 @@ typedef enum {
   /* maximum age of a connection to consider it for reuse (in seconds) */
   CINIT(MAXAGE_CONN, LONG, 288),
   /* Option to transfer delegated credential to libcurl */
-  CINIT(GSS_DELEGCRED, OBJECTPOINT, 999),  
+  CINIT(GSS_DELEGCRED, OBJECTPOINT, 289),  
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1925,6 +1925,8 @@ typedef enum {
 
   /* maximum age of a connection to consider it for reuse (in seconds) */
   CINIT(MAXAGE_CONN, LONG, 288),
+  /* Option to transfer delegated credential to libcurl */
+  CINIT(GSS_DELEGCRED, OBJECTPOINT, 999),  
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -66,8 +66,16 @@ OM_uint32 Curl_gss_init_sec_context(
   if(data->set.gssapi_delegation & CURLGSSAPI_DELEGATION_FLAG)
     req_flags |= GSS_C_DELEG_FLAG;
 
+  /*retrieve imposonated credential on Linux/Unix*/
+  gss_cred_id_t cred;
+  cred = GSS_C_NO_CREDENTIAL;
+  if(data->set.delegcred != NULL)
+    cred = (gss_cred_id_t)data->set.delegcred;
+
+  infof(data, "Deleg Cred = %x", cred);  
+
   return gss_init_sec_context(minor_status,
-                              GSS_C_NO_CREDENTIAL, /* cred_handle */
+                              cred, /* cred_handle */
                               context,
                               target_name,
                               mech_type,

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -66,13 +66,11 @@ OM_uint32 Curl_gss_init_sec_context(
   if(data->set.gssapi_delegation & CURLGSSAPI_DELEGATION_FLAG)
     req_flags |= GSS_C_DELEG_FLAG;
 
-  /*retrieve imposonated credential on Linux/Unix*/
+  /*retrieve impersonated credential on Linux/Unix*/
   gss_cred_id_t cred;
   cred = GSS_C_NO_CREDENTIAL;
   if(data->set.delegcred != NULL)
     cred = (gss_cred_id_t)data->set.delegcred;
-
-  infof(data, "Deleg Cred = %x", cred);  
 
   return gss_init_sec_context(minor_status,
                               cred, /* cred_handle */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -832,12 +832,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.expect_100_timeout = arg;
     break;
   case CURLOPT_GSS_DELEGCRED:
-  {
-      void *cred = va_arg(param, void *);
-      if (cred == NULL)
-          return CURLE_FAILED_INIT;
-      data->set.delegcred = cred;
-  }
+    void *cred = va_arg(param, void *);
+    data->set.delegcred = cred;
   break;
 
   case CURLOPT_HTTP09_ALLOWED:

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -831,6 +831,14 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     data->set.expect_100_timeout = arg;
     break;
+  case CURLOPT_GSS_DELEGCRED:
+  {
+      void *cred = va_arg(param, void *);
+      if (cred == NULL)
+          return CURLE_FAILED_INIT;
+      data->set.delegcred = cred;
+  }
+  break;
 
   case CURLOPT_HTTP09_ALLOWED:
     arg = va_arg(param, unsigned long);

--- a/lib/url.c
+++ b/lib/url.c
@@ -457,6 +457,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->proxytype = CURLPROXY_HTTP; /* defaults to HTTP proxy */
   set->httpauth = CURLAUTH_BASIC;  /* defaults to basic */
   set->proxyauth = CURLAUTH_BASIC; /* defaults to basic */
+  set->delegcred = NULL;
 
   /* SOCKS5 proxy auth defaults to username/password + GSS-API */
   set->socks5auth = CURLAUTH_BASIC | CURLAUTH_GSSAPI;


### PR DESCRIPTION
Hi, 
Currently, there is no option to pass through the cred to libcurl, so it can't support cred pass through from the original client.
This pr includes an enhancement to support the cred pass through feature.
The usage of the option is simply :

CURLcode lRetCode = curl_easy_setopt(mpEasyHandle, **CURLOPT_GSS_DELEGCRED**, iDelegCred);
where iDelegCred is the cred handle constructed from the token stands for the original cred.

Thanks
