### PR TITLE
progress: reset download/uploaded counter

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -238,6 +238,8 @@ void Curl_pgrsStartNow(struct Curl_easy *data)
   data->progress.ul_limit_start.tv_usec = 0;
   data->progress.dl_limit_start.tv_sec = 0;
   data->progress.dl_limit_start.tv_usec = 0;
+  data->progress.downloaded = 0;
+  data->progress.uploaded = 0;
   /* clear all bits except HIDE and HEADERS_OUT */
   data->progress.flags &= PGRS_HIDE|PGRS_HEADERS_OUT;
   Curl_ratelimit(data, data->progress.start);


### PR DESCRIPTION
... to make CURLOPT_MAX_RECV_SPEED_LARGE and
CURLOPT_MAX_SEND_SPEED_LARGE work correctly on subsequent transfers that
reuse the same handle.

Fixed-by: Ironbars13 on github
Fixes #4084