### PR TITLE
dynbuf: introduce internal generic dynamic buffer functions

### DIFF
--- a/docs/DYNBUF.md
+++ b/docs/DYNBUF.md
@@ -1,0 +1,80 @@
+# dynbuf
+
+This is the internal module for creating and handling "dynamic buffers". This
+means buffers that can be appended to, dynamically and grow in size to adapt.
+
+There will always be a terminating zero put at the end of the dynamic buffer.
+
+The `struct dynbuf` is used to hold data for each instance of a dynamic
+buffer. The members of that struct **MUST NOT** be accessed or modified
+without using the dedicated dynbuf API.
+
+## init
+
+    void Curl_dyn_init(struct dynbuf *s, size_t toobig);
+
+This inits a struct to use for dynbuf and it can't fail. The `toobig` value
+**must** be set to the maximum size we allow this buffer instance to grow to.
+The functions below will return `CURLE_OUT_OF_MEMORY` when hitting this limit.
+
+## free
+
+    void Curl_dyn_free(struct dynbuf *s);
+
+Free the associated memory and clean up. After a free, the `dynbuf` struct can
+be re-used to start appending new data to.
+
+## addn
+
+    CURLcode Curl_dyn_addn(struct dynbuf *s, const void *mem, size_t len);
+
+Append arbitrary data of a given length to the end of the buffer.
+
+## add
+
+    CURLcode Curl_dyn_add(struct dynbuf *s, const char *str);
+
+Append a C string to the end of the buffer.
+
+## addf
+
+    CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...);
+
+Append a `printf()`-style string to the end of the buffer.
+
+## reset
+
+    void Curl_dyn_reset(struct dynbuf *s);
+
+Reset the buffer length, but leave the allocation.
+
+## tail
+
+    CURLcode Curl_dyn_trail(struct dynbuf *s, size_t length)
+
+Keep `length` bytes of the buffer tail (the last `length` bytes of the
+buffer). The rest of the buffer is dropped. The specified `length` must not be
+larger than the buffer length.
+
+## ptr
+
+    char *Curl_dyn_ptr(const struct dynbuf *s);
+
+Returns a `char *` to the buffer. Since the buffer may be reallocated, this
+pointer should not be trusted or used anymore after the next buffer
+manipulation call.
+
+## uptr
+
+    unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
+
+Returns an `unsigned char *` to the buffer. Since the buffer may be
+reallocated, this pointer should not be trusted or used anymore after the next
+buffer manipulation call.
+
+## len
+
+    size_t Curl_dyn_len(const struct dynbuf *s);
+
+Returns the length of the buffer in bytes. Does not include the terminating
+zero byte.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -54,6 +54,7 @@ EXTRA_DIST =                                    \
  CONTRIBUTE.md                                  \
  CURL-DISABLE.md                                \
  DEPRECATE.md                                   \
+ DYNBUF.md                                      \
  ESNI.md                                        \
  EXPERIMENTAL.md                                \
  FAQ                                            \

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -60,7 +60,7 @@ LIB_CFILES = altsvc.c amigaos.c asyn-ares.c asyn-thread.c base64.c            \
   sendf.c setopt.c sha256.c share.c slist.c smb.c smtp.c socketpair.c socks.c \
   socks_gssapi.c socks_sspi.c speedcheck.c splay.c strcase.c strdup.c         \
   strerror.c strtok.c strtoofft.c system_win32.c telnet.c tftp.c timeval.c    \
-  transfer.c urlapi.c version.c warnless.c wildcard.c x509asn1.c
+  transfer.c urlapi.c version.c warnless.c wildcard.c x509asn1.c dynbuf.c
 
 LIB_HFILES = altsvc.h amigaos.h arpa_telnet.h asyn.h conncache.h connect.h    \
   content_encoding.h cookie.h curl_addrinfo.h curl_base64.h curl_ctype.h      \
@@ -79,7 +79,7 @@ LIB_HFILES = altsvc.h amigaos.h arpa_telnet.h asyn.h conncache.h connect.h    \
   smb.h smtp.h sockaddr.h socketpair.h socks.h speedcheck.h splay.h strcase.h \
   strdup.h strerror.h strtok.h strtoofft.h system_win32.h telnet.h tftp.h     \
   timeval.h transfer.h urlapi-int.h urldata.h warnless.h wildcard.h           \
