### PR TITLE
KNOWN_BUGS: Add entry 'Blocking socket operations'

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -101,6 +101,7 @@ problems may have been fixed or changed somewhat since this was written!
  11.7 signal-based resolver timeouts
  11.8 DoH leaks memory after followlocation
  11.9 DoH doesn't inherit all transfer options
+ 11.10 Blocking socket operations in non-blocking API
 
  12. LDAP and OpenLDAP
  12.1 OpenLDAP hangs after returning results
@@ -715,6 +716,10 @@ problems may have been fixed or changed somewhat since this was written!
 11.9 DoH doesn't inherit all transfer options
 
  https://github.com/curl/curl/issues/4578
+
+11.10 Blocking socket operations in non-blocking API
+
+ The list of blocking socket operations is in TODO section "More non-blocking".
 
 12. LDAP and OpenLDAP
 

--- a/docs/TODO
+++ b/docs/TODO
@@ -409,11 +409,21 @@
  Make sure we don't ever loop because of non-blocking sockets returning
  EWOULDBLOCK or similar. Blocking cases include:
 
- - Name resolves on non-windows unless c-ares or the threaded resolver is used
+ - Name resolves on non-windows unless c-ares or the threaded resolver is used.
+
+ - The threaded resolver may block on cleanup:
+ https://github.com/curl/curl/issues/4852
+
  - file:// transfers
+
  - TELNET transfers
+
+ - GSSAPI authentication for FTP transfers
+
  - The "DONE" operation (post transfer protocol-specific actions) for the
-   protocols SFTP, SMTP, FTP. Fixing Curl_done() for this is a worthy task.
+ protocols SFTP, SMTP, FTP. Fixing Curl_done() for this is a worthy task.
+
+ - curl_multi_remove_handle for any of the above. See section 2.3.
 
 2.2 Better support for same name resolves
 


### PR DESCRIPTION
- Add threaded resolver cleanup and GSSAPI for FTP to the TODO list of
  known blocking operations.

- New known bugs entry 'Blocking socket operations in non-blocking API'
  that directs to the TODO's list of known blocking operations.

Ref: https://github.com/curl/curl/pull/5214#issuecomment-612488021

Reported-by: Marc Hoersken

Closes #xxxx
