### PR TITLE
tool_setopt: handle a libcurl build without netrc support

### DIFF
--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -824,6 +824,16 @@ bool tool_setopt_skip(CURLoption tag)
     break;
   }
 #endif
+#ifdef CURL_DISABLE_NETRC
+#define USED_TAG
+  switch(tag) {
+  case CURLOPT_NETRC:
+  case CURLOPT_NETRC_FILE:
+    return TRUE;
+  default:
+    break;
+  }
+#endif
 
 #ifndef USED_TAG
   (void)tag;


### PR DESCRIPTION
Reported-by: codesniffer13 on github
Fixes #4302