### PR TITLE
socks: fix expected length of SOCKS5 reply

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -880,7 +880,7 @@ CURLcode Curl_SOCKS5(const char *proxy_user,
       return CURLE_COULDNT_CONNECT;
     }
 #endif
-    sx->outstanding = 10; /* minimum packet size is 10 */
+    len = sx->outstanding = 10; /* minimum packet size is 10 */
     sx->outp = socksreq;
     sxstate(conn, CONNECT_REQ_READ);
     /* FALLTHROUGH */


### PR DESCRIPTION
Commit 4a4b63daaa01 forgot to initialize the expected SOCKS5 reply length, and neither did it set it to the correct value of 10 when the reply ATYP is X'01'. This results in erroneously expecting more bytes when the request length is greater than the reply length (e.g., when remotely resolving the hostname).