### PR TITLE
CMake: Convert errant elseif() to else()

### DIFF
--- a/CMake/CurlSymbolHiding.cmake
+++ b/CMake/CurlSymbolHiding.cmake
@@ -53,7 +53,7 @@ elseif(MSVC)
     message(WARNING "Hiding private symbols regardless CURL_HIDDEN_SYMBOLS being disabled.")
     set(HIDES_CURL_PRIVATE_SYMBOLS TRUE)
   endif()
-elseif()
+else()
   set(HIDES_CURL_PRIVATE_SYMBOLS FALSE)
 endif()
 


### PR DESCRIPTION
CMake interprets an elseif() with no arguments as elseif(FALSE),
resulting in the elseif() block not being executed. That is not what
was intended here. Change the empty elseif() to an else() as it was
intended.

This was reported to CMake in [merge request !3515](https://gitlab.kitware.com/cmake/cmake/merge_requests/3515).

Reported-by: Artalus <artalus-mail@yandex.ru>