### PR TITLE
curl: error on --alt-svc use w/o support

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1278,7 +1278,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case 'b':
       switch(subletter) {
       case 'a': /* --alt-svc */
-        GetStr(&config->altsvc, nextarg);
+        if(curlinfo->features & CURL_VERSION_ALTSVC)
+          GetStr(&config->altsvc, nextarg);
+        else
+          return PARAM_LIBCURL_DOESNT_SUPPORT;
         break;
       default:  /* --cookie string coming up: */
         if(nextarg[0] == '@') {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1966,11 +1966,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->disallow_username_in_url)
           my_setopt(curl, CURLOPT_DISALLOW_USERNAME_IN_URL, 1L);
 
-#ifdef USE_ALTSVC
-        /* only if explicitly enabled in configure */
         if(config->altsvc)
           my_setopt_str(curl, CURLOPT_ALTSVC, config->altsvc);
-#endif
 
 #ifdef USE_METALINK
         if(!metalink && config->use_metalink) {


### PR DESCRIPTION
Make the tool check for alt-svc support at run-time and return error
accordingly if not present when the option is used.

Reported-by: Harry Sintonen (@piru)