### PR TITLE
server/getpart: make the "XML-parser" stricter

### DIFF
--- a/tests/curl_test_data.py
+++ b/tests/curl_test_data.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
+#                                  _   _ ____  _
 #  Project                     ___| | | |  _ \| |
 #                             / __| | | | |_) | |
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2017 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -30,7 +30,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-REPLY_DATA = re.compile("<reply>\s*<data>(.*?)</data>", re.MULTILINE | re.DOTALL)
+REPLY_DATA = re.compile("<reply>[ \t\n\r]*<data[^<]*>(.*?)</data>", re.MULTILINE | re.DOTALL)
 
 
 class TestData(object):

--- a/tests/data/test1451
+++ b/tests/data/test1451
@@ -8,7 +8,9 @@ SMB
 #
 # Server-side
 <reply>
-<data>Basic SMB test complete</data>
+<data nocheck="yes">
+Basic SMB test complete
+</data>
 </reply>
 
 #
@@ -20,10 +22,10 @@ smb
 <features>
 smb
 </features>
- <name>
+<name>
 Basic SMB request
- </name>
- <command>
+</name>
+<command>
 -u 'curltest:curltest' smb://%HOSTIP:%SMBPORT/TESTS/1451
 </command>
 </client>
@@ -31,6 +33,8 @@ Basic SMB request
 #
 # Verify data after the test has been "shot"
 <verify>
-<stdout>Basic SMB test complete</stdout>
+<stdout>
+Basic SMB test complete
+</stdout>
 </verify>
 </testcase>

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -23,6 +23,7 @@
 #use strict;
 
 my @xml;
+my $xmlfile;
 
 my $warning=0;
 my $trace=0;
@@ -80,11 +81,10 @@ sub getpart {
     my @this;
     my $inside=0;
     my $base64=0;
-
- #   print "Section: $section, part: $part\n";
+    my $line;
 
     for(@xml) {
- #       print "$inside: $_";
+        $line++;
         if(!$inside && ($_ =~ /^ *\<$section/)) {
             $inside++;
         }
@@ -105,6 +105,10 @@ sub getpart {
             $inside--;
         }
         elsif(($inside >= 1) && ($_ =~ /^ *\<\/$section/)) {
+            if($inside > 1) {
+                print STDERR "$xmlfile:$line:1: error: missing </$part> tag before </$section>\n";
+                @this = ("format error in $xmlfile");
+            }
             if($trace && @this) {
                 print STDERR "*** getpart.pm: $section/$part returned data!\n";
             }
@@ -165,6 +169,7 @@ sub loadtest {
     my ($file)=@_;
 
     undef @xml;
+    $xmlfile = $file;
 
     if(open(XML, "<$file")) {
         binmode XML; # for crapage systems, use binary


### PR DESCRIPTION
When extracting a `<section> <part>` and there's no `</part>` before `</section>`, this now outputs an error and returns a wrong string to make users spot the mistake.

Ref: #5070