### PR TITLE
select: fix poll-based check not detecting connect failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -220,17 +220,17 @@ environment:
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: autotools
         TESTING: ON
-        DISABLED_TESTS: "!19 ~1056 !1233"
+        DISABLED_TESTS: "~1056"
         CONFIG_ARGS: "--enable-debug --enable-werror --enable-alt-svc --disable-threaded-resolver --disable-proxy"
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: autotools
         TESTING: ON
-        DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
+        DISABLED_TESTS: "~1056"
         CONFIG_ARGS: "--enable-debug --enable-werror --enable-alt-svc --disable-threaded-resolver"
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: autotools
         TESTING: ON
-        DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
+        DISABLED_TESTS: "~1056"
         CONFIG_ARGS: "--enable-warnings --enable-werror"
 
 install:

--- a/lib/select.c
+++ b/lib/select.c
@@ -291,7 +291,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   }
   if(writefd != CURL_SOCKET_BAD) {
     pfd[num].fd = writefd;
-    pfd[num].events = POLLWRNORM|POLLOUT;
+    pfd[num].events = POLLWRNORM|POLLOUT|POLLPRI;
     pfd[num].revents = 0;
     num++;
   }
@@ -319,7 +319,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
   if(writefd != CURL_SOCKET_BAD) {
     if(pfd[num].revents & (POLLWRNORM|POLLOUT))
       ret |= CURL_CSELECT_OUT;
-    if(pfd[num].revents & (POLLERR|POLLHUP|POLLNVAL))
+    if(pfd[num].revents & (POLLERR|POLLHUP|POLLPRI|POLLNVAL))
       ret |= CURL_CSELECT_ERR;
   }
 


### PR DESCRIPTION
The select-based socket check correctly checks for connect
failures by adding the write socket also to fds_err.

The poll-based implementation (which internally can itself
fallback to select again) did not previously check for
connect failure by using POLLPRI with the write socket.

This commit makes sure connect failures can be detected
and handled if HAVE_POLL_FINE is defined, eg. on msys2-devel.
Therefore the related disabled tests can be enabled again.

Related to #5492