### PR TITLE
ntlm_sspi: fix bad use of CURLE_NOT_BUILT_IN

### DIFF
--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -105,8 +105,10 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   /* Query the security package for NTLM */
   status = s_pSecFn->QuerySecurityPackageInfo((TCHAR *) TEXT(SP_NAME_NTLM),
                                               &SecurityPackage);
-  if(status != SEC_E_OK)
-    return CURLE_NOT_BUILT_IN;
+  if(status != SEC_E_OK) {
+    failf(data, "SSPI: couldn't get auth info\n");
+    return CURLE_AUTH_ERROR;
+  }
 
   ntlm->token_max = SecurityPackage->cbMaxToken;
 


### PR DESCRIPTION
That return code is reserved for build-time conditional code not being
present while this was a regular run-time error from a Windows API.

Reported-by: wangp on github
Fixes #5349