### PR TITLE
appveyor: Use parallel compilation on appveyor with CMake

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -148,7 +148,7 @@ build_script:
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=""
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
-        cmake --build . --config %PRJ_CFG% --clean-first -- %BUILD_OPT%) else (
+        cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT%) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (
         cd projects &&
         .\\generate.bat %VC_VERSION% &&


### PR DESCRIPTION
Appveyor provides 2 CPUs for each builder[1], make sure to use parallel
compilation, when running with CMake. CMake learned this new option in
version 3.12[2] and the version provided by appveyor is fresh enough.

Curl doesn't really take that long to build and it is using the slowest
builder available, msbuild, so expect only a moderate improvement in
build times.

[1] https://www.appveyor.com/docs/build-environment/
[2] https://cmake.org/cmake/help/v3.12/release/3.12.html