### PR TITLE
Add IDN for Apple and iOS via System

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -756,6 +756,14 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
   hints.ai_socktype = (conn->transport == TRNSPRT_TCP)?
     SOCK_STREAM : SOCK_DGRAM;
 
+#ifdef USE_LIBIDN2
+  /* done earlier */
+#elif defined(__APPLE__)
+  if(!Curl_is_ASCII_name(hostname)) {
+    hints.ai_flags |= AI_CANONNAME;
+  }
+#endif
+
   reslv->start = Curl_now();
   /* fire up a new resolver thread! */
   if(init_resolve_thread(conn, hostname, port, &hints)) {

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -137,6 +137,16 @@ Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = PF_INET;
   hints.ai_socktype = SOCK_STREAM;
+
+#ifdef USE_LIBIDN2
+  /* done earlier */
+#elif defined(__APPLE__)
+  /* let MacOS or iOS do the IDN translation */
+  if(!Curl_is_ASCII_name(hostname)) {
+    hints.ai_flags |= AI_CANONNAME;
+  }
+#endif
+
   if(port) {
     msnprintf(sbuf, sizeof(sbuf), "%d", port);
     sbufptr = sbuf;

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -174,6 +174,15 @@ Curl_addrinfo *Curl_getaddrinfo(struct connectdata *conn,
   hints.ai_socktype = (conn->transport == TRNSPRT_TCP) ?
     SOCK_STREAM : SOCK_DGRAM;
 
+#ifdef USE_LIBIDN2
+  /* done earlier */
+#elif defined(__APPLE__)
+  /* let MacOS or iOS do the IDN translation */
+  if(!Curl_is_ASCII_name(hostname)) {
+    hints.ai_flags |= AI_CANONNAME;
+  }
+#endif
+
 #ifndef USE_RESOLVE_ON_IPS
   /*
    * The AI_NUMERICHOST must not be set to get synthesized IPv6 address from

--- a/lib/url.c
+++ b/lib/url.c
@@ -1526,6 +1526,8 @@ CURLcode Curl_idnconvert_hostname(struct connectdata *conn,
             Curl_winapi_strerror(GetLastError(), buffer, sizeof(buffer)));
       return CURLE_URL_MALFORMAT;
     }
+#elif defined(__APPLE__)
+  /* let MacOS or iOS do the IDN translation */
 #else
     infof(data, "IDN support not present, can't parse Unicode domains\n");
 #endif


### PR DESCRIPTION
This is a proposal for a better way to implement #5330 with using threaded resolver.
We ask MacOS and iOS to provide us the canonical name for IDN domains by setting AI_CANONNAME and then using the canon name as new host name for the HTTP request.