### PR TITLE
tests: Automatically deduce the tool name from the test case for unit tests

### DIFF
--- a/tests/data/test1300
+++ b/tests/data/test1300
@@ -18,9 +18,6 @@ unittest
  <name>
 llist unit tests
  </name>
-<tool>
-unit1300
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1301
+++ b/tests/data/test1301
@@ -18,9 +18,6 @@ unittest
  <name>
 curl_strcasecompare unit tests
  </name>
-<tool>
-unit1301
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1302
+++ b/tests/data/test1302
@@ -18,9 +18,6 @@ unittest
  <name>
 base64 encode/decode unit tests
  </name>
-<tool>
-unit1302
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1303
+++ b/tests/data/test1303
@@ -18,9 +18,6 @@ unittest
  <name>
 Curl_timeleft unit tests
  </name>
-<tool>
-unit1303
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1304
+++ b/tests/data/test1304
@@ -18,9 +18,6 @@ unittest
  <name>
 netrc parsing unit tests
  </name>
-<tool>
-unit1304
-</tool>
 <file name="log/netrc1304">
 machine example.com login admin password passwd
 machine curl.example.com login none password none

--- a/tests/data/test1305
+++ b/tests/data/test1305
@@ -19,9 +19,6 @@ unittest
  <name>
 internal hash create/destroy testing
  </name>
-<tool>
-unit1305
-</tool>
 <command>
 1305
 </command>

--- a/tests/data/test1306
+++ b/tests/data/test1306
@@ -19,9 +19,6 @@ unittest
  <name>
 internal hash create/add/destroy testing
  </name>
-<tool>
-unit1305
-</tool>
 <command>
 1306
 </command>

--- a/tests/data/test1307
+++ b/tests/data/test1307
@@ -20,9 +20,6 @@ ftp
  <name>
 internal Curl_fnmatch() testing
  </name>
-<tool>
-unit1307
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1308
+++ b/tests/data/test1308
@@ -20,9 +20,6 @@ http
  <name>
 formpost unit tests
  </name>
-<tool>
-unit1308
-</tool>
 <file name="log/test-1308">
 Piece of the file that is to uploaded as a formpost
 </file>

--- a/tests/data/test1309
+++ b/tests/data/test1309
@@ -18,9 +18,6 @@ unittest
  <name>
 splay unit tests
  </name>
-<tool>
-unit1309
-</tool>
 </client>
 
 <verify>

--- a/tests/data/test1323
+++ b/tests/data/test1323
@@ -17,6 +17,9 @@ curlx_tvdiff
 <server>
 none
 </server>
+<features>
+unittest
+</features>
 <name>
 curlx_tvdiff
 </name>

--- a/tests/data/test1323
+++ b/tests/data/test1323
@@ -23,9 +23,6 @@ unittest
 <name>
 curlx_tvdiff
 </name>
-<tool>
-unit1323
-</tool>
 </client>
 
 #

--- a/tests/data/test1330
+++ b/tests/data/test1330
@@ -20,11 +20,6 @@ none
 unittest
 TrackMemory
 </features>
-# tool is what to use instead of 'curl'
-<tool>
-unit1330
-</tool>
-
 <name>
 unit tests memory tracking operational
 </name>

--- a/tests/data/test1394
+++ b/tests/data/test1394
@@ -17,9 +17,6 @@ unittest
  <name>
 unit test for parse_cert_parameter()
  </name>
-<tool>
-unit1394
-</tool>
 </client>
 
 <verify>

--- a/tests/data/test1395
+++ b/tests/data/test1395
@@ -17,10 +17,6 @@ unittest
  <name>
 Curl_dedotdotify
  </name>
-<tool>
-unit1395
-</tool>
-
 </client>
 
 </testcase>

--- a/tests/data/test1396
+++ b/tests/data/test1396
@@ -19,9 +19,6 @@ unittest
  <name>
 curl_easy_escape and curl_easy_unescape
  </name>
-<tool>
-unit1396
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1397
+++ b/tests/data/test1397
@@ -19,9 +19,6 @@ unittest
  <name>
 Check wildcard certificate matching function Curl_cert_hostcheck
  </name>
-<tool>
-unit1397
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1398
+++ b/tests/data/test1398
@@ -18,9 +18,6 @@ unittest
  <name>
 curl_msnprintf unit tests
  </name>
-<tool>
-unit1398
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1399
+++ b/tests/data/test1399
@@ -18,9 +18,6 @@ unittest
  <name>
 Curl_pgrsTime unit tests
  </name>
-<tool>
-unit1399
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1600
+++ b/tests/data/test1600
@@ -19,9 +19,6 @@ NTLM
  <name>
 NTLM unit tests
  </name>
-<tool>
-unit1600
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1601
+++ b/tests/data/test1601
@@ -18,9 +18,6 @@ unittest
  <name>
 MD5 unit tests
  </name>
-<tool>
-unit1601
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1602
+++ b/tests/data/test1602
@@ -18,9 +18,6 @@ unittest
  <name>
 Internal hash create/add/destroy testing, exercising clean functions
  </name>
-<tool>
-unit1602
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1603
+++ b/tests/data/test1603
@@ -18,9 +18,6 @@ unittest
  <name>
 Internal hash add, retrieval, deletion testing
  </name>
-<tool>
-unit1603
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1604
+++ b/tests/data/test1604
@@ -17,9 +17,6 @@ unittest
  <name>
 Test WIN32/MSDOS filename sanitization
  </name>
-<tool>
-unit1604
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1605
+++ b/tests/data/test1605
@@ -17,9 +17,6 @@ unittest
  <name>
 Test negative data lengths as input to libcurl functions
  </name>
