### PR TITLE
GnuTLS: Always send client cert

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -664,7 +664,7 @@ gtls_connect_step1(struct connectdata *conn,
   }
 
   /* Initialize TLS session as a client */
-  init_flags = GNUTLS_CLIENT;
+  init_flags = GNUTLS_CLIENT | GNUTLS_FORCE_CLIENT_CERT;
 
 #if defined(GNUTLS_NO_TICKETS)
   /* Disable TLS session tickets */


### PR DESCRIPTION
TLS servers may request a certificate from the client. This request includes a list of 0 or more acceptable issuer DNs. The client may use this list to determine which certificate to send. GnuTLS's default behavior is to not send a client certificate if there is no match. However, OpenSSL's default behavior is to send the configured certificate. The `GNUTLS_FORCE_CLIENT_CERT` flag mimics OpenSSL behavior.

Fixes #1411