### PR TITLE
GnuTLS: Don't skip really long certificate fields

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -25,7 +25,6 @@ problems may have been fixed or changed somewhat since this was written!
  2. TLS
  2.1 CURLINFO_SSL_VERIFYRESULT has limited support
  2.2 DER in keychain
- 2.3 GnuTLS backend skips really long certificate fields
  2.4 DarwinSSL won't import PKCS#12 client certificates without a password
  2.5 Client cert handling with Issuer DN differs between backends
  2.6 CURL_GLOBAL_SSL
@@ -208,12 +207,6 @@ problems may have been fixed or changed somewhat since this was written!
 
  Curl doesn't recognize certificates in DER format in keychain, but it works
  with PEM.  https://curl.haxx.se/bug/view.cgi?id=1065
-
-2.3 GnuTLS backend skips really long certificate fields
-
- libcurl calls gnutls_x509_crt_get_dn() with a fixed buffer size and if the
- field is too long in the cert, it'll just return an error and the field will
- be displayed blank.
 
 2.4 DarwinSSL won't import PKCS#12 client certificates without a password
 

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1030,7 +1030,7 @@ gtls_connect_step3(struct connectdata *conn,
   gnutls_x509_crt_t x509_cert, x509_issuer;
   gnutls_datum_t issuerp;
   gnutls_datum_t certfields;
-  char certname[64] = ""; /* limited to 64 chars by ASN.1 */
+  char certname[65] = ""; /* limited to 64 chars by ASN.1 */
   size_t size;
   time_t certclock;
   const char *ptr;


### PR DESCRIPTION
This fixes 2.3 describes in `docs/KNOWN_BUGS`.
It is fixed by using the `..._dn2` function equivalents which allocate the required length rather than filling it into the fixed one.
The CN field was limited to 64 chars because that's the defined max amount in ASN.1