### PR TITLE
ntlm: free target_info before (re-)malloc

### DIFF
--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -191,6 +191,7 @@ static CURLcode ntlm_decode_type2_target(struct Curl_easy *data,
         return CURLE_BAD_CONTENT_ENCODING;
       }
 
+      free(ntlm->target_info); /* replace any previous data */
       ntlm->target_info = malloc(target_info_len);
       if(!ntlm->target_info)
         return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
OSS-Fuzz found a way this could get called again with the pointer still
pointing to a malloc'ed memory, leading to a leak.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24379