### PR TITLE
tool: do not declare functions with Curl_ prefix

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -697,8 +697,8 @@ cleanup:
   return slist;
 }
 
-LARGE_INTEGER Curl_freq;
-bool Curl_isVistaOrGreater;
+LARGE_INTEGER tool_freq;
+bool tool_isVistaOrGreater;
 
 CURLcode win32_init(void)
 {
@@ -713,13 +713,13 @@ CURLcode win32_init(void)
   VER_SET_CONDITION(mask, VER_MINORVERSION, op);
 
   if(VerifyVersionInfoA(&osvi, (VER_MAJORVERSION | VER_MINORVERSION), mask))
-    Curl_isVistaOrGreater = true;
+    tool_isVistaOrGreater = true;
   else if(GetLastError() == ERROR_OLD_WIN_VERSION)
-    Curl_isVistaOrGreater = false;
+    tool_isVistaOrGreater = false;
   else
     return CURLE_FAILED_INIT;
 
-  QueryPerformanceFrequency(&Curl_freq);
+  QueryPerformanceFrequency(&tool_freq);
   return CURLE_OK;
 }
 

--- a/src/tool_metalink.h
+++ b/src/tool_metalink.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2014, 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -28,31 +28,25 @@ struct GlobalConfig;
 struct OperationConfig;
 
 /* returns 1 for success, 0 otherwise (we use OpenSSL *_Init fncs directly) */
-typedef int (* Curl_digest_init_func)(void *context);
+typedef int (*digest_init_func)(void *context);
 
-typedef void (* Curl_digest_update_func)(void *context,
-                                         const unsigned char *data,
-                                         unsigned int len);
-typedef void (* Curl_digest_final_func)(unsigned char *result, void *context);
+typedef void (*digest_update_func)(void *context,
+                                   const unsigned char *data,
+                                   unsigned int len);
+typedef void (*digest_final_func)(unsigned char *result, void *context);
 
 typedef struct {
-  Curl_digest_init_func     digest_init;   /* Initialize context procedure */
-  Curl_digest_update_func   digest_update; /* Update context with data */
-  Curl_digest_final_func    digest_final;  /* Get final result procedure */
-  unsigned int           digest_ctxtsize;  /* Context structure size */
-  unsigned int           digest_resultlen; /* Result length (bytes) */
+  digest_init_func     digest_init;   /* Initialize context procedure */
+  digest_update_func   digest_update; /* Update context with data */
+  digest_final_func    digest_final;  /* Get final result procedure */
+  unsigned int         digest_ctxtsize;  /* Context structure size */
+  unsigned int         digest_resultlen; /* Result length (bytes) */
 } digest_params;
 
 typedef struct {
   const digest_params   *digest_hash;      /* Hash function definition */
   void                  *digest_hashctx;   /* Hash function context */
 } digest_context;
-
-digest_context * Curl_digest_init(const digest_params *dparams);
-int Curl_digest_update(digest_context *context,
-                       const unsigned char *data,
-                       unsigned int len);
-int Curl_digest_final(digest_context *context, unsigned char *result);
 
 typedef struct {
   const char *hash_name;

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -28,19 +28,19 @@
 #if defined(WIN32) && !defined(MSDOS)
 
 /* set in win32_init() */
-extern LARGE_INTEGER Curl_freq;
-extern bool Curl_isVistaOrGreater;
+extern LARGE_INTEGER tool_freq;
+extern bool tool_isVistaOrGreater;
 
 /* In case of bug fix this function has a counterpart in timeval.c */
 struct timeval tvnow(void)
 {
   struct timeval now;
-  if(Curl_isVistaOrGreater) { /* QPC timer might have issues pre-Vista */
+  if(tool_isVistaOrGreater) { /* QPC timer might have issues pre-Vista */
     LARGE_INTEGER count;
     QueryPerformanceCounter(&count);
-    now.tv_sec = (long)(count.QuadPart / Curl_freq.QuadPart);
-    now.tv_usec = (long)((count.QuadPart % Curl_freq.QuadPart) * 1000000 /
-                         Curl_freq.QuadPart);
+    now.tv_sec = (long)(count.QuadPart / tool_freq.QuadPart);
+    now.tv_usec = (long)((count.QuadPart % tool_freq.QuadPart) * 1000000 /
+                         tool_freq.QuadPart);
   }
   else {
     /* Disable /analyze warning that GetTickCount64 is preferred  */


### PR DESCRIPTION
To avoid collision risks with private libcurl symbols when linked with
static versions (or just versions not hiding internal symbols).

Reported-by: hydra3333 on github
Fixes #5219