### PR TITLE
docs: Explain behavior change in --tlsv1. options since 7.54

### DIFF
--- a/docs/cmdline-opts/tlsv1.0.d
+++ b/docs/cmdline-opts/tlsv1.0.d
@@ -4,3 +4,7 @@ Protocols: TLS
 Added: 7.34.0
 ---
 Forces curl to use TLS version 1.0 or later when connecting to a remote TLS server.
+
+In old versions of curl this option was documented to allow _only_ TLS 1.0,
+but behavior was inconsistent depending on the TLS library. Use --tls-max if
+you want to set a maximum TLS version.

--- a/docs/cmdline-opts/tlsv1.1.d
+++ b/docs/cmdline-opts/tlsv1.1.d
@@ -4,3 +4,7 @@ Protocols: TLS
 Added: 7.34.0
 ---
 Forces curl to use TLS version 1.1 or later when connecting to a remote TLS server.
+
+In old versions of curl this option was documented to allow _only_ TLS 1.1,
+but behavior was inconsistent depending on the TLS library. Use --tls-max if
+you want to set a maximum TLS version.

--- a/docs/cmdline-opts/tlsv1.2.d
+++ b/docs/cmdline-opts/tlsv1.2.d
@@ -4,3 +4,7 @@ Protocols: TLS
 Added: 7.34.0
 ---
 Forces curl to use TLS version 1.2 or later when connecting to a remote TLS server.
+
+In old versions of curl this option was documented to allow _only_ TLS 1.2,
+but behavior was inconsistent depending on the TLS library. Use --tls-max if
+you want to set a maximum TLS version.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
@@ -69,6 +69,11 @@ The flag defines maximum supported TLS version as TLSv1.2.
 The flag defines maximum supported TLS version as TLSv1.3.
 (Added in 7.54.0)
 .RE
+
+In versions of curl prior to 7.54 the CURL_SSLVERSION_TLS options were
+documented to allow \fIonly\fP the specified TLS version, but behavior was
+inconsistent depending on the TLS library.
+
 .SH DEFAULT
 CURL_SSLVERSION_DEFAULT
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -79,6 +79,11 @@ The flag defines maximum supported TLS version as TLS v1.2.
 The flag defines maximum supported TLS version as TLS v1.3.
 (Added in 7.54.0)
 .RE
+
+In versions of curl prior to 7.54 the CURL_SSLVERSION_TLS options were
+documented to allow \fIonly\fP the specified TLS version, but behavior was
+inconsistent depending on the TLS library.
+
 .SH DEFAULT
 CURL_SSLVERSION_DEFAULT
 .SH PROTOCOLS


### PR DESCRIPTION
Since 7.54 --tlsv1. options use the specified version or later, however
older versions of curl documented it as using just the specified version
which may or may not have happened depending on the TLS library.
Document this discrepancy to allay confusion for users familiar with the
old documentation that expect just the specified version.

Fixes https://github.com/curl/curl/issues/4097
Closes #xxxx