### PR TITLE
docs: add warnings about FILE: URLs on Windows

### DIFF
--- a/docs/cmdline-opts/url.d
+++ b/docs/cmdline-opts/url.d
@@ -14,5 +14,5 @@ setting a default protocol, see --proto-default for details.
 This option may be used any number of times. To control where this URL is
 written, use the --output or the --remote-name options.
 
-Warwning: On Windows, particular file:// accesses can be converted to network
+Warning: On Windows, particular file:// accesses can be converted to network
 accesses by the operating system. Beware!

--- a/docs/cmdline-opts/url.d
+++ b/docs/cmdline-opts/url.d
@@ -13,3 +13,6 @@ setting a default protocol, see --proto-default for details.
 
 This option may be used any number of times. To control where this URL is
 written, use the --output or the --remote-name options.
+
+Warwning: On Windows, particular file:// accesses can be converted to network
+accesses by the operating system. Beware!

--- a/docs/libcurl/libcurl-security.3
+++ b/docs/libcurl/libcurl-security.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -217,6 +217,32 @@ avoid that, keep control of what URLs to use and/or prevent curl/libcurl from
 using the protocol.
 
 By default, libcurl prohibits redirects to file:// URLs.
+
+.SH "Warning: file:// on Windows"
+The Windows operating system will automatically, and without any way for
+applications to disable it, try to establish a connection to another host over
+the network and access it (over SMB or other protocols), if only the correct
+file path is accessed.
+
+When first realizing this, the curl team tried to filter out such attempts in
+order to protect applications for inadvertent probes of for example internal
+networks etc. This resulted in CVE-2019-15601 and the associated security fix.
+
+However, we've since been made aware of the fact that the previous fix was far
+from adequate as there are several other ways to accomplish more or less the
+same thing: accessing a remote host over the network instead of the local file
+system.
+
+The conclusion we have come to is that this is a weakness or feature in the
+Windows operating system itself, that we as an application cannot safely
+protect users against. It would just be a whack-a-mole race we don't want to
+participate in. There are too many ways to do it and there's no knob we can
+use to turn off the practice.
+
+If you use curl or libcurl on Windows (any version), disable the use of the
+FILE protocol in curl or be prepared that accesses to a range of "magic paths"
+will potentially make your system try to access other hosts on your
+network. curl cannot protect you against this.
 .SH "What if the user can set the URL"
 Applications may find it tempting to let users set the URL that it can work
 on. That's probably fine, but opens up for mischief and trickery that you as

--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -152,6 +152,10 @@ path.
 ftp://user:password@ftp.example.com//readme.txt - This retrieves the readme.txt
 from the root directory when logging in as a specified user.
 
+.IP FILE
+When a FILE:// URL is accessed on Windows systems, it can be crafted in a way
+so that Windows attempts to connect to a (remote) machine when curl wants to
+read or write such a path.
 .IP SMTP
 The path part of a SMTP request specifies the host name to present during
 communication with the mail server. If the path is omitted then libcurl will


### PR DESCRIPTION
  - --url man page section
  - libcurl-security.3 gets the full text
  - CURLOPT_URL.3

Reported-by: Tim Sedlmeyer (via hackerone)

---
I intend to also:
  - send a special "warning" to the curl-library mailing list 
  - blog about it
  - update the [CVE-2019-15601](https://curl.haxx.se/docs/CVE-2019-15601.html) description to backpedal accordingly

I want to merge/post this information (no earlier than) March 16th to not make it get lost too much in the regular release noise this week.

To discuss: should we retract CVE-2019-15601 from the list of curl vulnerabilities or doesn't it matter?