### PR TITLE
ngtcp2: fix thread-safety bug in error-handling

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -256,8 +256,9 @@ static SSL_CTX *quic_ssl_ctx(struct Curl_easy *data)
   SSL_CTX_set_default_verify_paths(ssl_ctx);
 
   if(SSL_CTX_set_ciphersuites(ssl_ctx, QUIC_CIPHERS) != 1) {
-    failf(data, "SSL_CTX_set_ciphersuites: %s",
-          ERR_error_string(ERR_get_error(), NULL));
+    char error_buffer[256];
+    ERR_error_string_n(ERR_get_error(), error_buffer, sizeof(error_buffer));
+    failf(data, "SSL_CTX_set_ciphersuites: %s", error_buffer);
     return NULL;
   }
 


### PR DESCRIPTION
(I was idly looking around for `ERR_error_string` calls and noticed this. I don't have an ngtcp2 build environment set up so this hasn't even been compile-tested, but hopefully the CI will notice if I made a typo somewhere.)

`ERR_error_string(NULL)` should never be called. It places the error in a global buffer, which is not thread-safe. Use `ERR_error_string_n` with a local buffer instead.