-  x509asn1.h
+  x509asn1.h dynbuf.h
 
 LIB_RCFILES = libcurl.rc
 

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -261,15 +261,11 @@ done:
 static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
                                  const char *input, curlntlm state)
 {
-  char *buf = malloc(NTLM_BUFSIZE);
   size_t len_in = strlen(input), len_out = 0;
-
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
-  (void) data;
-#endif
-
-  if(!buf)
-    return CURLE_OUT_OF_MEMORY;
+  struct dynbuf b;
+  char *ptr = NULL;
+  unsigned char *buf = (unsigned char *)data->state.buffer;
+  Curl_dyn_init(&b, MAX_NTLM_WB_RESPONSE);
 
   while(len_in > 0) {
     ssize_t written = swrite(ntlm->ntlm_auth_hlpr_socket, input, len_in);
@@ -285,10 +281,8 @@ static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
   }
   /* Read one line */
   while(1) {
-    ssize_t size;
-    char *newbuf;
-
-    size = sread(ntlm->ntlm_auth_hlpr_socket, buf + len_out, NTLM_BUFSIZE);
+    ssize_t size =
+      sread(ntlm->ntlm_auth_hlpr_socket, buf, data->set.buffer_size);
     if(size == -1) {
       if(errno == EINTR)
         continue;
@@ -297,48 +291,41 @@ static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
     else if(size == 0)
       goto done;
 
-    len_out += size;
-    if(buf[len_out - 1] == '\n') {
-      buf[len_out - 1] = '\0';
-      break;
+    if(Curl_dyn_addn(&b, buf, size))
+      goto done;
+
+    len_out = Curl_dyn_len(&b);
+    ptr = Curl_dyn_ptr(&b);
+    if(len_out && ptr[len_out - 1] == '\n') {
+      ptr[len_out - 1] = '\0';
+      break; /* done! */
     }
-
-    if(len_out > MAX_NTLM_WB_RESPONSE) {
-      failf(data, "too large ntlm_wb response!");
-      free(buf);
-      return CURLE_OUT_OF_MEMORY;
-    }
-
-    newbuf = Curl_saferealloc(buf, len_out + NTLM_BUFSIZE);
-    if(!newbuf)
-      return CURLE_OUT_OF_MEMORY;
-
-    buf = newbuf;
+    /* loop */
   }
 
   /* Samba/winbind installed but not configured */
   if(state == NTLMSTATE_TYPE1 &&
      len_out == 3 &&
-     buf[0] == 'P' && buf[1] == 'W')
+     ptr[0] == 'P' && ptr[1] == 'W')
     goto done;
   /* invalid response */
   if(len_out < 4)
     goto done;
   if(state == NTLMSTATE_TYPE1 &&
-     (buf[0]!='Y' || buf[1]!='R' || buf[2]!=' '))
+     (ptr[0]!='Y' || ptr[1]!='R' || ptr[2]!=' '))
     goto done;
   if(state == NTLMSTATE_TYPE2 &&
-     (buf[0]!='K' || buf[1]!='K' || buf[2]!=' ') &&
-     (buf[0]!='A' || buf[1]!='F' || buf[2]!=' '))
+     (ptr[0]!='K' || ptr[1]!='K' || ptr[2]!=' ') &&
+     (ptr[0]!='A' || ptr[1]!='F' || ptr[2]!=' '))
     goto done;
 
-  ntlm->response = aprintf("%.*s", len_out - 4, buf + 3);
-  free(buf);
+  ntlm->response = strdup(ptr + 3);
+  Curl_dyn_free(&b);
   if(!ntlm->response)
     return CURLE_OUT_OF_MEMORY;
   return CURLE_OK;
 done:
