### PR TITLE
tests: fix narrowing conversion warnings

### DIFF
--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -68,7 +68,7 @@ struct timetest {
   int timeout_ms;
   int connecttimeout_ms;
   bool connecting;
-  time_t result;
+  timediff_t result;
   const char *comment;
 };
 
@@ -138,7 +138,7 @@ UNITTEST_START
   data->progress.t_startop.tv_usec = 0;
 
   for(i = 0; i < sizeof(run)/sizeof(run[0]); i++) {
-    time_t timeout;
+    timediff_t timeout;
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
     timeout =  Curl_timeleft(data, &now, run[i].connecting);

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -50,7 +50,7 @@ static void fake_t_startsingle_time(struct Curl_easy *data,
   data->progress.t_startsingle.tv_usec = fake_now.tv_usec;
 }
 
-static bool usec_matches_seconds(time_t time_usec, int expected_seconds)
+static bool usec_matches_seconds(timediff_t time_usec, int expected_seconds)
 {
   int time_sec = (int)(time_usec / usec_magnitude);
   bool same = (time_sec == expected_seconds);


### PR DESCRIPTION
`timediff_t` is 64 bits wide also on 32-bit systems since
commit b1616dad8f0.