### PR TITLE
ssh-libssh: do not specify O_APPEND when not in append mode

### DIFF
--- a/lib/ssh-libssh.c
+++ b/lib/ssh-libssh.c
@@ -1119,7 +1119,7 @@ static CURLcode myssh_statemach_act(struct connectdata *conn, bool *block)
         flags = O_WRONLY|O_APPEND;
       else
         /* Clear file before writing (normal behaviour) */
-        flags = O_WRONLY|O_APPEND|O_CREAT|O_TRUNC;
+        flags = O_WRONLY|O_CREAT|O_TRUNC;
 
       if(sshc->sftp_file)
         sftp_close(sshc->sftp_file);


### PR DESCRIPTION
Specifying O_APPEND in conjunction with O_TRUNC and O_CREAT does not
make much sense. And this combination of flags is not accepted by all
SFTP servers (at least not Apache SSHD).

Closes #4147