### PR TITLE
cleanup: s/curl_debug/curl_dbg_debug in comments and docs

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -773,7 +773,7 @@ Track Down Memory Leaks
 
   Add a line in your application code:
 
-       `curl_memdebug("dump");`
+       `curl_dbg_memdebug("dump");`
 
   This will make the malloc debug system output a full trace of all resource
   using functions to the given file name. Make sure you rebuild your program

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -113,9 +113,9 @@ static void memory_tracking_init(void)
     strcpy(fname, env);
     curl_free(env);
     curl_dbg_memdebug(fname);
-    /* this weird stuff here is to make curl_free() get called
-       before curl_memdebug() as otherwise memory tracking will
-       log a free() without an alloc! */
+    /* this weird stuff here is to make curl_free() get called before
+       curl_gdb_memdebug() as otherwise memory tracking will log a free()
+       without an alloc! */
   }
   /* if CURL_MEMLIMIT is set, this enables fail-on-alloc-number-N feature */
   env = curlx_getenv("CURL_MEMLIMIT");

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -97,9 +97,9 @@ static void memory_tracking_init(void)
     strcpy(fname, env);
     curl_free(env);
     curl_dbg_memdebug(fname);
-    /* this weird stuff here is to make curl_free() get called
-       before curl_memdebug() as otherwise memory tracking will
-       log a free() without an alloc! */
+    /* this weird stuff here is to make curl_free() get called before
+       curl_dbg_memdebug() as otherwise memory tracking will log a free()
+       without an alloc! */
   }
   /* if CURL_MEMLIMIT is set, this enables fail-on-alloc-number-N feature */
   env = curl_getenv("CURL_MEMLIMIT");


### PR DESCRIPTION
Leftovers from the function rename back in 76b63489495

Reported-by: Gisle Vanem
Bug: https://github.com/curl/curl/commit/f3e0f071b14fcb46a453f69bdf4e062bcaacf362#com
mitcomment-34601751