### PR TITLE
runtests: check for the disabled tests relative srcdir

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5446,7 +5446,7 @@ sub disabledtests {
             if($_ =~ /(\d+)/) {
                 my ($n) = $1;
                 $disabled{$n}=$n; # disable this test number
-                if(! -f "data/test$n") {
+                if(! -f "$srcdir/data/test$n") {
                     print STDERR "WARNING! Non-exiting test $n in DISABLED!\n";
                     # fail hard to make user notice
                     exit 1;


### PR DESCRIPTION
To make it work correctly for out-of-tree builds.

Follow-up to 75e8feb6fb08b