### PR TITLE
curl_setup_once: consistently use WHILE_FALSE in macros

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1226,7 +1226,7 @@ static int cookie_sort_ct(const void *p1, const void *p2)
       if(!d->field)                      \
         goto fail;                       \
     }                                    \
-  } while(0)
+  } WHILE_FALSE
 
 static struct Cookie *dup_cookie(struct Cookie *src)
 {

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -58,7 +58,7 @@ do {                                                                \
   (a)[1] = (unsigned char)((((unsigned long) (val)) >> 16) & 0xff); \
   (a)[2] = (unsigned char)((((unsigned long) (val)) >> 8) & 0xff);  \
   (a)[3] = (unsigned char)(((unsigned long) (val)) & 0xff);         \
-} while(0)
+} WHILE_FALSE;
 
 #ifdef HAVE_LONGLONG
 #define WPA_PUT_BE64(a, val)                                    \
@@ -71,7 +71,7 @@ do {                                                            \
   (a)[5] = (unsigned char)(((unsigned long long)(val)) >> 16);  \
   (a)[6] = (unsigned char)(((unsigned long long)(val)) >> 8);   \
   (a)[7] = (unsigned char)(((unsigned long long)(val)) & 0xff); \
-} while(0)
+} WHILE_FALSE;
 #else
 #define WPA_PUT_BE64(a, val)                                  \
 do {                                                          \

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -98,7 +98,7 @@
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR
 #define SSH_STRING_FREE_CHAR(x) \
-    do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } while(0)
+    do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } WHILE_FALSE
 #endif
 
 /* Local functions: */


### PR DESCRIPTION
The `WHILE_FALSE` construction is used to avoid compiler warnings in macro constructions. This fixes a few instances where it was not used in order to keep the code consistent.