### PR TITLE
nss: inspect returnvalue of token check

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -691,7 +691,10 @@ static CURLcode nss_load_key(struct connectdata *conn, int sockindex,
   tmp = SECMOD_WaitForAnyTokenEvent(pem_module, 0, 0);
   if(tmp)
     PK11_FreeSlot(tmp);
-  PK11_IsPresent(slot);
+  if(!PK11_IsPresent(slot)) {
+    PK11_FreeSlot(slot);
+    return CURLE_SSL_CERTPROBLEM;
+  }
 
   status = PK11_Authenticate(slot, PR_TRUE, SSL_SET_OPTION(key_passwd));
   PK11_FreeSlot(slot);


### PR DESCRIPTION
PK11_IsPresent() checks for the token for the given slot is available, and sets needlogin flags for the PK11_Authenticate() call.  Should it return false, we should however treat it as an error and bail out.

@kdudka is there a reason to ignore the returnvalue of PK11_IsPresent() that I'm not seeing?