### PR TITLE
bit as bool

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,10 @@ environment:
         SHARED: ON
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 15 2017 Win64"
+        PRJ_GEN: "Visual Studio 16 2019"
+        TARGET: "-A x64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: ON
@@ -24,9 +25,10 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 15 2017 Win64"
+        PRJ_GEN: "Visual Studio 16 2019"
+        TARGET: "-A x64"
         PRJ_CFG: Release
         OPENSSL: ON
         WINSSL: OFF
@@ -46,9 +48,10 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 15 2017 Win64"
+        PRJ_GEN: "Visual Studio 16 2019"
+        TARGET: "-A x64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF
@@ -57,9 +60,10 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 15 2017 Win64"
+        PRJ_GEN: "Visual Studio 16 2019"
+        TARGET: "-A x64"
         PRJ_CFG: Debug
         OPENSSL: OFF
         WINSSL: OFF
@@ -100,7 +104,7 @@ environment:
         WINSSL: OFF
         TESTING: OFF
         MSYS2_ARG_CONV_EXCL: "/*"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: VisualStudioSolution
         PRJ_CFG: "DLL Debug - DLL Windows SSPI - DLL WinIDN"
         TESTING: OFF
@@ -115,6 +119,7 @@ build_script:
     - if %BUILD_SYSTEM%==CMake (
         cmake .
         -G"%PRJ_GEN%"
+        %TARGET%
         -DCMAKE_USE_OPENSSL=%OPENSSL%
         -DCMAKE_USE_WINSSL=%WINSSL%
         -DHTTP_ONLY=%HTTP_ONLY%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,7 +104,7 @@ environment:
         WINSSL: OFF
         TESTING: OFF
         MSYS2_ARG_CONV_EXCL: "/*"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: VisualStudioSolution
         PRJ_CFG: "DLL Debug - DLL Windows SSPI - DLL WinIDN"
         TESTING: OFF

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -158,7 +158,12 @@ typedef ssize_t (Curl_recv)(struct connectdata *conn, /* connection data */
   ((x) && ((x)->magic == CURLEASY_MAGIC_NUMBER))
 
 /* the type we use for storing a single boolean bit */
+#ifdef _MSV_VER
+#define BIT(x) bool x
+#else
 typedef unsigned int bit;
+#define BIT(x) bit x:1
+#endif
 
 #ifdef HAVE_GSSAPI
 /* Types needed for krb5-ftp connections */
@@ -166,7 +171,7 @@ struct krb5buffer {
   void *data;
   size_t size;
   size_t index;
-  bit eof_flag:1;
+  BIT(eof_flag);
 };
 
 enum protection_level {
@@ -209,7 +214,7 @@ struct ssl_connect_data {
 #if defined(USE_SSL)
   struct ssl_backend_data *backend;
 #endif
-  bit use:1;
+  BIT(use);
 };
 
 struct ssl_primary_config {
@@ -223,10 +228,10 @@ struct ssl_primary_config {
   char *cipher_list;     /* list of ciphers to use */
   char *cipher_list13;   /* list of TLS 1.3 cipher suites to use */
   char *pinned_key;
-  bit verifypeer:1;      /* set TRUE if this is desired */
-  bit verifyhost:1;      /* set TRUE if CN/SAN must match hostname */
-  bit verifystatus:1;    /* set TRUE if certificate status must be checked */
-  bit sessionid:1;       /* cache session IDs or not */
+  BIT(verifypeer);       /* set TRUE if this is desired */
+  BIT(verifyhost);       /* set TRUE if CN/SAN must match hostname */
+  BIT(verifystatus);     /* set TRUE if certificate status must be checked */
+  BIT(sessionid);        /* cache session IDs or not */
 };
 
 struct ssl_config_data {
@@ -246,10 +251,10 @@ struct ssl_config_data {
   char *password; /* TLS password (for, e.g., SRP) */
   enum CURL_TLSAUTH authtype; /* TLS authentication type (default SRP) */
 #endif
-  bit certinfo:1;     /* gather lots of certificate info */
-  bit falsestart:1;
-  bit enable_beast:1; /* allow this flaw for interoperability's sake*/
-  bit no_revoke:1;    /* disable SSL certificate revocation checks */
+  BIT(certinfo);     /* gather lots of certificate info */
+  BIT(falsestart);
+  BIT(enable_beast); /* allow this flaw for interoperability's sake*/
+  BIT(no_revoke);    /* disable SSL certificate revocation checks */
 };
 
 struct ssl_general_config {
@@ -292,8 +297,8 @@ struct digestdata {
   char *qop;
   char *algorithm;
   int nc; /* nounce count */
-  bit stale:1; /* set true for re-negotiation */
-  bit userhash:1;
+  BIT(stale); /* set true for re-negotiation */
+  BIT(userhash);
 #endif
 };
 
@@ -387,10 +392,10 @@ struct negotiatedata {
   size_t output_token_length;
 #endif
 #endif
-  bool noauthpersist;
-  bool havenoauthpersist;
-  bool havenegdata;
-  bool havemultiplerequests;
+  BIT(noauthpersist);
+  BIT(havenoauthpersist);
+  BIT(havenegdata);
+  BIT(havemultiplerequests);
 };
 #endif
 
@@ -404,64 +409,64 @@ struct ConnectBits {
                                   is complete */
   bool tcpconnect[2]; /* the TCP layer (or similar) is connected, this is set
                          the first time on the first connect function call */
-  bit close:1; /* if set, we close the connection after this request */
-  bit reuse:1; /* if set, this is a re-used connection */
-  bit altused:1; /* this is an alt-svc "redirect" */
-  bit conn_to_host:1; /* if set, this connection has a "connect to host"
-                         that overrides the host in the URL */
-  bit conn_to_port:1; /* if set, this connection has a "connect to port"
-                         that overrides the port in the URL (remote port) */
-  bit proxy:1; /* if set, this transfer is done through a proxy - any type */
-  bit httpproxy:1;  /* if set, this transfer is done through a http proxy */
-  bit socksproxy:1; /* if set, this transfer is done through a socks proxy */
-  bit user_passwd:1; /* do we use user+password for this connection? */
-  bit proxy_user_passwd:1; /* user+password for the proxy? */
-  bit ipv6_ip:1; /* we communicate with a remote site specified with pure IPv6
-                    IP address */
-  bit ipv6:1;    /* we communicate with a site using an IPv6 address */
-  bit do_more:1; /* this is set TRUE if the ->curl_do_more() function is
-                    supposed to be called, after ->curl_do() */
-  bit protoconnstart:1;/* the protocol layer has STARTED its operation after
-                          the TCP layer connect */
-  bit retry:1;         /* this connection is about to get closed and then
-                          re-attempted at another connection. */
-  bit tunnel_proxy:1;  /* if CONNECT is used to "tunnel" through the proxy.
-                          This is implicit when SSL-protocols are used through
-                          proxies, but can also be enabled explicitly by
-                          apps */
-  bit authneg:1;       /* TRUE when the auth phase has started, which means
-                          that we are creating a request with an auth header,
-                          but it is not the final request in the auth
-                          negotiation. */
-  bit rewindaftersend:1;/* TRUE when the sending couldn't be stopped even
-                           though it will be discarded. When the whole send
-                           operation is done, we must call the data rewind
-                           callback. */
+  BIT(close); /* if set, we close the connection after this request */
+  BIT(reuse); /* if set, this is a re-used connection */
+  BIT(altused); /* this is an alt-svc "redirect" */
+  BIT(conn_to_host); /* if set, this connection has a "connect to host"
+                        that overrides the host in the URL */
+  BIT(conn_to_port); /* if set, this connection has a "connect to port"
+                        that overrides the port in the URL (remote port) */
+  BIT(proxy); /* if set, this transfer is done through a proxy - any type */
+  BIT(httpproxy);  /* if set, this transfer is done through a http proxy */
+  BIT(socksproxy); /* if set, this transfer is done through a socks proxy */
+  BIT(user_passwd); /* do we use user+password for this connection? */
+  BIT(proxy_user_passwd); /* user+password for the proxy? */
+  BIT(ipv6_ip); /* we communicate with a remote site specified with pure IPv6
+                   IP address */
+  BIT(ipv6);    /* we communicate with a site using an IPv6 address */
+  BIT(do_more); /* this is set TRUE if the ->curl_do_more() function is
+                   supposed to be called, after ->curl_do() */
+  BIT(protoconnstart);/* the protocol layer has STARTED its operation after
+                         the TCP layer connect */
+  BIT(retry);         /* this connection is about to get closed and then
+                         re-attempted at another connection. */
+  BIT(tunnel_proxy);  /* if CONNECT is used to "tunnel" through the proxy.
+                         This is implicit when SSL-protocols are used through
+                         proxies, but can also be enabled explicitly by
+                         apps */
+  BIT(authneg);       /* TRUE when the auth phase has started, which means
+                         that we are creating a request with an auth header,
+                         but it is not the final request in the auth
+                         negotiation. */
+  BIT(rewindaftersend);/* TRUE when the sending couldn't be stopped even
+                          though it will be discarded. When the whole send
+                          operation is done, we must call the data rewind
+                          callback. */
 #ifndef CURL_DISABLE_FTP
-  bit ftp_use_epsv:1;  /* As set with CURLOPT_FTP_USE_EPSV, but if we find out
-                          EPSV doesn't work we disable it for the forthcoming
-                          requests */
-  bit ftp_use_eprt:1;  /* As set with CURLOPT_FTP_USE_EPRT, but if we find out
-                          EPRT doesn't work we disable it for the forthcoming
-                          requests */
-  bit ftp_use_data_ssl:1; /* Enabled SSL for the data connection */
+  BIT(ftp_use_epsv);  /* As set with CURLOPT_FTP_USE_EPSV, but if we find out
+                         EPSV doesn't work we disable it for the forthcoming
+                         requests */
+  BIT(ftp_use_eprt);  /* As set with CURLOPT_FTP_USE_EPRT, but if we find out
+                         EPRT doesn't work we disable it for the forthcoming
+                         requests */
+  BIT(ftp_use_data_ssl); /* Enabled SSL for the data connection */
 #endif
-  bit netrc:1;         /* name+password provided by netrc */
-  bit userpwd_in_url:1; /* name+password found in url */
-  bit stream_was_rewound:1; /* The stream was rewound after a request read
-                               past the end of its response byte boundary */
-  bit proxy_connect_closed:1; /* TRUE if a proxy disconnected the connection
-                                 in a CONNECT request with auth, so that
-                                 libcurl should reconnect and continue. */
-  bit bound:1; /* set true if bind() has already been done on this socket/
-                  connection */
-  bit type_set:1;  /* type= was used in the URL */
-  bit multiplex:1; /* connection is multiplexed */
-  bit tcp_fastopen:1; /* use TCP Fast Open */
-  bit tls_enable_npn:1;  /* TLS NPN extension? */
-  bit tls_enable_alpn:1; /* TLS ALPN extension? */
-  bit socksproxy_connecting:1; /* connecting through a socks proxy */
-  bit connect_only:1;
+  BIT(netrc);         /* name+password provided by netrc */
+  BIT(userpwd_in_url); /* name+password found in url */
+  BIT(stream_was_rewound); /* The stream was rewound after a request read
+                              past the end of its response byte boundary */
+  BIT(proxy_connect_closed); /* TRUE if a proxy disconnected the connection
+                                in a CONNECT request with auth, so that
+                                libcurl should reconnect and continue. */
+  BIT(bound); /* set true if bind() has already been done on this socket/
+                 connection */
+  BIT(type_set);  /* type= was used in the URL */
+  BIT(multiplex); /* connection is multiplexed */
+  BIT(tcp_fastopen); /* use TCP Fast Open */
+  BIT(tls_enable_npn);  /* TLS NPN extension? */
+  BIT(tls_enable_alpn); /* TLS ALPN extension? */
+  BIT(socksproxy_connecting); /* connecting through a socks proxy */
+  BIT(connect_only);
 };
 
 struct hostname {
@@ -494,7 +499,7 @@ struct Curl_async {
   struct Curl_dns_entry *dns;
   int status; /* if done is TRUE, this is the status from the callback */
   void *os_specific;  /* 'struct thread_data' for Windows */
-  bit done:1;  /* set TRUE when the lookup is complete */
+  BIT(done);  /* set TRUE when the lookup is complete */
 };
 
 #define FIRSTSOCKET     0
@@ -777,8 +782,8 @@ struct http_connect_state {
     TUNNEL_CONNECT, /* CONNECT has been sent off */
     TUNNEL_COMPLETE /* CONNECT response received completely */
   } tunnel_state;
-  bit chunked_encoding:1;
-  bit close_connection:1;
+  BIT(chunked_encoding);
+  BIT(close_connection);
 };
 
 struct ldapconninfo;
@@ -953,7 +958,7 @@ struct connectdata {
   } allocptr;
 
 #ifdef HAVE_GSSAPI
-  bit sec_complete:1; /* if Kerberos is enabled for this connection */
+  BIT(sec_complete); /* if Kerberos is enabled for this connection */
   enum protection_level command_prot;
   enum protection_level data_prot;
   enum protection_level request_data_prot;
@@ -1046,16 +1051,16 @@ struct connectdata {
 
 #ifdef USE_UNIX_SOCKETS
   char *unix_domain_socket;
-  bit abstract_unix_socket:1;
+  BIT(abstract_unix_socket);
 #endif
-  bit tls_upgraded:1;
+  BIT(tls_upgraded);
   /* the two following *_inuse fields are only flags, not counters in any way.
      If TRUE it means the channel is in use, and if FALSE it means the channel
      is up for grabs by one. */
-  bit readchannel_inuse:1;  /* whether the read channel is in use by an easy
-                               handle */
-  bit writechannel_inuse:1; /* whether the write channel is in use by an easy
-                               handle */
+  BIT(readchannel_inuse);  /* whether the read channel is in use by an easy
+                              handle */
+  BIT(writechannel_inuse); /* whether the write channel is in use by an easy
+                              handle */
 };
 
 /* The end of connectdata. */
@@ -1097,8 +1102,8 @@ struct PureInfo {
                                  OpenSSL, GnuTLS, Schannel, NSS and GSKit
                                  builds. Asked for with CURLOPT_CERTINFO
                                  / CURLINFO_CERTINFO */
-  bit timecond:1;  /* set to TRUE if the time condition didn't match, which
-                      thus made the document NOT get fetched */
+  BIT(timecond);  /* set to TRUE if the time condition didn't match, which
+                     thus made the document NOT get fetched */
 };
 
 
@@ -1145,8 +1150,8 @@ struct Progress {
   curl_off_t speeder[ CURR_TIME ];
   struct curltime speeder_time[ CURR_TIME ];
   int speeder_c;
-  bit callback:1;  /* set when progress callback is used */
-  bit is_t_startransfer_set:1;
+  BIT(callback);  /* set when progress callback is used */
+  BIT(is_t_startransfer_set);
 };
 
 typedef enum {
@@ -1194,12 +1199,12 @@ struct auth {
   unsigned long picked;
   unsigned long avail; /* Bitmask for what the server reports to support for
                           this resource */
-  bit done:1;  /* TRUE when the auth phase is done and ready to do the
-                 *actual* request */
-  bit multipass:1; /* TRUE if this is not yet authenticated but within the
-                       auth multipass negotiation */
-  bit iestyle:1; /* TRUE if digest should be done IE-style or FALSE if it
-                     should be RFC compliant */
+  BIT(done);  /* TRUE when the auth phase is done and ready to do the
+                 actual request */
+  BIT(multipass); /* TRUE if this is not yet authenticated but within the
+                     auth multipass negotiation */
+  BIT(iestyle); /* TRUE if digest should be done IE-style or FALSE if it
+                   should be RFC compliant */
 };
 
 struct Curl_http2_dep {
@@ -1329,7 +1334,7 @@ struct UrlState {
 /* do FTP line-end conversions on most platforms */
 #define CURL_DO_LINEEND_CONV
   /* for FTP downloads: track CRLF sequences that span blocks */
-  bit prev_block_had_trailing_cr:1;
+  BIT(prev_block_had_trailing_cr);
   /* for FTP downloads: how many CRLFs did we converted to LFs? */
   curl_off_t crlf_conversions;
 #endif
@@ -1364,32 +1369,32 @@ struct UrlState {
   trailers_state trailers_state; /* whether we are sending trailers
                                        and what stage are we at */
 #ifdef CURLDEBUG
-  bit conncache_lock:1;
+  BIT(conncache_lock);
 #endif
   /* when curl_easy_perform() is called, the multi handle is "owned" by
      the easy handle so curl_easy_cleanup() on such an easy handle will
      also close the multi handle! */
-  bit multi_owned_by_easy:1;
+  BIT(multi_owned_by_easy);
 
-  bit this_is_a_follow:1; /* this is a followed Location: request */
-  bit refused_stream:1; /* this was refused, try again */
-  bit errorbuf:1; /* Set to TRUE if the error buffer is already filled in.
+  BIT(this_is_a_follow); /* this is a followed Location: request */
+  BIT(refused_stream); /* this was refused, try again */
+  BIT(errorbuf); /* Set to TRUE if the error buffer is already filled in.
                     This must be set to FALSE every time _easy_perform() is
                     called. */
-  bit allow_port:1; /* Is set.use_port allowed to take effect or not. This
+  BIT(allow_port); /* Is set.use_port allowed to take effect or not. This
                       is always set TRUE when curl_easy_perform() is called. */
-  bit authproblem:1; /* TRUE if there's some problem authenticating */
+  BIT(authproblem); /* TRUE if there's some problem authenticating */
   /* set after initial USER failure, to prevent an authentication loop */
-  bit ftp_trying_alternative:1;
-  bit wildcardmatch:1; /* enable wildcard matching */
-  bit expect100header:1;  /* TRUE if we added Expect: 100-continue */
-  bit use_range:1;
-  bit rangestringalloc:1; /* the range string is malloc()'ed */
-  bit done:1; /* set to FALSE when Curl_init_do() is called and set to TRUE
+  BIT(ftp_trying_alternative);
+  BIT(wildcardmatch); /* enable wildcard matching */
+  BIT(expect100header);  /* TRUE if we added Expect: 100-continue */
+  BIT(use_range);
+  BIT(rangestringalloc); /* the range string is malloc()'ed */
+  BIT(done); /* set to FALSE when Curl_init_do() is called and set to TRUE
                   when multi_done() is called, to prevent multi_done() to get
                   invoked twice when the multi interface is used. */
-  bit stream_depends_e:1; /* set or don't set the Exclusive bit */
-  bit previouslypending:1; /* this transfer WAS in the multi->pending queue */
+  BIT(stream_depends_e); /* set or don't set the Exclusive bit */
+  BIT(previouslypending); /* this transfer WAS in the multi->pending queue */
 };
 
 
@@ -1407,9 +1412,9 @@ struct DynamicStatic {
                                     curl_easy_setopt(COOKIEFILE) calls */
   struct curl_slist *resolve; /* set to point to the set.resolve list when
                                  this should be dealt with in pretransfer */
-  bit url_alloc:1;   /* URL string is malloc()'ed */
-  bit referer_alloc:1; /* referer string is malloc()ed */
-  bit wildcard_resolve:1; /* Set to true if any resolve change is a
+  BIT(url_alloc);   /* URL string is malloc()'ed */
+  BIT(referer_alloc); /* referer string is malloc()ed */
+  BIT(wildcard_resolve); /* Set to true if any resolve change is a
                               wildcard */
 };
 
@@ -1689,84 +1694,82 @@ struct UserDefined {
   CURLU *uh; /* URL handle for the current parsed URL */
   void *trailer_data; /* pointer to pass to trailer data callback */
   curl_trailer_callback trailer_callback; /* trailing data callback */
-  bit is_fread_set:1; /* has read callback been set to non-NULL? */
-  bit is_fwrite_set:1; /* has write callback been set to non-NULL? */
-  bit free_referer:1; /* set TRUE if 'referer' points to a string we
+  BIT(is_fread_set); /* has read callback been set to non-NULL? */
+  BIT(is_fwrite_set); /* has write callback been set to non-NULL? */
+  BIT(free_referer); /* set TRUE if 'referer' points to a string we
                         allocated */
-  bit tftp_no_options:1; /* do not send TFTP options requests */
-  bit sep_headers:1;     /* handle host and proxy headers separately */
-  bit cookiesession:1;   /* new cookie session? */
-  bit crlf:1;            /* convert crlf on ftp upload(?) */
-  bit strip_path_slash:1; /* strip off initial slash from path */
-  bit ssh_compression:1;            /* enable SSH compression */
+  BIT(tftp_no_options); /* do not send TFTP options requests */
+  BIT(sep_headers);     /* handle host and proxy headers separately */
+  BIT(cookiesession);   /* new cookie session? */
+  BIT(crlf);            /* convert crlf on ftp upload(?) */
+  BIT(strip_path_slash); /* strip off initial slash from path */
+  BIT(ssh_compression);            /* enable SSH compression */
 
 /* Here follows boolean settings that define how to behave during
    this session. They are STATIC, set by libcurl users or at least initially
    and they don't change during operations. */
-  bit get_filetime:1;     /* get the time and get of the remote file */
-  bit tunnel_thru_httpproxy:1; /* use CONNECT through a HTTP proxy */
-  bit prefer_ascii:1;     /* ASCII rather than binary */
-  bit ftp_append:1;       /* append, not overwrite, on upload */
-  bit ftp_list_only:1;    /* switch FTP command for listing directories */
+  BIT(get_filetime);     /* get the time and get of the remote file */
+  BIT(tunnel_thru_httpproxy); /* use CONNECT through a HTTP proxy */
+  BIT(prefer_ascii);     /* ASCII rather than binary */
+  BIT(ftp_append);       /* append, not overwrite, on upload */
+  BIT(ftp_list_only);    /* switch FTP command for listing directories */
 #ifndef CURL_DISABLE_FTP
-  bit ftp_use_port:1;     /* use the FTP PORT command */
-  bit ftp_use_epsv:1;   /* if EPSV is to be attempted or not */
-  bit ftp_use_eprt:1;   /* if EPRT is to be attempted or not */
-  bit ftp_use_pret:1;   /* if PRET is to be used before PASV or not */
-  bit ftp_skip_ip:1;    /* skip the IP address the FTP server passes on to
+  BIT(ftp_use_port);     /* use the FTP PORT command */
+  BIT(ftp_use_epsv);     /* if EPSV is to be attempted or not */
+  BIT(ftp_use_eprt);     /* if EPRT is to be attempted or not */
+  BIT(ftp_use_pret);     /* if PRET is to be used before PASV or not */
+  BIT(ftp_skip_ip);      /* skip the IP address the FTP server passes on to
                             us */
 #endif
-  bit hide_progress:1;    /* don't use the progress meter */
-  bit http_fail_on_error:1;  /* fail on HTTP error codes >= 400 */
-  bit http_keep_sending_on_error:1; /* for HTTP status codes >= 300 */
-  bit http_follow_location:1; /* follow HTTP redirects */
-  bit http_transfer_encoding:1; /* request compressed HTTP
-                                    transfer-encoding */
-  bit allow_auth_to_other_hosts:1;
-  bit include_header:1; /* include received protocol headers in data output */
-  bit http_set_referer:1; /* is a custom referer used */
-  bit http_auto_referer:1; /* set "correct" referer when following
-                               location: */
-  bit opt_no_body:1;    /* as set with CURLOPT_NOBODY */
-  bit upload:1;         /* upload request */
-  bit verbose:1;        /* output verbosity */
-  bit krb:1;            /* Kerberos connection requested */
-  bit reuse_forbid:1;   /* forbidden to be reused, close after use */
-  bit reuse_fresh:1;    /* do not re-use an existing connection  */
-
-  bit no_signal:1;      /* do not use any signal/alarm handler */
-  bit tcp_nodelay:1;    /* whether to enable TCP_NODELAY or not */
-  bit ignorecl:1;       /* ignore content length */
-  bit connect_only:1;   /* make connection, let application use the socket */
-  bit http_te_skip:1;   /* pass the raw body data to the user, even when
-                            transfer-encoded (chunked, compressed) */
-  bit http_ce_skip:1;   /* pass the raw body data to the user, even when
-                            content-encoded (chunked, compressed) */
-  bit proxy_transfer_mode:1; /* set transfer mode (;type=<a|i>) when doing
-                                 FTP via an HTTP proxy */
+  BIT(hide_progress);    /* don't use the progress meter */
+  BIT(http_fail_on_error);  /* fail on HTTP error codes >= 400 */
+  BIT(http_keep_sending_on_error); /* for HTTP status codes >= 300 */
+  BIT(http_follow_location); /* follow HTTP redirects */
+  BIT(http_transfer_encoding); /* request compressed HTTP transfer-encoding */
+  BIT(allow_auth_to_other_hosts);
+  BIT(include_header); /* include received protocol headers in data output */
+  BIT(http_set_referer); /* is a custom referer used */
+  BIT(http_auto_referer); /* set "correct" referer when following
+                             location: */
+  BIT(opt_no_body);    /* as set with CURLOPT_NOBODY */
+  BIT(upload);         /* upload request */
+  BIT(verbose);        /* output verbosity */
+  BIT(krb);            /* Kerberos connection requested */
+  BIT(reuse_forbid);   /* forbidden to be reused, close after use */
+  BIT(reuse_fresh);    /* do not re-use an existing connection  */
+  BIT(no_signal);      /* do not use any signal/alarm handler */
+  BIT(tcp_nodelay);    /* whether to enable TCP_NODELAY or not */
+  BIT(ignorecl);       /* ignore content length */
+  BIT(connect_only);   /* make connection, let application use the socket */
+  BIT(http_te_skip);   /* pass the raw body data to the user, even when
+                          transfer-encoded (chunked, compressed) */
+  BIT(http_ce_skip);   /* pass the raw body data to the user, even when
+                          content-encoded (chunked, compressed) */
+  BIT(proxy_transfer_mode); /* set transfer mode (;type=<a|i>) when doing
+                               FTP via an HTTP proxy */
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
-  bit socks5_gssapi_nec:1; /* Flag to support NEC SOCKS5 server */
+  BIT(socks5_gssapi_nec); /* Flag to support NEC SOCKS5 server */
 #endif
-  bit sasl_ir:1;         /* Enable/disable SASL initial response */
-  bit wildcard_enabled:1; /* enable wildcard matching */
-  bit tcp_keepalive:1;  /* use TCP keepalives */
-  bit tcp_fastopen:1;   /* use TCP Fast Open */
-  bit ssl_enable_npn:1; /* TLS NPN extension? */
-  bit ssl_enable_alpn:1;/* TLS ALPN extension? */
-  bit path_as_is:1;     /* allow dotdots? */
-  bit pipewait:1;       /* wait for multiplex status before starting a new
-                           connection */
-  bit suppress_connect_headers:1; /* suppress proxy CONNECT response headers
-                                      from user callbacks */
-  bit dns_shuffle_addresses:1; /* whether to shuffle addresses before use */
-  bit stream_depends_e:1; /* set or don't set the Exclusive bit */
-  bit haproxyprotocol:1; /* whether to send HAProxy PROXY protocol v1
-                             header */
-  bit abstract_unix_socket:1;
-  bit disallow_username_in_url:1; /* disallow username in url */
-  bit doh:1; /* DNS-over-HTTPS enabled */
-  bit doh_get:1; /* use GET for DoH requests, instead of POST */
-  bit http09_allowed:1; /* allow HTTP/0.9 responses */
+  BIT(sasl_ir);         /* Enable/disable SASL initial response */
+  BIT(wildcard_enabled); /* enable wildcard matching */
+  BIT(tcp_keepalive);  /* use TCP keepalives */
+  BIT(tcp_fastopen);   /* use TCP Fast Open */
+  BIT(ssl_enable_npn); /* TLS NPN extension? */
+  BIT(ssl_enable_alpn);/* TLS ALPN extension? */
+  BIT(path_as_is);     /* allow dotdots? */
+  BIT(pipewait);       /* wait for multiplex status before starting a new
+                          connection */
+  BIT(suppress_connect_headers); /* suppress proxy CONNECT response headers
+                                    from user callbacks */
+  BIT(dns_shuffle_addresses); /* whether to shuffle addresses before use */
+  BIT(stream_depends_e); /* set or don't set the Exclusive bit */
+  BIT(haproxyprotocol); /* whether to send HAProxy PROXY protocol v1
+                           header */
+  BIT(abstract_unix_socket);
+  BIT(disallow_username_in_url); /* disallow username in url */
+  BIT(doh); /* DNS-over-HTTPS enabled */
+  BIT(doh_get); /* use GET for DoH requests, instead of POST */
+  BIT(http09_allowed); /* allow HTTP/0.9 responses */
 };
 
 struct Names {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -620,20 +620,20 @@ struct SingleRequest {
 #ifndef CURL_DISABLE_DOH
   struct dohdata doh; /* DoH specific data for this request */
 #endif
-  bit header:1;       /* incoming data has HTTP header */
-  bit content_range:1; /* set TRUE if Content-Range: was found */
-  bit upload_done:1;  /* set to TRUE when doing chunked transfer-encoding
-                         upload and we're uploading the last chunk */
-  bit ignorebody:1;   /* we read a response-body but we ignore it! */
-  bit http_bodyless:1; /* HTTP response status code is between 100 and 199,
-                          204 or 304 */
-  bit chunk:1; /* if set, this is a chunked transfer-encoding */
-  bit upload_chunky:1; /* set TRUE if we are doing chunked transfer-encoding
-                          on upload */
-  bit getheader:1;    /* TRUE if header parsing is wanted */
-  bit forbidchunk:1;  /* used only to explicitly forbid chunk-upload for
-                         specific upload buffers. See readmoredata() in http.c
-                         for details. */
+  BIT(header);       /* incoming data has HTTP header */
+  BIT(content_range); /* set TRUE if Content-Range: was found */
+  BIT(upload_done);  /* set to TRUE when doing chunked transfer-encoding
+                        upload and we're uploading the last chunk */
+  BIT(ignorebody);   /* we read a response-body but we ignore it! */
+  BIT(http_bodyless); /* HTTP response status code is between 100 and 199,
+                         204 or 304 */
+  BIT(chunk); /* if set, this is a chunked transfer-encoding */
+  BIT(upload_chunky); /* set TRUE if we are doing chunked transfer-encoding
+                         on upload */
+  BIT(getheader);    /* TRUE if header parsing is wanted */
+  BIT(forbidchunk);  /* used only to explicitly forbid chunk-upload for
+                        specific upload buffers. See readmoredata() in http.c
+                        for details. */
 };
 
 /*

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -159,6 +159,7 @@ typedef ssize_t (Curl_recv)(struct connectdata *conn, /* connection data */
 
 /* the type we use for storing a single boolean bit */
 #ifdef _MSC_VER
+typedef bool bit;
 #define BIT(x) bool x
 #else
 typedef unsigned int bit;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -158,7 +158,7 @@ typedef ssize_t (Curl_recv)(struct connectdata *conn, /* connection data */
   ((x) && ((x)->magic == CURLEASY_MAGIC_NUMBER))
 
 /* the type we use for storing a single boolean bit */
-#ifdef _MSV_VER
+#ifdef _MSC_VER
 #define BIT(x) bool x
 #else
 typedef unsigned int bit;


### PR DESCRIPTION
Try making the 'bit' type as a plain 'bool' when building with VS.

This PR branch also has the VS2019 commit from #4383 so that we can see if it actually changes the compiler's view of things.

This is an alternative fix to what's in #4379 