### PR TITLE
curl: remove -J "informational" on stdout

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -425,10 +425,6 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     metalink_parser_context_delete(outs->metalink_parser);
 #endif /* USE_METALINK */
 
-  if(outs->is_cd_filename && outs->stream && !global->mute &&
-     outs->filename)
-    printf("curl: Saved to filename '%s'\n", outs->filename);
-
   /* if retry-max-time is non-zero, make sure we haven't exceeded the
      time */
   if(per->retry_numretries &&

--- a/tests/data/test1340
+++ b/tests/data/test1340
@@ -40,7 +40,7 @@ HTTP GET with -O -J and Content-Disposition, -D file
 CURL_TESTDIR=%PWD/log
 </setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/1340 -J -O -D log/heads1340
+http://%HOSTIP:%HTTPPORT/1340 -J -O -D log/heads1340 -w "curl: Saved to filename %{filename_effective}\n"
 </command>
 </client>
 
@@ -73,7 +73,7 @@ Content-Disposition: filename=name1340; charset=funny; option=strange
 </file2>
 
 <file3 name="log/stdout1340" mode="text">
-curl: Saved to filename '%PWD/log/name1340'
+curl: Saved to filename %PWD/log/name1340
 </file3>
 
 </verify>

--- a/tests/data/test1341
+++ b/tests/data/test1341
@@ -40,7 +40,7 @@ HTTP GET with -O -J and Content-Disposition, -D stdout
 CURL_TESTDIR=%PWD/log
 </setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/1341 -J -O -D -
+http://%HOSTIP:%HTTPPORT/1341 -J -O -D - -w "curl: Saved to filename %{filename_effective}\n"
 </command>
 </client>
 
@@ -70,7 +70,7 @@ Connection: close
 Content-Type: text/html
 Content-Disposition: filename=name1341; charset=funny; option=strange
 
-curl: Saved to filename '%PWD/log/name1341'
+curl: Saved to filename %PWD/log/name1341
 </file2>
 
 </verify>


### PR DESCRIPTION
curl would previously show "curl: Saved to filename 'name from header'"
if -J was used and a name was picked from the Content-Disposition
header. That output could interfer with other stdout output, such as -w.

This commit removes that output line.
Bug: https://curl.haxx.se/mail/archive-2020-05/0044.html
Reported-by: Коваленко Анатолий Викторович