### PR TITLE
ngtcp2 and altsvc fixes

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1601,9 +1601,11 @@ static CURLcode ng_flush_egress(struct connectdata *conn, int sockfd,
   case AF_INET:
     pktlen = NGTCP2_MAX_PKTLEN_IPV4;
     break;
+#ifdef ENABLE_IPV6
   case AF_INET6:
     pktlen = NGTCP2_MAX_PKTLEN_IPV6;
     break;
+#endif
   default:
     assert(0);
   }


### PR DESCRIPTION
This PR fixes the build for non-IPv6 targets.

In addition Alt-Svc header parsing was pretty much broken:

- before the flags parsing assumed there are single flags section that applied to all alternative protocols, resulting in the code parsing the flags from wrong location on multi-entry header.
- the code would get stuck in a busyloop if protocol wasn't followed by an equal sign.
- the parser would terminate on unknown protocols rather than ignoring them.
