### PR TITLE
alt-svc with quiche

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -56,8 +56,13 @@ static enum alpnid alpn2alpnid(char *name)
     return ALPN_h2;
   if(strcasecompare(name, "h2c"))
     return ALPN_h2c;
+#ifdef USE_QUICHE
+  if(strcasecompare(name, "h3-20"))
+    return ALPN_h3;
+#else
   if(strcasecompare(name, "h3"))
     return ALPN_h3;
+#endif
   return ALPN_none; /* unknown, probably rubbish input */
 }
 
@@ -72,7 +77,11 @@ const char *Curl_alpnid2str(enum alpnid id)
   case ALPN_h2c:
     return "h2c";
   case ALPN_h3:
+#ifdef USE_QUICHE
+    return "h3-20";
+#else
     return "h3";
+#endif
   default:
     return ""; /* bad */
   }

--- a/lib/url.c
+++ b/lib/url.c
@@ -1773,6 +1773,7 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
   conn->proxy_ssl_config.verifyhost = data->set.proxy_ssl.primary.verifyhost;
   conn->ip_version = data->set.ipver;
   conn->bits.connect_only = data->set.connect_only;
+  conn->transport = TRNSPRT_TCP; /* most of them are TCP streams */
 
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM) && \
     defined(NTLM_WB_ENABLED)
@@ -2109,7 +2110,6 @@ static CURLcode setup_connection_internals(struct connectdata *conn)
 {
   const struct Curl_handler * p;
   CURLcode result;
-  conn->transport = TRNSPRT_TCP; /* most of them are TCP streams */
 
   /* Perform setup complement if some. */
   p = conn->handler;


### PR DESCRIPTION
1. Use the ALPN string quiche supports when quiche is used
2. Init 'transport' earlier so that we can set it properly according to alt-svc
3. Make use of the HTTP version alt-svc suggests

This needs #4182 to play ball.