### PR TITLE
Fix curl_multi_poll() when extra_fds && !extra_nfds

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1147,7 +1147,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
     free(ufds);
   if(ret)
     *ret = retcode;
-  if(!extrawait || extra_fds || curlfds)
+  if(!extrawait || nfds)
     /* if any socket was checked */
     ;
   else {


### PR DESCRIPTION
The check if an extra wait is necessary was based not on the
number of extra fds but on the pointer.
If a non-null pointer was given in extra_fds, but extra_nfds
was zero, then the wait was skipped even though poll was not
called.