### PR TITLE
terminology: call them null-terminated strings

### DIFF
--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -51,7 +51,7 @@ to the function is encoded correctly.
 .SH AVAILABILITY
 Added in 7.15.4 and replaces the old \fIcurl_escape(3)\fP function.
 .SH RETURN VALUE
-A pointer to a zero terminated string or NULL if it failed.
+A pointer to a null-terminated string or NULL if it failed.
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();

--- a/docs/libcurl/curl_easy_strerror.3
+++ b/docs/libcurl/curl_easy_strerror.3
@@ -35,6 +35,6 @@ specific error descriptions generated at run-time.
 .SH AVAILABILITY
 This function was added in libcurl 7.12.0
 .SH RETURN VALUE
-A pointer to a zero terminated string.
+A pointer to a null-terminated string.
 .SH "SEE ALSO"
 .BR libcurl-errors "(3), " curl_multi_strerror "(3), " curl_share_strerror "(3)"

--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -49,6 +49,6 @@ You must \fIcurl_free(3)\fP the returned string when you're done with it.
 .SH AVAILABILITY
 Added in 7.15.4 and replaces the old \fIcurl_unescape(3)\fP function.
 .SH RETURN VALUE
-A pointer to a zero terminated string or NULL if it failed.
+A pointer to a null-terminated string or NULL if it failed.
 .SH "SEE ALSO"
 .BR curl_easy_escape "(3), " curl_free "(3)," RFC 3986

--- a/docs/libcurl/curl_escape.3
+++ b/docs/libcurl/curl_escape.3
@@ -43,6 +43,6 @@ You must \fIcurl_free(3)\fP the returned string when you're done with it.
 Since 7.15.4, \fIcurl_easy_escape(3)\fP should be used. This function will
 be removed in a future release.
 .SH RETURN VALUE
-A pointer to a zero terminated string or NULL if it failed.
+A pointer to a null-terminated string or NULL if it failed.
 .SH "SEE ALSO"
 .BR curl_unescape "(3), " curl_free "(3), " RFC 2396

--- a/docs/libcurl/curl_getenv.3
+++ b/docs/libcurl/curl_getenv.3
@@ -38,7 +38,7 @@ This function will be removed from the public libcurl API in a near future. It
 will instead be made "available" by source code access only, and then as
 curlx_getenv().
 .SH RETURN VALUE
-A pointer to a zero terminated string or NULL if it failed to find the
+A pointer to a null-terminated string or NULL if it failed to find the
 specified name.
 .SH NOTE
 Under unix operating systems, there isn't any point in returning an allocated

--- a/docs/libcurl/curl_mime_data.3
+++ b/docs/libcurl/curl_mime_data.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -34,7 +34,7 @@ curl_mime_data - set a mime part's body data from memory
 \fIdata\fP points to the data bytes: those are copied to the part and their
 storage may safely be reused after call.
 \fIdatasize\fP is the number of data bytes: it can be set to
-\fICURL_ZERO_TERMINATED\fP to indicate \fIdata\fP is a nul-terminated
+\fICURL_ZERO_TERMINATED\fP to indicate \fIdata\fP is a null-terminated
 character string.
 \fIpart\fP is the part's to assign contents to.
 

--- a/docs/libcurl/curl_mime_encoder.3
+++ b/docs/libcurl/curl_mime_encoder.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -33,7 +33,7 @@ curl_mime_encoder() requests a mime part's content to be encoded before being
 transmitted.
 
 \fIpart\fP is the part's handle to assign an encoder.
-\fIencoding\fP is a pointer to a zero-terminated encoding scheme. It may be
+\fIencoding\fP is a pointer to a null-terminated encoding scheme. It may be
 set to NULL to disable an encoder previously attached to the part. The encoding
 scheme storage may safely be reused after this function returns.
 

--- a/docs/libcurl/curl_mime_filedata.3
+++ b/docs/libcurl/curl_mime_filedata.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -35,9 +35,9 @@ data to a mime part.
 
 \fIpart\fP is the part's to assign contents to.
 
-\fIfilename\fP points to the nul-terminated file's path name. The pointer can
-be NULL to detach the previous part contents settings.  Filename storage can be
-safely be reused after this call.
+\fIfilename\fP points to the null-terminated file's path name. The pointer can
+be NULL to detach the previous part contents settings.  Filename storage can
+be safely be reused after this call.
 
 As a side effect, the part's remote file name is set to the base name of the
 given \fIfilename\fP if it is a valid named file. This can be undone or

--- a/docs/libcurl/curl_mime_filename.3
+++ b/docs/libcurl/curl_mime_filename.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -36,8 +36,8 @@ associated Content-Disposition generated header.
 
 \fIpart\fP is the part's handle to assign the remote file name to.
 
-\fIfilename\fP points to the nul-terminated file name string; it may be set to
-NULL to remove a previously attached remote file name.
+\fIfilename\fP points to the null-terminated file name string; it may be set
+to NULL to remove a previously attached remote file name.
 
 The remote file name string is copied into the part, thus the associated
 storage may safely be released or reused after call. Setting a part's file

--- a/docs/libcurl/curl_mime_name.3
+++ b/docs/libcurl/curl_mime_name.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -33,7 +33,7 @@ fields are named.
 
 \fIpart\fP is the part's handle to assign a name to.
 
-\fIname\fP points to the zero-terminated name string.
+\fIname\fP points to the null-terminated name string.
 
 The name string is copied into the part, thus the associated storage may
 safely be released or reused after call. Setting a part's name twice is valid:

--- a/docs/libcurl/curl_mime_type.3
+++ b/docs/libcurl/curl_mime_type.3
@@ -33,7 +33,7 @@ curl_mime_type - set a mime part's content type
 
 \fIpart\fP is the part's handle to assign the content type to.
 
-\fImimetype\fP points to the nul-terminated file mime type string; it may be
+\fImimetype\fP points to the null-terminated file mime type string; it may be
 set to NULL to remove a previously attached mime type.
 
 The mime type string is copied into the part, thus the associated storage may

--- a/docs/libcurl/curl_multi_strerror.3
+++ b/docs/libcurl/curl_multi_strerror.3
@@ -32,6 +32,6 @@ error code passed in the argument \fIerrornum\fP.
 .SH AVAILABILITY
 This function was added in libcurl 7.12.0
 .SH RETURN VALUE
