### PR TITLE
buildconf: cleanup

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -25,7 +25,7 @@
 # die prints argument string to stdout and exits this shell script.
 #
 die(){
-  echo "buildconf: $@"
+  echo "buildconf: $*"
   exit 1
 }
 

--- a/buildconf
+++ b/buildconf
@@ -351,6 +351,7 @@ if test -f m4/libtool.m4; then
 fi
 
 echo "buildconf: running aclocal"
+#shellcheck disable=SC2154
 ${ACLOCAL:-aclocal} -I m4 $ACLOCAL_FLAGS || die "aclocal command failed"
 
 echo "buildconf: converting all mv to mv -f in local aclocal.m4"

--- a/buildconf
+++ b/buildconf
@@ -363,13 +363,6 @@ ${AUTOHEADER:-autoheader} || die "autoheader command failed"
 echo "buildconf: running autoconf"
 ${AUTOCONF:-autoconf} || die "autoconf command failed"
 
-if test -d ares; then
-  cd ares
-  echo "buildconf: running in ares"
-  ./buildconf
-  cd ..
-fi
-
 echo "buildconf: running automake"
 ${AUTOMAKE:-automake} --add-missing --copy || die "automake command failed"
 


### PR DESCRIPTION
mainly to allow for a clean:

  $ shellcheck -fgcc --enable=all -S warning buildconf