### PR TITLE
writeout_json: use curl_off_t printf() option for the time output

### DIFF
--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -84,7 +84,8 @@ static int writeTime(FILE *str, CURL *curl, const char *key, CURLINFO ci)
   if(CURLE_OK == curl_easy_getinfo(curl, ci, &val)) {
     curl_off_t s = val / 1000000l;
     curl_off_t ms = val % 1000000l;
-    fprintf(str, "\"%s\":%ld.%06ld", key, s, ms);
+    fprintf(str, "\"%s\":%" CURL_FORMAT_CURL_OFF_T
+            ".%06" CURL_FORMAT_CURL_OFF_T, key, s, ms);
     return 1;
   }
   return 0;


### PR DESCRIPTION
Follow-up to: 04c03416e68fd635a15