### PR TITLE
url: extract and store username + password in the easy handle

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1503,6 +1503,9 @@ enum dupstring {
   STRING_ALTSVC,                /* CURLOPT_ALTSVC */
 #endif
   STRING_SASL_AUTHZID,          /* CURLOPT_SASL_AUTHZID */
+#ifndef CURL_DISABLE_PROXY
+  STRING_TEMP_URL,              /* temp URL storage for proxy use */
+#endif
   /* -- end of zero-terminated strings -- */
 
   STRING_LASTZEROTERMINATED,

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -57,7 +57,7 @@ test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
-test334 \
+test334 test335 \
 test340 \
 \
 test350 test351 test352 test353 test354 test355 test356 \

--- a/tests/data/test2047
+++ b/tests/data/test2047
@@ -92,7 +92,7 @@ OK
 1
 1
 3
-http://xn--4cab6c.se/20470001
+http://åäö.se/20470001
 text/plain; charset=us-ascii
 200
 </stdout>

--- a/tests/data/test335
+++ b/tests/data/test335
@@ -1,0 +1,102 @@
+# Mostly a duplicate of test168
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP proxy
+HTTP proxy Digest auth
+HTTP Digest auth
+HTTP auth in URL
+</keywords>
+</info>
+
+# Server-side
+<reply>
+
+# this is returned first since we get no proxy-auth
+<data>
+HTTP/1.1 407 Authorization Required to proxy me my dear swsclose
+Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
+
+And you should ignore this data.
+</data>
+
+# then this is returned since we get no server-auth
+<data1000>
+HTTP/1.1 401 Authorization to the remote host as well swsbounce swsclose
+WWW-Authenticate: Digest realm="realmweirdo", nonce="123456"
+
+you should ignore this data too
+</data1000>
+
+<data1001>
+HTTP/1.1 200 OK swsclose
+Server: no
+Content-Length: 15
+
+Nice auth sir!
+</data1001>
+
+<datacheck>
+HTTP/1.1 407 Authorization Required to proxy me my dear swsclose
+Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
+
+HTTP/1.1 401 Authorization to the remote host as well swsbounce swsclose
+WWW-Authenticate: Digest realm="realmweirdo", nonce="123456"
+
+HTTP/1.1 200 OK swsclose
+Server: no
+Content-Length: 15
+
+Nice auth sir!
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+!SSPI
+crypto
+</features>
+ <name>
+HTTP with proxy Digest and site Digest with creds in URLs
+ </name>
+ <command>
+http://digest:alot@data.from.server.requiring.digest.hohoho.com/335 --proxy http://foo:bar@%HOSTIP:%HTTPPORT --proxy-digest --digest
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent: curl/.*
+</strip>
+<protocol>
+GET http://data.from.server.requiring.digest.hohoho.com/335 HTTP/1.1
+Host: data.from.server.requiring.digest.hohoho.com
+User-Agent: curl/7.12.0-CVS (i686-pc-linux-gnu) libcurl/7.12.0-CVS OpenSSL/0.9.6b zlib/1.1.4 c-ares/1.2.0 libidn/0.4.3
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://data.from.server.requiring.digest.hohoho.com/335 HTTP/1.1
+Host: data.from.server.requiring.digest.hohoho.com
+Proxy-Authorization: Digest username="foo", realm="weirdorealm", nonce="12345", uri="/335", response="f61609cd8f5bb205ef4e169b2c5626cb"
+User-Agent: curl/7.12.0-CVS (i686-pc-linux-gnu) libcurl/7.12.0-CVS OpenSSL/0.9.6b zlib/1.1.4 c-ares/1.2.0 libidn/0.4.3
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://data.from.server.requiring.digest.hohoho.com/335 HTTP/1.1
+Host: data.from.server.requiring.digest.hohoho.com
+Proxy-Authorization: Digest username="foo", realm="weirdorealm", nonce="12345", uri="/335", response="f61609cd8f5bb205ef4e169b2c5626cb"
+Authorization: Digest username="digest", realm="realmweirdo", nonce="123456", uri="/335", response="08a2e2e684047f4219a38ddc189ac00c"
+User-Agent: curl/7.12.0-CVS (i686-pc-linux-gnu) libcurl/7.12.0-CVS OpenSSL/0.9.6b ipv6 zlib/1.1.4 GSS libidn/0.4.3
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
When a username and password are provided in the URL, they were not
correctly stored and remembered in the easy handle, only for the
connection, so when doing HTTP auth that uses multiple connections (like
Digest) curl mishaved.

Regression from 46e164069d1a5230 (7.62.0)

Test case 335 added to verify.

Reported-by: Mike Crowe

Fixes #4228