### PR TITLE
docs(h3): fix `--with-ssl` ngtcp2 configure flag

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -65,7 +65,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % LDFLAGS="-Wl,-rpath,<somewhere1>/lib" ./configure -with-ssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
+     % LDFLAGS="-Wl,-rpath,<somewhere1>/lib" ./configure --with-ssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
 
 ## Running


### PR DESCRIPTION
Fixes `--with-ssl` flag typo from `-with-ssl`