### PR TITLE
Makefile: run the cd commands in a subshell

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -289,15 +289,15 @@ cygwinbin:
 
 # We extend the standard install with a custom hook:
 install-data-hook:
-	cd include && $(MAKE) install
-	cd docs && $(MAKE) install
-	cd docs/libcurl && $(MAKE) install
+	(cd include && $(MAKE) install)
+	(cd docs && $(MAKE) install)
+	(cd docs/libcurl && $(MAKE) install)
 
 # We extend the standard uninstall with a custom hook:
 uninstall-hook:
-	cd include && $(MAKE) uninstall
-	cd docs && $(MAKE) uninstall
-	cd docs/libcurl && $(MAKE) uninstall
+	(cd include && $(MAKE) uninstall)
+	(cd docs && $(MAKE) uninstall)
+	(cd docs/libcurl && $(MAKE) uninstall)
 
 ca-bundle: lib/mk-ca-bundle.pl
 	@echo "generating a fresh ca-bundle.crt"
@@ -308,11 +308,11 @@ ca-firefox: lib/firefox-db2pem.sh
 	./lib/firefox-db2pem.sh lib/ca-bundle.crt
 
 checksrc:
-	cd lib && $(MAKE) checksrc
-	cd src && $(MAKE) checksrc
-	cd tests && $(MAKE) checksrc
-	cd include/curl && $(MAKE) checksrc
-	cd docs/examples && $(MAKE) checksrc
+	(cd lib && $(MAKE) checksrc)
+	(cd src && $(MAKE) checksrc)
+	(cd tests && $(MAKE) checksrc)
+	(cd include/curl && $(MAKE) checksrc)
+	(cd docs/examples && $(MAKE) checksrc)
 
 .PHONY: vc-ide
 


### PR DESCRIPTION
In [bmake](http://www.crufty.net/help/sjg/bmake.html), if the directory is changed (with cd or anything else), bmake won't return to the "root directory"  on the next command (in the same Makefile rule). This commit runs the cd command in a subshell so it would work in bmake. This has been applied in https://github.com/curl/curl/blob/fb6134427a2452d36b2002c0955fa13da1ffa8d9/Makefile.am#L726 so I don't see why it shouldn't apply anywhere else.

Logs:
[Before my commit](https://termbin.com/vkuy)
[After my commit](https://termbin.com/uze4)