### PR TITLE
azure: the macos cmake doesn't need to install cmake

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -141,7 +141,7 @@ jobs:
     pool:
       vmImage: 'macOS-latest'
     steps:
-    - script: brew update && brew install libtool autoconf automake nghttp2 pkg-config cmake openssl
+    - script: brew update && brew install libtool autoconf automake nghttp2 pkg-config openssl
       displayName: Install packages
 
     - script: cmake -H. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON && cmake --build build


### PR DESCRIPTION
~~~
 Error: cmake 3.15.5 is already installed
 To upgrade to 3.16.1, run `brew upgrade cmake`.