### PR TITLE
url: normalize CURLINFO_EFFECTIVE_URL

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1792,6 +1792,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   }
 
   if(!data->set.uh) {
+    char *newurl;
     uc = curl_url_set(uh, CURLUPART_URL, data->change.url,
                     CURLU_GUESS_SCHEME |
                     CURLU_NON_SUPPORT_SCHEME |
@@ -1802,6 +1803,15 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
       DEBUGF(infof(data, "curl_url_set rejected %s\n", data->change.url));
       return Curl_uc_to_curlcode(uc);
     }
+
+    /* after it was parsed, get the generated normalized version */
+    uc = curl_url_get(uh, CURLUPART_URL, &newurl, 0);
+    if(uc)
+      return Curl_uc_to_curlcode(uc);
+    if(data->change.url_alloc)
+      free(data->change.url);
+    data->change.url = newurl;
+    data->change.url_alloc = TRUE;
   }
 
   uc = curl_url_get(uh, CURLUPART_SCHEME, &data->state.up.scheme, 0);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -190,7 +190,7 @@ test1700 test1701 test1702 \
 \
 test1800 test1801 \
 \
-test1900 test1901 test1902 test1903 test1904 test1905 test1906 \
+test1900 test1901 test1902 test1903 test1904 test1905 test1906 test1907 \
 \
 test2000 test2001 test2002 test2003 test2004 test2005 test2006 test2007 \
 test2008 test2009 test2010 test2011 test2012 test2013 test2014 test2015 \

--- a/tests/data/test1907
+++ b/tests/data/test1907
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+CURLINFO_EFFECTIVE_URL
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Funny-head: yesyes swsclose
+Content-Length: 0
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+CURLINFO_EFFECTIVE_URL with non-scheme URL
+ </name>
+<tool>
+lib1907
+</tool>
+
+<command>
+%HOSTIP:%HTTPPORT/hello/../1907
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1907 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+<stdout>
+Effective URL: http://%HOSTIP:%HTTPPORT/1907
+</stdout>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -33,7 +33,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
  lib1558 lib1559 lib1560 \
  lib1591 lib1592 lib1593 lib1594 lib1596 \
- lib1900 lib1905 lib1906 \
+ lib1900 lib1905 lib1906 lib1907 \
  lib2033
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
@@ -565,6 +565,10 @@ lib1905_CPPFLAGS = $(AM_CPPFLAGS)
 lib1906_SOURCES = lib1906.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1906_LDADD = $(TESTUTIL_LIBS)
 lib1906_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1907_SOURCES = lib1907.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1907_LDADD = $(TESTUTIL_LIBS)
+lib1907_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib2033_SOURCES = libntlmconnect.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib2033_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1907.c
+++ b/tests/libtest/lib1907.c
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+  char *url_after;
+  CURL *curl;
+  CURLcode curl_code;
+  char error_buffer[CURL_ERROR_SIZE] = "";
+
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+  curl = curl_easy_init();
+  curl_easy_setopt(curl, CURLOPT_URL, URL);
+  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
+  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  curl_code = curl_easy_perform(curl);
+  if(!curl_code)
+    fprintf(stderr, "failure expected, "
+            "curl_easy_perform returned %ld: <%s>, <%s>\n",
+            (long) curl_code, curl_easy_strerror(curl_code), error_buffer);
+
+  /* print the used url */
+  if(!curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url_after))
+    printf("Effective URL: %s\n", url_after);
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return 0;
+}


### PR DESCRIPTION
The URL extracted with CURLINFO_EFFECTIVE_URL was returned as given as
input in most cases, which made it not get a scheme prefixed like before
if the URL was given without one, and it didn't remove dotdot sequences
etc.

Added test case 1907 to verify that this now works as intended and as
before 7.62.0.

Regression introduced in 7.62.0

Reported-by: Christophe Dervieux
Fixes #4491