### PR TITLE
multi: Improve parameter check for curl_multi_remove_handle

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -283,8 +283,8 @@ Things are fine.
 The passed-in handle is not a valid CURLM handle.
 .IP "CURLM_BAD_EASY_HANDLE (2)"
 An easy handle was not good/valid. It could mean that it isn't an easy handle
-at all, or possibly that the handle already is in used by this or another
-multi handle.
+at all, or possibly that the handle already is in use by this or another multi
+handle.
 .IP "CURLM_OUT_OF_MEMORY (3)"
 You are doomed.
 .IP "CURLM_INTERNAL_ERROR (4)"

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -700,6 +700,10 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   if(!data->multi)
     return CURLM_OK; /* it is already removed so let's say it is fine! */
 
+  /* Prevent users from trying to remove an easy handle from the wrong multi */
+  if(data->multi != multi)
+    return CURLM_BAD_EASY_HANDLE;
+
   if(multi->in_callback)
     return CURLM_RECURSIVE_API_CALL;
 


### PR DESCRIPTION
- If an easy handle is owned by a multi different from the one specified
  then return CURLM_BAD_EASY_HANDLE.

Prior to this change I assume user error could cause corruption.

Closes #xxxx
