### PR TITLE
checksrc: ban gmtime/localtime

### DIFF
--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,2 +1,3 @@
 disable TYPEDEFSTRUCT
 disable SNPRINTF
+disable BANNEDFUNC

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -592,7 +592,8 @@ sub scanfile {
 
         # scan for use of banned functions
         if($l =~ /^(.*\W)
-                   (gets|
+                   (gmtime|localtime|
+                    gets|
                     strtok|
                     v?sprintf|
                     (str|_mbs|_tcs|_wcs)n?cat|

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -624,6 +624,7 @@ CURLcode Curl_gmtime(time_t intime, struct tm *store)
   /* thread-safe version */
   tm = (struct tm *)gmtime_r(&intime, store);
 #else
+  /* !checksrc! disable BANNEDFUNC 1 */
   tm = gmtime(&intime);
   if(tm)
     *store = *tm; /* copy the pointed struct to the local copy */

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -65,6 +65,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
       known_offset = 1;
     }
     secs = epoch_offset + tv.tv_sec;
+    /* !checksrc! disable BANNEDFUNC 1 */
     now = localtime(&secs);  /* not thread safe but we don't care */
     msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
               now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);

--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,1 +1,2 @@
 disable TYPEDEFSTRUCT
+disable BANNEDFUNC

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -119,6 +119,7 @@ void logmsg(const char *msg, ...)
     known_offset = 1;
   }
   sec = epoch_offset + tv.tv_sec;
+  /* !checksrc! disable BANNEDFUNC 1 */
   now = localtime(&sec); /* not thread safe but we don't care */
 
   msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld",


### PR DESCRIPTION
They're not thread-safe so they should not be used in libcurl code.

Explictly enabled when deemed necessary and in examples and tests