### PR TITLE
schannel.c ignores tls-max when tlsv1.x isn't set

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -554,10 +554,6 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     switch(conn->ssl_config.version) {
     case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1:
-      schannel_cred.grbitEnabledProtocols = SP_PROT_TLS1_0_CLIENT |
-        SP_PROT_TLS1_1_CLIENT |
-        SP_PROT_TLS1_2_CLIENT;
-      break;
     case CURL_SSLVERSION_TLSv1_0:
     case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:


### PR DESCRIPTION
If you run `curl --tls-max 1.1 https://example.com` on Windows using SChannel, curl incorrectly ignores the `--tls-max 1.1` argument, and it uses TLS 1.2 instead.

This patch fixes it by using `set_ssl_version_min_max` to set `grbitEnabledProtocols` when `conn->ssl_config.version` is CURL_SSLVERSION_DEFAULT and `CURL_SSLVERSION_TLSv1`