### PR TITLE
[WIP] select: use timediff_t instead of time_t and int for timeout_ms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4062,6 +4062,19 @@ AC_CHECK_TYPE(sa_family_t,
 #endif
 ])
 
+# check for suseconds_t
+AC_CHECK_TYPE([suseconds_t],[
+  AC_DEFINE(HAVE_SUSECONDS_T, 1,
+    [Define to 1 if suseconds_t is an available type.])
+], ,[
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+])
+
 AC_MSG_CHECKING([if time_t is unsigned])
 CURL_RUN_IFELSE(
   [

--- a/lib/select.h
+++ b/lib/select.h
@@ -76,7 +76,7 @@ int Curl_select(curl_socket_t maxfd,
                 fd_set *fds_read,
                 fd_set *fds_write,
                 fd_set *fds_err,
-                time_t timeout_ms);
+                timediff_t timeout_ms);
 
 int Curl_socket_check(curl_socket_t readfd, curl_socket_t readfd2,
                       curl_socket_t writefd,
@@ -86,8 +86,8 @@ int Curl_socket_check(curl_socket_t readfd, curl_socket_t readfd2,
 #define SOCKET_WRITABLE(x,z) \
   Curl_socket_check(CURL_SOCKET_BAD, CURL_SOCKET_BAD, x, z)
 
-int Curl_poll(struct pollfd ufds[], unsigned int nfds, int timeout_ms);
-int Curl_wait_ms(int timeout_ms);
+int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms);
+int Curl_wait_ms(timediff_t timeout_ms);
 
 #ifdef TPF
 int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,


### PR DESCRIPTION
Make all functions in select.[ch] take timeout_ms as timediff_t
which should always be large enough and signed on all platforms
to take all possible timeout values and avoid type conversions.

Related to #5240 and #5286
Replaces #5107 and partially #5262

--

#5262 will be reduced to the code deduplication changes later on. I will also follow up with some tidy-up of all curl functions calling this code to remove obsolete conversions, like I did in the old PR with https://github.com/curl/curl/pull/5262/commits/31b298ced3c2f470d4dd3ce04d487c191514c8cb.

I also plan to introduce overflow checking for the math-based conversion from `timediff_t` to the individual `struct timeval` values. I will need to use some configure magic for that, because the individual struct members have different types on different platforms (eg. long on Windows compared to time_t and suseconds_t on Linux).

@bagder @jay please review if I still cover all the other type conversion overflow checks you introduced.