### PR TITLE
gtls: make gnutls_bye() not wait for response on shutdown

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1608,7 +1608,7 @@ static ssize_t gtls_send(struct connectdata *conn,
 static void close_one(struct ssl_connect_data *connssl)
 {
   if(BACKEND->session) {
-    gnutls_bye(BACKEND->session, GNUTLS_SHUT_RDWR);
+    gnutls_bye(BACKEND->session, GNUTLS_SHUT_WR);
     gnutls_deinit(BACKEND->session);
     BACKEND->session = NULL;
   }


### PR DESCRIPTION
... as it can make it wait there for a long time for no good purpose.

Patched-by: Jay Satiro
Reported-by: Bylon2 on github
Adviced-by: Nikos Mavrogiannopoulos

Fixes #4487