### PR TITLE
mqtt: remove code with no purpose

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -607,8 +607,6 @@ static CURLcode mqtt_doing(struct connectdata *conn, bool *done)
   case MQTT_PUBWAIT:
   case MQTT_PUB_REMAIN:
     result = mqtt_read_publish(conn, done);
-    if(result)
-      break;
     break;
 
   default:


### PR DESCRIPTION
Detected by Coverity. CID 1462319.

"The same code is executed when the condition result is true or false,
because the code in the if-then branch and after the if statement is
identical."