### PR TITLE
travis: update quiche builds for new boringssl layout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,8 @@ jobs:
     before_install:
     - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
   - env:
-    - T=novalgrind QUICHE="yes" C="--with-ssl=$HOME/quiche/deps/boringssl --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
+    - T=novalgrind QUICHE="yes" C="--with-ssl=$HOME/quiche/deps/boringssl/src --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    before_install:
-    - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
     addons:
       apt:
         <<: *common_apt

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -117,8 +117,8 @@ Build quiche and BoringSSL:
      % git clone --recursive https://github.com/cloudflare/quiche
      % cd quiche
      % cargo build --release --features pkg-config-meta,qlog
-     % mkdir deps/boringssl/lib
-     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/lib/
+     % mkdir deps/boringssl/src/lib
+     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
 
 Build curl:
 
@@ -126,7 +126,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl --with-quiche=$PWD/../quiche/target/release --enable-alt-svc
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release --enable-alt-svc
      % make
 
 ## Run

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -96,8 +96,8 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
   source $HOME/.cargo/env
   cd $HOME/quiche
   cargo build -v --release --features pkg-config-meta,qlog
-  mkdir -v deps/boringssl/lib
-  ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/lib/
+  mkdir -v deps/boringssl/src/lib
+  ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
 fi
 
 # Install common libraries.


### PR DESCRIPTION
This is required after https://github.com/cloudflare/quiche/pull/593
moved BoringSSL around slightly.

This also means that Go is not needed to build BoringSSL anymore (the
one provided by quiche anyway).

---

BTW, you might want to switch to the `master-with-bazel` branch of BoringSSL for the other builds too, so you don't have to install Go.