### PR TITLE
add date of 7.20 to CURLM_CALL_MULTI_PERFORM docs

### DIFF
--- a/docs/libcurl/curl_multi_perform.3
+++ b/docs/libcurl/curl_multi_perform.3
@@ -103,7 +103,7 @@ default:
 .SH "RETURN VALUE"
 CURLMcode type, general libcurl multi interface error code.
 
-Before version 7.20.0: If you receive \fICURLM_CALL_MULTI_PERFORM\fP, this
+Before version 7.20.0 (released on February 9 2010): If you receive \fICURLM_CALL_MULTI_PERFORM\fP, this
 basically means that you should call \fIcurl_multi_perform(3)\fP again, before
 you select() on more actions. You don't have to do it immediately, but the
 return code means that libcurl may have more data available to return or that

--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -271,7 +271,7 @@ interface. Also consider \fIcurl_multi_strerror(3)\fP.
 .IP "CURLM_CALL_MULTI_PERFORM (-1)"
 This is not really an error. It means you should call
 \fIcurl_multi_perform(3)\fP again without doing select() or similar in
-between. Before version 7.20.0 this could be returned by
+between. Before version 7.20.0 (released on February 9 2010) this could be returned by
 \fIcurl_multi_perform(3)\fP, but in later versions this return code is never
 used.
 .IP "CURLM_CALL_MULTI_SOCKET (-1)"


### PR DESCRIPTION
it helps make it obvious that most developers don't have to care about the CURLM_CALL_MULTI_PERFORM value (last release using it is nearly 11 years old, November 4 2009)