### PR TITLE
connect: output the same error msg on both code paths

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -934,10 +934,10 @@ CURLcode Curl_is_connected(struct connectdata *conn,
 
         return CURLE_OK;
       }
-      infof(data, "Connection failed\n");
     }
-    else if(rc & CURL_CSELECT_ERR)
+    else if(rc & CURL_CSELECT_ERR) {
       (void)verifyconnect(conn->tempsock[i], &error);
+    }
 
     /*
      * The connection failed here, we should attempt to connect to the "next


### PR DESCRIPTION
A failed verifyconnect on CURL_CSELECT_OUT printed the
error message "Connection failed", but the same failure
on CURL_CSELECT_ERR did not. This commit brings it in line.