### PR TITLE
Use UTF-8 encoding in comments

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -820,7 +820,7 @@ Curl_cookie_add(struct Curl_easy *data,
         break;
       case 1:
         /* This field got its explanation on the 23rd of May 2001 by
-           Andrés García:
+           AndrÃ©s GarcÃ­a:
 
            flag: A TRUE/FALSE value indicating if all machines within a given
            domain can access the variable. This value is set automatically by
@@ -834,7 +834,7 @@ Curl_cookie_add(struct Curl_easy *data,
       case 2:
         /* It turns out, that sometimes the file format allows the path
            field to remain not filled in, we try to detect this and work
-           around it! Andrés García made us aware of this... */
+           around it! AndrÃ©s GarcÃ­a made us aware of this... */
         if(strcmp("TRUE", ptr) && strcmp("FALSE", ptr)) {
           /* only if the path doesn't look like a boolean option! */
           co->path = strdup(ptr);

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -1,6 +1,6 @@
 /* GSSAPI/krb5 support for FTP - loosely based on old krb4.c
  *
- * Copyright (c) 1995, 1996, 1997, 1998, 1999 Kungliga Tekniska Högskolan
+ * Copyright (c) 1995, 1996, 1997, 1998, 1999 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * Copyright (c) 2004 - 2017 Daniel Stenberg
  * All rights reserved.

--- a/lib/security.c
+++ b/lib/security.c
@@ -7,7 +7,7 @@
  * rewrite to work around the paragraph 2 in the BSD licenses as explained
  * below.
  *
- * Copyright (c) 1998, 1999, 2017 Kungliga Tekniska Högskolan
+ * Copyright (c) 1998, 1999, 2017 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  *
  * Copyright (C) 2001 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -225,7 +225,7 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
   if(data->state.trailers_state == TRAILERS_SENDING) {
     /* if we're here then that means that we already sent the last empty chunk
        but we didn't send a final CR LF, so we sent 0 CR LF. We then start
-       pulling trailing data until we ²have no more at which point we
+       pulling trailing data until we have no more at which point we
        simply return to the previous point in the state machine as if
        nothing happened.
        */


### PR DESCRIPTION
Some editors and IDEs assume that source files use UTF-8 file encodings.
It also fixes the build with MSVC when `/utf-8` command line option is used (this option is mandatory for some other open-source projects, this is useful when using the same options is desired for building all libraries of a project)