### PR TITLE
multi_poll: avoid busy-loop when called without easy handles attached

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1157,6 +1157,10 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
     if(!curl_multi_timeout(multi, &sleep_ms) && sleep_ms) {
       if(sleep_ms > timeout_ms)
         sleep_ms = timeout_ms;
+      /* when there are no easy handles in the multi, this holds a -1
+         timeout */
+      else if((sleep_ms < 0) && extrawait)
+        sleep_ms = timeout_ms;
       Curl_wait_ms((int)sleep_ms);
     }
   }


### PR DESCRIPTION
Fixes #4594
Reported-by: 3dyd on github