### PR TITLE
configure: avoid undefined check_for_ca_bundle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2633,7 +2633,7 @@ dnl **********************************************************************
 dnl Check for the CA bundle
 dnl **********************************************************************
 
-if test "$check_for_ca_bundle" -gt 0; then
+if test -n "$check_for_ca_bundle"; then
   CURL_CHECK_CA_BUNDLE
 fi
 


### PR DESCRIPTION
instead of using a "greater than 0" test, check for variable being
set, as it is always set to 1, and could be left unset if non of
OPENSSL MBEDTLS GNUTLS WOLFSSL is being configured for.