### PR TITLE
curl.h: add two defines for the "pre ISO C" case

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -956,6 +956,8 @@ typedef enum {
 /* The macro "##" is ISO C, we assume pre-ISO C doesn't support it. */
 #define LONG          CURLOPTTYPE_LONG
 #define OBJECTPOINT   CURLOPTTYPE_OBJECTPOINT
+#define STRINGPOINT   CURLOPTTYPE_OBJECTPOINT
+#define SLISTPOINT    CURLOPTTYPE_OBJECTPOINT
 #define FUNCTIONPOINT CURLOPTTYPE_FUNCTIONPOINT
 #define OFF_T         CURLOPTTYPE_OFF_T
 #define CINIT(name,type,number) CURLOPT_/**/name = type + number


### PR DESCRIPTION
Without this fix, this caused a compilation failure on AIX with IBM xlc
13.1.3 compiler.

Reported-by: Ram Krushna Mishra
Fixes #4739