### PR TITLE
Support IPv6 adresses without getaddrinfo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1203,16 +1203,23 @@ AC_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
        ;;
   esac ],
 
-  AC_TRY_RUN([ /* is AF_INET6 available? */
+  AC_TRY_RUN([ /* are AF_INET6 and sockaddr_in6 available? */
 #include <sys/types.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #else
 #include <sys/socket.h>
+#include <netinet/in.h>
+#if defined (__TANDEM)
+# include <netinet/in6.h>
+#endif
 #endif
 #include <stdlib.h> /* for exit() */
 main()
 {
+ struct sockaddr_in6 s;
+ (void)s;
  if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
    exit(1);
  else
@@ -1227,8 +1234,12 @@ main()
   ipv6=yes
 ))
 
-# Check if struct sockaddr_in6 have sin6_scope_id member
 if test "$ipv6" = yes; then
+  curl_ipv6_msg="enabled"
+  AC_DEFINE(ENABLE_IPV6, 1, [Define if you want to enable IPv6 support])
+  IPV6_ENABLED=1
+  AC_SUBST(IPV6_ENABLED)
+
   AC_MSG_CHECKING([if struct sockaddr_in6 has sin6_scope_id member])
   AC_TRY_COMPILE([
 #include <sys/types.h>
@@ -4051,15 +4062,6 @@ AC_CHECK_FUNCS([fnmatch \
     ])
   fi
 ])
-
-if test "$ipv6" = "yes"; then
-  if test "$curl_cv_func_getaddrinfo" = "yes"; then
-    AC_DEFINE(ENABLE_IPV6, 1, [Define if you want to enable IPv6 support])
-    IPV6_ENABLED=1
-    AC_SUBST(IPV6_ENABLED)
-    curl_ipv6_msg="enabled"
-  fi
-fi
 
 CURL_CHECK_NONBLOCKING_SOCKET
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -698,6 +698,16 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 
   *waitp = 0; /* default to synchronous response */
 
+#ifdef ENABLE_IPV6
+  {
+    struct in6_addr in6;
+    /* check if this is an IPv6 address string */
+    if(Curl_inet_pton(AF_INET6, hostname, &in6) > 0)
+      /* This is an IPv6 address literal */
+      return Curl_ip2addr(AF_INET6, &in6, hostname, port);
+  }
+#endif /* ENABLE_IPV6 */
+
   if(Curl_inet_pton(AF_INET, hostname, &in) > 0)
     /* This is a dotted IP address 123.123.123.123-style */
     return Curl_ip2addr(AF_INET, &in, hostname, port);
@@ -741,7 +751,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
       /* This is a dotted IP address 123.123.123.123-style */
       return Curl_ip2addr(AF_INET, &in, hostname, port);
   }
-#ifdef CURLRES_IPV6
+#ifdef ENABLE_IPV6
   {
     struct in6_addr in6;
     /* check if this is an IPv6 address string */
@@ -749,7 +759,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
       /* This is an IPv6 address literal */
       return Curl_ip2addr(AF_INET6, &in6, hostname, port);
   }
-#endif /* CURLRES_IPV6 */
+#endif /* ENABLE_IPV6 */
 #endif /* !USE_RESOLVE_ON_IPS */
 
 #ifdef CURLRES_IPV6

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -577,7 +577,7 @@
 #  define CURLRES_SYNCH
 #endif
 
-#ifdef ENABLE_IPV6
+#if defined(ENABLE_IPV6) && defined(HAVE_GETADDRINFO)
 #  define CURLRES_IPV6
 #else
 #  define CURLRES_IPV4

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -131,6 +131,16 @@ Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
   struct in_addr in;
   struct hostent *buf = NULL;
 
+#ifdef ENABLE_IPV6
+  {
+    struct in6_addr in6;
+    /* check if this is an IPv6 address string */
+    if(Curl_inet_pton(AF_INET6, hostname, &in6) > 0)
+      /* This is an IPv6 address literal */
+      return Curl_ip2addr(AF_INET6, &in6, hostname, port);
+  }
+#endif /* ENABLE_IPV6 */
+
   if(Curl_inet_pton(AF_INET, hostname, &in) > 0)
     /* This is a dotted IP address 123.123.123.123-style */
     return Curl_ip2addr(AF_INET, &in, hostname, port);

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
   while(argc>arg) {
     if(!strcmp("--version", argv[arg])) {
       printf("resolve IPv4%s\n",
-#ifdef ENABLE_IPV6
+#if defined(CURLRES_IPV6)
              "/IPv6"
 #else
              ""
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
     puts("Usage: resolve [option] <host>\n"
          " --version\n"
          " --ipv4"
-#ifdef ENABLE_IPV6
+#if defined(CURLRES_IPV6)
          "\n --ipv6"
 #endif
          );
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
   atexit(win32_cleanup);
 #endif
 
-#ifdef ENABLE_IPV6
+#if defined(CURLRES_IPV6)
   if(use_ipv6) {
     /* Check that the system has IPv6 enabled before checking the resolver */
     curl_socket_t s = socket(PF_INET6, SOCK_DGRAM, 0);


### PR DESCRIPTION
This makes the autotools build behave like the CMake build in this regard: support IPv6 addresses (`ENABLE_IPV6`) by default as long as `AF_INET6` and `sockaddr_in6` are available. `getaddrinfo` is only needed for DNS resolution (`CURLRES_IPV6`).

This also fixes the CMake build with `ENABLE_IPV6` set to the default `ON`, `ENABLE_THREADED_RESOLVER` set to `OFF`, and no `getaddrinfo` available. The theaded resolver code guards the calls to `getaddrinfo` with `HAVE_GETADDRINFO`, but the synchronous resolver code assumes that `CURLRES_IPV6` implies `HAVE_GETADDRINFO`, which it did only implicitly when using the autotools build.

Tested with classic MinGW, which disables `getaddrinfo` by default by targeting Windows 2000, and both the threaded and synchronous resolvers.