### PR TITLE
Revert "travis: export the CC/CXX variables when set"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -439,8 +439,8 @@ matrix:
                       - zlib1g-dev
 
 before_install:
-    - export "${OVERRIDE_CC}"
-    - export "${OVERRIDE_CXX}"
+    - eval "${OVERRIDE_CC}"
+    - eval "${OVERRIDE_CXX}"
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi


### PR DESCRIPTION
This reverts commit 113db127ee2b2f874dfcce406103ffe666e11953 (from #4640)
since it broke the mac builds.

Reported-by: Jay Satiro
Fixes #4569