### PR TITLE
CI/azure: increase Windows job timeout once again

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
       container_cmd: ''
       configure: ''
       tflags: ''
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-2019'
     strategy:


### PR DESCRIPTION
Avoid aborted jobs due to performance issues on Azure DevOps.