### PR TITLE
http2: Fix erroneous debug message that h2 connection closed

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1727,8 +1727,6 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
 
     return retlen;
   }
-  /* If this stream is closed, return 0 to signal the http routine to close
-     the connection */
   if(stream->closed)
     return 0;
   *err = CURLE_AGAIN;


### PR DESCRIPTION
Prior to this change in libcurl debug builds http2 stream closure was
erroneously referred to as connection closure.

Before:
* nread <= 0, server closed connection, bailing

After:
* nread == 0, stream closed, bailing

Closes #xxxx

---

curld -v https://httpbin.org/get https://httpbin.org/get

~~~
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
...
* nread <= 0, server closed connection, bailing
* STATE: PERFORM => DONE handle 0x4acbc8; line 2195 (connection #0)
* multi_done
* Connection #0 to host httpbin.org left intact
* Expire cleared (transfer 0x4acbc8)
* STATE: INIT => CONNECT handle 0x4acbc8; line 1619 (connection #-5000)
* Found bundle for host httpbin.org: 0x477b70 [can multiplex]
* Re-using existing connection! (#0) with host httpbin.org
...
~~~

Curl_read calls the underlying read (http2_recv) which returns 0 when the stream is closed:

https://github.com/curl/curl/blob/b81e0b07784dc4c1e8d0a86194b9d28776d071c0/lib/transfer.c#L590-L629

https://github.com/curl/curl/blob/b81e0b07784dc4c1e8d0a86194b9d28776d071c0/lib/http2.c#L1730-L1733

I don't understand that comment. When the stream is closed that does not mean the connection should be closed.