### PR TITLE
altsvc: fix parser for lines ending with CRLF

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -431,6 +431,8 @@ static time_t debugtime(void *unused)
 #define time(x) debugtime(x)
 #endif
 
+#define ISNEWLINE(x) (((x) == '\n') || (x) == '\r')
+
 /*
  * Curl_altsvc_parse() takes an incoming alt-svc response header and stores
  * the data correctly in the cache.
@@ -520,12 +522,12 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
         /* Handle the optional 'ma' and 'persist' flags. Unknown flags
            are skipped. */
         for(;;) {
-          while(*p && ISBLANK(*p) && *p != ';' && *p != ',')
+          while(ISBLANK(*p))
             p++;
-          if(!*p || *p == ',')
+          if(*p != ';')
             break;
           p++; /* pass the semicolon */
-          if(!*p)
+          if(!*p || ISNEWLINE(*p))
             break;
           result = getalnum(&p, option, sizeof(option));
           if(result) {

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -63,7 +63,7 @@ UNITTEST_START
   fail_unless(asi->num == 4, "wrong number of entries");
   msnprintf(outname, sizeof(outname), "%s-out", arg);
 
-  result = Curl_altsvc_parse(curl, asi, "h2=\"example.com:8080\"",
+  result = Curl_altsvc_parse(curl, asi, "h2=\"example.com:8080\"\r\n",
                              ALPN_h1, "example.org", 8080);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse() failed!\n");
@@ -71,7 +71,7 @@ UNITTEST_START
   }
   fail_unless(asi->num == 5, "wrong number of entries");
 
-  result = Curl_altsvc_parse(curl, asi, "h3=\":8080\"",
+  result = Curl_altsvc_parse(curl, asi, "h3=\":8080\"\r\n",
                              ALPN_h1, "2.example.org", 8080);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse(2) failed!\n");
@@ -80,7 +80,7 @@ UNITTEST_START
   fail_unless(asi->num == 6, "wrong number of entries");
 
   result = Curl_altsvc_parse(curl, asi,
-                             "h2=\"example.com:8080\", h3=\"yesyes.com\"",
+                             "h2=\"example.com:8080\", h3=\"yesyes.com\"\r\n",
                              ALPN_h1, "3.example.org", 8080);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse(3) failed!\n");
@@ -89,7 +89,8 @@ UNITTEST_START
   /* that one should make two entries */
   fail_unless(asi->num == 8, "wrong number of entries");
 
-  result = Curl_altsvc_parse(curl, asi, "h2=\"example.com:443\"; ma = 120;",
+  result = Curl_altsvc_parse(curl, asi,
+                             "h2=\"example.com:443\"; ma = 120;\r\n",
                              ALPN_h2, "example.org", 80);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse(4) failed!\n");
@@ -98,7 +99,8 @@ UNITTEST_START
   fail_unless(asi->num == 9, "wrong number of entries");
 
   /* quoted 'ma' value */
-  result = Curl_altsvc_parse(curl, asi, "h2=\"example.net:443\"; ma=\"180\";",
+  result = Curl_altsvc_parse(curl, asi,
+                             "h2=\"example.net:443\"; ma=\"180\";\r\n",
                              ALPN_h2, "example.net", 80);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse(4) failed!\n");
@@ -106,9 +108,10 @@ UNITTEST_START
   }
   fail_unless(asi->num == 10, "wrong number of entries");
 
-  result = Curl_altsvc_parse(curl, asi,
-                             "h2=\":443\", h3=\":443\"; ma = 120; persist = 1",
-                             ALPN_h1, "curl.haxx.se", 80);
+  result =
+    Curl_altsvc_parse(curl, asi,
+                      "h2=\":443\", h3=\":443\"; ma = 120; persist = 1\r\n",
+                      ALPN_h1, "curl.haxx.se", 80);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse(5) failed!\n");
     unitfail++;
@@ -116,7 +119,7 @@ UNITTEST_START
   fail_unless(asi->num == 12, "wrong number of entries");
 
   /* clear that one again and decrease the counter */
-  result = Curl_altsvc_parse(curl, asi, "clear;",
+  result = Curl_altsvc_parse(curl, asi, "clear;\r\n",
                              ALPN_h1, "curl.haxx.se", 80);
   if(result) {
     fprintf(stderr, "Curl_altsvc_parse(6) failed!\n");


### PR DESCRIPTION
Fixed the alt-svc parser to treat a newline as end of line.

The unit tests in test 1654 were done without CRLF and thus didn't quite
match the real world. Now they use CRLF as well.

Reported-by: Peter Wu
Fixes #5445