### PR TITLE
url: Include the failure reason when curl_win32_idn_to_ascii() fails

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1514,7 +1514,9 @@ static CURLcode idnconvert_hostname(struct connectdata *conn,
       host->name = host->encalloc;
     }
     else {
-      failf(data, "Failed to convert %s to ACE;\n", host->name);
+      char buffer[STRERROR_LEN];
+      failf(data, "Failed to convert %s to ACE; %s\n", host->name,
+            Curl_winapi_strerror(GetLastError(), buffer, sizeof(buffer)));
       return CURLE_URL_MALFORMAT;
     }
 #else


### PR DESCRIPTION
Provide the failure reason in the failf() info just as we do for the libidn2 version of code. Otherwise we have output such as the following which doesn't help debug what the failure is:

`````
Failed to convert åäö.se to ACE.
`````
Rather than:

`````
Failed to convert åäö.se to ACE; No mapping for the Unicode character exists in the target multi-byte code page.
`````