### PR TITLE
multi: Change curl_multi_wait/poll to error on negative timeout

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -147,7 +147,7 @@ Function not found. A required zlib function was not found.
 .IP "CURLE_ABORTED_BY_CALLBACK (42)"
 Aborted by callback. A callback returned "abort" to libcurl.
 .IP "CURLE_BAD_FUNCTION_ARGUMENT (43)"
-Internal error. A function was called with a bad parameter.
+A function was called with a bad parameter.
 .IP "CURLE_INTERFACE_FAILED (45)"
 Interface error. A specified outgoing interface could not be used. Set which
 interface to use for outgoing connections' source IP address with
@@ -299,6 +299,8 @@ second time. (Added in 7.32.1)
 An API function was called from inside a callback.
 .IP "CURLM_WAKEUP_FAILURE (9)"
 Wakeup is unavailable or failed.
+.IP "CURLM_BAD_FUNCTION_ARGUMENT (10)"
+A function was called with a bad parameter.
 .SH "CURLSHcode"
 The "share" interface will return a CURLSHcode to indicate when an error has
 occurred.  Also consider \fIcurl_share_strerror(3)\fP.

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -334,6 +334,7 @@ CURLMSG_DONE                    7.9.6
 CURLMSG_NONE                    7.9.6
 CURLM_ADDED_ALREADY             7.32.1
 CURLM_BAD_EASY_HANDLE           7.9.6
+CURLM_BAD_FUNCTION_ARGUMENT     7.69.0
 CURLM_BAD_HANDLE                7.9.6
 CURLM_BAD_SOCKET                7.15.4
 CURLM_CALL_MULTI_PERFORM        7.9.6

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -72,7 +72,8 @@ typedef enum {
                             attempted to get added - again */
   CURLM_RECURSIVE_API_CALL, /* an api function was called from inside a
                                callback */
-  CURLM_WAKEUP_FAILURE, /* wakeup is unavailable or failed */
+  CURLM_WAKEUP_FAILURE,  /* wakeup is unavailable or failed */
+  CURLM_BAD_FUNCTION_ARGUMENT,  /* function called with a bad parameter */
   CURLM_LAST
 } CURLMcode;
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1048,6 +1048,9 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
   if(multi->in_callback)
     return CURLM_RECURSIVE_API_CALL;
 
+  if(timeout_ms < 0)
+    return CURLM_BAD_FUNCTION_ARGUMENT;
+
   /* Count up how many fds we have from the multi handle */
   data = multi->easyp;
   while(data) {

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -392,6 +392,9 @@ curl_multi_strerror(CURLMcode error)
   case CURLM_WAKEUP_FAILURE:
     return "Wakeup is unavailable or failed";
 
+  case CURLM_BAD_FUNCTION_ARGUMENT:
+    return "A libcurl function was given a bad argument";
+
   case CURLM_LAST:
     break;
   }

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -1816,7 +1816,9 @@
      d                 c                   8
      d  CURLM_WAKEUP_FAILURE...
      d                 c                   9
-     d  CURLM_LAST     c                   10
+     d  CURLM_BAD_FUNCTION_ARGUMENT...
+     d                 c                   10
+     d  CURLM_LAST     c                   11
       *
      d CURLMSG         s             10i 0 based(######ptr######)               Enum
      d  CURLMSG_NONE   c                   0

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -140,7 +140,8 @@ m6: Unknown option
 m7: The easy handle is already added to a multi handle
 m8: API function called from within callback
 m9: Wakeup is unavailable or failed
-m10: Unknown error
+m10: A libcurl function was given a bad argument
+m11: Unknown error
 s0: No error
 s1: Unknown share option
 s2: Share currently in use


### PR DESCRIPTION
- Add new error CURLM_BAD_FUNCTION_ARGUMENT and return that error when
  curl_multi_wait/poll is passed timeout param < 0.

Prior to this change passing a negative value to curl_multi_wait/poll
such as -1 could cause the function to wait forever.

Reported-by: hamstergene@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/4763

Closes #xxxx
