### PR TITLE
doh: fix off-by-one error in size check for doh_encode()

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -84,7 +84,7 @@ UNITTEST DOHcode doh_encode(const char *host,
   unsigned char *orig = dnsp;
   const char *hostp = host;
 
-  if(len < (12 + hostlen + 4))
+  if(len <= (12 + hostlen + 4))
     return DOH_TOO_SMALL_BUFFER;
 
   *dnsp++ = 0; /* 16 bit id */


### PR DESCRIPTION
When building the outgoing DNS packet, we typically need one byte more
than the length of the host name since each "label" needs a single byte
length. "a.b" needs four bytes.

This would previously lead to a single byte overwrite if the given input
host name was exactly 240 bytes, but the overwritten data is the length
variable that gets updated immediately afterwards, making the net result
that it only made a broken DNS packet.

Inspired-by: Paul Dreik