### PR TITLE
winbuild: Fix manifest embedding for proper OS version querying

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -393,11 +393,11 @@ CFGSET = true
 !IF "$(DEBUG)"=="yes"
 RC_FLAGS = /dDEBUGBUILD=1 /Fo $@ $(LIBCURL_SRC_DIR)\libcurl.rc
 CURL_CC       = $(CC_DEBUG) $(RTLIB_DEBUG)
-CURL_RC_FLAGS = /i../include /dDEBUGBUILD=1 /Fo $@ $(CURL_SRC_DIR)\curl.rc
+CURL_RC_FLAGS = $(CURL_RC_FLAGS) /i../include /dDEBUGBUILD=1 /Fo $@ $(CURL_SRC_DIR)\curl.rc
 !ELSE
 RC_FLAGS = /dDEBUGBUILD=0 /Fo $@ $(LIBCURL_SRC_DIR)\libcurl.rc
 CURL_CC       = $(CC_NODEBUG) $(RTLIB)
-CURL_RC_FLAGS = /i../include /dDEBUGBUILD=0 /Fo $@ $(CURL_SRC_DIR)\curl.rc
+CURL_RC_FLAGS = $(CURL_RC_FLAGS) /i../include /dDEBUGBUILD=0 /Fo $@ $(CURL_SRC_DIR)\curl.rc
 !ENDIF
 
 !IF "$(AS_DLL)" == "true"


### PR DESCRIPTION
I believe this will fix #4391. I don't have nghttp built on this machine to test with, so I cannot be sure. I can verify that building without this fix results in no manifest in the exe, and there is a manifest after this change. Without a manifest the OS version checks in the SChannel code will not be correct, and libcurl will not attempt to use ALPN in the TLS handshake.

This fixes commit ebd213270a017a6830928ee2e1f4a9cabc799898 in pull request #1221. That commit added the CURL_EMBED_MANIFEST flag to CURL_RC_FLAGS (line 361). However, later in the file CURL_RC_FLAGS is overwritten. The fix is to append values to CURL_RC_FLAGS instead of overwriting.