### PR TITLE
travis: do the arm64 build without the gcc8 override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -398,7 +398,6 @@ matrix:
           dist: bionic
           env:
               - T=debug C="--enable-alt-svc"
-              - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
           addons:
               apt:
                   sources:


### PR DESCRIPTION
Perhaps this avoids the segfaults?