-  free(buf);
+  Curl_dyn_free(&b);
   return CURLE_REMOTE_ACCESS_DENIED;
 }
 

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2018 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -70,12 +70,6 @@ typedef enum {
 #define DOH_MAX_ADDR 24
 #define DOH_MAX_CNAME 4
 
-struct cnamestore {
-  size_t len;       /* length of cname */
-  char *alloc;      /* allocated pointer */
-  size_t allocsize; /* allocated size */
-};
-
 struct dohaddr {
   int type;
   union {
@@ -85,11 +79,11 @@ struct dohaddr {
 };
 
 struct dohentry {
-  unsigned int ttl;
-  int numaddr;
+  struct dynbuf cname[DOH_MAX_CNAME];
   struct dohaddr addr[DOH_MAX_ADDR];
+  int numaddr;
+  unsigned int ttl;
   int numcname;
-  struct cnamestore cname[DOH_MAX_CNAME];
 };
 
 
@@ -103,6 +97,7 @@ DOHcode doh_decode(const unsigned char *doh,
                    size_t dohlen,
                    DNStype dnstype,
                    struct dohentry *d);
+void de_init(struct dohentry *d);
 void de_cleanup(struct dohentry *d);
 #endif
 

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -1,0 +1,225 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+#include "strdup.h"
+#include "dynbuf.h"
+
+/* The last 3 #include files should be in this order */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
+
+#define MIN_FIRST_ALLOC 32
+
+#define DYNINIT 0xbee51da /* random pattern */
+
+/*
+ * Init a dynbuf struct.
+ */
+void Curl_dyn_init(struct dynbuf *s, size_t toobig)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(toobig);
+  s->bufr = NULL;
+  s->leng = 0;
+  s->allc = 0;
+  s->toobig = toobig;
+#ifdef DEBUGBUILD
+  s->init = DYNINIT;
+#endif
+}
+
+/*
+ * free the buffer and re-init the necessary fields. It doesn't touch the
+ * 'init' field and thus this buffer can be reused to add data to again.
+ */
+void Curl_dyn_free(struct dynbuf *s)
+{
+  DEBUGASSERT(s);
+  Curl_safefree(s->bufr);
+  s->leng = s->allc = 0;
+}
+
+/*
+ * Store/append an chunk of memory to the dynbuf.
+ */
+static CURLcode dyn_nappend(struct dynbuf *s,
+                            const unsigned char *mem, size_t len)
+{
+  size_t indx = s->leng;
+  size_t a = s->allc;
+  size_t fit = len + indx + 1; /* new string + old string + zero byte */
+
+  /* try to detect if there's rubbish in the struct */
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(s->toobig);
+  DEBUGASSERT(indx < s->toobig);
+  DEBUGASSERT(!s->leng || s->bufr);
+
+  if(fit > s->toobig) {
+    Curl_dyn_free(s);
+    return CURLE_OUT_OF_MEMORY;
+  }
+  else if(!a) {
+    DEBUGASSERT(!indx);
+    /* first invoke */
+    if(fit < MIN_FIRST_ALLOC)
+      a = MIN_FIRST_ALLOC;
+    else
+      a = fit;
+  }
+  else {
+    while(a < fit)
+      a *= 2;
+  }
+
+  if(a != s->allc) {
+    s->bufr = Curl_saferealloc(s->bufr, a);
+    if(!s->bufr) {
+      s->leng = s->allc = 0;
+      return CURLE_OUT_OF_MEMORY;
+    }
+    s->allc = a;
+  }
+
+  if(len)
+    memcpy(&s->bufr[indx], mem, len);
+  s->leng = indx + len;
+  s->bufr[s->leng] = 0;
+  return CURLE_OK;
+}
+
+/*
+ * Clears the string, keeps the allocation. This can also be called on a
+ * buffer that already was freed.
+ */
+void Curl_dyn_reset(struct dynbuf *s)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  if(s->leng)
+    s->bufr[0] = 0;
+  s->leng = 0;
+}
+
+/*
+ * Specify the size of the tail to keep (number of bytes from the end of the
+ * buffer). The rest will be dropped.
+ */
+CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  if(trail > s->leng)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  else if(trail == s->leng)
+    return CURLE_OK;
+  else if(!trail) {
+    Curl_dyn_reset(s);
+  }
+  else {
+    memmove(&s->bufr[0], &s->bufr[s->leng - trail], trail);
+    s->leng = trail;
+  }
+  return CURLE_OK;
+
+}
+
+/*
+ * Appends a buffer with length.
+ */
+CURLcode Curl_dyn_addn(struct dynbuf *s, const void *mem, size_t len)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  return dyn_nappend(s, mem, len);
+}
+
+/*
+ * Append a zero terminated string at the end.
+ */
+CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
+{
+  size_t n = strlen(str);
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  return dyn_nappend(s, (unsigned char *)str, n);
+}
+
+/*
+ * Append a string printf()-style
+ */
+CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
+{
+  char *str;
+  va_list ap;
+  va_start(ap, fmt);
+  str = vaprintf(fmt, ap); /* this allocs a new string to append */
+  va_end(ap);
+
+  if(str) {
+    CURLcode result = dyn_nappend(s, (unsigned char *)str, strlen(str));
+    free(str);
+    return result;
+  }
+  /* If we failed, we cleanup the whole buffer and return error */
+  Curl_dyn_free(s);
+  return CURLE_OUT_OF_MEMORY;
+}
+
+/*
+ * Returns a pointer to the buffer.
+ */
+char *Curl_dyn_ptr(const struct dynbuf *s)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  return s->leng ? s->bufr : (char *)"";
+}
+
+/*
+ * Returns an unsigned pointer to the buffer.
+ */
+unsigned char *Curl_dyn_uptr(const struct dynbuf *s)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  return s->leng ? (unsigned char *)s->bufr : (unsigned char *)"";
+}
+
+/*
+ * Returns the length of the buffer.
+ */
+size_t Curl_dyn_len(const struct dynbuf *s)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  return s->leng;
+}

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -57,5 +57,6 @@ size_t Curl_dyn_len(const struct dynbuf *s);
 #define DYN_APRINTF         8000000
 #define DYN_RTSP_REQ_HEADER (64*1024)
 #define DYN_TRAILERS        (64*1024)
+#define DYN_PROXY_CONNECT_HEADERS 16384
 
 #endif

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -1,0 +1,61 @@
+#ifndef HEADER_CURL_DYNBUF_H
+#define HEADER_CURL_DYNBUF_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+struct dynbuf {
+  char *bufr;    /* point to a zero terminated allocated buffer */
+  size_t leng;   /* number of bytes *EXCLUDING* the zero terminator */
+  size_t allc;   /* size of the current allocation */
+  size_t toobig; /* size limit for the buffer */
+#ifdef DEBUGBUILD
+  int init;     /* detect API usage mistakes */
+#endif
+};
+
+void Curl_dyn_init(struct dynbuf *s, size_t toobig);
+void Curl_dyn_free(struct dynbuf *s);
+CURLcode Curl_dyn_addn(struct dynbuf *s, const void *mem, size_t len)
+  WARN_UNUSED_RESULT;
+CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
+  WARN_UNUSED_RESULT;
+CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
+  WARN_UNUSED_RESULT;
+void Curl_dyn_reset(struct dynbuf *s);
+CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail);
+char *Curl_dyn_ptr(const struct dynbuf *s);
+unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
+size_t Curl_dyn_len(const struct dynbuf *s);
+
+/* Dynamic buffer max sizes */
+#define DYN_DOH_RESPONSE    3000
+#define DYN_DOH_CNAME       256
+#define DYN_PAUSE_BUFFER    (64 * 1024 * 1024)
+#define DYN_HAXPROXY        2048
+#define DYN_HTTP_REQUEST    (128*1024)
+#define DYN_H2_HEADERS      (128*1024)
+#define DYN_H2_TRAILERS     (128*1024)
+#define DYN_APRINTF         8000000
+#define DYN_RTSP_REQ_HEADER (64*1024)
+#define DYN_TRAILERS        (64*1024)
+
+#endif

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -77,6 +77,7 @@
 #include "http_digest.h"
 #include "system_win32.h"
 #include "http2.h"
