### PR TITLE
strdup: remove the odd strlen check

### DIFF
--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -39,19 +39,14 @@ char *curlx_strdup(const char *str)
   if(!str)
     return (char *)NULL;
 
-  len = strlen(str);
+  len = strlen(str) + 1;
 
-  if(len >= ((size_t)-1) / sizeof(char))
-    return (char *)NULL;
-
-  newstr = malloc((len + 1)*sizeof(char));
+  newstr = malloc(len);
   if(!newstr)
     return (char *)NULL;
 
-  memcpy(newstr, str, (len + 1)*sizeof(char));
-
+  memcpy(newstr, str, len);
   return newstr;
-
 }
 #endif
 

--- a/src/tool_strdup.c
+++ b/src/tool_strdup.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -30,18 +30,13 @@ char *strdup(const char *str)
   if(!str)
     return (char *)NULL;
 
-  len = strlen(str);
+  len = strlen(str) + 1;
 
-  if(len >= ((size_t)-1) / sizeof(char))
-    return (char *)NULL;
-
-  newstr = malloc((len + 1)*sizeof(char));
+  newstr = malloc(len);
   if(!newstr)
     return (char *)NULL;
 
-  memcpy(newstr, str, (len + 1)*sizeof(char));
-
+  memcpy(newstr, str, len);
   return newstr;
-
 }
 #endif


### PR DESCRIPTION
It confuses code analyzers with its use of -1 for unsigned value. Also,
a check that's not normally used in strdup() code - and not necessary.