### PR TITLE
curl: add --parallel-immediate

### DIFF
--- a/docs/cmdline-opts/Makefile.inc
+++ b/docs/cmdline-opts/Makefile.inc
@@ -103,9 +103,10 @@ DPAGES =					\
   ntlm.d ntlm-wb.d				\
   oauth2-bearer.d				\
   output.d                                      \
+  parallel-immediate.d                          \
+  parallel-max.d                                \
   parallel.d                                    \
   pass.d                			\
-  parallel-max.d                                \
   path-as-is.d					\
   pinnedpubkey.d				\
   post301.d					\

--- a/docs/cmdline-opts/parallel-immediate.d
+++ b/docs/cmdline-opts/parallel-immediate.d
@@ -1,0 +1,9 @@
+Long: parallel-immediate
+Help: Do not wait for multiplexing (with --parallel)
+Added: 7.68.0
+See-also: parallel parallel-max
+---
+When doing parallel transfers, this option will instruct curl that it should
+rather prefer opening up more connections in parallel at once rather than
+waiting to see if new transfers can be added as multiplexed streams on another
+connection.

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -300,6 +300,7 @@ struct GlobalConfig {
 #endif
   bool parallel;
   long parallel_max;
+  bool parallel_connect;
   struct OperationConfig *first;
   struct OperationConfig *current;
   struct OperationConfig *last;   /* Always last in the struct */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -321,6 +321,7 @@ static const struct LongShort aliases[]= {
   {"z",  "time-cond",                ARG_STRING},
   {"Z",  "parallel",                 ARG_BOOL},
   {"Zb", "parallel-max",             ARG_STRING},
+  {"Zc", "parallel-connect",         ARG_BOOL},
   {"#",  "progress-bar",             ARG_BOOL},
   {"#m", "progress-meter",           ARG_BOOL},
   {":",  "next",                     ARG_NONE},
@@ -2153,6 +2154,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         if((global->parallel_max > MAX_PARALLEL) ||
            (global->parallel_max < 1))
           global->parallel_max = PARALLEL_DEFAULT;
+        break;
+      case 'c':   /* --parallel-connect */
+        global->parallel_connect = toggle;
         break;
       }
       break;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -321,7 +321,7 @@ static const struct LongShort aliases[]= {
   {"z",  "time-cond",                ARG_STRING},
   {"Z",  "parallel",                 ARG_BOOL},
   {"Zb", "parallel-max",             ARG_STRING},
-  {"Zc", "parallel-connect",         ARG_BOOL},
+  {"Zc", "parallel-immediate",       ARG_BOOL},
   {"#",  "progress-bar",             ARG_BOOL},
   {"#m", "progress-meter",           ARG_BOOL},
   {":",  "next",                     ARG_NONE},

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -279,6 +279,8 @@ static const struct helptxt helptext[] = {
    "Write to file instead of stdout"},
   {"-Z, --parallel",
    "Perform transfers in parallel"},
+  {"    --parallel-immediate",
+   "Do not wait for multiplexing (with --parallel)"},
   {"    --parallel-max",
    "Maximum concurrency for parallel transfers"},
   {"    --pass <phrase>",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1976,6 +1976,10 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
     if(result)
       break;
 
+    /* parallel connect means that we don't set PIPEWAIT since pipewait
+       will make libcurl prefer multiplexing */
+    (void)curl_easy_setopt(per->curl, CURLOPT_PIPEWAIT,
+                           global->parallel_connect ? 0L : 1L);
     (void)curl_easy_setopt(per->curl, CURLOPT_PRIVATE, per);
     (void)curl_easy_setopt(per->curl, CURLOPT_XFERINFOFUNCTION, xferinfo_cb);
     (void)curl_easy_setopt(per->curl, CURLOPT_XFERINFODATA, per);


### PR DESCRIPTION
Starting with this change when doing parallel transfers, without this
option set, curl will prefer to create new transfers multiplexed on an
existing connection rather than creating a brand new one.

--parallel-connect can be set to tell curl to prefer to use new
connections rather than to wait and try to multiplex.

libcurl-wise, this means that curl will set CURLOPT_PIPEWAIT by default
on parallel transfers.

Fixes #4494 
Suggested-by: Tom van der Woerdt