+#include "dynbuf.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -820,14 +821,11 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   if(!outcurl->state.buffer)
     goto fail;
 
-  outcurl->state.headerbuff = malloc(HEADERSIZE);
-  if(!outcurl->state.headerbuff)
-    goto fail;
-  outcurl->state.headersize = HEADERSIZE;
-
   /* copy all userdefined values */
   if(dupset(outcurl, data))
     goto fail;
+
+  Curl_dyn_init(&outcurl->state.headerb, CURL_MAX_HTTP_HEADER);
 
   /* the connection cache is setup on demand */
   outcurl->state.conn_cache = NULL;
@@ -921,7 +919,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
     curl_slist_free_all(outcurl->change.cookielist);
     outcurl->change.cookielist = NULL;
     Curl_safefree(outcurl->state.buffer);
-    Curl_safefree(outcurl->state.headerbuff);
+    Curl_dyn_free(&outcurl->state.headerb);
     Curl_safefree(outcurl->change.url);
     Curl_safefree(outcurl->change.referer);
     Curl_freeset(outcurl);
@@ -1040,7 +1038,7 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
       /* copy the structs to allow for immediate re-pausing */
       for(i = 0; i < data->state.tempcount; i++) {
         writebuf[i] = data->state.tempwrite[i];
-        data->state.tempwrite[i].buf = NULL;
+        Curl_dyn_init(&data->state.tempwrite[i].b, DYN_PAUSE_BUFFER);
       }
       data->state.tempcount = 0;
 
@@ -1054,9 +1052,10 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
         /* even if one function returns error, this loops through and frees
            all buffers */
         if(!result)
-          result = Curl_client_write(conn, writebuf[i].type, writebuf[i].buf,
-                                     writebuf[i].len);
-        free(writebuf[i].buf);
+          result = Curl_client_write(conn, writebuf[i].type,
+                                     Curl_dyn_ptr(&writebuf[i].b),
+                                     Curl_dyn_len(&writebuf[i].b));
+        Curl_dyn_free(&writebuf[i].b);
       }
 
       /* recover previous owner of the connection */

--- a/lib/easyif.h
+++ b/lib/easyif.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -42,7 +42,7 @@ const char *Curl_http2_strerror(uint32_t err);
 CURLcode Curl_http2_init(struct connectdata *conn);
 void Curl_http2_init_state(struct UrlState *state);
 void Curl_http2_init_userset(struct UserDefined *set);
