### PR TITLE
build: Disable Visual Studio warning "conditional expression is const…

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,7 +20,6 @@ list(APPEND HHEADERS
 
 if(MSVC)
   list(APPEND CSOURCES libcurl.rc)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4127")
 endif()
 
 # SET(CSOURCES

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1227,7 +1227,7 @@ static int cookie_sort_ct(const void *p1, const void *p2)
       if(!d->field)                      \
         goto fail;                       \
     }                                    \
-  } WHILE_FALSE
+  } while(0)
 
 static struct Cookie *dup_cookie(struct Cookie *src)
 {

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -62,7 +62,7 @@ char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w);
 #define Curl_convert_UTF8_to_tchar(ptr) Curl_convert_UTF8_to_wchar((ptr))
 #define Curl_convert_tchar_to_UTF8(ptr) Curl_convert_wchar_to_UTF8((ptr))
 #define Curl_unicodefree(ptr) \
-  do {if((ptr)) {free((ptr)); (ptr) = NULL;}} WHILE_FALSE
+  do {if((ptr)) {free((ptr)); (ptr) = NULL;}} while(0)
 
 typedef union {
   unsigned short       *tchar_ptr;
@@ -76,7 +76,7 @@ typedef union {
 #define Curl_convert_UTF8_to_tchar(ptr) (ptr)
 #define Curl_convert_tchar_to_UTF8(ptr) (ptr)
 #define Curl_unicodefree(ptr) \
-  do {(ptr) = NULL;} WHILE_FALSE
+  do {(ptr) = NULL;} while(0)
 
 typedef union {
   char                *tchar_ptr;

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -27,6 +27,14 @@
 #endif
 
 /*
+ * Disable Visual Studio warnings:
+ * 4127 "conditional expression is constant"
+ */
+#ifdef _MSC_VER
+#pragma warning(disable:4127)
+#endif
+
+/*
  * Define WIN32 when build target is Win32 API
  */
 
@@ -714,7 +722,7 @@ int netware_init(void);
  */
 
 #ifndef Curl_nop_stmt
-#  define Curl_nop_stmt do { } WHILE_FALSE
+#  define Curl_nop_stmt do { } while(0)
 #endif
 
 /*

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -330,27 +330,6 @@ struct timeval {
 #include "curl_ctype.h"
 
 /*
- * Macro WHILE_FALSE may be used to build single-iteration do-while loops,
- * avoiding compiler warnings. Mostly intended for other macro definitions.
- */
-
-#define WHILE_FALSE  while(0)
-
-#if defined(_MSC_VER) && !defined(__POCC__)
-#  undef WHILE_FALSE
-#  if (_MSC_VER < 1500)
-#    define WHILE_FALSE  while(1, 0)
-#  else
-#    define WHILE_FALSE \
-__pragma(warning(push)) \
-__pragma(warning(disable:4127)) \
-while(0) \
-__pragma(warning(pop))
-#  endif
-#endif
-
-
-/*
  * Typedef to 'int' if sig_atomic_t is not an available 'typedefed' type.
  */
 
@@ -387,7 +366,7 @@ typedef int sig_atomic_t;
 #ifdef DEBUGBUILD
 #define DEBUGF(x) x
 #else
-#define DEBUGF(x) do { } WHILE_FALSE
+#define DEBUGF(x) do { } while(0)
 #endif
 
 
@@ -398,7 +377,7 @@ typedef int sig_atomic_t;
 #if defined(DEBUGBUILD) && defined(HAVE_ASSERT_H)
 #define DEBUGASSERT(x) assert(x)
 #else
-#define DEBUGASSERT(x) do { } WHILE_FALSE
+#define DEBUGASSERT(x) do { } while(0)
 #endif
 
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -218,7 +218,7 @@ do {                                      \
   result = curl_easy_setopt(doh, x, y);   \
   if(result)                              \
     goto error;                           \
-} WHILE_FALSE
+} while(0)
 
 static CURLcode dohprobe(struct Curl_easy *data,
                          struct dnsprobe *p, DNStype dnstype,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -68,7 +68,7 @@
 #ifdef DEBUG_HTTP2
 #define H2BUGF(x) x
 #else
-#define H2BUGF(x) do { } WHILE_FALSE
+#define H2BUGF(x) do { } while(0)
 #endif
 
 

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -112,7 +112,7 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp);
   #define LDAP_TRACE(x)   do { \
                             _ldap_trace("%u: ", __LINE__); \
                             _ldap_trace x; \
-                          } WHILE_FALSE
+                          } while(0)
 
   static void _ldap_trace(const char *fmt, ...);
 #else

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -169,6 +169,6 @@ CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
  */
 
 #define Curl_safefree(ptr) \
