### PR TITLE
url: reject too long input when parsing credentials

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2586,6 +2586,12 @@ CURLcode Curl_parse_login_details(const char *login, const size_t len,
   size_t plen;
   size_t olen;
 
+  /* the input length check is because this is called directcly from setopt
+     and isn't going through the regular string length check */
+  size_t llen = strlen(login);
+  if(llen > CURL_MAX_INPUT_LENGTH)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+
   /* Attempt to find the password separator */
   if(passwdp) {
     psep = strchr(login, ':');


### PR DESCRIPTION
Since input passed to libcurl with CURLOPT_USERPWD and
CURLOPT_PROXYUSERPWD circumvents the regular string length check we have
in Curl_setstropt(), the input length limit is enforced in
Curl_parse_login_details too, separately.