-CURLcode Curl_http2_request_upgrade(Curl_send_buffer *req,
+CURLcode Curl_http2_request_upgrade(struct dynbuf *req,
                                     struct connectdata *conn);
 CURLcode Curl_http2_setup(struct connectdata *conn);
 CURLcode Curl_http2_switched(struct connectdata *conn,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -158,15 +158,15 @@ static CURLcode connect_init(struct connectdata *conn, bool reinit)
       return CURLE_OUT_OF_MEMORY;
     infof(conn->data, "allocate connect buffer!\n");
     conn->connect_state = s;
+    Curl_dyn_init(&s->rcvbuf, DYN_PROXY_CONNECT_HEADERS);
   }
   else {
     DEBUGASSERT(conn->connect_state);
     s = conn->connect_state;
+    Curl_dyn_reset(&s->rcvbuf);
   }
   s->tunnel_state = TUNNEL_INIT;
   s->keepon = TRUE;
-  s->line_start = s->connect_buffer;
-  s->ptr = s->line_start;
   s->cl = 0;
   s->close_connection = FALSE;
   return CURLE_OK;
@@ -176,6 +176,7 @@ static void connect_done(struct connectdata *conn)
 {
   struct http_connect_state *s = conn->connect_state;
   s->tunnel_state = TUNNEL_COMPLETE;
+  Curl_dyn_free(&s->rcvbuf);
   infof(conn->data, "CONNECT phase completed!\n");
 }
 
@@ -190,6 +191,8 @@ static CURLcode CONNECT(struct connectdata *conn,
   CURLcode result;
   curl_socket_t tunnelsocket = conn->sock[sockindex];
   struct http_connect_state *s = conn->connect_state;
+  char *linep;
+  size_t perline;
 
 #define SELECT_OK      0
 #define SELECT_ERROR   1
@@ -204,7 +207,7 @@ static CURLcode CONNECT(struct connectdata *conn,
     if(TUNNEL_INIT == s->tunnel_state) {
       /* BEGIN CONNECT PHASE */
       char *host_port;
-      struct dynbuf req_buffer;
+      struct dynbuf req;
 
       infof(data, "Establish HTTP proxy tunnel to %s:%d\n",
             hostname, remote_port);
@@ -220,7 +223,7 @@ static CURLcode CONNECT(struct connectdata *conn,
         return CURLE_OUT_OF_MEMORY;
 
       /* initialize a dynamic send-buffer */
-      Curl_dyn_init(&req_buffer, DYN_HTTP_REQUEST);
+      Curl_dyn_init(&req, DYN_HTTP_REQUEST);
 
       /* Setup the proxy-authorization header, if any */
       result = Curl_http_output_auth(conn, "CONNECT", host_port, TRUE);
@@ -243,7 +246,7 @@ static CURLcode CONNECT(struct connectdata *conn,
           aprintf("%s%s%s:%d", ipv6_ip?"[":"", hostname, ipv6_ip?"]":"",
                   remote_port);
         if(!hostheader) {
-          Curl_dyn_free(&req_buffer);
+          Curl_dyn_free(&req);
           return CURLE_OUT_OF_MEMORY;
         }
 
@@ -251,7 +254,7 @@ static CURLcode CONNECT(struct connectdata *conn,
           host = aprintf("Host: %s\r\n", hostheader);
           if(!host) {
             free(hostheader);
-            Curl_dyn_free(&req_buffer);
+            Curl_dyn_free(&req);
             return CURLE_OUT_OF_MEMORY;
           }
         }
@@ -263,7 +266,7 @@ static CURLcode CONNECT(struct connectdata *conn,
           useragent = conn->allocptr.uagent;
 
         result =
-          Curl_dyn_addf(&req_buffer,
+          Curl_dyn_addf(&req,
                         "CONNECT %s HTTP/%s\r\n"
                         "%s"  /* Host: */
                         "%s"  /* Proxy-Authorization */
@@ -282,29 +285,27 @@ static CURLcode CONNECT(struct connectdata *conn,
         free(hostheader);
 
         if(!result)
-          result = Curl_add_custom_headers(conn, TRUE, &req_buffer);
+          result = Curl_add_custom_headers(conn, TRUE, &req);
 
         if(!result)
           /* CRLF terminate the request */
-          result = Curl_dyn_addf(&req_buffer, "\r\n");
+          result = Curl_dyn_add(&req, "\r\n");
 
         if(!result) {
           /* Send the connect request to the proxy */
           /* BLOCKING */
-          result =
-            Curl_buffer_send(&req_buffer, conn,
-                             &data->info.request_size, 0, sockindex);
+          result = Curl_buffer_send(&req, conn, &data->info.request_size, 0,
+                                    sockindex);
         }
         if(result)
           failf(data, "Failed sending CONNECT to proxy");
       }
 
-      Curl_dyn_free(&req_buffer);
+      Curl_dyn_free(&req);
       if(result)
         return result;
 
       s->tunnel_state = TUNNEL_CONNECT;
-      s->perline = 0;
     } /* END CONNECT PHASE */
 
     check = Curl_timeleft(data, NULL, TRUE);
@@ -324,16 +325,11 @@ static CURLcode CONNECT(struct connectdata *conn,
 
       while(s->keepon) {
         ssize_t gotbytes;
-
-        /* make sure we have space to read more data */
-        if(s->ptr >= &s->connect_buffer[CONNECT_BUFFER_SIZE]) {
-          failf(data, "CONNECT response too large!");
-          return CURLE_RECV_ERROR;
-        }
+        char byte;
 
         /* Read one byte at a time to avoid a race condition. Wait at most one
            second before looping to ensure continuous pgrsUpdates. */
-        result = Curl_read(conn, tunnelsocket, s->ptr, 1, &gotbytes);
+        result = Curl_read(conn, tunnelsocket, &byte, 1, &gotbytes);
         if(result == CURLE_AGAIN)
           /* socket buffer drained, return */
           return CURLE_OK;
@@ -360,11 +356,9 @@ static CURLcode CONNECT(struct connectdata *conn,
           break;
         }
 
-
         if(s->keepon > TRUE) {
           /* This means we are currently ignoring a response-body */
 
-          s->ptr = s->connect_buffer;
           if(s->cl) {
             /* A Content-Length based body: simply count down the counter
                and make sure to break out of the loop when we're done! */
@@ -384,7 +378,7 @@ static CURLcode CONNECT(struct connectdata *conn,
 
             /* now parse the chunked piece of data so that we can
                properly tell when the stream ends */
-            r = Curl_httpchunk_read(conn, s->ptr, 1, &tookcareof, &extra);
+            r = Curl_httpchunk_read(conn, &byte, 1, &tookcareof, &extra);
             if(r == CHUNKE_STOP) {
               /* we're done reading chunks! */
               infof(data, "chunk reading DONE\n");
@@ -396,25 +390,27 @@ static CURLcode CONNECT(struct connectdata *conn,
           continue;
         }
 
-        s->perline++; /* amount of bytes in this line so far */
-
-        /* if this is not the end of a header line then continue */
-        if(*s->ptr != 0x0a) {
-          s->ptr++;
-          continue;
+        if(Curl_dyn_addn(&s->rcvbuf, &byte, 1)) {
+          failf(data, "CONNECT response too large!");
+          return CURLE_RECV_ERROR;
         }
 
+        /* if this is not the end of a header line then continue */
+        if(byte != 0x0a)
+          continue;
+
+        linep = Curl_dyn_ptr(&s->rcvbuf);
+        perline = Curl_dyn_len(&s->rcvbuf); /* amount of bytes in this line */
+
         /* convert from the network encoding */
-        result = Curl_convert_from_network(data, s->line_start,
-                                           (size_t)s->perline);
+        result = Curl_convert_from_network(data, linep, perline);
         /* Curl_convert_from_network calls failf if unsuccessful */
         if(result)
           return result;
 
         /* output debug if that is requested */
         if(data->set.verbose)
-          Curl_debug(data, CURLINFO_HEADER_IN,
-                     s->line_start, (size_t)s->perline);
+          Curl_debug(data, CURLINFO_HEADER_IN, linep, perline);
 
         if(!data->set.suppress_connect_headers) {
           /* send the header to the callback */
@@ -422,23 +418,22 @@ static CURLcode CONNECT(struct connectdata *conn,
           if(data->set.include_header)
             writetype |= CLIENTWRITE_BODY;
 
-          result = Curl_client_write(conn, writetype,
-                                     s->line_start, s->perline);
+          result = Curl_client_write(conn, writetype, linep, perline);
           if(result)
             return result;
         }
 
-        data->info.header_size += (long)s->perline;
-        data->req.headerbytecount += (long)s->perline;
+        data->info.header_size += (long)perline;
+        data->req.headerbytecount += (long)perline;
 
         /* Newlines are CRLF, so the CR is ignored as the line isn't
            really terminated until the LF comes. Treat a following CR
            as end-of-headers as well.*/
 
-        if(('\r' == s->line_start[0]) ||
-           ('\n' == s->line_start[0])) {
+        if(('\r' == linep[0]) ||
+           ('\n' == linep[0])) {
           /* end of response-headers from the proxy */
-          s->ptr = s->connect_buffer;
+
           if((407 == k->httpcode) && !data->state.authproblem) {
             /* If we get a 407 response code with content length
                when we have no auth problem, we must ignore the
@@ -455,21 +450,18 @@ static CURLcode CONNECT(struct connectdata *conn,
 
               infof(data, "Ignore chunked response-body\n");
 
-              /* We set ignorebody true here since the chunked
-                 decoder function will acknowledge that. Pay
-                 attention so that this is cleared again when this
-                 function returns! */
+              /* We set ignorebody true here since the chunked decoder
+                 function will acknowledge that. Pay attention so that this is
+                 cleared again when this function returns! */
               k->ignorebody = TRUE;
 
-              if(s->line_start[1] == '\n') {
-                /* this can only be a LF if the letter at index 0
-                   was a CR */
-                s->line_start++;
-              }
+              if(linep[1] == '\n')
+                /* this can only be a LF if the letter at index 0 was a CR */
+                linep++;
 
-              /* now parse the chunked piece of data so that we can
-                 properly tell when the stream ends */
-              r = Curl_httpchunk_read(conn, s->line_start + 1, 1, &gotbytes,
+              /* now parse the chunked piece of data so that we can properly
+                 tell when the stream ends */
+              r = Curl_httpchunk_read(conn, linep + 1, 1, &gotbytes,
                                       &extra);
               if(r == CHUNKE_STOP) {
                 /* we're done reading chunks! */
@@ -494,14 +486,13 @@ static CURLcode CONNECT(struct connectdata *conn,
           continue;
         }
 
-        s->line_start[s->perline] = 0; /* zero terminate the buffer */
-        if((checkprefix("WWW-Authenticate:", s->line_start) &&
+        if((checkprefix("WWW-Authenticate:", linep) &&
             (401 == k->httpcode)) ||
-           (checkprefix("Proxy-authenticate:", s->line_start) &&
+           (checkprefix("Proxy-authenticate:", linep) &&
             (407 == k->httpcode))) {
 
           bool proxy = (k->httpcode == 407) ? TRUE : FALSE;
-          char *auth = Curl_copy_header_value(s->line_start);
+          char *auth = Curl_copy_header_value(linep);
           if(!auth)
             return CURLE_OUT_OF_MEMORY;
 
@@ -512,7 +503,7 @@ static CURLcode CONNECT(struct connectdata *conn,
           if(result)
             return result;
         }
-        else if(checkprefix("Content-Length:", s->line_start)) {
+        else if(checkprefix("Content-Length:", linep)) {
           if(k->httpcode/100 == 2) {
             /* A client MUST ignore any Content-Length or Transfer-Encoding
                header fields received in a successful response to CONNECT.
@@ -521,13 +512,13 @@ static CURLcode CONNECT(struct connectdata *conn,
                   k->httpcode);
           }
           else {
-            (void)curlx_strtoofft(s->line_start +
+            (void)curlx_strtoofft(linep +
                                   strlen("Content-Length:"), NULL, 10, &s->cl);
           }
         }
-        else if(Curl_compareheader(s->line_start, "Connection:", "close"))
+        else if(Curl_compareheader(linep, "Connection:", "close"))
           s->close_connection = TRUE;
-        else if(checkprefix("Transfer-Encoding:", s->line_start)) {
+        else if(checkprefix("Transfer-Encoding:", linep)) {
           if(k->httpcode/100 == 2) {
             /* A client MUST ignore any Content-Length or Transfer-Encoding
                header fields received in a successful response to CONNECT.
@@ -535,7 +526,7 @@ static CURLcode CONNECT(struct connectdata *conn,
             infof(data, "Ignoring Transfer-Encoding in "
                   "CONNECT %03d response\n", k->httpcode);
           }
-          else if(Curl_compareheader(s->line_start,
+          else if(Curl_compareheader(linep,
                                      "Transfer-Encoding:", "chunked")) {
             infof(data, "CONNECT responded chunked\n");
             s->chunked_encoding = TRUE;
@@ -543,19 +534,16 @@ static CURLcode CONNECT(struct connectdata *conn,
             Curl_httpchunk_init(conn);
           }
         }
-        else if(Curl_compareheader(s->line_start,
-                                   "Proxy-Connection:", "close"))
+        else if(Curl_compareheader(linep, "Proxy-Connection:", "close"))
           s->close_connection = TRUE;
-        else if(2 == sscanf(s->line_start, "HTTP/1.%d %d",
+        else if(2 == sscanf(linep, "HTTP/1.%d %d",
                             &subversion,
                             &k->httpcode)) {
           /* store the HTTP code from the proxy */
           data->info.httpproxycode = k->httpcode;
         }
 
-        s->perline = 0; /* line starts over here */
-        s->ptr = s->connect_buffer;
-        s->line_start = s->ptr;
+        Curl_dyn_reset(&s->rcvbuf);
       } /* while there's buffer left and loop is requested */
 
       if(Curl_pgrsUpdate(conn))
@@ -616,6 +604,7 @@ static CURLcode CONNECT(struct connectdata *conn,
     if(conn->bits.proxy_connect_closed)
       /* this is not an error, just part of the connection negotiation */
       return CURLE_OK;
+    Curl_dyn_free(&s->rcvbuf);
     failf(data, "Received HTTP code %d from proxy after CONNECT",
           data->req.httpcode);
     return CURLE_RECV_ERROR;
@@ -637,6 +626,7 @@ static CURLcode CONNECT(struct connectdata *conn,
   data->req.ignorebody = FALSE; /* put it (back) to non-ignore state */
   conn->bits.rewindaftersend = FALSE; /* make sure this isn't set for the
                                          document request  */
+  Curl_dyn_free(&s->rcvbuf);
   return CURLE_OK;
 }
 

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -47,5 +47,6 @@ bool Curl_connect_ongoing(struct connectdata *conn);
 #endif
 
 void Curl_connect_free(struct Curl_easy *data);
+void Curl_connect_done(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_HTTP_PROXY_H */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -615,7 +615,7 @@ static CURLcode multi_done(struct Curl_easy *data,
   /* if the transfer was completed in a paused state there can be buffered
      data left to free */
   for(i = 0; i < data->state.tempcount; i++) {
-    free(data->state.tempwrite[i].buf);
+    Curl_dyn_free(&data->state.tempwrite[i].b);
   }
   data->state.tempcount = 0;
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -498,7 +498,6 @@ static CURLcode pausewrite(struct Curl_easy *data,
      is again enabled */
   struct SingleRequest *k = &data->req;
   struct UrlState *s = &data->state;
-  char *dupl;
   unsigned int i;
   bool newtype = TRUE;
 
@@ -518,43 +517,20 @@ static CURLcode pausewrite(struct Curl_easy *data,
   else
     i = 0;
 
-  if(!newtype) {
-    /* append new data to old data */
-
-    /* figure out the new size of the data to save */
-    size_t newlen = len + s->tempwrite[i].len;
-    /* allocate the new memory area */
-    char *newptr = realloc(s->tempwrite[i].buf, newlen);
-    if(!newptr)
-      return CURLE_OUT_OF_MEMORY;
-    /* copy the new data to the end of the new area */
-    memcpy(newptr + s->tempwrite[i].len, ptr, len);
-
-    /* update the pointer and the size */
-    s->tempwrite[i].buf = newptr;
-    s->tempwrite[i].len = newlen;
-
-    len = newlen; /* for the debug output below */
-  }
-  else {
-    dupl = Curl_memdup(ptr, len);
-    if(!dupl)
-      return CURLE_OUT_OF_MEMORY;
-
+  if(newtype) {
     /* store this information in the state struct for later use */
-    s->tempwrite[i].buf = dupl;
-    s->tempwrite[i].len = len;
+    Curl_dyn_init(&s->tempwrite[i].b, DYN_PAUSE_BUFFER);
     s->tempwrite[i].type = type;
 
     if(newtype)
       s->tempcount++;
   }
 
+  if(Curl_dyn_addn(&s->tempwrite[i].b, (unsigned char *)ptr, len))
+    return CURLE_OUT_OF_MEMORY;
+
   /* mark the connection as RECV paused */
   k->keepon |= KEEP_RECV_PAUSE;
-
-  DEBUGF(infof(data, "Paused %zu bytes in buffer for type %02x\n",
-               len, type));
 
   return CURLE_OK;
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -122,6 +122,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
 #include "strdup.h"
 #include "setopt.h"
 #include "altsvc.h"
+#include "dynbuf.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -380,7 +381,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
 
   up_free(data);
   Curl_safefree(data->state.buffer);
-  Curl_safefree(data->state.headerbuff);
+  Curl_dyn_free(&data->state.headerb);
   Curl_safefree(data->state.ulbuf);
   Curl_flush_cookies(data, TRUE);
 #ifdef USE_ALTSVC
@@ -408,8 +409,8 @@ CURLcode Curl_close(struct Curl_easy **datap)
   }
 
 #ifndef CURL_DISABLE_DOH
-  free(data->req.doh.probe[0].serverdoh.memory);
-  free(data->req.doh.probe[1].serverdoh.memory);
+  Curl_dyn_free(&data->req.doh.probe[0].serverdoh);
+  Curl_dyn_free(&data->req.doh.probe[1].serverdoh);
   curl_slist_free_all(data->req.doh.headers);
 #endif
 
@@ -609,15 +610,9 @@ CURLcode Curl_open(struct Curl_easy **curl)
     result = CURLE_OUT_OF_MEMORY;
   }
   else {
-    data->state.headerbuff = malloc(HEADERSIZE);
-    if(!data->state.headerbuff) {
-      DEBUGF(fprintf(stderr, "Error: malloc of headerbuff failed\n"));
-      result = CURLE_OUT_OF_MEMORY;
-    }
-    else {
-      result = Curl_init_userdefined(data);
-
-      data->state.headersize = HEADERSIZE;
+    result = Curl_init_userdefined(data);
+    if(!result) {
+      Curl_dyn_init(&data->state.headerb, CURL_MAX_HTTP_HEADER);
       Curl_convert_init(data);
       Curl_initinfo(data);
 
@@ -632,7 +627,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
   if(result) {
     Curl_resolver_cleanup(data->state.resolver);
     free(data->state.buffer);
-    free(data->state.headerbuff);
+    Curl_dyn_free(&data->state.headerb);
     Curl_freeset(data);
     free(data);
     data = NULL;
@@ -3964,7 +3959,6 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
   k->bytecount = 0;
 
   k->buf = data->state.buffer;
-  k->hbufp = data->state.headerbuff;
   k->ignorebody = FALSE;
 
   Curl_speedinit(data);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -788,15 +788,10 @@ struct proxy_info {
   char *passwd;  /* proxy password string, allocated */
 };
 
-#define CONNECT_BUFFER_SIZE 16384
-
 /* struct for HTTP CONNECT state data */
 struct http_connect_state {
-  char connect_buffer[CONNECT_BUFFER_SIZE];
-  int perline; /* count bytes per line */
+  struct dynbuf rcvbuf;
   int keepon;
-  char *line_start;
-  char *ptr; /* where to store more data */
   curl_off_t cl; /* size of content to read and ignore */
   enum {
     TUNNEL_INIT,    /* init/default/no tunnel state */

--- a/tests/data/test558
+++ b/tests/data/test558
@@ -38,7 +38,6 @@ nothing
 <file name="log/memdump">
 MEM lib558.c: malloc()
 MEM lib558.c: free()
-MEM escape.c: malloc()
 MEM strdup.c: realloc()
 MEM strdup.c: realloc()
 MEM escape.c: free()

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -59,7 +59,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib2033
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
- ../../lib/curl_ctype.c
+ ../../lib/curl_ctype.c  ../../lib/dynbuf.c ../../lib/strdup.c
 chkdecimalpoint_LDADD =
 chkdecimalpoint_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB \
  -DCURLX_NO_MEMORY_CALLBACKS

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -28,14 +28,18 @@ CURLX_SRCS = \
  ../../lib/nonblock.c \
  ../../lib/strtoofft.c \
  ../../lib/warnless.c \
- ../../lib/curl_ctype.c
+ ../../lib/curl_ctype.c \
+ ../../lib/dynbuf.c \
+ ../../lib/strdup.c
 
 CURLX_HDRS = \
  ../../lib/curlx.h \
  ../../lib/nonblock.h \
  ../../lib/strtoofft.h \
  ../../lib/warnless.h \
- ../../lib/curl_ctype.h
+ ../../lib/curl_ctype.h \
+ ../../lib/dynbuf.h \
+ ../../lib/strdup.h
 
 USEFUL = \
  getpart.c \

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2018 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -22,6 +22,7 @@
 #include "curlcheck.h"
 
 #include "doh.h"
+#include "dynbuf.h"
 
 static CURLcode unit_setup(void)
 {
@@ -184,7 +185,7 @@ UNITTEST_START
     char *ptr;
     size_t len;
     int u;
-    memset(&d, 0, sizeof(d));
+    de_init(&d);
     rc = doh_decode((const unsigned char *)resp[i].packet, resp[i].size,
                     resp[i].type, &d);
     if(rc != resp[i].rc) {
@@ -222,7 +223,7 @@ UNITTEST_START
     }
     for(u = 0; u < d.numcname; u++) {
       size_t o;
-      msnprintf(ptr, len, "%s ", d.cname[u].alloc);
+      msnprintf(ptr, len, "%s ", Curl_dyn_ptr(&d.cname[u]));
       o = strlen(ptr);
       len -= o;
       ptr += o;


### PR DESCRIPTION
A common set of functions instead of many separate implementations for
creating buffers that can grow when appending data to them. Existing
functionality has been ported over.

In my early basic testing, the total number of allocations seem at
roughly the same amount as before, possibly a few less.

See docs/DYNBUF.md for a description of the API.

Note that this patch is a net removal of many lines of code. Not immediately noticeable because this patch includes documentation and new source file headers etc.