### PR TITLE
curl: create easy handles on-demand and not ahead of time

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -22,11 +22,9 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-
 #include "tool_sdecls.h"
-
 #include "tool_metalink.h"
-
+#include "tool_urlglob.h"
 #include "tool_formparse.h"
 
 typedef enum {
@@ -36,6 +34,20 @@ typedef enum {
 } curl_error;
 
 struct GlobalConfig;
+
+struct State {
+  struct getout *urlnode;
+  URLGlob *inglob;
+  URLGlob *urls;
+  char *outfiles;
+  char *httpgetfields;
+  char *uploadfile;
+  unsigned long infilenum; /* number of files to upload */
+  unsigned long up;  /* upload file counter within a single upload glob */
+  unsigned long urlnum; /* how many iterations this single URL has with ranges
+                           etc */
+  unsigned long li;
+};
 
 struct OperationConfig {
   bool remote_time;
@@ -262,6 +274,7 @@ struct OperationConfig {
   struct GlobalConfig *global;
   struct OperationConfig *prev;
   struct OperationConfig *next;   /* Always last in the struct */
+  struct State state;             /* for create_transfer() */
 };
 
 struct GlobalConfig {

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -984,12 +984,14 @@ void delete_metalinkfile(metalinkfile *mlfile)
 
 void clean_metalink(struct OperationConfig *config)
 {
-  while(config->metalinkfile_list) {
-    metalinkfile *mlfile = config->metalinkfile_list;
-    config->metalinkfile_list = config->metalinkfile_list->next;
-    delete_metalinkfile(mlfile);
+  if(config) {
+    while(config->metalinkfile_list) {
+      metalinkfile *mlfile = config->metalinkfile_list;
+      config->metalinkfile_list = config->metalinkfile_list->next;
+      delete_metalinkfile(mlfile);
+    }
+    config->metalinkfile_last = 0;
   }
-  config->metalinkfile_last = 0;
 }
 
 void metalink_cleanup(void)

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -37,18 +37,20 @@
 
 void clean_getout(struct OperationConfig *config)
 {
-  struct getout *next;
-  struct getout *node = config->url_list;
+  if(config) {
+    struct getout *next;
+    struct getout *node = config->url_list;
 
-  while(node) {
-    next = node->next;
-    Curl_safefree(node->url);
-    Curl_safefree(node->outfile);
-    Curl_safefree(node->infile);
-    Curl_safefree(node);
-    node = next;
+    while(node) {
+      next = node->next;
+      Curl_safefree(node->url);
+      Curl_safefree(node->outfile);
+      Curl_safefree(node->infile);
+      Curl_safefree(node);
+      node = next;
+    }
+    config->url_list = NULL;
   }
-  config->url_list = NULL;
 }
 
 bool output_expected(const char *url, const char *uploadfile)

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -33,7 +33,7 @@
     if(!tool_setopt_skip(opt)) {                \
       result = (v);                             \
       if(result)                                \
-        goto show_error;                        \
+        break;                                  \
     }                                           \
   } WHILE_FALSE
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -488,6 +488,9 @@ void glob_cleanup(URLGlob* glob)
   size_t i;
   int elem;
 
+  if(!glob)
+    return;
+
   for(i = 0; i < glob->size; i++) {
     if((glob->pattern[i].type == UPTSet) &&
        (glob->pattern[i].content.Set.elements)) {

--- a/tests/data/test62
+++ b/tests/data/test62
@@ -29,7 +29,7 @@ http
 HTTP, send cookies when using custom Host:
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/we/want/62 http://%HOSTIP:%HTTPPORT/we/want?hoge=fuga -b log/jar62.txt -H "Host: www.host.foo.com"
+http://%HOSTIP:%HTTPPORT/we/want/62 http://%HOSTIP:%HTTPPORT/we/want/62?hoge=fuga -b log/jar62.txt -H "Host: www.host.foo.com"
 </command>
 <file name="log/jar62.txt">
 # Netscape HTTP Cookie File
@@ -55,7 +55,7 @@ Host: www.host.foo.com
 Accept: */*
 Cookie: test2=yes; test=yes
 
-GET /we/want?hoge=fuga HTTP/1.1
+GET /we/want/62?hoge=fuga HTTP/1.1
 Host: www.host.foo.com
 Accept: */*
 Cookie: test2=yes; test=yes


### PR DESCRIPTION
This should again enable crazy-large download ranges of the style
[1-10000000] that otherwise easily ran out of memory starting in 7.66.0
when this new handle allocating scheme was introduced.

Reported-by: Peter Sumatra
Fixes #4393
