### PR TITLE
OS400: Add CURLOPT_H3 symbols

### DIFF
--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -434,6 +434,9 @@
 /* Define to enable alt-svc support (experimental) */
 #undef USE_ALTSVC
 
+/* Define to enable HTTP3 support (experimental, requires NGTCP2 or QUICHE) */
+#undef ENABLE_QUIC
+
 /* Version number of package */
 #undef VERSION
 

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -138,6 +138,8 @@
      d                 c                   X'00800000'
      d CURL_VERSION_ALTSVC...
      d                 c                   X'01000000'
+     d CURL_VERSION_HTTP3...
+     d                 c                   X'02000000'
       *
      d CURL_HTTPPOST_FILENAME...
      d                 c                   X'00000001'
@@ -398,6 +400,9 @@
      d                 c                   X'00000100'
      d CURLU_GUESS_SCHEME...
      d                 c                   X'00000200'
+      *
+     d CURLH3_DIRECT...
+     d                 c                   X'00000001'
       *
       **************************************************************************
       *                                Types
@@ -1418,6 +1423,8 @@
      d                 c                   10287
      d  CURLOPT_MAXAGE_CONN...
      d                 c                   00288
+     d  CURLOPT_H3...
+     d                 c                   00289
       *
       /if not defined(CURL_NO_OLDIES)
      d  CURLOPT_FILE   c                   10001


### PR DESCRIPTION
Follow-up to 3af0e76 which added experimental H3 support.

Closes #xxxx

---

I'm not sure how HTTP3 support would work with OS400. In particular please take a close look at config-os400.