### PR TITLE
add SNI ServerName option (openssl)

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1954,6 +1954,9 @@ typedef enum {
   /* allow RCPT TO command to fail for some recipients */
   CURLOPT(CURLOPT_MAIL_RCPT_ALLLOWFAILS, CURLOPTTYPE_LONG, 290),
 
+  /* Specify ServerName of SNI extension in openssl ClientHello */
+  CURLOPT(CURLOPT_TLSSNI_NAME, CURLOPTTYPE_STRINGPOINT, 291),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -141,6 +141,11 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
   case CURLOPT_DNS_USE_GLOBAL_CACHE:
     /* deprecated */
     break;
+  case CURLOPT_TLSSNI_NAME:
+    /* set SNI ServerName in ClientHello */
+    result = Curl_setstropt(&data->set.str[STRING_SSL_SNI_NAME],
+                            va_arg(param, char *));
+    break;
   case CURLOPT_SSL_CIPHER_LIST:
     /* set a list of cipher we want to use in the SSL connection */
     result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST_ORIG],

--- a/lib/url.c
+++ b/lib/url.c
@@ -3567,6 +3567,8 @@ static CURLcode create_conn(struct Curl_easy *data,
     data->set.str[STRING_SSL_RANDOM_FILE];
   data->set.ssl.primary.egdsocket = data->set.str[STRING_SSL_EGDSOCKET];
   data->set.proxy_ssl.primary.egdsocket = data->set.str[STRING_SSL_EGDSOCKET];
+  data->set.ssl.primary.sni_name =
+    data->set.str[STRING_SSL_SNI_NAME];
   data->set.ssl.primary.cipher_list =
     data->set.str[STRING_SSL_CIPHER_LIST_ORIG];
   data->set.proxy_ssl.primary.cipher_list =

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -227,6 +227,7 @@ struct ssl_primary_config {
   char *clientcert;
   char *random_file;     /* path to file containing "random" data */
   char *egdsocket;       /* path to file containing the EGD daemon socket */
+  char *sni_name;     /* SNI Servername in ClientHello */
   char *cipher_list;     /* list of ciphers to use */
   char *cipher_list13;   /* list of TLS 1.3 cipher suites to use */
   char *pinned_key;
@@ -1531,6 +1532,7 @@ enum dupstring {
   STRING_SSL_CAFILE_PROXY, /* certificate file to verify peer against */
   STRING_SSL_PINNEDPUBLICKEY_ORIG, /* public key file to verify peer against */
   STRING_SSL_PINNEDPUBLICKEY_PROXY, /* public key file to verify proxy */
+  STRING_SSL_SNI_NAME, /* sni servername in clienthello */
   STRING_SSL_CIPHER_LIST_ORIG, /* list of ciphers to use */
   STRING_SSL_CIPHER_LIST_PROXY, /* list of ciphers to use */
   STRING_SSL_CIPHER13_LIST_ORIG, /* list of TLS 1.3 ciphers to use */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -96,6 +96,7 @@ Curl_ssl_config_matches(struct ssl_primary_config* data,
      Curl_safe_strcasecompare(data->clientcert, needle->clientcert) &&
      Curl_safe_strcasecompare(data->random_file, needle->random_file) &&
      Curl_safe_strcasecompare(data->egdsocket, needle->egdsocket) &&
+     Curl_safe_strcasecompare(data->sni_name, needle->sni_name) &&
      Curl_safe_strcasecompare(data->cipher_list, needle->cipher_list) &&
      Curl_safe_strcasecompare(data->cipher_list13, needle->cipher_list13) &&
      Curl_safe_strcasecompare(data->pinned_key, needle->pinned_key))
@@ -120,6 +121,7 @@ Curl_clone_primary_ssl_config(struct ssl_primary_config *source,
   CLONE_STRING(clientcert);
   CLONE_STRING(random_file);
   CLONE_STRING(egdsocket);
+  CLONE_STRING(sni_name);
   CLONE_STRING(cipher_list);
   CLONE_STRING(cipher_list13);
   CLONE_STRING(pinned_key);
@@ -134,6 +136,7 @@ void Curl_free_primary_ssl_config(struct ssl_primary_config* sslc)
   Curl_safefree(sslc->clientcert);
   Curl_safefree(sslc->random_file);
   Curl_safefree(sslc->egdsocket);
+  Curl_safefree(sslc->sni_name);
   Curl_safefree(sslc->cipher_list);
   Curl_safefree(sslc->cipher_list13);
   Curl_safefree(sslc->pinned_key);

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -132,6 +132,7 @@ struct OperationConfig {
   struct getout *url_out;   /* point to the node to fill in outfile */
   struct getout *url_ul;    /* point to the node to fill in upload */
   char *doh_url;
+  char *sni_name;
   char *cipher_list;
   char *proxy_cipher_list;
   char *cipher13_list;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -210,6 +210,7 @@ static const struct LongShort aliases[]= {
   {"13",  "tlsv1.3",                 ARG_NONE},
   {"1A", "tls13-ciphers",            ARG_STRING},
   {"1B", "proxy-tls13-ciphers",      ARG_STRING},
+  {"1C", "sniname",      ARG_STRING},
   {"2",  "sslv2",                    ARG_NONE},
   {"3",  "sslv3",                    ARG_NONE},
   {"4",  "ipv4",                     ARG_NONE},
@@ -1249,6 +1250,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case 'B': /* --proxy-tls13-ciphers */
         GetStr(&config->proxy_cipher13_list, nextarg);
+        break;
+      case 'C': /* --sniname */
+        GetStr(&config->sni_name, nextarg);
         break;
       }
       break;

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -473,6 +473,8 @@ static const struct helptxt helptext[] = {
    "TLS password"},
   {"    --tlsuser <name>",
    "TLS user name"},
+  {"    --sniname <name>",
+   "sni servername in ClientHello (OpenSSL)"},
   {"-1, --tlsv1",
    "Use TLSv1.0 or greater"},
   {"    --tlsv1.0",

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1692,6 +1692,9 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->doh_url)
           my_setopt_str(curl, CURLOPT_DOH_URL, config->doh_url);
 
+        if(config->sni_name)
+          my_setopt_str(curl, CURLOPT_TLSSNI_NAME, config->sni_name);
+
         if(config->cipher_list)
           my_setopt_str(curl, CURLOPT_SSL_CIPHER_LIST, config->cipher_list);
 


### PR DESCRIPTION
Add CURLOPT_TLSSNI_NAME

Add curl --sniname

It implements openssl s_client --servername and --noservername

--noservername equivalent to --sniname ""