### PR TITLE
progressbarinit: refuse to use the column width from terminals narrower than 20 columns

### DIFF
--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -251,7 +251,8 @@ void progressbarinit(struct ProgressData *bar,
       }
     }
 #endif /* TIOCGSIZE */
-    bar->width = cols;
+    if(cols > 20)
+      bar->width = cols;
   }
 
   if(!bar->width)


### PR DESCRIPTION
To avoid division by zero - or other issues.

Reported-by: Daniel Marjamäki