### PR TITLE
test1167: fixes in badsymbols.pl

### DIFF
--- a/tests/badsymbols.pl
+++ b/tests/badsymbols.pl
@@ -76,7 +76,8 @@ sub scanenums {
                 next;
             }
             # parse this!
-            $skipit = 0,
+            $skipit = 0;
+            next;
         }
         if($skipit) {
             next;
@@ -88,8 +89,7 @@ sub scanenums {
             if(($_ !~ /\}(;|)/) &&
                ($_ ne "typedef") &&
                ($_ ne "enum") &&
-               ($_ !~ /^[ \t]*$/) &&
-               ($_ ne "#")) {
+               ($_ !~ /^[ \t]*$/)) {
                 push @syms, $_;
             }
         }


### PR DESCRIPTION
Hello.
There is an issue with badsymbols.pl - it reports "#line" from preprocessor's output as a missing symbol. My commit fixes that problem.
```
=> perl -I. ./badsymbols.pl ./.. ./../include/curl
Bad symbols in public header files:
  #line
  #line
  ...
```
I also fixed a typo in the code (a semicolon instead of a comma).