### PR TITLE
Fix use of `-n' with unquoted envvars

### DIFF
--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -84,7 +84,7 @@ if [ "$T" = "normal" ]; then
   if [ -z $NOTESTS ]; then
     make test-nonflaky
   fi
-  if [ -n $CHECKSRC ]; then
+  if [ -n "$CHECKSRC" ]; then
     make checksrc
   fi
 fi


### PR DESCRIPTION
Shellcheck tells us "-n doesn't work with unquoted arguments. quote or use [[ ]]."

And testing shows:

```
docker run --rm -it ubuntu bash
root@fe85ce156856:/# [ -n $DOES_NOT_EXIST ] && echo "I ran"
I ran
root@fe85ce156856:/# [ -n "$DOES_NOT_EXIST" ] && echo "I ran"
root@fe85ce156856:/#
```