### PR TITLE
CURLOPT_TIMEOUT.3: Clarify transfer timeout time includes queue time

### DIFF
--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.3
@@ -40,11 +40,12 @@ In unix-like systems, this might cause signals to be used unless
 If both \fICURLOPT_TIMEOUT(3)\fP and \fICURLOPT_TIMEOUT_MS(3)\fP are set, the
 value set last will be used.
 
-Since this puts a hard limit for how long time a request is allowed to take,
-it has limited use in dynamic use cases with varying transfer times. You are
-then advised to explore \fICURLOPT_LOW_SPEED_LIMIT(3)\fP,
-\fICURLOPT_LOW_SPEED_TIME(3)\fP or using \fICURLOPT_PROGRESSFUNCTION(3)\fP to
-implement your own timeout logic.
+Since this option puts a hard limit on how long time a request is allowed to
+take, it has limited use in dynamic use cases with varying transfer times. That
+is especially apparent when using the multi interface, which may queue the
+transfer, and that time is included. You are advised to explore
+\fICURLOPT_LOW_SPEED_LIMIT(3)\fP, \fICURLOPT_LOW_SPEED_TIME(3)\fP or using
+\fICURLOPT_PROGRESSFUNCTION(3)\fP to implement your own timeout logic.
 .SH DEFAULT
 Default timeout is 0 (zero) which means it never times out during transfer.
 .SH PROTOCOLS


### PR DESCRIPTION
Prior to this change some users did not understand that the "request"
starts when the handle is added to the multi handle, or probably they
did not understand that some of those transfers may be queued and that
time is included in timeout.

Reported-by: Jeroen Ooms

Fixes https://github.com/curl/curl/issues/4486
Closes #xxxx

---

/cc @jeroen