### PR TITLE
FTP: support CURLOPT_SOCKOPTFUNCTION

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1037,13 +1037,14 @@ static void nosigpipe(struct connectdata *conn,
    Work-around: Make the Socket Send Buffer Size Larger Than the Program Send
    Buffer Size
 
-   The problem described in this knowledge-base is applied only to pre-Vista
-   Windows.  Following function trying to detect OS version and skips
-   SO_SNDBUF adjustment for Windows Vista and above.
+   The problem described in this knowledge-base is referencing Windows XP,
+   but the performance issue also occurs in Windows Vista and 7, but seems
+   solved in Windows 8 and later. Following function trying to detect OS version
+   and skips SO_SNDBUF adjustment for Windows 8 and above.
 */
 #define DETECT_OS_NONE 0
-#define DETECT_OS_PREVISTA 1
-#define DETECT_OS_VISTA_OR_LATER 2
+#define DETECT_OS_PRE_WIN8 1
+#define DETECT_OS_WIN8_OR_LATER 2
 
 void Curl_sndbufset(curl_socket_t sockfd)
 {
@@ -1054,14 +1055,14 @@ void Curl_sndbufset(curl_socket_t sockfd)
   static int detectOsState = DETECT_OS_NONE;
 
   if(detectOsState == DETECT_OS_NONE) {
-    if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
+    if(Curl_verify_windows_version(6, 2, PLATFORM_WINNT,
                                    VERSION_GREATER_THAN_EQUAL))
-      detectOsState = DETECT_OS_VISTA_OR_LATER;
+      detectOsState = DETECT_OS_WIN8_OR_LATER;
     else
-      detectOsState = DETECT_OS_PREVISTA;
+      detectOsState = DETECT_OS_PRE_WIN8;
   }
 
-  if(detectOsState == DETECT_OS_VISTA_OR_LATER)
+  if(detectOsState == DETECT_OS_WIN8_OR_LATER)
     return;
 
   if(getsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, (char *)&curval, &curlen) == 0)

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1039,8 +1039,8 @@ static void nosigpipe(struct connectdata *conn,
 
    The problem described in this knowledge-base is referencing Windows XP,
    but the performance issue also occurs in Windows Vista and 7, but seems
-   solved in Windows 8 and later. Following function trying to detect OS version
-   and skips SO_SNDBUF adjustment for Windows 8 and above.
+   solved in Windows 8 and later. Following function trying to detect OS
+   version and skips SO_SNDBUF adjustment for Windows 8 and above.
 */
 #define DETECT_OS_NONE 0
 #define DETECT_OS_PRE_WIN8 1

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -466,11 +466,12 @@ static CURLcode InitiateTransfer(struct connectdata *conn)
     Curl_sndbufset(conn->sock[SECONDARYSOCKET]);
 
     if(data->set.fsockopt) {
+      int error = 0;
       /* activate callback for setting socket options */
       Curl_set_in_callback(data, true);
-      int error = data->set.fsockopt(data->set.sockopt_client,
-                                     conn->sock[SECONDARYSOCKET],
-                                     CURLSOCKTYPE_IPCXN);
+      error = data->set.fsockopt(data->set.sockopt_client,
+                                 conn->sock[SECONDARYSOCKET],
+                                 CURLSOCKTYPE_IPCXN);
       Curl_set_in_callback(data, false);
 
       if(error)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -465,6 +465,18 @@ static CURLcode InitiateTransfer(struct connectdata *conn)
     /* set the SO_SNDBUF for the secondary socket for those who need it */
     Curl_sndbufset(conn->sock[SECONDARYSOCKET]);
 
+    if(data->set.fsockopt) {
+      /* activate callback for setting socket options */
+      Curl_set_in_callback(data, true);
+      int error = data->set.fsockopt(data->set.sockopt_client,
+                                     conn->sock[SECONDARYSOCKET],
+                                     CURLSOCKTYPE_IPCXN);
+      Curl_set_in_callback(data, false);
+
+      if(error)
+          return CURLE_ABORTED_BY_CALLBACK;
+     }
+
     Curl_setup_transfer(data, -1, -1, FALSE, SECONDARYSOCKET);
   }
   else {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -474,7 +474,7 @@ static CURLcode InitiateTransfer(struct connectdata *conn)
       Curl_set_in_callback(data, false);
 
       if(error)
-          return CURLE_ABORTED_BY_CALLBACK;
+        return CURLE_ABORTED_BY_CALLBACK;
      }
 
     Curl_setup_transfer(data, -1, -1, FALSE, SECONDARYSOCKET);


### PR DESCRIPTION
Hi,

for optimal upload speeds I'd like to customize SO_SNDBUF, but CURLOPT_SOCKOPTFUNCTION is currently not supported for FTP's data channel. This pull request adds support. Also, the default value for SO_SNDBUF is increased for Windows XP and earlier to handle a Windows-version specific performance problem. According to FTP upload testing, this increased SO_SNDBUF is also required for Windows Vista and Windows 7, but not for Windows 8 and later.

Best, Zenju