### PR TITLE
CMake: rebuild Makefile.inc.cmake when Makefile.inc changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1268,7 +1268,7 @@ function(transform_makefile_inc INPUT_FILE OUTPUT_FILE)
   string(REGEX REPLACE "\\$\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)" "\${\\1}" MAKEFILE_INC_TEXT ${MAKEFILE_INC_TEXT})    # Replace $() with ${}
   string(REGEX REPLACE "@([a-zA-Z_][a-zA-Z0-9_]*)@" "\${\\1}" MAKEFILE_INC_TEXT ${MAKEFILE_INC_TEXT})    # Replace @@ with ${}, even if that may not be read by CMake scripts.
   file(WRITE ${OUTPUT_FILE} ${MAKEFILE_INC_TEXT})
-
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${INPUT_FILE}")
 endfunction()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Otherwise the build might fail due to missing source files, as
demonstrated by the recent keylog.c addition on an existing build dir.