### PR TITLE
DOH: provision for using additional dedicated DOH probe slots

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -425,8 +425,9 @@ Curl_addrinfo *Curl_doh(struct connectdata *conn,
   error:
   curl_slist_free_all(data->req.doh.headers);
   data->req.doh.headers = NULL;
-  Curl_close(&data->req.doh.probe[0].easy);
-  Curl_close(&data->req.doh.probe[1].easy);
+  for(int slot = 0; slot < DOH_PROBE_SLOTS; slot++) {
+    Curl_close(&data->req.doh.probe[slot].easy);
+  }
   return NULL;
 }
 
@@ -937,46 +938,42 @@ UNITTEST void de_cleanup(struct dohentry *d)
 CURLcode Curl_doh_is_resolved(struct connectdata *conn,
                               struct Curl_dns_entry **dnsp)
 {
+  CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
   *dnsp = NULL; /* defaults to no response */
 
-  if(!data->req.doh.probe[0].easy && !data->req.doh.probe[1].easy) {
+  if(!data->req.doh.probe[DOH_PROBE_SLOT_IPADDR_V4].easy
+     && !data->req.doh.probe[DOH_PROBE_SLOT_IPADDR_V6].easy) {
     failf(data, "Could not DOH-resolve: %s", conn->async.hostname);
     return conn->bits.proxy?CURLE_COULDNT_RESOLVE_PROXY:
       CURLE_COULDNT_RESOLVE_HOST;
   }
   else if(!data->req.doh.pending) {
-    DOHcode rc;
-    DOHcode rc2;
+    DOHcode rc[DOH_PROBE_SLOTS];
     struct dohentry de;
     /* remove DOH handles from multi handle and close them */
-    curl_multi_remove_handle(data->multi, data->req.doh.probe[0].easy);
-    Curl_close(&data->req.doh.probe[0].easy);
-    curl_multi_remove_handle(data->multi, data->req.doh.probe[1].easy);
-    Curl_close(&data->req.doh.probe[1].easy);
+    for(int slot = 0; slot < DOH_PROBE_SLOTS; slot++) {
+      curl_multi_remove_handle(data->multi, data->req.doh.probe[slot].easy);
+      Curl_close(&data->req.doh.probe[slot].easy);
+    }
     /* parse the responses, create the struct and return it! */
     init_dohentry(&de);
-    rc = doh_decode(data->req.doh.probe[0].serverdoh.memory,
-                    data->req.doh.probe[0].serverdoh.size,
-                    data->req.doh.probe[0].dnstype,
-                    &de);
-    Curl_safefree(data->req.doh.probe[0].serverdoh.memory);
-    if(rc) {
-      infof(data, "DOH: %s type %s for %s\n", doh_strerror(rc),
-            type2name(data->req.doh.probe[0].dnstype),
-            data->req.doh.host);
-    }
-    rc2 = doh_decode(data->req.doh.probe[1].serverdoh.memory,
-                     data->req.doh.probe[1].serverdoh.size,
-                     data->req.doh.probe[1].dnstype,
-                     &de);
-    Curl_safefree(data->req.doh.probe[1].serverdoh.memory);
-    if(rc2) {
-      infof(data, "DOH: %s type %s for %s\n", doh_strerror(rc2),
-            type2name(data->req.doh.probe[1].dnstype),
-            data->req.doh.host);
-    }
-    if(!rc || !rc2) {
+    for(int slot = 0; slot < DOH_PROBE_SLOTS; slot++) {
+      rc[slot] = doh_decode(data->req.doh.probe[slot].serverdoh.memory,
+                            data->req.doh.probe[slot].serverdoh.size,
+                            data->req.doh.probe[slot].dnstype,
+                            &de);
+      Curl_safefree(data->req.doh.probe[slot].serverdoh.memory);
+      if(rc[slot]) {
+        infof(data, "DOH: %s type %s for %s\n", doh_strerror(rc[slot]),
+              type2name(data->req.doh.probe[slot].dnstype),
+              data->req.doh.host);
+      }
+    } /* next slot */
+
+    result = CURLE_COULDNT_RESOLVE_HOST; /* until we know better */
+    if(!rc[DOH_PROBE_SLOT_IPADDR_V4] || !rc[DOH_PROBE_SLOT_IPADDR_V6]) {
+      /* we have an address, of one kind or other */
       struct Curl_dns_entry *dns;
       struct Curl_addrinfo *ai;
 
@@ -998,21 +995,26 @@ CURLcode Curl_doh_is_resolved(struct connectdata *conn,
       if(data->share)
         Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
 
-      de_cleanup(&de);
-      if(!dns)
+      if(!dns) {
         /* returned failure, bail out nicely */
         Curl_freeaddrinfo(ai);
+      }
       else {
         conn->async.dns = dns;
         *dnsp = dns;
-        return CURLE_OK;
+        result = CURLE_OK;      /* address resolution OK */
       }
-    }
+    } /* address processing done */
+
+    /* Now process any build-specific attributes retrieved from DNS */
+
+    /* All done */
     de_cleanup(&de);
+    return result;
 
-    return CURLE_COULDNT_RESOLVE_HOST;
-  }
+  } /* !data->req.doh.pending */
 
+  /* else wait for pending DOH transactions to complete */
   return CURLE_OK;
 }
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -528,6 +528,24 @@ enum upgrade101 {
   UPGR101_WORKING             /* talking upgraded protocol */
 };
 
+enum doh_slots {
+  /* Explicit values for first two symbols so as to match hard-coded
+   * constants in existing code
+   */
+  DOH_PROBE_SLOT_IPADDR_V4 = 0, /* make 'V4' stand out for readability */
+  DOH_PROBE_SLOT_IPADDR_V6 = 1, /* 'V6' likewise */
+
+  /* Space here for (possibly build-specific) additional slot definitions */
+
+  /* for example */
+  /* #ifdef WANT_DOH_FOOBAR_TXT */
+  /*   DOH_PROBE_SLOT_FOOBAR_TXT, */
+  /* #endif */
+
+  /* AFTER all slot definitions, establish how many we have */
+  DOH_PROBE_SLOTS
+};
+
 struct dohresponse {
   unsigned char *memory;
   size_t size;
@@ -544,7 +562,7 @@ struct dnsprobe {
 
 struct dohdata {
   struct curl_slist *headers;
-  struct dnsprobe probe[2];
+  struct dnsprobe probe[DOH_PROBE_SLOTS];
   unsigned int pending; /* still outstanding requests */
   const char *host;
   int port;


### PR DESCRIPTION
DOH: provision for using additional dedicated DOH probe slots

The function *Curl_doh()* uses two dedicated “probe slots” for holding
DOH query state independently for each of the DNS QTYPEs, A and AAAA.
In some use cases, additional host attributes, also available from the DNS,
are needed as connection parameters. 

This PR simplifies coding for build-time allocation and run-time
management of extra probe slots which may be needed to hold
query state when retrieving such additional host attributes.

Relates to [this posting](https://curl.haxx.se/mail/lib-2019-11/0074.html) to the curl-library mailing list.
---- stop ----
