### PR TITLE
cmake: Show HTTPS-proxy in the features output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1264,6 +1264,7 @@ _add_if("NTLM_WB"     use_ntlm AND NOT CURL_DISABLE_HTTP AND NTLM_WB_ENABLED)
 _add_if("TLS-SRP"       USE_TLS_SRP)
 # TODO option --with-nghttp2 tests for nghttp2 lib and nghttp2/nghttp2.h header
 _add_if("HTTP2"         USE_NGHTTP2)
+_add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS OR USE_NSS))
 string(REPLACE ";" " " SUPPORT_FEATURES "${_items}")
 message(STATUS "Enabled features: ${SUPPORT_FEATURES}")
 


### PR DESCRIPTION
- Show HTTPS-proxy in the features output for those backends that
  support it: OpenSSL, GnuTLS and NSS.

Prior to this change HTTPS-proxy was missing from the cmake features
output even if curl was built with it. Only cmake output was affected.
Both the library and tool correctly reported the feature.

Bug: https://curl.haxx.se/mail/lib-2020-03/0008.html
Reported-by: David Lopes

Closes #xxxx