### PR TITLE
minor - cosmetic - mispelled word

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4400,7 +4400,7 @@ dnl
 AC_MSG_CHECKING([whether to support DNS shuffling])
 AC_ARG_ENABLE(dnsshuffle,
 AC_HELP_STRING([--enable-dnsshuffle],[Enable DNS shuffling])
-AC_HELP_STRING([--disable-dnsshuffle],[Disable DNS shufflinf]),
+AC_HELP_STRING([--disable-dnsshuffle],[Disable DNS shuffling]),
 [ case "$enableval" in
   no)
        AC_MSG_RESULT(no)


### PR DESCRIPTION
A word in the configure menu is mispelled.
"shufflinf instead of shuffling"
https://github.com/curl/curl/blob/93213b2421429af74a6da7f61566292aa978fb22/configure.ac#L4403