### PR TITLE
curl: fix mem-leak in parseconfig()

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -97,6 +97,8 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       int i = 0;
       char prefix = '.';
       do {
+        /* if it was allocated in a previous attempt */
+        free(pathalloc);
         /* check for .curlrc then _curlrc in the home dir */
         pathalloc = curl_maprintf("%s%s%ccurlrc", home, DIR_CHAR, prefix);
         if(!pathalloc) {

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -98,7 +98,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       char prefix = '.';
       do {
         /* if it was allocated in a previous attempt */
-        free(pathalloc);
+        curl_free(pathalloc);
         /* check for .curlrc then _curlrc in the home dir */
         pathalloc = curl_maprintf("%s%s%ccurlrc", home, DIR_CHAR, prefix);
         if(!pathalloc) {
@@ -287,7 +287,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
   else
     rc = 1; /* couldn't open the file */
 
-  free(pathalloc);
+  curl_free(pathalloc);
   return rc;
 }
 


### PR DESCRIPTION
When looping, first trying '.curlrc' and then '_curlrc', the function
would not free the first string.