### PR TITLE
urlapi: avoid index underflow for short ipv6 hostnames

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -598,6 +598,8 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname)
   if(hostname[0] == '[') {
     char dest[16]; /* fits a binary IPv6 address */
     const char *l = "0123456789abcdefABCDEF:.";
+    if(hlen <= 2)
+      return CURLUE_MALFORMED_INPUT;
     hostname++;
     hlen -= 2;
 


### PR DESCRIPTION
See https://github.com/curl/curl/blob/a89aeb54519b3b20d093f0d0b0e650344dc399fd/lib/urlapi.c#L596-L604
If the input hostname is "[",
hlen will underflow to max of size_t when it is subtracted with 2 at line 602.

hostname[hlen] at line 604 will then cause a warning by ubsanitizer:

runtime error: addition of unsigned offset to 0x........ overflowed to 0x............

I think that in practice, the generated code will work, and the output
of hostname[hlen] will be the first character "[".

This can be demonstrated by the following program (tested in both clang and gcc,
with -O3)

#include <string.h>
#include <stdlib.h>
#include <stdio.h>
int main() {
  char* hostname=strdup("[");
  size_t hlen = strlen(hostname);

  hlen-=2;
  hostname++;
  printf("character is %d\n",+hostname[hlen]);
  free(hostname-1);
}


I found this through fuzzing, and even if it seems harmless, the proper
thing is to return early with an error.