### PR TITLE
lib: s/Curl_timeleft/Curl_timeout

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -425,7 +425,7 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
   if(entry)
     *entry = NULL; /* clear on entry */
 
-  timeout = Curl_timeleft(data, &now, TRUE);
+  timeout = Curl_timeout(data, &now, TRUE);
   if(timeout < 0) {
     /* already expired! */
     connclose(conn, "Timed out before name resolve started");

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -170,7 +170,7 @@ singleipconnect(struct connectdata *conn,
                 int tempindex);          /* 0 or 1 among the temp ones */
 
 /*
- * Curl_timeleft() returns the amount of milliseconds left allowed for the
+ * Curl_timeout() returns the amount of milliseconds left allowed for the
  * transfer/connection. If the value is 0, there's no timeout (ie there's
  * infinite time left). If the value is negative, the timeout time has already
  * elapsed.
@@ -184,7 +184,7 @@ singleipconnect(struct connectdata *conn,
  *
  * @unittest: 1303
  */
-timediff_t Curl_timeleft(struct Curl_easy *data,
+timediff_t Curl_timeout(struct Curl_easy *data,
                          struct curltime *nowp,
                          bool duringconnect)
 {
@@ -838,7 +838,7 @@ CURLcode Curl_is_connected(struct connectdata *conn,
   now = Curl_now();
 
   /* figure out how long time we have left to connect */
-  allow = Curl_timeleft(data, &now, TRUE);
+  allow = Curl_timeout(data, &now, TRUE);
 
   if(allow < 0) {
     /* time-out, bail out, go home */
@@ -1306,7 +1306,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,  /* context */
   struct curltime before = Curl_now();
   CURLcode result = CURLE_COULDNT_CONNECT;
   int i;
-  timediff_t timeout_ms = Curl_timeleft(data, &before, TRUE);
+  timediff_t timeout_ms = Curl_timeout(data, &before, TRUE);
 
   if(timeout_ms < 0) {
     /* a precaution, no need to continue if time already is up */

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -36,7 +36,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,
 
 /* generic function that returns how much time there's left to run, according
    to the timeouts set */
-timediff_t Curl_timeleft(struct Curl_easy *data,
+timediff_t Curl_timeout(struct Curl_easy *data,
                          struct curltime *nowp,
                          bool duringconnect);
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -262,7 +262,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
     url = nurl;
   }
 
-  timeout_ms = Curl_timeleft(data, NULL, TRUE);
+  timeout_ms = Curl_timeout(data, NULL, TRUE);
   if(timeout_ms <= 0) {
     result = CURLE_OPERATION_TIMEDOUT;
     goto error;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -334,7 +334,7 @@ static timediff_t ftp_timeleft_accept(struct Curl_easy *data)
   now = Curl_now();
 
   /* check if the generic timeout possibly is set shorter */
-  other =  Curl_timeleft(data, &now, FALSE);
+  other =  Curl_timeout(data, &now, FALSE);
   if(other && (other < timeout_ms))
     /* note that this also works fine for when other happens to be negative
        due to it already having elapsed */

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -142,7 +142,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
     else
       break;
 
-    timeout_ms = Curl_timeleft(conn->data, NULL, FALSE);
+    timeout_ms = Curl_timeout(conn->data, NULL, FALSE);
     if(timeout_ms < 0) {
       result = CURLE_OPERATION_TIMEDOUT;
       break;

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -313,7 +313,7 @@ static CURLcode CONNECT(struct connectdata *conn,
       s->perline = 0;
     } /* END CONNECT PHASE */
 
-    check = Curl_timeleft(data, NULL, TRUE);
+    check = Curl_timeout(data, NULL, TRUE);
     if(check <= 0) {
       failf(data, "Proxy CONNECT aborted due to timeout");
       return CURLE_OPERATION_TIMEDOUT;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1569,7 +1569,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
        (data->mstate < CURLM_STATE_COMPLETED)) {
       /* we need to wait for the connect state as only then is the start time
          stored, but we must not check already completed handles */
-      timeout_ms = Curl_timeleft(data, &now,
+      timeout_ms = Curl_timeout(data, &now,
                                  (data->mstate <= CURLM_STATE_DO)?
                                  TRUE:FALSE);
 

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -205,7 +205,7 @@ static CURLcode tftp_set_timeouts(tftp_state_data_t *state)
   time(&state->start_time);
 
   /* Compute drop-dead time */
-  timeout_ms = Curl_timeleft(state->conn->data, NULL, start);
+  timeout_ms = Curl_timeout(state->conn->data, NULL, start);
 
   if(timeout_ms < 0) {
     /* time-out, bail out, go home */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1298,7 +1298,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
     return result;
 
   if(k->keepon) {
-    if(0 > Curl_timeleft(data, &k->now, FALSE)) {
+    if(0 > Curl_timeout(data, &k->now, FALSE)) {
       if(k->size != -1) {
         failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
               " milliseconds with %" CURL_FORMAT_CURL_OFF_T " out of %"

--- a/lib/url.c
+++ b/lib/url.c
@@ -3123,7 +3123,7 @@ static CURLcode resolve_server(struct Curl_easy *data,
                                bool *async)
 {
   CURLcode result = CURLE_OK;
-  timediff_t timeout_ms = Curl_timeleft(data, NULL, TRUE);
+  timediff_t timeout_ms = Curl_timeout(data, NULL, TRUE);
 
   DEBUGASSERT(conn);
   DEBUGASSERT(data);

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -661,7 +661,7 @@ static CURLcode bearssl_connect_common(struct connectdata *conn,
         ssl_connect_2_reading == connssl->connecting_state ||
         ssl_connect_2_writing == connssl->connecting_state) {
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -819,7 +819,7 @@ static CURLcode gskit_connect_step1(struct connectdata *conn, int sockindex)
   if(!result) {
     /* Compute the handshake timeout. Since GSKit granularity is 1 second,
        we round up the required value. */
-    long timeout = Curl_timeleft(data, NULL, TRUE);
+    long timeout = Curl_timeout(data, NULL, TRUE);
     if(timeout < 0)
       result = CURLE_OPERATION_TIMEDOUT;
     else
@@ -932,7 +932,7 @@ static CURLcode gskit_connect_step2(struct connectdata *conn, int sockindex,
   /* Poll or wait for end of SSL asynchronous handshake. */
 
   for(;;) {
-    long timeout_ms = nonblocking? 0: Curl_timeleft(data, NULL, TRUE);
+    long timeout_ms = nonblocking? 0: Curl_timeout(data, NULL, TRUE);
     if(timeout_ms < 0)
       timeout_ms = 0;
     stmv.tv_sec = timeout_ms / 1000;
@@ -1074,7 +1074,7 @@ static CURLcode gskit_connect_common(struct connectdata *conn, int sockindex,
   /* Step 1: create session, start handshake. */
   if(connssl->connecting_state == ssl_connect_1) {
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -1093,7 +1093,7 @@ static CURLcode gskit_connect_common(struct connectdata *conn, int sockindex,
   /* Step 2: check if handshake is over. */
   if(!result && connssl->connecting_state == ssl_connect_2) {
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -291,7 +291,7 @@ static CURLcode handshake(struct connectdata *conn,
     int rc;
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, duringconnect);
+    timeout_ms = Curl_timeout(data, NULL, duringconnect);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -903,7 +903,7 @@ mbed_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -920,7 +920,7 @@ mbed_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -505,7 +505,7 @@ mesalink_connect_common(struct connectdata *conn, int sockindex,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -523,7 +523,7 @@ mesalink_connect_common(struct connectdata *conn, int sockindex,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2135,15 +2135,15 @@ static CURLcode nss_do_connect(struct connectdata *conn, int sockindex)
 
 
   /* check timeout situation */
-  const timediff_t time_left = Curl_timeleft(data, NULL, TRUE);
-  if(time_left < 0) {
+  const timediff_t timeout_ms = Curl_timeout(data, NULL, TRUE);
+  if(timeout_ms < 0) {
     failf(data, "timed out before SSL handshake");
     result = CURLE_OPERATION_TIMEDOUT;
     goto error;
   }
 
   /* Force the handshake now */
-  timeout = PR_MillisecondsToInterval((PRUint32) time_left);
+  timeout = PR_MillisecondsToInterval((PRUint32) timeout_ms);
   if(SSL_ForceHandshakeWithTimeout(backend->handle, timeout) != SECSuccess) {
     if(PR_GetError() == PR_WOULD_BLOCK_ERROR)
       /* blocking direction is updated by nss_update_connecting_state() */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3701,7 +3701,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -3719,7 +3719,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1445,7 +1445,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* check out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -1463,7 +1463,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -1636,7 +1636,7 @@ schannel_send(struct connectdata *conn, int sockindex,
 
       this_write = 0;
 
-      timeout_ms = Curl_timeleft(conn->data, NULL, FALSE);
+      timeout_ms = Curl_timeout(conn->data, NULL, FALSE);
       if(timeout_ms < 0) {
         /* we already got the timeout */
         failf(conn->data, "schannel: timed out sending data "

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2820,7 +2820,7 @@ sectransp_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -2838,7 +2838,7 @@ sectransp_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -811,7 +811,7 @@ wolfssl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -829,7 +829,7 @@ wolfssl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timeout_ms = Curl_timeout(data, NULL, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/tests/data/test1303
+++ b/tests/data/test1303
@@ -2,7 +2,7 @@
 <info>
 <keywords>
 unittest
-Curl_timeleft
+Curl_timeout
 </keywords>
 </info>
 
@@ -16,7 +16,7 @@ none
 unittest
 </features>
  <name>
-Curl_timeleft unit tests
+Curl_timeout unit tests
  </name>
 </client>
 </testcase>

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -141,7 +141,7 @@ UNITTEST_START
     timediff_t timeout;
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
-    timeout =  Curl_timeleft(data, &now, run[i].connecting);
+    timeout =  Curl_timeout(data, &now, run[i].connecting);
     if(timeout != run[i].result)
       fail(run[i].comment);
   }


### PR DESCRIPTION
- Rename Curl_timeleft to Curl_timeout because the former name has led
  to some confusion about what it returns.

- Fix libssh2 and wolfssh blocking logic for the case when no timeout
  was set.

Prior to this change several of us made programming mistakes by assuming
that when Curl_timeleft returned 0 that meant 0 ms left, when actually 0
is used to signal that there is no timeout. Most of the mistakes were
fixed in prior commits, and the remaining are fixed in this commit.

For that reason I've changed the name to Curl_timeout to better indicate
it is returning a calculated timeout. It is generally apparent in the
code that a timeout of 0 is used to indicate no timeout.

Ref: c35af29
Ref: 0510cce

Closes #xxxx
