### PR TITLE
configure: repair the check if argv can be written to

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1282,12 +1282,14 @@ dnl Check if the operating system allows programs to write to their own argv[]
 dnl **********************************************************************
 
 AC_MSG_CHECKING([if argv can be written to])
-CURL_RUN_IFELSE([
-int main(int argc, char ** argv) {
-    argv[0][0] = ' ';
-    return (argv[0][0] == ' ')?0:1;
+CURL_RUN_IFELSE([[
+int main(int argc, char **argv)
+{
+  (void)argc;
+  argv[0][0] = ' ';
+  return (argv[0][0] == ' ')?0:1;
 }
-],[
+]],[
   curl_cv_writable_argv=yes
 ],[
   curl_cv_writable_argv=no


### PR DESCRIPTION
Due to bad escaping of the test code, the test wouldn't build and thus
result in a negative test result, which would lead to the unconditional
assumption that overwriting the arguments doesn't work and thus curl
would never hide credentials given in the command line, even when it
would otherwise be possible.

Regression from commit 2d4c2152c

Reported-by: huzunhao on github
Fixes #5470