### PR TITLE
lib: fix conversion warnings for SOCKET_WRITABLE/READABLE

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -68,7 +68,9 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
       result = CURLE_OPERATION_TIMEDOUT;
       break;
     }
-    if(SOCKET_READABLE(sockfd, timeleft) <= 0) {
+    if(timeleft > TIME_T_MAX)
+      timeleft = TIME_T_MAX;
+    if(SOCKET_READABLE(sockfd, (time_t)timeleft) <= 0) {
       result = ~CURLE_OK;
       break;
     }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1555,8 +1555,9 @@ schannel_send(struct connectdata *conn, int sockindex,
         written = -1;
         break;
       }
-
-      what = SOCKET_WRITABLE(conn->sock[sockindex], timeleft);
+      if(timeleft > TIME_T_MAX)
+        timeleft = TIME_T_MAX;
+      what = SOCKET_WRITABLE(conn->sock[sockindex], (time_t)timeleft);
       if(what < 0) {
         /* fatal error */
         failf(conn->data, "select/poll on SSL socket, errno: %d", SOCKERRNO);


### PR DESCRIPTION
- If loss of data may occur converting a timediff_t to time_t and
  the time value is > INT_MAX then treat it as INT_MAX.

This is a follow-up to 8843678 which removed the (time_t) typecast
from the macros so that conversion warnings could be identified.

Closes #xxxx

---

CI failure: https://dev.azure.com/daniel0244/curl/_build/results?buildId=1383&view=logs&j=c2efc944-8be4-5924-87ca-71452e4ab024&t=d381528a-c0f3-5d52-3548-84b8c904b9c7&l=77