### PR TITLE
Fix theoretical integer overflow in Curl_auth_create_plain_message

### DIFF
--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -81,7 +81,8 @@ CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
   plen = strlen(passwd);
 
   /* Compute binary message length. Check for overflows. */
-  if(((zlen + clen) > SIZE_T_MAX/4) || (plen > (SIZE_T_MAX/2 - 2)))
+  if((zlen > SIZE_T_MAX/4) || (clen > SIZE_T_MAX/4) ||
+     (plen > (SIZE_T_MAX/2 - 2)))
     return CURLE_OUT_OF_MEMORY;
   plainlen = zlen + clen + plen + 2;
 


### PR DESCRIPTION
This PR fixes an incorrect integer overflow check in Curl_auth_create_plain_message.

The security impact of the potential integer overflow has been discussed with @bagder on hackerone. We agreed this is more of a theoretical vulnerability, as the integer overflow would only be triggerable on systems using 32-bits size_t and have over 4GB of available memory space.

We still thought this was worth fixing.