### PR TITLE
gtls: Fixed compilation when GnuTLS < 3.5.0

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -664,7 +664,11 @@ gtls_connect_step1(struct connectdata *conn,
   }
 
   /* Initialize TLS session as a client */
-  init_flags = GNUTLS_CLIENT | GNUTLS_FORCE_CLIENT_CERT;
+  init_flags = GNUTLS_CLIENT;
+
+#if defined(GNUTLS_FORCE_CLIENT_CERT)
+  init_flags |= GNUTLS_FORCE_CLIENT_CERT;
+#endif
 
 #if defined(GNUTLS_NO_TICKETS)
   /* Disable TLS session tickets */


### PR DESCRIPTION
Commit 41fcb4f6 from #4958 breaks compiling with GnuTLS older than 3.5.0 (Specifically 3.4.10) with the following error:

````
/curl/lib/vtls/gtls.c:667:32: error: 'GNUTLS_FORCE_CLIENT_CERT' undeclared (first use in this function)
init_flags = GNUTLS_CLIENT | GNUTLS_FORCE_CLIENT_CERT;
````
See this [autobuild ](https://curl.haxx.se/dev/log.cgi?id=20200227003158-5061#prob1)for more details.

With this fix, curl builds successfully and executes `runtest.pl` with the following summary:

````
Warning: dict server unexpectedly alive
Warning: smb server unexpectedly alive
TESTDONE: 1247 tests out of 1247 reported OK: 100%
TESTDONE: 1319 tests were considered during 462 seconds.
make[1]: Leaving directory '/home/steve/Development/cc2k/tests'
````