### PR TITLE
curl: improve the existing file check with -J

### DIFF
--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -456,6 +456,16 @@ FILE *curl_dbg_fopen(const char *file, const char *mode,
   return res;
 }
 
+FILE *curl_dbg_fdopen(int filedes, const char *mode,
+                      int line, const char *source)
+{
+  FILE *res = fdopen(filedes, mode);
+  if(source)
+    curl_dbg_log("FILE %s:%d fdopen(\"%d\",\"%s\") = %p\n",
+                 source, line, filedes, mode, (void *)res);
+  return res;
+}
+
 int curl_dbg_fclose(FILE *file, int line, const char *source)
 {
   int res;

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -8,7 +8,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -79,6 +79,9 @@ CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
 /* FILE functions */
 CURL_EXTERN FILE *curl_dbg_fopen(const char *file, const char *mode, int line,
                                  const char *source);
+CURL_EXTERN FILE *curl_dbg_fdopen(int filedes, const char *mode,
+                                  int line, const char *source);
+
 CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
 
 #ifndef MEMDEBUG_NODEFINES

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -53,9 +53,20 @@ bool tool_create_output_file(struct OutStruct *outs,
 
   if(outs->is_cd_filename) {
     /* don't overwrite existing files */
-    int fd = open(outs->filename, O_CREAT | O_WRONLY | O_EXCL, 0666);
-    if(fd != -1)
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+    int fd = open(outs->filename, O_CREAT | O_WRONLY | O_EXCL | O_BINARY,
+                  S_IRUSR | S_IWUSR
+#ifdef S_IRGRP
+                  | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+#endif
+      );
+    if(fd != -1) {
       file = fdopen(fd, "wb");
+      if(!file)
+        close(fd);
+    }
   }
   else
     /* open file for writing */


### PR DESCRIPTION
Previously a file that isn't user-readable but is user-writable would
not be properly avoided and would get overwritten.

Reported-by: BrumBrum on hackerone
Bug: https://hackerone.com/reports/926638