### PR TITLE
docs: Update a few leftover mentions of DarwinSSL

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -25,7 +25,7 @@ problems may have been fixed or changed somewhat since this was written!
  2. TLS
  2.1 CURLINFO_SSL_VERIFYRESULT has limited support
  2.2 DER in keychain
- 2.4 DarwinSSL won't import PKCS#12 client certificates without a password
+ 2.4 Secure Transport won't import PKCS#12 client certificates without a password
  2.5 Client cert handling with Issuer DN differs between backends
  2.6 CURL_GLOBAL_SSL
  2.7 Client cert (MTLS) issues with Schannel
@@ -209,7 +209,7 @@ problems may have been fixed or changed somewhat since this was written!
  Curl doesn't recognize certificates in DER format in keychain, but it works
  with PEM.  https://curl.haxx.se/bug/view.cgi?id=1065
 
-2.4 DarwinSSL won't import PKCS#12 client certificates without a password
+2.4 Secure Transport won't import PKCS#12 client certificates without a password
 
  libcurl calls SecPKCS12Import with the PKCS#12 client certificate, but that
  function rejects certificates that do not have a password.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -37,7 +37,7 @@ the SSL layer libcurl uses may use a work-around for this flaw although it
 might cause interoperability problems with some (older) SSL
 implementations. WARNING: avoiding this work-around lessens the security, and
 by setting this option to 1 you ask for exactly that.  This option is only
-supported for DarwinSSL, NSS and OpenSSL.
+supported for Secure Transport, NSS and OpenSSL.
 .IP CURLSSLOPT_NO_REVOKE
 Tells libcurl to disable certificate revocation checks for those SSL backends
 where such behavior is present. This option is only supported for Schannel

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -37,7 +37,7 @@ the SSL layer libcurl uses may use a work-around for this flaw although it
 might cause interoperability problems with some (older) SSL
 implementations. WARNING: avoiding this work-around lessens the security, and
 by setting this option to 1 you ask for exactly that.  This option is only
-supported for DarwinSSL, NSS and OpenSSL.
+supported for Secure Transport, NSS and OpenSSL.
 .IP CURLSSLOPT_NO_REVOKE
 Tells libcurl to disable certificate revocation checks for those SSL backends
 where such behavior is present. This option is only supported for Schannel

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -64,8 +64,8 @@ This option controls checking the server's certificate's claimed identity.
 The server could be lying.  To control lying, see
 \fICURLOPT_SSL_VERIFYPEER(3)\fP.
 .SH LIMITATIONS
-DarwinSSL: If \fIverify\fP value is 0, then SNI is also disabled. SNI is a TLS
-extension that sends the hostname to the server. The server may use that
+Secure Transport: If \fIverify\fP value is 0, then SNI is also disabled. SNI is
+a TLS extension that sends the hostname to the server. The server may use that
 information to do such things as sending back a specific certificate for the
 hostname, or forwarding the request to a specific origin server. Some hostnames
 may be inaccessible if SNI is not sent.


### PR DESCRIPTION
Commit 76a9c3c4be10b3d4d379d5b23ca76806bbae536a renamed DarwinSSL to the more correct/common name Secure Transport, but a few mentions in the docs remained.