### PR TITLE
HTTP3.md: Clarify cargo build directory

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -115,6 +115,7 @@ Build curl
 Build quiche and BoringSSL:
 
      % git clone --recursive https://github.com/cloudflare/quiche
+     % cd ..
      % cargo build --release --features pkg-config-meta,qlog
      % mkdir deps/boringssl/lib
      % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/lib/

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -115,7 +115,7 @@ Build curl
 Build quiche and BoringSSL:
 
      % git clone --recursive https://github.com/cloudflare/quiche
-     % cd ..
+     % cd quiche
      % cargo build --release --features pkg-config-meta,qlog
      % mkdir deps/boringssl/lib
      % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/lib/


### PR DESCRIPTION
Cargo needs to be called from within the 'quiche' directory. Build instructions for other components have the 'cd ..' command explicitly specified, so this adds it to the quiche build instructions.