### PR TITLE
Fix test 1238 causing shortly following tests 1242 and 1243 to fail

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,9 +69,9 @@ task:
     - SKIP_TESTS=''
     - uname -r
     - case `uname -r` in
-        13.0*) SKIP_TESTS='~1242 ~1243 ~2002 ~2003 !SFTP !SCP';;
-        12.1*) SKIP_TESTS='~1242 ~1243 ~2002 ~2003 !SFTP !SCP';;
-        11.3*) SKIP_TESTS='~1242 ~1243 ~2002 ~2003 !SFTP !SCP';;
+        13.0*) SKIP_TESTS='!SFTP !SCP';;
+        12.1*) SKIP_TESTS='!SFTP !SCP';;
+        11.3*) SKIP_TESTS='!SFTP !SCP';;
       esac
     - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky ${SKIP_TESTS}" test-nonflaky
   install_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -220,12 +220,12 @@ environment:
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: autotools
         TESTING: ON
-        DISABLED_TESTS: "!19 ~1056 !1233 ~1242 ~1243 ~2002 ~2003"
+        DISABLED_TESTS: "!19 ~1056 !1233"
         CONFIG_ARGS: "--enable-debug --enable-werror --enable-alt-svc --disable-threaded-resolver --disable-proxy"
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: autotools
         TESTING: ON
-        DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233 ~1242 ~1243 ~2002 ~2003"
+        DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
         CONFIG_ARGS: "--enable-debug --enable-werror --enable-alt-svc --disable-threaded-resolver"
 
 install:

--- a/tests/data/test1238
+++ b/tests/data/test1238
@@ -24,6 +24,14 @@ writedelay: 2
 <server>
 tftp
 </server>
+# Always kill the TFTP server to not affect following tests, due
+# to this test potentially keeping the TFTP server busy waiting
+# for another 5 seconds after this test has already terminated.
+# On some plattforms and CI not enough time passes between this
+# test and the next tests 1242 and 1243, causing them to fail.
+<killserver>
+tftp
+</killserver>
  <name>
 slow TFTP retrieve cancel due to -Y and -y
  </name>


### PR DESCRIPTION
At the moment tests 1242 and 1243 fail if the TFTP server is still busy with test 1238.

Therefore the TFTP server will now be killed after test 1238. This PR also includes other TFTP fixes.