### PR TITLE
Do not write output file if server respond with http code 304

### DIFF
--- a/docs/libcurl/curl_easy_getinfo.3
+++ b/docs/libcurl/curl_easy_getinfo.3
@@ -210,7 +210,7 @@ TLS session info that can be used for further processing.  See
 \fICURLINFO_TLS_SESSION(3)\fP. Deprecated option, use
 \fICURLINFO_TLS_SSL_PTR(3)\fP instead!
 .IP CURLINFO_CONDITION_UNMET
-Whether or not a time conditional was met.
+Whether or not a time conditional was met or 304 HTTP response.
 See \fICURLINFO_CONDITION_UNMET(3)\fP
 .IP CURLINFO_RTSP_SESSION_ID
 RTSP session ID.

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
@@ -22,7 +22,7 @@
 .\"
 .TH CURLINFO_CONDITION_UNMET 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
 .SH NAME
-CURLINFO_CONDITION_UNMET \- get info on unmet time conditional
+CURLINFO_CONDITION_UNMET \- get info on unmet time conditional or 304 HTTP response.
 .SH SYNOPSIS
 #include <curl/curl.h>
 
@@ -32,7 +32,9 @@ Pass a pointer to a long to receive the number 1 if the condition provided in
 the previous request didn't match (see \fICURLOPT_TIMECONDITION(3)\fP). Alas,
 if this returns a 1 you know that the reason you didn't get data in return is
 because it didn't fulfill the condition. The long this argument points to will
-get a zero stored if the condition instead was met.
+get a zero stored if the condition instead was met. This can also return 1 if
+the server responded with a 304 HTTP status code, for example after sending a
+custom "If-Match-*" header.
 .SH PROTOCOLS
 HTTP and some
 .SH EXAMPLE

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -239,8 +239,11 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
     *param_longp = data->info.conn_local_port;
     break;
   case CURLINFO_CONDITION_UNMET:
-    /* return if the condition prevented the document to get transferred */
-    *param_longp = data->info.timecond ? 1L : 0L;
+    if(data->info.httpcode == 304)
+      *param_longp = 1L;
+    else
+      /* return if the condition prevented the document to get transferred */
+      *param_longp = data->info.timecond ? 1L : 0L;
     break;
   case CURLINFO_RTSP_CLIENT_CSEQ:
     *param_longp = data->state.rtsp_next_client_CSeq;


### PR DESCRIPTION
Using the --etag-compare option, we can ask the server to either send
the file if it was updated or respond with a 304 response code to
signify that the file did not change.
This commit recognize this response code and avoid writing the output
file, which avoid truncating a previously downloaded file.

This fix issue #5181.

Unfortunately, I don't know how to write a test case for this...