### PR TITLE
smb: init *msg to NULL in smb_send_and_recv()

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -606,6 +606,7 @@ static CURLcode smb_send_and_recv(struct connectdata *conn, void **msg)
 {
   struct smb_conn *smbc = &conn->proto.smbc;
   CURLcode result;
+  *msg = NULL; /* if it returns early */
 
   /* Check if there is data in the transfer buffer */
   if(!smbc->send_size && smbc->upload_size) {


### PR DESCRIPTION
... it might otherwise return OK from this function leaving that pointer
uninitialized.

Bug: https://crbug.com/oss-fuzz/16907