### PR TITLE
urlapi: Guess URLs starting with "mail." as SMTP

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -931,7 +931,7 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
         schemep = "ldap";
       else if(checkprefix("imap.", hostname))
         schemep = "imap";
-      else if(checkprefix("smtp.", hostname))
+      else if(checkprefix("smtp.", hostname) || checkprefix("mail.", hostname))
         schemep = "smtp";
       else if(checkprefix("pop3.", hostname))
         schemep = "pop3";


### PR DESCRIPTION
Many SMTP servers use the subdomain "mail".

Beside some private servers like mine, also some providers do this. E.g GMX