### PR TITLE
Prevent runtime warning on OS400 when CURL_DISABLE_PROXY is not defined.

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1141,8 +1141,13 @@ curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
   if(testwarn) {
     testwarn = 0;
 
+#ifndef CURL_DISABLE_PROXY
+    if((int) STRING_LASTZEROTERMINATED != (int) STRING_TEMP_URL + 1 ||
+       (int) STRING_LAST != (int) STRING_COPYPOSTFIELDS + 1)
+#else
     if((int) STRING_LASTZEROTERMINATED != (int) STRING_SASL_AUTHZID + 1 ||
        (int) STRING_LAST != (int) STRING_COPYPOSTFIELDS + 1)
+#endif
       curl_mfprintf(stderr,
        "*** WARNING: curl_easy_setopt_ccsid() should be reworked ***\n");
   }


### PR DESCRIPTION
"*** WARNING: curl_easy_setopt_ccsid() should be reworked ***" appears at runtime on OS400 when using curl_easy_setopt_ccsid() because the checks added in ccsidcurl.c to handle ASCII to EBCDIC string conversions does not correctly cater for CURL_DISABLE_PROXY being defined. When this is defined the integer value of STRING_LASTZEROTERMINATED is STRING_SASL_AUTHZID + 1, however when it is not defined the value is STRING_TEMP_URL + 1. The code that generates the runtime warning should factor this into its checks.