### PR TITLE
ftpserver: don't verify SMTP MAIL FROM names

### DIFF
--- a/tests/data/test914
+++ b/tests/data/test914
@@ -8,6 +8,9 @@ SMTP
 #
 # Server-side
 <reply>
+<servercmd>
+REPLY MAIL 501 not fine enough
+</servercmd>
 </reply>
 
 #

--- a/tests/data/test955
+++ b/tests/data/test955
@@ -8,6 +8,9 @@ SMTP
 #
 # Server-side
 <reply>
+<servercmd>
+REPLY MAIL 501 not fine enough
+</servercmd>
 </reply>
 
 #

--- a/tests/data/test959
+++ b/tests/data/test959
@@ -8,6 +8,9 @@ SMTP
 #
 # Server-side
 <reply>
+<servercmd>
+REPLY MAIL 501 not fine enough
+</servercmd>
 </reply>
 
 #

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -835,13 +835,8 @@ sub MAIL_smtp {
             }
         }
 
-        # Validate the from address (only <> and a valid email address inside
-        # <> are allowed, such as <user@example.com>)
-        if (($from eq "<>") ||
-            (!$smtputf8 && $from =~
-              /^<([a-zA-Z0-9._%+-]+)\@(([a-zA-Z0-9-]+)\.)+([a-zA-Z]{2,4})>$/) ||
-            ($smtputf8 && $from =~
-              /^<([a-zA-Z0-9\x{80}-\x{ff}._%+-]+)\@(([a-zA-Z0-9\x{80}-\x{ff}-]+)\.)+([a-zA-Z]{2,4})>$/)) {
+        # this server doesn't "validate" MAIL FROM addresses
+        if (length($from)) {
             my @found;
             my $valid = 1;
 


### PR DESCRIPTION
Rely on tests asking the names to get refused instead. Edited test 914
and 955 accordingly.