### PR TITLE
bug: Let -D merge headers in one file again

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -871,7 +871,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->headerfile) {
           /* open file for output: */
           if(strcmp(config->headerfile, "-")) {
-            FILE *newfile = fopen(config->headerfile, "wb");
+            FILE *newfile;
+            newfile = fopen(config->headerfile, per->prev == NULL?"wb":"ab");
             if(!newfile) {
               warnf(config->global, "Failed to open %s\n", config->headerfile);
               result = CURLE_WRITE_ERROR;

--- a/tests/data/test2006
+++ b/tests/data/test2006
@@ -86,6 +86,10 @@ Accept: */*
 Some data delivered from an HTTP resource
 </file1>
 <file2 name="log/heads2006">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 14:49:01 GMT
 Server: test-server/fake

--- a/tests/data/test2007
+++ b/tests/data/test2007
@@ -90,6 +90,10 @@ Something delivered from an HTTP resource
 s/Last-Modified:.*//
 </stripfile2>
 <file2 name="log/heads2007">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 14:50:02 GMT
 Server: test-server/fake

--- a/tests/data/test2008
+++ b/tests/data/test2008
@@ -82,6 +82,10 @@ Some stuff delivered from an HTTP resource
 s/Last-Modified:.*//
 </stripfile2>
 <file2 name="log/heads2008">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 15:23:48 GMT
 Server: test-server/fake

--- a/tests/data/test2009
+++ b/tests/data/test2009
@@ -83,6 +83,10 @@ Some contents delivered from an HTTP resource
 s/Last-Modified:.*//
 </stripfile2>
 <file2 name="log/heads2009">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 16:27:17 GMT
 Server: test-server/fake

--- a/tests/data/test2010
+++ b/tests/data/test2010
@@ -82,6 +82,10 @@ Contents delivered from an HTTP resource
 s/Last-Modified:.*//
 </stripfile2>
 <file2 name="log/heads2010">
+Content-Length: 496
+Accept-ranges: bytes
+
+
 HTTP/1.1 200 OK
 Date: Thu, 21 Jun 2012 17:37:27 GMT
 Server: test-server/fake


### PR DESCRIPTION
Fix for #4753
We check if this is the first run of the function, if so create a new file. The function is getting executed node by node of the linked list so we just check if it the first node by checking if the previous element is NULL.