### PR TITLE
tool_getparam: make --krb option work again

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -813,7 +813,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case 'x': /* --krb */
         /* kerberos level string */
-        if(curlinfo->features & CURL_VERSION_KERBEROS4)
+        if(curlinfo->features & CURL_VERSION_SPNEGO)
           GetStr(&config->krblevel, nextarg);
         else
           return PARAM_LIBCURL_DOESNT_SUPPORT;


### PR DESCRIPTION
It was disabled by mistake in commit [curl-7_37_1-23-ge38ba4301](https://github.com/curl/curl/commit/curl-7_37_1-23-ge38ba4301).

Bug: https://bugzilla.redhat.com/1833193