### PR TITLE
Fix #include condition and documentation on Plan 9

### DIFF
--- a/plan9/BUILD.PLAN9.txt
+++ b/plan9/BUILD.PLAN9.txt
@@ -17,10 +17,10 @@ Instruction
 ===========
 First, you should construct namespace as like described below:
 
-% bind -a ../lib lib
-% bind -a ../src src
-% bind -a ../include include
-% bind -a .. .
+% bind -ac ../lib lib
+% bind -ac ../src src
+% bind -ac ../include include
+% bind -ac .. .
 
 Then you will see as shown below (excerpt):
 

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -20,7 +20,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-#ifdef HAVE_STRCASECMP
+#if defined(HAVE_STRCASECMP) && defined(HAVE_STRINGS_H)
 #include <strings.h>
 #endif
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -29,6 +29,10 @@
 #  include <locale.h>
 #endif
 
+#ifdef HAVE_SYS_SELECT_H
+#  include <sys/select.h>
+#endif
+
 #ifdef __VMS
 #  include <fabdef.h>
 #endif


### PR DESCRIPTION
I've fixed three problems on building *curl*.

1. A building documentation for Plan 9 is missing `-c` flag of *bind(1)*
2. *select* is undeclared in **src/tool_operate.c**
3. Although *strcasecmp* is presented by standard libs but there is a case of the libs don't have **strings.h**