### PR TITLE
wording: avoid possibly negative associations in tests

### DIFF
--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -138,13 +138,13 @@ static struct testcase get_parts_list[] ={
   {"https://[::1]",
    "https | [11] | [12] | [13] | [::1] | [15] | / | [16] | [17]",
    0, 0, CURLUE_OK },
-  {"user:moo@ftp.example.com/color/#green?no-black",
+  {"user:moo@ftp.example.com/color/#green?no-red",
    "ftp | user | moo | [13] | ftp.example.com | [15] | /color/ | [16] | "
-   "green?no-black",
+   "green?no-red",
    CURLU_GUESS_SCHEME, 0, CURLUE_OK },
-  {"ftp.user:moo@example.com/color/#green?no-black",
+  {"ftp.user:moo@example.com/color/#green?no-red",
    "http | ftp.user | moo | [13] | example.com | [15] | /color/ | [16] | "
-   "green?no-black",
+   "green?no-red",
    CURLU_GUESS_SCHEME, 0, CURLUE_OK },
 #ifdef WIN32
   {"file:/C:\\programs\\foo",
@@ -157,25 +157,25 @@ static struct testcase get_parts_list[] ={
    "file | [11] | [12] | [13] | [14] | [15] | C:\\programs\\foo | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
 #endif
-  {"https://example.com/color/#green?no-black",
+  {"https://example.com/color/#green?no-red",
    "https | [11] | [12] | [13] | example.com | [15] | /color/ | [16] | "
-   "green?no-black",
+   "green?no-red",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
-  {"https://example.com/color/#green#no-black",
+  {"https://example.com/color/#green#no-red",
    "https | [11] | [12] | [13] | example.com | [15] | /color/ | [16] | "
-   "green#no-black",
+   "green#no-red",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
-  {"https://example.com/color/?green#no-black",
+  {"https://example.com/color/?green#no-red",
    "https | [11] | [12] | [13] | example.com | [15] | /color/ | green | "
-   "no-black",
+   "no-red",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
-  {"https://example.com/#color/?green#no-black",
+  {"https://example.com/#color/?green#no-red",
    "https | [11] | [12] | [13] | example.com | [15] | / | [16] | "
-   "color/?green#no-black",
+   "color/?green#no-red",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
-  {"https://example.#com/color/?green#no-black",
+  {"https://example.#com/color/?green#no-red",
    "https | [11] | [12] | [13] | example. | [15] | / | [16] | "
-   "com/color/?green#no-black",
+   "com/color/?green#no-red",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
   {"http://[ab.be:1]/x", "",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_MALFORMED_INPUT},


### PR DESCRIPTION
This is a follow-up to https://github.com/curl/curl/pull/5546 and related to the replaced stereotypes as well as the comments that have been made in there; to quote one:

> I don't see why we couldn't just change the wording if there's even just a risk that the use of these phrases actually are doing things worse for a minority.

In order to stay consequent and in line with this "initiative", this PR changes a wording that **could** be taken even more seriously if seen from another perspective.

The question remains of how far this should go and if these particular measures actually make sense while running the risk of leading such an important and sensitive topic to absurdity.