### PR TITLE
tool_getparam: escape spaces in form content with +

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
           compiler: gcc
           dist: trusty
           env:
-              - T=normal C="--enable-ares"
+              - T=debug C="--enable-ares --enable-debug "
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
           compiler: gcc
           dist: trusty
           env:
-              - T=debug C="--enable-ares --enable-debug "
+              - T=normal C="--enable-ares"
               - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
         - os: linux
           compiler: gcc

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -338,13 +338,6 @@ problems may have been fixed or changed somewhat since this was written!
 
  See https://github.com/curl/curl/issues/2051
 
-4.5 Improve --data-urlencode space encoding
-
- ASCII space characters in --data-urlencode are currently encoded as %20
- rather than +, which RFC 1866 says should be used.
-
- See https://github.com/curl/curl/issues/3229
-
 5. Build and portability issues
 
 5.1 USE_UNIX_SOCKETS on Windows

--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -62,7 +62,7 @@ if [ "$T" = "normal" ]; then
     # Only done on Linux since we're not permitted to on mac.
     sudo rm -f /usr/bin/curl
   fi
-  ./configure --enable-warnings --enable-werror $C
+  ./configure --enable-warnings --enable-werror $C CFLAGS="-g -fno-omit-frame-pointer"
   make
   make examples
   if [ -z $NOTESTS ]; then

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1420,6 +1420,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
             size_t outlen;
             char *n;
             char *reenc = replace_url_encoded_space_with_plus(enc);
+            fprintf(stderr, "enc: %p\n", enc);
+            fprintf(stderr, "reenc: %p\n", reenc);
             curl_free(enc);
             if(!reenc)
               return PARAM_NO_MEM;
@@ -1429,20 +1431,27 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                encoded string */
             outlen = nlen + strlen(enc) + 2;
             n = malloc(outlen);
+            fprintf(stderr, "n: %p\n", n);
             if(!n) {
               free(enc);
               return PARAM_NO_MEM;
             }
             if(nlen > 0) { /* only append '=' if we have a name */
+              fprintf(stderr, "marker1\n");
               msnprintf(n, outlen, "%.*s=%s", nlen, nextarg, enc);
+              fprintf(stderr, "marker2\n");
               size = outlen-1;
             }
             else {
+              fprintf(stderr, "marker3\n");
               strcpy(n, enc);
+              fprintf(stderr, "marker4\n");
               size = outlen-2; /* since no '=' was inserted */
             }
             free(enc);
             postdata = n;
+            fprintf(stderr, "postdata = n. size %zu, strlen(postdata): %zu\n",
+                    size, strlen(postdata));
           }
           else
             return PARAM_NO_MEM;
@@ -1509,17 +1518,25 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         char *oldpost = config->postfields;
         curl_off_t oldlen = config->postfieldsize;
         curl_off_t newlen = oldlen + curlx_uztoso(size) + 2;
+        fprintf(stderr, "marker6\n");
         config->postfields = malloc((size_t)newlen);
+        fprintf(stderr, "config->postfields: %p\n", config->postfields);
+        fprintf(stderr, "marker7\n");
         if(!config->postfields) {
           Curl_safefree(oldpost);
           Curl_safefree(postdata);
           return PARAM_NO_MEM;
         }
+        fprintf(stderr, "marker8\n");
         memcpy(config->postfields, oldpost, (size_t)oldlen);
+        fprintf(stderr, "marker9\n");
         /* use byte value 0x26 for '&' to accommodate non-ASCII platforms */
         config->postfields[oldlen] = '\x26';
+        fprintf(stderr, "marker10\n");
         memcpy(&config->postfields[oldlen + 1], postdata, size);
+        fprintf(stderr, "marker11\n");
         config->postfields[oldlen + 1 + size] = '\0';
+        fprintf(stderr, "marker12\n");
         Curl_safefree(oldpost);
         Curl_safefree(postdata);
         config->postfieldsize += size + 1;

--- a/tests/data/test1015
+++ b/tests/data/test1015
@@ -28,7 +28,7 @@ http
 --data-urlencode
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/1015 --data-urlencode "my name is moo[]" --data-urlencode "y e s=s_i_r" --data-urlencode "v_alue@log/1015.txt" --data-urlencode @log/1015.txt 
+http://%HOSTIP:%HTTPPORT/1015 --data-urlencode "my name is moo[] " --data-urlencode "y e s=s_i r" --data-urlencode "v_alue@log/1015.txt" --data-urlencode @log/1015.txt --data-urlencode double%20encoded
 </command>
 <file name="log/1015.txt">
 content to _?!#$'|<>
@@ -46,10 +46,10 @@ POST /1015 HTTP/1.1
 User-Agent: curl/7.17.2-CVS (i686-pc-linux-gnu) libcurl/7.17.2-CVS OpenSSL/0.9.8g zlib/1.2.3.3 c-ares/1.5.2-CVS libidn/1.1 libssh2/0.19.0-C
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 133
+Content-Length: 139
 Content-Type: application/x-www-form-urlencoded
 
-my%20name%20is%20moo%5B%5D&y e s=s_i_r&v_alue=content%20to%20_%3F%21%23%24%27%7C%3C%3E%0A&content%20to%20_%3F%21%23%24%27%7C%3C%3E%0A
+my+name+is+moo%5B%5D+&y e s=s_i+r&v_alue=content+to+_%3F%21%23%24%27%7C%3C%3E%0A&content+to+_%3F%21%23%24%27%7C%3C%3E%0A&double%2520encoded
 </protocol>
 </verify>
 </testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -658,7 +658,7 @@ sub torture {
                 $valgrindcmd .= "--suppressions=$srcdir/valgrind.supp ";
                 # $valgrindcmd .= "--gen-suppressions=all ";
                 $valgrindcmd .= "--num-callers=16 ";
-                $valgrindcmd .= "${valgrind_logfile}=$LOGDIR/valgrind$testnum";
+                $valgrindcmd .= "--track-origins=yes ";
                 $cmd = "$valgrindcmd $testcmd";
             }
         }


### PR DESCRIPTION
According to RFC1866, in form-urlencoded content "space characters are
replaced by `+', and then reserved characters are escaped as per URL."

Fixes #3229

(This is me cleaning up and taking #4924 further)