### PR TITLE
libssh2: add support for forcing a specific host key

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -655,6 +655,10 @@ static CURLcode ssh_check_fingerprint(struct connectdata *conn)
  */
 static CURLcode ssh_force_knownhost_key_type(struct connectdata *conn)
 {
+  CURLcode result = CURLE_OK; 
+
+#ifdef HAVE_LIBSSH2_KNOWNHOST_API
+
 #ifdef LIBSSH2_KNOWNHOST_KEY_ED25519
   static const char * const hostkey_method_ssh_ed25519
     = "ssh-ed25519";
@@ -676,7 +680,7 @@ static CURLcode ssh_force_knownhost_key_type(struct connectdata *conn)
   static const char * const hostkey_method_ssh_dss
     = "ssh-dss";
 
-  CURLcode result = CURLE_OK;
+
   const char *hostkey_method = NULL;
   struct ssh_conn *sshc = &conn->proto.sshc;
   struct Curl_easy *data = conn->data;
@@ -745,6 +749,9 @@ static CURLcode ssh_force_knownhost_key_type(struct connectdata *conn)
               sshc->ssh_session, LIBSSH2_METHOD_HOSTKEY, hostkey_method));
     }
   }
+
+#endif /* HAVE_LIBSSH2_KNOWNHOST_API */
+
   return result;
 }
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -696,6 +696,11 @@ static CURLcode ssh_force_knownhost_key_type(struct connectdata *conn)
       /* square brackets, followed by a colon and the port */
       if(store->name[0] == '[') {
         kh_name_end = strstr(store->name, "]:");
+        if(!kh_name_end) {
+          infof(data, "Invalid host pattern %s in %s\n",
+              store->name, data->set.str[STRING_SSH_KNOWNHOSTS]);
+          continue;
+        }
         port = atoi(kh_name_end + 2);
         if(kh_name_end && (port == conn->remote_port)) {
           kh_name_size = strlen(store->name) - 1 - strlen(kh_name_end);
@@ -714,7 +719,7 @@ static CURLcode ssh_force_knownhost_key_type(struct connectdata *conn)
     if(found) {
       infof(data, "Found host %s in %s\n",
           store->name, data->set.str[STRING_SSH_KNOWNHOSTS]);
-      /* TODO: do we need to check the host and key format here as well?*/
+
       switch(store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK) {
 #ifdef LIBSSH2_KNOWNHOST_KEY_ED25519
       case LIBSSH2_KNOWNHOST_KEY_ED25519:


### PR DESCRIPTION
Currently, curl (with libssh2) does not take keys from your known_hosts file into account when talking to a server. With this patch the known_hosts file will be searched for an entry matching the hostname and, if found, libssh2 will be told to claim this key type from the server.