### PR TITLE
Curl_addr2string: take an addrlen argument too

### DIFF
--- a/lib/connect.h
+++ b/lib/connect.h
@@ -51,7 +51,8 @@ timediff_t Curl_timeleft(struct Curl_easy *data,
 curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
                                   struct connectdata **connp);
 
-bool Curl_addr2string(struct sockaddr *sa, char *addr, long *port);
+bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
+                      char *addr, long *port);
 
 /*
  * Check if a connection seems to be alive.

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -541,12 +541,11 @@ CURLcode Curl_quic_connect(struct connectdata *conn,
   uint8_t paramsbuf[64];
   ngtcp2_transport_params params;
   ssize_t nwrite;
-  (void)addrlen;
 
   qs->conn = conn;
 
   /* extract the used address as a string */
-  if(!Curl_addr2string((struct sockaddr*)addr, ipbuf, &port)) {
+  if(!Curl_addr2string((struct sockaddr*)addr, addrlen, ipbuf, &port)) {
     char buffer[STRERROR_LEN];
     failf(data, "ssrem inet_ntop() failed with errno %d: %s",
           errno, Curl_strerror(errno, buffer, sizeof(buffer)));

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -150,7 +150,7 @@ UNITTEST_START
       if(tests[i].address[j] == &skip)
         continue;
 
-      if(addr && !Curl_addr2string(addr->ai_addr,
+      if(addr && !Curl_addr2string(addr->ai_addr, addr->ai_addrlen,
                                    ipaddress, &port)) {
         fprintf(stderr, "%s:%d tests[%d] failed. getaddressinfo failed.\n",
                 __FILE__, __LINE__, i);

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -150,7 +150,7 @@ UNITTEST_START
       if(!addr && !tests[i].address[j])
         break;
 
-      if(addr && !Curl_addr2string(addr->ai_addr,
+      if(addr && !Curl_addr2string(addr->ai_addr, addr->ai_addrlen,
                                    ipaddress, &port)) {
         fprintf(stderr, "%s:%d tests[%d] failed. Curl_addr2string failed.\n",
                 __FILE__, __LINE__, i);


### PR DESCRIPTION
This allows the function to figure out if a unix domain socket has a
file name or not associated with it! When a socket is created with
socketpair(), as done in the fuzzer testing, the path struct member is
uninitialized and must not be accessed.

Bug: https://crbug.com/oss-fuzz/16699