### PR TITLE
[CI] Increasing fuzz time

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'curl'
-        fuzz-seconds: 600
+        fuzz-seconds: 2400
         dry-run: false
 
     - name: Upload Crash


### PR DESCRIPTION
This will allow more time for fuzzing. Other CI workflow takes ~ 2 hours so CIFuzz will still not be a bottleneck.  