### PR TITLE
tests: Change NTLM tests to require SSL

### DIFF
--- a/tests/data/test1008
+++ b/tests/data/test1008
@@ -86,6 +86,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test1021
+++ b/tests/data/test1021
@@ -91,6 +91,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test1097
+++ b/tests/data/test1097
@@ -45,6 +45,7 @@ https
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>

--- a/tests/data/test1100
+++ b/tests/data/test1100
@@ -63,6 +63,7 @@ This is the final page !
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test1215
+++ b/tests/data/test1215
@@ -58,6 +58,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test150
+++ b/tests/data/test150
@@ -57,6 +57,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test155
+++ b/tests/data/test155
@@ -76,6 +76,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test159
+++ b/tests/data/test159
@@ -43,6 +43,7 @@ This is not the real page either!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test162
+++ b/tests/data/test162
@@ -27,6 +27,7 @@ isn't because there's no Proxy-Authorization: NTLM header
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 proxy
 </features>

--- a/tests/data/test169
+++ b/tests/data/test169
@@ -77,6 +77,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test170
+++ b/tests/data/test170
@@ -19,6 +19,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 proxy
 </features>

--- a/tests/data/test176
+++ b/tests/data/test176
@@ -48,6 +48,7 @@ content for you
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2025
+++ b/tests/data/test2025
@@ -195,6 +195,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2028
+++ b/tests/data/test2028
@@ -231,6 +231,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2029
+++ b/tests/data/test2029
@@ -168,6 +168,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2030
+++ b/tests/data/test2030
@@ -220,6 +220,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2031
+++ b/tests/data/test2031
@@ -234,6 +234,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2032
+++ b/tests/data/test2032
@@ -66,6 +66,7 @@ Data connection 2: 402
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test2033
+++ b/tests/data/test2033
@@ -67,6 +67,7 @@ Data connection 2: 402
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
 <server>

--- a/tests/data/test209
+++ b/tests/data/test209
@@ -77,6 +77,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test213
+++ b/tests/data/test213
@@ -77,6 +77,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test239
+++ b/tests/data/test239
@@ -52,6 +52,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test243
+++ b/tests/data/test243
@@ -73,6 +73,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test265
+++ b/tests/data/test265
@@ -78,6 +78,7 @@ http
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test267
+++ b/tests/data/test267
@@ -56,6 +56,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test547
+++ b/tests/data/test547
@@ -76,6 +76,7 @@ lib547
 </tool>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test548
+++ b/tests/data/test548
@@ -76,6 +76,7 @@ lib548
 </tool>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test555
+++ b/tests/data/test555
@@ -81,6 +81,7 @@ lib555
 </tool>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test590
+++ b/tests/data/test590
@@ -74,6 +74,7 @@ lib590
 </tool>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test67
+++ b/tests/data/test67
@@ -56,6 +56,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test68
+++ b/tests/data/test68
@@ -55,6 +55,7 @@ Wrong password dude. Get it fixed and return.
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test69
+++ b/tests/data/test69
@@ -72,6 +72,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test81
+++ b/tests/data/test81
@@ -55,6 +55,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 proxy

--- a/tests/data/test822
+++ b/tests/data/test822
@@ -35,6 +35,7 @@ imap
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test827
+++ b/tests/data/test827
@@ -36,6 +36,7 @@ imap
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test831
+++ b/tests/data/test831
@@ -28,6 +28,7 @@ imap
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>

--- a/tests/data/test834
+++ b/tests/data/test834
@@ -39,6 +39,7 @@ imap
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>

--- a/tests/data/test868
+++ b/tests/data/test868
@@ -37,6 +37,7 @@ pop3
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test873
+++ b/tests/data/test873
@@ -37,6 +37,7 @@ pop3
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test877
+++ b/tests/data/test877
@@ -29,6 +29,7 @@ pop3
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>

--- a/tests/data/test880
+++ b/tests/data/test880
@@ -41,6 +41,7 @@ pop3
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>

--- a/tests/data/test89
+++ b/tests/data/test89
@@ -89,6 +89,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test90
+++ b/tests/data/test90
@@ -127,6 +127,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test906
+++ b/tests/data/test906
@@ -27,6 +27,7 @@ smtp
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test91
+++ b/tests/data/test91
@@ -73,6 +73,7 @@ Finally, this is the real page!
 <client>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test921
+++ b/tests/data/test921
@@ -27,6 +27,7 @@ smtp
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 debug
 </features>

--- a/tests/data/test933
+++ b/tests/data/test933
@@ -28,6 +28,7 @@ smtp
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>

--- a/tests/data/test936
+++ b/tests/data/test936
@@ -31,6 +31,7 @@ smtp
 </server>
 <features>
 NTLM
+SSL
 !SSPI
 </features>
  <name>


### PR DESCRIPTION
Prior to this change tests that required NTLM feature did not require
SSL feature.

There are pending changes to cmake builds that will allow enabling NTLM
in non-SSL builds in Windows. In that case the NTLM auth strings created
are different from what is expected by the NTLM tests and they fail:

"The issue with NTLM is that previous non-SSL builds would not enable
NTLM and so the NTLM tests would be skipped."

Assisted-by: marc-groundctl@users.noreply.github.com

Ref: https://github.com/curl/curl/pull/4717#issuecomment-566218729

Closes #xxxx

---

/cc @marc-groundctl 