### PR TITLE
easy: resize receive buffer on easy handle reset

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -942,6 +942,8 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
  */
 void curl_easy_reset(struct Curl_easy *data)
 {
+  long old_buffer_size = data->set.buffer_size;
+
   Curl_free_request_state(data);
 
   /* zero out UserDefined data: */
@@ -965,6 +967,18 @@ void curl_easy_reset(struct Curl_easy *data)
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
   Curl_http_auth_cleanup_digest(data);
 #endif
+
+  /* resize receive buffer */
+  if(old_buffer_size != data->set.buffer_size) {
+    char *newbuff = realloc(data->state.buffer, data->set.buffer_size + 1);
+    if(!newbuff) {
+      DEBUGF(fprintf(stderr, "Error: realloc of buffer failed\n"));
+      /* nothing we can do here except use the old size */
+      data->set.buffer_size = old_buffer_size;
+    }
+    else
+      data->state.buffer = newbuff;
+  }
 }
 
 /*


### PR DESCRIPTION
- In curl_easy_reset attempt to resize the receive buffer to its default
  size. If realloc fails then continue using the previous size.

Prior to this change curl_easy_reset did not properly handle resetting
the receive buffer (data->state.buffer). It reset the variable holding
its size (data->set.buffer_size) to the default size (READBUFFER_SIZE)
but then did not actually resize the buffer. If a user resized the
buffer by using CURLOPT_BUFFERSIZE to set the size smaller than the
default, later called curl_easy_reset and attempted to reuse the handle
then a heap overflow would very likely occur during that handle's next
transfer.

Reported-by: Felix Hädicke

Fixes https://github.com/curl/curl/issues/4143
Closes #xxxx