### PR TITLE
source cleanup: remove all custom typedef structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ scripts/curl.fish
 curl_fuzzer
 curl_fuzzer_seed_corpus.zip
 libstandaloneengine.a
-.checksrc
+

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -244,3 +244,22 @@ depending on a build-time conditional:
     #endif
 
     int content = magic(3);
+
+## No typedefed structs
+
+Use structs by all means, but do not typedef them. Use the `struct name` way
+of identifying them:
+
+    struct something {
+       void *valid;
+       size_t way_to_write;
+    };
+    struct something instance;
+
+**Not okay**:
+
+    typedef struct {
+       void *wrong;
+       size_t way_to_write;
+    } something;
+    something instance;

--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,0 +1,2 @@
+disable TYPEDEFSTRUCT
+disable SNPRINTF

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -67,4 +67,4 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)(@PERL@ $(top_srcdir)/lib/checksrc.pl -ASNPRINTF $(srcdir)/*.c)
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.c)

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2115,8 +2115,8 @@ CURL_EXTERN int curl_strequal(const char *s1, const char *s2);
 CURL_EXTERN int curl_strnequal(const char *s1, const char *s2, size_t n);
 
 /* Mime/form handling support. */
-typedef struct curl_mime_s      curl_mime;      /* Mime context. */
-typedef struct curl_mimepart_s  curl_mimepart;  /* Mime part context. */
+typedef struct curl_mime      curl_mime;      /* Mime context. */
+typedef struct curl_mimepart  curl_mimepart;  /* Mime part context. */
 
 /*
  * NAME curl_mime_init()
@@ -2490,10 +2490,11 @@ struct curl_slist {
  * subsequent attempt to change it will result in a CURLSSLSET_TOO_LATE.
  */
 
-typedef struct {
+struct curl_ssl_backend {
   curl_sslbackend id;
   const char *name;
-} curl_ssl_backend;
+};
+typedef struct curl_ssl_backend curl_ssl_backend;
 
 typedef enum {
   CURLSSLSET_OK = 0,
@@ -2745,7 +2746,7 @@ typedef enum {
    from above. */
 #define CURLVERSION_NOW CURLVERSION_SEVENTH
 
-typedef struct {
+struct curl_version_info_data {
   CURLversion age;          /* age of the returned struct */
   const char *version;      /* LIBCURL_VERSION */
   unsigned int version_num; /* LIBCURL_VERSION_NUM */
@@ -2789,7 +2790,8 @@ typedef struct {
   const char *capath;          /* the built-in default CURLOPT_CAPATH, might
                                   be NULL */
 
-} curl_version_info_data;
+};
+typedef struct curl_version_info_data curl_version_info_data;
 
 #define CURL_VERSION_IPV6         (1<<0)  /* IPv6-enabled */
 #define CURL_VERSION_KERBEROS4    (1<<1)  /* Kerberos V4 auth is supported

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -87,7 +87,8 @@
 
 struct ResolverResults {
   int num_pending; /* number of ares_gethostbyname() requests */
-  Curl_addrinfo *temp_ai; /* intermediary result while fetching c-ares parts */
+  struct Curl_addrinfo *temp_ai; /* intermediary result while fetching c-ares
+                                    parts */
   int last_status;
   struct curltime happy_eyeballs_dns_time; /* when this timer started, or 0 */
 };
@@ -494,9 +495,9 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
 
 /* Connects results to the list */
 static void compound_results(struct ResolverResults *res,
-                             Curl_addrinfo *ai)
+                             struct Curl_addrinfo *ai)
 {
-  Curl_addrinfo *ai_tail;
+  struct Curl_addrinfo *ai_tail;
   if(!ai)
     return;
   ai_tail = ai;
@@ -538,7 +539,7 @@ static void query_completed_cb(void *arg,  /* (struct connectdata *) */
     res->num_pending--;
 
     if(CURL_ASYNC_SUCCESS == status) {
-      Curl_addrinfo *ai = Curl_he2ai(hostent, conn->async.port);
+      struct Curl_addrinfo *ai = Curl_he2ai(hostent, conn->async.port);
       if(ai) {
         compound_results(res, ai);
       }
@@ -617,10 +618,10 @@ static void query_completed_cb(void *arg,  /* (struct connectdata *) */
  * memory we need to free after use. That memory *MUST* be freed with
  * Curl_freeaddrinfo(), nothing else.
  */
-Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
-                                         const char *hostname,
-                                         int port,
-                                         int *waitp)
+struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
+                                                const char *hostname,
+                                                int port,
+                                                int *waitp)
 {
   char *bufp;
   struct Curl_easy *data = conn->data;

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -169,7 +169,7 @@ struct thread_sync_data {
   curl_socket_t sock_pair[2]; /* socket pair */
 #endif
   int sock_error;
-  Curl_addrinfo *res;
+  struct Curl_addrinfo *res;
 #ifdef HAVE_GETADDRINFO
   struct addrinfo hints;
 #endif
@@ -690,10 +690,10 @@ int Curl_resolver_getsock(struct connectdata *conn,
 /*
  * Curl_getaddrinfo() - for platforms without getaddrinfo
  */
-Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
-                                         const char *hostname,
-                                         int port,
-                                         int *waitp)
+struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
+                                                const char *hostname,
+                                                int port,
+                                                int *waitp)
 {
   struct Curl_easy *data = conn->data;
   struct resdata *reslv = (struct resdata *)data->state.resolver;
@@ -718,10 +718,10 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 /*
  * Curl_resolver_getaddrinfo() - for getaddrinfo
  */
-Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
-                                         const char *hostname,
-                                         int port,
-                                         int *waitp)
+struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
+                                                const char *hostname,
+                                                int port,
+                                                int *waitp)
 {
   struct addrinfo hints;
   int pf = PF_INET;

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -153,10 +153,10 @@ CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
  * Each resolver backend must of course make sure to return data in the
  * correct format to comply with this.
  */
-Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
-                                         const char *hostname,
-                                         int port,
-                                         int *waitp);
+struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
+                                                const char *hostname,
+                                                int port,
+                                                int *waitp);
 
 #ifndef CURLRES_ASYNCH
 /* convert these functions if an asynch resolver isn't used */

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -81,6 +81,7 @@ my %warnings = (
     'SIZEOFNOPAREN'    => 'use of sizeof without parentheses',
     'SNPRINTF'         => 'use of snprintf',
     'ONELINECONDITION' => 'conditional block on the same line as the if()',
+    'TYPEDEFSTRUCT'    => 'typedefed struct',
     );
 
 sub readwhitelist {
@@ -115,6 +116,14 @@ sub readlocalfile {
                 next;
             }
             $warnings{$1} = $warnings_extended{$1};
+        }
+        elsif (/^\s*disable ([A-Z]+)$/) {
+            if(!defined($warnings{$1})) {
+                print STDERR "invalid warning specified in .checksrc: \"$1\"\n";
+                next;
+            }
+            # Accept-list
+            push @alist, $1;
         }
         else {
             die "Invalid format in $dir/.checksrc on line $i\n";
@@ -696,6 +705,13 @@ sub scanfile {
             checkwarn("SEMINOSPACE",
                       $line, length($1)+1, $file, $ol,
                       "no space after semicolon");
+        }
+
+        # typedef struct ... {
+        if($nostr =~ /^(.*)typedef struct.*{/) {
+            checkwarn("TYPEDEFSTRUCT",
+                      $line, length($1)+1, $file, $ol,
+                      "typedef'ed struct");
         }
 
         # check for more than one consecutive space before open brace or

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -724,6 +724,7 @@ Vista
   /* Replicating logic present in afunix.h of newer Windows 10 SDK versions */
 # define UNIX_PATH_MAX 108
 # include <ws2tcpip.h>
+  /* !checksrc! disable TYPEDEFSTRUCT 1 */
   typedef struct sockaddr_un {
     ADDRESS_FAMILY sun_family;
     char sun_path[UNIX_PATH_MAX];

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -166,7 +166,7 @@ tcpkeepalive(struct Curl_easy *data,
 
 static CURLcode
 singleipconnect(struct connectdata *conn,
-                const Curl_addrinfo *ai, /* start connecting to this */
+                const struct Curl_addrinfo *ai, /* start connecting to this */
                 int tempindex);          /* 0 or 1 among the temp ones */
 
 /*
@@ -558,11 +558,11 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
 
 /* update tempaddr[tempindex] (to the next entry), makes sure to stick
    to the correct family */
-static Curl_addrinfo *ainext(struct connectdata *conn,
-                             int tempindex,
-                             bool next) /* use current or next entry */
+static struct Curl_addrinfo *ainext(struct connectdata *conn,
+                                    int tempindex,
+                                    bool next) /* use current or next entry */
 {
-  Curl_addrinfo *ai = conn->tempaddr[tempindex];
+  struct Curl_addrinfo *ai = conn->tempaddr[tempindex];
   if(ai && next)
     ai = ai->ai_next;
   while(ai && (ai->ai_family != conn->tempfamily[tempindex]))
@@ -587,7 +587,7 @@ static CURLcode trynextip(struct connectdata *conn,
   conn->tempsock[tempindex] = CURL_SOCKET_BAD;
 
   if(sockindex == FIRSTSOCKET) {
-    Curl_addrinfo *ai = conn->tempaddr[tempindex];
+    struct Curl_addrinfo *ai = conn->tempaddr[tempindex];
 
     while(ai) {
       if(ai) {
@@ -1113,7 +1113,7 @@ void Curl_sndbufset(curl_socket_t sockfd)
  * having connected.
  */
 static CURLcode singleipconnect(struct connectdata *conn,
-                                const Curl_addrinfo *ai,
+                                const struct Curl_addrinfo *ai,
                                 int tempindex)
 {
   struct Curl_sockaddr_ex addr;
@@ -1485,7 +1485,7 @@ int Curl_closesocket(struct connectdata *conn,
  *
  */
 CURLcode Curl_socket(struct connectdata *conn,
-                     const Curl_addrinfo *ai,
+                     const struct Curl_addrinfo *ai,
                      struct Curl_sockaddr_ex *addr,
                      curl_socket_t *sockfd)
 {

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -105,7 +105,7 @@ struct Curl_sockaddr_ex {
  *
  */
 CURLcode Curl_socket(struct connectdata *conn,
-                     const Curl_addrinfo *ai,
+                     const struct Curl_addrinfo *ai,
                      struct Curl_sockaddr_ex *addr,
                      curl_socket_t *sockfd);
 

--- a/lib/content_encoding.h
+++ b/lib/content_encoding.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,31 +23,31 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-/* Decoding writer. */
-typedef struct contenc_writer_s contenc_writer;
-typedef struct content_encoding_s content_encoding;
-
-struct contenc_writer_s {
-  const content_encoding *handler;  /* Encoding handler. */
-  contenc_writer *downstream;  /* Downstream writer. */
+struct contenc_writer {
+  const struct content_encoding *handler;  /* Encoding handler. */
+  struct contenc_writer *downstream;  /* Downstream writer. */
   void *params;  /* Encoding-specific storage (variable length). */
 };
 
 /* Content encoding writer. */
-struct content_encoding_s {
+struct content_encoding {
   const char *name;        /* Encoding name. */
   const char *alias;       /* Encoding name alias. */
-  CURLcode (*init_writer)(struct connectdata *conn, contenc_writer *writer);
-  CURLcode (*unencode_write)(struct connectdata *conn, contenc_writer *writer,
+  CURLcode (*init_writer)(struct connectdata *conn,
+                          struct contenc_writer *writer);
+  CURLcode (*unencode_write)(struct connectdata *conn,
+                             struct contenc_writer *writer,
                              const char *buf, size_t nbytes);
-  void (*close_writer)(struct connectdata *conn, contenc_writer *writer);
+  void (*close_writer)(struct connectdata *conn,
+                       struct contenc_writer *writer);
   size_t paramsize;
 };
 
 
 CURLcode Curl_build_unencoding_stack(struct connectdata *conn,
                                      const char *enclist, int maybechunked);
-CURLcode Curl_unencode_write(struct connectdata *conn, contenc_writer *writer,
+CURLcode Curl_unencode_write(struct connectdata *conn,
+                             struct contenc_writer *writer,
                              const char *buf, size_t nbytes);
 void Curl_unencode_cleanup(struct connectdata *conn);
 char *Curl_all_content_encodings(void);

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -78,10 +78,10 @@
 #endif
 
 void
-Curl_freeaddrinfo(Curl_addrinfo *cahead)
+Curl_freeaddrinfo(struct Curl_addrinfo *cahead)
 {
-  Curl_addrinfo *vqualifier canext;
-  Curl_addrinfo *ca;
+  struct Curl_addrinfo *vqualifier canext;
+  struct Curl_addrinfo *ca;
 
   for(ca = cahead; ca != NULL; ca = canext) {
     free(ca->ai_addr);
@@ -112,13 +112,13 @@ int
 Curl_getaddrinfo_ex(const char *nodename,
                     const char *servname,
                     const struct addrinfo *hints,
-                    Curl_addrinfo **result)
+                    struct Curl_addrinfo **result)
 {
   const struct addrinfo *ai;
   struct addrinfo *aihead;
-  Curl_addrinfo *cafirst = NULL;
-  Curl_addrinfo *calast = NULL;
-  Curl_addrinfo *ca;
+  struct Curl_addrinfo *cafirst = NULL;
+  struct Curl_addrinfo *calast = NULL;
+  struct Curl_addrinfo *ca;
   size_t ss_size;
   int error;
 
@@ -151,7 +151,7 @@ Curl_getaddrinfo_ex(const char *nodename,
     if((size_t)ai->ai_addrlen < ss_size)
       continue;
 
-    ca = malloc(sizeof(Curl_addrinfo));
+    ca = malloc(sizeof(struct Curl_addrinfo));
     if(!ca) {
       error = EAI_MEMORY;
       break;
@@ -252,7 +252,6 @@ Curl_getaddrinfo_ex(const char *nodename,
  *       struct sockaddr      *ai_addr;
  *       struct Curl_addrinfo *ai_next;
  *     };
- *     typedef struct Curl_addrinfo Curl_addrinfo;
  *
  *   hostent defined in <netdb.h>
  *
@@ -269,12 +268,12 @@ Curl_getaddrinfo_ex(const char *nodename,
  *     #define h_addr  h_addr_list[0]
  */
 
-Curl_addrinfo *
+struct Curl_addrinfo *
 Curl_he2ai(const struct hostent *he, int port)
 {
-  Curl_addrinfo *ai;
-  Curl_addrinfo *prevai = NULL;
-  Curl_addrinfo *firstai = NULL;
+  struct Curl_addrinfo *ai;
+  struct Curl_addrinfo *prevai = NULL;
+  struct Curl_addrinfo *firstai = NULL;
   struct sockaddr_in *addr;
 #ifdef ENABLE_IPV6
   struct sockaddr_in6 *addr6;
@@ -299,7 +298,7 @@ Curl_he2ai(const struct hostent *he, int port)
 #endif
       ss_size = sizeof(struct sockaddr_in);
 
-    ai = calloc(1, sizeof(Curl_addrinfo));
+    ai = calloc(1, sizeof(struct Curl_addrinfo));
     if(!ai) {
       result = CURLE_OUT_OF_MEMORY;
       break;
@@ -389,10 +388,10 @@ struct namebuff {
  * given address/host
  */
 
-Curl_addrinfo *
+struct Curl_addrinfo *
 Curl_ip2addr(int af, const void *inaddr, const char *hostname, int port)
 {
-  Curl_addrinfo *ai;
+  struct Curl_addrinfo *ai;
 
 #if defined(__VMS) && \
     defined(__INITIAL_POINTER_SIZE) && (__INITIAL_POINTER_SIZE == 64)
@@ -465,7 +464,7 @@ Curl_ip2addr(int af, const void *inaddr, const char *hostname, int port)
  * Given an IPv4 or IPv6 dotted string address, this converts it to a proper
  * allocated Curl_addrinfo struct and returns it.
  */
-Curl_addrinfo *Curl_str2addr(char *address, int port)
+struct Curl_addrinfo *Curl_str2addr(char *address, int port)
 {
   struct in_addr in;
   if(Curl_inet_pton(AF_INET, address, &in) > 0)
@@ -488,15 +487,16 @@ Curl_addrinfo *Curl_str2addr(char *address, int port)
  * struct initialized with this path.
  * Set '*longpath' to TRUE if the error is a too long path.
  */
-Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath, bool abstract)
+struct Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath,
+                                     bool abstract)
 {
-  Curl_addrinfo *ai;
+  struct Curl_addrinfo *ai;
   struct sockaddr_un *sa_un;
   size_t path_len;
 
   *longpath = FALSE;
 
-  ai = calloc(1, sizeof(Curl_addrinfo));
+  ai = calloc(1, sizeof(struct Curl_addrinfo));
   if(!ai)
     return NULL;
   ai->ai_addr = calloc(1, sizeof(struct sockaddr_un));
@@ -594,9 +594,9 @@ curl_dbg_getaddrinfo(const char *hostname,
  * Work-arounds the sin6_port is always zero bug on iOS 9.3.2 and Mac OS X
  * 10.11.5.
  */
-void Curl_addrinfo_set_port(Curl_addrinfo *addrinfo, int port)
+void Curl_addrinfo_set_port(struct Curl_addrinfo *addrinfo, int port)
 {
-  Curl_addrinfo *ca;
+  struct Curl_addrinfo *ca;
   struct sockaddr_in *addr;
 #ifdef ENABLE_IPV6
   struct sockaddr_in6 *addr6;

--- a/lib/curl_addrinfo.h
+++ b/lib/curl_addrinfo.h
@@ -58,29 +58,29 @@ struct Curl_addrinfo {
   struct sockaddr      *ai_addr;
   struct Curl_addrinfo *ai_next;
 };
-typedef struct Curl_addrinfo Curl_addrinfo;
 
 void
-Curl_freeaddrinfo(Curl_addrinfo *cahead);
+Curl_freeaddrinfo(struct Curl_addrinfo *cahead);
 
 #ifdef HAVE_GETADDRINFO
 int
 Curl_getaddrinfo_ex(const char *nodename,
                     const char *servname,
                     const struct addrinfo *hints,
-                    Curl_addrinfo **result);
+                    struct Curl_addrinfo **result);
 #endif
 
-Curl_addrinfo *
+struct Curl_addrinfo *
 Curl_he2ai(const struct hostent *he, int port);
 
-Curl_addrinfo *
+struct Curl_addrinfo *
 Curl_ip2addr(int af, const void *inaddr, const char *hostname, int port);
 
-Curl_addrinfo *Curl_str2addr(char *dotted, int port);
+struct Curl_addrinfo *Curl_str2addr(char *dotted, int port);
 
 #ifdef USE_UNIX_SOCKETS
-Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath, bool abstract);
+struct Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath,
+                                     bool abstract);
 #endif
 
 #if defined(CURLDEBUG) && defined(HAVE_GETADDRINFO) && \
@@ -98,7 +98,7 @@ curl_dbg_getaddrinfo(const char *hostname, const char *service,
 
 #ifdef HAVE_GETADDRINFO
 #ifdef USE_RESOLVE_ON_IPS
-void Curl_addrinfo_set_port(Curl_addrinfo *addrinfo, int port);
+void Curl_addrinfo_set_port(struct Curl_addrinfo *addrinfo, int port);
 #else
 #define Curl_addrinfo_set_port(x,y)
 #endif

--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -34,37 +34,35 @@ typedef void    (* HMAC_hfinal_func)(unsigned char *result, void *context);
 
 
 /* Per-hash function HMAC parameters. */
-
-typedef struct {
-  HMAC_hinit_func       hmac_hinit;     /* Initialize context procedure. */
+struct HMAC_params {
+  HMAC_hinit_func
+  hmac_hinit;     /* Initialize context procedure. */
   HMAC_hupdate_func     hmac_hupdate;   /* Update context with data. */
   HMAC_hfinal_func      hmac_hfinal;    /* Get final result procedure. */
   unsigned int          hmac_ctxtsize;  /* Context structure size. */
   unsigned int          hmac_maxkeylen; /* Maximum key length (bytes). */
   unsigned int          hmac_resultlen; /* Result length (bytes). */
-} HMAC_params;
+};
 
 
 /* HMAC computation context. */
-
-typedef struct {
-  const HMAC_params *hmac_hash; /* Hash function definition. */
+struct HMAC_context {
+  const struct HMAC_params *hmac_hash; /* Hash function definition. */
   void *hmac_hashctxt1;         /* Hash function context 1. */
   void *hmac_hashctxt2;         /* Hash function context 2. */
-} HMAC_context;
+};
 
 
 /* Prototypes. */
-
-HMAC_context * Curl_HMAC_init(const HMAC_params *hashparams,
-                              const unsigned char *key,
-                              unsigned int keylen);
-int Curl_HMAC_update(HMAC_context *context,
+struct HMAC_context *Curl_HMAC_init(const struct HMAC_params *hashparams,
+                                    const unsigned char *key,
+                                    unsigned int keylen);
+int Curl_HMAC_update(struct HMAC_context *context,
                      const unsigned char *data,
                      unsigned int len);
-int Curl_HMAC_final(HMAC_context *context, unsigned char *result);
+int Curl_HMAC_final(struct HMAC_context *context, unsigned char *result);
 
-CURLcode Curl_hmacit(const HMAC_params *hashparams,
+CURLcode Curl_hmacit(const struct HMAC_params *hashparams,
                      const unsigned char *key, const size_t keylen,
                      const unsigned char *data, const size_t datalen,
                      unsigned char *output);

--- a/lib/curl_md5.h
+++ b/lib/curl_md5.h
@@ -33,30 +33,30 @@ typedef void (* Curl_MD5_update_func)(void *context,
                                       unsigned int len);
 typedef void (* Curl_MD5_final_func)(unsigned char *result, void *context);
 
-typedef struct {
+struct MD5_params {
   Curl_MD5_init_func     md5_init_func;   /* Initialize context procedure */
   Curl_MD5_update_func   md5_update_func; /* Update context with data */
   Curl_MD5_final_func    md5_final_func;  /* Get final result procedure */
   unsigned int           md5_ctxtsize;  /* Context structure size */
   unsigned int           md5_resultlen; /* Result length (bytes) */
-} MD5_params;
+};
 
-typedef struct {
-  const MD5_params      *md5_hash;      /* Hash function definition */
+struct MD5_context {
+  const struct MD5_params *md5_hash;    /* Hash function definition */
   void                  *md5_hashctx;   /* Hash function context */
-} MD5_context;
+};
 
-extern const MD5_params Curl_DIGEST_MD5[1];
-extern const HMAC_params Curl_HMAC_MD5[1];
+extern const struct MD5_params Curl_DIGEST_MD5[1];
+extern const struct HMAC_params Curl_HMAC_MD5[1];
 
 void Curl_md5it(unsigned char *output, const unsigned char *input,
                 const size_t len);
 
-MD5_context * Curl_MD5_init(const MD5_params *md5params);
-CURLcode Curl_MD5_update(MD5_context *context,
+struct MD5_context *Curl_MD5_init(const struct MD5_params *md5params);
+CURLcode Curl_MD5_update(struct MD5_context *context,
                          const unsigned char *data,
                          unsigned int len);
-CURLcode Curl_MD5_final(MD5_context *context, unsigned char *result);
+CURLcode Curl_MD5_final(struct MD5_context *context, unsigned char *result);
 
 #endif
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -373,10 +373,10 @@ static CURLcode dohprobe(struct Curl_easy *data,
  * 'Curl_addrinfo *' with the address information.
  */
 
-Curl_addrinfo *Curl_doh(struct connectdata *conn,
-                        const char *hostname,
-                        int port,
-                        int *waitp)
+struct Curl_addrinfo *Curl_doh(struct connectdata *conn,
+                               const char *hostname,
+                               int port,
+                               int *waitp)
 {
   struct Curl_easy *data = conn->data;
   CURLcode result = CURLE_OK;
@@ -790,12 +790,12 @@ static void showdoh(struct Curl_easy *data,
  * must be an associated call later to Curl_freeaddrinfo().
  */
 
-static Curl_addrinfo *
+static struct Curl_addrinfo *
 doh2ai(const struct dohentry *de, const char *hostname, int port)
 {
-  Curl_addrinfo *ai;
-  Curl_addrinfo *prevai = NULL;
-  Curl_addrinfo *firstai = NULL;
+  struct Curl_addrinfo *ai;
+  struct Curl_addrinfo *prevai = NULL;
+  struct Curl_addrinfo *firstai = NULL;
   struct sockaddr_in *addr;
 #ifdef ENABLE_IPV6
   struct sockaddr_in6 *addr6;
@@ -824,7 +824,7 @@ doh2ai(const struct dohentry *de, const char *hostname, int port)
       addrtype = AF_INET;
     }
 
-    ai = calloc(1, sizeof(Curl_addrinfo));
+    ai = calloc(1, sizeof(struct Curl_addrinfo));
     if(!ai) {
       result = CURLE_OUT_OF_MEMORY;
       break;

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -32,10 +32,10 @@
  * and returns a 'Curl_addrinfo *' with the address information.
  */
 
-Curl_addrinfo *Curl_doh(struct connectdata *conn,
-                        const char *hostname,
-                        int port,
-                        int *waitp);
+struct Curl_addrinfo *Curl_doh(struct connectdata *conn,
+                               const char *hostname,
+                               int port,
+                               int *waitp);
 
 CURLcode Curl_doh_is_resolved(struct connectdata *conn,
                               struct Curl_dns_entry **dns);

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -123,11 +123,11 @@ AddHttpPost(char *name, size_t namelength,
  * parent_form_info is NULL.
  *
  ***************************************************************************/
-static FormInfo * AddFormInfo(char *value,
-                              char *contenttype,
-                              FormInfo *parent_form_info)
+static struct FormInfo *AddFormInfo(char *value,
+                                    char *contenttype,
+                                    struct FormInfo *parent_form_info)
 {
-  FormInfo *form_info;
+  struct FormInfo *form_info;
   form_info = calloc(1, sizeof(struct FormInfo));
   if(form_info) {
     if(value)
@@ -204,7 +204,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
                      struct curl_httppost **last_post,
                      va_list params)
 {
-  FormInfo *first_form, *current_form, *form = NULL;
+  struct FormInfo *first_form, *current_form, *form = NULL;
   CURLFORMcode return_value = CURL_FORMADD_OK;
   const char *prevtype = NULL;
   struct curl_httppost *post = NULL;
@@ -521,7 +521,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
   if(CURL_FORMADD_OK != return_value) {
     /* On error, free allocated fields for all nodes of the FormInfo linked
        list without deallocating nodes. List nodes are deallocated later on */
-    FormInfo *ptr;
+    struct FormInfo *ptr;
     for(ptr = first_form; ptr != NULL; ptr = ptr->more) {
       if(ptr->name_alloc) {
         Curl_safefree(ptr->name);
@@ -650,7 +650,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
       /* On error, free allocated fields for nodes of the FormInfo linked
          list which are not already owned by the httppost linked list
          without deallocating nodes. List nodes are deallocated later on */
-      FormInfo *ptr;
+      struct FormInfo *ptr;
       for(ptr = form; ptr != NULL; ptr = ptr->more) {
         if(ptr->name_alloc) {
           Curl_safefree(ptr->name);
@@ -676,7 +676,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
      fields given that these have either been deallocated or are owned
      now by the httppost linked list */
   while(first_form) {
-    FormInfo *ptr = first_form->more;
+    struct FormInfo *ptr = first_form->more;
     free(first_form);
     first_form = ptr;
   }

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,7 +27,7 @@
 #ifndef CURL_DISABLE_MIME
 
 /* used by FormAdd for temporary storage */
-typedef struct FormInfo {
+struct FormInfo {
   char *name;
   bool name_alloc;
   size_t namelength;
@@ -45,7 +45,7 @@ typedef struct FormInfo {
   char *userp;        /* pointer for the read callback */
   struct curl_slist *contentheader;
   struct FormInfo *more;
-} FormInfo;
+};
 
 CURLcode Curl_getformdata(struct Curl_easy *data,
                           curl_mimepart *,

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -113,7 +113,7 @@ static CURLcode ftp_parse_url_path(struct connectdata *conn);
 static CURLcode ftp_regular_transfer(struct connectdata *conn, bool *done);
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
 static void ftp_pasv_verbose(struct connectdata *conn,
-                             Curl_addrinfo *ai,
+                             struct Curl_addrinfo *ai,
                              char *newhost, /* ascii version */
                              int port);
 #endif
@@ -913,7 +913,7 @@ static CURLcode ftp_state_use_port(struct connectdata *conn,
   char myhost[MAX_IPADR_LEN + 1] = "";
 
   struct Curl_sockaddr_storage ss;
-  Curl_addrinfo *res, *ai;
+  struct Curl_addrinfo *res, *ai;
   curl_socklen_t sslen;
   char hbuf[NI_MAXHOST];
   struct sockaddr *sa = (struct sockaddr *)&ss;
@@ -3442,7 +3442,7 @@ static CURLcode ftp_nb_type(struct connectdata *conn,
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
 static void
 ftp_pasv_verbose(struct connectdata *conn,
-                 Curl_addrinfo *ai,
+                 struct Curl_addrinfo *ai,
                  char *newhost, /* ascii version */
                  int port)
 {

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -48,13 +48,13 @@ static const unsigned char hmac_opad = 0x5C;
 
 
 
-HMAC_context *
-Curl_HMAC_init(const HMAC_params * hashparams,
+struct HMAC_context *
+Curl_HMAC_init(const struct HMAC_params *hashparams,
                const unsigned char *key,
                unsigned int keylen)
 {
   size_t i;
-  HMAC_context *ctxt;
+  struct HMAC_context *ctxt;
   unsigned char *hkey;
   unsigned char b;
 
@@ -101,7 +101,7 @@ Curl_HMAC_init(const HMAC_params * hashparams,
   return ctxt;
 }
 
-int Curl_HMAC_update(HMAC_context * ctxt,
+int Curl_HMAC_update(struct HMAC_context *ctxt,
                      const unsigned char *data,
                      unsigned int len)
 {
@@ -111,9 +111,9 @@ int Curl_HMAC_update(HMAC_context * ctxt,
 }
 
 
-int Curl_HMAC_final(HMAC_context *ctxt, unsigned char *result)
+int Curl_HMAC_final(struct HMAC_context *ctxt, unsigned char *result)
 {
-  const HMAC_params * hashparams = ctxt->hmac_hash;
+  const struct HMAC_params *hashparams = ctxt->hmac_hash;
 
   /* Do not get result if called with a null parameter: only release
      storage. */
@@ -147,12 +147,13 @@ int Curl_HMAC_final(HMAC_context *ctxt, unsigned char *result)
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_hmacit(const HMAC_params *hashparams,
+CURLcode Curl_hmacit(const struct HMAC_params *hashparams,
                      const unsigned char *key, const size_t keylen,
                      const unsigned char *data, const size_t datalen,
                      unsigned char *output)
 {
-  HMAC_context *ctxt = Curl_HMAC_init(hashparams, key, curlx_uztoui(keylen));
+  struct HMAC_context *ctxt =
+    Curl_HMAC_init(hashparams, key, curlx_uztoui(keylen));
 
   if(!ctxt)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -117,10 +117,10 @@ CURLcode Curl_addrinfo_callback(struct connectdata *conn,
  * name resolve layers (selected at build-time). They all take this same set
  * of arguments
  */
-Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
-                                const char *hostname,
-                                int port,
-                                int *waitp)
+struct Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
+                                       const char *hostname,
+                                       int port,
+                                       int *waitp)
 {
   return Curl_resolver_getaddrinfo(conn, hostname, port, waitp);
 }

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -120,7 +120,7 @@ static void freednsentry(void *freethis);
 /*
  * Return # of addresses in a Curl_addrinfo struct
  */
-int Curl_num_addresses(const Curl_addrinfo *addr)
+int Curl_num_addresses(const struct Curl_addrinfo *addr)
 {
   int i = 0;
   while(addr) {
@@ -137,8 +137,8 @@ int Curl_num_addresses(const Curl_addrinfo *addr)
  *
  * If the conversion fails, it returns NULL.
  */
-const char *
-Curl_printable_address(const Curl_addrinfo *ai, char *buf, size_t bufsize)
+const char *Curl_printable_address(const struct Curl_addrinfo *ai, char *buf,
+                                   size_t bufsize)
 {
   const struct sockaddr_in *sa4;
   const struct in_addr *ipaddr4;
@@ -337,7 +337,7 @@ Curl_fetch_addr(struct connectdata *conn,
 
 #ifndef CURL_DISABLE_SHUFFLE_DNS
 UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
-                                    Curl_addrinfo **addr);
+                                    struct Curl_addrinfo **addr);
 /*
  * Curl_shuffle_addr() shuffles the order of addresses in a 'Curl_addrinfo'
  * struct by re-linking its linked list.
@@ -351,13 +351,13 @@ UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
  * @unittest: 1608
  */
 UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
-                                    Curl_addrinfo **addr)
+                                    struct Curl_addrinfo **addr)
 {
   CURLcode result = CURLE_OK;
   const int num_addrs = Curl_num_addresses(*addr);
 
   if(num_addrs > 1) {
-    Curl_addrinfo **nodes;
+    struct Curl_addrinfo **nodes;
     infof(data, "Shuffling %i addresses", num_addrs);
 
     nodes = malloc(num_addrs*sizeof(*nodes));
@@ -376,7 +376,7 @@ UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
       if(rnd) {
         /* Fisher-Yates shuffle */
         if(Curl_rand(data, (unsigned char *)rnd, rnd_size) == CURLE_OK) {
-          Curl_addrinfo *swap_tmp;
+          struct Curl_addrinfo *swap_tmp;
           for(i = num_addrs - 1; i > 0; i--) {
             swap_tmp = nodes[rnd[i] % (i + 1)];
             nodes[rnd[i] % (i + 1)] = nodes[i];
@@ -415,7 +415,7 @@ UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
  */
 struct Curl_dns_entry *
 Curl_cache_addr(struct Curl_easy *data,
-                Curl_addrinfo *addr,
+                struct Curl_addrinfo *addr,
                 const char *hostname,
                 int port)
 {
@@ -513,7 +513,7 @@ enum resolve_t Curl_resolv(struct connectdata *conn,
   if(!dns) {
     /* The entry was not in the cache. Resolve it to IP address */
 
-    Curl_addrinfo *addr = NULL;
+    struct Curl_addrinfo *addr = NULL;
     int respwait = 0;
 #ifndef USE_RESOLVE_ON_IPS
     struct in_addr in;
@@ -890,7 +890,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
     }
     else {
       struct Curl_dns_entry *dns;
-      Curl_addrinfo *head = NULL, *tail = NULL;
+      struct Curl_addrinfo *head = NULL, *tail = NULL;
       size_t entry_len;
       char address[64];
 #if !defined(CURL_DISABLE_VERBOSE_STRINGS)
@@ -924,7 +924,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
 
       while(*end_ptr) {
         size_t alen;
-        Curl_addrinfo *ai;
+        struct Curl_addrinfo *ai;
 
         addr_begin = end_ptr + 1;
         addr_end = strchr(addr_begin, ',');

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -64,7 +64,7 @@ struct connectdata;
 struct curl_hash *Curl_global_host_cache_init(void);
 
 struct Curl_dns_entry {
-  Curl_addrinfo *addr;
+  struct Curl_addrinfo *addr;
   /* timestamp == 0 -- CURLOPT_RESOLVE entry, doesn't timeout */
   time_t timestamp;
   /* use-counter, use Curl_resolv_unlock to release reference */
@@ -117,10 +117,10 @@ bool Curl_ipvalid(struct connectdata *conn);
  * name resolve layers (selected at build-time). They all take this same set
  * of arguments
  */
-Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
-                                const char *hostname,
-                                int port,
-                                int *waitp);
+struct Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
+                                       const char *hostname,
+                                       int port,
+                                       int *waitp);
 
 
 /* unlock a previously resolved dns entry */
@@ -134,7 +134,7 @@ int Curl_mk_dnscache(struct curl_hash *hash);
 void Curl_hostcache_prune(struct Curl_easy *data);
 
 /* Return # of addresses in a Curl_addrinfo struct */
-int Curl_num_addresses(const Curl_addrinfo *addr);
+int Curl_num_addresses(const struct Curl_addrinfo *addr);
 
 #if defined(CURLDEBUG) && defined(HAVE_GETNAMEINFO)
 int curl_dogetnameinfo(GETNAMEINFO_QUAL_ARG1 GETNAMEINFO_TYPE_ARG1 sa,
@@ -146,7 +146,7 @@ int curl_dogetnameinfo(GETNAMEINFO_QUAL_ARG1 GETNAMEINFO_TYPE_ARG1 sa,
 #endif
 
 /* IPv4 threadsafe resolve function used for synch and asynch builds */
-Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname, int port);
+struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname, int port);
 
 CURLcode Curl_once_resolved(struct connectdata *conn, bool *protocol_connect);
 
@@ -158,14 +158,14 @@ CURLcode Curl_once_resolved(struct connectdata *conn, bool *protocol_connect);
  */
 CURLcode Curl_addrinfo_callback(struct connectdata *conn,
                                 int status,
-                                Curl_addrinfo *ai);
+                                struct Curl_addrinfo *ai);
 
 /*
  * Curl_printable_address() returns a printable version of the 1st address
  * given in the 'ip' argument. The result will be stored in the buf that is
  * bufsize bytes big.
  */
-const char *Curl_printable_address(const Curl_addrinfo *ip,
+const char *Curl_printable_address(const struct Curl_addrinfo *ip,
                                    char *buf, size_t bufsize);
 
 /*
@@ -187,7 +187,7 @@ Curl_fetch_addr(struct connectdata *conn,
  * Returns the Curl_dns_entry entry pointer or NULL if the storage failed.
  */
 struct Curl_dns_entry *
-Curl_cache_addr(struct Curl_easy *data, Curl_addrinfo *addr,
+Curl_cache_addr(struct Curl_easy *data, struct Curl_addrinfo *addr,
                 const char *hostname, int port);
 
 #ifndef INADDR_NONE

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -88,12 +88,12 @@ bool Curl_ipvalid(struct connectdata *conn)
  * flavours have thread-safe versions of the plain gethostbyname() etc.
  *
  */
-Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
-                                const char *hostname,
-                                int port,
-                                int *waitp)
+struct Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
+                                       const char *hostname,
+                                       int port,
+                                       int *waitp)
 {
-  Curl_addrinfo *ai = NULL;
+  struct Curl_addrinfo *ai = NULL;
 
 #ifdef CURL_DISABLE_VERBOSE_STRINGS
   (void)conn;
@@ -119,13 +119,13 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
  * implying that only threadsafe code and function calls may be used.
  *
  */
-Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
-                                   int port)
+struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
+                                          int port)
 {
 #if !defined(HAVE_GETADDRINFO_THREADSAFE) && defined(HAVE_GETHOSTBYNAME_R_3)
   int res;
 #endif
-  Curl_addrinfo *ai = NULL;
+  struct Curl_addrinfo *ai = NULL;
   struct hostent *h = NULL;
   struct hostent *buf = NULL;
 

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -103,7 +103,8 @@ bool Curl_ipvalid(struct connectdata *conn)
 #if defined(CURLRES_SYNCH)
 
 #ifdef DEBUG_ADDRINFO
-static void dump_addrinfo(struct connectdata *conn, const Curl_addrinfo *ai)
+static void dump_addrinfo(struct connectdata *conn,
+                          const struct Curl_addrinfo *ai)
 {
   printf("dump_addrinfo:\n");
   for(; ai; ai = ai->ai_next) {
@@ -132,13 +133,13 @@ static void dump_addrinfo(struct connectdata *conn, const Curl_addrinfo *ai)
  * memory we need to free after use. That memory *MUST* be freed with
  * Curl_freeaddrinfo(), nothing else.
  */
-Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
-                                const char *hostname,
-                                int port,
-                                int *waitp)
+struct Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
+                                       const char *hostname,
+                                       int port,
+                                       int *waitp)
 {
   struct addrinfo hints;
-  Curl_addrinfo *res;
+  struct Curl_addrinfo *res;
   int error;
   char sbuf[12];
   char *sbufptr = NULL;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -5,7 +5,7 @@
  *                | (__| |_| |  _ <| |___
  *                 \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -75,7 +75,7 @@
 
 /* Use our own implementation. */
 
-typedef struct {
+struct ldap_urldesc {
   char   *lud_host;
   int     lud_port;
 #if defined(USE_WIN32_LDAP)
@@ -95,10 +95,10 @@ typedef struct {
   size_t    lud_attrs_dups; /* how many were dup'ed, this field is not in the
                                "real" struct so can only be used in code
                                without HAVE_LDAP_URL_PARSE defined */
-} CURL_LDAPURLDesc;
+};
 
 #undef LDAPURLDesc
-#define LDAPURLDesc             CURL_LDAPURLDesc
+#define LDAPURLDesc struct ldap_urldesc
 
 static int  _ldap_url_parse(const struct connectdata *conn,
                             LDAPURLDesc **ludp);

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -139,10 +139,11 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 /* The last #include file should be: */
 #include "memdebug.h"
 
-typedef struct {
+struct md4_ctx {
   HCRYPTPROV hCryptProv;
   HCRYPTHASH hHash;
-} MD4_CTX;
+};
+typedef struct md4_ctx MD4_CTX;
 
 static void MD4_Init(MD4_CTX *ctx)
 {
@@ -184,10 +185,11 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 /* The last #include file should be: */
 #include "memdebug.h"
 
-typedef struct {
+struct md4_ctx {
   void *data;
   unsigned long size;
-} MD4_CTX;
+};
+typedef struct md4_ctx MD4_CTX;
 
 static void MD4_Init(MD4_CTX *ctx)
 {
@@ -266,12 +268,13 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 /* Any 32-bit or wider unsigned integer data type will do */
 typedef unsigned int MD4_u32plus;
 
-typedef struct {
+struct md4_ctx {
   MD4_u32plus lo, hi;
   MD4_u32plus a, b, c, d;
   unsigned char buffer[64];
   MD4_u32plus block[16];
-} MD4_CTX;
+};
+typedef struct md4_ctx MD4_CTX;
 
 static void MD4_Init(MD4_CTX *ctx);
 static void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size);

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -179,10 +179,11 @@ static void MD5_Final(unsigned char *digest, MD5_CTX *ctx)
 /* The last #include file should be: */
 #include "memdebug.h"
 
-typedef struct {
+struct md5_ctx {
   HCRYPTPROV hCryptProv;
   HCRYPTHASH hHash;
-} MD5_CTX;
+};
+typedef struct md5_ctx MD5_CTX;
 
 static void MD5_Init(MD5_CTX *ctx)
 {
@@ -261,12 +262,13 @@ static void MD5_Final(unsigned char *digest, MD5_CTX *ctx)
 /* Any 32-bit or wider unsigned integer data type will do */
 typedef unsigned int MD5_u32plus;
 
-typedef struct {
+struct md5_ctx {
   MD5_u32plus lo, hi;
   MD5_u32plus a, b, c, d;
   unsigned char buffer[64];
   MD5_u32plus block[16];
-} MD5_CTX;
+};
+typedef struct md5_ctx MD5_CTX;
 
 static void MD5_Init(MD5_CTX *ctx);
 static void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size);
@@ -528,7 +530,7 @@ static void MD5_Final(unsigned char *result, MD5_CTX *ctx)
 
 #endif /* CRYPTO LIBS */
 
-const HMAC_params Curl_HMAC_MD5[] = {
+const struct HMAC_params Curl_HMAC_MD5[] = {
   {
     /* Hash initialization function. */
     CURLX_FUNCTION_CAST(HMAC_hinit_func, MD5_Init),
@@ -545,7 +547,7 @@ const HMAC_params Curl_HMAC_MD5[] = {
   }
 };
 
-const MD5_params Curl_DIGEST_MD5[] = {
+const struct MD5_params Curl_DIGEST_MD5[] = {
   {
     /* Digest initialization function */
     CURLX_FUNCTION_CAST(Curl_MD5_init_func, MD5_Init),
@@ -573,9 +575,9 @@ void Curl_md5it(unsigned char *outbuffer, const unsigned char *input,
   MD5_Final(outbuffer, &ctx);
 }
 
-MD5_context *Curl_MD5_init(const MD5_params *md5params)
+struct MD5_context *Curl_MD5_init(const struct MD5_params *md5params)
 {
-  MD5_context *ctxt;
+  struct MD5_context *ctxt;
 
   /* Create MD5 context */
   ctxt = malloc(sizeof(*ctxt));
@@ -597,7 +599,7 @@ MD5_context *Curl_MD5_init(const MD5_params *md5params)
   return ctxt;
 }
 
-CURLcode Curl_MD5_update(MD5_context *context,
+CURLcode Curl_MD5_update(struct MD5_context *context,
                          const unsigned char *data,
                          unsigned int len)
 {
@@ -606,7 +608,7 @@ CURLcode Curl_MD5_update(MD5_context *context,
   return CURLE_OK;
 }
 
-CURLcode Curl_MD5_final(MD5_context *context, unsigned char *result)
+CURLcode Curl_MD5_final(struct MD5_context *context, unsigned char *result)
 {
   (*context->md5_hash->md5_final_func)(result, context->md5_hashctx);
 

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -71,7 +71,7 @@ static size_t encoder_qp_read(char *buffer, size_t size, bool ateof,
                               curl_mimepart *part);
 static curl_off_t encoder_qp_size(curl_mimepart *part);
 
-static const mime_encoder encoders[] = {
+static const struct mime_encoder encoders[] = {
   {"binary", encoder_nop_read, encoder_nop_size},
   {"8bit", encoder_nop_read, encoder_nop_size},
   {"7bit", encoder_7bit_read, encoder_nop_size},
@@ -269,7 +269,8 @@ static char *Curl_basename(char *path)
 
 
 /* Set readback state. */
-static void mimesetstate(mime_state *state, enum mimestate tok, void *ptr)
+static void mimesetstate(struct mime_state *state,
+                         enum mimestate tok, void *ptr)
 {
   state->state = tok;
   state->ptr = ptr;
@@ -342,7 +343,7 @@ static char *strippath(const char *fullfile)
 }
 
 /* Initialize data encoder state. */
-static void cleanup_encoder_state(mime_encoder_state *p)
+static void cleanup_encoder_state(struct mime_encoder_state *p)
 {
   p->pos = 0;
   p->bufbeg = 0;
@@ -352,9 +353,9 @@ static void cleanup_encoder_state(mime_encoder_state *p)
 
 /* Dummy encoder. This is used for 8bit and binary content encodings. */
 static size_t encoder_nop_read(char *buffer, size_t size, bool ateof,
-                               curl_mimepart *part)
+                               struct curl_mimepart *part)
 {
-  mime_encoder_state *st = &part->encstate;
+  struct mime_encoder_state *st = &part->encstate;
   size_t insize = st->bufend - st->bufbeg;
 
   (void) ateof;
@@ -382,7 +383,7 @@ static curl_off_t encoder_nop_size(curl_mimepart *part)
 static size_t encoder_7bit_read(char *buffer, size_t size, bool ateof,
                                 curl_mimepart *part)
 {
-  mime_encoder_state *st = &part->encstate;
+  struct mime_encoder_state *st = &part->encstate;
   size_t cursize = st->bufend - st->bufbeg;
 
   (void) ateof;
@@ -408,7 +409,7 @@ static size_t encoder_7bit_read(char *buffer, size_t size, bool ateof,
 static size_t encoder_base64_read(char *buffer, size_t size, bool ateof,
                                 curl_mimepart *part)
 {
-  mime_encoder_state *st = &part->encstate;
+  struct mime_encoder_state *st = &part->encstate;
   size_t cursize = 0;
   int i;
   char *ptr = buffer;
@@ -512,7 +513,7 @@ static curl_off_t encoder_base64_size(curl_mimepart *part)
  * Check if a CRLF or end of data is in input buffer at current position + n.
  * Return -1 if more data needed, 1 if CRLF or end of data, else 0.
  */
-static int qp_lookahead_eol(mime_encoder_state *st, int ateof, size_t n)
+static int qp_lookahead_eol(struct mime_encoder_state *st, int ateof, size_t n)
 {
   n += st->bufbeg;
   if(n >= st->bufend && ateof)
@@ -529,7 +530,7 @@ static int qp_lookahead_eol(mime_encoder_state *st, int ateof, size_t n)
 static size_t encoder_qp_read(char *buffer, size_t size, bool ateof,
                               curl_mimepart *part)
 {
-  mime_encoder_state *st = &part->encstate;
+  struct mime_encoder_state *st = &part->encstate;
   char *ptr = buffer;
   size_t cursize = 0;
   int softlinebreak;
@@ -740,7 +741,7 @@ static void mime_file_free(void *ptr)
 /* Argument is a pointer to the mime structure. */
 
 /* Readback a byte string segment. */
-static size_t readback_bytes(mime_state *state,
+static size_t readback_bytes(struct mime_state *state,
                              char *buffer, size_t bufsize,
                              const char *bytes, size_t numbytes,
                              const char *trail)
@@ -839,7 +840,7 @@ static size_t read_part_content(curl_mimepart *part,
 static size_t read_encoded_part_content(curl_mimepart *part, char *buffer,
                                         size_t bufsize, bool *hasread)
 {
-  mime_encoder_state *st = &part->encstate;
+  struct mime_encoder_state *st = &part->encstate;
   size_t cursize = 0;
   size_t sz;
   bool ateof = FALSE;
@@ -1502,7 +1503,7 @@ CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype)
 CURLcode curl_mime_encoder(curl_mimepart *part, const char *encoding)
 {
   CURLcode result = CURLE_BAD_FUNCTION_ARGUMENT;
-  const mime_encoder *mep;
+  const struct mime_encoder *mep;
 
   if(!part)
     return result;

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -69,43 +69,43 @@ enum mimestrategy {
 };
 
 /* Content transfer encoder. */
-typedef struct {
+struct mime_encoder {
   const char *   name;          /* Encoding name. */
   size_t         (*encodefunc)(char *buffer, size_t size, bool ateof,
                                curl_mimepart *part);  /* Encoded read. */
   curl_off_t     (*sizefunc)(curl_mimepart *part);  /* Encoded size. */
-}  mime_encoder;
+};
 
 /* Content transfer encoder state. */
-typedef struct {
+struct mime_encoder_state {
   size_t         pos;           /* Position on output line. */
   size_t         bufbeg;        /* Next data index in input buffer. */
   size_t         bufend;        /* First unused byte index in input buffer. */
   char           buf[ENCODING_BUFFER_SIZE]; /* Input buffer. */
-}  mime_encoder_state;
+};
 
 /* Mime readback state. */
-typedef struct {
+struct mime_state {
   enum mimestate state;       /* Current state token. */
   void *ptr;                  /* State-dependent pointer. */
   curl_off_t offset;          /* State-dependent offset. */
-}  mime_state;
+};
 
 /* minimum buffer size for the boundary string */
 #define MIME_BOUNDARY_LEN (24 + MIME_RAND_BOUNDARY_CHARS + 1)
 
 /* A mime multipart. */
-struct curl_mime_s {
+struct curl_mime {
   struct Curl_easy *easy;          /* The associated easy handle. */
   curl_mimepart *parent;           /* Parent part. */
   curl_mimepart *firstpart;        /* First part. */
   curl_mimepart *lastpart;         /* Last part. */
   char boundary[MIME_BOUNDARY_LEN]; /* The part boundary. */
-  mime_state state;                /* Current readback state. */
+  struct mime_state state;         /* Current readback state. */
 };
 
 /* A mime part. */
-struct curl_mimepart_s {
+struct curl_mimepart {
   struct Curl_easy *easy;          /* The associated easy handle. */
   curl_mime *parent;               /* Parent mime structure. */
   curl_mimepart *nextpart;         /* Forward linked list. */
@@ -123,9 +123,9 @@ struct curl_mimepart_s {
   char *name;                      /* Data name. */
   curl_off_t datasize;             /* Expected data size. */
   unsigned int flags;              /* Flags. */
-  mime_state state;                /* Current readback state. */
-  const mime_encoder *encoder;     /* Content data encoder. */
-  mime_encoder_state encstate;     /* Data encoder state. */
+  struct mime_state state;         /* Current readback state. */
+  const struct mime_encoder *encoder; /* Content data encoder. */
+  struct mime_encoder_state encstate; /* Data encoder state. */
   size_t lastreadstatus;           /* Last read callback returned status. */
 };
 
@@ -135,21 +135,23 @@ CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...);
   !defined(CURL_DISABLE_SMTP) || !defined(CURL_DISABLE_IMAP)
 
 /* Prototypes. */
-void Curl_mime_initpart(curl_mimepart *part, struct Curl_easy *easy);
-void Curl_mime_cleanpart(curl_mimepart *part);
-CURLcode Curl_mime_duppart(curl_mimepart *dst, const curl_mimepart *src);
-CURLcode Curl_mime_set_subparts(curl_mimepart *part,
-                                curl_mime *subparts, int take_ownership);
-CURLcode Curl_mime_prepare_headers(curl_mimepart *part,
+void Curl_mime_initpart(struct curl_mimepart *part, struct Curl_easy *easy);
+void Curl_mime_cleanpart(struct curl_mimepart *part);
+CURLcode Curl_mime_duppart(struct curl_mimepart *dst,
+                           const curl_mimepart *src);
+CURLcode Curl_mime_set_subparts(struct curl_mimepart *part,
+                                struct curl_mime *subparts,
+                                int take_ownership);
+CURLcode Curl_mime_prepare_headers(struct curl_mimepart *part,
                                    const char *contenttype,
                                    const char *disposition,
                                    enum mimestrategy strategy);
-curl_off_t Curl_mime_size(curl_mimepart *part);
+curl_off_t Curl_mime_size(struct curl_mimepart *part);
 size_t Curl_mime_read(char *buffer, size_t size, size_t nitems,
                       void *instream);
-CURLcode Curl_mime_rewind(curl_mimepart *part);
+CURLcode Curl_mime_rewind(struct curl_mimepart *part);
 const char *Curl_mime_contenttype(const char *filename);
-void Curl_mime_unpause(curl_mimepart *part);
+void Curl_mime_unpause(struct curl_mimepart *part);
 
 #else
 /* if disabled */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -146,7 +146,7 @@ enum {
   FLAGS_FLOATG     = 1<<19  /* %g or %G */
 };
 
-typedef struct {
+struct va_stack {
   FormatType type;
   int flags;
   long width;     /* width OR width parameter number */
@@ -160,7 +160,7 @@ typedef struct {
     } num;
     double dnum;
   } data;
-} va_stack_t;
+};
 
 struct nsprintf {
   char *buffer;
@@ -223,8 +223,8 @@ static bool dprintf_IsQualifierNoDollar(const char *fmt)
  *
  ******************************************************************/
 
-static int dprintf_Pass1(const char *format, va_stack_t *vto, char **endpos,
-                         va_list arglist)
+static int dprintf_Pass1(const char *format, struct va_stack *vto,
+                         char **endpos, va_list arglist)
 {
   char *fmt = (char *)format;
   int param_num = 0;
@@ -570,13 +570,11 @@ static int dprintf_formatf(
   long param; /* current parameter to read */
   long param_num = 0; /* parameter counter */
 
-  va_stack_t vto[MAX_PARAMETERS];
+  struct va_stack vto[MAX_PARAMETERS];
   char *endpos[MAX_PARAMETERS];
   char **end;
-
   char work[BUFFSIZE];
-
-  va_stack_t *p;
+  struct va_stack *p;
 
   /* 'workend' points to the final buffer byte position, but with an extra
      byte as margin to avoid the (false?) warning Coverity gives us

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -6,7 +6,7 @@
  *                 \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2010, Howard Chu, <hyc@openldap.org>
- * Copyright (C) 2011 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2011 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -162,10 +162,10 @@ struct ldapconninfo {
   bool didbind;
 };
 
-typedef struct ldapreqinfo {
+struct ldapreqinfo {
   int msgid;
   int nument;
-} ldapreqinfo;
+};
 
 static CURLcode ldap_setup_connection(struct connectdata *conn)
 {
@@ -374,7 +374,7 @@ static CURLcode ldap_disconnect(struct connectdata *conn, bool dead_connection)
 static CURLcode ldap_do(struct connectdata *conn, bool *done)
 {
   struct ldapconninfo *li = conn->proto.ldapc;
-  ldapreqinfo *lr;
+  struct ldapreqinfo *lr;
   CURLcode status = CURLE_OK;
   int rc = 0;
   LDAPURLDesc *ludp = NULL;
@@ -406,7 +406,7 @@ static CURLcode ldap_do(struct connectdata *conn, bool *done)
     failf(data, "LDAP local: ldap_search_ext %s", ldap_err2string(rc));
     return CURLE_LDAP_SEARCH_FAILED;
   }
-  lr = calloc(1, sizeof(ldapreqinfo));
+  lr = calloc(1, sizeof(struct ldapreqinfo));
   if(!lr)
     return CURLE_OUT_OF_MEMORY;
   lr->msgid = msgid;
@@ -419,7 +419,7 @@ static CURLcode ldap_do(struct connectdata *conn, bool *done)
 static CURLcode ldap_done(struct connectdata *conn, CURLcode res,
                           bool premature)
 {
-  ldapreqinfo *lr = conn->data->req.protop;
+  struct ldapreqinfo *lr = conn->data->req.protop;
 
   (void)res;
   (void)premature;
@@ -443,7 +443,7 @@ static ssize_t ldap_recv(struct connectdata *conn, int sockindex, char *buf,
 {
   struct ldapconninfo *li = conn->proto.ldapc;
   struct Curl_easy *data = conn->data;
-  ldapreqinfo *lr = data->req.protop;
+  struct ldapreqinfo *lr = data->req.protop;
   int rc, ret;
   LDAPMessage *msg = NULL;
   LDAPMessage *ent;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -412,7 +412,7 @@ static CURLcode pop3_perform_apop(struct connectdata *conn)
   CURLcode result = CURLE_OK;
   struct pop3_conn *pop3c = &conn->proto.pop3c;
   size_t i;
-  MD5_context *ctxt;
+  struct MD5_context *ctxt;
   unsigned char digest[MD5_DIGEST_LEN];
   char secret[2 * MD5_DIGEST_LEN + 1];
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -196,10 +196,11 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 
 #include <wincrypt.h>
 
-typedef struct {
+struct sha256_ctx {
   HCRYPTPROV hCryptProv;
   HCRYPTHASH hHash;
-} SHA256_CTX;
+};
+typedef struct sha256_ctx SHA256_CTX;
 
 #if !defined(CALG_SHA_256)
 #define CALG_SHA_256 0x0000800c
@@ -280,7 +281,7 @@ do {                                                          \
 } while(0)
 #endif
 
-typedef struct sha256_state {
+struct sha256_state {
 #ifdef HAVE_LONGLONG
   unsigned long long length;
 #else
@@ -288,7 +289,8 @@ typedef struct sha256_state {
 #endif
   unsigned long state[8], curlen;
   unsigned char buf[64];
-} SHA256_CTX;
+};
+typedef struct sha256_state SHA256_CTX;
 
 /* The K array */
 static const unsigned long K[64] = {

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -271,7 +271,7 @@ CURLcode Curl_SOCKS4(const char *proxy_user,
     /* FALLTHROUGH */
   CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
-    Curl_addrinfo *hp = NULL;
+    struct Curl_addrinfo *hp = NULL;
     char buf[64];
     /*
      * We cannot use 'hostent' as a struct that Curl_resolv() returns.  It
@@ -773,7 +773,7 @@ CURLcode Curl_SOCKS5(const char *proxy_user,
     /* FALLTHROUGH */
   CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
-    Curl_addrinfo *hp = NULL;
+    struct Curl_addrinfo *hp = NULL;
     if(dns)
       hp = dns->addr;
     if(!hp) {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -613,8 +613,8 @@ struct SingleRequest {
   enum expect100 exp100;        /* expect 100 continue state */
   enum upgrade101 upgr101;      /* 101 upgrade state */
 
-  struct contenc_writer_s *writer_stack;  /* Content unencoding stack. */
-                                          /* See sec 3.5, RFC2616. */
+  /* Content unencoding stack. See sec 3.5, RFC2616. */
+  struct contenc_writer *writer_stack;
   time_t timeofdoc;
   long bodywrites;
   char *buf;
@@ -875,8 +875,8 @@ struct connectdata {
   /* 'ip_addr' is the particular IP we connected to. It points to a struct
      within the DNS cache, so this pointer is only valid as long as the DNS
      cache entry remains locked. It gets unlocked in Curl_done() */
-  Curl_addrinfo *ip_addr;
-  Curl_addrinfo *tempaddr[2]; /* for happy eyeballs */
+  struct Curl_addrinfo *ip_addr;
+  struct Curl_addrinfo *tempaddr[2]; /* for happy eyeballs */
 
   /* 'ip_addr_str' is the ip_addr data as a human readable string.
      It remains available as long as the connection does, which is longer than

--- a/lib/vauth/cram.c
+++ b/lib/vauth/cram.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -96,7 +96,7 @@ CURLcode Curl_auth_create_cram_md5_message(struct Curl_easy *data,
 {
   CURLcode result = CURLE_OK;
   size_t chlglen = 0;
-  HMAC_context *ctxt;
+  struct HMAC_context *ctxt;
   unsigned char digest[MD5_DIGEST_LEN];
   char *response;
 

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -358,7 +358,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                                              char **outptr, size_t *outlen)
 {
   size_t i;
-  MD5_context *ctxt;
+  struct MD5_context *ctxt;
   char *response = NULL;
   unsigned char digest[MD5_DIGEST_LEN];
   char HA1_hex[2 * MD5_DIGEST_LEN + 1];

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -108,13 +108,13 @@ struct ssl_backend_data {
 #define BACKEND connssl->backend
 
 /* Supported ciphers. */
-typedef struct {
+struct gskit_cipher {
   const char *name;            /* Cipher name. */
   const char *gsktoken;        /* Corresponding token for GSKit String. */
   unsigned int versions;       /* SSL version flags. */
-}  gskit_cipher;
+};
 
-static const gskit_cipher  ciphertable[] = {
+static const struct gskit_cipher  ciphertable[] = {
   { "null-md5",         "01",
       CURL_GSKPROTO_SSLV3_MASK | CURL_GSKPROTO_TLSV10_MASK |
       CURL_GSKPROTO_TLSV11_MASK | CURL_GSKPROTO_TLSV12_MASK },
@@ -307,7 +307,7 @@ static CURLcode set_ciphers(struct connectdata *conn,
   struct Curl_easy *data = conn->data;
   const char *cipherlist = SSL_CONN_CONFIG(cipher_list);
   const char *clp;
-  const gskit_cipher *ctp;
+  const struct gskit_cipher *ctp;
   int i;
   int l;
   bool unsupported;

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -101,10 +101,10 @@ struct ptr_list_wrap {
   struct curl_llist_element node;
 };
 
-typedef struct {
+struct cipher_s {
   const char *name;
   int num;
-} cipher_s;
+};
 
 #define PK11_SETATTRS(_attr, _idx, _type, _val, _len) do {  \
   CK_ATTRIBUTE *ptr = (_attr) + ((_idx)++);                 \
@@ -116,7 +116,7 @@ typedef struct {
 #define CERT_NewTempCertificate __CERT_NewTempCertificate
 
 #define NUM_OF_CIPHERS sizeof(cipherlist)/sizeof(cipherlist[0])
-static const cipher_s cipherlist[] = {
+static const struct cipher_s cipherlist[] = {
   /* SSL2 cipher suites */
   {"rc4",                        SSL_EN_RC4_128_WITH_MD5},
   {"rc4-md5",                    SSL_EN_RC4_128_WITH_MD5},

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -215,11 +215,11 @@
 #define ENABLE_SSLKEYLOGFILE
 
 #ifdef ENABLE_SSLKEYLOGFILE
-typedef struct ssl_tap_state {
+struct ssl_tap_state {
   int master_key_length;
   unsigned char master_key[SSL_MAX_MASTER_KEY_LENGTH];
   unsigned char client_random[SSL3_RANDOM_SIZE];
-} ssl_tap_state_t;
+};
 #endif /* ENABLE_SSLKEYLOGFILE */
 
 struct ssl_backend_data {
@@ -229,7 +229,7 @@ struct ssl_backend_data {
   X509*    server_cert;
 #ifdef ENABLE_SSLKEYLOGFILE
   /* tap_state holds the last seen master key if we're logging them */
-  ssl_tap_state_t tap_state;
+  struct ssl_tap_state tap_state;
 #endif
 };
 
@@ -280,7 +280,7 @@ static void ossl_keylog_callback(const SSL *ssl, const char *line)
  * tap_ssl_key is called by libcurl to make the CLIENT_RANDOMs if the OpenSSL
  * being used doesn't have native support for doing that.
  */
-static void tap_ssl_key(const SSL *ssl, ssl_tap_state_t *state)
+static void tap_ssl_key(const SSL *ssl, struct ssl_tap_state *state)
 {
   const char *hex = "0123456789ABCDEF";
   int pos, i;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2243,8 +2243,8 @@ static CURLcode pkp_pin_peer_pubkey(struct connectdata *conn, int sockindex,
     SECURITY_STATUS sspi_status;
     const char *x509_der;
     DWORD x509_der_len;
-    curl_X509certificate x509_parsed;
-    curl_asn1Element *pubkey;
+    struct Curl_X509certificate x509_parsed;
+    struct Curl_asn1Element *pubkey;
 
     sspi_status =
       s_pSecFn->QueryContextAttributes(&BACKEND->ctxt->ctxt_handle,

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -57,7 +57,7 @@
 #define BEGIN_CERT "-----BEGIN CERTIFICATE-----"
 #define END_CERT "\n-----END CERTIFICATE-----"
 
-typedef struct {
+struct cert_chain_engine_config_win7 {
   DWORD cbSize;
   HCERTSTORE hRestrictedRoot;
   HCERTSTORE hRestrictedTrust;
@@ -70,7 +70,7 @@ typedef struct {
   DWORD CycleDetectionModulus;
   HCERTSTORE hExclusiveRoot;
   HCERTSTORE hExclusiveTrustedPeople;
-} CERT_CHAIN_ENGINE_CONFIG_WIN7, *PCERT_CHAIN_ENGINE_CONFIG_WIN7;
+};
 
 static int is_cr_or_lf(char c)
 {
@@ -585,7 +585,7 @@ CURLcode Curl_verify_certificate(struct connectdata *conn, int sockindex)
     }
 
     if(result == CURLE_OK) {
-      CERT_CHAIN_ENGINE_CONFIG_WIN7 engine_config;
+      struct cert_chain_engine_config_win7 engine_config;
       BOOL create_engine_result;
 
       memset(&engine_config, 0, sizeof(engine_config));

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1084,7 +1084,7 @@ bool Curl_none_false_start(void)
 CURLcode Curl_none_md5sum(unsigned char *input, size_t inputlen,
                           unsigned char *md5sum, size_t md5len UNUSED_PARAM)
 {
-  MD5_context *MD5pw;
+  struct MD5_context *MD5pw;
 
   (void)md5len;
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -511,8 +511,8 @@ wolfssl_connect_step2(struct connectdata *conn,
     X509 *x509;
     const char *x509_der;
     int x509_der_len;
-    curl_X509certificate x509_parsed;
-    curl_asn1Element *pubkey;
+    struct Curl_X509certificate x509_parsed;
+    struct Curl_asn1Element *pubkey;
     CURLcode result;
 
     x509 = SSL_get_peer_certificate(backend->handle);

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -44,7 +44,7 @@
 static const char       cnOID[] = "2.5.4.3";    /* Common name. */
 static const char       sanOID[] = "2.5.29.17"; /* Subject alternative name. */
 
-static const curl_OID   OIDtable[] = {
+static const struct Curl_OID OIDtable[] = {
   { "1.2.840.10040.4.1",        "dsa" },
   { "1.2.840.10040.4.3",        "dsa-with-sha1" },
   { "1.2.840.10045.2.1",        "ecPublicKey" },
@@ -103,16 +103,16 @@ static const curl_OID   OIDtable[] = {
  * Please note there is no pretention here to rewrite a full SSL library.
  */
 
-static const char *getASN1Element(curl_asn1Element *elem,
+static const char *getASN1Element(struct Curl_asn1Element *elem,
                                   const char *beg, const char *end)
   WARN_UNUSED_RESULT;
 
-static const char *getASN1Element(curl_asn1Element *elem,
+static const char *getASN1Element(struct Curl_asn1Element *elem,
                                   const char *beg, const char *end)
 {
   unsigned char b;
   unsigned long len;
-  curl_asn1Element lelem;
+  struct Curl_asn1Element lelem;
 
   /* Get a single ASN.1 element into `elem', parse ASN.1 string at `beg'
      ending at `end'.
@@ -176,9 +176,9 @@ static const char *getASN1Element(curl_asn1Element *elem,
  * Search the null terminated OID or OID identifier in local table.
  * Return the table entry pointer or NULL if not found.
  */
-static const curl_OID *searchOID(const char *oid)
+static const struct Curl_OID *searchOID(const char *oid)
 {
-  const curl_OID *op;
+  const struct Curl_OID *op;
   for(op = OIDtable; op->numoid; op++)
     if(!strcmp(op->numoid, oid) || strcasecompare(op->textoid, oid))
       return op;
@@ -445,7 +445,7 @@ static const char *OID2str(const char *beg, const char *end, bool symbolic)
         buf[buflen] = '\0';
 
         if(symbolic) {
-          const curl_OID *op = searchOID(buf);
+          const struct Curl_OID *op = searchOID(buf);
           if(op) {
             free(buf);
             buf = strdup(op->textoid);
@@ -565,7 +565,7 @@ static const char *UTime2str(const char *beg, const char *end)
  * Convert an ASN.1 element to a printable string.
  * Return the dynamically allocated string, or NULL if an error occurs.
  */
-static const char *ASN1tostr(curl_asn1Element *elem, int type)
+static const char *ASN1tostr(struct Curl_asn1Element *elem, int type)
 {
   if(elem->constructed)
     return NULL; /* No conversion of structured elements. */
@@ -609,12 +609,12 @@ static const char *ASN1tostr(curl_asn1Element *elem, int type)
  * ASCII encode distinguished name at `dn' into the `buflen'-sized buffer at
  * `buf'.  Return the total string length, even if larger than `buflen'.
  */
-static ssize_t encodeDN(char *buf, size_t buflen, curl_asn1Element *dn)
+static ssize_t encodeDN(char *buf, size_t buflen, struct Curl_asn1Element *dn)
 {
-  curl_asn1Element rdn;
-  curl_asn1Element atv;
-  curl_asn1Element oid;
-  curl_asn1Element value;
+  struct Curl_asn1Element rdn;
+  struct Curl_asn1Element atv;
+  struct Curl_asn1Element oid;
+  struct Curl_asn1Element value;
   size_t l = 0;
   const char *p1;
   const char *p2;
@@ -683,7 +683,7 @@ static ssize_t encodeDN(char *buf, size_t buflen, curl_asn1Element *dn)
  * Convert an ASN.1 distinguished name into a printable string.
  * Return the dynamically allocated string, or NULL if an error occurs.
  */
-static const char *DNtostr(curl_asn1Element *dn)
+static const char *DNtostr(struct Curl_asn1Element *dn)
 {
   char *buf = NULL;
   ssize_t buflen = encodeDN(NULL, 0, dn);
@@ -703,11 +703,11 @@ static const char *DNtostr(curl_asn1Element *dn)
  * Syntax is assumed to have already been checked by the SSL backend.
  * See RFC 5280.
  */
-int Curl_parseX509(curl_X509certificate *cert,
+int Curl_parseX509(struct Curl_X509certificate *cert,
                    const char *beg, const char *end)
 {
-  curl_asn1Element elem;
-  curl_asn1Element tbsCertificate;
+  struct Curl_asn1Element elem;
+  struct Curl_asn1Element tbsCertificate;
   const char *ccp;
   static const char defaultVersion = 0;  /* v1. */
 
@@ -835,10 +835,10 @@ static size_t copySubstring(char *to, const char *from)
   return i;
 }
 
-static const char *dumpAlgo(curl_asn1Element *param,
+static const char *dumpAlgo(struct Curl_asn1Element *param,
                             const char *beg, const char *end)
 {
-  curl_asn1Element oid;
+  struct Curl_asn1Element oid;
 
   /* Get algorithm parameters and return algorithm name. */
 
@@ -855,7 +855,7 @@ static const char *dumpAlgo(curl_asn1Element *param,
 }
 
 static void do_pubkey_field(struct Curl_easy *data, int certnum,
-                            const char *label, curl_asn1Element *elem)
+                            const char *label, struct Curl_asn1Element *elem)
 {
   const char *output;
 
@@ -872,11 +872,11 @@ static void do_pubkey_field(struct Curl_easy *data, int certnum,
 }
 
 static void do_pubkey(struct Curl_easy *data, int certnum,
-                      const char *algo, curl_asn1Element *param,
-                      curl_asn1Element *pubkey)
+                      const char *algo, struct Curl_asn1Element *param,
+                      struct Curl_asn1Element *pubkey)
 {
-  curl_asn1Element elem;
-  curl_asn1Element pk;
+  struct Curl_asn1Element elem;
+  struct Curl_asn1Element pk;
   const char *p;
 
   /* Generate all information records for the public key. */
@@ -950,9 +950,9 @@ CURLcode Curl_extract_certinfo(struct connectdata *conn,
                                const char *beg,
                                const char *end)
 {
-  curl_X509certificate cert;
+  struct Curl_X509certificate cert;
   struct Curl_easy *data = conn->data;
-  curl_asn1Element param;
+  struct Curl_asn1Element param;
   const char *ccp;
   char *cp1;
   size_t cl1;
@@ -1111,7 +1111,7 @@ CURLcode Curl_extract_certinfo(struct connectdata *conn,
 static const char *checkOID(const char *beg, const char *end,
                             const char *oid)
 {
-  curl_asn1Element e;
+  struct Curl_asn1Element e;
   const char *ccp;
   const char *p;
   bool matched;
@@ -1136,22 +1136,21 @@ CURLcode Curl_verifyhost(struct connectdata *conn,
                          const char *beg, const char *end)
 {
   struct Curl_easy *data = conn->data;
-  curl_X509certificate cert;
-  curl_asn1Element dn;
-  curl_asn1Element elem;
-  curl_asn1Element ext;
-  curl_asn1Element name;
+  struct Curl_X509certificate cert;
+  struct Curl_asn1Element dn;
+  struct Curl_asn1Element elem;
+  struct Curl_asn1Element ext;
+  struct Curl_asn1Element name;
   const char *p;
   const char *q;
   char *dnsname;
   int matched = -1;
   size_t addrlen = (size_t) -1;
   ssize_t len;
-  const char * const hostname = SSL_IS_PROXY()? conn->http_proxy.host.name:
-                                                conn->host.name;
-  const char * const dispname = SSL_IS_PROXY()?
-                                  conn->http_proxy.host.dispname:
-                                  conn->host.dispname;
+  const char *const hostname = SSL_IS_PROXY()?
+    conn->http_proxy.host.name : conn->host.name;
+  const char *const dispname = SSL_IS_PROXY()?
+    conn->http_proxy.host.dispname : conn->host.dispname;
 #ifdef ENABLE_IPV6
   struct in6_addr addr;
 #else

--- a/lib/x509asn1.h
+++ b/lib/x509asn1.h
@@ -8,7 +8,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -79,52 +79,51 @@
  */
 
 /* ASN.1 parsed element. */
-typedef struct {
-  const char *  header;         /* Pointer to header byte. */
-  const char *  beg;            /* Pointer to element data. */
-  const char *  end;            /* Pointer to 1st byte after element. */
-  unsigned char class;          /* ASN.1 element class. */
-  unsigned char tag;            /* ASN.1 element tag. */
-  bool          constructed;    /* Element is constructed. */
-}  curl_asn1Element;
+struct Curl_asn1Element {
+  const char *header;         /* Pointer to header byte. */
+  const char *beg;            /* Pointer to element data. */
+  const char *end;            /* Pointer to 1st byte after element. */
+  unsigned char class;        /* ASN.1 element class. */
+  unsigned char tag;          /* ASN.1 element tag. */
+  bool          constructed;  /* Element is constructed. */
+};
 
 
 /* ASN.1 OID table entry. */
-typedef struct {
-  const char *  numoid;         /* Dotted-numeric OID. */
-  const char *  textoid;        /* OID name. */
-}  curl_OID;
+struct Curl_OID {
+  const char *numoid;  /* Dotted-numeric OID. */
+  const char *textoid; /* OID name. */
+};
 
 
 /* X509 certificate: RFC 5280. */
-typedef struct {
-  curl_asn1Element      certificate;
-  curl_asn1Element      version;
-  curl_asn1Element      serialNumber;
-  curl_asn1Element      signatureAlgorithm;
-  curl_asn1Element      signature;
-  curl_asn1Element      issuer;
-  curl_asn1Element      notBefore;
-  curl_asn1Element      notAfter;
-  curl_asn1Element      subject;
-  curl_asn1Element      subjectPublicKeyInfo;
-  curl_asn1Element      subjectPublicKeyAlgorithm;
-  curl_asn1Element      subjectPublicKey;
-  curl_asn1Element      issuerUniqueID;
-  curl_asn1Element      subjectUniqueID;
-  curl_asn1Element      extensions;
-}  curl_X509certificate;
-
+struct Curl_X509certificate {
+  struct Curl_asn1Element certificate;
+  struct Curl_asn1Element version;
+  struct Curl_asn1Element serialNumber;
+  struct Curl_asn1Element signatureAlgorithm;
+  struct Curl_asn1Element signature;
+  struct Curl_asn1Element issuer;
+  struct Curl_asn1Element notBefore;
+  struct Curl_asn1Element notAfter;
+  struct Curl_asn1Element subject;
+  struct Curl_asn1Element subjectPublicKeyInfo;
+  struct Curl_asn1Element subjectPublicKeyAlgorithm;
+  struct Curl_asn1Element subjectPublicKey;
+  struct Curl_asn1Element issuerUniqueID;
+  struct Curl_asn1Element subjectUniqueID;
+  struct Curl_asn1Element extensions;
+};
 
 /*
  * Prototypes.
  */
 
-const char *Curl_getASN1Element(curl_asn1Element *elem,
-                                 const char *beg, const char *end);
-const char *Curl_ASN1tostr(curl_asn1Element *elem, int type);
-const char *Curl_DNtostr(curl_asn1Element *dn);
-int Curl_parseX509(curl_X509certificate *cert,
+const char *Curl_getASN1Element(struct Curl_asn1Element *elem,
+                                const char *beg, const char *end);
+const char *Curl_ASN1tostr(struct Curl_asn1Element *elem, int type);
+const char *Curl_DNtostr(struct Curl_asn1Element *dn);
+int Curl_parseX509(struct Curl_X509certificate *cert,
                    const char *beg, const char *end);
 CURLcode Curl_extract_certinfo(struct connectdata *conn, int certnum,
                                const char *beg, const char *end);

--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -85,8 +85,6 @@ if [ "$T" = "normal" ]; then
     make test-nonflaky
   fi
   if [ -n $CHECKSRC ]; then
-    echo "enable COPYRIGHTYEAR" > ./docs/examples/.checksrc
-    echo "enable COPYRIGHTYEAR" > ./include/curl/.checksrc
     make checksrc
   fi
 fi

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -37,8 +37,8 @@ struct GlobalConfig;
 
 struct State {
   struct getout *urlnode;
-  URLGlob *inglob;
-  URLGlob *urls;
+  struct URLGlob *inglob;
+  struct URLGlob *urls;
   char *outfiles;
   char *httpgetfields;
   char *uploadfile;
@@ -194,8 +194,8 @@ struct OperationConfig {
   curl_off_t condtime;
   struct curl_slist *headers;
   struct curl_slist *proxyheaders;
-  tool_mime *mimeroot;
-  tool_mime *mimecurrent;
+  struct tool_mime *mimeroot;
+  struct tool_mime *mimecurrent;
   curl_mime *mimepost;
   struct curl_slist *telnet_options;
   struct curl_slist *resolve;
@@ -261,8 +261,8 @@ struct OperationConfig {
   bool native_ca_store;        /* use the native os ca store */
 
   bool use_metalink;        /* process given URLs as metalink XML file */
-  metalinkfile *metalinkfile_list; /* point to the first node */
-  metalinkfile *metalinkfile_last; /* point to the last/current node */
+  struct metalinkfile *metalinkfile_list; /* point to the first node */
+  struct metalinkfile *metalinkfile_last; /* point to the last/current node */
   char *oauth_bearer;             /* OAuth 2.0 bearer token */
   bool nonpn;                     /* enable/disable TLS NPN extension */
   bool noalpn;                    /* enable/disable TLS ALPN extension */

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -42,9 +42,10 @@
 #define CONST_SAFEFREE(x)       Curl_safefree(*((void **) &(x)))
 
 /* tool_mime functions. */
-static tool_mime *tool_mime_new(tool_mime *parent, toolmimekind kind)
+static struct tool_mime *tool_mime_new(struct tool_mime *parent,
+                                       toolmimekind kind)
 {
-  tool_mime *m = (tool_mime *) calloc(1, sizeof(*m));
+  struct tool_mime *m = (struct tool_mime *) calloc(1, sizeof(*m));
 
   if(m) {
     m->kind = kind;
@@ -57,14 +58,15 @@ static tool_mime *tool_mime_new(tool_mime *parent, toolmimekind kind)
   return m;
 }
 
-static tool_mime *tool_mime_new_parts(tool_mime *parent)
+static struct tool_mime *tool_mime_new_parts(struct tool_mime *parent)
 {
   return tool_mime_new(parent, TOOLMIME_PARTS);
 }
 
-static tool_mime *tool_mime_new_data(tool_mime *parent, const char *data)
+static struct tool_mime *tool_mime_new_data(struct tool_mime *parent,
+                                            const char *data)
 {
-  tool_mime *m = NULL;
+  struct tool_mime *m = NULL;
 
   data = strdup(data);
   if(data) {
@@ -77,13 +79,13 @@ static tool_mime *tool_mime_new_data(tool_mime *parent, const char *data)
   return m;
 }
 
-static tool_mime *tool_mime_new_filedata(tool_mime *parent,
-                                         const char *filename,
-                                         bool isremotefile,
-                                         CURLcode *errcode)
+static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
+                                                const char *filename,
+                                                bool isremotefile,
+                                                CURLcode *errcode)
 {
   CURLcode result = CURLE_OK;
-  tool_mime *m = NULL;
+  struct tool_mime *m = NULL;
 
   *errcode = CURLE_OUT_OF_MEMORY;
   if(strcmp(filename, "-")) {
@@ -159,7 +161,7 @@ static tool_mime *tool_mime_new_filedata(tool_mime *parent,
   return m;
 }
 
-void tool_mime_free(tool_mime *mime)
+void tool_mime_free(struct tool_mime *mime)
 {
   if(mime) {
     if(mime->subparts)
@@ -181,7 +183,7 @@ void tool_mime_free(tool_mime *mime)
 size_t tool_mime_stdin_read(char *buffer,
                             size_t size, size_t nitems, void *arg)
 {
-  tool_mime *sip = (tool_mime *) arg;
+  struct tool_mime *sip = (struct tool_mime *) arg;
   curl_off_t bytesleft;
   (void) size;  /* Always 1: ignored. */
 
@@ -216,7 +218,7 @@ size_t tool_mime_stdin_read(char *buffer,
 
 int tool_mime_stdin_seek(void *instream, curl_off_t offset, int whence)
 {
-  tool_mime *sip = (tool_mime *) instream;
+  struct tool_mime *sip = (struct tool_mime *) instream;
 
   switch(whence) {
   case SEEK_CUR:
@@ -238,7 +240,8 @@ int tool_mime_stdin_seek(void *instream, curl_off_t offset, int whence)
 
 /* Translate an internal mime tree into a libcurl mime tree. */
 
-static CURLcode tool2curlparts(CURL *curl, tool_mime *m, curl_mime *mime)
+static CURLcode tool2curlparts(CURL *curl, struct tool_mime *m,
+                               curl_mime *mime)
 {
   CURLcode ret = CURLE_OK;
   curl_mimepart *part = NULL;
@@ -323,7 +326,7 @@ static CURLcode tool2curlparts(CURL *curl, tool_mime *m, curl_mime *mime)
   return ret;
 }
 
-CURLcode tool2curlmime(CURL *curl, tool_mime *m, curl_mime **mime)
+CURLcode tool2curlmime(CURL *curl, struct tool_mime *m, curl_mime **mime)
 {
   CURLcode ret = CURLE_OK;
 
@@ -733,8 +736,8 @@ static int get_param_part(struct OperationConfig *config, char endchar,
 
 int formparse(struct OperationConfig *config,
               const char *input,
-              tool_mime **mimeroot,
-              tool_mime **mimecurrent,
+              struct tool_mime **mimeroot,
+              struct tool_mime **mimecurrent,
               bool literal_value)
 {
   /* input MUST be a string in the format 'name=contents' and we'll
@@ -747,7 +750,7 @@ int formparse(struct OperationConfig *config,
   char *filename = NULL;
   char *encoder = NULL;
   struct curl_slist *headers = NULL;
-  tool_mime *part = NULL;
+  struct tool_mime *part = NULL;
   CURLcode res;
 
   /* Allocate the main mime structure if needed. */
@@ -794,7 +797,7 @@ int formparse(struct OperationConfig *config,
 
       /* we use the @-letter to indicate file name(s) */
 
-      tool_mime *subparts = NULL;
+      struct tool_mime *subparts = NULL;
 
       do {
         /* since this was a file, it may have a content-type specifier

--- a/src/tool_formparse.h
+++ b/src/tool_formparse.h
@@ -35,12 +35,11 @@ typedef enum {
   TOOLMIME_STDINDATA
 } toolmimekind;
 
-typedef struct tool_mime        tool_mime;
 struct tool_mime {
   /* Structural fields. */
   toolmimekind kind;            /* Part kind. */
-  tool_mime *parent;            /* Parent item. */
-  tool_mime *prev;              /* Previous sibling (reverse order link). */
+  struct tool_mime *parent;     /* Parent item. */
+  struct tool_mime *prev;       /* Previous sibling (reverse order link). */
   /* Common fields. */
   const char *data;             /* Actual data or data filename. */
   const char *name;             /* Part name. */
@@ -49,7 +48,7 @@ struct tool_mime {
   const char *encoder;          /* Part's requested encoding. */
   struct curl_slist *headers;   /* User-defined headers. */
   /* TOOLMIME_PARTS fields. */
-  tool_mime *subparts;          /* Part's subparts. */
+  struct tool_mime *subparts;   /* Part's subparts. */
   /* TOOLMIME_STDIN/TOOLMIME_STDINDATA fields. */
   curl_off_t origin;            /* Stdin read origin offset. */
   curl_off_t size;              /* Stdin data size. */
@@ -63,10 +62,10 @@ int tool_mime_stdin_seek(void *instream, curl_off_t offset, int whence);
 
 int formparse(struct OperationConfig *config,
               const char *input,
-              tool_mime **mimeroot,
-              tool_mime **mimecurrent,
+              struct tool_mime **mimeroot,
+              struct tool_mime **mimecurrent,
               bool literal_value);
-CURLcode tool2curlmime(CURL *curl, tool_mime *m, curl_mime **mime);
-void tool_mime_free(tool_mime *mime);
+CURLcode tool2curlmime(CURL *curl, struct tool_mime *m, curl_mime **mime);
+void tool_mime_free(struct tool_mime *mime);
 
 #endif /* HEADER_CURL_TOOL_FORMPARSE_H */

--- a/src/tool_metalink.h
+++ b/src/tool_metalink.h
@@ -35,46 +35,46 @@ typedef void (*digest_update_func)(void *context,
                                    unsigned int len);
 typedef void (*digest_final_func)(unsigned char *result, void *context);
 
-typedef struct {
+struct digest_params {
   digest_init_func     digest_init;   /* Initialize context procedure */
   digest_update_func   digest_update; /* Update context with data */
   digest_final_func    digest_final;  /* Get final result procedure */
   unsigned int         digest_ctxtsize;  /* Context structure size */
   unsigned int         digest_resultlen; /* Result length (bytes) */
-} digest_params;
+};
 
-typedef struct {
-  const digest_params   *digest_hash;      /* Hash function definition */
+struct digest_context {
+  const struct digest_params *digest_hash; /* Hash function definition */
   void                  *digest_hashctx;   /* Hash function context */
-} digest_context;
+};
 
-typedef struct {
+struct metalink_digest_def {
   const char *hash_name;
-  const digest_params *dparams;
-} metalink_digest_def;
+  const struct digest_params *dparams;
+};
 
-typedef struct {
+struct metalink_digest_alias {
   const char *alias_name;
-  const metalink_digest_def *digest_def;
-} metalink_digest_alias;
+  const struct metalink_digest_def *digest_def;
+};
 
-typedef struct metalink_checksum {
-  const metalink_digest_def *digest_def;
+struct metalink_checksum {
+  const struct metalink_digest_def *digest_def;
   /* raw digest value, not ascii hex digest */
   unsigned char *digest;
-} metalink_checksum;
+};
 
-typedef struct metalink_resource {
+struct metalink_resource {
   struct metalink_resource *next;
   char *url;
-} metalink_resource;
+};
 
-typedef struct metalinkfile {
+struct metalinkfile {
   struct metalinkfile *next;
   char *filename;
-  metalink_checksum *checksum;
-  metalink_resource *resource;
-} metalinkfile;
+  struct metalink_checksum *checksum;
+  struct metalink_resource *resource;
+};
 
 #ifdef USE_METALINK
 
@@ -89,18 +89,18 @@ typedef struct metalinkfile {
                                     (CURL_REQ_LIBMETALINK_MINOR * 100) + \
                                      CURL_REQ_LIBMETALINK_PATCH)
 
-extern const digest_params MD5_DIGEST_PARAMS[1];
-extern const digest_params SHA1_DIGEST_PARAMS[1];
-extern const digest_params SHA256_DIGEST_PARAMS[1];
+extern const struct digest_params MD5_DIGEST_PARAMS[1];
+extern const struct digest_params SHA1_DIGEST_PARAMS[1];
+extern const struct digest_params SHA256_DIGEST_PARAMS[1];
 
 #include <metalink/metalink.h>
 
 /*
  * Counts the resource in the metalinkfile.
  */
-int count_next_metalink_resource(metalinkfile *mlfile);
+int count_next_metalink_resource(struct metalinkfile *mlfile);
 
-void delete_metalinkfile(metalinkfile *mlfile);
+void delete_metalinkfile(struct metalinkfile *mlfile);
 void clean_metalink(struct OperationConfig *config);
 
 /*
@@ -143,7 +143,7 @@ int check_metalink_content_type(const char *content_type);
  *   Metalink does not contain checksum.
  */
 int metalink_check_hash(struct GlobalConfig *config,
-                        metalinkfile *mlfile,
+                        struct metalinkfile *mlfile,
                         const char *filename);
 
 /*

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -699,7 +699,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 {
   CURLcode result = CURLE_OK;
   struct getout *urlnode;
-  metalinkfile *mlfile_last = NULL;
+  struct metalinkfile *mlfile_last = NULL;
   bool orig_noprogress = global->noprogress;
   bool orig_isatty = global->isatty;
   struct State *state = &config->state;
@@ -740,10 +740,10 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
   while(config->state.urlnode) {
     char *infiles; /* might be a glob pattern */
-    URLGlob *inglob = state->inglob;
+    struct URLGlob *inglob = state->inglob;
     bool metalink = FALSE; /* metalink download? */
-    metalinkfile *mlfile;
-    metalink_resource *mlres;
+    struct metalinkfile *mlfile;
+    struct metalink_resource *mlres;
 
     urlnode = config->state.urlnode;
     if(urlnode->flags & GETOUT_METALINK) {

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -38,8 +38,8 @@ struct per_transfer {
   struct timeval retrystart;
   bool metalink; /* nonzero for metalink download. */
   bool metalink_next_res;
-  metalinkfile *mlfile;
-  metalink_resource *mlres;
+  struct metalinkfile *mlfile;
+  struct metalink_resource *mlres;
   char *this_url;
   char *outfile;
   bool infdopen; /* TRUE if infd needs closing */

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -43,7 +43,7 @@
 #define NV1(e, v) {#e, (v)}
 #define NVEND {NULL, 0}         /* sentinel to mark end of list */
 
-const NameValue setopt_nv_CURLPROXY[] = {
+const struct NameValue setopt_nv_CURLPROXY[] = {
   NV(CURLPROXY_HTTP),
   NV(CURLPROXY_HTTP_1_0),
   NV(CURLPROXY_HTTPS),
@@ -54,7 +54,7 @@ const NameValue setopt_nv_CURLPROXY[] = {
   NVEND,
 };
 
-const NameValue setopt_nv_CURL_SOCKS_PROXY[] = {
+const struct NameValue setopt_nv_CURL_SOCKS_PROXY[] = {
   NV(CURLPROXY_SOCKS4),
   NV(CURLPROXY_SOCKS5),
   NV(CURLPROXY_SOCKS4A),
@@ -62,7 +62,7 @@ const NameValue setopt_nv_CURL_SOCKS_PROXY[] = {
   NVEND,
 };
 
-const NameValueUnsigned setopt_nv_CURLAUTH[] = {
+const struct NameValueUnsigned setopt_nv_CURLAUTH[] = {
   NV(CURLAUTH_ANY),             /* combination */
   NV(CURLAUTH_ANYSAFE),         /* combination */
   NV(CURLAUTH_BASIC),
@@ -76,7 +76,7 @@ const NameValueUnsigned setopt_nv_CURLAUTH[] = {
   NVEND,
 };
 
-const NameValue setopt_nv_CURL_HTTP_VERSION[] = {
+const struct NameValue setopt_nv_CURL_HTTP_VERSION[] = {
   NV(CURL_HTTP_VERSION_NONE),
   NV(CURL_HTTP_VERSION_1_0),
   NV(CURL_HTTP_VERSION_1_1),
@@ -86,7 +86,7 @@ const NameValue setopt_nv_CURL_HTTP_VERSION[] = {
   NVEND,
 };
 
-const NameValue setopt_nv_CURL_SSLVERSION[] = {
+const struct NameValue setopt_nv_CURL_SSLVERSION[] = {
   NV(CURL_SSLVERSION_DEFAULT),
   NV(CURL_SSLVERSION_TLSv1),
   NV(CURL_SSLVERSION_SSLv2),
@@ -98,7 +98,7 @@ const NameValue setopt_nv_CURL_SSLVERSION[] = {
   NVEND,
 };
 
-const NameValue setopt_nv_CURL_TIMECOND[] = {
+const struct NameValue setopt_nv_CURL_TIMECOND[] = {
   NV(CURL_TIMECOND_IFMODSINCE),
   NV(CURL_TIMECOND_IFUNMODSINCE),
   NV(CURL_TIMECOND_LASTMOD),
@@ -106,14 +106,14 @@ const NameValue setopt_nv_CURL_TIMECOND[] = {
   NVEND,
 };
 
-const NameValue setopt_nv_CURLFTPSSL_CCC[] = {
+const struct NameValue setopt_nv_CURLFTPSSL_CCC[] = {
   NV(CURLFTPSSL_CCC_NONE),
   NV(CURLFTPSSL_CCC_PASSIVE),
   NV(CURLFTPSSL_CCC_ACTIVE),
   NVEND,
 };
 
-const NameValue setopt_nv_CURLUSESSL[] = {
+const struct NameValue setopt_nv_CURLUSESSL[] = {
   NV(CURLUSESSL_NONE),
   NV(CURLUSESSL_TRY),
   NV(CURLUSESSL_CONTROL),
@@ -121,7 +121,7 @@ const NameValue setopt_nv_CURLUSESSL[] = {
   NVEND,
 };
 
-const NameValueUnsigned setopt_nv_CURLSSLOPT[] = {
+const struct NameValueUnsigned setopt_nv_CURLSSLOPT[] = {
   NV(CURLSSLOPT_ALLOW_BEAST),
   NV(CURLSSLOPT_NO_REVOKE),
   NV(CURLSSLOPT_NO_PARTIALCHAIN),
@@ -130,7 +130,7 @@ const NameValueUnsigned setopt_nv_CURLSSLOPT[] = {
   NVEND,
 };
 
-const NameValue setopt_nv_CURL_NETRC[] = {
+const struct NameValue setopt_nv_CURL_NETRC[] = {
   NV(CURL_NETRC_IGNORED),
   NV(CURL_NETRC_OPTIONAL),
   NV(CURL_NETRC_REQUIRED),
@@ -139,7 +139,7 @@ const NameValue setopt_nv_CURL_NETRC[] = {
 
 /* These mappings essentially triplicated - see
  * tool_libinfo.c and tool_paramhlp.c */
-const NameValue setopt_nv_CURLPROTO[] = {
+const struct NameValue setopt_nv_CURLPROTO[] = {
   NV(CURLPROTO_ALL),            /* combination */
   NV(CURLPROTO_DICT),
   NV(CURLPROTO_FILE),
@@ -167,7 +167,7 @@ const NameValue setopt_nv_CURLPROTO[] = {
 };
 
 /* These options have non-zero default values. */
-static const NameValue setopt_nv_CURLNONZERODEFAULTS[] = {
+static const struct NameValue setopt_nv_CURLNONZERODEFAULTS[] = {
   NV1(CURLOPT_SSL_VERIFYPEER, 1),
   NV1(CURLOPT_SSL_VERIFYHOST, 1),
   NV1(CURLOPT_SSL_ENABLE_NPN, 1),
@@ -273,7 +273,7 @@ static char *c_escape(const char *str, size_t len)
 /* setopt wrapper for enum types */
 CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
                           const char *name, CURLoption tag,
-                          const NameValue *nvlist, long lval)
+                          const struct NameValue *nvlist, long lval)
 {
   CURLcode ret = CURLE_OK;
   bool skip = FALSE;
@@ -284,7 +284,7 @@ CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
 
   if(config->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
-    const NameValue *nv = NULL;
+    const struct NameValue *nv = NULL;
     for(nv = nvlist; nv->name; nv++) {
       if(nv->value == lval)
         break; /* found it */
@@ -307,7 +307,7 @@ CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
 /* setopt wrapper for flags */
 CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
                            const char *name, CURLoption tag,
-                           const NameValue *nvlist, long lval)
+                           const struct NameValue *nvlist, long lval)
 {
   CURLcode ret = CURLE_OK;
   bool skip = FALSE;
@@ -320,7 +320,7 @@ CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
     /* we only use this for real if --libcurl was used */
     char preamble[80];          /* should accommodate any symbol name */
     long rest = lval;           /* bits not handled yet */
-    const NameValue *nv = NULL;
+    const struct NameValue *nv = NULL;
     msnprintf(preamble, sizeof(preamble),
               "curl_easy_setopt(hnd, %s, ", name);
     for(nv = nvlist; nv->name; nv++) {
@@ -349,7 +349,7 @@ CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
 /* setopt wrapper for bitmasks */
 CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
                              const char *name, CURLoption tag,
-                             const NameValueUnsigned *nvlist,
+                             const struct NameValueUnsigned *nvlist,
                              long lval)
 {
   CURLcode ret = CURLE_OK;
@@ -363,7 +363,7 @@ CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
     /* we only use this for real if --libcurl was used */
     char preamble[80];
     unsigned long rest = (unsigned long)lval;
-    const NameValueUnsigned *nv = NULL;
+    const struct NameValueUnsigned *nv = NULL;
     msnprintf(preamble, sizeof(preamble),
               "curl_easy_setopt(hnd, %s, ", name);
     for(nv = nvlist; nv->name; nv++) {
@@ -418,13 +418,13 @@ static CURLcode libcurl_generate_slist(struct curl_slist *slist, int *slistno)
 
 static CURLcode libcurl_generate_mime(CURL *curl,
                                       struct GlobalConfig *config,
-                                      tool_mime *toolmime,
+                                      struct tool_mime *toolmime,
                                       int *mimeno);     /* Forward. */
 
 /* Wrapper to generate source code for a mime part. */
 static CURLcode libcurl_generate_mime_part(CURL *curl,
                                            struct GlobalConfig *config,
-                                           tool_mime *part,
+                                           struct tool_mime *part,
                                            int mimeno)
 {
   CURLcode ret = CURLE_OK;
@@ -557,7 +557,7 @@ nomem:
 /* Wrapper to generate source code for a mime structure. */
 static CURLcode libcurl_generate_mime(CURL *curl,
                                       struct GlobalConfig *config,
-                                      tool_mime *toolmime,
+                                      struct tool_mime *toolmime,
                                       int *mimeno)
 {
   CURLcode ret = CURLE_OK;
@@ -641,7 +641,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *config,
     /* Value is expected to be a long */
     long lval = va_arg(arg, long);
     long defval = 0L;
-    const NameValue *nv = NULL;
+    const struct NameValue *nv = NULL;
     for(nv = setopt_nv_CURLNONZERODEFAULTS; nv->name; nv++) {
       if(!strcmp(name, nv->name)) {
         defval = nv->value;

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -43,27 +43,27 @@ bool tool_setopt_skip(CURLoption tag);
 #ifndef CURL_DISABLE_LIBCURL_OPTION
 
 /* Associate symbolic names with option values */
-typedef struct {
+struct NameValue {
   const char *name;
   long value;
-} NameValue;
+};
 
-typedef struct {
+struct NameValueUnsigned {
   const char *name;
   unsigned long value;
-} NameValueUnsigned;
+};
 
-extern const NameValue setopt_nv_CURLPROXY[];
-extern const NameValue setopt_nv_CURL_SOCKS_PROXY[];
-extern const NameValue setopt_nv_CURL_HTTP_VERSION[];
-extern const NameValue setopt_nv_CURL_SSLVERSION[];
-extern const NameValue setopt_nv_CURL_TIMECOND[];
-extern const NameValue setopt_nv_CURLFTPSSL_CCC[];
-extern const NameValue setopt_nv_CURLUSESSL[];
-extern const NameValueUnsigned setopt_nv_CURLSSLOPT[];
-extern const NameValue setopt_nv_CURL_NETRC[];
-extern const NameValue setopt_nv_CURLPROTO[];
-extern const NameValueUnsigned setopt_nv_CURLAUTH[];
+extern const struct NameValue setopt_nv_CURLPROXY[];
+extern const struct NameValue setopt_nv_CURL_SOCKS_PROXY[];
+extern const struct NameValue setopt_nv_CURL_HTTP_VERSION[];
+extern const struct NameValue setopt_nv_CURL_SSLVERSION[];
+extern const struct NameValue setopt_nv_CURL_TIMECOND[];
+extern const struct NameValue setopt_nv_CURLFTPSSL_CCC[];
+extern const struct NameValue setopt_nv_CURLUSESSL[];
+extern const struct NameValueUnsigned setopt_nv_CURLSSLOPT[];
+extern const struct NameValue setopt_nv_CURL_NETRC[];
+extern const struct NameValue setopt_nv_CURLPROTO[];
+extern const struct NameValueUnsigned setopt_nv_CURLAUTH[];
 
 /* Map options to NameValue sets */
 #define setopt_nv_CURLOPT_HTTP_VERSION setopt_nv_CURL_HTTP_VERSION
@@ -85,13 +85,13 @@ extern const NameValueUnsigned setopt_nv_CURLAUTH[];
 
 CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
                           const char *name, CURLoption tag,
-                          const NameValue *nv, long lval);
+                          const struct NameValue *nv, long lval);
 CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
                            const char *name, CURLoption tag,
-                           const NameValue *nv, long lval);
+                           const struct NameValue *nv, long lval);
 CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
                              const char *name, CURLoption tag,
-                             const NameValueUnsigned *nv, long lval);
+                             const struct NameValueUnsigned *nv, long lval);
 CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *config,
                               const char *name, CURLoption tag,
                               curl_mime *mimepost);

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -34,9 +34,9 @@
 #define GLOBERROR(string, column, code) \
   glob->error = string, glob->pos = column, code
 
-static CURLcode glob_fixed(URLGlob *glob, char *fixed, size_t len)
+static CURLcode glob_fixed(struct URLGlob *glob, char *fixed, size_t len)
 {
-  URLPattern *pat = &glob->pattern[glob->size];
+  struct URLPattern *pat = &glob->pattern[glob->size];
   pat->type = UPTSet;
   pat->content.Set.size = 1;
   pat->content.Set.ptr_s = 0;
@@ -74,14 +74,14 @@ static int multiply(unsigned long *amount, long with)
   return 0;
 }
 
-static CURLcode glob_set(URLGlob *glob, char **patternp,
+static CURLcode glob_set(struct URLGlob *glob, char **patternp,
                          size_t *posp, unsigned long *amount,
                          int globindex)
 {
   /* processes a set expression with the point behind the opening '{'
      ','-separated elements are collected until the next closing '}'
   */
-  URLPattern *pat;
+  struct URLPattern *pat;
   bool done = FALSE;
   char *buf = glob->glob_buffer;
   char *pattern = *patternp;
@@ -168,7 +168,7 @@ static CURLcode glob_set(URLGlob *glob, char **patternp,
   return CURLE_OK;
 }
 
-static CURLcode glob_range(URLGlob *glob, char **patternp,
+static CURLcode glob_range(struct URLGlob *glob, char **patternp,
                            size_t *posp, unsigned long *amount,
                            int globindex)
 {
@@ -178,7 +178,7 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
      - num range with leading zeros: e.g. "001-999]"
      expression is checked for well-formedness and collected until the next ']'
   */
-  URLPattern *pat;
+  struct URLPattern *pat;
   int rc;
   char *pattern = *patternp;
   char *c;
@@ -349,7 +349,7 @@ static bool peek_ipv6(const char *str, size_t *skip)
   }
 }
 
-static CURLcode glob_parse(URLGlob *glob, char *pattern,
+static CURLcode glob_parse(struct URLGlob *glob, char *pattern,
                            size_t pos, unsigned long *amount)
 {
   /* processes a literal string component of a URL
@@ -427,14 +427,14 @@ static CURLcode glob_parse(URLGlob *glob, char *pattern,
   return res;
 }
 
-CURLcode glob_url(URLGlob **glob, char *url, unsigned long *urlnum,
+CURLcode glob_url(struct URLGlob **glob, char *url, unsigned long *urlnum,
                   FILE *error)
 {
   /*
    * We can deal with any-size, just make a buffer with the same length
    * as the specified URL!
    */
-  URLGlob *glob_expand;
+  struct URLGlob *glob_expand;
   unsigned long amount = 0;
   char *glob_buffer;
   CURLcode res;
@@ -446,7 +446,7 @@ CURLcode glob_url(URLGlob **glob, char *url, unsigned long *urlnum,
     return CURLE_OUT_OF_MEMORY;
   glob_buffer[0] = 0;
 
-  glob_expand = calloc(1, sizeof(URLGlob));
+  glob_expand = calloc(1, sizeof(struct URLGlob));
   if(!glob_expand) {
     Curl_safefree(glob_buffer);
     return CURLE_OUT_OF_MEMORY;
@@ -483,7 +483,7 @@ CURLcode glob_url(URLGlob **glob, char *url, unsigned long *urlnum,
   return CURLE_OK;
 }
 
-void glob_cleanup(URLGlob* glob)
+void glob_cleanup(struct URLGlob *glob)
 {
   size_t i;
   int elem;
@@ -506,9 +506,9 @@ void glob_cleanup(URLGlob* glob)
   Curl_safefree(glob);
 }
 
-CURLcode glob_next_url(char **globbed, URLGlob *glob)
+CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
 {
-  URLPattern *pat;
+  struct URLPattern *pat;
   size_t i;
   size_t len;
   size_t buflen = glob->urllen + 1;
@@ -600,7 +600,7 @@ CURLcode glob_next_url(char **globbed, URLGlob *glob)
   return CURLE_OK;
 }
 
-CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
+CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
 {
   char *target;
   size_t allocsize;
@@ -625,7 +625,7 @@ CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
     if(*filename == '#' && ISDIGIT(filename[1])) {
       char *ptr = filename;
       unsigned long num = strtoul(&filename[1], &filename, 10);
-      URLPattern *pat = NULL;
+      struct URLPattern *pat = NULL;
 
       if(num && (num < glob->size)) {
         unsigned long i;

--- a/src/tool_urlglob.h
+++ b/src/tool_urlglob.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -29,7 +29,7 @@ typedef enum {
   UPTNumRange
 } URLPatternType;
 
-typedef struct {
+struct URLPattern {
   URLPatternType type;
   int globindex; /* the number of this particular glob or -1 if not used
                     within {} or [] */
@@ -53,24 +53,24 @@ typedef struct {
       unsigned long step;
     } NumRange;
   } content;
-} URLPattern;
+};
 
 /* the total number of globs supported */
 #define GLOB_PATTERN_NUM 100
 
-typedef struct {
-  URLPattern pattern[GLOB_PATTERN_NUM];
+struct URLGlob {
+  struct URLPattern pattern[GLOB_PATTERN_NUM];
   size_t size;
   size_t urllen;
   char *glob_buffer;
   char beenhere;
   const char *error; /* error message */
   size_t pos;        /* column position of error or 0 */
-} URLGlob;
+};
 
-CURLcode glob_url(URLGlob**, char *, unsigned long *, FILE *);
-CURLcode glob_next_url(char **, URLGlob *);
-CURLcode glob_match_url(char **, char *, URLGlob *);
-void glob_cleanup(URLGlob* glob);
+CURLcode glob_url(struct URLGlob**, char *, unsigned long *, FILE *);
+CURLcode glob_next_url(char **, struct URLGlob *);
+CURLcode glob_match_url(char **, char *, struct URLGlob *);
+void glob_cleanup(struct URLGlob *glob);
 
 #endif /* HEADER_CURL_TOOL_URLGLOB_H */

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -122,13 +122,13 @@ void vms_special_exit(int code, int vms_show)
  */
 
 /* Structure to hold a DECC$* feature name and its desired value. */
-typedef struct {
+struct decc_feat_t {
   char *name;
   int value;
-} decc_feat_t;
+};
 
 /* Array of DECC$* feature names and their desired values. */
-static decc_feat_t decc_feat_array[] = {
+static struct decc_feat_t decc_feat_array[] = {
   /* Preserve command-line case with SET PROCESS/PARSE_STYLE=EXTENDED */
   { "DECC$ARGV_PARSE_STYLE", 1 },
   /* Preserve case for file names on ODS5 disks. */

--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,0 +1,1 @@
+disable TYPEDEFSTRUCT

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -40,12 +40,12 @@
 #define F_CONTENTRANGE  (1 << 3)        /* Server sends content-range hdr. */
 #define F_IGNOREBODY    (1 << 4)        /* Body should be ignored. */
 
-typedef struct {
+struct testparams {
   unsigned int flags; /* ORed flags as above. */
   CURLcode result; /* Code that should be returned by curl_easy_perform(). */
-}  testparams;
+};
 
-static const testparams params[] = {
+static const struct testparams params[] = {
   { 0,                                                             CURLE_OK },
   {                                 F_CONTENTRANGE,                CURLE_OK },
   {                        F_FAIL,                                 CURLE_OK },
@@ -82,7 +82,7 @@ static size_t writedata(char *data, size_t size, size_t nmemb, void *userdata)
   return size * nmemb;
 }
 
-static int onetest(CURL *curl, const char *url, const testparams *p)
+static int onetest(CURL *curl, const char *url, const struct testparams *p)
 {
   CURLcode res;
   unsigned int replyselector;

--- a/tests/libtest/lib576.c
+++ b/tests/libtest/lib576.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -24,10 +24,10 @@
 #include "testutil.h"
 #include "memdebug.h"
 
-typedef struct {
+struct chunk_data {
   int remains;
   int print_content;
-} chunk_data_t;
+};
 
 static
 long chunk_bgn(const struct curl_fileinfo *finfo, void *ptr, int remains);
@@ -37,7 +37,7 @@ long chunk_end(void *ptr);
 static
 long chunk_bgn(const struct curl_fileinfo *finfo, void *ptr, int remains)
 {
-  chunk_data_t *ch_d = ptr;
+  struct chunk_data *ch_d = ptr;
   ch_d->remains = remains;
 
   printf("=============================================================\n");
@@ -87,7 +87,7 @@ long chunk_bgn(const struct curl_fileinfo *finfo, void *ptr, int remains)
 static
 long chunk_end(void *ptr)
 {
-  chunk_data_t *ch_d = ptr;
+  struct chunk_data *ch_d = ptr;
   if(ch_d->print_content) {
     ch_d->print_content = 0;
     printf("-------------------------------------------------------------\n");
@@ -101,7 +101,7 @@ int test(char *URL)
 {
   CURL *handle = NULL;
   CURLcode res = CURLE_OK;
-  chunk_data_t chunk_data = {0, 0};
+  struct chunk_data chunk_data = {0, 0};
   curl_global_init(CURL_GLOBAL_ALL);
   handle = curl_easy_init();
   if(!handle) {

--- a/tests/unit/unit1305.c
+++ b/tests/unit/unit1305.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -73,11 +73,11 @@ static void unit_stop(void)
   curl_global_cleanup();
 }
 
-static Curl_addrinfo *fake_ai(void)
+static struct Curl_addrinfo *fake_ai(void)
 {
-  static Curl_addrinfo *ai;
+  static struct Curl_addrinfo *ai;
 
-  ai = calloc(1, sizeof(Curl_addrinfo));
+  ai = calloc(1, sizeof(struct Curl_addrinfo));
   if(!ai)
     return NULL;
 

--- a/tests/unit/unit1608.c
+++ b/tests/unit/unit1608.c
@@ -24,7 +24,7 @@
 #include "hostip.h"
 
 CURLcode Curl_shuffle_addr(struct Curl_easy *data,
-                           Curl_addrinfo **addr);
+                           struct Curl_addrinfo **addr);
 
 #define NUM_ADDRS 8
 static struct Curl_addrinfo addrs[NUM_ADDRS];


### PR DESCRIPTION
- Stick to a single unified way to use structs
- Make checksrc complain on 'typedef struct {'
- Allow them in tests, public headers and examples