-A pointer to a zero terminated string.
+A pointer to a null-terminated string.
 .SH "SEE ALSO"
 .BR libcurl-errors "(3), " curl_easy_strerror "(3), " curl_share_strerror "(3)"

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -32,6 +32,6 @@ error code passed in the argument \fIerrornum\fP.
 .SH AVAILABILITY
 This function was added in libcurl 7.12.0
 .SH RETURN VALUE
-A pointer to a zero terminated string.
+A pointer to a null-terminated string.
 .SH "SEE ALSO"
 .BR libcurl-errors "(3), " curl_multi_strerror "(3), " curl_easy_strerror "(3)"

--- a/docs/libcurl/curl_unescape.3
+++ b/docs/libcurl/curl_unescape.3
@@ -43,6 +43,6 @@ You must \fIcurl_free(3)\fP the returned string when you're done with it.
 Since 7.15.4, \fIcurl_easy_unescape(3)\fP should be used. This function will
 be removed in a future release.
 .SH RETURN VALUE
-A pointer to a zero terminated string or NULL if it failed.
+A pointer to a null-terminated string or NULL if it failed.
 .SH "SEE ALSO"
 .br curl_easy_escape "(3)," curl_easy_unescape "(3)," curl_free "(3)," RFC 2396

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -35,7 +35,7 @@ Given the \fIurl\fP handle of an already parsed URL, this function lets the
 user set/update individual pieces of it.
 
 The \fIpart\fP argument should identify the particular URL part (see list
-below) to set or change, with \fIcontent\fP pointing to a zero terminated
+below) to set or change, with \fIcontent\fP pointing to a null-terminated
 string with the new contents for that URL part. The contents should be in the
 form and encoding they'd use in a URL: URL encoded.
 
@@ -51,7 +51,7 @@ populated with a URL, the new URL can be relative to the previous.
 When successfully setting a new URL, relative or absolute, the handle contents
 will be replaced with the information of the newly set URL.
 
-Pass a pointer to a zero terminated string to the \fIurl\fP parameter. The
+Pass a pointer to a null-terminated string to the \fIurl\fP parameter. The
 string must point to a correctly formatted "RFC 3986+" URL or be a NULL
 pointer.
 .IP CURLUPART_SCHEME

--- a/docs/libcurl/curl_version.3
+++ b/docs/libcurl/curl_version.3
@@ -33,7 +33,7 @@ its important components (like OpenSSL version).
 
 We recommend using \fIcurl_version_info(3)\fP instead!
 .SH RETURN VALUE
-A pointer to a zero terminated string. The string resides in a statically
+A pointer to a null-terminated string. The string resides in a statically
 allocated buffer and must not be freed by the caller.
 .SH "SEE ALSO"
 .BR curl_version_info "(3)"

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
@@ -28,7 +28,7 @@ CURLINFO_LOCAL_IP \- get local IP address of last connection
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_LOCAL_IP, char **ip);
 .SH DESCRIPTION
-Pass a pointer to a char pointer to receive the pointer to a zero-terminated
+Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the IP address of the local end of most recent connection done
 with this \fBcurl\fP handle. This string may be IPv6 when that is
 enabled. Note that you get a pointer to a memory area that will be re-used at

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
@@ -28,7 +28,7 @@ CURLINFO_PRIMARY_IP \- get IP address of last connection
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRIMARY_IP, char **ip);
 .SH DESCRIPTION
-Pass a pointer to a char pointer to receive the pointer to a zero-terminated
+Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the IP address of the most recent connection done with this
 \fBcurl\fP handle. This string may be IPv6 when that is enabled. Note that you
 get a pointer to a memory area that will be re-used at next request so you

--- a/docs/libcurl/opts/CURLINFO_SCHEME.3
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.3
@@ -28,7 +28,7 @@ CURLINFO_SCHEME \- get the URL scheme (sometimes called protocol) used in the co
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SCHEME, char **scheme);
 .SH DESCRIPTION
-Pass a pointer to a char pointer to receive the pointer to a zero-terminated
+Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the URL scheme used for the most recent connection done with
 this CURL \fBhandle\fP.
 

--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
@@ -29,7 +29,7 @@ CURLOPT_ABSTRACT_UNIX_SOCKET \- set an abstract Unix domain socket
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ABSTRACT_UNIX_SOCKET, char *path);
 .SH DESCRIPTION
 Enables the use of an abstract Unix domain socket instead of establishing a TCP
-connection to a host. The parameter should be a char * to a zero terminated string
+connection to a host. The parameter should be a char * to a null-terminated string
 holding the path of the socket. The path will be set to \fIpath\fP prefixed by a
 NULL byte (this is the convention for abstract sockets, however it should be stressed
 that the path passed to this function should not contain a leading NULL).

--- a/docs/libcurl/opts/CURLOPT_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.3
@@ -28,7 +28,7 @@ CURLOPT_CAINFO \- path to Certificate Authority (CA) bundle
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CAINFO, char *path);
 .SH DESCRIPTION
-Pass a char * to a zero terminated string naming a file holding one or more
+Pass a char * to a null-terminated string naming a file holding one or more
 certificates to verify the peer with.
 
 If \fICURLOPT_SSL_VERIFYPEER(3)\fP is zero and you avoid verifying the

--- a/docs/libcurl/opts/CURLOPT_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_CAPATH.3
@@ -28,7 +28,7 @@ CURLOPT_CAPATH \- specify directory holding CA certificates
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CAPATH, char *capath);
 .SH DESCRIPTION
-Pass a char * to a zero terminated string naming a directory holding multiple
+Pass a char * to a null-terminated string naming a directory holding multiple
 CA certificates to verify the peer with. If libcurl is built against OpenSSL,
 the certificate directory must be prepared using the openssl c_rehash utility.
 This makes sense only when used in combination with the

--- a/docs/libcurl/opts/CURLOPT_COOKIE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.3
@@ -28,7 +28,7 @@ CURLOPT_COOKIE \- set contents of HTTP Cookie header
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIE, char *cookie);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It will be used to
+Pass a pointer to a null-terminated string as parameter. It will be used to
 set a cookie in the HTTP request. The format of the string should be
 NAME=CONTENTS, where NAME is the cookie name and CONTENTS is what the cookie
 should contain.

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
@@ -28,7 +28,7 @@ CURLOPT_COOKIEFILE \- file name to read cookies from
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIEFILE, char *filename);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It should point to
+Pass a pointer to a null-terminated string as parameter. It should point to
 the file name of your file holding cookie data to read. The cookie data can be
 in either the old Netscape / Mozilla cookie data format or just regular HTTP
 headers (Set-Cookie style) dumped to a file.

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
@@ -28,7 +28,7 @@ CURLOPT_COOKIEJAR \- file name to store cookies to
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIEJAR, char *filename);
 .SH DESCRIPTION
