### PR TITLE
smtp: set auth correctly

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -625,8 +625,7 @@ static CURLcode smtp_perform_mail(struct connectdata *conn)
         utf8 = TRUE;
 
       if(host.name) {
-        free(from);
-        from = aprintf("<%s@%s>", address, host.name);
+        auth = aprintf("<%s@%s>", address, host.name);
 
         Curl_free_idnconverted_hostname(&host);
       }
@@ -636,8 +635,6 @@ static CURLcode smtp_perform_mail(struct connectdata *conn)
         auth = aprintf("<%s>", address);
 
       free(address);
-      if(!from)
-        return CURLE_OUT_OF_MEMORY;
     }
     else
       /* Empty AUTH, RFC-2554, sect. 5 */


### PR DESCRIPTION
Regression since 7.69.0 and 68fb25fa3fcff.

The code wrongly assigned 'from' instead of 'auth' which probably was a
copy and paste mistake from other code, leading to that auth could
remain NULL and later cause an error to be returned.

Assisted-by: Eric Sauvageau
Fixes #5294