### PR TITLE
Fix harmless two byte buffer write overflow in doh_encode

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -74,6 +74,8 @@ static const char *doh_strerror(DOHcode code)
 #define UNITTEST static
 #endif
 
+/* @unittest 1655
+ */
 UNITTEST DOHcode doh_encode(const char *host,
                             DNStype dnstype,
                             unsigned char *dnsp, /* buffer */
@@ -139,7 +141,10 @@ UNITTEST DOHcode doh_encode(const char *host,
   *dnsp++ = DNS_CLASS_IN; /* IN - "the Internet" */
 
   *olen = dnsp - orig;
-  assert(*olen == expected_len);
+
+  /* verify that our assumption of length is valid, since
+   * this has lead to buffer overflows in this function */
+  DEBUGASSERT(*olen == expected_len);
   return DOH_OK;
 }
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -80,11 +80,18 @@ UNITTEST DOHcode doh_encode(const char *host,
                             size_t len,  /* buffer size */
                             size_t *olen) /* output length */
 {
-  size_t hostlen = strlen(host);
+  const size_t hostlen = strlen(host);
   unsigned char *orig = dnsp;
   const char *hostp = host;
 
-  if(len < (12 + hostlen + 4))
+  /* The expected output length does not depend on the number of dots within
+   * the host name. It will always be two more than the length of the host
+   * name, one for the size and one trailing null. In case there are dots,
+   * each dot adds one size but removes the need to store the dot, net zero.
+   */
+  const size_t expected_len = 12 + ( 1 + hostlen + 1) + 4;
+
+  if(len < expected_len)
     return DOH_TOO_SMALL_BUFFER;
 
   *dnsp++ = 0; /* 16 bit id */
@@ -132,6 +139,7 @@ UNITTEST DOHcode doh_encode(const char *host,
   *dnsp++ = DNS_CLASS_IN; /* IN - "the Internet" */
 
   *olen = dnsp - orig;
+  assert(*olen == expected_len);
   return DOH_OK;
 }
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -183,7 +183,7 @@ test1590 test1591 test1592 test1593 test1594 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
 test1608 test1609 test1620 test1621 \
 \
-test1650 test1651 test1652 test1653 test1654 \
+test1650 test1651 test1652 test1653 test1654 test1655 \
 \
 test1700 test1701 test1702 \
 \

--- a/tests/data/test1655
+++ b/tests/data/test1655
@@ -16,7 +16,7 @@ none
 unittest
 </features>
  <name>
-unit test for doh_encode and doh_decode
+unit test for doh_encode
  </name>
 <tool>
 unit1655

--- a/tests/data/test1655
+++ b/tests/data/test1655
@@ -1,0 +1,26 @@
+<testcase>
+<info>
+<keywords>
+unittest
+doh
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+unit test for doh_encode and doh_decode
+ </name>
+<tool>
+unit1655
+</tool>
+</client>
+
+</testcase>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -22,6 +22,7 @@ set(UT_SRC
 # Broken link on Linux
 #  unit1604.c
   unit1620.c
+  unit1655.c
   )
 
 set(UT_COMMON_FILES ../libtest/first.c ../libtest/test.h curlcheck.h)

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -11,7 +11,7 @@ UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307 \
  unit1399 \
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
  unit1608 unit1609 unit1620 unit1621 \
- unit1650 unit1651 unit1652 unit1653 unit1654
+ unit1650 unit1651 unit1652 unit1653 unit1654 unit1655
 
 unit1300_SOURCES = unit1300.c $(UNITFILES)
 unit1300_CPPFLAGS = $(AM_CPPFLAGS)
@@ -118,3 +118,7 @@ unit1653_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1654_SOURCES = unit1654.c $(UNITFILES)
 unit1654_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1655_SOURCES = unit1655.c $(UNITFILES)
+unit1655_CPPFLAGS = $(AM_CPPFLAGS)
+

--- a/tests/unit/README
+++ b/tests/unit/README
@@ -35,6 +35,9 @@ We put tests that focus on an area or a specific function into a single C
 source file. The source file should be named 'unitNNNN.c' where NNNN is a
 number that starts with 1300 and you can pick the next free number.
 
+Add your test to tests/unit/Makefile.inc (if it is a unit test).
+Add your test data to tests/data/Makefile.inc
+
 You also need a separate file called tests/data/testNNNN (using the same
 number) that describes your test case. See the test1300 file for inspiration
 and the tests/FILEFORMAT documentation.
@@ -46,9 +49,10 @@ For the actual C file, here's a very simple example:
 
 #include "a libcurl header.h" /* from the lib dir */
 
-static void unit_setup( void )
+static CURLcode unit_setup( void )
 {
   /* whatever you want done first */
+  return CURLE_OK;
 }
 
 static void unit_stop( void )

--- a/tests/unit/unit1655.c
+++ b/tests/unit/unit1655.c
@@ -1,57 +1,68 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
 #include "curlcheck.h"
 
 #include "doh.h" /* from the lib dir */
 
-static CURLcode unit_setup(  )
+static CURLcode unit_setup(void)
 {
   /* whatever you want done first */
   return CURLE_OK;
 }
 
-static void unit_stop( void )
+static void unit_stop(void)
 {
-  /* done before shutting down and exiting */
+    /* done before shutting down and exiting */
 }
-
 
 UNITTEST_START
 
-DNStype dnstype=DNS_TYPE_A;
+DNStype dnstype = DNS_TYPE_A;
 unsigned char buffer[128];
-const size_t buflen=sizeof(buffer);
-const size_t magic1=9765;
-size_t olen1=magic1;
-const char* sunshine1="a.com";
-const char* sunshine2="aa.com";
-DOHcode ret=doh_encode(sunshine1,dnstype,buffer,buflen,&olen1);
+const size_t buflen = sizeof(buffer);
+const size_t magic1 = 9765;
+size_t olen1 = magic1;
+const char *sunshine1 = "a.com";
+const char *sunshine2 = "aa.com";
+DOHcode ret = doh_encode(sunshine1, dnstype, buffer, buflen, &olen1);
 fail_unless(ret == DOH_OK, "sunshine case 1 should pass fine");
 fail_if(olen1 == magic1, "olen has not been assigned properly");
-fail_unless(olen1>strlen(sunshine1), "bad out length");
+fail_unless(olen1 > strlen(sunshine1), "bad out length");
 
 /* add one letter, the response should be one longer */
-size_t olen2=magic1;
-DOHcode ret2=doh_encode(sunshine2,dnstype,buffer,buflen,&olen2);
+size_t olen2 = magic1;
+DOHcode ret2 = doh_encode(sunshine2, dnstype, buffer, buflen, &olen2);
 fail_unless(ret2 == DOH_OK, "sunshine case 2 should pass fine");
 fail_if(olen2 == magic1, "olen has not been assigned properly");
-fail_unless(olen1 +1 == olen2, "olen should grow with the hostname");
+fail_unless(olen1 + 1 == olen2, "olen should grow with the hostname");
 
 /* pass a short buffer, should fail */
 size_t olen;
-ret=doh_encode(sunshine1,dnstype,buffer,olen1-1,&olen);
+ret = doh_encode(sunshine1, dnstype, buffer, olen1 - 1, &olen);
 fail_if(ret == DOH_OK, "short buffer should have been noticed");
 
 /* pass a minimum buffer, should succeed */
-ret=doh_encode(sunshine1,dnstype,buffer,olen1,&olen);
-fail_unless(ret == DOH_OK, "minimal length buffer should have been sufficient");
+ret = doh_encode(sunshine1, dnstype, buffer, olen1, &olen);
+fail_unless(ret == DOH_OK, "minimal length buffer should be long enough");
 fail_unless(olen == olen1, "bad buffer length");
-
-/* here you start doing things and checking that the results are good */
-/*
-  int size=0;
-  int* head=NULL;
-  fail_unless( size == 0 , "initial size should be zero" );
-  fail_if( head == NULL , "head should not be initiated to NULL" );
-*/
-  /* you end the test code like this: */
 
 UNITTEST_STOP

--- a/tests/unit/unit1655.c
+++ b/tests/unit/unit1655.c
@@ -1,0 +1,57 @@
+#include "curlcheck.h"
+
+#include "doh.h" /* from the lib dir */
+
+static CURLcode unit_setup(  )
+{
+  /* whatever you want done first */
+  return CURLE_OK;
+}
+
+static void unit_stop( void )
+{
+  /* done before shutting down and exiting */
+}
+
+
+UNITTEST_START
+
+DNStype dnstype=DNS_TYPE_A;
+unsigned char buffer[128];
+const size_t buflen=sizeof(buffer);
+const size_t magic1=9765;
+size_t olen1=magic1;
+const char* sunshine1="a.com";
+const char* sunshine2="aa.com";
+DOHcode ret=doh_encode(sunshine1,dnstype,buffer,buflen,&olen1);
+fail_unless(ret == DOH_OK, "sunshine case 1 should pass fine");
+fail_if(olen1 == magic1, "olen has not been assigned properly");
+fail_unless(olen1>strlen(sunshine1), "bad out length");
+
+/* add one letter, the response should be one longer */
+size_t olen2=magic1;
+DOHcode ret2=doh_encode(sunshine2,dnstype,buffer,buflen,&olen2);
+fail_unless(ret2 == DOH_OK, "sunshine case 2 should pass fine");
+fail_if(olen2 == magic1, "olen has not been assigned properly");
+fail_unless(olen1 +1 == olen2, "olen should grow with the hostname");
+
+/* pass a short buffer, should fail */
+size_t olen;
+ret=doh_encode(sunshine1,dnstype,buffer,olen1-1,&olen);
+fail_if(ret == DOH_OK, "short buffer should have been noticed");
+
+/* pass a minimum buffer, should succeed */
+ret=doh_encode(sunshine1,dnstype,buffer,olen1,&olen);
+fail_unless(ret == DOH_OK, "minimal length buffer should have been sufficient");
+fail_unless(olen == olen1, "bad buffer length");
+
+/* here you start doing things and checking that the results are good */
+/*
+  int size=0;
+  int* head=NULL;
+  fail_unless( size == 0 , "initial size should be zero" );
+  fail_if( head == NULL , "head should not be initiated to NULL" );
+*/
+  /* you end the test code like this: */
+
+UNITTEST_STOP


### PR DESCRIPTION
The check for buffer length in https://github.com/curl/curl/blob/5977664d2f0cbe02796b55695ef61c494bc80451/lib/doh.c#L87 is wrong, which leads to a two byte buffer write overflow. 

I reported a related bug in [curl/doh](https://github.com/curl/doh/blob/541073829865a72963d80e0efbb13382a3447621/doh.c#L237) at an early stage when investigating this, via private email to @bagder. After looking further into it, I filed on hackerone, and after discussions there it was concluded that
 - it is harmless 
 - https://github.com/curl/curl/pull/4345 is insufficient
 - this pull request replaces it, if favourable reviewed

doh_encode() is an internal function, and the only exposure it gets is through https://github.com/curl/curl/blob/5977664d2f0cbe02796b55695ef61c494bc80451/lib/doh.c#L195 where it writes into a fixed length buffer in [struct dnsprobe](https://github.com/curl/curl/blob/5977664d2f0cbe02796b55695ef61c494bc80451/lib/urldata.h#L532)

The only way to trigger this externally is to use doh and use a hostname of a particular length such that it is short enough not to be caught by the length check, but long enough to write outside the buffer.

If the overflow happens, it is luckily harmless, because the overwrite goes into the length member of
 [struct dnsprobe](https://github.com/curl/curl/blob/5977664d2f0cbe02796b55695ef61c494bc80451/lib/urldata.h#L533). That length member is overwritten by https://github.com/curl/curl/blob/5977664d2f0cbe02796b55695ef61c494bc80451/lib/doh.c#L134 and all is well again. I do not believe the compiler is allowed to rearrange the length write with the buffer write, as it can't assume the char pointer to the buffer does not alias with the size. 
 
This pull request adds a unit test which proves the bug and that it has been fixed.

To trigger the behaviour, the following curl command can be used (the lenght of the weird hostname is carefully selected and no part between the dots may be longer than 63):
```
src/curl --doh-url https://irrelevant/ x....xxxxxxxxxxxxxxxxxxxxx.x....x.xxxxxxxxxx.xxxxxxxxx.xxxxxxxxxxx.xxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.x.x.......xxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx......xxxxxx.....xx..........xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxx..x......xxxxxxxx..xxxxxxxxxxxxxxxxxxx.x...xxxx.x.x.x...xxxxx
```
