### PR TITLE
openssl: close_notify on the initial connection markes it for close

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3878,7 +3878,10 @@ static ssize_t ossl_recv(struct connectdata *conn, /* connection data */
       break;
     case SSL_ERROR_ZERO_RETURN: /* no more data */
       /* close_notify alert */
-      connclose(conn, "TLS close_notify");
+      if(num == FIRSTSOCKET)
+        /* mark the connection for close if it is indeed the control
+           connection */
+        connclose(conn, "TLS close_notify");
       break;
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:


### PR DESCRIPTION
... for FTPS transfers, we are destined to get it on the data connection
without that being a signal to close the control connection!

Regression since 3f5da4e59a556fc (7.65.0)

Reported-by: Zenju on github
Fixes #4329