### PR TITLE
tests: run (some) servers on "any port"

### DIFF
--- a/tests/data/test1028
+++ b/tests/data/test1028
@@ -19,7 +19,7 @@ Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake swsclose
 Content-Type: text/html
 Funny-head: yesyes
-Location: ftp://127.0.0.1:8992/10280002
+Location: ftp://%HOSTIP:%FTPPORT/10280002
 Content-Length: 0
 Connection: close
 
@@ -47,10 +47,6 @@ HTTP Location: redirect to FTP URL
  <command>
 http://%HOSTIP:%HTTPPORT/10280001 -L
 </command>
-# The data section doesn't do variable substitution, so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%FTPPORT' ne '8992' );"
-</precheck>
 </client>
 
 #

--- a/tests/data/test1055
+++ b/tests/data/test1055
@@ -18,7 +18,7 @@ HTTP/1.1 307 OK
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake swsclose
 Content-Type: text/html
-Location: ftp://127.0.0.1:8992/1055
+Location: ftp://%HOSTIP:%FTPPORT/1055
 Content-Length: 0
 Connection: close
 
@@ -38,10 +38,6 @@ HTTP PUT Location: redirect to FTP URL
  <command>
 http://%HOSTIP:%HTTPPORT/1055 -L -T log/test1055.txt
 </command>
-# The data section doesn't do variable substitution, so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%FTPPORT' ne '8992' );"
-</precheck>
 <file name="log/test1055.txt">
 Weird
      file

--- a/tests/data/test1056
+++ b/tests/data/test1056
@@ -13,7 +13,7 @@ IPv6
 <reply>
 <data>
 HTTP/1.1 302 OK swsclose
-Location: http://[::1%259999]:8994/moo/10560002
+Location: http://[::1%259999]:%HTTP6PORT/moo/10560002
 Date: Thu, 31 Jul 2008 14:49:00 GMT
 Connection: close
 
@@ -27,7 +27,7 @@ body
 </data2>
 <datacheck>
 HTTP/1.1 302 OK swsclose
-Location: http://[::1%259999]:8994/moo/10560002
+Location: http://[::1%259999]:%HTTP6PORT/moo/10560002
 Date: Thu, 31 Jul 2008 14:49:00 GMT
 Connection: close
 
@@ -55,10 +55,6 @@ HTTP follow redirect from IPv4 to IPv6 with scope
  <command>
 http://%HOSTIP:%HTTPPORT/we/are/all/twits/1056 -L
 </command>
-# The data section doesn't do variable substitution, so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOST6IP' ne '[::1]' || '%HTTP6PORT' ne '8994' );"
-</precheck>
 </client>
 
 #

--- a/tests/data/test1245
+++ b/tests/data/test1245
@@ -18,7 +18,7 @@ HTTP/1.1 301 OK swsclose
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
 Content-Length: 0
-Location: ftp://127.0.0.1:8992/1245
+Location: ftp://%HOSTIP:%FTPPORT/1245
 Connection: close
 
 </data>
@@ -37,10 +37,6 @@ ftp
 <command>
 --location --proto +all,-ftp --proto-redir -all,+ftp http://%HOSTIP:%HTTPPORT/1245
 </command>
-# The data section doesn't do variable substitution, so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%FTPPORT' ne '8992' );"
-</precheck>
 </client>
 
 #

--- a/tests/data/test1448
+++ b/tests/data/test1448
@@ -17,7 +17,7 @@ HTTP/1.1 302 OK swsbounce
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Content-Length: 9
 Content-Type: text/plain
-Location: http://åäö.se:8990/14480001
+Location: http://åäö.se:%HTTPPORT/14480001
 
 redirect
 </data>
@@ -52,7 +52,7 @@ Redirect following to UTF-8 IDN host name
  </name>
 
  <command>
-http://åäö.se:%HTTPPORT/1448 --resolve xn--4cab6c.se:%HTTPPORT:%HOSTIP -L --connect-to %HOSTIP:8990:%HOSTIP:%HTTPPORT
+http://åäö.se:%HTTPPORT/1448 --resolve xn--4cab6c.se:%HTTPPORT:%HOSTIP -L --connect-to %HOSTIP:%HTTPPORT:%HOSTIP:%HTTPPORT
 </command>
 </client>
 

--- a/tests/data/test2006
+++ b/tests/data/test2006
@@ -85,8 +85,15 @@ Accept: */*
 <file1 name="log/download2006">
 Some data delivered from an HTTP resource
 </file1>
+
+# The Content-Length replace here is to handle with 4/5 digit port number in
+# the content
+<stripfile2>
+s/Last-Modified:.*//
+s/Content-Length: 49[67]/Content-Length: yeps/
+</stripfile2>
 <file2 name="log/heads2006">
