### PR TITLE
openssl: Fix compilation on Windows when ngtcp2 is enabled

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -31,6 +31,10 @@
 
 #include <limits.h>
 
+#if defined(USE_WIN32_CRYPTO)
+#include <wincrypt.h> /* must appear before all other includes below */
+#endif
+
 #include "urldata.h"
 #include "sendf.h"
 #include "formdata.h" /* for the boundary function */
@@ -47,10 +51,6 @@
 #include "multiif.h"
 #include "strerror.h"
 #include "curl_printf.h"
-
-#if defined(USE_WIN32_CRYPTO)
-#include <wincrypt.h>
-#endif
 
 #include <openssl/ssl.h>
 #include <openssl/rand.h>


### PR DESCRIPTION
The `wincrypt.h` Windows header defines a number of preprocessor macros that conflict with identically named OpenSSL types. For example, it defines the following macros:

```
#define X509_NAME                           ((LPCSTR) 7)
#define OCSP_REQUEST                        ((LPCSTR) 66)
#define OCSP_RESPONSE                       ((LPCSTR) 67)
```

Which conflict with these OpenSSL types and cause compile errors:

```
typedef struct X509_name_st X509_NAME;
typedef struct ocsp_request_st OCSP_REQUEST;
typedef struct ocsp_response_st OCSP_RESPONSE;
```

OpenSSL headers already try to avoid these conflicts by [undefining these Windows macros](https://github.com/openssl/openssl/blob/15dfa0/include/openssl/types.h#L71-L78). However, that requires that `wincrypt.h` is included _before_ any OpenSSL header.

In curl's `vtls/openssl.c` file, there is at least one configuration where an OpenSSL header is included before `wincrypt.h`. If `ngtcp2` is enabled, for example, then the `urldata.h` include ends up including OpenSSL headers transitively like this:

```
Note: including file: urldata.h
Note: including file:  quic.h
Note: including file:   vquic/ngtcp2.h
Note: including file:    openssl/ssl.h
```

That include happens [here](https://github.com/curl/curl/blob/14c17a/lib/vquic/ngtcp2.h#L32).

In order to solve these conflicts and fix the compile issues when `ngtcp2` is enabled, we need to move the `wincrypt.h` include as early as possible.