### PR TITLE
smbserver: pin Python version to 2 since we are not yet 3 compatible

### DIFF
--- a/tests/python_dependencies/impacket/smb.py
+++ b/tests/python_dependencies/impacket/smb.py
@@ -57,10 +57,14 @@ import hashlib
 unicode_support = 0
 unicode_convert = 1
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+import sys
+if sys.version_info.major >= 3:
+    from io import StringIO
+else:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
 
 # Dialect for SMB1
 SMB_DIALECT = 'NT LM 0.12'

--- a/tests/python_dependencies/impacket/smbserver.py
+++ b/tests/python_dependencies/impacket/smbserver.py
@@ -29,9 +29,10 @@ import struct
 import sys
 if sys.version_info.major >= 3:
     import configparser
+    import socketserver
 else:
     import ConfigParser as configparser
-import SocketServer
+    import SocketServer as socketserver
 import threading
 import logging
 import logging.config
@@ -3519,7 +3520,7 @@ class Ioctls:
         return validateNegotiateInfo.getData(), errorCode
 
 
-class SMBSERVERHandler(SocketServer.BaseRequestHandler):
+class SMBSERVERHandler(socketserver.BaseRequestHandler):
     def __init__(self, request, client_address, server, select_poll = False):
         self.__SMB = server
         self.__ip, self.__port = client_address
@@ -3528,7 +3529,7 @@ class SMBSERVERHandler(SocketServer.BaseRequestHandler):
         self.__timeOut = 60*5
         self.__select_poll = select_poll
         #self.__connId = os.getpid()
-        SocketServer.BaseRequestHandler.__init__(self, request, client_address, server)
+        socketserver.BaseRequestHandler.__init__(self, request, client_address, server)
 
     def handle(self):
         self.__SMB.log("Incoming connection (%s,%d)" % (self.__ip, self.__port))
@@ -3570,13 +3571,13 @@ class SMBSERVERHandler(SocketServer.BaseRequestHandler):
         # Thread/process is dying, we should tell the main SMB thread to remove all this thread data
         self.__SMB.log("Closing down connection (%s,%d)" % (self.__ip, self.__port))
         self.__SMB.removeConnection(self.__connId)
-        return SocketServer.BaseRequestHandler.finish(self)
+        return socketserver.BaseRequestHandler.finish(self)
 
-class SMBSERVER(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
-#class SMBSERVER(SocketServer.ForkingMixIn, SocketServer.TCPServer):
+class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
+#class SMBSERVER(socketserver.ForkingMixIn, socketserver.TCPServer):
     def __init__(self, server_address, handler_class=SMBSERVERHandler, config_parser = None):
-        SocketServer.TCPServer.allow_reuse_address = True
-        SocketServer.TCPServer.__init__(self, server_address, handler_class)
+        socketserver.TCPServer.allow_reuse_address = True
+        socketserver.TCPServer.__init__(self, server_address, handler_class)
 
         # Server name and OS to be presented whenever is necessary
         self.__serverName   = ''

--- a/tests/python_dependencies/impacket/spnego.py
+++ b/tests/python_dependencies/impacket/spnego.py
@@ -31,7 +31,7 @@ MechTypes = {
 '*\x86H\x86\xf7\x12\x01\x02\x02': 'KRB5 - Kerberos 5',
 '*\x86H\x86\xf7\x12\x01\x02\x02\x03': 'KRB5 - Kerberos 5 - User to User'
 }
-TypesMech = dict((v,k) for k, v in MechTypes.iteritems())
+TypesMech = dict((v,k) for k, v in MechTypes.items())
 
 def asn1encode(data = ''):
     #res = asn1.SEQUENCE(str).encode()

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  Project                     ___| | | |  _ \| |


### PR DESCRIPTION
Even though the existing code can be fixed to run on Python 3, the
tests will fail due to the Unicode transition the protocol is invalid.

Follow up to ee63837