### PR TITLE
[WIP] select: always use time_t for timeout_ms

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -509,7 +509,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     before = Curl_now();
 
     /* wait for activity or timeout */
-    pollrc = Curl_poll(fds, numfds, (int)ev->ms);
+    pollrc = Curl_poll(fds, numfds, ev->ms);
 
     after = Curl_now();
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1235,7 +1235,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
          timeout */
       else if((sleep_ms < 0) && extrawait)
         sleep_ms = timeout_ms;
-      Curl_wait_ms((int)sleep_ms);
+      Curl_wait_ms(sleep_ms);
     }
   }
 

--- a/lib/select.h
+++ b/lib/select.h
@@ -86,8 +86,8 @@ int Curl_socket_check(curl_socket_t readfd, curl_socket_t readfd2,
 #define SOCKET_WRITABLE(x,z) \
   Curl_socket_check(CURL_SOCKET_BAD, CURL_SOCKET_BAD, x, (time_t)z)
 
-int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms);
-int Curl_wait_ms(int timeout_ms);
+int Curl_poll(struct pollfd ufds[], unsigned int nfds, time_t timeout_ms);
+int Curl_wait_ms(time_t timeout_ms);
 
 #ifdef TPF
 int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,


### PR DESCRIPTION
Align/unify data type of timeout variables in `select.[ch]`.