### PR TITLE
test: Add test for JSON writeout

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -50,6 +50,9 @@ curl CONNECT request. (Added in 7.12.4)
 .B http_version
 The http version that was effectively used. (Added in 7.50.0)
 .TP
+.B json
+A JSON object with all available keys.
+.TP
 .B local_ip
 The IP address of the local end of the most recently done connection - can be
 either IPv4 or IPv6 (Added in 7.29.0)

--- a/packages/Symbian/group/curl.mmp
+++ b/packages/Symbian/group/curl.mmp
@@ -45,6 +45,7 @@ SOURCE \
     tool_vms.c \
     tool_writeenv.c \
     tool_writeout.c \
+    tool_writeout_json.c \
     tool_xattr.c
 
 SOURCEPATH  ../../../lib

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -62,6 +62,7 @@ CURL_CFILES = \
   tool_util.c \
   tool_vms.c \
   tool_writeout.c \
+  tool_writeout_json.c \
   tool_xattr.c
 
 CURL_HFILES = \
@@ -107,6 +108,7 @@ CURL_HFILES = \
   tool_version.h \
   tool_vms.h \
   tool_writeout.h \
+  tool_writeout_json.h \
   tool_xattr.h
 
 CURL_RCFILES = curl.rc

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -25,6 +25,7 @@
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_writeout.h"
+#include "tool_writeout_json.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -62,6 +63,7 @@ typedef enum {
   VAR_SCHEME,
   VAR_STDOUT,
   VAR_STDERR,
+  VAR_JSON,
   VAR_NUM_OF_VARS /* must be the last */
 } replaceid;
 
@@ -105,6 +107,7 @@ static const struct variable replacements[]={
   {"scheme", VAR_SCHEME},
   {"stdout", VAR_STDOUT},
   {"stderr", VAR_STDERR},
+  {"json", VAR_JSON},
   {NULL, VAR_NONE}
 };
 
@@ -334,6 +337,8 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
               case VAR_STDERR:
                 stream = stderr;
                 break;
