### PR TITLE
test: Set envvar CURL_TESTNUM when test is running

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -182,7 +182,8 @@ The curl Test Suite
  1.9 Test input files
 
   All test cases are put in the data/ subdirectory. Each test is stored in the
-  file named according to the test number.
+  file named according to the test number. The current running test is
+  set in the envvar "CURL_TESTNUM"
 
   See FILEFORMAT for the description of the test case files.
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5509,6 +5509,7 @@ $start = time();
 
 foreach $testnum (@at) {
 
+    $ENV{CURL_TESTNUM} = $testnum;
     $lasttest = $testnum if($testnum > $lasttest);
     $count++;
 
@@ -5535,6 +5536,8 @@ foreach $testnum (@at) {
     elsif(!$error) {
         $ok++; # successful test counter
     }
+    # Unset the CURL_TESTNUM envvar
+    delete($ENV{CURL_TESTNUM});
 
     # loop for next test
 }


### PR DESCRIPTION
This sets the envvar "CURL_TESTNUM" to the current running test and unsets it once it is done.

The motivation for this is that you can't always over give the testnum in some URL schemes or at least it is not intended like this then (DICT for example)