### PR TITLE
smtp: make MAIL FROM not alter the string if no utf-8 is used

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -580,19 +580,18 @@ static CURLcode smtp_perform_mail(struct connectdata *conn)
     /* Establish whether we should report SMTPUTF8 to the server for this
        mailbox as per RFC-6531 sect. 3.1 point 4 and sect. 3.4 */
     utf8 = (conn->proto.smtpc.utf8_supported) &&
-           ((host.encalloc) || (!Curl_is_ASCII_name(address)) ||
-            (!Curl_is_ASCII_name(host.name)));
+      ((host.encalloc) || (!Curl_is_ASCII_name(address)) ||
+       (!Curl_is_ASCII_name(host.name)));
 
-    if(host.name) {
+    if(host.name && utf8)
       from = aprintf("<%s@%s>", address, host.name);
-
-      Curl_free_idnconverted_hostname(&host);
-    }
+    else if(data->set.str[STRING_MAIL_FROM][0] == '<')
+      from = aprintf("%s", data->set.str[STRING_MAIL_FROM]);
     else
-      /* An invalid mailbox was provided but we'll simply let the server worry
-         about that and reply with a 501 error */
-      from = aprintf("<%s>", address);
+      from = aprintf("<%s>", data->set.str[STRING_MAIL_FROM]);
 
+    if(host.name)
+      Curl_free_idnconverted_hostname(&host);
     free(address);
   }
   else

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -224,5 +224,5 @@ test2078 \
 test2080 \
 test2100 \
 \
-test3000 test3001 \
-test3002 test3003 test3004 test3005 test3006 test3007
+test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
+test3008

--- a/tests/data/test3008
+++ b/tests/data/test3008
@@ -1,0 +1,51 @@
+<testcase>
+<info>
+<keywords>
+SMTP
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+smtp
+</server>
+<name>
+SMTP with "funny" --mail-from
+</name>
+<stdin>
+From: different
+To: another
+
+body
+</stdin>
+ <command>
+smtp://%HOSTIP:%SMTPPORT/3008 --mail-rcpt hello@example.com --mail-from "DI-Programme (Entwicklungssystem) <username@localhost>" -T -
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+EHLO 3008
+MAIL FROM:<DI-Programme (Entwicklungssystem) <username@localhost>>
+RCPT TO:<hello@example.com>
+DATA
+QUIT
+</protocol>
+<upload>
+From: different
+To: another
+
+body
+.
+</upload>
+</verify>
+</testcase>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -835,13 +835,8 @@ sub MAIL_smtp {
             }
         }
 
-        # Validate the from address (only <> and a valid email address inside
-        # <> are allowed, such as <user@example.com>)
-        if (($from eq "<>") ||
-            (!$smtputf8 && $from =~
-              /^<([a-zA-Z0-9._%+-]+)\@(([a-zA-Z0-9-]+)\.)+([a-zA-Z]{2,4})>$/) ||
-            ($smtputf8 && $from =~
-              /^<([a-zA-Z0-9\x{80}-\x{ff}._%+-]+)\@(([a-zA-Z0-9\x{80}-\x{ff}-]+)\.)+([a-zA-Z]{2,4})>$/)) {
+        # this server doesn't "validate" MAIL FROM addresses
+        if (length($from)) {
             my @found;
             my $valid = 1;
 


### PR DESCRIPTION
This reverts to previous behavior when UTF-8 isn't used, and puts the
trust back at the application user to provide the correct input.

Regression brought in 68fb25f (curl 7.69.0)

Added test 3008 to verify.

Also made the test SMTP server NOT attempt to verify the address
provided in the MAIL FROM command.

Reported-by: Michael Osipov
Fixes #5618