### PR TITLE
ftpserver: Corrected the e-mail address regex in MAIL_smtp() and RCTP_smtp()

### DIFF
--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -828,7 +828,7 @@ sub MAIL_smtp {
         # Validate the from address (only <> and a valid email address inside
         # <> are allowed, such as <user@example.com>)
         if ((!$from) || (($from ne "<>") && ($from !~
-            /^<([a-zA-Z0-9._%+-]+)\@([a-zA-Z0-9.-]+).([a-zA-Z]{2,4})>$/))) {
+            /^<([a-zA-Z0-9._%+-]+)\@(([a-zA-Z0-9-]+)\.)+([a-zA-Z]{2,4})>$/))) {
             sendcontrol "501 Invalid address\r\n";
         }
         else {
@@ -872,7 +872,7 @@ sub RCPT_smtp {
         # Validate the to address (only a valid email address inside <> is
         # allowed, such as <user@example.com>)
         if ($to !~
-            /^<([a-zA-Z0-9._%+-]+)\@([a-zA-Z0-9.-]+).([a-zA-Z]{2,4})>$/) {
+            /^<([a-zA-Z0-9._%+-]+)\@(([a-zA-Z0-9-]+)\.)+([a-zA-Z]{2,4})>$/) {
             sendcontrol "501 Invalid address\r\n";
         }
         else {


### PR DESCRIPTION
The dot character between the host and the tld was not being escaped, which meant it specified a match of 'any' character rather than an explicit dot separator.

Additionally removed the dot character from the host name as it allowed the following to be specified as a valid address in our test cases:

<bad@example......com>

Both are typos from 98f7ca7e and 8880f84e :(

I can't remember whether my intention was to allow sub-domains to be specified in the host or not with these additional dots, but by placing it outside of the host means it can only be specified once per domain and by placing a + after the new grouping support for sub-domains is kept.
