### PR TITLE
macos.yml: run when pushed to master or */ci + PRs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull requests, but only for the
+  # master branch
+  push:
+    branches:
+      - master
+      - '*/ci'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   fuzzing:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull requests, but only for the
+  # master branch
+  push:
+    branches:
+      - master
+      - '*/ci'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   autotools:


### PR DESCRIPTION
To avoid double-builds when using "local" branches for PRs.