### PR TITLE
socks: Fix blocking timeout logic

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -171,7 +171,8 @@ singleipconnect(struct connectdata *conn,
 
 /*
  * Curl_timeleft() returns the amount of milliseconds left allowed for the
- * transfer/connection. If the value is negative, the timeout time has already
+ * transfer/connection. If the value is 0, there's no timeout (ie there's
+ * infinite time left). If the value is negative, the timeout time has already
  * elapsed.
  *
  * The start time is stored in progress.t_startsingle - as set with

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -62,15 +62,15 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
   int result;
   *n = 0;
   for(;;) {
-    timediff_t timeleft = Curl_timeleft(conn->data, NULL, TRUE);
-    if(timeleft < 0) {
+    timediff_t timeout_ms = Curl_timeleft(conn->data, NULL, TRUE);
+    if(timeout_ms < 0) {
       /* we already got the timeout */
       result = CURLE_OPERATION_TIMEDOUT;
       break;
     }
-    if(timeleft > TIME_T_MAX)
-      timeleft = TIME_T_MAX;
-    if(SOCKET_READABLE(sockfd, (time_t)timeleft) <= 0) {
+    if(!timeout_ms || timeout_ms > TIME_T_MAX)
+      timeout_ms = TIME_T_MAX;
+    if(SOCKET_READABLE(sockfd, (time_t)timeout_ms) <= 0) {
       result = ~CURLE_OK;
       break;
     }


### PR DESCRIPTION
- Document in Curl_timeleft's comment block that returning 0 signals no
  timeout (ie there's infinite time left).

- Fix SOCKS' Curl_blockread_all for the case when no timeout was set.

Prior to this change if the timeout had a value of 0 and that was passed
to SOCKET_READABLE it would return right away instead of blocking. That
was likely because it was not well understood that when Curl_timeleft
returns 0 it is not a timeout of 0 ms but actually means no timeout.

Ref: https://github.com/curl/curl/pull/5214#issuecomment-612512360

Closes #xxxx