### PR TITLE
setopt: make INFILESIZE and POSTFIELDSIZE do the same thing

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -793,10 +793,10 @@ static CURLcode dupset(struct Curl_easy *dst, struct Curl_easy *src)
 
   /* duplicate memory areas pointed to */
   i = STRING_COPYPOSTFIELDS;
-  if(src->set.postfieldsize && src->set.str[i]) {
-    /* postfieldsize is curl_off_t, Curl_memdup() takes a size_t ... */
+  if(src->set.filesize && src->set.str[i]) {
+    /* filesize is curl_off_t, Curl_memdup() takes a size_t ... */
     dst->set.str[i] = Curl_memdup(src->set.str[i],
-                                  curlx_sotouz(src->set.postfieldsize));
+                                  curlx_sotouz(src->set.filesize));
     if(!dst->set.str[i])
       return CURLE_OUT_OF_MEMORY;
     /* point to the new copy */

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -319,7 +319,7 @@ static CURLcode mqtt_publish(struct connectdata *conn)
 {
   CURLcode result;
   char *payload = conn->data->set.postfields;
-  size_t payloadlen = (size_t)conn->data->set.postfieldsize;
+  size_t payloadlen = (size_t)conn->data->set.filesize;
   char *topic = NULL;
   size_t topiclen;
   unsigned char *pkt = NULL;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1474,7 +1474,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     data->state.infilesize = data->set.filesize;
   else if((data->state.httpreq != HTTPREQ_GET) &&
           (data->state.httpreq != HTTPREQ_HEAD)) {
-    data->state.infilesize = data->set.postfieldsize;
+    data->state.infilesize = data->set.filesize;
     if(data->set.postfields && (data->state.infilesize == -1))
       data->state.infilesize = (curl_off_t)strlen(data->set.postfields);
   }

--- a/lib/url.c
+++ b/lib/url.c
@@ -470,7 +470,6 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->convfromutf8    = ZERO_NULL;
 
   set->filesize = -1;        /* we don't know the size */
-  set->postfieldsize = -1;   /* unknown size */
   set->maxredirs = -1;       /* allow any amount by default */
 
   set->method = HTTPREQ_GET; /* Default HTTP request */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1612,9 +1612,6 @@ struct UserDefined {
                         bit represents a request, from 301 to 303 */
   void *postfields;  /* if POST, set the fields' values here */
   curl_seek_callback seek_func;      /* function that seeks the input */
-  curl_off_t postfieldsize; /* if POST, this might have a size to use instead
-                               of strlen(), and then the data *may* be binary
-                               (contain zero bytes) */
   unsigned short localport; /* local port number to bind to */
   int localportrange; /* number of additional port numbers to test in case the
                          'localport' one can't be bind()ed */


### PR DESCRIPTION
They're both used to set the size of the request body so let's treat
them as identical internally.