### PR TITLE
ntlm: Removed the dependency on the TLS libaries when using MD5

### DIFF
--- a/lib/curl_md5.h
+++ b/lib/curl_md5.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,8 +49,8 @@ typedef struct {
 extern const MD5_params Curl_DIGEST_MD5[1];
 extern const HMAC_params Curl_HMAC_MD5[1];
 
-void Curl_md5it(unsigned char *output,
-                const unsigned char *input);
+void Curl_md5it(unsigned char *output, const unsigned char *input,
+                const size_t len);
 
 MD5_context * Curl_MD5_init(const MD5_params *md5params);
 CURLcode Curl_MD5_update(MD5_context *context,

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -46,11 +46,9 @@
 #define USE_NTRESPONSES
 
 /* Define USE_NTLM2SESSION in order to make the type-3 message include the
-   NTLM2Session response message, requires USE_NTRESPONSES defined to 1 and a
-   Crypto engine that we have curl_ssl_md5sum() for. */
-#if defined(USE_NTRESPONSES) && \
-  (!defined(USE_WIN32_CRYPTO) || \
-  (defined(USE_SSL) && !defined(CURL_DISABLE_CRYPTO_AUTH)))
+   NTLM2Session response message, requires USE_NTRESPONSES defined to 1 and
+   MD5 support */
+#if defined(USE_NTRESPONSES) && !defined(CURL_DISABLE_CRYPTO_AUTH)
 #define USE_NTLM2SESSION
 #endif
 

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -27,7 +27,8 @@
 
 #define SHA256_DIGEST_LENGTH 32
 
-void Curl_sha256it(unsigned char *outbuffer, const unsigned char *input);
+void Curl_sha256it(unsigned char *outbuffer, const unsigned char *input,
+                   const size_t len);
 
 #endif
 

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -513,12 +513,13 @@ const MD5_params Curl_DIGEST_MD5[] = {
 /*
  * @unittest: 1601
  */
-void Curl_md5it(unsigned char *outbuffer, /* 16 bytes */
-                const unsigned char *input)
+void Curl_md5it(unsigned char *outbuffer, const unsigned char *input,
+                const size_t len)
 {
   MD5_CTX ctx;
+
   MD5_Init(&ctx);
-  MD5_Update(&ctx, input, curlx_uztoui(strlen((char *)input)));
+  MD5_Update(&ctx, input, curlx_uztoui(len));
   MD5_Final(outbuffer, &ctx);
 }
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -259,12 +259,13 @@ static int SHA256_Final(unsigned char *out,
 /*
  * @unittest: 1610
  */
-void Curl_sha256it(unsigned char *outbuffer, /* 32 unsigned chars */
-                   const unsigned char *input)
+void Curl_sha256it(unsigned char *outbuffer, const unsigned char *input,
+                   const size_t len)
 {
   SHA256_CTX ctx;
+
   SHA256_Init(&ctx);
-  SHA256_Update(&ctx, input, curlx_uztoui(strlen((char *)input)));
+  SHA256_Update(&ctx, input, curlx_uztoui(len));
   SHA256_Final(outbuffer, &ctx);
 }
 

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -660,7 +660,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 }
 
 /*
- * _Curl_auth_create_digest_http_message()
+ * auth_create_digest_http_message()
  *
  * This is used to generate a HTTP DIGEST response message ready for sending
  * to the recipient.
@@ -679,7 +679,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
  *
  * Returns CURLE_OK on success.
  */
-static CURLcode _Curl_auth_create_digest_http_message(
+static CURLcode auth_create_digest_http_message(
                   struct Curl_easy *data,
                   const char *userp,
                   const char *passwdp,
@@ -955,21 +955,21 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
   switch(digest->algo) {
   case CURLDIGESTALGO_MD5:
   case CURLDIGESTALGO_MD5SESS:
-    return _Curl_auth_create_digest_http_message(data, userp, passwdp,
-                                                 request, uripath, digest,
-                                                 outptr, outlen,
-                                                 auth_digest_md5_to_ascii,
-                                                 Curl_md5it);
+    return auth_create_digest_http_message(data, userp, passwdp,
+                                           request, uripath, digest,
+                                           outptr, outlen,
+                                           auth_digest_md5_to_ascii,
+                                           Curl_md5it);
 
   case CURLDIGESTALGO_SHA256:
   case CURLDIGESTALGO_SHA256SESS:
   case CURLDIGESTALGO_SHA512_256:
   case CURLDIGESTALGO_SHA512_256SESS:
-    return _Curl_auth_create_digest_http_message(data, userp, passwdp,
-                                                 request, uripath, digest,
-                                                 outptr, outlen,
-                                                 auth_digest_sha256_to_ascii,
-                                                 Curl_sha256it);
+    return auth_create_digest_http_message(data, userp, passwdp,
+                                           request, uripath, digest,
+                                           outptr, outlen,
+                                           auth_digest_sha256_to_ascii,
+                                           Curl_sha256it);
 
   default:
     return CURLE_UNSUPPORTED_PROTOCOL;

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -62,7 +62,7 @@
    what ultimately goes over the network.
 */
 #define CURL_OUTPUT_DIGEST_CONV(a, b) \
-  result = Curl_convert_to_network(a, (char *)b, strlen((const char *)b)); \
+  result = Curl_convert_to_network(a, b, strlen(b)); \
   if(result) { \
     free(b); \
     return result; \
@@ -688,12 +688,12 @@ static CURLcode auth_create_digest_http_message(
                   struct digestdata *digest,
                   char **outptr, size_t *outlen,
                   void (*convert_to_ascii)(unsigned char *, unsigned char *),
-                  void (*hash)(unsigned char *, const unsigned char *))
+                  void (*hash)(unsigned char *, const unsigned char *,
+                               const size_t))
 {
   CURLcode result;
   unsigned char hashbuf[32]; /* 32 bytes/256 bits */
   unsigned char request_digest[65];
-  unsigned char *hashthis;
   unsigned char ha1[65];    /* 64 digits and 1 zero byte */
   unsigned char ha2[65];    /* 64 digits and 1 zero byte */
   char userh[65];
@@ -701,6 +701,7 @@ static CURLcode auth_create_digest_http_message(
   size_t cnonce_sz = 0;
   char *userp_quoted;
   char *response = NULL;
+  char *hashthis = NULL;
   char *tmp = NULL;
 
   if(!digest->nc)
@@ -722,12 +723,12 @@ static CURLcode auth_create_digest_http_message(
   }
 
   if(digest->userhash) {
-    hashthis = (unsigned char *) aprintf("%s:%s", userp, digest->realm);
+    hashthis = aprintf("%s:%s", userp, digest->realm);
     if(!hashthis)
       return CURLE_OUT_OF_MEMORY;
 
     CURL_OUTPUT_DIGEST_CONV(data, hashthis);
-    hash(hashbuf, hashthis);
+    hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
     free(hashthis);
     convert_to_ascii(hashbuf, (unsigned char *)userh);
   }
@@ -743,14 +744,13 @@ static CURLcode auth_create_digest_http_message(
            unq(nonce-value) ":" unq(cnonce-value)
   */
 
-  hashthis = (unsigned char *)
-    aprintf("%s:%s:%s", digest->userhash ? userh : userp,
-                                    digest->realm, passwdp);
+  hashthis = aprintf("%s:%s:%s", digest->userhash ? userh : userp,
+                                 digest->realm, passwdp);
   if(!hashthis)
     return CURLE_OUT_OF_MEMORY;
 
   CURL_OUTPUT_DIGEST_CONV(data, hashthis); /* convert on non-ASCII machines */
-  hash(hashbuf, hashthis);
+  hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
   free(hashthis);
   convert_to_ascii(hashbuf, ha1);
 
@@ -763,7 +763,7 @@ static CURLcode auth_create_digest_http_message(
       return CURLE_OUT_OF_MEMORY;
 
     CURL_OUTPUT_DIGEST_CONV(data, tmp); /* Convert on non-ASCII machines */
-    hash(hashbuf, (unsigned char *) tmp);
+    hash(hashbuf, (unsigned char *) tmp, strlen(tmp));
     free(tmp);
     convert_to_ascii(hashbuf, ha1);
   }
@@ -781,19 +781,19 @@ static CURLcode auth_create_digest_http_message(
     5.1.1 of RFC 2616)
   */
 
-  hashthis = (unsigned char *) aprintf("%s:%s", request, uripath);
+  hashthis = aprintf("%s:%s", request, uripath);
   if(!hashthis)
     return CURLE_OUT_OF_MEMORY;
 
   if(digest->qop && strcasecompare(digest->qop, "auth-int")) {
     /* We don't support auth-int for PUT or POST */
     char hashed[65];
-    unsigned char *hashthis2;
+    char *hashthis2;
 
-    hash(hashbuf, (const unsigned char *)"");
+    hash(hashbuf, (const unsigned char *)"", 0);
     convert_to_ascii(hashbuf, (unsigned char *)hashed);
 
-    hashthis2 = (unsigned char *)aprintf("%s:%s", hashthis, hashed);
+    hashthis2 = aprintf("%s:%s", hashthis, hashed);
     free(hashthis);
     hashthis = hashthis2;
   }
@@ -802,31 +802,23 @@ static CURLcode auth_create_digest_http_message(
     return CURLE_OUT_OF_MEMORY;
 
   CURL_OUTPUT_DIGEST_CONV(data, hashthis); /* convert on non-ASCII machines */
-  hash(hashbuf, hashthis);
+  hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
   free(hashthis);
   convert_to_ascii(hashbuf, ha2);
 
   if(digest->qop) {
-    hashthis = (unsigned char *) aprintf("%s:%s:%08x:%s:%s:%s",
-                                        ha1,
-                                        digest->nonce,
-                                        digest->nc,
-                                        digest->cnonce,
-                                        digest->qop,
-                                        ha2);
+    hashthis = aprintf("%s:%s:%08x:%s:%s:%s", ha1, digest->nonce, digest->nc,
+                       digest->cnonce, digest->qop, ha2);
   }
   else {
-    hashthis = (unsigned char *) aprintf("%s:%s:%s",
-                                        ha1,
-                                        digest->nonce,
-                                        ha2);
+    hashthis = aprintf("%s:%s:%s", ha1, digest->nonce, ha2);
   }
 
   if(!hashthis)
     return CURLE_OUT_OF_MEMORY;
 
   CURL_OUTPUT_DIGEST_CONV(data, hashthis); /* convert on non-ASCII machines */
-  hash(hashbuf, hashthis);
+  hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
   free(hashthis);
   convert_to_ascii(hashbuf, request_digest);
 

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -40,6 +40,7 @@
 #include "curl_ntlm_core.h"
 #include "curl_gethostname.h"
 #include "curl_multibyte.h"
+#include "curl_md5.h"
 #include "warnless.h"
 #include "rand.h"
 #include "vtls/vtls.h"
@@ -621,11 +622,11 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
     memcpy(tmp, &ntlm->nonce[0], 8);
     memcpy(tmp + 8, entropy, 8);
 
-    result = Curl_ssl_md5sum(tmp, 16, md5sum, MD5_DIGEST_LENGTH);
-    if(!result)
-      /* We shall only use the first 8 bytes of md5sum, but the des code in
-         Curl_ntlm_core_lm_resp only encrypt the first 8 bytes */
-      result = Curl_ntlm_core_mk_nt_hash(data, passwdp, ntbuffer);
+    Curl_md5it(md5sum, tmp, 16);
+
+    /* We shall only use the first 8 bytes of md5sum, but the des code in
+       Curl_ntlm_core_lm_resp only encrypt the first 8 bytes */
+    result = Curl_ntlm_core_mk_nt_hash(data, passwdp, ntbuffer);
     if(result)
       return result;
 

--- a/tests/unit/unit1601.c
+++ b/tests/unit/unit1601.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -36,18 +36,20 @@ static void unit_stop(void)
 UNITTEST_START
 
 #ifndef CURL_DISABLE_CRYPTO_AUTH
-  unsigned char output[16];
+  const char string1[] = "1";
+  const char string2[] = "hello-you-fool";
+  unsigned char output[MD5_DIGEST_LEN];
   unsigned char *testp = output;
-  Curl_md5it(output, (const unsigned char *)"1");
 
-/* !checksrc! disable LONGLINE 2 */
-  verify_memory(testp,
-                "\xc4\xca\x42\x38\xa0\xb9\x23\x82\x0d\xcc\x50\x9a\x6f\x75\x84\x9b", 16);
+  Curl_md5it(output, (const unsigned char *) string1, strlen(string1));
 
-  Curl_md5it(output, (const unsigned char *)"hello-you-fool");
+  verify_memory(testp, "\xc4\xca\x42\x38\xa0\xb9\x23\x82\x0d\xcc\x50\x9a\x6f"
+                "\x75\x84\x9b", MD5_DIGEST_LEN);
 
-  verify_memory(testp,
-                "\x88\x67\x0b\x6d\x5d\x74\x2f\xad\xa5\xcd\xf9\xb6\x82\x87\x5f\x22", 16);
+  Curl_md5it(output, (const unsigned char *) string2, strlen(string2));
+
+  verify_memory(testp, "\x88\x67\x0b\x6d\x5d\x74\x2f\xad\xa5\xcd\xf9\xb6\x82"
+                "\x87\x5f\x22", MD5_DIGEST_LEN);
 #endif
 
 

--- a/tests/unit/unit1610.c
+++ b/tests/unit/unit1610.c
@@ -41,14 +41,14 @@ UNITTEST_START
   unsigned char output[SHA256_DIGEST_LENGTH];
   unsigned char *testp = output;
 
-  Curl_sha256it(output, (const unsigned char *) string1);
+  Curl_sha256it(output, (const unsigned char *) string1, strlen(string1));
 
   verify_memory(testp,
                 "\x6b\x86\xb2\x73\xff\x34\xfc\xe1\x9d\x6b\x80\x4e\xff\x5a\x3f"
                 "\x57\x47\xad\xa4\xea\xa2\x2f\x1d\x49\xc0\x1e\x52\xdd\xb7\x87"
                 "\x5b\x4b", SHA256_DIGEST_LENGTH);
 
-  Curl_sha256it(output, (const unsigned char *) string2);
+  Curl_sha256it(output, (const unsigned char *) string2, strlen(string2));
 
   verify_memory(testp,
                 "\xcb\xb1\x6a\x8a\xb9\xcb\xb9\x35\xa8\xcb\xa0\x2e\x28\xc0\x26"


### PR DESCRIPTION
As we have our own MD5 implementation use the MD5 wrapper to remove the TLS dependency.

Whilst related, this is independent to the work currently happening in [`captain-caveman:vtls_3des`](https://github.com/captain-caveman2k/curl/tree/vtls_3des) to remove the dependency on the TLS libraries for 3DES.
