### PR TITLE
curl.1: Quote globbed URLs

### DIFF
--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -53,16 +53,16 @@ braces and quoting the URL as in:
 
 or you can get sequences of alphanumeric series by using [] as in:
 
-  ftp://ftp.example.com/file[1-100].txt
+  "ftp://ftp.example.com/file[1-100].txt"
 
-  ftp://ftp.example.com/file[001-100].txt    (with leading zeros)
+  "ftp://ftp.example.com/file[001-100].txt"    (with leading zeros)
 
-  ftp://ftp.example.com/file[a-z].txt
+  "ftp://ftp.example.com/file[a-z].txt"
 
 Nested sequences are not supported, but you can use several ones next to each
 other:
 
-  http://example.com/archive[1996-1999]/vol[1-4]/part{a,b,c}.html
+  "http://example.com/archive[1996-1999]/vol[1-4]/part{a,b,c}.html"
 
 You can specify any amount of URLs on the command line. They will be fetched
 in a sequential manner in the specified order. You can specify command line
@@ -71,9 +71,9 @@ options and URLs mixed and in any order on the command line.
 You can specify a step counter for the ranges to get every Nth number or
 letter:
 
-  http://example.com/file[1-100:10].txt
+  "http://example.com/file[1-100:10].txt"
 
-  http://example.com/file[a-z:2].txt
+  "http://example.com/file[a-z:2].txt"
 
 When using [] or {} sequences when invoked from a command line prompt, you
 probably have to put the full URL within double quotes to avoid the shell from
@@ -83,7 +83,7 @@ for example '&', '?' and '*'.
 Provide the IPv6 zone index in the URL with an escaped percentage sign and the
 interface name. Like in
 
-  http://[fe80::3%25eth0]/
+  "http://[fe80::3%25eth0]/"
 
 If you specify URL without protocol:// prefix, curl will attempt to guess what
 protocol you might want. It will then default to HTTP but try other protocols


### PR DESCRIPTION
- Quote the globbing example URLs that contain characters [] {} since
  otherwise they may be interpreted as shell metacharacters.

Bug: https://github.com/curl/curl/issues/5388
Reported-by: John Simpson

Closes #xxxx