-Pass a \fIfilename\fP as char *, zero terminated. This will make libcurl write
+Pass a \fIfilename\fP as char *, null-terminated. This will make libcurl write
 all internally known cookies to the specified file when
 \fIcurl_easy_cleanup(3)\fP is called. If no cookies are known, no file will be
 created. Specify "-" as filename to instead have the cookies written to

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
@@ -36,7 +36,7 @@ to overwrite the original data after setting this option.
 Because data are copied, care must be taken when using this option in
 conjunction with \fICURLOPT_POSTFIELDSIZE(3)\fP or
 \fICURLOPT_POSTFIELDSIZE_LARGE(3)\fP: If the size has not been set prior to
-\fICURLOPT_COPYPOSTFIELDS(3)\fP, the data is assumed to be a zero terminated
+\fICURLOPT_COPYPOSTFIELDS(3)\fP, the data is assumed to be a null-terminated
 string; else the stored size informs the library about the byte count to
 copy. In any case, the size must not be changed after
 \fICURLOPT_COPYPOSTFIELDS(3)\fP, unless another \fICURLOPT_POSTFIELDS(3)\fP or

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.3
@@ -28,7 +28,7 @@ CURLOPT_CRLFILE \- specify a Certificate Revocation List file
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CRLFILE, char *file);
 .SH DESCRIPTION
-Pass a char * to a zero terminated string naming a \fIfile\fP with the
+Pass a char * to a null-terminated string naming a \fIfile\fP with the
 concatenation of CRL (in PEM format) to use in the certificate validation that
 occurs during the SSL exchange.
 

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
@@ -28,7 +28,7 @@ CURLOPT_CUSTOMREQUEST \- custom string for request
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CUSTOMREQUEST, char *request);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter.
+Pass a pointer to a null-terminated string as parameter.
 
 When you change the request method by setting \fICURLOPT_CUSTOMREQUEST(3)\fP
 to something, you don't actually change how libcurl behaves or acts in regards

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
@@ -54,7 +54,7 @@ shown above.
 \fICURLOPT_VERBOSE(3)\fP is in effect. This callback receives debug
 information, as specified in the \fItype\fP argument. This function must
 return 0. The \fIdata\fP pointed to by the char * passed to this function WILL
-NOT be zero terminated, but will be exactly of the \fIsize\fP as told by the
+NOT be null-terminated, but will be exactly of the \fIsize\fP as told by the
 \fIsize\fP argument.
 
 The \fIuserptr\fP argument is the pointer set with \fICURLOPT_DEBUGDATA(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -29,7 +29,7 @@ CURLOPT_DOH_URL \- provide the DNS-over-HTTPS URL
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_URL, char *URL);
 .SH DESCRIPTION
 Pass in a pointer to a \fIURL\fP for the DOH server to use for name
-resolving. The parameter should be a char * to a zero terminated string which
+resolving. The parameter should be a char * to a null-terminated string which
 must be URL-encoded in the following format: "https://host:port/path". It MUST
 specify a HTTPS URL.
 

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
@@ -28,7 +28,7 @@ CURLOPT_EGDSOCKET \- set EGD socket path
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_EGDSOCKET, char *path);
 .SH DESCRIPTION
-Pass a char * to the zero terminated path name to the Entropy Gathering Daemon
+Pass a char * to the null-terminated path name to the Entropy Gathering Daemon
 socket. It will be used to seed the random engine for SSL.
 
 The application does not have to keep the string around after setting this

--- a/docs/libcurl/opts/CURLOPT_FTPPORT.3
+++ b/docs/libcurl/opts/CURLOPT_FTPPORT.3
@@ -28,7 +28,7 @@ CURLOPT_FTPPORT \- make FTP transfer active
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTPPORT, char *spec);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It specifies that the
+Pass a pointer to a null-terminated string as parameter. It specifies that the
 FTP transfer will be made actively and the given string will be used to get
 the IP address to use for the FTP PORT instruction.
 

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
@@ -28,7 +28,7 @@ CURLOPT_FTP_ACCOUNT \- set account info for FTP
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_ACCOUNT, char *account);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string (or NULL to disable). When an FTP
+Pass a pointer to a null-terminated string (or NULL to disable). When an FTP
 server asks for "account data" after user name and password has been provided,
 this data is sent off using the ACCT command.
 

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
@@ -41,7 +41,7 @@ data. The header callback will be called once for each header and only
 complete header lines are passed on to the callback. Parsing headers is very
 easy using this. \fIbuffer\fP points to the delivered data, and the size of
 that data is \fInitems\fP; \fIsize\fP is always 1. Do not assume that the
-header line is zero terminated!
+header line is null-terminated!
 
 The pointer named \fIuserdata\fP is the one you set with the
 \fICURLOPT_HEADERDATA(3)\fP option.

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
@@ -28,7 +28,7 @@ CURLOPT_ISSUERCERT \- issuer SSL certificate filename
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ISSUERCERT, char *file);
 .SH DESCRIPTION
-Pass a char * to a zero terminated string naming a \fIfile\fP holding a CA
+Pass a char * to a null-terminated string naming a \fIfile\fP holding a CA
 certificate in PEM format. If the option is set, an additional check against
 the peer certificate is performed to verify the issuer is indeed the one
 associated with the certificate provided by the option. This additional check

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
@@ -28,7 +28,7 @@ CURLOPT_KEYPASSWD \- set passphrase to private key
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_KEYPASSWD, char *pwd);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It will be used as
+Pass a pointer to a null-terminated string as parameter. It will be used as
 the password required to use the \fICURLOPT_SSLKEY(3)\fP or
 \fICURLOPT_SSH_PRIVATE_KEYFILE(3)\fP private key.  You never needed a pass
 phrase to load a certificate but you need one to load your private key.

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
@@ -28,7 +28,7 @@ CURLOPT_LOGIN_OPTIONS \- set login options
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOGIN_OPTIONS, char *options);
 .SH DESCRIPTION
-Pass a char * as parameter, which should be pointing to the zero terminated
+Pass a char * as parameter, which should be pointing to the null-terminated
 \fIoptions\fP string to use for the transfer.
 
 For more information about the login options please see RFC2384, RFC5092 and

