### PR TITLE
openssl: adapt to functions marked as deprecated since version 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1891,13 +1891,9 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
         [Define to 1 if using OpenSSL 3 or later.])
       dnl OpenSSLv3 marks the DES functions deprecated but we have no
       dnl replacements (yet) so tell the compiler to not warn for them
-      case "$compiler_id" in
-        CLANG | GNU_C)
-          CFLAGS="$CFLAGS -Wno-deprecated-declarations"
-          ;;
-        *)
-          ;;
-      esac
+      dnl
+      dnl Ask OpenSSL to suppress the warnings.
+      CPPFLAGS="$CPPFLAGS -DOPENSSL_SUPPRESS_DEPRECATED"
       ssl_msg="OpenSSL v3+"
     ],[
       AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -1873,6 +1873,35 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
     ],[
       AC_MSG_RESULT([no])
     ])
+
+    AC_MSG_CHECKING([for OpenSSL >= v3])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+#include <openssl/opensslv.h>
+      ]],[[
+        #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+        return 0;
+        #else
+        #error older than 3
+        #endif
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
+      AC_DEFINE_UNQUOTED(HAVE_OPENSSL3, 1,
+        [Define to 1 if using OpenSSL 3 or later.])
+      dnl OpenSSLv3 marks the DES functions deprecated but we have no
+      dnl replacements (yet) so tell the compiler to not warn for them
+      case "$compiler_id" in
+        CLANG | GNU_C)
+          CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+          ;;
+        *)
+          ;;
+      esac
+      ssl_msg="OpenSSL v3+"
+    ],[
+      AC_MSG_RESULT([no])
+    ])
   fi
 
   if test "$OPENSSL_ENABLED" = "1"; then

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -29,6 +29,10 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+/* OpenSSL 3.0.0 marks the MD4 functions as deprecated */
+#define OPENSSL_NO_MD4
+#endif
 #endif /* USE_OPENSSL */
 
 #ifdef USE_MBEDTLS


### PR DESCRIPTION
OpenSSL 3 deprecates SSL_CTX_load_verify_locations and the MD4, DES functions we use.

This commit fixes the MD4 and SSL_CTX_load_verify_locations warnings.

 - [x] SSL_CTX_load_verify_locations
 - [x] MD4
 - [x] DES

The DES warnings are simply inhibited so far.