### PR TITLE
cmake: add aliases so exported target names are available in tree.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -92,6 +92,11 @@ add_library(
   ${HHEADERS} ${CSOURCES}
   )
 
+add_library(
+  ${PROJECT_NAME}::${LIB_NAME}
+  ALIAS ${LIB_NAME}
+  )
+
 if(MSVC AND NOT BUILD_SHARED_LIBS)
   set_target_properties(${LIB_NAME} PROPERTIES STATIC_LIBRARY_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
 endif()
@@ -143,5 +148,5 @@ install(TARGETS ${LIB_NAME}
 
 export(TARGETS ${LIB_NAME}
        APPEND FILE ${PROJECT_BINARY_DIR}/libcurl-target.cmake
-       NAMESPACE CURL::
+       NAMESPACE ${PROJECT_NAME}::
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,11 @@ add_executable(
   ${CURL_FILES}
   )
 
+add_executable(
+  ${PROJECT_NAME}::${EXE_NAME}
+  ALIAS ${EXE_NAME}
+  )
+
 if(CURL_HAS_LTO)
   set_target_properties(${EXE_NAME} PROPERTIES
     INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
@@ -99,5 +104,5 @@ target_link_libraries(${EXE_NAME} libcurl ${CURL_LIBS})
 install(TARGETS ${EXE_NAME} EXPORT ${TARGETS_EXPORT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 export(TARGETS ${EXE_NAME}
        APPEND FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
-       NAMESPACE CURL::
+       NAMESPACE ${PROJECT_NAME}::
 )


### PR DESCRIPTION
One of the common patterns in CMake 3.x is the "superbuild" pattern, where the source trees of a dependencies are nested under a master project. In order for the projects to be modular (be agnostic to whether or not the dependencies are nested or not), the in-tree build process needs to generate the same targets as finding the dependencies out of tree. For example:

```
cmake_minimum_required(VERSION 3.14)
project(curl-example VERSION 0.0.1 LANGUAGES CXX)

option(USE_SYSTEM_CURL "Use the system cURL" OFF)

if (USE_SYSTEM_CURL)
    find_package(CURL REQUIRED)
else ()
    add_subdirectory(${PROJECT_SOURCE_DIR}/dependencies/curl)
endif()

add_executable(example ${PROJECT_SOURCE_DIR}/src/example.cpp)
target_link_libraries(example PRIVATE CURL::libcurl)
```

Using _find_package_ to find cURL will create the _CURL::libcurl_ target, but adding the source code directly only adds _libcurl_. Aliasing _libcurl_ to _CURL::libcurl_ lets you keep the _target_link_libraries_ line the same regardless of the source of the dependency.