--- a/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
@@ -28,7 +28,7 @@ CURLOPT_MAIL_AUTH \- SMTP authentication address
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAIL_AUTH, char *auth);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. This will be used to
+Pass a pointer to a null-terminated string as parameter. This will be used to
 specify the authentication address (identity) of a submitted message that is
 being relayed to another server.
 

--- a/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
@@ -28,7 +28,7 @@ CURLOPT_MAIL_FROM \- SMTP sender address
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAIL_FROM, char *from);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. This should be used
+Pass a pointer to a null-terminated string as parameter. This should be used
 to specify the sender's email address when sending SMTP mail with libcurl.
 
 An originator email address should be specified with angled brackets (<>)

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
@@ -28,7 +28,7 @@ CURLOPT_NETRC_FILE \- file name to read .netrc info from
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NETRC_FILE, char *file);
 .SH DESCRIPTION
-Pass a char * as parameter, pointing to a zero terminated string containing
+Pass a char * as parameter, pointing to a null-terminated string containing
 the full path name to the \fIfile\fP you want libcurl to use as .netrc
 file. If this option is omitted, and \fICURLOPT_NETRC(3)\fP is set, libcurl
 will attempt to find a .netrc file in the current user's home

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -28,7 +28,7 @@ CURLOPT_NOPROXY \- disable proxy use for specific hosts
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NOPROXY, char *noproxy);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string. The string consists of a comma
+Pass a pointer to a null-terminated string. The string consists of a comma
 separated list of host names that do not require a proxy to get reached, even
 if one is specified.  The only wildcard available is a single * character,
 which matches all hosts, and effectively disables the proxy. Each name in this

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.3
@@ -28,7 +28,7 @@ CURLOPT_PASSWORD \- password to use in authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PASSWORD, char *pwd);
 .SH DESCRIPTION
-Pass a char * as parameter, which should be pointing to the zero terminated
+Pass a char * as parameter, which should be pointing to the null-terminated
 password to use for the transfer.
 
 The \fICURLOPT_PASSWORD(3)\fP option should be used in conjunction with the

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -28,7 +28,7 @@ CURLOPT_PINNEDPUBLICKEY \- set pinned public key
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PINNEDPUBLICKEY, char *pinnedpubkey);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string can be the
+Pass a pointer to a null-terminated string as parameter. The string can be the
 file name of your pinned public key. The file format expected is "PEM" or "DER".
 The string can also be any number of base64 encoded sha256 hashes preceded by
 "sha256//" and separated by ";"

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
@@ -29,7 +29,7 @@ CURLOPT_PRE_PROXY \- set pre-proxy to use
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PRE_PROXY, char *preproxy);
 .SH DESCRIPTION
 Set the \fIpreproxy\fP to use for the upcoming request. The parameter
-should be a char * to a zero terminated string holding the host name or dotted
+should be a char * to a null-terminated string holding the host name or dotted
 numerical IP address. A numerical IPv6 address must be written within
 [brackets].
 

--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -29,7 +29,7 @@ CURLOPT_PROXY \- set proxy to use
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY, char *proxy);
 .SH DESCRIPTION
 Set the \fIproxy\fP to use for the upcoming request. The parameter should be a
-char * to a zero terminated string holding the host name or dotted numerical
+char * to a null-terminated string holding the host name or dotted numerical
 IP address. A numerical IPv6 address must be written within [brackets].
 
 To specify port number in this string, append :[port] to the end of the host

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
@@ -28,7 +28,7 @@ CURLOPT_PROXYPASSWORD \- password to use with proxy authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYPASSWORD, char *pwd);
 .SH DESCRIPTION
-Pass a char * as parameter, which should be pointing to the zero terminated
+Pass a char * as parameter, which should be pointing to the null-terminated
 password to use for authentication with the proxy.
 
 The \fICURLOPT_PROXYPASSWORD(3)\fP option should be used in conjunction with

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
@@ -30,7 +30,7 @@ CURLOPT_PROXYUSERNAME \- user name to use for proxy authentication
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYUSERNAME,
                           char *username);
 .SH DESCRIPTION
-Pass a char * as parameter, which should be pointing to the zero terminated
+Pass a char * as parameter, which should be pointing to the null-terminated
 user name to use for the transfer.
 
 \fICURLOPT_PROXYUSERNAME(3)\fP sets the user name to be used in protocol

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CAINFO, char *path);
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 
-Pass a char * to a zero terminated string naming a file holding one or more
+Pass a char * to a null-terminated string naming a file holding one or more
 certificates to verify the HTTPS proxy with.
 
 If \fICURLOPT_PROXY_SSL_VERIFYPEER(3)\fP is zero and you avoid verifying the

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_CAPATH \- specify directory holding proxy CA certificates
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CAPATH, char *capath);
 .SH DESCRIPTION
-Pass a char * to a zero terminated string naming a directory holding multiple
+Pass a char * to a null-terminated string naming a directory holding multiple
 CA certificates to verify the HTTPS proxy with. If libcurl is built against
 OpenSSL, the certificate directory must be prepared using the openssl c_rehash
 utility. This makes sense only when \fICURLOPT_PROXY_SSL_VERIFYPEER(3)\fP is

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CRLFILE, char *file);
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 
-Pass a char * to a zero terminated string naming a \fIfile\fP with the
+Pass a char * to a null-terminated string naming a \fIfile\fP with the
 concatenation of CRL (in PEM format) to use in the certificate validation that
 occurs during the SSL exchange.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_ISSUERCERT \- proxy issuer SSL certificate filename
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_ISSUERCERT, char *file);
 .SH DESCRIPTION
