### PR TITLE
etag: allow both --etag-compare and --etag-save in same cmdline

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -889,16 +889,6 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           }
         }
 
-        /* disallowing simultaneous use of --etag-save and --etag-compare */
-        if(config->etag_save_file && config->etag_compare_file) {
-          warnf(
-            config->global,
-            "Cannot use --etag-save and --etag-compare at the same time\n");
-
-          result = CURLE_UNKNOWN_OPTION;
-          break;
-        }
-
         /* --etag-save */
         etag_save = &per->etag_save;
         etag_save->stream = stdout;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -58,7 +58,7 @@ test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
-\
+test343 \
 test350 test351 test352 test353 test354 test355 test356 \
 test393 test394 test395 \
 \

--- a/tests/data/test343
+++ b/tests/data/test343
@@ -1,0 +1,61 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-11111"
+Accept-Ranges: bytes
+Content-Length: 0
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Both --etag-compare and --etag-save to save new Etag
+</name>
+<file name="log/etag343">
+21025-dc7-39462498
+</file>
+<command>
+http://%HOSTIP:%HTTPPORT/343 --etag-compare log/etag343 --etag-save log/out343
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /343 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+If-None-Match: "21025-dc7-39462498"
+
+</protocol>
+<file name="log/out343">
+21025-dc7-11111
+</file>
+</verify>
+</testcase>


### PR DESCRIPTION
It makes it very practical when the etag updates.

Fixes #4669