### PR TITLE
curl-functions.m4: remove inappropriate AC_REQUIRE

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -7289,8 +7289,6 @@ dnl CURL_LIBRARY_PATH variable. It keeps the LD_LIBRARY_PATH
 dnl changes contained within this macro.
 
 AC_DEFUN([CURL_RUN_IFELSE], [
-   AC_REQUIRE([AC_RUN_IFELSE])dnl
-
    old=$LD_LIBRARY_PATH
    LD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
    export LD_LIBRARY_PATH


### PR DESCRIPTION
AC_REQUIRE means "if this macro hasn't been executed already, execute it".  So in a wrapper around AC_RUN_IFELSE, AC_REQUIRE(AC_RUN_IFELSE) isn't correct at that will execute AC_RUN_IFELSE without any arguments.

With autoconf 2.69 this is basically a no-op, but with autoconf 2.70, AC_RUN_IFELSE without a default value when cross-compiling is fatal. The result is that curl with autoconf 2.70 cannot cross-compile.

Closes #5126.