### PR TITLE
Correction of a comment in /docs/examples/url2file.c.

### DIFF
--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
   /* Switch on full protocol/debug output while testing */
   curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, 1L);
 
-  /* disable progress meter, set to 0L to enable and disable debug output */
+  /* disable progress meter, set to 0L to enable debug output */
   curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
 
   /* send all data to this function  */

--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
   /* Switch on full protocol/debug output while testing */
   curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, 1L);
 
-  /* disable progress meter, set to 0L to enable debug output */
+  /* disable progress meter, set to 0L to enable it */
   curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
 
   /* send all data to this function  */


### PR DESCRIPTION
I stumbled upon the url2file.c example and i noticed this
comment:
`/* disable progress meter, set to 0L to enable and disable debug output */`

I think it would look better if it read: 
`/* disable progress meter, set to 0L to enable debug output */`

I think the comment is confusing, as it is today, because it suggests
that two things happen at the same time here, setting it to 0L both
enables and disables debug output at the same time, like the Schrödinger's
cat of CURLOPTs.

Then I learn that the reason CURLOPT_NOPROGRESS is set to 1L in the following
line is to disable output and that setting it to 0L is reversing this action.

This is why I am doing this pull request.