### PR TITLE
url: make sure pushed streams get an allocated download buffer

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1642,10 +1642,11 @@ static CURLcode protocol_connect(struct connectdata *conn,
 }
 
 /*
- * preconnect() is called immediately before a connect starts. When a redirect
- * is followed, this is then called multiple times during a single transfer.
+ * Curl_preconnect() is called immediately before a connect starts. When a
+ * redirect is followed, this is then called multiple times during a single
+ * transfer.
  */
-static CURLcode preconnect(struct Curl_easy *data)
+CURLcode Curl_preconnect(struct Curl_easy *data)
 {
   if(!data->state.buffer) {
     data->state.buffer = malloc(data->set.buffer_size + 1);
@@ -1763,7 +1764,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     case CURLM_STATE_CONNECT:
       /* Connect. We want to get a connection identifier filled in. */
       /* init this transfer. */
-      result = preconnect(data);
+      result = Curl_preconnect(data);
       if(result)
         break;
 

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -37,6 +37,7 @@ void Curl_detach_connnection(struct Curl_easy *data);
 bool Curl_multiplex_wanted(const struct Curl_multi *multi);
 void Curl_set_in_callback(struct Curl_easy *data, bool value);
 bool Curl_is_in_callback(struct Curl_easy *easy);
+CURLcode Curl_preconnect(struct Curl_easy *data);
 
 /* Internal version of curl_multi_init() accepts size parameters for the
    socket and connection hashes */

--- a/lib/url.c
+++ b/lib/url.c
@@ -3981,6 +3981,11 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
 {
   struct SingleRequest *k = &data->req;
 
+  /* if this is a pushed stream, we need this: */
+  CURLcode result = Curl_preconnect(data);
+  if(result)
+    return result;
+
   if(conn) {
     conn->bits.do_more = FALSE; /* by default there's no curl_do_more() to
                                    use */


### PR DESCRIPTION
Follow-up to c4e6968127e876b0

When a new transfer is created, as a resuly of an acknowledged push,
that transfer needs a download buffer allocated.