### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/cmdline-opts/alt-svc.d
+++ b/docs/cmdline-opts/alt-svc.d
@@ -4,7 +4,7 @@ Protocols: HTTPS
 Help: Enable alt-svc with this cache file
 Added: 7.64.1
 ---
-WARNING: this option is experiemental. Do not use in production.
+WARNING: this option is experimental. Do not use in production.
 
 This option enables the alt-svc parser in curl. If the file name points to an
 existing alt-svc cache file, that will be used. After a completed transfer,

--- a/docs/cmdline-opts/http3.d
+++ b/docs/cmdline-opts/http3.d
@@ -8,7 +8,7 @@ Help: Use HTTP v3
 See-also: http1.1 http2
 ---
 
-WARNING: this option is experiemental. Do not use in production.
+WARNING: this option is experimental. Do not use in production.
 
 Tells curl to use HTTP version 3 directly to the host and port number used in
 the URL. A normal HTTP/3 transaction will be done to a host and then get


### PR DESCRIPTION
'experiemental' --> 'experimental"