### PR TITLE
checksrc: warn for "onelinecondition"

### DIFF
--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -129,11 +129,11 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
               unsigned int ifscope = Curl_ipv6_scope(iface->ifa_addr);
 
               if(ifscope != remote_scope) {
-                /* We are interested only in interface addresses whose
-                   scope matches the remote address we want to
-                   connect to: global for global, link-local for
-                   link-local, etc... */
-                if(res == IF2IP_NOT_FOUND) res = IF2IP_AF_NOT_SUPPORTED;
+                /* We are interested only in interface addresses whose scope
+                   matches the remote address we want to connect to: global
+                   for global, link-local for link-local, etc... */
+                if(res == IF2IP_NOT_FOUND)
+                  res = IF2IP_AF_NOT_SUPPORTED;
                 continue;
               }
 

--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -227,7 +227,8 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
 
     gss_release_buffer(&gss_status, &gss_send_token);
     gss_release_buffer(&gss_status, &gss_recv_token);
-    if(gss_major_status != GSS_S_CONTINUE_NEEDED) break;
+    if(gss_major_status != GSS_S_CONTINUE_NEEDED)
+      break;
 
     /* analyse response */
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1824,7 +1824,8 @@ static CURLcode verifystatus(struct connectdata *conn,
   }
 
 end:
-  if(br) OCSP_BASICRESP_free(br);
+  if(br)
+    OCSP_BASICRESP_free(br);
   OCSP_RESPONSE_free(rsp);
 
   return result;

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -285,7 +285,8 @@ CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
     /* we only use this for real if --libcurl was used */
     const NameValue *nv = NULL;
     for(nv = nvlist; nv->name; nv++) {
-      if(nv->value == lval) break; /* found it */
+      if(nv->value == lval)
+        break; /* found it */
     }
     if(! nv->name) {
       /* If no definition was found, output an explicit value.

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -44,11 +44,13 @@
 
 #include "curl_printf.h"
 
-#define test_setopt(A,B,C) \
-  if((res = curl_easy_setopt((A), (B), (C))) != CURLE_OK) goto test_cleanup
+#define test_setopt(A,B,C)                                      \
+  if((res = curl_easy_setopt((A), (B), (C))) != CURLE_OK)       \
+    goto test_cleanup
 
-#define test_multi_setopt(A,B,C) \
-  if((res = curl_multi_setopt((A), (B), (C))) != CURLE_OK) goto test_cleanup
+#define test_multi_setopt(A,B,C)                                \
+  if((res = curl_multi_setopt((A), (B), (C))) != CURLE_OK)      \
+    goto test_cleanup
 
 extern char *libtest_arg2; /* set by first.c to the argv[2] or NULL */
 extern char *libtest_arg3; /* set by first.c to the argv[3] or NULL */

--- a/tests/unit/unit1394.c
+++ b/tests/unit/unit1394.c
@@ -122,8 +122,10 @@ UNITTEST_START
         fail("assertion failure");
       }
     }
-    if(certname) free(certname);
-    if(passphrase) free(passphrase);
+    if(certname)
+      free(certname);
+    if(passphrase)
+      free(passphrase);
   }
 
 UNITTEST_STOP


### PR DESCRIPTION
Make checksrc verify that we insert newline after if() conditions and fix a few places where this updated checksrc pointed out this mistake to exist in.

The check is a little naive and will only work for single-line conditions but I think they are the most common for this code style anyway.