### PR TITLE
runtests: use a unix domain socket path with the pid in the name

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5455,7 +5455,7 @@ $DICTPORT        = $base++; # DICT port
 $SMBPORT         = $base++; # SMB port
 $SMBSPORT        = $base++; # SMBS port
 $NEGTELNETPORT   = $base++; # TELNET port with negotiation
-$HTTPUNIXPATH    = 'http.sock'; # HTTP server Unix domain socket path
+$HTTPUNIXPATH    = "http$$.sock"; # HTTP server Unix domain socket path
 
 $maxport         = $base-1; # updated base port number
 


### PR DESCRIPTION
To make it impossible for test cases to access the file name without
using the proper variable for the purpose.