### PR TITLE
sha256: Added TLS library based implementations

### DIFF
--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -179,6 +179,45 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
   (void) CC_SHA256_Final(digest, ctx);
 }
 
+#elif defined(USE_WIN32_CRYPTO)
+
+#include <wincrypt.h>
+
+typedef struct {
+  HCRYPTPROV hCryptProv;
+  HCRYPTHASH hHash;
+} SHA256_CTX;
+
+static void SHA256_Init(SHA256_CTX *ctx)
+{
+  if(CryptAcquireContext(&ctx->hCryptProv, NULL, NULL,
+                         PROV_RSA_AES, CRYPT_VERIFYCONTEXT)) {
+    CryptCreateHash(ctx->hCryptProv, CALG_SHA_256, 0, 0, &ctx->hHash);
+  }
+}
+
+static void SHA256_Update(SHA256_CTX *ctx,
+                          const unsigned char *data,
+                          unsigned int length)
+{
+  CryptHashData(ctx->hHash, (unsigned char *) data, length, 0);
+}
+
+static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
+{
+  unsigned long length;
+
+  CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0);
+  if(length == SHA256_DIGEST_LENGTH)
+    CryptGetHashParam(ctx->hHash, HP_HASHVAL, digest, &length, 0);
+
+  if(ctx->hHash)
+    CryptDestroyHash(ctx->hHash);
+
+  if(ctx->hCryptProv)
+    CryptReleaseContext(ctx->hCryptProv, 0);
+}
+
 #else
 
 /* When no other crypto library is available we use this code segment */

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -71,6 +71,35 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
   sha256_digest(ctx, SHA256_DIGEST_SIZE, digest);
 }
 
+#elif defined(USE_GNUTLS)
+
+#include <gcrypt.h>
+
+#include "curl_memory.h"
+
+/* The last #include file should be: */
+#include "memdebug.h"
+
+typedef gcry_md_hd_t SHA256_CTX;
+
+static void SHA256_Init(SHA256_CTX *ctx)
+{
+  gcry_md_open(ctx, GCRY_MD_SHA256, 0);
+}
+
+static void SHA256_Update(SHA256_CTX *ctx,
+                          const unsigned char *data,
+                          unsigned int length)
+{
+  gcry_md_write(*ctx, data, length);
+}
+
+static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
+{
+  memcpy(digest, gcry_md_read(*ctx, 0), SHA256_DIGEST_LENGTH);
+  gcry_md_close(*ctx);
+}
+
 #else
 
 /* When no other crypto library is available we use this code segment */

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -148,6 +148,37 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 #endif
 }
 
+#elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
+              (__MAC_OS_X_VERSION_MAX_ALLOWED >= 1040)) || \
+      (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && \
+              (__IPHONE_OS_VERSION_MAX_ALLOWED >= 20000))
+
+#include <CommonCrypto/CommonDigest.h>
+
+#include "curl_memory.h"
+
+/* The last #include file should be: */
+#include "memdebug.h"
+
+typedef CC_SHA256_CTX SHA256_CTX;
+
+static void SHA256_Init(SHA256_CTX *ctx)
+{
+  (void) CC_SHA224_Init(ctx);
+}
+
+static void SHA256_Update(SHA256_CTX *ctx,
+                          const unsigned char *data,
+                          unsigned int length)
+{
+  (void) CC_SHA256_Update(ctx, data, length);
+}
+
+static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
+{
+  (void) CC_SHA256_Final(digest, ctx);
+}
+
 #else
 
 /* When no other crypto library is available we use this code segment */

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -38,9 +38,39 @@
 
 #endif
 
-#ifdef USE_OPENSSL_SHA256
+#if defined(USE_OPENSSL_SHA256)
+
 /* When OpenSSL is available we use the SHA256-function from OpenSSL */
 #include <openssl/sha.h>
+
+#elif defined(USE_GNUTLS_NETTLE)
+
+#include <nettle/sha.h>
+
+#include "curl_memory.h"
+
+/* The last #include file should be: */
+#include "memdebug.h"
+
+typedef struct sha256_ctx SHA256_CTX;
+
+static void SHA256_Init(SHA256_CTX *ctx)
+{
+  sha256_init(ctx);
+}
+
+static void SHA256_Update(SHA256_CTX *ctx,
+                          const unsigned char *data,
+                          unsigned int length)
+{
+  sha256_update(ctx, length, data);
+}
+
+static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
+{
+  sha256_digest(ctx, SHA256_DIGEST_SIZE, digest);
+}
+
 #else
 
 /* When no other crypto library is available we use this code segment */


### PR DESCRIPTION
Implemented SHA256 support through the following TLS libraries rather than limiting to either OpenSSL or our own native implementation:

- GNU TLS Nettle
- GNU TLS gcrypt
- mbed TLS
- SecureTransport
- WinCrypt
