### PR TITLE
build: fixed build for systems with select() in unistd.h

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1887,6 +1887,8 @@ struct Library *SocketBase = NULL;
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
@@ -1950,6 +1952,8 @@ struct Library *SocketBase = NULL;
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>

--- a/configure.ac
+++ b/configure.ac
@@ -3887,6 +3887,8 @@ dnl default includes
 #endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -46,6 +46,8 @@
 
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 
 #include "urldata.h"

--- a/lib/select.c
+++ b/lib/select.c
@@ -24,6 +24,8 @@
 
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 
 #if !defined(HAVE_SELECT) && !defined(HAVE_POLL_FINE)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -48,6 +48,8 @@
 
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 
 #ifndef HAVE_SOCKET

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -31,6 +31,8 @@
 
 #ifdef HAVE_SYS_SELECT_H
 #  include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#  include <unistd.h>
 #endif
 
 #ifdef __VMS

--- a/src/tool_sleep.c
+++ b/src/tool_sleep.c
@@ -23,6 +23,8 @@
 
 #ifdef HAVE_SYS_SELECT_H
 #  include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#  include <unistd.h>
 #endif
 
 #ifdef HAVE_POLL_H

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -36,6 +36,8 @@
 #ifdef HAVE_SYS_SELECT_H
 /* since so many tests use select(), we can just as well include it here */
 #include <sys/select.h>
+#elif defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 
 #ifdef TPF


### PR DESCRIPTION
Fixes build on systems that are missing sys/select.h but have have select() prototype in unistd.h instead.