### PR TITLE
configure: cleanup wolfssl + pkg-config conflicts when cross compiling.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2380,6 +2380,7 @@ if test -z "$ssl_backends" -o "x$OPT_WOLFSSL" != xno; then
       OPT_WOLFSSL=""
     fi
 
+    dnl try pkg-config magic
     CURL_CHECK_PKGCONFIG(wolfssl, [$wolfpkg])
     AC_MSG_NOTICE([Check dir $wolfpkg])
 
@@ -2398,9 +2399,12 @@ if test -z "$ssl_backends" -o "x$OPT_WOLFSSL" != xno; then
       wolfssllibpath=`echo $addld | $SED -e 's/^-L//'`
     else
       addlib=-lwolfssl
-      addld=-L$OPT_WOLFSSL/lib$libsuff
-      addcflags=-I$OPT_WOLFSSL/include
-      wolfssllibpath=$OPT_WOLFSSL/lib$libsuff
+      dnl use system defaults if user does not supply a path
+      if test -n "$OPT_WOLFSSL"; then
+        addld=-L$OPT_WOLFSSL/lib$libsuff
+        addcflags=-I$OPT_WOLFSSL/include
+        wolfssllibpath=$OPT_WOLFSSL/lib$libsuff
+      fi
     fi
 
     if test "x$USE_WOLFSSL" != "xyes"; then
@@ -2452,7 +2456,7 @@ if test -z "$ssl_backends" -o "x$OPT_WOLFSSL" != xno; then
       dnl wolfssl/ctaocrypt/types.h needs SIZEOF_LONG_LONG defined!
       AX_COMPILE_CHECK_SIZEOF(long long)
 
-      LIBS="-lwolfssl -lm $LIBS"
+      LIBS="$addlib -lm $LIBS"
 
       dnl Recent WolfSSL versions build without SSLv3 by default
       dnl WolfSSL needs configure --enable-opensslextra to have *get_peer*
@@ -2464,12 +2468,19 @@ if test -z "$ssl_backends" -o "x$OPT_WOLFSSL" != xno; then
 
       dnl if this symbol is present, we want the include path to include the
       dnl OpenSSL API root as well
-      AC_CHECK_FUNC(wolfSSL_DES_set_odd_parity,
+      AC_CHECK_FUNC(wolfSSL_DES_ecb_encrypt,
         [
-            AC_DEFINE(HAVE_WOLFSSL_DES_SET_ODD_PARITY, 1,
-                      [if you have wolfSSL_DES_set_odd_parity])
-            CPPFLAGS="$addcflags/wolfssl $CPPFLAGS"
-            AC_MSG_NOTICE([Add $addcflags/wolfssl to CPPFLAGS])
+            AC_DEFINE(HAVE_WOLFSSL_DES_ECB_ENCRYPT, 1,
+                      [if you have wolfSSL_DES_ecb_encrypt])
+            if test -n "$addcflags"; then
+              CPPFLAGS="$addcflags/wolfssl $CPPFLAGS"
+              AC_MSG_NOTICE([Add $addcflags/wolfssl to CPPFLAGS])
+            else
+              dnl user didn't give a path, so guess/hope they installed wolfssl
+              dnl headers to system default location
+              CPPFLAGS="-I$includedir/wolfssl $CPPFLAGS"
+              AC_MSG_NOTICE([Add $includedir/wolfssl to CPPFLAGS])
+            fi
             WOLFSSL_NTLM=1
         ]
         )

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -641,7 +641,7 @@ int netware_init(void);
   defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_SECTRANSP) ||  \
   defined(USE_OS400CRYPTO) || defined(USE_WIN32_CRYPTO) ||              \
   defined(USE_MBEDTLS) ||                                               \
-  (defined(USE_WOLFSSL) && defined(HAVE_WOLFSSL_DES_SET_ODD_PARITY))
+  (defined(USE_WOLFSSL) && defined(HAVE_WOLFSSL_DES_ECB_ENCRYPT))
 
 #define USE_NTLM
 


### PR DESCRIPTION
Also choose a different wolfSSL function to test for NTLM support. The versions of wolfSSL I have to test against (4.3 and 4.4) have the "wolfSSL_DES_ecb_encrypt" function (which is used in the NTLM code) behind an extra #ifdef that you have to go out of your way to enable.

Bug: #5605