### PR TITLE
manpage: add three previously undocumented environment variables

### DIFF
--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -36,7 +36,23 @@ accesses the target URL through the proxy.
 
 The list of host names can also be include numerical IP addresses, and IPv6
 versions should then be given without enclosing brackets.
-
+.IP "CURL_SSL_BACKEND <TLS backend>"
+If curl was built with support for "MultiSSL", meaning that it has built-in
+support for more than one TLS backend, this environment variable can be set to
+the case insensitive name of the particular backend to use when curl is
+invokved. Setting a name that isn't a built-in alternative, will make curl
+stay with the default.
+.IP "QLOGDIR <directory name>"
+If curl was built with HTTP/3 support, setting this environment variable to a
+local directory will make curl produce qlogs in that directory, using file
+names named after the destination connection id (in hex). Do note that these
+files can become rather large. Works with both QUIC backends.
+.IP "SSLKEYLOGFILE <file name>"
+If you set this environment variable to a file name, curl will store TLS
+secrets from its connections in that file when invoked to enable you to
+analyze the TLS traffic in real time using network analyzing tools such as
+Wireshark. This works with the following TLS backends: OpenSSL, libressl,
+BoringSSL, GnuTLS, NSS and wolfSSL.
 .SH "PROXY PROTOCOL PREFIXES"
 Since curl version 7.21.7, the proxy string may be specified with a
 protocol:// prefix to specify alternative proxy protocols.


### PR DESCRIPTION
CURL_SSL_BACKEND, QLOGDIR and SSLKEYLOGFILE