### PR TITLE
cmake: Avoid MSVC C4273 warnings in send/recv checks

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -63,6 +63,9 @@ if(curl_cv_recv)
                 unset(curl_cv_func_recv_test CACHE)
                 check_c_source_compiles("
                   ${_source_epilogue}
+                  #ifdef WINSOCK_API_LINKAGE
+                  WINSOCK_API_LINKAGE
+                  #endif
                   extern ${recv_retv} ${signature_call_conv}
                   recv(${recv_arg1}, ${recv_arg2}, ${recv_arg3}, ${recv_arg4});
                   int main(void) {
@@ -127,6 +130,9 @@ if(curl_cv_send)
                 unset(curl_cv_func_send_test CACHE)
                 check_c_source_compiles("
                   ${_source_epilogue}
+                  #ifdef WINSOCK_API_LINKAGE
+                  WINSOCK_API_LINKAGE
+                  #endif
                   extern ${send_retv} ${signature_call_conv}
                   send(${send_arg1}, ${send_arg2}, ${send_arg3}, ${send_arg4});
                   int main(void) {


### PR DESCRIPTION
We use `check_c_source_compiles` to check possible send/recv signatures
by reproducing the forward declarations from system headers.  On Windows
the `winsock2.h` header adds dll linkage settings to its forward
declaration.  If ours does not match the compiler warns:

    warning C4273: 'recv': inconsistent dll linkage

Add `WINSOCK_API_LINKAGE` to our test signatures when it is defined so
that our linkage is consistent with that from `winsock2.h`.

Fixes: #4764