### PR TITLE
parsedate: offer a getdate_capped() alternative

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -161,7 +161,7 @@ static CURLcode altsvc_add(struct altsvcinfo *asi, char *line)
               date, &persist, &prio);
   if(9 == rc) {
     struct altsvc *as;
-    time_t expires = curl_getdate(date, NULL);
+    time_t expires = Curl_getdate_capped(date, NULL);
     as = altsvc_create(srchost, dsthost, srcalpn, dstalpn, srcport, dstport);
     if(as) {
       as->expires = expires;

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -161,7 +161,7 @@ static CURLcode altsvc_add(struct altsvcinfo *asi, char *line)
               date, &persist, &prio);
   if(9 == rc) {
     struct altsvc *as;
-    time_t expires = Curl_getdate_capped(date, NULL);
+    time_t expires = Curl_getdate_capped(date);
     as = altsvc_create(srchost, dsthost, srcalpn, dstalpn, srcport, dstport);
     if(as) {
       as->expires = expires;

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -96,6 +96,7 @@ Example set of cookies:
 #include "curl_get_line.h"
 #include "curl_memrchr.h"
 #include "inet_pton.h"
+#include "parsedate.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -715,7 +716,7 @@ Curl_cookie_add(struct Curl_easy *data,
     else if(co->expirestr) {
       /* Note that if the date couldn't get parsed for whatever reason,
          the cookie will be treated as a session cookie */
-      co->expires = curl_getdate(co->expirestr, NULL);
+      co->expires = Curl_getdate_capped(co->expirestr, NULL);
 
       /* Session cookies have expires set to 0 so if we get that back
          from the date parser let's add a second to make it a

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -716,7 +716,7 @@ Curl_cookie_add(struct Curl_easy *data,
     else if(co->expirestr) {
       /* Note that if the date couldn't get parsed for whatever reason,
          the cookie will be treated as a session cookie */
-      co->expires = Curl_getdate_capped(co->expirestr, NULL);
+      co->expires = Curl_getdate_capped(co->expirestr);
 
       /* Session cookies have expires set to 0 so if we get that back
          from the date parser let's add a second to make it a

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2045,7 +2045,7 @@ static CURLcode ftp_state_mdtm_resp(struct connectdata *conn,
                   "%04d%02d%02d %02d:%02d:%02d GMT",
                   year, month, day, hour, minute, second);
         /* now, convert this into a time() value: */
-        data->info.filetime = curl_getdate(timebuf, &secs);
+        data->info.filetime = Curl_getdate_capped(timebuf, &secs);
       }
 
 #ifdef CURL_FTP_HTTPSTYLE_HEAD

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2039,13 +2039,11 @@ static CURLcode ftp_state_mdtm_resp(struct connectdata *conn,
                      &year, &month, &day, &hour, &minute, &second)) {
         /* we have a time, reformat it */
         char timebuf[24];
-        time_t secs = time(NULL);
-
         msnprintf(timebuf, sizeof(timebuf),
                   "%04d%02d%02d %02d:%02d:%02d GMT",
                   year, month, day, hour, minute, second);
         /* now, convert this into a time() value: */
-        data->info.filetime = Curl_getdate_capped(timebuf, &secs);
+        data->info.filetime = Curl_getdate_capped(timebuf);
       }
 
 #ifdef CURL_FTP_HTTPSTYLE_HEAD

--- a/lib/http.c
+++ b/lib/http.c
@@ -3974,7 +3974,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
     else if(checkprefix("Retry-After:", k->p)) {
       /* Retry-After = HTTP-date / delay-seconds */
       curl_off_t retry_after = 0; /* zero for unknown or "now" */
-      time_t date = curl_getdate(&k->p[12], NULL);
+      time_t date = Curl_getdate_capped(&k->p[12], NULL);
       if(-1 == date) {
         /* not a date, try it as a decimal number */
         (void)curlx_strtoofft(&k->p[12], NULL, 10, &retry_after);
@@ -4033,8 +4033,8 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
     else if(!k->http_bodyless && checkprefix("Last-Modified:", k->p) &&
             (data->set.timecondition || data->set.get_filetime) ) {
       time_t secs = time(NULL);
-      k->timeofdoc = curl_getdate(k->p + strlen("Last-Modified:"),
-                                  &secs);
+      k->timeofdoc = Curl_getdate_capped(k->p + strlen("Last-Modified:"),
+                                         &secs);
       if(data->set.get_filetime)
         data->info.filetime = k->timeofdoc;
     }

--- a/lib/http.c
+++ b/lib/http.c
@@ -3974,7 +3974,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
     else if(checkprefix("Retry-After:", k->p)) {
       /* Retry-After = HTTP-date / delay-seconds */
       curl_off_t retry_after = 0; /* zero for unknown or "now" */
-      time_t date = Curl_getdate_capped(&k->p[12], NULL);
+      time_t date = Curl_getdate_capped(&k->p[12]);
       if(-1 == date) {
         /* not a date, try it as a decimal number */
         (void)curlx_strtoofft(&k->p[12], NULL, 10, &retry_after);
@@ -4032,9 +4032,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
 #endif
     else if(!k->http_bodyless && checkprefix("Last-Modified:", k->p) &&
             (data->set.timecondition || data->set.get_filetime) ) {
-      time_t secs = time(NULL);
-      k->timeofdoc = Curl_getdate_capped(k->p + strlen("Last-Modified:"),
-                                         &secs);
+      k->timeofdoc = Curl_getdate_capped(k->p + strlen("Last-Modified:"));
       if(data->set.get_filetime)
         data->info.filetime = k->timeofdoc;
     }

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -591,11 +591,10 @@ time_t curl_getdate(const char *p, const time_t *now)
    TIME_T_MAX in case the parsed time value was too big, instead of an
    error. */
 
-time_t Curl_getdate_capped(const char *p, const time_t *now)
+time_t Curl_getdate_capped(const char *p)
 {
   time_t parsed = -1;
   int rc = parsedate(p, &parsed);
-  (void)now; /* legacy argument from the past that we ignore */
 
   switch(rc) {
   case PARSEDATE_OK:

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -587,6 +587,31 @@ time_t curl_getdate(const char *p, const time_t *now)
   return -1;
 }
 
+/* Curl_getdate_capped() differs from curl_getdate() in that this will return
+   TIME_T_MAX in case the parsed time value was too big, instead of an
+   error. */
+
+time_t Curl_getdate_capped(const char *p, const time_t *now)
+{
+  time_t parsed = -1;
+  int rc = parsedate(p, &parsed);
+  (void)now; /* legacy argument from the past that we ignore */
+
+  switch(rc) {
+  case PARSEDATE_OK:
+    if(parsed == -1)
+      /* avoid returning -1 for a working scenario */
+      parsed++;
+    return parsed;
+  case PARSEDATE_LATER:
+    /* this returns the maximum time value */
+    return parsed;
+  default:
+    return -1; /* everything else is fail */
+  }
+  /* UNREACHABLE */
+}
+
 /*
  * Curl_gmtime() is a gmtime() replacement for portability. Do not use the
  * gmtime_r() or gmtime() functions anywhere else but here.

--- a/lib/parsedate.h
+++ b/lib/parsedate.h
@@ -27,4 +27,10 @@ extern const char * const Curl_month[12];
 
 CURLcode Curl_gmtime(time_t intime, struct tm *store);
 
+/* Curl_getdate_capped() differs from curl_getdate() in that this will return
+   TIME_T_MAX in case the parsed time value was too big, instead of an
+   error. */
+
+time_t Curl_getdate_capped(const char *p, const time_t *now);
+
 #endif /* HEADER_CURL_PARSEDATE_H */

--- a/lib/parsedate.h
+++ b/lib/parsedate.h
@@ -31,6 +31,6 @@ CURLcode Curl_gmtime(time_t intime, struct tm *store);
    TIME_T_MAX in case the parsed time value was too big, instead of an
    error. */
 
-time_t Curl_getdate_capped(const char *p, const time_t *now);
+time_t Curl_getdate_capped(const char *p);
 
 #endif /* HEADER_CURL_PARSEDATE_H */


### PR DESCRIPTION
... and use internally. This function will return TIME_T_MAX instead of
failure if the parsed data is found to be larger than what can be
represented. TIME_T_MAX being the largest value curl can represent.

Reported-by: @Tuniwutzi

This is an alternative take than but very similar to #4152