### PR TITLE
Potential security issue in lib/easy.c: Unchecked return from initialization function

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -609,6 +609,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
       if(msg) {
         result = msg->data.result;
         done = TRUE;
+        sleep_ms = 0;
       }
     }
   }


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `lib/easy.c` 
Function: `curl_multi_timeout` 
https://github.com/curl/curl/blob/aa73eb47/lib/easy.c#L616
Code extract:

```cpp
        /* If it returns without any filedescriptor instantly, we need to
           avoid busy-looping during periods where it has nothing particular
           to wait for */
        curl_multi_timeout(multi, &sleep_ms); <------ HERE
        if(sleep_ms) {
          if(sleep_ms > 1000)
```

