### PR TITLE
checksrc: fix regexp for ASSIGNWITHINCONDITION

### DIFF
--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -457,7 +457,7 @@ sub scanfile {
             }
         }
 
-        if($nostr =~ /^((.*)(if) *\()(.*)\)/) {
+        if($nostr =~ /^((.*)(if) *\()(.*)\) [{\n]/) {
             my $pos = length($1);
             if($4 =~ / = /) {
                 checkwarn("ASSIGNWITHINCONDITION",

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -97,7 +97,6 @@
 
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR
-/* !checksrc! disable ASSIGNWITHINCONDITION 1 */
 #define SSH_STRING_FREE_CHAR(x) \
     do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } while(0)
 #endif


### PR DESCRIPTION
The regexp looking for assignments within conditions was too greedy and matched a too long string in the case of multiple conditionals on the same line. This is basically only a problem in single line macros, and the code which exemplified this was essentially:
```C
do { if((x) != NULL) { x = NULL; } } while(0)
```
..where the final parenthesis of `while(0)` matched the regexp, and the legal assignment in the block triggered the warning. Fix by making the regexp less greedy by matching for the tell-tale signs of the if statement ending.