### PR TITLE
doh: fix curl handle option inheritance

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -269,25 +269,25 @@ static CURLcode dohprobe(struct Curl_easy *data,
     ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 #endif
     ERROR_CHECK_SETOPT(CURLOPT_TIMEOUT_MS, (long)timeout_ms);
-    if(data->set.verbose)
-      ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, 1L);
-    if(data->set.no_signal)
-      ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
+    ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, data->set.verbose ? 1L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, data->set.no_signal ? 1L : 0L);
 
     /* Inherit *some* SSL options from the user's transfer. This is a
        best-guess as to which options are needed for compatibility. #3661 */
-    if(data->set.ssl.falsestart)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_FALSESTART, 1L);
-    if(data->set.ssl.primary.verifyhost)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYHOST, 2L);
-    if(data->set.proxy_ssl.primary.verifyhost)
-      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYHOST, 2L);
-    if(data->set.ssl.primary.verifypeer)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYPEER, 1L);
-    if(data->set.proxy_ssl.primary.verifypeer)
-      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYPEER, 1L);
-    if(data->set.ssl.primary.verifystatus)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYSTATUS, 1L);
+    ERROR_CHECK_SETOPT(CURLOPT_CERTINFO,
+      data->set.ssl.certinfo ? 1L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_SSL_FALSESTART,
+      data->set.ssl.falsestart ? 1L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYHOST,
+      data->set.ssl.primary.verifyhost ? 2L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYHOST,
+      data->set.proxy_ssl.primary.verifyhost ? 2L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYPEER,
+      data->set.ssl.primary.verifypeer ? 1L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYPEER,
+      data->set.proxy_ssl.primary.verifypeer ? 1L : 0L);
+    ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYSTATUS,
+      data->set.ssl.primary.verifystatus ? 1L : 0L);
     if(data->set.str[STRING_SSL_CAFILE_ORIG]) {
       ERROR_CHECK_SETOPT(CURLOPT_CAINFO,
         data->set.str[STRING_SSL_CAFILE_ORIG]);
@@ -312,8 +312,6 @@ static CURLcode dohprobe(struct Curl_easy *data,
       ERROR_CHECK_SETOPT(CURLOPT_PROXY_CRLFILE,
         data->set.str[STRING_SSL_CRLFILE_PROXY]);
     }
-    if(data->set.ssl.certinfo)
-      ERROR_CHECK_SETOPT(CURLOPT_CERTINFO, 1L);
     if(data->set.str[STRING_SSL_RANDOM_FILE]) {
       ERROR_CHECK_SETOPT(CURLOPT_RANDOM_FILE,
         data->set.str[STRING_SSL_RANDOM_FILE]);

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -191,10 +191,10 @@ static int Curl_doh_done(struct Curl_easy *doh, CURLcode result)
 }
 
 #define ERROR_CHECK_SETOPT(x,y) \
-do {                                      \
-  result = curl_easy_setopt(doh, x, y);   \
-  if(result)                              \
-    goto error;                           \
+do {                                         \
+  result = curl_easy_setopt(doh, x, y);      \
+  if(result && result != CURLE_NOT_BUILT_IN) \
+    goto error;                              \
 } WHILE_FALSE
 
 static CURLcode dohprobe(struct Curl_easy *data,

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -269,51 +269,69 @@ static CURLcode dohprobe(struct Curl_easy *data,
     ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 #endif
     ERROR_CHECK_SETOPT(CURLOPT_TIMEOUT_MS, (long)timeout_ms);
-    ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, data->set.verbose ? 1L : 0L);
-    ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, data->set.no_signal ? 1L : 0L);
+    if(data->set.verbose)
+      ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, 1L);
+    if(data->set.no_signal)
+      ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
 
     /* Inherit *some* SSL options from the user's transfer. This is a
-       best-guess as to which options are needed for compatibility. (#3661)
-       Ignore errors setting the SSL options since they may legitimately return
-       CURLE_NOT_BUILT_IN or CURLE_UNKNOWN_OPTION. */
-    curl_easy_setopt(doh, CURLOPT_CERTINFO,
-      data->set.ssl.certinfo ? 1L : 0L);
-    curl_easy_setopt(doh, CURLOPT_SSL_FALSESTART,
-      data->set.ssl.falsestart ? 1L : 0L);
-    curl_easy_setopt(doh, CURLOPT_SSL_VERIFYHOST,
-      data->set.ssl.primary.verifyhost ? 2L : 0L);
-    curl_easy_setopt(doh, CURLOPT_PROXY_SSL_VERIFYHOST,
-      data->set.proxy_ssl.primary.verifyhost ? 2L : 0L);
-    curl_easy_setopt(doh, CURLOPT_SSL_VERIFYPEER,
-      data->set.ssl.primary.verifypeer ? 1L : 0L);
-    curl_easy_setopt(doh, CURLOPT_PROXY_SSL_VERIFYPEER,
-      data->set.proxy_ssl.primary.verifypeer ? 1L : 0L);
-    curl_easy_setopt(doh, CURLOPT_SSL_VERIFYSTATUS,
-      data->set.ssl.primary.verifystatus ? 1L : 0L);
-    curl_easy_setopt(doh, CURLOPT_CAINFO,
-      data->set.str[STRING_SSL_CAFILE_ORIG]);
-    curl_easy_setopt(doh, CURLOPT_PROXY_CAINFO,
-      data->set.str[STRING_SSL_CAFILE_PROXY]);
-    curl_easy_setopt(doh, CURLOPT_CAPATH,
-      data->set.str[STRING_SSL_CAPATH_ORIG]);
-    curl_easy_setopt(doh, CURLOPT_PROXY_CAPATH,
-      data->set.str[STRING_SSL_CAPATH_PROXY]);
-    curl_easy_setopt(doh, CURLOPT_CRLFILE,
-      data->set.str[STRING_SSL_CRLFILE_ORIG]);
-    curl_easy_setopt(doh, CURLOPT_PROXY_CRLFILE,
-      data->set.str[STRING_SSL_CRLFILE_PROXY]);
-    curl_easy_setopt(doh, CURLOPT_RANDOM_FILE,
-      data->set.str[STRING_SSL_RANDOM_FILE]);
-    curl_easy_setopt(doh, CURLOPT_EGDSOCKET,
-      data->set.str[STRING_SSL_EGDSOCKET]);
-    curl_easy_setopt(doh, CURLOPT_SSL_OPTIONS,
-      data->set.ssl.no_revoke ? CURLSSLOPT_NO_REVOKE : 0);
-    curl_easy_setopt(doh, CURLOPT_PROXY_SSL_OPTIONS,
-      data->set.proxy_ssl.no_revoke ? CURLSSLOPT_NO_REVOKE : 0);
-    curl_easy_setopt(doh, CURLOPT_SSL_CTX_FUNCTION,
-      data->set.ssl.fsslctx);
-    curl_easy_setopt(doh, CURLOPT_SSL_CTX_DATA,
-      data->set.ssl.fsslctxp);
+       best-guess as to which options are needed for compatibility. #3661 */
+    if(data->set.ssl.falsestart)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_FALSESTART, 1L);
+    if(!data->set.ssl.primary.verifyhost)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYHOST, 0L);
+    if(!data->set.ssl.primary.verifypeer)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYPEER, 0L);
+#ifndef CURL_DISABLE_PROXY
+    if(!data->set.proxy_ssl.primary.verifyhost)
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
+    if(!data->set.proxy_ssl.primary.verifypeer)
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
+#endif
+    if(data->set.ssl.primary.verifystatus)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYSTATUS, 1L);
+    if(data->set.str[STRING_SSL_CAFILE_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_CAINFO,
+        data->set.str[STRING_SSL_CAFILE_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CAFILE_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_CAINFO,
+        data->set.str[STRING_SSL_CAFILE_PROXY]);
+    }
+    if(data->set.str[STRING_SSL_CAPATH_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_CAPATH,
+        data->set.str[STRING_SSL_CAPATH_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CAPATH_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_CAPATH,
+        data->set.str[STRING_SSL_CAPATH_PROXY]);
+    }
+    if(data->set.str[STRING_SSL_CRLFILE_ORIG]) {
+      ERROR_CHECK_SETOPT(CURLOPT_CRLFILE,
+        data->set.str[STRING_SSL_CRLFILE_ORIG]);
+    }
+    if(data->set.str[STRING_SSL_CRLFILE_PROXY]) {
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_CRLFILE,
+        data->set.str[STRING_SSL_CRLFILE_PROXY]);
+    }
+    if(data->set.ssl.certinfo)
+      ERROR_CHECK_SETOPT(CURLOPT_CERTINFO, 1L);
+    if(data->set.str[STRING_SSL_RANDOM_FILE]) {
+      ERROR_CHECK_SETOPT(CURLOPT_RANDOM_FILE,
+        data->set.str[STRING_SSL_RANDOM_FILE]);
+    }
+    if(data->set.str[STRING_SSL_EGDSOCKET]) {
+      ERROR_CHECK_SETOPT(CURLOPT_EGDSOCKET,
+        data->set.str[STRING_SSL_EGDSOCKET]);
+    }
+    if(data->set.ssl.no_revoke)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
+    if(data->set.proxy_ssl.no_revoke)
+      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
+    if(data->set.ssl.fsslctx)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_FUNCTION, data->set.ssl.fsslctx);
+    if(data->set.ssl.fsslctxp)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_DATA, data->set.ssl.fsslctxp);
 
     doh->set.fmultidone = Curl_doh_done;
     doh->set.dohfor = data; /* identify for which transfer this is done */


