### PR TITLE
test2043: use revoked.badssl.com instead of revoked.grc.com

### DIFF
--- a/tests/data/test2043
+++ b/tests/data/test2043
@@ -19,7 +19,7 @@ none
 Disable certificate revocation checks
  </name>
  <command>
---ssl-no-revoke -I https://revoked.grc.com/
+--ssl-no-revoke -I https://revoked.badssl.com/
 </command>
 </client>
 


### PR DESCRIPTION
The certificate of revoked.grc.com has expired on 2020-04-13.