### PR TITLE
add torture test on azure

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -81,6 +81,27 @@ jobs:
     - script: make test-nonflaky
       displayName: 'test'
 
+  - job: torture
+    displayName: ubuntu torture tests
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - script: sudo apt install libnghttp2-dev
+      displayName: 'apt install'
+
+    - script: ./buildconf && ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-alt-svc
+      displayName: 'Run configure'
+
+    - script: make
+      displayName: 'make'
+
+    - script: make "TFLAGS=-n -t --shallow=40 '!FTP'" test-nonflaky
+      displayName: 'torture test'
+
+##########################################
+### macOS jobs below
+##########################################
+
   - job: macos_plain
     displayName: macos default
     pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -6,13 +6,17 @@
 trigger:
 - master
 
+##########################################
+### Linux jobs first
+##########################################
+
 jobs:
   - job: vanilla_ubuntu
     displayName: unbuntu default
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-    - script: ./buildconf && ./configure
+    - script: ./buildconf && ./configure --enable-debug --enable-werror
       displayName: 'Run configure'
 
     - script: make


### PR DESCRIPTION
This is a more complete torture test than what has run on travis, as a first shot to see how much it can complete on azure.

- [x] #4699 introduced "shallow" torture
- [x] #4705 fixed leak in curl tool upload logic
- [x] #4706 fixed etags memory leak
- [x] #4707 fixed segfault in alt-svc save
- [x] #4709 addressed *five* separate test problems
- [x] #4710 double-free in OOM in the ntlm-wb code
- [x] shallow torture tests run all through ok