+              case VAR_JSON:
+                ourWriteOutJSON(curl, outs, stream);
               default:
                 break;
               }

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -1,0 +1,201 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "tool_setup.h"
+
+
+#ifdef HAVE_LOCALE_H
+#  include <locale.h>
+#endif
+
+
+#define ENABLE_CURLX_PRINTF
+
+
+/* use our own printf() functions */
+#include "curlx.h"
+#include "tool_cfgable.h"
+#include "tool_writeout_json.h"
+
+
+typedef enum {
+  JSON_NONE,
+  JSON_STRING,
+  JSON_LONG,
+  JSON_DOUBLE,
+  JSON_VERSION,
+  JSON_FILENAME
+} jsontype;
+
+struct mapping {
+  const char *key;
+  jsontype type;
+  CURLINFO cinfo;
+};
+
+static const struct mapping mappings[]={
+  {"url_effective", JSON_STRING, CURLINFO_EFFECTIVE_URL},
+  {"http_code", JSON_LONG, CURLINFO_RESPONSE_CODE},
+  {"response_code", JSON_LONG, CURLINFO_RESPONSE_CODE},
+  {"http_connect", JSON_LONG, CURLINFO_HTTP_CONNECTCODE},
+  {"time_total", JSON_DOUBLE, CURLINFO_TOTAL_TIME},
+  {"time_namelookup", JSON_DOUBLE, CURLINFO_NAMELOOKUP_TIME},
+  {"time_connect", JSON_DOUBLE, CURLINFO_CONNECT_TIME},
+  {"time_appconnect", JSON_DOUBLE, CURLINFO_APPCONNECT_TIME},
+  {"time_pretransfer", JSON_DOUBLE, CURLINFO_PRETRANSFER_TIME},
+  {"time_starttransfer", JSON_DOUBLE, CURLINFO_STARTTRANSFER_TIME},
+  {"size_header", JSON_LONG, CURLINFO_HEADER_SIZE},
+  {"size_request", JSON_LONG, CURLINFO_REQUEST_SIZE},
+  {"size_download", JSON_DOUBLE, CURLINFO_SIZE_DOWNLOAD},
+  {"size_upload", JSON_DOUBLE, CURLINFO_SIZE_UPLOAD},
+  {"speed_download", JSON_DOUBLE, CURLINFO_SPEED_DOWNLOAD},
+  {"speed_upload", JSON_DOUBLE, CURLINFO_SPEED_UPLOAD},
+  {"content_type", JSON_STRING, CURLINFO_CONTENT_TYPE},
+  {"num_connects", JSON_LONG, CURLINFO_NUM_CONNECTS},
+  {"time_redirect", JSON_DOUBLE, CURLINFO_REDIRECT_TIME},
+  {"num_redirects", JSON_LONG, CURLINFO_REDIRECT_COUNT},
+  {"ftp_entry_path", JSON_STRING, CURLINFO_FTP_ENTRY_PATH},
+  {"redirect_url", JSON_STRING, CURLINFO_REDIRECT_URL},
+  {"ssl_verify_result", JSON_LONG, CURLINFO_SSL_VERIFYRESULT},
+  {"proxy_ssl_verify_result", JSON_LONG, CURLINFO_PROXY_SSL_VERIFYRESULT},
+  {"filename_effective", JSON_FILENAME, CURLINFO_NONE},
+  {"remote_ip", JSON_STRING, CURLINFO_PRIMARY_IP},
+  {"remote_port", JSON_LONG, CURLINFO_PRIMARY_PORT},
+  {"local_ip", JSON_STRING, CURLINFO_LOCAL_IP},
+  {"local_port", JSON_LONG, CURLINFO_LOCAL_PORT},
+  {"http_version", JSON_VERSION, CURLINFO_HTTP_VERSION},
+  {"scheme", JSON_STRING, CURLINFO_SCHEME},
+  {NULL, JSON_NONE, CURLINFO_NONE}
+};
+
+static const char *http_version[] = {
+  "0",   /* CURL_HTTP_VERSION_NONE */
+  "1",   /* CURL_HTTP_VERSION_1_0 */
+  "1.1", /* CURL_HTTP_VERSION_1_1 */
+  "2"    /* CURL_HTTP_VERSION_2 */
+  "3"    /* CURL_HTTP_VERSION_3 */
+};
+
+static void json_escape(FILE *stream, const char *in)
+{
+  const char *i = in;
+  const char *in_end = in + strlen(in);
+
+  for(; i < in_end; i++) {
+    switch(*i) {
+    case '\\':
+      fputs("\\\\", stream);
+      break;
+    case '\"':
+      fputs("\\\"", stream);
+      break;
+    case '\b':
+      fputs("\\b", stream);
+      break;
+    case '\f':
+      fputs("\\f", stream);
+      break;
+    case '\n':
+      fputs("\\n", stream);
+      break;
+    case '\r':
+      fputs("\\r", stream);
+      break;
+    case '\t':
+      fputs("\\t", stream);
+      break;
+    default:
+      if (*i < 32) {
+        fprintf(stream, "u%04x", *i);
+      }
+      else {
+        fputc(*i, stream);
+      }
+      break;
+    };
+  }
+}
+
+
+void ourWriteOutJSON(CURL *curl, struct OutStruct *outs, FILE *stream)
+{
+  char *stringp = NULL;
+  long longinfo;
+  double doubleinfo;
+  int i;
+
+#ifdef HAVE_SETLOCALE
+  /* to produce valid JSON: disable any locale conversion of numbers */
+  const char *current_locale = setlocale(LC_NUMERIC, NULL);
+  setlocale(LC_NUMERIC, "POSIX");
+#endif
+
+  fputs("{", stream);
+  for(i = 0; mappings[i].key != NULL; i++) {
+    const char *k = mappings[i].key;
+    CURLINFO cinfo = mappings[i].cinfo;
+    switch(mappings[i].type) {
+    case JSON_STRING:
+      if((CURLE_OK == curl_easy_getinfo(curl, cinfo, &stringp)) && stringp) {
+        fprintf(stream, "\"%s\":\"", k);
+        json_escape(stream, stringp);
+        fprintf(stream, "\",");
+      }
+      break;
+    case JSON_LONG:
+      longinfo = 0;
+      if(CURLE_OK == curl_easy_getinfo(curl, cinfo, &longinfo)) {
+        fprintf(stream, "\"%s\":%ld,", k, longinfo);
+      }
+      break;
+    case JSON_DOUBLE:
+      if(CURLE_OK == curl_easy_getinfo(curl, cinfo, &doubleinfo)) {
+        fprintf(stream, "\"%s\":%.6f,", k, doubleinfo);
+      }
+      break;
+    case JSON_FILENAME:
+      if(outs->filename) {
+        fprintf(stream, "\"%s\":\"", k);
+        json_escape(stream, outs->filename);
+        fprintf(stream, "\",");
+
+      }
+      else {
+        fprintf(stream, "\"%s\":null,", k);
+      }
+      break;
+    case JSON_VERSION:
+      if(CURLE_OK == curl_easy_getinfo(curl, cinfo, &longinfo) &&
+         (longinfo >= 0) &&
+         (longinfo < (long)(sizeof(http_version)/sizeof(char *)))) {
+        fprintf(stream, "\"%s\":\"%s\",", k, http_version[longinfo]);
+      }
+      break;
+    default:
+      break;
+    }
+  }
+  fprintf(stream, "\"curl_version\":\"%s\"}", curl_version());
+
+#ifdef HAVE_SETLOCALE
+  setlocale(LC_NUMERIC, current_locale);
+#endif
+}

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -56,18 +56,22 @@ static const struct mapping mappings[]={
   {"http_code", JSON_LONG, CURLINFO_RESPONSE_CODE},
   {"response_code", JSON_LONG, CURLINFO_RESPONSE_CODE},
   {"http_connect", JSON_LONG, CURLINFO_HTTP_CONNECTCODE},
+#ifndef DEBUGBUILD
   {"time_total", JSON_DOUBLE, CURLINFO_TOTAL_TIME},
   {"time_namelookup", JSON_DOUBLE, CURLINFO_NAMELOOKUP_TIME},
   {"time_connect", JSON_DOUBLE, CURLINFO_CONNECT_TIME},
   {"time_appconnect", JSON_DOUBLE, CURLINFO_APPCONNECT_TIME},
   {"time_pretransfer", JSON_DOUBLE, CURLINFO_PRETRANSFER_TIME},
   {"time_starttransfer", JSON_DOUBLE, CURLINFO_STARTTRANSFER_TIME},
+#endif
   {"size_header", JSON_LONG, CURLINFO_HEADER_SIZE},
   {"size_request", JSON_LONG, CURLINFO_REQUEST_SIZE},
   {"size_download", JSON_DOUBLE, CURLINFO_SIZE_DOWNLOAD},
   {"size_upload", JSON_DOUBLE, CURLINFO_SIZE_UPLOAD},
+#ifndef DEBUGBUILD
   {"speed_download", JSON_DOUBLE, CURLINFO_SPEED_DOWNLOAD},
   {"speed_upload", JSON_DOUBLE, CURLINFO_SPEED_UPLOAD},
+#endif
   {"content_type", JSON_STRING, CURLINFO_CONTENT_TYPE},
   {"num_connects", JSON_LONG, CURLINFO_NUM_CONNECTS},
   {"time_redirect", JSON_DOUBLE, CURLINFO_REDIRECT_TIME},
@@ -79,8 +83,10 @@ static const struct mapping mappings[]={
   {"filename_effective", JSON_FILENAME, CURLINFO_NONE},
   {"remote_ip", JSON_STRING, CURLINFO_PRIMARY_IP},
   {"remote_port", JSON_LONG, CURLINFO_PRIMARY_PORT},
+#ifndef DEBUGBUILD
   {"local_ip", JSON_STRING, CURLINFO_LOCAL_IP},
   {"local_port", JSON_LONG, CURLINFO_LOCAL_PORT},
+#endif
   {"http_version", JSON_VERSION, CURLINFO_HTTP_VERSION},
   {"scheme", JSON_STRING, CURLINFO_SCHEME},
   {NULL, JSON_NONE, CURLINFO_NONE}
@@ -193,7 +199,11 @@ void ourWriteOutJSON(CURL *curl, struct OutStruct *outs, FILE *stream)
       break;
     }
   }