-  do { free((ptr)); (ptr) = NULL;} WHILE_FALSE
+  do { free((ptr)); (ptr) = NULL;} while(0)
 
 #endif /* HEADER_CURL_MEMDEBUG_H */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -104,7 +104,7 @@ static const char upper_digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
       done++; \
     else \
      return done; /* return immediately on failure */ \
-  } WHILE_FALSE
+  } while(0)
 
 /* Data type to read from the arglist */
 typedef enum {

--- a/lib/select.h
+++ b/lib/select.h
@@ -109,7 +109,7 @@ int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,
     SET_SOCKERRNO(EINVAL); \
     return -1; \
   } \
-} WHILE_FALSE
+} while(0)
 #endif
 
 #endif /* HEADER_CURL_SELECT_H */

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -224,7 +224,7 @@ bool Curl_recv_has_postponed_data(struct connectdata *conn, int sockindex)
   (void)sockindex;
   return false;
 }
-#define pre_receive_plain(c,n) do {} WHILE_FALSE
+#define pre_receive_plain(c,n) do {} while(0)
 #define get_pre_recved(c,n,b,l) 0
 #endif /* ! USE_RECV_BEFORE_SEND_WORKAROUND */
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -58,7 +58,7 @@ do {                                                                \
   (a)[1] = (unsigned char)((((unsigned long) (val)) >> 16) & 0xff); \
   (a)[2] = (unsigned char)((((unsigned long) (val)) >> 8) & 0xff);  \
   (a)[3] = (unsigned char)(((unsigned long) (val)) & 0xff);         \
-} WHILE_FALSE;
+} while(0)
 
 #ifdef HAVE_LONGLONG
 #define WPA_PUT_BE64(a, val)                                    \
@@ -71,7 +71,7 @@ do {                                                            \
   (a)[5] = (unsigned char)(((unsigned long long)(val)) >> 16);  \
   (a)[6] = (unsigned char)(((unsigned long long)(val)) >> 8);   \
   (a)[7] = (unsigned char)(((unsigned long long)(val)) & 0xff); \
-} WHILE_FALSE;
+} while(0)
 #else
 #define WPA_PUT_BE64(a, val)                                  \
 do {                                                          \

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -69,12 +69,12 @@
   do {                                                  \
     x->subend = x->subpointer;                          \
     CURL_SB_CLEAR(x);                                   \
-  } WHILE_FALSE
+  } while(0)
 #define CURL_SB_ACCUM(x,c)                                      \
   do {                                                          \
     if(x->subpointer < (x->subbuffer + sizeof(x->subbuffer)))   \
       *x->subpointer++ = (c);                                   \
-  } WHILE_FALSE
+  } while(0)
 
 #define  CURL_SB_GET(x) ((*x->subpointer++)&0xff)
 #define  CURL_SB_LEN(x) (x->subend - x->subpointer)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1177,7 +1177,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
     }
 
 
