### PR TITLE
conncache: CONNECT_ONLY connections assumed always in-use

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -519,7 +519,8 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
     while(curr) {
       conn = curr->ptr;
 
-      if(!CONN_INUSE(conn) && !conn->data && !conn->bits.close) {
+      if(!CONN_INUSE(conn) && !conn->data && !conn->bits.close &&
+         !conn->bits.connect_only) {
         /* Set higher score for the age passed since the connection was used */
         score = Curl_timediff(now, conn->lastused);
 


### PR DESCRIPTION
This makes them never to be considered "the oldest" to be discarded when
reaching the connection cache limit. The reasoning here is that
CONNECT_ONLY is primarily used in combination with using the
connection's socket post connect and since that is used outside of
curl's knowledge we must assume that it is in use until explicitly
closed.

Reported-by: Pavel Pavlov
Reported-by: Pavel Löbl
Fixes #4426
Fixes #4369