### PR TITLE
easy: remove dead code

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -690,10 +690,6 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
 
   sigpipe_ignore(data, &pipe_st);
 
-  /* assign this after curl_multi_add_handle() since that function checks for
-     it and rejects this handle otherwise */
-  data->multi = multi;
-
   /* run the transfer */
   result = events ? easy_events(multi) : easy_transfer(multi);
 


### PR DESCRIPTION
multi is already assigned to data->multi by curl_multi_add_handle.

Closes #xxxx

---

Was the assignment done intentionally or is it just a remnant? When would data->multi not be multi?

