### PR TITLE
multi: add curl_multi_init2 for advanced multi init

### DIFF
--- a/docs/libcurl/Makefile.inc
+++ b/docs/libcurl/Makefile.inc
@@ -45,6 +45,7 @@ man_MANS = \
  curl_multi_fdset.3 \
  curl_multi_info_read.3 \
  curl_multi_init.3 \
+ curl_multi_init2.3 \
  curl_multi_perform.3 \
  curl_multi_poll.3 \
  curl_multi_remove_handle.3 \

--- a/docs/libcurl/Makefile.inc
+++ b/docs/libcurl/Makefile.inc
@@ -45,7 +45,7 @@ man_MANS = \
  curl_multi_fdset.3 \
  curl_multi_info_read.3 \
  curl_multi_init.3 \
- curl_multi_init2.3 \
+ curl_multi_init_advanced.3 \
  curl_multi_perform.3 \
  curl_multi_poll.3 \
  curl_multi_remove_handle.3 \

--- a/docs/libcurl/curl_multi_init.3
+++ b/docs/libcurl/curl_multi_init.3
@@ -33,11 +33,11 @@ multi-functions, sometimes referred to as a multi handle in some places in the
 documentation. This init call MUST have a corresponding call to
 \fIcurl_multi_cleanup(3)\fP when the operation is complete.
 
-\fIcurl_multi_init2(3)\fP is the same as this function except that it allows
-setting advanced init options. (7.69.0)
+\fIcurl_multi_init_advanced(3)\fP is the same as this function except that it
+allows setting advanced init options. (7.69.0)
 .SH RETURN VALUE
 If this function returns NULL, something went wrong and you cannot use the
 other curl functions.
 .SH "SEE ALSO"
-.BR curl_multi_init2 "(3)"
+.BR curl_multi_init_advanced "(3)"
 .BR curl_multi_cleanup "(3)," curl_global_init "(3)," curl_easy_init "(3)"

--- a/docs/libcurl/curl_multi_init2.3
+++ b/docs/libcurl/curl_multi_init2.3
@@ -19,13 +19,14 @@
 .\" * KIND, either express or implied.
 .\" *
 .\" **************************************************************************
-.TH curl_multi_init 3 "1 March 2002" "libcurl 7.9.5" "libcurl Manual"
+.TH curl_multi_init2 3 "21 January 2020" "libcurl 7.69.0" "libcurl Manual"
 .SH NAME
-curl_multi_init - create a multi handle
+curl_multi_init2 - create a multi handle with advanced init options
 .SH SYNOPSIS
 .B #include <curl/curl.h>
 .sp
-.BI "CURLM *curl_multi_init( );"
+.BI "CURLM *curl_multi_init2(int " socket_table_hashsize ", "
+.BI "int " conn_table_hashsize ", int " flags " );"
 .ad
 .SH DESCRIPTION
 This function returns a CURLM handle to be used as input to all the other
@@ -33,11 +34,28 @@ multi-functions, sometimes referred to as a multi handle in some places in the
 documentation. This init call MUST have a corresponding call to
 \fIcurl_multi_cleanup(3)\fP when the operation is complete.
 
-\fIcurl_multi_init2(3)\fP is the same as this function except that it allows
-setting advanced init options. (7.69.0)
+\fBsocket_table_hashsize\fP sets the size of the hash table used to keep track
+of sockets. \fBconn_table_hashsize\fP sets the size of the hash table used to
+keep track of connections. Set both parameters to 0 to use the default values,
+unless a curl developer says otherwise.
+
+\fBflags\fP refer to the FLAGS section below.
+
+\fIcurl_multi_init(3)\fP is the same as this function except that it doesn't
+allow setting advanced init options.
+.SH FLAGS
+.IP CURL_MULTI_DISABLE_POLL_WAKEUP
+Since 7.68.0 each multi has a wakeup socket pair to allow waking
+\fIcurl_multi_poll(3)\fP from a different thread. The wakeup socket pair is 2
+sockets that remain open for the life of the multi. If your socket resources
+are very limited you can use this flag to disable the wakeup socket pair. Note
+\fIcurl_multi_wakeup(3)\fP will return an error if there is no wakeup socket
+pair.
+.SH AVAILABILITY
+7.69.0
 .SH RETURN VALUE
 If this function returns NULL, something went wrong and you cannot use the
 other curl functions.
 .SH "SEE ALSO"
-.BR curl_multi_init2 "(3)"
+.BR curl_multi_init "(3)"
 .BR curl_multi_cleanup "(3)," curl_global_init "(3)," curl_easy_init "(3)"

