### PR TITLE
curl: Add Terminal-Colors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4487,6 +4487,24 @@ AC_HELP_STRING([--disable-progress-meter],[Disable progress-meter]),
 )
 
 dnl ************************************************************
+dnl disable terminal colors
+dnl
+AC_MSG_CHECKING([whether to support terminal-colors])
+AC_ARG_ENABLE(terminal-colors,
+AC_HELP_STRING([--enable-terminal-colors],[Enable terminal-colors])
+AC_HELP_STRING([--disable-terminal-colors],[Disable terminal-colors]),
+[ case "$enableval" in
+  no)
+       AC_MSG_RESULT(no)
+       AC_DEFINE(CURL_DISABLE_TERMINAL_COLORS, 1, [disable terminal-colors])
+       ;;
+  *)   AC_MSG_RESULT(yes)
+       ;;
+  esac ],
+       AC_MSG_RESULT(yes)
+)
+
+dnl ************************************************************
 dnl disable shuffle DNS support
 dnl
 AC_MSG_CHECKING([whether to support DNS shuffling])

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -30,15 +30,25 @@
 
 #include "memdebug.h" /* keep this as LAST include */
 
+#ifndef CURL_DISABLE_TERMINAL_COLORS
+#define WARN_PREFIX "\033[33mWarning: \033[0m"
+#define NOTE_PREFIX "\033[36mNote: \033[0m"
+#else
 #define WARN_PREFIX "Warning: "
 #define NOTE_PREFIX "Note: "
+#endif
 
 static void voutf(struct GlobalConfig *config,
                   const char *prefix,
                   const char *fmt,
                   va_list ap)
 {
-  size_t width = (79 - strlen(prefix));
+  unsigned short maxlength = 79;
+  #ifndef CURL_DISABLE_TERMINAL_COLORS
+  /* Terminal color sequences are 16 characters long (starter and escaper) */
+  maxlength += 16;
+  #endif
+  size_t width = (maxlength - strlen(prefix));
   if(!config->mute) {
     size_t len;
     char *ptr;


### PR DESCRIPTION
# Description
This PR adds a new opt in function called `terminal-colors`.
It prints the word `"Warning: "` in yellow and `"Note: "` in Cyan.
You can disable it with `--disable-terminal-colors`.
If this is too incompatible (even if these codes are standard on most terminals) we might need to make it opt out.
Please also review my modification to the configure.ac as I'm a complete disaster when it comes to build system ;)
# Example (Warning)
![grafik](https://user-images.githubusercontent.com/12272949/69894740-2e043700-1324-11ea-9bfa-db80d72faf0b.png)
