### PR TITLE
FTP: tests for https://github.com/curl/curl/pull/4382

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -83,7 +83,7 @@ test617 test618 test619 test620 test621 test622 test623 test624 test625 \
 test626 test627 test628 test629 test630 test631 test632 test633 test634 \
 test635 test636 test637 test638 test639 test640 test641 test642 \
 test643 test644 test645 test646 test647 test648 test649 test650 test651 \
-test652 test653 test654 test655 test656 test658 test659 test660 \
+test652 test653 test654 test655 test656 test658 test659 test660 test661 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test661
+++ b/tests/data/test661
@@ -1,0 +1,73 @@
+<testcase>
+<info>
+<keywords>
+FTP
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib661
+</tool>
+
+ <name>
+Avoid redundant CWDs
+ </name>
+ <command>
+ftp://%HOSTIP:%FTPPORT/
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+CWD /folderA
+EPSV
+TYPE I
+RETR 661
+CWD /folderB
+EPSV
+RETR 661
+QUIT
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+TYPE I
+RETR /folderA/661
+CWD /folderB
+EPSV
+RETR 661
+EPSV
+RETR /folderA/661
+QUIT
+USER anonymous
+PASS ftp@example.com
+PWD
+SYST
+QUIT
+USER anonymous
+PASS ftp@example.com
+PWD
+SYST
+SYST
+QUIT
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -22,7 +22,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib571 lib572 lib573 lib574 lib575 lib576        lib578 lib579 lib582   \
  lib583 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598 lib599   \
  lib643 lib644 lib645 lib650 lib651 lib652 lib653 lib654 lib655 lib658   \
- lib659 \
+ lib659 lib661 \
  lib1156 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
@@ -344,6 +344,9 @@ lib658_CPPFLAGS = $(AM_CPPFLAGS)
 lib659_SOURCES = lib659.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib659_LDADD = $(TESTUTIL_LIBS)
 lib659_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib661_SOURCES = lib661.c $(SUPPORTFILES)
+lib661_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1500_SOURCES = lib1500.c $(SUPPORTFILES) $(TESTUTIL)
 lib1500_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -1,0 +1,149 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+   CURLcode res;
+   CURL *curl = NULL;
+   char *newURL = NULL;
+   struct curl_slist *slist = NULL;
+
+   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+     fprintf(stderr, "curl_global_init() failed\n");
+     return TEST_ERR_MAJOR_BAD;
+   }
+
+   curl = curl_easy_init();
+   if(!curl) {
+     fprintf(stderr, "curl_easy_init() failed\n");
+     res = TEST_ERR_MAJOR_BAD;
+     goto test_cleanup;
+   }
+
+   /* test: CURLFTPMETHOD_SINGLECWD with absolute path should
+            skip CWD to entry path */
+   newURL = aprintf("%s/folderA/661", URL);
+   test_setopt(curl, CURLOPT_URL, newURL);
+   test_setopt(curl, CURLOPT_VERBOSE, 1L);
+   test_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_SINGLECWD);
+   res = curl_easy_perform(curl);
+
+   free(newURL);
+   newURL = aprintf("%s/folderB/661", URL);
+   test_setopt(curl, CURLOPT_URL, newURL);
+   res = curl_easy_perform(curl);
+   
+   /* test: CURLFTPMETHOD_NOCWD with absolute path should 
+      never emit CWD (for both new and reused easy handle) */
+   curl_easy_cleanup(curl);
+   curl = curl_easy_init();
+   if(!curl) {
+     fprintf(stderr, "curl_easy_init() failed\n");
+     res = TEST_ERR_MAJOR_BAD;
+     goto test_cleanup;
+   }
+
+   free(newURL);
+   newURL = aprintf("%s/folderA/661", URL);
+   test_setopt(curl, CURLOPT_URL, newURL);
+   test_setopt(curl, CURLOPT_VERBOSE, 1L);
+   test_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_NOCWD);
+   res = curl_easy_perform(curl);
+
+   free(newURL);
+   newURL = aprintf("%s/folderB/661", URL);
+   test_setopt(curl, CURLOPT_URL, newURL);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_SINGLECWD);
+   res = curl_easy_perform(curl);
+
+   free(newURL);
+   newURL = aprintf("%s/folderA/661", URL);
+   test_setopt(curl, CURLOPT_URL, newURL);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_NOCWD);
+   res = curl_easy_perform(curl);
+
+   /* test: CURLFTPMETHOD_NOCWD with home-relative path should
+      not emit CWD for first FTP access after login */
+   curl_easy_cleanup(curl);
+   curl = curl_easy_init();
+   if(!curl) {
+     fprintf(stderr, "curl_easy_init() failed\n");
+     res = TEST_ERR_MAJOR_BAD;
+     goto test_cleanup;
+   }
+
+   slist = curl_slist_append(NULL, "SYST");
+   if(slist == NULL) {
+     fprintf(stderr, "curl_slist_append() failed\n");
+     res = TEST_ERR_MAJOR_BAD;
+     goto test_cleanup;
+   }
+
+   test_setopt(curl, CURLOPT_URL, URL);
+   test_setopt(curl, CURLOPT_VERBOSE, 1L);
+   test_setopt(curl, CURLOPT_NOBODY, 1L);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_NOCWD);
+   test_setopt(curl, CURLOPT_QUOTE, slist);
+   res = curl_easy_perform(curl);
+
+   /* test: CURLFTPMETHOD_SINGLECWD with home-relative path should
+      not emit CWD for first FTP access after login */
+   curl_easy_cleanup(curl);
+   curl = curl_easy_init();
+   if(!curl) {
+     fprintf(stderr, "curl_easy_init() failed\n");
+     res = TEST_ERR_MAJOR_BAD;
+     goto test_cleanup;
+   }
+
+   test_setopt(curl, CURLOPT_URL, URL);
+   test_setopt(curl, CURLOPT_VERBOSE, 1L);
+   test_setopt(curl, CURLOPT_NOBODY, 1L);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_SINGLECWD);
+   test_setopt(curl, CURLOPT_QUOTE, slist);
+   res = curl_easy_perform(curl);
+
+   /* test: CURLFTPMETHOD_NOCWD with home-relative path should
+      not emit CWD for second FTP access when not needed +
+      bonus: see if path buffering survives curl_easy_reset() */
+   curl_easy_reset(curl);
+   test_setopt(curl, CURLOPT_URL, URL);
+   test_setopt(curl, CURLOPT_VERBOSE, 1L);
+   test_setopt(curl, CURLOPT_NOBODY, 1L);
+   test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_NOCWD);
+   test_setopt(curl, CURLOPT_QUOTE, slist);
+   res = curl_easy_perform(curl);
+
+
+test_cleanup:
+
+   curl_slist_free_all(slist);
+   free(newURL);
+   curl_easy_cleanup(curl);
+   curl_global_cleanup();
+
+   return (int)res;
+}

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -73,6 +73,7 @@ int test(char *URL)
    test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_NOCWD);
    res = curl_easy_perform(curl);
 
