### PR TITLE
cmdline: Fix handling of OperationConfig linked list

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2258,6 +2258,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
         char *nextarg = (i < (argc - 1)) ? argv[i + 1] : NULL;
 
         result = getparameter(flag, nextarg, &passarg, global, config);
+        config = global->last;
         if(result == PARAM_NEXT_OPERATION) {
           /* Reset result as PARAM_NEXT_OPERATION is only used here and not
              returned from this function */

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -76,7 +76,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
   FILE *file = NULL;
   bool usedarg = FALSE;
   int rc = 0;
-  struct OperationConfig *operation = global->first;
+  struct OperationConfig *operation = global->last;
   char *pathalloc = NULL;
 
   if(!filename || !*filename) {
@@ -233,6 +233,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       fprintf(stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
       res = getparameter(option, param, &usedarg, global, operation);
+      operation = global->last;
 
       if(!res && param && *param && !usedarg)
         /* we passed in a parameter that wasn't used! */


### PR DESCRIPTION
Ensures that -K/--config inserts new items at the end of the list
instead of overwriting the second item, and that after a -K/--config
option has been parsed, the option parser's view of the current
config is update.

Fixes #5120