### PR TITLE
smb: Use the correct error code if opening the file was denied

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -785,6 +785,8 @@ static CURLcode smb_request_state(struct connectdata *conn, bool *done)
   case SMB_OPEN:
     if(h->status || smbc->got < sizeof(struct smb_nt_create_response)) {
       req->result = CURLE_REMOTE_FILE_NOT_FOUND;
+      if(h->status == smb_swap32(SMB_ERR_NOACCESS))
+        req->result = CURLE_REMOTE_ACCESS_DENIED;
       next_state = SMB_TREE_DISCONNECT;
       break;
     }


### PR DESCRIPTION
I was puzzled by the error code i got when trying to download a protected file over smb:

```
curl   -u "kodi:$KODI_PW" -v  smb://localhost/kodi/notreadable.txt
...
curl: (78) Remote file not found
```
While tshark reports:

```
tshark -i lo -Y smb
...
   16 0.008405497          ::1 → ::1          SMB 189 NT Create AndX Request, Path: notreadable.txt
   18 0.008770106          ::1 → ::1          SMB 125 NT Create AndX Response, Error: Access denied
```

With this commit:
```
./src/curl   -u "kodi:$KODI_PW" -v  smb://localhost/kodi/notreadable.txt
curl: (9) Access denied to remote resource
```
```