### PR TITLE
Reverse the order of insertion for SChannel certinfo

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1181,6 +1181,7 @@ struct Adder_args
   struct connectdata *conn;
   CURLcode result;
   int idx;
+  int certs_count;
 };
 
 static bool
@@ -1191,7 +1192,9 @@ add_cert_to_certinfo(const CERT_CONTEXT *ccert_context, void *raw_arg)
   if(valid_cert_encoding(ccert_context)) {
     const char *beg = (const char *) ccert_context->pbCertEncoded;
     const char *end = beg + ccert_context->cbCertEncoded;
-    args->result = Curl_extract_certinfo(args->conn, (args->idx)++, beg, end);
+    int insert_index = (args->certs_count - 1) - (args->idx);
+    args->result = Curl_extract_certinfo(args->conn, insert_index, beg, end);
+    (args->idx)++;
   }
   return args->result == CURLE_OK;
 }
@@ -1326,6 +1329,7 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
       struct Adder_args args;
       args.conn = conn;
       args.idx = 0;
+      args.certs_count = certs_count;
       traverse_cert_store(ccert_context, add_cert_to_certinfo, &args);
       result = args.result;
     }


### PR DESCRIPTION
Related issue: #4518

This PR will reverse the order of insertion of certificates when certinfo is requested and using SChannel backend. This is to make the order consistent with OpenSSL, that is to have the peer certificate first instead of last.

The line with `(args->idx)++` could probably be merged into `int insert_index = (args->certs_count - 1) - (args->idx);` , but I believe saving one line of code is not worth reducing the readability of it.