--- a/docs/libcurl/curl_multi_init_advanced.3
+++ b/docs/libcurl/curl_multi_init_advanced.3
@@ -19,25 +19,19 @@
 .\" * KIND, either express or implied.
 .\" *
 .\" **************************************************************************
-.TH curl_multi_init2 3 "21 January 2020" "libcurl 7.69.0" "libcurl Manual"
+.TH curl_multi_init_advanced 3 "21 January 2020" "libcurl 7.69.0" "libcurl Manual"
 .SH NAME
-curl_multi_init2 - create a multi handle with advanced init options
+curl_multi_init_advanced - create a multi handle with advanced init options
 .SH SYNOPSIS
 .B #include <curl/curl.h>
 .sp
-.BI "CURLM *curl_multi_init2(int " socket_table_hashsize ", "
-.BI "int " conn_table_hashsize ", int " flags " );"
+.BI "CURLM *curl_multi_init_advanced(int " flags ", ... );"
 .ad
 .SH DESCRIPTION
 This function returns a CURLM handle to be used as input to all the other
 multi-functions, sometimes referred to as a multi handle in some places in the
 documentation. This init call MUST have a corresponding call to
 \fIcurl_multi_cleanup(3)\fP when the operation is complete.
-
-\fBsocket_table_hashsize\fP sets the size of the hash table used to keep track
-of sockets. \fBconn_table_hashsize\fP sets the size of the hash table used to
-keep track of connections. Set both parameters to 0 to use the default values,
-unless a curl developer says otherwise.
 
 \fBflags\fP refer to the FLAGS section below.
 
@@ -51,11 +45,18 @@ sockets that remain open for the life of the multi. If your socket resources
 are very limited you can use this flag to disable the wakeup socket pair. Note
 \fIcurl_multi_wakeup(3)\fP will return an error if there is no wakeup socket
 pair.
+.IP CURL_MULTI_EXTENDED_INIT_OPTIONS
+(Reserved) If this flag is used then there is a second argument that is a
+pointer to a variable-length struct with extended initialization options.
 .SH AVAILABILITY
 7.69.0
 .SH RETURN VALUE
 If this function returns NULL, something went wrong and you cannot use the
 other curl functions.
+.SH EXAMPLE
+.nf
+CURLM *multi = curl_multi_init_advanced(CURL_MULTI_DISABLE_POLL_WAKEUP);
+.fi
 .SH "SEE ALSO"
 .BR curl_multi_init "(3)"
 .BR curl_multi_cleanup "(3)," curl_global_init "(3)," curl_easy_init "(3)"

--- a/docs/libcurl/curl_multi_poll.3
+++ b/docs/libcurl/curl_multi_poll.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -49,9 +49,11 @@ number can include both libcurl internal descriptors as well as descriptors
 provided in \fIextra_fds\fP.
 
 The \fIcurl_multi_wakeup(3)\fP function can be used from another thread to
-wake up this function and return faster. This is one of the details
-that makes this function different than \fIcurl_multi_wait(3)\fP which cannot
-be woken up this way.
+wake up this function and return faster. The ability to wake up is one of the
+details that makes this function different than \fIcurl_multi_wait(3)\fP which
+cannot be woken up this way. (Note wakeup can be disabled and libcurl has no
+internal thread synchronization; refer to the wakeup function's documentation
+for more info.)
 
 If no extra file descriptors are provided and libcurl has no file descriptor
 to offer to wait for, this function will instead wait during \fItimeout_ms\fP

--- a/docs/libcurl/curl_multi_wakeup.3
+++ b/docs/libcurl/curl_multi_wakeup.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -28,9 +28,14 @@ curl_multi_wakeup - wakes up a sleeping curl_multi_poll call
 CURLMcode curl_multi_wakeup(CURLM *multi_handle);
 .ad
 .SH DESCRIPTION
-This function can be called from any thread and it wakes up a
-sleeping \fIcurl_multi_poll(3)\fP call that is currently (or will be)
-waiting for activity or a timeout.
+This function can be called from any thread and it wakes up a sleeping
+\fIcurl_multi_poll(3)\fP call that is currently (or will be) waiting for
+activity or a timeout.
+
+Warning: \fBlibcurl has no internal thread synchronization.\fP This function
+can be called from any thread for as long as you can ensure that
+\fIcurl_multi_cleanup(3)\fP has not been called on the multi. For more
+information on thread safety read \fIlibcurl-thread(3)\fP.
 
 If the function is called when there is no \fIcurl_multi_poll(3)\fP call,
 it will cause the next call to return immediately.
