### PR TITLE
md4: Use non-deprecated functions in mbedTLS >= 2.7.0

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -29,10 +29,16 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
-#endif
+#endif /* USE_OPENSSL */
+
 #ifdef USE_MBEDTLS
 #include <mbedtls/config.h>
+#include <mbedtls/version.h>
+
+#if(MBEDTLS_VERSION_NUMBER >= 0x02070000)
+  #define HAS_RESULT_CODE_BASED_FUNCTIONS
 #endif
+#endif /* USE_MBEDTLS */
 
 #if defined(USE_GNUTLS_NETTLE)
 
@@ -182,6 +188,7 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 #include <mbedtls/md4.h>
 
 #include "curl_memory.h"
+
 /* The last #include file should be: */
 #include "memdebug.h"
 
@@ -210,7 +217,11 @@ static void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size)
 static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 {
   if(ctx->data != NULL) {
+#ifndef HAS_RESULT_CODE_BASED_FUNCTIONS
     mbedtls_md4(ctx->data, ctx->size, result);
+#else
+    (void) mbedtls_md4_ret(ctx->data, ctx->size, result);
+#endif
 
     Curl_safefree(ctx->data);
     ctx->size = 0;


### PR DESCRIPTION
Compiling --with-warnings enabled produces the following:
````
/curl/lib/md4.c:213:5: warning: 'mbedtls_md4' is deprecated [-Wdeprecated-declarations]
````

As of mbedTLS 2.7.0 all hash functions return 0 on success and the new functions whilst use a similar name have `_ret` appended to them.

See this [autobuild](https://curl.haxx.se/dev/log.cgi?id=20200226173150-1306) for more details.

