### PR TITLE
output.d: quote the URL when globbing

### DIFF
--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -5,9 +5,9 @@ Help: Write to file instead of stdout
 See-also: remote-name remote-name-all remote-header-name
 ---
 Write output to <file> instead of stdout. If you are using {} or [] to fetch
-multiple documents, you can use '#' followed by a number in the <file>
-specifier. That variable will be replaced with the current string for the URL
-being fetched. Like in:
+multiple documents, you should quote the URL and you can use '#' followed by a
+number in the <file> specifier. That variable will be replaced with the current
+string for the URL being fetched. Like in:
 
  curl "http://{one,two}.example.com" -o "file_#1.txt"
 

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -9,11 +9,11 @@ multiple documents, you can use '#' followed by a number in the <file>
 specifier. That variable will be replaced with the current string for the URL
 being fetched. Like in:
 
- curl http://{one,two}.example.com -o "file_#1.txt"
+ curl "http://{one,two}.example.com" -o "file_#1.txt"
 
 or use several variables like:
 
- curl http://{site,host}.host[1-5].com -o "#1_#2"
+ curl "http://{site,host}.host[1-5].com" -o "#1_#2"
 
 You may use this option as many times as the number of URLs you have. For
 example, if you specify two URLs on the same command line, you can use it like

--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -46,9 +46,9 @@ The URL syntax is protocol-dependent. You'll find a detailed description in
 RFC 3986.
 
 You can specify multiple URLs or parts of URLs by writing part sets within
-braces as in:
+braces and quoting the URL as in:
 
-  http://site.{one,two,three}.com
+  "http://site.{one,two,three}.com"
 
 or you can get sequences of alphanumeric series by using [] as in:
 


### PR DESCRIPTION
Some shells do globbing of their own unless the URL is quoted, so maybe
encourage this.