### PR TITLE
multi: skip EINTR check on wakeup socket if it was closed

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1194,14 +1194,16 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
       if(use_wakeup && multi->wakeup_pair[0] != CURL_SOCKET_BAD) {
         if(ufds[curlfds + extra_nfds].revents & POLLIN) {
           char buf[64];
+          ssize_t nread;
           while(1) {
             /* the reading socket is non-blocking, try to read
                data from it until it receives an error (except EINTR).
                In normal cases it will get EAGAIN or EWOULDBLOCK
                when there is no more data, breaking the loop. */
-            if(sread(multi->wakeup_pair[0], buf, sizeof(buf)) <= 0) {
+            nread = sread(multi->wakeup_pair[0], buf, sizeof(buf));
+            if(nread <= 0) {
 #ifndef USE_WINSOCK
-              if(EINTR == SOCKERRNO)
+              if(nread < 0 && EINTR == SOCKERRNO)
                 continue;
 #endif
               break;


### PR DESCRIPTION
- Don't check errno on wakeup socket if sread returned 0 since sread
  doesn't set errno in that case.

This is a follow-up to cf7760a from several days ago which fixed
Curl_multi_wait to stop busy looping sread on the non-blocking wakeup
socket if it was closed (ie sread returns 0). Due to a logic error it
was still possible to busy loop in that case if errno == EINTR.

Closes #xxxx