### PR TITLE
vauth: return CURLE_AUTH_ERROR on gss_init_sec_context() failure

### DIFF
--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -148,7 +148,7 @@ CURLcode Curl_output_negotiate(struct connectdata *conn, bool proxy)
     }
     if(!neg_ctx->context) {
       result = Curl_input_negotiate(conn, proxy, "Negotiate");
-      if(result == CURLE_LOGIN_DENIED) {
+      if(result == CURLE_AUTH_ERROR) {
         /* negotiate auth failed, let's continue unauthenticated to stay
          * compatible with the behavior before curl-7_64_0-158-g6c6035532 */
         authp->done = TRUE;

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -170,7 +170,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     Curl_gss_log_error(data, "gss_init_sec_context() failed: ",
                        major_status, minor_status);
 
-    return CURLE_LOGIN_DENIED;
+    return CURLE_AUTH_ERROR;
   }
 
   if(!output_token.value || !output_token.length) {

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -165,7 +165,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                          nego->p_identity, NULL, NULL,
                                          nego->credentials, &expiry);
     if(nego->status != SEC_E_OK)
-      return CURLE_LOGIN_DENIED;
+      return CURLE_AUTH_ERROR;
 
     /* Allocate our new context handle */
     nego->context = calloc(1, sizeof(CtxtHandle));


### PR DESCRIPTION
This is a follow-up to https://github.com/curl/curl/pull/3864 .