-Pass a char * to a zero terminated string naming a \fIfile\fP holding a CA
+Pass a char * to a null-terminated string naming a \fIfile\fP holding a CA
 certificate in PEM format. If the option is set, an additional check against
 the peer certificate is performed to verify the issuer of the the HTTPS proxy
 is indeed the one associated with the certificate provided by the option.

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_KEYPASSWD, char *pwd);
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 
-Pass a pointer to a zero terminated string as parameter. It will be used as
+Pass a pointer to a null-terminated string as parameter. It will be used as
 the password required to use the \fICURLOPT_PROXY_SSLKEY(3)\fP private key.
 You never needed a pass phrase to load a certificate but you need one to load
 your private key.

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_PINNEDPUBLICKEY \- set pinned public key for https proxy
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_PINNEDPUBLICKEY, char *pinnedpubkey);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string can be the
+Pass a pointer to a null-terminated string as parameter. The string can be the
 file name of your pinned public key. The file format expected is "PEM" or "DER".
 The string can also be any number of base64 encoded sha256 hashes preceded by
 "sha256//" and separated by ";"

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERT, char *cert);
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your client certificate used to connect to the HTTPS proxy.
 The default format is "P12" on Secure Transport and "PEM" on other engines,
 and can be changed with \fICURLOPT_PROXY_SSLCERTTYPE(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_SSLCERTTYPE \- specify type of the proxy client SSL certificate
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERTTYPE, char *type);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your client certificate used when connecting to an HTTPS proxy.
 
 Supported formats are "PEM" and "DER", except with Secure Transport. OpenSSL

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_SSLKEY \- specify private keyfile for TLS and SSL proxy client cer
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLKEY, char *keyfile);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your private key used for connecting to the HTTPS proxy. The
 default format is "PEM" and can be changed with
 \fICURLOPT_PROXY_SSLKEYTYPE(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLKEYTYPE, char *type);
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your private key. Supported formats are "PEM", "DER" and "ENG".
 
 The application does not have to keep the string around after setting this

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_SSL_CIPHER_LIST \- specify ciphers to use for proxy TLS
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_CIPHER_LIST, char *list);
 .SH DESCRIPTION
-Pass a char *, pointing to a zero terminated string holding the list of
+Pass a char *, pointing to a null-terminated string holding the list of
 ciphers to use for the connection to the HTTPS proxy. The list must be
 syntactically correct, it consists of one or more cipher strings separated by
 colons. Commas or spaces are also acceptable separators but colons are

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_TLS13_CIPHERS \- ciphers suites for proxy TLS 1.3
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLS13_CIPHERS, char *list);
 .SH DESCRIPTION
-Pass a char *, pointing to a zero terminated string holding the list of cipher
+Pass a char *, pointing to a null-terminated string holding the list of cipher
 suites to use for the TLS 1.3 connection to a proxy. The list must be
 syntactically correct, it consists of one or more cipher suite strings
 separated by colons.

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_TLSAUTH_PASSWORD \- password to use for proxy TLS authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_PASSWORD, char *pwd);
 .SH DESCRIPTION
-Pass a char * as parameter, which should point to the zero terminated password
+Pass a char * as parameter, which should point to the null-terminated password
 to use for the TLS authentication method specified with the
 \fICURLOPT_PROXY_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_PROXY_TLSAUTH_USERNAME(3)\fP option also be set.

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_TLSAUTH_TYPE \- set proxy TLS authentication methods
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_TYPE, char *type);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the method of the TLS authentication used for the HTTPS connection. Supported
 method is "SRP".
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
@@ -28,7 +28,7 @@ CURLOPT_PROXY_TLSAUTH_USERNAME \- user name to use for proxy TLS authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_USERNAME, char *user);
 .SH DESCRIPTION
-Pass a char * as parameter, which should point to the zero terminated username
+Pass a char * as parameter, which should point to the null-terminated username
 to use for the HTTPS proxy TLS authentication method specified with the
 \fICURLOPT_PROXY_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_PROXY_TLSAUTH_PASSWORD(3)\fP option also be set.

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
@@ -28,7 +28,7 @@ CURLOPT_RANDOM_FILE \- specify a source for random data
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RANDOM_FILE, char *path);
 .SH DESCRIPTION
-Pass a char * to a zero terminated file name. The file might be used to read
+Pass a char * to a null-terminated file name. The file might be used to read
 from to seed the random engine for SSL and more.
 
 The application does not have to keep the string around after setting this

--- a/docs/libcurl/opts/CURLOPT_REFERER.3
+++ b/docs/libcurl/opts/CURLOPT_REFERER.3
@@ -28,7 +28,7 @@ CURLOPT_REFERER \- set the HTTP referer header
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_REFERER, char *where);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It will be used to
+Pass a pointer to a null-terminated string as parameter. It will be used to
 set the Referer: header in the http request sent to the remote server. This
 can be used to fool servers or scripts. You can also set any custom header
 with \fICURLOPT_HTTPHEADER(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
+++ b/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
@@ -28,7 +28,7 @@ CURLOPT_SASL_AUTHZID \- authorisation identity (identity to act as)
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SASL_AUTHZID, char *authzid);
 .SH DESCRIPTION
-Pass a char * as parameter, which should be pointing to the zero terminated
+Pass a char * as parameter, which should be pointing to the null-terminated
 authorisation identity (authzid) for the transfer. Only applicable to the PLAIN
 SASL authentication mechanism where it is optional.
 

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
@@ -44,7 +44,7 @@ enum curl_khmatch {
 };
 
 struct curl_khkey {
-  const char *key; /* points to a zero-terminated string encoded with
+  const char *key; /* points to a null-terminated string encoded with
                       base64 if len is zero, otherwise to the "raw"
                       data */
   size_t len;

--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
@@ -28,7 +28,7 @@ CURLOPT_SSH_KNOWNHOSTS \- file name holding the SSH known hosts
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_KNOWNHOSTS, char *fname);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string holding the file name of the
+Pass a pointer to a null-terminated string holding the file name of the
 known_host file to use.  The known_hosts file should use the OpenSSH file
 format as supported by libssh2. If this file is specified, libcurl will only
 accept connections with hosts that are known and present in that file, with a

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.3
@@ -28,7 +28,7 @@ CURLOPT_SSLCERT \- set SSL client certificate
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERT, char *cert);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your client certificate. The default format is "P12" on
 Secure Transport and "PEM" on other engines, and can be changed with
 \fICURLOPT_SSLCERTTYPE(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
@@ -28,7 +28,7 @@ CURLOPT_SSLCERTTYPE \- specify type of the client SSL certificate
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERTTYPE, char *type);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your certificate. Supported formats are "PEM" and "DER", except
 with Secure Transport. OpenSSL (versions 0.9.3 and later) and Secure Transport
 (on iOS 5 or later, or OS X 10.7 or later) also support "P12" for

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE.3
@@ -28,7 +28,7 @@ CURLOPT_SSLENGINE \- set SSL engine identifier
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLENGINE, char *id);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It will be used as
+Pass a pointer to a null-terminated string as parameter. It will be used as
 the identifier for the crypto engine you want to use for your private key.
 
 The application does not have to keep the string around after setting this

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.3
@@ -28,7 +28,7 @@ CURLOPT_SSLKEY \- specify private keyfile for TLS and SSL client cert
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLKEY, char *keyfile);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your private key. The default format is "PEM" and can be
 changed with \fICURLOPT_SSLKEYTYPE(3)\fP.
 

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
@@ -28,7 +28,7 @@ CURLOPT_SSLKEYTYPE \- set type of the private key file
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLKEYTYPE, char *type);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your private key. Supported formats are "PEM", "DER" and "ENG".
 
 The format "ENG" enables you to load the private key from a crypto engine. In

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -28,7 +28,7 @@ CURLOPT_SSL_CIPHER_LIST \- specify ciphers to use for TLS
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CIPHER_LIST, char *list);
 .SH DESCRIPTION
