### PR TITLE
curl_multi_setopt: fix compiler warning "result is always false"

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2962,9 +2962,7 @@ CURLMcode curl_multi_setopt(struct Curl_multi *multi,
       long streams = va_arg(param, long);
       if(streams < 1)
         streams = 100;
-      multi->max_concurrent_streams =
-        (streams > (long)INITIAL_MAX_CONCURRENT_STREAMS)?
-        INITIAL_MAX_CONCURRENT_STREAMS : (unsigned int)streams;
+      multi->max_concurrent_streams = curlx_sltoui(streams);
     }
     break;
   default:


### PR DESCRIPTION
On systems with 32 bit long the expression is always false. Avoid
the warning.

Reported-by: Gisle Vanem
Bug: https://github.com/curl/curl/commit/61a08508f6a458fe21bbb18cd2a9bac2f039452b#commitcomment-40941232