### PR TITLE
ngtcp2: fix build with current ngtcp2 master implementing draft 28

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -50,8 +50,10 @@
 #define MAX_ALTSVC_ALPNLENSTR "10"
 #define MAX_ALTSVC_ALPNLEN 10
 
-#if (defined(USE_QUICHE) || defined(USE_NGTCP2)) && !defined(UNITTESTS)
+#if defined(USE_QUICHE) && !defined(UNITTESTS)
 #define H3VERSION "h3-27"
+#elif defined(USE_NGTCP2) && !defined(UNITTESTS)
+#define H3VERSION "h3-28"
 #else
 #define H3VERSION "h3"
 #endif


### PR DESCRIPTION
Based on client.cc changes from ngtcp2. Tested with current git master,
ngtcp2 commit 411a05b2b25c, nghttp3 commit 65ff479d4380.
___
Passes manual tests with:
```
src/curl -v --http3 https://test.privateoctopus.com:4434
src/curl -v --http3 https://test.privateoctopus.com:4433
src/curl -v --http3 https://nghttp2.org:4433
```
Fails with `https://cloudflare.com/` because ngtcp2 advertises draft 28 support while the current edge only supports draft 27. This was found in a Wireshark capture: Initial packet received a Version Negotiation response, this repeated twice and then curl gave up. The curl output could probably be improved to report this incompatibility instead of just "Resource temporarily unavailable":
```
$ src/curl -v --http3 https://cloudflare.com
*   Trying 104.17.176.85:443...
* Connect socket 3 over QUIC to 104.17.176.85:443
* connect to 104.17.176.85 port 443 failed: Resource temporarily unavailable
*   Trying 104.17.175.85:443...
* Connect socket 6 over QUIC to 104.17.175.85:443
* connect to 104.17.175.85 port 443 failed: Resource temporarily unavailable
*   Trying 2606:4700::6811:af55:443...
* Immediate connect fail for 2606:4700::6811:af55: Network is unreachable
*   Trying 2606:4700::6811:b055:443...
* Immediate connect fail for 2606:4700::6811:b055: Network is unreachable
* Failed to connect to cloudflare.com port 443: Resource temporarily unavailable
* Closing connection 0
curl: (7) Failed to connect to cloudflare.com port 443: Resource temporarily unavailable
```
Also observed were memory leaks on the error path. The successful cases were find however.