### PR TITLE
CMake: Add runtests.pl targets, do not build test programs unless necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@
 # The output .so file lacks the soname number which we currently have within the lib/Makefile.am file
 # Add full (4 or 5 libs) SSL support
 # Add INSTALL target (EXTRA_DIST variables in Makefile.am may be moved to Makefile.inc so that CMake/CPack is aware of what's to include).
-# Add CTests(?)
 # Check on all possible platforms
 # Test with as many configurations possible (With or without any option)
 # Create scripts that help keeping the CMake build system up to date (to reduce maintenance). According to Tetetest:
@@ -38,7 +37,7 @@
 # To check:
 # (From Daniel Stenberg) The cmake build selected to run gcc with -fPIC on my box while the plain configure script did not.
 # (From Daniel Stenberg) The gcc command line use neither -g nor any -O options. As a developer, I also treasure our configure scripts's --enable-debug option that sets a long range of "picky" compiler options.
-cmake_minimum_required(VERSION 3.0...3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.2...3.16 FATAL_ERROR)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
@@ -221,10 +220,6 @@ cmake_dependent_option(ENABLE_MANUAL "to provide the built-in manual"
     ON "NROFF_USEFUL;PERL_FOUND"
     OFF)
 
-if(NOT PERL_FOUND)
-  message(STATUS "Perl not found, testing disabled.")
-  set(BUILD_TESTING OFF)
-endif()
 if(ENABLE_MANUAL)
   set(USE_MANUAL ON)
 endif()
@@ -1227,8 +1222,10 @@ if(BUILD_CURL_EXE)
   add_subdirectory(src)
 endif()
 
