### PR TITLE
tool_cb_wrt: fix outfile mode flags for Windows

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -26,6 +26,8 @@
 #include <fcntl.h>
 #endif
 
+#include <sys/stat.h>
+
 #define ENABLE_CURLX_PRINTF
 /* use our own printf() functions */
 #include "curlx.h"
@@ -57,9 +59,10 @@ bool tool_create_output_file(struct OutStruct *outs,
 #define O_BINARY 0
 #endif
     int fd = open(outs->filename, O_CREAT | O_WRONLY | O_EXCL | O_BINARY,
-                  S_IRUSR | S_IWUSR
-#ifdef S_IRGRP
-                  | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+#ifdef WIN32
+                  S_IREAD | S_IWRITE
+#else
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
 #endif
       );
     if(fd != -1) {


### PR DESCRIPTION
Windows only accepts a combination of S_IREAD and S_IWRITE. It does not
acknowledge other combinations, for which it may generate an assertion.

This is a follow-up to 81b4e99 from yesterday, which improved the
existing file check with -J.

Ref: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen#remarks
Ref: https://github.com/curl/curl/pull/5731

Closes #xxx