### PR TITLE
vtls: free ssl_config leftovers on out-of-memory

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -489,6 +489,7 @@ CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
   store->scheme = conn->handler->scheme;
 
   if(!Curl_clone_primary_ssl_config(ssl_config, &store->ssl_config)) {
+    Curl_free_primary_ssl_config(&store->ssl_config);
     store->sessionid = NULL; /* let caller free sessionid */
     free(clone_host);
     free(clone_conn_to_host);


### PR DESCRIPTION
Torture testing 2034 and 2037 found this.

Reported-by: Marc Hörsken
Fixes #5108