### PR TITLE
easy: Fix curl_easy_duphandle for builds missing IPv6 that use c-ares

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -884,14 +884,25 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
     goto fail;
 
 #ifdef USE_ARES
-  if(Curl_set_dns_servers(outcurl, data->set.str[STRING_DNS_SERVERS]))
-    goto fail;
-  if(Curl_set_dns_interface(outcurl, data->set.str[STRING_DNS_INTERFACE]))
-    goto fail;
-  if(Curl_set_dns_local_ip4(outcurl, data->set.str[STRING_DNS_LOCAL_IP4]))
-    goto fail;
-  if(Curl_set_dns_local_ip6(outcurl, data->set.str[STRING_DNS_LOCAL_IP6]))
-    goto fail;
+  {
+    CURLcode rc;
+
+    rc = Curl_set_dns_servers(outcurl, data->set.str[STRING_DNS_SERVERS]);
+    if(rc && rc != CURLE_NOT_BUILT_IN)
+      goto fail;
+
+    rc = Curl_set_dns_interface(outcurl, data->set.str[STRING_DNS_INTERFACE]);
+    if(rc && rc != CURLE_NOT_BUILT_IN)
+      goto fail;
+
+    rc = Curl_set_dns_local_ip4(outcurl, data->set.str[STRING_DNS_LOCAL_IP4]);
+    if(rc && rc != CURLE_NOT_BUILT_IN)
+      goto fail;
+
+    rc = Curl_set_dns_local_ip6(outcurl, data->set.str[STRING_DNS_LOCAL_IP6]);
+    if(rc && rc != CURLE_NOT_BUILT_IN)
+      goto fail;
+  }
 #endif /* USE_ARES */
 
   Curl_convert_setup(outcurl);


### PR DESCRIPTION
- Ignore CURLE_NOT_BUILT_IN errors returned by c-ares functions in
  curl_easy_duphandle.

Prior to this change if c-ares was used as the resolver backend and
either it was too old or libcurl was built without IPv6 support then
some of our resolver functions could return CURLE_NOT_BUILT_IN to
curl_easy_duphandle causing it to fail.

Caused by c8f086b which shipped in 7.69.1.

Reported-by: Karl Chen

Fixes https://github.com/curl/curl/issues/5097
Closes #xxxx
