### PR TITLE
Revert "file: on Windows, refuse paths that start with \\"

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -136,7 +136,7 @@ static CURLcode file_connect(struct connectdata *conn, bool *done)
   struct Curl_easy *data = conn->data;
   char *real_path;
   struct FILEPROTO *file = data->req.protop;
-  int fd = -1;
+  int fd;
 #ifdef DOS_FILESYSTEM
   size_t i;
   char *actual_path;
@@ -181,9 +181,7 @@ static CURLcode file_connect(struct connectdata *conn, bool *done)
       return CURLE_URL_MALFORMAT;
     }
 
-  if(strncmp("\\\\", actual_path, 2))
-    /* refuse to open path that starts with two backslashes */
-    fd = open_readonly(actual_path, O_RDONLY|O_BINARY);
+  fd = open_readonly(actual_path, O_RDONLY|O_BINARY);
   file->path = actual_path;
 #else
   if(memchr(real_path, 0, real_path_len)) {


### PR DESCRIPTION
This reverts commit 1b71bc532bde8621fd3260843f8197182a467ff2.

Reminded-by: Chris Roberts
Bug: https://curl.haxx.se/mail/archive-2020-04/0013.html