### PR TITLE
curl.1: Missing lines caused by undefined macros

### DIFF
--- a/docs/cmdline-opts/data.d
+++ b/docs/cmdline-opts/data.d
@@ -24,7 +24,7 @@ chunk that looks like \&'name=daniel&skill=lousy'.
 If you start the data with the letter @, the rest should be a file name to
 read the data from, or - if you want curl to read the data from
 stdin. Multiple files can also be specified. Posting data from a file named
-'foobar' would thus be done with --data @foobar. When --data is told to read
+\&'foobar' would thus be done with --data @foobar. When --data is told to read
 from a file like that, carriage returns and newlines will be stripped out. If
 you don't want the @ character to have a special interpretation use --data-raw
 instead.

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -5,7 +5,7 @@ Help: Private key file name
 ---
 Private key file name. Allows you to provide your private key in this separate
 file. For SSH, if not specified, curl tries the following candidates in order:
-'~/.ssh/id_rsa', '~/.ssh/id_dsa', './id_rsa', './id_dsa'.
+\&'~/.ssh/id_rsa', '~/.ssh/id_dsa', './id_rsa', './id_dsa'.
 
 If curl is built against OpenSSL library, and the engine pkcs11 is available,
 then a PKCS#11 URI (RFC 7512) can be used to specify a private key located in a

--- a/docs/cmdline-opts/proto.d
+++ b/docs/cmdline-opts/proto.d
@@ -6,7 +6,7 @@ Added: 7.20.2
 ---
 Tells curl to limit what protocols it may use in the transfer. Protocols are
 evaluated left to right, are comma separated, and are each a protocol name or
-'all', optionally prefixed by zero or more modifiers. Available modifiers are:
+\&'all', optionally prefixed by zero or more modifiers. Available modifiers are:
 .RS
 .TP 3
 .B +


### PR DESCRIPTION
  Some lines begin with a "'" (apostrophe, single quote), which is then
interpreted as a control character in *roff.

  Such lines are interpreted as being a call to a macro, and if
undefined, the lines are removed from the output.

Bug: https://bugs.debian.org/926352
Signed-off-by: Bjarni Ingi Gislason <bjarniig@rhi.hi.is>

---

This patch was sent to the Debian bug tracker at https://bugs.debian.org/926352 but it's not Debian-specific.