### PR TITLE
configure: use pkg-config to detect quiche

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ matrix:
           compiler: gcc
           dist: xenial
           env:
-              - T=novalgrind BORINGSSL=yes QUICHE="yes" C="--with-ssl=$HOME/boringssl --with-quiche=$home/quiche --enable-alt-svc" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
+              - T=novalgrind BORINGSSL=yes QUICHE="yes" C="--with-ssl=$HOME/boringssl --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=/home/travis/boringssl/lib:$HOME/quiche/target/release:/usr/local/lib
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
           addons:
               apt:
@@ -435,7 +435,7 @@ before_script:
         curl https://sh.rustup.rs -sSf | sh -s -- -y &&
         source $HOME/.cargo/env &&
         cd quiche &&
-        QUICHE_BSSL_PATH=$HOME/boringssl cargo build -v --release)
+        QUICHE_BSSL_PATH=$HOME/boringssl cargo build -v --release --features pkg-config-meta)
       fi
     - |
       if [ $TRAVIS_OS_NAME = linux ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -3534,14 +3534,19 @@ AC_HELP_STRING([--with-quiche=PATH],[Enable quiche usage])
 AC_HELP_STRING([--without-quiche],[Disable quiche usage]),
   [OPT_QUICHE=$withval])
 case "$OPT_QUICHE" in
-  *)
+  no)
+    dnl --without-quiche option used
+    want_quiche="no"
+    ;;
+  yes)
     dnl --with-quiche option used without path
     want_quiche="default"
     want_quiche_path=""
     ;;
-  no)
-    dnl --without-quiche option used
-    want_quiche="no"
+  *)
+    dnl --with-quiche option used with path
+    want_quiche="yes"
+    want_quiche_path="$withval"
     ;;
 esac
 
@@ -3551,36 +3556,55 @@ if test X"$want_quiche" != Xno; then
   CLEANCPPFLAGS="$CPPFLAGS"
   CLEANLIBS="$LIBS"
 
-  LIB_QUICHE="-lquiche -ldl -lpthread"
-  CPP_QUICHE="-I$OPT_QUICHE/include"
-  LD_QUICHE="-L$OPT_QUICHE/target/release"
+  CURL_CHECK_PKGCONFIG(quiche, $want_quiche_path)
 
-  LDFLAGS="$LDFLAGS $LD_QUICHE"
-  CPPFLAGS="$CPPFLAGS $CPP_QUICHE"
-  LIBS="$LIB_QUICHE $LIBS"
+  if test "$PKGCONFIG" != "no" ; then
+    LIB_QUICHE=`CURL_EXPORT_PCDIR([$want_quiche_path])
+      $PKGCONFIG --libs-only-l quiche`
+    AC_MSG_NOTICE([-l is $LIB_QUICHE])
 
-  if test "x$cross_compiling" != "xyes"; then
-    DIR_QUICHE=`echo $LD_QUICHE | $SED -e 's/-L//'`
+    CPP_QUICHE=`CURL_EXPORT_PCDIR([$want_quiche_path]) dnl
+      $PKGCONFIG --cflags-only-I quiche`
+    AC_MSG_NOTICE([-I is $CPP_QUICHE])
+
+    LD_QUICHE=`CURL_EXPORT_PCDIR([$want_quiche_path])
+      $PKGCONFIG --libs-only-L quiche`
+    AC_MSG_NOTICE([-L is $LD_QUICHE])
+
+    LDFLAGS="$LDFLAGS $LD_QUICHE"
+    CPPFLAGS="$CPPFLAGS $CPP_QUICHE"
+    LIBS="$LIB_QUICHE $LIBS"
+
+    if test "x$cross_compiling" != "xyes"; then
+      DIR_QUICHE=`echo $LD_QUICHE | $SED -e 's/-L//'`
+    fi
+    AC_CHECK_LIB(quiche, quiche_connect,
+      [
+       AC_CHECK_HEADERS(quiche.h,
+          experimental="$experimental HTTP3"
+          AC_MSG_NOTICE([HTTP3 support is experimental])
+          curl_h3_msg="enabled (quiche)"
+          QUICHE_ENABLED=1
+          AC_DEFINE(USE_QUICHE, 1, [if quiche is in use])
+          AC_SUBST(USE_QUICHE, [1])
+          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_QUICHE"
+          export CURL_LIBRARY_PATH
+          AC_MSG_NOTICE([Added $DIR_QUICHE to CURL_LIBRARY_PATH]),
+       )
+      ],
+        dnl not found, revert back to clean variables
+        LDFLAGS=$CLEANLDFLAGS
+        CPPFLAGS=$CLEANCPPFLAGS
+        LIBS=$CLEANLIBS
+    )
+  else
+    dnl no nghttp3 pkg-config found, deal with it
+    if test X"$want_quiche" != Xdefault; then
+      dnl To avoid link errors, we do not allow --with-nghttp3 without
+      dnl a pkgconfig file
+      AC_MSG_ERROR([--with-quiche was specified but could not find quiche pkg-config file.])
+    fi
   fi
-  AC_CHECK_LIB(quiche, quiche_connect,
-    [
-     AC_CHECK_HEADERS(quiche.h,
-        experimental="$experimental HTTP3"
-        AC_MSG_NOTICE([HTTP3 support is experimental])
-        curl_h3_msg="enabled (quiche)"
-        QUICHE_ENABLED=1
-        AC_DEFINE(USE_QUICHE, 1, [if quiche is in use])
-        AC_SUBST(USE_QUICHE, [1])
-        CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_QUICHE"
-        export CURL_LIBRARY_PATH
-        AC_MSG_NOTICE([Added $DIR_QUICHE to CURL_LIBRARY_PATH]),
-     )
-    ],
-      dnl not found, revert back to clean variables
-      LDFLAGS=$CLEANLDFLAGS
-      CPPFLAGS=$CLEANCPPFLAGS
-      LIBS=$CLEANLIBS
-  )
 fi
 
 dnl **********************************************************************

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -84,10 +84,10 @@ you'll just get ld.so linker errors.
 Clone quiche and BoringSSL:
 
      % git clone --recursive https://github.com/cloudflare/quiche
-     % cd quiche/deps/boringssl
 
 Build BoringSSL (it needs to be built manually so it can be reused with curl):
 
+     % cd quiche/deps/boringssl
      % mkdir build
      % cd build
      % cmake -DCMAKE_POSITION_INDEPENDENT_CODE=on ..
@@ -100,7 +100,7 @@ Build BoringSSL (it needs to be built manually so it can be reused with curl):
 Build quiche:
 
      % cd ../..
-     % QUICHE_BSSL_PATH=$PWD/deps/boringssl cargo build --release
+     % QUICHE_BSSL_PATH=$PWD/deps/boringssl cargo build --release --features pkg-config-meta
 
 Clone and build curl:
 
@@ -108,7 +108,7 @@ Clone and build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure --with-ssl=$PWD/../quiche/deps/boringssl/.openssl --with-quiche=$PWD/../quiche --enable-debug
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl/.openssl --with-quiche=$PWD/../quiche/target/release
      % make -j`nproc`
 
 ## Running


### PR DESCRIPTION
This removes the need to hard-code the quiche target path in
configure.ac.

This depends on https://github.com/cloudflare/quiche/pull/128