### PR TITLE
Change for out-of-source build

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -64,16 +64,7 @@ findtool(){
 #
 removethis(){
   if test "$#" = "1"; then
-    find . -depth -name $1 -print > buildconf.tmp.$$
-    while read fdname
-    do
-      if test -f "$fdname"; then
-        rm -f "$fdname"
-      elif test -d "$fdname"; then
-        rm -f -r "$fdname"
-      fi
-    done < buildconf.tmp.$$
-    rm -f buildconf.tmp.$$
+    find . -depth -name $1 -print -exec rm -rf {} \;
   fi
 }
 


### PR DESCRIPTION
We use to build Curl sources in our project and wanted to have out-of-source build. To make it able we need to avoid of use the current paths. In Curl sources we found this single place where for cleanup the current path was used for temporary files. We can suggest to avoid of its use and run 'find' command to find and remove needed files.
Need for https://github.com/tarantool/tarantool/issues/4874