### PR TITLE
CI/macos: unconditionally enable warnings-as-errors with autotools

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
           install: nghttp2
         - name: debug
           install: nghttp2
-          configure: --enable-debug --enable-werror --without-brotli --enable-mqtt
+          configure: --enable-debug --enable-mqtt
         - name: libssh2
           install: nghttp2 libssh2
           configure: --enable-debug --with-libssh2
@@ -32,7 +32,7 @@ jobs:
           configure: --enable-debug --enable-ares
         - name: HTTP only
           install: nghttp2
-          configure: --enable-debug --enable-werror --enable-maintainer-mode --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap --disable-pop3 --disable-rtmp --disable-rtsp --disable-scp --disable-sftp --disable-smb --disable-smtp --disable-telnet --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi --without-libidn2 --without-libmetalink --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 --without-ntlm-auth --without-ssl --without-zlib
+          configure: --enable-debug --enable-maintainer-mode --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap --disable-pop3 --disable-rtmp --disable-rtsp --disable-scp --disable-sftp --disable-smb --disable-smtp --disable-telnet --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi --without-libidn2 --without-libmetalink --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 --without-ntlm-auth --without-ssl --without-zlib
         - name: SecureTransport metalink
           install: nghttp2 openssl libmetalink
           configure: --enable-debug --without-ssl --with-darwinssl --with-libmetalink
@@ -55,8 +55,11 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - run: ./buildconf && ./configure ${{ matrix.build.configure }}
+    - run: ./buildconf && ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
       name: 'configure'
+      env:
+        # -Wvla is caused by brotli
+        CFLAGS: -Wno-vla
 
     - run: make
       name: 'make'


### PR DESCRIPTION
Previously, warnings were only visible in the output for most jobs.