### PR TITLE
FTPFILE_NOCWD: Avoid redundant CWDs

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4099,6 +4099,9 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
   const char *path_to_use = ftp->path;
   const char *cur_pos;
   const char *filename = NULL;
+  char *path = NULL;
+  size_t pathlen = 0;
+  CURLcode result = CURLE_OK;
 
   cur_pos = path_to_use; /* current position in path. point at the begin of
                             next path component */
@@ -4255,10 +4258,7 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
 
   /* prevpath and ftpc->file are url-decoded so convert the input path
      before we compare the strings */
-  char *path = NULL;
-  size_t pathlen = 0;
-  CURLcode result =
-    Curl_urldecode(conn->data, ftp->path, 0, &path, &pathlen, TRUE);
+  result = Curl_urldecode(conn->data, ftp->path, 0, &path, &pathlen, TRUE);
   if(result) {
     freedirs(ftpc);
     return result;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4267,7 +4267,7 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
   if((data->set.ftp_filemethod == FTPFILE_NOCWD) && (path[0] == '/'))
     ftpc->cwddone = TRUE; /* skip CWD for absolute paths */
   else { /* newly created FTP connections are already in entry path */
-    const char* oldpath = conn->bits.reuse ? ftpc->prevpath : "";
+    const char *oldpath = conn->bits.reuse ? ftpc->prevpath : "";
     if(oldpath) {
       if(data->set.ftp_filemethod == FTPFILE_NOCWD)
         pathlen = 0; /* CWD to entry for relative paths */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4143,7 +4143,6 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
     slash_pos = strrchr(cur_pos, '/');
     if(slash_pos || !*cur_pos) {
       size_t dirlen = slash_pos-cur_pos;
-      CURLcode result;
 
       ftpc->dirs = calloc(1, sizeof(ftpc->dirs[0]));
       if(!ftpc->dirs)
@@ -4194,10 +4193,9 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
              CWD requires a parameter and a non-existent parameter a) doesn't
              work on many servers and b) has no effect on the others. */
           size_t len = slash_pos - cur_pos + absolute_dir;
-          CURLcode result =
-            Curl_urldecode(conn->data, cur_pos - absolute_dir, len,
-                           &ftpc->dirs[ftpc->dirdepth], NULL,
-                           TRUE);
+          result = Curl_urldecode(conn->data, cur_pos - absolute_dir, len,
+                                  &ftpc->dirs[ftpc->dirdepth], NULL,
+                                  TRUE);
           if(result) {
             freedirs(ftpc);
             return result;
@@ -4236,8 +4234,7 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
   } /* switch */
 
   if(filename && *filename) {
-    CURLcode result =
-      Curl_urldecode(conn->data, filename, 0,  &ftpc->file, NULL, TRUE);
+    result = Curl_urldecode(conn->data, filename, 0,  &ftpc->file, NULL, TRUE);
 
     if(result) {
       freedirs(ftpc);

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3198,7 +3198,7 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
       free(ftpc->prevpath);
 
       if(!ftpc->cwdfail) {
-        if (data->set.ftp_filemethod == FTPFILE_NOCWD)
+        if(data->set.ftp_filemethod == FTPFILE_NOCWD)
           pathlen = 0; /* relative path => working directory is FTP home */
         else
           pathlen -= ftpc->file?strlen(ftpc->file):0; /* file is url-decoded */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -870,7 +870,7 @@ static CURLcode ftp_state_cwd(struct connectdata *conn)
     /* FTPFILE_NOCWD with full path: expect ftpc->cwddone! */
     DEBUGASSERT((conn->data->set.ftp_filemethod != FTPFILE_NOCWD) ||
                 !(ftpc->dirdepth && ftpc->dirs[0][0] == '/'));
-    
+
     ftpc->count2 = 0; /* count2 counts failed CWDs */
 
     /* count3 is set to allow a MKD to fail once. In the case when first CWD
@@ -3215,7 +3215,7 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
     if(ftpc->prevpath)
       infof(data, "Remembering we are in dir \"%s\"\n", ftpc->prevpath);
   }
-  
+
   /* free the dir tree and file parts */
   freedirs(ftpc);
 
@@ -4252,7 +4252,7 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
   }
 
   ftpc->cwddone = FALSE; /* default to not done */
-  
+
   /* prevpath and ftpc->file are url-decoded so convert the input path
      before we compare the strings */
   char *path = NULL;

--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -122,7 +122,7 @@ struct ftp_conn {
   char **dirs;   /* realloc()ed array for path components */
   int dirdepth;  /* number of entries used in the 'dirs' array */
   int diralloc;  /* number of entries allocated for the 'dirs' array */
-  char *file;    /* decoded file */
+  char *file;    /* url-decoded file name (or path) */
   bool dont_check;  /* Set to TRUE to prevent the final (post-transfer)
                        file size and 226/250 status check. It should still
                        read the line, just ignore the result. */
@@ -135,8 +135,7 @@ struct ftp_conn {
   bool cwdfail;     /* set TRUE if a CWD command fails, as then we must prevent
                        caching the current directory */
   bool wait_data_conn; /* this is set TRUE if data connection is waited */
-  char *prevpath;   /* conn->path from the previous transfer */
-  curl_ftpfile prevmethod; /* ftp method in previous transfer  */
+  char *prevpath;   /* url-decoded conn->path from the previous transfer */
   char transfertype; /* set by ftp_transfertype for use by Curl_client_write()a
                         and others (A/I or zero) */
   int count1; /* general purpose counter for the state machine */


### PR DESCRIPTION
Hi,

here's the final integration of my changes from https://github.com/curl/curl/pull/4331 for FTPFILE_NOCWD when an absolute path is specified. There shouldn't be any change in behavior, only optimizations if it is determined that CWDs are not needed:

FTPFILE_NOCWD + full path:
=> preserve ftpc->prevpath

FTPFILE_NOCWD + relative path:
=> do nothing if prevpath = ""

Starting a new connection:
=>  assume prevpath == "" and avoid duplicate "CWD entrypath" not just for FTPFILE_NOCWD, but in all cases.


A few observations:
1. The code frequently makes the assumption that slashes are not urlencoded in ftp->path: path evaluation often happens *before* Curl_urldecode. This is not a huge problem, but something libcurl clients need to know, and makes API usage slightly more difficult (e.g. a client has to split his FTP paths by /, then url-encode the component names, then merge again before passing as CURLOPT_URL. FreeFileSync already does that, but this could be simplified.)

2. When dealing with servers that require "OPTS UTF8" for UTF8 support (e.g. Microsoft FTP Service), this could break libcurl's CWD handling if ftpc->entrypath contains non-ASCII chars. libcurl retrieves ftpc->entrypath (via PWD) before a libcurl client had a chance to set "OPTS UTF8", and once he has, future "CWD ftpc->entrypath" will likely fail. This is not a problem anymore (due to this pull request) for FreeFileSync which is using absolute FTP paths, so libcurl never issues the previous command.

3. There is further optimization potential when libcurl clients switch between using absolute and relative paths. E.g. first FTPFILE_SINGLECWD access might download "/home/file.txt", while the second one asks for "file2.txt", so a redundant CWD could be avoided, because both operate in "/home".

4. The pull request is working correctly in my FTP test scenarios, but will likely break a few libcurl tests due to less "CWD"s, which I'll see to patch as well.

Best, Zenju