### PR TITLE
quiche: reject headers in the wrong order

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -84,6 +84,7 @@ CURLE_FUNCTION_NOT_FOUND        7.1
 CURLE_GOT_NOTHING               7.9.1
 CURLE_HTTP2                     7.38.0
 CURLE_HTTP2_STREAM              7.49.0
+CURLE_HTTP3                     7.68.0
 CURLE_HTTP_NOT_FOUND            7.1
 CURLE_HTTP_PORT_FAILED          7.3           7.12.0
 CURLE_HTTP_POST_ERROR           7.1

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -501,7 +501,9 @@ typedef enum {
   CURLE_FTP_COULDNT_SET_TYPE,    /* 17 */
   CURLE_PARTIAL_FILE,            /* 18 */
   CURLE_FTP_COULDNT_RETR_FILE,   /* 19 */
-  CURLE_OBSOLETE20,              /* 20 - NOT USED */
+  CURLE_HTTP3,                   /* 20 - An HTTP/3 layer problem.
+                                    [was obsoleted in August 2007 for 7.17.0,
+                                    reused in November 2019 for 7.67.1] */
   CURLE_QUOTE_ERROR,             /* 21 - quote command failure */
   CURLE_HTTP_RETURNED_ERROR,     /* 22 */
   CURLE_WRITE_ERROR,             /* 23 */

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -314,8 +314,10 @@ curl_easy_strerror(CURLcode error)
   case CURLE_AUTH_ERROR:
     return "An authentication function returned an error";
 
+  case CURLE_HTTP3:
+    return "HTTP/3 error";
+
     /* error codes not used by current libcurl */
-  case CURLE_OBSOLETE20:
   case CURLE_OBSOLETE24:
   case CURLE_OBSOLETE29:
   case CURLE_OBSOLETE32:

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -379,6 +379,9 @@ static int cb_each_header(uint8_t *name, size_t name_len,
               headers->destlen, "HTTP/3 %.*s\n",
               (int) value_len, value);
   }
+  else if(!headers->nlen) {
+    return CURLE_HTTP3;
+  }
   else {
     msnprintf(headers->dest,
               headers->destlen, "%.*s: %.*s\n",
@@ -433,7 +436,9 @@ static ssize_t h3_stream_recv(struct connectdata *conn,
     case QUICHE_H3_EVENT_HEADERS:
       rc = quiche_h3_event_for_each_header(ev, cb_each_header, &headers);
       if(rc) {
-        /* what do we do about this? */
+        *curlcode = rc;
+        failf(data, "Error in HTTP/3 response header");
+        break;
       }
       recvd = headers.nlen;
       break;

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -52,7 +52,7 @@ e16: Error in the HTTP2 framing layer
 e17: FTP: couldn't set file type
 e18: Transferred a partial file
 e19: FTP: couldn't retrieve (RETR failed) the specified file
-e20: Unknown error
+e20: HTTP/3 error
 e21: Quote command returned error
 e22: HTTP response code said error
 e23: Failed writing received data to disk/application


### PR DESCRIPTION
Pseudo header MUST come before regular headers or cause an error.

Reported-by: Cynthia Coan
Fixes #4571