### PR TITLE
Update HTTP3.md

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -55,7 +55,7 @@ Build ngtcp2
      % git clone https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -i
-     % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somehere1>/lib" --prefix==<somewhere3>
+     % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somehere1>/lib" --prefix=<somewhere3>
      % make
      % make install
 


### PR DESCRIPTION
Fix `prefix` parameter for `ngtcp2` build.