### PR TITLE
test1558: use double slash after file:

### DIFF
--- a/tests/data/test1558
+++ b/tests/data/test1558
@@ -23,12 +23,8 @@ lib1558
 <name>
 CURLINFO_PROTOCOL for file:// transfer
 </name>
-<setenv>
-# force MSYS2 to not convert the file: URL
-MSYS2_ARG_CONV_EXCL=file:
-</setenv>
 <command>
-file:%FILE_PWD/log/data1558
+file://%FILE_PWD/log/data1558
 </command>
 <file name="log/data1558">
 hello


### PR DESCRIPTION
Classic MinGW / MSYS 1 doesn't support `MSYS2_ARG_CONV_EXCL`, so this
test unnecessarily failed when using `file:/` instead of `file:///`.