### PR TITLE
tests: use %FILE_PWD for file:// URLs

### DIFF
--- a/tests/data/test1016
+++ b/tests/data/test1016
@@ -23,7 +23,7 @@ file
 X-Y range on a file:// URL to stdout
  </name>
 <command option="no-include">
--r 1-4 file://localhost/%PWD/log/test1016.txt 
+-r 1-4 file://localhost%FILE_PWD/log/test1016.txt 
 </command>
 <file name="log/test1016.txt">
 1234567890

--- a/tests/data/test1017
+++ b/tests/data/test1017
@@ -24,7 +24,7 @@ file
 0-Y range on a file:// URL to stdout
  </name>
 <command option="no-include">
--r 0-3 file://localhost/%PWD/log/test1017.txt 
+-r 0-3 file://localhost%FILE_PWD/log/test1017.txt 
 </command>
 <file name="log/test1017.txt">
 1234567890

--- a/tests/data/test1018
+++ b/tests/data/test1018
@@ -23,7 +23,7 @@ file
 X-X range on a file:// URL to stdout
  </name>
 <command option="no-include">
--r 4-4 file://localhost/%PWD/log/test1018.txt 
+-r 4-4 file://localhost%FILE_PWD/log/test1018.txt 
 </command>
 <file name="log/test1018.txt">
 1234567890

--- a/tests/data/test1019
+++ b/tests/data/test1019
@@ -24,7 +24,7 @@ file
 X- range on a file:// URL to stdout
  </name>
 <command option="no-include">
--r 7- file://localhost/%PWD/log/test1019.txt 
+-r 7- file://localhost%FILE_PWD/log/test1019.txt 
 </command>
 <file name="log/test1019.txt">
 1234567890

--- a/tests/data/test1020
+++ b/tests/data/test1020
@@ -24,7 +24,7 @@ file
 -Y range on a file:// URL to stdout
  </name>
 <command option="no-include">
--r -9 file://localhost/%PWD/log/test1020.txt 
+-r -9 file://localhost%FILE_PWD/log/test1020.txt 
 </command>
 <file name="log/test1020.txt">
 1234567890

--- a/tests/data/test1063
+++ b/tests/data/test1063
@@ -28,7 +28,7 @@ Invalid large X- range on a file://
 # This range value is 2**32+7, which will be truncated to the valid value 7
 # if the large file support is not working correctly
  <command>
--r 4294967303- file://localhost/%PWD/log/test1063.txt 
+-r 4294967303- file://localhost%FILE_PWD/log/test1063.txt 
 </command>
 <file name="log/test1063.txt">
 1234567890

--- a/tests/data/test1220
+++ b/tests/data/test1220
@@ -21,7 +21,7 @@ file
 file:// URLs with query string
  </name>
 <command option="no-include">
-file://localhost/%PWD/log/test1220.txt?a_query=foobar#afragment
+file://localhost%FILE_PWD/log/test1220.txt?a_query=foobar#afragment
 </command>
 <file name="log/test1220.txt">
 contents in a single file

--- a/tests/data/test1445
+++ b/tests/data/test1445
@@ -21,7 +21,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/log/test1445.dir
 file:// with --remote-time
  </name>
  <command>
-file://localhost/%PWD/log/test1445.dir/plainfile.txt --remote-time
+file://localhost%FILE_PWD/log/test1445.dir/plainfile.txt --remote-time
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/log/test1445.dir && \

--- a/tests/data/test200
+++ b/tests/data/test200
@@ -24,7 +24,7 @@ file
 basic file:// file
  </name>
 <command option="no-include">
-file://localhost/%PWD/log/test200.txt
+file://localhost%FILE_PWD/log/test200.txt
 </command>
 <file name="log/test200.txt">
 foo

--- a/tests/data/test2000
+++ b/tests/data/test2000
@@ -32,7 +32,7 @@ file
 FTP RETR followed by FILE
  </name>
 <command option="no-include">
-ftp://%HOSTIP:%FTPPORT/2000 file://localhost/%PWD/log/test2000.txt
+ftp://%HOSTIP:%FTPPORT/2000 file://localhost%FILE_PWD/log/test2000.txt
 </command>
 <file name="log/test2000.txt">
 foo

--- a/tests/data/test2001
+++ b/tests/data/test2001
@@ -49,7 +49,7 @@ file
 HTTP GET followed by FTP RETR followed by FILE
  </name>
 <command option="no-include">
-http://%HOSTIP:%HTTPPORT/20010001 ftp://%HOSTIP:%FTPPORT/20010002 file://localhost/%PWD/log/test2001.txt
+http://%HOSTIP:%HTTPPORT/20010001 ftp://%HOSTIP:%FTPPORT/20010002 file://localhost%FILE_PWD/log/test2001.txt
 </command>
 <file name="log/test2001.txt">
 foo

