### PR TITLE
DOH: support query for RRset at child node of hostname node

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -86,8 +86,14 @@ UNITTEST DOHcode doh_encodepfx(const char *host,
   const size_t hostlen = strlen(host);
   unsigned char *orig = dnsp;
   const size_t preflen = prefix ? strlen(prefix) : 0;
-  const char *fragment[] = { prefix, host };
-  const int fragments = sizeof(fragment)/sizeof(*fragment);
+  size_t expected_len;
+  int i;
+
+  /* For C89 ... */
+  char *fragment[2];
+  int fragments = 2;
+  fragment[0] = (char *) prefix;
+  fragment[1] = (char *) host;
 
   /* The expected output length is 16 bytes more than the length of
    * the QNAME-encoding of the host name.
@@ -111,7 +117,6 @@ UNITTEST DOHcode doh_encodepfx(const char *host,
    * the overall length by one.
    */
 
-  size_t expected_len;
   DEBUGASSERT(hostlen);
   expected_len = 12 + hostlen + preflen + 1 + 4;
   if(host[hostlen-1]!='.')
@@ -140,7 +145,7 @@ UNITTEST DOHcode doh_encodepfx(const char *host,
   *dnsp++ = '\0'; /* ARCOUNT */
 
   /* encode each label and store it in the QNAME */
-  for(int i = 0; i < fragments; i++) {
+  for(i = 0; i < fragments; i++) {
     char *hostp = (char *)fragment[i];
     if(hostp)
       while(*hostp) {

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -76,12 +76,12 @@ static const char *doh_strerror(DOHcode code)
 
 /* @unittest 1655
  */
-UNITTEST DOHcode doh_encodepfx(const char *host,
-                               const char *prefix,
-                               DNStype dnstype,
-                               unsigned char *dnsp, /* buffer */
-                               size_t len,  /* buffer size */
-                               size_t *olen) /* output length */
+UNITTEST DOHcode doh_encode(const char *host,
+                            const char *prefix,
+                            DNStype dnstype,
+                            unsigned char *dnsp, /* buffer */
+                            size_t len,  /* buffer size */
+                            size_t *olen) /* output length */
 {
   const size_t hostlen = strlen(host);
   unsigned char *orig = dnsp;
@@ -188,9 +188,6 @@ UNITTEST DOHcode doh_encodepfx(const char *host,
   return DOH_OK;
 }
 
-#define doh_encode(host, dnstype, dnsp, len, olen) \
-  (doh_encodepfx(host, NULL, dnstype, dnsp, len, olen))
-
 static size_t
 doh_write_cb(void *contents, size_t size, size_t nmemb, void *userp)
 {
@@ -238,20 +235,20 @@ do {                                      \
     goto error;                           \
 } while(0)
 
-static CURLcode dohprobepfx(struct Curl_easy *data,
-                            struct dnsprobe *p, DNStype dnstype,
-                            const char *prefix,
-                            const char *host,
-                            const char *url, CURLM *multi,
-                            struct curl_slist *headers)
+static CURLcode dohprobe(struct Curl_easy *data,
+                         struct dnsprobe *p, DNStype dnstype,
+                         const char *prefix,
+                         const char *host,
+                         const char *url, CURLM *multi,
+                         struct curl_slist *headers)
 {
   struct Curl_easy *doh = NULL;
   char *nurl = NULL;
   CURLcode result = CURLE_OK;
   timediff_t timeout_ms;
-  DOHcode d = doh_encodepfx(host, prefix, dnstype,
-                            p->dohbuffer, sizeof(p->dohbuffer),
-                            &p->dohlen);
+  DOHcode d = doh_encode(host, prefix, dnstype,
+                         p->dohbuffer, sizeof(p->dohbuffer),
+                         &p->dohlen);
   if(d) {
     failf(data, "Failed to encode DOH packet [%d]\n", d);
     return CURLE_OUT_OF_MEMORY;
@@ -396,9 +393,6 @@ static CURLcode dohprobepfx(struct Curl_easy *data,
   return result;
 }
 
-#define dohprobe(data, p, dnstype, host, url, multi, headers) \
-  (dohprobepfx(data, p, dnstype, NULL, host, url, multi, headers))
-
 /*
  * Curl_doh() resolves a name using DOH. It resolves a name and returns a
  * 'Curl_addrinfo *' with the address information.
@@ -431,7 +425,8 @@ Curl_addrinfo *Curl_doh(struct connectdata *conn,
   if(conn->ip_version != CURL_IPRESOLVE_V6) {
     /* create IPv4 DOH request */
     result = dohprobe(data, &data->req.doh.probe[DOH_PROBE_SLOT_IPADDR_V4],
-                      DNS_TYPE_A, hostname, data->set.str[STRING_DOH],
+                      DNS_TYPE_A, NULL, hostname,
+                      data->set.str[STRING_DOH],
                       data->multi, data->req.doh.headers);
     if(result)
       goto error;
@@ -441,7 +436,8 @@ Curl_addrinfo *Curl_doh(struct connectdata *conn,
   if(conn->ip_version != CURL_IPRESOLVE_V4) {
     /* create IPv6 DOH request */
     result = dohprobe(data, &data->req.doh.probe[DOH_PROBE_SLOT_IPADDR_V6],
-                      DNS_TYPE_AAAA, hostname, data->set.str[STRING_DOH],
+                      DNS_TYPE_AAAA, NULL, hostname,
+                      data->set.str[STRING_DOH],
                       data->multi, data->req.doh.headers);
     if(result)
       goto error;

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -94,11 +94,14 @@ struct dohentry {
 
 
 #ifdef DEBUGBUILD
-DOHcode doh_encode(const char *host,
-                   DNStype dnstype,
-                   unsigned char *dnsp, /* buffer */
-                   size_t len,  /* buffer size */
-                   size_t *olen); /* output length */
+#define doh_encode(host, dnstype, dnsp, len, olen) \
+  (doh_encodepfx(host, NULL, dnstype, dnsp, len, olen))
+DOHcode doh_encodepfx(const char *host,
+                      const char *prefix,
+                      DNStype dnstype,
+                      unsigned char *dnsp, /* buffer */
+                      size_t len,  /* buffer size */
+                      size_t *olen); /* output length */
 DOHcode doh_decode(unsigned char *doh,
                    size_t dohlen,
                    DNStype dnstype,

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -94,14 +94,12 @@ struct dohentry {
 
 
 #ifdef DEBUGBUILD
-#define doh_encode(host, dnstype, dnsp, len, olen) \
-  (doh_encodepfx(host, NULL, dnstype, dnsp, len, olen))
-DOHcode doh_encodepfx(const char *host,
-                      const char *prefix,
-                      DNStype dnstype,
-                      unsigned char *dnsp, /* buffer */
-                      size_t len,  /* buffer size */
-                      size_t *olen); /* output length */
+DOHcode doh_encode(const char *host,
+                   const char *prefix,
+                   DNStype dnstype,
+                   unsigned char *dnsp, /* buffer */
+                   size_t len,  /* buffer size */
+                   size_t *olen); /* output length */
 DOHcode doh_decode(unsigned char *doh,
                    size_t dohlen,
                    DNStype dnstype,

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -561,6 +561,7 @@ struct dohresponse {
 struct dnsprobe {
   CURL *easy;
   int dnstype;
+  char *prefix;                 /* specific to request, like dnstype */
   unsigned char dohbuffer[512];
   size_t dohlen;
   struct dohresponse serverdoh;

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -157,7 +157,7 @@ UNITTEST_START
   size_t i;
   unsigned char *p;
   for(i = 0; i < sizeof(req) / sizeof(req[0]); i++) {
-    int rc = doh_encode(req[i].name, req[i].type,
+    int rc = doh_encode(req[i].name, NULL, req[i].type,
                         buffer, sizeof(buffer), &size);
     if(rc != req[i].rc) {
       fprintf(stderr, "req %zu: Expected return code %d got %d\n", i,


### PR DESCRIPTION
DOH: support query for RRset at child node of hostname node

As documented in RFC8552, some host attributes are published in the DNS at a child 
(or descendant) node of the node which corresponds to the hostname. 

This PR extends the functionality of *dohprobe()* and *doh_encode()* by adding a parameter 
to represent the prefix which identifies the child node relative to the hostname node. 
These functions are renamed respectively as *dohprobepfx()* and *doh_encodepfx()*. 
Pre-processor macros are provided to simulate the existing function prototypes. 
Additional test cases are added to the related unit test.

An anticipated use case is the retrieval of ESNI public-key data from TXT records 
with prefix "_esni". A subsequent PR is planned which will propose support for 
DOH queries with QTYPE=TXT.
 
