### PR TITLE
travis: do not use OVERRIDE_CC if empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -439,8 +439,8 @@ matrix:
                       - zlib1g-dev
 
 before_install:
-    - export "${OVERRIDE_CC}"
-    - export "${OVERRIDE_CXX}"
+  - test -z "$OVERRIDE_CC" || export "${OVERRIDE_CC}"
+  - test -z "$OVERRIDE_CXX" || export "${OVERRIDE_CXX}"
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi


### PR DESCRIPTION
Fixes macOS build where OVERRIDE_CC and OVERRIDE_CXX are not set.

Reported-by: Jay Satiro
