### PR TITLE
examples/sslbackend: fix -Wchar-subscripts warning

### DIFF
--- a/docs/examples/sslbackend.c
+++ b/docs/examples/sslbackend.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
     return 0;
   }
-  else if(isdigit(*name)) {
+  else if(isdigit((int)(unsigned char)*name)) {
     int id = atoi(name);
 
     result = curl_global_sslset((curl_sslbackend)id, NULL, NULL);


### PR DESCRIPTION
With the `isdigit` implementation that comes with MSYS2, the argument
is used as an array subscript, resulting in a -Wchar-subscripts
warning. `isdigit`'s behavior is undefined if the argument is negative
and not EOF [0]. As done in lib/curl_ctype.h, cast the `char` variable
to `unsigned char` to avoid that.

[0] https://en.cppreference.com/w/c/string/byte/isdigit