### PR TITLE
libcurl: use chunked Transfer-Encoding for HTTP_POST if size unknown

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2247,8 +2247,9 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
   else {
     if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
        (((httpreq == HTTPREQ_POST_MIME || httpreq == HTTPREQ_POST_FORM) &&
-       http->postsize < 0) ||
-       (data->set.upload && data->state.infilesize == -1))) {
+         http->postsize < 0) ||
+        ((data->set.upload || httpreq == HTTPREQ_POST) &&
+         data->state.infilesize == -1))) {
       if(conn->bits.authneg)
         /* don't enable chunked during auth neg */
         ;

--- a/tests/data/test1514
+++ b/tests/data/test1514
@@ -4,13 +4,14 @@
 HTTP
 HTTP POST
 Content-Length
+chunked Transfer-Encoding
 </keywords>
 </info>
 
 # Server-side
 <reply>
 <data nocheck="yes">
-HTTP/1.1 411 Length Required
+HTTP/1.1 200 OK
 Date: Sun, 19 Jan 2014 18:50:58 GMT
 Server: test-server/fake swsclose
 Connection: close
@@ -36,12 +37,26 @@ http://%HOSTIP:%HTTPPORT/1514
 # Verify data after the test has been "shot"
 <verify>
 # Content-Length header is not present
+# Transfer-Encoding header is added automatically
 <protocol>
 POST /1514 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
+Transfer-Encoding: chunked
 Content-Type: application/x-www-form-urlencoded
 Expect: 100-continue
+
+1
+d
+1
+u
+1
+m
+1
+m
+1
+y
+0
 
 </protocol>
 </verify>


### PR DESCRIPTION
If using the read callback for HTTP_POST, and POSTFIELDSIZE is not set,
automatically add a Transfer-Encoding: chunked header, same as it is
already done for HTTP_PUT, HTTP_POST_FORM and HTTP_POST_MIME.
Update test 1514 according to the new behaviour.