### PR TITLE
global_init: move the 'initialized' counter bump to the end

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -140,7 +140,7 @@ curl_calloc_callback Curl_ccalloc;
  */
 static CURLcode global_init(long flags, bool memoryfuncs)
 {
-  if(initialized++)
+  if(initialized)
     return CURLE_OK;
 
   if(memoryfuncs) {
@@ -200,6 +200,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 
   Curl_version_init();
 
+  initialized++;
   return CURLE_OK;
 }
 


### PR DESCRIPTION
... so that failures in the global init function don't count as a
working init and it can then be called again.

Reported-by: Paul Groke
Fixes #4636