### PR TITLE
Allow connect-only connections to be closed when unused

### DIFF
--- a/tests/data/test1554
+++ b/tests/data/test1554
@@ -50,22 +50,28 @@ run 1: foobar and so on fun!
 <- Mutex unlock
 -> Mutex lock
 <- Mutex unlock
-run 1: foobar and so on fun!
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
 -> Mutex lock
 <- Mutex unlock
 run 1: foobar and so on fun!
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+-> Mutex lock
+<- Mutex unlock
+run 1: foobar and so on fun!
+-> Mutex lock
+<- Mutex unlock
 -> Mutex lock
 <- Mutex unlock
 -> Mutex lock


### PR DESCRIPTION
As mentioned in https://github.com/curl/curl/issues/4426#issuecomment-565101461, commit 1d5c427 fixes issue 4426 but introduces another issue where connect-only connections completed in a multi handle would be kept alive for the entire lifetime of that multi handle.  This patch disassociates these connections from their easy handle when that easy handle is removed from the multi, allowing them to be cleaned up normally.