### PR TITLE
FindLibSSH2: add "libssh2" as possible name for library

### DIFF
--- a/CMake/FindLibSSH2.cmake
+++ b/CMake/FindLibSSH2.cmake
@@ -12,7 +12,7 @@ endif()
 find_path(LIBSSH2_INCLUDE_DIR libssh2.h
 )
 
-find_library(LIBSSH2_LIBRARY NAMES ssh2
+find_library(LIBSSH2_LIBRARY NAMES ssh2 libssh2
 )
 
 if(LIBSSH2_INCLUDE_DIR)


### PR DESCRIPTION
LibSSH2 CMake installation may name the library "libssh2" instead of "ssh2".