### PR TITLE
curl -w: handle a blank input file correctly

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -65,7 +65,7 @@ ParameterError file2string(char **bufp, FILE *file)
     size_t alloc_needed;
     char buffer[256];
     size_t stringlen = 0;
-    string = malloc(alloc);
+    string = calloc(1, alloc);
     if(!string)
       return PARAM_NO_MEM;
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -143,7 +143,7 @@ test1236 test1237 test1238 test1239 test1240 test1241 test1242 test1243 \
 test1244 test1245 test1246 test1247 test1248 test1249 test1250 test1251 \
 test1252 test1253 test1254 test1255 test1256 test1257 test1258 test1259 \
 test1260 test1261 test1262 test1263 test1264 test1265 test1266 test1267 \
-test1268 test1269 test1270 \
+test1268 test1269 test1270 test1271 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 test1292 test1293 \

--- a/tests/data/test1271
+++ b/tests/data/test1271
@@ -1,0 +1,48 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+--write-out
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 This is a weirdo text message swsclose
+Content-Length: 4
+Connection: close
+
+Moo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+--write-out from file with empty file
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/we/want/our/1271 -w @log/blank1271
+</command>
+<file name="log/blank1271">
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /we/want/our/1271 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Previously it would end up with an uninitialized memory buffer that
would lead to a crash or junk getting output.

Added test 1271 to verify.

Reported-by: Brian Carpenter