### PR TITLE
add idn for MacOS and iOS

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1564,9 +1564,9 @@ void Curl_free_idnconverted_hostname(struct hostname *host)
   }
 #elif defined(USE_WIN32_IDN)
   if(host->encalloc) {
-  free(host->encalloc); /* must be freed with free() since this was
+    free(host->encalloc); /* must be freed with free() since this was
                            allocated by curl_win32_idn_to_ascii */
-  host->encalloc = NULL;
+    host->encalloc = NULL;
   }
 #elif defined(HAVE_NETDB_H) && defined(__APPLE__)
   if(host->encalloc) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -1537,7 +1537,7 @@ CURLcode Curl_idnconvert_hostname(struct connectdata *conn,
     if(p) {
       if(p->h_name && (p->h_name[0] != 0)) {
         /* host name is idn encoded by MacOS */
-        const char *name = strdup(p->h_name);
+        char *name = strdup(p->h_name);
         if(name) {
           host->encalloc = name; 
           host->name = name;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1539,11 +1539,11 @@ CURLcode Curl_idnconvert_hostname(struct connectdata *conn,
         /* host name is idn encoded by MacOS */
         char *name = strdup(p->h_name);
         if(name) {
-          host->encalloc = name; 
+          host->encalloc = name;
           host->name = name;
         }
       }
-	}
+    }
 #else
     infof(data, "IDN support not present, can't parse Unicode domains\n");
 #endif


### PR DESCRIPTION
we let do MacOS and iOS the IDN encoding via gethostbyname.
Makes a query to e.g. Müller.de work on MacOS without using libidn.
Still if libidn is present, it will be preferred.