### PR TITLE
mime: return CURL_READFUNC_ABORT back to parent

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -765,6 +765,7 @@ static size_t read_encoded_part_content(curl_mimepart *part,
         break;
       case CURL_READFUNC_ABORT:
       case CURL_READFUNC_PAUSE:
+        return sz;
       case READ_ERROR:
         return cursize? cursize: sz;
       default:
@@ -794,6 +795,7 @@ static size_t read_encoded_part_content(curl_mimepart *part,
       break;
     case CURL_READFUNC_ABORT:
     case CURL_READFUNC_PAUSE:
+      return sz;
     case READ_ERROR:
       return cursize? cursize: sz;
     default:
@@ -878,10 +880,11 @@ static size_t readback_part(curl_mimepart *part,
           part->fp = NULL;
         }
         /* FALLTHROUGH */
-      case CURL_READFUNC_ABORT:
-      case CURL_READFUNC_PAUSE:
       case READ_ERROR:
         return cursize? cursize: sz;
+      case CURL_READFUNC_ABORT:
+      case CURL_READFUNC_PAUSE:
+        return sz;
       }
       break;
     case MIMESTATE_END:
@@ -966,6 +969,7 @@ static size_t mime_subparts_read(char *buffer, size_t size, size_t nitems,
       switch(sz) {
       case CURL_READFUNC_ABORT:
       case CURL_READFUNC_PAUSE:
+        return sz;
       case READ_ERROR:
         return cursize? cursize: sz;
       case 0:

--- a/tests/data/test644
+++ b/tests/data/test644
@@ -4,7 +4,6 @@
 HTTP
 HTTP POST
 HTTP MIME POST
-flaky
 </keywords>
 </info>
 
@@ -46,9 +45,6 @@ Host: %HOSTIP:%HTTPPORT
 Accept: */*
 Content-Length: 718
 Content-Type: multipart/form-data; boundary=----------------------------
-
-------------------------------
-Content-Disposition: form-data; name="sendfile"; filename="postit2.c"
 
 </protocol>
 # CURLE_ABORTED_BY_CALLBACK (42)

--- a/tests/libtest/lib643.c
+++ b/tests/libtest/lib643.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -41,10 +41,15 @@ struct WriteThis {
 static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
 #ifdef LIB644
+  static int count = 0;
   (void)ptr;
   (void)size;
   (void)nmemb;
   (void)userp;
+  if(++count > 1) {
+    printf("Wrongly called >1 times\n");
+    exit(1); /* trigger major failure */
+  }
   return CURL_READFUNC_ABORT;
 #else
 


### PR DESCRIPTION
When *ABORT is returned from the callback, the transfer must stop
immediately and the return code must be passed back to the parent all
the way up to Curl_fillreadbuffer().

Test 644 was supposed to verify this but it wasn't done right. Now it
makes sure the callback is never called again after CURL_READFUNC_ABORT
is returned and it also makes sure the data transfer is actually
stopped as instructed.

Also removed the 'flaky' keyword since the test is now modified.

Fixes #4813
Reported-by: MrdUkk on github