### PR TITLE
libcurl: Restrict redirect schemes (follow-up)

### DIFF
--- a/docs/cmdline-opts/proto-redir.d
+++ b/docs/cmdline-opts/proto-redir.d
@@ -11,7 +11,8 @@ Example, allow only HTTP and HTTPS on redirect:
 
  curl --proto-redir -all,http,https http://example.com
 
-By default curl will allow all protocols on redirect except several disabled
-for security reasons: Since 7.19.4 FILE and SCP are disabled, and since 7.40.0
-SMB and SMBS are also disabled. Specifying \fIall\fP or \fI+all\fP enables all
-protocols on redirect, including those disabled for security.
+By default curl will allow HTTP, HTTPS, FTP and FTPS on redirect (7.65.2).
+Older versions of curl allowed all protocols on redirect except several
+disabled for security reasons: Since 7.19.4 FILE and SCP are disabled, and
+since 7.40.0 SMB and SMBS are also disabled. Specifying \fIall\fP or \fI+all\fP
+enables all protocols on redirect, including those disabled for security.

--- a/docs/libcurl/libcurl-security.3
+++ b/docs/libcurl/libcurl-security.3
@@ -97,8 +97,8 @@ Never ever switch off certificate verification.
 The \fICURLOPT_FOLLOWLOCATION(3)\fP option automatically follows HTTP
 redirects sent by a remote server.  These redirects can refer to any kind of
 URL, not just HTTP. libcurl restricts the protocols allowed to be used in
-redirects for security reasons: only HTTP, HTTPS and FTP are enabled by
-default. Applications may opt to restrict thus set further.
+redirects for security reasons: only HTTP, HTTPS, FTP and FTPS are
+enabled by default. Applications may opt to restrict that set further.
 
 A redirect to a file: URL would cause the libcurl to read (or write) arbitrary
 files from the local filesystem.  If the application returns the data back to

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
@@ -39,7 +39,8 @@ libcurl will follow.
 
 libcurl limits what protocols it automatically follows to. The accepted
 protocols are set with \fICURLOPT_REDIR_PROTOCOLS(3)\fP. By default libcurl
-will allow all protocols on redirect except those disabled for security
+will allow HTTP, HTTPS, FTP and FTPS on redirect (7.65.2). Older versions of
+libcurl allowed all protocols on redirect except those disabled for security
 reasons: Since 7.19.4 FILE and SCP are disabled, and since 7.40.0 SMB and SMBS
 are also disabled.
 

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
@@ -37,10 +37,11 @@ redirections.
 Protocols denied by \fICURLOPT_PROTOCOLS(3)\fP are not overridden by this
 option.
 
-By default libcurl will allow all protocols on redirect except several disabled
-for security reasons: Since 7.19.4 FILE and SCP are disabled, and since 7.40.0
-SMB and SMBS are also disabled. \fICURLPROTO_ALL\fP enables all protocols on
-redirect, including those disabled for security.
+By default libcurl will allow HTTP, HTTPS, FTP and FTPS on redirect (7.65.2).
+Older versions of libcurl allowed all protocols on redirect except several
+disabled for security reasons: Since 7.19.4 FILE and SCP are disabled, and
+since 7.40.0 SMB and SMBS are also disabled. \fICURLPROTO_ALL\fP enables all
+protocols on redirect, including those disabled for security.
 
 These are the available protocol defines:
 .nf

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1575,7 +1575,7 @@ typedef enum {
   /* set the bitmask for the protocols that libcurl is allowed to follow to,
      as a subset of the CURLOPT_PROTOCOLS ones. That means the protocol needs
      to be set in both bitmasks to be allowed to get redirected to. Defaults
-     to all protocols except FILE and SCP. */
+     to HTTP, HTTPS, FTP and FTPS. */
   CINIT(REDIR_PROTOCOLS, LONG, 182),
 
   /* set the SSH knownhost file name to use */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2375,7 +2375,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /* set the bitmask for the protocols that libcurl is allowed to follow to,
        as a subset of the CURLOPT_PROTOCOLS ones. That means the protocol needs
        to be set in both bitmasks to be allowed to get redirected to. Defaults
-       to all protocols except FILE and SCP. */
+       to HTTP, HTTPS, FTP and FTPS. */
     data->set.redir_protocols = va_arg(param, long);
     break;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -488,7 +488,8 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
      define since we internally only use the lower 16 bits for the passed
      in bitmask to not conflict with the private bits */
   set->allowed_protocols = CURLPROTO_ALL;
-  set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP;
+  set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP |
+                         CURLPROTO_FTPS;
 
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   /*


### PR DESCRIPTION
- Allow FTPS on redirect.

- Update default allowed redirect protocols in documentation.

Follow-up to 6080ea0.

Closes #xxxx

---

/cc @linosgian