### PR TITLE
tests: fix conflict between Cygwin/msys and Windows PIDs

### DIFF
--- a/tests/dictserver.py
+++ b/tests/dictserver.py
@@ -51,8 +51,11 @@ def dictserver(options):
     """
     if options.pidfile:
         pid = os.getpid()
+        # see tests/server/util.c function write_pidfile
+        if os.name == "nt":
+            pid += 65536
         with open(options.pidfile, "w") as f:
-            f.write("{0}".format(pid))
+            f.write(str(pid))
 
     local_bind = (options.host, options.port)
     log.info("[DICT] Listening on %s", local_bind)
@@ -85,7 +88,11 @@ class DictHandler(socketserver.BaseRequestHandler):
             if VERIFIED_REQ in data:
                 log.debug("[DICT] Received verification request from test "
                           "framework")
-                response_data = VERIFIED_RSP.format(pid=os.getpid())
+                pid = os.getpid()
+                # see tests/server/util.c function write_pidfile
+                if os.name == "nt":
+                    pid += 65536
+                response_data = VERIFIED_RSP.format(pid=pid)
             else:
                 log.debug("[DICT] Received normal request")
                 response_data = "No matches"

--- a/tests/ftp.pm
+++ b/tests/ftp.pm
@@ -97,13 +97,15 @@ sub pidexists {
     if($pid > 0) {
         # verify if currently existing Windows process
         if ($pid > 65536 && os_is_win()) {
-            my $winpid = $pid - 65536;
-            my $filter = "PID eq $winpid";
-            my $result = `tasklist -fi \"$filter\" 2>nul`;
-            if(index($result, "$winpid") != -1) {
-                return -$winpid;
+            $pid -= 65536;
+            if($^O ne 'MSWin32') {
+                my $filter = "PID eq $pid";
+                my $result = `tasklist -fi \"$filter\" 2>nul`;
+                if(index($result, "$pid") != -1) {
+                    return -$pid;
+                }
+                return 0;
             }
-            return 0;
         }
 
         # verify if currently existing and alive
@@ -124,13 +126,15 @@ sub pidterm {
     if($pid > 0) {
         # request the process to quit
         if ($pid > 65536 && os_is_win()) {
-            my $winpid = $pid - 65536;
-            my $filter = "PID eq $winpid";
-            my $result = `tasklist -fi \"$filter\" 2>nul`;
-            if(index($result, "$winpid") != -1) {
-                system("taskkill -fi \"$filter\" >nul 2>&1");
+            $pid -= 65536;
+            if($^O ne 'MSWin32') {
+                my $filter = "PID eq $pid";
+                my $result = `tasklist -fi \"$filter\" 2>nul`;
+                if(index($result, "$pid") != -1) {
+                    system("taskkill -fi \"$filter\" >nul 2>&1");
+                }
+                return;
             }
-            return;
         }
 
         # signal the process to terminate
@@ -147,15 +151,17 @@ sub pidkill {
     if($pid > 0) {
         # request the process to quit
         if ($pid > 65536 && os_is_win()) {
-            my $winpid = $pid - 65536;
-            my $filter = "PID eq $winpid";
-            my $result = `tasklist -fi \"$filter\" 2>nul`;
-            if(index($result, "$winpid") != -1) {
-                system("taskkill -f -fi \"$filter\" >nul 2>&1");
-                # Windows XP Home compatibility
-                system("tskill $winpid >nul 2>&1");
+            $pid -= 65536;
+            if($^O ne 'MSWin32') {
+                my $filter = "PID eq $pid";
+                my $result = `tasklist -fi \"$filter\" 2>nul`;
+                if(index($result, "$pid") != -1) {
+                    system("taskkill -f -fi \"$filter\" >nul 2>&1");
+                    # Windows XP Home compatibility
+                    system("tskill $pid >nul 2>&1");
+                }
+                return;
             }
-            return;
         }
 
         # signal the process to terminate

--- a/tests/ftp.pm
+++ b/tests/ftp.pm
@@ -42,6 +42,10 @@ use serverhelp qw(
     datasockf_pidfilename
     );
 
+use pathhelp qw(
+    os_is_win
+    );
+
 #######################################################################
 # portable_sleep uses Time::HiRes::sleep if available and falls back
 # to the classic approach of using select(undef, undef, undef, ...).
@@ -55,7 +59,7 @@ sub portable_sleep {
     if($Time::HiRes::VERSION) {
         Time::HiRes::sleep($seconds);
     }
-    elsif ($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys') {
+    elsif (os_is_win()) {
         Win32::Sleep($seconds*1000);
     }
     else {
@@ -91,18 +95,20 @@ sub pidexists {
     my $pid = $_[0];
 
     if($pid > 0) {
+        # verify if currently existing Windows process
+        if ($pid > 65536 && os_is_win()) {
+            my $winpid = $pid - 65536;
+            my $filter = "PID eq $winpid";
+            my $result = `tasklist -fi \"$filter\" 2>nul`;
+            if(index($result, "$winpid") != -1) {
+                return -$winpid;
+            }
+            return 0;
+        }
+
         # verify if currently existing and alive
         if(kill(0, $pid)) {
             return $pid;
-        }
-
-        # verify if currently existing Windows process
-        if($^O eq "msys") {
-            my $filter = "PID eq $pid";
-            my $result = `tasklist -fi \"$filter\" 2>nul`;
-            if(index($result, "$pid") != -1) {
-                return -$pid;
-            }
         }
     }
 
@@ -116,17 +122,19 @@ sub pidterm {
     my $pid = $_[0];
 
     if($pid > 0) {
-        # signal the process to terminate
-        kill("TERM", $pid);
-
         # request the process to quit
-        if($^O eq "msys") {
-            my $filter = "PID eq $pid";
+        if ($pid > 65536 && os_is_win()) {
+            my $winpid = $pid - 65536;
+            my $filter = "PID eq $winpid";
             my $result = `tasklist -fi \"$filter\" 2>nul`;
-            if(index($result, "$pid") != -1) {
+            if(index($result, "$winpid") != -1) {
                 system("taskkill -fi \"$filter\" >nul 2>&1");
             }
+            return;
         }
+
+        # signal the process to terminate
+        kill("TERM", $pid);
     }
 }
 
@@ -137,19 +145,21 @@ sub pidkill {
     my $pid = $_[0];
 
     if($pid > 0) {
-        # signal the process to terminate
-        kill("KILL", $pid);
-
         # request the process to quit
-        if($^O eq "msys") {
-            my $filter = "PID eq $pid";
+        if ($pid > 65536 && os_is_win()) {
+            my $winpid = $pid - 65536;
+            my $filter = "PID eq $winpid";
             my $result = `tasklist -fi \"$filter\" 2>nul`;
-            if(index($result, "$pid") != -1) {
+            if(index($result, "$winpid") != -1) {
                 system("taskkill -f -fi \"$filter\" >nul 2>&1");
                 # Windows XP Home compatibility
-                system("tskill $pid >nul 2>&1");
+                system("tskill $winpid >nul 2>&1");
             }
+            return;
         }
+
+        # signal the process to terminate
+        kill("KILL", $pid);
     }
 }
 

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -703,7 +703,7 @@ sub close_dataconn {
         logmsg "DATA sockfilt for $datasockf_mode data channel quits ".
                "(pid $datapid)\n";
         print DWRITE "QUIT\n";
-        waitpid($datapid, 0);
+        pidwait($datapid, 0);
         unlink($datasockf_pidfile) if(-f $datasockf_pidfile);
         logmsg "DATA sockfilt for $datasockf_mode data channel quit ".
                "(pid $datapid)\n";

--- a/tests/negtelnetserver.py
+++ b/tests/negtelnetserver.py
@@ -49,6 +49,9 @@ def telnetserver(options):
     """
     if options.pidfile:
         pid = os.getpid()
