### PR TITLE
curl: exit the create_transfers loop on errors

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1885,15 +1885,9 @@ static CURLcode create_transfers(struct GlobalConfig *global,
         urls = NULL;
       }
 
-      if(infilenum > 1) {
-        /* when file globbing, exit loop upon critical error */
-        if(is_fatal_error(result))
-          break;
-      }
-      else if(result)
-        /* when not file globbing, exit loop upon any error */
+      if(result)
+        /* exit loop upon error */
         break;
-
     } /* loop to the next globbed upload file */
 
     /* Free loop-local allocated memory */
@@ -1913,6 +1907,9 @@ static CURLcode create_transfers(struct GlobalConfig *global,
     Curl_safefree(urlnode->infile);
     urlnode->flags = 0;
 
+    if(result)
+      /* exit loop upon error */
+      break;
   } /* for-loop through all URLs */
   quit_curl:
 


### PR DESCRIPTION
When looping around the ranges and given URLs to create transfers, all
errors should exit the loop and return. Previously it would keep
looping.

Reported-by: SumatraPeter on github
Bug: #4393