### PR TITLE
tool_operate: fix implicit call to easysrc_cleanup

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2286,8 +2286,12 @@ CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[])
         struct OperationConfig *operation = config->first;
         CURLSH *share = curl_share_init();
         if(!share) {
-          /* Cleanup the libcurl source output */
-          easysrc_cleanup();
+#ifndef CURL_DISABLE_LIBCURL_OPTION
+          if(config->libcurl) {
+            /* Cleanup the libcurl source output */
+            easysrc_cleanup();
+          }
+#endif
           return CURLE_OUT_OF_MEMORY;
         }
 


### PR DESCRIPTION
easysrc_cleanup is only defined when CURL_DISABLE_LIBCURL_OPTION is
defined, and prior to this change would be called regardless.

Bug: https://github.com/curl/curl/pull/3804#issuecomment-513922637
Reported-by: Marcel Raad

Closes #xxxx