### PR TITLE
timeouts: move ms timeouts to timediff_t from int and long

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -510,7 +510,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     before = Curl_now();
 
     /* wait for activity or timeout */
-    pollrc = Curl_poll(fds, numfds, (int)ev->ms);
+    pollrc = Curl_poll(fds, numfds, ev->ms);
 
     after = Curl_now();
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1255,7 +1255,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
          timeout */
       else if((sleep_ms < 0) && extrawait)
         sleep_ms = timeout_ms;
-      Curl_wait_ms((int)sleep_ms);
+      Curl_wait_ms(sleep_ms);
     }
   }
 

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -69,7 +69,7 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
       break;
     }
     if(!timeout_ms)
-      timeout_ms = TIME_T_MAX;
+      timeout_ms = TIMEDIFF_T_MAX;
     if(SOCKET_READABLE(sockfd, timeout_ms) <= 0) {
       result = ~CURLE_OK;
       break;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1315,7 +1315,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
   DWORD readfile_read;
   int err;
 #else
-  int interval_ms;
+  timediff_t interval_ms;
   struct pollfd pfd[2];
   int poll_cnt;
   curl_off_t total_dl = 0;


### PR DESCRIPTION
Now that all functions in select.[ch] take timediff_t instead
of the limited time_t or int, we can remove type conversions
and related preprocessor checks to silence compiler warnings.