### PR TITLE
server/util: fix logmsg format using curl_off_t argument

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -290,7 +290,7 @@ int write_pidfile(const char *filename)
 #endif
   fprintf(pidfile, "%" CURL_FORMAT_CURL_OFF_T "\n", pid);
   fclose(pidfile);
-  logmsg("Wrote pid % " CURL_FORMAT_CURL_OFF_T " to %s", pid, filename);
+  logmsg("Wrote pid %" CURL_FORMAT_CURL_OFF_T " to %s", pid, filename);
   return 1; /* success */
 }
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -290,7 +290,7 @@ int write_pidfile(const char *filename)
 #endif
   fprintf(pidfile, "%" CURL_FORMAT_CURL_OFF_T "\n", pid);
   fclose(pidfile);
-  logmsg("Wrote pid %ld to %s", pid, filename);
+  logmsg("Wrote pid % " CURL_FORMAT_CURL_OFF_T " to %s", pid, filename);
   return 1; /* success */
 }
 


### PR DESCRIPTION
... this caused segfaults on armv7.

Regression added in dd0365d560aea5a (7.70.0)