### PR TITLE
lib: never define CURL_CA_BUNDLE with a getenv

### DIFF
--- a/lib/Makefile.netware
+++ b/lib/Makefile.netware
@@ -669,8 +669,6 @@ endif
 	@echo $(DL)#endif$(DL) >> $@
 ifdef CABUNDLE
 	@echo $(DL)#define CURL_CA_BUNDLE "$(CABUNDLE)"$(DL) >> $@
-else
-	@echo $(DL)#define CURL_CA_BUNDLE getenv("CURL_CA_BUNDLE")$(DL) >> $@
 endif
 
 $(EXPORTF): $(CURL_INC)/curl/curl.h $(CURL_INC)/curl/easy.h $(CURL_INC)/curl/multi.h $(CURL_INC)/curl/mprintf.h

--- a/lib/config-dos.h
+++ b/lib/config-dos.h
@@ -151,8 +151,6 @@
   #define ssize_t  int
 #endif
 
-#define CURL_CA_BUNDLE  getenv("CURL_CA_BUNDLE")
-
 /* Target HAVE_x section */
 
 #if defined(DJGPP)


### PR DESCRIPTION
- it breaks the build (since 6de756c9b1de34b7a1)
- it's not documented and not consistent across platforms
- the curl tool does that getenv magic

Bug: https://github.com/curl/curl/commit/6de756c#r38127030
Reported-by: Gisle Vanem

This is my preferred fix instead of #5161.