### PR TITLE
curl: make the etag load logic work without fseek

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -922,7 +922,6 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->etag_compare_file) {
           char *etag_from_file = NULL;
           char *header = NULL;
-          size_t file_size = 0;
 
           /* open file for reading: */
           FILE *file = fopen(config->etag_compare_file, FOPEN_READTEXT);
@@ -935,23 +934,11 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             break;
           }
 
-          /* get file size */
-          fseek(file, 0, SEEK_END);
-          file_size = ftell(file);
-
-          /*
-           * check if file is empty, if it's not load etag
-           * else continue with empty etag
-           */
-          if(file_size != 0) {
-            fseek(file, 0, SEEK_SET);
-            file2string(&etag_from_file, file);
-
+          if((PARAM_OK == file2string(&etag_from_file, file)) &&
+             etag_from_file)
             header = aprintf("If-None-Match: \"%s\"", etag_from_file);
-          }
-          else {
+          else
             header = aprintf("If-None-Match: \"\"");
-          }
 
           if(!header) {
             warnf(


### PR DESCRIPTION
The fseek()s were unnecessary and caused Coverity warning CID 1456554