### PR TITLE
urlapi: question mark within fragment is still fragment

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -849,13 +849,13 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
   if(junkscan(path))
     return CURLUE_MALFORMED_INPUT;
 
+  fragment = strchr(path, '#');
+  if(fragment)
+    *fragment++ = 0;
+
   query = strchr(path, '?');
   if(query)
     *query++ = 0;
-
-  fragment = strchr(query?query:path, '#');
-  if(fragment)
-    *fragment++ = 0;
 
   if(!path[0])
     /* if there's no path set, unset */

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -140,6 +140,26 @@ static struct testcase get_parts_list[] ={
    "file | [11] | [12] | [13] | [14] | [15] | C:\\programs\\foo | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
 #endif
+  {"https://example.com/color/#green?no-black",
+   "https | [11] | [12] | [13] | example.com | [15] | /color/ | [16] | "
+   "green?no-black",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
+  {"https://example.com/color/#green#no-black",
+   "https | [11] | [12] | [13] | example.com | [15] | /color/ | [16] | "
+   "green#no-black",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
+  {"https://example.com/color/?green#no-black",
+   "https | [11] | [12] | [13] | example.com | [15] | /color/ | green | "
+   "no-black",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
+  {"https://example.com/#color/?green#no-black",
+   "https | [11] | [12] | [13] | example.com | [15] | / | [16] | "
+   "color/?green#no-black",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
+  {"https://example.#com/color/?green#no-black",
+   "https | [11] | [12] | [13] | example. | [15] | / | [16] | "
+   "com/color/?green#no-black",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
   {"http://[ab.be:1]/x", "",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_MALFORMED_INPUT},
   {"http://[ab.be]/x", "",


### PR DESCRIPTION
The parser would check for a query part before fragment, which caused it
to do wrong when the fragment contains a question mark.

Extended test 1560 to verify.

Reported-by: Alex Konev
Fixes #4412