+        # see tests/server/util.c function write_pidfile
+        if os.name == "nt":
+            pid += 65536
         with open(options.pidfile, "w") as f:
             f.write(str(pid))
 
@@ -86,7 +89,11 @@ class NegotiatingTelnetHandler(socketserver.BaseRequestHandler):
 
             if VERIFIED_REQ.encode('utf-8') in data:
                 log.debug("Received verification request from test framework")
-                response = VERIFIED_RSP.format(pid=os.getpid())
+                pid = os.getpid()
+                # see tests/server/util.c function write_pidfile
+                if os.name == "nt":
+                    pid += 65536
+                response = VERIFIED_RSP.format(pid=pid)
                 response_data = response.encode('utf-8')
             else:
                 log.debug("Received normal request - echoing back")

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -441,7 +441,7 @@ sub checkdied {
     if((not defined $pid) || $pid <= 0) {
         return 0;
     }
-    my $rc = waitpid($pid, &WNOHANG);
+    my $rc = pidwait($pid, &WNOHANG);
     return ($rc == $pid)?1:0;
 }
 

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -329,6 +329,7 @@ if($stunnel_version >= 400) {
 # Set file permissions on certificate pem file.
 #
 chmod(0600, $certfile) if(-f $certfile);
+print STDERR "RUN: $cmd\n" if($verbose);
 
 #***************************************************************************
 # Run tstunnel on Windows.
@@ -341,8 +342,10 @@ if($tstunnel_windows) {
     }
 
     # Put an "exec" in front of the command so that the child process
-    # keeps this child's process ID.
+    # keeps this child's process ID by being tied to the spawned shell.
     exec("exec $cmd") || die "Can't exec() $cmd: $!";
+    # exec() will create a new process, but ties the existance of the
+    # new process to the parent waiting perl.exe and sh.exe processes.
 
     # exec() should never return back here to this process. We protect
     # ourselves by calling die() just in case something goes really bad.

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -269,6 +269,15 @@ int write_pidfile(const char *filename)
     logmsg("Couldn't write pid file: %s %s", filename, strerror(errno));
     return 0; /* fail */
   }
