### PR TITLE
asyn-thread: Don't block waiting on resolver threads during multi_done

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -114,7 +114,9 @@ struct orphaned_threads {
   /* Count of threads in the list that are in the process of or have exited.
      (ie .exiting member of the thread_list item is set true) */
   size_t exiting_count;
-} orphaned_threads;
+};
+
+static struct orphaned_threads orphaned_threads;
 
 /* Flags for wait_and_destroy_orphaned_threads().
    They're documented above the function definition. */

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -37,9 +37,8 @@
 #  define curl_mutex_t           CRITICAL_SECTION
 #  define curl_thread_t          HANDLE
 #  define curl_thread_t_null     (HANDLE)0
-/* The Windows init/destroy macros are set to return 0 (success) even if the
-   respective Windows API functions do not return values. That makes them
-   behave the same as pthreads init/destroy which return 0 on success. */
+/* The Windows init macro is made to return 0 on success so that it behaves the
+   same as pthreads init which returns 0 on success. */
 #  if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
       (_WIN32_WINNT < _WIN32_WINNT_VISTA) || \
       (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
@@ -49,7 +48,7 @@
 #  endif
 #  define Curl_mutex_acquire(m)  EnterCriticalSection(m)
 #  define Curl_mutex_release(m)  LeaveCriticalSection(m)
-#  define Curl_mutex_destroy(m)  (DeleteCriticalSection(m), 0)
+#  define Curl_mutex_destroy(m)  DeleteCriticalSection(m)
 #endif
 
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -37,16 +37,19 @@
 #  define curl_mutex_t           CRITICAL_SECTION
 #  define curl_thread_t          HANDLE
 #  define curl_thread_t_null     (HANDLE)0
+/* The Windows init/destroy macros are set to return 0 (success) even if the
+   respective Windows API functions do not return values. That makes them
+   behave the same as pthreads init/destroy which return 0 on success. */
 #  if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
       (_WIN32_WINNT < _WIN32_WINNT_VISTA) || \
       (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-#    define Curl_mutex_init(m)   InitializeCriticalSection(m)
+#    define Curl_mutex_init(m)   (InitializeCriticalSection(m), 0)
 #  else
-#    define Curl_mutex_init(m)   InitializeCriticalSectionEx(m, 0, 1)
+#    define Curl_mutex_init(m)   (!InitializeCriticalSectionEx(m, 0, 1))
 #  endif
 #  define Curl_mutex_acquire(m)  EnterCriticalSection(m)
 #  define Curl_mutex_release(m)  LeaveCriticalSection(m)
-#  define Curl_mutex_destroy(m)  DeleteCriticalSection(m)
+#  define Curl_mutex_destroy(m)  (DeleteCriticalSection(m), 0)
 #endif
 
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -552,8 +552,10 @@ static CURLcode multi_done(struct Curl_easy *data,
 
   conn->data = data; /* ensure the connection uses this transfer now */
 
-  /* Stop the resolver and free its own resources (but not dns_entry yet). */
-  Curl_resolver_kill(conn);
+  /* Cancel the resolver (but not dns_entry yet). We used to call
+     Curl_resolver_kill here but that blocks waiting for incomplete resolve
+     threads (eg getaddrinfo has not returned), which may take a while. */
+  Curl_resolver_cancel(conn);
 
   /* Cleanup possible redirect junk */
   Curl_safefree(data->req.newurl);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -509,7 +509,7 @@ struct Curl_async {
   int port;
   struct Curl_dns_entry *dns;
   int status; /* if done is TRUE, this is the status from the callback */
-  void *os_specific;  /* 'struct thread_data' for Windows */
+  void *os_specific;  /* resolver backend / os specific data */
   BIT(done);  /* set TRUE when the lookup is complete */
 };
 


### PR DESCRIPTION
This commit changes the behavior of libcurl to no longer block on
incomplete resolve threads from the parent thread (ie the user's thread
which is the multi perform thread) during multi_done.

Instead it now orphans those threads in a master list which is culled
periodically by soon-to-be exiting orphans to wait on and destroy those
that are in the process of or have since exited, which is fast. On
global cleanup we wait on and destroy any remaining threads, which may
be slow but at that point we cannot defer it any longer.

Ideally we would not wait for orphaned threads at all, but we have to
because after global cleanup the user may choose to unload the shared
library that is/contains libcurl.

Note: thread_wait_resolv (Curl_resolver_wait_resolv) which blocks
waiting for a resolver thread remains unchanged, since that is
essentially the purpose of the function. It is currently called by FTP
and SOCKS code, and continues to be a known issue that those two may
block waiting for async resolves to finish.

Fixes https://github.com/curl/curl/issues/4852
Closes #xxxx