### PR TITLE
checksrc fixup for ASSIGNWITHINCONDITION

### DIFF
--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -457,7 +457,7 @@ sub scanfile {
             }
         }
 
-        if($nostr =~ /^((.*)(if) *\()(.*)\) [{\n]/) {
+        if($nostr =~ /^((.*)(if) *\()(.*)\)/) {
             my $pos = length($1);
             if($4 =~ / = /) {
                 checkwarn("ASSIGNWITHINCONDITION",

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -61,8 +61,13 @@ char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w);
 
 #define Curl_convert_UTF8_to_tchar(ptr) Curl_convert_UTF8_to_wchar((ptr))
 #define Curl_convert_tchar_to_UTF8(ptr) Curl_convert_wchar_to_UTF8((ptr))
-#define Curl_unicodefree(ptr) \
-  do {if((ptr)) {free((ptr)); (ptr) = NULL;}} while(0)
+#define Curl_unicodefree(ptr)                           \
+  do {                                                  \
+    if(ptr) {                                           \
+      free(ptr);                                        \
+      (ptr) = NULL;                                     \
+    }                                                   \
+  } while(0)
 
 typedef union {
   unsigned short       *tchar_ptr;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -97,9 +97,13 @@
 
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR
-/* !checksrc! disable ASSIGNWITHINCONDITION 1 */
-#define SSH_STRING_FREE_CHAR(x) \
-    do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } while(0)
+#define SSH_STRING_FREE_CHAR(x)                 \
+  do {                                          \
+    if(x) {                                     \
+      ssh_string_free_char(x);                  \
+      x = NULL;                                 \
+    }                                           \
+  } while(0)
 #endif
 
 /* Local functions: */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -97,6 +97,7 @@
 
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR
+/* !checksrc! disable ASSIGNWITHINCONDITION 1 */
 #define SSH_STRING_FREE_CHAR(x) \
     do { if((x) != NULL) { ssh_string_free_char(x); x = NULL; } } while(0)
 #endif

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -137,7 +137,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.c
+	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.[ch]
 
 if CURLDEBUG
 # for debug builds, we scan the sources on all regular make invokes

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,7 +20,7 @@
  *
  ***************************************************************************/
 
-/* !checksrc! disable ASSIGNWITHINCONDITION all */
+/* !checksrc! disable ASSIGNWITHINCONDITION 14 */
 
 /* Now include the curl_setup.h file from libcurl's private libdir (the source
    version, but that might include "curl_config.h" from the build dir so we

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -62,7 +62,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.c
+	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.[ch]
 
 if CURLDEBUG
 # for debug builds, we scan the sources on all regular make invokes

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -70,7 +70,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.c
+	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.[ch]
 
 if BUILD_UNITTESTS
 noinst_PROGRAMS = $(UNITPROGS)


### PR DESCRIPTION
- reverts ba82673dac3e8d00a76aa5e3779a0cb80e7442af due to the problems mentioned in #4683 
- makes sure checksrc runs on some headers files we missed out
- edit some macros to remove ASSIGNWITHINCONDITION exceptions

The `tests/libtest/test.h` still has the exception because that file creates macros that is supposed to be single expressions and I didn't feel like changing that in this PR.

/cc @danielgustafsson and @jay 