### PR TITLE
[WIP] tool: Add option --retry-flaky to retry partial transfers

### DIFF
--- a/docs/cmdline-opts/Makefile.inc
+++ b/docs/cmdline-opts/Makefile.inc
@@ -157,6 +157,7 @@ DPAGES =					\
   resolve.d					\
   retry-connrefused.d				\
   retry-delay.d					\
+  retry-flaky.d					\
   retry-max-time.d				\
   retry.d					\
   sasl-authzid.d					\

--- a/docs/cmdline-opts/retry-flaky.d
+++ b/docs/cmdline-opts/retry-flaky.d
@@ -1,0 +1,19 @@
+Long: retry-flaky
+Help: Retry on partial transfer errors (heed warnings; use with --retry)
+Added: 7.68.0
+---
+In addition to the other conditions, consider partial transfer errors as
+transient errors too for --retry. This option is used together with --retry.
+
+For server compatibility curl attempts to retry failed flaky transfers as
+close as possible to how they were stated. It removes output data from a
+failed partial transfer that was written to an output file. However this is not
+true of data redirected to a | pipe or > file, which are not reset. We suggest
+don't parse or record output via redirect in combination with this option,
+since you may receive duplicate data. Furthermore don't use this option as a
+default option (eg in curlrc) for that reason.
+
+Partial transfer errors are CURLE_COULDNT_RESOLVE_HOST (6),
+CURLE_FTP_CANT_GET_HOST (15), CURLE_HTTP2 (16), CURLE_PARTIAL_FILE (18),
+CURLE_SSL_CONNECT_ERROR (35), CURLE_GOT_NOTHING (52), CURLE_SEND_ERROR (55),
+CURLE_RECV_ERROR (56), CURLE_HTTP2_STREAM (92). More may be added as needed.

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -223,6 +223,7 @@ struct OperationConfig {
   bool retry_connrefused;   /* set connection refused as a transient error */
   long retry_delay;         /* delay between retries (in seconds) */
   long retry_maxtime;       /* maximum time to keep retrying */
+  bool retry_flaky;         /* set partial transfer errors as transient */
 
   char *ftp_account;        /* for ACCT */
   char *ftp_alternative_to_user;  /* send command if USER/PASS fails */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -197,6 +197,7 @@ static const struct LongShort aliases[]= {
   {"$Y", "suppress-connect-headers", ARG_BOOL},
   {"$Z", "compressed-ssh",           ARG_BOOL},
   {"$~", "happy-eyeballs-timeout-ms", ARG_STRING},
+  {"$!", "retry-flaky",              ARG_BOOL},
   {"0",   "http1.0",                 ARG_NONE},
   {"01",  "http1.1",                 ARG_NONE},
   {"02",  "http2",                   ARG_NONE},
@@ -921,6 +922,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = str2unummax(&config->retry_maxtime, nextarg, LONG_MAX/1000);
         if(err)
           return err;
+        break;
+      case '!': /* --retry-flaky */
+        config->retry_flaky = toggle;
         break;
 
       case 'k': /* --proxy-negotiate */

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -391,6 +391,8 @@ static const struct helptxt helptext[] = {
    "Retry on connection refused (use with --retry)"},
   {"    --retry-delay <seconds>",
    "Wait time between retries"},
+  {"    --retry-flaky",
+   "Retry on partial transfer errors (heed warnings; use with --retry)"},
   {"    --retry-max-time <seconds>",
    "Retry only within this period"},
   {"    --sasl-authzid <identity> ",


### PR DESCRIPTION
- Add an option to retry transfers that failed due to flakiness:
  CURLE_COULDNT_RESOLVE_HOST (6)
  CURLE_FTP_CANT_GET_HOST (15)
  CURLE_HTTP2 (16)
  CURLE_PARTIAL_FILE (18)
  CURLE_SSL_CONNECT_ERROR (35)
  CURLE_GOT_NOTHING (52)
  CURLE_SEND_ERROR (55)
  CURLE_RECV_ERROR (56)
  CURLE_HTTP2_STREAM (92)

WIP, untested.

Closes #xxxx

===

Ref: #4461 
Ref: python-trio/trio#1231
Ref: elastic/elasticsearch#48560

@njsmith has reported retry is not as robust as some users may need. I've opened this PR for discussion, however I wonder if something like `for i in {1..5}; do curl ... && break || sleep 5; done
` would be sufficient.
