### PR TITLE
DEPRECATE: fixup versions and spelling

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -25,7 +25,7 @@ in the September 2019 release (possibly called curl 7.68.0).
 The polarssl TLS library has not had an update in over three years. The last
 release was done on [January 7
 2016](https://tls.mbed.org/tech-updates/releases). This library has been
-superceded by the mbedTLS library, which is the current incarnation of
+superseded by the mbedTLS library, which is the current incarnation of
 PolarSSL. curl has supported mbedTLS since 2015.
 
 It seems unlikely that this library is a good choice for users to get proper
@@ -38,7 +38,7 @@ should also be able to update their TLS library.
 
 ### State
 
-In the curl 7.66.0 release (July 17, 2019) the ability to build with this TLS
+In the curl 7.65.2 release (July 17, 2019) the ability to build with this TLS
 backend is removed from the configure script. The code remains and can be
 built and used going forward, but it has to be manually enabled in a build (or
 the configure removal reverted).
@@ -47,4 +47,5 @@ the configure removal reverted).
 
 The support for PolarSSL and all code for it will be completely removed from
 the curl code base six months after it ships disabled in configure in a
-release. In the release on or near February 27, 2020. (Named 7.70.0?)
+release. In the release on or near February 27, 2020. (possibly called curl
+7.70.0).


### PR DESCRIPTION
Correctly set the July 17 version to 7.65.2, and update spelling to be consistent. Also fix a typo.