### PR TITLE
quiche: enable qlog output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3814,6 +3814,7 @@ if test X"$want_quiche" != Xno; then
           QUICHE_ENABLED=1
           AC_DEFINE(USE_QUICHE, 1, [if quiche is in use])
           AC_SUBST(USE_QUICHE, [1])
+          AC_CHECK_FUNCS([quiche_conn_set_qlog_fd])
           CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_QUICHE"
           export CURL_LIBRARY_PATH
           AC_MSG_NOTICE([Added $DIR_QUICHE to CURL_LIBRARY_PATH]),

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -58,5 +58,5 @@ size_t Curl_dyn_len(const struct dynbuf *s);
 #define DYN_RTSP_REQ_HEADER (64*1024)
 #define DYN_TRAILERS        (64*1024)
 #define DYN_PROXY_CONNECT_HEADERS 16384
-
+#define DYN_QLOG_NAME       1024
 #endif

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -95,7 +95,7 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
   cd $HOME/quiche
-  QUICHE_BSSL_PATH=$HOME/boringssl cargo build -v --release --features pkg-config-meta
+  QUICHE_BSSL_PATH=$HOME/boringssl cargo build -v --release --features pkg-config-meta,qlog
 fi
 
 # Install common libraries.


### PR DESCRIPTION
quiche has the potential to log qlog files. To enable this, you must
build quiche with the qlog feature enabled `cargo build --features
qlog`. curl then passes a file descriptor to quiche, which takes
ownership of the file. The FD transfer only works on UNIX.

The convention is to enable logging when the QLOGDIR environment is
set. This should be a path to a folder where files are written with the
naming template <SCID>.qlog.

Co-authored-by: Lucas Pardue
Replaces #5337