### PR TITLE
configure.ac: Disable metalink support if an incompatible SSL/TLS specified

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2770,6 +2770,12 @@ if test X"$OPT_LIBMETALINK" != Xno; then
       AC_MSG_NOTICE([libmetalink library defective or too old])
       want_metalink="no"
     ])
+    if test "x$OPENSSL_ENABLED" != "x1" -a "x$USE_WINDOWS_SSPI" != "x1" \
+        -a "x$GNUTLS_ENABLED" != "x1" -a "x$MBEDTLS_ENABLED" != "x1" \
+        -a "x$NSS_ENABLED" != "x1" -a "x$SECURETRANSPORT_ENABLED" != "x1"; then
+      AC_MSG_WARN([metalink support requires a compatible SSL/TLS backend])
+      want_metalink="no"
+    fi
     CPPFLAGS="$clean_CPPFLAGS"
     LDFLAGS="$clean_LDFLAGS"
     LIBS="$clean_LIBS"


### PR DESCRIPTION
`tool_metalink.c` only supports cryptography from OpenSSL, GnuTLS, NSS, The Win32 Crypto library and Apple's Common Crypto library.

If an TLS backend such as WolfSSL or BearSSL is specified the the following error is given during compilation along with a load of unresolved extern errors:
````
Can't compile METALINK support without a crypto library.
````

This can be seen in the [mbedTLS](https://curl.haxx.se/dev/log.cgi?id=20200229173147-19617) and [WolfSSL](https://curl.haxx.se/dev/log.cgi?id=20200229203148-32368) autobuilds.