### PR TITLE
page-header: add protocol details to the curl.1 man page

### DIFF
--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -124,7 +124,7 @@ without using TLS.
 curl can do directory lookups for you, with or without TLS.
 .IP MQTT
 curl supports MQTT version 3. Downloading over MQTT equals "subscribe" to a
-topic while uploading/posting equals "publishe" on a topic. MQTT support is
+topic while uploading/posting equals "publish" on a topic. MQTT support is
 experimental and TLS based MQTT is not supported (yet).
 .IP POP3(S)
 Downloading from a pop3 server means getting a mail. With or without using

--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -99,6 +99,55 @@ getting many files from the same server will not do multiple connects /
 handshakes. This improves speed. Of course this is only done on files
 specified on a single command line and cannot be used between separate curl
 invokes.
+.SH PROTOCOLS
+curl supports numerous protocols, or put in URL terms: schemes. Your
+particular build may not support them all.
+.IP DICT
+Lets you lookup words using online dictionaries.
+.IP FILE
+Read or write local files. curl does not support accessing file:// URL
+remotely, but when running on Microsft Windows using the native UNC approach
+will work.
+.IP FTP(S)
+curl supports the File Transfer Protocol with a lot of tweaks and levers. With
+or without using TLS.
+.IP GOPHER
+Retrieve files.
+.IP HTTP(S)
+curl supports HTTP with numerous options and variations. It can speak HTTP
+version 0.9, 1.0, 1.1, 2 and 3 depending on build options and the correct
+command line options.
+.IP IMAP(S)
+Using the mail reading protocol, curl can "download" emails for you. With or
+without using TLS.
+.IP LDAP(S)
+curl can do directory lookups for you, with or without TLS.
+.IP MQTT
+curl supports MQTT version 3. Downloading over MQTT equals "subscribe" to a
+topic while uploading/posting equals "publishe" on a topic. MQTT support is
+experimental and TLS based MQTT is not supported (yet).
+.IP POP3(S)
+Downloading from a pop3 server means getting a mail. With or without using
+TLS.
+.IP RTMP(S)
+The Realtime Messaging Protocol is primarily used to server streaming media
+and curl can download it.
+.IP RTSP
+curl supports RTSP 1.0 downloads.
+.IP SCP
+curl supports SSH version 2 scp transfers.
+.IP SFTP
+curl supports SFTP (draft 5) done over SSH version 2.
+.IP SMB(S)
+curl supports SMB version 1 for upload and download.
+.IP SMTP(S)
+Uploading contents to an SMTP server means sending an email. With or without
+TLS.
+.IP TELNET
+Telling curl to fetch a telnet URL starts an interactive session where it
+sends what it reads on stdin and outputs what the server sends it.
+.IP TFTP
+curl can do TFTP downloads and uploads.
 .SH "PROGRESS METER"
 curl normally displays a progress meter during operations, indicating the
 amount of transferred data, transfer speeds and estimated time left, etc. The


### PR DESCRIPTION
Added protocol and version specific information about all protocols curl
supports.

Fixes #5679
Reported-by: tbugfinder on github