### PR TITLE
nss: check for PK11_CreateDigestContext() returning NULL

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2374,6 +2374,9 @@ static CURLcode Curl_nss_md5sum(unsigned char *tmp, /* input */
   PK11Context *MD5pw = PK11_CreateDigestContext(SEC_OID_MD5);
   unsigned int MD5out;
 
+  if(!MD5pw)
+    return CURLE_OUT_OF_MEMORY;
+
   PK11_DigestOp(MD5pw, tmp, curlx_uztoui(tmplen));
   PK11_DigestFinal(MD5pw, md5sum, &MD5out, curlx_uztoui(md5len));
   PK11_DestroyContext(MD5pw, PR_TRUE);
@@ -2388,6 +2391,9 @@ static CURLcode Curl_nss_sha256sum(const unsigned char *tmp, /* input */
 {
   PK11Context *SHA256pw = PK11_CreateDigestContext(SEC_OID_SHA256);
   unsigned int SHA256out;
+
+  if(!SHA256pw)
+    return CURLE_OUT_OF_MEMORY;
 
   PK11_DigestOp(SHA256pw, tmp, curlx_uztoui(tmplen));
   PK11_DigestFinal(SHA256pw, sha256sum, &SHA256out, curlx_uztoui(sha256len));


### PR DESCRIPTION
... to avoid crashes!

Reported-by: Hao Wu
Fixes #5302