### PR TITLE
curl_setup: fix `CURLRES_IPV6` condition

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -571,6 +571,12 @@
  * Mutually exclusive CURLRES_* definitions.
  */
 
+#if defined(ENABLE_IPV6) && defined(HAVE_GETADDRINFO)
+#  define CURLRES_IPV6
+#else
+#  define CURLRES_IPV4
+#endif
+
 #ifdef USE_ARES
 #  define CURLRES_ASYNCH
 #  define CURLRES_ARES
@@ -583,12 +589,6 @@
 #  define CURLRES_THREADED
 #else
 #  define CURLRES_SYNCH
-#endif
-
-#if defined(ENABLE_IPV6) && defined(HAVE_GETADDRINFO)
-#  define CURLRES_IPV6
-#else
-#  define CURLRES_IPV4
 #endif
 
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
Move the definition of `CURLRES_IPV6` to before undefining
`HAVE_GETADDRINFO`. Regression from commit 67a08dca27a which caused
some tests to fail and others to be skipped with c-ares.

Fixes https://github.com/curl/curl/issues/4673