### PR TITLE
configure.ac: Disable metalink if mbedTLS is specified

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2771,8 +2771,8 @@ if test X"$OPT_LIBMETALINK" != Xno; then
       want_metalink="no"
     ])
     if test "x$OPENSSL_ENABLED" != "x1" -a "x$USE_WINDOWS_SSPI" != "x1" \
-        -a "x$GNUTLS_ENABLED" != "x1" -a "x$MBEDTLS_ENABLED" != "x1" \
-        -a "x$NSS_ENABLED" != "x1" -a "x$SECURETRANSPORT_ENABLED" != "x1"; then
+        -a "x$GNUTLS_ENABLED" != "x1" -a "x$NSS_ENABLED" != "x1" \
+        -a "x$SECURETRANSPORT_ENABLED" != "x1"; then
       AC_MSG_WARN([metalink support requires a compatible SSL/TLS backend])
       want_metalink="no"
     fi


### PR DESCRIPTION
Follow up to cdcc9df1 and #5006. Even though I mentioned mbedTLS as being one of the backends that metalink needs to be disabled for, I seem to have included it in the list of allowed SSL/TLS backends in comnfigure.ac :(

As seen in this more recent [autobuild](https://curl.haxx.se/dev/log.cgi?id=20200302013216-2326#prob1).