### PR TITLE
tests: Add percent progress bar to runtests.pl

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,11 +64,11 @@ if CROSSCOMPILING
 TEST = @echo "NOTICE: we can't run the tests when cross-compiling!"
 else # if not cross-compiling:
 TEST = srcdir=$(srcdir) $(PERL) $(PERLFLAGS) $(srcdir)/runtests.pl
-TEST_Q = -a -s
-TEST_AM = -a -am
-TEST_F = -a -p -r
-TEST_T = -a -t
-TEST_E = -a -e
+TEST_Q = -a -% -s
+TEST_AM = -a -% -am
+TEST_F = -a -% -p -r
+TEST_T = -a -% -t
+TEST_E = -a -% -e
 
 # !flaky means that it'll skip all tests using the flaky keyword
 TEST_NF = -a -p !flaky

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -20,7 +20,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH runtests.pl 1 "2 Feb 2010" "Curl 7.69.0" "runtests"
+.TH runtests.pl 1 "25 Jun 2020" "Curl 7.72.0" "runtests"
 .SH NAME
 runtests.pl \- run one or more test cases
 .SH SYNOPSIS
@@ -129,6 +129,8 @@ Enable verbose output. Speaks more than default.
 Provide a path to a custom curl binary to run when verifying that the servers
 running are indeed our test servers. Default is the curl executable in the
 build tree.
+.IP "-%"
+Shows a percentage value based on how many tests are still left.
 .SH "RUNNING TESTS"
 Many tests have conditions that must be met before the test case can run
 fine. They could depend on built-in features in libcurl or features present in

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -334,6 +334,7 @@ my $keepoutfiles; # keep stdout and stderr files after tests
 my $listonly;     # only list the tests
 my $postmortem;   # display detailed info about failed tests
 my $run_event_based; # run curl with --test-event to test the event API
+my $show_percentage; # Show a percentage value based on how many tests are still left.
 
 my %run;          # running server
 my %doesntrun;    # servers that don't work, identified by pidfile
@@ -4498,9 +4499,16 @@ sub singletest {
     my $took = $timevrfyend{$testnum} - $timeprepini{$testnum};
     my $duration = sprintf("duration: %02d:%02d",
                            $sofar/60, $sofar%60);
+    my $percent = ($count / $total) * 100;
     if(!$automakestyle) {
+        if($show_percentage) {
+        logmsg sprintf("OK (%-3d out of %-3d, %s, took %.3fs, %s, completion: %.2f%%)\n",
+                       $count, $total, $left, $took, $duration, $percent);
+        }
+        else {
         logmsg sprintf("OK (%-3d out of %-3d, %s, took %.3fs, %s)\n",
                        $count, $total, $left, $took, $duration);
+        }
     }
     else {
         logmsg "PASS: $testnum - $testname\n";
@@ -5215,6 +5223,9 @@ while(@ARGV) {
 
         $VCURL="\"$ARGV[1]\"";
         shift @ARGV;
+    }
+    elsif ($ARGV[0] eq "-%") {
+        $show_percentage = 1;
     }
     elsif ($ARGV[0] eq "-d") {
         # have the servers display protocol output


### PR DESCRIPTION
I (and probably many others) prefer to have a percentage based progress as this gives a quicker and more reliable way on how much tests still need to be performed (compared to xx OUT OF xx and remaining).

It displays the percentage value up the second value after the digit.

**Screenshot**
![grafik](https://user-images.githubusercontent.com/12272949/85325436-e9143d80-b4cb-11ea-84a9-8e6f624a0989.png)