-include(CTest)
-if(BUILD_TESTING)
+option(BUILD_TESTING "Build tests" "${PERL_FOUND}")
+if(NOT PERL_FOUND)
+  message(STATUS "Perl not found, testing disabled.")
+elseif(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 

--- a/docs/TODO
+++ b/docs/TODO
@@ -1071,14 +1071,6 @@ that doesn't exist on the server, just like --ftp-create-dirs.
  to no impact, neither on the performance nor on the general functionality of
  curl.
 
-19.3 cmake test suite improvements
-
- The cmake build doesn't support 'make show' so it doesn't know which tests
- are in the makefile or not (making appveyor builds do many false warnings
- about it) nor does it support running the test suite if building out-of-tree.
-
- See https://github.com/curl/curl/issues/3109
-
 20. Test suite
 
 20.1 SSL tunnel

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@
 # KIND, either express or implied.
 #
 ###########################################################################
+add_custom_target(testdeps)
 add_subdirectory(data)
 add_subdirectory(libtest)
 add_subdirectory(server)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,3 +24,28 @@ add_subdirectory(data)
 add_subdirectory(libtest)
 add_subdirectory(server)
 add_subdirectory(unit)
+
+function(add_runtests targetname test_flags)
+  # Use a special '${TFLAGS}' placeholder as last argument which will be
+  # replaced by the contents of the environment variable in runtests.pl.
+  # This is a workaround for CMake's limitation where commands executed by
+  # 'make' or 'ninja' cannot portably reference environment variables.
+  string(REPLACE " " ";" test_flags_list "${test_flags}")
+  add_custom_target(${targetname}
+    COMMAND
+      "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/runtests.pl"
+      ${test_flags_list}
+      "\${TFLAGS}"
+    DEPENDS testdeps
+    VERBATIM USES_TERMINAL
+  )
+endfunction()
+
+add_runtests(test           "")
+add_runtests(test-quiet     "-a -s")
+add_runtests(test-am        "-a -am")
+add_runtests(test-full      "-a -p -r")
+# !flaky means that it'll skip all tests using the flaky keyword
+add_runtests(test-nonflaky  "-a -p !flaky")
+add_runtests(test-torture   "-a -t")
+add_runtests(test-event     "-a -e")

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -22,7 +22,8 @@
 set(TARGET_LABEL_PREFIX "Test ")
 
 function(setup_test TEST_NAME)          # ARGN are the files in the test
-  add_executable( ${TEST_NAME} ${ARGN} )
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${ARGN})
+  add_dependencies(testdeps ${TEST_NAME})
   string(TOUPPER ${TEST_NAME} UPPER_TEST_NAME)
 
   include_directories(
@@ -58,7 +59,8 @@ endforeach()
 # Allows for hostname override to make tests machine independent.
 # TODO this cmake build assumes a shared build, detect static linking here!
 if(NOT WIN32)
-  add_library(hostname MODULE sethostname.c sethostname.h)
+  add_library(hostname MODULE EXCLUDE_FROM_ALL sethostname.c sethostname.h)
+  add_dependencies(testdeps hostname)
   # Output to .libs for compatibility with autotools, the test data expects a
   # library at (tests)/libtest/.libs/libhostname.so
   set_target_properties(hostname PROPERTIES

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -56,8 +56,14 @@
 # These should be the only variables that might be needed to get edited:
 
 BEGIN {
-    push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
-    push(@INC, ".");
+    # Define srcdir to the location of the tests source directory. This is
+    # usually set by the Makefile, but for out-of-tree builds with direct
+    # invocation of runtests.pl, it may not be set.
+    if(!defined $ENV{'srcdir'}) {
+        use File::Basename;
+        $ENV{'srcdir'} = dirname(__FILE__);
+    }
+    push(@INC, $ENV{'srcdir'});
     # run time statistics needs Time::HiRes
     eval {
         no warnings "all";
@@ -560,7 +566,11 @@ sub checkcmd {
 #
 my $disttests;
 sub get_disttests {
-    my @dist = `cd data && make show`;
+    my $makeCmd = 'make';
+    if(-f "../CMakeCache.txt") {
+        $makeCmd = 'cmake --build ../.. --target';
+    }
+    my @dist = `cd data && $makeCmd show`;
     $disttests = join("", @dist);
 }
 
@@ -5138,6 +5148,13 @@ disabledtests("$TESTDIR/DISABLED.local");
 #######################################################################
 # Check options to this test program
 #
+
+# Special case for CMake: replace '${TFLAGS}' by the contents of the
+# environment variable (if any).
+if(@ARGV && $ARGV[-1] eq '${TFLAGS}') {
+    pop @ARGV;
+    push(@ARGV, split(' ', $ENV{'TFLAGS'})) if defined($ENV{'TFLAGS'});
+}
 
 my $number=0;
 my $fromnum=-1;

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -26,7 +26,8 @@ if(MSVC)
 endif()
 
 function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
-  add_executable(${TEST_NAME} ${ARGN})
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${ARGN})
+  add_dependencies(testdeps ${TEST_NAME})
   string(TOUPPER ${TEST_NAME} UPPER_TEST_NAME)
 
   include_directories(

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -20,6 +20,9 @@
 #
 ###########################################################################
 
+# TODO build a special libcurlu library for unittests.
+return()
+
 set(UT_SRC
   unit1300.c
   unit1301.c
@@ -63,16 +66,4 @@ foreach(_testfile ${UT_SRC})
   target_link_libraries(${_testname} libcurl ${CURL_LIBS})
   set_target_properties(${_testname}
       PROPERTIES COMPILE_DEFINITIONS "UNITTESTS")
-
-  if(HIDES_CURL_PRIVATE_SYMBOLS)
-    set_target_properties(${_testname}
-      PROPERTIES
-      EXCLUDE_FROM_ALL TRUE
-      EXCLUDE_FROM_DEFAULT_BUILD TRUE
-    )
-  else()
-    add_test(NAME ${_testname}
-             COMMAND ${_testname} "http://www.google.com"
-    )
-  endif()
 endforeach()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -58,7 +58,8 @@ include_directories(
 foreach(_testfile ${UT_SRC})
 
   get_filename_component(_testname ${_testfile} NAME_WE)
-  add_executable(${_testname} ${_testfile} ${UT_COMMON_FILES})
+  add_executable(${_testname} EXCLUDE_FROM_ALL ${_testfile} ${UT_COMMON_FILES})
+  #add_dependencies(testdeps ${_testname})
   target_link_libraries(${_testname} libcurl ${CURL_LIBS})
   set_target_properties(${_testname}
       PROPERTIES COMPILE_DEFINITIONS "UNITTESTS")


### PR DESCRIPTION
Executive overview, see invididual commits for details:

 * Fix runtests.pl to work with CMake out-of-tree builds.
 * Add test, test-nonflaky, etc. targets that run runtests.pl (mirrors autotools functionality).

Minor details:

* Remove ctest support since there are no tests and it causes conflicts.
* Bump CMake minimum version from 3.0 to 3.2. It could be bumped further to 3.5 [with no loss of platform support](https://wiki.wireshark.org/Development/Support_library_version_tracking#CMake) if desired.

The next step is to run these tests for the CMake builds in CI, but that would introduce a conflict with my cmake-http3 branch that also modifies the travis config, so I'll wait for that to get merged first.

<details><summary>ninja test-nonflaky summary</summary>

```
TESTDONE: 1117 tests out of 1120 reported OK: 99%
TESTFAIL: These test cases failed: 1014 1026 1139 
TESTDONE: 1352 tests were considered during 1310 seconds.
TESTINFO: 232 tests were skipped due to these restraints:
TESTINFO: "configured as DISABLED" 19 times (323, 530, 584, 594, 836, 882, 938, 1209, 1211 and 10 more)
TESTINFO: "curl has threaded-resolver support" 1 times (506)
TESTINFO: "curl lacks debug support" 85 times (67, 68, 69, 81, 89, 90, 91, 150, 155 and 76 more)
TESTINFO: "curl lacks mqtt support" 7 times (1190, 1191, 1192, 1193, 1194, 1195, 1196)
TESTINFO: "curl lacks Metalink support" 16 times (2005, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 and 7 more)
TESTINFO: "curl lacks TLS-SRP support" 4 times (320, 321, 322, 324)
TESTINFO: "curl lacks TrackMemory support" 2 times (96, 558)
TESTINFO: "Resolving IPv6 'ip6-localhost' didn't work" 2 times (241, 1083)
TESTINFO: "curl has ipv6 support" 1 times (1454)
TESTINFO: "curl lacks idn support" 14 times (165, 962, 963, 964, 965, 966, 967, 968, 969 and 5 more)
TESTINFO: "curl lacks WinSSL support" 2 times (2043, 2070)
TESTINFO: "disabled by keyword" 9 times (573, 587, 644, 1086, 1113, 1162, 1163, 1208, 2032)
TESTINFO: "openssl engine not supported" 1 times (307)
TESTINFO: "curl lacks GSS-API support" 5 times (1282, 2056, 2057, 2077, 2078)
TESTINFO: "failed starting SMB server" 1 times (1451)
TESTINFO: "curl lacks unittest support" 38 times (1300, 1301, 1302, 1303, 1304, 1305, 1306, 1308, 1309 and 29 more)
TESTINFO: "curl lacks alt-svc support" 4 times (355, 358, 359, 1908)
TESTINFO: "curl lacks PSL support" 1 times (1136)
TESTINFO: "Test requires default test server host and port" 12 times (842, 843, 844, 845, 887, 888, 889, 890, 946 and 3 more)
TESTINFO: "curl lacks NTLM_WB support" 1 times (1310)
TESTINFO: "curl lacks http/2 server support" 3 times (1700, 1701, 1702)
TESTINFO: "curl lacks brotli support" 3 times (314, 315, 316)
TESTINFO: "curl lacks http/2 support" 1 times (1800)
```
</details>

The failing tests seem to be existing CMake issues that can be fixed later:

<details><summary>test 1014...[Compare curl --version with curl-config --features]</summary>

```
test 1014...[Compare curl --version with curl-config --features]
Mismatch in features lists:
curl:        asynchdns https-proxy ipv6 libz ntlm ssl unixsockets
curl-config: asynchdns https-proxy idn ipv6 libz ntlm ssl unix-sockets
 postcheck FAILED
== Contents of files in the log/ dir after test 1014
=== Start of file commands.log
 /usr/bin/valgrind --tool=memcheck --quiet --leak-check=yes --suppressions=/tmp/curl/tests/valgrind.supp --num-callers=16 --log-file=log/valgrind1014 ../src/curl --output log/curl1014.out  --include --trace-ascii log/trace1014 --trace-time --version >log/stdout1014 2>log/stderr1014
=== End of file commands.log
=== Start of file ftpserver.cmd
 Testnum 1014
=== End of file ftpserver.cmd
=== Start of file stdout1014
 curl 7.71.0-DEV (Linux) libcurl/7.71.0-DEV OpenSSL/1.1.1g zlib/1.2.11 libssh2/1.9.0
 Release-Date: [unreleased]
 Protocols: dict file ftp ftps gopher http https imap imaps ldap pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp 
 Features: AsynchDNS HTTPS-proxy IPv6 Largefile libz NTLM SSL UnixSockets
=== End of file stdout1014
```
</details>

<details><summary>test 1026...[curl --manual ]</summary>

```
test 1026...[curl --manual ]
 postcheck FAILED
== Contents of files in the log/ dir after test 1026
=== Start of file commands.log
 /usr/bin/valgrind --tool=memcheck --quiet --leak-check=yes --suppressions=/tmp/curl/tests/valgrind.supp --num-callers=16 --log-file=log/valgrind1026 ../src/curl --output log/curl1026.out  --include --trace-ascii log/trace1026 --trace-time --manual >log/stdout1026 2>log/stderr1026
=== End of file commands.log
=== Start of file ftpserver.cmd
 Testnum 1026
=== End of file ftpserver.cmd
=== Start of file stdout1026
                                   _   _ ____  _
   Project                     ___| | | |  _ \| |
                              / __| | | | |_) | |
                             | (__| |_| |  _ <| |___
                              \___|\___/|_| \_\_____|
=== End of file stdout1026
```
</details>

<details><summary>test 1139...[Verify that all libcurl options have man pages]</summary>

```
test 1139...[Verify that all libcurl options have man pages]

perl -I/tmp/curl/tests  returned 231, when expecting 0
 exit FAILED
== Contents of files in the log/ dir after test 1139
=== Start of file commands.log
 perl -I/tmp/curl/tests /tmp/curl/tests/manpage-scan.pl /tmp/curl/tests/.. /tmp/curl-tmp/tests/.. >log/stdout1139 2>log/stderr1139
=== End of file commands.log
=== Start of file ftpserver.cmd
 Testnum 1139
=== End of file ftpserver.cmd
=== Start of file stderr1139
 -k, --insecure is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlsv1.2 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --keepalive-time is not in curl.1 (but in tool_getparam.c tool_help.c)
 --data-raw is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ssl-no-revoke is not in curl.1 (but in tool_getparam.c tool_help.c)
 --location-trusted is not in curl.1 (but in tool_getparam.c tool_help.c)
 --pass is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy1.0 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --digest is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ntlm-wb is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-capath is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-ssl-ccc is not in curl.1 (but in tool_getparam.c tool_help.c)
 -K, --config is not in curl.1 (but in tool_getparam.c tool_help.c)
 --url is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tls13-ciphers is not in curl.1 (but in tool_getparam.c tool_help.c)
 --resolve is not in curl.1 (but in tool_getparam.c tool_help.c)
 --retry-connrefused is not in curl.1 (but in tool_getparam.c tool_help.c)
 -m, --max-time is not in curl.1 (but in tool_getparam.c tool_help.c)
 --abstract-unix-socket is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ciphers is not in curl.1 (but in tool_getparam.c tool_help.c)
 --styled-output is not in curl.1 (but in tool_getparam.c tool_help.c)
 --service-name is not in curl.1 (but in tool_getparam.c tool_help.c)
 -A, --user-agent is not in curl.1 (but in tool_getparam.c tool_help.c)
 -#, --progress-bar is not in curl.1 (but in tool_getparam.c tool_help.c)
 -B, --use-ascii is not in curl.1 (but in tool_getparam.c tool_help.c)
 -Q, --quote is not in curl.1 (but in tool_getparam.c tool_help.c)
 -h, --help is not in curl.1 (but in tool_getparam.c tool_help.c)
 --mail-auth is not in curl.1 (but in tool_getparam.c tool_help.c)
 -p, --proxytunnel is not in curl.1 (but in tool_getparam.c tool_help.c)
 --compressed-ssh is not in curl.1 (but in tool_getparam.c tool_help.c)
 --parallel-immediate is not in curl.1 (but in tool_getparam.c tool_help.c)
 -D, --dump-header is not in curl.1 (but in tool_getparam.c tool_help.c)
 --http2-prior-knowledge is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks5-gssapi is not in curl.1 (but in tool_getparam.c tool_help.c)
 -x, --proxy is not in curl.1 (but in tool_getparam.c tool_help.c)
 --retry-max-time is not in curl.1 (but in tool_getparam.c tool_help.c)
 --dns-interface is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ntlm is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-skip-pasv-ip is not in curl.1 (but in tool_getparam.c tool_help.c)
 --negotiate is not in curl.1 (but in tool_getparam.c tool_help.c)
 --alt-svc is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks5 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-tlsv1 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --interface is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ssl-allow-beast is not in curl.1 (but in tool_getparam.c tool_help.c)
 --no-progress-meter is not in curl.1 (but in tool_getparam.c tool_help.c)
 -F, --form is not in curl.1 (but in tool_getparam.c tool_help.c)
 --post303 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -2, --sslv2 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --max-filesize is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-crlfile is not in curl.1 (but in tool_getparam.c tool_help.c)
 -q, --disable is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ssl is not in curl.1 (but in tool_getparam.c tool_help.c)
 --fail-early is not in curl.1 (but in tool_getparam.c tool_help.c)
 --stderr is not in curl.1 (but in tool_getparam.c tool_help.c)
 -P, --ftp-port is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-header is not in curl.1 (but in tool_getparam.c tool_help.c)
 --xattr is not in curl.1 (but in tool_getparam.c tool_help.c)
 -i, --include is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-cert is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-tlsauthtype is not in curl.1 (but in tool_getparam.c tool_help.c)
 --capath is not in curl.1 (but in tool_getparam.c tool_help.c)
 --no-npn is not in curl.1 (but in tool_getparam.c tool_help.c)
 -N, --no-buffer is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-digest is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlsv1.0 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --connect-timeout is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tls-max is not in curl.1 (but in tool_getparam.c tool_help.c)
 --expect100-timeout is not in curl.1 (but in tool_getparam.c tool_help.c)
 --engine is not in curl.1 (but in tool_getparam.c tool_help.c)
 --etag-compare is not in curl.1 (but in tool_getparam.c tool_help.c)
 --max-redirs is not in curl.1 (but in tool_getparam.c tool_help.c)
 --netrc-optional is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-insecure is not in curl.1 (but in tool_getparam.c tool_help.c)
 -U, --proxy-user is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-service-name is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlsv1.3 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -b, --cookie is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ssl-revoke-best-effort is not in curl.1 (but in tool_getparam.c tool_help.c)
 --key is not in curl.1 (but in tool_getparam.c tool_help.c)
 -y, --speed-time is not in curl.1 (but in tool_getparam.c tool_help.c)
 -3, --sslv3 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -E, --cert is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-ssl-allow-beast is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proto-default is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-account is not in curl.1 (but in tool_getparam.c tool_help.c)
 --disable-eprt is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-ntlm is not in curl.1 (but in tool_getparam.c tool_help.c)
 --post302 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --dns-ipv4-addr is not in curl.1 (but in tool_getparam.c tool_help.c)
 -g, --globoff is not in curl.1 (but in tool_getparam.c tool_help.c)
 --remote-name-all is not in curl.1 (but in tool_getparam.c tool_help.c)
 -j, --junk-session-cookies is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-ssl-control is not in curl.1 (but in tool_getparam.c tool_help.c)
 -T, --upload-file is not in curl.1 (but in tool_getparam.c tool_help.c)
 --oauth2-bearer is not in curl.1 (but in tool_getparam.c tool_help.c)
 --retry is not in curl.1 (but in tool_getparam.c tool_help.c)
 --trace-ascii is not in curl.1 (but in tool_getparam.c tool_help.c)
 --basic is not in curl.1 (but in tool_getparam.c tool_help.c)
 --random-file is not in curl.1 (but in tool_getparam.c tool_help.c)
 -6, --ipv6 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --unix-socket is not in curl.1 (but in tool_getparam.c tool_help.c)
 --crlf is not in curl.1 (but in tool_getparam.c tool_help.c)
 --egd-file is not in curl.1 (but in tool_getparam.c tool_help.c)
 --etag-save is not in curl.1 (but in tool_getparam.c tool_help.c)
 --data-urlencode is not in curl.1 (but in tool_getparam.c tool_help.c)
 -X, --request is not in curl.1 (but in tool_getparam.c tool_help.c)
 -z, --time-cond is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tftp-blksize is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks4a is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tftp-no-options is not in curl.1 (but in tool_getparam.c tool_help.c)
 --create-dirs is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-pret is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks5-hostname is not in curl.1 (but in tool_getparam.c tool_help.c)
 -f, --fail is not in curl.1 (but in tool_getparam.c tool_help.c)
 --no-sessionid is not in curl.1 (but in tool_getparam.c tool_help.c)
 --mail-rcpt-allowfails is not in curl.1 (but in tool_getparam.c tool_help.c)
 -l, --list-only is not in curl.1 (but in tool_getparam.c tool_help.c)
 -L, --location is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks5-gssapi-service is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-alternative-to-user is not in curl.1 (but in tool_getparam.c tool_help.c)
 --key-type is not in curl.1 (but in tool_getparam.c tool_help.c)
 --mail-from is not in curl.1 (but in tool_getparam.c tool_help.c)
 --post301 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -H, --header is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-negotiate is not in curl.1 (but in tool_getparam.c tool_help.c)
 -M, --manual is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-pinnedpubkey is not in curl.1 (but in tool_getparam.c tool_help.c)
 -1, --tlsv1 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -J, --remote-header-name is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlspassword is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proto is not in curl.1 (but in tool_getparam.c tool_help.c)
 --suppress-connect-headers is not in curl.1 (but in tool_getparam.c tool_help.c)
 --doh-url is not in curl.1 (but in tool_getparam.c tool_help.c)
 --trace-time is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-ciphers is not in curl.1 (but in tool_getparam.c tool_help.c)
 --happy-eyeballs-timeout-ms is not in curl.1 (but in tool_getparam.c tool_help.c)
 --sasl-authzid is not in curl.1 (but in tool_getparam.c tool_help.c)
 --dns-ipv6-addr is not in curl.1 (but in tool_getparam.c tool_help.c)
 -4, --ipv4 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --local-port is not in curl.1 (but in tool_getparam.c tool_help.c)
 -c, --cookie-jar is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-ssl-ccc-mode is not in curl.1 (but in tool_getparam.c tool_help.c)
 --dns-servers is not in curl.1 (but in tool_getparam.c tool_help.c)
 -R, --remote-time is not in curl.1 (but in tool_getparam.c tool_help.c)
 --data-binary is not in curl.1 (but in tool_getparam.c tool_help.c)
 --cert-status is not in curl.1 (but in tool_getparam.c tool_help.c)
 -O, --remote-name is not in curl.1 (but in tool_getparam.c tool_help.c)
 --no-alpn is not in curl.1 (but in tool_getparam.c tool_help.c)
 -a, --append is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks4 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-tls13-ciphers is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-pass is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks5-gssapi-nec is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tcp-nodelay is not in curl.1 (but in tool_getparam.c tool_help.c)
 -Y, --speed-limit is not in curl.1 (but in tool_getparam.c tool_help.c)
 --limit-rate is not in curl.1 (but in tool_getparam.c tool_help.c)
 -:, --next is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-cert-type is not in curl.1 (but in tool_getparam.c tool_help.c)
 -G, --get is not in curl.1 (but in tool_getparam.c tool_help.c)
 --false-start is not in curl.1 (but in tool_getparam.c tool_help.c)
 --anyauth is not in curl.1 (but in tool_getparam.c tool_help.c)
 -Z, --parallel is not in curl.1 (but in tool_getparam.c tool_help.c)
 -v, --verbose is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-key-type is not in curl.1 (but in tool_getparam.c tool_help.c)
 --trace is not in curl.1 (but in tool_getparam.c tool_help.c)
 --cacert is not in curl.1 (but in tool_getparam.c tool_help.c)
 --form-string is not in curl.1 (but in tool_getparam.c tool_help.c)
 -w, --write-out is not in curl.1 (but in tool_getparam.c tool_help.c)
 -o, --output is not in curl.1 (but in tool_getparam.c tool_help.c)
 --http1.1 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --connect-to is not in curl.1 (but in tool_getparam.c tool_help.c)
 -n, --netrc is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-anyauth is not in curl.1 (but in tool_getparam.c tool_help.c)
 --metalink is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ssl-reqd is not in curl.1 (but in tool_getparam.c tool_help.c)
 -S, --show-error is not in curl.1 (but in tool_getparam.c tool_help.c)
 -C, --continue-at is not in curl.1 (but in tool_getparam.c tool_help.c)
 --disable-epsv is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlsauthtype is not in curl.1 (but in tool_getparam.c tool_help.c)
 --http3 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -0, --http1.0 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-key is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-cacert is not in curl.1 (but in tool_getparam.c tool_help.c)
 -V, --version is not in curl.1 (but in tool_getparam.c tool_help.c)
 --libcurl is not in curl.1 (but in tool_getparam.c tool_help.c)
 --hostpubmd5 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --delegation is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-tlspassword is not in curl.1 (but in tool_getparam.c tool_help.c)
 --noproxy is not in curl.1 (but in tool_getparam.c tool_help.c)
 --cert-type is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-tlsuser is not in curl.1 (but in tool_getparam.c tool_help.c)
 --request-target is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-create-dirs is not in curl.1 (but in tool_getparam.c tool_help.c)
 --sasl-ir is not in curl.1 (but in tool_getparam.c tool_help.c)
 --http2 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -t, --telnet-option is not in curl.1 (but in tool_getparam.c tool_help.c)
 --http0.9 is not in curl.1 (but in tool_getparam.c tool_help.c)
 -u, --user is not in curl.1 (but in tool_getparam.c tool_help.c)
 --netrc-file is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-pasv is not in curl.1 (but in tool_getparam.c tool_help.c)
 --socks5-basic is not in curl.1 (but in tool_getparam.c tool_help.c)
 --login-options is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proto-redir is not in curl.1 (but in tool_getparam.c tool_help.c)
 --parallel-max is not in curl.1 (but in tool_getparam.c tool_help.c)
 --no-keepalive is not in curl.1 (but in tool_getparam.c tool_help.c)
 -e, --referer is not in curl.1 (but in tool_getparam.c tool_help.c)
 -r, --range is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlsuser is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tr-encoding is not in curl.1 (but in tool_getparam.c tool_help.c)
 --proxy-basic is not in curl.1 (but in tool_getparam.c tool_help.c)
 --path-as-is is not in curl.1 (but in tool_getparam.c tool_help.c)
 --krb is not in curl.1 (but in tool_getparam.c tool_help.c)
 --mail-rcpt is not in curl.1 (but in tool_getparam.c tool_help.c)
 --pubkey is not in curl.1 (but in tool_getparam.c tool_help.c)
 --raw is not in curl.1 (but in tool_getparam.c tool_help.c)
 --retry-delay is not in curl.1 (but in tool_getparam.c tool_help.c)
 -s, --silent is not in curl.1 (but in tool_getparam.c tool_help.c)
 --crlfile is not in curl.1 (but in tool_getparam.c tool_help.c)
 --preproxy is not in curl.1 (but in tool_getparam.c tool_help.c)
 --pinnedpubkey is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tcp-fastopen is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ftp-method is not in curl.1 (but in tool_getparam.c tool_help.c)
 --tlsv1.1 is not in curl.1 (but in tool_getparam.c tool_help.c)
 --haproxy-protocol is not in curl.1 (but in tool_getparam.c tool_help.c)
 --compressed is not in curl.1 (but in tool_getparam.c tool_help.c)
 --disallow-username-in-url is not in curl.1 (but in tool_getparam.c tool_help.c)
 --data-ascii is not in curl.1 (but in tool_getparam.c tool_help.c)
 -I, --head is not in curl.1 (but in tool_getparam.c tool_help.c)
 --ignore-content-length is not in curl.1 (but in tool_getparam.c tool_help.c)
 -d, --data is not in curl.1 (but in tool_getparam.c tool_help.c)
=== End of file stderr1139
```
</details>