### PR TITLE
ldap: Stop using wide char version of ldapp_err2string

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -119,6 +119,12 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp);
   #define LDAP_TRACE(x)   Curl_nop_stmt
 #endif
 
+#if defined(USE_WIN32_LDAP) && defined(ldap_err2string)
+/* Use ansi error strings in UNICODE builds */
+#undef ldap_err2string
+#define ldap_err2string ldap_err2stringA
+#endif
+
 
 static CURLcode Curl_ldap(struct connectdata *conn, bool *done);
 


### PR DESCRIPTION
Despite ldapp_err2string being documented by MS as returning a
PCHAR (char *), when UNICODE it is mapped to ldap_err2stringW and
returns PWCHAR (wchar_t *).

We have lots of code like that expects ldap_err2string to return char *,
most of it failf used like this:

failf(data, "LDAP local: Some error: %s", ldap_err2string(rc));

Closes #xxxx

---

This from
Winldap.h in 7.0A:

~~~
#ifndef LDAP_UNICODE
#ifdef UNICODE
#define LDAP_UNICODE 1
#else
#define LDAP_UNICODE 0
#endif
#endif

...

#if LDAP_UNICODE

#define ldap_err2string ldap_err2stringW

...
~~~

https://docs.microsoft.com/en-us/windows/win32/api/winldap/nf-winldap-ldap_err2string
