### PR TITLE
date parsing: Cookie expiry fallback

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -96,6 +96,7 @@ Example set of cookies:
 #include "curl_get_line.h"
 #include "curl_memrchr.h"
 #include "inet_pton.h"
+#include "parsedate.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -713,9 +714,10 @@ Curl_cookie_add(struct Curl_easy *data,
       }
     }
     else if(co->expirestr) {
-      /* Note that if the date couldn't get parsed for whatever reason,
-         the cookie will be treated as a session cookie */
-      co->expires = curl_getdate(co->expirestr, NULL);
+      /* Note that if the date couldn't get parsed,
+         the cookie will be treated as a session cookie,
+         except in case of time_t overflow, when TIME_T_MAX will be used */
+      co->expires = Curl_parse_expiry(co->expirestr);
 
       /* Session cookies have expires set to 0 so if we get that back
          from the date parser let's add a second to make it a

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -716,7 +716,7 @@ Curl_cookie_add(struct Curl_easy *data,
     else if(co->expirestr) {
       /* Note that if the date couldn't get parsed,
          the cookie will be treated as a session cookie,
-         except in case of time_t overflow, when TIME_T_MAX will be used */
+         except in case of time_t overflow, when the largest reasonable time_t will be used */
       co->expires = Curl_parse_expiry(co->expirestr);
 
       /* Session cookies have expires set to 0 so if we get that back

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -716,7 +716,8 @@ Curl_cookie_add(struct Curl_easy *data,
     else if(co->expirestr) {
       /* Note that if the date couldn't get parsed,
          the cookie will be treated as a session cookie,
-         except in case of time_t overflow, when the largest reasonable time_t will be used */
+         except in case of time_t overflow,
+         when the largest reasonable time_t will be used */
       co->expires = Curl_parse_expiry(co->expirestr);
 
       /* Session cookies have expires set to 0 so if we get that back

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -505,7 +505,7 @@ static int parsedate(const char *date, time_t *output)
 #ifdef HAVE_TIME_T_UNSIGNED
   /* an unsigned 32 bit time_t can only hold dates to 2106 */
   if(yearnum > 2105) {
-    /* return 1.1.2105, 00:00 in the given timezone to avoid returning a later time than specified */
+    /* return 1.1.2105 00:00 to avoid returning a later time than specified */
     secnum = 0;
     minnum = 0;
     hournum = 0;
@@ -517,7 +517,7 @@ static int parsedate(const char *date, time_t *output)
 #else
   /* a signed 32 bit time_t can only hold dates to the beginning of 2038 */
   if(yearnum > 2037) {
-    /* return 1.1.2038, 00:00 in the given timezone to avoid returning a later time than specified */
+    /* return 1.1.2038 00:00 to avoid returning a later time than specified */
     secnum = 0;
     minnum = 0;
     hournum = 0;
@@ -580,7 +580,7 @@ static int parsedate(const char *date, time_t *output)
 }
 #endif
 
-time_t Curl_parse_expiry(const char* p)
+time_t Curl_parse_expiry(const char *p)
 {
   time_t parsed = -1;
   int rc = parsedate(p, &parsed);

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -591,7 +591,7 @@ time_t Curl_parse_expiry(const char *p)
       parsed++;
     return parsed;
   }
-  
+
   /* everything else is fail */
   return -1;
 }

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -527,8 +527,13 @@ static int parsedate(const char *date, time_t *output)
     returncode = PARSEDATE_LATER;
   }
   if(yearnum < 1903) {
-    *output = TIME_T_MIN;
-    return PARSEDATE_SOONER;
+    secnum = 59;
+    minnum = 59;
+    hournum = 23;
+    mdaynum = 31;
+    monnum = 11;
+    yearnum = 1902;
+    returncode = PARSEDATE_SOONER;
   }
 #endif
 
@@ -585,7 +590,7 @@ time_t Curl_parse_expiry(const char *p)
   time_t parsed = -1;
   int rc = parsedate(p, &parsed);
 
-  if(rc == PARSEDATE_OK || rc == PARSEDATE_LATER) {
+  if(rc == PARSEDATE_OK || rc == PARSEDATE_LATER || rc == PARSEDATE_SOONER) {
     if(parsed == -1)
       /* avoid returning -1 for a working scenario */
       parsed++;

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -567,6 +567,24 @@ static int parsedate(const char *date, time_t *output)
 }
 #endif
 
+time_t Curl_parse_expiry(const char* p)
+{
+  time_t parsed = -1;
+  int rc = parsedate(p, &parsed);
+
+  if(rc == PARSEDATE_OK) {
+    if(parsed == -1)
+      /* avoid returning -1 for a working scenario */
+      parsed++;
+    return parsed;
+  } else if(rc == PARSEDATE_LATER) {
+    /* return the max possible expiry if we cannot hold the real value */
+    return TIME_T_MAX;
+  }
+  /* everything else is fail */
+  return -1;
+}
+
 time_t curl_getdate(const char *p, const time_t *now)
 {
   time_t parsed = -1;

--- a/lib/parsedate.h
+++ b/lib/parsedate.h
@@ -25,6 +25,8 @@
 extern const char * const Curl_wkday[7];
 extern const char * const Curl_month[12];
 
+time_t Curl_parse_expiry(const char* p);
+
 CURLcode Curl_gmtime(time_t intime, struct tm *store);
 
 #endif /* HEADER_CURL_PARSEDATE_H */

--- a/lib/parsedate.h
+++ b/lib/parsedate.h
@@ -25,7 +25,7 @@
 extern const char * const Curl_wkday[7];
 extern const char * const Curl_month[12];
 
-time_t Curl_parse_expiry(const char* p);
+time_t Curl_parse_expiry(const char *p);
 
 CURLcode Curl_gmtime(time_t intime, struct tm *store);
 


### PR DESCRIPTION
This PR suggests a different behavior for parsing cookie expiry dates.

Two changes were made:
1. Add `Curl_parse_expiry` which is used to parse HTTP cookie expiry dates. The only difference to `curl_getdate` is that it does not return an error in case of `PARSEDATE_LATER`. This means that cookies with expiry later than 2038 do not get parsed as session cookies any more, but as cookies with the latest possible expiry timestamp.
**Reason:** I use curl in a project where the server returns cookies with expiry dates of 2087 and later (for whatever reason). Curl treating these as session cookies and ignoring them upon restart caused big issues and seems counter-intuitive to me.
2. Change the behavior of parsedate to not return `TIME_T_MAX` when we are unsure if we can represent the given date in `time_t`. Instead, return the timestamp for `01.01.2038, 00:00` in the timezone specified in the date string. 
**Reason:** This ensures that we never return a later timestamp than specified in the datestring, so the returncode `PARSEDATE_LATER` does not lie. Note that this does not change the behavior of `curl_getdate`, which returns an error if the returncode is not `PARSEDATE_OK`.

**Note:** I added `Curl_parse_expiry` to avoid a change to the behavior of the public interface by changing `curl_getdate`.

ToDo:
- [x] Make `parsedate` consistent by replacing this code:
    ```
  if(yearnum < 1903) {
        *output = TIME_T_MIN;
        return PARSEDATE_SOONER;
  }
    ```
    With an equivalent mechanic to that used in overflow.
- [x] Make `Curl_parse_expiry` deal with `PARSEDATE_SOONER` the same way it deals with `PARSEDATE_LATER` for consistency
- [ ] Add unit tests for this behavior