### PR TITLE
OpenSSL: have CURLOPT_CRLFILE imply CURLSSLOPT_NO_PARTIALCHAIN

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -33,10 +33,13 @@ concatenation of CRL (in PEM format) to use in the certificate validation that
 occurs during the SSL exchange.
 
 When curl is built to use NSS or GnuTLS, there is no way to influence the use
-of CRL passed to help in the verification process. When libcurl is built with
-OpenSSL support, X509_V_FLAG_CRL_CHECK and X509_V_FLAG_CRL_CHECK_ALL are both
-set, requiring CRL check against all the elements of the certificate chain if
-a CRL file is passed.
+of CRL passed to help in the verification process.
+
+When libcurl is built with OpenSSL support, X509_V_FLAG_CRL_CHECK and
+X509_V_FLAG_CRL_CHECK_ALL are both set, requiring CRL check against all the
+elements of the certificate chain if a CRL file is passed. Also note that
+\fICURLOPT_CRLFILE(3)\fP will imply \fBCURLSSLOPT_NO_PARTIALCHAIN\fP (see
+\fICURLOPT_SSL_OPTIONS(3)\fP) since curl 7.71.0 due to an OpenSSL bug.
 
 This option makes sense only when used in combination with the
 \fICURLOPT_SSL_VERIFYPEER(3)\fP option.

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2973,11 +2973,15 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
                          X509_V_FLAG_TRUSTED_FIRST);
 #endif
 #ifdef X509_V_FLAG_PARTIAL_CHAIN
-    if(!SSL_SET_OPTION(no_partialchain)) {
+    if(!SSL_SET_OPTION(no_partialchain) && !ssl_crlfile) {
       /* Have intermediate certificates in the trust store be treated as
          trust-anchors, in the same way as self-signed root CA certificates
          are. This allows users to verify servers using the intermediate cert
-         only, instead of needing the whole chain. */
+         only, instead of needing the whole chain.
+
+         Due to OpenSSL bug https://github.com/openssl/openssl/issues/5081 we
+         cannot do partial chains with CRL check.
+      */
       X509_STORE_set_flags(SSL_CTX_get_cert_store(backend->ctx),
                            X509_V_FLAG_PARTIAL_CHAIN);
     }


### PR DESCRIPTION
... to avoid an OpenSSL bug that otherwise makes the CRL check to fail.

Reported-by: Michael Kaufmann
Fixes #5374