### PR TITLE
openssl: Fix CA fallback logic for OpenSSL 3.0 build

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3024,7 +3024,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
 #endif
 
 #ifdef CURL_CA_FALLBACK
-  else if(verifypeer) {
+  if(verifypeer && !ssl_cafile && !ssl_capath) {
     /* verifying the peer without any CA certificates won't
        work so use openssl's built in default as fallback */
     SSL_CTX_set_default_verify_paths(backend->ctx);


### PR DESCRIPTION
Prior to this change I assume a build error would occur when
CURL_CA_FALLBACK was used.

Closes #xxxx

---

I don't have an OpenSSL 3.0 build to test this but the verify API changes we made for that version did not take into account it was expected an `if` block would precede the `else` block used by CURL_CA_FALLBACK.