### PR TITLE
*_sspi: fix bad uses of CURLE_NOT_BUILT_IN

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -134,7 +134,8 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   if(status != SEC_E_OK) {
     free(input_token);
 
-    return CURLE_NOT_BUILT_IN;
+    failf(data, "SSPI: couldn't get auth info\n");
+    return CURLE_AUTH_ERROR;
   }
 
   token_max = SecurityPackage->cbMaxToken;
@@ -431,8 +432,10 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
   /* Query the security package for DigestSSP */
   status = s_pSecFn->QuerySecurityPackageInfo((TCHAR *) TEXT(SP_NAME_DIGEST),
                                               &SecurityPackage);
-  if(status != SEC_E_OK)
-    return CURLE_NOT_BUILT_IN;
+  if(status != SEC_E_OK) {
+    failf(data, "SSPI: couldn't get auth info\n");
+    return CURLE_AUTH_ERROR;
+  }
 
   token_max = SecurityPackage->cbMaxToken;
 

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -125,7 +125,8 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
                                                 TEXT(SP_NAME_KERBEROS),
                                                 &SecurityPackage);
     if(status != SEC_E_OK) {
-      return CURLE_NOT_BUILT_IN;
+      failf(data, "SSPI: couldn't get auth info\n");
+      return CURLE_AUTH_ERROR;
     }
 
     krb5->token_max = SecurityPackage->cbMaxToken;

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -129,8 +129,10 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     nego->status = s_pSecFn->QuerySecurityPackageInfo((TCHAR *)
                                                       TEXT(SP_NAME_NEGOTIATE),
                                                       &SecurityPackage);
-    if(nego->status != SEC_E_OK)
-      return CURLE_NOT_BUILT_IN;
+    if(nego->status != SEC_E_OK) {
+      failf(data, "SSPI: couldn't get auth info\n");
+      return CURLE_AUTH_ERROR;
+    }
 
     nego->token_max = SecurityPackage->cbMaxToken;
 


### PR DESCRIPTION
Return CURLE_AUTH_ERROR instead of CURLE_NOT_BUILT_IN for other
instances of QuerySecurityPackageInfo failing, as in
commit 2a81439553286f12cd04a4bdcdf66d8e026d8201.