### PR TITLE
doh: fix undefined behaviour in swap

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -419,8 +419,14 @@ static unsigned short get16bit(unsigned char *doh, int index)
 
 static unsigned int get32bit(unsigned char *doh, int index)
 {
-  return (doh[index] << 24) | (doh[index + 1] << 16) |
-    (doh[index + 2] << 8) | doh[index + 3];
+   /* make clang and gcc optimize this to bswap by incrementing
+      the pointer first. */
+   doh += index;
+
+   /* avoid undefined behaviour by casting to unsigned before shifting
+      24 bits, possibly into the sign bit. codegen is same, but
+      ub sanitizer won't be upset */
+  return ( (unsigned)doh[0] << 24) | (doh[1] << 16) |(doh[2] << 8) | doh[3];
 }
 
 static DOHcode store_a(unsigned char *doh, int index, struct dohentry *d)


### PR DESCRIPTION
The undefined behaviour is annoying when running fuzzing with
sanitizers. The codegen is the same, but the meaning is now
not up for dispute. See https://cppinsights.io/s/516a2ff4

By incrementing the pointer first, both gcc and clang recognize this
as a bswap and optimizes it to a single instruction.
See https://godbolt.org/z/994Zpx
