### PR TITLE
Restore use Windows CA store as a fallback on curl.exe

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2449,6 +2449,14 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
       else {
         result = FindWin32CACert(config, tls_backend_info->backend,
                                  TEXT("curl-ca-bundle.crt"));
+#if defined(USE_WIN32_CRYPTO)
+        if(!config->cacert && !config->capath) {
+          /* user, and environment did not specify any ca file or path
+             and there is no "curl-ca-bundle.crt" file in standard path
+             so the only possible solution is using the windows ca store */
+          config->native_ca_store = TRUE;
+        }
+#endif
       }
 #endif
     }


### PR DESCRIPTION
This reverts commit bc052cc87858684774849398ad1073d56d7f09e9.
tool_operate: Don't use Windows CA store as a fallback"

Here is why I created PR #4346 :

when an user install only curl.exe build from openss in his tool folder, verify the ssl cert of https server with Windows CA store instead always giving error message.
For user, this is liek the curl.exe build with schannel.

But commit bc052cc87858684774849398ad1073d56d7f09e9 on PR #5585 removed this behaviour, so just copy curl.exe and run 
`curl https://curl.haxx.se/
`

fail.

@jay @bagder 

