### PR TITLE
openssl: include openssl/x509.h

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -56,6 +56,7 @@
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
+#include <openssl/x509.h>
 #ifndef OPENSSL_NO_DSA
 #include <openssl/dsa.h>
 #endif


### PR DESCRIPTION
Fix the boringssl build error on travis:

../lib/.libs/libcurl.so: undefined reference to `X509_get_X509_PUBKEY'