-<tool>
-unit1605
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1606
+++ b/tests/data/test1606
@@ -18,9 +18,6 @@ unittest
  <name>
 verify speedcheck
  </name>
-<tool>
-unit1606
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1607
+++ b/tests/data/test1607
@@ -18,9 +18,6 @@ unittest
  <name>
 CURLOPT_RESOLVE parsing
  </name>
-<tool>
-unit1607
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1608
+++ b/tests/data/test1608
@@ -18,9 +18,6 @@ unittest
  <name>
 verify DNS shuffling
  </name>
-<tool>
-unit1608
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1609
+++ b/tests/data/test1609
@@ -18,9 +18,6 @@ unittest
  <name>
 CURLOPT_RESOLVE parsing
  </name>
-<tool>
-unit1609
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1610
+++ b/tests/data/test1610
@@ -18,9 +18,6 @@ unittest
  <name>
 SHA256 unit tests
  </name>
-<tool>
-unit1610
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1611
+++ b/tests/data/test1611
@@ -18,9 +18,6 @@ unittest
  <name>
 MD4 unit tests
  </name>
-<tool>
-unit1611
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1612
+++ b/tests/data/test1612
@@ -18,9 +18,6 @@ unittest
  <name>
 HMAC unit tests
  </name>
-<tool>
-unit1612
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1620
+++ b/tests/data/test1620
@@ -18,9 +18,6 @@ unittest
  <name>
 unit tests for url.c
  </name>
-<tool>
-unit1620
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1621
+++ b/tests/data/test1621
@@ -19,9 +19,6 @@ https
  <name>
 unit tests for stripcredentials from URL
  </name>
-<tool>
-unit1621
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1650
+++ b/tests/data/test1650
@@ -19,9 +19,6 @@ DoH
  <name>
 DOH
  </name>
-<tool>
-unit1650
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1651
+++ b/tests/data/test1651
@@ -18,9 +18,6 @@ unittest
  <name>
 x509 parsing
  </name>
-<tool>
-unit1651
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test1652
+++ b/tests/data/test1652
@@ -16,8 +16,5 @@ unittest
 <name>
 infof
 </name>
-<tool>
-unit1652
-</tool>
 </client>
 </testcase>

--- a/tests/data/test1653
+++ b/tests/data/test1653
@@ -16,8 +16,5 @@ unittest
 <name>
 urlapi
 </name>
-<tool>
-unit1653
-</tool>
 </client>
 </testcase>

--- a/tests/data/test1654
+++ b/tests/data/test1654
@@ -26,9 +26,6 @@ alt-svc
 <command>
 log/1654
 </command>
-<tool>
-unit1654
-</tool>
 <file name="log/1654" mode="text">
 h2 example.com 443 h3 shiny.example.com 8443 "20191231 00:00:00" 0 1
 # a comment

--- a/tests/data/test1655
+++ b/tests/data/test1655
@@ -19,9 +19,6 @@ DoH
  <name>
 unit test for doh_encode
  </name>
-<tool>
-unit1655
-</tool>
 </client>
 
 </testcase>

--- a/tests/data/test517
+++ b/tests/data/test517
@@ -15,11 +15,6 @@ unittest
 <server>
 none
 </server>
-# tool is what to use instead of 'curl'
-<tool>
-lib517
-</tool>
-
  <name>
 curl_getdate() testing
  </name>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -296,7 +296,8 @@ my %timevrfyend; # timestamp for each test result verification end
 
 my $testnumcheck; # test number, set in singletest sub.
 my %oldenv;
-my %feature; # array of enabled features
+my %feature;      # array of enabled features
+my %keywords;     # array of keywords from the test spec
 
 #######################################################################
 # variables that command line options may set
@@ -3306,21 +3307,26 @@ sub singletest {
     }
 
     if(!$why) {
-        my @keywords = getpart("info", "keywords");
+        my @info_keywords = getpart("info", "keywords");
         my $match;
         my $k;
 
-        if(!$keywords[0]) {
+        # Clear the list of keywords from the last test
+        %keywords = {};
+
+        if(!$info_keywords[0]) {
             $why = "missing the <keywords> section!";
         }
 
-        for $k (@keywords) {
+        for $k (@info_keywords) {
             chomp $k;
             if ($disabled_keywords{lc($k)}) {
                 $why = "disabled by keyword";
             } elsif ($enabled_keywords{lc($k)}) {
                 $match = 1;
             }
+
+            $keywords{$k} = 1;
         }
 
         if(!$why && !$match && %enabled_keywords) {
@@ -3616,7 +3622,7 @@ sub singletest {
         $tool=$CMDLINE;
         $disablevalgrind=1;
     }
-    elsif(!$tool) {
+    elsif(!$tool && !$keywords{"unittest"}) {
         # run curl, add suitable command line options
         my $inc="";
         if((!$cmdhash{'option'}) || ($cmdhash{'option'} !~ /no-include/)) {
@@ -3635,6 +3641,11 @@ sub singletest {
     else {
         $cmdargs = " $cmd"; # $cmd is the command line for the test file
         $CURLOUT = $STDOUT; # sends received data to stdout
+
+        # Default the tool to a unit test with the same name as the test spec
+        if($keywords{"unittest"} && !$tool) {
+            $tool="unit$testnum";
+        }
 
         if($tool =~ /^lib/) {
             $CMDLINE="$LIBDIR/$tool";


### PR DESCRIPTION
It is still possible to override the executable to run during the test, using the `<tool>` tag, but this patch removes the requirement that the tag **must** be present for unit tests.

It also removes the possibility of human error when existing test specs are used as the basis for new tests, as recently witnessed in 81c37124.