### PR TITLE
test1591: fix spelling of http feature

### DIFF
--- a/tests/data/test1591
+++ b/tests/data/test1591
@@ -19,7 +19,7 @@ Server: test-server/fake
 # Client-side
 <client>
 <features>
-HTTP
+http
 </features>
 <server>
 http


### PR DESCRIPTION
The test never got run because the feature name is `http` in lowercase.