### PR TITLE
quiche: handle pseudo headers in another order

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1618,6 +1618,7 @@ CURLcode Curl_http_done(struct connectdata *conn,
   }
 
   Curl_http2_done(conn, premature);
+  Curl_http3_done(data);
 
   Curl_mime_cleanpart(&http->form);
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -163,8 +163,6 @@ struct HTTP {
   int32_t stream_id; /* stream we are interested in */
 
   bool bodystarted;
-  /* We store non-final and final response headers here, per-stream */
-  Curl_send_buffer *header_recvbuf;
   size_t nread_header_recvbuf; /* number of bytes in header_recvbuf fed into
                                   upper layer */
   Curl_send_buffer *trailer_recvbuf;
@@ -184,6 +182,8 @@ struct HTTP {
   size_t memlen; /* size of data copied to mem */
 #endif
 #if defined(USE_NGHTTP2) || defined(ENABLE_QUIC)
+  /* We store non-final and final response headers here, per-stream */
+  Curl_send_buffer *header_recvbuf;
   /* fields used by both HTTP/2 and HTTP/3 */
   const uint8_t *upload_mem; /* points to a buffer to read from */
   size_t upload_len; /* size of the buffer 'upload_mem' points to */

--- a/lib/quic.h
+++ b/lib/quic.h
@@ -45,9 +45,11 @@ CURLcode Curl_quic_is_connected(struct connectdata *conn,
                                 bool *connected);
 int Curl_quic_ver(char *p, size_t len);
 CURLcode Curl_quic_done_sending(struct connectdata *conn);
+void Curl_http3_done(struct Curl_easy *data);
 
 #else /* ENABLE_QUIC */
 #define Curl_quic_done_sending(x)
+#define Curl_http3_done(x);
 #endif /* !ENABLE_QUIC */
 
 #endif /* HEADER_CURL_QUIC_H */

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1575,6 +1575,10 @@ static CURLcode ng_flush_egress(struct connectdata *conn, int sockfd,
   return CURLE_OK;
 }
 
+void Curl_http3_done(struct Curl_easy *data)
+{
+  (void)data;
+}
 /*
  * Called from transfer.c:done_sending when we stop HTTP/3 uploading.
  */


### PR DESCRIPTION
:status doesn't have to be the first header from quiche to arrive so
this code now makes sure to handle such events. HTTP/3 (and HTTP/2)
mandates:

"All pseudo-header fields MUST appear in the header block before regular
header fields"

Fixes #4571