### PR TITLE
openssl: prevent recursive function calls from ctx callbacks

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2806,8 +2806,10 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 
   /* give application a chance to interfere with SSL set up. */
   if(data->set.ssl.fsslctx) {
+    Curl_set_in_callback(data, true);
     result = (*data->set.ssl.fsslctx)(data, BACKEND->ctx,
                                       data->set.ssl.fsslctxp);
+    Curl_set_in_callback(data, false);
     if(result) {
       failf(data, "error signaled by ssl ctx callback");
       return result;


### PR DESCRIPTION
Follow the pattern of many other callbacks.

Ref: #4546