### PR TITLE
Simplify quiche build instructions, fix build with static boringssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ jobs:
     before_install:
     - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
   - env:
-    - T=novalgrind BORINGSSL=yes QUICHE="yes" C="--with-ssl=$HOME/boringssl --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=/home/travis/boringssl/lib:$HOME/quiche/target/release:/usr/local/lib
+    - T=novalgrind QUICHE="yes" C="--with-ssl=$HOME/quiche/deps/boringssl --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     before_install:
     - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)

--- a/configure.ac
+++ b/configure.ac
@@ -1744,6 +1744,8 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
        # only set this if pkg-config wasn't used
        CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include/openssl -I$PREFIX_OPENSSL/include"
      fi
+     # Linking previously failed, try extra paths from --with-ssl or pkg-config.
+     # Use a different function name to avoid reusing the earlier cached result.
      AC_CHECK_LIB(crypto, HMAC_Init_ex,[
        HAVECRYPTO="yes"
        LIBS="-lcrypto $LIBS"], [
@@ -1765,6 +1767,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
        [
          AC_MSG_RESULT(no)
          dnl ok, so what about both -ldl and -lpthread?
+         dnl This may be necessary for static libraries.
 
          AC_MSG_CHECKING([OpenSSL linking with -ldl and -lpthread])
          LIBS="$CLEANLIBS -lcrypto -ldl -lpthread"
@@ -4312,9 +4315,17 @@ if test "$want_pthreads" != "no"; then
   AC_CHECK_HEADER(pthread.h,
     [ AC_DEFINE(HAVE_PTHREAD_H, 1, [if you have <pthread.h>])
       save_CFLAGS="$CFLAGS"
+      dnl When statically linking against boringssl, -lpthread is added to LIBS.
+      dnl Make sure to that this does not pass the check below, we really want
+      dnl -pthread in CFLAGS as recommended for GCC. This also ensures that
+      dnl lib1541 and lib1565 tests are built with these options. Otherwise
+      dnl they fail the build since tests/libtest/Makefile.am clears LIBS.
+      save_LIBS="$LIBS"
 
-      dnl first check for function without lib
+      LIBS=
+      dnl Check for libc variants without a separate pthread lib like bionic
       AC_CHECK_FUNC(pthread_create, [USE_THREADS_POSIX=1] )
+      LIBS="$save_LIBS"
 
       dnl on HPUX, life is more complicated...
       case $host in

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -112,26 +112,12 @@ Build curl
 
 ## build
 
-Clone quiche and BoringSSL:
+Build quiche and BoringSSL:
 
      % git clone --recursive https://github.com/cloudflare/quiche
-
-Build BoringSSL (it needs to be built manually so it can be reused with curl):
-
-     % cd quiche/deps/boringssl
-     % mkdir build
-     % cd build
-     % cmake -DCMAKE_POSITION_INDEPENDENT_CODE=on ..
-     % make
-     % cd ..
-     % mkdir -p .openssl/lib
-     % cp build/crypto/libcrypto.a build/ssl/libssl.a .openssl/lib
-     % ln -s $PWD/include .openssl
-
-Build quiche:
-
-     % cd ../..
-     % QUICHE_BSSL_PATH=$PWD/deps/boringssl cargo build --release --features pkg-config-meta,qlog
+     % cargo build --release --features pkg-config-meta,qlog
+     % mkdir deps/boringssl/lib
+     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/lib/
 
 Build curl:
 
@@ -139,7 +125,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl/.openssl --with-quiche=$PWD/../quiche/target/release --enable-alt-svc
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl --with-quiche=$PWD/../quiche/target/release --enable-alt-svc
      % make
 
 ## Run

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -91,11 +91,13 @@ fi
 
 if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
   cd $HOME
-  git clone --depth=1 https://github.com/cloudflare/quiche.git
+  git clone --depth=1 --recursive https://github.com/cloudflare/quiche.git
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
   cd $HOME/quiche
-  QUICHE_BSSL_PATH=$HOME/boringssl cargo build -v --release --features pkg-config-meta,qlog
+  cargo build -v --release --features pkg-config-meta,qlog
+  mkdir -v deps/boringssl/lib
+  ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/lib/
 fi
 
 # Install common libraries.


### PR DESCRIPTION
Instructions to build quiche with the bundled boringssl plus a bugfix for configure.ac that was triggered when those instructions were followed by CI. See the individual commit messages for the boring details.
___
This was found by comparing the following build logs:
- Build with static boringssl without the configure.ac fix: https://travis-ci.org/github/curl/curl/jobs/686949660
- Old instructions with a separate, shared library build. https://travis-ci.org/github/curl/curl/jobs/686982630 (`BORINGSSL=yes` causes curl to build a shared and static lib in scripts/travis/before_script.sh)

```diff
@@ -2621,8 +2097,5 @@ checking whether to enable Windows native SSL/TLS (Windows native builds only)..
 checking whether to enable Secure Transport... no
 checking whether to enable Amiga native SSL/TLS (AmiSSL)... no
-checking for HMAC_Update in -lcrypto... no
-checking for HMAC_Init_ex in -lcrypto... no
-checking OpenSSL linking with -ldl... no
-checking OpenSSL linking with -ldl and -lpthread... yes
+checking for HMAC_Update in -lcrypto... yes
 checking for SSL_connect in -lssl... yes
 checking openssl/x509.h usability... yes
@@ -2650,5 +2123,5 @@ checking for BoringSSL... yes
 checking for libressl... no
 checking for OpenSSL >= v3... no
-configure: Added /home/travis/quiche/deps/boringssl/lib to CURL_LIBRARY_PATH
+configure: Added /home/travis/boringssl/lib to CURL_LIBRARY_PATH
 checking for OpenSSL headers version... 1.1.0 - 0x1010007f
 checking for OpenSSL library version... 0.9.8
@@ -3131,5 +2604,6 @@ checking pthread.h usability... yes
 checking pthread.h presence... yes
 checking for pthread.h... yes
-checking for pthread_create... yes
+checking for pthread_create... no
+checking for pthread_create in -lpthread... yes
 checking convert -I options to -isystem... yes
 checking whether to enable verbose strings... yes
```
And the difference in CFLAGS/LIBS (word-diff):
```diff
@@ -3189,8 +2663,8 @@ configure: Configured to build curl/libcurl:
  Install prefix:   /usr/local
  Compiler:         gcc
   CFLAGS:          -Werror-implicit-function-declaration -O2 -Wno-system-headers {+-pthread+}
   CPPFLAGS:        -isystem [-/home/travis/quiche/deps/boringssl/include-]{+/home/travis/boringssl/include+} -isystem [-/home/travis/quiche/dep>
   LDFLAGS:         [--L/home/travis/quiche/deps/boringssl/lib-]{+-L/home/travis/boringssl/lib+} -L/usr/local/lib -L/home/travis/quiche/target/r>
   LIBS:            -lquiche -lnghttp2 -lidn2 -lpsl -lssl {+-lcrypto+} -lldap -llber -lbrotlidec -lz[--lcrypto -ldl -lpthread-]

  curl version:     7.71.0-DEV
```