### PR TITLE
configure: check for OpenSSL flavor with thread-unsafe init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@ curl_verbose_msg="enabled (--disable-verbose)"
    curl_rtmp_msg="no      (--with-librtmp)"
   curl_mtlnk_msg="no      (--with-libmetalink)"
     curl_psl_msg="no      (--with-libpsl)"
+ curl_ssl_threadsafe="yes"
 
     ssl_backends=
 
@@ -1887,6 +1888,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
        fi
     fi
     CURL_CHECK_OPENSSL_API
+    CURL_CHECK_OPENSSL_THREADSAFE
     check_for_ca_bundle=1
   fi
 
@@ -4910,6 +4912,7 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   HTTP2:            ${curl_h2_msg}
   HTTP3:            ${curl_h3_msg}
   ESNI:             ${curl_esni_msg}
+  SSL thread-safe:  ${curl_ssl_threadsafe}
   Protocols:        ${SUPPORT_PROTOCOLS}
   Features:         ${SUPPORT_FEATURES}
 ])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2011, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -275,4 +275,30 @@ AC_DEFUN([CURL_CHECK_OPENSSL_API], [
   if test "$tst_match" != "yes"; then
     AC_MSG_WARN([$tst_warns])
   fi
+])
+
+dnl CURL_CHECK_OPENSSL_THREADSAFE
+dnl OpenSSL >= 1.1.0 and BoringSSL have thread-safe init
+dnl -----------------------------------------------------
+
+AC_DEFUN([CURL_CHECK_OPENSSL_THREADSAFE], [
+  AC_MSG_CHECKING([for thread-safe OpenSSL flavor])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      #include <openssl/opensslv.h>
+    ]],[[
+      #if ((OPENSSL_VERSION_NUMBER < 0x10100000L) || \
+        defined(LIBRESSL_VERSION_NUMBER)) && \
+        !defined(OPENSSL_IS_BORINGSSL)
+      #error "not thread-safe"
+      #endif
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE_UNQUOTED(HAVE_OPENSSL_THREADSAFE, 1,
+      [Define to 1 if using a thread-safe OpenSSL flavor])
+  ],[
+    AC_MSG_RESULT([no])
+    curl_ssl_threadsafe="no"
+ ])
 ])


### PR DESCRIPTION
I want to be able to use this to set a feature flag or something for when `curl_global_init` is thread-safe.