### PR TITLE
Revert "multi: implement wait using winsock events"

### DIFF
--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -138,13 +138,9 @@ struct Curl_multi {
                                     previous callback */
   unsigned int max_concurrent_streams;
 
-#ifdef USE_WINSOCK
-  WSAEVENT wsa_event; /* winsock event used for waits */
-#else
 #ifdef ENABLE_WAKEUP
   curl_socket_t wakeup_pair[2]; /* socketpair() used for wakeup
                                    0 is used for read, 1 is used for write */
-#endif
 #endif
   /* multiplexing wanted */
   bool multiplexing;


### PR DESCRIPTION
This reverts commit 8bc25c590e530de87595d1bb3577f699eb1309b9.

That commit (from #5397) introduced a regression in 7.71.0.

Reported-by: tmkk on github
Fixes #5631