### PR TITLE
CURLOPT_SSL_VERIFYHOST: treat the value 1 as 2

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -42,8 +42,15 @@ Curl considers the proxy the intended one when the Common Name field or a
 Subject Alternate Name field in the certificate matches the host name in the
 proxy string which you told curl to use.
 
-When the \fIverify\fP value is 1L, \fIcurl_easy_setopt\fP will return an error
-and the option value will not be changed due to old legacy reasons.
+If \fIverify\fP value is set to 1:
+
+In 7.28.0 and earlier: treated as a debug option of some sorts, not supported
+anymore due to frequently leading to programmer mistakes.
+
+From 7.28.1 to 7.65.3: setting it to 1 made curl_easy_setopt() return an error
+and leaving the flag untouched.
+
+From 7.66.0: treats 1 and 2 the same.
 
 When the \fIverify\fP value is 0L, the connection succeeds regardless of the
 names used in the certificate. Use that ability with caution!

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -45,11 +45,15 @@ Curl considers the server the intended one when the Common Name field or a
 Subject Alternate Name field in the certificate matches the host name in the
 URL to which you told Curl to connect.
 
-When the \fIverify\fP value is 1, \fIcurl_easy_setopt\fP will return an error
-and the option value will not be changed.  It was previously (in 7.28.0 and
-earlier) a debug option of some sorts, but it is no longer supported due to
-frequently leading to programmer mistakes. Future versions will stop returning
-an error for 1 and just treat 1 and 2 the same.
+If \fIverify\fP value is set to 1:
+
+In 7.28.0 and earlier: treated as a debug option of some sorts, not supported
+anymore due to frequently leading to programmer mistakes.
+
+From 7.28.1 to 7.65.3: setting it to 1 made curl_easy_setopt() return an error
+and leaving the flag untouched.
+
+From 7.66.0: treats 1 and 2 the same.
 
 When the \fIverify\fP value is 0, the connection succeeds regardless of the
 names in the certificate. Use that ability with caution!

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1783,16 +1783,9 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     arg = va_arg(param, long);
 
     /* Obviously people are not reading documentation and too many thought
-       this argument took a boolean when it wasn't and misused it. We thus ban
-       1 as a sensible input and we warn about its use. Then we only have the
-       2 action internally stored as TRUE. */
-
-    if(1 == arg) {
-      failf(data, "CURLOPT_SSL_VERIFYHOST no longer supports 1 as value!");
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    }
-
-    data->set.ssl.primary.verifyhost = (0 != arg) ? TRUE : FALSE;
+       this argument took a boolean when it wasn't and misused it.
+       Treat 1 and 2 the same */
+    data->set.ssl.primary.verifyhost = (bool)((arg & 3) ? TRUE : FALSE);
 
     /* Update the current connection ssl_config. */
     if(data->conn) {
@@ -1807,17 +1800,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      */
     arg = va_arg(param, long);
 
-    /* Obviously people are not reading documentation and too many thought
-       this argument took a boolean when it wasn't and misused it. We thus ban
-       1 as a sensible input and we warn about its use. Then we only have the
-       2 action internally stored as TRUE. */
-
-    if(1 == arg) {
-      failf(data, "CURLOPT_SSL_VERIFYHOST no longer supports 1 as value!");
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    }
-
-    data->set.proxy_ssl.primary.verifyhost = (0 != arg)?TRUE:FALSE;
+    /* Treat both 1 and 2 as TRUE */
+    data->set.proxy_ssl.primary.verifyhost = (bool)((arg & 3)?TRUE:FALSE);
 
     /* Update the current connection proxy_ssl_config. */
     if(data->conn) {


### PR DESCRIPTION
For a long time we returned error when setting the value to 1 to make
applications notice that we stopped supported the old behavior for
1. Starting now, we treat 1 and 2 exactly the same.