+#if defined(WIN32) || defined(_WIN32)
+  /* store pid + 65536 to avoid conflict with Cygwin/msys PIDs, see also:
+   * - https://cygwin.com/git/?p=newlib-cygwin.git;a=commit; ↵
+   *   h=b5e1003722cb14235c4f166be72c09acdffc62ea
+   * - https://cygwin.com/git/?p=newlib-cygwin.git;a=commit; ↵
+   *   h=448cf5aa4b429d5a9cebf92a0da4ab4b5b6d23fe
+   */
+  pid += 65536;
+#endif
   fprintf(pidfile, "%ld\n", pid);
   fclose(pidfile);
   logmsg("Wrote pid %ld to %s", pid, filename);

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -61,8 +61,11 @@ def smbserver(options):
     """
     if options.pidfile:
         pid = os.getpid()
+        # see tests/server/util.c function write_pidfile
+        if os.name == "nt":
+            pid += 65536
         with open(options.pidfile, "w") as f:
-            f.write("{0}".format(pid))
+            f.write(str(pid))
 
     # Here we write a mini config for the server
     smb_config = configparser.ConfigParser()
@@ -267,7 +270,11 @@ class TestSmbServer(imp_smbserver.SMBSERVER):
 
         if requested_filename == VERIFIED_REQ:
             log.debug("[SMB] Verifying server is alive")
-            contents = VERIFIED_RSP.format(pid=os.getpid()).encode('utf-8')
+            pid = os.getpid()
+            # see tests/server/util.c function write_pidfile
+            if os.name == "nt":
+                pid += 65536
+            contents = VERIFIED_RSP.format(pid=pid).encode('utf-8')
 
         self.write_to_fid(fid, contents)
         return fid, filename


### PR DESCRIPTION
Add 65536 to Windows PIDs to allow Windows specific treatment in POSIX Perl based test suite.

See also:
- https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=b5e1003722cb14235c4f166be72c09acdffc62ea
- https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=448cf5aa4b429d5a9cebf92a0da4ab4b5b6d23fe

Replaces #5178


This will hopefully fix the random issues encountered with Windows CI builds as described in #5034.