### PR TITLE
Try to fix possible output file race-condition

### DIFF
--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -135,6 +135,7 @@ void Curl_win32_cleanup(long init_flags)
     WSACleanup();
 #endif
   }
+  _flushall();
 }
 
 #if !defined(LOAD_WITH_ALTERED_SEARCH_PATH)

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -188,6 +188,7 @@ void win32_init(void)
 void win32_cleanup(void)
 {
   WSACleanup();
+  _flushall();
 }
 #endif  /* USE_WINSOCK */
 


### PR DESCRIPTION
For some reason files are sometimes not visible to `runtests.pl` directly after curl task or test server termination. Maybe this will help.

This will probably need to be worked an. For example some pre-checks regarding the existence of `_flushall()` could be required.

cc @bagder maybe you can this on your Windows machine to see if it helps with the issues you were facing. I cannot reproduce these issues locally, I have just seen them on AppVeyor.