### PR TITLE
version: fix for builds using a thread-unsafe CURL_CA_BUNDLE

### DIFF
--- a/lib/Makefile.netware
+++ b/lib/Makefile.netware
@@ -670,7 +670,9 @@ endif
 ifdef CABUNDLE
 	@echo $(DL)#define CURL_CA_BUNDLE "$(CABUNDLE)"$(DL) >> $@
 else
+	@echo $(DL)/* Thread-unsafe hack to get CURL_CA_BUNDLE at runtime. Legacy OSes only.  */$(DL) >> $@
 	@echo $(DL)#define CURL_CA_BUNDLE getenv("CURL_CA_BUNDLE")$(DL) >> $@
+	@echo $(DL)#define CURL_CA_BUNDLE_THREAD_UNSAFE 1$(DL) >> $@
 endif
 
 $(EXPORTF): $(CURL_INC)/curl/curl.h $(CURL_INC)/curl/easy.h $(CURL_INC)/curl/multi.h $(CURL_INC)/curl/mprintf.h

--- a/lib/config-dos.h
+++ b/lib/config-dos.h
@@ -151,7 +151,9 @@
   #define ssize_t  int
 #endif
 
+/* Thread-unsafe hack to get CURL_CA_BUNDLE at runtime. Legacy OSes only.  */
 #define CURL_CA_BUNDLE  getenv("CURL_CA_BUNDLE")
+#define CURL_CA_BUNDLE_THREAD_UNSAFE 1
 
 /* Target HAVE_x section */
 

--- a/lib/version.c
+++ b/lib/version.c
@@ -405,7 +405,7 @@ static curl_version_info_data version_info = {
   0,    /* nghttp2 version number */
   NULL, /* nghttp2 version string */
   NULL, /* quic library string */
-#ifdef CURL_CA_BUNDLE
+#if defined(CURL_CA_BUNDLE) && !defined(CURL_CA_BUNDLE_THREAD_UNSAFE)
   CURL_CA_BUNDLE, /* cainfo */
 #else
   NULL,


### PR DESCRIPTION
- If CURL_CA_BUNDLE is thread-unsafe then do not point to it in the
  version information. This would only happen in the case of the getenv
  hack that is used for legacy OSes (DOS, Netware).

This is a follow-up to 6de756c which added cainfo and capath support to
the version information. CURL_CA_BUNDLE (which is cainfo) is typically
a literal string determined at build-time but we have some legacy OSes
(DOS, Netware) that determine it at runtime by using an environment
variable of the same name, ie: getenv("CURL_CA_BUNDLE").

Bug: https://github.com/curl/curl/commit/6de756c#r38127030
Reported-by: Gisle Vanem

Closes #xxxx

---

/cc @gvanem 