### PR TITLE
file2memory: use a define instead of -1 unsigned value

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -115,8 +115,8 @@ ParameterError file2memory(char **bufp, size_t *size, FILE *file)
     size_t alloc = 512;
     do {
       if(!buffer || (alloc == nused)) {
-        /* size_t overflow detection for huge files */
-        if(alloc + 1 > ((size_t)-1)/2) {
+        /* size_t overflow detection and avoiding huge files */
+        if(alloc >= (SIZE_T_MAX/4)) {
           Curl_safefree(buffer);
           return PARAM_NO_MEM;
         }


### PR DESCRIPTION
... to use the maximum value for 'size_t' when detecting integer overflow.
Changed the limit to max/4 as already that seems unreasonably large.

Codacy didn't like the previous approach.