### PR TITLE
url: make the updated credentials URL-encoded in the URL

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2788,12 +2788,14 @@ static CURLcode override_login(struct Curl_easy *data,
 
   /* for updated strings, we update them in the URL */
   if(user_changed) {
-    uc = curl_url_set(data->state.uh, CURLUPART_USER, *userp, 0);
+    uc = curl_url_set(data->state.uh, CURLUPART_USER, *userp,
+                      CURLU_URLENCODE);
     if(uc)
       return Curl_uc_to_curlcode(uc);
   }
   if(passwd_changed) {
-    uc = curl_url_set(data->state.uh, CURLUPART_PASSWORD, *passwdp, 0);
+    uc = curl_url_set(data->state.uh, CURLUPART_PASSWORD, *passwdp,
+                      CURLU_URLENCODE);
     if(uc)
       return Curl_uc_to_curlcode(uc);
   }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -136,6 +136,7 @@ test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
 test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
 test1152 test1153 test1154 test1155 test1156 test1157 test1158 test1159 \
 test1160 test1161 test1162 test1163 test1164 test1165 test1166 test1167 \
+test1168 \
 \
 test1170 test1171 test1172 test1173 test1174 test1175 test1176 test1177 \
 \

--- a/tests/data/test1168
+++ b/tests/data/test1168
@@ -1,0 +1,78 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+followlocation
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 301 This is a weirdo text message swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Location: /data/11680002.txt
+Connection: close
+
+This server reply is for testing a simple Location: following
+
+</data>
+<data2>
+HTTP/1.1 200 Followed here fine swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 52
+
+If this is received, the location following worked
+
+</data2>
+<datacheck>
+HTTP/1.1 301 This is a weirdo text message swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Location: /data/11680002.txt
+Connection: close
+
+HTTP/1.1 200 Followed here fine swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 52
+
+If this is received, the location following worked
+
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP redirect with credentials using # in user and password
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/want/1168 -L -u "catmai#d:#DZaRJYrixKE*gFY"
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /want/1168 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic Y2F0bWFpI2Q6I0RaYVJKWXJpeEtFKmdGWQ==
+Accept: */*
+
+GET /data/11680002.txt HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic Y2F0bWFpI2Q6I0RaYVJKWXJpeEtFKmdGWQ==
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Found-by: Gregory Jefferis
Reported-by: Jeroen Ooms
Added test 1168 to verify. Bug spotted when doing a redirect.
Bug: https://github.com/jeroen/curl/issues/224