### PR TITLE
http2: move state-init from creation to pre-transfer

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1537,6 +1537,7 @@ static int h2_session_send(struct Curl_easy *data,
 
     H2BUGF(infof(data, "Queuing PRIORITY on stream %u (easy %p)\n",
                  stream->stream_id, data));
+    DEBUGASSERT(stream->stream_id != -1);
     rv = nghttp2_submit_priority(h2, NGHTTP2_FLAG_NONE, stream->stream_id,
                                  &pri_spec);
     if(rv)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1510,6 +1510,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
       }
     }
 #endif
+    Curl_http2_init_state(&data->state);
   }
 
   return result;

--- a/lib/url.c
+++ b/lib/url.c
@@ -619,8 +619,6 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
       data->progress.flags |= PGRS_HIDE;
       data->state.current_speed = -1; /* init to negative == impossible */
-
-      Curl_http2_init_state(&data->state);
     }
   }
 


### PR DESCRIPTION
To make sure that the HTTP/2 state is initialized correctly for
duplicated handles. It would otherwise easily generate "spurious"
PRIORITY frames to get sent over HTTP/2 connections when duplicated easy
handles were used.

Reported-by: Daniel Silverstone
Fixes #4303