### PR TITLE
multi_cleanup: close leftover DOH handles

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -399,9 +399,6 @@ CURLcode Curl_close(struct Curl_easy *data)
     Curl_share_unlock(data, CURL_LOCK_DATA_SHARE);
   }
 
-  /* Leave no dangling DOH handles behind */
-  Curl_close(data->req.doh.probe[0].easy);
-  Curl_close(data->req.doh.probe[1].easy);
   free(data->req.doh.probe[0].serverdoh.memory);
   free(data->req.doh.probe[1].serverdoh.memory);
   curl_slist_free_all(data->req.doh.headers);
@@ -1986,6 +1983,10 @@ void Curl_free_request_state(struct Curl_easy *data)
 {
   Curl_safefree(data->req.protop);
   Curl_safefree(data->req.newurl);
+  Curl_close(data->req.doh.probe[0].easy);
+  data->req.doh.probe[0].easy = NULL;
+  Curl_close(data->req.doh.probe[1].easy);
+  data->req.doh.probe[1].easy = NULL;
 }
 
 


### PR DESCRIPTION
If curl_multi_cleanup() is called without all DOH handles having been
removed, make sure this is done or they will leak their memory.

Reported-by: Paul Dreik
Fixes #4463