### PR TITLE
multi_wait: stop loop when sread() returns zero

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1199,7 +1199,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
                data from it until it receives an error (except EINTR).
                In normal cases it will get EAGAIN or EWOULDBLOCK
                when there is no more data, breaking the loop. */
-            if(sread(multi->wakeup_pair[0], buf, sizeof(buf)) < 0) {
+            if(sread(multi->wakeup_pair[0], buf, sizeof(buf)) <= 0) {
 #ifndef USE_WINSOCK
               if(EINTR == SOCKERRNO)
                 continue;


### PR DESCRIPTION
It's unclear why it would ever return zero here, but this change fixes
Robert's problem and it shouldn't loop forever...

Reported-by: Robert Dunaj
Buf: https://curl.haxx.se/mail/archive-2020-02/0011.html