### PR TITLE
[CMakeLists.txt] Remove explicit `CMAKE_ANSI_CFLAGS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,10 +229,6 @@ if(ENABLE_MANUAL)
   set(USE_MANUAL ON)
 endif()
 
-# We need ansi c-flags, especially on HP
-set(CMAKE_C_FLAGS "${CMAKE_ANSI_CFLAGS} ${CMAKE_C_FLAGS}")
-set(CMAKE_REQUIRED_FLAGS ${CMAKE_ANSI_CFLAGS})
-
 if(CURL_STATIC_CRT)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")


### PR DESCRIPTION
Hadn't seen the `CMAKE_ANSI_CFLAGS` flag before, searched it and found: https://gitlab.kitware.com/cmake/cmake/commit/5a834b0bb0bc2889bb67bdaac37ce9b17d4f0f59