### PR TITLE
ci/tests: fix escaping of testnames and disable proxy for CI APIs

### DIFF
--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -35,8 +35,11 @@ sub appveyor_check_environment {
 
 sub appveyor_create_test_result {
     my ($testnum, $testname)=@_;
+    $testname =~ s/\\/\\\\/g;
+    $testname =~ s/\'/\\\'/g;
+    $testname =~ s/\"/\\\"/g;
     my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`curl --silent \\
+    my $appveyor_result=`curl --silent --noproxy "*" \\
     --header "Content-Type: application/json" \\
     --data "
         {
@@ -80,7 +83,7 @@ sub appveyor_update_test_result {
         $appveyor_category = 'Error';
     }
     my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`curl --silent --request PUT \\
+    my $appveyor_result=`curl --silent --noproxy "*" --request PUT \\
     --header "Content-Type: application/json" \\
     --data "
         {
@@ -94,11 +97,11 @@ sub appveyor_update_test_result {
     "$appveyor_baseurl/api/tests"`;
     print $appveyor_result;
     if($appveyor_category eq 'Error') {
-        $appveyor_result=`curl --silent \\
+        $appveyor_result=`curl --silent --noproxy "*" \\
         --header "Content-Type: application/json" \\
         --data "
             {
-                'message': '$testname',
+                'message': '$testname $appveyor_outcome',
                 'category': '$appveyor_category',
                 'details': 'Test $testnum $appveyor_outcome'
             }

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -38,7 +38,7 @@ sub azure_check_environment {
 
 sub azure_create_test_run {
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`curl --silent \\
+    my $azure_run=`curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -57,8 +57,11 @@ sub azure_create_test_run {
 
 sub azure_create_test_result {
     my ($azure_run_id, $testnum, $testname)=@_;
+    $testname =~ s/\\/\\\\/g;
+    $testname =~ s/\'/\\\'/g;
+    $testname =~ s/\"/\\\"/g;
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`curl --silent \\
+    my $azure_result=`curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -101,7 +104,7 @@ sub azure_update_test_result {
         $azure_outcome = 'Failed';
     }
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`curl --silent --request PATCH \\
+    my $azure_result=`curl --silent --noproxy "*" --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -125,7 +128,7 @@ sub azure_update_test_result {
 sub azure_update_test_run {
     my ($azure_run_id)=@_;
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`curl --silent --request PATCH \\
+    my $azure_run=`curl --silent --noproxy "*" --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "


### PR DESCRIPTION
Fixes error messages like the following in the AppVeyor builds:
```
{
    "message": "Object reference not set to an instance of an object.",
    "exceptionMessage": "Object reference not set to an instance of an object.",
    "exceptionType": "System.NullReferenceException",
    "stackTrace": "
   at Appveyor.BuildAgent.BuildJobHubClient.<UpdateTests>b__47_0(UpdateTestRequest t)
   at System.Linq.Enumerable.WhereSelectArrayIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Appveyor.BuildAgent.BuildJobHubClient.UpdateTests(String jobId, UpdateTestRequest[] tests)
   at Appveyor.BuildAgent.Controllers.TestsController.UpdateTest(UpdateTestRequest test)
   at System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ActionExecutor.<>c__DisplayClassc.<GetExecutor>b__6(Object instance, Object[] methodParameters)
   at System.Web.Http.Controllers.ReflectedHttpActionDescriptor.ExecuteAsync(HttpControllerContext controllerContext, IDictionary`2 arguments, CancellationToken cancellationToken)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Web.Http.Controllers.ApiControllerActionInvoker.<InvokeActionAsyncCore>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Web.Http.Controllers.ExceptionFilterResult.<ExecuteAsync>d__0.MoveNext()
    "
}
```