### PR TITLE
http09: disable HTTP/0.9 by default in both tool and library

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -5,21 +5,6 @@ email the curl-library mailing list as soon as possible and explain to us why
 this is a problem for you and how your use case can't be satisfied properly
 using a work around.
 
-## HTTP/0.9
-
-Supporting this is non-obvious and might even come as a surprise to some
-users. Potentially even being a security risk in some cases.
-
-### State
-
-curl 7.64.0 introduces options to disable/enable support for this protocol
-version. The default remains supported for now.
-
-### Removal
-
-The support for HTTP/0.9 will be switched to disabled by default in 6 months,
-in the September 2019 release (possibly called curl 7.68.0).
-
 ## PolarSSL
 
 The polarssl TLS library has not had an update in over three years. The last

--- a/docs/cmdline-opts/http0.9.d
+++ b/docs/cmdline-opts/http0.9.d
@@ -10,5 +10,4 @@ HTTP/0.9 is a completely headerless response and therefore you can also
 connect with this to non-HTTP servers and still get a response since curl will
 simply transparently downgrade - if allowed.
 
-A future curl version will deny continuing if the response isn't at least
-HTTP/1.0 unless this option is used.
+Since curl 7.66.0, HTTP/0.9 is disabled by default.

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -31,12 +31,12 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTP09_ALLOWED, long allowed);
 Pass the long argument \fIallowed\fP set to 1L to allow HTTP/0.9 responses.
 
 A HTTP/0.9 response is a server response entirely without headers and only a
-body, while you can connect to lots of random TCP services and still get a
-response that curl might consider to be HTTP/0.9.
+body. You can connect to lots of random TCP services and still get a response
+that curl might consider to be HTTP/0.9!
 .SH DEFAULT
-curl allows HTTP/0.9 responses by default.
+curl allowed HTTP/0.9 responses by default before 7.66.0
 
-A future curl version will require this option to be set to allow HTTP/0.9
+Since 7.66.0, libcurl requires this option set to 1L to allow HTTP/0.9
 responses.
 .SH PROTOCOLS
 HTTP

--- a/lib/url.c
+++ b/lib/url.c
@@ -546,7 +546,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->upkeep_interval_ms = CURL_UPKEEP_INTERVAL_DEFAULT;
   set->maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */
   set->maxage_conn = 118;
-  set->http09_allowed = TRUE;
+  set->http09_allowed = FALSE;
   set->httpversion =
 #ifdef USE_NGHTTP2
     CURL_HTTP_VERSION_2TLS

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -43,7 +43,7 @@ void config_init(struct OperationConfig* config)
   config->proto_default = NULL;
   config->tcp_nodelay = TRUE; /* enabled by default */
   config->happy_eyeballs_timeout_ms = CURL_HET_DEFAULT;
-  config->http09_allowed = TRUE;
+  config->http09_allowed = FALSE;
 }
 
 static void free_config_fields(struct OperationConfig *config)

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -129,7 +129,7 @@ test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
 test1152 test1153 test1154 test1155 test1156 test1157 test1158 test1159 \
 test1160 test1161 test1162 test1163 test1164 test1165 \
-test1170 test1171 test1172 test1173 \
+test1170 test1171 test1172 test1173 test1174 \
 \
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \
 test1208 test1209 test1210 test1211 test1212 test1213 test1214 test1215 \

--- a/tests/data/test1174
+++ b/tests/data/test1174
@@ -1,0 +1,50 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP/0.9
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+-foo- swsclose
+</data>
+<datacheck>
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP/0.9 GET response denied by default
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/1174
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1174 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+# unsupported protocol
+<errorcode>
+1
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1401
+++ b/tests/data/test1401
@@ -88,7 +88,6 @@ int main(int argc, char *argv[])
   curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, slist1);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "MyUA");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
-  curl_easy_setopt(hnd, CURLOPT_HTTP09_ALLOWED, 1L);
   curl_easy_setopt(hnd, CURLOPT_COOKIE, "chocolate=chip");
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/tests/data/test1402
+++ b/tests/data/test1402
@@ -80,7 +80,6 @@ int main(int argc, char *argv[])
   curl_easy_setopt(hnd, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)16);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
-  curl_easy_setopt(hnd, CURLOPT_HTTP09_ALLOWED, 1L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
 

--- a/tests/data/test1403
+++ b/tests/data/test1403
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
   curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/1403?foo=bar&baz=quux");
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
-  curl_easy_setopt(hnd, CURLOPT_HTTP09_ALLOWED, 1L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
 

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -146,7 +146,6 @@ int main(int argc, char *argv[])
   curl_easy_setopt(hnd, CURLOPT_MIMEPOST, mime1);
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
-  curl_easy_setopt(hnd, CURLOPT_HTTP09_ALLOWED, 1L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
 

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -66,7 +66,6 @@ int main(int argc, char *argv[])
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
   curl_easy_setopt(hnd, CURLOPT_URL, "imap://%HOSTIP:%IMAPPORT/1420/;MAILINDEX=1");
   curl_easy_setopt(hnd, CURLOPT_USERPWD, "user:secret");
-  curl_easy_setopt(hnd, CURLOPT_HTTP09_ALLOWED, 1L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
 


### PR DESCRIPTION
As the plan has been laid out in DEPRECATED. Update docs accordingly and
verify in test 1174.