### PR TITLE
select: move duplicate select preparation code into Curl_select

### DIFF
--- a/lib/select.c
+++ b/lib/select.c
@@ -119,7 +119,7 @@ int Curl_select(curl_socket_t maxfd,
 {
   struct timeval pending_tv;
   struct timeval *ptimeout;
-  int pending_ms = 0;
+  int pending_ms;
   int r;
 
 #ifdef USE_WINSOCK
@@ -197,7 +197,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
 {
 #ifdef HAVE_POLL_FINE
   struct pollfd pfd[3];
-  int pending_ms = 0;
+  int pending_ms;
   int num;
 #else
   fd_set fds_read;
@@ -252,7 +252,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
     pending_ms = (int)timeout_ms;
   else if(timeout_ms < 0)
     pending_ms = -1;
-  else if(!timeout_ms)
+  else
     pending_ms = 0;
   r = poll(pfd, num, pending_ms);
 
@@ -374,7 +374,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
 int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
 {
 #ifdef HAVE_POLL_FINE
-  int pending_ms = 0;
+  int pending_ms;
 #else
   fd_set fds_read;
   fd_set fds_write;
@@ -409,7 +409,7 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms)
     pending_ms = timeout_ms;
   else if(timeout_ms < 0)
     pending_ms = -1;
-  else if(!timeout_ms)
+  else
     pending_ms = 0;
   r = poll(ufds, nfds, pending_ms);
 

--- a/lib/select.c
+++ b/lib/select.c
@@ -122,6 +122,12 @@ int Curl_select(curl_socket_t maxfd,
   int pending_ms;
   int r;
 
+#if SIZEOF_TIME_T != SIZEOF_INT
+  /* wrap-around precaution */
+  if(timeout_ms >= INT_MAX)
+    timeout_ms = INT_MAX;
+#endif
+
 #ifdef USE_WINSOCK
   /* WinSock select() can't handle zero events.  See the comment below. */
   if((!fds_read || fds_read->fd_count == 0) &&

--- a/lib/select.h
+++ b/lib/select.h
@@ -72,6 +72,12 @@ struct pollfd
    therefore defined here */
 #define CURL_CSELECT_IN2 (CURL_CSELECT_ERR << 1)
 
+int Curl_select(curl_socket_t maxfd,
+                fd_set *fds_read,
+                fd_set *fds_write,
+                fd_set *fds_err,
+                time_t timeout_ms);
+
 int Curl_socket_check(curl_socket_t readfd, curl_socket_t readfd2,
                       curl_socket_t writefd,
                       time_t timeout_ms);


### PR DESCRIPTION
This introduces a re-used wrapper around select() to aid in Windows compatibility and timeout struct setup/preparation.