### PR TITLE
nss: use TLSv1.3 as default if supported

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1734,20 +1734,16 @@ static CURLcode nss_init_sslver(SSLVersionRange *sslver,
   CURLcode result;
   const long min = SSL_CONN_CONFIG(version);
   const long max = SSL_CONN_CONFIG(version_max);
-
-  /* map CURL_SSLVERSION_DEFAULT to NSS default */
-  if(min == CURL_SSLVERSION_DEFAULT || max == CURL_SSLVERSION_MAX_DEFAULT) {
-    /* map CURL_SSLVERSION_DEFAULT to NSS default */
-    if(SSL_VersionRangeGetDefault(ssl_variant_stream, sslver) != SECSuccess)
-      return CURLE_SSL_CONNECT_ERROR;
-    /* ... but make sure we use at least TLSv1.0 according to libcurl API */
-    if(sslver->min < SSL_LIBRARY_VERSION_TLS_1_0)
-      sslver->min = SSL_LIBRARY_VERSION_TLS_1_0;
-  }
+  SSLVersionRange vrange;
 
   switch(min) {
   case CURL_SSLVERSION_TLSv1:
   case CURL_SSLVERSION_DEFAULT:
+    /* Bump our minimum TLS version if NSS has stricter requirements. */
+    if(SSL_VersionRangeGetDefault(ssl_variant_stream, &vrange) != SECSuccess)
+      return CURLE_SSL_CONNECT_ERROR;
+    if(sslver->min < vrange.min)
+      sslver->min = vrange.min;
     break;
   default:
     result = nss_sslver_from_curl(&sslver->min, min);


### PR DESCRIPTION
SSL_VersionRangeGetDefault returns (TLSv1.0, TLSv1.2) as supported
range in NSS 3.45. It looks like the intention is to raise the minimum
version rather than lowering the maximum, so adjust accordingly. Note
that the caller (nss_setup_connect) initializes the version range to
(TLSv1.0, TLSv1.3), so there is no need to check for >= TLSv1.0 again.
___
Fixes version negotiation when no `--tlsv1.3` option is provided.
```
before$ src/curl https://wireshark.org -vI   
*   Trying 104.25.218.21:443...
...
* SSL connection using TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

after$ src/curl https://wireshark.org -vI 
*   Trying 104.25.219.21:443...
...
* SSL connection using TLS_AES_128_GCM_SHA256
```

This fixes an issue with PR #3262, @kdudka rightfully observed that the proposed change is no-op (the maximum version in `sslver` was ignored).