### PR TITLE
github: Instructions to post "uname -a" on Unix systems in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -15,3 +15,5 @@
 [curl -V output]
 
 ### operating system
+
+<!-- On Unix please post the output of "uname -a" -->


### PR DESCRIPTION
Example output (Debian 10)
```
Linux debian 4.19.0-6-amd64 #1 SMP Debian 4.19.67-2+deb10u2 (2019-11-11) x86_64 GNU/Linux
```
This makes getting help much easier especially it helps to determine the lib(curl) version if the person is using it from the repository of their distro. Also it would avoid that people give unclear names about their OS like `Ubuntu` instead of something like `Ubuntu 18.04`