### PR TITLE
http: fix proxy auth with blank password

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -308,7 +308,7 @@ static CURLcode http_output_basic(struct connectdata *conn, bool proxy)
     pwd = conn->passwd;
   }
 
-  out = aprintf("%s:%s", user, pwd);
+  out = aprintf("%s:%s", user, pwd ? pwd : "");
   if(!out)
     return CURLE_OUT_OF_MEMORY;
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -58,7 +58,7 @@ test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
-test343 test344 test345 \
+test343 test344 test345 test346 \
 test350 test351 test352 test353 test354 test355 test356 test357 test358 \
 test359 \
 test393 test394 test395 \

--- a/tests/data/test346
+++ b/tests/data/test346
@@ -1,0 +1,57 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+proxy
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP GET over proxy with credentials using blank passwords
+</name>
+<command>
+-x http://%HOSTIP:%HTTPPORT/346 -U puser: -u suser: http://remote.example/346
+</command>
+</client>
+
+#
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET http://remote.example/346 HTTP/1.1
+Host: remote.example
+Proxy-Authorization: Basic cHVzZXI6
+Authorization: Basic c3VzZXI6
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test346
+++ b/tests/data/test346
@@ -28,6 +28,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<feature>
+proxy
+</feature>
 <server>
 http
 </server>

--- a/tests/data/test346
+++ b/tests/data/test346
@@ -28,9 +28,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
-<feature>
+<features>
 proxy
-</feature>
+</features>
 <server>
 http
 </server>


### PR DESCRIPTION
Regression in 7.71.0

Added test case 346 to verify.

Reported-by: Kristoffer Gleditsch
Fixes #5613