### PR TITLE
HTTP3: run built target from src/curl

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -106,10 +106,10 @@ Clone and build curl:
 
 Use HTTP/3 directly:
 
-    curl --http3 https://nghttp2.org:8443/
+    src/curl --http3 https://nghttp2.org:8443/
 
 Upgrade via Alt-Svc:
 
-    curl --alt-svc altsvc.cache https://quic.aiortc.org/
+    src/curl --alt-svc altsvc.cache https://quic.aiortc.org/
 
 See this [list of public HTTP/3 servers](https://bagder.github.io/HTTP3-test/)


### PR DESCRIPTION
After building curl with HTTP/3 support, I spent some time to find out where the built file was created.
Stating that the file has to run from `src/curl` in the documentation would help