### PR TITLE
altsvc: remove the num field from the altsvc struct

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -169,7 +169,6 @@ static CURLcode altsvc_add(struct altsvcinfo *asi, char *line)
       as->prio = prio;
       as->persist = persist ? 1 : 0;
       Curl_llist_insert_next(&asi->list, asi->list.tail, as, &as->node);
-      asi->num++; /* one more entry */
     }
   }
 
@@ -410,7 +409,6 @@ static void altsvc_flush(struct altsvcinfo *asi, enum alpnid srcalpnid,
        strcasecompare(srchost, as->src.host)) {
       Curl_llist_remove(&asi->list, e, NULL);
       altsvc_free(as);
-      asi->num--;
     }
   }
 }
@@ -577,7 +575,6 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
             as->expires = maxage + time(NULL);
             as->persist = persist;
             Curl_llist_insert_next(&asi->list, asi->list.tail, as, &as->node);
-            asi->num++; /* one more entry */
             infof(data, "Added alt-svc: %s:%d over %s\n", dsthost, dstport,
                   Curl_alpnid2str(dstalpnid));
           }

--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -52,7 +52,6 @@ struct altsvc {
 struct altsvcinfo {
   char *filename;
   struct curl_llist list; /* list of entries */
-  size_t num; /* number of alt-svc entries */
   long flags; /* the publicly set bitmask */
 };
 

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -60,7 +60,7 @@ UNITTEST_START
   curl = curl_easy_init();
   if(!curl)
     goto fail;
-  fail_unless(asi->num == 4, "wrong number of entries");
+  fail_unless(asi->list.size == 4, "wrong number of entries");
   msnprintf(outname, sizeof(outname), "%s-out", arg);
 
   result = Curl_altsvc_parse(curl, asi, "h2=\"example.com:8080\"\r\n",
@@ -69,7 +69,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse() failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 5, "wrong number of entries");
+  fail_unless(asi->list.size == 5, "wrong number of entries");
 
   result = Curl_altsvc_parse(curl, asi, "h3=\":8080\"\r\n",
                              ALPN_h1, "2.example.org", 8080);
@@ -77,7 +77,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(2) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 6, "wrong number of entries");
+  fail_unless(asi->list.size == 6, "wrong number of entries");
 
   result = Curl_altsvc_parse(curl, asi,
                              "h2=\"example.com:8080\", h3=\"yesyes.com\"\r\n",
@@ -87,7 +87,7 @@ UNITTEST_START
     unitfail++;
   }
   /* that one should make two entries */
-  fail_unless(asi->num == 8, "wrong number of entries");
+  fail_unless(asi->list.size == 8, "wrong number of entries");
 
   result = Curl_altsvc_parse(curl, asi,
                              "h2=\"example.com:443\"; ma = 120;\r\n",
@@ -96,7 +96,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(4) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 9, "wrong number of entries");
+  fail_unless(asi->list.size == 9, "wrong number of entries");
 
   /* quoted 'ma' value */
   result = Curl_altsvc_parse(curl, asi,
@@ -106,7 +106,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(4) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 10, "wrong number of entries");
+  fail_unless(asi->list.size == 10, "wrong number of entries");
 
   result =
     Curl_altsvc_parse(curl, asi,
@@ -116,7 +116,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(5) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 12, "wrong number of entries");
+  fail_unless(asi->list.size == 12, "wrong number of entries");
 
   /* clear that one again and decrease the counter */
   result = Curl_altsvc_parse(curl, asi, "clear;\r\n",
@@ -125,7 +125,7 @@ UNITTEST_START
     fprintf(stderr, "Curl_altsvc_parse(6) failed!\n");
     unitfail++;
   }
-  fail_unless(asi->num == 10, "wrong number of entries");
+  fail_unless(asi->list.size == 10, "wrong number of entries");
 
   Curl_altsvc_save(curl, asi, outname);
 


### PR DESCRIPTION
It was superfluous since we have the list.size alredy

Reported-by: Jay Satiro
Fixes #5553

/cc @jay 