-  } WHILE_FALSE; /* just to break out from! */
+  } while(0); /* just to break out from! */
 
   return CURLE_OK;
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -674,7 +674,7 @@ static void conn_reset_all_postponed_data(struct connectdata *conn)
 }
 #else  /* ! USE_RECV_BEFORE_SEND_WORKAROUND */
 /* Use "do-nothing" macro instead of function when workaround not used */
-#define conn_reset_all_postponed_data(c) do {} WHILE_FALSE
+#define conn_reset_all_postponed_data(c) do {} while(0)
 #endif /* ! USE_RECV_BEFORE_SEND_WORKAROUND */
 
 

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -49,7 +49,7 @@
 #ifdef DEBUG_HTTP3
 #define H3BUGF(x) x
 #else
-#define H3BUGF(x) do { } WHILE_FALSE
+#define H3BUGF(x) do { } while(0)
 #endif
 
 /*

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -45,7 +45,7 @@
 #ifdef DEBUG_HTTP3
 #define H3BUGF(x) x
 #else
-#define H3BUGF(x) do { } WHILE_FALSE
+#define H3BUGF(x) do { } while(0)
 #endif
 
 #define QUIC_MAX_STREAMS (256*1024)

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -98,7 +98,7 @@
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR
 #define SSH_STRING_FREE_CHAR(x) \
-    do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } WHILE_FALSE
+    do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } while(0)
 #endif
 
 /* Local functions: */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -113,7 +113,7 @@ typedef struct {
   ptr->type = (_type);                                      \
   ptr->pValue = (_val);                                     \
   ptr->ulValueLen = (_len);                                 \
-} WHILE_FALSE
+} while(0)
 
 #define CERT_NewTempCertificate __CERT_NewTempCertificate
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3081,7 +3081,7 @@ do {                              \
   Curl_ssl_push_certinfo_len(data, _num, _label, ptr, info_len); \
   if(1 != BIO_reset(mem))                                        \
     break;                                                       \
-} WHILE_FALSE
+} while(0)
 
 static void pubkey_show(struct Curl_easy *data,
                         BIO *mem,
@@ -3113,7 +3113,7 @@ do {                              \
   if(_type->_name) { \
     pubkey_show(data, mem, _num, #_type, #_name, _type->_name); \
   } \
-} WHILE_FALSE
+} while(0)
 #endif
 
 static int X509V3_ext(struct Curl_easy *data,

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -38,33 +38,6 @@
 
 #include "memdebug.h" /* keep this as LAST include */
 
-/*
- * Macros ALWAYS_TRUE and ALWAYS_FALSE are used to avoid compiler warnings.
- */
-
-#define ALWAYS_TRUE   (1)
-#define ALWAYS_FALSE  (0)
-
-#if defined(_MSC_VER) && !defined(__POCC__)
-#  undef ALWAYS_TRUE
-#  undef ALWAYS_FALSE
-#  if (_MSC_VER < 1500)
-#    define ALWAYS_TRUE   (0, 1)
-#    define ALWAYS_FALSE  (1, 0)
-#  else
-#    define ALWAYS_TRUE \
-__pragma(warning(push)) \
-__pragma(warning(disable:4127)) \
-(1) \
-__pragma(warning(pop))
-#    define ALWAYS_FALSE \
-__pragma(warning(push)) \
-__pragma(warning(disable:4127)) \
-(0) \
-__pragma(warning(pop))
-#  endif
-#endif
-
 #ifdef WIN32
 #  undef  PATH_MAX
 #  define PATH_MAX MAX_PATH
@@ -79,9 +52,9 @@ __pragma(warning(pop))
 #endif
 
 #ifdef WIN32
-#  define _use_lfn(f) ALWAYS_TRUE   /* long file names always available */
+#  define _use_lfn(f) (1)   /* long file names always available */
 #elif !defined(__DJGPP__) || (__DJGPP__ < 2)  /* DJGPP 2.0 has _use_lfn() */
-#  define _use_lfn(f) ALWAYS_FALSE  /* long file names never available */
+#  define _use_lfn(f) (0)  /* long file names never available */
 #elif defined(__DJGPP__)
 #  include <fcntl.h>                /* _use_lfn(f) prototype */
 #endif

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -123,7 +123,7 @@ CURLcode easysrc_addf(struct slist_wc **plist, const char *fmt, ...)
   return ret;
 }
 
-#define CHKRET(v) do {CURLcode ret = (v); if(ret) return ret;} WHILE_FALSE
+#define CHKRET(v) do {CURLcode ret = (v); if(ret) return ret;} while(0)
 
 CURLcode easysrc_init(void)
 {

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -58,7 +58,7 @@
     if(!(*(str)))          \
       return PARAM_NO_MEM; \
   } \
-} WHILE_FALSE
+} while(0)
 
 struct LongShort {
   const char *letter; /* short name option */

--- a/src/tool_metalink.c
+++ b/src/tool_metalink.c
@@ -119,7 +119,7 @@ struct win32_crypto_hash {
     *(str) = strdup((val)); \
   if(!(val)) \
     return PARAM_NO_MEM; \
-} WHILE_FALSE
+} while(0)
 
 #if defined(USE_OPENSSL)
 /* Functions are already defined */

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -181,18 +181,18 @@ static const NameValue setopt_nv_CURLNONZERODEFAULTS[] = {
   ret = easysrc_add args; \
   if(ret) \
     goto nomem; \
-} WHILE_FALSE
+} while(0)
 #define ADDF(args) do { \
   ret = easysrc_addf args; \
   if(ret) \
     goto nomem; \
