### PR TITLE
curl_version_info.3: CURL_VERSION_KERBEROS4 is deprecated

### DIFF
--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -150,7 +150,7 @@ letters. (Added in 7.12.0)
 .IP CURL_VERSION_IPV6
 supports IPv6
 .IP CURL_VERSION_KERBEROS4
-supports Kerberos V4 (when using FTP)
+supports Kerberos V4 (when using FTP). Legacy bit. Deprecated since 7.33.0.
 .IP CURL_VERSION_KERBEROS5
 supports Kerberos V5 authentication for FTP, IMAP, POP3, SMTP and SOCKSv5 proxy
 (Added in 7.40.0)


### PR DESCRIPTION
This came up in #5640. It make sense to clarify this in the docs!

Reminded-by: Kamil Dudka