### PR TITLE
http2: now require nghttp2 >= 1.12.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -3379,9 +3379,9 @@ if test X"$want_h2" != Xno; then
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
 
-    # use nghttp2_option_set_no_recv_client_magic to require nghttp2
-    # >= 1.0.0
-    AC_CHECK_LIB(nghttp2, nghttp2_option_set_no_recv_client_magic,
+    # use nghttp2_session_set_local_window_size to require nghttp2
+    # >= 1.12.0
+    AC_CHECK_LIB(nghttp2, nghttp2_session_set_local_window_size,
       [
        AC_CHECK_HEADERS(nghttp2/nghttp2.h,
           curl_h2_msg="enabled (nghttp2)"

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -97,7 +97,7 @@ Dependencies
  - NSS          3.14.x
  - PolarSSL     1.3.0
  - Heimdal      ?
- - nghttp2      1.0.0
+ - nghttp2      1.12.0
 
 Operating Systems
 -----------------


### PR DESCRIPTION
To simplify our code and since earlier versions lack important function
calls libcurl needs to function correctly.

nghttp2 1.12.0 was relased on June 26, 2016.