### PR TITLE
tests: fix portability issue with Perl waitpid on Windows

### DIFF
--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -703,7 +703,7 @@ sub close_dataconn {
         logmsg "DATA sockfilt for $datasockf_mode data channel quits ".
                "(pid $datapid)\n";
         print DWRITE "QUIT\n";
-        waitpid($datapid, 0);
+        portable_waitpid($datapid, 0);
         unlink($datasockf_pidfile) if(-f $datasockf_pidfile);
         logmsg "DATA sockfilt for $datasockf_mode data channel quit ".
                "(pid $datapid)\n";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -441,7 +441,7 @@ sub checkdied {
     if((not defined $pid) || $pid <= 0) {
         return 0;
     }
-    my $rc = waitpid($pid, &WNOHANG);
+    my $rc = portable_waitpid($pid, &WNOHANG);
     return ($rc == $pid)?1:0;
 }
 


### PR DESCRIPTION
Perl waitpid without WNOHANG can cause random freezes on Windows.

cc @bagder for Perl code review 😄 