### PR TITLE
multi_done: if multiplexed, make conn->data point to another transfer

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -591,6 +591,9 @@ static CURLcode multi_done(struct Curl_easy *data,
   detach_connnection(data);
   if(CONN_INUSE(conn)) {
     /* Stop if still used. */
+    /* conn->data must not remain pointing to this transfer since it is going
+       away! Find another to own it! */
+    conn->data = conn->easyq.head->ptr;
     CONN_UNLOCK(data);
     DEBUGF(infof(data, "Connection still in use %zu, "
                  "no more multi_done now!\n",

--- a/lib/url.c
+++ b/lib/url.c
@@ -1213,6 +1213,8 @@ ConnectionExists(struct Curl_easy *data,
         }
       }
 
+      DEBUGASSERT(!check->data || GOOD_EASY_HANDLE(check->data));
+
       if(!canmultiplex && check->data)
         /* this request can't be multiplexed but the checked connection is
            already in use so we skip it */


### PR DESCRIPTION
... since the current transfer is being killed. Setting to NULL is
wrong, leaving it pointing to 'data' is wrong since that handle might be
about to get freed.

Fixes #4845
Reported-by: dmitrmax on github