### PR TITLE
time: reduce calls to Curl_now()

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -625,7 +625,7 @@ CURLcode Curl_resolver_is_resolved(struct connectdata *conn,
   else {
     /* poll for name lookup done with exponential backoff up to 250ms */
     /* should be fine even if this converts to 32 bit */
-    timediff_t elapsed = Curl_timediff(Curl_now(),
+    timediff_t elapsed = Curl_timediff(data->multi->mnow,
                                        data->progress.t_startsingle);
     if(elapsed < 0)
       elapsed = 0;
@@ -671,7 +671,7 @@ int Curl_resolver_getsock(struct connectdata *conn,
   }
   else {
 #endif
-    ms = Curl_timediff(Curl_now(), reslv->start);
+    ms = Curl_timediff(data->multi->mnow, reslv->start);
     if(ms < 3)
       milli = 0;
     else if(ms <= 50)
@@ -703,7 +703,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 
   *waitp = 0; /* default to synchronous response */
 
-  reslv->start = Curl_now();
+  reslv->start = data->multi->mnow;
 
   /* fire up a new resolver thread! */
   if(init_resolve_thread(conn, hostname, port, NULL)) {
@@ -759,7 +759,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
   hints.ai_socktype = (conn->transport == TRNSPRT_TCP)?
     SOCK_STREAM : SOCK_DGRAM;
 
-  reslv->start = Curl_now();
+  reslv->start = data->multi->mnow;
   /* fire up a new resolver thread! */
   if(init_resolve_thread(conn, hostname, port, &hints)) {
     *waitp = 1; /* expect asynchronous response */

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -625,7 +625,7 @@ CURLcode Curl_resolver_is_resolved(struct connectdata *conn,
   else {
     /* poll for name lookup done with exponential backoff up to 250ms */
     /* should be fine even if this converts to 32 bit */
-    timediff_t elapsed = Curl_timediff(data->multi->mnow,
+    timediff_t elapsed = Curl_timediff(Curl_mnow(data->multi),
                                        data->progress.t_startsingle);
     if(elapsed < 0)
       elapsed = 0;
@@ -671,7 +671,7 @@ int Curl_resolver_getsock(struct connectdata *conn,
   }
   else {
 #endif
-    ms = Curl_timediff(data->multi->mnow, reslv->start);
+    ms = Curl_timediff(Curl_mnow(data->multi), reslv->start);
     if(ms < 3)
       milli = 0;
     else if(ms <= 50)
@@ -703,7 +703,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 
   *waitp = 0; /* default to synchronous response */
 
-  reslv->start = data->multi->mnow;
+  reslv->start = Curl_mnow(data->multi);
 
   /* fire up a new resolver thread! */
   if(init_resolve_thread(conn, hostname, port, NULL)) {
@@ -759,7 +759,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
   hints.ai_socktype = (conn->transport == TRNSPRT_TCP)?
     SOCK_STREAM : SOCK_DGRAM;
 
-  reslv->start = data->multi->mnow;
+  reslv->start = Curl_mnow(data->multi);
   /* fire up a new resolver thread! */
   if(init_resolve_thread(conn, hostname, port, &hints)) {
     *waitp = 1; /* expect asynchronous response */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -400,7 +400,7 @@ bool Curl_conncache_return_conn(struct Curl_easy *data,
     data->multi->maxconnects;
   struct connectdata *conn_candidate = NULL;
 
-  conn->lastused = Curl_now(); /* it was used up until now */
+  conn->lastused = Curl_mnow(data->multi); /* it was used up until now */
   if(maxconnects > 0 &&
      Curl_conncache_size(data) > maxconnects) {
     infof(data, "Connection cache is full, closing the oldest one.\n");
@@ -438,7 +438,7 @@ Curl_conncache_extract_bundle(struct Curl_easy *data,
 
   (void)data;
 
-  now = Curl_now();
+  now = Curl_mnow(data->multi);
 
   curr = bundle->conn_list.head;
   while(curr) {
@@ -487,7 +487,7 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
   struct connectbundle *bundle;
   struct connectbundle *bundle_candidate = NULL;
 
-  now = Curl_now();
+  now = Curl_mnow(data->multi);
 
   CONNCACHE_LOCK(data);
   Curl_hash_start_iterate(&connc->hash, &iter);

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -36,9 +36,7 @@ CURLcode Curl_connecthost(struct connectdata *conn,
 
 /* generic function that returns how much time there's left to run, according
    to the timeouts set */
-timediff_t Curl_timeleft(struct Curl_easy *data,
-                         struct curltime *nowp,
-                         bool duringconnect);
+timediff_t Curl_timeleft(struct Curl_easy *data, bool duringconnect);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -250,7 +250,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
     url = nurl;
   }
 
-  timeout_ms = Curl_timeleft(data, NULL, TRUE);
+  timeout_ms = Curl_timeleft(data, TRUE);
   if(timeout_ms <= 0) {
     result = CURLE_OPERATION_TIMEDOUT;
     goto error;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -507,12 +507,10 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     }
 
     /* get the time stamp to use to figure out how long poll takes */
-    before = Curl_now();
-
+    before = Curl_mnow(multi);
     /* wait for activity or timeout */
     pollrc = Curl_poll(fds, numfds, ev->ms);
-
-    after = Curl_now();
+    after = Curl_now_update(multi);
 
     ev->msbump = FALSE; /* reset here */
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -346,7 +346,7 @@ static CURLcode file_upload(struct connectdata *conn)
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else
-      result = Curl_speedcheck(data, Curl_now());
+      result = Curl_speedcheck(data);
   }
   if(!result && Curl_pgrsUpdate(conn))
     result = CURLE_ABORTED_BY_CALLBACK;
@@ -533,7 +533,7 @@ static CURLcode file_do(struct connectdata *conn, bool *done)
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else
-      result = Curl_speedcheck(data, Curl_now());
+      result = Curl_speedcheck(data);
   }
   if(Curl_pgrsUpdate(conn))
     result = CURLE_ABORTED_BY_CALLBACK;

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -142,7 +142,7 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
     else
       break;
 
-    timeout_ms = Curl_timeleft(conn->data, NULL, FALSE);
+    timeout_ms = Curl_timeleft(conn->data, FALSE);
     if(timeout_ms < 0) {
       result = CURLE_OPERATION_TIMEDOUT;
       break;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -783,7 +783,7 @@ clean_up:
      the time we spent until now! */
   if(prev_alarm) {
     /* there was an alarm() set before us, now put it back */
-    timediff_t elapsed_secs = Curl_timediff(Curl_now(),
+    timediff_t elapsed_secs = Curl_timediff(data->multi->mnow,
                                             conn->created) / 1000;
 
     /* the alarm period is counted in even number of seconds */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -783,7 +783,7 @@ clean_up:
      the time we spent until now! */
   if(prev_alarm) {
     /* there was an alarm() set before us, now put it back */
-    timediff_t elapsed_secs = Curl_timediff(data->multi->mnow,
+    timediff_t elapsed_secs = Curl_timediff(Curl_mnow(data->multi),
                                             conn->created) / 1000;
 
     /* the alarm period is counted in even number of seconds */

--- a/lib/http.c
+++ b/lib/http.c
@@ -2973,6 +2973,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
   if(data->req.writebytecount) {
     /* if a request-body has been sent off, we make sure this progress is noted
        properly */
+    Curl_now_update(data->multi); /* sending that data could be slow */
     Curl_pgrsSetUploadCounter(data, data->req.writebytecount);
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -224,7 +224,7 @@ static unsigned int http2_conncheck(struct connectdata *check,
   }
 
   if(checks_to_perform & CONNCHECK_KEEPALIVE) {
-    struct curltime now = Curl_now();
+    struct curltime now = Curl_mnow(check->data->multi);
     timediff_t elapsed = Curl_timediff(now, check->keepalive);
 
     if(elapsed > check->upkeep_interval_ms) {

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -309,7 +309,7 @@ static CURLcode CONNECT(struct connectdata *conn,
       s->tunnel_state = TUNNEL_CONNECT;
     } /* END CONNECT PHASE */
 
-    check = Curl_timeleft(data, NULL, TRUE);
+    check = Curl_timeleft(data, TRUE);
     if(check <= 0) {
       failf(data, "Proxy CONNECT aborted due to timeout");
       return CURLE_OPERATION_TIMEDOUT;

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -85,6 +85,15 @@ struct Curl_multi {
   struct Curl_easy *easyp;
   struct Curl_easy *easylp; /* last node */
 
+  /* Update time with Curl_now_update(), read time with Curl_mnow(). Never
+     access this variable directly. */
+  struct curltime mulnow;
+#ifdef CURLDEBUG
+  /* for debug-logging where the now time was updated last */
+  const char *now_file;
+  int now_lineno;
+#endif
+
   int num_easy; /* amount of entries in the linked list above. */
   int num_alive; /* amount of easy handles that are added but have not yet
                     reached COMPLETE state */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -38,6 +38,24 @@ bool Curl_multiplex_wanted(const struct Curl_multi *multi);
 void Curl_set_in_callback(struct Curl_easy *data, bool value);
 bool Curl_is_in_callback(struct Curl_easy *easy);
 
+struct curltime Curl_now_update_func(struct Curl_multi *m);
+#ifdef CURLDEBUG
+struct curltime Curl_now_update_debug(struct Curl_multi *multi,
+                                      const char *file, int fileno);
+#define Curl_now_update(x) Curl_now_update_debug(x, __FILE__, __LINE__)
+#else
+#define Curl_now_update(x) Curl_now_update_func(x)
+#endif
+
+struct curltime Curl_mnow_func(const struct Curl_multi *multi);
+#ifdef CURLDEBUG
+struct curltime Curl_mnow_debug(struct Curl_multi *multi,
+                                const char *file, int fileno);
+#define Curl_mnow(x) Curl_mnow_debug(x, __FILE__, __LINE__)
+#else
+#define Curl_mnow(x) Curl_mnow_func(x)
+#endif
+
 /* Internal version of curl_multi_init() accepts size parameters for the
    socket and connection hashes */
 struct Curl_multi *Curl_multi_handle(int hashsize, int chashsize);

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -58,7 +58,7 @@ struct pingpong {
                      server */
   size_t sendleft; /* number of bytes left to send from the sendthis buffer */
   size_t sendsize; /* total size of the sendthis buffer */
-  struct curltime response; /* set to Curl_now() when a command has been sent
+  struct curltime response; /* set to curren time when a command has been sent
                                off, used to time-out response reading */
   timediff_t response_time; /* When no timeout is given, this is the amount of
                                milliseconds we await for a server response. */
@@ -89,7 +89,6 @@ void Curl_pp_init(struct pingpong *pp);
 /* Returns timeout in ms. 0 or negative number means the timeout has already
    triggered */
 timediff_t Curl_pp_state_timeout(struct pingpong *pp, bool disconnecting);
-
 
 /***********************************************************************
  *

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -168,7 +168,7 @@ void Curl_pgrsResetTransferSizes(struct Curl_easy *data)
  */
 void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 {
-  struct curltime now = Curl_now();
+  struct curltime now = Curl_mnow(data->multi);
   timediff_t *delta = NULL;
 
   switch(timer) {
@@ -233,7 +233,7 @@ void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 void Curl_pgrsStartNow(struct Curl_easy *data)
 {
   data->progress.speeder_c = 0; /* reset the progress meter display */
-  data->progress.start = Curl_now();
+  data->progress.start = Curl_mnow(data->multi);
   data->progress.is_t_startransfer_set = false;
   data->progress.ul_limit_start.tv_sec = 0;
   data->progress.ul_limit_start.tv_usec = 0;
@@ -243,7 +243,7 @@ void Curl_pgrsStartNow(struct Curl_easy *data)
   data->progress.uploaded = 0;
   /* clear all bits except HIDE and HEADERS_OUT */
   data->progress.flags &= PGRS_HIDE|PGRS_HEADERS_OUT;
-  Curl_ratelimit(data, data->progress.start);
+  Curl_ratelimit(data);
 }
 
 /*
@@ -316,8 +316,9 @@ void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 /*
  * Update the timestamp and sizestamp to use for rate limit calculations.
  */
-void Curl_ratelimit(struct Curl_easy *data, struct curltime now)
+void Curl_ratelimit(struct Curl_easy *data)
 {
+  struct curltime now = Curl_mnow(data->multi);
   /* don't set a new stamp unless the time since last update is long enough */
   if(data->set.max_recv_speed > 0) {
     if(Curl_timediff(now, data->progress.dl_limit_start) >=
@@ -581,7 +582,7 @@ static void progress_meter(struct connectdata *conn)
 int Curl_pgrsUpdate(struct connectdata *conn)
 {
   struct Curl_easy *data = conn->data;
-  struct curltime now = Curl_now(); /* what time is it */
+  struct curltime now = Curl_mnow(data->multi); /* what time is it */
   bool showprogress = progress_calc(conn, now);
   if(!(data->progress.flags & PGRS_HIDE)) {
     if(data->set.fxferinfo) {

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -46,7 +46,7 @@ void Curl_pgrsSetDownloadSize(struct Curl_easy *data, curl_off_t size);
 void Curl_pgrsSetUploadSize(struct Curl_easy *data, curl_off_t size);
 void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size);
 void Curl_pgrsSetUploadCounter(struct Curl_easy *data, curl_off_t size);
-void Curl_ratelimit(struct Curl_easy *data, struct curltime now);
+void Curl_ratelimit(struct Curl_easy *data);
 int Curl_pgrsUpdate(struct connectdata *);
 void Curl_pgrsResetTransferSizes(struct Curl_easy *data);
 void Curl_pgrsTime(struct Curl_easy *data, timerid timer);

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -30,6 +30,7 @@
 #include "vtls/vtls.h"
 #include "sendf.h"
 #include "rand.h"
+#include "multiif.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -86,7 +87,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 #endif
 
   if(!seeded) {
-    struct curltime now = Curl_now();
+    struct curltime now = Curl_mnow(data->multi);
     infof(data, "WARNING: Using weak random seed\n");
     randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
     randseed = randseed * 1103515245 + 12345;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1412,7 +1412,7 @@ static CURLcode smtp_done(struct connectdata *conn, CURLcode status,
     }
     else {
       /* Successfully sent so adjust the response timeout relative to now */
-      pp->response = Curl_now();
+      pp->response = Curl_mnow(data->multi);
 
       free(eob);
     }

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -62,7 +62,7 @@ int Curl_blockread_all(struct connectdata *conn, /* connection data */
   int result;
   *n = 0;
   for(;;) {
-    timediff_t timeout_ms = Curl_timeleft(conn->data, NULL, TRUE);
+    timediff_t timeout_ms = Curl_timeleft(conn->data, TRUE);
     if(timeout_ms < 0) {
       /* we already got the timeout */
       result = CURLE_OPERATION_TIMEDOUT;

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2017, 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -36,9 +36,9 @@ void Curl_speedinit(struct Curl_easy *data)
 /*
  * @unittest: 1606
  */
-CURLcode Curl_speedcheck(struct Curl_easy *data,
-                         struct curltime now)
+CURLcode Curl_speedcheck(struct Curl_easy *data)
 {
+  struct curltime now = Curl_mnow(data->multi);
   if((data->progress.current_speed >= 0) && data->set.low_speed_time) {
     if(data->progress.current_speed < data->set.low_speed_limit) {
       if(!data->state.keeps_speed.tv_sec)

--- a/lib/speedcheck.h
+++ b/lib/speedcheck.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,7 +27,5 @@
 #include "timeval.h"
 
 void Curl_speedinit(struct Curl_easy *data);
-CURLcode Curl_speedcheck(struct Curl_easy *data,
-                         struct curltime now);
-
+CURLcode Curl_speedcheck(struct Curl_easy *data);
 #endif /* HEADER_CURL_SPEEDCHECK_H */

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -56,6 +56,7 @@
 #include "select.h"
 #include "strcase.h"
 #include "warnless.h"
+#include "multiif.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -1559,7 +1560,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     }
 
     if(data->set.timeout) {
-      now = Curl_now();
+      now = data->multi->mnow;
       if(Curl_timediff(now, conn->created) >= data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;
@@ -1677,7 +1678,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     } /* poll switch statement */
 
     if(data->set.timeout) {
-      now = Curl_now();
+      now = Curl_mnow(data->multi);
       if(Curl_timediff(now, conn->created) >= data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1560,7 +1560,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     }
 
     if(data->set.timeout) {
-      now = data->multi->mnow;
+      now = Curl_mnow(data->multi);
       if(Curl_timediff(now, conn->created) >= data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -205,7 +205,7 @@ static CURLcode tftp_set_timeouts(struct tftp_state_data *state)
   time(&state->start_time);
 
   /* Compute drop-dead time */
-  timeout_ms = Curl_timeleft(state->conn->data, NULL, start);
+  timeout_ms = Curl_timeleft(state->conn->data, start);
 
   if(timeout_ms < 0) {
     /* time-out, bail out, go home */
@@ -1315,7 +1315,7 @@ static CURLcode tftp_doing(struct connectdata *conn, bool *dophase_done)
     if(Curl_pgrsUpdate(conn))
       result = CURLE_ABORTED_BY_CALLBACK;
     else
-      result = Curl_speedcheck(conn->data, Curl_now());
+      result = Curl_speedcheck(conn->data);
   }
   return result;
 }

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -24,6 +24,12 @@
 
 #if defined(WIN32) && !defined(MSDOS)
 
+/*
+ * Curl_now() returns the current time with microsecond accuracy - but it
+ * SHOULD BE AVOIDED. Instead use Curl_mnow(). To force a time refresh, use
+ * Curl_now_update().
+ */
+
 /* set in win32_init() */
 extern LARGE_INTEGER Curl_freq;
 extern bool Curl_isVistaOrGreater;

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -614,7 +614,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
       Curl_pgrsTime(data, TIMER_STARTTRANSFER);
       if(k->exp100 > EXP100_SEND_DATA)
         /* set time stamp to compare with when waiting for the 100 */
-        k->start100 = Curl_now();
+        k->start100 = Curl_mnow(data->multi);
     }
 
     *didwhat |= KEEP_RECV;
@@ -1033,7 +1033,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
              go into the Expect: 100 state and await such a header */
           k->exp100 = EXP100_AWAITING_CONTINUE; /* wait for the header */
           k->keepon &= ~KEEP_SEND;         /* disable writing */
-          k->start100 = Curl_now();       /* timeout count starts now */
+          k->start100 = Curl_mnow(data->multi); /* timeout count starts now */
           *didwhat &= ~KEEP_SEND;  /* we didn't write anything actually */
           /* set a timeout for the multi interface */
           Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
@@ -1209,7 +1209,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
   struct SingleRequest *k = &data->req;
   CURLcode result;
   int didwhat = 0;
-
+  struct curltime now = Curl_mnow(data->multi);
   curl_socket_t fd_read;
   curl_socket_t fd_write;
   int select_res = conn->cselect_bits;
@@ -1261,7 +1261,6 @@ CURLcode Curl_readwrite(struct connectdata *conn,
       return result;
   }
 
-  k->now = Curl_now();
   if(didwhat) {
     ;
   }
@@ -1281,7 +1280,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
 
       */
 
-      timediff_t ms = Curl_timediff(k->now, k->start100);
+      timediff_t ms = Curl_timediff(now, k->start100);
       if(ms >= data->set.expect_100_timeout) {
         /* we've waited long enough, continue anyway */
         k->exp100 = EXP100_SEND_DATA;
@@ -1295,23 +1294,23 @@ CURLcode Curl_readwrite(struct connectdata *conn,
   if(Curl_pgrsUpdate(conn))
     result = CURLE_ABORTED_BY_CALLBACK;
   else
-    result = Curl_speedcheck(data, k->now);
+    result = Curl_speedcheck(data);
   if(result)
     return result;
 
   if(k->keepon) {
-    if(0 > Curl_timeleft(data, &k->now, FALSE)) {
+    if(0 > Curl_timeleft(data, FALSE)) {
       if(k->size != -1) {
         failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
               " milliseconds with %" CURL_FORMAT_CURL_OFF_T " out of %"
               CURL_FORMAT_CURL_OFF_T " bytes received",
-              Curl_timediff(k->now, data->progress.t_startsingle),
+              Curl_timediff(now, data->progress.t_startsingle),
               k->bytecount, k->size);
       }
       else {
         failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
               " milliseconds with %" CURL_FORMAT_CURL_OFF_T " bytes received",
-              Curl_timediff(k->now, data->progress.t_startsingle),
+              Curl_timediff(now, data->progress.t_startsingle),
               k->bytecount);
       }
       return CURLE_OPERATION_TIMEDOUT;
@@ -1902,7 +1901,7 @@ Curl_setup_transfer(
          (http->sending == HTTPSEND_BODY)) {
         /* wait with write until we either got 100-continue or a timeout */
         k->exp100 = EXP100_AWAITING_CONTINUE;
-        k->start100 = Curl_now();
+        k->start100 = Curl_mnow(data->multi);
 
         /* Set a timeout for the multi interface. Add the inaccuracy margin so
            that we don't fire slightly too early and get denied to run. */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -606,7 +606,6 @@ struct SingleRequest {
                                    CURLE_GOT_NOTHING error code */
 
   struct curltime start;         /* transfer started at this time */
-  struct curltime now;           /* current time */
   enum {
     HEADER_NORMAL,              /* no bad header at all */
     HEADER_PARTHEADER,          /* part of the chunk is a bad header, the rest
@@ -949,7 +948,6 @@ struct connectdata {
   int httpversion;        /* the HTTP version*10 reported by the server */
   int rtspversion;        /* the RTSP version*10 reported by the server */
 
-  struct curltime now;     /* "current" time */
   struct curltime created; /* creation time */
   struct curltime lastused; /* when returned to the connection cache */
   curl_socket_t sock[2]; /* two sockets, the second is used for the data

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2089,7 +2089,7 @@ static CURLcode myssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     timediff_t left = 1000;
-    struct curltime now = Curl_now();
+    struct curltime now = data->multi->mnow;
 
     result = myssh_statemach_act(conn, &block);
     if(result)
@@ -2099,11 +2099,11 @@ static CURLcode myssh_block_statemach(struct connectdata *conn,
       if(Curl_pgrsUpdate(conn))
         return CURLE_ABORTED_BY_CALLBACK;
 
-      result = Curl_speedcheck(data, now);
+      result = Curl_speedcheck(data);
       if(result)
         break;
 
-      left = Curl_timeleft(data, NULL, FALSE);
+      left = Curl_timeleft(data, FALSE);
       if(left < 0) {
         failf(data, "Operation timed out");
         return CURLE_OPERATION_TIMEDOUT;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2089,7 +2089,7 @@ static CURLcode myssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     timediff_t left = 1000;
-    struct curltime now = data->multi->mnow;
+    struct curltime now = Curl_mnow(data->multi);
 
     result = myssh_statemach_act(conn, &block);
     if(result)

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2942,7 +2942,6 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     timediff_t left = 1000;
-    struct curltime now = Curl_now();
 
     result = ssh_statemach_act(conn, &block);
     if(result)
@@ -2951,11 +2950,11 @@ static CURLcode ssh_block_statemach(struct connectdata *conn,
     if(Curl_pgrsUpdate(conn))
       return CURLE_ABORTED_BY_CALLBACK;
 
-    result = Curl_speedcheck(data, now);
+    result = Curl_speedcheck(data);
     if(result)
       break;
 
-    left = Curl_timeleft(data, NULL, duringconnect);
+    left = Curl_timeleft(data, duringconnect);
     if(left < 0) {
       failf(data, "Operation timed out");
       return CURLE_OPERATION_TIMEDOUT;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -982,7 +982,7 @@ static CURLcode wssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     timediff_t left = 1000;
-    struct curltime now = Curl_now();
+    struct curltime now = data->multi->mnow;
 
     result = wssh_statemach_act(conn, &block);
     if(result)
@@ -992,11 +992,11 @@ static CURLcode wssh_block_statemach(struct connectdata *conn,
       if(Curl_pgrsUpdate(conn))
         return CURLE_ABORTED_BY_CALLBACK;
 
-      result = Curl_speedcheck(data, now);
+      result = Curl_speedcheck(data);
       if(result)
         break;
 
-      left = Curl_timeleft(data, NULL, FALSE);
+      left = Curl_timeleft(data, FALSE);
       if(left < 0) {
         failf(data, "Operation timed out");
         return CURLE_OPERATION_TIMEDOUT;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -982,7 +982,7 @@ static CURLcode wssh_block_statemach(struct connectdata *conn,
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     timediff_t left = 1000;
-    struct curltime now = data->multi->mnow;
+    struct curltime now = Curl_mnow(data->multi);
 
     result = wssh_statemach_act(conn, &block);
     if(result)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3974,7 +3974,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
 
   if(ssl_connect_1 == connssl->connecting_state) {
     /* Find out how much more time we're allowed */
-    const timediff_t timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    const timediff_t timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */
@@ -3992,7 +3992,7 @@ static CURLcode ossl_connect_common(struct connectdata *conn,
         ssl_connect_2_writing == connssl->connecting_state) {
 
     /* check allowed time left */
-    const timediff_t timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    const timediff_t timeout_ms = Curl_timeleft(data, TRUE);
 
     if(timeout_ms < 0) {
       /* no need to continue if time already is up */

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,7 +49,7 @@ static void unit_stop(void)
 #define BASE 1000000
 
 /* macro to set the pretended current time */
-#define NOW(x,y) now.tv_sec = x; now.tv_usec = y
+#define NOW(x,y) nowp->tv_sec = x; nowp->tv_usec = y
 /* macro to set the millisecond based timeouts to use */
 #define TIMEOUTS(x,y) data->set.timeout = x; data->set.connecttimeout = y
 
@@ -74,7 +74,7 @@ struct timetest {
 
 UNITTEST_START
 {
-  struct curltime now;
+  struct curltime *nowp = &data->multi->mulnow;
   unsigned int i;
 
   const struct timetest run[] = {
@@ -141,7 +141,7 @@ UNITTEST_START
     timediff_t timeout;
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
-    timeout =  Curl_timeleft(data, &now, run[i].connecting);
+    timeout =  Curl_timeleft(data, run[i].connecting);
     if(timeout != run[i].result)
       fail(run[i].comment);
   }

--- a/tests/unit/unit1606.c
+++ b/tests/unit/unit1606.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,7 +49,6 @@ static int runawhile(long time_limit,
                      int dec)
 {
   int counter = 1;
-  struct curltime now = {1, 0};
   CURLcode result;
   int finaltime;
 
@@ -57,18 +56,20 @@ static int runawhile(long time_limit,
   curl_easy_setopt(easy, CURLOPT_LOW_SPEED_TIME, time_limit);
   Curl_speedinit(easy);
 
+  easy->multi->mulnow.tv_sec = 1;
+  easy->multi->mulnow.tv_usec = 0;
   do {
     /* fake the current transfer speed */
     easy->progress.current_speed = speed;
-    result = Curl_speedcheck(easy, now);
+    result = Curl_speedcheck(easy);
     if(result)
       break;
     /* step the time */
-    now.tv_sec = ++counter;
+    easy->multi->mulnow.tv_sec = ++counter;
     speed -= dec;
   } while(counter < 100);
 
-  finaltime = (int)(now.tv_sec - 1);
+  finaltime = (int)(easy->multi->mulnow.tv_sec - 1);
 
   return finaltime;
 }


### PR DESCRIPTION
Curl_now() returns the current time with microsecond accuracy - but
should not be used superfluously.

Instead use Curl_mnow(), which is a cached "reasonably updated" current
time. To force a time refresh, use Curl_now_update(). Each API entry
point should force a time refresh, as well as after any potential waits
or delays.

As an extra debug-helper: debug builds will get a check in Curl_mnow()
that compares the "cached" time with the Curl_now() time and warns on
stderr if the delta is 5000 microseconds or more. It also keeps the
source name + line number of the most recent update to aid.

Fixes #5574