### PR TITLE
src/makefile: fix uncompressed hugehelp.c generation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,7 +123,7 @@ $(HUGE): $(MANPAGE) $(MKHELP)
 else # HAVE_LIBZ
 # This generates the tool_hugehelp.c file uncompressed only
 $(HUGE): $(MANPAGE) $(MKHELP)
-	$(HUGECMD)(echo '#include "tool_setup.h"' > $(HUGE):    \
+	$(HUGECMD)(echo '#include "tool_setup.h"' > $(HUGE);    \
 	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) >> $(HUGE) )
 endif
 


### PR DESCRIPTION
Regression from 5cf5d57ab9 (7.64.1)

Fixed-by: Lance Ware
Fixes #4176