### PR TITLE
Ensure HTTP 429 triggers --retry

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -468,6 +468,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
 
         switch(response) {
+        case 429: /* Too Many Requests (RFC6585) */
         case 500: /* Internal Server Error */
         case 502: /* Bad Gateway */
         case 503: /* Service Unavailable */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -179,7 +179,7 @@ test1540 test1541 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 \
 \
-test1590 test1591 test1592 test1593 test1594 \
+test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
 test1608 test1609 test1620 test1621 \

--- a/tests/data/test1596
+++ b/tests/data/test1596
@@ -12,7 +12,7 @@ If-Modified-Since
 # Server-side
 <reply>
 <data nocheck="yes">
-HTTP/1.1 503 Error
+HTTP/1.1 429 Too Many Requests
 Date: Thu, 11 Jul 2019 02:26:59 GMT
 Server: test-server/swsclose
 Retry-After: Thu, 11 Jul 2024 02:26:59 GMT


### PR DESCRIPTION
This completes #3794 by making the `--retry` logic be triggered also on `HTTP/1.1 429 Too Many Requests` from [RFC6586](https://tools.ietf.org/html/rfc6585) e.g. as used by [Zenodo API](https://developers.zenodo.org/) and as initially mentioned in #3794 by john-hascall.

Also make sure the new tests from #4195 are enabled (although the existing tests seemed to worked fine even modified for 429 status code, as the handling logic is in `src/tool_operate.c` was not involved by test?)

Note that the caller still needs to use `--retry n` to enable handling of the `Retry-After` header.