### PR TITLE
travis: don't build BoringSSL tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -451,7 +451,7 @@ before_script:
         mkdir build &&
         cd build &&
         CXX="g++" CC="gcc" cmake -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=1 .. &&
-        make &&
+        make bssl &&
         cd .. &&
         mkdir lib &&
         cd lib &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache:
         - $HOME/mesalink-1.0.0
         - $HOME/nghttp2-1.39.2
 
+go:
+    - stable
+
 env:
     global:
         - LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
I _think_ this should fix the BoringSSL-enabled builds on Travis CI, as
well as make them slightly faster.