### PR TITLE
setopt: unset NOBODY switches to GET if still HEAD

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -274,6 +274,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     if(data->set.opt_no_body)
       /* in HTTP lingo, no body means using the HEAD request... */
       data->set.method = HTTPREQ_HEAD;
+    else if(data->set.method == HTTPREQ_HEAD)
+      data->set.method = HTTPREQ_GET;
     break;
   case CURLOPT_FAILONERROR:
     /*


### PR DESCRIPTION
Unsetting CURLOPT_NOBODY with 0L when doing HTTP has no documented
action but before 7.71.0 that used to switch back to GET and with this
change (assuming the method is still set to HEAD) this behavior is
brought back.

Reported-by: causal-agent on github
Isssue: #5725