### PR TITLE
tests: show mismatch failures directly in terminal output

### DIFF
--- a/tests/data/test1119
+++ b/tests/data/test1119
@@ -22,4 +22,10 @@ Verify that symbols-in-versions and headers are in sync
 </command>
 </client>
 
+<verify>
+<stdout>
+OK
+</stdout>
+</verify>
+
 </testcase>

--- a/tests/data/test1139
+++ b/tests/data/test1139
@@ -15,13 +15,19 @@ documentation
 none
 </server>
 
- <name>
+<name>
 Verify that all libcurl options have man pages
- </name>
+</name>
 
 <command type="perl">
 %SRCDIR/manpage-scan.pl %SRCDIR/.. %PWD/..
 </command>
 </client>
+
+<verify>
+<stderr>
+0
+</stderr>
+</verify>
 
 </testcase>

--- a/tests/manpage-scan.pl
+++ b/tests/manpage-scan.pl
@@ -288,4 +288,4 @@ foreach my $o (keys %opts) {
     }
 }
 
-exit $errors;
+print STDERR "$errors\n";

--- a/tests/symbol-scan.pl
+++ b/tests/symbol-scan.pl
@@ -178,3 +178,6 @@ if($summary) {
 if($misses) {
     exit 2; # there are stuff to attend to!
 }
+else {
+    print "OK\n";
+}


### PR DESCRIPTION
So that failures will be displayed in the terminal, as it makes test failures
visually displayed easier and faster.