### PR TITLE
Use -lquiche to link to quiche

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3551,7 +3551,7 @@ if test X"$want_quiche" != Xno; then
   CLEANCPPFLAGS="$CPPFLAGS"
   CLEANLIBS="$LIBS"
 
-  LIB_QUICHE="-l:libquiche.a -ldl -lpthread"
+  LIB_QUICHE="-lquiche -ldl -lpthread"
   CPP_QUICHE="-I$OPT_QUICHE/include"
   LD_QUICHE="-L$OPT_QUICHE/target/release"
 


### PR DESCRIPTION
When attempting to build with Quiche (using the [instructions](https://github.com/curl/curl/blob/master/docs/HTTP3.md)), I couldn't get autoconf to accept that I had `-l:libquiche.a` in the specified directory. I'm building on macOS.  

After changing it to `-lquiche` it built fine. Judging by the absence of any other `-l:` options in the autoconf file, I'm led to believe that this change is correct (I'm not too familiar with autoconf or make).

If I did get it wrong, please let me know how to build with Quiche.