### PR TITLE
url: only reuse TLS connections with matching pinning

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3519,6 +3519,10 @@ static CURLcode create_conn(struct Curl_easy *data,
     data->set.str[STRING_SSL_CIPHER13_LIST_ORIG];
   data->set.proxy_ssl.primary.cipher_list13 =
     data->set.str[STRING_SSL_CIPHER13_LIST_PROXY];
+  data->set.ssl.primary.pinned_key =
+    data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG];
+  data->set.proxy_ssl.primary.pinned_key =
+    data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY];
 
   data->set.ssl.CRLfile = data->set.str[STRING_SSL_CRLFILE_ORIG];
   data->set.proxy_ssl.CRLfile = data->set.str[STRING_SSL_CRLFILE_PROXY];

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -222,6 +222,7 @@ struct ssl_primary_config {
   char *egdsocket;       /* path to file containing the EGD daemon socket */
   char *cipher_list;     /* list of ciphers to use */
   char *cipher_list13;   /* list of TLS 1.3 cipher suites to use */
+  char *pinned_key;
   bit verifypeer:1;      /* set TRUE if this is desired */
   bit verifyhost:1;      /* set TRUE if CN/SAN must match hostname */
   bit verifystatus:1;    /* set TRUE if certificate status must be checked */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -122,6 +122,7 @@ Curl_clone_primary_ssl_config(struct ssl_primary_config *source,
   CLONE_STRING(egdsocket);
   CLONE_STRING(cipher_list);
   CLONE_STRING(cipher_list13);
+  CLONE_STRING(pinned_key);
 
   return TRUE;
 }
@@ -135,6 +136,7 @@ void Curl_free_primary_ssl_config(struct ssl_primary_config* sslc)
   Curl_safefree(sslc->egdsocket);
   Curl_safefree(sslc->cipher_list);
   Curl_safefree(sslc->cipher_list13);
+  Curl_safefree(sslc->pinned_key);
 }
 
 #ifdef USE_SSL

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -97,7 +97,8 @@ Curl_ssl_config_matches(struct ssl_primary_config* data,
      Curl_safe_strcasecompare(data->random_file, needle->random_file) &&
      Curl_safe_strcasecompare(data->egdsocket, needle->egdsocket) &&
      Curl_safe_strcasecompare(data->cipher_list, needle->cipher_list) &&
-     Curl_safe_strcasecompare(data->cipher_list13, needle->cipher_list13))
+     Curl_safe_strcasecompare(data->cipher_list13, needle->cipher_list13) &&
+     Curl_safe_strcasecompare(data->pinned_key, needle->pinned_key))
     return TRUE;
 
   return FALSE;


### PR DESCRIPTION
If the requests have different CURLOPT_PINNEDPUBLICKEY strings set, the
connection should not be reused.

Bug: https://curl.haxx.se/mail/lib-2019-09/0061.html
Reported-by: Sebastian Haglund