### PR TITLE
curl: use errorf() better

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -166,17 +166,17 @@ static CURLcode main_init(struct GlobalConfig *config)
         config->first->global = config;
       }
       else {
-        helpf(stderr, "error retrieving curl library information\n");
+        errorf(config, "error retrieving curl library information\n");
         free(config->first);
       }
     }
     else {
-      helpf(stderr, "error initializing curl library\n");
+      errorf(config, "error initializing curl library\n");
       free(config->first);
     }
   }
   else {
-    helpf(stderr, "error initializing curl\n");
+    errorf(config, "error initializing curl\n");
     result = CURLE_FAILED_INIT;
   }
 

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -105,9 +105,9 @@ void warnf(struct GlobalConfig *config, const char *fmt, ...)
   va_end(ap);
 }
 /*
- * Emit help formatted message on given stream.
+ * Emit help formatted message on given stream. This is for errors with or
+ * related to command line arguments.
  */
-
 void helpf(FILE *errors, const char *fmt, ...)
 {
   if(fmt) {
@@ -125,7 +125,8 @@ void helpf(FILE *errors, const char *fmt, ...)
 }
 
 /*
- * Emit error message on error stream if not muted.
+ * Emit error message on error stream if not muted. When errors are not tied
+ * to command line arguments, use helpf() for such errors.
  */
 void errorf(struct GlobalConfig *config, const char *fmt, ...)
 {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -706,7 +706,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         httpgetfields = state->httpgetfields = strdup(config->postfields);
         Curl_safefree(config->postfields);
         if(!httpgetfields) {
-          helpf(global->errors, "out of memory\n");
+          errorf(global, "out of memory\n");
           result = CURLE_OUT_OF_MEMORY;
         }
         else if(SetHTTPrequest(config,
@@ -768,7 +768,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
     if(urlnode->outfile && !state->outfiles) {
       state->outfiles = strdup(urlnode->outfile);
       if(!state->outfiles) {
-        helpf(global->errors, "out of memory\n");
+        errorf(global, "out of memory\n");
         result = CURLE_OUT_OF_MEMORY;
         break;
       }
@@ -796,12 +796,12 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           if(inglob) {
             result = glob_next_url(&state->uploadfile, inglob);
             if(result == CURLE_OUT_OF_MEMORY)
-              helpf(global->errors, "out of memory\n");
+              errorf(global, "out of memory\n");
           }
           else if(!state->up) {
             state->uploadfile = strdup(infiles);
             if(!state->uploadfile) {
-              helpf(global->errors, "out of memory\n");
+              errorf(global, "out of memory\n");
               result = CURLE_OUT_OF_MEMORY;
             }
           }
@@ -1030,7 +1030,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             if(result)
               break;
             if(!*per->outfile && !config->content_disposition) {
-              helpf(global->errors, "Remote file name has no length!\n");
+              errorf(global, "Remote file name has no length!\n");
               result = CURLE_WRITE_ERROR;
               break;
             }
@@ -1087,7 +1087,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             FILE *file = fopen(per->outfile, "ab");
 #endif
             if(!file) {
-              helpf(global->errors, "Can't open '%s'!\n", per->outfile);
+              errorf(global, "Can't open '%s'!\n", per->outfile);
               result = CURLE_WRITE_ERROR;
               break;
             }
@@ -2288,7 +2288,7 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
         config->cacert = strdup(env);
         if(!config->cacert) {
           curl_free(env);
-          helpf(global->errors, "out of memory\n");
+          errorf(global, "out of memory\n");
           return CURLE_OUT_OF_MEMORY;
         }
       }
@@ -2309,7 +2309,7 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
             config->cacert = strdup(env);
             if(!config->cacert) {
               curl_free(env);
-              helpf(global->errors, "out of memory\n");
+              errorf(global, "out of memory\n");
               return CURLE_OUT_OF_MEMORY;
             }
           }
@@ -2496,7 +2496,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
 #endif
       }
       else
-        helpf(global->errors, "out of memory\n");
+        errorf(global, "out of memory\n");
     }
   }
 

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -606,7 +606,7 @@ CURLcode get_args(struct OperationConfig *config, const size_t i)
   if(!config->useragent) {
     config->useragent = my_useragent();
     if(!config->useragent) {
-      helpf(config->global->errors, "out of memory\n");
+      errorf(config->global, "out of memory\n");
       result = CURLE_OUT_OF_MEMORY;
     }
   }


### PR DESCRIPTION
Change series of error outputs to use errorf().

Only errors that are due to mistakes in command line option usage should
use helpf(), other types of errors in the tool should rather use
errorf().