### PR TITLE
configure: allow disabling warnings

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -886,36 +886,36 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
         #
         if test "$want_warnings" = "yes"; then
           tmp_CFLAGS="$tmp_CFLAGS -pedantic"
-          tmp_CFLAGS="$tmp_CFLAGS -Wall -Wextra"
-          tmp_CFLAGS="$tmp_CFLAGS -Wpointer-arith -Wwrite-strings"
-          tmp_CFLAGS="$tmp_CFLAGS -Wshadow"
-          tmp_CFLAGS="$tmp_CFLAGS -Winline -Wnested-externs"
-          tmp_CFLAGS="$tmp_CFLAGS -Wmissing-declarations"
-          tmp_CFLAGS="$tmp_CFLAGS -Wmissing-prototypes"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all extra])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shadow])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [inline nested-externs])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-declarations])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-prototypes])
           tmp_CFLAGS="$tmp_CFLAGS -Wno-long-long"
-          tmp_CFLAGS="$tmp_CFLAGS -Wfloat-equal"
-          tmp_CFLAGS="$tmp_CFLAGS -Wno-multichar -Wsign-compare"
-          tmp_CFLAGS="$tmp_CFLAGS -Wundef"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [float-equal])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [no-multichar sign-compare])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [undef])
           tmp_CFLAGS="$tmp_CFLAGS -Wno-format-nonliteral"
-          tmp_CFLAGS="$tmp_CFLAGS -Wendif-labels -Wstrict-prototypes"
-          tmp_CFLAGS="$tmp_CFLAGS -Wdeclaration-after-statement"
-          tmp_CFLAGS="$tmp_CFLAGS -Wcast-align"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [endif-labels strict-prototypes])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [declaration-after-statement])
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-align])
           tmp_CFLAGS="$tmp_CFLAGS -Wno-system-headers"
-          tmp_CFLAGS="$tmp_CFLAGS -Wshorten-64-to-32"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shorten-64-to-32])
           #
           dnl Only clang 1.1 or later
           if test "$compiler_num" -ge "101"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wunused"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused])
           fi
           #
           dnl Only clang 2.8 or later
           if test "$compiler_num" -ge "208"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wvla"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [vla])
           fi
           #
           dnl Only clang 2.9 or later
           if test "$compiler_num" -ge "209"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wshift-sign-overflow"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shift-sign-overflow])
           fi
           #
           dnl Only clang 3.2 or later
@@ -926,19 +926,19 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
               dnl mingw because the libtool wrapper executable causes them
               ;;
             *)
-              tmp_CFLAGS="$tmp_CFLAGS -Wmissing-variable-declarations"
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-variable-declarations])
               ;;
             esac
           fi
           #
           dnl Only clang 3.6 or later
           if test "$compiler_num" -ge "306"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [double-promotion])
           fi
           #
           dnl Only clang 3.9 or later
           if test "$compiler_num" -ge "309"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wcomma"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [comma])
             # avoid the varargs warning, fixed in 4.0
             # https://bugs.llvm.org/show_bug.cgi?id=29140
             if test "$compiler_num" -lt "400"; then
@@ -968,43 +968,45 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           fi
           #
           dnl Set of options we believe *ALL* gcc versions support:
-          tmp_CFLAGS="$tmp_CFLAGS -Wall -W"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all])
+          tmp_CFLAGS="$tmp_CFLAGS -W"
           #
           dnl Only gcc 1.4 or later
           if test "$compiler_num" -ge "104"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wpointer-arith -Wwrite-strings"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pointer-arith write-strings])
             dnl If not cross-compiling with a gcc older than 3.0
             if test "x$cross_compiling" != "xyes" ||
               test "$compiler_num" -ge "300"; then
-              tmp_CFLAGS="$tmp_CFLAGS -Wunused -Wshadow"
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused shadow])
             fi
           fi
           #
           dnl Only gcc 2.7 or later
           if test "$compiler_num" -ge "207"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Winline -Wnested-externs"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [inline nested-externs])
             dnl If not cross-compiling with a gcc older than 3.0
             if test "x$cross_compiling" != "xyes" ||
               test "$compiler_num" -ge "300"; then
-              tmp_CFLAGS="$tmp_CFLAGS -Wmissing-declarations"
-              tmp_CFLAGS="$tmp_CFLAGS -Wmissing-prototypes"
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-declarations])
+              CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-prototypes])
             fi
           fi
           #
           dnl Only gcc 2.95 or later
           if test "$compiler_num" -ge "295"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-long-long"
-            tmp_CFLAGS="$tmp_CFLAGS -Wbad-function-cast"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [bad-function-cast])
           fi
           #
           dnl Only gcc 2.96 or later
           if test "$compiler_num" -ge "296"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wfloat-equal"
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-multichar -Wsign-compare"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [float-equal])
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-multichar"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sign-compare])
             dnl -Wundef used only if gcc is 2.96 or later since we get
             dnl lots of "`_POSIX_C_SOURCE' is not defined" in system
             dnl headers with gcc 2.95.4 on FreeBSD 4.9
-            tmp_CFLAGS="$tmp_CFLAGS -Wundef"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [undef])
           fi
           #
           dnl Only gcc 2.97 or later
