### PR TITLE
test165: set LC_ALL=en_US.UTF-8 too

### DIFF
--- a/tests/data/test165
+++ b/tests/data/test165
@@ -32,7 +32,7 @@ idn
 proxy
 </features>
 <setenv>
-LC_ALL=
+LC_ALL=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 </setenv>
 <precheck>


### PR DESCRIPTION
On my current Debian Unstable with libidn2 2.2.0, I get an error if
LC_ALL is set to blank. Then curl errors out with:

curl: (3) Failed to convert www.åäö.se to ACE; could not convert string to UTF-8