### PR TITLE
curl: cap the maximum allowed values for retry time arguments

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -911,12 +911,12 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         config->retry_connrefused = toggle;
         break;
       case 'h': /* --retry-delay */
-        err = str2unum(&config->retry_delay, nextarg);
+        err = str2unummax(&config->retry_delay, nextarg, LONG_MAX/1000);
         if(err)
           return err;
         break;
       case 'i': /* --retry-max-time */
-        err = str2unum(&config->retry_maxtime, nextarg);
+        err = str2unummax(&config->retry_maxtime, nextarg, LONG_MAX/1000);
         if(err)
           return err;
         break;

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -198,6 +198,28 @@ ParameterError str2unum(long *val, const char *str)
 }
 
 /*
+ * Parse the string and write the long in the given address if it is below the
+ * maximum allowed value. Return PARAM_OK on success, otherwise a parameter
+ * error enum. ONLY ACCEPTS POSITIVE NUMBERS!
+ *
+ * Since this function gets called with the 'nextarg' pointer from within the
+ * getparameter a lot, we must check it for NULL before accessing the str
+ * data.
+ */
+
+ParameterError str2unummax(long *val, const char *str, long max)
+{
+  ParameterError result = str2unum(val, str);
+  if(result != PARAM_OK)
+    return result;
+  if(*val > max)
+    return PARAM_NUMBER_TOO_LARGE;
+
+  return PARAM_OK;
+}
+
+
+/*
  * Parse the string and write the double in the given address. Return PARAM_OK
  * on success, otherwise a parameter specific error enum.
  *

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -33,6 +33,7 @@ void cleanarg(char *str);
 
 ParameterError str2num(long *val, const char *str);
 ParameterError str2unum(long *val, const char *str);
+ParameterError str2unummax(long *val, const char *str, long max);
 ParameterError str2udouble(double *val, const char *str, long max);
 
 long proto2num(struct OperationConfig *config, long *val, const char *str);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -140,7 +140,7 @@ test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 test1252 test1253 test1254 test1255 test1256 test1257 test1258 test1259 \
 test1260 test1261 test1262 test1263 test1264 test1265 test1266 test1267 \
-test1268 \
+test1268 test1269 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 test1292 \

--- a/tests/data/test1269
+++ b/tests/data/test1269
@@ -1,0 +1,34 @@
+<testcase>
+<info>
+<keywords>
+--retry-delay
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+ <name>
+too large --retry-delay value
+ </name>
+ <command>
+--retry 3 --retry-delay 9223372036854776 http://%HOSTIP:%HTTPPORT/1269
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
... to avoid integer overflows later when multiplying with 1000 to
convert seconds to milliseconds.

Added test 1269 to verify.

Reported-by: Jason Lee