### PR TITLE
Provide the response and error message as write-out "variables"

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2525,7 +2525,7 @@ AC_DEFUN([CURL_MAC_CFLAGS], [
     AC_MSG_CHECKING([for *version-min in CFLAGS])
     min=""
     if test -z "$(echo $CFLAGS | grep m.*os.*-version-min)"; then
-      min="-mmacosx-version-min=10.8"
+      min="-mmacosx-version-min=10.13"
       CFLAGS="$CFLAGS $min"
     fi
     if test -z "$min"; then

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -115,6 +115,14 @@ From this point on, the --write-out output will be written to standard output.
 This is the default, but can be used to switch back after switching to stderr.
 (Added in 7.63.0)
 .TP
+.B content
+From this point on, the result of response content.
+(Added in 7.63.0)
+.TP
+.B error
+From this point on, the result of error message.
+(Added in 7.63.0)
+.TP
 .B time_appconnect
 The time, in seconds, it took from the start until the SSL/SSH/etc
 connect/handshake to the remote host was completed. (Added in 7.19.0)

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -196,7 +196,15 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   }
   else
 #endif
+  if(NULL != outs->buffer_stream) {
+    rc = fwrite(buffer, sz, nmemb, outs->buffer_stream);
+    if(NULL != outs->filename) {
+      rc = fwrite(buffer, sz, nmemb, outs->stream);
+    }
+  }
+  else {
     rc = fwrite(buffer, sz, nmemb, outs->stream);
+  }
 
   if(bytes == rc)
     /* we added this amount of data to the output */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -983,6 +983,16 @@ static CURLcode create_transfers(struct GlobalConfig *global,
           outs->s_isreg = TRUE;
         }
 
+        if(NULL != config->writeout &&
+            NULL != strstr(config->writeout, "%{content}")) {
+          FILE *bufferStream = NULL;
+          bufferStream = open_memstream(&outs->bodybuf, &outs->bodysize);
+          fflush(bufferStream);
+          if(bufferStream != NULL) {
+            outs->buffer_stream = bufferStream;
+          }
+        }
+
         if(per->uploadfile && !stdin_upload(per->uploadfile)) {
           /*
            * We have specified a file to upload and it isn't "-".
@@ -1096,6 +1106,16 @@ static CURLcode create_transfers(struct GlobalConfig *global,
 
         if(!global->errors)
           global->errors = stderr;
+
+        if(NULL != config->writeout &&
+          NULL != strstr(config->writeout, "%{error}")) {
+          FILE *errorStream = NULL;
+          errorStream = open_memstream(&outs->errorbuf, &outs->errorsize);
+          fflush(errorStream);
+          if(errorStream != NULL) {
+            global->errors = errorStream;
+          }
+        }
 
         if((!per->outfile || !strcmp(per->outfile, "-")) &&
            !config->use_ascii) {

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -69,9 +69,14 @@ struct OutStruct {
   bool s_isreg;
   bool fopened;
   FILE *stream;
+  FILE *buffer_stream;
+  char *bodybuf;
+  char *errorbuf;
   struct OperationConfig *config;
   curl_off_t bytes;
   curl_off_t init;
+  size_t bodysize;
+  size_t errorsize;
 #ifdef USE_METALINK
   metalink_parser_context_t *metalink_parser;
 #endif /* USE_METALINK */


### PR DESCRIPTION
This pull request is to fix the stdout and stderr in write out option. You can see my completed effect in below illustration:
![QQ图片20190720213352](https://user-images.githubusercontent.com/5964503/61579311-2e9aee80-ab36-11e9-90ba-956f04e2443e.png)
![QQ图片20190720213407](https://user-images.githubusercontent.com/5964503/61579312-3195df00-ab36-11e9-8520-074a029a47f5.png)

Notice:
The curl-format.t content is 
``
{"http_code" : %{http_code}, "time_namelookup":  %{time_namelookup}, "time_connect":  %{time_connect}, "time_appconnect": %{time_appconnect},"time_pretransfer": %{time_pretransfer}, "time_redirect": %{time_redirect}, "time_starttransfer": %{time_starttransfer}, "time_total": %{time_total}, "stdout": "%{stdout}", "stderr": "%{stderr}"}
``
