### PR TITLE
curl_share_setopt.3: Note sharing cookies doesn't enable the engine

### DIFF
--- a/docs/libcurl/curl_share_setopt.3
+++ b/docs/libcurl/curl_share_setopt.3
@@ -59,6 +59,8 @@ be set to one of the values described below.
 .RS
 .IP CURL_LOCK_DATA_COOKIE
 Cookie data will be shared across the easy handles using this shared object.
+Note that this does not activate an easy handle's cookie handling. You can do
+that separately by using \fICURLOPT_COOKIEFILE(3)\fP for example.
 .IP CURL_LOCK_DATA_DNS
 Cached DNS hosts will be shared across the easy handles using this shared
 object. Note that when you use the multi interface, all easy handles added to


### PR DESCRIPTION
Follow-up to d0a7ee3 which fixed a bug in 7.66.0 that caused
CURL_LOCK_DATA_COOKIE to enable the easy handle's cookie engine.

Bug: https://curl.haxx.se/mail/lib-2020-03/0019.html
Reported-by: Felipe Gasper

Closes #xxxx