### PR TITLE
strerror: Increase STRERROR_LEN 128 -> 256

### DIFF
--- a/lib/strerror.h
+++ b/lib/strerror.h
@@ -24,7 +24,7 @@
 
 #include "urldata.h"
 
-#define STRERROR_LEN 128 /* a suitable length */
+#define STRERROR_LEN 256 /* a suitable length */
 
 const char *Curl_strerror(int err, char *buf, size_t buflen);
 #if defined(WIN32) || defined(_WIN32_WCE)


### PR DESCRIPTION
STRERROR_LEN is the constant used throughout the library to set the size
of the buffer on the stack that the curl strerror functions write to.

Prior to this change some extended length Windows error messages could
be truncated.

Closes #xxxx