### PR TITLE
appveyor: collect libcurl.dll with version suffix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -294,5 +294,5 @@ branches:
 artifacts:
   - path: '**/curl.exe'
     name: curl
-  - path: '**/libcurl.dll'
+  - path: '**/*curl*.dll'
     name: libcurl


### PR DESCRIPTION
Currently the wildcard is not matching DLLs generated by the msys/mingw based builds.