### PR TITLE
[WIP] Reduce code duplication and improve timeout handling in select.c

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -509,7 +509,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     before = Curl_now();
 
     /* wait for activity or timeout */
-    pollrc = Curl_poll(fds, numfds, (int)ev->ms);
+    pollrc = Curl_poll(fds, numfds, ev->ms);
 
     after = Curl_now();
 

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -147,8 +147,8 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
       result = CURLE_OPERATION_TIMEDOUT;
       break;
     }
-    if(!timeout_ms || timeout_ms > TIME_T_MAX)
-      timeout_ms = TIME_T_MAX;
+    if(!timeout_ms)
+      timeout_ms = TIMEDIFF_T_MAX;
 
     /* Don't busyloop. The entire loop thing is a work-around as it causes a
        BLOCKING behavior which is a NO-NO. This function should rather be
@@ -156,7 +156,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
        possible to send now will be sent in the doing function repeatedly
        until the entire request is sent.
     */
-    what = SOCKET_WRITABLE(sockfd, (time_t)timeout_ms);
+    what = SOCKET_WRITABLE(sockfd, timeout_ms);
     if(what < 0) {
       result = CURLE_SEND_ERROR;
       break;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1239,7 +1239,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
          timeout */
       else if((sleep_ms < 0) && extrawait)
         sleep_ms = timeout_ms;
-      Curl_wait_ms((int)sleep_ms);
+      Curl_wait_ms(sleep_ms);
     }
   }
 

--- a/lib/select.h
+++ b/lib/select.h
@@ -76,18 +76,18 @@ int Curl_select(curl_socket_t maxfd,
                 fd_set *fds_read,
                 fd_set *fds_write,
                 fd_set *fds_err,
-                time_t timeout_ms);
+                timediff_t timeout_ms);
 
 int Curl_socket_check(curl_socket_t readfd, curl_socket_t readfd2,
                       curl_socket_t writefd,
-                      time_t timeout_ms);
+                      timediff_t timeout_ms);
 #define SOCKET_READABLE(x,z) \
   Curl_socket_check(x, CURL_SOCKET_BAD, CURL_SOCKET_BAD, z)
 #define SOCKET_WRITABLE(x,z) \
   Curl_socket_check(CURL_SOCKET_BAD, CURL_SOCKET_BAD, x, z)
 
-int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms);
-int Curl_wait_ms(int timeout_ms);
+int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms);
+int Curl_wait_ms(timediff_t timeout_ms);
 
 #ifdef TPF
 int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -68,8 +68,8 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
       result = CURLE_OPERATION_TIMEDOUT;
       break;
     }
-    if(!timeout_ms || timeout_ms > TIME_T_MAX)
-      timeout_ms = TIME_T_MAX;
+    if(!timeout_ms)
+      timeout_ms = TIMEDIFF_T_MAX;
     if(SOCKET_READABLE(sockfd, (time_t)timeout_ms) <= 0) {
       result = ~CURLE_OK;
       break;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2994,7 +2994,7 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
         fd_write = sock;
       /* wait for the socket to become ready */
       (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD, fd_write,
-                              left>1000?1000:(time_t)left);
+                              left>1000?1000:left);
     }
 #endif
 

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -642,7 +642,7 @@ static CURLcode bearssl_connect_common(struct connectdata *conn,
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   curl_socket_t sockfd = conn->sock[sockindex];
-  time_t timeout_ms;
+  timediff_t timeout_ms;
   int what;
 
   /* check if the connection has already been established */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -310,7 +310,7 @@ static CURLcode handshake(struct connectdata *conn,
 
       what = Curl_socket_check(readfd, CURL_SOCKET_BAD, writefd,
                                nonblocking?0:
-                               timeout_ms?(time_t)timeout_ms:1000);
+                               timeout_ms?timeout_ms:1000);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -938,7 +938,7 @@ mbed_connect_common(struct connectdata *conn,
         connssl->connecting_state?sockfd:CURL_SOCKET_BAD;
 
       what = Curl_socket_check(readfd, CURL_SOCKET_BAD, writefd,
-                               nonblocking ? 0 : (time_t)timeout_ms);
+                               nonblocking ? 0 : timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -544,7 +544,7 @@ mesalink_connect_common(struct connectdata *conn, int sockindex,
 
       what = Curl_socket_check(
         readfd, CURL_SOCKET_BAD, writefd,
-        nonblocking ? 0 : (time_t)timeout_ms);
+        nonblocking ? 0 : timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3737,7 +3737,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
         connssl->connecting_state?sockfd:CURL_SOCKET_BAD;
 
       what = Curl_socket_check(readfd, CURL_SOCKET_BAD, writefd,
-                               nonblocking?0:(time_t)timeout_ms);
+                               nonblocking?0:timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1481,7 +1481,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
         connssl->connecting_state ? sockfd : CURL_SOCKET_BAD;
 
       what = Curl_socket_check(readfd, CURL_SOCKET_BAD, writefd,
-                               nonblocking ? 0 : (time_t)timeout_ms);
+                               nonblocking ? 0 : timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL/TLS socket, errno: %d", SOCKERRNO);
@@ -1645,9 +1645,9 @@ schannel_send(struct connectdata *conn, int sockindex,
         written = -1;
         break;
       }
-      if(!timeout_ms || timeout_ms > TIME_T_MAX)
-        timeout_ms = TIME_T_MAX;
-      what = SOCKET_WRITABLE(conn->sock[sockindex], (time_t)timeout_ms);
+      if(!timeout_ms)
+        timeout_ms = TIMEDIFF_T_MAX;
+      what = SOCKET_WRITABLE(conn->sock[sockindex], timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(conn->data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2856,7 +2856,7 @@ sectransp_connect_common(struct connectdata *conn,
       connssl->connecting_state?sockfd:CURL_SOCKET_BAD;
 
       what = Curl_socket_check(readfd, CURL_SOCKET_BAD, writefd,
-                               nonblocking?0:(time_t)timeout_ms);
+                               nonblocking?0:timeout_ms);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -800,7 +800,7 @@ wolfssl_connect_common(struct connectdata *conn,
   struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   curl_socket_t sockfd = conn->sock[sockindex];
-  time_t timeout_ms;
+  timdiff_t timeout_ms;
   int what;
 
   /* check if the connection has already been established */


### PR DESCRIPTION
This PR will contain individual follow-up commits for the changes discussed in #5107 and #5240 as well as commits to reduce the code duplication inside `select.c` by re-using existing logic. This PR is neither complete nor ready for review yet, I am just creating it as a draft to have CI functionality at hand.

**Commits / Phases of this PR:**
- select: reduce duplication of Curl_poll in Curl_socket_check
   Change Curl_socket_check to use select-fallback in Curl_poll
   instead of implementing it in Curl_socket_check and Curl_poll.

**TODO:**
- [x] cleanup comments left around from code that was already moved/deduped
- [x] use `timediff_t` instead of `time_t` and `int` where appropriate and handle #5240 internally.
- [x] make sure the functions behave correctly regarding timeouts on POSIX and Windows, eg. avoid sleeping forever if no sockets were provided in all functions.