### PR TITLE
doc: nghttp2 1.12.0 required

### DIFF
--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -18,7 +18,7 @@ parts. The reason for this is that HTTP/2 is much more complex at that layer
 than HTTP/1.1 (which we implement on our own) and that nghttp2 is an already
 existing and well functional library.
 
-We require at least version 1.0.0.
+We require at least version 1.12.0.
 
 Over an http:// URL
 -------------------


### PR DESCRIPTION
since nghttp2_session_set_local_window_size is needed

Proof in configure.ac:
https://github.com/curl/curl/blob/27ea8fc2faa4e4753a9cff0a7f48d1dba68013d6/configure.ac#L3388-L3390

I found it when trying to build with ./configure --with-nghttp2 while having libnghttp2 1.7.1-1