### PR TITLE
lib1564: reduce number of mid-wait wakeup calls

### DIFF
--- a/tests/libtest/lib1564.c
+++ b/tests/libtest/lib1564.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,7 +26,7 @@
 #include "memdebug.h"
 
 #define TEST_HANG_TIMEOUT 60 * 1000
-#define WAKEUP_NUM 1234567
+#define WAKEUP_NUM 10
 
 int test(char *URL)
 {


### PR DESCRIPTION
This test does A LOT of *wakeup() calls and then calls curl_multi_poll()
twice. The first *poll() is then expected to return early and the second
not - as the first is supposed to drain the socketpair pipe.

It turns out however that when given "excessive" amounts of writes to
the pipe, some operating systems (the Solaris based are known) will
return EAGAIN before the pipe is drained, which in our test case causes
the second *poll() call to also abort early.

This change attempts to avoid the OS-specific behaviors in the test by
reducing the amount of wakeup calls from 1234567 to 10.

Reported-by: Andy Fiddaman (@citrus-it)
Fixes #5037