### PR TITLE
cleanup: remove DOT_CHAR completely

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -486,7 +486,6 @@
 #ifdef WIN32
 
 #  define DIR_CHAR      "\\"
-#  define DOT_CHAR      "_"
 
 #else /* WIN32 */
 
@@ -512,14 +511,6 @@
 #  endif
 
 #  define DIR_CHAR      "/"
-#  ifndef DOT_CHAR
-#    define DOT_CHAR      "."
-#  endif
-
-#  ifdef MSDOS
-#    undef DOT_CHAR
-#    define DOT_CHAR      "_"
-#  endif
 
 #  ifndef fileno /* sunos 4 have this as a macro! */
      int fileno(FILE *stream);

--- a/lib/url.c
+++ b/lib/url.c
@@ -2860,8 +2860,7 @@ static CURLcode override_login(struct Curl_easy *data,
                           &netrc_user_changed, &netrc_passwd_changed,
                           data->set.str[STRING_NETRC_FILE]);
     if(ret > 0) {
-      infof(data, "Couldn't find host %s in the "
-            DOT_CHAR "netrc file; using defaults\n",
+      infof(data, "Couldn't find host %s in the .netrc file; using defaults\n",
             conn->host.name);
     }
     else if(ret < 0) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1487,7 +1487,7 @@ static CURLcode create_transfers(struct GlobalConfig *global,
             result = CURLE_OUT_OF_MEMORY;
             home = homedir();
             if(home) {
-              file = aprintf("%s/%sssh/known_hosts", home, DOT_CHAR);
+              file = aprintf("%s/.ssh/known_hosts", home);
               if(file) {
                 /* new in curl 7.19.6 */
                 result = res_setopt_str(curl, CURLOPT_SSH_KNOWNHOSTS, file);


### PR DESCRIPTION
Follow-up to f9c7ba9096ec

The use of DOT_CHAR for ".ssh" was probably a mistake and is removed
now.

Pointed-out-by: Gisle Vanem
Bug: https://github.com/curl/curl/pull/4230#issuecomment-522960638