### PR TITLE
CURLKHSTAT_FINE_REPLACE_TO_FILE

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
@@ -28,6 +28,7 @@ CURLOPT_SSH_KEYFUNCTION \- callback for known host matching logic
 #include <curl/curl.h>
 
 enum curl_khstat {
+  CURLKHSTAT_FINE_REPLACE_TO_FILE,
   CURLKHSTAT_FINE_ADD_TO_FILE,
   CURLKHSTAT_FINE,
   CURLKHSTAT_REJECT, /* reject the connection, return an error */
@@ -73,6 +74,12 @@ info from libcurl on the matching status and a custom pointer (set with
 \fICURLOPT_SSH_KEYDATA(3)\fP). It MUST return one of the following return
 codes to tell libcurl how to act:
 
+.IP CURLKHSTAT_FINE_REPLACE_TO_FILE
+The new host+key is accepted and libcurl will replace the old host+key into the 
+known_hosts file before continuing with the connection. This will also add the 
+new host+key combo to the known_host pool kept in memory if it wasn't already 
+present there. The adding of data to the file is done by completely replacing 
+the file with a new copy, so the permissions of the file must allow this.
 .IP CURLKHSTAT_FINE_ADD_TO_FILE
 The host+key is accepted and libcurl will append it to the known_hosts file
 before continuing with the connection. This will also add the host+key combo

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -783,6 +783,7 @@ struct curl_khkey {
 /* this is the set of return values expected from the curl_sshkeycallback
    callback */
 enum curl_khstat {
+  CURLKHSTAT_FINE_REPLACE_TO_FILE,
   CURLKHSTAT_FINE_ADD_TO_FILE,
   CURLKHSTAT_FINE,
   CURLKHSTAT_REJECT, /* reject the connection, return an error */


### PR DESCRIPTION
add the functionality to remove the old host+key that doesn't match anymore. It's usefull to prevent the knownhost file to grow too much.

I've a problem during the compilation: 

 NMAKE : fatal error U1073: incapable d'obtenir '..\src\tool_hugehelp.c'