### PR TITLE
doh: restrict opertion to HTTP|HTTPS on debug builds

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -258,7 +258,10 @@ static CURLcode dohprobe(struct Curl_easy *data,
 #ifdef USE_NGHTTP2
     ERROR_CHECK_SETOPT(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
 #endif
-#ifndef CURLDEBUG
+#ifdef CURLDEBUG
+    /* allow plain HTTP in debug builds */
+    ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
+#else
     /* enforce HTTPS if not debug */
     ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
 #endif


### PR DESCRIPTION
... as allowing all URL schemes causes problems with the fuzzer.

Reported-by: Paul Dreik
Bug: https://curl.haxx.se/mail/lib-2019-09/0091.html