### PR TITLE
altsvc: accept quoted ma and persist values

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -442,6 +442,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
       char option[32];
       unsigned long num;
       char *end_ptr;
+      bool quoted = FALSE;
       semip++; /* pass the semicolon */
       result = getalnum(&semip, option, sizeof(option));
       if(result)
@@ -451,12 +452,21 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
       if(*semip != '=')
         continue;
       semip++;
+      while(*semip && ISBLANK(*semip))
+        semip++;
+      if(*semip == '\"') {
+        /* quoted value */
+        semip++;
+        quoted = TRUE;
+      }
       num = strtoul(semip, &end_ptr, 10);
-      if(num < ULONG_MAX) {
+      if((end_ptr != semip) && num && (num < ULONG_MAX)) {
         if(strcasecompare("ma", option))
           maxage = num;
         else if(strcasecompare("persist", option) && (num == 1))
           persist = TRUE;
+        if(quoted && (*end_ptr == '\"'))
+          end_ptr++;
       }
       semip = end_ptr;
     }

--- a/tests/data/test1654
+++ b/tests/data/test1654
@@ -53,6 +53,7 @@ h1 2.example.org 8080 h3 2.example.org 8080 "20190125 22:34:21" 0 0
 h1 3.example.org 8080 h2 example.com 8080 "20190125 22:34:21" 0 0
 h1 3.example.org 8080 h3 yesyes.com 8080 "20190125 22:34:21" 0 0
 h2 example.org 80 h2 example.com 443 "20190124 22:36:21" 0 0
+h2 example.net 80 h2 example.net 443 "20190124 22:37:21" 0 0
 </file>
 </verify>
 </testcase>

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -97,6 +97,15 @@ UNITTEST_START
   }
   fail_unless(asi->num == 9, "wrong number of entries");
 
+  /* quoted 'ma' value */
+  result = Curl_altsvc_parse(curl, asi, "h2=\"example.net:443\"; ma=\"180\";",
+                             ALPN_h2, "example.net", 80);
+  if(result) {
+    fprintf(stderr, "Curl_altsvc_parse(4) failed!\n");
+    unitfail++;
+  }
+  fail_unless(asi->num == 10, "wrong number of entries");
+
   result = Curl_altsvc_parse(curl, asi,
                              "h2=\":443\", h3=\":443\"; ma = 120; persist = 1",
                              ALPN_h1, "curl.haxx.se", 80);
@@ -104,7 +113,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(5) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 11, "wrong number of entries");
+  fail_unless(asi->num == 12, "wrong number of entries");
 
   /* clear that one again and decrease the counter */
   result = Curl_altsvc_parse(curl, asi, "clear;",
@@ -113,7 +122,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(6) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 9, "wrong number of entries");
+  fail_unless(asi->num == 10, "wrong number of entries");
 
   Curl_altsvc_save(asi, outname);
 


### PR DESCRIPTION
As mandated by the spec. Test 1654 is extended to verify.