### PR TITLE
transfer: Switch PUT to GET/HEAD on 303 redirect

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -177,7 +177,7 @@ test1450 test1451 test1452 test1453 test1454 test1455 test1456 test1457 \
 test1458 test1459 test1500 test1501 test1502 test1503 test1504 test1505 \
 test1506 test1507 test1508 test1509 test1510 test1511 test1512 test1513 \
 test1514 test1515 test1516 test1517 test1518 test1519 test1520 test1521 \
-test1522 test1523 \
+test1522 test1523 test1524 \
 \
 test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
 test1533 test1534 test1535 test1536 test1537 test1538 \

--- a/tests/data/test1524
+++ b/tests/data/test1524
@@ -1,0 +1,77 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP PUT
+followlocation
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 303 OK swsclose
+Location: moo.html&testcase=/15240002
+Connection: close
+
+</data>
+<data2>
+HTTP/1.1 200 OK swsclose
+Location: this should be ignored
+Connection: close
+
+body
+</data2>
+<datacheck>
+HTTP/1.1 303 OK swsclose
+Location: moo.html&testcase=/15240002
+Connection: close
+
+HTTP/1.1 200 OK swsclose
+Location: this should be ignored
+Connection: close
+
+body
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP PUT with 303 redirect
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/blah/1524 -L -T log/upload1524.txt
+</command>
+<file name="log/upload1524.txt">
+moo
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol nonewline="yes">
+PUT /blah/1524 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Content-Length: 4
+Expect: 100-continue
+
+moo
+GET /blah/moo.html&testcase=/15240002 HTTP/1.1
+User-Agent: this should be ignored
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Prior to this change if there was a 303 reply to a PUT request then
the subsequent request to respond to that redirect would also be a PUT.
It was determined that was most likely incorrect based on the language
of the RFCs. Basically 303 means "see other" resource, which implies it
is most likely not the same resource, therefore we should not try to PUT
to that different resource.

Refer to the discussion in #5237 for more information.

Fixes https://github.com/curl/curl/issues/5237
Closes #xxxx

---

In Curl_http it will override the request string to PUT when data->set.upload is true, which is why I decided to fix this issue by setting data->set.upload as false on 303.

https://github.com/curl/curl/blob/b81e0b07784dc4c1e8d0a86194b9d28776d071c0/lib/http.c#L2070-L2073

/cc @PofMagicfingers @jzakrzewski 