### PR TITLE
tool_getparam: form-urlencoded content escape fix

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1416,6 +1416,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           char *enc = curl_easy_escape(NULL, postdata, (int)size);
           Curl_safefree(postdata); /* no matter if it worked or not */
           if(enc) {
+            size_t outlen;
+            char *n;
+
             /* fix space encoding per RFC1866 */
             char *reenc = replace_url_encoded_space_with_plus(enc);
             curl_free(enc);
@@ -1424,8 +1427,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 
             /* now make a string with the name from above and append the
                encoded string */
-            size_t outlen = nlen + strlen(reenc) + 2;
-            char *n = malloc(outlen);
+            outlen = nlen + strlen(reenc) + 2;
+            n = malloc(outlen);
             if(!n) {
               curl_free(reenc);
               return PARAM_NO_MEM;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -498,6 +498,35 @@ static ParameterError GetSizeParameter(struct GlobalConfig *global,
   return PARAM_OK;
 }
 
+static char *replace_url_encoded_space_with_plus(const char *in)
+{
+  size_t inlen = strlen(in);
+  size_t in_index = 0;
+  size_t out_index = 0;
+
+  char *out = malloc(inlen + 1);
+  if(!out)
+    return NULL;
+
+  while(in_index < inlen) {
+    if(in[in_index] == '%'
+        && in[in_index + 1] == '2'
+        && in[in_index + 2] == '0') {
+      out[out_index] = '+';
+      in_index += 3;
+    }
+    else {
+      out[out_index] = in[in_index];
+      in_index++;
+    }
+    out_index++;
+  }
+
+  out[out_index] = 0; /* terminate string */
+
+  return out;
+}
+
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
                             bool *usedarg,    /* set to TRUE if the arg
@@ -1387,23 +1416,29 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           char *enc = curl_easy_escape(NULL, postdata, (int)size);
           Curl_safefree(postdata); /* no matter if it worked or not */
           if(enc) {
+            /* fix space encoding per RFC1866 */
+            char *reenc = replace_url_encoded_space_with_plus(enc);
+            curl_free(enc);
+            if(!reenc)
+              return PARAM_NO_MEM;
+
             /* now make a string with the name from above and append the
                encoded string */
-            size_t outlen = nlen + strlen(enc) + 2;
+            size_t outlen = nlen + strlen(reenc) + 2;
             char *n = malloc(outlen);
             if(!n) {
-              curl_free(enc);
+              curl_free(reenc);
               return PARAM_NO_MEM;
             }
             if(nlen > 0) { /* only append '=' if we have a name */
-              msnprintf(n, outlen, "%.*s=%s", nlen, nextarg, enc);
+              msnprintf(n, outlen, "%.*s=%s", nlen, nextarg, reenc);
               size = outlen-1;
             }
             else {
-              strcpy(n, enc);
+              strcpy(n, reenc);
               size = outlen-2; /* since no '=' was inserted */
             }
-            curl_free(enc);
+            curl_free(reenc);
             postdata = n;
           }
           else

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -503,13 +503,15 @@ static char *replace_url_encoded_space_with_plus(const char *in)
   size_t inlen = strlen(in);
   size_t in_index = 0;
   size_t out_index = 0;
+  size_t in_replace_limit = inlen - 2; /* no room for %20 beyond this */
 
   char *out = malloc(inlen + 1);
   if(!out)
     return NULL;
 
   while(in_index < inlen) {
-    if(in[in_index] == '%'
+    if(in_index < in_replace_limit
+        && in[in_index] == '%'
         && in[in_index + 1] == '2'
         && in[in_index + 2] == '0') {
       out[out_index] = '+';

--- a/tests/data/test1015
+++ b/tests/data/test1015
@@ -28,7 +28,7 @@ http
 --data-urlencode
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/1015 --data-urlencode "my name is moo[]" --data-urlencode "y e s=s_i_r" --data-urlencode "v_alue@log/1015.txt" --data-urlencode @log/1015.txt --data-urlencode double%20encoded
+http://%HOSTIP:%HTTPPORT/1015 --data-urlencode "my name is moo[] " --data-urlencode "y e s=s_i_r" --data-urlencode "v_alue@log/1015.txt" --data-urlencode @log/1015.txt --data-urlencode double%20encoded
 </command>
 <file name="log/1015.txt">
 content to _?!#$'|<>
@@ -46,10 +46,10 @@ POST /1015 HTTP/1.1
 User-Agent: curl/7.17.2-CVS (i686-pc-linux-gnu) libcurl/7.17.2-CVS OpenSSL/0.9.8g zlib/1.2.3.3 c-ares/1.5.2-CVS libidn/1.1 libssh2/0.19.0-C
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 138
+Content-Length: 139
 Content-Type: application/x-www-form-urlencoded
 
-my+name+is+moo%5B%5D&y e s=s_i_r&v_alue=content+to+_%3F%21%23%24%27%7C%3C%3E%0A&content+to+_%3F%21%23%24%27%7C%3C%3E%0A&double%2520encoded
+my+name+is+moo%5B%5D+&y e s=s_i_r&v_alue=content+to+_%3F%21%23%24%27%7C%3C%3E%0A&content+to+_%3F%21%23%24%27%7C%3C%3E%0A&double%2520encoded
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test1015
+++ b/tests/data/test1015
@@ -28,7 +28,7 @@ http
 --data-urlencode
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/1015 --data-urlencode "my name is moo[]" --data-urlencode "y e s=s_i_r" --data-urlencode "v_alue@log/1015.txt" --data-urlencode @log/1015.txt 
+http://%HOSTIP:%HTTPPORT/1015 --data-urlencode "my name is moo[]" --data-urlencode "y e s=s_i_r" --data-urlencode "v_alue@log/1015.txt" --data-urlencode @log/1015.txt --data-urlencode double%20encoded
 </command>
 <file name="log/1015.txt">
 content to _?!#$'|<>
@@ -46,10 +46,10 @@ POST /1015 HTTP/1.1
 User-Agent: curl/7.17.2-CVS (i686-pc-linux-gnu) libcurl/7.17.2-CVS OpenSSL/0.9.8g zlib/1.2.3.3 c-ares/1.5.2-CVS libidn/1.1 libssh2/0.19.0-C
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 133
+Content-Length: 138
 Content-Type: application/x-www-form-urlencoded
 
-my%20name%20is%20moo%5B%5D&y e s=s_i_r&v_alue=content%20to%20_%3F%21%23%24%27%7C%3C%3E%0A&content%20to%20_%3F%21%23%24%27%7C%3C%3E%0A
+my+name+is+moo%5B%5D&y e s=s_i_r&v_alue=content+to+_%3F%21%23%24%27%7C%3C%3E%0A&content+to+_%3F%21%23%24%27%7C%3C%3E%0A&double%2520encoded
 </protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
This PR addresses KNOWN_BUGS 4.5 Improve --data-urlencode space encoding

- Escapes spaces in form-urlencoded strings with + instead of %20
- ~~Escapes names as well as values~~

RFC1866: https://tools.ietf.org/html/rfc1866#section-8.2.1

> 8.2.1. The form-urlencoded Media Type
>
>   The default encoding for all forms is `application/x-www-form-
>   urlencoded'. A form data set is represented in this media type as
>   follows:
>
>    1. The form field names and values are escaped: space
>    characters are replaced by `+', and then reserved characters
>    are escaped as per [URL]

Prior discussion:
https://github.com/curl/curl/issues/3229
https://github.com/curl/curl/pull/4906
