### PR TITLE
configure: document 'compiler_num' for gcc

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -151,8 +151,17 @@ AC_DEFUN([CURL_CHECK_COMPILER_DEC_C], [
 
 dnl CURL_CHECK_COMPILER_GNU_C
 dnl -------------------------------------------------
-dnl Verify if compiler being used is GNU C.
-
+dnl Verify if compiler being used is GNU C
+dnl
+dnl $compiler_num will be set to MAJOR * 100 + MINOR for gcc less than version
+dnl 7 and just $MAJOR * 100 for gcc version 7 and later.
+dnl
+dnl Examples:
+dnl Version 1.2.3 => 102
+dnl Version 2.95  => 295
+dnl Version 4.7 =>   407
+dnl Version 9.2.1 => 900
+dnl
 AC_DEFUN([CURL_CHECK_COMPILER_GNU_C], [
   AC_REQUIRE([CURL_CHECK_COMPILER_INTEL_C])dnl
   AC_REQUIRE([CURL_CHECK_COMPILER_CLANG])dnl


### PR DESCRIPTION
The CURL_CHECK_COMPILER_GNU_C function sets the number to MAJOR*100 +
MINOR and ignores the patch version, and since gcc version 7 it only
sets it to MAJOR*100.

Reported-by: Stepan Efremov
Ref: #5067