-} WHILE_FALSE
+} while(0)
 #define NULL_CHECK(p) do { \
   if(!p) { \
     ret = CURLE_OUT_OF_MEMORY; \
     goto nomem; \
   } \
-} WHILE_FALSE
+} while(0)
 
 #define DECL0(s) ADD((&easysrc_decl, s))
 #define DECL1(f,a) ADDF((&easysrc_decl, f,a))

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -35,7 +35,7 @@
       if(result)                                \
         break;                                  \
     }                                           \
-  } WHILE_FALSE
+  } while(0)
 
 /* allow removed features to simulate success: */
 bool tool_setopt_skip(CURLoption tag);

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(TARGET_LABEL_PREFIX "Test ")
 
-if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4127")
-endif()
-
 function(setup_test TEST_NAME)          # ARGN are the files in the test
   add_executable( ${TEST_NAME} ${ARGN} )
   string(TOUPPER ${TEST_NAME} UPPER_TEST_NAME)

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -131,7 +131,7 @@ extern int unitfail;
     fprintf(stderr, "%s:%d curl_easy_init() failed\n", (Y), (Z)); \
     res = TEST_ERR_EASY_INIT;                                     \
   }                                                               \
-} WHILE_FALSE
+} while(0)
 
 #define res_easy_init(A) \
   exe_easy_init((A), (__FILE__), (__LINE__))
@@ -140,7 +140,7 @@ extern int unitfail;
   exe_easy_init((A), (Y), (Z));   \
   if(res)                         \
     goto test_cleanup;            \
-} WHILE_FALSE
+} while(0)
 
 #define easy_init(A) \
   chk_easy_init((A), (__FILE__), (__LINE__))
@@ -152,7 +152,7 @@ extern int unitfail;
     fprintf(stderr, "%s:%d curl_multi_init() failed\n", (Y), (Z)); \
     res = TEST_ERR_MULTI_INIT;                                     \
   }                                                                \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_init(A) \
   exe_multi_init((A), (__FILE__), (__LINE__))
@@ -161,7 +161,7 @@ extern int unitfail;
   exe_multi_init((A), (Y), (Z));   \
   if(res)                          \
     goto test_cleanup;             \
-} WHILE_FALSE
+} while(0)
 
 #define multi_init(A) \
   chk_multi_init((A), (__FILE__), (__LINE__))
