### PR TITLE
cirrus-ci: disable the FreeBSD 13 builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
   freebsd_instance:
     matrix:
       # A stable 13.0 image likely won't be available before early 2021
-      image_family: freebsd-13-0-snap
+      # image_family: freebsd-13-0-snap
       image_family: freebsd-12-1
       # The stable 11.3 image causes "Agent is not responding" so use a snapshot
       image_family: freebsd-11-3-snap


### PR DESCRIPTION
FreeBSD 13.0 is apparently close to a year away from a stable release
and has proven to cause intermittent builds failures recently.

Assisted-by: Dan Fandrich
Assisted-by: Fedor Korotkov
Fixes #5028