### PR TITLE
Curl_is_ASCII_name: handle a NULL argument

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1773,8 +1773,6 @@ static CURLcode smtp_parse_address(struct connectdata *conn, const char *fqma,
        and send the host name using UTF-8 rather than as 7-bit ACE (which is
        our preference) */
   }
-  else
-    host->name = NULL;
 
   /* Extract the local address from the mailbox */
   *address = dup;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1438,7 +1438,11 @@ void Curl_verboseconnect(struct connectdata *conn)
  */
 bool Curl_is_ASCII_name(const char *hostname)
 {
+  /* get an UNSIGNED local version of the pointer */
   const unsigned char *ch = (const unsigned char *)hostname;
+
+  if(!hostname) /* bad input, consider it ASCII! */
+    return TRUE;
 
   while(*ch) {
     if(*ch++ & 0x80)


### PR DESCRIPTION
Make the function tolerate a NULL pointer input to avoid dereferencing
that pointer.

Follow-up to efce3ea5a85126d
Detected by OSS-Fuzz

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20907
Fixes #4985