### PR TITLE
ngtcp2: use overflow buffer for extra HTTP/3 data

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1618,6 +1618,7 @@ CURLcode Curl_http_done(struct connectdata *conn,
   }
 
   Curl_http2_done(conn, premature);
+  Curl_quic_done(data, premature);
 
   Curl_mime_cleanpart(&http->form);
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -193,6 +193,7 @@ struct HTTP {
 #ifdef ENABLE_QUIC
   /*********** for HTTP/3 we store stream-local data here *************/
   int64_t stream3_id; /* stream we are interested in */
+  bool firstheader;  /* FALSE until headers arrive */
   bool firstbody;  /* FALSE until body arrives */
   bool h3req;    /* FALSE until request is issued */
   bool upload_done;
@@ -200,6 +201,9 @@ struct HTTP {
 #ifdef USE_NGHTTP3
   size_t unacked_window;
   struct h3out *h3out; /* per-stream buffers for upload */
+  char *overflow_buf; /* excess data received during a single Curl_read */
+  size_t overflow_buflen; /* amount of data currently in overflow_buf */
+  size_t overflow_bufsize; /* size of the overflow_buf allocation */
 #endif
 };
 

--- a/lib/quic.h
+++ b/lib/quic.h
@@ -45,9 +45,13 @@ CURLcode Curl_quic_is_connected(struct connectdata *conn,
                                 bool *connected);
 int Curl_quic_ver(char *p, size_t len);
 CURLcode Curl_quic_done_sending(struct connectdata *conn);
+void Curl_quic_done(struct Curl_easy *data, bool premature);
+bool Curl_quic_data_pending(const struct Curl_easy *data);
 
 #else /* ENABLE_QUIC */
 #define Curl_quic_done_sending(x)
+#define Curl_quic_done(x,y)
+#define Curl_quic_data_pending(x)
 #endif /* !ENABLE_QUIC */
 
 #endif /* HEADER_CURL_QUIC_H */

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -785,4 +785,23 @@ CURLcode Curl_quic_done_sending(struct connectdata *conn)
   return CURLE_OK;
 }
 
+/*
+ * Called from http.c:Curl_http_done when a request completes.
+ */
+void Curl_quic_done(struct Curl_easy *data, bool premature)
+{
+  (void)data;
+  (void)premature;
+}
+
+/*
+ * Called from transfer.c:data_pending to know if we should keep looping
+ * to receive more data from the connection.
+ */
+bool Curl_quic_data_pending(const struct Curl_easy *data)
+{
+  (void)data;
+  return FALSE;
+}
+
 #endif


### PR DESCRIPTION
Fixes: #4525

This change adds a new dynamically sized buffer, called the _overflow buffer_, that is used when the following conditions are true:

1. The transfer is using HTTP/3 with the ngtcp2 backend.
2. During a single call to Curl_read, we find more HTTP/3 data (headers + body) that we can fit in the receive buffer in one go. This can happen when the receive buffer is small and a burst of data that includes QPACK-compressed headers is received from the server (see discussion in #4525).

This is an alternative to #4602 that doesn't resize the receive buffer itself. I like this approach better.