-Pass a char *, pointing to a zero terminated string holding the list of
+Pass a char *, pointing to a null-terminated string holding the list of
 ciphers to use for the SSL connection. The list must be syntactically correct,
 it consists of one or more cipher strings separated by colons. Commas or
 spaces are also acceptable separators but colons are normally used, \&!, \&-

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
@@ -28,7 +28,7 @@ CURLOPT_TLS13_CIPHERS \- specify ciphers suites to use for TLS 1.3
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLS13_CIPHERS, char *list);
 .SH DESCRIPTION
-Pass a char *, pointing to a zero terminated string holding the list of cipher
+Pass a char *, pointing to a null-terminated string holding the list of cipher
 suites to use for the TLS 1.3 connection. The list must be syntactically
 correct, it consists of one or more cipher suite strings separated by colons.
 

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
@@ -28,7 +28,7 @@ CURLOPT_TLSAUTH_PASSWORD \- password to use for TLS authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLSAUTH_PASSWORD, char *pwd);
 .SH DESCRIPTION
-Pass a char * as parameter, which should point to the zero terminated password
+Pass a char * as parameter, which should point to the null-terminated password
 to use for the TLS authentication method specified with the
 \fICURLOPT_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_TLSAUTH_USERNAME(3)\fP option also be set.

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
@@ -28,7 +28,7 @@ CURLOPT_TLSAUTH_TYPE \- set TLS authentication methods
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLSAUTH_TYPE, char *type);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. The string should be
+Pass a pointer to a null-terminated string as parameter. The string should be
 the method of the TLS authentication. Supported method is "SRP".
 
 .IP SRP

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
@@ -28,7 +28,7 @@ CURLOPT_TLSAUTH_USERNAME \- user name to use for TLS authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLSAUTH_USERNAME, char *user);
 .SH DESCRIPTION
-Pass a char * as parameter, which should point to the zero terminated username
+Pass a char * as parameter, which should point to the null-terminated username
 to use for the TLS authentication method specified with the
 \fICURLOPT_TLSAUTH_TYPE(3)\fP option. Requires that the
 \fICURLOPT_TLSAUTH_PASSWORD(3)\fP option also be set.

--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -29,7 +29,7 @@ CURLOPT_URL \- provide the URL to use in the request
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_URL, char *URL);
 .SH DESCRIPTION
 Pass in a pointer to the \fIURL\fP to work with. The parameter should be a
-char * to a zero terminated string which must be URL-encoded in the following
+char * to a null-terminated string which must be URL-encoded in the following
 format:
 
 scheme://host:port/path

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.3
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.3
@@ -28,7 +28,7 @@ CURLOPT_USERAGENT \- set HTTP user-agent header
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERAGENT, char *ua);
 .SH DESCRIPTION
-Pass a pointer to a zero terminated string as parameter. It will be used to
+Pass a pointer to a null-terminated string as parameter. It will be used to
 set the User-Agent: header in the HTTP request sent to the remote server. This
 can be used to fool servers or scripts. You can also set any custom header
 with \fICURLOPT_HTTPHEADER(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.3
@@ -30,7 +30,7 @@ CURLOPT_USERNAME \- user name to use in authentication
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERNAME,
                           char *username);
 .SH DESCRIPTION
-Pass a char * as parameter, which should be pointing to the zero terminated
+Pass a char * as parameter, which should be pointing to the null-terminated
 user name to use for the transfer.
 
 \fICURLOPT_USERNAME(3)\fP sets the user name to be used in protocol

--- a/docs/libcurl/opts/CURLOPT_USERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.3
@@ -28,7 +28,7 @@ CURLOPT_USERPWD \- user name and password to use in authentication
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERPWD, char *userpwd);
 .SH DESCRIPTION
-Pass a char * as parameter, pointing to a zero terminated login details string
+Pass a char * as parameter, pointing to a null-terminated login details string
 for the connection. The format of which is: [user name]:[password].
 
 When using Kerberos V5 authentication with a Windows based server, you should

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -52,7 +52,7 @@ means 100K.
 This function may be called with zero bytes data if the transferred file is
 empty.
 
-The data passed to this function will not be zero terminated!
+The data passed to this function will not be null-terminated!
 
 Set the \fIuserdata\fP argument with the \fICURLOPT_WRITEDATA(3)\fP option.
 

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
@@ -28,7 +28,7 @@ CURLOPT_XOAUTH2_BEARER \- specify OAuth 2.0 access token
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_XOAUTH2_BEARER, char *token);
 .SH DESCRIPTION
