### PR TITLE
ssh knownhost improvement

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -793,8 +793,8 @@ enum curl_khmatch {
   CURLKHMATCH_LAST      /* not for use, only a marker for last-in-list */
 };
 
-typedef int (*curl_func_lock) (HANDLE handle);
-typedef int (*curl_func_unlock) (HANDLE handle);
+typedef int (*curl_func_lock) (void* handle);
+typedef int (*curl_func_unlock) (void* handle);
 
 typedef int
   (*curl_sshkeycallback) (CURL *easy,     /* easy handle */

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -781,6 +781,7 @@ enum curl_khstat {
   CURLKHSTAT_DEFER,  /* do not accept it, but we can't answer right now so
                         this causes a CURLE_DEFER error but otherwise the
                         connection will be left intact etc */
+  CURLKHSTAT_FINE_REPLACE_TO_FILE, /* replace the old entry*/
   CURLKHSTAT_LAST    /* not for use, only a marker for last-in-list */
 };
 
@@ -791,6 +792,9 @@ enum curl_khmatch {
   CURLKHMATCH_MISSING,  /* no matching host/key found */
   CURLKHMATCH_LAST      /* not for use, only a marker for last-in-list */
 };
+
+typedef int (*curl_func_lock) (HANDLE handle);
+typedef int (*curl_func_unlock) (HANDLE handle);
 
 typedef int
   (*curl_sshkeycallback) (CURL *easy,     /* easy handle */
@@ -1926,6 +1930,15 @@ typedef enum {
 
   /* SASL authorisation identity */
   CINIT(SASL_AUTHZID, STRINGPOINT, 289),
+
+  /* SSH handle the global known_host file to use */
+  CINIT(SSH_KNOWNHOSTS_HANDLE_KH, OBJECTPOINT, 290),
+
+  /* SSH handle of the lock to use */
+  CINIT(SSH_KNOWNHOSTS_HANDLE_LOCK, OBJECTPOINT, 291),
+  
+  CINIT(FUNCTION_LOCK,OBJECTPOINT,292),
+  CINIT(FUNCTION_UNLOCK,OBJECTPOINT,293),
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2288,20 +2288,20 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /* the pointer handle to store the handle of the known_host  */
     data->set.ssh_knowhost_pkh = va_arg(param, void**);
     break;
-    
+
   case CURLOPT_SSH_KNOWNHOSTS_HANDLE_LOCK:
     /* the handle to the lock */
     data->set.ssh_knowhost_hlock = va_arg(param, void*);
     break;
-    
+
   case CURLOPT_FUNCTION_LOCK:
     data->set.func_lock = va_arg(param, curl_func_lock);
     break;
-    
+
   case CURLOPT_FUNCTION_UNLOCK:
     data->set.func_unlock = va_arg(param, curl_func_unlock);
     break;
-    
+
   case CURLOPT_SSH_KEYFUNCTION:
     /* setting to NULL is fine since the ssh.c functions themselves will
        then rever to use the internal default */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2284,6 +2284,24 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
                             va_arg(param, char *));
     break;
 
+  case CURLOPT_SSH_KNOWNHOSTS_HANDLE_KH:
+    /* the pointer handle to store the handle of the known_host  */
+    data->set.ssh_knowhost_pkh = va_arg(param, void**);
+    break;
+    
+  case CURLOPT_SSH_KNOWNHOSTS_HANDLE_LOCK:
+    /* the handle to the lock */
+    data->set.ssh_knowhost_hlock = va_arg(param, void*);
+    break;
+    
+  case CURLOPT_FUNCTION_LOCK:
+    data->set.func_lock = va_arg(param, curl_func_lock);
+    break;
+    
+  case CURLOPT_FUNCTION_UNLOCK:
+    data->set.func_unlock = va_arg(param, curl_func_unlock);
+    break;
+    
   case CURLOPT_SSH_KEYFUNCTION:
     /* setting to NULL is fine since the ssh.c functions themselves will
        then rever to use the internal default */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2286,12 +2286,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_SSH_KNOWNHOSTS_HANDLE_KH:
     /* the pointer handle to store the handle of the known_host  */
-    data->set.ssh_knowhost_pkh = va_arg(param, void**);
+    data->set.ssh_knowhost_pkh = va_arg(param, void **);
     break;
 
   case CURLOPT_SSH_KNOWNHOSTS_HANDLE_LOCK:
     /* the handle to the lock */
-    data->set.ssh_knowhost_hlock = va_arg(param, void*);
+    data->set.ssh_knowhost_hlock = va_arg(param, void *);
     break;
 
   case CURLOPT_FUNCTION_LOCK:

--- a/lib/url.c
+++ b/lib/url.c
@@ -483,10 +483,10 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 #ifdef USE_TLS_SRP
   set->ssl.authtype = CURL_TLSAUTH_NONE;
 #endif
-  set->ssh_knowhost_pkh = NULL; /*default 
-									no common file for knownhost*/
+  set->ssh_knowhost_pkh = NULL; /*default
+                                    no common file for knownhost*/
   set->ssh_knowhost_hlock = NULL;/*default
-									no common lock handle for knownhost*/
+                                    no common lock handle for knownhost*/
 
   set->ssh_auth_types = CURLSSH_AUTH_DEFAULT; /* defaults to any auth
                                                       type */

--- a/lib/url.c
+++ b/lib/url.c
@@ -483,9 +483,11 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 #ifdef USE_TLS_SRP
   set->ssl.authtype = CURL_TLSAUTH_NONE;
 #endif
-  set->ssh_knowhost_pkh = NULL; /*default no common file for knownhost*/
-  set->ssh_knowhost_hlock = NULL; /*default no common lock handle for knownhost*/
-  
+  set->ssh_knowhost_pkh = NULL; /*default 
+									no common file for knownhost*/
+  set->ssh_knowhost_hlock = NULL;/*default
+									no common lock handle for knownhost*/
+
   set->ssh_auth_types = CURLSSH_AUTH_DEFAULT; /* defaults to any auth
                                                       type */
   set->ssl.primary.sessionid = TRUE; /* session ID caching enabled by

--- a/lib/url.c
+++ b/lib/url.c
@@ -472,6 +472,8 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   Curl_mime_initpart(&set->mimepost, data);
 
+  set->func_lock = NULL;
+  set->func_unlock = NULL;
   /*
    * libcurl 7.10 introduced SSL verification *by default*! This needs to be
    * switched off unless wanted.
@@ -481,6 +483,9 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 #ifdef USE_TLS_SRP
   set->ssl.authtype = CURL_TLSAUTH_NONE;
 #endif
+  set->ssh_knowhost_pkh = NULL; /*default no common file for knownhost*/
+  set->ssh_knowhost_hlock = NULL; /*default no common lock handle for knownhost*/
+  
   set->ssh_auth_types = CURLSSH_AUTH_DEFAULT; /* defaults to any auth
                                                       type */
   set->ssl.primary.sessionid = TRUE; /* session ID caching enabled by

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1661,8 +1661,8 @@ struct UserDefined {
   long new_file_perms;    /* Permissions to use when creating remote files */
   long new_directory_perms; /* Permissions to use when creating remote dirs */
   long ssh_auth_types;   /* allowed SSH auth types */
-  void** ssh_knowhost_pkh; /* common file for knownhost */
-  void* ssh_knowhost_hlock; /* common lock handle for knownhost */
+  void **ssh_knowhost_pkh; /* common file for knownhost */
+  void *ssh_knowhost_hlock; /* common lock handle for knownhost */
   char *str[STRING_LAST]; /* array of strings, pointing to allocated memory */
   unsigned int scope_id;  /* Scope id for IPv6 */
   long allowed_protocols;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1650,6 +1650,8 @@ struct UserDefined {
   int ftp_create_missing_dirs; /* 1 - create directories that don't exist
                                   2 - the same but also allow MKD to fail once
                                */
+  curl_func_lock func_lock;
+  curl_func_unlock func_unlock;
   curl_sshkeycallback ssh_keyfunc; /* key matching callback */
   void *ssh_keyfunc_userp;         /* custom pointer to callback */
   enum CURL_NETRC_OPTION
@@ -1659,6 +1661,8 @@ struct UserDefined {
   long new_file_perms;    /* Permissions to use when creating remote files */
   long new_directory_perms; /* Permissions to use when creating remote dirs */
   long ssh_auth_types;   /* allowed SSH auth types */
+  void** ssh_knowhost_pkh; /* common file for knownhost */
+  void* ssh_knowhost_hlock; /* common lock handle for knownhost */
   char *str[STRING_LAST]; /* array of strings, pointing to allocated memory */
   unsigned int scope_id;  /* Scope id for IPv6 */
   long allowed_protocols;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -559,7 +559,8 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
         if(addrc)
           infof(data, "Warning adding the known host %s failed!\n",
                 conn->host.name);
-        else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE || rc == CURLKHSTAT_FINE_REPLACE_TO_FILE) {
+        else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE 
+                || rc == CURLKHSTAT_FINE_REPLACE_TO_FILE) {
           /* now we write the entire in-memory list of known hosts to the
              known_hosts file */
           int wrc =
@@ -2922,7 +2923,8 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
     /*global known_host file ?*/
     if(data->set.ssh_knowhost_pkh) {
       ssh->kh = *(data->set.ssh_knowhost_pkh);
-    }else ssh->kh = NULL;
+    }
+    else ssh->kh = NULL;
 
     if(ssh->kh == NULL) {
       int rc;
@@ -2930,7 +2932,8 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
       if(!ssh->kh) {
         libssh2_session_free(ssh->ssh_session);
         return CURLE_FAILED_INIT;
-      }else if(data->set.ssh_knowhost_pkh) {
+      }
+      else if(data->set.ssh_knowhost_pkh) {
         *(data->set.ssh_knowhost_pkh) = ssh->kh;
       }
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -452,7 +452,7 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
                                                     &keylen, &keytype);
     int keycheck = LIBSSH2_KNOWNHOST_CHECK_FAILURE;
     int keybit = 0;
-    
+
     if(data->set.ssh_knowhost_hlock && data->set.func_lock)
       data->set.func_lock(data->set.ssh_knowhost_hlock);
 
@@ -471,7 +471,7 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
 
       keybit = (keytype == LIBSSH2_HOSTKEY_TYPE_RSA)?
         LIBSSH2_KNOWNHOST_KEY_SSHRSA:LIBSSH2_KNOWNHOST_KEY_SSHDSS;
-      
+
 #ifdef HAVE_LIBSSH2_KNOWNHOST_CHECKP
       keycheck = libssh2_knownhost_checkp(sshc->kh,
                                           conn->host.name,
@@ -2600,7 +2600,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
     case SSH_SESSION_FREE:
 #ifdef HAVE_LIBSSH2_KNOWNHOST_API
       if(sshc->kh) {
-        if(data->set.ssh_knowhost_pkh==NULL)libssh2_knownhost_free(sshc->kh);
+        if(data->set.ssh_knowhost_pkh == NULL)libssh2_knownhost_free(sshc->kh);
         sshc->kh = NULL;
       }
 #endif
@@ -2923,7 +2923,7 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
     if(data->set.ssh_knowhost_pkh) {
       ssh->kh = *(data->set.ssh_knowhost_pkh);
     }else ssh->kh = NULL;
-    
+
     if(ssh->kh == NULL) {
       int rc;
       ssh->kh = libssh2_knownhost_init(ssh->ssh_session);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -454,7 +454,7 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
     int keybit = 0;
     
     if(data->set.ssh_knowhost_hlock && data->set.func_lock)
-		data->set.func_lock(data->set.ssh_knowhost_hlock);
+      data->set.func_lock(data->set.ssh_knowhost_hlock);
 
     if(remotekey) {
       /*
@@ -544,9 +544,9 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
     case CURLKHSTAT_FINE_REPLACE_TO_FILE:
       /* proceed */
       if(keycheck != LIBSSH2_KNOWNHOST_CHECK_MATCH) {
-		int addrc;
-        if(rc == CURLKHSTAT_FINE_REPLACE_TO_FILE && host){
-            libssh2_knownhost_del(sshc->kh, host);
+        int addrc;
+        if(rc == CURLKHSTAT_FINE_REPLACE_TO_FILE && host) {
+          libssh2_knownhost_del(sshc->kh, host);
         }
         /* the found host+key didn't match but has been told to be fine
            anyway so we add it in memory */
@@ -575,7 +575,7 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
       break;
     }
     if(data->set.ssh_knowhost_hlock && data->set.func_unlock)
-		data->set.func_unlock(data->set.ssh_knowhost_hlock);
+        data->set.func_unlock(data->set.ssh_knowhost_hlock);
   }
 #else /* HAVE_LIBSSH2_KNOWNHOST_API */
   (void)conn;
@@ -2918,32 +2918,32 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
   if(data->set.str[STRING_SSH_KNOWNHOSTS]) {
     /*handle to global lock ?*/
     if(data->set.ssh_knowhost_hlock && data->set.func_lock)
-		data->set.func_lock(data->set.ssh_knowhost_hlock);
+      data->set.func_lock(data->set.ssh_knowhost_hlock);
     /*global known_host file ?*/
-    if(data->set.ssh_knowhost_pkh){
-        ssh->kh = *(data->set.ssh_knowhost_pkh);
+    if(data->set.ssh_knowhost_pkh) {
+      ssh->kh = *(data->set.ssh_knowhost_pkh);
     }else ssh->kh = NULL;
     
-    if(ssh->kh == NULL){
-        int rc;
-        ssh->kh = libssh2_knownhost_init(ssh->ssh_session);
-        if(!ssh->kh) {
-          libssh2_session_free(ssh->ssh_session);
-          return CURLE_FAILED_INIT;
-        }else if(data->set.ssh_knowhost_pkh){
-            *(data->set.ssh_knowhost_pkh) = ssh->kh;
-        }
+    if(ssh->kh == NULL) {
+      int rc;
+      ssh->kh = libssh2_knownhost_init(ssh->ssh_session);
+      if(!ssh->kh) {
+        libssh2_session_free(ssh->ssh_session);
+        return CURLE_FAILED_INIT;
+      }else if(data->set.ssh_knowhost_pkh) {
+        *(data->set.ssh_knowhost_pkh) = ssh->kh;
+      }
 
-        /* read all known hosts from there */
-        rc = libssh2_knownhost_readfile(ssh->kh,
-                                        data->set.str[STRING_SSH_KNOWNHOSTS],
-                                        LIBSSH2_KNOWNHOST_FILE_OPENSSH);
-        if(rc < 0)
-          infof(data, "Failed to read known hosts from %s\n",
-                data->set.str[STRING_SSH_KNOWNHOSTS]);
+      /* read all known hosts from there */
+      rc = libssh2_knownhost_readfile(ssh->kh,
+                                      data->set.str[STRING_SSH_KNOWNHOSTS],
+                                      LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+      if(rc < 0)
+        infof(data, "Failed to read known hosts from %s\n",
+              data->set.str[STRING_SSH_KNOWNHOSTS]);
     }
     if(data->set.ssh_knowhost_hlock && data->set.func_unlock)
-		data->set.func_unlock(data->set.ssh_knowhost_hlock);
+      data->set.func_unlock(data->set.ssh_knowhost_hlock);
   }
 #endif /* HAVE_LIBSSH2_KNOWNHOST_API */
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -453,7 +453,8 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
     int keycheck = LIBSSH2_KNOWNHOST_CHECK_FAILURE;
     int keybit = 0;
     
-    if(data->set.ssh_knowhost_hlock && data->set.func_lock)data->set.func_lock(data->set.ssh_knowhost_hlock);
+    if(data->set.ssh_knowhost_hlock && data->set.func_lock)
+		data->set.func_lock(data->set.ssh_knowhost_hlock);
 
     if(remotekey) {
       /*
@@ -573,7 +574,8 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
       }
       break;
     }
-    if(data->set.ssh_knowhost_hlock && data->set.func_unlock)data->set.func_unlock(data->set.ssh_knowhost_hlock);
+    if(data->set.ssh_knowhost_hlock && data->set.func_unlock)
+		data->set.func_unlock(data->set.ssh_knowhost_hlock);
   }
 #else /* HAVE_LIBSSH2_KNOWNHOST_API */
   (void)conn;
@@ -2915,7 +2917,8 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
 #ifdef HAVE_LIBSSH2_KNOWNHOST_API
   if(data->set.str[STRING_SSH_KNOWNHOSTS]) {
     /*handle to global lock ?*/
-    if(data->set.ssh_knowhost_hlock && data->set.func_lock)data->set.func_lock(data->set.ssh_knowhost_hlock);
+    if(data->set.ssh_knowhost_hlock && data->set.func_lock)
+		data->set.func_lock(data->set.ssh_knowhost_hlock);
     /*global known_host file ?*/
     if(data->set.ssh_knowhost_pkh){
         ssh->kh = *(data->set.ssh_knowhost_pkh);
@@ -2939,7 +2942,8 @@ static CURLcode ssh_connect(struct connectdata *conn, bool *done)
           infof(data, "Failed to read known hosts from %s\n",
                 data->set.str[STRING_SSH_KNOWNHOSTS]);
     }
-    if(data->set.ssh_knowhost_hlock && data->set.func_unlock)data->set.func_unlock(data->set.ssh_knowhost_hlock);
+    if(data->set.ssh_knowhost_hlock && data->set.func_unlock)
+		data->set.func_unlock(data->set.ssh_knowhost_hlock);
   }
 #endif /* HAVE_LIBSSH2_KNOWNHOST_API */
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -559,7 +559,7 @@ static CURLcode ssh_knownhost(struct connectdata *conn)
         if(addrc)
           infof(data, "Warning adding the known host %s failed!\n",
                 conn->host.name);
-        else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE 
+        else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE
                 || rc == CURLKHSTAT_FINE_REPLACE_TO_FILE) {
           /* now we write the entire in-memory list of known hosts to the
              known_hosts file */


### PR DESCRIPTION
for my project I need a better handling of the know_host file:

I looked at the CURLSHOPT_LOCKFUNC mechanism, but it doesn't suit my need. 
( I need a lock mechanism different for each known_host file )

So I added a lock mechanism with two callback and a handle:

-   curl_func_lock func_lock; <== generic function
-   curl_func_unlock func_unlock; <== generic function
-   void* ssh_knowhost_hlock; <== handle for the lock mechanism used only for the known_host file

I need also to have one known_host file for multiple connection, so I added a pointer to an handle. If this pointer is not null, the handle of the known_host file is stored in the pointer.

I also need the ability to change an old fingerprint, so I added the option :

CURLKHSTAT_FINE_REPLACE_TO_FILE when the function ssh_keyfunc is called.


It's my first time that I make a pull request, so if there is something not correct with my english, or my code, tell me, I will change if it's possible.

Micka,

