### PR TITLE
Make libcurl respect SSL_CERT_* env vars

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -134,6 +134,9 @@ curl_calloc_callback Curl_ccalloc;
 #  pragma warning(default:4232) /* MSVC extension, dllimport identity */
 #endif
 
+char *Curl_ssl_cert_dir = NULL;
+char *Curl_ssl_cert_file = NULL;
+
 /**
  * curl_global_init() globally initializes curl given a bitwise set of the
  * different features of what to initialize.
@@ -154,6 +157,9 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
 #endif
   }
+
+  Curl_ssl_cert_dir = curl_getenv("SSL_CERT_DIR");
+  Curl_ssl_cert_file = curl_getenv("SSL_CERT_FILE");
 
   if(!Curl_ssl_init()) {
     DEBUGF(fprintf(stderr, "Error: Curl_ssl_init failed\n"));
@@ -263,6 +269,9 @@ void curl_global_cleanup(void)
 
   Curl_ssl_cleanup();
   Curl_resolver_global_cleanup();
+
+  free(Curl_ssl_cert_dir);
+  free(Curl_ssl_cert_file);
 
 #ifdef WIN32
   Curl_win32_cleanup(init_flags);

--- a/lib/url.c
+++ b/lib/url.c
@@ -131,6 +131,9 @@ static void conn_free(struct connectdata *conn);
 static void free_idnconverted_hostname(struct hostname *host);
 static unsigned int get_protocol_family(unsigned int protocol);
 
+extern char *Curl_ssl_cert_dir;
+extern char *Curl_ssl_cert_file;
+
 /* Some parts of the code (e.g. chunked encoding) assume this buffer has at
  * more than just a few bytes to play with. Don't let it become too small or
  * bad things will happen.
@@ -534,6 +537,27 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
     if(result)
       return result;
 #endif
+    if(Curl_ssl_cert_dir) {
+      result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_ORIG],
+                              Curl_ssl_cert_dir);
+      if(result)
+        return result;
+      result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_PROXY],
+                              Curl_ssl_cert_dir);
+      if(result)
+        return result;
+    }
+
+    if(Curl_ssl_cert_file) {
+      result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_ORIG],
+                              Curl_ssl_cert_file);
+      if(result)
+        return result;
+      result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY],
+                              Curl_ssl_cert_file);
+      if(result)
+        return result;
+    }
   }
 
   set->wildcard_enabled = FALSE;


### PR DESCRIPTION
Currently, only the curl utility respects these environment variables. As far as I understand, this is because `getenv` is not thread-safe (https://curl.haxx.se/mail/lib-2016-08/0118.html). However, it's possible to fetch these variables during global init.