### PR TITLE
urldata: avoid 'generic', use dedicated pointers

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -199,13 +199,13 @@ static CURLcode rtmp_setup_connection(struct connectdata *conn)
     RTMP_Free(r);
     return CURLE_URL_MALFORMAT;
   }
-  conn->proto.generic = r;
+  conn->proto.rtmp = r;
   return CURLE_OK;
 }
 
 static CURLcode rtmp_connect(struct connectdata *conn, bool *done)
 {
-  RTMP *r = conn->proto.generic;
+  RTMP *r = conn->proto.rtmp;
   SET_RCVTIMEO(tv, 10);
 
   r->m_sb.sb_socket = (int)conn->sock[FIRSTSOCKET];
@@ -240,7 +240,7 @@ static CURLcode rtmp_connect(struct connectdata *conn, bool *done)
 static CURLcode rtmp_do(struct connectdata *conn, bool *done)
 {
   struct Curl_easy *data = conn->data;
-  RTMP *r = conn->proto.generic;
+  RTMP *r = conn->proto.rtmp;
 
   if(!RTMP_ConnectStream(r, 0))
     return CURLE_FAILED_INIT;
@@ -268,10 +268,10 @@ static CURLcode rtmp_done(struct connectdata *conn, CURLcode status,
 static CURLcode rtmp_disconnect(struct connectdata *conn,
                                 bool dead_connection)
 {
-  RTMP *r = conn->proto.generic;
+  RTMP *r = conn->proto.rtmp;
   (void)dead_connection;
   if(r) {
-    conn->proto.generic = NULL;
+    conn->proto.rtmp = NULL;
     RTMP_Close(r);
     RTMP_Free(r);
   }
@@ -281,7 +281,7 @@ static CURLcode rtmp_disconnect(struct connectdata *conn,
 static ssize_t rtmp_recv(struct connectdata *conn, int sockindex, char *buf,
                          size_t len, CURLcode *err)
 {
-  RTMP *r = conn->proto.generic;
+  RTMP *r = conn->proto.rtmp;
   ssize_t nread;
 
   (void)sockindex; /* unused */
@@ -302,7 +302,7 @@ static ssize_t rtmp_recv(struct connectdata *conn, int sockindex, char *buf,
 static ssize_t rtmp_send(struct connectdata *conn, int sockindex,
                          const void *buf, size_t len, CURLcode *err)
 {
-  RTMP *r = conn->proto.generic;
+  RTMP *r = conn->proto.rtmp;
   ssize_t num;
 
   (void)sockindex; /* unused */

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -151,7 +151,7 @@ static const char *url_errs[] = {
   "bad or missing extensions"
 };
 
-typedef struct ldapconninfo {
+struct ldapconninfo {
   LDAP *ld;
   Curl_recv *recv;  /* for stacking SSL handler */
   Curl_send *send;
@@ -160,7 +160,7 @@ typedef struct ldapconninfo {
   bool ssldone;
   bool sslinst;
   bool didbind;
-} ldapconninfo;
+};
 
 typedef struct ldapreqinfo {
   int msgid;
@@ -169,7 +169,7 @@ typedef struct ldapreqinfo {
 
 static CURLcode ldap_setup_connection(struct connectdata *conn)
 {
-  ldapconninfo *li;
+  struct ldapconninfo *li;
   LDAPURLDesc *lud;
   struct Curl_easy *data = conn->data;
   int rc, proto;
@@ -190,11 +190,11 @@ static CURLcode ldap_setup_connection(struct connectdata *conn)
   proto = ldap_pvt_url_scheme2proto(lud->lud_scheme);
   ldap_free_urldesc(lud);
 
-  li = calloc(1, sizeof(ldapconninfo));
+  li = calloc(1, sizeof(struct ldapconninfo));
   if(!li)
     return CURLE_OUT_OF_MEMORY;
   li->proto = proto;
-  conn->proto.generic = li;
+  conn->proto.ldapc = li;
   connkeep(conn, "OpenLDAP default");
   return CURLE_OK;
 }
@@ -205,7 +205,7 @@ static Sockbuf_IO ldapsb_tls;
 
 static CURLcode ldap_connect(struct connectdata *conn, bool *done)
 {
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   struct Curl_easy *data = conn->data;
   int rc, proto = LDAP_VERSION3;
   char hosturl[1024];
@@ -252,7 +252,7 @@ static CURLcode ldap_connect(struct connectdata *conn, bool *done)
 
 static CURLcode ldap_connecting(struct connectdata *conn, bool *done)
 {
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   struct Curl_easy *data = conn->data;
   LDAPMessage *msg = NULL;
   struct timeval tv = {0, 1}, *tvp;
@@ -357,7 +357,7 @@ static CURLcode ldap_connecting(struct connectdata *conn, bool *done)
 
 static CURLcode ldap_disconnect(struct connectdata *conn, bool dead_connection)
 {
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   (void) dead_connection;
 
   if(li) {
@@ -365,7 +365,7 @@ static CURLcode ldap_disconnect(struct connectdata *conn, bool dead_connection)
       ldap_unbind_ext(li->ld, NULL, NULL);
       li->ld = NULL;
     }
-    conn->proto.generic = NULL;
+    conn->proto.ldapc = NULL;
     free(li);
   }
   return CURLE_OK;
@@ -373,7 +373,7 @@ static CURLcode ldap_disconnect(struct connectdata *conn, bool dead_connection)
 
 static CURLcode ldap_do(struct connectdata *conn, bool *done)
 {
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   ldapreqinfo *lr;
   CURLcode status = CURLE_OK;
   int rc = 0;
@@ -427,7 +427,7 @@ static CURLcode ldap_done(struct connectdata *conn, CURLcode res,
   if(lr) {
     /* if there was a search in progress, abandon it */
     if(lr->msgid) {
-      ldapconninfo *li = conn->proto.generic;
+      struct ldapconninfo *li = conn->proto.ldapc;
       ldap_abandon_ext(li->ld, lr->msgid, NULL, NULL);
       lr->msgid = 0;
     }
@@ -441,7 +441,7 @@ static CURLcode ldap_done(struct connectdata *conn, CURLcode res,
 static ssize_t ldap_recv(struct connectdata *conn, int sockindex, char *buf,
                          size_t len, CURLcode *err)
 {
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   struct Curl_easy *data = conn->data;
   ldapreqinfo *lr = data->req.protop;
   int rc, ret;
@@ -718,7 +718,7 @@ static ber_slen_t
 ldapsb_tls_read(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len)
 {
   struct connectdata *conn = sbiod->sbiod_pvt;
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   ber_slen_t ret;
   CURLcode err = CURLE_RECV_ERROR;
 
@@ -733,7 +733,7 @@ static ber_slen_t
 ldapsb_tls_write(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len)
 {
   struct connectdata *conn = sbiod->sbiod_pvt;
-  ldapconninfo *li = conn->proto.generic;
+  struct ldapconninfo *li = conn->proto.ldapc;
   ber_slen_t ret;
   CURLcode err = CURLE_SEND_ERROR;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -780,6 +780,8 @@ struct http_connect_state {
   bit close_connection:1;
 };
 
+struct ldapconninfo;
+
 /*
  * The connectdata struct contains all fields and variables that should be
  * unique for an entire connection.
@@ -1018,7 +1020,8 @@ struct connectdata {
     struct smtp_conn smtpc;
     struct rtsp_conn rtspc;
     struct smb_conn smbc;
-    void *generic; /* RTMP and LDAP use this */
+    void *rtmp;
+    struct ldapconninfo *ldapc;
   } proto;
 
   int cselect_bits; /* bitmask of socket events */


### PR DESCRIPTION
For the 'proto' union within the connectdata struct.