### PR TITLE
global_init: atomic initialize counter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -118,6 +118,7 @@ AC_SUBST(libext)
 dnl figure out the libcurl version
 CURLVERSION=`$SED -ne 's/^#define LIBCURL_VERSION "\(.*\)".*/\1/p' ${srcdir}/include/curl/curlver.h`
 XC_CHECK_PROG_CC
+CURL_ATOMIC
 
 dnl for --enable-code-coverage
 CURL_COVERAGE

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -84,8 +84,13 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+/* _Atomic is a C11 feature */
+#ifndef HAVE_ATOMIC
+#define _Atomic
+#endif
+
 /* true globals -- for curl_global_init() and curl_global_cleanup() */
-static unsigned int  initialized;
+static _Atomic unsigned int  initialized;
 static long          init_flags;
 
 /*
@@ -140,8 +145,7 @@ curl_calloc_callback Curl_ccalloc;
  */
 static CURLcode global_init(long flags, bool memoryfuncs)
 {
-  if(initialized++)
-    return CURLE_OK;
+  initialized++;
 
   if(memoryfuncs) {
     /* Setup the default memory functions here (again) */
@@ -258,8 +262,13 @@ void curl_global_cleanup(void)
   if(!initialized)
     return;
 
+#ifdef WIN32
+  if(InterlockedDecrement((LPLONG)&initialized))
+    return;
+#else
   if(--initialized)
     return;
+#endif
 
   Curl_ssl_cleanup();
   Curl_resolver_global_cleanup();

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -7334,3 +7334,26 @@ AC_DEFUN([CURL_COVERAGE],[
     LIBS="$LIBS -lgcov"
   fi
 ])
+
+dnl CURL_ATOMIC
+dnl --------------------------------------------------
+dnl Check if _Atomic works
+dnl
+AC_DEFUN([CURL_ATOMIC],[
+  AC_MSG_CHECKING([if _Atomic is available])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_unistd
+    ]],[[
+      _Atomic int i = 0;
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE_UNQUOTED(HAVE_ATOMIC, 1,
+      [Define to 1 if you have _Atomic support.])
+    tst_atomic="yes"
+  ],[
+    AC_MSG_RESULT([no])
+    tst_atomic="no"
+  ])
+])


### PR DESCRIPTION
With the use a Windows specific function and _Atomic for the rest.
    
`_Atomic` is a C11 feature that when available makes the init reference counter atomic and thread-safe.
    
init: call the init functions independent of counter
    
cleanup: decrements the counter and will only do the cleanups when the counter reaches zero

Part of the thread-safe `curl_global_init` effort.