### PR TITLE
tls: remove the BACKEND define

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2019, Michael Forney, <mforney@mforney.org>
+ * Copyright (C) 2019 - 2020, Michael Forney, <mforney@mforney.org>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -55,8 +55,6 @@ struct ssl_backend_data {
   /* size of pending write, yet to be flushed */
   size_t pending_write;
 };
-
-#define BACKEND connssl->backend
 
 struct cafile_parser {
   CURLcode err;
@@ -300,6 +298,7 @@ static CURLcode bearssl_connect_step1(struct connectdata *conn, int sockindex)
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   const char * const ssl_cafile = SSL_CONN_CONFIG(CAfile);
   const char *hostname = SSL_IS_PROXY() ? conn->http_proxy.host.name :
     conn->host.name;
@@ -343,7 +342,7 @@ static CURLcode bearssl_connect_step1(struct connectdata *conn, int sockindex)
   }
 
   if(ssl_cafile) {
-    ret = load_cafile(ssl_cafile, &BACKEND->anchors, &BACKEND->anchors_len);
+    ret = load_cafile(ssl_cafile, &backend->anchors, &backend->anchors_len);
     if(ret != CURLE_OK) {
       if(verifypeer) {
         failf(data, "error setting certificate verify locations:\n"
@@ -356,24 +355,24 @@ static CURLcode bearssl_connect_step1(struct connectdata *conn, int sockindex)
   }
 
   /* initialize SSL context */
-  br_ssl_client_init_full(&BACKEND->ctx, &BACKEND->x509.minimal,
-                          BACKEND->anchors, BACKEND->anchors_len);
-  br_ssl_engine_set_versions(&BACKEND->ctx.eng, version_min, version_max);
-  br_ssl_engine_set_buffer(&BACKEND->ctx.eng, BACKEND->buf,
-                           sizeof(BACKEND->buf), 1);
+  br_ssl_client_init_full(&backend->ctx, &backend->x509.minimal,
+                          backend->anchors, backend->anchors_len);
+  br_ssl_engine_set_versions(&backend->ctx.eng, version_min, version_max);
+  br_ssl_engine_set_buffer(&backend->ctx.eng, backend->buf,
+                           sizeof(backend->buf), 1);
 
   /* initialize X.509 context */
-  BACKEND->x509.vtable = &x509_vtable;
-  BACKEND->x509.verifypeer = verifypeer;
-  BACKEND->x509.verifyhost = verifyhost;
-  br_ssl_engine_set_x509(&BACKEND->ctx.eng, &BACKEND->x509.vtable);
+  backend->x509.vtable = &x509_vtable;
+  backend->x509.verifypeer = verifypeer;
+  backend->x509.verifyhost = verifyhost;
+  br_ssl_engine_set_x509(&backend->ctx.eng, &backend->x509.vtable);
 
   if(SSL_SET_OPTION(primary.sessionid)) {
     void *session;
 
     Curl_ssl_sessionid_lock(conn);
     if(!Curl_ssl_getsessionid(conn, &session, NULL, sockindex)) {
-      br_ssl_engine_set_session_parameters(&BACKEND->ctx.eng, session);
+      br_ssl_engine_set_session_parameters(&backend->ctx.eng, session);
       infof(data, "BearSSL: re-using session ID\n");
     }
     Curl_ssl_sessionid_unlock(conn);
@@ -389,16 +388,16 @@ static CURLcode bearssl_connect_step1(struct connectdata *conn, int sockindex)
 #ifdef USE_NGHTTP2
     if(data->set.httpversion >= CURL_HTTP_VERSION_2 &&
        (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)) {
-      BACKEND->protocols[cur++] = NGHTTP2_PROTO_VERSION_ID;
+      backend->protocols[cur++] = NGHTTP2_PROTO_VERSION_ID;
       infof(data, "ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
     }
 #endif
 
-    BACKEND->protocols[cur++] = ALPN_HTTP_1_1;
+    backend->protocols[cur++] = ALPN_HTTP_1_1;
     infof(data, "ALPN, offering %s\n", ALPN_HTTP_1_1);
 
-    br_ssl_engine_set_protocol_names(&BACKEND->ctx.eng,
-                                     BACKEND->protocols, cur);
+    br_ssl_engine_set_protocol_names(&backend->ctx.eng,
+                                     backend->protocols, cur);
   }
 
   if((1 == Curl_inet_pton(AF_INET, hostname, &addr))
@@ -414,9 +413,9 @@ static CURLcode bearssl_connect_step1(struct connectdata *conn, int sockindex)
     hostname = NULL;
   }
 
-  if(!br_ssl_client_reset(&BACKEND->ctx, hostname, 0))
+  if(!br_ssl_client_reset(&backend->ctx, hostname, 0))
     return CURLE_FAILED_INIT;
-  BACKEND->active = TRUE;
+  backend->active = TRUE;
 
   connssl->connecting_state = ssl_connect_2;
 
@@ -428,6 +427,7 @@ static CURLcode bearssl_run_until(struct connectdata *conn, int sockindex,
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   curl_socket_t sockfd = conn->sock[sockindex];
   unsigned state;
   unsigned char *buf;
@@ -436,9 +436,9 @@ static CURLcode bearssl_run_until(struct connectdata *conn, int sockindex,
   int err;
 
   for(;;) {
-    state = br_ssl_engine_current_state(&BACKEND->ctx.eng);
+    state = br_ssl_engine_current_state(&backend->ctx.eng);
     if(state & BR_SSL_CLOSED) {
-      err = br_ssl_engine_last_error(&BACKEND->ctx.eng);
+      err = br_ssl_engine_last_error(&backend->ctx.eng);
       switch(err) {
       case BR_ERR_OK:
         /* TLS close notify */
@@ -468,7 +468,7 @@ static CURLcode bearssl_run_until(struct connectdata *conn, int sockindex,
     if(state & target)
       return CURLE_OK;
     if(state & BR_SSL_SENDREC) {
-      buf = br_ssl_engine_sendrec_buf(&BACKEND->ctx.eng, &len);
+      buf = br_ssl_engine_sendrec_buf(&backend->ctx.eng, &len);
       ret = swrite(sockfd, buf, len);
       if(ret == -1) {
         if(SOCKERRNO == EAGAIN || SOCKERRNO == EWOULDBLOCK) {
@@ -478,10 +478,10 @@ static CURLcode bearssl_run_until(struct connectdata *conn, int sockindex,
         }
         return CURLE_WRITE_ERROR;
       }
-      br_ssl_engine_sendrec_ack(&BACKEND->ctx.eng, ret);
+      br_ssl_engine_sendrec_ack(&backend->ctx.eng, ret);
     }
     else if(state & BR_SSL_RECVREC) {
-      buf = br_ssl_engine_recvrec_buf(&BACKEND->ctx.eng, &len);
+      buf = br_ssl_engine_recvrec_buf(&backend->ctx.eng, &len);
       ret = sread(sockfd, buf, len);
       if(ret == 0) {
         failf(data, "SSL: EOF without close notify");
@@ -495,7 +495,7 @@ static CURLcode bearssl_run_until(struct connectdata *conn, int sockindex,
         }
         return CURLE_READ_ERROR;
       }
-      br_ssl_engine_recvrec_ack(&BACKEND->ctx.eng, ret);
+      br_ssl_engine_recvrec_ack(&backend->ctx.eng, ret);
     }
   }
 }
@@ -504,13 +504,14 @@ static CURLcode bearssl_connect_step2(struct connectdata *conn, int sockindex)
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   CURLcode ret;
 
   ret = bearssl_run_until(conn, sockindex, BR_SSL_SENDAPP | BR_SSL_RECVAPP);
   if(ret == CURLE_AGAIN)
     return CURLE_OK;
   if(ret == CURLE_OK) {
-    if(br_ssl_engine_current_state(&BACKEND->ctx.eng) == BR_SSL_CLOSED) {
+    if(br_ssl_engine_current_state(&backend->ctx.eng) == BR_SSL_CLOSED) {
       failf(data, "SSL: connection closed during handshake");
       return CURLE_SSL_CONNECT_ERROR;
     }
@@ -523,6 +524,7 @@ static CURLcode bearssl_connect_step3(struct connectdata *conn, int sockindex)
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   CURLcode ret;
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
@@ -530,7 +532,7 @@ static CURLcode bearssl_connect_step3(struct connectdata *conn, int sockindex)
   if(conn->bits.tls_enable_alpn) {
     const char *protocol;
 
-    protocol = br_ssl_engine_get_selected_protocol(&BACKEND->ctx.eng);
+    protocol = br_ssl_engine_get_selected_protocol(&backend->ctx.eng);
     if(protocol) {
       infof(data, "ALPN, server accepted to use %s\n", protocol);
 
@@ -558,7 +560,7 @@ static CURLcode bearssl_connect_step3(struct connectdata *conn, int sockindex)
     session = malloc(sizeof(*session));
     if(!session)
       return CURLE_OUT_OF_MEMORY;
-    br_ssl_engine_get_session_parameters(&BACKEND->ctx.eng, session);
+    br_ssl_engine_get_session_parameters(&backend->ctx.eng, session);
     Curl_ssl_sessionid_lock(conn);
     incache = !(Curl_ssl_getsessionid(conn, &oldsession, NULL, sockindex));
     if(incache)
@@ -581,6 +583,7 @@ static ssize_t bearssl_send(struct connectdata *conn, int sockindex,
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   unsigned char *app;
   size_t applen;
 
@@ -588,23 +591,23 @@ static ssize_t bearssl_send(struct connectdata *conn, int sockindex,
     *err = bearssl_run_until(conn, sockindex, BR_SSL_SENDAPP);
     if (*err != CURLE_OK)
       return -1;
-    app = br_ssl_engine_sendapp_buf(&BACKEND->ctx.eng, &applen);
+    app = br_ssl_engine_sendapp_buf(&backend->ctx.eng, &applen);
     if(!app) {
       failf(data, "SSL: connection closed during write");
       *err = CURLE_SEND_ERROR;
       return -1;
     }
-    if(BACKEND->pending_write) {
-      applen = BACKEND->pending_write;
-      BACKEND->pending_write = 0;
+    if(backend->pending_write) {
+      applen = backend->pending_write;
+      backend->pending_write = 0;
       return applen;
     }
     if(applen > len)
       applen = len;
     memcpy(app, buf, applen);
-    br_ssl_engine_sendapp_ack(&BACKEND->ctx.eng, applen);
-    br_ssl_engine_flush(&BACKEND->ctx.eng, 0);
-    BACKEND->pending_write = applen;
+    br_ssl_engine_sendapp_ack(&backend->ctx.eng, applen);
+    br_ssl_engine_flush(&backend->ctx.eng, 0);
+    backend->pending_write = applen;
   }
 }
 
@@ -612,19 +615,20 @@ static ssize_t bearssl_recv(struct connectdata *conn, int sockindex,
                             char *buf, size_t len, CURLcode *err)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   unsigned char *app;
   size_t applen;
 
   *err = bearssl_run_until(conn, sockindex, BR_SSL_RECVAPP);
   if(*err != CURLE_OK)
     return -1;
-  app = br_ssl_engine_recvapp_buf(&BACKEND->ctx.eng, &applen);
+  app = br_ssl_engine_recvapp_buf(&backend->ctx.eng, &applen);
   if(!app)
     return 0;
   if(applen > len)
     applen = len;
   memcpy(buf, app, applen);
-  br_ssl_engine_recvapp_ack(&BACKEND->ctx.eng, applen);
+  br_ssl_engine_recvapp_ack(&backend->ctx.eng, applen);
 
   return applen;
 }
@@ -739,8 +743,8 @@ static bool Curl_bearssl_data_pending(const struct connectdata *conn,
                                       int connindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
-
-  return br_ssl_engine_current_state(&BACKEND->ctx.eng) & BR_SSL_RECVAPP;
+  struct ssl_backend_data *backend = connssl->backend;
+  return br_ssl_engine_current_state(&backend->ctx.eng) & BR_SSL_RECVAPP;
 }
 
 static CURLcode Curl_bearssl_random(struct Curl_easy *data UNUSED_PARAM,
@@ -786,21 +790,23 @@ static CURLcode Curl_bearssl_connect_nonblocking(struct connectdata *conn,
 static void *Curl_bearssl_get_internals(struct ssl_connect_data *connssl,
                                         CURLINFO info UNUSED_PARAM)
 {
-  return &BACKEND->ctx;
+  struct ssl_backend_data *backend = connssl->backend;
+  return &backend->ctx;
 }
 
 static void Curl_bearssl_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   size_t i;
 
-  if(BACKEND->active) {
-    br_ssl_engine_close(&BACKEND->ctx.eng);
+  if(backend->active) {
+    br_ssl_engine_close(&backend->ctx.eng);
     (void)bearssl_run_until(conn, sockindex, BR_SSL_CLOSED);
   }
-  for(i = 0; i < BACKEND->anchors_len; ++i)
-    free(BACKEND->anchors[i].dn.data);
-  free(BACKEND->anchors);
+  for(i = 0; i < backend->anchors_len; ++i)
+    free(backend->anchors[i].dn.data);
+  free(backend->anchors);
 }
 
 static void Curl_bearssl_session_free(void *ptr)
@@ -836,9 +842,7 @@ static CURLcode Curl_bearssl_sha256sum(const unsigned char *input,
 
 const struct Curl_ssl Curl_ssl_bearssl = {
   { CURLSSLBACKEND_BEARSSL, "bearssl" },
-
   0,
-
   sizeof(struct ssl_backend_data),
 
   Curl_none_init,

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -75,8 +75,6 @@ struct ssl_backend_data {
   const char *protocols[3];
 };
 
-#define BACKEND connssl->backend
-
 /* apply threading? */
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 #define THREADING_SUPPORT
@@ -196,6 +194,7 @@ set_ssl_version_min_max(struct connectdata *conn, int sockindex)
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   int mbedtls_ver_min = MBEDTLS_SSL_MINOR_VERSION_1;
   int mbedtls_ver_max = MBEDTLS_SSL_MINOR_VERSION_1;
   long ssl_version = SSL_CONN_CONFIG(version);
@@ -227,9 +226,9 @@ set_ssl_version_min_max(struct connectdata *conn, int sockindex)
     return result;
   }
 
-  mbedtls_ssl_conf_min_version(&BACKEND->config, MBEDTLS_SSL_MAJOR_VERSION_3,
+  mbedtls_ssl_conf_min_version(&backend->config, MBEDTLS_SSL_MAJOR_VERSION_3,
                                mbedtls_ver_min);
-  mbedtls_ssl_conf_max_version(&BACKEND->config, MBEDTLS_SSL_MAJOR_VERSION_3,
+  mbedtls_ssl_conf_max_version(&backend->config, MBEDTLS_SSL_MAJOR_VERSION_3,
                                mbedtls_ver_max);
 
   return result;
@@ -241,6 +240,7 @@ mbed_connect_step1(struct connectdata *conn,
 {
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data* connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   const char * const ssl_cafile = SSL_CONN_CONFIG(CAfile);
   const bool verifypeer = SSL_CONN_CONFIG(verifypeer);
   const char * const ssl_capath = SSL_CONN_CONFIG(CApath);
@@ -261,9 +261,9 @@ mbed_connect_step1(struct connectdata *conn,
 
 #ifdef THREADING_SUPPORT
   entropy_init_mutex(&ts_entropy);
-  mbedtls_ctr_drbg_init(&BACKEND->ctr_drbg);
+  mbedtls_ctr_drbg_init(&backend->ctr_drbg);
 
-  ret = mbedtls_ctr_drbg_seed(&BACKEND->ctr_drbg, entropy_func_mutex,
+  ret = mbedtls_ctr_drbg_seed(&backend->ctr_drbg, entropy_func_mutex,
                               &ts_entropy, NULL, 0);
   if(ret) {
 #ifdef MBEDTLS_ERROR_C
@@ -273,11 +273,11 @@ mbed_connect_step1(struct connectdata *conn,
           -ret, errorbuf);
   }
 #else
-  mbedtls_entropy_init(&BACKEND->entropy);
-  mbedtls_ctr_drbg_init(&BACKEND->ctr_drbg);
+  mbedtls_entropy_init(&backend->entropy);
+  mbedtls_ctr_drbg_init(&backend->ctr_drbg);
 
-  ret = mbedtls_ctr_drbg_seed(&BACKEND->ctr_drbg, mbedtls_entropy_func,
-                              &BACKEND->entropy, NULL, 0);
+  ret = mbedtls_ctr_drbg_seed(&backend->ctr_drbg, mbedtls_entropy_func,
+                              &backend->entropy, NULL, 0);
   if(ret) {
 #ifdef MBEDTLS_ERROR_C
     mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
@@ -288,10 +288,10 @@ mbed_connect_step1(struct connectdata *conn,
 #endif /* THREADING_SUPPORT */
 
   /* Load the trusted CA */
-  mbedtls_x509_crt_init(&BACKEND->cacert);
+  mbedtls_x509_crt_init(&backend->cacert);
 
   if(ssl_cafile) {
-    ret = mbedtls_x509_crt_parse_file(&BACKEND->cacert, ssl_cafile);
+    ret = mbedtls_x509_crt_parse_file(&backend->cacert, ssl_cafile);
 
     if(ret<0) {
 #ifdef MBEDTLS_ERROR_C
@@ -306,7 +306,7 @@ mbed_connect_step1(struct connectdata *conn,
   }
 
   if(ssl_capath) {
-    ret = mbedtls_x509_crt_parse_path(&BACKEND->cacert, ssl_capath);
+    ret = mbedtls_x509_crt_parse_path(&backend->cacert, ssl_capath);
 
     if(ret<0) {
 #ifdef MBEDTLS_ERROR_C
@@ -321,10 +321,10 @@ mbed_connect_step1(struct connectdata *conn,
   }
 
   /* Load the client certificate */
-  mbedtls_x509_crt_init(&BACKEND->clicert);
+  mbedtls_x509_crt_init(&backend->clicert);
 
   if(ssl_cert) {
-    ret = mbedtls_x509_crt_parse_file(&BACKEND->clicert, ssl_cert);
+    ret = mbedtls_x509_crt_parse_file(&backend->clicert, ssl_cert);
 
     if(ret) {
 #ifdef MBEDTLS_ERROR_C
@@ -338,13 +338,13 @@ mbed_connect_step1(struct connectdata *conn,
   }
 
   /* Load the client private key */
-  mbedtls_pk_init(&BACKEND->pk);
+  mbedtls_pk_init(&backend->pk);
 
   if(SSL_SET_OPTION(key)) {
-    ret = mbedtls_pk_parse_keyfile(&BACKEND->pk, SSL_SET_OPTION(key),
+    ret = mbedtls_pk_parse_keyfile(&backend->pk, SSL_SET_OPTION(key),
                                    SSL_SET_OPTION(key_passwd));
-    if(ret == 0 && !(mbedtls_pk_can_do(&BACKEND->pk, MBEDTLS_PK_RSA) ||
-                     mbedtls_pk_can_do(&BACKEND->pk, MBEDTLS_PK_ECKEY)))
+    if(ret == 0 && !(mbedtls_pk_can_do(&backend->pk, MBEDTLS_PK_RSA) ||
+                     mbedtls_pk_can_do(&backend->pk, MBEDTLS_PK_ECKEY)))
       ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 
     if(ret) {
@@ -359,10 +359,10 @@ mbed_connect_step1(struct connectdata *conn,
   }
 
   /* Load the CRL */
-  mbedtls_x509_crl_init(&BACKEND->crl);
+  mbedtls_x509_crl_init(&backend->crl);
 
   if(ssl_crlfile) {
-    ret = mbedtls_x509_crl_parse_file(&BACKEND->crl, ssl_crlfile);
+    ret = mbedtls_x509_crl_parse_file(&backend->crl, ssl_crlfile);
 
     if(ret) {
 #ifdef MBEDTLS_ERROR_C
@@ -377,14 +377,14 @@ mbed_connect_step1(struct connectdata *conn,
 
   infof(data, "mbedTLS: Connecting to %s:%ld\n", hostname, port);
 
-  mbedtls_ssl_config_init(&BACKEND->config);
+  mbedtls_ssl_config_init(&backend->config);
 
-  mbedtls_ssl_init(&BACKEND->ssl);
-  if(mbedtls_ssl_setup(&BACKEND->ssl, &BACKEND->config)) {
+  mbedtls_ssl_init(&backend->ssl);
+  if(mbedtls_ssl_setup(&backend->ssl, &backend->config)) {
     failf(data, "mbedTLS: ssl_init failed");
     return CURLE_SSL_CONNECT_ERROR;
   }
-  ret = mbedtls_ssl_config_defaults(&BACKEND->config,
+  ret = mbedtls_ssl_config_defaults(&backend->config,
                                     MBEDTLS_SSL_IS_CLIENT,
                                     MBEDTLS_SSL_TRANSPORT_STREAM,
                                     MBEDTLS_SSL_PRESET_DEFAULT);
@@ -394,20 +394,20 @@ mbed_connect_step1(struct connectdata *conn,
   }
 
   /* new profile with RSA min key len = 1024 ... */
-  mbedtls_ssl_conf_cert_profile(&BACKEND->config,
+  mbedtls_ssl_conf_cert_profile(&backend->config,
                                 &mbedtls_x509_crt_profile_fr);
 
   switch(SSL_CONN_CONFIG(version)) {
   case CURL_SSLVERSION_DEFAULT:
   case CURL_SSLVERSION_TLSv1:
-    mbedtls_ssl_conf_min_version(&BACKEND->config, MBEDTLS_SSL_MAJOR_VERSION_3,
+    mbedtls_ssl_conf_min_version(&backend->config, MBEDTLS_SSL_MAJOR_VERSION_3,
                                  MBEDTLS_SSL_MINOR_VERSION_1);
     infof(data, "mbedTLS: Set min SSL version to TLS 1.0\n");
     break;
   case CURL_SSLVERSION_SSLv3:
-    mbedtls_ssl_conf_min_version(&BACKEND->config, MBEDTLS_SSL_MAJOR_VERSION_3,
+    mbedtls_ssl_conf_min_version(&backend->config, MBEDTLS_SSL_MAJOR_VERSION_3,
                                  MBEDTLS_SSL_MINOR_VERSION_0);
-    mbedtls_ssl_conf_max_version(&BACKEND->config, MBEDTLS_SSL_MAJOR_VERSION_3,
+    mbedtls_ssl_conf_max_version(&backend->config, MBEDTLS_SSL_MAJOR_VERSION_3,
                                  MBEDTLS_SSL_MINOR_VERSION_0);
     infof(data, "mbedTLS: Set SSL version to SSLv3\n");
     break;
@@ -426,25 +426,25 @@ mbed_connect_step1(struct connectdata *conn,
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-  mbedtls_ssl_conf_authmode(&BACKEND->config, MBEDTLS_SSL_VERIFY_OPTIONAL);
+  mbedtls_ssl_conf_authmode(&backend->config, MBEDTLS_SSL_VERIFY_OPTIONAL);
 
-  mbedtls_ssl_conf_rng(&BACKEND->config, mbedtls_ctr_drbg_random,
-                       &BACKEND->ctr_drbg);
-  mbedtls_ssl_set_bio(&BACKEND->ssl, &conn->sock[sockindex],
+  mbedtls_ssl_conf_rng(&backend->config, mbedtls_ctr_drbg_random,
+                       &backend->ctr_drbg);
+  mbedtls_ssl_set_bio(&backend->ssl, &conn->sock[sockindex],
                       mbedtls_net_send,
                       mbedtls_net_recv,
                       NULL /*  rev_timeout() */);
 
-  mbedtls_ssl_conf_ciphersuites(&BACKEND->config,
+  mbedtls_ssl_conf_ciphersuites(&backend->config,
                                 mbedtls_ssl_list_ciphersuites());
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
-  mbedtls_ssl_conf_renegotiation(&BACKEND->config,
+  mbedtls_ssl_conf_renegotiation(&backend->config,
                                  MBEDTLS_SSL_RENEGOTIATION_ENABLED);
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS)
-  mbedtls_ssl_conf_session_tickets(&BACKEND->config,
+  mbedtls_ssl_conf_session_tickets(&backend->config,
                                    MBEDTLS_SSL_SESSION_TICKETS_DISABLED);
 #endif
 
@@ -454,7 +454,7 @@ mbed_connect_step1(struct connectdata *conn,
 
     Curl_ssl_sessionid_lock(conn);
     if(!Curl_ssl_getsessionid(conn, &old_session, NULL, sockindex)) {
-      ret = mbedtls_ssl_set_session(&BACKEND->ssl, old_session);
+      ret = mbedtls_ssl_set_session(&backend->ssl, old_session);
       if(ret) {
         Curl_ssl_sessionid_unlock(conn);
         failf(data, "mbedtls_ssl_set_session returned -0x%x", -ret);
@@ -465,15 +465,15 @@ mbed_connect_step1(struct connectdata *conn,
     Curl_ssl_sessionid_unlock(conn);
   }
 
-  mbedtls_ssl_conf_ca_chain(&BACKEND->config,
-                            &BACKEND->cacert,
-                            &BACKEND->crl);
+  mbedtls_ssl_conf_ca_chain(&backend->config,
+                            &backend->cacert,
+                            &backend->crl);
 
   if(SSL_SET_OPTION(key)) {
-    mbedtls_ssl_conf_own_cert(&BACKEND->config,
-                              &BACKEND->clicert, &BACKEND->pk);
+    mbedtls_ssl_conf_own_cert(&backend->config,
+                              &backend->clicert, &backend->pk);
   }
-  if(mbedtls_ssl_set_hostname(&BACKEND->ssl, hostname)) {
+  if(mbedtls_ssl_set_hostname(&backend->ssl, hostname)) {
     /* mbedtls_ssl_set_hostname() sets the name to use in CN/SAN checks *and*
        the name to set in the SNI extension. So even if curl connects to a
        host specified as an IP address, this function must be used. */
@@ -483,7 +483,7 @@ mbed_connect_step1(struct connectdata *conn,
 
 #ifdef HAS_ALPN
   if(conn->bits.tls_enable_alpn) {
-    const char **p = &BACKEND->protocols[0];
+    const char **p = &backend->protocols[0];
 #ifdef USE_NGHTTP2
     if(data->set.httpversion >= CURL_HTTP_VERSION_2)
       *p++ = NGHTTP2_PROTO_VERSION_ID;
@@ -492,19 +492,19 @@ mbed_connect_step1(struct connectdata *conn,
     *p = NULL;
     /* this function doesn't clone the protocols array, which is why we need
        to keep it around */
-    if(mbedtls_ssl_conf_alpn_protocols(&BACKEND->config,
-                                       &BACKEND->protocols[0])) {
+    if(mbedtls_ssl_conf_alpn_protocols(&backend->config,
+                                       &backend->protocols[0])) {
       failf(data, "Failed setting ALPN protocols");
       return CURLE_SSL_CONNECT_ERROR;
     }
-    for(p = &BACKEND->protocols[0]; *p; ++p)
+    for(p = &backend->protocols[0]; *p; ++p)
       infof(data, "ALPN, offering %s\n", *p);
   }
 #endif
 
 #ifdef MBEDTLS_DEBUG
   /* In order to make that work in mbedtls MBEDTLS_DEBUG_C must be defined. */
-  mbedtls_ssl_conf_dbg(&BACKEND->config, mbed_debug, data);
+  mbedtls_ssl_conf_dbg(&backend->config, mbed_debug, data);
   /* - 0 No debug
    * - 1 Error
    * - 2 State change
@@ -516,7 +516,7 @@ mbed_connect_step1(struct connectdata *conn,
 
   /* give application a chance to interfere with mbedTLS set up. */
   if(data->set.ssl.fsslctx) {
-    ret = (*data->set.ssl.fsslctx)(data, &BACKEND->config,
+    ret = (*data->set.ssl.fsslctx)(data, &backend->config,
                                    data->set.ssl.fsslctxp);
     if(ret) {
       failf(data, "error signaled by ssl ctx callback");
@@ -536,15 +536,16 @@ mbed_connect_step2(struct connectdata *conn,
   int ret;
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data* connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   const mbedtls_x509_crt *peercert;
   const char * const pinnedpubkey = SSL_IS_PROXY() ?
-        data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY] :
-        data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG];
+    data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY] :
+    data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG];
 
   conn->recv[sockindex] = mbed_recv;
   conn->send[sockindex] = mbed_send;
 
-  ret = mbedtls_ssl_handshake(&BACKEND->ssl);
+  ret = mbedtls_ssl_handshake(&backend->ssl);
 
   if(ret == MBEDTLS_ERR_SSL_WANT_READ) {
     connssl->connecting_state = ssl_connect_2_reading;
@@ -566,10 +567,10 @@ mbed_connect_step2(struct connectdata *conn,
   }
 
   infof(data, "mbedTLS: Handshake complete, cipher is %s\n",
-        mbedtls_ssl_get_ciphersuite(&BACKEND->ssl)
+        mbedtls_ssl_get_ciphersuite(&backend->ssl)
     );
 
-  ret = mbedtls_ssl_get_verify_result(&BACKEND->ssl);
+  ret = mbedtls_ssl_get_verify_result(&backend->ssl);
 
   if(!SSL_CONN_CONFIG(verifyhost))
     /* Ignore hostname errors if verifyhost is disabled */
@@ -594,7 +595,7 @@ mbed_connect_step2(struct connectdata *conn,
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 
-  peercert = mbedtls_ssl_get_peer_cert(&BACKEND->ssl);
+  peercert = mbedtls_ssl_get_peer_cert(&backend->ssl);
 
   if(peercert && data->set.verbose) {
     const size_t bufsize = 16384;
@@ -664,7 +665,7 @@ mbed_connect_step2(struct connectdata *conn,
 
 #ifdef HAS_ALPN
   if(conn->bits.tls_enable_alpn) {
-    const char *next_protocol = mbedtls_ssl_get_alpn_protocol(&BACKEND->ssl);
+    const char *next_protocol = mbedtls_ssl_get_alpn_protocol(&backend->ssl);
 
     if(next_protocol) {
       infof(data, "ALPN, server accepted to use %s\n", next_protocol);
@@ -701,6 +702,7 @@ mbed_connect_step3(struct connectdata *conn,
 {
   CURLcode retcode = CURLE_OK;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   struct Curl_easy *data = conn->data;
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
@@ -716,7 +718,7 @@ mbed_connect_step3(struct connectdata *conn,
 
     mbedtls_ssl_session_init(our_ssl_sessionid);
 
-    ret = mbedtls_ssl_get_session(&BACKEND->ssl, our_ssl_sessionid);
+    ret = mbedtls_ssl_get_session(&backend->ssl, our_ssl_sessionid);
     if(ret) {
       if(ret != MBEDTLS_ERR_SSL_ALLOC_FAILED)
         mbedtls_ssl_session_free(our_ssl_sessionid);
@@ -750,9 +752,10 @@ static ssize_t mbed_send(struct connectdata *conn, int sockindex,
                          CURLcode *curlcode)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
   int ret = -1;
 
-  ret = mbedtls_ssl_write(&BACKEND->ssl,
+  ret = mbedtls_ssl_write(&backend->ssl,
                           (unsigned char *)mem, len);
 
   if(ret < 0) {
@@ -772,15 +775,16 @@ static void Curl_mbedtls_close_all(struct Curl_easy *data)
 static void Curl_mbedtls_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
-  mbedtls_pk_free(&BACKEND->pk);
-  mbedtls_x509_crt_free(&BACKEND->clicert);
-  mbedtls_x509_crt_free(&BACKEND->cacert);
-  mbedtls_x509_crl_free(&BACKEND->crl);
-  mbedtls_ssl_config_free(&BACKEND->config);
-  mbedtls_ssl_free(&BACKEND->ssl);
-  mbedtls_ctr_drbg_free(&BACKEND->ctr_drbg);
+  struct ssl_backend_data *backend = connssl->backend;
+  mbedtls_pk_free(&backend->pk);
+  mbedtls_x509_crt_free(&backend->clicert);
+  mbedtls_x509_crt_free(&backend->cacert);
+  mbedtls_x509_crl_free(&backend->crl);
+  mbedtls_ssl_config_free(&backend->config);
+  mbedtls_ssl_free(&backend->ssl);
+  mbedtls_ctr_drbg_free(&backend->ctr_drbg);
 #ifndef THREADING_SUPPORT
-  mbedtls_entropy_free(&BACKEND->entropy);
+  mbedtls_entropy_free(&backend->entropy);
 #endif /* THREADING_SUPPORT */
 }
 
@@ -789,11 +793,12 @@ static ssize_t mbed_recv(struct connectdata *conn, int num,
                          CURLcode *curlcode)
 {
   struct ssl_connect_data *connssl = &conn->ssl[num];
+  struct ssl_backend_data *backend = connssl->backend;
   int ret = -1;
   ssize_t len = -1;
 
   memset(buf, 0, buffersize);
-  ret = mbedtls_ssl_read(&BACKEND->ssl, (unsigned char *)buf,
+  ret = mbedtls_ssl_read(&backend->ssl, (unsigned char *)buf,
                          buffersize);
 
   if(ret <= 0) {
@@ -1029,7 +1034,8 @@ static bool Curl_mbedtls_data_pending(const struct connectdata *conn,
                                       int sockindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[sockindex];
-  return mbedtls_ssl_get_bytes_avail(&BACKEND->ssl) != 0;
+  struct ssl_backend_data *backend = connssl->backend;
+  return mbedtls_ssl_get_bytes_avail(&backend->ssl) != 0;
 }
 
 static CURLcode Curl_mbedtls_sha256sum(const unsigned char *input,
@@ -1051,8 +1057,9 @@ static CURLcode Curl_mbedtls_sha256sum(const unsigned char *input,
 static void *Curl_mbedtls_get_internals(struct ssl_connect_data *connssl,
                                         CURLINFO info UNUSED_PARAM)
 {
+  struct ssl_backend_data *backend = connssl->backend;
   (void)info;
-  return &BACKEND->ssl;
+  return &backend->ssl;
 }
 
 const struct Curl_ssl Curl_ssl_mbedtls = {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -228,8 +228,6 @@ struct ssl_backend_data {
 #endif
 };
 
-#define BACKEND connssl->backend
-
 /*
  * Number of bytes to read from the random number seed file. This must be
  * a finite value (because some entropy "files" like /dev/urandom have
@@ -1269,19 +1267,19 @@ static struct curl_slist *Curl_ossl_engines_list(struct Curl_easy *data)
   return list;
 }
 
-
 static void ossl_close(struct ssl_connect_data *connssl)
 {
-  if(BACKEND->handle) {
-    (void)SSL_shutdown(BACKEND->handle);
-    SSL_set_connect_state(BACKEND->handle);
+  struct ssl_backend_data *backend = connssl->backend;
+  if(backend->handle) {
+    (void)SSL_shutdown(backend->handle);
+    SSL_set_connect_state(backend->handle);
 
-    SSL_free(BACKEND->handle);
-    BACKEND->handle = NULL;
+    SSL_free(backend->handle);
+    backend->handle = NULL;
   }
-  if(BACKEND->ctx) {
-    SSL_CTX_free(BACKEND->ctx);
-    BACKEND->ctx = NULL;
+  if(backend->ctx) {
+    SSL_CTX_free(backend->ctx);
+    backend->ctx = NULL;
   }
 }
 
@@ -1310,6 +1308,7 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
   int buffsize;
   int err;
   bool done = FALSE;
+  struct ssl_backend_data *backend = connssl->backend;
 
 #ifndef CURL_DISABLE_FTP
   /* This has only been tested on the proftpd server, and the mod_tls code
@@ -1318,10 +1317,10 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
      we do not send one. Let's hope other servers do the same... */
 
   if(data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE)
-      (void)SSL_shutdown(BACKEND->handle);
+      (void)SSL_shutdown(backend->handle);
 #endif
 
-  if(BACKEND->handle) {
+  if(backend->handle) {
     buffsize = (int)sizeof(buf);
     while(!done) {
       int what = SOCKET_READABLE(conn->sock[sockindex],
@@ -1331,8 +1330,8 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
 
         /* Something to read, let's do it and hope that it is the close
            notify alert from the server */
-        nread = (ssize_t)SSL_read(BACKEND->handle, buf, buffsize);
-        err = SSL_get_error(BACKEND->handle, (int)nread);
+        nread = (ssize_t)SSL_read(backend->handle, buf, buffsize);
+        err = SSL_get_error(backend->handle, (int)nread);
 
         switch(err) {
         case SSL_ERROR_NONE: /* this is not an error */
@@ -1377,7 +1376,7 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
 
     if(data->set.verbose) {
 #ifdef HAVE_SSL_GET_SHUTDOWN
-      switch(SSL_get_shutdown(BACKEND->handle)) {
+      switch(SSL_get_shutdown(backend->handle)) {
       case SSL_SENT_SHUTDOWN:
         infof(data, "SSL_get_shutdown() returned SSL_SENT_SHUTDOWN\n");
         break;
@@ -1392,8 +1391,8 @@ static int Curl_ossl_shutdown(struct connectdata *conn, int sockindex)
 #endif
     }
 
-    SSL_free(BACKEND->handle);
-    BACKEND->handle = NULL;
+    SSL_free(backend->handle);
+    backend->handle = NULL;
   }
   return retval;
 }
@@ -1712,13 +1711,13 @@ static CURLcode verifystatus(struct connectdata *conn,
   const unsigned char *p;
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
-
   OCSP_RESPONSE *rsp = NULL;
   OCSP_BASICRESP *br = NULL;
   X509_STORE     *st = NULL;
   STACK_OF(X509) *ch = NULL;
+  struct ssl_backend_data *backend = connssl->backend;
 
-  long len = SSL_get_tlsext_status_ocsp_resp(BACKEND->handle, &status);
+  long len = SSL_get_tlsext_status_ocsp_resp(backend->handle, &status);
 
   if(!status) {
     failf(data, "No OCSP response received");
@@ -1748,8 +1747,8 @@ static CURLcode verifystatus(struct connectdata *conn,
     goto end;
   }
 
-  ch = SSL_get_peer_cert_chain(BACKEND->handle);
-  st = SSL_CTX_get_cert_store(BACKEND->ctx);
+  ch = SSL_get_peer_cert_chain(backend->handle);
+  st = SSL_CTX_get_cert_store(backend->ctx);
 
 #if ((OPENSSL_VERSION_NUMBER <= 0x1000201fL) /* Fixed after 1.0.2a */ || \
      (defined(LIBRESSL_VERSION_NUMBER) &&                               \
@@ -2270,7 +2269,7 @@ set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
 #ifdef TLS1_3_VERSION
     {
       struct ssl_connect_data *connssl = &conn->ssl[sockindex];
-      SSL_CTX_set_max_proto_version(BACKEND->ctx, TLS1_3_VERSION);
+      SSL_CTX_set_max_proto_version(backend->ctx, TLS1_3_VERSION);
       *ctx_options |= SSL_OP_NO_TLSv1_2;
     }
 #else
@@ -2419,6 +2418,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   const bool verifypeer = SSL_CONN_CONFIG(verifypeer);
   const char * const ssl_crlfile = SSL_SET_OPTION(CRLfile);
   char error_buffer[256];
+  struct ssl_backend_data *backend = connssl->backend;
 
   DEBUGASSERT(ssl_connect_1 == connssl->connecting_state);
 
@@ -2477,25 +2477,25 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-  if(BACKEND->ctx)
-    SSL_CTX_free(BACKEND->ctx);
-  BACKEND->ctx = SSL_CTX_new(req_method);
+  if(backend->ctx)
+    SSL_CTX_free(backend->ctx);
+  backend->ctx = SSL_CTX_new(req_method);
 
-  if(!BACKEND->ctx) {
+  if(!backend->ctx) {
     failf(data, "SSL: couldn't create a context: %s",
           ossl_strerror(ERR_peek_error(), error_buffer, sizeof(error_buffer)));
     return CURLE_OUT_OF_MEMORY;
   }
 
 #ifdef SSL_MODE_RELEASE_BUFFERS
-  SSL_CTX_set_mode(BACKEND->ctx, SSL_MODE_RELEASE_BUFFERS);
+  SSL_CTX_set_mode(backend->ctx, SSL_MODE_RELEASE_BUFFERS);
 #endif
 
 #ifdef SSL_CTRL_SET_MSG_CALLBACK
   if(data->set.fdebug && data->set.verbose) {
     /* the SSL trace callback is only used for verbose logging */
-    SSL_CTX_set_msg_callback(BACKEND->ctx, ssl_tls_trace);
-    SSL_CTX_set_msg_callback_arg(BACKEND->ctx, conn);
+    SSL_CTX_set_msg_callback(backend->ctx, ssl_tls_trace);
+    SSL_CTX_set_msg_callback_arg(backend->ctx, conn);
   }
 #endif
 
@@ -2561,8 +2561,8 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     /* "--sslv2" option means SSLv2 only, disable all others */
     case CURL_SSLVERSION_SSLv2:
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
-      SSL_CTX_set_min_proto_version(BACKEND->ctx, SSL2_VERSION);
-      SSL_CTX_set_max_proto_version(BACKEND->ctx, SSL2_VERSION);
+      SSL_CTX_set_min_proto_version(backend->ctx, SSL2_VERSION);
+      SSL_CTX_set_max_proto_version(backend->ctx, SSL2_VERSION);
 #else
       ctx_options |= SSL_OP_NO_SSLv3;
       ctx_options |= SSL_OP_NO_TLSv1;
@@ -2579,8 +2579,8 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     /* "--sslv3" option means SSLv3 only, disable all others */
     case CURL_SSLVERSION_SSLv3:
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
-      SSL_CTX_set_min_proto_version(BACKEND->ctx, SSL3_VERSION);
-      SSL_CTX_set_max_proto_version(BACKEND->ctx, SSL3_VERSION);
+      SSL_CTX_set_min_proto_version(backend->ctx, SSL3_VERSION);
+      SSL_CTX_set_max_proto_version(backend->ctx, SSL3_VERSION);
 #else
       ctx_options |= SSL_OP_NO_SSLv2;
       ctx_options |= SSL_OP_NO_TLSv1;
@@ -2607,7 +2607,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
       ctx_options |= SSL_OP_NO_SSLv3;
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* 1.1.0 */
-      result = set_ssl_version_min_max(BACKEND->ctx, conn);
+      result = set_ssl_version_min_max(backend->ctx, conn);
 #else
       result = set_ssl_version_min_max_legacy(&ctx_options, conn, sockindex);
 #endif
@@ -2620,11 +2620,11 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
       return CURLE_SSL_CONNECT_ERROR;
   }
 
-  SSL_CTX_set_options(BACKEND->ctx, ctx_options);
+  SSL_CTX_set_options(backend->ctx, ctx_options);
 
 #ifdef HAS_NPN
   if(conn->bits.tls_enable_npn)
-    SSL_CTX_set_next_proto_select_cb(BACKEND->ctx, select_next_proto_cb, conn);
+    SSL_CTX_set_next_proto_select_cb(backend->ctx, select_next_proto_cb, conn);
 #endif
 
 #ifdef HAS_ALPN
@@ -2652,12 +2652,12 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     /* expects length prefixed preference ordered list of protocols in wire
      * format
      */
-    SSL_CTX_set_alpn_protos(BACKEND->ctx, protocols, cur);
+    SSL_CTX_set_alpn_protos(backend->ctx, protocols, cur);
   }
 #endif
 
   if(ssl_cert || ssl_cert_type) {
-    if(!cert_stuff(conn, BACKEND->ctx, ssl_cert, ssl_cert_type,
+    if(!cert_stuff(conn, backend->ctx, ssl_cert, ssl_cert_type,
                    SSL_SET_OPTION(key), SSL_SET_OPTION(key_type),
                    SSL_SET_OPTION(key_passwd))) {
       /* failf() is already done in cert_stuff() */
@@ -2669,7 +2669,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   if(!ciphers)
     ciphers = (char *)DEFAULT_CIPHER_SELECTION;
   if(ciphers) {
-    if(!SSL_CTX_set_cipher_list(BACKEND->ctx, ciphers)) {
+    if(!SSL_CTX_set_cipher_list(backend->ctx, ciphers)) {
       failf(data, "failed setting cipher list: %s", ciphers);
       return CURLE_SSL_CIPHER;
     }
@@ -2680,7 +2680,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   {
     char *ciphers13 = SSL_CONN_CONFIG(cipher_list13);
     if(ciphers13) {
-      if(!SSL_CTX_set_ciphersuites(BACKEND->ctx, ciphers13)) {
+      if(!SSL_CTX_set_ciphersuites(backend->ctx, ciphers13)) {
         failf(data, "failed setting TLS 1.3 cipher suite: %s", ciphers13);
         return CURLE_SSL_CIPHER;
       }
@@ -2691,7 +2691,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 
 #ifdef HAVE_SSL_CTX_SET_POST_HANDSHAKE_AUTH
   /* OpenSSL 1.1.1 requires clients to opt-in for PHA */
-  SSL_CTX_set_post_handshake_auth(BACKEND->ctx, 1);
+  SSL_CTX_set_post_handshake_auth(backend->ctx, 1);
 #endif
 
 #ifdef USE_TLS_SRP
@@ -2700,18 +2700,18 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 
     infof(data, "Using TLS-SRP username: %s\n", ssl_username);
 
-    if(!SSL_CTX_set_srp_username(BACKEND->ctx, ssl_username)) {
+    if(!SSL_CTX_set_srp_username(backend->ctx, ssl_username)) {
       failf(data, "Unable to set SRP user name");
       return CURLE_BAD_FUNCTION_ARGUMENT;
     }
-    if(!SSL_CTX_set_srp_password(BACKEND->ctx, SSL_SET_OPTION(password))) {
+    if(!SSL_CTX_set_srp_password(backend->ctx, SSL_SET_OPTION(password))) {
       failf(data, "failed setting SRP password");
       return CURLE_BAD_FUNCTION_ARGUMENT;
     }
     if(!SSL_CONN_CONFIG(cipher_list)) {
       infof(data, "Setting cipher list SRP\n");
 
-      if(!SSL_CTX_set_cipher_list(BACKEND->ctx, "SRP")) {
+      if(!SSL_CTX_set_cipher_list(backend->ctx, "SRP")) {
         failf(data, "failed setting SRP cipher list");
         return CURLE_SSL_CIPHER;
       }
@@ -2722,7 +2722,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   if(ssl_cafile || ssl_capath) {
     /* tell SSL where to find CA certificates that are used to verify
        the servers certificate. */
-    if(!SSL_CTX_load_verify_locations(BACKEND->ctx, ssl_cafile, ssl_capath)) {
+    if(!SSL_CTX_load_verify_locations(backend->ctx, ssl_cafile, ssl_capath)) {
       if(verifypeer) {
         /* Fail if we insist on successfully verifying the server. */
         failf(data, "error setting certificate verify locations:\n"
@@ -2750,14 +2750,14 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   else if(verifypeer) {
     /* verifying the peer without any CA certificates won't
        work so use openssl's built in default as fallback */
-    SSL_CTX_set_default_verify_paths(BACKEND->ctx);
+    SSL_CTX_set_default_verify_paths(backend->ctx);
   }
 #endif
 
   if(ssl_crlfile) {
     /* tell SSL where to find CRL file that is used to check certificate
      * revocation */
-    lookup = X509_STORE_add_lookup(SSL_CTX_get_cert_store(BACKEND->ctx),
+    lookup = X509_STORE_add_lookup(SSL_CTX_get_cert_store(backend->ctx),
                                  X509_LOOKUP_file());
     if(!lookup ||
        (!X509_load_crl_file(lookup, ssl_crlfile, X509_FILETYPE_PEM)) ) {
@@ -2766,7 +2766,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     }
     /* Everything is fine. */
     infof(data, "successfully load CRL file:\n");
-    X509_STORE_set_flags(SSL_CTX_get_cert_store(BACKEND->ctx),
+    X509_STORE_set_flags(SSL_CTX_get_cert_store(backend->ctx),
                          X509_V_FLAG_CRL_CHECK|X509_V_FLAG_CRL_CHECK_ALL);
 
     infof(data, "  CRLfile: %s\n", ssl_crlfile);
@@ -2781,7 +2781,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
        https://rt.openssl.org/Ticket/Display.html?id=3621&user=guest&pass=guest
     */
 #if defined(X509_V_FLAG_TRUSTED_FIRST) && !defined(X509_V_FLAG_NO_ALT_CHAINS)
-    X509_STORE_set_flags(SSL_CTX_get_cert_store(BACKEND->ctx),
+    X509_STORE_set_flags(SSL_CTX_get_cert_store(backend->ctx),
                          X509_V_FLAG_TRUSTED_FIRST);
 #endif
 #ifdef X509_V_FLAG_PARTIAL_CHAIN
@@ -2790,7 +2790,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
          trust-anchors, in the same way as self-signed root CA certificates
          are. This allows users to verify servers using the intermediate cert
          only, instead of needing the whole chain. */
-      X509_STORE_set_flags(SSL_CTX_get_cert_store(BACKEND->ctx),
+      X509_STORE_set_flags(SSL_CTX_get_cert_store(backend->ctx),
                            X509_V_FLAG_PARTIAL_CHAIN);
     }
 #endif
@@ -2800,13 +2800,13 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
    * fail to connect if the verification fails, or if it should continue
    * anyway. In the latter case the result of the verification is checked with
    * SSL_get_verify_result() below. */
-  SSL_CTX_set_verify(BACKEND->ctx,
+  SSL_CTX_set_verify(backend->ctx,
                      verifypeer ? SSL_VERIFY_PEER : SSL_VERIFY_NONE, NULL);
 
   /* Enable logging of secrets to the file specified in env SSLKEYLOGFILE. */
 #if defined(ENABLE_SSLKEYLOGFILE) && defined(HAVE_KEYLOG_CALLBACK)
   if(keylog_file_fp) {
-    SSL_CTX_set_keylog_callback(BACKEND->ctx, ossl_keylog_callback);
+    SSL_CTX_set_keylog_callback(backend->ctx, ossl_keylog_callback);
   }
 #endif
 
@@ -2814,14 +2814,14 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
    * callback. Use the "external storage" mode to avoid that OpenSSL creates
    * an internal session cache.
    */
-  SSL_CTX_set_session_cache_mode(BACKEND->ctx,
+  SSL_CTX_set_session_cache_mode(backend->ctx,
       SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL);
-  SSL_CTX_sess_set_new_cb(BACKEND->ctx, ossl_new_session_cb);
+  SSL_CTX_sess_set_new_cb(backend->ctx, ossl_new_session_cb);
 
   /* give application a chance to interfere with SSL set up. */
   if(data->set.ssl.fsslctx) {
     Curl_set_in_callback(data, true);
-    result = (*data->set.ssl.fsslctx)(data, BACKEND->ctx,
+    result = (*data->set.ssl.fsslctx)(data, backend->ctx,
                                       data->set.ssl.fsslctxp);
     Curl_set_in_callback(data, false);
     if(result) {
@@ -2831,10 +2831,10 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
   }
 
   /* Lets make an SSL structure */
-  if(BACKEND->handle)
-    SSL_free(BACKEND->handle);
-  BACKEND->handle = SSL_new(BACKEND->ctx);
-  if(!BACKEND->handle) {
+  if(backend->handle)
+    SSL_free(backend->handle);
+  backend->handle = SSL_new(backend->ctx);
+  if(!backend->handle) {
     failf(data, "SSL: couldn't create a context (handle)!");
     return CURLE_OUT_OF_MEMORY;
   }
@@ -2842,23 +2842,23 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 #if (OPENSSL_VERSION_NUMBER >= 0x0090808fL) && !defined(OPENSSL_NO_TLSEXT) && \
     !defined(OPENSSL_NO_OCSP)
   if(SSL_CONN_CONFIG(verifystatus))
-    SSL_set_tlsext_status_type(BACKEND->handle, TLSEXT_STATUSTYPE_ocsp);
+    SSL_set_tlsext_status_type(backend->handle, TLSEXT_STATUSTYPE_ocsp);
 #endif
 
 #if defined(OPENSSL_IS_BORINGSSL) && defined(ALLOW_RENEG)
-  SSL_set_renegotiate_mode(BACKEND->handle, ssl_renegotiate_freely);
+  SSL_set_renegotiate_mode(backend->handle, ssl_renegotiate_freely);
 #endif
 
-  SSL_set_connect_state(BACKEND->handle);
+  SSL_set_connect_state(backend->handle);
 
-  BACKEND->server_cert = 0x0;
+  backend->server_cert = 0x0;
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
   if((0 == Curl_inet_pton(AF_INET, hostname, &addr)) &&
 #ifdef ENABLE_IPV6
      (0 == Curl_inet_pton(AF_INET6, hostname, &addr)) &&
 #endif
      sni &&
-     !SSL_set_tlsext_host_name(BACKEND->handle, hostname))
+     !SSL_set_tlsext_host_name(backend->handle, hostname))
     infof(data, "WARNING: failed to configure server name indication (SNI) "
           "TLS extension\n");
 #endif
@@ -2872,14 +2872,14 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     if(connectdata_idx >= 0 && sockindex_idx >= 0) {
       /* Store the data needed for the "new session" callback.
        * The sockindex is stored as a pointer to an array element. */
-      SSL_set_ex_data(BACKEND->handle, connectdata_idx, conn);
-      SSL_set_ex_data(BACKEND->handle, sockindex_idx, conn->sock + sockindex);
+      SSL_set_ex_data(backend->handle, connectdata_idx, conn);
+      SSL_set_ex_data(backend->handle, sockindex_idx, conn->sock + sockindex);
     }
 
     Curl_ssl_sessionid_lock(conn);
     if(!Curl_ssl_getsessionid(conn, &ssl_sessionid, NULL, sockindex)) {
       /* we got a session id, use it! */
-      if(!SSL_set_session(BACKEND->handle, ssl_sessionid)) {
+      if(!SSL_set_session(backend->handle, ssl_sessionid)) {
         Curl_ssl_sessionid_unlock(conn);
         failf(data, "SSL: SSL_set_session failed: %s",
               ossl_strerror(ERR_get_error(), error_buffer,
@@ -2899,9 +2899,9 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
     DEBUGASSERT(handle != NULL);
     DEBUGASSERT(bio != NULL);
     BIO_set_ssl(bio, handle, FALSE);
-    SSL_set_bio(BACKEND->handle, bio, bio);
+    SSL_set_bio(backend->handle, bio, bio);
   }
-  else if(!SSL_set_fd(BACKEND->handle, (int)sockfd)) {
+  else if(!SSL_set_fd(backend->handle, (int)sockfd)) {
     /* pass the raw socket into the SSL layers */
     failf(data, "SSL: SSL_set_fd failed: %s",
           ossl_strerror(ERR_get_error(), error_buffer, sizeof(error_buffer)));
@@ -2920,24 +2920,25 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   long * const certverifyresult = SSL_IS_PROXY() ?
     &data->set.proxy_ssl.certverifyresult : &data->set.ssl.certverifyresult;
+  struct ssl_backend_data *backend = connssl->backend;
   DEBUGASSERT(ssl_connect_2 == connssl->connecting_state
               || ssl_connect_2_reading == connssl->connecting_state
               || ssl_connect_2_writing == connssl->connecting_state);
 
   ERR_clear_error();
 
-  err = SSL_connect(BACKEND->handle);
+  err = SSL_connect(backend->handle);
   /* If keylogging is enabled but the keylog callback is not supported then log
      secrets here, immediately after SSL_connect by using tap_ssl_key. */
 #if defined(ENABLE_SSLKEYLOGFILE) && !defined(HAVE_KEYLOG_CALLBACK)
-  tap_ssl_key(BACKEND->handle, &BACKEND->tap_state);
+  tap_ssl_key(backend->handle, &backend->tap_state);
 #endif
 
   /* 1  is fine
      0  is "not successful but was shut down controlled"
      <0 is "handshake was not successful, because a fatal error occurred" */
   if(1 != err) {
-    int detail = SSL_get_error(BACKEND->handle, err);
+    int detail = SSL_get_error(backend->handle, err);
 
     if(SSL_ERROR_WANT_READ == detail) {
       connssl->connecting_state = ssl_connect_2_reading;
@@ -2977,7 +2978,7 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
          (reason == SSL_R_CERTIFICATE_VERIFY_FAILED)) {
         result = CURLE_PEER_FAILED_VERIFICATION;
 
-        lerr = SSL_get_verify_result(BACKEND->handle);
+        lerr = SSL_get_verify_result(backend->handle);
         if(lerr != X509_V_OK) {
           *certverifyresult = lerr;
           msnprintf(error_buffer, sizeof(error_buffer),
@@ -3026,8 +3027,8 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
 
     /* Informational message */
     infof(data, "SSL connection using %s / %s\n",
-          get_ssl_version_txt(BACKEND->handle),
-          SSL_get_cipher(BACKEND->handle));
+          get_ssl_version_txt(backend->handle),
+          SSL_get_cipher(backend->handle));
 
 #ifdef HAS_ALPN
     /* Sets data and len to negotiated protocol, len is 0 if no protocol was
@@ -3036,7 +3037,7 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
     if(conn->bits.tls_enable_alpn) {
       const unsigned char *neg_protocol;
       unsigned int len;
-      SSL_get0_alpn_selected(BACKEND->handle, &neg_protocol, &len);
+      SSL_get0_alpn_selected(backend->handle, &neg_protocol, &len);
       if(len != 0) {
         infof(data, "ALPN, server accepted to use %.*s\n", len, neg_protocol);
 
@@ -3171,8 +3172,9 @@ static CURLcode get_cert_chain(struct connectdata *conn,
   struct Curl_easy *data = conn->data;
   numcert_t numcerts;
   BIO *mem;
+  struct ssl_backend_data *backend = connssl->backend;
 
-  sk = SSL_get_peer_cert_chain(BACKEND->handle);
+  sk = SSL_get_peer_cert_chain(backend->handle);
   if(!sk) {
     return CURLE_OUT_OF_MEMORY;
   }
@@ -3458,13 +3460,14 @@ static CURLcode servercert(struct connectdata *conn,
   long * const certverifyresult = SSL_IS_PROXY() ?
     &data->set.proxy_ssl.certverifyresult : &data->set.ssl.certverifyresult;
   BIO *mem = BIO_new(BIO_s_mem());
+  struct ssl_backend_data *backend = connssl->backend;
 
   if(data->set.ssl.certinfo)
     /* we've been asked to gather certificate info! */
     (void)get_cert_chain(conn, connssl);
 
-  BACKEND->server_cert = SSL_get_peer_certificate(BACKEND->handle);
-  if(!BACKEND->server_cert) {
+  backend->server_cert = SSL_get_peer_certificate(backend->handle);
+  if(!backend->server_cert) {
     BIO_free(mem);
     if(!strict)
       return CURLE_OK;
@@ -3475,19 +3478,19 @@ static CURLcode servercert(struct connectdata *conn,
 
   infof(data, "%s certificate:\n", SSL_IS_PROXY() ? "Proxy" : "Server");
 
-  rc = x509_name_oneline(X509_get_subject_name(BACKEND->server_cert),
+  rc = x509_name_oneline(X509_get_subject_name(backend->server_cert),
                          buffer, sizeof(buffer));
   infof(data, " subject: %s\n", rc?"[NONE]":buffer);
 
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
   {
     long len;
-    ASN1_TIME_print(mem, X509_get0_notBefore(BACKEND->server_cert));
+    ASN1_TIME_print(mem, X509_get0_notBefore(backend->server_cert));
     len = BIO_get_mem_data(mem, (char **) &ptr);
     infof(data, " start date: %.*s\n", len, ptr);
     (void)BIO_reset(mem);
 
-    ASN1_TIME_print(mem, X509_get0_notAfter(BACKEND->server_cert));
+    ASN1_TIME_print(mem, X509_get0_notAfter(backend->server_cert));
     len = BIO_get_mem_data(mem, (char **) &ptr);
     infof(data, " expire date: %.*s\n", len, ptr);
     (void)BIO_reset(mem);
@@ -3497,15 +3500,15 @@ static CURLcode servercert(struct connectdata *conn,
   BIO_free(mem);
 
   if(SSL_CONN_CONFIG(verifyhost)) {
-    result = verifyhost(conn, BACKEND->server_cert);
+    result = verifyhost(conn, backend->server_cert);
     if(result) {
-      X509_free(BACKEND->server_cert);
-      BACKEND->server_cert = NULL;
+      X509_free(backend->server_cert);
+      backend->server_cert = NULL;
       return result;
     }
   }
 
-  rc = x509_name_oneline(X509_get_issuer_name(BACKEND->server_cert),
+  rc = x509_name_oneline(X509_get_issuer_name(backend->server_cert),
                          buffer, sizeof(buffer));
   if(rc) {
     if(strict)
@@ -3527,8 +3530,8 @@ static CURLcode servercert(struct connectdata *conn,
               " error %s",
               ossl_strerror(ERR_get_error(), error_buffer,
                             sizeof(error_buffer)) );
-        X509_free(BACKEND->server_cert);
-        BACKEND->server_cert = NULL;
+        X509_free(backend->server_cert);
+        backend->server_cert = NULL;
         return CURLE_OUT_OF_MEMORY;
       }
 
@@ -3537,8 +3540,8 @@ static CURLcode servercert(struct connectdata *conn,
           failf(data, "SSL: Unable to open issuer cert (%s)",
                 SSL_SET_OPTION(issuercert));
         BIO_free(fp);
-        X509_free(BACKEND->server_cert);
-        BACKEND->server_cert = NULL;
+        X509_free(backend->server_cert);
+        backend->server_cert = NULL;
         return CURLE_SSL_ISSUER_ERROR;
       }
 
@@ -3549,19 +3552,19 @@ static CURLcode servercert(struct connectdata *conn,
                 SSL_SET_OPTION(issuercert));
         BIO_free(fp);
         X509_free(issuer);
-        X509_free(BACKEND->server_cert);
-        BACKEND->server_cert = NULL;
+        X509_free(backend->server_cert);
+        backend->server_cert = NULL;
         return CURLE_SSL_ISSUER_ERROR;
       }
 
-      if(X509_check_issued(issuer, BACKEND->server_cert) != X509_V_OK) {
+      if(X509_check_issued(issuer, backend->server_cert) != X509_V_OK) {
         if(strict)
           failf(data, "SSL: Certificate issuer check failed (%s)",
                 SSL_SET_OPTION(issuercert));
         BIO_free(fp);
         X509_free(issuer);
-        X509_free(BACKEND->server_cert);
-        BACKEND->server_cert = NULL;
+        X509_free(backend->server_cert);
+        backend->server_cert = NULL;
         return CURLE_SSL_ISSUER_ERROR;
       }
 
@@ -3571,7 +3574,7 @@ static CURLcode servercert(struct connectdata *conn,
       X509_free(issuer);
     }
 
-    lerr = *certverifyresult = SSL_get_verify_result(BACKEND->handle);
+    lerr = *certverifyresult = SSL_get_verify_result(backend->handle);
 
     if(*certverifyresult != X509_V_OK) {
       if(SSL_CONN_CONFIG(verifypeer)) {
@@ -3596,8 +3599,8 @@ static CURLcode servercert(struct connectdata *conn,
   if(SSL_CONN_CONFIG(verifystatus)) {
     result = verifystatus(conn, connssl);
     if(result) {
-      X509_free(BACKEND->server_cert);
-      BACKEND->server_cert = NULL;
+      X509_free(backend->server_cert);
+      backend->server_cert = NULL;
       return result;
     }
   }
@@ -3610,13 +3613,13 @@ static CURLcode servercert(struct connectdata *conn,
   ptr = SSL_IS_PROXY() ? data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY] :
                          data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG];
   if(!result && ptr) {
-    result = pkp_pin_peer_pubkey(data, BACKEND->server_cert, ptr);
+    result = pkp_pin_peer_pubkey(data, backend->server_cert, ptr);
     if(result)
       failf(data, "SSL: public key does not match pinned public key!");
   }
 
-  X509_free(BACKEND->server_cert);
-  BACKEND->server_cert = NULL;
+  X509_free(backend->server_cert);
+  backend->server_cert = NULL;
   connssl->connecting_state = ssl_connect_done;
 
   return result;
@@ -3810,14 +3813,15 @@ static ssize_t ossl_send(struct connectdata *conn,
   int memlen;
   int rc;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
 
   ERR_clear_error();
 
   memlen = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
-  rc = SSL_write(BACKEND->handle, mem, memlen);
+  rc = SSL_write(backend->handle, mem, memlen);
 
   if(rc <= 0) {
-    err = SSL_get_error(BACKEND->handle, rc);
+    err = SSL_get_error(backend->handle, rc);
 
     switch(err) {
     case SSL_ERROR_WANT_READ:
@@ -3884,14 +3888,15 @@ static ssize_t ossl_recv(struct connectdata *conn, /* connection data */
   ssize_t nread;
   int buffsize;
   struct ssl_connect_data *connssl = &conn->ssl[num];
+  struct ssl_backend_data *backend = connssl->backend;
 
   ERR_clear_error();
 
   buffsize = (buffersize > (size_t)INT_MAX) ? INT_MAX : (int)buffersize;
-  nread = (ssize_t)SSL_read(BACKEND->handle, buf, buffsize);
+  nread = (ssize_t)SSL_read(backend->handle, buf, buffsize);
   if(nread <= 0) {
     /* failed SSL_read */
-    int err = SSL_get_error(BACKEND->handle, (int)nread);
+    int err = SSL_get_error(backend->handle, (int)nread);
 
     switch(err) {
     case SSL_ERROR_NONE: /* this is not an error */
@@ -4097,8 +4102,9 @@ static void *Curl_ossl_get_internals(struct ssl_connect_data *connssl,
                                      CURLINFO info)
 {
   /* Legacy: CURLINFO_TLS_SESSION must return an SSL_CTX pointer. */
+  struct ssl_backend_data *backend = connssl->backend;
   return info == CURLINFO_TLS_SESSION ?
-         (void *)BACKEND->ctx : (void *)BACKEND->handle;
+         (void *)backend->ctx : (void *)backend->handle;
 }
 
 const struct Curl_ssl Curl_ssl_openssl = {


### PR DESCRIPTION
The use of `#define BACKEND connssl->backend` in the TLS backends is a discouraged way of writing code, it hides what's actually happening, it makes the code harder to follow and it makes it more complicated to work with using debuggers. Remove.

This PR does not remove the define from all backends, only from the ones I was able to build locally.