### PR TITLE
Revert "buildconf: use find -execdir instead, remove -print and the a…

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -64,7 +64,7 @@ findtool(){
 #
 removethis(){
   if test "$#" = "1"; then
-    find . -depth -name $1 -execdir rm -rf {} \;
+    find . -depth -name $1 -print -exec rm -rf {} \;
   fi
 }
 


### PR DESCRIPTION
…res files"

This partially reverts commit c712009838f44211958854de431315586995bc61.

Keep the ares_ files removed but bring back the older way to run find,
to make it work with busybox's find, as apparently that's being used.

Reported-by: Max Peal
Fixes #5483