### PR TITLE
Changes in Makefile.vc to honor the value passed to ENABLE_OPENSSL_AUTO_LOAD_CONFIG option

### DIFF
--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1999 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1999 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -138,6 +138,12 @@ USE_WINSSL = false
 
 !IFNDEF ENABLE_OPENSSL_AUTO_LOAD_CONFIG
 ENABLE_OPENSSL_AUTO_LOAD_CONFIG = true
+!ELSEIF "$(ENABLE_OPENSSL_AUTO_LOAD_CONFIG)"=="yes"
+!UNDEF ENABLE_OPENSSL_AUTO_LOAD_CONFIG
+ENABLE_OPENSSL_AUTO_LOAD_CONFIG = true
+!ELSEIF "$(ENABLE_OPENSSL_AUTO_LOAD_CONFIG)"=="no"
+!UNDEF ENABLE_OPENSSL_AUTO_LOAD_CONFIG
+ENABLE_OPENSSL_AUTO_LOAD_CONFIG = false
 !ENDIF
 
 CONFIG_NAME_LIB = libcurl


### PR DESCRIPTION
Currently while building on Windows platform even if we pass the ENABLE_OPENSSL_AUTO_LOAD_CONFIG options with value as "no" it does not set the CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG flag.
Made changes so that ENABLE_OPENSSL_AUTO_LOAD_CONFIG will be honored.
Also removed some ^M chars from file.