### PR TITLE
examples/http2-upload: fix a crash

### DIFF
--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 /* somewhat unix-specific */
 #include <sys/time.h>
@@ -149,6 +150,11 @@ static void setup(struct transfer *t, int num)
   snprintf(filename, 128, "dl-%d", num);
 
   t->out = fopen(filename, "wb");
+  if (!t->out)
+  {
+    fprintf(stderr, "error: could not open file %s for writing: %s\n", filename, strerror(errno));
+    exit(1);
+  }
 
   /* write to this file */
   curl_easy_setopt(hnd, CURLOPT_WRITEDATA, t->out);

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -34,6 +34,7 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+#include <curl/mprintf.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 /* This little trick will just make sure that we don't enable pipelining for
@@ -147,12 +148,12 @@ static void setup(struct transfer *t, int num)
 
   hnd = t->easy = curl_easy_init();
 
-  snprintf(filename, 128, "dl-%d", num);
+  curl_msnprintf(filename, 128, "dl-%d", num);
 
   t->out = fopen(filename, "wb");
-  if (!t->out)
-  {
-    fprintf(stderr, "error: could not open file %s for writing: %s\n", filename, strerror(errno));
+  if(!t->out) {
+    fprintf(stderr, "error: could not open file %s for writing: %s\n",
+            filename, strerror(errno));
     exit(1);
   }
 

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <errno.h>
 
 /* somewhat unix-specific */
 #include <sys/time.h>
@@ -178,14 +179,29 @@ static void setup(struct input *i, int num, const char *upload)
   i->num = num;
   snprintf(filename, 128, "dl-%d", num);
   out = fopen(filename, "wb");
+  if (!out)
+  {
+    fprintf(stderr, "error: could not open file %s for writing: %s\n", upload, strerror(errno));
+    exit(1);
+  }
 
   snprintf(url, 256, "https://localhost:8443/upload-%d", num);
 
   /* get the file size of the local file */
-  stat(upload, &file_info);
+  if (!stat(upload, &file_info))
+  {
+    fprintf(stderr, "error: could not stat file %s: %s\n", upload, strerror(errno));
+    exit(1);
+  }
+
   uploadsize = file_info.st_size;
 
   i->in = fopen(upload, "rb");
+  if (!i->in)
+  {
+    fprintf(stderr, "error: could not open file %s for reading: %s\n", upload, strerror(errno));
+    exit(1);
+  }
 
   /* write to this file */
   curl_easy_setopt(hnd, CURLOPT_WRITEDATA, out);

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -36,6 +36,7 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+#include <curl/mprintf.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 /* This little trick will just make sure that we don't enable pipelining for
@@ -124,8 +125,8 @@ int my_trace(CURL *handle, curl_infotype type,
   }
   secs = epoch_offset + tv.tv_sec;
   now = localtime(&secs);  /* not thread safe but we don't care */
-  snprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld",
-           now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);
+  curl_msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld",
+                 now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);
 
   switch(type) {
   case CURLINFO_TEXT:
@@ -177,29 +178,29 @@ static void setup(struct input *i, int num, const char *upload)
 
   hnd = i->hnd = curl_easy_init();
   i->num = num;
-  snprintf(filename, 128, "dl-%d", num);
+  curl_msnprintf(filename, 128, "dl-%d", num);
   out = fopen(filename, "wb");
-  if (!out)
-  {
-    fprintf(stderr, "error: could not open file %s for writing: %s\n", upload, strerror(errno));
+  if(!out) {
+    fprintf(stderr, "error: could not open file %s for writing: %s\n", upload,
+            strerror(errno));
     exit(1);
   }
 
-  snprintf(url, 256, "https://localhost:8443/upload-%d", num);
+  curl_msnprintf(url, 256, "https://localhost:8443/upload-%d", num);
 
   /* get the file size of the local file */
-  if (stat(upload, &file_info))
-  {
-    fprintf(stderr, "error: could not stat file %s: %s\n", upload, strerror(errno));
+  if(stat(upload, &file_info)) {
+    fprintf(stderr, "error: could not stat file %s: %s\n", upload,
+            strerror(errno));
     exit(1);
   }
 
   uploadsize = file_info.st_size;
 
   i->in = fopen(upload, "rb");
-  if (!i->in)
-  {
-    fprintf(stderr, "error: could not open file %s for reading: %s\n", upload, strerror(errno));
+  if(!i->in) {
+    fprintf(stderr, "error: could not open file %s for reading: %s\n", upload,
+            strerror(errno));
     exit(1);
   }
 

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -188,7 +188,7 @@ static void setup(struct input *i, int num, const char *upload)
   snprintf(url, 256, "https://localhost:8443/upload-%d", num);
 
   /* get the file size of the local file */
-  if (!stat(upload, &file_info))
+  if (stat(upload, &file_info))
   {
     fprintf(stderr, "error: could not stat file %s: %s\n", upload, strerror(errno));
     exit(1);


### PR DESCRIPTION
If `index.html` does not exist in the directory from which the example
is invoked, the `fopen(upload, "rb")` invocation in `setup` would fail,
returning `NULL`.  This value is subsequently passed as the `FILE*` argument
of the `fread` invocation in the `read_callback` function, which is the
actual cause of the crash (apparently `fread` assumes that argument to
be non-null).

In addition, mitigate some possible crashes of similar origin.