### PR DESCRIPTION
Prior to this change some doh handle options inherited from the user's
easy handle were only inherited if they were turned on, not if they were
off.

~~~
[API option] : [Default API setting]
CURLOPT_CERTINFO              : OFF
CURLOPT_NOSIGNAL              : OFF
CURLOPT_PROXY_SSL_VERIFYHOST  : ON    <-- affected
CURLOPT_PROXY_SSL_VERIFYPEER  : ON    <-- affected
CURLOPT_SSL_FALSESTART        : OFF
CURLOPT_SSL_VERIFYHOST        : ON    <-- affected
CURLOPT_SSL_VERIFYPEER        : ON    <-- affected
CURLOPT_SSL_VERIFYSTATUS      : OFF
CURLOPT_VERBOSE               : OFF
~~~

For example if CURLOPT_SSL_VERIFYPEER was turned off by the user then
that would not have been inherited by the doh handle and its verify peer
setting would have defaulted to on.

Prior to this change users were not able to disable SSL verification of
the DOH server.

Reported-by: 3dyd@users.noreply.github.com

Fixes #4578
Closes #xxxx

---

fixed by changing the pattern

Before:
~~~c
    if(data->set.proxy_ssl.primary.verifyhost)
      ERROR_CHECK_SETOPT(CURLOPT_PROXY_SSL_VERIFYHOST, 2L);
~~~

After:
~~~c
    ERROR_CHECK_SETOPT(CURLOPT_SSL_VERIFYHOST,
      data->set.ssl.primary.verifyhost ? 2L : 0L);
~~~