### PR TITLE
runtests: get textaware info from curl instead of perl

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2678,6 +2678,7 @@ sub checksystem {
                 # This is a Windows MinGW build or native build, we need to use
                 # Win32-style path.
                 $pwd = pathhelp::sys_native_current_path();
+                $has_textaware = 1;
             }
            if ($libcurl =~ /(winssl|schannel)/i) {
                $has_winssl=1;
@@ -3024,7 +3025,6 @@ sub checksystem {
             }
         }
     }
-    $has_textaware = ($^O eq 'MSWin32') || ($^O eq 'msys');
 
     logmsg "***************************************** \n";
 


### PR DESCRIPTION
The MSYS system on Windows can run the test suite for curl built with
any toolset. When built with the MSYS GCC, curl uses Unix line endings,
while it uses Windows line endings when built with the MinGW GCC, and
`^O` reports 'msys' in both cases. Use the curl executable itself to
determine the line endings instead, which reports 'x86_64-pc-msys' when
built with the MSYS GCC.