### PR TITLE
ci/tests: fix Azure Pipelines not running for pull requests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -4,8 +4,16 @@
 # https://aka.ms/yaml
 
 trigger:
-- 'master'
-- '*/ci'
+  branches:
+    include:
+    - 'master'
+    - '*/ci'
+
+pr:
+  branches:
+    include:
+    - 'master'
+    - '*/ci'
 
 stages:
 


### PR DESCRIPTION
Let's see if this makes Azure Pipelines run for PRs again.

It did not for the following PRs suddenly:
- #5110 
- #5109 
- #5107 
- #5106 
- #5103 
- #5094 

and maybe more...