### PR TITLE
create_conn: remove silly pipelining leftover logic

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3594,24 +3594,6 @@ static CURLcode create_conn(struct Curl_easy *data,
   else
     reuse = ConnectionExists(data, conn, &conn_temp, &force_reuse, &waitpipe);
 
-  /* If we found a reusable connection that is now marked as in use, we may
-     still want to open a new connection if we are multiplexing. */
-  if(reuse && !force_reuse && IsMultiplexingPossible(data, conn_temp)) {
-    size_t multiplexed = CONN_INUSE(conn_temp);
-    if(multiplexed > 0) {
-      infof(data, "Found connection %ld, with %zu requests on it\n",
-            conn_temp->connection_id, multiplexed);
-
-      if(Curl_conncache_bundle_size(conn_temp) < max_host_connections &&
-         Curl_conncache_size(data) < max_total_connections) {
-        /* We want a new connection anyway */
-        reuse = FALSE;
-
-        infof(data, "We can reuse, but we want a new connection anyway\n");
-      }
-    }
-  }
-
   if(reuse) {
     /*
      * We already have a connection for this, we got the former connection


### PR DESCRIPTION
... as it would prefer new connections rather than multiplexing! The
code is a leftover from the Pipelining code that was translated wrongly
into a multiplexing-only world.

Reported-by: Kunal Ekawde
Bug: https://curl.haxx.se/mail/lib-2019-12/0060.html