### PR TITLE
test1560: require IPv6 for IPv6 aware URL parsing

### DIFF
--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -22,6 +22,7 @@ imap
 ldap
 dict
 ftp
+ipv6
 </features>
  <name>
 URL API


### PR DESCRIPTION
The URL parser function can't reject a bad IPv6 address properly when
curl was built without IPv6 support.

Reported-by: Marcel Raad
Fixes #4556