### PR TITLE
CURLOPT_HEADEROPT: Use and free curl_slist.

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.3
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.3
@@ -57,12 +57,14 @@ if(curl) {
   list = curl_slist_append(list, "Accept:");
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://localhost:8080");
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   /* HTTPS over a proxy makes a separate CONNECT to the proxy, so tell
      libcurl to not send the custom headers to the proxy. Keep them
      separate! */
   curl_easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
   ret = curl_easy_perform(curl);
+  curl_slist_free_all(list);
   curl_easy_cleanup(curl);
 }
 .fi


### PR DESCRIPTION
Fix an issue where example builds a curl_slist, but fails to actually
use it, or free it.