### PR TITLE
test970: improve the test

### DIFF
--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -159,6 +159,19 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
       break;
     }
   }
+  /* use another variable for this to allow different values */
+  timestr = getenv("CURL_DEBUG_SIZE");
+  if(timestr) {
+    unsigned long val = strtol(timestr, NULL, 10);
+    switch(info) {
+    case CURLINFO_HEADER_SIZE:
+    case CURLINFO_REQUEST_SIZE:
+      *param_longp = (long)val;
+      return CURLE_OK;
+    default:
+      break;
+    }
+  }
 #endif
 
   switch(info) {

--- a/tests/data/test970
+++ b/tests/data/test970
@@ -16,12 +16,12 @@ Server: test-server/fake
 Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
 ETag: "21025-dc7-39462498"
 Accept-Ranges: bytes
-Content-Length: 6
+Content-Length: 445
 Connection: close
 Content-Type: text/html
 Funny-head: yesyes
 
--foo-
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
 </data>
 </reply>
 
@@ -38,11 +38,11 @@ debug
 CURL_TIME=13
 CURL_VERSION=curl-unit-test-fake-version
 </setenv>
- <name>
+<name>
 HTTP GET with JSON output
- </name>
- <command>
-http://%HOSTIP:%HTTPPORT/970 --write-out '%{json}'
+</name>
+<command option="no-include">
+http://%HOSTIP:%HTTPPORT/970 --write-out '%{json}' -o log/out970
 </command>
 </client>
 
@@ -59,19 +59,7 @@ Accept: */*
 
 </protocol>
 <stdout nonewline="yes">
-HTTP/1.1 200 OK
-Date: Thu, 09 Nov 2010 14:49:00 GMT
-Server: test-server/fake
-Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
-ETag: "21025-dc7-39462498"
-Accept-Ranges: bytes
-Content-Length: 6
-Connection: close
-Content-Type: text/html
-Funny-head: yesyes
-
--foo-
-{"url_effective":"http://%HOSTIP:%HTTPPORT/970","http_code":200,"response_code":200,"http_connect":0,"time_total":0.000013,"time_namelookup":0.000013,"time_connect":0.000013,"time_appconnect":0.000013,"time_pretransfer":0.000013,"time_starttransfer":0.000013,"size_header":250,"size_request":85,"size_download":6,"size_upload":0,"speed_download":0.000013,"speed_upload":0.000013,"content_type":"text/html","num_connects":1,"time_redirect":0.000013,"num_redirects":0,"ssl_verify_result":0,"proxy_ssl_verify_result":0,"filename_effective":null,"remote_ip":"%HOSTIP","remote_port":%HTTPPORT,"local_ip":"127.0.0.1","local_port":13,"http_version":"1.1","scheme":"HTTP","curl_version":"curl-unit-test-fake-version"}
+{"url_effective":"http://%HOSTIP:%HTTPPORT/970","http_code":200,"response_code":200,"http_connect":0,"time_total":0.000013,"time_namelookup":0.000013,"time_connect":0.000013,"time_appconnect":0.000013,"time_pretransfer":0.000013,"time_starttransfer":0.000013,"size_header":252,"size_request":85,"size_download":445,"size_upload":0,"speed_download":0.000013,"speed_upload":0.000013,"content_type":"text/html","num_connects":1,"time_redirect":0.000013,"num_redirects":0,"ssl_verify_result":0,"proxy_ssl_verify_result":0,"filename_effective":"log/out970","remote_ip":"%HOSTIP","remote_port":%HTTPPORT,"local_ip":"127.0.0.1","local_port":13,"http_version":"1.1","scheme":"HTTP","curl_version":"curl-unit-test-fake-version"}
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test970
+++ b/tests/data/test970
@@ -36,6 +36,7 @@ debug
 </features>
 <setenv>
 CURL_TIME=13
+CURL_DEBUG_SIZE=4019
 CURL_VERSION=curl-unit-test-fake-version
 </setenv>
 <name>
@@ -59,7 +60,7 @@ Accept: */*
 
 </protocol>
 <stdout nonewline="yes">
-{"url_effective":"http://%HOSTIP:%HTTPPORT/970","http_code":200,"response_code":200,"http_connect":0,"time_total":0.000013,"time_namelookup":0.000013,"time_connect":0.000013,"time_appconnect":0.000013,"time_pretransfer":0.000013,"time_starttransfer":0.000013,"size_header":252,"size_request":85,"size_download":445,"size_upload":0,"speed_download":0.000013,"speed_upload":0.000013,"content_type":"text/html","num_connects":1,"time_redirect":0.000013,"num_redirects":0,"ssl_verify_result":0,"proxy_ssl_verify_result":0,"filename_effective":"log/out970","remote_ip":"%HOSTIP","remote_port":%HTTPPORT,"local_ip":"127.0.0.1","local_port":13,"http_version":"1.1","scheme":"HTTP","curl_version":"curl-unit-test-fake-version"}
+{"url_effective":"http://%HOSTIP:%HTTPPORT/970","http_code":200,"response_code":200,"http_connect":0,"time_total":0.000013,"time_namelookup":0.000013,"time_connect":0.000013,"time_appconnect":0.000013,"time_pretransfer":0.000013,"time_starttransfer":0.000013,"size_header":4019,"size_request":4019,"size_download":445,"size_upload":0,"speed_download":0.000013,"speed_upload":0.000013,"content_type":"text/html","num_connects":1,"time_redirect":0.000013,"num_redirects":0,"ssl_verify_result":0,"proxy_ssl_verify_result":0,"filename_effective":"log/out970","remote_ip":"%HOSTIP","remote_port":%HTTPPORT,"local_ip":"127.0.0.1","local_port":13,"http_version":"1.1","scheme":"HTTP","curl_version":"curl-unit-test-fake-version"}
 </stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
- send more data to make problems more obvious
- don't start the data with minus, it makes diffs harder to read
- skip the headers in the stdout comparison
- save to a file name to also verify 'filename_effective'

Ref: #5131

This should make it a bit better for debugging the remaining issues in #5131 