@@ -176,7 +176,7 @@ extern int unitfail;
             (Y), (Z), (int)ec, curl_easy_strerror(ec));    \
     res = (int)ec;                                         \
   }                                                        \
-} WHILE_FALSE
+} while(0)
 
 #define res_easy_setopt(A, B, C) \
   exe_easy_setopt((A), (B), (C), (__FILE__), (__LINE__))
@@ -185,7 +185,7 @@ extern int unitfail;
   exe_easy_setopt((A), (B), (C), (Y), (Z)); \
   if(res)                                   \
     goto test_cleanup;                      \
-} WHILE_FALSE
+} while(0)
 
 #define easy_setopt(A, B, C) \
   chk_easy_setopt((A), (B), (C), (__FILE__), (__LINE__))
@@ -200,7 +200,7 @@ extern int unitfail;
             (Y), (Z), (int)ec, curl_multi_strerror(ec));    \
     res = (int)ec;                                          \
   }                                                         \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_setopt(A,B,C) \
   exe_multi_setopt((A), (B), (C), (__FILE__), (__LINE__))
@@ -209,7 +209,7 @@ extern int unitfail;
   exe_multi_setopt((A), (B), (C), (Y), (Z)); \
   if(res)                                    \
     goto test_cleanup;                       \
-} WHILE_FALSE
+} while(0)
 
 #define multi_setopt(A,B,C) \
   chk_multi_setopt((A), (B), (C), (__FILE__), (__LINE__))
@@ -224,7 +224,7 @@ extern int unitfail;
             (Y), (Z), (int)ec, curl_multi_strerror(ec));     \
     res = (int)ec;                                           \
   }                                                          \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_add_handle(A, B) \
   exe_multi_add_handle((A), (B), (__FILE__), (__LINE__))
@@ -233,7 +233,7 @@ extern int unitfail;
   exe_multi_add_handle((A), (B), (Y), (Z));   \
   if(res)                                     \
     goto test_cleanup;                        \
-} WHILE_FALSE
+} while(0)
 
 #define multi_add_handle(A, B) \
   chk_multi_add_handle((A), (B), (__FILE__), (__LINE__))
@@ -248,7 +248,7 @@ extern int unitfail;
             (Y), (Z), (int)ec, curl_multi_strerror(ec));        \
     res = (int)ec;                                              \
   }                                                             \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_remove_handle(A, B) \
   exe_multi_remove_handle((A), (B), (__FILE__), (__LINE__))
@@ -257,7 +257,7 @@ extern int unitfail;
   exe_multi_remove_handle((A), (B), (Y), (Z));   \
   if(res)                                        \
     goto test_cleanup;                           \
-} WHILE_FALSE
+} while(0)
 
 
 #define multi_remove_handle(A, B) \
@@ -279,7 +279,7 @@ extern int unitfail;
             (Y), (Z), (int)*((B)));                              \
     res = TEST_ERR_NUM_HANDLES;                                  \
   }                                                              \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_perform(A, B) \
   exe_multi_perform((A), (B), (__FILE__), (__LINE__))
@@ -288,7 +288,7 @@ extern int unitfail;
   exe_multi_perform((A), (B), (Y), (Z));   \
   if(res)                                  \
     goto test_cleanup;                     \
-} WHILE_FALSE
+} while(0)
 
 #define multi_perform(A,B) \
   chk_multi_perform((A), (B), (__FILE__), (__LINE__))
@@ -309,7 +309,7 @@ extern int unitfail;
             (Y), (Z), (int)*((E)));                                  \
     res = TEST_ERR_NUM_HANDLES;                                      \
   }                                                                  \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_fdset(A, B, C, D, E) \
   exe_multi_fdset((A), (B), (C), (D), (E), (__FILE__), (__LINE__))
@@ -318,7 +318,7 @@ extern int unitfail;
     exe_multi_fdset((A), (B), (C), (D), (E), (Y), (Z)); \
     if(res)                                             \
       goto test_cleanup;                                \
