### PR TITLE
cirrus-ci: upgrade 11-STABLE to 11.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,8 +29,7 @@ task:
       # A stable 13.0 image likely won't be available before early 2021
       # image_family: freebsd-13-0-snap
       image_family: freebsd-12-1
-      # The stable 11.3 image causes "Agent is not responding" so use a snapshot
-      image_family: freebsd-11-3-snap
+      image_family: freebsd-11-4
 
   env:
     CIRRUS_CLONE_DEPTH: 10
@@ -71,7 +70,7 @@ task:
     - case `uname -r` in
         13.0*) SKIP_TESTS='!SFTP !SCP';;
         12.1*) SKIP_TESTS='!SFTP !SCP';;
-        11.3*) SKIP_TESTS='!SFTP !SCP';;
+        11.*) SKIP_TESTS='!SFTP !SCP';;
       esac
     - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky ${SKIP_TESTS}" test-nonflaky
   install_script:


### PR DESCRIPTION
Released June 23, 2020 and meant to be the last in the 11
series, so make sure that all other references reflect all 11
versions, and therefore they can all be retired together later.

Successfully built as shown by:
https://cirrus-ci.com/task/4602997093171200