### PR TITLE
tests: add `connect to non-listen` keywords

### DIFF
--- a/tests/data/test1233
+++ b/tests/data/test1233
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 FTP
+connect to non-listen
 </keywords>
 </info>
 

--- a/tests/data/test504
+++ b/tests/data/test504
@@ -6,6 +6,7 @@ HTTP GET
 HTTP proxy
 multi
 FAILURE
+connect to non-listen
 </keywords>
 </info>
 


### PR DESCRIPTION
These tests try to connect to ports nothing is listening on.