### PR TITLE
cookie: avoid harmless use after free

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1646,6 +1646,7 @@ void Curl_flush_cookies(struct Curl_easy *data, int cleanup)
 
   if(cleanup && (!data->share || (data->cookies != data->share->cookies))) {
     Curl_cookie_cleanup(data->cookies);
+    data->cookies=NULL;
   }
   Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
 }

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1646,7 +1646,7 @@ void Curl_flush_cookies(struct Curl_easy *data, int cleanup)
 
   if(cleanup && (!data->share || (data->cookies != data->share->cookies))) {
     Curl_cookie_cleanup(data->cookies);
-    data->cookies=NULL;
+    data->cookies = NULL;
   }
   Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
 }


### PR DESCRIPTION
This fix removes a use after free which can be triggered by
the internal cookie fuzzer, but otherwise is probably
impossible to trigger from an ordinary application (Thanks @bagder for checking).

The following program reproduces it:

```c
        curl_global_init(CURL_GLOBAL_DEFAULT);
        CURL*  handle=curl_easy_init();
        CookieInfo* info=Curl_cookie_init(handle,NULL,NULL,false);
        curl_easy_setopt(handle, CURLOPT_COOKIEJAR, "/dev/null");
        Curl_flush_cookies(handle, true);
        Curl_cookie_cleanup(info);
        curl_easy_cleanup(handle);
        curl_global_cleanup();
```
This was found through fuzzing.