### PR TITLE
Removed uneeded decleration within for

### DIFF
--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -116,7 +116,8 @@ size_t follow_links(CURLM *multi_handle, memory *mem, char *url)
     return 0;
   }
   size_t count = 0;
-  for(int i = 0; i < nodeset->nodeNr; i++) {
+  int i = 0;
+  for(i = 0; i < nodeset->nodeNr; i++) {
     double r = rand();
     int x = r * nodeset->nodeNr / RAND_MAX;
     const xmlNode *node = nodeset->nodeTab[x]->xmlChildrenNode;

--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -116,7 +116,7 @@ size_t follow_links(CURLM *multi_handle, memory *mem, char *url)
     return 0;
   }
   size_t count = 0;
-  int i = 0;
+  int i;
   for(i = 0; i < nodeset->nodeNr; i++) {
     double r = rand();
     int x = r * nodeset->nodeNr / RAND_MAX;

--- a/tests/unit/unit1655.c
+++ b/tests/unit/unit1655.c
@@ -75,6 +75,7 @@ do {
     "this.is.an.otherwise-valid.hostname."
     "with-a-label-of-greater-length-than-the-sixty-three-characters-"
     "specified.in.the.RFCs.";
+  int i;
 
   struct test {
     const char *name;
@@ -96,7 +97,7 @@ do {
     { max, DOH_OK }                      /* expect buffer overwrite */
   };
 
-  for(int i = 0; i < (int)(sizeof(playlist)/sizeof(*playlist)); i++) {
+  for(i = 0; i < (int)(sizeof(playlist)/sizeof(*playlist)); i++) {
     const char *name = playlist[i].name;
     size_t olen = 100000;
     struct demo victim;


### PR DESCRIPTION
fixed error: 'for' loop initial declaration used outside C99 mode
by declaring `i` in the beginning of the block instead of inside the for loop

gcc version 3.3.5 (Debian 1:3.3.5-13)

after fix and successful compilation, `make test` results:
https://pastebin.com/znEufH5H