### PR TITLE
curl: --no-progress-meter

### DIFF
--- a/docs/cmdline-opts/progress-meter.d
+++ b/docs/cmdline-opts/progress-meter.d
@@ -1,0 +1,8 @@
+Long: progress-meter
+Help: Show the progress meter
+See-also: verbose silent
+Added: 7.67.0
+---
+Option to only switch the progress meter output on or off (with
+--no-progress-meter) without muting or otherwise affecting warning and
+informational messages like --silent does.

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -322,6 +322,7 @@ static const struct LongShort aliases[]= {
   {"Z",  "parallel",                 ARG_BOOL},
   {"Zb", "parallel-max",             ARG_STRING},
   {"#",  "progress-bar",             ARG_BOOL},
+  {"#m", "progress-meter",           ARG_BOOL},
   {":",  "next",                     ARG_NONE},
 };
 
@@ -1172,11 +1173,16 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       }
       break;
-    case '#': /* --progress-bar */
-      if(toggle)
-        global->progressmode = CURL_PROGRESS_BAR;
-      else
-        global->progressmode = CURL_PROGRESS_STATS;
+    case '#':
+      switch(subletter) {
+      case 'm': /* --progress-meter */
+        global->noprogress = !toggle;
+        break;
+      default:  /* --progress-bar */
+        global->progressmode =
+          toggle ? CURL_PROGRESS_BAR : CURL_PROGRESS_STATS;
+        break;
+      }
       break;
     case ':': /* --next */
       return PARAM_NEXT_OPERATION;

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -295,6 +295,8 @@ static const struct helptxt helptext[] = {
    "Use this proxy first"},
   {"-#, --progress-bar",
    "Display transfer progress as a bar"},
+  {"    --progress-meter",
+   "Show the progress meter"},
   {"    --proto <protocols>",
    "Enable/disable PROTOCOLS"},
   {"    --proto-default <protocol>",


### PR DESCRIPTION
New option that allows a user to ONLY switch off curl's progress meter
and leave everything else in "talkative" mode.

Fixes #4422