### PR TITLE
defines: avoid underscore-prefixed defines

### DIFF
--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -108,7 +108,7 @@ typedef struct _SockInfo
   GlobalInfo *global;
 } SockInfo;
 
-#define __case(code) \
+#define mycase(code) \
   case code: s = __STRING(code)
 
 /* Die if we get a bad CURLMcode somewhere */
@@ -117,14 +117,14 @@ static void mcode_or_die(const char *where, CURLMcode code)
   if(CURLM_OK != code) {
     const char *s;
     switch(code) {
-      __case(CURLM_BAD_HANDLE); break;
-      __case(CURLM_BAD_EASY_HANDLE); break;
-      __case(CURLM_OUT_OF_MEMORY); break;
-      __case(CURLM_INTERNAL_ERROR); break;
-      __case(CURLM_UNKNOWN_OPTION); break;
-      __case(CURLM_LAST); break;
+      mycase(CURLM_BAD_HANDLE); break;
+      mycase(CURLM_BAD_EASY_HANDLE); break;
+      mycase(CURLM_OUT_OF_MEMORY); break;
+      mycase(CURLM_INTERNAL_ERROR); break;
+      mycase(CURLM_UNKNOWN_OPTION); break;
+      mycase(CURLM_LAST); break;
       default: s = "CURLM_unknown"; break;
-      __case(CURLM_BAD_SOCKET);
+      mycase(CURLM_BAD_SOCKET);
       fprintf(MSG_OUT, "ERROR: %s returns %s\n", where, s);
       /* ignore this error */
       return;

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -109,7 +109,7 @@ typedef struct _SockInfo
   GlobalInfo *global;
 } SockInfo;
 
-#define __case(code) \
+#define mycase(code) \
   case code: s = __STRING(code)
 
 /* Die if we get a bad CURLMcode somewhere */
@@ -118,14 +118,14 @@ static void mcode_or_die(const char *where, CURLMcode code)
   if(CURLM_OK != code) {
     const char *s;
     switch(code) {
-      __case(CURLM_BAD_HANDLE); break;
-      __case(CURLM_BAD_EASY_HANDLE); break;
-      __case(CURLM_OUT_OF_MEMORY); break;
-      __case(CURLM_INTERNAL_ERROR); break;
-      __case(CURLM_UNKNOWN_OPTION); break;
-      __case(CURLM_LAST); break;
+      mycase(CURLM_BAD_HANDLE); break;
+      mycase(CURLM_BAD_EASY_HANDLE); break;
+      mycase(CURLM_OUT_OF_MEMORY); break;
+      mycase(CURLM_INTERNAL_ERROR); break;
+      mycase(CURLM_UNKNOWN_OPTION); break;
+      mycase(CURLM_LAST); break;
       default: s = "CURLM_unknown"; break;
-      __case(CURLM_BAD_SOCKET);
+      mycase(CURLM_BAD_SOCKET);
       fprintf(MSG_OUT, "ERROR: %s returns %s\n", where, s);
       /* ignore this error */
       return;

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURL_H
-#define __CURL_CURL_H
+#ifndef CURLINC_CURL_H
+#define CURLINC_CURL_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -2879,4 +2879,4 @@ CURL_EXTERN CURLcode curl_easy_pause(CURL *handle, int bitmask);
 #endif /* __STDC__ >= 1 */
 #endif /* gcc >= 4.3 && !__cplusplus */
 
-#endif /* __CURL_CURL_H */
+#endif /* CURLINC_CURL_H */

--- a/include/curl/curlver.h
+++ b/include/curl/curlver.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_CURLVER_H
-#define __CURL_CURLVER_H
+#ifndef CURLINC_CURLVER_H
+#define CURLINC_CURLVER_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -74,4 +74,4 @@
 #define CURL_AT_LEAST_VERSION(x,y,z) \
   (LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(x, y, z))
 
-#endif /* __CURL_CURLVER_H */
+#endif /* CURLINC_CURLVER_H */

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_EASY_H
-#define __CURL_EASY_H
+#ifndef CURLINC_EASY_H
+#define CURLINC_EASY_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_MPRINTF_H
-#define __CURL_MPRINTF_H
+#ifndef CURLINC_MPRINTF_H
+#define CURLINC_MPRINTF_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -47,4 +47,4 @@ CURL_EXTERN char *curl_mvaprintf(const char *format, va_list args);
 }
 #endif
 
-#endif /* __CURL_MPRINTF_H */
+#endif /* CURLINC_MPRINTF_H */

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_MULTI_H
-#define __CURL_MULTI_H
+#ifndef CURLINC_MULTI_H
+#define CURLINC_MULTI_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |

--- a/include/curl/stdcheaders.h
+++ b/include/curl/stdcheaders.h
@@ -1,5 +1,5 @@
-#ifndef __STDC_HEADERS_H
-#define __STDC_HEADERS_H
+#ifndef CURLINC_STDCHEADERS_H
+#define CURLINC_STDCHEADERS_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -30,4 +30,4 @@ size_t fwrite(const void *, size_t, size_t, FILE *);
 int strcasecmp(const char *, const char *);
 int strncasecmp(const char *, const char *, size_t);
 
-#endif /* __STDC_HEADERS_H */
+#endif /* CURLINC_STDCHEADERS_H */

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_SYSTEM_H
-#define __CURL_SYSTEM_H
+#ifndef CURLINC_SYSTEM_H
+#define CURLINC_SYSTEM_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -473,21 +473,21 @@
  */
 
 #if defined(__BORLANDC__) && (__BORLANDC__ == 0x0551)
-#  define __CURL_OFF_T_C_HLPR2(x) x
-#  define __CURL_OFF_T_C_HLPR1(x) __CURL_OFF_T_C_HLPR2(x)
-#  define CURL_OFF_T_C(Val)  __CURL_OFF_T_C_HLPR1(Val) ## \
-                             __CURL_OFF_T_C_HLPR1(CURL_SUFFIX_CURL_OFF_T)
-#  define CURL_OFF_TU_C(Val) __CURL_OFF_T_C_HLPR1(Val) ## \
-                             __CURL_OFF_T_C_HLPR1(CURL_SUFFIX_CURL_OFF_TU)
+#  define CURLINC_OFF_T_C_HLPR2(x) x
+#  define CURLINC_OFF_T_C_HLPR1(x) CURLINC_OFF_T_C_HLPR2(x)
+#  define CURL_OFF_T_C(Val)  CURLINC_OFF_T_C_HLPR1(Val) ## \
+                             CURLINC_OFF_T_C_HLPR1(CURL_SUFFIX_CURL_OFF_T)
+#  define CURL_OFF_TU_C(Val) CURLINC_OFF_T_C_HLPR1(Val) ## \
+                             CURLINC_OFF_T_C_HLPR1(CURL_SUFFIX_CURL_OFF_TU)
 #else
 #  ifdef CURL_ISOCPP
-#    define __CURL_OFF_T_C_HLPR2(Val,Suffix) Val ## Suffix
+#    define CURLINC_OFF_T_C_HLPR2(Val,Suffix) Val ## Suffix
 #  else
-#    define __CURL_OFF_T_C_HLPR2(Val,Suffix) Val/**/Suffix
+#    define CURLINC_OFF_T_C_HLPR2(Val,Suffix) Val/**/Suffix
 #  endif
-#  define __CURL_OFF_T_C_HLPR1(Val,Suffix) __CURL_OFF_T_C_HLPR2(Val,Suffix)
-#  define CURL_OFF_T_C(Val)  __CURL_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_T)
-#  define CURL_OFF_TU_C(Val) __CURL_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_TU)
+#  define CURLINC_OFF_T_C_HLPR1(Val,Suffix) CURLINC_OFF_T_C_HLPR2(Val,Suffix)
+#  define CURL_OFF_T_C(Val)  CURLINC_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_T)
+#  define CURL_OFF_TU_C(Val) CURLINC_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_TU)
 #endif
 
-#endif /* __CURL_SYSTEM_H */
+#endif /* CURLINC_SYSTEM_H */

--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_TYPECHECK_GCC_H
-#define __CURL_TYPECHECK_GCC_H
+#ifndef CURLINC_TYPECHECK_GCC_H
+#define CURLINC_TYPECHECK_GCC_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -25,10 +25,10 @@
 /* wraps curl_easy_setopt() with typechecking */
 
 /* To add a new kind of warning, add an
- *   if(_curl_is_sometype_option(_curl_opt))
- *     if(!_curl_is_sometype(value))
+ *   if(curlcheck_sometype_option(_curl_opt))
+ *     if(!curlcheck_sometype(value))
  *       _curl_easy_setopt_err_sometype();
- * block and define _curl_is_sometype_option, _curl_is_sometype and
+ * block and define curlcheck_sometype_option, curlcheck_sometype and
  * _curl_easy_setopt_err_sometype below
  *
  * NOTE: We use two nested 'if' statements here instead of the && operator, in
@@ -38,112 +38,112 @@
  * To add an option that uses the same type as an existing option, you'll just
  * need to extend the appropriate _curl_*_option macro
  */
-#define curl_easy_setopt(handle, option, value)                               \
-__extension__ ({                                                              \
-  __typeof__(option) _curl_opt = option;                                     \
-  if(__builtin_constant_p(_curl_opt)) {                                       \
-    if(_curl_is_long_option(_curl_opt))                                       \
-      if(!_curl_is_long(value))                                               \
-        _curl_easy_setopt_err_long();                                         \
-    if(_curl_is_off_t_option(_curl_opt))                                      \
-      if(!_curl_is_off_t(value))                                              \
-        _curl_easy_setopt_err_curl_off_t();                                   \
-    if(_curl_is_string_option(_curl_opt))                                     \
-      if(!_curl_is_string(value))                                             \
-        _curl_easy_setopt_err_string();                                       \
-    if(_curl_is_write_cb_option(_curl_opt))                                   \
-      if(!_curl_is_write_cb(value))                                           \
-        _curl_easy_setopt_err_write_callback();                               \
-    if((_curl_opt) == CURLOPT_RESOLVER_START_FUNCTION)                        \
-      if(!_curl_is_resolver_start_callback(value))                            \
-        _curl_easy_setopt_err_resolver_start_callback();                      \
-    if((_curl_opt) == CURLOPT_READFUNCTION)                                   \
-      if(!_curl_is_read_cb(value))                                            \
-        _curl_easy_setopt_err_read_cb();                                      \
-    if((_curl_opt) == CURLOPT_IOCTLFUNCTION)                                  \
-      if(!_curl_is_ioctl_cb(value))                                           \
-        _curl_easy_setopt_err_ioctl_cb();                                     \
-    if((_curl_opt) == CURLOPT_SOCKOPTFUNCTION)                                \
-      if(!_curl_is_sockopt_cb(value))                                         \
-        _curl_easy_setopt_err_sockopt_cb();                                   \
-    if((_curl_opt) == CURLOPT_OPENSOCKETFUNCTION)                             \
-      if(!_curl_is_opensocket_cb(value))                                      \
-        _curl_easy_setopt_err_opensocket_cb();                                \
-    if((_curl_opt) == CURLOPT_PROGRESSFUNCTION)                               \
-      if(!_curl_is_progress_cb(value))                                        \
-        _curl_easy_setopt_err_progress_cb();                                  \
-    if((_curl_opt) == CURLOPT_DEBUGFUNCTION)                                  \
-      if(!_curl_is_debug_cb(value))                                           \
-        _curl_easy_setopt_err_debug_cb();                                     \
-    if((_curl_opt) == CURLOPT_SSL_CTX_FUNCTION)                               \
-      if(!_curl_is_ssl_ctx_cb(value))                                         \
-        _curl_easy_setopt_err_ssl_ctx_cb();                                   \
-    if(_curl_is_conv_cb_option(_curl_opt))                                    \
-      if(!_curl_is_conv_cb(value))                                            \
-        _curl_easy_setopt_err_conv_cb();                                      \
-    if((_curl_opt) == CURLOPT_SEEKFUNCTION)                                   \
-      if(!_curl_is_seek_cb(value))                                            \
-        _curl_easy_setopt_err_seek_cb();                                      \
-    if(_curl_is_cb_data_option(_curl_opt))                                    \
-      if(!_curl_is_cb_data(value))                                            \
-        _curl_easy_setopt_err_cb_data();                                      \
-    if((_curl_opt) == CURLOPT_ERRORBUFFER)                                    \
-      if(!_curl_is_error_buffer(value))                                       \
-        _curl_easy_setopt_err_error_buffer();                                 \
-    if((_curl_opt) == CURLOPT_STDERR)                                         \
-      if(!_curl_is_FILE(value))                                               \
-        _curl_easy_setopt_err_FILE();                                         \
-    if(_curl_is_postfields_option(_curl_opt))                                 \
-      if(!_curl_is_postfields(value))                                         \
-        _curl_easy_setopt_err_postfields();                                   \
-    if((_curl_opt) == CURLOPT_HTTPPOST)                                       \
-      if(!_curl_is_arr((value), struct curl_httppost))                        \
-        _curl_easy_setopt_err_curl_httpost();                                 \
-    if((_curl_opt) == CURLOPT_MIMEPOST)                                       \
-      if(!_curl_is_ptr((value), curl_mime))                                   \
-        _curl_easy_setopt_err_curl_mimepost();                                \
-    if(_curl_is_slist_option(_curl_opt))                                      \
-      if(!_curl_is_arr((value), struct curl_slist))                           \
-        _curl_easy_setopt_err_curl_slist();                                   \
-    if((_curl_opt) == CURLOPT_SHARE)                                          \
-      if(!_curl_is_ptr((value), CURLSH))                                      \
-        _curl_easy_setopt_err_CURLSH();                                       \
-  }                                                                           \
-  curl_easy_setopt(handle, _curl_opt, value);                                 \
-})
+#define curl_easy_setopt(handle, option, value)                         \
+  __extension__({                                                       \
+      __typeof__(option) _curl_opt = option;                            \
+      if(__builtin_constant_p(_curl_opt)) {                             \
+        if(curlcheck_long_option(_curl_opt))                            \
+          if(!curlcheck_long(value))                                    \
+            _curl_easy_setopt_err_long();                               \
+        if(curlcheck_off_t_option(_curl_opt))                           \
+          if(!curlcheck_off_t(value))                                   \
+            _curl_easy_setopt_err_curl_off_t();                         \
+        if(curlcheck_string_option(_curl_opt))                          \
+          if(!curlcheck_string(value))                                  \
+            _curl_easy_setopt_err_string();                             \
+        if(curlcheck_write_cb_option(_curl_opt))                        \
+          if(!curlcheck_write_cb(value))                                \
+            _curl_easy_setopt_err_write_callback();                     \
+        if((_curl_opt) == CURLOPT_RESOLVER_START_FUNCTION)              \
+          if(!curlcheck_resolver_start_callback(value))                 \
+            _curl_easy_setopt_err_resolver_start_callback();            \
+        if((_curl_opt) == CURLOPT_READFUNCTION)                         \
+          if(!curlcheck_read_cb(value))                                 \
+            _curl_easy_setopt_err_read_cb();                            \
+        if((_curl_opt) == CURLOPT_IOCTLFUNCTION)                        \
+          if(!curlcheck_ioctl_cb(value))                                \
+            _curl_easy_setopt_err_ioctl_cb();                           \
+        if((_curl_opt) == CURLOPT_SOCKOPTFUNCTION)                      \
+          if(!curlcheck_sockopt_cb(value))                              \
+            _curl_easy_setopt_err_sockopt_cb();                         \
+        if((_curl_opt) == CURLOPT_OPENSOCKETFUNCTION)                   \
+          if(!curlcheck_opensocket_cb(value))                           \
+            _curl_easy_setopt_err_opensocket_cb();                      \
+        if((_curl_opt) == CURLOPT_PROGRESSFUNCTION)                     \
+          if(!curlcheck_progress_cb(value))                             \
+            _curl_easy_setopt_err_progress_cb();                        \
+        if((_curl_opt) == CURLOPT_DEBUGFUNCTION)                        \
+          if(!curlcheck_debug_cb(value))                                \
+            _curl_easy_setopt_err_debug_cb();                           \
+        if((_curl_opt) == CURLOPT_SSL_CTX_FUNCTION)                     \
+          if(!curlcheck_ssl_ctx_cb(value))                              \
+            _curl_easy_setopt_err_ssl_ctx_cb();                         \
+        if(curlcheck_conv_cb_option(_curl_opt))                         \
+          if(!curlcheck_conv_cb(value))                                 \
+            _curl_easy_setopt_err_conv_cb();                            \
+        if((_curl_opt) == CURLOPT_SEEKFUNCTION)                         \
+          if(!curlcheck_seek_cb(value))                                 \
+            _curl_easy_setopt_err_seek_cb();                            \
+        if(curlcheck_cb_data_option(_curl_opt))                         \
+          if(!curlcheck_cb_data(value))                                 \
+            _curl_easy_setopt_err_cb_data();                            \
+        if((_curl_opt) == CURLOPT_ERRORBUFFER)                          \
+          if(!curlcheck_error_buffer(value))                            \
+            _curl_easy_setopt_err_error_buffer();                       \
+        if((_curl_opt) == CURLOPT_STDERR)                               \
+          if(!curlcheck_FILE(value))                                    \
+            _curl_easy_setopt_err_FILE();                               \
+        if(curlcheck_postfields_option(_curl_opt))                      \
+          if(!curlcheck_postfields(value))                              \
+            _curl_easy_setopt_err_postfields();                         \
+        if((_curl_opt) == CURLOPT_HTTPPOST)                             \
+          if(!curlcheck_arr((value), struct curl_httppost))             \
+            _curl_easy_setopt_err_curl_httpost();                       \
+        if((_curl_opt) == CURLOPT_MIMEPOST)                             \
+          if(!curlcheck_ptr((value), curl_mime))                        \
+            _curl_easy_setopt_err_curl_mimepost();                      \
+        if(curlcheck_slist_option(_curl_opt))                           \
+          if(!curlcheck_arr((value), struct curl_slist))                \
+            _curl_easy_setopt_err_curl_slist();                         \
+        if((_curl_opt) == CURLOPT_SHARE)                                \
+          if(!curlcheck_ptr((value), CURLSH))                           \
+            _curl_easy_setopt_err_CURLSH();                             \
+      }                                                                 \
+      curl_easy_setopt(handle, _curl_opt, value);                       \
+    })
 
 /* wraps curl_easy_getinfo() with typechecking */
-#define curl_easy_getinfo(handle, info, arg)                                  \
-__extension__ ({                                                              \
-  __typeof__(info) _curl_info = info;                                         \
-  if(__builtin_constant_p(_curl_info)) {                                      \
-    if(_curl_is_string_info(_curl_info))                                      \
-      if(!_curl_is_arr((arg), char *))                                        \
-        _curl_easy_getinfo_err_string();                                      \
-    if(_curl_is_long_info(_curl_info))                                        \
-      if(!_curl_is_arr((arg), long))                                          \
-        _curl_easy_getinfo_err_long();                                        \
-    if(_curl_is_double_info(_curl_info))                                      \
-      if(!_curl_is_arr((arg), double))                                        \
-        _curl_easy_getinfo_err_double();                                      \
-    if(_curl_is_slist_info(_curl_info))                                       \
-      if(!_curl_is_arr((arg), struct curl_slist *))                           \
-        _curl_easy_getinfo_err_curl_slist();                                  \
-    if(_curl_is_tlssessioninfo_info(_curl_info))                              \
-      if(!_curl_is_arr((arg), struct curl_tlssessioninfo *))                  \
-        _curl_easy_getinfo_err_curl_tlssesssioninfo();                        \
-    if(_curl_is_certinfo_info(_curl_info))                                    \
-      if(!_curl_is_arr((arg), struct curl_certinfo *))                        \
-        _curl_easy_getinfo_err_curl_certinfo();                               \
-    if(_curl_is_socket_info(_curl_info))                                      \
-      if(!_curl_is_arr((arg), curl_socket_t))                                 \
-        _curl_easy_getinfo_err_curl_socket();                                 \
-    if(_curl_is_off_t_info(_curl_info))                                       \
-      if(!_curl_is_arr((arg), curl_off_t))                                    \
-        _curl_easy_getinfo_err_curl_off_t();                                  \
-  }                                                                           \
-  curl_easy_getinfo(handle, _curl_info, arg);                                 \
-})
+#define curl_easy_getinfo(handle, info, arg)                            \
+  __extension__({                                                      \
+      __typeof__(info) _curl_info = info;                               \
+      if(__builtin_constant_p(_curl_info)) {                            \
+        if(curlcheck_string_info(_curl_info))                           \
+          if(!curlcheck_arr((arg), char *))                             \
+            _curl_easy_getinfo_err_string();                            \
+        if(curlcheck_long_info(_curl_info))                             \
+          if(!curlcheck_arr((arg), long))                               \
+            _curl_easy_getinfo_err_long();                              \
+        if(curlcheck_double_info(_curl_info))                           \
+          if(!curlcheck_arr((arg), double))                             \
+            _curl_easy_getinfo_err_double();                            \
+        if(curlcheck_slist_info(_curl_info))                            \
+          if(!curlcheck_arr((arg), struct curl_slist *))                \
+            _curl_easy_getinfo_err_curl_slist();                        \
+        if(curlcheck_tlssessioninfo_info(_curl_info))                   \
+          if(!curlcheck_arr((arg), struct curl_tlssessioninfo *))       \
+            _curl_easy_getinfo_err_curl_tlssesssioninfo();              \
+        if(curlcheck_certinfo_info(_curl_info))                         \
+          if(!curlcheck_arr((arg), struct curl_certinfo *))             \
+            _curl_easy_getinfo_err_curl_certinfo();                     \
+        if(curlcheck_socket_info(_curl_info))                           \
+          if(!curlcheck_arr((arg), curl_socket_t))                      \
+            _curl_easy_getinfo_err_curl_socket();                       \
+        if(curlcheck_off_t_info(_curl_info))                            \
+          if(!curlcheck_arr((arg), curl_off_t))                         \
+            _curl_easy_getinfo_err_curl_off_t();                        \
+      }                                                                 \
+      curl_easy_getinfo(handle, _curl_info, arg);                       \
+    })
 
 /*
  * For now, just make sure that the functions are called with three arguments
@@ -156,83 +156,83 @@ __extension__ ({                                                              \
  * functions */
 
 /* To define a new warning, use _CURL_WARNING(identifier, "message") */
-#define _CURL_WARNING(id, message)                                            \
-  static void __attribute__((__warning__(message)))                           \
-  __attribute__((__unused__)) __attribute__((__noinline__))                   \
+#define CURLWARNING(id, message)                                        \
+  static void __attribute__((__warning__(message)))                     \
+  __attribute__((__unused__)) __attribute__((__noinline__))             \
   id(void) { __asm__(""); }
 
-_CURL_WARNING(_curl_easy_setopt_err_long,
+CURLWARNING(_curl_easy_setopt_err_long,
   "curl_easy_setopt expects a long argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_curl_off_t,
+CURLWARNING(_curl_easy_setopt_err_curl_off_t,
   "curl_easy_setopt expects a curl_off_t argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_string,
+CURLWARNING(_curl_easy_setopt_err_string,
               "curl_easy_setopt expects a "
               "string ('char *' or char[]) argument for this option"
   )
-_CURL_WARNING(_curl_easy_setopt_err_write_callback,
+CURLWARNING(_curl_easy_setopt_err_write_callback,
   "curl_easy_setopt expects a curl_write_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_resolver_start_callback,
+CURLWARNING(_curl_easy_setopt_err_resolver_start_callback,
               "curl_easy_setopt expects a "
               "curl_resolver_start_callback argument for this option"
   )
-_CURL_WARNING(_curl_easy_setopt_err_read_cb,
+CURLWARNING(_curl_easy_setopt_err_read_cb,
   "curl_easy_setopt expects a curl_read_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_ioctl_cb,
+CURLWARNING(_curl_easy_setopt_err_ioctl_cb,
   "curl_easy_setopt expects a curl_ioctl_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_sockopt_cb,
+CURLWARNING(_curl_easy_setopt_err_sockopt_cb,
   "curl_easy_setopt expects a curl_sockopt_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_opensocket_cb,
+CURLWARNING(_curl_easy_setopt_err_opensocket_cb,
               "curl_easy_setopt expects a "
               "curl_opensocket_callback argument for this option"
   )
-_CURL_WARNING(_curl_easy_setopt_err_progress_cb,
+CURLWARNING(_curl_easy_setopt_err_progress_cb,
   "curl_easy_setopt expects a curl_progress_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_debug_cb,
+CURLWARNING(_curl_easy_setopt_err_debug_cb,
   "curl_easy_setopt expects a curl_debug_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_ssl_ctx_cb,
+CURLWARNING(_curl_easy_setopt_err_ssl_ctx_cb,
   "curl_easy_setopt expects a curl_ssl_ctx_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_conv_cb,
+CURLWARNING(_curl_easy_setopt_err_conv_cb,
   "curl_easy_setopt expects a curl_conv_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_seek_cb,
+CURLWARNING(_curl_easy_setopt_err_seek_cb,
   "curl_easy_setopt expects a curl_seek_callback argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_cb_data,
+CURLWARNING(_curl_easy_setopt_err_cb_data,
               "curl_easy_setopt expects a "
               "private data pointer as argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_error_buffer,
+CURLWARNING(_curl_easy_setopt_err_error_buffer,
               "curl_easy_setopt expects a "
               "char buffer of CURL_ERROR_SIZE as argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_FILE,
+CURLWARNING(_curl_easy_setopt_err_FILE,
   "curl_easy_setopt expects a 'FILE *' argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_postfields,
+CURLWARNING(_curl_easy_setopt_err_postfields,
   "curl_easy_setopt expects a 'void *' or 'char *' argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_curl_httpost,
+CURLWARNING(_curl_easy_setopt_err_curl_httpost,
               "curl_easy_setopt expects a 'struct curl_httppost *' "
               "argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_curl_mimepost,
+CURLWARNING(_curl_easy_setopt_err_curl_mimepost,
               "curl_easy_setopt expects a 'curl_mime *' "
               "argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_curl_slist,
+CURLWARNING(_curl_easy_setopt_err_curl_slist,
   "curl_easy_setopt expects a 'struct curl_slist *' argument for this option")
-_CURL_WARNING(_curl_easy_setopt_err_CURLSH,
+CURLWARNING(_curl_easy_setopt_err_CURLSH,
   "curl_easy_setopt expects a CURLSH* argument for this option")
 
-_CURL_WARNING(_curl_easy_getinfo_err_string,
+CURLWARNING(_curl_easy_getinfo_err_string,
   "curl_easy_getinfo expects a pointer to 'char *' for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_long,
+CURLWARNING(_curl_easy_getinfo_err_long,
   "curl_easy_getinfo expects a pointer to long for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_double,
+CURLWARNING(_curl_easy_getinfo_err_double,
   "curl_easy_getinfo expects a pointer to double for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_curl_slist,
+CURLWARNING(_curl_easy_getinfo_err_curl_slist,
   "curl_easy_getinfo expects a pointer to 'struct curl_slist *' for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_curl_tlssesssioninfo,
+CURLWARNING(_curl_easy_getinfo_err_curl_tlssesssioninfo,
               "curl_easy_getinfo expects a pointer to "
               "'struct curl_tlssessioninfo *' for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_curl_certinfo,
+CURLWARNING(_curl_easy_getinfo_err_curl_certinfo,
               "curl_easy_getinfo expects a pointer to "
               "'struct curl_certinfo *' for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_curl_socket,
+CURLWARNING(_curl_easy_getinfo_err_curl_socket,
   "curl_easy_getinfo expects a pointer to curl_socket_t for this info")
-_CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
+CURLWARNING(_curl_easy_getinfo_err_curl_off_t,
   "curl_easy_getinfo expects a pointer to curl_off_t for this info")
 
 /* groups of curl_easy_setops options that take the same type of argument */
@@ -244,14 +244,14 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
  */
 
 /* evaluates to true if option takes a long argument */
-#define _curl_is_long_option(option)                                          \
+#define curlcheck_long_option(option)                   \
   (0 < (option) && (option) < CURLOPTTYPE_OBJECTPOINT)
 
-#define _curl_is_off_t_option(option)                                         \
+#define curlcheck_off_t_option(option)          \
   ((option) > CURLOPTTYPE_OFF_T)
 
 /* evaluates to true if option takes a char* argument */
-#define _curl_is_string_option(option)                                        \
+#define curlcheck_string_option(option)                                       \
   ((option) == CURLOPT_ABSTRACT_UNIX_SOCKET ||                                \
    (option) == CURLOPT_ACCEPT_ENCODING ||                                     \
    (option) == CURLOPT_ALTSVC ||                                              \
@@ -337,18 +337,18 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
    0)
 
 /* evaluates to true if option takes a curl_write_callback argument */
-#define _curl_is_write_cb_option(option)                                      \
-  ((option) == CURLOPT_HEADERFUNCTION ||                                      \
+#define curlcheck_write_cb_option(option)                               \
+  ((option) == CURLOPT_HEADERFUNCTION ||                                \
    (option) == CURLOPT_WRITEFUNCTION)
 
 /* evaluates to true if option takes a curl_conv_callback argument */
-#define _curl_is_conv_cb_option(option)                                       \
-  ((option) == CURLOPT_CONV_TO_NETWORK_FUNCTION ||                            \
-   (option) == CURLOPT_CONV_FROM_NETWORK_FUNCTION ||                          \
+#define curlcheck_conv_cb_option(option)                                \
+  ((option) == CURLOPT_CONV_TO_NETWORK_FUNCTION ||                      \
+   (option) == CURLOPT_CONV_FROM_NETWORK_FUNCTION ||                    \
    (option) == CURLOPT_CONV_FROM_UTF8_FUNCTION)
 
 /* evaluates to true if option takes a data argument to pass to a callback */
-#define _curl_is_cb_data_option(option)                                       \
+#define curlcheck_cb_data_option(option)                                      \
   ((option) == CURLOPT_CHUNK_DATA ||                                          \
    (option) == CURLOPT_CLOSESOCKETDATA ||                                     \
    (option) == CURLOPT_DEBUGDATA ||                                           \
@@ -370,13 +370,13 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
    0)
 
 /* evaluates to true if option takes a POST data argument (void* or char*) */
-#define _curl_is_postfields_option(option)                                    \
+#define curlcheck_postfields_option(option)                                   \
   ((option) == CURLOPT_POSTFIELDS ||                                          \
    (option) == CURLOPT_COPYPOSTFIELDS ||                                      \
    0)
 
 /* evaluates to true if option takes a struct curl_slist * argument */
-#define _curl_is_slist_option(option)                                         \
+#define curlcheck_slist_option(option)                                        \
   ((option) == CURLOPT_HTTP200ALIASES ||                                      \
    (option) == CURLOPT_HTTPHEADER ||                                          \
    (option) == CURLOPT_MAIL_RCPT ||                                           \
@@ -392,40 +392,40 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
 /* groups of curl_easy_getinfo infos that take the same type of argument */
 
 /* evaluates to true if info expects a pointer to char * argument */
-#define _curl_is_string_info(info)                                            \
+#define curlcheck_string_info(info)                     \
   (CURLINFO_STRING < (info) && (info) < CURLINFO_LONG)
 
 /* evaluates to true if info expects a pointer to long argument */
-#define _curl_is_long_info(info)                                              \
+#define curlcheck_long_info(info)                       \
   (CURLINFO_LONG < (info) && (info) < CURLINFO_DOUBLE)
 
 /* evaluates to true if info expects a pointer to double argument */
-#define _curl_is_double_info(info)                                            \
+#define curlcheck_double_info(info)                     \
   (CURLINFO_DOUBLE < (info) && (info) < CURLINFO_SLIST)
 
 /* true if info expects a pointer to struct curl_slist * argument */
-#define _curl_is_slist_info(info)                                       \
+#define curlcheck_slist_info(info)                                      \
   (((info) == CURLINFO_SSL_ENGINES) || ((info) == CURLINFO_COOKIELIST))
 
 /* true if info expects a pointer to struct curl_tlssessioninfo * argument */
-#define _curl_is_tlssessioninfo_info(info)                              \
+#define curlcheck_tlssessioninfo_info(info)                              \
   (((info) == CURLINFO_TLS_SSL_PTR) || ((info) == CURLINFO_TLS_SESSION))
 
 /* true if info expects a pointer to struct curl_certinfo * argument */
-#define _curl_is_certinfo_info(info) ((info) == CURLINFO_CERTINFO)
+#define curlcheck_certinfo_info(info) ((info) == CURLINFO_CERTINFO)
 
 /* true if info expects a pointer to struct curl_socket_t argument */
-#define _curl_is_socket_info(info)                                            \
+#define curlcheck_socket_info(info)                     \
   (CURLINFO_SOCKET < (info) && (info) < CURLINFO_OFF_T)
 
 /* true if info expects a pointer to curl_off_t argument */
-#define _curl_is_off_t_info(info)                                             \
+#define curlcheck_off_t_info(info)              \
   (CURLINFO_OFF_T < (info))
 
 
 /* typecheck helpers -- check whether given expression has requested type*/
 
-/* For pointers, you can use the _curl_is_ptr/_curl_is_arr macros,
+/* For pointers, you can use the curlcheck_ptr/curlcheck_arr macros,
  * otherwise define a new macro. Search for __builtin_types_compatible_p
  * in the GCC manual.
  * NOTE: these macros MUST NOT EVALUATE their arguments! The argument is
@@ -435,35 +435,35 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
  */
 
 /* XXX: should evaluate to true if expr is a pointer */
-#define _curl_is_any_ptr(expr)                                                \
+#define curlcheck_any_ptr(expr)                 \
   (sizeof(expr) == sizeof(void *))
 
 /* evaluates to true if expr is NULL */
 /* XXX: must not evaluate expr, so this check is not accurate */
-#define _curl_is_NULL(expr)                                                   \
+#define curlcheck_NULL(expr)                                            \
   (__builtin_types_compatible_p(__typeof__(expr), __typeof__(NULL)))
 
 /* evaluates to true if expr is type*, const type* or NULL */
-#define _curl_is_ptr(expr, type)                                              \
-  (_curl_is_NULL(expr) ||                                                     \
-   __builtin_types_compatible_p(__typeof__(expr), type *) ||                  \
+#define curlcheck_ptr(expr, type)                                       \
+  (curlcheck_NULL(expr) ||                                              \
+   __builtin_types_compatible_p(__typeof__(expr), type *) ||            \
    __builtin_types_compatible_p(__typeof__(expr), const type *))
 
 /* evaluates to true if expr is one of type[], type*, NULL or const type* */
-#define _curl_is_arr(expr, type)                                              \
-  (_curl_is_ptr((expr), type) ||                                              \
+#define curlcheck_arr(expr, type)                                       \
+  (curlcheck_ptr((expr), type) ||                                       \
    __builtin_types_compatible_p(__typeof__(expr), type []))
 
 /* evaluates to true if expr is a string */
-#define _curl_is_string(expr)                                                 \
-  (_curl_is_arr((expr), char) ||                                              \
-   _curl_is_arr((expr), signed char) ||                                       \
-   _curl_is_arr((expr), unsigned char))
+#define curlcheck_string(expr)                                          \
+  (curlcheck_arr((expr), char) ||                                       \
+   curlcheck_arr((expr), signed char) ||                                \
+   curlcheck_arr((expr), unsigned char))
 
 /* evaluates to true if expr is a long (no matter the signedness)
  * XXX: for now, int is also accepted (and therefore short and char, which
  * are promoted to int when passed to a variadic function) */
-#define _curl_is_long(expr)                                                   \
+#define curlcheck_long(expr)                                                  \
   (__builtin_types_compatible_p(__typeof__(expr), long) ||                    \
    __builtin_types_compatible_p(__typeof__(expr), signed long) ||             \
    __builtin_types_compatible_p(__typeof__(expr), unsigned long) ||           \
@@ -478,59 +478,59 @@ _CURL_WARNING(_curl_easy_getinfo_err_curl_off_t,
    __builtin_types_compatible_p(__typeof__(expr), unsigned char))
 
 /* evaluates to true if expr is of type curl_off_t */
-#define _curl_is_off_t(expr)                                                  \
+#define curlcheck_off_t(expr)                                   \
   (__builtin_types_compatible_p(__typeof__(expr), curl_off_t))
 
 /* evaluates to true if expr is abuffer suitable for CURLOPT_ERRORBUFFER */
 /* XXX: also check size of an char[] array? */
-#define _curl_is_error_buffer(expr)                                           \
-  (_curl_is_NULL(expr) ||                                                     \
-   __builtin_types_compatible_p(__typeof__(expr), char *) ||                  \
+#define curlcheck_error_buffer(expr)                                    \
+  (curlcheck_NULL(expr) ||                                              \
+   __builtin_types_compatible_p(__typeof__(expr), char *) ||            \
    __builtin_types_compatible_p(__typeof__(expr), char[]))
 
 /* evaluates to true if expr is of type (const) void* or (const) FILE* */
 #if 0
-#define _curl_is_cb_data(expr)                                                \
-  (_curl_is_ptr((expr), void) ||                                              \
-   _curl_is_ptr((expr), FILE))
+#define curlcheck_cb_data(expr)                                         \
+  (curlcheck_ptr((expr), void) ||                                       \
+   curlcheck_ptr((expr), FILE))
 #else /* be less strict */
-#define _curl_is_cb_data(expr)                                                \
-  _curl_is_any_ptr(expr)
+#define curlcheck_cb_data(expr)                 \
+  curlcheck_any_ptr(expr)
 #endif
 
 /* evaluates to true if expr is of type FILE* */
-#define _curl_is_FILE(expr)                                             \
-  (_curl_is_NULL(expr) ||                                              \
+#define curlcheck_FILE(expr)                                            \
+  (curlcheck_NULL(expr) ||                                              \
    (__builtin_types_compatible_p(__typeof__(expr), FILE *)))
 
 /* evaluates to true if expr can be passed as POST data (void* or char*) */
-#define _curl_is_postfields(expr)                                             \
-  (_curl_is_ptr((expr), void) ||                                              \
-   _curl_is_arr((expr), char) ||                                              \
-   _curl_is_arr((expr), unsigned char))
+#define curlcheck_postfields(expr)                                      \
+  (curlcheck_ptr((expr), void) ||                                       \
+   curlcheck_arr((expr), char) ||                                       \
+   curlcheck_arr((expr), unsigned char))
 
 /* helper: __builtin_types_compatible_p distinguishes between functions and
  * function pointers, hide it */
-#define _curl_callback_compatible(func, type)                                 \
-  (__builtin_types_compatible_p(__typeof__(func), type) ||                    \
+#define curlcheck_cb_compatible(func, type)                             \
+  (__builtin_types_compatible_p(__typeof__(func), type) ||              \
    __builtin_types_compatible_p(__typeof__(func) *, type))
 
 /* evaluates to true if expr is of type curl_resolver_start_callback */
-#define _curl_is_resolver_start_callback(expr)       \
-  (_curl_is_NULL(expr) || \
-   _curl_callback_compatible((expr), curl_resolver_start_callback))
+#define curlcheck_resolver_start_callback(expr)       \
+  (curlcheck_NULL(expr) || \
+   curlcheck_cb_compatible((expr), curl_resolver_start_callback))
 
 /* evaluates to true if expr is of type curl_read_callback or "similar" */
-#define _curl_is_read_cb(expr)                                          \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), __typeof__(fread) *) ||                  \
-   _curl_callback_compatible((expr), curl_read_callback) ||                   \
-   _curl_callback_compatible((expr), _curl_read_callback1) ||                 \
-   _curl_callback_compatible((expr), _curl_read_callback2) ||                 \
-   _curl_callback_compatible((expr), _curl_read_callback3) ||                 \
-   _curl_callback_compatible((expr), _curl_read_callback4) ||                 \
-   _curl_callback_compatible((expr), _curl_read_callback5) ||                 \
-   _curl_callback_compatible((expr), _curl_read_callback6))
+#define curlcheck_read_cb(expr)                                         \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), __typeof__(fread) *) ||              \
+   curlcheck_cb_compatible((expr), curl_read_callback) ||               \
+   curlcheck_cb_compatible((expr), _curl_read_callback1) ||             \
+   curlcheck_cb_compatible((expr), _curl_read_callback2) ||             \
+   curlcheck_cb_compatible((expr), _curl_read_callback3) ||             \
+   curlcheck_cb_compatible((expr), _curl_read_callback4) ||             \
+   curlcheck_cb_compatible((expr), _curl_read_callback5) ||             \
+   curlcheck_cb_compatible((expr), _curl_read_callback6))
 typedef size_t (*_curl_read_callback1)(char *, size_t, size_t, void *);
 typedef size_t (*_curl_read_callback2)(char *, size_t, size_t, const void *);
 typedef size_t (*_curl_read_callback3)(char *, size_t, size_t, FILE *);
@@ -539,16 +539,16 @@ typedef size_t (*_curl_read_callback5)(void *, size_t, size_t, const void *);
 typedef size_t (*_curl_read_callback6)(void *, size_t, size_t, FILE *);
 
 /* evaluates to true if expr is of type curl_write_callback or "similar" */
-#define _curl_is_write_cb(expr)                                               \
-  (_curl_is_read_cb(expr) ||                                            \
-   _curl_callback_compatible((expr), __typeof__(fwrite) *) ||                 \
-   _curl_callback_compatible((expr), curl_write_callback) ||                  \
-   _curl_callback_compatible((expr), _curl_write_callback1) ||                \
-   _curl_callback_compatible((expr), _curl_write_callback2) ||                \
-   _curl_callback_compatible((expr), _curl_write_callback3) ||                \
-   _curl_callback_compatible((expr), _curl_write_callback4) ||                \
-   _curl_callback_compatible((expr), _curl_write_callback5) ||                \
-   _curl_callback_compatible((expr), _curl_write_callback6))
+#define curlcheck_write_cb(expr)                                        \
+  (curlcheck_read_cb(expr) ||                                           \
+   curlcheck_cb_compatible((expr), __typeof__(fwrite) *) ||             \
+   curlcheck_cb_compatible((expr), curl_write_callback) ||              \
+   curlcheck_cb_compatible((expr), _curl_write_callback1) ||            \
+   curlcheck_cb_compatible((expr), _curl_write_callback2) ||            \
+   curlcheck_cb_compatible((expr), _curl_write_callback3) ||            \
+   curlcheck_cb_compatible((expr), _curl_write_callback4) ||            \
+   curlcheck_cb_compatible((expr), _curl_write_callback5) ||            \
+   curlcheck_cb_compatible((expr), _curl_write_callback6))
 typedef size_t (*_curl_write_callback1)(const char *, size_t, size_t, void *);
 typedef size_t (*_curl_write_callback2)(const char *, size_t, size_t,
                                        const void *);
@@ -559,37 +559,37 @@ typedef size_t (*_curl_write_callback5)(const void *, size_t, size_t,
 typedef size_t (*_curl_write_callback6)(const void *, size_t, size_t, FILE *);
 
 /* evaluates to true if expr is of type curl_ioctl_callback or "similar" */
-#define _curl_is_ioctl_cb(expr)                                         \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_ioctl_callback) ||                  \
-   _curl_callback_compatible((expr), _curl_ioctl_callback1) ||                \
-   _curl_callback_compatible((expr), _curl_ioctl_callback2) ||                \
-   _curl_callback_compatible((expr), _curl_ioctl_callback3) ||                \
-   _curl_callback_compatible((expr), _curl_ioctl_callback4))
+#define curlcheck_ioctl_cb(expr)                                        \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_ioctl_callback) ||              \
+   curlcheck_cb_compatible((expr), _curl_ioctl_callback1) ||            \
+   curlcheck_cb_compatible((expr), _curl_ioctl_callback2) ||            \
+   curlcheck_cb_compatible((expr), _curl_ioctl_callback3) ||            \
+   curlcheck_cb_compatible((expr), _curl_ioctl_callback4))
 typedef curlioerr (*_curl_ioctl_callback1)(CURL *, int, void *);
 typedef curlioerr (*_curl_ioctl_callback2)(CURL *, int, const void *);
 typedef curlioerr (*_curl_ioctl_callback3)(CURL *, curliocmd, void *);
 typedef curlioerr (*_curl_ioctl_callback4)(CURL *, curliocmd, const void *);
 
 /* evaluates to true if expr is of type curl_sockopt_callback or "similar" */
-#define _curl_is_sockopt_cb(expr)                                       \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_sockopt_callback) ||                \
-   _curl_callback_compatible((expr), _curl_sockopt_callback1) ||              \
-   _curl_callback_compatible((expr), _curl_sockopt_callback2))
+#define curlcheck_sockopt_cb(expr)                                      \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_sockopt_callback) ||            \
+   curlcheck_cb_compatible((expr), _curl_sockopt_callback1) ||          \
+   curlcheck_cb_compatible((expr), _curl_sockopt_callback2))
 typedef int (*_curl_sockopt_callback1)(void *, curl_socket_t, curlsocktype);
 typedef int (*_curl_sockopt_callback2)(const void *, curl_socket_t,
                                       curlsocktype);
 
 /* evaluates to true if expr is of type curl_opensocket_callback or
    "similar" */
-#define _curl_is_opensocket_cb(expr)                                    \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_opensocket_callback) ||             \
-   _curl_callback_compatible((expr), _curl_opensocket_callback1) ||           \
-   _curl_callback_compatible((expr), _curl_opensocket_callback2) ||           \
-   _curl_callback_compatible((expr), _curl_opensocket_callback3) ||           \
-   _curl_callback_compatible((expr), _curl_opensocket_callback4))
+#define curlcheck_opensocket_cb(expr)                                   \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_opensocket_callback) ||         \
+   curlcheck_cb_compatible((expr), _curl_opensocket_callback1) ||       \
+   curlcheck_cb_compatible((expr), _curl_opensocket_callback2) ||       \
+   curlcheck_cb_compatible((expr), _curl_opensocket_callback3) ||       \
+   curlcheck_cb_compatible((expr), _curl_opensocket_callback4))
 typedef curl_socket_t (*_curl_opensocket_callback1)
   (void *, curlsocktype, struct curl_sockaddr *);
 typedef curl_socket_t (*_curl_opensocket_callback2)
@@ -600,28 +600,28 @@ typedef curl_socket_t (*_curl_opensocket_callback4)
   (const void *, curlsocktype, const struct curl_sockaddr *);
 
 /* evaluates to true if expr is of type curl_progress_callback or "similar" */
-#define _curl_is_progress_cb(expr)                                      \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_progress_callback) ||               \
-   _curl_callback_compatible((expr), _curl_progress_callback1) ||             \
-   _curl_callback_compatible((expr), _curl_progress_callback2))
+#define curlcheck_progress_cb(expr)                                     \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_progress_callback) ||           \
+   curlcheck_cb_compatible((expr), _curl_progress_callback1) ||         \
+   curlcheck_cb_compatible((expr), _curl_progress_callback2))
 typedef int (*_curl_progress_callback1)(void *,
     double, double, double, double);
 typedef int (*_curl_progress_callback2)(const void *,
     double, double, double, double);
 
 /* evaluates to true if expr is of type curl_debug_callback or "similar" */
-#define _curl_is_debug_cb(expr)                                         \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_debug_callback) ||                  \
-   _curl_callback_compatible((expr), _curl_debug_callback1) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback2) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback3) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback4) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback5) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback6) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback7) ||                \
-   _curl_callback_compatible((expr), _curl_debug_callback8))
+#define curlcheck_debug_cb(expr)                                        \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_debug_callback) ||              \
+   curlcheck_cb_compatible((expr), _curl_debug_callback1) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback2) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback3) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback4) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback5) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback6) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback7) ||            \
+   curlcheck_cb_compatible((expr), _curl_debug_callback8))
 typedef int (*_curl_debug_callback1) (CURL *,
     curl_infotype, char *, size_t, void *);
 typedef int (*_curl_debug_callback2) (CURL *,
@@ -641,17 +641,17 @@ typedef int (*_curl_debug_callback8) (CURL *,
 
 /* evaluates to true if expr is of type curl_ssl_ctx_callback or "similar" */
 /* this is getting even messier... */
-#define _curl_is_ssl_ctx_cb(expr)                                       \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_ssl_ctx_callback) ||                \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback1) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback2) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback3) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback4) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback5) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback6) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback7) ||              \
-   _curl_callback_compatible((expr), _curl_ssl_ctx_callback8))
+#define curlcheck_ssl_ctx_cb(expr)                                      \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_ssl_ctx_callback) ||            \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback1) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback2) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback3) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback4) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback5) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback6) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback7) ||          \
+   curlcheck_cb_compatible((expr), _curl_ssl_ctx_callback8))
 typedef CURLcode (*_curl_ssl_ctx_callback1)(CURL *, void *, void *);
 typedef CURLcode (*_curl_ssl_ctx_callback2)(CURL *, void *, const void *);
 typedef CURLcode (*_curl_ssl_ctx_callback3)(CURL *, const void *, void *);
@@ -674,26 +674,26 @@ typedef _curl_ssl_ctx_callback1 _curl_ssl_ctx_callback8;
 #endif
 
 /* evaluates to true if expr is of type curl_conv_callback or "similar" */
-#define _curl_is_conv_cb(expr)                                          \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_conv_callback) ||                   \
-   _curl_callback_compatible((expr), _curl_conv_callback1) ||                 \
-   _curl_callback_compatible((expr), _curl_conv_callback2) ||                 \
-   _curl_callback_compatible((expr), _curl_conv_callback3) ||                 \
-   _curl_callback_compatible((expr), _curl_conv_callback4))
+#define curlcheck_conv_cb(expr)                                         \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_conv_callback) ||               \
+   curlcheck_cb_compatible((expr), _curl_conv_callback1) ||             \
+   curlcheck_cb_compatible((expr), _curl_conv_callback2) ||             \
+   curlcheck_cb_compatible((expr), _curl_conv_callback3) ||             \
+   curlcheck_cb_compatible((expr), _curl_conv_callback4))
 typedef CURLcode (*_curl_conv_callback1)(char *, size_t length);
 typedef CURLcode (*_curl_conv_callback2)(const char *, size_t length);
 typedef CURLcode (*_curl_conv_callback3)(void *, size_t length);
 typedef CURLcode (*_curl_conv_callback4)(const void *, size_t length);
 
 /* evaluates to true if expr is of type curl_seek_callback or "similar" */
-#define _curl_is_seek_cb(expr)                                          \
-  (_curl_is_NULL(expr) ||                                                     \
-   _curl_callback_compatible((expr), curl_seek_callback) ||                   \
-   _curl_callback_compatible((expr), _curl_seek_callback1) ||                 \
-   _curl_callback_compatible((expr), _curl_seek_callback2))
+#define curlcheck_seek_cb(expr)                                         \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_seek_callback) ||               \
+   curlcheck_cb_compatible((expr), _curl_seek_callback1) ||             \
+   curlcheck_cb_compatible((expr), _curl_seek_callback2))
 typedef CURLcode (*_curl_seek_callback1)(void *, curl_off_t, int);
 typedef CURLcode (*_curl_seek_callback2)(const void *, curl_off_t, int);
 
 
-#endif /* __CURL_TYPECHECK_GCC_H */
+#endif /* CURLINC_TYPECHECK_GCC_H */

--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -1,5 +1,5 @@
-#ifndef __CURL_URLAPI_H
-#define __CURL_URLAPI_H
+#ifndef CURLINC_URLAPI_H
+#define CURLINC_URLAPI_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -120,4 +120,4 @@ CURL_EXTERN CURLUcode curl_url_set(CURLU *handle, CURLUPart what,
 } /* end of extern "C" */
 #endif
 
-#endif
+#endif /* CURLINC_URLAPI_H */

--- a/packages/OS400/ccsidcurl.h
+++ b/packages/OS400/ccsidcurl.h
@@ -1,3 +1,5 @@
+#ifndef CURLINC_CCSIDCURL_H
+#define CURLINC_CCSIDCURL_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -5,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,10 +22,6 @@
  *
  *
  ***************************************************************************/
-
-#ifndef __CURL_CCSIDCURL_H
-#define __CURL_CCSIDCURL_H
-
 #include "curl.h"
 #include "easy.h"
 #include "multi.h"

--- a/tests/symbol-scan.pl
+++ b/tests/symbol-scan.pl
@@ -119,11 +119,13 @@ for my $e (sort @syms) {
     # CURL_EXTERN - is a define used for libcurl functions that are external,
     # public. No app or other code should ever use it.
     #
+    # CURLINC_ - defines for header dual-include prevention, ignore those.
+    #
     # *_LAST and *_LASTENTRY are just prefix for the placeholders used for the
     # last entry in many enum series.
     #
 
-    if($e =~ /(OBSOLETE|^CURL_EXTERN|_LAST\z|_LASTENTRY\z)/) {
+    if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z)/) {
         $ignored++;
         next;
     }


### PR DESCRIPTION
Double-underscored or underscore plus uppercase letter at least.

... as they're claimed to be reserved.

Fixes #4254