### PR TITLE
alt-svc: more liberal ALPN name parsing

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -343,7 +343,7 @@ static CURLcode getalnum(const char **ptr, char *alpnbuf, size_t buflen)
   while(*p && ISBLANK(*p))
     p++;
   protop = p;
-  while(*p && ISALNUM(*p))
+  while(*p && !ISBLANK(*p) && (*p != ';') && (*p != '='))
     p++;
   len = p - protop;
 

--- a/tests/data/test356
+++ b/tests/data/test356
@@ -16,7 +16,7 @@ Content-Length: 6
 Connection: close
 Content-Type: text/html
 Funny-head: yesyes
-Alt-Svc: h1="nowhere.foo:81"
+Alt-Svc: h1="nowhere.foo:81", un-kno22!wn=":82"
 
 -foo-
 </data>


### PR DESCRIPTION
Allow pretty much anything to be part of the ALPN identifier. In
particular minus, which is used for "h3-20" (in-progress HTTP/3
versions) etc.

Updated test 356.