### PR TITLE
Fix typo in curl.h comment

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2434,7 +2434,7 @@ CURL_EXTERN CURLcode curl_global_init(long flags);
  * initialize libcurl and set user defined memory management callback
  * functions.  Users can implement memory management routines to check for
  * memory leaks, check for mis-use of the curl library etc.  User registered
- * callback routines with be invoked by this library instead of the system
+ * callback routines will be invoked by this library instead of the system
  * memory management routines like malloc, free etc.
  */
 CURL_EXTERN CURLcode curl_global_init_mem(long flags,


### PR DESCRIPTION
"routines with be invoked" -> "routines will be invoked"