### PR TITLE
CURLOPT_CAINFO_BLOB feature + OpenSSL backend implementation

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1971,6 +1971,10 @@ typedef enum {
   CURLOPT(CURLOPT_PROXY_ISSUERCERT, CURLOPTTYPE_STRINGPOINT, 296),
   CURLOPT(CURLOPT_PROXY_ISSUERCERT_BLOB, CURLOPTTYPE_BLOB, 297),
 
+  /* The CAinfo blob used to validate the peer certificate
+     this option is used only if SSL_VERIFYPEER is true */
+  CURLOPT(CURLOPT_CAINFO_BLOB, CURLOPTTYPE_BLOB, 298),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2060,6 +2060,13 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
                              va_arg(param, struct curl_blob *));
     break;
 #endif
+  case CURLOPT_CAINFO_BLOB:
+    /*
+     * Set CA info for SSL connection. Specify blob of the CA certificate
+     */
+    result = Curl_setblobopt(&data->set.blobs[BLOB_SSL_CAINFO_ORIG],
+                             va_arg(param, struct curl_blob *));
+    break;
 #ifndef CURL_DISABLE_TELNET
   case CURLOPT_TELNETOPTIONS:
     /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -3652,6 +3652,7 @@ static CURLcode create_conn(struct Curl_easy *data,
 #endif
 #endif
 
+  data->set.ssl.cainfo_blob = data->set.blobs[BLOB_SSL_CAINFO_ORIG];
   data->set.ssl.cert_blob = data->set.blobs[BLOB_CERT_ORIG];
   data->set.ssl.key_blob = data->set.blobs[BLOB_KEY_ORIG];
   data->set.ssl.issuercert_blob = data->set.blobs[BLOB_SSL_ISSUERCERT_ORIG];

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -239,6 +239,7 @@ struct ssl_primary_config {
 struct ssl_config_data {
   struct ssl_primary_config primary;
   long certverifyresult; /* result from the certificate verification */
+  struct curl_blob *cainfo_blob;
   char *CRLfile;   /* CRL to check certificate revocation */
   char *issuercert;/* optional issuer certificate filename */
   struct curl_blob *issuercert_blob;
@@ -1584,6 +1585,7 @@ enum dupblob {
   BLOB_KEY_PROXY,
   BLOB_SSL_ISSUERCERT_ORIG,
   BLOB_SSL_ISSUERCERT_PROXY,
+  BLOB_SSL_CAINFO_ORIG,
   BLOB_LAST
 };
 


### PR DESCRIPTION
This allows setting CAinfo bundle from memory.
This is an improved version of my old CABUNDLE/CABUNDLESIZE pull request.

I can also create an mbedTLS implementation if necessary.