+#ifndef DEBUGBUILD
   fprintf(stream, "\"curl_version\":\"%s\"}", curl_version());
+#else
+  fprintf(stream, "\"curl_version\":\"debug\"}");
+#endif
 
 #ifdef HAVE_SETLOCALE
   setlocale(LC_NUMERIC, current_locale);

--- a/src/tool_writeout_json.h
+++ b/src/tool_writeout_json.h
@@ -1,0 +1,28 @@
+#ifndef HEADER_CURL_TOOL_WRITEOUT_JSON_H
+#define HEADER_CURL_TOOL_WRITEOUT_JSON_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "tool_setup.h"
+
+void ourWriteOutJSON(CURL *curl, struct OutStruct *outs, FILE *stream);
+
+#endif /* HEADER_CURL_TOOL_WRITEOUT_H */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -209,4 +209,4 @@ test2080 \
 test2100 \
 \
 test3000 test3001 \
-test3002 test3003 test3004 test3005 test3006 test3007
+test3002 test3003 test3004 test3005 test3006 test3007 test3008

--- a/tests/data/test3008
+++ b/tests/data/test3008
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 04 Feb 2020 14:49:00 GMT
+Content-Length: 8
+Connection: close
+
+monster
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP GET -w json without dynamic values
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/3008 -w "%{json}\n"
+</command>
+<features>
+debug
+</features>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /3008 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+
+<stdout>
+HTTP/1.1 200 OK
+Date: Thu, 04 Feb 2020 14:49:00 GMT
+Content-Length: 8
+Connection: close
+
+monster
+{"url_effective":"http://%HOSTIP:%HTTPPORT/3008","http_code":200,"response_code":200,"http_connect":0,"size_header":89,"size_request":86,"size_download":8.000000,"size_upload":0.000000,"num_connects":1,"time_redirect":0.000000,"num_redirects":0,"ssl_verify_result":0,"proxy_ssl_verify_result":0,"filename_effective":null,"remote_ip":"127.0.0.1","remote_port":8990,"http_version":"1.1","scheme":"HTTP","curl_version":"debug"}
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
cc @mgumz
This is based on #4870, please review this first.

This adds a test for the JSON output. If curl gets complied with `--enable-debug`, one JSON value gets changed and those which can't be tested in the test framework for technical reason are cutted off.

Feedback welcome.
Before this gets merged it needs a rebase from master after #4870 (if the base PR ) gets merged.