-Pass a char * as parameter, which should point to the zero terminated OAuth
+Pass a char * as parameter, which should point to the null-terminated OAuth
 2.0 Bearer Access Token for use with HTTP, IMAP, POP3 and SMTP servers
 that support the OAuth 2.0 Authorization Framework.
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -774,7 +774,7 @@ enum curl_khtype {
 };
 
 struct curl_khkey {
-  const char *key; /* points to a zero-terminated string encoded with base64
+  const char *key; /* points to a null-terminated string encoded with base64
                       if len is zero, otherwise to the "raw" data */
   size_t len;
   enum curl_khtype keytype;
@@ -1446,7 +1446,7 @@ typedef enum {
   /* 132 OBSOLETE. Gone in 7.16.0 */
   /* 133 OBSOLETE. Gone in 7.16.0 */
 
-  /* zero terminated string for pass on to the FTP server when asked for
+  /* null-terminated string for pass on to the FTP server when asked for
      "account" info */
   CURLOPT(CURLOPT_FTP_ACCOUNT, CURLOPTTYPE_STRINGPOINT, 134),
 
@@ -2118,7 +2118,7 @@ typedef enum {
   CURL_TIMECOND_LAST
 } curl_TimeCond;
 
-/* Special size_t value signaling a zero-terminated string. */
+/* Special size_t value signaling a null-terminated string. */
 #define CURL_ZERO_TERMINATED ((size_t) -1)
 
 /* curl_strequal() and curl_strnequal() are subject for removal in a future

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -267,7 +267,7 @@ CURL_EXTERN CURLMsg *curl_multi_info_read(CURLM *multi_handle,
  *          value into the equivalent human readable error string.  This is
  *          useful for printing meaningful error messages.
  *
- * Returns: A pointer to a zero-terminated error message.
+ * Returns: A pointer to a null-terminated error message.
  */
 CURL_EXTERN const char *curl_multi_strerror(CURLMcode);
 

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -755,7 +755,7 @@ Curl_cookie_add(struct Curl_easy *data,
         co->path = malloc(pathlen + 1); /* one extra for the zero byte */
         if(co->path) {
           memcpy(co->path, path, pathlen);
-          co->path[pathlen] = 0; /* zero terminate */
+          co->path[pathlen] = 0; /* null-terminate */
           co->spath = sanitize_cookie_path(co->path);
           if(!co->spath)
             badcookie = TRUE; /* out of memory bad */

--- a/lib/dotdot.c
+++ b/lib/dotdot.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -39,7 +39,7 @@
  * Curl_dedotdotify()
  * @unittest: 1395
  *
- * This function gets a zero-terminated path with dot and dotdot sequences
+ * This function gets a null-terminated path with dot and dotdot sequences
  * passed in and strips them off according to the rules in RFC 3986 section
  * 5.2.4.
  *
@@ -62,7 +62,7 @@ char *Curl_dedotdotify(const char *input)
   if(!out)
     return NULL; /* out of memory */
 
-  *out = 0; /* zero terminates, for inputs like "./" */
+  *out = 0; /* null-terminates, for inputs like "./" */
 
   /* get a cloned copy of the input */
   clone = strdup(input);
@@ -129,7 +129,7 @@ char *Curl_dedotdotify(const char *input)
         if(*outptr == '/')
           break;
       }
-      *outptr = 0; /* zero-terminate where it stops */
+      *outptr = 0; /* null-terminate where it stops */
     }
     else if(!strcmp("/..", clone)) {
       clone[2]='/';
@@ -141,7 +141,7 @@ char *Curl_dedotdotify(const char *input)
         if(*outptr == '/')
           break;
       }
-      *outptr = 0; /* zero-terminate where it stops */
+      *outptr = 0; /* null-terminate where it stops */
     }
 
     /*  D.  if the input buffer consists only of "." or "..", then remove

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -161,7 +161,7 @@ CURLcode Curl_dyn_addn(struct dynbuf *s, const void *mem, size_t len)
 }
 
 /*
- * Append a zero terminated string at the end.
+ * Append a null-terminated string at the end.
  */
 CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
 {

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -23,7 +23,7 @@
  ***************************************************************************/
 
 struct dynbuf {
-  char *bufr;    /* point to a zero terminated allocated buffer */
+  char *bufr;    /* point to a null-terminated allocated buffer */
   size_t leng;   /* number of bytes *EXCLUDING* the zero terminator */
   size_t allc;   /* size of the current allocation */
   size_t toobig; /* size limit for the buffer */

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -602,7 +602,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         /* Note that there's small risk that form->name is NULL here if the
            app passed in a bad combo, so we better check for that first. */
         if(form->name) {
-          /* copy name (without strdup; possibly not nul-terminated) */
+          /* copy name (without strdup; possibly not null-terminated) */
           form->name = Curl_memdup(form->name, form->namelength?
                                    form->namelength:
                                    strlen(form->name) + 1);
@@ -771,7 +771,7 @@ void curl_formfree(struct curl_httppost *form)
 }
 
 
-/* Set mime part name, taking care of non nul-terminated name string. */
+/* Set mime part name, taking care of non null-terminated name string. */
 static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
 {
   char *zname;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2827,7 +2827,7 @@ static CURLcode ftp_statemach_act(struct connectdata *conn)
             store++;
             ptr++;
           }
-          *store = '\0'; /* zero terminate */
+          *store = '\0'; /* null-terminate */
         }
         if(entry_extracted) {
           /* If the path name does not look like an absolute path (i.e.: it
@@ -2891,7 +2891,7 @@ static CURLcode ftp_statemach_act(struct connectdata *conn)
           ptr++;
         for(store = os; *ptr && *ptr != ' ';)
           *store++ = *ptr++;
-        *store = '\0'; /* zero terminate */
+        *store = '\0'; /* null-terminate */
 
         /* Check for special servers here. */
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -270,7 +270,7 @@ char *Curl_copy_header_value(const char *header)
     return NULL;
 
   memcpy(value, start, len);
-  value[len] = 0; /* zero terminate */
+  value[len] = 0; /* null-terminate */
 
   return value;
 }

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1419,7 +1419,7 @@ CURLcode curl_mime_data(curl_mimepart *part,
 
     if(datasize)
       memcpy(part->data, data, datasize);
-    part->data[datasize] = '\0';    /* Set a nul terminator as sentinel. */
+    part->data[datasize] = '\0';    /* Set a null terminator as sentinel. */
 
     part->readfunc = mime_mem_read;
     part->seekfunc = mime_mem_seek;

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -384,10 +384,10 @@ CURLcode Curl_pp_readresp(curl_socket_t sockfd,
 
           if(pp->endofresp(conn, pp->linestart_resp, perline, code)) {
             /* This is the end of the last line, copy the last line to the
-               start of the buffer and zero terminate, for old times sake */
+               start of the buffer and null-terminate, for old times sake */
             size_t n = ptr - pp->linestart_resp;
             memmove(buf, pp->linestart_resp, n);
-            buf[n] = 0; /* zero terminate */
+            buf[n] = 0; /* null-terminate */
             keepon = FALSE;
             pp->linestart_resp = ptr + 1; /* advance pointer */
             i++; /* skip this before getting out */

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -795,7 +795,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
 
 #endif /* end of not Windows */
 
-  buf[max] = '\0'; /* make sure the string is zero terminated */
+  buf[max] = '\0'; /* make sure the string is null-terminated */
 
   /* strip trailing '\r\n' or '\n'. */
   p = strrchr(buf, '\n');

--- a/lib/strtok.c
+++ b/lib/strtok.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -52,7 +52,7 @@ Curl_strtok_r(char *ptr, const char *sep, char **end)
 
     if(**end) {
       /* the end is not a null byte */
-      **end = '\0';  /* zero terminate it! */
+      **end = '\0';  /* null-terminate it! */
       ++*end;        /* advance the last pointer to beyond the null byte */
     }
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -225,7 +225,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
       break;
     }
   }
-  *optr = 0; /* zero terminate output buffer */
+  *optr = 0; /* null-terminate output buffer */
 
 }
 
@@ -584,7 +584,7 @@ static CURLUcode junkscan(const char *part)
       0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
       0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
       0x7f,
-      0x00 /* zero terminate */
+      0x00 /* null-terminate */
     };
     size_t n = strlen(part);
     size_t nfine = strcspn(part, badbytes);
@@ -1398,7 +1398,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
         i = (const unsigned char *)part;
         for(o = enc; *i; ++o, ++i)
           *o = (*i == ' ') ? '+' : *i;
-        *o = 0; /* zero terminate */
+        *o = 0; /* null-terminate */
         part = strdup(enc);
         if(!part) {
           free(enc);
@@ -1422,7 +1422,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
           o += 3;
         }
       }