@@ -1023,13 +1025,13 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only gcc 3.3 or later
           if test "$compiler_num" -ge "303"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wendif-labels -Wstrict-prototypes"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [endif-labels strict-prototypes])
           fi
           #
           dnl Only gcc 3.4 or later
           if test "$compiler_num" -ge "304"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wdeclaration-after-statement"
-            tmp_CFLAGS="$tmp_CFLAGS -Wold-style-definition"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [declaration-after-statement])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [old-style-definition])
           fi
           #
           dnl Only gcc 4.0 or later
@@ -1039,15 +1041,17 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only gcc 4.2 or later
           if test "$compiler_num" -ge "402"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wcast-align"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-align])
           fi
           #
           dnl Only gcc 4.3 or later
           if test "$compiler_num" -ge "403"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wtype-limits -Wold-style-declaration"
-            tmp_CFLAGS="$tmp_CFLAGS -Wmissing-parameter-type -Wempty-body"
-            tmp_CFLAGS="$tmp_CFLAGS -Wclobbered -Wignored-qualifiers"
-            tmp_CFLAGS="$tmp_CFLAGS -Wconversion -Wno-sign-conversion -Wvla"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits old-style-declaration])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-parameter-type empty-body])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [clobbered ignored-qualifiers])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion])
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [vla])
             dnl required for -Warray-bounds, included in -Wall
             tmp_CFLAGS="$tmp_CFLAGS -ftree-vrp"
           fi
@@ -1062,7 +1066,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only gcc 4.6 or later
           if test "$compiler_num" -ge "406"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [double-promotion])
           fi
           #
           dnl only gcc 4.8 or later
@@ -1077,18 +1081,19 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           #
           dnl Only gcc 6 or later
           if test "$compiler_num" -ge "600"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wshift-negative-value"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shift-negative-value])
             tmp_CFLAGS="$tmp_CFLAGS -Wshift-overflow=2"
-            tmp_CFLAGS="$tmp_CFLAGS -Wnull-dereference -fdelete-null-pointer-checks"
-            tmp_CFLAGS="$tmp_CFLAGS -Wduplicated-cond"
-            tmp_CFLAGS="$tmp_CFLAGS -Wunused-const-variable"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [null-dereference])
+            tmp_CFLAGS="$tmp_CFLAGS -fdelete-null-pointer-checks"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [duplicated-cond])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unused-const-variable])
           fi
           #
           dnl Only gcc 7 or later
           if test "$compiler_num" -ge "700"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wduplicated-branches"
-            tmp_CFLAGS="$tmp_CFLAGS -Wrestrict"
-            tmp_CFLAGS="$tmp_CFLAGS -Walloc-zero"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [duplicated-branches])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [restrict])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [alloc-zero])
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-overflow=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough=4"
@@ -1214,11 +1219,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
         #
         if test "$want_warnings" = "yes"; then
           dnl Activate all warnings
-          tmp_CFLAGS="$tmp_CFLAGS -Wall"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [all])
           dnl Make string constants be of type const char *
-          tmp_CFLAGS="$tmp_CFLAGS -Wwrite-strings"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [write-strings])
           dnl Warn use of unsupported GCC features ignored by TCC
-          tmp_CFLAGS="$tmp_CFLAGS -Wunsupported"
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unsupported])
         fi
         ;;
         #
@@ -1643,5 +1648,26 @@ AC_DEFUN([CURL_VAR_STRIP], [
   done
   dnl squeeze whitespace out of result
   [$1]="$ac_var_stripped"
+  squeeze [$1]
+])
+
+dnl CURL_ADD_COMPILER_WARNINGS (WARNING-LIST, NEW-WARNINGS)
+dnl -------------------------------------------------------
+dnl Contents of variable WARNING-LIST and NEW-WARNINGS are
+dnl handled as whitespace separated lists of words.
+dnl Add each compiler warning from NEW-WARNINGS that has not
+dnl been disabled via CFLAGS to WARNING-LIST.
+
+AC_DEFUN([CURL_ADD_COMPILER_WARNINGS], [
+  AC_REQUIRE([CURL_SHFUNC_SQUEEZE])dnl
+  ac_var_added_warnings=""
+  for warning in [$2]; do
+    CURL_VAR_MATCH(CFLAGS, [-Wno-$warning -W$warning])
+    if test "$ac_var_match_word" = "no"; then
+      ac_var_added_warnings="$ac_var_added_warnings -W$warning"
+    fi
+  done
+  dnl squeeze whitespace out of result
+  [$1]="$[$1] $ac_var_added_warnings"
   squeeze [$1]
 ])


### PR DESCRIPTION
With `--enable-warnings`, it was not possible to disable warnings via
CFLAGS that got explicitly enabled with that warnings. Now warnings are
not enabled anymore if they are explicitly disabled (or enabled) in
CFLAGS. This works for at least GCC, clang, and TCC as they have
corresponding `-Wno-` options for every warning.

I'm not fluent with m4, so there might be a better or cleaner way to do that.
Tested with GCC (on Windows and macOS) and clang (on macOS), but TCC should behave the same.