@@ -41,6 +46,9 @@ possible that multiple calls to this function will wake up the same waiting
 operation.
 
 This function has no effect on \fIcurl_multi_wait(3)\fP calls.
+
+The wakeup feature may be disabled for a multi via \fIcurl_multi_init2(3)\fP.
+If the wakeup feature is disabled then this function will return an error.
 .SH RETURN VALUE
 CURLMcode type, general libcurl multi interface error code.
 .SH AVAILABILITY
@@ -83,4 +91,5 @@ if(something makes us decide to stop thread 1) {
 
 .fi
 .SH "SEE ALSO"
-.BR curl_multi_poll "(3), " curl_multi_wait "(3)"
+.BR curl_multi_poll "(3), " curl_multi_wait "(3)," curl_multi_init2 "(3),"
+.BR libcurl-thread "(3)"

--- a/docs/libcurl/curl_multi_wakeup.3
+++ b/docs/libcurl/curl_multi_wakeup.3
@@ -33,9 +33,10 @@ This function can be called from any thread and it wakes up a sleeping
 activity or a timeout.
 
 Warning: \fBlibcurl has no internal thread synchronization.\fP This function
-can be called from any thread for as long as you can ensure that
-\fIcurl_multi_cleanup(3)\fP has not been called on the multi. For more
-information on thread safety read \fIlibcurl-thread(3)\fP.
+can be called on a multi handle in use by another thread so long as you have
+synchronized with curl_multi_init and curl_multi_cleanup, such that it is only
+called in between. Typically a synchronization object could be used to ensure
+this, since those routines set memory barriers. Refer to the EXAMPLE.
 
 If the function is called when there is no \fIcurl_multi_poll(3)\fP call,
 it will cause the next call to return immediately.
@@ -47,24 +48,37 @@ operation.
 
 This function has no effect on \fIcurl_multi_wait(3)\fP calls.
 
-The wakeup feature may be disabled for a multi via \fIcurl_multi_init2(3)\fP.
-If the wakeup feature is disabled then this function will return an error.
+The wakeup feature may be disabled for a multi via
+\fIcurl_multi_init_advanced(3)\fP. If the wakeup feature is disabled then this
+function will return an error.
 .SH RETURN VALUE
 CURLMcode type, general libcurl multi interface error code.
 .SH AVAILABILITY
 Added in 7.68.0
 .SH EXAMPLE
 .nf
-CURL *easy_handle;
-CURLM *multi_handle;
+/*
+ * this is thread 1
+ */
+CURL *easy_handle = curl_easy_init();
+CURLM *multi_handle = curl_multi_init();
+
+/* expose shared multi pointer with synchronization */
+Lock(shared->mutex);
+shared->multi = multi_handle;
+Unlock(shared->mutex);
 
 /* add the individual easy handle */
 curl_multi_add_handle(multi_handle, easy_handle);
 
-/* this is thread 1 */
 do {
   CURLMcode mc;
   int numfds;
+
+  Lock(shared->mutex);
+  if(shared->bye)
+    break;
+  Unlock(shared->mutex);
 
   mc = curl_multi_perform(multi_handle, &still_running);
 
@@ -72,24 +86,35 @@ do {
     /* wait for activity, timeout or wakeup */
     mc = curl_multi_poll(multi_handle, NULL, 0, 10000, &numfds);
   }
-
-  if(time_to_die())
-    exit(1);
-
 } while(still_running);
 
 curl_multi_remove_handle(multi_handle, easy_handle);
 
-/* this is thread 2 */
+Lock(shared->mutex);
+shared->multi = NULL;
+Unlock(shared->mutex);
+
+/* cleanup occurs AFTER synchronization */
+curl_multi_cleanup(multi_handle);
+
+exit_thread();
+
+/* 
+ * this is thread 2
+ */
 
 if(something makes us decide to stop thread 1) {
 
-  set_something_to_signal_thread_1_to_exit();
+  Lock(shared->mutex);
+  if(shared->multi)
+    curl_multi_wakeup(shared->multi);
+  shared->bye = true;
+  Unock(shared->mutex);
 
-  curl_multi_wakeup(multi_handle);
+  exit_thread();
 }
 
 .fi
 .SH "SEE ALSO"
-.BR curl_multi_poll "(3), " curl_multi_wait "(3)," curl_multi_init2 "(3),"
-.BR libcurl-thread "(3)"
+.BR curl_multi_poll "(3)," curl_multi_init_advanced "(3), "
+.BR curl_multi_wait "(3)," libcurl-thread "(3)"

--- a/docs/libcurl/libcurl-thread.3
+++ b/docs/libcurl/libcurl-thread.3
@@ -28,9 +28,11 @@ libcurl is thread safe but has no internal thread synchronization. You may have
 to provide your own locking should you meet any of the thread safety exceptions
 below.
 
-\fBHandles.\fP You must \fBnever\fP share the same handle in multiple threads.
+\fBHandles.\fP You must never share the same handle in multiple threads.
 You can pass the handles around among threads, but you must never use a single
-handle from more than one thread at any given time.
+handle from more than one thread at any given time. \fBException:\fP
+\fIcurl_multi_wakeup(3)\fP can be called from any thread for as long as you can
+ensure that \fIcurl_multi_cleanup(3)\fP has not been called on the multi.
 
 \fBShared objects.\fP You can share certain data between multiple handles by
 using the share interface but you must provide your own locking and set

--- a/docs/libcurl/libcurl-thread.3
+++ b/docs/libcurl/libcurl-thread.3
@@ -25,14 +25,14 @@
 libcurl-thread \- libcurl thread safety
 .SH "Multi-threading with libcurl"
 libcurl is thread safe but has no internal thread synchronization. You may have
-to provide your own locking should you meet any of the thread safety exceptions
-below.
+to provide your own synchronization should you meet any of the thread safety
+exceptions below.
 
 \fBHandles.\fP You must never share the same handle in multiple threads.
 You can pass the handles around among threads, but you must never use a single
-handle from more than one thread at any given time. \fBException:\fP
-\fIcurl_multi_wakeup(3)\fP can be called from any thread for as long as you can
-ensure that \fIcurl_multi_cleanup(3)\fP has not been called on the multi.
+handle from more than one thread at any given time. (\fBException:\fP
+\fIcurl_multi_wakeup(3)\fP can be called on a multi handle in use by another
+thread, with limited synchronization.)
 
 \fBShared objects.\fP You can share certain data between multiple handles by
 using the share interface but you must provide your own locking and set

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -863,6 +863,7 @@ CURL_LOCK_TYPE_COOKIE           7.10          -           7.10.2
 CURL_LOCK_TYPE_DNS              7.10          -           7.10.2
 CURL_LOCK_TYPE_NONE             7.10          -           7.10.2
 CURL_LOCK_TYPE_SSL_SESSION      7.10          -           7.10.2
+CURL_MULTI_DISABLE_POLL_WAKEUP  7.69.0
 CURL_MAX_HTTP_HEADER            7.19.7
 CURL_MAX_READ_SIZE              7.53.0
 CURL_MAX_WRITE_SIZE             7.9.7

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -449,6 +449,21 @@ typedef int (*curl_push_callback)(CURL *parent,
                                   struct curl_pushheaders *headers,
                                   void *userp);
 
+
+/* Initialization flags for curl_multi_init2 (Curl_multi_handle) */
+#define CURL_MULTI_DISABLE_POLL_WAKEUP    (1<<0)
+
+/*
+ * Name:    curl_multi_init2()
+ *
+ * Desc:    inititalize multi-style curl usage, with initialization options
+ *
+ * Returns: a new CURLM handle to use in all 'curl_multi' functions.
+ */
+CURL_EXTERN CURLM *curl_multi_init2(int socket_table_hashsize,
+                                    int conn_table_hashsize,
+                                    int flags);
+
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -449,20 +449,19 @@ typedef int (*curl_push_callback)(CURL *parent,
                                   struct curl_pushheaders *headers,
                                   void *userp);
 
-
-/* Initialization flags for curl_multi_init2 (Curl_multi_handle) */
-#define CURL_MULTI_DISABLE_POLL_WAKEUP    (1<<0)
-
 /*
- * Name:    curl_multi_init2()
+ * Name:    curl_multi_init_advanced()
  *
- * Desc:    inititalize multi-style curl usage, with initialization options
+ * Desc:    inititalize multi-style curl usage, with advanced init options
  *
  * Returns: a new CURLM handle to use in all 'curl_multi' functions.
  */
-CURL_EXTERN CURLM *curl_multi_init2(int socket_table_hashsize,
-                                    int conn_table_hashsize,
-                                    int flags);
+
+/* This flag disables the socketpair used by curl_multi_wakeup to wake up
+   curl_multi_poll. */
+#define CURL_MULTI_DISABLE_POLL_WAKEUP    (1<<0)
+
+CURL_EXTERN CURLM *curl_multi_init_advanced(int flags, ...);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -673,7 +673,7 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
   else {
     /* this multi handle will only ever have a single easy handled attached
        to it, so make it use minimal hashes */
-    multi = Curl_multi_handle(1, 3);
+    multi = Curl_multi_handle(1, 3, 0);
     if(!multi)
       return CURLE_OUT_OF_MEMORY;
     data->multi_easy = multi;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -406,21 +406,22 @@ struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
   return NULL;
 }
 
-struct Curl_multi *curl_multi_init(void)
+struct Curl_multi *curl_multi_init_advanced(int flags, ...)
 {
+  /* This function accepts variable arguments, for future use.
+     If CURL_MULTI_EXTENDED_INIT_OPTIONS is set then the second argument is a
+     pointer to a variable-length struct that can increase in size.
+
+     if((flags & CURL_MULTI_EXTENDED_INIT_OPTIONS))
+       options = va_arg(arg, struct curl_multi_extended_init_options *);
+  */
   return Curl_multi_handle(CURL_SOCKET_HASH_TABLE_SIZE,
-                           CURL_CONNECTION_HASH_SIZE, 0);
+                           CURL_CONNECTION_HASH_SIZE, flags);
 }
 
