### PR TITLE
fix vs2019 warnings: conversion from 'bit' to 'bool'

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -344,7 +344,7 @@ void Curl_cookie_loadfiles(struct Curl_easy *data)
       struct CookieInfo *newcookies = Curl_cookie_init(data,
                                         list->data,
                                         data->cookies,
-                                        data->set.cookiesession);
+                                        (bool)data->set.cookiesession);
       if(!newcookies)
         /* Failure may be due to OOM or a bad cookie; both are ignored
          * but only the first should be

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -840,7 +840,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
     outcurl->cookies = Curl_cookie_init(data,
                                         data->cookies->filename,
                                         outcurl->cookies,
-                                        data->set.cookiesession);
+                                        (bool)data->set.cookiesession);
     if(!outcurl->cookies)
       goto fail;
   }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1512,7 +1512,7 @@ static CURLcode ftp_state_type(struct connectdata *conn)
      information. Which in FTP can't be much more than the file size and
      date. */
   if(data->set.opt_no_body && ftpc->file &&
-     ftp_need_type(conn, data->set.prefer_ascii)) {
+     ftp_need_type(conn, (bool)data->set.prefer_ascii)) {
     /* The SIZE command is _not_ RFC 959 specified, and therefore many servers
        may not support it! It is however the only way we have to get a file's
        size! */
@@ -1522,7 +1522,7 @@ static CURLcode ftp_state_type(struct connectdata *conn)
 
     /* Some servers return different sizes for different modes, and thus we
        must set the proper type before we check the size */
-    result = ftp_nb_type(conn, data->set.prefer_ascii, FTP_TYPE);
+    result = ftp_nb_type(conn, (bool)data->set.prefer_ascii, FTP_TYPE);
     if(result)
       return result;
   }
@@ -3566,7 +3566,7 @@ static CURLcode ftp_do_more(struct connectdata *conn, int *completep)
       }
     }
     else if(data->set.upload) {
-      result = ftp_nb_type(conn, data->set.prefer_ascii, FTP_STOR_TYPE);
+      result = ftp_nb_type(conn, (bool)data->set.prefer_ascii, FTP_STOR_TYPE);
       if(result)
         return result;
 
@@ -3606,7 +3606,7 @@ static CURLcode ftp_do_more(struct connectdata *conn, int *completep)
         /* otherwise just fall through */
       }
       else {
-        result = ftp_nb_type(conn, data->set.prefer_ascii, FTP_RETR_TYPE);
+        result = ftp_nb_type(conn, (bool)data->set.prefer_ascii, FTP_RETR_TYPE);
         if(result)
           return result;
       }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3606,7 +3606,8 @@ static CURLcode ftp_do_more(struct connectdata *conn, int *completep)
         /* otherwise just fall through */
       }
       else {
-        result = ftp_nb_type(conn, (bool)data->set.prefer_ascii, FTP_RETR_TYPE);
+        result = ftp_nb_type(conn, (bool)data->set.prefer_ascii,
+                             FTP_RETR_TYPE);
         if(result)
           return result;
       }

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -237,7 +237,7 @@ static CURLcode CONNECT(struct connectdata *conn,
         const char *useragent = "";
         const char *http = (conn->http_proxy.proxytype == CURLPROXY_HTTP_1_0) ?
           "1.0" : "1.1";
-        bool ipv6_ip = conn->bits.ipv6_ip;
+        bool ipv6_ip = (bool)conn->bits.ipv6_ip;
         char *hostheader;
 
         /* the hostname may be different */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -706,7 +706,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * have been made.
      */
     newcookies = Curl_cookie_init(data, NULL, data->cookies,
-                                  data->set.cookiesession);
+                                  (bool)data->set.cookiesession);
     if(!newcookies)
       result = CURLE_OUT_OF_MEMORY;
     data->cookies = newcookies;

--- a/lib/url.c
+++ b/lib/url.c
@@ -3097,7 +3097,7 @@ static CURLcode resolve_server(struct Curl_easy *data,
       else {
         bool longpath = FALSE;
         hostaddr->addr = Curl_unix2addr(path, &longpath,
-                                        conn->abstract_unix_socket);
+                                        (bool)conn->abstract_unix_socket);
         if(hostaddr->addr)
           hostaddr->inuse++;
         else {


### PR DESCRIPTION
when use a bit variable to call function which need a bool, Visual Studio 2019 display:
warning C4244:  'function': conversion from 'bit' to 'bool', possible loss of data

This simple PR just add a (bool) cast