### PR TITLE
Fix read off end of array due to bad pointer math in getworkingpath f…

### DIFF
--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -55,7 +55,7 @@ CURLcode Curl_getworkingpath(struct connectdata *conn,
     }
     if((working_path_len > 3) && (!memcmp(working_path, "/~/", 3)))
       /* It is referenced to the home directory, so strip the leading '/~/' */
-      memcpy(real_path, working_path + 3, 4 + working_path_len-3);
+      memcpy(real_path, working_path + 3, working_path_len - 2);
     else
       memcpy(real_path, working_path, 1 + working_path_len);
   }


### PR DESCRIPTION
@VictorSCushman and I came across this issue with help from Valgrind

The problem is reproducible by creating a basic application using the library to download a file from a url of this pattern: scp://user@host/~/\* and running it through valgrind memcheck on Ubuntu 18.04. The actual error is an "invalid read of size 1"

We narrowed it down to this line below. Here's an explanation of our reasoning:

Given working_path as "/~/file.txt", working_path_len is calculated as 11 and real_path is a buffer allocated with a size of 12 (working_path_len + 1 for null terminator).

The memcpy below takes working_path + 3 as its source to strip the "/~/" leaving just "file.txt" which is of size 8 + 1 for null terminator. Therefore the length that should be memcopied should be 9 but below the length will be (4 + 11 - 3 = 12) and we will read off the end of working_path since our source pointer is actually working_path + 3 and our length is the full length of working_path including null terminator

I've tested this fix and it works fine for me and stops valgrind from complaining. Are there any problems that could be caused by this fix that my testing could have missed?


