### PR TITLE
writeout: support to generate JSON output

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -50,6 +50,9 @@ curl CONNECT request. (Added in 7.12.4)
 .B http_version
 The http version that was effectively used. (Added in 7.50.0)
 .TP
+.B json
+A JSON object with all available keys.
+.TP
 .B local_ip
 The IP address of the local end of the most recently done connection - can be
 either IPv4 or IPv6 (Added in 7.29.0)

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -147,6 +147,20 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
     long          *to_long;
   } lptr;
 
+#ifdef DEBUGBUILD
+  char *timestr = getenv("CURL_TIME");
+  if(timestr) {
+    unsigned long val = strtol(timestr, NULL, 10);
+    switch(info) {
+    case CURLINFO_LOCAL_PORT:
+      *param_longp = (long)val;
+      return CURLE_OK;
+    default:
+      break;
+    }
+  }
+#endif
+
   switch(info) {
   case CURLINFO_RESPONSE_CODE:
     *param_longp = data->info.httpcode;
@@ -258,6 +272,27 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
 static CURLcode getinfo_offt(struct Curl_easy *data, CURLINFO info,
                              curl_off_t *param_offt)
 {
+#ifdef DEBUGBUILD
+  char *timestr = getenv("CURL_TIME");
+  if(timestr) {
+    unsigned long val = strtol(timestr, NULL, 10);
+    switch(info) {
+    case CURLINFO_TOTAL_TIME_T:
+    case CURLINFO_NAMELOOKUP_TIME_T:
+    case CURLINFO_CONNECT_TIME_T:
+    case CURLINFO_APPCONNECT_TIME_T:
+    case CURLINFO_PRETRANSFER_TIME_T:
+    case CURLINFO_STARTTRANSFER_TIME_T:
+    case CURLINFO_REDIRECT_TIME_T:
+    case CURLINFO_SPEED_DOWNLOAD_T:
+    case CURLINFO_SPEED_UPLOAD_T:
+      *param_offt = (curl_off_t)val;
+      return CURLE_OK;
+    default:
+      break;
+    }
+  }
+#endif
   switch(info) {
   case CURLINFO_FILETIME_T:
     *param_offt = (curl_off_t)data->info.filetime;
@@ -282,7 +317,7 @@ static CURLcode getinfo_offt(struct Curl_easy *data, CURLINFO info,
     *param_offt = (data->progress.flags & PGRS_UL_SIZE_KNOWN)?
       data->progress.size_ul:-1;
     break;
-  case CURLINFO_TOTAL_TIME_T:
+   case CURLINFO_TOTAL_TIME_T:
     *param_offt = data->progress.timespent;
     break;
   case CURLINFO_NAMELOOKUP_TIME_T:
@@ -316,6 +351,27 @@ static CURLcode getinfo_offt(struct Curl_easy *data, CURLINFO info,
 static CURLcode getinfo_double(struct Curl_easy *data, CURLINFO info,
                                double *param_doublep)
 {
+#ifdef DEBUGBUILD
+  char *timestr = getenv("CURL_TIME");
+  if(timestr) {
+    unsigned long val = strtol(timestr, NULL, 10);
+    switch(info) {
+    case CURLINFO_TOTAL_TIME:
+    case CURLINFO_NAMELOOKUP_TIME:
+    case CURLINFO_CONNECT_TIME:
+    case CURLINFO_APPCONNECT_TIME:
+    case CURLINFO_PRETRANSFER_TIME:
+    case CURLINFO_STARTTRANSFER_TIME:
+    case CURLINFO_REDIRECT_TIME:
+    case CURLINFO_SPEED_DOWNLOAD:
+    case CURLINFO_SPEED_UPLOAD:
+      *param_doublep = (double)val;
+      return CURLE_OK;
+    default:
+      break;
+    }
+  }
+#endif
   switch(info) {
   case CURLINFO_TOTAL_TIME:
     *param_doublep = DOUBLE_SECS(data->progress.timespent);

--- a/lib/version.c
+++ b/lib/version.c
@@ -91,6 +91,17 @@ char *curl_version(void)
   char *outp;
   size_t outlen;
   const char *src[14];
+
+#ifdef DEBUGBUILD
+  /* Override version string when environment variable CURL_VERSION is set */
+  const char *debugversion = getenv("CURL_VERSION");
+  if(debugversion) {
+    strncpy(out, debugversion, sizeof(out)-1);
+    out[sizeof(out)-1] = '\0';
+    return out;
+  }
+#endif
+
 #ifdef USE_SSL
   char ssl_version[40];
 #endif

--- a/packages/Symbian/group/curl.mmp
+++ b/packages/Symbian/group/curl.mmp
@@ -45,6 +45,7 @@ SOURCE \
     tool_vms.c \
     tool_writeenv.c \
     tool_writeout.c \
+    tool_writeout_json.c \
     tool_xattr.c
 
 SOURCEPATH  ../../../lib

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -62,6 +62,7 @@ CURL_CFILES = \
   tool_util.c \
   tool_vms.c \
   tool_writeout.c \
+  tool_writeout_json.c \
   tool_xattr.c
 
 CURL_HFILES = \
@@ -107,6 +108,7 @@ CURL_HFILES = \
   tool_version.h \
   tool_vms.h \
   tool_writeout.h \
+  tool_writeout_json.h \
   tool_xattr.h
 
 CURL_RCFILES = curl.rc

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -25,6 +25,7 @@
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_writeout.h"
+#include "tool_writeout_json.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -62,6 +63,7 @@ typedef enum {
   VAR_SCHEME,
   VAR_STDOUT,
   VAR_STDERR,
+  VAR_JSON,
   VAR_NUM_OF_VARS /* must be the last */
 } replaceid;
 
@@ -105,6 +107,7 @@ static const struct variable replacements[]={
   {"scheme", VAR_SCHEME},
   {"stdout", VAR_STDOUT},
   {"stderr", VAR_STDERR},
+  {"json", VAR_JSON},
   {NULL, VAR_NONE}
 };
 
@@ -334,6 +337,8 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
               case VAR_STDERR:
                 stream = stderr;
                 break;
+              case VAR_JSON:
+                ourWriteOutJSON(curl, outs, stream);
               default:
                 break;
               }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -29,86 +29,78 @@
 
 #include "memdebug.h" /* keep this as LAST include */
 
-typedef enum {
-  VAR_NONE,       /* must be the first */
-  VAR_TOTAL_TIME,
-  VAR_NAMELOOKUP_TIME,
-  VAR_CONNECT_TIME,
-  VAR_APPCONNECT_TIME,
-  VAR_PRETRANSFER_TIME,
-  VAR_STARTTRANSFER_TIME,
-  VAR_SIZE_DOWNLOAD,
-  VAR_SIZE_UPLOAD,
-  VAR_SPEED_DOWNLOAD,
-  VAR_SPEED_UPLOAD,
-  VAR_HTTP_CODE,
-  VAR_HTTP_CODE_PROXY,
-  VAR_HEADER_SIZE,
-  VAR_REQUEST_SIZE,
-  VAR_EFFECTIVE_URL,
-  VAR_CONTENT_TYPE,
-  VAR_NUM_CONNECTS,
-  VAR_REDIRECT_TIME,
-  VAR_REDIRECT_COUNT,
-  VAR_FTP_ENTRY_PATH,
-  VAR_REDIRECT_URL,
-  VAR_SSL_VERIFY_RESULT,
-  VAR_PROXY_SSL_VERIFY_RESULT,
-  VAR_EFFECTIVE_FILENAME,
-  VAR_PRIMARY_IP,
-  VAR_PRIMARY_PORT,
-  VAR_LOCAL_IP,
-  VAR_LOCAL_PORT,
-  VAR_HTTP_VERSION,
-  VAR_SCHEME,
-  VAR_STDOUT,
-  VAR_STDERR,
-  VAR_JSON,
-  VAR_NUM_OF_VARS /* must be the last */
-} replaceid;
+static const struct writeoutvar variables[]={
 
-struct variable {
-  const char *name;
-  replaceid id;
-};
-
-
-static const struct variable replacements[]={
-  {"url_effective", VAR_EFFECTIVE_URL},
-  {"http_code", VAR_HTTP_CODE},
-  {"response_code", VAR_HTTP_CODE},
-  {"http_connect", VAR_HTTP_CODE_PROXY},
-  {"time_total", VAR_TOTAL_TIME},
-  {"time_namelookup", VAR_NAMELOOKUP_TIME},
-  {"time_connect", VAR_CONNECT_TIME},
-  {"time_appconnect", VAR_APPCONNECT_TIME},
-  {"time_pretransfer", VAR_PRETRANSFER_TIME},
-  {"time_starttransfer", VAR_STARTTRANSFER_TIME},
-  {"size_header", VAR_HEADER_SIZE},
-  {"size_request", VAR_REQUEST_SIZE},
-  {"size_download", VAR_SIZE_DOWNLOAD},
-  {"size_upload", VAR_SIZE_UPLOAD},
-  {"speed_download", VAR_SPEED_DOWNLOAD},
-  {"speed_upload", VAR_SPEED_UPLOAD},
-  {"content_type", VAR_CONTENT_TYPE},
-  {"num_connects", VAR_NUM_CONNECTS},
-  {"time_redirect", VAR_REDIRECT_TIME},
-  {"num_redirects", VAR_REDIRECT_COUNT},
-  {"ftp_entry_path", VAR_FTP_ENTRY_PATH},
-  {"redirect_url", VAR_REDIRECT_URL},
-  {"ssl_verify_result", VAR_SSL_VERIFY_RESULT},
-  {"proxy_ssl_verify_result", VAR_PROXY_SSL_VERIFY_RESULT},
-  {"filename_effective", VAR_EFFECTIVE_FILENAME},
-  {"remote_ip", VAR_PRIMARY_IP},
-  {"remote_port", VAR_PRIMARY_PORT},
-  {"local_ip", VAR_LOCAL_IP},
-  {"local_port", VAR_LOCAL_PORT},
-  {"http_version", VAR_HTTP_VERSION},
-  {"scheme", VAR_SCHEME},
-  {"stdout", VAR_STDOUT},
-  {"stderr", VAR_STDERR},
-  {"json", VAR_JSON},
-  {NULL, VAR_NONE}
+  {"url_effective", VAR_EFFECTIVE_URL, 0,
+      CURLINFO_EFFECTIVE_URL, JSON_STRING},
+  {"http_code", VAR_HTTP_CODE, 0,
+      CURLINFO_RESPONSE_CODE, JSON_LONG},
+  {"response_code", VAR_HTTP_CODE, 0,
+      CURLINFO_RESPONSE_CODE, JSON_LONG},
+  {"http_connect", VAR_HTTP_CODE_PROXY, 0,
+      CURLINFO_HTTP_CONNECTCODE, JSON_LONG},
+  {"time_total", VAR_TOTAL_TIME, 0,
+      CURLINFO_TOTAL_TIME_T, JSON_TIME},
+  {"time_namelookup", VAR_NAMELOOKUP_TIME, 0,
+      CURLINFO_NAMELOOKUP_TIME_T, JSON_TIME},
+  {"time_connect", VAR_CONNECT_TIME, 0,
+      CURLINFO_CONNECT_TIME_T, JSON_TIME},
+  {"time_appconnect", VAR_APPCONNECT_TIME, 0,
+      CURLINFO_APPCONNECT_TIME_T, JSON_TIME},
+  {"time_pretransfer", VAR_PRETRANSFER_TIME, 0,
+      CURLINFO_PRETRANSFER_TIME_T, JSON_TIME},
+  {"time_starttransfer", VAR_STARTTRANSFER_TIME, 0,
+      CURLINFO_STARTTRANSFER_TIME_T, JSON_TIME},
+  {"size_header", VAR_HEADER_SIZE, 0,
+      CURLINFO_HEADER_SIZE, JSON_LONG},
+  {"size_request", VAR_REQUEST_SIZE, 0,
+      CURLINFO_REQUEST_SIZE, JSON_LONG},
+  {"size_download", VAR_SIZE_DOWNLOAD, 0,
+      CURLINFO_SIZE_DOWNLOAD_T, JSON_LONG},
+  {"size_upload", VAR_SIZE_UPLOAD, 0,
+      CURLINFO_SIZE_UPLOAD_T, JSON_LONG},
+  {"speed_download", VAR_SPEED_DOWNLOAD, 0,
+      CURLINFO_SPEED_DOWNLOAD_T, JSON_TIME},
+  {"speed_upload", VAR_SPEED_UPLOAD, 0,
+      CURLINFO_SPEED_UPLOAD_T, JSON_TIME},
+  {"content_type", VAR_CONTENT_TYPE, 0,
+      CURLINFO_CONTENT_TYPE, JSON_STRING},
+  {"num_connects", VAR_NUM_CONNECTS, 0,
+      CURLINFO_NUM_CONNECTS, JSON_LONG},
+  {"time_redirect", VAR_REDIRECT_TIME, 0,
+      CURLINFO_REDIRECT_TIME_T, JSON_TIME},
+  {"num_redirects", VAR_REDIRECT_COUNT, 0,
+      CURLINFO_REDIRECT_COUNT, JSON_LONG},
+  {"ftp_entry_path", VAR_FTP_ENTRY_PATH, 0,
+      CURLINFO_FTP_ENTRY_PATH, JSON_STRING},
+  {"redirect_url", VAR_REDIRECT_URL, 0,
+      CURLINFO_REDIRECT_URL, JSON_STRING},
+  {"ssl_verify_result", VAR_SSL_VERIFY_RESULT, 0,
+      CURLINFO_SSL_VERIFYRESULT, JSON_LONG},
+  {"proxy_ssl_verify_result", VAR_PROXY_SSL_VERIFY_RESULT, 0,
+      CURLINFO_PROXY_SSL_VERIFYRESULT, JSON_LONG},
+  {"filename_effective", VAR_EFFECTIVE_FILENAME, 0,
+      0, JSON_FILENAME},
+  {"remote_ip", VAR_PRIMARY_IP, 0,
+      CURLINFO_PRIMARY_IP, JSON_STRING},
+  {"remote_port", VAR_PRIMARY_PORT, 0,
+      CURLINFO_PRIMARY_PORT, JSON_LONG},
+  {"local_ip", VAR_LOCAL_IP, 0,
+      CURLINFO_LOCAL_IP, JSON_STRING},
+  {"local_port", VAR_LOCAL_PORT, 0,
+      CURLINFO_LOCAL_PORT, JSON_LONG},
+  {"http_version", VAR_HTTP_VERSION, 0,
+      CURLINFO_HTTP_VERSION, JSON_VERSION},
+  {"scheme", VAR_SCHEME, 0,
+      CURLINFO_SCHEME, JSON_STRING},
+  {"stdout", VAR_STDOUT, 1,
+      0, JSON_NONE},
+  {"stderr", VAR_STDERR, 1,
+      0, JSON_NONE},
+  {"json", VAR_JSON, 1,
+      0, JSON_NONE},
+  {NULL, VAR_NONE, 1,
+      0, JSON_NONE}
 };
 
 void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
@@ -141,10 +133,10 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
           }
           keepit = *end;
           *end = 0; /* zero terminate */
-          for(i = 0; replacements[i].name; i++) {
-            if(curl_strequal(ptr, replacements[i].name)) {
+          for(i = 0; variables[i].name; i++) {
+            if(curl_strequal(ptr, variables[i].name)) {
               match = TRUE;
-              switch(replacements[i].id) {
+              switch(variables[i].id) {
               case VAR_EFFECTIVE_URL:
                 if((CURLE_OK ==
                     curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &stringp))
@@ -338,7 +330,7 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
                 stream = stderr;
                 break;
               case VAR_JSON:
-                ourWriteOutJSON(curl, outs, stream);
+                ourWriteOutJSON(variables, curl, outs, stream);
               default:
                 break;
               }

--- a/src/tool_writeout.h
+++ b/src/tool_writeout.h
@@ -23,6 +23,61 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
+typedef enum {
+  VAR_NONE,       /* must be the first */
+  VAR_TOTAL_TIME,
+  VAR_NAMELOOKUP_TIME,
+  VAR_CONNECT_TIME,
+  VAR_APPCONNECT_TIME,
+  VAR_PRETRANSFER_TIME,
+  VAR_STARTTRANSFER_TIME,
+  VAR_SIZE_DOWNLOAD,
+  VAR_SIZE_UPLOAD,
+  VAR_SPEED_DOWNLOAD,
+  VAR_SPEED_UPLOAD,
+  VAR_HTTP_CODE,
+  VAR_HTTP_CODE_PROXY,
+  VAR_HEADER_SIZE,
+  VAR_REQUEST_SIZE,
+  VAR_EFFECTIVE_URL,
+  VAR_CONTENT_TYPE,
+  VAR_NUM_CONNECTS,
+  VAR_REDIRECT_TIME,
+  VAR_REDIRECT_COUNT,
+  VAR_FTP_ENTRY_PATH,
+  VAR_REDIRECT_URL,
+  VAR_SSL_VERIFY_RESULT,
+  VAR_PROXY_SSL_VERIFY_RESULT,
+  VAR_EFFECTIVE_FILENAME,
+  VAR_PRIMARY_IP,
+  VAR_PRIMARY_PORT,
+  VAR_LOCAL_IP,
+  VAR_LOCAL_PORT,
+  VAR_HTTP_VERSION,
+  VAR_SCHEME,
+  VAR_STDOUT,
+  VAR_STDERR,
+  VAR_JSON,
+  VAR_NUM_OF_VARS /* must be the last */
+} writeoutid;
+
+typedef enum {
+  JSON_NONE,
+  JSON_STRING,
+  JSON_LONG,
+  JSON_TIME,
+  JSON_VERSION,
+  JSON_FILENAME
+} jsontype;
+
+struct writeoutvar {
+  const char *name;
+  writeoutid id;
+  int is_ctrl;
+  CURLINFO cinfo;
+  jsontype jsontype;
+};
+
 void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo);
 
 #endif /* HEADER_CURL_TOOL_WRITEOUT_H */

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -1,0 +1,224 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "tool_setup.h"
+
+#define ENABLE_CURLX_PRINTF
+
+/* use our own printf() functions */
+#include "curlx.h"
+#include "tool_cfgable.h"
+#include "tool_writeout_json.h"
+
+
+typedef enum {
+  JSON_NONE,
+  JSON_STRING,
+  JSON_LONG,
+  JSON_TIME,
+  JSON_VERSION,
+  JSON_FILENAME
+} jsontype;
+
+struct mapping {
+  const char *key;
+  jsontype type;
+  CURLINFO cinfo;
+};
+
+static const struct mapping mappings[]={
+  {"url_effective", JSON_STRING, CURLINFO_EFFECTIVE_URL},
+  {"http_code", JSON_LONG, CURLINFO_RESPONSE_CODE},
+  {"response_code", JSON_LONG, CURLINFO_RESPONSE_CODE},
+  {"http_connect", JSON_LONG, CURLINFO_HTTP_CONNECTCODE},
+  {"time_total", JSON_TIME, CURLINFO_TOTAL_TIME_T},
+  {"time_namelookup", JSON_TIME, CURLINFO_NAMELOOKUP_TIME_T},
+  {"time_connect", JSON_TIME, CURLINFO_CONNECT_TIME_T},
+  {"time_appconnect", JSON_TIME, CURLINFO_APPCONNECT_TIME_T},
+  {"time_pretransfer", JSON_TIME, CURLINFO_PRETRANSFER_TIME_T},
+  {"time_starttransfer", JSON_TIME, CURLINFO_STARTTRANSFER_TIME_T},
+  {"size_header", JSON_LONG, CURLINFO_HEADER_SIZE},
+  {"size_request", JSON_LONG, CURLINFO_REQUEST_SIZE},
+  {"size_download", JSON_LONG, CURLINFO_SIZE_DOWNLOAD_T},
+  {"size_upload", JSON_LONG, CURLINFO_SIZE_UPLOAD_T},
+  {"speed_download", JSON_TIME, CURLINFO_SPEED_DOWNLOAD_T},
+  {"speed_upload", JSON_TIME, CURLINFO_SPEED_UPLOAD_T},
+  {"content_type", JSON_STRING, CURLINFO_CONTENT_TYPE},
+  {"num_connects", JSON_LONG, CURLINFO_NUM_CONNECTS},
+  {"time_redirect", JSON_TIME, CURLINFO_REDIRECT_TIME_T},
+  {"num_redirects", JSON_LONG, CURLINFO_REDIRECT_COUNT},
+  {"ftp_entry_path", JSON_STRING, CURLINFO_FTP_ENTRY_PATH},
+  {"redirect_url", JSON_STRING, CURLINFO_REDIRECT_URL},
+  {"ssl_verify_result", JSON_LONG, CURLINFO_SSL_VERIFYRESULT},
+  {"proxy_ssl_verify_result", JSON_LONG, CURLINFO_PROXY_SSL_VERIFYRESULT},
+  {"filename_effective", JSON_FILENAME, CURLINFO_NONE},
+  {"remote_ip", JSON_STRING, CURLINFO_PRIMARY_IP},
+  {"remote_port", JSON_LONG, CURLINFO_PRIMARY_PORT},
+  {"local_ip", JSON_STRING, CURLINFO_LOCAL_IP},
+  {"local_port", JSON_LONG, CURLINFO_LOCAL_PORT},
+  {"http_version", JSON_VERSION, CURLINFO_HTTP_VERSION},
+  {"scheme", JSON_STRING, CURLINFO_SCHEME},
+  {NULL, JSON_NONE, CURLINFO_NONE}
+};
+
+static const char *http_version[] = {
+  "0",   /* CURL_HTTP_VERSION_NONE */
+  "1",   /* CURL_HTTP_VERSION_1_0 */
+  "1.1", /* CURL_HTTP_VERSION_1_1 */
+  "2"    /* CURL_HTTP_VERSION_2 */
+  "3"    /* CURL_HTTP_VERSION_3 */
+};
+
+static void jsonEscape(FILE *stream, const char *in)
+{
+  const char *i = in;
+  const char *in_end = in + strlen(in);
+
+  for(; i < in_end; i++) {
+    switch(*i) {
+    case '\\':
+      fputs("\\\\", stream);
+      break;
+    case '\"':
+      fputs("\\\"", stream);
+      break;
+    case '\b':
+      fputs("\\b", stream);
+      break;
+    case '\f':
+      fputs("\\f", stream);
+      break;
+    case '\n':
+      fputs("\\n", stream);
+      break;
+    case '\r':
+      fputs("\\r", stream);
+      break;
+    case '\t':
+      fputs("\\t", stream);
+      break;
+    default:
+      if (*i < 32) {
+        fprintf(stream, "u%04x", *i);
+      }
+      else {
+        fputc(*i, stream);
+      }
+      break;
+    };
+  }
+}
+
+static int writeTime(FILE *str, CURL *curl, const char *key, CURLINFO ci)
+{
+  curl_off_t val = 0;
+  if(CURLE_OK == curl_easy_getinfo(curl, ci, &val)) {
+    curl_off_t s = val / 1000000l;
+    curl_off_t ms = val % 1000000l;
+    fprintf(str, "\"%s\":%ld.%06ld", key, s, ms);
+    return 1;
+  }
+  return 0;
+}
+
+static int writeString(FILE *str, CURL *curl, const char *key, CURLINFO ci)
+{
+  char *valp = NULL;
+  if((CURLE_OK == curl_easy_getinfo(curl, ci, &valp)) && valp) {
+    fprintf(str, "\"%s\":\"", key);
+    jsonEscape(str, valp);
+    fprintf(str, "\"");
+    return 1;
+  }
+  return 0;
+}
+
+static int writeLong(FILE *str, CURL *curl, const char *key, CURLINFO ci)
+{
+  curl_off_t val = 0;
+  if(CURLE_OK == curl_easy_getinfo(curl, ci, &val)) {
+    fprintf(str, "\"%s\":%ld", key, val);
+    return 1;
+  }
+  return 0;
+}
+
+static int writeFilename(FILE *str, const char *key, const char *filename)
+{
+  if(filename) {
+    fprintf(str, "\"%s\":\"", key);
+    jsonEscape(str, filename);
+    fprintf(str, "\"");
+  }
+  else {
+    fprintf(str, "\"%s\":null", key);
+  }
+  return 1;
+}
+
+static int writeVersion(FILE *str, CURL *curl, const char *key, CURLINFO ci)
+{
+  long version = 0;
+  if(CURLE_OK == curl_easy_getinfo(curl, ci, &version) &&
+     (version >= 0) &&
+     (version < (long)(sizeof(http_version)/sizeof(char *)))) {
+    fprintf(str, "\"%s\":\"%s\"", key, http_version[version]);
+    return 1;
+  }
+  return 0;
+}
+
+void ourWriteOutJSON(CURL *curl, struct OutStruct *outs, FILE *stream)
+{
+  int i;
+
+  fputs("{", stream);
+  for(i = 0; mappings[i].key != NULL; i++) {
+    const char *key = mappings[i].key;
+    CURLINFO cinfo = mappings[i].cinfo;
+    int ok = 0;
+    switch(mappings[i].type) {
+    case JSON_STRING:
+      ok = writeString(stream, curl, key, cinfo);
+      break;
+    case JSON_LONG:
+      ok = writeLong(stream, curl, key, cinfo);
+      break;
+    case JSON_TIME:
+      ok = writeTime(stream, curl, key, cinfo);
+      break;
+    case JSON_FILENAME:
+      ok = writeFilename(stream, key, outs->filename);
+      break;
+    case JSON_VERSION:
+      ok = writeVersion(stream, curl, key, cinfo);
+      break;
+    default:
+      break;
+    }
+
+    if(ok) {
+      fputs(",", stream);
+    }
+  }
+
+  fprintf(stream, "\"curl_version\":\"%s\"}", curl_version());
+}

--- a/src/tool_writeout_json.h
+++ b/src/tool_writeout_json.h
@@ -1,0 +1,28 @@
+#ifndef HEADER_CURL_TOOL_WRITEOUT_JSON_H
+#define HEADER_CURL_TOOL_WRITEOUT_JSON_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "tool_setup.h"
+
+void ourWriteOutJSON(CURL *curl, struct OutStruct *outs, FILE *stream);
+
+#endif /* HEADER_CURL_TOOL_WRITEOUT_H */

--- a/src/tool_writeout_json.h
+++ b/src/tool_writeout_json.h
@@ -22,7 +22,9 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
+#include "tool_writeout.h"
 
-void ourWriteOutJSON(CURL *curl, struct OutStruct *outs, FILE *stream);
+void ourWriteOutJSON(const struct writeoutvar mappings[],
+        CURL *curl, struct OutStruct *outs, FILE *stream);
 
 #endif /* HEADER_CURL_TOOL_WRITEOUT_H */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -109,7 +109,7 @@ test927 test928 test929 test930 test931 test932 test933 test934 test935 \
 test936 test937 test938 test939 test940 test941 test942 test943 test944 \
 test945 test946 test947 test948 test949 test950 test951 test952 test953 \
 test954 test955 test956 test957 test958 test959 test960 test961 test962 \
-test963 test964 test965 test966 test967 test968 test969 \
+test963 test964 test965 test966 test967 test968 test969 test970 \
 \
 test1000 test1001 test1002 test1003 test1004 test1005 test1006 test1007 \
 test1008 test1009 test1010 test1011 test1012 test1013 test1014 test1015 \

--- a/tests/data/test970
+++ b/tests/data/test970
@@ -1,0 +1,77 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+debug
+</features>
+<setenv>
+CURL_TIME=13
+CURL_VERSION=curl-unit-test-fake-version
+</setenv>
+ <name>
+HTTP GET with JSON output
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/970 --write-out '%{json}'
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /970 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+<stdout nonewline="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+{"url_effective":"http://127.0.0.1:8990/970","http_code":200,"response_code":200,"http_connect":0,"time_total":0.000013,"time_namelookup":0.000013,"time_connect":0.000013,"time_appconnect":0.000013,"time_pretransfer":0.000013,"time_starttransfer":0.000013,"size_header":250,"size_request":85,"size_download":6,"size_upload":0,"speed_download":0.000013,"speed_upload":0.000013,"content_type":"text/html","num_connects":1,"time_redirect":0.000013,"num_redirects":0,"ssl_verify_result":0,"proxy_ssl_verify_result":0,"filename_effective":null,"remote_ip":"127.0.0.1","remote_port":8990,"local_ip":"127.0.0.1","local_port":13,"http_version":"1.1","scheme":"HTTP","curl_version":"curl-unit-test-fake-version"}
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
This commit adds support to generate JSON via the writeout feature:

    -w "%{json}"

It leverages the existing infrastructure as much as possible. Thus,
generating the JSON on STDERR is possible by:

    -w "%{stderr}%{json}"

This implements a variant of https://github.com/curl/curl/wiki/JSON#--write-out-json.