### PR TITLE
test970: make it require proxy support

### DIFF
--- a/tests/data/test970
+++ b/tests/data/test970
@@ -33,6 +33,7 @@ http
 </server>
 <features>
 debug
+proxy
 </features>
 <setenv>
 CURL_TIME=13


### PR DESCRIPTION
This test verifies the -w %json output and the test case includes a full
generated "blob". If there's no proxy support built into libcurl, it
will return an error for proxy related info variables and they will not
be included in the json, thus causing a mismatch and this test fails.

Reported-by: Marc Hörsken
Fixes #5501