### PR TITLE
ngtcp2: sync with current master

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -757,7 +757,9 @@ static ngtcp2_conn_callbacks ng_callbacks = {
   cb_extend_max_stream_data,
   NULL, /* dcid_status */
   NULL, /* handshake_confirmed */
-  NULL  /* recv_new_token */
+  NULL, /* recv_new_token */
+  ngtcp2_crypto_delete_crypto_aead_ctx_cb,
+  ngtcp2_crypto_delete_crypto_cipher_ctx_cb
 };
 
 /*


### PR DESCRIPTION
ngtcp2 added two new callbacks

Reported-by: Lucien Zürcher
Fixes #5624