### PR TITLE
docs: disambiguate CURLUPART_HOST is for host name (ie no port)

### DIFF
--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -76,8 +76,8 @@ Scheme cannot be URL decoded on get.
 .IP CURLUPART_PASSWORD
 .IP CURLUPART_OPTIONS
 .IP CURLUPART_HOST
-If the host part is an IPv6 numeric address, the zoneid will not be part of
-the extracted host but is provided separately in \fICURLUPART_ZONEID\fP.
+The host name. If it is an IPv6 numeric address, the zoneid will not be part of
+it but is provided separately in \fICURLUPART_ZONEID\fP.
 .IP CURLUPART_ZONEID
 If the host name is a numeric IPv6 address, this field might also be set.
 .IP CURLUPART_PORT

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -60,8 +60,9 @@ Scheme cannot be URL decoded on set.
 .IP CURLUPART_PASSWORD
 .IP CURLUPART_OPTIONS
 .IP CURLUPART_HOST
-The host name can use IDNA. The string must then be encoded as your locale
-says or UTF-8 (when winidn is used).
+The host name. If it is IDNA the string must then be encoded as your locale
+says or UTF-8 (when WinIDN is used). If it is a bracketed IPv6 numeric address
+it may contain a zone id (or you can use CURLUPART_ZONEID).
 .IP CURLUPART_ZONEID
 If the host name is a numeric IPv6 address, this field can also be set.
 .IP CURLUPART_PORT


### PR DESCRIPTION
Make it clear that it's for host name and not hostname:port (which could be implied by calling it host).

Another thing I added but only to set was _"If it is a bracketed IPv6 numeric address it may contain a zone id (or you can use CURLUPART_ZONEID)."_ because right now we allow for example `[fe80::20c:29ff:fe9c:409b%25foo]` and it parses out the zone id.