### PR TITLE
Improved quic and happy eyeballs connects

### DIFF
--- a/lib/quic.h
+++ b/lib/quic.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -47,11 +47,13 @@ int Curl_quic_ver(char *p, size_t len);
 CURLcode Curl_quic_done_sending(struct connectdata *conn);
 void Curl_quic_done(struct Curl_easy *data, bool premature);
 bool Curl_quic_data_pending(const struct Curl_easy *data);
+void Curl_quic_disconnect(struct connectdata *conn, int tempindex);
 
 #else /* ENABLE_QUIC */
 #define Curl_quic_done_sending(x)
 #define Curl_quic_done(x,y)
 #define Curl_quic_data_pending(x)
+#define Curl_quic_disconnect(x,y)
 #endif /* !ENABLE_QUIC */
 
 #endif /* HEADER_CURL_QUIC_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -981,8 +981,10 @@ struct connectdata {
   struct curltime connecttime;
   /* The two fields below get set in Curl_connecthost */
   int num_addr; /* number of addresses to try to connect to */
-  timediff_t timeoutms_per_addr; /* how long time in milliseconds to spend on
-                                    trying to connect to each IP address */
+
+  /* how long time in milliseconds to spend on trying to connect to each IP
+     address, per family */
+  timediff_t timeoutms_per_addr[2];
 
   const struct Curl_handler *handler; /* Connection's protocol handler */
   const struct Curl_handler *given;   /* The protocol first given */
@@ -1245,7 +1247,8 @@ typedef enum {
   EXPIRE_100_TIMEOUT,
   EXPIRE_ASYNC_NAME,
   EXPIRE_CONNECTTIMEOUT,
-  EXPIRE_DNS_PER_NAME,
+  EXPIRE_DNS_PER_NAME, /* family1 */
+  EXPIRE_DNS_PER_NAME2, /* family2 */
   EXPIRE_HAPPY_EYEBALLS_DNS, /* See asyn-ares.c */
   EXPIRE_HAPPY_EYEBALLS,
   EXPIRE_MULTI_PENDING,

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -889,12 +889,13 @@ static CURLcode qs_disconnect(struct quicsocket *qs)
 #elif defined(USE_GNUTLS)
     gnutls_deinit(qs->ssl);
 #endif
+  qs->ssl = NULL;
 #ifdef USE_GNUTLS
   if(qs->cred)
     gnutls_certificate_free_credentials(qs->cred);
 #endif
   for(i = 0; i < 3; i++)
-    free(qs->crypto_data[i].buf);
+    Curl_safefree(qs->crypto_data[i].buf);
   nghttp3_conn_del(qs->h3conn);
   ngtcp2_conn_del(qs->qconn);
 #ifdef USE_OPENSSL

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -452,8 +452,8 @@ static int tp_send_func(gnutls_session_t ssl, gnutls_buffer_t extdata)
     paramsbuf, sizeof(paramsbuf), NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO,
     &params);
   if(nwrite < 0) {
-    fprintf(stderr, "ngtcp2_encode_transport_params: %s\n",
-          ngtcp2_strerror((int)nwrite));
+    H3BUGF(fprintf(stderr, "ngtcp2_encode_transport_params: %s\n",
+                   ngtcp2_strerror((int)nwrite)));
     return -1;
   }
 
@@ -479,8 +479,8 @@ static int quic_init_ssl(struct quicsocket *qs)
 
   rc = gnutls_priority_set_direct(qs->ssl, QUIC_PRIORITY, NULL);
   if(rc < 0) {
-    fprintf(stderr, "gnutls_priority_set_direct failed: %s\n",
-            gnutls_strerror(rc));
+    H3BUGF(fprintf(stderr, "gnutls_priority_set_direct failed: %s\n",
+                   gnutls_strerror(rc)));
     return 1;
   }
 
@@ -496,8 +496,8 @@ static int quic_init_ssl(struct quicsocket *qs)
                                    GNUTLS_EXT_FLAG_CLIENT_HELLO |
                                    GNUTLS_EXT_FLAG_EE);
   if(rc < 0) {
-    fprintf(stderr, "gnutls_session_ext_register failed: %s\n",
-            gnutls_strerror(rc));
+    H3BUGF(fprintf(stderr, "gnutls_session_ext_register failed: %s\n",
+                   gnutls_strerror(rc)));
     return 1;
   }
 
@@ -512,22 +512,24 @@ static int quic_init_ssl(struct quicsocket *qs)
 
   rc = gnutls_certificate_allocate_credentials(&qs->cred);
   if(rc < 0) {
-    fprintf(stderr, "gnutls_certificate_allocate_credentials failed: %s\n",
-            gnutls_strerror(rc));
+    H3BUGF(fprintf(stderr,
+                   "gnutls_certificate_allocate_credentials failed: %s\n",
+                   gnutls_strerror(rc)));
     return 1;
   }
 
   rc = gnutls_certificate_set_x509_system_trust(qs->cred);
   if(rc < 0) {
-    fprintf(stderr, "gnutls_certificate_set_x509_system_trust failed: %s\n",
-            gnutls_strerror(rc));
+    H3BUGF(fprintf(stderr,
+                   "gnutls_certificate_set_x509_system_trust failed: %s\n",
+                   gnutls_strerror(rc)));
     return 1;
   }
 
   rc = gnutls_credentials_set(qs->ssl, GNUTLS_CRD_CERTIFICATE, qs->cred);
   if(rc < 0) {
-    fprintf(stderr, "gnutls_credentials_set failed: %s\n",
-            gnutls_strerror(rc));
+    H3BUGF(fprintf(stderr, "gnutls_credentials_set failed: %s\n",
+                   gnutls_strerror(rc)));
     return 1;
   }
 

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -107,6 +107,14 @@ static CURLcode quiche_disconnect(struct connectdata *conn,
   (void)dead_connection;
   return qs_disconnect(qs);
 }
+
+void Curl_quic_disconnect(struct connectdata *conn,
+                          int tempindex)
+{
+  if(conn->transport == TRNSPRT_QUIC)
+    qs_disconnect(&conn->hequic[tempindex]);
+}
+
 static unsigned int quiche_conncheck(struct connectdata *conn,
                                      unsigned int checks_to_perform)
 {


### PR DESCRIPTION
This patch series fixes a ngtcp2 QUIC connect crash (#5565)

when I had that fixed, I spotted that happy eyeballs didn't work correctly either with QUIC, and in fact not with regular TCP either when the first family was still trying to connect when the second family runs out of addresses to try.

when I had that fixed, I spotted a memory leak in failed QUIC connections so I added a `Curl_quic_disconnect` function to let us cleanup QUIC resources better from connection code.

and while doing all this, I noticed a bunch of `fprintf()` calls linger in ngtcp2.c that we don't like!