### PR TITLE
[git]: Add tests/server/disabled to .gitignore

### DIFF
--- a/tests/server/.gitignore
+++ b/tests/server/.gitignore
@@ -6,3 +6,4 @@ sockfilt
 sws
 tftpd
 socksd
+disabled


### PR DESCRIPTION
After I did `make test`, I realized that a new file called `tests/server/disabled` is being generated and listed in the upstaged git changes.

Using cat on this file shows that it is a binary:
```
ELF>P@9@8
         @@@@h���@@��   @> (.>>����DDP�td   <<Q�tdR�t>��/lib64/ld-linux-x86-64.so.2GNUGNU���%�
�g[��Qa��e�m `~ - Q"libpthread.so.0_ITM_deregisterTMCloneTable_ITM_registerTMCloneTablelibc.so.6__cxa_finalize__libc_start_mainGLIBC_2.2.5__gmon_start__Gu�i	0�  @�?�?�?�?�?H�H��/H��t��H���H�=�����f/�DH�=�/H��/H9�tH�>/H��tTL�:H������H�=q/H�5j/H)�H��H��H��?H�H��tH�/H����fD���=1/u/UH�=�.H��t
                                                                                                      H�=/�����h����	/]�����{���f.��AWI��AVI��AUA��ATL�%�,UH�-�,SL)�H�����H��t�L��L��D��A��H��H9�u�H�[]A\A]A^A_��H�H��8����,����<����L���T<��������$zRx
                                                           ����+zRx
                                                                  $����FJ
                                                                         �?�;*3$"Dx��\p���DtX���]B�E�E �E(�H0�H8�G@j8A0A(B BB�p���0�G
�����0
�
 @�	������o`���o���oN���o> @GCC: (Debian 8.3.0-6) 8.3.0��0�`	�

 
@�  @>>>�?@@(@��
0>(@Q>x         ��
  ���<!���>�>>� �@�
@�(@� �"disabled.ccrtstuff.cderegister_tm_clones__do_global_dtors_auxcompleted.7325__do_global_dtors_aux_fini_array_entryframe_dummy__frame_dummy_init_array_entry__FRAME_END____init_array_end_DYNAMIC__init_array_start__GNU_EH_FRAME_HDR_GLOBAL_OFFSET_TABLE___libc_csu_fini_ITM_deregisterTMCloneTable_edata__libc_start_main@@GLIBC_2.2.5__data_start__gmon_start____dso_handle_IO_stdin_used__libc_csu_init__bss_startmain__TMC_END___ITM_registerTMCloneTable__cxa_finalize@@GLIBC_2.2.5.symtab.strtab.shstrtab.interp.note.ABI-tag.note.gnu.build-id.gnu.hash.dynsym.dynstr.gnu.version.gnu.version_r.rela.dyn.init.plt.got.text.fini.rodata.eh_frame_hdr.eh_frame.init_array.fini_array.dynamic.got.plt.data.bss.comment�#�� 1��$D��No
                                                                                                                                                    00V���^���oNN
                                                                                                                                                                 k���o``z����  �@@a���	�  �  <�@�>.��?���@(@(�0(0H0� 6�
                          8�%
```