### PR TITLE
FTP: allow "rubbish" prepended to the SIZE response

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2242,9 +2242,25 @@ static CURLcode ftp_state_size_resp(struct connectdata *conn,
   char *buf = data->state.buffer;
 
   /* get the size from the ascii string: */
-  if(ftpcode == 213)
+  if(ftpcode == 213) {
+    /* To allow servers to prepend "rubbish" in the response string, we scan
+       for all the digits at the end of the response and parse only those as a
+       number. */
+    char *start = &buf[4];
+    char *fdigit = strchr(start, '\r');
+    if(fdigit) {
+      do
+        fdigit--;
+      while(ISDIGIT(*fdigit) && (fdigit > start));
+      if(!ISDIGIT(*fdigit))
+        fdigit++;
+    }
+    else
+      fdigit = start;
     /* ignores parsing errors, which will make the size remain unknown */
-    (void)curlx_strtoofft(buf + 4, NULL, 0, &filesize);
+    (void)curlx_strtoofft(fdigit, NULL, 0, &filesize);
+
+  }
 
   if(instate == FTP_SIZE) {
 #ifdef CURL_FTP_HTTPSTYLE_HEAD

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -57,7 +57,7 @@ test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
-test334 test335 \
+test334 test335 test336 test337 \
 test340 \
 \
 test350 test351 test352 test353 test354 test355 test356 \

--- a/tests/data/test336
+++ b/tests/data/test336
@@ -1,0 +1,58 @@
+<testcase>
+<info>
+<keywords>
+FTP
+PASV
+TYPE A
+RETR
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</data>
+<datacheck nonewline="yes">
+data
+</datacheck>
+<servercmd>
+REPLY EPSV 500 no such command
+REPLY SIZE 500 no such command
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+FTP range download when SIZE doesn't work
+ </name>
+ <command>
+ftp://%HOSTIP:%FTPPORT/336 --use-ascii --range 3-6
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+PASV
+TYPE A
+SIZE 336
+REST 3
+RETR 336
+ABOR
+QUIT
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test337
+++ b/tests/data/test337
@@ -1,0 +1,58 @@
+<testcase>
+<info>
+<keywords>
+FTP
+PASV
+TYPE A
+RETR
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</data>
+<datacheck nonewline="yes">
+data
+</datacheck>
+<servercmd>
+REPLY EPSV 500 no such command
+REPLY SIZE 213 file: 213, Size =51
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+FTP range download with SIZE returning extra crap
+ </name>
+ <command>
+ftp://%HOSTIP:%FTPPORT/337 --use-ascii --range 3-6
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+PASV
+TYPE A
+SIZE 337
+REST 3
+RETR 337
+ABOR
+QUIT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
It is debatable whether this is allowed by the protocol but apparently
there are legacy proprietary servers doing this.

Reported-by: Philippe Marguinaud