### PR TITLE
Introducing the "shallow" torture mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -543,7 +543,7 @@ script:
              make TFLAGS=-n test-nonflaky
              make "TFLAGS=-n -e" test-nonflaky
              tests="1 200 300 500 700 800 900 1000 1100 1200 1302 1400 1502 3000"
-             make "TFLAGS=-n -t $tests" test-nonflaky
+             make "TFLAGS=-n --shallow=40 -t $tests" test-nonflaky
         fi
     - |
         set -eo pipefail

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -84,6 +84,11 @@ Display run time statistics. (Requires Perl Time::HiRes module)
 Display full run time statistics. (Requires Perl Time::HiRes module)
 .IP "-s"
 Shorter output. Speaks less than default.
+.IP "--shallow=[num](,seed)"
+Used together with \fB-t\fP. This limits the number of tests to fail in
+torture mode to no more than 'num' per test case. If this reduces the amount,
+the given 'seed' will be used to randomly discard entries to fail until the
+amount is 'num'.
 .IP "-t[num]"
 Selects a \fBtorture\fP test for the given tests. This makes runtests.pl first
 run the tests once and count the number of memory allocations made. It then


### PR DESCRIPTION
With a new option to `runtests.pl`, we can limit the number of failures to cause for each test case and should then possible be able to run over more tests in the CI and elsewhere.

When running over a large amount of tests, torture mode tests the same function failures (in the common code paths) a very large number of times. That then makes them so slow that we can never really run them much and thus they decrease in value.