### PR TITLE
Makefile.m32: Improve windres parameter compatibility

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -106,7 +106,7 @@ CFLAGS += -fno-strict-aliasing
 # comment LDFLAGS below to keep debug info
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -O COFF
+RCFLAGS = --include-dir=$(PROOT)/include -O coff
 
 # Set environment var ARCH to your architecture to override autodetection.
 ifndef ARCH

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -99,7 +99,7 @@ LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL) -s
 AR = $(CURL_AR)
 RANLIB = $(CURL_RANLIB)
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -DDEBUGBUILD=0 -O COFF
+RCFLAGS = --include-dir=$(PROOT)/include -DDEBUGBUILD=0 -O coff
 STRIP   = $(CROSSPREFIX)strip -g
 
 # Set environment var ARCH to your architecture to override autodetection.

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -107,7 +107,7 @@ CFLAGS += -fno-strict-aliasing
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s
 AR = $(CURL_AR)
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -O COFF -DCURL_EMBED_MANIFEST
+RCFLAGS = --include-dir=$(PROOT)/include -O coff -DCURL_EMBED_MANIFEST
 STRIP   = $(CROSSPREFIX)strip -g
 
 # We may need these someday


### PR DESCRIPTION
- s/COFF/coff/

Some versions of windres do not recognize uppercase COFF as a valid
way to specify the COFF output format.

Reported-by: Steven Penny

Fixes https://github.com/curl/curl/issues/5099
Closes #xxxx