### PR TITLE
url: alloc the download buffer at transfer start

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -531,6 +531,11 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
 void Curl_conncache_close_all_connections(struct conncache *connc)
 {
   struct connectdata *conn;
+  char buffer[READBUFFER_MIN];
+  if(!connc->closure_handle)
+    return;
+  connc->closure_handle->state.buffer = buffer;
+  connc->closure_handle->set.buffer_size = READBUFFER_MIN;
 
   conn = conncache_find_first_connection(connc);
   while(conn) {
@@ -547,6 +552,7 @@ void Curl_conncache_close_all_connections(struct conncache *connc)
     conn = conncache_find_first_connection(connc);
   }
 
+  connc->closure_handle->state.buffer = NULL;
   if(connc->closure_handle) {
     SIGPIPE_VARIABLE(pipe_st);
     sigpipe_ignore(connc->closure_handle, &pipe_st);

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -829,9 +829,6 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
    * the likeliness of us forgetting to init a buffer here in the future.
    */
   outcurl->set.buffer_size = data->set.buffer_size;
-  outcurl->state.buffer = malloc(outcurl->set.buffer_size + 1);
-  if(!outcurl->state.buffer)
-    goto fail;
 
   /* copy all userdefined values */
   if(dupset(outcurl, data))
@@ -947,8 +944,6 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
  */
 void curl_easy_reset(struct Curl_easy *data)
 {
-  long old_buffer_size = data->set.buffer_size;
-
   Curl_free_request_state(data);
 
   /* zero out UserDefined data: */
@@ -972,18 +967,6 @@ void curl_easy_reset(struct Curl_easy *data)
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
   Curl_http_auth_cleanup_digest(data);
 #endif
-
-  /* resize receive buffer */
-  if(old_buffer_size != data->set.buffer_size) {
-    char *newbuff = realloc(data->state.buffer, data->set.buffer_size + 1);
-    if(!newbuff) {
-      DEBUGF(fprintf(stderr, "Error: realloc of buffer failed\n"));
-      /* nothing we can do here except use the old size */
-      data->set.buffer_size = old_buffer_size;
-    }
-    else
-      data->state.buffer = newbuff;
-  }
 }
 
 /*

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -258,15 +258,14 @@ static unsigned int http2_conncheck(struct connectdata *check,
 void Curl_http2_setup_req(struct Curl_easy *data)
 {
   struct HTTP *http = data->req.protop;
-
   http->bodystarted = FALSE;
   http->status_code = -1;
   http->pausedata = NULL;
   http->pauselen = 0;
   http->closed = FALSE;
   http->close_handled = FALSE;
-  http->mem = data->state.buffer;
-  http->len = data->set.buffer_size;
+  http->mem = NULL;
+  http->len = 0;
   http->memlen = 0;
 }
 
@@ -2103,6 +2102,8 @@ CURLcode Curl_http2_setup(struct connectdata *conn)
   struct http_conn *httpc = &conn->proto.httpc;
   struct HTTP *stream = conn->data->req.protop;
 
+  DEBUGASSERT(conn->data->state.buffer);
+
   stream->stream_id = -1;
 
   Curl_dyn_init(&stream->header_recvbuf, DYN_H2_HEADERS);
@@ -2126,6 +2127,8 @@ CURLcode Curl_http2_setup(struct connectdata *conn)
   stream->upload_left = 0;
   stream->upload_mem = NULL;
   stream->upload_len = 0;
+  stream->mem = conn->data->state.buffer;
+  stream->len = conn->data->set.buffer_size;
 
   httpc->inbuflen = 0;
   httpc->nread_inbuf = 0;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2076,7 +2076,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       arg = READBUFFER_MIN;
 
     /* Resize if new size */
-    if(arg != data->set.buffer_size) {
+    if((arg != data->set.buffer_size) && data->state.buffer) {
       char *newbuff = realloc(data->state.buffer, arg + 1);
       if(!newbuff) {
         DEBUGF(fprintf(stderr, "Error: realloc of buffer failed\n"));

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -627,7 +627,6 @@ struct SingleRequest {
   struct contenc_writer *writer_stack;
   time_t timeofdoc;
   long bodywrites;
-  char *buf;
   int keepon;
   char *location;   /* This points to an allocated version of the Location:
                        header data */

--- a/tests/data/test509
+++ b/tests/data/test509
@@ -34,10 +34,7 @@ nothing
 # Verify data after the test has been "shot"
 <verify>
 <stdout>
-seen custom_calloc()
-seen custom_malloc()
-seen custom_realloc()
-seen custom_free()
+Callbacks were invoked!
 </stdout>
 </verify>
 

--- a/tests/libtest/lib509.c
+++ b/tests/libtest/lib509.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -34,70 +34,35 @@
  * memory callbacks which should be calling 'the real thing'.
  */
 
-/*
-#include "memdebug.h"
-*/
+static int seen;
 
-static int seen_malloc = 0;
-static int seen_free = 0;
-static int seen_realloc = 0;
-static int seen_strdup = 0;
-static int seen_calloc = 0;
-
-void *custom_malloc(size_t size);
-void custom_free(void *ptr);
-void *custom_realloc(void *ptr, size_t size);
-char *custom_strdup(const char *ptr);
-void *custom_calloc(size_t nmemb, size_t size);
-
-
-void *custom_calloc(size_t nmemb, size_t size)
+static void *custom_calloc(size_t nmemb, size_t size)
 {
-  if(!seen_calloc) {
-    printf("seen custom_calloc()\n");
-    seen_calloc = 1;
-  }
+  seen++;
   return (calloc)(nmemb, size);
 }
 
-void *custom_malloc(size_t size)
+static void *custom_malloc(size_t size)
 {
-  if(!seen_malloc && seen_calloc) {
-    printf("seen custom_malloc()\n");
-    seen_malloc = 1;
-  }
+  seen++;
   return (malloc)(size);
 }
 
-char *custom_strdup(const char *ptr)
+static char *custom_strdup(const char *ptr)
 {
-  if(!seen_strdup && seen_malloc) {
-    /* currently (2013.03.13), memory tracking enabled builds do not call
-       the strdup callback, in this case malloc callback and memcpy are used
-       instead. If some day this is changed the following printf() should be
-       uncommented, and a line added to test definition.
-    printf("seen custom_strdup()\n");
-    */
-    seen_strdup = 1;
-  }
+  seen++;
   return (strdup)(ptr);
 }
 
-void *custom_realloc(void *ptr, size_t size)
+static void *custom_realloc(void *ptr, size_t size)
 {
-  if(!seen_realloc && seen_malloc) {
-    printf("seen custom_realloc()\n");
-    seen_realloc = 1;
-  }
+  seen++;
   return (realloc)(ptr, size);
 }
 
-void custom_free(void *ptr)
+static void custom_free(void *ptr)
 {
-  if(!seen_free && seen_realloc) {
-    printf("seen custom_free()\n");
-    seen_free = 1;
-  }
+  seen++;
   (free)(ptr);
 }
 
@@ -110,7 +75,6 @@ int test(char *URL)
   CURL *curl;
   int asize;
   char *str = NULL;
-
   (void)URL;
 
   res = curl_global_init_mem(CURL_GLOBAL_ALL,
@@ -135,6 +99,9 @@ int test(char *URL)
 
   asize = (int)sizeof(a);
   str = curl_easy_escape(curl, (char *)a, asize); /* uses realloc() */
+
+  if(seen)
+    printf("Callbacks were invoked!\n");
 
 test_cleanup:
 


### PR DESCRIPTION
It removes the extra alloc when a new size is set with setopt() and
reduces memory for unused easy handles.