### PR TITLE
cookies: using a share with cookies doesn't enable the cookie engine

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1090,6 +1090,8 @@ Curl_cookie_add(struct Curl_easy *data,
  *
  * If 'newsession' is TRUE, discard all "session cookies" on read from file.
  *
+ * Note that 'data' might be called as NULL pointer.
+ *
  * Returns NULL on out of memory. Invalid cookies are ignored.
  ****************************************************************************/
 struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
@@ -1160,6 +1162,8 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
   }
 
   c->running = TRUE;          /* now, we're running */
+  if(data)
+    data->state.cookie_engine = TRUE;
 
   return c;
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -2676,7 +2676,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
     struct Cookie *co = NULL; /* no cookies from start */
     int count = 0;
 
-    if(data->cookies) {
+    if(data->cookies && data->state.cookie_engine) {
       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE, CURL_LOCK_ACCESS_SINGLE);
       co = Curl_cookie_getlist(data->cookies,
                                conn->allocptr.cookiehost?
@@ -4013,7 +4013,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
         data->state.resume_from = 0; /* get everything */
     }
 #if !defined(CURL_DISABLE_COOKIES)
-    else if(data->cookies &&
+    else if(data->cookies && data->state.cookie_engine &&
             checkprefix("Set-Cookie:", k->p)) {
       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE,
                       CURL_LOCK_ACCESS_SINGLE);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1397,6 +1397,7 @@ struct UrlState {
                   invoked twice when the multi interface is used. */
   BIT(stream_depends_e); /* set or don't set the Exclusive bit */
   BIT(previouslypending); /* this transfer WAS in the multi->pending queue */
+  BIT(cookie_engine);
 };
 
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -129,7 +129,7 @@ test1128 test1129 test1130 test1131 test1132 test1133 test1134 test1135 \
 test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
 test1152 test1153 test1154 test1155 test1156 test1157 test1158 test1159 \
-test1160 test1161 test1162 test1163 test1164 test1165 \
+test1160 test1161 test1162 test1163 test1164 test1165 test1166 \
 test1170 test1171 test1172 test1173 test1174 \
 \
 test1200 test1201 test1202 test1203 test1204 test1205 test1206 test1207 \

--- a/tests/data/test1166
+++ b/tests/data/test1166
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+followlocation
+cookies
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Set-Cookie: trackyou=want; path=/
+Content-Length: 68
+
+This server reply is for testing a Location: following with cookies
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP response with cookies but not receiving!
+ </name>
+ <command>h
+http://%HOSTIP:%HTTPPORT/want/1166 http://%HOSTIP:%HTTPPORT/want/1166
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /want/1166 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /want/1166 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1166
+++ b/tests/data/test1166
@@ -29,7 +29,7 @@ http
  <name>
 HTTP response with cookies but not receiving!
  </name>
- <command>h
+ <command>
 http://%HOSTIP:%HTTPPORT/want/1166 http://%HOSTIP:%HTTPPORT/want/1166
 </command>
 </client>

--- a/tests/data/test506
+++ b/tests/data/test506
@@ -115,94 +115,98 @@ CURLOPT_SHARE
 lock:   share  [Pigs in space]: 16
 unlock: share  [Pigs in space]: 17
 PERFORM
-lock:   dns    [Pigs in space]: 18
-unlock: dns    [Pigs in space]: 19
+lock:   cookie [Pigs in space]: 18
+unlock: cookie [Pigs in space]: 19
 lock:   dns    [Pigs in space]: 20
 unlock: dns    [Pigs in space]: 21
-lock:   cookie [Pigs in space]: 22
-unlock: cookie [Pigs in space]: 23
+lock:   dns    [Pigs in space]: 22
+unlock: dns    [Pigs in space]: 23
 lock:   cookie [Pigs in space]: 24
 unlock: cookie [Pigs in space]: 25
 lock:   cookie [Pigs in space]: 26
 unlock: cookie [Pigs in space]: 27
 lock:   cookie [Pigs in space]: 28
 unlock: cookie [Pigs in space]: 29
+lock:   cookie [Pigs in space]: 30
+unlock: cookie [Pigs in space]: 31
 run 1: set cookie 1, 2 and 3
-lock:   dns    [Pigs in space]: 30
-unlock: dns    [Pigs in space]: 31
 lock:   dns    [Pigs in space]: 32
 unlock: dns    [Pigs in space]: 33
+lock:   dns    [Pigs in space]: 34
+unlock: dns    [Pigs in space]: 35
 CLEANUP
-lock:   cookie [Pigs in space]: 34
-unlock: cookie [Pigs in space]: 35
-lock:   share  [Pigs in space]: 36
-unlock: share  [Pigs in space]: 37
-*** run 2
-CURLOPT_SHARE
+lock:   cookie [Pigs in space]: 36
+unlock: cookie [Pigs in space]: 37
 lock:   share  [Pigs in space]: 38
 unlock: share  [Pigs in space]: 39
+*** run 2
+CURLOPT_SHARE
+lock:   share  [Pigs in space]: 40
+unlock: share  [Pigs in space]: 41
 PERFORM
-lock:   dns    [Pigs in space]: 40
-unlock: dns    [Pigs in space]: 41
 lock:   cookie [Pigs in space]: 42
 unlock: cookie [Pigs in space]: 43
-lock:   cookie [Pigs in space]: 44
-unlock: cookie [Pigs in space]: 45
+lock:   dns    [Pigs in space]: 44
+unlock: dns    [Pigs in space]: 45
 lock:   cookie [Pigs in space]: 46
 unlock: cookie [Pigs in space]: 47
+lock:   cookie [Pigs in space]: 48
+unlock: cookie [Pigs in space]: 49
+lock:   cookie [Pigs in space]: 50
+unlock: cookie [Pigs in space]: 51
 run 2: set cookie 4 and 5
-lock:   dns    [Pigs in space]: 48
-unlock: dns    [Pigs in space]: 49
-lock:   dns    [Pigs in space]: 50
-unlock: dns    [Pigs in space]: 51
+lock:   dns    [Pigs in space]: 52
+unlock: dns    [Pigs in space]: 53
+lock:   dns    [Pigs in space]: 54
+unlock: dns    [Pigs in space]: 55
 CLEANUP
-lock:   cookie [Pigs in space]: 52
-unlock: cookie [Pigs in space]: 53
-lock:   share  [Pigs in space]: 54
-unlock: share  [Pigs in space]: 55
+lock:   cookie [Pigs in space]: 56
+unlock: cookie [Pigs in space]: 57
+lock:   share  [Pigs in space]: 58
+unlock: share  [Pigs in space]: 59
 *** run 3
 CURLOPT_SHARE
-lock:   share  [Pigs in space]: 56
-unlock: share  [Pigs in space]: 57
+lock:   share  [Pigs in space]: 60
+unlock: share  [Pigs in space]: 61
 CURLOPT_COOKIEJAR
 CURLOPT_COOKIELIST FLUSH
-lock:   cookie [Pigs in space]: 58
-unlock: cookie [Pigs in space]: 59
-PERFORM
-lock:   dns    [Pigs in space]: 60
-unlock: dns    [Pigs in space]: 61
 lock:   cookie [Pigs in space]: 62
 unlock: cookie [Pigs in space]: 63
-lock:   cookie [Pigs in space]: 64
-unlock: cookie [Pigs in space]: 65
+PERFORM
+lock:   dns    [Pigs in space]: 64
+unlock: dns    [Pigs in space]: 65
 lock:   cookie [Pigs in space]: 66
 unlock: cookie [Pigs in space]: 67
 lock:   cookie [Pigs in space]: 68
 unlock: cookie [Pigs in space]: 69
 lock:   cookie [Pigs in space]: 70
 unlock: cookie [Pigs in space]: 71
+lock:   cookie [Pigs in space]: 72
+unlock: cookie [Pigs in space]: 73
+lock:   cookie [Pigs in space]: 74
+unlock: cookie [Pigs in space]: 75
 run 3: overwrite cookie 1 and 4, set cookie 6 with and without tailmatch
-lock:   dns    [Pigs in space]: 72
-unlock: dns    [Pigs in space]: 73
-lock:   dns    [Pigs in space]: 74
-unlock: dns    [Pigs in space]: 75
+lock:   dns    [Pigs in space]: 76
+unlock: dns    [Pigs in space]: 77
+lock:   dns    [Pigs in space]: 78
+unlock: dns    [Pigs in space]: 79
 CLEANUP
-lock:   cookie [Pigs in space]: 76
-unlock: cookie [Pigs in space]: 77
-lock:   share  [Pigs in space]: 78
-unlock: share  [Pigs in space]: 79
+lock:   cookie [Pigs in space]: 80
+unlock: cookie [Pigs in space]: 81
+lock:   share  [Pigs in space]: 82
+unlock: share  [Pigs in space]: 83
 CURLOPT_SHARE
-lock:   share  [Pigs in space]: 80
-unlock: share  [Pigs in space]: 81
+lock:   share  [Pigs in space]: 84
+unlock: share  [Pigs in space]: 85
 CURLOPT_COOKIELIST ALL
-lock:   cookie [Pigs in space]: 82
-unlock: cookie [Pigs in space]: 83
-CURLOPT_COOKIEJAR
-CURLOPT_COOKIELIST RELOAD
-lock:   cookie [Pigs in space]: 84
-unlock: cookie [Pigs in space]: 85
 lock:   cookie [Pigs in space]: 86
 unlock: cookie [Pigs in space]: 87
+CURLOPT_COOKIEJAR
+CURLOPT_COOKIELIST RELOAD
+lock:   cookie [Pigs in space]: 88
+unlock: cookie [Pigs in space]: 89
+lock:   cookie [Pigs in space]: 90
+unlock: cookie [Pigs in space]: 91
 loaded cookies:
 -----------------
   www.host.foo.com	FALSE	/	FALSE	1993463787	test6	six_more
@@ -215,17 +219,17 @@ loaded cookies:
   .host.foo.com	TRUE	/	FALSE	1896263787	injected	yes
 -----------------
 try SHARE_CLEANUP...
-lock:   share  [Pigs in space]: 88
-unlock: share  [Pigs in space]: 89
-SHARE_CLEANUP failed, correct
-CLEANUP
-lock:   cookie [Pigs in space]: 90
-unlock: cookie [Pigs in space]: 91
 lock:   share  [Pigs in space]: 92
 unlock: share  [Pigs in space]: 93
+SHARE_CLEANUP failed, correct
+CLEANUP
+lock:   cookie [Pigs in space]: 94
+unlock: cookie [Pigs in space]: 95
+lock:   share  [Pigs in space]: 96
+unlock: share  [Pigs in space]: 97
 SHARE_CLEANUP
-lock:   share  [Pigs in space]: 94
-unlock: share  [Pigs in space]: 95
+lock:   share  [Pigs in space]: 98
+unlock: share  [Pigs in space]: 99
 GLOBAL_CLEANUP
 </stdout>
 <file name="log/jar506" mode="text">

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -142,6 +142,7 @@ static void *fire(void *ptr)
   curl_easy_setopt(curl, CURLOPT_VERBOSE,    1L);
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
   curl_easy_setopt(curl, CURLOPT_URL,        tdata->url);
+  curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
   printf("CURLOPT_SHARE\n");
   curl_easy_setopt(curl, CURLOPT_SHARE, tdata->share);
 


### PR DESCRIPTION
The 'share object' only sets the storage area for cookies. The "cookie
engine" still needs to be enabled or activated using the normal cookie
options.

Test 1166 verifies
Fixes #4429 