-  } WHILE_FALSE
+  } while(0)
 
 #define multi_fdset(A, B, C, D, E) \
   chk_multi_fdset((A), (B), (C), (D), (E), (__FILE__), (__LINE__))
@@ -339,7 +339,7 @@ extern int unitfail;
             (Y), (Z), (long)*((B)));                         \
     res = TEST_ERR_BAD_TIMEOUT;                              \
   }                                                          \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_timeout(A, B) \
   exe_multi_timeout((A), (B), (__FILE__), (__LINE__))
@@ -348,7 +348,7 @@ extern int unitfail;
     exe_multi_timeout((A), (B), (Y), (Z)); \
     if(res)                                \
       goto test_cleanup;                   \
-  } WHILE_FALSE
+  } while(0)
 
 #define multi_timeout(A, B) \
   chk_multi_timeout((A), (B), (__FILE__), (__LINE__))
@@ -369,7 +369,7 @@ extern int unitfail;
             (Y), (Z), (int)*((E)));                                 \
     res = TEST_ERR_NUM_HANDLES;                                     \
   }                                                                 \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_poll(A, B, C, D, E) \
   exe_multi_poll((A), (B), (C), (D), (E), (__FILE__), (__LINE__))
@@ -378,7 +378,7 @@ extern int unitfail;
   exe_multi_poll((A), (B), (C), (D), (E), (Y), (Z)); \
   if(res)                                            \
     goto test_cleanup;                               \
-} WHILE_FALSE
+} while(0)
 
 #define multi_poll(A, B, C, D, E) \
   chk_multi_poll((A), (B), (C), (D), (E), (__FILE__), (__LINE__))
@@ -393,7 +393,7 @@ extern int unitfail;
             (Y), (Z), (int)ec, curl_multi_strerror(ec)); \
     res = (int)ec;                                       \
   }                                                      \
-} WHILE_FALSE
+} while(0)
 
 #define res_multi_wakeup(A) \
   exe_multi_wakeup((A), (__FILE__), (__LINE__))
@@ -402,7 +402,7 @@ extern int unitfail;
   exe_multi_wakeup((A), (Y), (Z));     \
   if(res)                              \
     goto test_cleanup;                 \
-} WHILE_FALSE
+} while(0)
 
 #define multi_wakeup(A) \
   chk_multi_wakeup((A), (__FILE__), (__LINE__))
@@ -418,7 +418,7 @@ extern int unitfail;
               (Y), (Z), ec, strerror(ec));                      \
       res = TEST_ERR_SELECT;                                    \
     }                                                           \
-  } WHILE_FALSE
+  } while(0)
 
 #define res_select_test(A, B, C, D, E) \
   exe_select_test((A), (B), (C), (D), (E), (__FILE__), (__LINE__))
@@ -427,7 +427,7 @@ extern int unitfail;
     exe_select_test((A), (B), (C), (D), (E), (Y), (Z)); \
     if(res)                                             \
       goto test_cleanup;                                \
-  } WHILE_FALSE
+  } while(0)
 
 #define select_test(A, B, C, D, E) \
   chk_select_test((A), (B), (C), (D), (E), (__FILE__), (__LINE__))
@@ -436,7 +436,7 @@ extern int unitfail;
 
 #define start_test_timing() do { \
   tv_test_start = tutil_tvnow(); \
-} WHILE_FALSE
+} while(0)
 
 #define exe_test_timedout(Y,Z) do {                                    \
   if(tutil_tvdiff(tutil_tvnow(), tv_test_start) > TEST_HANG_TIMEOUT) { \
@@ -444,7 +444,7 @@ extern int unitfail;
                     "that it would have run forever.\n", (Y), (Z));    \
     res = TEST_ERR_RUNS_FOREVER;                                       \
   }                                                                    \
