### PR TITLE
libcurl: Restrict redirect schemes

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -488,9 +488,8 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
      define since we internally only use the lower 16 bits for the passed
      in bitmask to not conflict with the private bits */
   set->allowed_protocols = CURLPROTO_ALL;
-  set->redir_protocols = CURLPROTO_ALL &  /* All except FILE, SCP and SMB */
-                          ~(CURLPROTO_FILE | CURLPROTO_SCP | CURLPROTO_SMB |
-                            CURLPROTO_SMBS);
+  set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP
+                        | CURLPROTO_FTPS;
 
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -488,8 +488,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
      define since we internally only use the lower 16 bits for the passed
      in bitmask to not conflict with the private bits */
   set->allowed_protocols = CURLPROTO_ALL;
-  set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP
-                        | CURLPROTO_FTPS;
+  set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP;
 
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   /*

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -175,7 +175,7 @@ test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 test1541 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
-test1558 test1559 test1560 test1561 test1562 \
+test1558 test1559 test1560 test1561 test1562 test1563 \
 \
 test1590 test1591 test1592 \
 \

--- a/tests/data/test1563
+++ b/tests/data/test1563
@@ -1,0 +1,51 @@
+<testcase>
+<info>
+<keywords>
+GOPHER
+HTTP GET
+followlocation
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data1>
+HTTP/1.1 302 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+Location: gopher://www.example.co.uk
+
+nomnom
+</data1>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Make sure redirects to CURLPROTO_GOPHER are forbidden by default
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/15630001 -L -H "Host: www.example.com"
+</command>
+</client>
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<errorcode>
+1
+</errorcode>
+<protocol>
+GET /15630001 HTTP/1.1
+Host: www.example.com
+Accept: */*
+
+</protocol>
+
+</verify>
+
+</testcase>


### PR DESCRIPTION
All protocols except for `CURLPROTO_FILE/CURLPROTO_SMB` and their TLS counterpart were allowed for redirects. This vastly broadens the exploitation surface in case of a vulnerability such as [SSRF](https://www.acunetix.com/blog/articles/server-side-request-forgery-vulnerability/),
where libcurl-based clients are forced to make requests to arbitrary (usually internal) hosts.

For instance, `CURLPROTO_GOPHER` can be used to smuggle any TCP-based
protocol by URL-encoding a payload in the URI. Gopher will open a TCP connection and send the payload. 

An example of what an adversary can do looks like the following:
`gopher://some.elasticsearch.node:9200/_DELETE%20/some_index%20HTTP%2F1.0%0A`
What this will do is delete the selected (e.g. `some_index`) elasticsearch index from the elasticsearch node.

For more information about `gopher` and other protocols used in exploitation, refer to [this](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Request%20Forgery#ssrf-exploitation-via-url-scheme).
Although the [official documentation](https://curl.haxx.se/libcurl/security.html) states some issues around these protocols, I believe that the convenience of allowing such redirects is outweighed by the importance they hold for exploitation.
  
This PR flips the blacklisting logic of only stating which protocols should be denied and makes this a whitelist of only HTTP/HTTPS and FTP/FTPS. This is also "future-proof", so that other newly supported protocols in the future won't bite any unsuspected user, through redirects.
All other protocols have to be explicitly enabled for redirects through `CURLOPT_REDIR_PROTOCOLS`.

For context there is already a discussion on the [curl-library mailing list](https://curl.haxx.se/mail/lib-2019-07/0007.html) about this.

Awaiting your comments on this.