### PR TITLE
Testing Windows cross-builds via Azure Pipelines and Docker Containers

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -4,13 +4,18 @@
 # https://aka.ms/yaml
 
 trigger:
-- master
+- 'master'
+- '*/ci'
+
+stages:
 
 ##########################################
 ### Linux jobs first
 ##########################################
 
-jobs:
+- stage: linux
+  dependsOn: []
+  jobs:
   - job: vanilla_ubuntu
     displayName: unbuntu default
     pool:
@@ -81,6 +86,9 @@ jobs:
     - script: make test-nonflaky
       displayName: 'test'
 
+- stage: linux_torture
+  dependsOn: linux
+  jobs:
   - job: torture
     displayName: ubuntu torture tests
     pool:
@@ -102,6 +110,9 @@ jobs:
 ### macOS jobs below
 ##########################################
 
+- stage: macos
+  dependsOn: []
+  jobs:
   - job: macos_plain
     displayName: macos default
     pool:
@@ -147,6 +158,9 @@ jobs:
     - script: cmake -H. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON && cmake --build build
       displayName: 'Run cmake'
 
+- stage: macos_torture
+  dependsOn: macos
+  jobs:
   - job: macos_torture
     displayName: macos torture
     pool:
@@ -164,3 +178,207 @@ jobs:
     - script: make "TFLAGS=-n -t --shallow=25 '!FTP'" test-nonflaky
       displayName: 'torture test'
 
+##########################################
+### Windows jobs below
+##########################################
+
+- stage: windows
+  dependsOn: []
+  jobs:
+  - job: windows_msys2_mingw32_debug_openssl
+    displayName: msys2 mingw32 debug openssl
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+      env:
+        MSYSTEM: MINGW32
+        MSYS2_PATH_TYPE: inherit
+        TFLAGS: "!323 !1056 !1299"
+    steps:
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=i686-w64-mingw32 --build=i686-w64-mingw32 --enable-debug --enable-werror"
+      displayName: 'Run configure'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys2_mingw64_debug_openssl
+    displayName: msys2 mingw64 debug openssl
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+      env:
+        MSYSTEM: MINGW64
+        MSYS2_PATH_TYPE: inherit
+        TFLAGS: "!323 !1056 !1299"
+    steps:
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --enable-debug --enable-werror"
+      displayName: 'Run configure'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys1_mingw_debug_openssl
+    displayName: msys1 mingw debug openssl
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
+      env:
+        TFLAGS: "!203 !1056 !1143"
+    steps:
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug"
+      displayName: 'Run configure'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys1_mingw32_debug_openssl
+    displayName: msys1 mingw32 debug openssl
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys1-mingw32:ltsc2019
+      env:
+        TFLAGS: "!203 !1056 !1143 !1299"
+    steps:
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --without-zlib"
+      displayName: 'Run configure'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys1_mingw64_debug_openssl
+    displayName: msys1 mingw64 debug openssl
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys1-mingw64:ltsc2019
+      env:
+        TFLAGS: "!203 !1056 !1143 !1299"
+    steps:
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --without-zlib"
+      displayName: 'Run configure'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys2_mingw32_debug_schannel
+    displayName: msys2 mingw32 debug schannel
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+      env:
+        MSYSTEM: MINGW32
+        MSYS2_PATH_TYPE: inherit
+        TFLAGS: "!165 !310 !1013 !1056 !1299 !1448 !2034 !2037 !2041 !2046 !2047 !3000 !3001"
+    steps:
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=i686-w64-mingw32 --build=i686-w64-mingw32 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn"
+      displayName: 'Run configure'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys2_mingw64_debug_schannel
+    displayName: msys2 mingw64 debug schannel
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+      env:
+        MSYSTEM: MINGW64
+        MSYS2_PATH_TYPE: inherit
+        TFLAGS: "!165 !310 !1013 !1056 !1299 !1448 !2034 !2037 !2041 !2046 !2047 !3000 !3001"
+    steps:
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn"
+      displayName: 'Run configure'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys1_mingw_debug_schannel
+    displayName: msys1 mingw debug schannel
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
+      env:
+        TFLAGS: "!203 !305 !310 !311 !312 !313 !404 !1013 !1056 !1143 !2034 !2035 !2037 !2038 !2041 !2042 !2048 !3000 !3001"
+    steps:
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug --enable-sspi --without-ssl --with-schannel --with-winidn"
+      displayName: 'Run configure'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys1_mingw32_debug_schannel
+    displayName: msys1 mingw32 debug schannel
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys1-mingw32:ltsc2019
+      env:
+        TFLAGS: "!203 !310 !1013 !1056 !1143 !1299 !2034 !2037 !2041 !3000 !3001"
+    steps:
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --without-zlib"
+      displayName: 'Run configure'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'
+
+  - job: windows_msys1_mingw64_debug_schannel
+    displayName: msys1 mingw64 debug schannel
+    timeoutInMinutes: 60
+    pool:
+      vmImage: 'windows-2019'
+    container:
+      image: mback2k/curl-docker-winbuildenv-msys1-mingw64:ltsc2019
+      env:
+        TFLAGS: "!203 !310 !1013 !1056 !1143 !1299 !2034 !2037 !2041 !3000 !3001"
+    steps:
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && ./buildconf && ./configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64  --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --without-zlib"
+      displayName: 'Run configure'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make"
+      displayName: 'make'
+
+    - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
+      displayName: 'test'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,8 +16,8 @@ stages:
 - stage: linux
   dependsOn: []
   jobs:
