### PR TITLE
doh: respect timeout and restrict debug builds to http and https

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -264,6 +264,9 @@ static CURLcode dohprobe(struct Curl_easy *data,
 #ifndef CURLDEBUG
     /* enforce HTTPS if not debug */
     ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+#else
+    /* in debug mode, also allow http */
+    ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 #endif
     ERROR_CHECK_SETOPT(CURLOPT_TIMEOUT_MS, (long)timeout_ms);
     if(data->set.verbose)

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -240,7 +240,10 @@ static CURLcode dohprobe(struct Curl_easy *data,
   }
 
   timeout_ms = Curl_timeleft(data, NULL, TRUE);
-
+  if(timeout_ms <= 0) {
+    result = CURLE_OPERATION_TIMEDOUT;
+    goto error;
+  }
   /* Curl_open() is the internal version of curl_easy_init() */
   result = Curl_open(&doh);
   if(!result) {


### PR DESCRIPTION
doh did not time out properly. This change makes it return early with CURLE_OPERATION_TIMEDOUT.

In debug builds, doh could be configured to use any protocol, which lead to it trying to do doh over pop3 when the http fuzzer was running. It is now restricted to http and https.