### PR TITLE
h3 happy eyeballs

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -790,6 +790,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
         conn->sock[sockindex] = conn->tempsock[i];
         conn->ip_addr = conn->tempaddr[i];
         conn->tempsock[i] = CURL_SOCKET_BAD;
+        connkeep(conn, "HTTP/3 default");
       }
       return result;
     }
@@ -858,7 +859,9 @@ CURLcode Curl_is_connected(struct connectdata *conn,
     else if(rc & CURL_CSELECT_ERR)
       (void)verifyconnect(conn->tempsock[i], &error);
 
+#ifdef ENABLE_QUIC
     error:
+#endif
     /*
      * The connection failed here, we should attempt to connect to the "next
      * address" for the given host. But first remember the latest error.

--- a/lib/http.c
+++ b/lib/http.c
@@ -1565,10 +1565,8 @@ static CURLcode https_connecting(struct connectdata *conn, bool *done)
 
 #ifdef ENABLE_QUIC
   if(conn->transport == TRNSPRT_QUIC) {
-    result = Curl_quic_is_connected(conn, FIRSTSOCKET, done);
-    if(result)
-      connclose(conn, "Failed HTTPS connection (over QUIC)");
-    return result;
+    *done = TRUE;
+    return CURLE_OK;
   }
 #endif
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -832,7 +832,13 @@ static int waitconnect_getsock(struct connectdata *conn,
   for(i = 0; i<2; i++) {
     if(conn->tempsock[i] != CURL_SOCKET_BAD) {
       sock[s] = conn->tempsock[i];
-      rc |= GETSOCK_WRITESOCK(s++);
+      rc |= GETSOCK_WRITESOCK(s);
+#ifdef ENABLE_QUIC
+      if(conn->transport == TRNSPRT_QUIC)
+        /* when connecting QUIC, we want to read the socket too */
+        rc |= GETSOCK_READSOCK(s);
+#endif
+      s++;
     }
   }
 

--- a/lib/quic.h
+++ b/lib/quic.h
@@ -37,10 +37,12 @@
 /* functions provided by the specific backends */
 CURLcode Curl_quic_connect(struct connectdata *conn,
                            curl_socket_t sockfd,
+                           int sockindex,
                            const struct sockaddr *addr,
                            socklen_t addrlen);
-CURLcode Curl_quic_is_connected(struct connectdata *conn, int sockindex,
-                                bool *done);
+CURLcode Curl_quic_is_connected(struct connectdata *conn,
+                                curl_socket_t sockfd,
+                                bool *connected);
 int Curl_quic_ver(char *p, size_t len);
 
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -836,7 +836,8 @@ struct connectdata {
   } transport;
 
 #ifdef ENABLE_QUIC
-  struct quicsocket quic;
+  struct quicsocket hequic[2]; /* two, for happy eyeballs! */
+  struct quicsocket *quic;
 #endif
 
   struct hostname host;

--- a/lib/vquic/ngtcp2.h
+++ b/lib/vquic/ngtcp2.h
@@ -39,7 +39,8 @@ struct quic_handshake {
 };
 
 struct quicsocket {
-  ngtcp2_conn *conn;
+  struct connectdata *conn; /* point back to the connection */
+  ngtcp2_conn *qconn;
   ngtcp2_cid dcid;
   ngtcp2_cid scid;
   uint32_t version;
@@ -64,11 +65,6 @@ struct quicsocket {
 
 #include "urldata.h"
 
-CURLcode Curl_quic_connect(struct connectdata *conn,
-                           curl_socket_t sockfd,
-                           const struct sockaddr *addr,
-                           socklen_t addrlen);
-int Curl_quic_ver(char *p, size_t len);
 #endif
 
 #endif /* HEADER_CURL_VQUIC_NGTCP2_H */


### PR DESCRIPTION
Restructured the QUIC code to allow and perform parallel connect attempts so that happy eyeballs (racing ipv4 vs ipv6 connects) work.

Unfortunately this seems to also have broken the ngtcp2 backend somewhat and I'm struggling to figure out how.