### PR TITLE
pause: force a connection (re-)check after unpausing

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1034,6 +1034,10 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
   if((newstate & (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) !=
      (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) {
     Curl_expire(data, 0, EXPIRE_RUN_NOW); /* get this handle going again */
+
+    /* force a recv/send check of this connection, as the data might've been
+       read off the socket already */
+    data->conn->cselect_bits = CURL_CSELECT_IN | CURL_CSELECT_OUT;
     if(data->multi)
       Curl_update_timer(data->multi);
   }


### PR DESCRIPTION
There might be data available that was already read off the socket, for
example in the TLS layer.

Reported-by: Anders Berg
Fixes #4966