### PR TITLE
setopt: Fix ALPN / NPN option setting when built without HTTP2

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2612,14 +2612,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = CURLE_NOT_BUILT_IN;
 #endif
     break;
-#ifdef USE_NGHTTP2
   case CURLOPT_SSL_ENABLE_NPN:
     data->set.ssl_enable_npn = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
   case CURLOPT_SSL_ENABLE_ALPN:
     data->set.ssl_enable_alpn = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
-#endif
 #ifdef USE_UNIX_SOCKETS
   case CURLOPT_UNIX_SOCKET_PATH:
     data->set.abstract_unix_socket = FALSE;


### PR DESCRIPTION
- Stop treating lack of HTTP2 as an unknown option error result for
  CURLOPT_SSL_ENABLE_ALPN and CURLOPT_SSL_ENABLE_NPN.

Prior to this change it was impossible to disable ALPN / NPN if libcurl
was built without HTTP2. Setting either option would result in
CURLE_UNKNOWN_OPTION and the respective internal option would not be
set. That was incorrect since ALPN and NPN are used independent of
HTTP2.

Reported-by: Shailesh Kapse

Fixes https://github.com/curl/curl/issues/4668
Closes #xxxx