### PR TITLE
multi: Condition 'extrawait' is always true

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1281,7 +1281,7 @@ static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
         sleep_ms = timeout_ms;
       /* when there are no easy handles in the multi, this holds a -1
          timeout */
-      else if((sleep_ms < 0) && extrawait)
+      else if(sleep_ms < 0)
         sleep_ms = timeout_ms;
       Curl_wait_ms(sleep_ms);
     }


### PR DESCRIPTION
Reported by Codacy.