### PR TITLE
http: mark POSTs with no body as "upload done" from the start

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3044,6 +3044,8 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
   }
   if(result)
     return result;
+  if(!postsize)
+    data->req.upload_done = TRUE;
 
   if(data->req.writebytecount) {
     /* if a request-body has been sent off, we make sure this progress is noted


### PR DESCRIPTION
As we have logic that checks if we get a >= 400 reponse code back before
the upload is done, which then got confused since it wasn't "done" but
yet there was no data to send!

Reported-by: @IvanoG
Fixes #4996