### PR TITLE
tests: add %NOLISTENPORT and use it

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -365,6 +365,7 @@ Available substitute variables include:
 - `%IMAPPORT` - Port number of the IMAP server
 - `%MQTTPORT` - Port number of the MQTT server
 - `%NEGTELNETPORT` - Port number of the telnet server
+- `%NOLISTENPORT` - Port number where no service is listening
 - `%POP36PORT` - IPv6 port number of the POP3 server
 - `%POP3PORT` - Port number of the POP3 server
 - `%POSIX_PWD` - Current directory somewhat mingw friendly

--- a/tests/data/test19
+++ b/tests/data/test19
@@ -24,7 +24,7 @@ http
 attempt connect to non-listening socket
  </name>
  <command>
-%HOSTIP:2
+%HOSTIP:%NOLISTENPORT
 </command>
 </client>
 

--- a/tests/data/test504
+++ b/tests/data/test504
@@ -32,7 +32,7 @@ lib504
 simple multi through local proxy without listener
  </name>
  <command>
-http://%HOSTIP:%HTTPSPORT/504 %HOSTIP:55555
+http://%HOSTIP:%HTTPSPORT/504 %HOSTIP:%NOLISTENPORT
 </command>
 </client>
 

--- a/tests/data/test702
+++ b/tests/data/test702
@@ -31,7 +31,7 @@ proxy
 Attempt connect to non-listening HTTP server via SOCKS4 proxy
  </name>
  <command>
---socks4 %HOSTIP:%SOCKSPORT http://%HOSTIP:60000
+--socks4 %HOSTIP:%SOCKSPORT http://%HOSTIP:%NOLISTENPORT
 </command>
 </client>
 

--- a/tests/data/test703
+++ b/tests/data/test703
@@ -31,7 +31,7 @@ proxy
 Attempt connect to non-listening HTTP server via SOCKS5 proxy
  </name>
  <command>
---socks5 %HOSTIP:%SOCKSPORT http://%HOSTIP:60000
+--socks5 %HOSTIP:%SOCKSPORT http://%HOSTIP:%NOLISTENPORT
 </command>
 </client>
 

--- a/tests/data/test704
+++ b/tests/data/test704
@@ -23,7 +23,7 @@ http
 Attempt connect to non-listening SOCKS4 proxy
  </name>
  <command>
---socks4 %HOSTIP:2 http://%HOSTIP:%HTTPPORT/704
+--socks4 %HOSTIP:%NOLISTENPORT http://%HOSTIP:%HTTPPORT/704
 </command>
 <features>
 proxy

--- a/tests/data/test705
+++ b/tests/data/test705
@@ -23,7 +23,7 @@ http
 Attempt connect to non-listening SOCKS5 proxy
  </name>
  <command>
---socks5 %HOSTIP:2 http://%HOSTIP:%HTTPPORT/705
+--socks5 %HOSTIP:%NOLISTENPORT http://%HOSTIP:%HTTPPORT/705
 </command>
 <features>
 proxy

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -126,6 +126,7 @@ my $maxport;     # maximum used port number
 
 my $noport="[not running]";
 
+my $NOLISTENPORT=2;      # port number we use for a local non-listening service
 my $MQTTPORT=$noport;    # MQTT server port
 my $HTTPPORT=$noport;    # HTTP server port
 my $HTTP6PORT=$noport;   # HTTP IPv6 server port
@@ -3229,6 +3230,7 @@ sub subVariables {
     $$thing =~ s/${prefix}SMBPORT/$SMBPORT/g;
     $$thing =~ s/${prefix}SMBSPORT/$SMBSPORT/g;
     $$thing =~ s/${prefix}NEGTELNETPORT/$NEGTELNETPORT/g;
+    $$thing =~ s/${prefix}NOLISTENPORT/$NOLISTENPORT/g;
 
     # server Unix domain socket paths
     $$thing =~ s/${prefix}HTTPUNIXPATH/$HTTPUNIXPATH/g;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -126,7 +126,7 @@ my $maxport;     # maximum used port number
 
 my $noport="[not running]";
 
-my $NOLISTENPORT=2;      # port number we use for a local non-listening service
+my $NOLISTENPORT=47;     # port number we use for a local non-listening service
 my $MQTTPORT=$noport;    # MQTT server port
 my $HTTPPORT=$noport;    # HTTP server port
 my $HTTP6PORT=$noport;   # HTTP IPv6 server port


### PR DESCRIPTION
The purpose with this variable is to provide a port number that is
reasonably likely to not have a listener on the local host so that tests
can try connect failures against it. It uses port 2.

Updated six tests to use it instead of the previous different ports.