### PR TITLE
Fixed possible deference of NULL pointer

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2133,7 +2133,8 @@ static CURLcode operate_do(struct GlobalConfig *global,
      * ignored. We allow setting CA location for schannel only when explicitly
      * specified by the user via CURLOPT_CAINFO / --cacert.
      */
-    if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL) {
+    if((tls_backend_info) &&
+       (tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL)) {
       char *env;
       env = curlx_getenv("CURL_CA_BUNDLE");
       if(env) {


### PR DESCRIPTION
The analysis from Visual Studio is as follows:

2117: 'tls_backend_info' is NULL
2117: 'tls_backend_info' is an Output from 'curl_easy_getinfo'
2125: Skip this branch (assume 'result' is false)
2136: 'tls_backend_info' is dereferenced but may still be NULL

The only way the result from `curl_easy_getinfo()` can be NULL is if there is no support for SSL.

Can this code be executed when there is non SSL backend?
