### PR TITLE
test for pr 5183

### DIFF
--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -239,8 +239,11 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
     *param_longp = data->info.conn_local_port;
     break;
   case CURLINFO_CONDITION_UNMET:
-    /* return if the condition prevented the document to get transferred */
-    *param_longp = data->info.timecond ? 1L : 0L;
+    if(data->info.httpcode == 304)
+      *param_longp = 1L;
+    else
+      /* return if the condition prevented the document to get transferred */
+      *param_longp = data->info.timecond ? 1L : 0L;
     break;
   case CURLINFO_RTSP_CLIENT_CSEQ:
     *param_longp = data->state.rtsp_next_client_CSeq;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -183,6 +183,7 @@ test1533 test1534 test1535 test1536 test1537 test1538 \
 test1540 test1541 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 test1564 test1565 \
+test1566 \
 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \

--- a/tests/data/test1566
+++ b/tests/data/test1566
@@ -1,0 +1,65 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+--etag-compare
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 304 Not modified
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Connection: close
+Content-Type: text/html
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+--etag-compare that gets a 304 back shouldn't overwrite the file
+</name>
+<command option="no-output,no-include">
+http://%HOSTIP:%HTTPPORT/1566 -o log/output1566 --etag-compare log/etag1566
+</command>
+<file name="log/etag1566">
+123456
+</file>
+<file1 name="log/output1566">
+downloaded already
+</file1>
+
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1566 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+If-None-Match: "123456"
+
+</protocol>
+
+# verify that the target file is untouched
+<file name="log/output1566">
+downloaded already
+</file>
+</verify>
+</testcase>


### PR DESCRIPTION
This adds test 1566 that verifies the fix in #5183. It includes the PR commit itself for now as well, but it will be removed once #5183 is merged and this test has proven to work correctly.

Without PR #5183, this test fails.