-  - job: vanilla_ubuntu
-    displayName: unbuntu default
+  - job: vanilla
+    displayName: ubuntu default
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -113,13 +113,13 @@ stages:
 - stage: macos
   dependsOn: []
   jobs:
-  - job: macos_plain
+  - job: macos_vanilla
     displayName: macos default
     pool:
       vmImage: 'macOS-latest'
     steps:
     - script: brew update && brew install libtool autoconf automake nghttp2 pkg-config
-      displayName: Install packages
+      displayName: 'brew install'
 
     - script: ./buildconf && ./configure --enable-debug --enable-werror --without-brotli
       displayName: 'Run configure'
@@ -136,7 +136,7 @@ stages:
       vmImage: 'macOS-latest'
     steps:
     - script: brew update && brew install libtool autoconf automake nghttp2 pkg-config libssh2
-      displayName: Install packages
+      displayName: 'brew install'
 
     - script: ./buildconf && ./configure --with-libssh2 --enable-debug
       displayName: 'Run configure'

--- a/tests/python_dependencies/impacket/smbserver.py
+++ b/tests/python_dependencies/impacket/smbserver.py
@@ -26,7 +26,10 @@ import socket
 import time
 import datetime
 import struct
-import ConfigParser
+try: # Python 3
+    import configparser
+except ImportError: # Python 2
+    import ConfigParser as configparser
 import SocketServer
 import threading
 import logging
@@ -4130,7 +4133,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
         if self.__serverConfig is None:
             if configFile is None:
                 configFile = 'smb.conf'
-            self.__serverConfig = ConfigParser.ConfigParser()
+            self.__serverConfig = configparser.ConfigParser()
             self.__serverConfig.read(configFile)
 
         self.__serverName   = self.__serverConfig.get('global','server_name')


### PR DESCRIPTION
This PR adds new Azure Pipelines builds using Docker Containers running MinGW and MinGW-w64 using MSYS1 and MSYS2.

The intent is to replace the broken Windows builds on curlbuild.uxnr.de with these.

The Docker Containers are hosted in a separate Git repository which I intent to move to the curl organisation on Github, even though they may also be useful for the libssh2 project:
https://github.com/mback2k/curl-docker-winbuildenv

As you can see here the builds are currently looking fine, even though I had to disable some test cases which have always been failing on Windows, especially with Schannel instead of OpenSSL:
https://mback2k.visualstudio.com/curl/_build/results?buildId=723&view=results

Of course I will re-enable the Linux and Mac OS X builds once ready while I am rebasing and merging this PR myself if it is approved. I would also suggest to separate the builds into stages, so that the longer running builds are only performed if the short builds completed successful:
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/stages?view=azure-devops

What do you think? @bagder @jay @MarcelRaad 