### PR TITLE
sendf: make failf() use the mvsnprintf() return code

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -267,8 +267,7 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
     size_t len;
     char error[CURL_ERROR_SIZE + 2];
     va_start(ap, fmt);
-    mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
-    len = strlen(error);
+    len = mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
 
     if(data->set.errorbuffer && !data->state.errorbuf) {
       strcpy(data->set.errorbuffer, error);


### PR DESCRIPTION
... and avoid a strlen() call. Fixes a MonocleAI warning.

Reported-by: MonocleAI
Fixes #5413