### PR TITLE
curl_getenv.3: Fix the memory handling description

### DIFF
--- a/docs/libcurl/curl_getenv.3
+++ b/docs/libcurl/curl_getenv.3
@@ -31,15 +31,15 @@ curl_getenv - return value for environment name
 curl_getenv() is a portable wrapper for the getenv() function, meant to
 emulate its behaviour and provide an identical interface for all operating
 systems libcurl builds on (including win32).
+
+You must \fIcurl_free(3)\fP the returned string when you're done with it.
 .SH AVAILABILITY
 This function will be removed from the public libcurl API in a near future. It
 will instead be made "available" by source code access only, and then as
 curlx_getenv().
 .SH RETURN VALUE
-If successful, curl_getenv() returns a pointer to the value of the specified
-environment. The memory it refers to is malloc()ed so the application must
-free() this when the data is no longer needed. When \fIcurl_getenv(3)\fP fails
-to find the specified name, it returns a null pointer.
+A pointer to a zero terminated string or NULL if it failed to find the
+specified name.
 .SH NOTE
 Under unix operating systems, there isn't any point in returning an allocated
 memory, although other systems won't work properly if this isn't done. The


### PR DESCRIPTION
- Tell the user to call curl_free() to free the pointer returned by
  curl_getenv().

Prior to this change the user was directed to call free(), but that
would not work in cases where the library and application use separate C
runtimes and therefore have separate heap memory management.

Closes #xxxx