### PR TITLE
Replace confusing 80 by 75

### DIFF
--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -31,7 +31,7 @@ Example subscribe:
 
 Example publish:
 
-    curl -d 80 mqtt://host/home/bedroom/dimmer
+    curl -d 75 mqtt://host/home/bedroom/dimmer
 
 ## What does curl deliver as a response to a subscribe
 


### PR DESCRIPTION
I was a bit surprised by the `80`: first thought: what's HTTP doing here? ;)