### PR TITLE
travis: use go stable, (second try)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,11 @@ matrix:
         - os: linux
           compiler: gcc
           dist: xenial
+          before_install:
+              # Install and use the current stable release of Go
+              - gimme --list
+              - eval "$(gimme stable)"
+              - gimme --list
           env:
               - T=novalgrind BORINGSSL=yes C="--with-ssl=$HOME/boringssl" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
@@ -99,6 +104,11 @@ matrix:
         - os: linux
           compiler: gcc
           dist: xenial
+          before_install:
+              # Install and use the current stable release of Go
+              - gimme --list
+              - eval "$(gimme stable)"
+              - gimme --list
           env:
               - T=novalgrind BORINGSSL=yes QUICHE="yes" C="--with-ssl=$HOME/boringssl --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=/home/travis/boringssl/lib:$HOME/quiche/target/release:/usr/local/lib
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
@@ -411,10 +421,6 @@ matrix:
 before_install:
     - eval "${OVERRIDE_CC}"
     - eval "${OVERRIDE_CXX}"
-    # Install and use the current stable release of Go
-    - gimme --list
-    - eval "$(gimme stable)"
-    - gimme --list
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi

--- a/lib/url.c
+++ b/lib/url.c
@@ -1874,7 +1874,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     /* this is for file:// transfers, get a dummy made */
     hostname = (char *)"";
 
-  if(hostname[0] == '[') {
+  else if(hostname[0] == '[') {
     /* This looks like an IPv6 address literal. See if there is an address
        scope. */
     size_t hlen;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1870,11 +1870,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   (void)curl_url_get(uh, CURLUPART_QUERY, &data->state.up.query, 0);
 
   hostname = data->state.up.hostname;
-  if(!hostname)
-    /* this is for file:// transfers, get a dummy made */
-    hostname = (char *)"";
-
-  else if(hostname[0] == '[') {
+  if(hostname && hostname[0] == '[') {
     /* This looks like an IPv6 address literal. See if there is an address
        scope. */
     size_t hlen;
@@ -1888,7 +1884,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   }
 
   /* make sure the connect struct gets its own copy of the host name */
-  conn->host.rawalloc = strdup(hostname);
+  conn->host.rawalloc = strdup(hostname ? hostname : "");
   if(!conn->host.rawalloc)
     return CURLE_OUT_OF_MEMORY;
   conn->host.name = conn->host.rawalloc;


### PR DESCRIPTION
Mac builds have been failing since 52db0b8 was added to use go stable in all builds. Based on the failures it looks like gimme is not available in Mac images? I've written support to find out but also I'd like to see if it's possible to limit getting go latest stable to just the boringssl builds.

Ref: https://github.com/curl/curl/pull/4361