### PR TITLE
RELEASE-PROCEDURE: feature win is closed post-release a few days

### DIFF
--- a/docs/RELEASE-PROCEDURE.md
+++ b/docs/RELEASE-PROCEDURE.md
@@ -61,12 +61,12 @@ celebrate
 curl release scheduling
 =======================
 
-Basics
-------
+Release Cycle
+-------------
 
 We do releases every 8 weeks on Wednesdays. If critical problems arise, we can
 insert releases outside of the schedule or we can move the release date - but
-this is very rare.
+this is rare.
 
 Each 8 week release cycle is split in two 4-week periods.
 
@@ -78,14 +78,22 @@ Each 8 week release cycle is split in two 4-week periods.
   then only focus on fixing bugs and polishing things to make a solid coming
   release.
 
+- After a regular procedure-following release (made on Wednesdays), the
+  feature window remains closed until the following Monday in case of special
+  actions or patch releases etc.
+
+If a future release date happens to end up on a "bad date", like in the middle
+of common public holidays or when the lead release manager is away traveling,
+the release date can be moved forwards or backwards a full week. This is then
+advertised well in advance.
+
 Coming dates
 ------------
 
 Based on the description above, here are some planned release dates (at the
 time of this writing):
 
-- January 8, 2020
-- March 4, 2020
+- March 4, 2020 (7.69.0)
 - April 29, 2020
 - June 24, 2020
 - August 19, 2020


### PR DESCRIPTION
We've tried to uphold this already but let's make it official by publicly stating this is the way we do it.