### PR TITLE
sendf: improve the message on client write errors

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -593,7 +593,7 @@ static CURLcode chop_write(struct connectdata *conn,
         return pausewrite(data, type, ptr, len);
       }
       if(wrote != chunklen) {
-        failf(data, "Failed writing response data to the destination");
+        failf(data, "Failure writing output to destination");
         return CURLE_WRITE_ERROR;
       }
     }

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -593,7 +593,7 @@ static CURLcode chop_write(struct connectdata *conn,
         return pausewrite(data, type, ptr, len);
       }
       if(wrote != chunklen) {
-        failf(data, "Failed writing body (%zu != %zu)", wrote, chunklen);
+        failf(data, "Failed writing response data to the destination");
         return CURLE_WRITE_ERROR;
       }
     }


### PR DESCRIPTION
Replace "Failed writing body (X != Y)" with "Failed writing response
data to the destination"

Reported-by: coinhubs on github
Fixes #5594