### PR TITLE
tests/getpart.pm: lock files for content verification

### DIFF
--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -22,6 +22,8 @@
 
 #use strict;
 
+use Fcntl qw(:flock);
+
 my @xml;
 my $xmlfile;
 
@@ -297,9 +299,11 @@ sub loadarray {
     my @array;
 
     open(TEMP, "<$filename");
+    flock(TEMP, LOCK_EX);
     while(<TEMP>) {
         push @array, $_;
     }
+    flock(TEMP, LOCK_UN);
     close(TEMP);
     return @array;
 }


### PR DESCRIPTION
To avoid flaky test results due to random incomplete or empty log
files on some platforms (eg. Windows) we lock the files for reading.

Replaces #5224