### PR TITLE
examples/multithread.c: call curl_global_cleanup()

### DIFF
--- a/docs/examples/multithread.c
+++ b/docs/examples/multithread.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -89,6 +89,6 @@ int main(int argc, char **argv)
     pthread_join(tid[i], NULL);
     fprintf(stderr, "Thread %d terminated\n", i);
   }
-
+  curl_global_cleanup();
   return 0;
 }


### PR DESCRIPTION
Reported-by: qiandu2006 on github
Fixes #5622