### PR TITLE
multi: fix outdated comment

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -730,8 +730,8 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
        we don't leave a half-baked one around */
     if(easy_owns_conn) {
 
-      /* multi_done() clears the conn->data field to lose the association
-         between the easy handle and the connection
+      /* multi_done() clears the association between the easy handle and the
+         connection.
 
          Note that this ignores the return code simply because there's
          nothing really useful to do with it anyway! */


### PR DESCRIPTION
- Do not say that conn->data is "cleared" by multi_done().

If the connection is in use then multi_done assigns another easy handle
still using the connection to conn->data, therefore in that case it is
not cleared.

Closes #xxxx