### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,6 +7,18 @@ document does not describe how to install curl or libcurl using such a binary
 package. This document describes how to compile, build and install curl and
 libcurl from source code.
 
+## Building using vcpkg
+
+You can download and install curl and libcurl using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install curl[tool]
+
+The curl port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Building from git
 
 If you get your code off a git repository instead of a release tarball, see


### PR DESCRIPTION
Curl is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for curl and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build curl, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/curl/portfile.cmake). We try to keep the library maintained as close as possible to the original library.
