### PR TITLE
test1539: do a HTTP 1.0 POST without a set size (fails)

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -180,14 +180,13 @@ test1442 test1443 test1444 test1445 test1446 test1447 test1448 test1449 \
 test1450 test1451 test1452 test1453 test1454 test1455 test1456 test1457 \
 test1458 test1459 test1460 \
 \
-test1500 test1501 test1502 test1503 test1504 test1505 \
-test1506 test1507 test1508 test1509 test1510 test1511 test1512 test1513 \
-test1514 test1515 test1516 test1517 test1518 test1519 test1520 test1521 \
-test1522 test1523 test1524 \
-\
-test1525 test1526 test1527 test1528 test1529 test1530 test1531 test1532 \
-test1533 test1534 test1535 test1536 test1537 test1538 \
+test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
+test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
+test1516 test1517 test1518 test1519 test1520 test1521 test1522 test1523 \
+test1524 test1525 test1526 test1527 test1528 test1529 test1530 test1531 \
+test1532 test1533 test1534 test1535 test1536 test1537 test1538 test1539 \
 test1540 test1541 \
+\
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 test1564 test1565 \
 test1566 \

--- a/tests/data/test1539
+++ b/tests/data/test1539
@@ -1,0 +1,43 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+Content-Length
+chunked Transfer-Encoding
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Sun, 19 Jan 2014 18:50:58 GMT
+Server: test-server/fake swsclose
+Connection: close
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+lib1539
+</tool>
+<name>
+HTTP 1.0 POST with read callback and unknown data size
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/1539
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+25
+</errorcode>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -53,7 +53,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
  lib1518         lib1520 lib1521 lib1522 lib1523 \
  lib1525 lib1526 lib1527 lib1528 lib1529 lib1530 lib1531 lib1532 lib1533 \
- lib1534 lib1535 lib1536 lib1537 lib1538 \
+ lib1534 lib1535 lib1536 lib1537 lib1538 lib1539 \
  lib1540 lib1541 \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
  lib1558 lib1559 lib1560 lib1564 lib1565 \
@@ -541,6 +541,10 @@ lib1537_CPPFLAGS = $(AM_CPPFLAGS)
 lib1538_SOURCES = lib1538.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1538_LDADD = $(TESTUTIL_LIBS)
 lib1538_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1539_SOURCES = lib1514.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1539_LDADD = $(TESTUTIL_LIBS)
+lib1539_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1539
 
 lib1540_SOURCES = lib1540.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1540_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1514.c
+++ b/tests/libtest/lib1514.c
@@ -68,6 +68,10 @@ int test(char *URL)
   /* Purposely omit to set CURLOPT_POSTFIELDSIZE */
   easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
   easy_setopt(curl, CURLOPT_READDATA, &pooh);
+#ifdef LIB1539
+  /* speak HTTP 1.0 - no chunked! */
+  easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+#endif
 
   result = curl_easy_perform(curl);
 


### PR DESCRIPTION
Attempt to reproduce #5593. Test case 1514 is very similar but uses
HTTP/1.1 and thus switches to chunked.