### PR TITLE
alt-svc: send Alt-Used: in redirected requests

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -12,7 +12,6 @@
 
  Name                           Introduced  Deprecated  Removed
 
-CURLALTSVC_ALTUSED              7.64.1
 CURLALTSVC_H1                   7.64.1
 CURLALTSVC_H2                   7.64.1
 CURLALTSVC_H3                   7.64.1

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -883,7 +883,7 @@ typedef enum {
 
 /* CURLALTSVC_* are bits for the CURLOPT_ALTSVC_CTRL option */
 #define CURLALTSVC_IMMEDIATELY  (1<<0)
-#define CURLALTSVC_ALTUSED      (1<<1)
+
 #define CURLALTSVC_READONLYFILE (1<<2)
 #define CURLALTSVC_H1           (1<<3)
 #define CURLALTSVC_H2           (1<<4)

--- a/lib/url.c
+++ b/lib/url.c
@@ -3187,6 +3187,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
       conn->bits.conn_to_host = TRUE;
       conn->conn_to_port = nport;
       conn->bits.conn_to_port = TRUE;
+      conn->bits.altused = TRUE;
       infof(data, "Alt-svc connecting from [%s]%s:%d to [%s]%s:%d\n",
             Curl_alpnid2str(salpnid), host, conn->remote_port,
             Curl_alpnid2str(nalpnid), hostd, nport);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -405,6 +405,7 @@ struct ConnectBits {
                          the first time on the first connect function call */
   bit close:1; /* if set, we close the connection after this request */
   bit reuse:1; /* if set, this is a re-used connection */
+  bit altused:1; /* this is an alt-svc "redirect" */
   bit conn_to_host:1; /* if set, this connection has a "connect to host"
                          that overrides the host in the URL */
   bit conn_to_port:1; /* if set, this connection has a "connect to port"


### PR DESCRIPTION
RFC 7838 section 5:

   When using an alternative service, clients SHOULD include an Alt-Used
   header field in all requests.