### PR TITLE
appveyor: publish artifacts on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,3 +176,9 @@ branches:
     only:
         - master
         - /\/ci$/
+
+artifacts:
+  - path: '**/curl.exe'
+    name: curl
+  - path: '**/libcurl.dll'
+    name: libcurl


### PR DESCRIPTION
This allows obtaining upstream builds of curl directly from appveyor for
all the available configurations