### PR TITLE
smb: check for full size message before reading message details

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -682,7 +682,8 @@ static CURLcode smb_connection_state(struct connectdata *conn, bool *done)
 
   switch(smbc->state) {
   case SMB_NEGOTIATE:
-    if(h->status || smbc->got < sizeof(*nrsp) + sizeof(smbc->challenge) - 1) {
+    if((smbc->got < sizeof(*nrsp) + sizeof(smbc->challenge) - 1) ||
+       h->status) {
       connclose(conn, "SMB: negotiation failed");
       return CURLE_COULDNT_CONNECT;
     }


### PR DESCRIPTION
To avoid reading of uninitialized data.

Assisted-by: Max Dymond
Bug: https://crbug.com/oss-fuzz/16907