### PR TITLE
Potential security issue in src/tool_operate.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1657,6 +1657,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           }
           if(config->proxy_insecure_ok) {
             my_setopt(curl, CURLOPT_PROXY_SSL_VERIFYPEER, 0L);
+            protocol = 0;
             my_setopt(curl, CURLOPT_PROXY_SSL_VERIFYHOST, 0L);
           }
           else {


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/curl/curl/blob/aa73eb47/src/tool_operate.c#L1660
Code extract:

```cpp
              long protocol;

              curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
              curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol); <------ HERE

              if((protocol == CURLPROTO_FTP || protocol == CURLPROTO_FTPS) &&
```