-} WHILE_FALSE
+} while(0)
 
 #define res_test_timedout() \
   exe_test_timedout((__FILE__), (__LINE__))
@@ -453,7 +453,7 @@ extern int unitfail;
     exe_test_timedout(Y, Z);         \
     if(res)                          \
       goto test_cleanup;             \
-  } WHILE_FALSE
+  } while(0)
 
 #define abort_on_test_timeout() \
   chk_test_timedout((__FILE__), (__LINE__))
@@ -468,7 +468,7 @@ extern int unitfail;
             (Y), (Z), (int)ec, curl_easy_strerror(ec)); \
     res = (int)ec;                                      \
   }                                                     \
-} WHILE_FALSE
+} while(0)
 
 #define res_global_init(A) \
   exe_global_init((A), (__FILE__), (__LINE__))
@@ -477,7 +477,7 @@ extern int unitfail;
     exe_global_init((A), (Y), (Z));   \
     if(res)                           \
       return res;                     \
-  } WHILE_FALSE
+  } while(0)
 
 /* global_init() is different than other macros. In case of
    failure it 'return's instead of going to 'test_cleanup'. */

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TARGET_LABEL_PREFIX "Test server ")
 
 if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4127 /wd4306")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4306")
 endif()
 
 function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test

--- a/tests/unit/curlcheck.h
+++ b/tests/unit/curlcheck.h
@@ -52,7 +52,7 @@
     fprintf(stderr, "%s:%d test failed: '%s'\n",                       \
             __FILE__, __LINE__, msg);                                  \
     unitfail++;                                                        \
-  } WHILE_FALSE
+  } while(0)
 
 
 /* The abort macros mark the current test step as failed, and exit the test */
@@ -77,7 +77,7 @@
             __FILE__, __LINE__, msg);                         \
     unitfail++;                                               \
     goto unit_test_abort;                                     \
-  } WHILE_FALSE
+  } while(0)
 
 
 

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -61,11 +61,11 @@ CC = cl.exe
 !IF "$(VC)"=="6"
 CC_NODEBUG  = $(CC) /O2 /DNDEBUG
 CC_DEBUG    = $(CC) /Od /Gm /Zi /D_DEBUG /GZ
-CFLAGS      = /I. /I../lib /I../include /nologo /W4 /wd4127 /GX /DWIN32 /YX /FD /c /DBUILDING_LIBCURL
+CFLAGS      = /I. /I../lib /I../include /nologo /W4 /GX /DWIN32 /YX /FD /c /DBUILDING_LIBCURL
 !ELSE
 CC_NODEBUG  = $(CC) /O2 /DNDEBUG
 CC_DEBUG    = $(CC) /Od /D_DEBUG /RTC1 /Z7 /LDd
-CFLAGS      = /I. /I ../lib /I../include /nologo /W4 /wd4127 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL
+CFLAGS      = /I. /I ../lib /I../include /nologo /W4 /EHsc /DWIN32 /FD /c /DBUILDING_LIBCURL
 !ENDIF
 
 LFLAGS     = /nologo /machine:$(MACHINE)


### PR DESCRIPTION
…ant"

- Disable warning C4127 "conditional expression is constant" when
  building with Microsoft's compiler.

C4127 was already disabled in the limited circumstance of the WHILE_FALSE
macro which disabled the warning specifically for while(0). This commit
removes the WHILE_FALSE macro in favor of disabling C4127 everywhere.

We have various macros that cause 0 or 1 to be evaluated, which causes
warning C4127 in Visual Studio. For example this causes it:

#define Curl_resolver_asynch() 1

Full behavior is not clearly defined and inconsistent across versions.
However it is documented that since VS 2015 Update 3 Microsoft has
addressed this somewhat but not entirely, not warning on while(true) for
example.

Prior to this change some C4127 warnings occurred when I built with
Visual Studio.

Closes #xxxx

---

/cc @danielgustafsson 