### PR TITLE
cirrus-ci: disable FreeBSD 13 (again)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ task:
   freebsd_instance:
     matrix:
       # A stable 13.0 image likely won't be available before early 2021
-      image_family: freebsd-13-0-snap
+      # image_family: freebsd-13-0-snap
       image_family: freebsd-12-1
       # The stable 11.3 image causes "Agent is not responding" so use a snapshot
       image_family: freebsd-11-3-snap


### PR DESCRIPTION
It has been failing for a good while again. This time we better leave it
disabled until we have more reason to believe it behaves.