### PR TITLE
Use both --etag-compare and --etag-save with the same etag file name

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -905,35 +905,6 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         /* default output stream is stdout */
         outs->stream = stdout;
 
-        /* --etag-save */
-        etag_save = &per->etag_save;
-        etag_save->stream = stdout;
-
-        if(config->etag_save_file) {
-          /* open file for output: */
-          if(strcmp(config->etag_save_file, "-")) {
-            FILE *newfile = fopen(config->etag_save_file, "wb");
-            if(!newfile) {
-              warnf(
-                config->global,
-                "Failed to open %s\n", config->etag_save_file);
-
-              result = CURLE_WRITE_ERROR;
-              break;
-            }
-            else {
-              etag_save->filename = config->etag_save_file;
-              etag_save->s_isreg = TRUE;
-              etag_save->fopened = TRUE;
-              etag_save->stream = newfile;
-            }
-          }
-          else {
-            /* always use binary mode for protocol header output */
-            set_binmode(etag_save->stream);
-          }
-        }
-
         /* --etag-compare */
         if(config->etag_compare_file) {
           char *etag_from_file = NULL;
@@ -941,7 +912,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
           /* open file for reading: */
           FILE *file = fopen(config->etag_compare_file, FOPEN_READTEXT);
-          if(!file) {
+          if(!file && !config->etag_save_file) {
             errorf(config->global,
                    "Failed to open %s\n", config->etag_compare_file);
             result = CURLE_READ_ERROR;
@@ -972,6 +943,35 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
           if(file) {
             fclose(file);
+          }
+        }
+
+        /* --etag-save */
+        etag_save = &per->etag_save;
+        etag_save->stream = stdout;
+
+        if(config->etag_save_file) {
+          /* open file for output: */
+          if(strcmp(config->etag_save_file, "-")) {
+            FILE *newfile = fopen(config->etag_save_file, "wb");
+            if(!newfile) {
+              warnf(
+                config->global,
+                "Failed to open %s\n", config->etag_save_file);
+
+              result = CURLE_WRITE_ERROR;
+              break;
+            }
+            else {
+              etag_save->filename = config->etag_save_file;
+              etag_save->s_isreg = TRUE;
+              etag_save->fopened = TRUE;
+              etag_save->stream = newfile;
+            }
+          }
+          else {
+            /* always use binary mode for protocol header output */
+            set_binmode(etag_save->stream);
           }
         }
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -58,7 +58,7 @@ test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
-test343 \
+test343 test344 test345 \
 test350 test351 test352 test353 test354 test355 test356 test357 \
 test393 test394 test395 \
 \

--- a/tests/data/test344
+++ b/tests/data/test344
@@ -1,0 +1,58 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-11111"
+Accept-Ranges: bytes
+Content-Length: 0
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Both --etag-compare and --etag-save to save new Etag using the same filename and log/etag344 does not exists
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/344 --etag-compare log/etag344 --etag-save log/etag344
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /344 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+If-None-Match: ""
+
+</protocol>
+<file name="log/etag344">
+21025-dc7-11111
+</file>
+</verify>
+</testcase>

--- a/tests/data/test344
+++ b/tests/data/test344
@@ -31,7 +31,7 @@ Funny-head: yesyes
 http
 </server>
 <name>
-Both --etag-compare and --etag-save to save new Etag using the same filename and log/etag344 does not exists
+Both --etag-compare and -save store new Etag using non-existing file
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/344 --etag-compare log/etag344 --etag-save log/etag344

--- a/tests/data/test345
+++ b/tests/data/test345
@@ -1,0 +1,61 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-11111"
+Accept-Ranges: bytes
+Content-Length: 0
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Both --etag-compare and --etag-save to save new Etag using the same filename and log/etag345 does exists
+</name>
+<file name="log/etag345">
+21025-dc7-39462498
+</file>
+<command>
+http://%HOSTIP:%HTTPPORT/345 --etag-compare log/etag345 --etag-save log/etag345
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /345 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+If-None-Match: "21025-dc7-39462498"
+
+</protocol>
+<file name="log/etag345">
+21025-dc7-11111
+</file>
+</verify>
+</testcase>

--- a/tests/data/test345
+++ b/tests/data/test345
@@ -31,7 +31,7 @@ Funny-head: yesyes
 http
 </server>
 <name>
-Both --etag-compare and --etag-save to save new Etag using the same filename and log/etag345 does exists
+Both --etag-compare and -save store new Etag using one pre-existing file
 </name>
 <file name="log/etag345">
 21025-dc7-39462498


### PR DESCRIPTION
This change inverse the order of processing for the --etag-compare and
--etag-save option to process first --etag-compare.
This in turn allows to use the same file name to compare and save an
etag.
The original behavior of not failing if the etag file does not exists is
conserved.

This fixes issue #5179.