### PR TITLE
Use .curlrc and .netrc windows as well

### DIFF
--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -40,7 +40,7 @@ Unix-like systems (which returns the home dir given the current user in your
 system). On Windows, it then checks for the APPDATA variable, or as a last
 resort the '%USERPROFILE%\\Application Data'.
 
-2) On windows, if there is no _curlrc file in the home dir, it checks for one
+2) On windows, if there is no .curlrc file in the home dir, it checks for one
 in the same dir the curl executable is placed. On Unix-like systems, it will
 simply try to load .curlrc from the determined home dir.
 

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -45,27 +45,27 @@ enum host_lookup_state {
   HOSTVALID     /* this is "our" machine! */
 };
 
+#define NETRC_FILE_MISSING 1
+#define NETRC_FAILED -1
+#define NETRC_SUCCESS 0
+
 /*
- * @unittest: 1304
- *
- * *loginp and *passwordp MUST be allocated if they aren't NULL when passed
- * in.
+ * Returns zero on success.
  */
-int Curl_parsenetrc(const char *host,
-                    char **loginp,
-                    char **passwordp,
-                    bool *login_changed,
-                    bool *password_changed,
-                    char *netrcfile)
+static int parsenetrc(const char *host,
+                      char **loginp,
+                      char **passwordp,
+                      bool *login_changed,
+                      bool *password_changed,
+                      char *netrcfile)
 {
   FILE *file;
-  int retcode = 1;
+  int retcode = NETRC_FILE_MISSING;
   char *login = *loginp;
   char *password = *passwordp;
   bool specific_login = (login && *login != 0);
   bool login_alloc = FALSE;
   bool password_alloc = FALSE;
-  bool netrc_alloc = FALSE;
   enum host_lookup_state state = NOTHING;
 
   char state_login = 0;      /* Found a login keyword */
@@ -73,51 +73,9 @@ int Curl_parsenetrc(const char *host,
   int state_our_login = FALSE;  /* With specific_login, found *our* login
                                    name */
 
-#define NETRC DOT_CHAR "netrc"
-
-  if(!netrcfile) {
-    bool home_alloc = FALSE;
-    char *home = curl_getenv("HOME"); /* portable environment reader */
-    if(home) {
-      home_alloc = TRUE;
-#if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
-    }
-    else {
-      struct passwd pw, *pw_res;
-      char pwbuf[1024];
-      if(!getpwuid_r(geteuid(), &pw, pwbuf, sizeof(pwbuf), &pw_res)
-         && pw_res) {
-        home = strdup(pw.pw_dir);
-        if(!home)
-          return -1;
-        home_alloc = TRUE;
-      }
-#elif defined(HAVE_GETPWUID) && defined(HAVE_GETEUID)
-    }
-    else {
-      struct passwd *pw;
-      pw = getpwuid(geteuid());
-      if(pw) {
-        home = pw->pw_dir;
-      }
-#endif
-    }
-
-    if(!home)
-      return retcode; /* no home directory found (or possibly out of memory) */
-
-    netrcfile = curl_maprintf("%s%s%s", home, DIR_CHAR, NETRC);
-    if(home_alloc)
-      free(home);
-    if(!netrcfile) {
-      return -1;
-    }
-    netrc_alloc = TRUE;
-  }
+  DEBUGASSERT(netrcfile);
 
   file = fopen(netrcfile, FOPEN_READTEXT);
-  if(netrc_alloc)
-    free(netrcfile);
   if(file) {
     char *tok;
     char *tok_buf;
@@ -148,14 +106,14 @@ int Curl_parsenetrc(const char *host,
           }
           else if(strcasecompare("default", tok)) {
             state = HOSTVALID;
-            retcode = 0; /* we did find our host */
+            retcode = NETRC_SUCCESS; /* we did find our host */
           }
           break;
         case HOSTFOUND:
           if(strcasecompare(host, tok)) {
             /* and yes, this is our host! */
             state = HOSTVALID;
-            retcode = 0; /* we did find our host */
+            retcode = NETRC_SUCCESS; /* we did find our host */
           }
           else
             /* not our host */
@@ -174,7 +132,7 @@ int Curl_parsenetrc(const char *host,
               }
               login = strdup(tok);
               if(!login) {
-                retcode = -1; /* allocation failed */
+                retcode = NETRC_FAILED; /* allocation failed */
                 goto out;
               }
               login_alloc = TRUE;
@@ -190,7 +148,7 @@ int Curl_parsenetrc(const char *host,
               }
               password = strdup(tok);
               if(!password) {
-                retcode = -1; /* allocation failed */
+                retcode = NETRC_FAILED; /* allocation failed */
                 goto out;
               }
               password_alloc = TRUE;
@@ -215,6 +173,7 @@ int Curl_parsenetrc(const char *host,
 
     out:
     if(!retcode) {
+      /* success */
       *login_changed = FALSE;
       *password_changed = FALSE;
       if(login_alloc) {
@@ -239,6 +198,75 @@ int Curl_parsenetrc(const char *host,
     fclose(file);
   }
 
+  return retcode;
+}
+
+/*
+ * @unittest: 1304
+ *
+ * *loginp and *passwordp MUST be allocated if they aren't NULL when passed
+ * in.
+ */
+int Curl_parsenetrc(const char *host,
+                    char **loginp,
+                    char **passwordp,
+                    bool *login_changed,
+                    bool *password_changed,
+                    char *netrcfile)
+{
+  int retcode = 1;
+  char *filealloc = NULL;
+
+  if(!netrcfile) {
+    char *home = curl_getenv("HOME"); /* portable environment reader */
+    if(home) {
+#if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)
+    }
+    else {
+      struct passwd pw, *pw_res;
+      char pwbuf[1024];
+      if(!getpwuid_r(geteuid(), &pw, pwbuf, sizeof(pwbuf), &pw_res)
+         && pw_res) {
+        home = strdup(pw.pw_dir);
+        if(!home)
+          return -1;
+      }
+#elif defined(HAVE_GETPWUID) && defined(HAVE_GETEUID)
+    }
+    else {
+      struct passwd *pw;
+      pw = getpwuid(geteuid());
+      if(pw) {
+        home = pw->pw_dir;
+      }
+#endif
+    }
+
+    if(!home)
+      return retcode; /* no home directory found (or possibly out of
+                         memory) */
+
+    filealloc = curl_maprintf("%s%s.netrc", home, DIR_CHAR);
+    if(!filealloc)
+      return -1;
+    retcode = parsenetrc(host, loginp, passwordp, login_changed,
+                         password_changed, filealloc);
+    free(filealloc);
+#ifdef WIN32
+    if(retcode == NETRC_FILE_MISSING) {
+      /* fallback to the old-style "_netrc" file */
+      filealloc = curl_maprintf("%s%s_netrc", home, DIR_CHAR);
+      if(!filealloc)
+        return -1;
+      retcode = parsenetrc(host, loginp, passwordp, login_changed,
+                           password_changed, filealloc);
+      free(filealloc);
+    }
+#endif
+  }
+  else
+    retcode = parsenetrc(host, loginp, passwordp, login_changed,
+                         password_changed, netrcfile);
   return retcode;
 }
 


### PR DESCRIPTION
1. Make libcurl on windows first check for `.netrc` then if missing, go for `_netrc`
2. Make curl on windows first check for `.curlrc` then if missing, go for `.curlrc`

This is my refresh of the code started in #3989 by @captain-caveman2k. The main point of this exercise is unification. Stick to the dot version primarily, support the underscore for compatibility.

The _netrc thing is marked as a ["known issue" for git on windows](https://github.com/git-for-windows/build-extra/blob/master/ReleaseNotes.md#known-issues).

I'm thinking maybe @dscho, @jay and @gvanem might have opinions.