### PR TITLE
Allow timeout of -1 for curl_multi_poll

### DIFF
--- a/docs/libcurl/curl_multi_poll.3
+++ b/docs/libcurl/curl_multi_poll.3
@@ -35,10 +35,11 @@ CURLMcode curl_multi_poll(CURLM *multi_handle,
 .SH DESCRIPTION
 \fIcurl_multi_poll(3)\fP polls all file descriptors used by the curl easy
 handles contained in the given multi handle set.  It will block until activity
-is detected on at least one of the handles or \fItimeout_ms\fP has passed.
-Alternatively, if the multi handle has a pending internal timeout that has a
-shorter expiry time than \fItimeout_ms\fP, that shorter time will be used
-instead to make sure timeout accuracy is reasonably kept.
+is detected on at least one of the handles, or \fItimeout_ms\fP has passed
+(unless \ftimeout_ms\fP is -1). Alternatively, if the multi handle has a
+pending internal timeout that has a shorter expiry time than \fItimeout_ms\fP
+(or if \ftimeout_ms\fP is -1), that shorter time will be used instead to make
+sure timeout accuracy is reasonably kept.
 
 The calling application may pass additional curl_waitfd structures which are
 similar to \fIpoll(2)\fP's pollfd structure to be waited on in the same call.

--- a/docs/libcurl/curl_multi_poll.3
+++ b/docs/libcurl/curl_multi_poll.3
@@ -113,6 +113,8 @@ CURLMcode type, general libcurl multi interface error code. See
 \fIlibcurl-errors(3)\fP
 .SH AVAILABILITY
 This function was added in libcurl 7.66.0.
+
+Passing -1 as \ftimeout_ms\fP is valid since 7.69.0; prior to that, doing so had undefined behaviour.
 .SH "SEE ALSO"
 .BR curl_multi_fdset "(3), " curl_multi_perform "(3), "
 .BR curl_multi_wait "(3), " curl_multi_wakeup "(3)"

--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -35,10 +35,11 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
 .SH DESCRIPTION
 \fIcurl_multi_wait(3)\fP polls all file descriptors used by the curl easy
 handles contained in the given multi handle set.  It will block until activity
-is detected on at least one of the handles or \fItimeout_ms\fP has passed.
+is detected on at least one of the handles, or \fItimeout_ms\fP has passed
+(unless \ftimeout_ms\fP is -1).
 Alternatively, if the multi handle has a pending internal timeout that has a
-shorter expiry time than \fItimeout_ms\fP, that shorter time will be used
-instead to make sure timeout accuracy is reasonably kept.
+shorter expiry time than \fItimeout_ms\fP (or if \ftimeout_ms\fP is -1), that
+shorter time will be used instead to make sure timeout accuracy is reasonably kept.
 
 The calling application may pass additional curl_waitfd structures which are
 similar to \fIpoll(2)\fP's pollfd structure to be waited on in the same call.

--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -36,10 +36,10 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
 \fIcurl_multi_wait(3)\fP polls all file descriptors used by the curl easy
 handles contained in the given multi handle set.  It will block until activity
 is detected on at least one of the handles, or \fItimeout_ms\fP has passed
-(unless \ftimeout_ms\fP is -1).
-Alternatively, if the multi handle has a pending internal timeout that has a
-shorter expiry time than \fItimeout_ms\fP (or if \ftimeout_ms\fP is -1), that
-shorter time will be used instead to make sure timeout accuracy is reasonably kept.
+(unless \ftimeout_ms\fP is -1). Alternatively, if the multi handle has a
+pending internal timeout that has a shorter expiry time than \fItimeout_ms\fP
+(or if \ftimeout_ms\fP is -1), that shorter time will be used instead to make
+sure timeout accuracy is reasonably kept.
 
 The calling application may pass additional curl_waitfd structures which are
 similar to \fIpoll(2)\fP's pollfd structure to be waited on in the same call.
@@ -120,5 +120,7 @@ CURLMcode type, general libcurl multi interface error code. See
 \fIlibcurl-errors(3)\fP
 .SH AVAILABILITY
 This function was added in libcurl 7.28.0.
+
+Passing -1 as \ftimeout_ms\fP is valid since 7.69.0; prior to that, doing so had undefined behaviour.
 .SH "SEE ALSO"
 .BR curl_multi_fdset "(3), " curl_multi_perform "(3)", curl_multi_poll "(3) ",

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1053,9 +1053,6 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
   if(multi->in_callback)
     return CURLM_RECURSIVE_API_CALL;
 
-  if(timeout_ms < 0)
-    return CURLM_BAD_FUNCTION_ARGUMENT;
-
   /* Count up how many fds we have from the multi handle */
   data = multi->easyp;
   while(data) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1084,7 +1084,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
      the outside, then use the shorter time! But only if the internal timer
      is actually larger than -1! */
   (void)multi_timeout(multi, &timeout_internal);
-  if((timeout_internal >= 0) && (timeout_internal < (long)timeout_ms))
+  if((timeout_internal >= 0) && ((timeout_internal < (long)timeout_ms) || (timeout_ms == -1)))
     timeout_ms = (int)timeout_internal;
 
   curlfds = nfds; /* number of internal file descriptors */


### PR DESCRIPTION
This seems to be the only change needed to allow timeout=-1 (which is, admittedly, not a documented valid value for that parameter) to work as it would with POSIX poll(). This is useful when applications don't need it to wake except on I/O activity, an expiry, or curl_multi_wakeup.

Currently, if there's no I/O activity or a curl_multi_wakeup call, the poll hangs forever _even if a connection timeout expires_.