### PR TITLE
transfer: fix memory-leak with CURLOPT_CURLU in a duped handle

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1441,8 +1441,9 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 
   if(!data->change.url && data->set.uh) {
     CURLUcode uc;
+    free(data->set.str[STRING_SET_URL]);
     uc = curl_url_get(data->set.uh,
-                        CURLUPART_URL, &data->set.str[STRING_SET_URL], 0);
+                      CURLUPART_URL, &data->set.str[STRING_SET_URL], 0);
     if(uc) {
       failf(data, "No URL set!");
       return CURLE_URL_MALFORMAT;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -89,7 +89,7 @@ test635 test636 test637 test638 test639 test640 test641 test642 \
 test643 test644 test645 test646 test647 test648 test649 test650 test651 \
 test652 test653 test654 test655 test656 test658 test659 test660 test661 \
 test662 test663 test664 test665 test666 test667 test668 test669 \
-test670 test671 test672 test673 \
+test670 test671 test672 test673 test674 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test674
+++ b/tests/data/test674
@@ -1,0 +1,57 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+CURLOPT_CURLU
+curl_easy_duphandle
+</keywords>
+</info>
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+<client>
+<server>
+http
+</server>
+<tool>
+lib674
+</tool>
+<name>
+Set CURLOPT_CURLU and dupe the handle
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/674
+</command>
+</client>
+
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /674 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /674 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -47,7 +47,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib583 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598 lib599   \
  lib643 lib644 lib645 lib650 lib651 lib652 lib653 lib654 lib655 lib658   \
  lib659 lib661 lib666 lib667 lib668 \
- lib670 lib671 lib672 lib673 \
+ lib670 lib671 lib672 lib673 lib674 \
  lib1156 \
  lib1500 lib1501 lib1502 lib1503 lib1504 lib1505 lib1506 lib1507 lib1508 \
  lib1509 lib1510 lib1511 lib1512 lib1513 lib1514 lib1515         lib1517 \
@@ -399,6 +399,10 @@ lib672_CPPFLAGS = $(AM_CPPFLAGS) -DLIB672
 lib673_SOURCES = lib670.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib673_LDADD = $(TESTUTIL_LIBS)
 lib673_CPPFLAGS = $(AM_CPPFLAGS) -DLIB673
+
+lib674_SOURCES = lib674.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib674_LDADD = $(TESTUTIL_LIBS)
+lib674_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1500_SOURCES = lib1500.c $(SUPPORTFILES) $(TESTUTIL)
 lib1500_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib674.c
+++ b/tests/libtest/lib674.c
@@ -1,0 +1,81 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+/*
+ * Get a single URL without select().
+ */
+
+int test(char *URL)
+{
+  CURL *handle = NULL;
+  CURL *handle2;
+  CURLcode res = 0;
+  CURLU *urlp = NULL;
+  CURLUcode uc = 0;
+
+  global_init(CURL_GLOBAL_ALL);
+  easy_init(handle);
+
+  urlp = curl_url();
+
+  if(!urlp) {
+    fprintf(stderr, "problem init URL api.");
+    goto test_cleanup;
+  }
+
+  uc = curl_url_set(urlp, CURLUPART_URL, URL, 0);
+  if(uc) {
+    fprintf(stderr, "problem setting CURLUPART_URL.");
+    goto test_cleanup;
+  }
+
+  /* demonstrate override behavior */
+
+
+  easy_setopt(handle, CURLOPT_CURLU, urlp);
+  easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+
+  res = curl_easy_perform(handle);
+
+  if(res) {
+    fprintf(stderr, "%s:%d curl_easy_perform() failed with code %d (%s)\n",
+            __FILE__, __LINE__, res, curl_easy_strerror(res));
+    goto test_cleanup;
+  }
+
+  handle2 = curl_easy_duphandle(handle);
+  res = curl_easy_perform(handle2);
+  curl_easy_cleanup(handle2);
+
+test_cleanup:
+
+  curl_url_cleanup(urlp);
+  curl_easy_cleanup(handle);
+  curl_global_cleanup();
+
+  return res;
+}


### PR DESCRIPTION
Added test case 674 to reproduce and verify the bug report.

Fixes #5665
Reported-by: NobodyXu