### PR TITLE
tool: make a few char pointers point to const char instead

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1985,8 +1985,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       {
         /* byte range requested */
-        char *tmp_range;
-        tmp_range = nextarg;
+        const char *tmp_range = nextarg;
         while(*tmp_range != '\0') {
           if(!ISDIGIT(*tmp_range) && *tmp_range != '-' && *tmp_range != ',') {
             warnf(global, "Invalid character is found in given range. "

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -560,7 +560,7 @@ int ftpcccmethod(struct OperationConfig *config, const char *str)
   return CURLFTPSSL_CCC_PASSIVE;
 }
 
-long delegation(struct OperationConfig *config, char *str)
+long delegation(struct OperationConfig *config, const char *str)
 {
   if(curl_strequal("none", str))
     return CURLGSSAPI_DELEGATION_NONE;

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -50,7 +50,7 @@ int ftpfilemethod(struct OperationConfig *config, const char *str);
 
 int ftpcccmethod(struct OperationConfig *config, const char *str);
 
-long delegation(struct OperationConfig *config, char *str);
+long delegation(struct OperationConfig *config, const char *str);
 
 ParameterError str2tls_max(long *val, const char *str);
 


### PR DESCRIPTION
These are read-only.

Extracted from https://github.com/curl/curl/pull/3784. If I remember correctly, they need to be const to suppress compiler warnings when using the functions from curl_multibyte.h.