--- a/tests/data/test2002
+++ b/tests/data/test2002
@@ -58,7 +58,7 @@ tftp
 HTTP GET followed by FTP RETR followed by FILE followed by TFTP RRQ
  </name>
 <command option="no-include">
-http://%HOSTIP:%HTTPPORT/20020001 ftp://%HOSTIP:%FTPPORT/20020002 file://localhost/%PWD/log/test2002.txt tftp://%HOSTIP:%TFTPPORT//20020003
+http://%HOSTIP:%HTTPPORT/20020001 ftp://%HOSTIP:%FTPPORT/20020002 file://localhost%FILE_PWD/log/test2002.txt tftp://%HOSTIP:%TFTPPORT//20020003
 </command>
 <file name="log/test2002.txt">
 foo

--- a/tests/data/test2003
+++ b/tests/data/test2003
@@ -58,7 +58,7 @@ tftp
 HTTP GET followed by FTP RETR followed by FILE followed by TFTP RRQ then again in reverse order
  </name>
 <command option="no-include">
-http://%HOSTIP:%HTTPPORT/20030001 ftp://%HOSTIP:%FTPPORT/20030002 file://localhost/%PWD/log/test2003.txt tftp://%HOSTIP:%TFTPPORT//20030003 tftp://%HOSTIP:%TFTPPORT//20030003 file://localhost/%PWD/log/test2003.txt ftp://%HOSTIP:%FTPPORT/20030002 http://%HOSTIP:%HTTPPORT/20030001
+http://%HOSTIP:%HTTPPORT/20030001 ftp://%HOSTIP:%FTPPORT/20030002 file://localhost%FILE_PWD/log/test2003.txt tftp://%HOSTIP:%TFTPPORT//20030003 tftp://%HOSTIP:%TFTPPORT//20030003 file://localhost%FILE_PWD/log/test2003.txt ftp://%HOSTIP:%FTPPORT/20030002 http://%HOSTIP:%HTTPPORT/20030001
 </command>
 <file name="log/test2003.txt">
 foo

--- a/tests/data/test2004
+++ b/tests/data/test2004
@@ -30,7 +30,7 @@ sftp
 TFTP RRQ followed by SFTP retrieval followed by FILE followed by SCP retrieval then again in reverse order
  </name>
 <command option="no-include">
---key curl_client_key --pubkey curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//2004 sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost/%PWD/log/test2004.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt tftp://%HOSTIP:%TFTPPORT//2004 --insecure
+--key curl_client_key --pubkey curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//2004 sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost%FILE_PWD/log/test2004.txt scp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt file://localhost%FILE_PWD/log/test2004.txt sftp://%HOSTIP:%SSHPORT%POSIX_PWD/log/test2004.txt tftp://%HOSTIP:%TFTPPORT//2004 --insecure
 </command>
 <file name="log/test2004.txt">
 This is test data

--- a/tests/data/test202
+++ b/tests/data/test202
@@ -20,7 +20,7 @@ file
 two file:// URLs to stdout
  </name>
 <command option="no-include">
-file://localhost/%PWD/log/test202.txt FILE://localhost/%PWD/log/test202.txt
+file://localhost%FILE_PWD/log/test202.txt FILE://localhost%FILE_PWD/log/test202.txt
 </command>
 <file name="log/test202.txt">
 contents in a single file

--- a/tests/data/test204
+++ b/tests/data/test204
@@ -16,7 +16,7 @@ file
 "upload" with file://
  </name>
 <command option="no-include">
-file://localhost/%PWD/log/result204.txt -T log/upload204.txt
+file://localhost%FILE_PWD/log/result204.txt -T log/upload204.txt
 </command>
 <file name="log/upload204.txt">
 data

--- a/tests/data/test2071
+++ b/tests/data/test2071
@@ -24,7 +24,7 @@ file
 basic file:// file with "127.0.0.1" hostname
  </name>
 <command option="no-include">
-file://127.0.0.1/%PWD/log/test2070.txt
+file://127.0.0.1%FILE_PWD/log/test2070.txt
 </command>
 <file name="log/test2070.txt">
 foo

--- a/tests/data/test231
+++ b/tests/data/test231
@@ -23,7 +23,7 @@ file
 file:// with resume
  </name>
 <command option="no-include">
-file://localhost/%PWD/log/test231.txt -C 10
+file://localhost%FILE_PWD/log/test231.txt -C 10
 </command>
 <file name="log/test231.txt">
 A01234567

--- a/tests/data/test288
+++ b/tests/data/test288
@@ -31,7 +31,7 @@ file:// with (unsupported) proxy, authentication and range
 all_proxy=http://fake:user@%HOSTIP:%HTTPPORT/
 </setenv>
 <command option="no-include">
-file://localhost/%PWD/log/test288.txt
+file://localhost%FILE_PWD/log/test288.txt
 </command>
 <file name="log/test288.txt">
 foo


### PR DESCRIPTION
This way, we always have exactly one slash after the host name, making
the tests pass when curl is compiled with the MSYS GCC.