### PR TITLE
curl: avoid uncessary libcurl timeouts (in parallel mode)

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1972,14 +1972,17 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
 
   while(!done && !mcode && still_running) {
     int numfds;
+    struct timeval before = tvnow();
+    long delta;
 
     mcode = curl_multi_wait(multi, NULL, 0, 1000, &numfds);
+    delta = tvdiff(tvnow(), before);
 
     if(!mcode) {
-      if(!numfds) {
+      if(!numfds && (delta < 30)) {
         long sleep_ms;
 
-        /* If it returns without any filedescriptor instantly, we need to
+        /* If it returns without any file descriptor instantly, we need to
            avoid busy-looping during periods where it has nothing particular
            to wait for */
         curl_multi_timeout(multi, &sleep_ms);


### PR DESCRIPTION
When curl_multi_wait() returns OK without file descriptors to wait for, it might already have done a long timeout.
