### PR TITLE
sws: search for "Testno:" header uncondtionally if no testno

### DIFF
--- a/tests/data/test1455
+++ b/tests/data/test1455
@@ -37,7 +37,7 @@ http
 HTTP GET when PROXY Protocol enabled
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/1455 --haproxy-protocol
+http://%HOSTIP:%HTTPPORT/1455 --haproxy-protocol -H "Testno: 1455"
 </command>
 <features>
 proxy
@@ -58,6 +58,7 @@ proxy-line
 GET /1455 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
+Testno: 1455
 
 </protocol>
 </verify>

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -367,6 +367,8 @@ static int parse_servercmd(struct httprequest *req)
 
   filename = test2file(req->testno);
   req->close = FALSE;
+  req->connmon = FALSE;
+
   stream = fopen(filename, "rb");
   if(!stream) {
     error = errno;
@@ -390,8 +392,6 @@ static int parse_servercmd(struct httprequest *req)
       req->open = FALSE; /* closes connection */
       return 1; /* done */
     }
-
-    req->connmon = FALSE;
 
     cmd = orgcmd;
     while(cmd && cmdsize) {
@@ -540,12 +540,11 @@ static int ProcessRequest(struct httprequest *req)
         msnprintf(logbuf, sizeof(logbuf), "Requested test number %ld part %ld",
                   req->testno, req->partno);
         logmsg("%s", logbuf);
-
-        /* find and parse <servercmd> for this test */
-        parse_servercmd(req);
       }
-      else
+      else {
+        logmsg("No test number");
         req->testno = DOCNUMBER_NOTHING;
+      }
 
     }
 
@@ -606,14 +605,6 @@ static int ProcessRequest(struct httprequest *req)
     }
 
     if(req->testno == DOCNUMBER_NOTHING) {
-      /* check for a Testno: header with the test case number */
-      char *testno = strstr(line, "\nTestno: ");
-      if(testno) {
-        req->testno = strtol(&testno[9], NULL, 10);
-        logmsg("Found test number %d in Testno: header!", req->testno);
-      }
-    }
-    if(req->testno == DOCNUMBER_NOTHING) {
       /* Still no test case number. Try to get the the number off the last dot
          instead, IE we consider the TLD to be the test number. Test 123 can
          then be written as "example.com.123". */
@@ -653,8 +644,8 @@ static int ProcessRequest(struct httprequest *req)
     }
   }
   else if((req->offset >= 3) && (req->testno == DOCNUMBER_NOTHING)) {
-    logmsg("** Unusual request. Starts with %02x %02x %02x",
-           line[0], line[1], line[2]);
+    logmsg("** Unusual request. Starts with %02x %02x %02x (%c%c%c)",
+           line[0], line[1], line[2], line[0], line[1], line[2]);
   }
 
   if(!end) {
@@ -662,7 +653,22 @@ static int ProcessRequest(struct httprequest *req)
     logmsg("request not complete yet");
     return 0; /* not complete yet */
   }
-  logmsg("- request found to be complete");
+  logmsg("- request found to be complete (%d)", req->testno);
+
+  if(req->testno == DOCNUMBER_NOTHING) {
+    /* check for a Testno: header with the test case number */
+    char *testno = strstr(line, "\nTestno: ");
+    if(testno) {
+      req->testno = strtol(&testno[9], NULL, 10);
+      logmsg("Found test number %d in Testno: header!", req->testno);
+    }
+    else {
+      logmsg("No Testno: header");
+    }
+  }
+
+  /* find and parse <servercmd> for this test */
+  parse_servercmd(req);
 
   if(use_gopher) {
     /* when using gopher we cannot check the request until the entire


### PR DESCRIPTION
Even if the initial request line wasn't found. With the fix to 1455, the
test number is now detected correctly.

(Problem found when running tests in random order.)