### PR TITLE
ci/tests: Send test results to Azure DevOps for reporting purposes

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -29,6 +29,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: disable_ipv6
     displayName: ubuntu w/o IPv6
@@ -43,6 +45,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: disable_http_smtp_imap
     displayName: ubuntu w/o HTTP/SMTP/IMAP
@@ -57,6 +61,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: disable_thredres
     displayName: ubuntu sync resolver
@@ -71,6 +77,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: http_only
     displayName: ubuntu HTTP only
@@ -85,6 +93,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
 - stage: linux_torture
   dependsOn: linux
@@ -129,6 +139,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: macos_libssh2
     displayName: macos libssh2
@@ -146,6 +158,8 @@ stages:
 
     - script: make test-nonflaky
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: macos_cmake
     displayName: macos cmake openssl
@@ -205,6 +219,8 @@ stages:
 
     - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys2_mingw64_debug_openssl
     displayName: msys2 mingw64 debug openssl
@@ -226,6 +242,8 @@ stages:
 
     - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys1_mingw_debug_openssl
     displayName: msys1 mingw debug openssl
@@ -245,6 +263,8 @@ stages:
 
     - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys1_mingw32_debug_openssl
     displayName: msys1 mingw32 debug openssl
@@ -264,6 +284,8 @@ stages:
 
     - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys1_mingw64_debug_openssl
     displayName: msys1 mingw64 debug openssl
@@ -283,6 +305,8 @@ stages:
 
     - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys2_mingw32_debug_schannel
     displayName: msys2 mingw32 debug schannel
@@ -304,6 +328,8 @@ stages:
 
     - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys2_mingw64_debug_schannel
     displayName: msys2 mingw64 debug schannel
@@ -325,6 +351,8 @@ stages:
 
     - script: C:\msys64\usr\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys1_mingw_debug_schannel
     displayName: msys1 mingw debug schannel
@@ -344,6 +372,8 @@ stages:
 
     - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys1_mingw32_debug_schannel
     displayName: msys1 mingw32 debug schannel
@@ -363,6 +393,8 @@ stages:
 
     - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
 
   - job: windows_msys1_mingw64_debug_schannel
     displayName: msys1 mingw64 debug schannel
@@ -382,3 +414,5 @@ stages:
 
     - script: C:\MinGW\msys\1.0\bin\sh -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
+      env:
+        AZURE_ACCESS_TOKEN: "$(System.AccessToken)"

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -1,0 +1,120 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2020, Marc Hoersken, <info@marc-hoersken.de>
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.haxx.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+###########################################################################
+
+use strict;
+use warnings;
+
+use POSIX qw(strftime);
+
+sub azure_create_test_run {
+    my $azure_run=`curl \\
+    --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
+    --header "Content-Type: application/json" \\
+    --data "
+        {
+            'name': '$ENV{'AGENT_JOBNAME'}',
+            'automated': true,
+            'build': {'id': '$ENV{'BUILD_BUILDID'}'}
+        }
+    " \\
+    "https://dev.azure.com/$ENV{'BUILD_REPOSITORY_NAME'}/_apis/test/runs?api-version=5.0"`;
+    if($azure_run =~ /"id":(\d+)/) {
+        return $1;
+    }
+    return "";
+}
+
+sub azure_create_test_result {
+    my ($azure_run_id, $testnum, $testname)=@_;
+    my $azure_result=`curl \\
+    --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
+    --header "Content-Type: application/json" \\
+    --data "
+        [
+            {
+                'build': {'id': '$ENV{'BUILD_BUILDID'}'},
+                'testCase': {'id': $testnum},
+                'testCaseTitle': '$testname',
+                'automatedTestName': 'curl.tests.$testnum',
+                'outcome': 'InProgress'
+            }
+        ]
+    " \\
+    "https://dev.azure.com/$ENV{'BUILD_REPOSITORY_NAME'}/_apis/test/runs/$azure_run_id/results?api-version=5.0"`;
+    if($azure_result =~ /\[\{"id":(\d+)/) {
+        return $1;
+    }
+    return "";
+}
+
+sub azure_update_test_result {
+    my ($azure_run_id, $azure_result_id, $testnum, $error, $timeprepini, $timevrfyend)=@_;
+    my $azure_start = strftime "%FT%XZ", gmtime  $timeprepini;
+    my $azure_complete = strftime "%FT%XZ", gmtime $timevrfyend;
+    my $azure_duration = sprintf("%.0f", ($timevrfyend-$timeprepini)*1000);
+    my $azure_outcome;
+    if(!$error) {
+        $azure_outcome = 'Passed';
+    }
+    else {
+        $azure_outcome = 'Failed';
+    }
+    my $azure_result=`curl --request PATCH \\
+    --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
+    --header "Content-Type: application/json" \\
+    --data "
+        [
+            {
+                'id': $azure_result_id,
+                'outcome': '$azure_outcome',
+                'startedDate': '$azure_start',
+                'completedDate': '$azure_complete',
+                'durationInMs': $azure_duration
+            }
+        ]
+    " \\
+    "https://dev.azure.com/$ENV{'BUILD_REPOSITORY_NAME'}/_apis/test/runs/$azure_run_id/results?api-version=5.0"`;
+    if($azure_result =~ /\[\{"id":(\d+)/) {
+        return $1;
+    }
+    return "";
+}
+
+sub azure_update_test_run {
+    my ($azure_run_id)=@_;
+    my $azure_run=`curl --request PATCH \\
+    --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
+    --header "Content-Type: application/json" \\
+    --data "
+        {
+            'state': 'Completed'
+        }
+    " \\
+    "https://dev.azure.com/$ENV{'BUILD_REPOSITORY_NAME'}/_apis/test/runs/$azure_run_id?api-version=5.0"`;
+    if($azure_run =~ /"id":(\d+)/) {
+        return $1;
+    }
+    return "";
+}
+
+1;


### PR DESCRIPTION
This PR adds support for test case reporting within builds running on Azure DevOps / Pipelines.

An example can be seen here: https://mback2k.visualstudio.com/curl/_build/results?buildId=751&view=ms.vss-test-web.build-test-results-tab
![image](https://user-images.githubusercontent.com/231943/75098112-9de82d80-55b2-11ea-973f-c0949c3a171a.png)
Unfortunately the detailed test result statistics will only be available to project members:
![image](https://user-images.githubusercontent.com/231943/75097940-cb33dc00-55b0-11ea-85f2-e457e2a93593.png)
![image](https://user-images.githubusercontent.com/231943/75097945-dc7ce880-55b0-11ea-95dc-83bd1afa5025.png)

What do you think about this? This PR is not yet ready to be merged, because it needs some final rebase/fix before merge, especially in case PR #4866 is merged before.