### PR TITLE
doh: clean up dangling DOH handles on easy close

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -399,6 +399,12 @@ CURLcode Curl_close(struct Curl_easy *data)
     Curl_share_unlock(data, CURL_LOCK_DATA_SHARE);
   }
 
+  /* Leave no dangling DOH handles behind */
+  Curl_close(data->req.doh.probe[0].easy);
+  Curl_close(data->req.doh.probe[1].easy);
+  free(data->req.doh.probe[0].serverdoh.memory);
+  free(data->req.doh.probe[1].serverdoh.memory);
+
   /* destruct wildcard structures if it is needed */
   Curl_wildcard_dtor(&data->wildcard);
   Curl_freeset(data);


### PR DESCRIPTION
If you set the same URL for target as for DoH (and it isn't a DoH
server), like "https://example.com" in both, the easy handles used for
the DoH requests could be left "dangling" and end up not getting freed.

Reported-by: Paul Dreik @pauldreik 