### PR TITLE
travis: build ngtcp2 with --enable-lib-only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -469,7 +469,7 @@ before_script:
        git clone --depth 1 https://github.com/ngtcp2/ngtcp2 &&
        cd ngtcp2 &&
        autoreconf -i &&
-       ./configure PKG_CONFIG_PATH=$HOME/ngbuild/lib/pkgconfig LDFLAGS="-Wl,-rpath,$HOME/ngbuild/lib" --prefix=$HOME/ngbuild &&
+       ./configure PKG_CONFIG_PATH=$HOME/ngbuild/lib/pkgconfig LDFLAGS="-Wl,-rpath,$HOME/ngbuild/lib" --prefix=$HOME/ngbuild --enable-lib-only &&
        make && make install)
       fi
     - |


### PR DESCRIPTION
... makes it skip the examples and other stuff we don't neeed.