-Content-Length: 496
+Content-Length: yeps
 Accept-ranges: bytes
 
 
@@ -110,9 +117,6 @@ Metalink: fetching (log/download2006) from (http://%HOSTIP:%HTTPPORT/2006) OK
 Metalink: validating (log/download2006)...
 Metalink: validating (log/download2006) [sha-256] OK
 </file4>
-<stripfile2>
-s/Last-Modified:.*//
-</stripfile2>
 <stripfile4>
 $_ = '' if (($_ !~ /^Metalink: /) && ($_ !~ /error/i) && ($_ !~ /warn/i))
 </stripfile4>

--- a/tests/data/test2007
+++ b/tests/data/test2007
@@ -86,11 +86,14 @@ Accept: */*
 <file1 name="log/download2007">
 Something delivered from an HTTP resource
 </file1>
+# The Content-Length replace here is to handle with 4/5 digit port number in
+# the content
 <stripfile2>
 s/Last-Modified:.*//
+s/Content-Length: 49[67]/Content-Length: yeps/
 </stripfile2>
 <file2 name="log/heads2007">
-Content-Length: 496
+Content-Length: yeps
 Accept-ranges: bytes
 
 

--- a/tests/data/test2008
+++ b/tests/data/test2008
@@ -78,11 +78,14 @@ Accept: */*
 <file1 name="log/download2008">
 Some stuff delivered from an HTTP resource
 </file1>
+# The Content-Length replace here is to handle with 4/5 digit port number in
+# the content
 <stripfile2>
 s/Last-Modified:.*//
+s/Content-Length: 49[67]/Content-Length: yeps/
 </stripfile2>
 <file2 name="log/heads2008">
-Content-Length: 496
+Content-Length: yeps
 Accept-ranges: bytes
 
 

--- a/tests/data/test2009
+++ b/tests/data/test2009
@@ -79,11 +79,14 @@ Accept: */*
 <file1 name="log/download2009">
 Some contents delivered from an HTTP resource
 </file1>
+# The Content-Length replace here is to handle with 4/5 digit port number in
+# the content
 <stripfile2>
 s/Last-Modified:.*//
+s/Content-Length: 49[67]/Content-Length: yeps/
 </stripfile2>
 <file2 name="log/heads2009">
-Content-Length: 496
+Content-Length: yeps
 Accept-ranges: bytes
 
 

--- a/tests/data/test2010
+++ b/tests/data/test2010
@@ -78,11 +78,14 @@ Accept: */*
 <file1 name="log/download2010">
 Contents delivered from an HTTP resource
 </file1>
+# The Content-Length replace here is to handle with 4/5 digit port number in
+# the content
 <stripfile2>
 s/Last-Modified:.*//
+s/Content-Length: 49[67]/Content-Length: yeps/
 </stripfile2>
 <file2 name="log/heads2010">
-Content-Length: 496
+Content-Length: yeps
 Accept-ranges: bytes
 
 

--- a/tests/data/test309
+++ b/tests/data/test309
@@ -14,7 +14,7 @@ followlocation
 HTTP/1.1 301 This is a weirdo text message swsclose
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
-Location: https://127.0.0.1:8991/data/3090002.txt?coolsite=yes
+Location: https://127.0.0.1:%HTTPSPORT/data/3090002.txt?coolsite=yes
 Connection: close
 
 This server reply is for testing a simple Location: following to HTTPS URL
@@ -33,7 +33,7 @@ If this is received, the location following worked
 HTTP/1.1 301 This is a weirdo text message swsclose
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
-Location: https://127.0.0.1:8991/data/3090002.txt?coolsite=yes
+Location: https://127.0.0.1:%HTTPSPORT/data/3090002.txt?coolsite=yes
 Connection: close
 
 HTTP/1.1 200 Followed here fine swsclose
@@ -61,10 +61,6 @@ HTTP Location: redirect to HTTPS URL
  <command>
 -k http://%HOSTIP:%HTTPPORT/want/309 -L
 </command>
-# The data section doesn't do variable substitution, so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%HTTPSPORT' ne '8991' );"
-</precheck>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -96,6 +96,7 @@ my $listenaddr = '127.0.0.1';  # default address for listener port
 # global vars used for file names
 #
 my $pidfile;            # server pid file name
+my $portfile=".ftpserver.port"; # server port file name
 my $logfile;            # server log file name
 my $mainsockf_pidfile;  # pid file for primary connection sockfilt process
 my $mainsockf_logfile;  # log file for primary connection sockfilt process
@@ -191,6 +192,7 @@ sub exit_signal_handler {
     # For now, simply mimic old behavior.
     killsockfilters($proto, $ipvnum, $idnum, $verbose);
     unlink($pidfile);
+    unlink($portfile);
     if($serverlogslocked) {
         $serverlogslocked = 0;
         clear_advisor_read_lock($SERVERLOGS_LOCK);
@@ -390,6 +392,7 @@ sub sysread_or_die {
                "line $lcaller. $srvrname server, sysread error: $!\n";
         killsockfilters($proto, $ipvnum, $idnum, $verbose);
         unlink($pidfile);
+        unlink($portfile);
         if($serverlogslocked) {
             $serverlogslocked = 0;
             clear_advisor_read_lock($SERVERLOGS_LOCK);
@@ -404,6 +407,7 @@ sub sysread_or_die {
                "line $lcaller. $srvrname server, read zero\n";
         killsockfilters($proto, $ipvnum, $idnum, $verbose);
         unlink($pidfile);
+        unlink($portfile);
         if($serverlogslocked) {
             $serverlogslocked = 0;
             clear_advisor_read_lock($SERVERLOGS_LOCK);
@@ -418,6 +422,7 @@ sub startsf {
     my $mainsockfcmd = "./server/sockfilt".exe_ext('SRV')." " .
         "--ipv$ipvnum --port $port " .
         "--pidfile \"$mainsockf_pidfile\" " .
+        "--portfile \"$portfile\" " .
         "--logfile \"$mainsockf_logfile\"";
     $sfpid = open2(*SFREAD, *SFWRITE, $mainsockfcmd);
 
@@ -431,6 +436,7 @@ sub startsf {
         logmsg "Failed sockfilt command: $mainsockfcmd\n";
         killsockfilters($proto, $ipvnum, $idnum, $verbose);
         unlink($pidfile);
+        unlink($portfile);
         if($serverlogslocked) {
             $serverlogslocked = 0;
             clear_advisor_read_lock($SERVERLOGS_LOCK);
@@ -2900,6 +2906,7 @@ sub customize {
 # --id        # server instance number
 # --proto     # server protocol
 # --pidfile   # server pid file
+# --portfile  # server port file
 # --logfile   # server log file
 # --ipv4      # server IP version 4
 # --ipv6      # server IP version 6
@@ -2937,6 +2944,12 @@ while(@ARGV) {
             shift @ARGV;
         }
     }
+    elsif($ARGV[0] eq '--portfile') {
+        if($ARGV[1]) {
+            $portfile = $ARGV[1];
+            shift @ARGV;
+        }
+    }
     elsif($ARGV[0] eq '--logfile') {
         if($ARGV[1]) {
             $logfile = $ARGV[1];
@@ -2952,8 +2965,8 @@ while(@ARGV) {
         $listenaddr = '::1' if($listenaddr eq '127.0.0.1');
     }
     elsif($ARGV[0] eq '--port') {
-        if($ARGV[1] && ($ARGV[1] =~ /^(\d+)$/)) {
-            $port = $1 if($1 > 1024);
+        if($ARGV[1] =~ /^(\d+)$/) {
+            $port = $1;
             shift @ARGV;
         }
     }
@@ -3013,6 +3026,15 @@ $SIG{TERM} = \&exit_signal_handler;
 
 startsf();
 
+# actual port
+if($portfile && !$port) {
+    my $aport;
+    open(P, "<$portfile");
+    $aport = <P>;
+    close(P);
+    $port = 0 + $aport;
+}
+
 logmsg sprintf("%s server listens on port IPv${ipvnum}/${port}\n", uc($proto));
 
 open(PID, ">$pidfile");
@@ -3020,7 +3042,6 @@ print PID $$."\n";
 close(PID);
 
 logmsg("logged pid $$ in $pidfile\n");
-
 
 while(1) {
 

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -209,6 +209,31 @@ sub loadtest {
     return 0;
 }
 
+sub fulltest {
+    return @xml;
+}
+
+# write the test to the given file
+sub savetest {
+    my ($file)=@_;
+
+    if(open(XML, ">$file")) {
+        binmode XML; # for crapage systems, use binary
+        for(@xml) {
+            print XML $_;
+        }
+        close(XML);
+    }
+    else {
+        # failure
+        if($warning) {
+            print STDERR "file $file wouldn't open!\n";
+        }
+        return 1;
+    }
+    return 0;
+}
+
 #
 # Strip off all lines that match the specified pattern and return
 # the new array.

--- a/tests/httpserver.pl
+++ b/tests/httpserver.pl
@@ -44,8 +44,9 @@ my $unix_socket;     # location to place a listening Unix socket
 my $ipvnum = 4;      # default IP version of http server
 my $idnum = 1;       # default http server instance number
 my $proto = 'http';  # protocol the http server speaks
-my $pidfile;         # http server pid file
-my $logfile;         # http server log file
+my $pidfile;         # pid file
+my $portfile;        # port number file
+my $logfile;         # log file
 my $connect;         # IP to connect to on CONNECT
 my $srcdir;
 my $gopher = 0;
@@ -58,6 +59,12 @@ while(@ARGV) {
     if($ARGV[0] eq '--pidfile') {
         if($ARGV[1]) {
             $pidfile = $ARGV[1];
+            shift @ARGV;
+        }
+    }
+    elsif($ARGV[0] eq '--portfile') {
+        if($ARGV[1]) {
+            $portfile = $ARGV[1];
             shift @ARGV;
         }
     }
@@ -122,11 +129,16 @@ if(!$srcdir) {
 if(!$pidfile) {
     $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
 }
+if(!$portfile) {
+    $portfile = "$path/". server_portfilename($proto, $ipvnum, $idnum);
+}
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);
 }
 
-$flags .= "--pidfile \"$pidfile\" --logfile \"$logfile\" ";
+$flags .= "--pidfile \"$pidfile\" ".
+    "--logfile \"$logfile\" ".
+    "--portfile \"$portfile\" ";
 $flags .= "--gopher " if($gopher);
 $flags .= "--connect $connect " if($connect);
 if($ipvnum eq 'unix') {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -156,7 +156,7 @@ my $SMBPORT;             # SMB server port
 my $SMBSPORT;            # SMBS server port
 my $NEGTELNETPORT;       # TELNET server port with negotiation
 
-my $SSHSRVMD5;           # MD5 of ssh server public key
+my $SSHSRVMD5 = "[uninitialized]"; # MD5 of ssh server public key
 
 my $srcdir = $ENV{'srcdir'} || '.';
 my $CURL="../src/curl".exe_ext('TOOL'); # what curl executable to run on the tests
@@ -1559,7 +1559,7 @@ sub runhttpserver {
     $pid2 = $pid3;
 
     if($verbose) {
-        logmsg "RUN: $srvrname server is now running PID $httppid\n";
+        logmsg "RUN: $srvrname server is on PID $httppid port $port\n";
     }
 
     sleep(1);
@@ -3119,9 +3119,7 @@ sub checksystem {
     logmsg ("* Port range: $minport-$maxport\n");
 
     if($verbose) {
-        logmsg "* Ports:\n";
-
-        logmsg sprintf("*   HTTP/%d ", $HTTPPORT);
+        logmsg "* Ports: ";
         logmsg sprintf("FTP/%d ", $FTPPORT);
         logmsg sprintf("FTP2/%d ", $FTP2PORT);
         logmsg sprintf("RTSP/%d ", $RTSPPORT);
@@ -3131,7 +3129,6 @@ sub checksystem {
         }
         logmsg sprintf("\n*   TFTP/%d ", $TFTPPORT);
         if($http_ipv6) {
-            logmsg sprintf("HTTP-IPv6/%d ", $HTTP6PORT);
             logmsg sprintf("RTSP-IPv6/%d ", $RTSP6PORT);
         }
         if($ftp_ipv6) {
@@ -3139,10 +3136,6 @@ sub checksystem {
         }
         if($tftp_ipv6) {
             logmsg sprintf("TFTP-IPv6/%d ", $TFTP6PORT);
-        }
-        logmsg sprintf("\n*   GOPHER/%d ", $GOPHERPORT);
-        if($gopher_ipv6) {
-            logmsg sprintf("GOPHER-IPv6/%d", $GOPHER6PORT);
         }
         logmsg sprintf("\n*   SSH/%d ", $SSHPORT);
         logmsg sprintf("SOCKS/%d ", $SOCKSPORT);
@@ -3184,105 +3177,83 @@ sub checksystem {
 # a command, in either case passed by reference
 #
 sub subVariables {
-  my ($thing) = @_;
+    my ($thing, $prefix) = @_;
 
-  # ports
+    if(!$prefix) {
+        $prefix = "%";
+    }
 
-  $$thing =~ s/%FTP6PORT/$FTP6PORT/g;
-  $$thing =~ s/%FTP2PORT/$FTP2PORT/g;
-  $$thing =~ s/%FTPSPORT/$FTPSPORT/g;
-  $$thing =~ s/%FTPPORT/$FTPPORT/g;
+    # test server ports
+    $$thing =~ s/${prefix}FTP6PORT/$FTP6PORT/g;
+    $$thing =~ s/${prefix}FTP2PORT/$FTP2PORT/g;
+    $$thing =~ s/${prefix}FTPSPORT/$FTPSPORT/g;
+    $$thing =~ s/${prefix}FTPPORT/$FTPPORT/g;
+    $$thing =~ s/${prefix}GOPHER6PORT/$GOPHER6PORT/g;
+    $$thing =~ s/${prefix}GOPHERPORT/$GOPHERPORT/g;
+    $$thing =~ s/${prefix}HTTPTLS6PORT/$HTTPTLS6PORT/g;
+    $$thing =~ s/${prefix}HTTPTLSPORT/$HTTPTLSPORT/g;
+    $$thing =~ s/${prefix}HTTP6PORT/$HTTP6PORT/g;
+    $$thing =~ s/${prefix}HTTPSPORT/$HTTPSPORT/g;
+    $$thing =~ s/${prefix}HTTP2PORT/$HTTP2PORT/g;
+    $$thing =~ s/${prefix}HTTPPORT/$HTTPPORT/g;
+    $$thing =~ s/${prefix}PROXYPORT/$HTTPPROXYPORT/g;
+    $$thing =~ s/${prefix}MQTTPORT/$MQTTPORT/g;
+    $$thing =~ s/${prefix}IMAP6PORT/$IMAP6PORT/g;
+    $$thing =~ s/${prefix}IMAPPORT/$IMAPPORT/g;
+    $$thing =~ s/${prefix}POP36PORT/$POP36PORT/g;
+    $$thing =~ s/${prefix}POP3PORT/$POP3PORT/g;
+    $$thing =~ s/${prefix}RTSP6PORT/$RTSP6PORT/g;
+    $$thing =~ s/${prefix}RTSPPORT/$RTSPPORT/g;
+    $$thing =~ s/${prefix}SMTP6PORT/$SMTP6PORT/g;
+    $$thing =~ s/${prefix}SMTPPORT/$SMTPPORT/g;
+    $$thing =~ s/${prefix}SOCKSPORT/$SOCKSPORT/g;
+    $$thing =~ s/${prefix}SSHPORT/$SSHPORT/g;
+    $$thing =~ s/${prefix}TFTP6PORT/$TFTP6PORT/g;
+    $$thing =~ s/${prefix}TFTPPORT/$TFTPPORT/g;
+    $$thing =~ s/${prefix}DICTPORT/$DICTPORT/g;
+    $$thing =~ s/${prefix}SMBPORT/$SMBPORT/g;
+    $$thing =~ s/${prefix}SMBSPORT/$SMBSPORT/g;
+    $$thing =~ s/${prefix}NEGTELNETPORT/$NEGTELNETPORT/g;
 
-  $$thing =~ s/%GOPHER6PORT/$GOPHER6PORT/g;
-  $$thing =~ s/%GOPHERPORT/$GOPHERPORT/g;
+    # server Unix domain socket paths
+    $$thing =~ s/${prefix}HTTPUNIXPATH/$HTTPUNIXPATH/g;
 
-  $$thing =~ s/%HTTPTLS6PORT/$HTTPTLS6PORT/g;
-  $$thing =~ s/%HTTPTLSPORT/$HTTPTLSPORT/g;
-  $$thing =~ s/%HTTP6PORT/$HTTP6PORT/g;
-  $$thing =~ s/%HTTPSPORT/$HTTPSPORT/g;
-  $$thing =~ s/%HTTP2PORT/$HTTP2PORT/g;
-  $$thing =~ s/%HTTPPORT/$HTTPPORT/g;
-  $$thing =~ s/%PROXYPORT/$HTTPPROXYPORT/g;
-  $$thing =~ s/%MQTTPORT/$MQTTPORT/g;
+    # client IP addresses
+    $$thing =~ s/${prefix}CLIENT6IP/$CLIENT6IP/g;
+    $$thing =~ s/${prefix}CLIENTIP/$CLIENTIP/g;
 
-  $$thing =~ s/%IMAP6PORT/$IMAP6PORT/g;
-  $$thing =~ s/%IMAPPORT/$IMAPPORT/g;
+    # server IP addresses
+    $$thing =~ s/${prefix}HOST6IP/$HOST6IP/g;
+    $$thing =~ s/${prefix}HOSTIP/$HOSTIP/g;
 
-  $$thing =~ s/%POP36PORT/$POP36PORT/g;
-  $$thing =~ s/%POP3PORT/$POP3PORT/g;
+    # misc
+    $$thing =~ s/${prefix}CURL/$CURL/g;
+    $$thing =~ s/${prefix}PWD/$pwd/g;
+    $$thing =~ s/${prefix}POSIX_PWD/$posix_pwd/g;
 
-  $$thing =~ s/%RTSP6PORT/$RTSP6PORT/g;
-  $$thing =~ s/%RTSPPORT/$RTSPPORT/g;
+    my $file_pwd = $pwd;
+    if($file_pwd !~ /^\//) {
+        $file_pwd = "/$file_pwd";
+    }
 
-  $$thing =~ s/%SMTP6PORT/$SMTP6PORT/g;
-  $$thing =~ s/%SMTPPORT/$SMTPPORT/g;
+    $$thing =~ s/${prefix}FILE_PWD/$file_pwd/g;
+    $$thing =~ s/${prefix}SRCDIR/$srcdir/g;
+    $$thing =~ s/${prefix}USER/$USER/g;
 
-  $$thing =~ s/%SOCKSPORT/$SOCKSPORT/g;
-  $$thing =~ s/%SSHPORT/$SSHPORT/g;
+    $$thing =~ s/${prefix}SSHSRVMD5/$SSHSRVMD5/g;
 
-  $$thing =~ s/%TFTP6PORT/$TFTP6PORT/g;
-  $$thing =~ s/%TFTPPORT/$TFTPPORT/g;
+    # The purpose of FTPTIME2 and FTPTIME3 is to provide times that can be
+    # used for time-out tests and that would work on most hosts as these
+    # adjust for the startup/check time for this particular host. We needed to
+    # do this to make the test suite run better on very slow hosts.
+    my $ftp2 = $ftpchecktime * 2;
+    my $ftp3 = $ftpchecktime * 3;
 
-  $$thing =~ s/%DICTPORT/$DICTPORT/g;
+    $$thing =~ s/${prefix}FTPTIME2/$ftp2/g;
+    $$thing =~ s/${prefix}FTPTIME3/$ftp3/g;
 
-  $$thing =~ s/%SMBPORT/$SMBPORT/g;
-  $$thing =~ s/%SMBSPORT/$SMBSPORT/g;
-
-  $$thing =~ s/%NEGTELNETPORT/$NEGTELNETPORT/g;
-
-  # server Unix domain socket paths
-
-  $$thing =~ s/%HTTPUNIXPATH/$HTTPUNIXPATH/g;
-
-  # client IP addresses
-
-  $$thing =~ s/%CLIENT6IP/$CLIENT6IP/g;
-  $$thing =~ s/%CLIENTIP/$CLIENTIP/g;
-
-  # server IP addresses
-
-  $$thing =~ s/%HOST6IP/$HOST6IP/g;
-  $$thing =~ s/%HOSTIP/$HOSTIP/g;
-
-  # misc
-
-  $$thing =~ s/%CURL/$CURL/g;
-  $$thing =~ s/%PWD/$pwd/g;
-  $$thing =~ s/%POSIX_PWD/$posix_pwd/g;
-
-  my $file_pwd = $pwd;
-  if($file_pwd !~ /^\//) {
-      $file_pwd = "/$file_pwd";
-  }
-
-  $$thing =~ s/%FILE_PWD/$file_pwd/g;
-  $$thing =~ s/%SRCDIR/$srcdir/g;
-  $$thing =~ s/%USER/$USER/g;
-
-  if($$thing =~ /%SSHSRVMD5/) {
-      if(!$SSHSRVMD5) {
-          my $msg = "Fatal: Missing SSH server pubkey MD5. Is server running?";
-          logmsg "$msg\n";
-          stopservers($verbose);
-          die $msg;
-      }
-      $$thing =~ s/%SSHSRVMD5/$SSHSRVMD5/g;
-  }
-
-  # The purpose of FTPTIME2 and FTPTIME3 is to provide times that can be
-  # used for time-out tests and that would work on most hosts as these
-  # adjust for the startup/check time for this particular host. We needed
-  # to do this to make the test suite run better on very slow hosts.
-
-  my $ftp2 = $ftpchecktime * 2;
-  my $ftp3 = $ftpchecktime * 3;
-
-  $$thing =~ s/%FTPTIME2/$ftp2/g;
-  $$thing =~ s/%FTPTIME3/$ftp3/g;
-
-  # HTTP2
-
-  $$thing =~ s/%H2CVER/$h2cver/g;
+    # HTTP2
+    $$thing =~ s/${prefix}H2CVER/$h2cver/g;
 }
 
 sub fixarray {
@@ -3498,6 +3469,25 @@ sub singletest {
         $why = serverfortest($testnum);
     }
 
+    # Save a preprocessed version of the entire test file. This allows more
+    # "basic" test case readers to enjoy variable replacements.
+    my @entiretest = fulltest();
+    my $otest = "log/test$testnum";
+    open(D, ">$otest");
+    my $diff;
+    for my $s (@entiretest) {
+        my $f = $s;
+        subVariables(\$s, "%");
+        if($f ne $s) {
+            $diff++;
+        }
+        print D $s;
+    }
+    close(D);
+    # remove the separate test file again if nothing was updated to keep
+    # things simpler
+    unlink($otest) if(!$diff);
+
     # timestamp required servers verification end
     $timesrvrend{$testnum} = Time::HiRes::time();
 
@@ -3615,6 +3605,9 @@ sub singletest {
             map s/\r\n/\n/g, @reply;
             map s/\n/\r\n/g, @reply;
         }
+    }
+    for my $r (@reply) {
+        subVariables(\$r);
     }
 
     # this is the valid protocol blurb curl should generate
@@ -4462,7 +4455,7 @@ sub singletest {
             $ok .= "v";
         }
         else {
-            if(!$short && !$disablevalgrind) {
+            if($verbose && !$disablevalgrind) {
                 logmsg " valgrind SKIPPED\n";
             }
             $ok .= "-"; # skipped
@@ -5661,6 +5654,9 @@ sub displaylogs {
         }
         if(($log =~ /^valgrind\d+/) && ($log !~ /^valgrind$testnum(\..*|)$/)) {
             next; # skip valgrindNnn of other tests
+        }
+        if(($log =~ /^test$testnum$/)) {
+            next; # skip test$testnum since it can be very big
         }
         logmsg "=== Start of file $log\n";
         displaylogcontent("$LOGDIR/$log");

--- a/tests/server/fake_ntlm.c
+++ b/tests/server/fake_ntlm.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2010, Mandy Wu, <mandy.wu@intel.com>
- * Copyright (C) 2011 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2011 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -112,7 +112,6 @@ int main(int argc, char *argv[])
   char buf[1024];
   char logfilename[256];
   FILE *stream;
-  char *filename;
   int error;
   char *type1_input = NULL, *type3_input = NULL;
   char *type1_output = NULL, *type3_output = NULL;
@@ -186,12 +185,10 @@ int main(int argc, char *argv[])
     path = env;
   }
 
-  filename = test2file(testnum);
-  stream = fopen(filename, "rb");
+  stream = test2fopen(testnum);
   if(!stream) {
     error = errno;
     logmsg("fopen() failed with error: %d %s", error, strerror(error));
-    logmsg("Error opening file: %s", filename);
     logmsg("Couldn't open test file %ld", testnum);
     exit(1);
   }
@@ -205,13 +202,11 @@ int main(int argc, char *argv[])
     }
   }
 
-  stream = fopen(filename, "rb");
+  stream = test2fopen(testnum);
   if(!stream) {
     error = errno;
     logmsg("fopen() failed with error: %d %s", error, strerror(error));
-    logmsg("Error opening file: %s", filename);
     logmsg("Couldn't open test file %ld", testnum);
-    exit(1);
   }
   else {
     size = 0;
@@ -225,11 +220,10 @@ int main(int argc, char *argv[])
 
   while(fgets(buf, sizeof(buf), stdin)) {
     if(strcmp(buf, type1_input) == 0) {
-      stream = fopen(filename, "rb");
+      stream = test2fopen(testnum);
       if(!stream) {
         error = errno;
         logmsg("fopen() failed with error: %d %s", error, strerror(error));
-        logmsg("Error opening file: %s", filename);
         logmsg("Couldn't open test file %ld", testnum);
         exit(1);
       }
@@ -247,11 +241,10 @@ int main(int argc, char *argv[])
       fflush(stdout);
     }
     else if(strncmp(buf, type3_input, strlen(type3_input)) == 0) {
-      stream = fopen(filename, "rb");
+      stream = test2fopen(testnum);
       if(!stream) {
         error = errno;
         logmsg("fopen() failed with error: %d %s", error, strerror(error));
-        logmsg("Error opening file: %s", filename);
         logmsg("Couldn't open test file %ld", testnum);
         exit(1);
       }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -446,7 +446,6 @@ static curl_socket_t mqttit(curl_socket_t fd)
   size_t remaining_length = 0;
   size_t bytes = 0; /* remaining length field size in bytes */
   char client_id[MAX_CLIENT_ID_LENGTH];
-  char *filename;
   long testno;
 
   static const char protocol[7] = {
@@ -550,8 +549,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
         char *data;
         size_t datalen;
         logmsg("Found test number %ld", testno);
-        filename = test2file(testno);
-        stream = fopen(filename, "rb");
+        stream = test2fopen(testno);
         error = getpart(&data, &datalen, "reply", "data", stream);
         if(!error)
           publish(dump, fd, packet_id, topic, data, datalen);

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1304,6 +1304,7 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   const char *pidname = ".sockfilt.pid";
+  const char *portfile = NULL; /* none by default */
   bool juggle_again;
   int rc;
   int error;
@@ -1330,6 +1331,11 @@ int main(int argc, char *argv[])
       arg++;
       if(argc>arg)
         pidname = argv[arg++];
+    }
+    else if(!strcmp("--portfile", argv[arg])) {
+      arg++;
+      if(argc > arg)
+        portfile = argv[arg++];
     }
     else if(!strcmp("--logfile", argv[arg])) {
       arg++;
@@ -1360,12 +1366,6 @@ int main(int argc, char *argv[])
       if(argc>arg) {
         char *endptr;
         unsigned long ulnum = strtoul(argv[arg], &endptr, 10);
-        if((endptr != argv[arg] + strlen(argv[arg])) ||
-           ((ulnum != 0UL) && ((ulnum < 1025UL) || (ulnum > 65535UL)))) {
-          fprintf(stderr, "sockfilt: invalid --port argument (%s)\n",
-                  argv[arg]);
-          return 0;
-        }
         port = curlx_ultous(ulnum);
         arg++;
       }
@@ -1500,6 +1500,13 @@ int main(int argc, char *argv[])
   if(!wrotepidfile) {
     write_stdout("FAIL\n", 5);
     goto sockfilt_cleanup;
+  }
+  if(portfile) {
+    wrotepidfile = write_portfile(portfile, port);
+    if(!wrotepidfile) {
+      write_stdout("FAIL\n", 5);
+      goto sockfilt_cleanup;
+    }
   }
 
   do {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -235,18 +235,15 @@ static bool socket_domain_is_ip(void)
 static int parse_servercmd(struct httprequest *req)
 {
   FILE *stream;
-  char *filename;
   int error;
 
-  filename = test2file(req->testno);
+  stream = test2fopen(req->testno);
   req->close = FALSE;
   req->connmon = FALSE;
 
-  stream = fopen(filename, "rb");
   if(!stream) {
     error = errno;
     logmsg("fopen() failed with error: %d %s", error, strerror(error));
-    logmsg("  [1] Error opening file: %s", filename);
     logmsg("  Couldn't open test file %ld", req->testno);
     req->open = FALSE; /* closes connection */
     return 1; /* done */
@@ -991,7 +988,6 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
   }
   else {
     char partbuf[80];
-    char *filename = test2file(req->testno);
 
     /* select the <data> tag for "normal" requests and the <connect> one
        for CONNECT requests (within the <reply> section) */
@@ -1004,11 +1000,10 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
 
     logmsg("Send response test%ld section <%s>", req->testno, partbuf);
 
-    stream = fopen(filename, "rb");
+    stream = test2fopen(req->testno);
     if(!stream) {
       error = errno;
       logmsg("fopen() failed with error: %d %s", error, strerror(error));
-      logmsg("  [3] Error opening file: %s", filename);
       return 0;
     }
     else {
@@ -1027,11 +1022,10 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     }
 
     /* re-open the same file again */
-    stream = fopen(filename, "rb");
+    stream = test2fopen(req->testno);
     if(!stream) {
       error = errno;
       logmsg("fopen() failed with error: %d %s", error, strerror(error));
-      logmsg("  [4] Error opening file: %s", filename);
       free(ptr);
       return 0;
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -194,11 +194,21 @@ void win32_cleanup(void)
 /* set by the main code to point to where the test dir is */
 const char *path = ".";
 
-char *test2file(long testno)
+FILE *test2fopen(long testno)
 {
-  static char filename[256];
+  FILE *stream;
+  char filename[256];
+  /* first try the alternative, preprocessed, file */
+  msnprintf(filename, sizeof(filename), ALTTEST_DATA_PATH, path, testno);
+  stream = fopen(filename, "rb");
+  if(stream)
+    return stream;
+
+  /* then try the source version */
   msnprintf(filename, sizeof(filename), TEST_DATA_PATH, path, testno);
-  return filename;
+  stream = fopen(filename, "rb");
+
+  return stream;
 }
 
 /*

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -28,6 +28,7 @@ void logmsg(const char *msg, ...);
 long timediff(struct timeval newer, struct timeval older);
 
 #define TEST_DATA_PATH "%s/data/test%ld"
+#define ALTTEST_DATA_PATH "%s/log/test%ld"
 
 #define SERVERLOGS_LOCK "log/serverlogs.lock"
 
@@ -53,8 +54,9 @@ void win32_init(void);
 void win32_cleanup(void);
 #endif  /* USE_WINSOCK */
 
-/* returns the path name to the test case file */
-char *test2file(long testno);
+/* fopens the test case file */
+FILE *test2fopen(long testno);
+
 int wait_ms(int timeout_ms);
 int write_pidfile(const char *filename);
 int write_portfile(const char *filename, int port);


### PR DESCRIPTION
Makes the test servers (sws and ftpserver) for HTTP, Gopher, FTP, IMAP, POP3, SMTP listen on a currently unused port and runtests adapts to that! Removed the need and use of a fixed port number for these tests.

# Test case preprocessing

In order to work correctly with flexible port number for all test cases and all protocols, runtests now *preprocesses* every test case before it is started and the updated test case file is stored as `log/test$num`. Each protocol test server should now look for the preprocessed version first, then fall back to the original test file only if not found. This allows proper variable substitution in the entire test case and also makes it work for all protocols and test servers at once.