### PR TITLE
checksrc: invoke script with -D to find .checksrc proper

### DIFF
--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -67,4 +67,4 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)(@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.c)
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/lib/checksrc.pl -D$(srcdir) $(srcdir)/*.c)

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -137,7 +137,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl $(srcdir)/*.[ch]
+	$(CHECKSRC)@PERL@ $(top_srcdir)/lib/checksrc.pl -D$(srcdir) $(srcdir)/*.[ch]
 
 if CURLDEBUG
 # for debug builds, we scan the sources on all regular make invokes


### PR DESCRIPTION
Without the -D command line option, checksrc.pl won't know which
directory to load the ".checksrc" file from when building out of the
source tree.

Reported-by: Marcel Raad
Fixes #5715