### PR TITLE
ftp: convert 'sock_accepted' to a plain boolean

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1428,12 +1428,11 @@ int Curl_closesocket(struct connectdata *conn,
                       curl_socket_t sock)
 {
   if(conn && conn->fclosesocket) {
-    if((sock == conn->sock[SECONDARYSOCKET]) &&
-       conn->sock_accepted[SECONDARYSOCKET])
+    if((sock == conn->sock[SECONDARYSOCKET]) && conn->sock_accepted)
       /* if this socket matches the second socket, and that was created with
          accept, then we MUST NOT call the callback but clear the accepted
          status */
-      conn->sock_accepted[SECONDARYSOCKET] = FALSE;
+      conn->sock_accepted = FALSE;
     else {
       int rc;
       Curl_multi_closed(conn->data, sock);

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -291,7 +291,7 @@ static CURLcode AcceptServerConnect(struct connectdata *conn)
 
   conn->sock[SECONDARYSOCKET] = s;
   (void)curlx_nonblock(s, TRUE); /* enable non-blocking */
-  conn->sock_accepted[SECONDARYSOCKET] = TRUE;
+  conn->sock_accepted = TRUE;
 
   if(data->set.fsockopt) {
     int error = 0;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -925,8 +925,6 @@ struct connectdata {
   curl_socket_t sock[2]; /* two sockets, the second is used for the data
                             transfer when doing FTP */
   curl_socket_t tempsock[2]; /* temporary sockets for happy eyeballs */
-  bool sock_accepted[2]; /* TRUE if the socket on this index was created with
-                            accept() */
   Curl_recv *recv[2];
   Curl_send *send[2];
 
@@ -1081,6 +1079,8 @@ struct connectdata {
                               handle */
   BIT(writechannel_inuse); /* whether the write channel is in use by an easy
                               handle */
+  BIT(sock_accepted); /* TRUE if the SECONDARYSOCKET was created with
+                         accept() */
 };
 
 /* The end of connectdata. */


### PR DESCRIPTION
This was an array indexed with sockindex but it was only ever used for
the secondary socket.