### PR TITLE
hostip: make Curl_printable_address not return anything

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -960,11 +960,12 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
         char ipaddress[MAX_IPADR_LEN];
         char buffer[STRERROR_LEN];
-        Curl_printable_address(conn->tempaddr[i], ipaddress, MAX_IPADR_LEN);
-#endif
+        Curl_printable_address(conn->tempaddr[i], ipaddress,
+                               sizeof(ipaddress));
         infof(data, "connect to %s port %ld failed: %s\n",
               ipaddress, conn->port,
               Curl_strerror(error, buffer, sizeof(buffer)));
+#endif
 
         conn->timeoutms_per_addr = conn->tempaddr[i]->ai_next == NULL ?
           allow : allow / 2;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -131,14 +131,14 @@ int Curl_num_addresses(const struct Curl_addrinfo *addr)
 }
 
 /*
- * Curl_printable_address() returns a printable version of the 1st address
+ * Curl_printable_address() stores a printable version of the 1st address
  * given in the 'ai' argument. The result will be stored in the buf that is
  * bufsize bytes big.
  *
- * If the conversion fails, it returns NULL.
+ * If the conversion fails, the target buffer is empty.
  */
-const char *Curl_printable_address(const struct Curl_addrinfo *ai, char *buf,
-                                   size_t bufsize)
+void Curl_printable_address(const struct Curl_addrinfo *ai, char *buf,
+                            size_t bufsize)
 {
   const struct sockaddr_in *sa4;
   const struct in_addr *ipaddr4;
@@ -146,24 +146,27 @@ const char *Curl_printable_address(const struct Curl_addrinfo *ai, char *buf,
   const struct sockaddr_in6 *sa6;
   const struct in6_addr *ipaddr6;
 #endif
+  DEBUGASSERT(bufsize);
+  buf[0] = 0;
 
   switch(ai->ai_family) {
     case AF_INET:
       sa4 = (const void *)ai->ai_addr;
       ipaddr4 = &sa4->sin_addr;
-      return Curl_inet_ntop(ai->ai_family, (const void *)ipaddr4, buf,
-                            bufsize);
+      Curl_inet_ntop(ai->ai_family, (const void *)ipaddr4, buf,
+                     bufsize);
+      return;
 #ifdef ENABLE_IPV6
     case AF_INET6:
       sa6 = (const void *)ai->ai_addr;
       ipaddr6 = &sa6->sin6_addr;
-      return Curl_inet_ntop(ai->ai_family, (const void *)ipaddr6, buf,
-                            bufsize);
+      Curl_inet_ntop(ai->ai_family, (const void *)ipaddr6, buf,
+                     bufsize);
+      return;
 #endif
-    default:
+  default:
       break;
   }
-  return NULL;
 }
 
 /*

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -140,32 +140,26 @@ int Curl_num_addresses(const struct Curl_addrinfo *addr)
 void Curl_printable_address(const struct Curl_addrinfo *ai, char *buf,
                             size_t bufsize)
 {
-  const struct sockaddr_in *sa4;
-  const struct in_addr *ipaddr4;
-#ifdef ENABLE_IPV6
-  const struct sockaddr_in6 *sa6;
-  const struct in6_addr *ipaddr6;
-#endif
   DEBUGASSERT(bufsize);
   buf[0] = 0;
 
   switch(ai->ai_family) {
-    case AF_INET:
-      sa4 = (const void *)ai->ai_addr;
-      ipaddr4 = &sa4->sin_addr;
-      Curl_inet_ntop(ai->ai_family, (const void *)ipaddr4, buf,
-                     bufsize);
-      return;
+  case AF_INET: {
+    const struct sockaddr_in *sa4 = (const void *)ai->ai_addr;
+    const struct in_addr *ipaddr4 = &sa4->sin_addr;
+    (void)Curl_inet_ntop(ai->ai_family, (const void *)ipaddr4, buf, bufsize);
+    break;
+  }
 #ifdef ENABLE_IPV6
-    case AF_INET6:
-      sa6 = (const void *)ai->ai_addr;
-      ipaddr6 = &sa6->sin6_addr;
-      Curl_inet_ntop(ai->ai_family, (const void *)ipaddr6, buf,
-                     bufsize);
-      return;
+  case AF_INET6: {
+    const struct sockaddr_in6 *sa6 = (const void *)ai->ai_addr;
+    const struct in6_addr *ipaddr6 = &sa6->sin6_addr;
+    (void)Curl_inet_ntop(ai->ai_family, (const void *)ipaddr6, buf, bufsize);
+    break;
+  }
 #endif
   default:
-      break;
+    break;
   }
 }
 

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -165,8 +165,8 @@ CURLcode Curl_addrinfo_callback(struct connectdata *conn,
  * given in the 'ip' argument. The result will be stored in the buf that is
  * bufsize bytes big.
  */
-const char *Curl_printable_address(const struct Curl_addrinfo *ip,
-                                   char *buf, size_t bufsize);
+void Curl_printable_address(const struct Curl_addrinfo *ip,
+                            char *buf, size_t bufsize);
 
 /*
  * Curl_fetch_addr() fetches a 'Curl_dns_entry' already in the DNS cache.

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -111,13 +111,8 @@ static void dump_addrinfo(struct connectdata *conn,
     char buf[INET6_ADDRSTRLEN];
     printf("    fam %2d, CNAME %s, ",
            ai->ai_family, ai->ai_canonname ? ai->ai_canonname : "<none>");
-    if(Curl_printable_address(ai, buf, sizeof(buf)))
-      printf("%s\n", buf);
-    else {
-      char buffer[STRERROR_LEN];
-      printf("failed; %s\n",
-             Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
-    }
+    Curl_printable_address(ai, buf, sizeof(buf));
+    printf("%s\n", buf);
   }
 }
 #else

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -774,6 +774,7 @@ CURLcode Curl_SOCKS5(const char *proxy_user,
   CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     struct Curl_addrinfo *hp = NULL;
+    size_t destlen;
     if(dns)
       hp = dns->addr;
     if(!hp) {
@@ -782,13 +783,9 @@ CURLcode Curl_SOCKS5(const char *proxy_user,
       return CURLE_COULDNT_RESOLVE_HOST;
     }
 
-    if(Curl_printable_address(hp, dest, sizeof(dest))) {
-      size_t destlen = strlen(dest);
-      msnprintf(dest + destlen, sizeof(dest) - destlen, ":%d", remote_port);
-    }
-    else {
-      strcpy(dest, "unknown");
-    }
+    Curl_printable_address(hp, dest, sizeof(dest));
+    destlen = strlen(dest);
+    msnprintf(dest + destlen, sizeof(dest) - destlen, ":%d", remote_port);
 
     len = 0;
     socksreq[len++] = 5; /* version (SOCKS5) */


### PR DESCRIPTION
It was not used much anyway and instead we let it store a blank buffer
in case of failure.

Reported-by: MonocleAI
Fixes #5411