### PR TITLE
http2: only do the *done() cleanups for HTTP

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1174,7 +1174,8 @@ void Curl_http2_done(struct Curl_easy *data, bool premature)
     http->push_headers = NULL;
   }
 
-  if(!httpc->h2) /* not HTTP/2 ? */
+  if(!(data->conn->handler->protocol&PROTO_FAMILY_HTTP) ||
+     !httpc->h2) /* not HTTP/2 ? */
     return;
 
   if(premature) {


### PR DESCRIPTION
This might fix the fuzzer issue.