### PR TITLE
scripts: use last set tag if none given (delta and contributors)

### DIFF
--- a/scripts/contributors.sh
+++ b/scripts/contributors.sh
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2013-2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2013-2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -29,9 +29,13 @@
 
 start=$1
 
-if test -z "$start"; then
+if test "$start" = "-h"; then
     echo "Usage: $0 <since this tag/hash> [--releasenotes]"
     exit
+fi
+if test -z "$start"; then
+    start=`git tag --sort=taggerdate | tail -1`;
+    echo "Since $start:"
 fi
 
 # filter out Author:, Commit: and *by: lines

--- a/scripts/delta
+++ b/scripts/delta
@@ -30,9 +30,13 @@
 
 $start = $ARGV[0];
 
-if($start eq "") {
+if($start eq "-h") {
     print "Usage: summary [tag]\n";
     exit;
+}
+elsif($start eq "") {
+    $start = `git tag --sort=taggerdate | tail -1`;
+    chomp $start;
 }
 
 $commits = `git log --oneline $start.. | wc -l`;
@@ -45,8 +49,8 @@ $acommitters = `git shortlog -s | wc -l`;
 # delta from now compared to before
 $ncommitters = $acommitters - $bcommitters;
 
-# number of contributors right now (according to THANKS)
-$acontribs = `cat docs/THANKS | grep -c '^[^ ]'`;
+# number of contributors right now
+$acontribs = `./scripts/contrithanks.sh | grep -c '^[^ ]'`;
 # number when the tag tag was set
 $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
 # delta
@@ -118,7 +122,7 @@ printf "Commit authors: %d out of which %d are new (out of %d)\n",
     $committers, $ncommitters, $acommitters;
 printf "Contributors in RELEASE-NOTES: %d\n",
     $numcontributors;
-printf "New contributors (in THANKS): %d (out of %d)\n",
+printf "New contributors: %d (out of %d)\n",
     $contribs, $acontribs;
 printf "New curl_easy_setopt() options: %d (out of %d)\n",
     $nsetopts, $asetopts;


### PR DESCRIPTION
Makes 'delta' and 'contributors.sh' easier to use.

Make the delta script invoke contrithanks to get current number of
contributors instead of counting THANKS, for accuracy.