### PR TITLE
test1456: remove the use of a fixed local port

### DIFF
--- a/tests/data/test1456
+++ b/tests/data/test1456
@@ -40,7 +40,7 @@ http-ipv6
 HTTP-IPv6 GET with PROXY protocol
  </name>
  <command>
--g "http://%HOST6IP:%HTTP6PORT/1456" --local-port 44444 --haproxy-protocol
+-g "http://%HOST6IP:%HTTP6PORT/1456" --haproxy-protocol
 </command>
 <features>
 proxy
@@ -53,8 +53,14 @@ proxy
 <strip>
 ^User-Agent:
 </strip>
+
+# Strip off the (random) local port number. This test used to use a fixed
+# local port number that frequently causes the test to fail
+<strippart>
+s/PROXY TCP6 ::1 ::1 (\d+) (\d+)/PROXY TCP6 ::1 ::1 $2/
+</strippart>
 <protocol>
-PROXY TCP6 ::1 ::1 44444 %HTTP6PORT
+PROXY TCP6 ::1 ::1 %HTTP6PORT
 GET /1456 HTTP/1.1
 Host: %HOST6IP:%HTTP6PORT
 Accept: */*


### PR DESCRIPTION
Fixup the test to instead not compare the port number. It sometimes
caused problems like this:

"curl: (45) bind failed with errno 98: Address already in use"