-struct Curl_multi *curl_multi_init2(int socket_table_hashsize,
-                                    int conn_table_hashsize,
-                                    int flags)
+struct Curl_multi *curl_multi_init(void)
 {
-  if(socket_table_hashsize <= 0)
-    socket_table_hashsize = CURL_SOCKET_HASH_TABLE_SIZE;
-  if(conn_table_hashsize <= 0)
-    conn_table_hashsize = CURL_CONNECTION_HASH_SIZE;
-  return Curl_multi_handle(socket_table_hashsize, conn_table_hashsize, flags);
+  return curl_multi_init_advanced(0);
 }
 
 CURLMcode curl_multi_add_handle(struct Curl_multi *multi,

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -39,7 +39,7 @@ bool Curl_is_in_callback(struct Curl_easy *easy);
 
 /* Internal version of curl_multi_init() accepts size parameters for the
    socket and connection hashes */
-struct Curl_multi *Curl_multi_handle(int hashsize, int chashsize);
+struct Curl_multi *Curl_multi_handle(int hashsize, int chashsize, int flags);
 
 /* the write bits start at bit 16 for the *getsock() bitmap */
 #define GETSOCK_WRITEBITSTART 16

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -110,6 +110,7 @@ my %api = (
     'curl_multi_fdset' => 'API',
     'curl_multi_info_read' => 'API',
     'curl_multi_init' => 'API',
+    'curl_multi_init_advanced' => 'API',
     'curl_multi_perform' => 'API',
     'curl_multi_remove_handle' => 'API',
     'curl_multi_setopt' => 'API',

--- a/tests/data/test1135
+++ b/tests/data/test1135
@@ -105,6 +105,7 @@ CURL_EXTERN CURLMcode curl_multi_setopt(CURLM *multi_handle,
 CURL_EXTERN CURLMcode curl_multi_assign(CURLM *multi_handle,
 CURL_EXTERN char *curl_pushheader_bynum(struct curl_pushheaders *h,
 CURL_EXTERN char *curl_pushheader_byname(struct curl_pushheaders *h,
+CURL_EXTERN CURLM *curl_multi_init2(int socket_table_hashsize,
 </stdout>
 </verify>
 

--- a/tests/data/test1135
+++ b/tests/data/test1135
@@ -105,7 +105,7 @@ CURL_EXTERN CURLMcode curl_multi_setopt(CURLM *multi_handle,
 CURL_EXTERN CURLMcode curl_multi_assign(CURLM *multi_handle,
 CURL_EXTERN char *curl_pushheader_bynum(struct curl_pushheaders *h,
 CURL_EXTERN char *curl_pushheader_byname(struct curl_pushheaders *h,
-CURL_EXTERN CURLM *curl_multi_init2(int socket_table_hashsize,
+CURL_EXTERN CURLM *curl_multi_init_advanced(int flags, ...);
 </stdout>
 </verify>
 


### PR DESCRIPTION
Allow initializing a multi with a specific socket table hash size,
connection cache hash size, and flags. Flag
CURL_MULTI_DISABLE_POLL_WAKEUP can be used to disable the
curl_multi_poll wakeup socketpair. A user requested the option to
disable creating those sockets due to resource constraints.

Prior to this change it was not possible to disable the wakeup
socketpair (added in 7.68.0) used by the multi.

Reported-by: Anders Bakken

Fixes https://github.com/curl/curl/issues/4829
Closes #xxxx

---

/cc @Andersbakken