### PR TITLE
config-win32: cpu-machine-OS for Windows on ARM

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -737,7 +737,7 @@ Vista
 #define OS "x86_64-pc-win32"
 #elif defined(_M_IA64) || defined(__ia64__) /* Itanium */
 #define OS "ia64-pc-win32"
-#elif defined(_M_ARM_NT) || defined(__arm__) /* ARMv7-Thumb2 (Windows RT, Windows 10 IoT) */
+#elif defined(_M_ARM_NT) || defined(__arm__) /* ARMv7-Thumb2 (Windows RT) */
 #define OS "thumbv7a-pc-win32"
 #elif defined(_M_ARM64) || defined(__aarch64__) /* ARM64 (Windows 10) */
 #define OS "aarch64-pc-win32"

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -735,8 +735,12 @@ Vista
 #define OS "i386-pc-win32"
 #elif defined(_M_X64) || defined(__x86_64__) /* x86_64 (MSVC >=2005 or gcc) */
 #define OS "x86_64-pc-win32"
-#elif defined(_M_IA64) /* Itanium */
+#elif defined(_M_IA64) || defined(__ia64__) /* Itanium */
 #define OS "ia64-pc-win32"
+#elif defined(_M_ARM_NT) || defined(__arm__) /* ARMv7-Thumb2 (Windows RT, Windows 10 IoT) */
+#define OS "thumbv7a-pc-win32"
+#elif defined(_M_ARM64) || defined(__aarch64__) /* ARM64 (Windows 10) */
+#define OS "aarch64-pc-win32"
 #else
 #define OS "unknown-pc-win32"
 #endif


### PR DESCRIPTION
Define the OS macro properly for Windows on ARM builds.  Also, we might as well add the GCC-style IA-64 macro.