### PR TITLE
Rework HTTP/2 closed connection logic and consolidate http2 mem_recv() calls in one place.

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1689,6 +1689,7 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
     }
     else {
       nread = httpc->inbuflen - httpc->nread_inbuf;
+      (void)nread;  /* silence warning, used in debug */
       H2BUGF(infof(data, "Use data left in connection buffer, nread=%zd\n",
                    nread));
     }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1203,14 +1203,6 @@ void Curl_http2_done(struct Curl_easy *data, bool premature)
     }
     http->stream_id = 0;
   }
-
-  if (0 == nghttp2_session_check_request_allowed(httpc->h2)) {
-    /* No more requests are allowed in the current session, so
-       the connection may not be reused. This is set when a
-       GOAWAY frame has been received or when the limit of stream
-       identifiers has been reached. */
-    connclose(data->conn, "http/2: No new requests allowed");
-  }
 }
 
 /*
@@ -1339,7 +1331,7 @@ static int h2_process_pending_input(struct connectdata *conn,
   inbuf = httpc->inbuf + httpc->nread_inbuf;
 
   rv = nghttp2_session_mem_recv(httpc->h2, (const uint8_t *)inbuf, nread);
-  if (rv < 0 ) {
+  if(rv < 0 ) {
     failf(data,
           "h2_process_pending_input: nghttp2_session_mem_recv() returned "
           "%zd:%s\n", rv, nghttp2_strerror((int)rv));
@@ -1368,7 +1360,7 @@ static int h2_process_pending_input(struct connectdata *conn,
     return -1;
   }
 
-  if (nghttp2_session_check_request_allowed(httpc->h2) == 0) {
+  if(nghttp2_session_check_request_allowed(httpc->h2) == 0) {
     /* No more requests are allowed in the current session, so
        the connection may not be reused. This is set when a
        GOAWAY frame has been received or when the limit of stream
@@ -1703,7 +1695,7 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
       H2BUGF(infof(data, "Use data left in connection buffer, nread=%zd\n", nread));
     }
 
-    if (h2_process_pending_input(conn, httpc, err) != 0)
+    if(h2_process_pending_input(conn, httpc, err) != 0)
       return -1;
   }
   if(stream->memlen) {
@@ -2262,7 +2254,7 @@ CURLcode Curl_http2_switched(struct connectdata *conn,
 
   DEBUGASSERT(httpc->nread_inbuf == 0);
 
-  if (-1 == h2_process_pending_input(conn, httpc, &result))
+  if(-1 == h2_process_pending_input(conn, httpc, &result))
     return CURLE_HTTP2;
 
   return CURLE_OK;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1331,7 +1331,7 @@ static int h2_process_pending_input(struct connectdata *conn,
   inbuf = httpc->inbuf + httpc->nread_inbuf;
 
   rv = nghttp2_session_mem_recv(httpc->h2, (const uint8_t *)inbuf, nread);
-  if(rv < 0 ) {
+  if(rv < 0) {
     failf(data,
           "h2_process_pending_input: nghttp2_session_mem_recv() returned "
           "%zd:%s\n", rv, nghttp2_strerror((int)rv));
@@ -1692,7 +1692,8 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
     }
     else {
       nread = httpc->inbuflen - httpc->nread_inbuf;
-      H2BUGF(infof(data, "Use data left in connection buffer, nread=%zd\n", nread));
+      H2BUGF(infof(data, "Use data left in connection buffer, nread=%zd\n",
+                   nread));
     }
 
     if(h2_process_pending_input(conn, httpc, err) != 0)
@@ -2049,7 +2050,7 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
   h2_pri_spec(conn->data, &pri_spec);
 
   H2BUGF(infof(conn->data, "http2_send request allowed %d (easy handle %p)\n",
-         nghttp2_session_check_request_allowed(h2), (void*)conn->data));
+         nghttp2_session_check_request_allowed(h2), (void *)conn->data));
 
   switch(conn->data->state.httpreq) {
   case HTTPREQ_POST:
@@ -2075,8 +2076,9 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
   Curl_safefree(nva);
 
   if(stream_id < 0) {
-    H2BUGF(infof(conn->data, "http2_send() nghttp2_submit_request error (%s)%d\n",
-        nghttp2_strerror(stream_id), stream_id));
+    H2BUGF(infof(conn->data,
+                 "http2_send() nghttp2_submit_request error (%s)%d\n",
+                 nghttp2_strerror(stream_id), stream_id));
     *err = CURLE_SEND_ERROR;
     return -1;
   }
@@ -2089,8 +2091,9 @@ static ssize_t http2_send(struct connectdata *conn, int sockindex,
    * priority update since the nghttp2_submit_request() call above */
   rv = nghttp2_session_send(h2);
   if(rv != 0) {
-    H2BUGF(infof(conn->data, "http2_send() nghttp2_session_send error (%s)%d\n",
-        nghttp2_strerror(rv), rv));
+    H2BUGF(infof(conn->data,
+                 "http2_send() nghttp2_session_send error (%s)%d\n",
+                 nghttp2_strerror(rv), rv));
 
     *err = CURLE_SEND_ERROR;
     return -1;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1535,7 +1535,6 @@ static int h2_session_send(struct Curl_easy *data,
 static ssize_t http2_recv(struct connectdata *conn, int sockindex,
                           char *mem, size_t len, CURLcode *err)
 {
-  ssize_t rv;
   ssize_t nread;
   struct http_conn *httpc = &conn->proto.httpc;
   struct Curl_easy *data = conn->data;
@@ -1656,7 +1655,6 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
     return -1;
   }
   else {
-    char *inbuf;
     /* remember where to store incoming data for this stream and how big the
        buffer is */
     stream->mem = mem;
@@ -1686,7 +1684,6 @@ static ssize_t http2_recv(struct connectdata *conn, int sockindex,
       H2BUGF(infof(data, "nread=%zd\n", nread));
 
       httpc->inbuflen = nread;
-      inbuf = httpc->inbuf;
 
       DEBUGASSERT(httpc->nread_inbuf == 0);
     }
@@ -2178,7 +2175,6 @@ CURLcode Curl_http2_switched(struct connectdata *conn,
   CURLcode result;
   struct http_conn *httpc = &conn->proto.httpc;
   int rv;
-  ssize_t nproc;
   struct Curl_easy *data = conn->data;
   struct HTTP *stream = conn->data->req.protop;
 


### PR DESCRIPTION
Previously there were several locations that called
nghttp2_session_mem_recv and handled responses slightly differently.
Those have been converted to call the existing
h2_process_pending_input() function.

Moved the end-of-session check to h2_process_pending_input() since
the only place the end-of-session state can change is after nghttp2
processes additional input frames.

This will likely fix the fuzzing error. While I don't have a root
cause the out-of-bounds read seems like a use after free, so moving
the nghttp2_session_check_request_allowed() call to a location with
a guaranteed nghttp2 session seems reasonable.

Also updated a few nghttp2 callsites to include error messages and
added a few additional error checks.

This attempts to address https://github.com/curl/curl/issues/5646