### PR TITLE
Fix warnings from autobuilds

### DIFF
--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -176,7 +176,7 @@ sub checkwarn {
 
 $file = shift @ARGV;
 
-while(1) {
+while(defined $file) {
 
     if($file =~ /-D(.*)/) {
         $dir = $1;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -749,7 +749,7 @@ clean_up:
                                             conn->created) / 1000;
 
     /* the alarm period is counted in even number of seconds */
-    unsigned long alarm_set = prev_alarm - elapsed_secs;
+    unsigned long alarm_set = (unsigned long)(prev_alarm - elapsed_secs);
 
     if(!alarm_set ||
        ((alarm_set >= 0x80000000) && (prev_alarm < 0x80000000)) ) {

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -596,7 +596,9 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname)
   size_t hlen = strlen(hostname);
 
   if(hostname[0] == '[') {
+#ifdef ENABLE_IPV6
     char dest[16]; /* fits a binary IPv6 address */
+#endif
     const char *l = "0123456789abcdefABCDEF:.";
     if(hlen < 5) /* '[::1]' is the shortest possible valid string */
       return CURLUE_MALFORMED_INPUT;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2822,7 +2822,7 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
         fd_write = sock;
       /* wait for the socket to become ready */
       (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD, fd_write,
-                              left>1000?1000:left); /* ignore result */
+                              left>1000?1000:(time_t)left);
     }
 #endif
 


### PR DESCRIPTION
- implicit narrowing conversions
- unused local variable `dest`
- use of uninitialized value `$file` in pattern match