### PR TITLE
test1248: use %NOLISTENPORT instead of a port of a non-running server

### DIFF
--- a/tests/data/test1248
+++ b/tests/data/test1248
@@ -29,7 +29,7 @@ http
 Access a non-proxied host with using the combination of --proxy option and --noproxy option
 </name>
 <command>
-http://user:secret@%HOSTIP:%HTTPPORT/1248 --proxy http://dummy:%PROXYPORT/ --noproxy %HOSTIP --max-time 5
+http://user:secret@%HOSTIP:%HTTPPORT/1248 --proxy http://dummy:%NOLISTENPORT/ --noproxy %HOSTIP --max-time 5
 </command>
 </client>
 

--- a/tests/data/test1249
+++ b/tests/data/test1249
@@ -32,7 +32,7 @@ Access a non-proxied host with using the combination of --proxy option and NO_PR
 NO_PROXY=%HOSTIP
 </setenv>
 <command>
-http://user:secret@%HOSTIP:%HTTPPORT/1249 --proxy http://dummy:%PROXYPORT/ --max-time 5
+http://user:secret@%HOSTIP:%HTTPPORT/1249 --proxy http://dummy:%NOLISTENPORT/ --max-time 5
 </command>
 </client>
 


### PR DESCRIPTION
Otherwise the test fails when run stand-alone!