### PR TITLE
select: make Curl_socket_check take timediff_t timeout

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -147,8 +147,8 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
       result = CURLE_OPERATION_TIMEDOUT;
       break;
     }
-    if(!timeout_ms || timeout_ms > TIME_T_MAX)
-      timeout_ms = TIME_T_MAX;
+    if(!timeout_ms)
+      timeout_ms = TIMEDIFF_T_MAX;
 
     /* Don't busyloop. The entire loop thing is a work-around as it causes a
        BLOCKING behavior which is a NO-NO. This function should rather be
@@ -156,7 +156,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
        possible to send now will be sent in the doing function repeatedly
        until the entire request is sent.
     */
-    what = SOCKET_WRITABLE(sockfd, (time_t)timeout_ms);
+    what = SOCKET_WRITABLE(sockfd, timeout_ms);
     if(what < 0) {
       result = CURLE_SEND_ERROR;
       break;

--- a/lib/select.c
+++ b/lib/select.c
@@ -201,7 +201,7 @@ int Curl_select(curl_socket_t maxfd,
 int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
                       curl_socket_t readfd1,
                       curl_socket_t writefd, /* socket to write to */
-                      time_t timeout_ms)     /* milliseconds to wait */
+                      timediff_t timeout_ms)     /* milliseconds to wait */
 {
 #ifdef HAVE_POLL_FINE
   struct pollfd pfd[3];

--- a/lib/select.c
+++ b/lib/select.c
@@ -333,7 +333,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
      curl_socket_t is unsigned in such cases and thus -1 is the largest
      value).
   */
-  r = Curl_select(maxfd, &fds_read, &fds_write, &fds_err, timeout_ms);
+  r = Curl_select(maxfd, &fds_read, &fds_write, &fds_err, (time_t)timeout_ms);
 
   if(r < 0)
     return -1;

--- a/lib/select.h
+++ b/lib/select.h
@@ -80,7 +80,7 @@ int Curl_select(curl_socket_t maxfd,
 
 int Curl_socket_check(curl_socket_t readfd, curl_socket_t readfd2,
                       curl_socket_t writefd,
-                      time_t timeout_ms);
+                      timediff_t timeout_ms);
 #define SOCKET_READABLE(x,z) \
   Curl_socket_check(x, CURL_SOCKET_BAD, CURL_SOCKET_BAD, z)
 #define SOCKET_WRITABLE(x,z) \

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1645,9 +1645,9 @@ schannel_send(struct connectdata *conn, int sockindex,
         written = -1;
         break;
       }
-      if(!timeout_ms || timeout_ms > TIME_T_MAX)
-        timeout_ms = TIME_T_MAX;
-      what = SOCKET_WRITABLE(conn->sock[sockindex], (time_t)timeout_ms);
+      if(!timeout_ms)
+        timeout_ms = TIMEDIFF_T_MAX;
+      what = SOCKET_WRITABLE(conn->sock[sockindex], timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(conn->data, "select/poll on SSL socket, errno: %d", SOCKERRNO);


### PR DESCRIPTION
Coverity found CID 1461718:

Integer handling issues (CONSTANT_EXPRESSION_RESULT) "timeout_ms >
9223372036854775807L" is always false regardless of the values of its
operands. This occurs as the logical second operand of "||".