### PR TITLE
conn-reuse: requests wanting NTLM can reuse non-NTLM connections

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1282,8 +1282,14 @@ ConnectionExists(struct Curl_easy *data,
            partway through a handshake!) */
         if(wantNTLMhttp) {
           if(strcmp(needle->user, check->user) ||
-             strcmp(needle->passwd, check->passwd))
+             strcmp(needle->passwd, check->passwd)) {
+
+            /* we prefer a credential match, but this is at least a connection
+               that can be reused and "upgraded" to NTLM */
+            if(check->http_ntlm_state == NTLMSTATE_NONE)
+              chosen = check;
             continue;
+          }
         }
         else if(check->http_ntlm_state != NTLMSTATE_NONE) {
           /* Connection is using NTLM auth but we don't want NTLM */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -57,7 +57,7 @@ test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
-test334 test335 test336 test337 \
+test334 test335 test336 test337 test338 \
 test340 \
 \
 test350 test351 test352 test353 test354 test355 test356 \

--- a/tests/data/test338
+++ b/tests/data/test338
@@ -1,0 +1,63 @@
+# See https://github.com/curl/curl/issues/4499
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+<servercmd>
+connection-monitor
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+ANYAUTH connection reuse of non-authed connection
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/338 --next http://%HOSTIP:%HTTPPORT/338 --anyauth -u foo:moo
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /338 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /338 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+[DISCONNECT]
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Added test case 338 to verify.

Reported-by: Daniel Silverstone
Fixes #4499