### PR TITLE
connect: return CURLE_OPERATION_TIMEDOUT for errno == ETIMEDOUT

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,6 +24,8 @@ task:
   test_script:
     # blackhole?
     - sysctl net.inet.tcp.blackhole
+    # make sure we don't run blackhole != 0
+    - sudo sysctl net.inet.tcp.blackhole=0
     # Some tests won't run if run as root so run them as another user.
     # Make directories world writable so the test step can write wherever it needs.
     - find . -type d -exec chmod 777 {} \;

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,8 @@ task:
   compile_script:
     - make V=1
   test_script:
+    # blackhole?
+    - sysctl net.inet.tcp.blackhole
     # Some tests won't run if run as root so run them as another user.
     # Make directories world writable so the test step can write wherever it needs.
     - find . -type d -exec chmod 777 {} \;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -976,6 +976,14 @@ CURLcode Curl_is_connected(struct connectdata *conn,
     failf(data, "Failed to connect to %s port %ld: %s",
           hostname, conn->port,
           Curl_strerror(error, buffer, sizeof(buffer)));
+
+#ifdef WSAETIMEDOUT
+    if(WSAETIMEDOUT == data->state.os_errno)
+      result = CURLE_OPERATION_TIMEDOUT;
+#elif defined(ETIMEDOUT)
+    if(ETIMEDOUT == data->state.os_errno)
+      result = CURLE_OPERATION_TIMEDOUT;
+#endif
   }
 
   return result;

--- a/tests/data/test19
+++ b/tests/data/test19
@@ -24,7 +24,7 @@ http
 attempt connect to non-listening socket
  </name>
  <command>
-%HOSTIP:60000
+%HOSTIP:2
 </command>
 </client>
 

--- a/tests/data/test704
+++ b/tests/data/test704
@@ -23,7 +23,7 @@ http
 Attempt connect to non-listening SOCKS4 proxy
  </name>
  <command>
---socks4 %HOSTIP:60000 http://%HOSTIP:%HTTPPORT/704
+--socks4 %HOSTIP:2 http://%HOSTIP:%HTTPPORT/704
 </command>
 </client>
 

--- a/tests/data/test705
+++ b/tests/data/test705
@@ -23,7 +23,7 @@ http
 Attempt connect to non-listening SOCKS5 proxy
  </name>
  <command>
---socks5 %HOSTIP:60000 http://%HOSTIP:%HTTPPORT/705
+--socks5 %HOSTIP:2 http://%HOSTIP:%HTTPPORT/705
 </command>
 </client>
 


### PR DESCRIPTION
Previosly all connect() failures would return CURLE_COULDNT_CONNECT, no
matter what errno said.

This makes for example --retry work on these transfer failures.

Fixes #4461