### PR TITLE
test1148: tolerate progress updates better (again)

### DIFF
--- a/tests/data/test1148
+++ b/tests/data/test1148
@@ -37,9 +37,6 @@ progress-bar
  <command>
 http://%HOSTIP:%HTTPPORT/1148 -# --stderr log/stderrlog1148
 </command>
-<precheck>
-perl -e '$ENV{"LC_NUMERIC"} = "en_US.UTF-8"; print "Test requires point as decimal separator" if system("./libtest/chkdecimalpoint");'
-</precheck>
 <setenv>
 LC_ALL=
 LC_NUMERIC=en_US.UTF-8
@@ -57,13 +54,16 @@ Host: %HOSTIP:%HTTPPORT
 Accept: */*
 
 </protocol>
-# This allows the last 4 letters of the bar to get updated without it
-# matters. We're mostly checking the width of it anyway.
+
+# Check that the progress finished at 100% and has the right bar width.
+# Note the dot in 100.0% is regex to match any character since different
+# locales use different separators.
 <file name="log/stderrlog1148" mode="text">
-bar 100.0%
+correct
 </file>
 <stripfile>
-s/####################################################################..../bar/
+s/.*\r#{72} 100.0%/correct/
 </stripfile>
+
 </verify>
 </testcase>


### PR DESCRIPTION
- Ignore intermediate progress updates.

- Support locales that use a character other than period as decimal
  separator (eg 100,0%).

test1148 checks that the progress finishes at 100% and has the right
bar width. Prior to this change the test assumed that the only progress
reported for such a quick transfer was 100%, however in rare instances
(like in the CI where transfer time can slow considerably) there may be
intermediate updates. For example, below is stderrlog1148 from a failed
CI run with explicit \r and \n added (it is one line; broken up so that
it's easier to understand).

~~~
\r
\r##################################                                        48.3%
\r######################################################################## 100.0%
\n
~~~

Closes #xxxx

---

The improvements made in 6cbe969 (#2488) didn't go far enough.

CI failure: https://github.com/jay/curl/runs/565278274#step:6:2297

To reproduce:
~~~diff
diff --git a/src/tool_cb_prg.c b/src/tool_cb_prg.c
index aad451b..77d892e 100644
--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -194,6 +194,8 @@ int tool_progress_cb(void *clientp,
       num = MAX_BARLENGTH;
     memset(line, '#', num);
     line[num] = '\0';
+    /* !checksrc! disable LONGLINE 1 */
+    fprintf(bar->out, "%s", "\r##################################                                        48.3%");
     msnprintf(format, sizeof(format), "\r%%-%ds %%5.1f%%%%", barwidth);
     fprintf(bar->out, format, line, percent);
   }
~~~