### PR TITLE
data.d: remove "Multiple files can also be specified"

### DIFF
--- a/docs/cmdline-opts/data.d
+++ b/docs/cmdline-opts/data.d
@@ -22,9 +22,8 @@ data pieces specified will be merged together with a separating
 chunk that looks like \&'name=daniel&skill=lousy'.
 
 If you start the data with the letter @, the rest should be a file name to
-read the data from, or - if you want curl to read the data from
-stdin. Multiple files can also be specified. Posting data from a file named
-\&'foobar' would thus be done with --data @foobar. When --data is told to read
-from a file like that, carriage returns and newlines will be stripped out. If
-you don't want the @ character to have a special interpretation use --data-raw
-instead.
+read the data from, or - if you want curl to read the data from stdin. Posting
+data from a file named \&'foobar' would thus be done with --data @foobar. When
+--data is told to read from a file like that, carriage returns and newlines
+will be stripped out. If you don't want the @ character to have a special
+interpretation use --data-raw instead.


### PR DESCRIPTION
It is superfluous and could even be misleading.

Bug: https://curl.haxx.se/mail/archive-2020-01/0016.html
Reported-by: Mike Norton