### PR TITLE
GnuTLS: Backend support for CURLINFO_SSL_VERIFYRESULT

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -200,8 +200,8 @@ problems may have been fixed or changed somewhat since this was written!
 
 2.1 CURLINFO_SSL_VERIFYRESULT has limited support
 
- CURLINFO_SSL_VERIFYRESULT is only implemented for the OpenSSL and NSS
- backends, so relying on this information in a generic app is flaky.
+ CURLINFO_SSL_VERIFYRESULT is only implemented for the OpenSSL, NSS and
+ GnuTLS backends, so relying on this information in a generic app is flaky.
 
 2.2 DER in keychain
 

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.3
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.3
@@ -50,7 +50,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.5. Only set by the OpenSSL/libressl/boringssl and NSS backends.
+Added in 7.5. Only set by the OpenSSL/libressl/boringssl, NSS and GnuTLS backends.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"


### PR DESCRIPTION
This makes it possible to get a return for peer verification when getting `CURLINFO_SSL_VERIFYRESULT` when using GnuTLS