### PR TITLE
altsvc: decrease entry count when expired entry is removed

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -629,6 +629,7 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
       /* an expired entry, remove */
       Curl_llist_remove(&asi->list, e, NULL);
       altsvc_free(as);
+      asi->num--;
       continue;
     }
     if((as->src.alpnid == srcalpnid) &&


### PR DESCRIPTION
Prior to this change the lookup function did not adjust the count
when purging expired entries. AFAICS the count is only used by test
unit1654 so there does not appear to have been any consequence.

Closes #xxxx

---

I noticed this while investigating #5552 but it is not related.