### PR TITLE
multi: update comment to say easyp list is linear

### DIFF
--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -81,7 +81,7 @@ struct Curl_multi {
      this multi handle with an easy handle. Set this to CURL_MULTI_HANDLE. */
   long type;
 
-  /* We have a doubly-linked circular list with easy handles */
+  /* We have a doubly-linked list with easy handles */
   struct Curl_easy *easyp;
   struct Curl_easy *easylp; /* last node */
 


### PR DESCRIPTION
Since 09b9fc900 (multi: remove 'Curl_one_easy' struct, phase 1,
2013-08-02), the easy handle list is not circular but ends with
->next pointing to NULL.

Reported-by: Masaya Suzuki <masayasuzuki@google.com>