### PR TITLE
travis: do not use OVERRIDE_CC or OVERRIDE_CXX if empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -439,8 +439,8 @@ matrix:
                       - zlib1g-dev
 
 before_install:
-  - export "${OVERRIDE_CC-no=nothing}"
-  - export "${OVERRIDE_CXX-no=nothing}"
+  - export "${OVERRIDE_CC-blank=}"
+  - export "${OVERRIDE_CXX-blank=}"
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -439,8 +439,8 @@ matrix:
                       - zlib1g-dev
 
 before_install:
-  - [ -z "$OVERRIDE_CC" ] || export "${OVERRIDE_CC}"
-  - [ -z "$OVERRIDE_CXX" ] || export "${OVERRIDE_CXX}"
+  - export "${OVERRIDE_CC-no=nothing}"
+  - export "${OVERRIDE_CXX-no=nothing}"
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -439,8 +439,8 @@ matrix:
                       - zlib1g-dev
 
 before_install:
-    - export "${OVERRIDE_CC}"
-    - export "${OVERRIDE_CXX}"
+  - [ -z "$OVERRIDE_CC" ] || export "${OVERRIDE_CC}"
+  - [ -z "$OVERRIDE_CXX" ] || export "${OVERRIDE_CXX}"
 
 install:
   - if [ "$T" = "coverage" ]; then pip2 install --user cpp-coveralls; fi


### PR DESCRIPTION
Fixes the macOS builds where OVERRIDE_CC and OVERRIDE_CXX are not set.

Reported-by: Jay Satiro

(This is a copy of #4661 just to see if the travis weirdness show up again.)