### PR TITLE
url: fix CURLU and location following

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1836,11 +1836,12 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   CURLU *uh;
   CURLUcode uc;
   char *hostname;
+  bool use_set_uh = (data->set.uh && !data->state.this_is_a_follow);
 
   up_free(data); /* cleanup previous leftovers first */
 
   /* parse the URL */
-  if(data->set.uh) {
+  if(use_set_uh) {
     uh = data->state.uh = curl_url_dup(data->set.uh);
   }
   else {
@@ -1863,7 +1864,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     data->change.url_alloc = TRUE;
   }
 
-  if(!data->set.uh) {
+  if(!use_set_uh) {
     char *newurl;
     uc = curl_url_set(uh, CURLUPART_URL, data->change.url,
                     CURLU_GUESS_SCHEME |

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -189,7 +189,7 @@ test1540 test1541 \
 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 test1564 test1565 \
-test1566 \
+test1566 test1567 \
 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \

--- a/tests/data/test1567
+++ b/tests/data/test1567
@@ -1,0 +1,73 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+URL API
+CURLOPT_CURLU
+CURLOPT_FOLLOWLOCATION
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Content-Length: 6
+Location: /15670002
+
+-foo-
+</data>
+<data2>
+HTTP/1.1 200 OK
+Content-Length: 11
+
+redirected
+</data2>
+<datacheck>
+redirected
+redirected
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib1567
+</tool>
+
+ <name>
+re-run redirected transfer without setting CURLU URL again
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/1567
+</command>
+</client>
+
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /1567 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /15670002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /1567 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /15670002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -56,7 +56,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1534 lib1535 lib1536 lib1537 lib1538 lib1539 \
  lib1540 lib1541 \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
- lib1558 lib1559 lib1560 lib1564 lib1565 \
+ lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 \
  lib1591 lib1592 lib1593 lib1594 lib1596 \
  lib1900 lib1905 lib1906 lib1907 lib1908 lib1910 \
  lib2033 lib3010
@@ -603,6 +603,9 @@ lib1564_CPPFLAGS = $(AM_CPPFLAGS)
 lib1565_SOURCES = lib1565.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1565_LDADD = $(TESTUTIL_LIBS)
 lib1565_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1567_SOURCES = lib1567.c $(SUPPORTFILES)
+lib1567_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1591_SOURCES = lib1591.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1591_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1567.c
+++ b/tests/libtest/lib1567.c
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "memdebug.h"
+
+#include <curl/multi.h>
+
+int test(char *URL)
+{
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+
+  global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+  if(curl) {
+    CURLU *u = curl_url();
+    if(u) {
+      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+      curl_url_set(u, CURLUPART_URL, URL, 0);
+      curl_easy_setopt(curl, CURLOPT_CURLU, u);
+      res = curl_easy_perform(curl);
+
+      fprintf(stderr, "****************************** Do it again\n");
+      res = curl_easy_perform(curl);
+      curl_url_cleanup(u);
+    }
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+  return (int)res;
+}


### PR DESCRIPTION
Prior to this change if the user set a URL handle (CURLOPT_CURLU) it was
incorrectly used for the location follow, resulting in infinite requests
to the original location.

Reported-by: sspiri@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/5709
Closes #xxxx