### PR TITLE
Fixed access-> waccess to file for Windows Plarform

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -129,15 +129,15 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
   return result;
 }
 
-int curlx_win32_access(const char* path, int mode)
+int curlx_win32_access(const char *path, int mode)
 {
     int result = -1;
 #ifdef _UNICODE
-    wchar_t* path_w = curlx_convert_UTF8_to_wchar(path);
+    wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
 #endif /* _UNICODE */
 
 #if defined(_UNICODE)
-    if (path_w)
+    if(path_w)
         result = _waccess(path_w, mode);
     else
 #endif /* _UNICODE */

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -129,4 +129,25 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
   return result;
 }
 
+int curlx_win32_access(const char* path, int mode)
+{
+    int result = -1;
+#ifdef _UNICODE
+    wchar_t* path_w = curlx_convert_UTF8_to_wchar(path);
+#endif /* _UNICODE */
+
+#if defined(_UNICODE)
+    if (path_w)
+        result = _waccess(path_w, mode);
+    else
+#endif /* _UNICODE */
+        result = _access(path, mode);
+
+#ifdef _UNICODE
+    free(path_w);
+#endif
+
+    return result;
+}
+
 #endif /* USE_WIN32_LARGE_FILES || USE_WIN32_SMALL_FILES */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -335,6 +335,7 @@
 #  define struct_stat                struct _stati64
 #  define LSEEK_ERROR                (__int64)-1
 #  define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
+#  define access(fname,mode)         curlx_win32_access(fname, mode)
    int curlx_win32_stat(const char *path, struct_stat *buffer);
    FILE *curlx_win32_fopen(const char *filename, const char *mode);
 #endif
@@ -354,6 +355,7 @@
 #    define stat(fname,stp)            curlx_win32_stat(fname, stp)
 #    define struct_stat                struct _stat
 #    define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
+#    define access(fname,mode)         curlx_win32_access(fname, mode)
      int curlx_win32_stat(const char *path, struct_stat *buffer);
      FILE *curlx_win32_fopen(const char *filename, const char *mode);
 #  endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -338,6 +338,7 @@
 #  define access(fname,mode)         curlx_win32_access(fname, mode)
    int curlx_win32_stat(const char *path, struct_stat *buffer);
    FILE *curlx_win32_fopen(const char *filename, const char *mode);
+   int curlx_win32_access(const char *path, int mode);
 #endif
 
 /*
@@ -358,6 +359,7 @@
 #    define access(fname,mode)         curlx_win32_access(fname, mode)
      int curlx_win32_stat(const char *path, struct_stat *buffer);
      FILE *curlx_win32_fopen(const char *filename, const char *mode);
+     int curlx_win32_access(const char *path, int mode);
 #  endif
 #  define LSEEK_ERROR                (long)-1
 #endif


### PR DESCRIPTION
The reason is quite simple. For Unicode Paths call to the simple access function leads to error. 

```
CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
{
  CURLcode result = CURLE_OK;

  if(!part)
    return CURLE_BAD_FUNCTION_ARGUMENT;

  cleanup_part_content(part);

  if(filename) {
    char *base;
    struct_stat sbuf; 

    if(stat(filename, &sbuf) || access(filename, R_OK)) //<- This line causes error for unicode paths
      result = CURLE_READ_ERROR;

    part->data = strdup(filename);
    if(!part->data)
      result = CURLE_OUT_OF_MEMORY;

    part->datasize = -1;
    if(!result && S_ISREG(sbuf.st_mode)) {
      part->datasize = filesize(filename, sbuf);
      part->seekfunc = mime_file_seek;
    }

    part->readfunc = mime_file_read;
    part->freefunc = mime_file_free;
    part->kind = MIMEKIND_FILE;

    /* As a side effect, set the filename to the current file's base name.
       It is possible to withdraw this by explicitly calling
       curl_mime_filename() with a NULL filename argument after the current
       call. */
    base = strippath(filename);
    if(!base)
      result = CURLE_OUT_OF_MEMORY;
    else {
      CURLcode res = curl_mime_filename(part, base);

      if(res)
        result = res;
      free(base);
    }
  }
  return result;
}
```