### PR TITLE
Enable retry mechanism for file://

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -455,6 +455,14 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
       if(ECONNREFUSED == oserrno)
         retry = RETRY_CONNREFUSED;
     }
+    else if (CURLE_FILE_COULDNT_READ_FILE == result) {
+      /*
+       * treat unreadable file condition as retryable and regard it as
+       * `refused' in a way, so that the requested file may be
+       * available while retrying (= waiting for some processing)
+       */
+      retry = RETRY_CONNREFUSED;
+    }
     else if((CURLE_OK == result) ||
             (config->failonerror &&
              (CURLE_HTTP_RETURNED_ERROR == result))) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -455,7 +455,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
       if(ECONNREFUSED == oserrno)
         retry = RETRY_CONNREFUSED;
     }
-    else if (CURLE_FILE_COULDNT_READ_FILE == result) {
+    else if(CURLE_FILE_COULDNT_READ_FILE == result) {
       /*
        * treat unreadable file condition as retryable and regard it as
        * `refused' in a way, so that the requested file may be


### PR DESCRIPTION
(This is my first pull request to `curl`. I routinely use it and just love it for its handiness. I'm really happy to get a chance to contribute to it.)

_Yes, this PR may sound odd at first sight. But please listen to my reasoning a bit. I'm backed with actual use cases._

This PR makes curl's retry mechanism work with the `file://` protocol as with other protocols including `http(s)://`. Although it may sound pointless to _retry_ local files, which should just be _there_ when executing `curl`. However, by this way, `curl` can be used in shell scripts **to wait for some files to be created by other processes**, which are signalling some event:

```bash
ryoqun@ubuqun:~/work/curl/curl$ sleep 6 && touch something-is-ready & ./src/curl -v --retry 10 --retry-delay 2 file://$(realpath something-is-ready) && echo $?
[4] 18376
* Couldn't open file /home/ryoqun/work/curl/curl/something-is-ready
* Closing connection -1
curl: (37) Couldn't open file /home/ryoqun/work/curl/curl/something-is-ready
Warning: Transient problem: connection refused Will retry in 2 seconds. 10 
Warning: retries left.
* Couldn't open file /home/ryoqun/work/curl/curl/something-is-ready
* Closing connection -1
curl: (37) Couldn't open file /home/ryoqun/work/curl/curl/something-is-ready
Warning: Transient problem: connection refused Will retry in 2 seconds. 9 
Warning: retries left.
* Couldn't open file /home/ryoqun/work/curl/curl/something-is-ready
* Closing connection -1
curl: (37) Couldn't open file /home/ryoqun/work/curl/curl/something-is-ready
Warning: Transient problem: connection refused Will retry in 2 seconds. 8 
Warning: retries left.
* Closing connection 0
[4]   Done                    sleep 6 && touch something-is-ready
0
```

The root problem is that there is no readily available mechanism for waiting a file on the shell scripting environment (*1) (*2). Basically, we're forced to write some tiny retry loops tediously and repeatedly. Note that the two cited StackOverflow's questions are heavily viewed (32k times and 29k times, respectively).

So out of my serendipity, I noticed `curl`'s retry mechanism can be reused with `file://` nicely with customizable retry count and delay!

I've encountered several times for this use cases.

First is when waiting for `sc_ready` file creted by the SauceConnect tool. My script was just like [this](https://github.com/intercom/scripts-1/blob/1b831ae5297c23c5c209ad992d4d3e7fcb2f2c73/packages/sauce_connect.sh#L28) (this `while` could be an infinite loop, by the way).

Second is waiting for [a completion (empty) file when our daemon process is successfully started](https://github.com/solana-labs/solana/pull/6945/files#r347079217).

And other cases where I can't publicly cite the code base. :)

The required modification is very small (just 3 more lines excluding a comment). It may be odd a bit, but the very concept of _retries of (universal) resource retrievals_ can logically generalized to the `file://` from other realistic transfer protocols. So, its maintenance cost and intrusiveness should be minimal.

Lastly, as I'm not familiar with `curl`'s codebase, my implementation may be wrong or need an accompanying test. At least, it works as intended locally. In that case, please let me know!

Imagine a world where this handiness is available on millions of desktops and servers. As said, this might be out of scope for curl's use case. But I can bet this will be appreciated by many others.

*1: https://unix.stackexchange.com/questions/185283/how-do-i-wait-for-a-file-in-the-shell-script
*2: https://superuser.com/questions/878640/unix-script-wait-until-a-file-exists