### PR TITLE
Remove prototypes of no longer exported functions

### DIFF
--- a/lib/curl_endian.h
+++ b/lib/curl_endian.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -30,9 +30,6 @@ unsigned int Curl_read32_le(const unsigned char *buf);
 
 /* Converts a 16-bit integer from big endian */
 unsigned short Curl_read16_be(const unsigned char *buf);
-
-/* Converts a 32-bit integer to little endian */
-void Curl_write32_le(const int value, unsigned char *buffer);
 
 #if (CURL_SIZEOF_CURL_OFF_T > 4)
 /* Converts a 64-bit integer to little endian */

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -61,7 +61,6 @@ struct connectdata;
  * Returns a struct curl_hash pointer on success, NULL on failure.
  */
 struct curl_hash *Curl_global_host_cache_init(void);
-void Curl_global_host_cache_dtor(void);
 
 struct Curl_dns_entry {
   Curl_addrinfo *addr;
@@ -123,9 +122,6 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
 /* unlock a previously resolved dns entry */
 void Curl_resolv_unlock(struct Curl_easy *data,
                         struct Curl_dns_entry *dns);
-
-/* for debugging purposes only: */
-void Curl_scan_cache_used(void *user, void *ptr);
 
 /* init a new dns cache and return success */
 int Curl_mk_dnscache(struct curl_hash *hash);
@@ -235,11 +231,6 @@ CURLcode Curl_set_dns_local_ip6(struct Curl_easy *data,
  * Clean off entries from the cache
  */
 void Curl_hostcache_clean(struct Curl_easy *data, struct curl_hash *hash);
-
-/*
- * Destroy the hostcache of this handle.
- */
-void Curl_hostcache_destroy(struct Curl_easy *data);
 
 /*
  * Populate the cache with specified entries from CURLOPT_RESOLVE.

--- a/lib/http.c
+++ b/lib/http.c
@@ -383,7 +383,7 @@ static bool pickoneauth(struct auth *pick, unsigned long mask)
 }
 
 /*
- * Curl_http_perhapsrewind()
+ * http_perhapsrewind()
  *
  * If we are doing POST or PUT {
  *   If we have more data to send {

--- a/lib/http.h
+++ b/lib/http.h
@@ -82,7 +82,6 @@ CURLcode Curl_http_compile_trailers(struct curl_slist *trailers,
 CURLcode Curl_http(struct connectdata *conn, bool *done);
 CURLcode Curl_http_done(struct connectdata *, CURLcode, bool premature);
 CURLcode Curl_http_connect(struct connectdata *conn, bool *done);
-CURLcode Curl_http_setup_conn(struct connectdata *conn);
 
 /* The following functions are defined in http_chunks.c */
 void Curl_httpchunk_init(struct connectdata *conn);
@@ -90,11 +89,9 @@ CHUNKcode Curl_httpchunk_read(struct connectdata *conn, char *datap,
                               ssize_t length, ssize_t *wrote);
 
 /* These functions are in http.c */
-void Curl_http_auth_stage(struct Curl_easy *data, int stage);
 CURLcode Curl_http_input_auth(struct connectdata *conn, bool proxy,
                               const char *auth);
 CURLcode Curl_http_auth_act(struct connectdata *conn);
-CURLcode Curl_http_perhapsrewind(struct connectdata *conn);
 
 /* If only the PICKNONE bit is set, there has been a round-trip and we
    selected to use no auth at all. Ie, we actively select no auth, as opposed

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -269,7 +269,7 @@ static unsigned int http2_conncheck(struct connectdata *check,
   return ret_val;
 }
 
-/* called from Curl_http_setup_conn */
+/* called from http_setup_conn */
 void Curl_http2_setup_req(struct Curl_easy *data)
 {
   struct HTTP *http = data->req.protop;
@@ -286,7 +286,7 @@ void Curl_http2_setup_req(struct Curl_easy *data)
   http->memlen = 0;
 }
 
-/* called from Curl_http_setup_conn */
+/* called from http_setup_conn */
 void Curl_http2_setup_conn(struct connectdata *conn)
 {
   conn->proto.httpc.settings.max_concurrent_streams =

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -42,13 +42,12 @@ const char *Curl_http2_strerror(uint32_t err);
 CURLcode Curl_http2_init(struct connectdata *conn);
 void Curl_http2_init_state(struct UrlState *state);
 void Curl_http2_init_userset(struct UserDefined *set);
-CURLcode Curl_http2_send_request(struct connectdata *conn);
 CURLcode Curl_http2_request_upgrade(Curl_send_buffer *req,
                                     struct connectdata *conn);
 CURLcode Curl_http2_setup(struct connectdata *conn);
 CURLcode Curl_http2_switched(struct connectdata *conn,
                              const char *data, size_t nread);
-/* called from Curl_http_setup_conn */
+/* called from http_setup_conn */
 void Curl_http2_setup_conn(struct connectdata *conn);
 void Curl_http2_setup_req(struct Curl_easy *data);
 void Curl_http2_done(struct connectdata *conn, bool premature);
@@ -63,7 +62,6 @@ void Curl_http2_cleanup_dependencies(struct Curl_easy *data);
 /* returns true if the HTTP/2 stream error was HTTP_1_1_REQUIRED */
 bool Curl_h2_http_1_1_error(struct connectdata *conn);
 #else /* USE_NGHTTP2 */
-#define Curl_http2_send_request(x) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_request_upgrade(x,y) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_setup(x) CURLE_UNSUPPORTED_PROTOCOL
 #define Curl_http2_switched(x,y,z) CURLE_UNSUPPORTED_PROTOCOL

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -31,7 +31,6 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id);
 void Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
 void Curl_update_timer(struct Curl_multi *multi);
-void Curl_detach_connnection(struct Curl_easy *data);
 void Curl_attach_connnection(struct Curl_easy *data,
                              struct connectdata *conn);
 bool Curl_multiplex_wanted(const struct Curl_multi *multi);

--- a/lib/splay.h
+++ b/lib/splay.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1997 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1997 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -58,11 +58,5 @@ int Curl_splayremovebyaddr(struct Curl_tree *t,
                                    ( ((i.tv_sec)  > (j.tv_sec)) ?  1 : \
                                    ( ((i.tv_usec) < (j.tv_usec)) ? -1 : \
                                    ( ((i.tv_usec) > (j.tv_usec)) ?  1 : 0))))
-
-#ifdef DEBUGBUILD
-void Curl_splayprint(struct Curl_tree * t, int d, char output);
-#else
-#define Curl_splayprint(x,y,z) Curl_nop_stmt
-#endif
 
 #endif /* HEADER_CURL_SPLAY_H */

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -29,7 +29,6 @@ char *Curl_checkheaders(const struct connectdata *conn,
 void Curl_init_CONNECT(struct Curl_easy *data);
 
 CURLcode Curl_pretransfer(struct Curl_easy *data);
-CURLcode Curl_second_connect(struct connectdata *conn);
 CURLcode Curl_posttransfer(struct Curl_easy *data);
 
 typedef enum {

--- a/lib/url.h
+++ b/lib/url.h
@@ -48,8 +48,6 @@ CURLcode Curl_open(struct Curl_easy **curl);
 CURLcode Curl_init_userdefined(struct Curl_easy *data);
 
 void Curl_freeset(struct Curl_easy * data);
-/* free the URL pieces */
-void Curl_up_free(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy *data); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
@@ -71,7 +69,6 @@ int Curl_doing_getsock(struct connectdata *conn,
 CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userptr, char **passwdptr,
                                   char **optionsptr);
-void Curl_close_connections(struct Curl_easy *data);
 CURLcode Curl_upkeep(struct conncache *conn_cache, void *data);
 
 const struct Curl_handler *Curl_builtin_scheme(const char *scheme);

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -26,9 +26,6 @@
 #define MAX_SCHEME_LEN 40
 
 bool Curl_is_absolute_url(const char *url, char *scheme, size_t buflen);
-char *Curl_concat_url(const char *base, const char *relurl);
-size_t Curl_strlen_url(const char *url, bool relative);
-void Curl_strcpy_url(char *output, const char *url, bool relative);
 
 #ifdef DEBUGBUILD
 CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname);


### PR DESCRIPTION
Reading [this post on PostgreSQL Hackers](https://postgr.es/m/CAD21AoDuAYsRb3Q9aobkFZ6DZMWxsyg4HOmgkwgeWNfSkTwGxw@mail.gmail.com) made me curious what the script would do to our codebase, and it didn't disappoint. There were a leftover few prototypes of Curl_ functions that we used to
export but no longer do, this removes those prototypes and cleans up any
comments still referring to them.

Curl_write32_le(), Curl_strcpy_url(), Curl_strlen_url(), Curl_up_free() Curl_concat_url(), Curl_detach_connnection(), Curl_http_setup_conn() were made static in 05b100aee247bb9bec8e9a1b0166496aa4248d1c. Curl_http_perhapsrewind() made static in 574aecee208f79d391f10d57520b3.

For the remainder, I didn't trawl the Git logs hard enough to capture their exact time of deletion, but they were all gone: Curl_splayprint(), Curl_http2_send_request(), Curl_global_host_cache_dtor(), Curl_scan_cache_used(), Curl_hostcache_destroy(), Curl_second_connect(), Curl_http_auth_stage() and Curl_close_connections().