### PR TITLE
[docs/examples/curlx] Initialise 'mimetype'

### DIFF
--- a/docs/examples/curlx.c
+++ b/docs/examples/curlx.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
 
   binaryptr = malloc(tabLength);
 
-  p.verbose = 0;
+  memset(&p, '\0', sizeof(p));
   p.errorbio = BIO_new_fp(stderr, BIO_NOCLOSE);
 
   curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -372,7 +372,7 @@ int main(int argc, char **argv)
     args++;
   }
 
-  if(mimetype == NULL || mimetypeaccept == NULL)
+  if(mimetype == NULL || mimetypeaccept == NULL || p.p12file == NULL)
     badarg = 1;
 
   if(badarg) {

--- a/docs/examples/curlx.c
+++ b/docs/examples/curlx.c
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
 
   int tabLength = 100;
   char *binaryptr;
-  char *mimetype;
+  char *mimetype = NULL;
   char *mimetypeaccept = NULL;
   char *contenttype;
   const char **pp;


### PR DESCRIPTION
With MSVC's option `/RTCu` (Uninitialized local usage checks), a simple `curlx.exe` fails with a dialogue box:
![curlx-RTC](https://user-images.githubusercontent.com/945271/63350407-a8a0dc00-c35d-11e9-8e73-eb9f6913c933.png)

A simple fix is just to initialise to NULL.