### PR TITLE
curl: fix memory leaked by parse_metalink()

### DIFF
--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -965,7 +965,7 @@ static void delete_metalink_resource(metalink_resource *res)
   Curl_safefree(res);
 }
 
-static void delete_metalinkfile(metalinkfile *mlfile)
+void delete_metalinkfile(metalinkfile *mlfile)
 {
   metalink_resource *res;
   if(mlfile == NULL) {

--- a/src/tool_metalink.h
+++ b/src/tool_metalink.h
@@ -105,6 +105,8 @@ extern const digest_params SHA256_DIGEST_PARAMS[1];
  * Counts the resource in the metalinkfile.
  */
 int count_next_metalink_resource(metalinkfile *mlfile);
+
+void delete_metalinkfile(metalinkfile *mlfile);
 void clean_metalink(struct OperationConfig *config);
 
 /*

--- a/src/tool_metalink.h
+++ b/src/tool_metalink.h
@@ -160,6 +160,7 @@ void metalink_cleanup(void);
 #else /* USE_METALINK */
 
 #define count_next_metalink_resource(x)  0
+#define delete_metalinkfile(x)  (void)x
 #define clean_metalink(x)  (void)x
 
 /* metalink_cleanup() takes no arguments */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2073,6 +2073,10 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
     result = post_transfer(global, share, per, result, &retry);
     if(retry)
       continue;
+
+    /* Release metalink related resources here */
+    delete_metalinkfile(per->mlfile);
+
     per = del_transfer(per);
 
     /* Bail out upon critical errors or --fail-early */


### PR DESCRIPTION
This commit fixes a regression introduced by curl-7_65_3-5-gb88940850.
Detected by tests 2005, 2008, 2009, 2010, 2011, and 2012 with valgrind
and libmetalink enabled.