### PR TITLE
unit1604.c: fix implicit conv from 'SANITIZEcode' to 'CURLcode'

### DIFF
--- a/tests/unit/unit1604.c
+++ b/tests/unit/unit1604.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -78,7 +78,7 @@ struct data {
   const char *input;
   int flags;
   const char *expected_output;
-  CURLcode expected_result;
+  SANITIZEcode expected_result;
 };
 
 UNITTEST_START
@@ -304,8 +304,9 @@ UNITTEST_START
     char *flagstr = NULL;
     char *received_ccstr = NULL;
     char *expected_ccstr = NULL;
+    SANITIZEcode res;
 
-    CURLcode res = sanitize_file_name(&output, data[i].input, data[i].flags);
+    res = sanitize_file_name(&output, data[i].input, data[i].flags);
 
     if(res == data[i].expected_result &&
        ((!output && !data[i].expected_output) ||


### PR DESCRIPTION
GCC 10 warns about this with warning: implicit conversion
  from 'SANITIZEcode' to 'CURLcode' [-Wenum-conversion]

Since 'expected_result' is not really of type 'CURLcode' and
it is not exposed in any way, we can just use 'SANITIZEcode'.