### PR TITLE
include: make CURLE_HTTP3 use a new error code

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -256,6 +256,9 @@ Stream error in the HTTP/2 framing layer.
 An API function was called from inside a callback.
 .IP "CURLE_AUTH_ERROR (94)"
 An authentication function returned an error.
+.IP "CURLE_HTTP3 (95)"
+A problem was detected in the HTTP/3 layer. This is somewhat generic and can
+be one out of several problems, see the error buffer for details.
 .IP "CURLE_OBSOLETE*"
 These error codes will never be returned. They were used in an old libcurl
 version and are currently unused.

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -501,9 +501,7 @@ typedef enum {
   CURLE_FTP_COULDNT_SET_TYPE,    /* 17 */
   CURLE_PARTIAL_FILE,            /* 18 */
   CURLE_FTP_COULDNT_RETR_FILE,   /* 19 */
-  CURLE_HTTP3,                   /* 20 - An HTTP/3 layer problem.
-                                    [was obsoleted in August 2007 for 7.17.0,
-                                    reused in November 2019 for 7.67.1] */
+  CURLE_OBSOLETE20,              /* 20 - NOT USED */
   CURLE_QUOTE_ERROR,             /* 21 - quote command failure */
   CURLE_HTTP_RETURNED_ERROR,     /* 22 */
   CURLE_WRITE_ERROR,             /* 23 */
@@ -604,6 +602,7 @@ typedef enum {
                                     inside a callback */
   CURLE_AUTH_ERROR,              /* 94 - an authentication function returned an
                                     error */
+  CURLE_HTTP3,                   /* 95 - An HTTP/3 layer problem */
   CURL_LAST /* never use! */
 } CURLcode;
 

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -318,6 +318,7 @@ curl_easy_strerror(CURLcode error)
     return "HTTP/3 error";
 
     /* error codes not used by current libcurl */
+  case CURLE_OBSOLETE20:
   case CURLE_OBSOLETE24:
   case CURLE_OBSOLETE29:
   case CURLE_OBSOLETE32:

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -52,7 +52,7 @@ e16: Error in the HTTP2 framing layer
 e17: FTP: couldn't set file type
 e18: Transferred a partial file
 e19: FTP: couldn't retrieve (RETR failed) the specified file
-e20: HTTP/3 error
+e20: Unknown error
 e21: Quote command returned error
 e22: HTTP response code said error
 e23: Failed writing received data to disk/application
@@ -127,7 +127,8 @@ e91: SSL server certificate status verification FAILED
 e92: Stream error in the HTTP/2 framing layer
 e93: API function called from within callback
 e94: An authentication function returned an error
-e95: Unknown error
+e95: HTTP/3 error
+e96: Unknown error
 m-1: Please call curl_multi_perform() soon
 m0: No error
 m1: Invalid multi handle


### PR DESCRIPTION
To avoid potential issues with error code reuse.

Reported-by: Christoph M. Becker
Assisted-by: Dan Fandrich
Fixes #4601