### PR TITLE
ngtcp2: on h3 stream close, call expire

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -833,7 +833,7 @@ static int cb_h3_stream_close(nghttp3_conn *conn, int64_t stream_id,
   fprintf(stderr, "cb_h3_stream_close CALLED\n");
 
   stream->closed = TRUE;
-
+  Curl_expire(data, 0, EXPIRE_QUIC);
   return 0;
 }
 


### PR DESCRIPTION
... to trigger a new read to detect the stream close!