### PR TITLE
HTTP-COOKIES: mention that a trailing newline is required

### DIFF
--- a/docs/HTTP-COOKIES.md
+++ b/docs/HTTP-COOKIES.md
@@ -49,17 +49,20 @@
   that start with `#` are treated as comments.
 
   Each line that each specifies a single cookie consists of seven text fields
-  separated with TAB characters.
+  separated with TAB characters. A valid line must end with a newline
+  character.
 
-  |Field| Type  | Example     | Meaning                                       |
-  |---|---------|-------------|-----------------------------------------------|
-  | 0 | string  | example.com | Domain name                                   |
-  | 1 | boolean | FALSE       | Include subdomains                            |
-  | 2 | string  | /foobar/    | Path                                          |
-  | 3 | boolean | TRUE        | Send/receive over HTTPS only                  |
-  | 4 | number  | 1462299217  | Expires at – seconds since Jan 1st 1970, or 0 |
-  | 5 | string  | person      | Name of the cookie                            |
-  | 6 | string  | daniel      | Value of the cookie                           |
+### Fields in the file
+
+  Field number, what type and example data and the meaning of it:
+
+  0. string `example.com` - the domain name
+  1. boolean `FALSE` - include subdomains
+  2. string `/foobar/` - path
+  3. boolean `TRUE` - send/receive over HTTPS only
+  4. number `1462299217` - expires at - seconds since Jan 1st 1970, or 0
+  5. string `person` - name of the cookie
+  6. string `daniel` - value of the cookie
 
 ## Cookies with curl the command line tool
 


### PR DESCRIPTION
... so that we know we got the whole and not a partial line.

Also, changed the formatting of the fields away from a table again since
the table format requires a github-markdown tool version that we don't
run on the web server atm.

Reported-by: Sunny Bean
Fixes #4946