### PR TITLE
dynbuf: return NULL when there's no buffer length

### DIFF
--- a/docs/DYNBUF.md
+++ b/docs/DYNBUF.md
@@ -60,17 +60,17 @@ larger than the buffer length.
 
     char *Curl_dyn_ptr(const struct dynbuf *s);
 
-Returns a `char *` to the buffer. Since the buffer may be reallocated, this
-pointer should not be trusted or used anymore after the next buffer
-manipulation call.
+Returns a `char *` to the buffer if it has a length, otherwise a NULL. Since
+the buffer may be reallocated, this pointer should not be trusted or used
+anymore after the next buffer manipulation call.
 
 ## uptr
 
     unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
 
-Returns an `unsigned char *` to the buffer. Since the buffer may be
-reallocated, this pointer should not be trusted or used anymore after the next
-buffer manipulation call.
+Returns an `unsigned char *` to the buffer if it has a length, otherwise a
+NULL. Since the buffer may be reallocated, this pointer should not be trusted
+or used anymore after the next buffer manipulation call.
 
 ## len
 

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -201,7 +201,7 @@ char *Curl_dyn_ptr(const struct dynbuf *s)
   DEBUGASSERT(s);
   DEBUGASSERT(s->init == DYNINIT);
   DEBUGASSERT(!s->leng || s->bufr);
-  return s->leng ? s->bufr : (char *)"";
+  return s->bufr;
 }
 
 /*
@@ -212,7 +212,7 @@ unsigned char *Curl_dyn_uptr(const struct dynbuf *s)
   DEBUGASSERT(s);
   DEBUGASSERT(s->init == DYNINIT);
   DEBUGASSERT(!s->leng || s->bufr);
-  return s->leng ? (unsigned char *)s->bufr : (unsigned char *)"";
+  return (unsigned char *)s->bufr;
 }
 
 /*


### PR DESCRIPTION
... as returning a "" is not a good idea as the string is supposed to be
allocated and returning a const string will cause issues.

Reported-by: Brian Carpenter
Follow-up to ed35d6590e72c