-      *o = 0; /* zero terminate */
+      *o = 0; /* null-terminate */
       newp = enc;
       if(free_part)
         free((char *)part);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1564,7 +1564,7 @@ enum dupstring {
   STRING_DNS_LOCAL_IP4,
   STRING_DNS_LOCAL_IP6,
 
-  /* -- end of zero-terminated strings -- */
+  /* -- end of null-terminated strings -- */
 
   STRING_LASTZEROTERMINATED,
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1636,7 +1636,7 @@ static CURLcode verifyhost(struct connectdata *conn, X509 *server_cert)
              type itself: for example for an IA5String the data will be ASCII"
 
              It has been however verified that in 0.9.6 and 0.9.7, IA5String
-             is always zero-terminated.
+             is always null-terminated.
           */
           if((altlen == strlen(altptr)) &&
              /* if this isn't true, there was an embedded zero in the name

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -706,7 +706,7 @@ CURLcode Curl_ssl_init_certinfo(struct Curl_easy *data, int num)
 }
 
 /*
- * 'value' is NOT a zero terminated string
+ * 'value' is NOT a null-terminated string
  */
 CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
                                     int certnum,
@@ -728,10 +728,10 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
   /* sprintf the label and colon */
   msnprintf(output, outlen, "%s:", label);
 
-  /* memcpy the value (it might not be zero terminated) */
+  /* memcpy the value (it might not be null-terminated) */
   memcpy(&output[labellen + 1], value, valuelen);
 
-  /* zero terminate the output */
+  /* null-terminate the output */
   output[labellen + 1 + valuelen] = 0;
 
   nl = Curl_slist_append_nodup(ci->certinfo[certnum], output);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -966,7 +966,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         if(*p) {
           /* if there's anything more than a plain decimal number */
           rc = sscanf(p, " - %6s", lrange);
-          *p = 0; /* zero terminate to make str2unum() work below */
+          *p = 0; /* null-terminate to make str2unum() work below */
         }
         else
           rc = 0;
@@ -1517,7 +1517,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         /* Automatic referer requested, this may be combined with a
            set initial one */
         config->autoreferer = TRUE;
-        *ptr = 0; /* zero terminate here */
+        *ptr = 0; /* null-terminate here */
       }
       else
         config->autoreferer = FALSE;

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -238,7 +238,7 @@ char *getpass_r(const char *prompt, /* prompt to display */
   fputs(prompt, stderr);
   nread = read(fd, password, buflen);
   if(nread > 0)
-    password[--nread] = '\0'; /* zero terminate where enter is stored */
+    password[--nread] = '\0'; /* null-terminate where enter is stored */
   else
     password[0] = '\0'; /* got nothing */
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -173,7 +173,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       /* ... and has ended here */
 
       if(*line)
-        *line++ = '\0'; /* zero terminate, we have a local copy of the data */
+        *line++ = '\0'; /* null-terminate, we have a local copy of the data */
 
 #ifdef DEBUG_CONFIG
       fprintf(stderr, "GOT: %s\n", option);
@@ -203,7 +203,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
           line++;
 
         if(*line) {
-          *line = '\0'; /* zero terminate */
+          *line = '\0'; /* null-terminate */
 
           /* to detect mistakes better, see if there's data following */
           line++;
@@ -329,7 +329,7 @@ static const char *unslashquote(const char *line, char *param)
     else
       *param++ = *line++;
   }
-  *param = '\0'; /* always zero terminate */
+  *param = '\0'; /* always null-terminate */
   return line;
 }
 

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -131,7 +131,7 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
             continue;
           }
           keepit = *end;
-          *end = 0; /* zero terminate */
+          *end = 0; /* null-terminate */
           for(i = 0; variables[i].name; i++) {
             if(curl_strequal(ptr, variables[i].name)) {
               match = TRUE;

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -101,7 +101,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_HEADER, 1L);
 #ifdef LIB548
-  /* set the data to POST with a mere pointer to a zero-terminated string */
+  /* set the data to POST with a mere pointer to a null-terminated string */
   test_setopt(curl, CURLOPT_POSTFIELDS, UPLOADTHIS);
 #else
   /* 547 style, which means reading the POST data from a callback */

--- a/tests/libtest/lib553.c
+++ b/tests/libtest/lib553.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -77,7 +77,7 @@ int test(char *URL)
   for(i = 0; i < NUM_HEADERS; i++) {
     int len = msnprintf(buf, sizeof(buf), "Header%d: ", i);
     memset(&buf[len], 'A', SIZE_HEADERS);
-    buf[len + SIZE_HEADERS] = 0; /* zero terminate */
+    buf[len + SIZE_HEADERS] = 0; /* null-terminate */
     hl = curl_slist_append(headerlist,  buf);
     if(!hl)
       goto test_cleanup;

--- a/tests/libtest/lib651.c
+++ b/tests/libtest/lib651.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -40,7 +40,7 @@ int test(char *URL)
   for(i = 0; i < size ; i++)
     memset(&buffer[i * 1000], 65 + i, 1000);
 
-  buffer[ sizeof(buffer)-1] = 0; /* zero terminate */
+  buffer[ sizeof(buffer)-1] = 0; /* null-terminate */
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");


### PR DESCRIPTION
Updated terminology in docs, comments and phrases to refer to C strings
as "null-terminated". Done to unify with how most other C oriented docs
refer of them and what users in general seem to prefer (based on a
single highly unscientific poll on twitter).

Reported-by: coinhubs on github
Fixes #5598