### PR TITLE
tool_operate: fix add_parallel_transfers when more are in queue

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2055,7 +2055,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
   *addedp = FALSE;
   *morep = FALSE;
   result = create_transfer(global, share, addedp);
-  if(result || !*addedp)
+  if(result)
     return result;
   for(per = transfers; per && (all_added < global->parallel_max);
       per = per->next) {


### PR DESCRIPTION
Trying to return early from the function if no new transfers were added
would break the "morep" argument and cause issues. This could lead to zero
content "transfers" (within quotes since they would never be started)
when parallel-max was reduced.

Reported-by: Gavin Wong (@flashercs)
Analyzed-by: Jay Satiro (@jay)
Fixes #4937