+   /* curve ball: CWD /folderB before reusing connection with _NOCWD */
    free(newURL);
    newURL = aprintf("%s/folderB/661", URL);
    test_setopt(curl, CURLOPT_URL, newURL);

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -54,8 +54,8 @@ int test(char *URL)
    newURL = aprintf("%s/folderB/661", URL);
    test_setopt(curl, CURLOPT_URL, newURL);
    res = curl_easy_perform(curl);
-   
-   /* test: CURLFTPMETHOD_NOCWD with absolute path should 
+
+   /* test: CURLFTPMETHOD_NOCWD with absolute path should
       never emit CWD (for both new and reused easy handle) */
    curl_easy_cleanup(curl);
    curl = curl_easy_init();


### PR DESCRIPTION
Hi,

here is a test covering all the changes of https://github.com/curl/curl/pull/4382
and also my first libcurl test, so I hope this one works out.

In short, these are the tests:
________________________________________________________________

CURLFTPMETHOD_SINGLECWD ftp://server.com//folderA
CURLFTPMETHOD_SINGLECWD ftp://server.com//folderB
=> emit exactly 2 CWD for absolute-path accesses
________________________________________________________________

CURLFTPMETHOD_NOCWD     ftp://server.com//folderA
CURLFTPMETHOD_SINGLECWD ftp://server.com//folderB
CURLFTPMETHOD_NOCWD     ftp://server.com//folderA
=> only one CWD for CURLFTPMETHOD_SINGLECWD, no CWD for the other absolute-path accesses
________________________________________________________________

CURLFTPMETHOD_NOCWD ftp://server.com/  CURLOPT_QUOTE "SYST"
=> no CWDs (since newly created connection is already in entry path)
________________________________________________________________

CURLFTPMETHOD_SINGLECWD ftp://server.com/  CURLOPT_QUOTE "SYST"
=> no CWDs (since newly created connection is already in entry path)
________________________________________________________________

CURLFTPMETHOD_SINGLECWD ftp://server.com/  CURLOPT_QUOTE "SYST"
CURLFTPMETHOD_NOCWD     ftp://server.com/  CURLOPT_QUOTE "SYST"
=> no CWDs (since reused connection is still in entry path)
________________________________________________________________


I also found references to libcurl tests in:
\packages\vms\setup_gnv_curl_build.com
\tests\libtest\CMakeLists.txt
...but I'm not sure if these files need to be adapted, too. It doesn't seem like it.


Best, Zenju