### PR TITLE
curl: only accept COLUMNS less than 10000

### DIFF
--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -210,7 +210,8 @@ void progressbarinit(struct ProgressData *bar,
   if(colp) {
     char *endptr;
     long num = strtol(colp, &endptr, 10);
-    if((endptr != colp) && (endptr == colp + strlen(colp)) && (num > 20))
+    if((endptr != colp) && (endptr == colp + strlen(colp)) && (num > 20) &&
+       (num < 10000))
       bar->width = (int)num;
     curl_free(colp);
   }


### PR DESCRIPTION
... as larger values would rather indicate something silly (and could
potentially cause buffer problems).

Reported-by: pendrek at hackerone