### PR TITLE
libssh2: fix variable type

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -685,7 +685,7 @@ static CURLcode ssh_force_knownhost_key_type(struct connectdata *conn)
   struct Curl_easy *data = conn->data;
   struct libssh2_knownhost* store = NULL;
   const char *kh_name_end = NULL;
-  long unsigned int kh_name_size = 0;
+  size_t kh_name_size = 0;
   int port = 0;
   bool found = false;
 


### PR DESCRIPTION
This led to a conversion warning on 64-bit MinGW, which has 32-bit
`long` but 64-bit `size_t`.