### PR TITLE
Improve test server signal handling and select_ws on Windows

### DIFF
--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -676,7 +676,7 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   }
 
   /* allocate internal array for the internal event handles */
-  handles = calloc(nfds, sizeof(HANDLE));
+  handles = calloc(nfds + 1, sizeof(HANDLE));
   if(handles == NULL) {
     CloseHandle(abort);
     CloseHandle(mutex);
@@ -785,8 +785,18 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
     }
   }
 
+  /* wait on the number of handles */
+  wait = nfd;
+
+  /* make sure we stop waiting on exit signal event */
+  if(got_exit_event) {
+    /* we allocated handles nfds + 1 for this */
+    handles[nfd] = got_exit_event;
+    wait += 1;
+  }
+
   /* wait for one of the internal handles to trigger */
-  wait = WaitForMultipleObjectsEx(nfd, handles, FALSE, timeout_ms, FALSE);
+  wait = WaitForMultipleObjectsEx(wait, handles, FALSE, timeout_ms, FALSE);
 
   /* wait for internal mutex to lock event handling in threads */
   WaitForSingleObjectEx(mutex, INFINITE, FALSE);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -632,7 +632,7 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   }
   if(signum) {
     logmsg("ctrl_event_handler: %d -> %d", dwCtrlType, signum);
-    exit_signal_handler(signum);
+    raise(signum);
   }
   return TRUE;
 }
@@ -656,7 +656,7 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
     }
     if(signum) {
       logmsg("main_window_proc: %d -> %d", uMsg, signum);
-      exit_signal_handler(signum);
+      raise(signum);
     }
   }
   return DefWindowProc(hwnd, uMsg, wParam, lParam);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -803,8 +803,15 @@ void restore_signal_handlers(bool keep_sigalrm)
 #ifdef WIN32
   (void)SetConsoleCtrlHandler(ctrl_event_handler, FALSE);
   if(thread_main_window && thread_main_id) {
-    if(PostThreadMessage(thread_main_id, WM_APP, 0, 0))
-      (void)WaitForSingleObjectEx(thread_main_window, INFINITE, TRUE);
+    if(PostThreadMessage(thread_main_id, WM_APP, 0, 0)) {
+      if(WaitForSingleObjectEx(thread_main_window, INFINITE, TRUE)) {
+        if(CloseHandle(thread_main_window)) {
+          thread_main_window = NULL;
+          thread_main_id = 0;
+        }
+      }
+    }
+  }
   }
 #endif
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -580,6 +580,11 @@ volatile int got_exit_signal = 0;
 /* if next is set indicates the first signal handled in exit_signal_handler */
 volatile int exit_signal = 0;
 
+#ifdef WIN32
+/* event which if set indicates that the program should finish */
+HANDLE got_exit_event = NULL;
+#endif
+
 /* signal handler that will be triggered to indicate that the program
  * should finish its execution in a controlled manner as soon as possible.
  * The first time this is called it will set got_exit_signal to one and
@@ -592,6 +597,10 @@ static RETSIGTYPE exit_signal_handler(int signum)
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;
+#ifdef WIN32
+    if(got_exit_event)
+      (void)SetEvent(got_exit_event);
+#endif
   }
   (void)signal(signum, exit_signal_handler);
   errno = old_errno;
@@ -712,6 +721,12 @@ static DWORD WINAPI main_window_loop(LPVOID lpParameter)
 
 void install_signal_handlers(bool keep_sigalrm)
 {
+#ifdef WIN32
+  /* setup windows exit event before any signal can trigger */
+  got_exit_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if(!got_exit_event)
+    logmsg("cannot create exit event");
+#endif
 #ifdef SIGHUP
   /* ignore SIGHUP signal */
   old_sighup_handler = signal(SIGHUP, SIG_IGN);
@@ -812,6 +827,10 @@ void restore_signal_handlers(bool keep_sigalrm)
       }
     }
   }
+  if(got_exit_event) {
+    if(CloseHandle(got_exit_event)) {
+      got_exit_event = NULL;
+    }
   }
 #endif
 }

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -70,6 +70,11 @@ extern volatile int got_exit_signal;
 /* global variable which if set indicates the first signal handled */
 extern volatile int exit_signal;
 
+#ifdef WIN32
+/* global event which if set indicates that the program should finish */
+extern HANDLE got_exit_event;
+#endif
+
 void install_signal_handlers(bool keep_sigalrm);
 void restore_signal_handlers(bool keep_sigalrm);
 


### PR DESCRIPTION
- **tests/server/util.c**: use raise instead of calling signal handler

    Use raise to trigger signal handler instead of calling it
    directly and causing potential unexpected control flow.

- **tests/server/util.c**: fix thread handle not being closed

- **tests/server/util.[ch]**: add exit event to stop waiting on Windows

    This commit adds a global exit event to the test servers that
    Windows-specific wait routines can use to get triggered if the
    program was signaled to be terminated, eg. select_ws in sockfilt.c

    The exit event will be managed by the signal handling code and is
    set to not reset automatically to support multiple wait routines.

- **sockfilt**: make select_ws stop waiting on exit signal event

    This makes sure that select_ws behaves similar to real select
    which stops waiting on a signal handler being triggered.

    This makes it possible to gracefully stop sockfilt.exe on
    Windows with taskkill /IM sockfilt.exe (without /F force flag).
