### PR TITLE
runtests: support dynamicly base64 encoded sections in tests

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -21,6 +21,25 @@ variables are substituted by the their respective contents and the output
 version of the test file is stored as `log/testNUM`. That version is what will
 be read and used by the test servers.
 
+## Base64 Encoding
+
+In the preprocess stage, a special instruction can be used to have runtests.pl
+base64 encode a certain section and insert in the generated output file. This
+is in particular good for test cases where the test tool is expected to pass
+in base64 encoded content that might use dynamic information that is unique
+for this particular test invocation, like the server port number.
+
+To insert a base64 encoded string into the output, use this syntax:
+
+    %b64[ data to encode ]b64%
+
+The data to encode can then use any of the existing variables mentioned below,
+or even percent-encoded individual bytes. As an example, insert the HTTP
+server's port number (in ASCII) followed by a space and the hexadecimal byte
+9a:
+
+    %b64[%HTTPPORT %9a]b64%
+
 # Variables
 
 When the test is preprocessed, a range of "variables" in the test file will be

--- a/tests/data/test842
+++ b/tests/data/test842
@@ -15,7 +15,7 @@ RFC7628
 <servercmd>
 AUTH OAUTHBEARER
 REPLY AUTHENTICATE +
-REPLY bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMwFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ== A002 OK AUTHENTICATE completed
+REPLY %b64[n,a=user,%01host=127.0.0.1%01port=%IMAPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64% A002 OK AUTHENTICATE completed
 </servercmd>
 <data>
 From: me@somewhere
@@ -42,9 +42,6 @@ IMAP OAuth 2.0 (OAUTHBEARER) authentication
 </command>
 # The protocol section doesn't support ways of specifying the raw data in the
 # base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%IMAPPORT' ne '9003' );"
-</precheck>
 </client>
 
 #
@@ -53,7 +50,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <protocol>
 A001 CAPABILITY
 A002 AUTHENTICATE OAUTHBEARER
-bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMwFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+%b64[n,a=user,%01host=127.0.0.1%01port=%IMAPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 A003 SELECT 842
 A004 FETCH 1 BODY[]
 A005 LOGOUT

--- a/tests/data/test843
+++ b/tests/data/test843
@@ -41,11 +41,6 @@ IMAP OAuth 2.0 (OAUTHBEARER) authentication with initial response
  <command>
 'imap://%HOSTIP:%IMAPPORT/843/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%IMAPPORT' ne '9003' );"
-</precheck>
 </client>
 
 #
@@ -53,7 +48,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <verify>
 <protocol>
 A001 CAPABILITY
-A002 AUTHENTICATE OAUTHBEARER bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMwFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+A002 AUTHENTICATE OAUTHBEARER %b64[n,a=user,%01host=127.0.0.1%01port=%IMAPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 A003 SELECT 843
 A004 FETCH 1 BODY[]
 A005 LOGOUT

--- a/tests/data/test844
+++ b/tests/data/test844
@@ -15,9 +15,7 @@ RFC7628
 <servercmd>
 AUTH OAUTHBEARER
 REPLY AUTHENTICATE +
-REPLY bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMwFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ== +
-eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIiwic2NvcGUiOiJleGFtcGxlX3Njb3BlIiwib3BlbmlkLWNvbmZpZ3VyYXRpb24iOiJodHRwczovL2V4YW1wbGUuY29tLy53ZWxsLWtub3duL29wZW5pZC1jb25maWd1cmF0aW9uIn0=
-REPLY AQ== A002 NO Authentication failed
+REPLY %b64[n,a=user,%01host=127.0.0.1%01port=%IMAPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64% A002 NO Authentication failed
 </servercmd>
 </reply>
 
@@ -33,11 +31,6 @@ IMAP OAuth 2.0 (OAUTHBEARER) failure as continuation
  <command>
 'imap://%HOSTIP:%IMAPPORT/844/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%IMAPPORT' ne '9003' );"
-</precheck>
 </client>
 
 #
@@ -53,8 +46,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <protocol>
 A001 CAPABILITY
 A002 AUTHENTICATE OAUTHBEARER
-bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMwFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
-AQ==
+%b64[n,a=user,%01host=127.0.0.1%01port=%IMAPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test845
+++ b/tests/data/test845
@@ -33,11 +33,6 @@ IMAP OAuth 2.0 (OAUTHBEARER) failure as continuation with initial response
  <command>
 'imap://%HOSTIP:%IMAPPORT/845/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%IMAPPORT' ne '9003' );"
-</precheck>
 </client>
 
 #
@@ -52,8 +47,8 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 # transfer and such a connection will not get a "LOGOUT"
 <protocol>
 A001 CAPABILITY
-A002 AUTHENTICATE OAUTHBEARER bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMwFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
-AQ==
+A002 AUTHENTICATE OAUTHBEARER %b64[n,a=user,%01host=127.0.0.1%01port=%IMAPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
+%b64[%01]b64%
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test887
+++ b/tests/data/test887
@@ -17,7 +17,7 @@ RFC7628
 <servercmd>
 AUTH OAUTHBEARER
 REPLY AUTH +
-REPLY bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ== +OK Login successful
+REPLY %b64[n,a=user,%01host=127.0.0.1%01port=%POP3PORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64% +OK Login successful
 </servercmd>
 <data>
 From: me@somewhere
@@ -42,11 +42,6 @@ POP3 OAuth 2.0 (OAUTHBEARER) authentication
  <command>
 pop3://%HOSTIP:%POP3PORT/887 -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%POP3PORT' ne '9001' );"
-</precheck>
 </client>
 
 #
@@ -55,7 +50,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <protocol>
 CAPA
 AUTH OAUTHBEARER
-bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+%b64[n,a=user,%01host=127.0.0.1%01port=%POP3PORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 RETR 887
 QUIT
 </protocol>

--- a/tests/data/test888
+++ b/tests/data/test888
@@ -42,11 +42,6 @@ POP3 OAuth 2.0 (OAUTHBEARER) authentication with initial response
  <command>
 pop3://%HOSTIP:%POP3PORT/888 -u user --oauth2-bearer mF_9.B5f-4.1JqM --sasl-ir
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%POP3PORT' ne '9001' );"
-</precheck>
 </client>
 
 #
@@ -54,7 +49,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <verify>
 <protocol>
 CAPA
-AUTH OAUTHBEARER bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+AUTH OAUTHBEARER %b64[n,a=user,%01host=127.0.0.1%01port=%POP3PORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 RETR 888
 QUIT
 </protocol>

--- a/tests/data/test889
+++ b/tests/data/test889
@@ -17,7 +17,7 @@ RFC7628
 <servercmd>
 AUTH OAUTHBEARER
 REPLY AUTH +
-REPLY bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ== + eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIiwic2NvcGUiOiJleGFtcGxlX3Njb3BlIiwib3BlbmlkLWNvbmZpZ3VyYXRpb24iOiJodHRwczovL2V4YW1wbGUuY29tLy53ZWxsLWtub3duL29wZW5pZC1jb25maWd1cmF0aW9uIn0
+REPLY %b64[n,a=user,%01host=127.0.0.1%01port=%POP3PORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64% + eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIiwic2NvcGUiOiJleGFtcGxlX3Njb3BlIiwib3BlbmlkLWNvbmZpZ3VyYXRpb24iOiJodHRwczovL2V4YW1wbGUuY29tLy53ZWxsLWtub3duL29wZW5pZC1jb25maWd1cmF0aW9uIn0
 REPLY AQ== -ERR Authentication failed
 </servercmd>
 </reply>
@@ -34,11 +34,6 @@ POP3 OAuth 2.0 (OAUTHBEARER) failure as continuation
  <command>
 pop3://%HOSTIP:%POP3PORT/889 -u user --oauth2-bearer mF_9.B5f-4.1JqM
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%POP3PORT' ne '9001' );"
-</precheck>
 </client>
 
 #
@@ -54,7 +49,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <protocol>
 CAPA
 AUTH OAUTHBEARER
-bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+%b64[n,a=user,%01host=127.0.0.1%01port=%POP3PORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 AQ==
 </protocol>
 </verify>

--- a/tests/data/test890
+++ b/tests/data/test890
@@ -34,11 +34,6 @@ POP3 OAuth 2.0 (OAUTHBEARER) failure as continuation with initial response
  <command>
 pop3://%HOSTIP:%POP3PORT/890 -u user --oauth2-bearer mF_9.B5f-4.1JqM --sasl-ir
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%POP3PORT' ne '9001' );"
-</precheck>
 </client>
 
 #
@@ -53,7 +48,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 # transfer and such a connection will not get a "QUIT"
 <protocol>
 CAPA
-AUTH OAUTHBEARER bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwMQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+AUTH OAUTHBEARER %b64[n,a=user,%01host=127.0.0.1%01port=%POP3PORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 AQ==
 </protocol>
 </verify>

--- a/tests/data/test946
+++ b/tests/data/test946
@@ -16,7 +16,7 @@ RFC7628
 <servercmd>
 AUTH OAUTHBEARER
 REPLY AUTH 334 OAUTHBEARER supported
-REPLY bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwNQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ== 235 Authenticated
+REPLY %b64[n,a=user,%01host=127.0.0.1%01port=%SMTPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64% 235 Authenticated
 </servercmd>
 </reply>
 
@@ -35,11 +35,6 @@ mail body
  <command>
 smtp://%HOSTIP:%SMTPPORT/946 --mail-rcpt recipient@example.com --mail-from sender@example.com -u user --oauth2-bearer mF_9.B5f-4.1JqM -T -
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%SMTPPORT' ne '9005' );"
-</precheck>
 </client>
 
 #
@@ -48,7 +43,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <protocol>
 EHLO 946
 AUTH OAUTHBEARER
-bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwNQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+%b64[n,a=user,%01host=127.0.0.1%01port=%SMTPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 MAIL FROM:<sender@example.com>
 RCPT TO:<recipient@example.com>
 DATA

--- a/tests/data/test947
+++ b/tests/data/test947
@@ -35,11 +35,6 @@ mail body
  <command>
 smtp://%HOSTIP:%SMTPPORT/947 --mail-rcpt recipient@example.com --mail-from sender@example.com -u user --oauth2-bearer mF_9.B5f-4.1JqM --sasl-ir -T -
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%SMTPPORT' ne '9005' );"
-</precheck>
 </client>
 
 #
@@ -47,7 +42,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <verify>
 <protocol>
 EHLO 947
-AUTH OAUTHBEARER bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwNQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+AUTH OAUTHBEARER %b64[n,a=user,%01host=127.0.0.1%01port=%SMTPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 MAIL FROM:<sender@example.com>
 RCPT TO:<recipient@example.com>
 DATA

--- a/tests/data/test948
+++ b/tests/data/test948
@@ -16,7 +16,7 @@ RFC7628
 <servercmd>
 AUTH OAUTHBEARER
 REPLY AUTH 334 OAUTHBEARER supported
-REPLY bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwNQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ== 334 eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIiwic2NvcGUiOiJleGFtcGxlX3Njb3BlIiwib3BlbmlkLWNvbmZpZ3VyYXRpb24iOiJodHRwczovL2V4YW1wbGUuY29tLy53ZWxsLWtub3duL29wZW5pZC1jb25maWd1cmF0aW9uIn0
+REPLY %b64[n,a=user,%01host=127.0.0.1%01port=%SMTPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64% 334 eyJzdGF0dXMiOiJpbnZhbGlkX3Rva2VuIiwic2NvcGUiOiJleGFtcGxlX3Njb3BlIiwib3BlbmlkLWNvbmZpZ3VyYXRpb24iOiJodHRwczovL2V4YW1wbGUuY29tLy53ZWxsLWtub3duL29wZW5pZC1jb25maWd1cmF0aW9uIn0
 REPLY AQ== 535 Username and Password not accepted. Learn more at\r\n535 http://support.example.com/mail/oauth
 </servercmd>
 </reply>
@@ -36,11 +36,6 @@ mail body
  <command>
 smtp://%HOSTIP:%SMTPPORT/948 --mail-rcpt recipient@example.com --mail-from sender@example.com -u user --oauth2-bearer mF_9.B5f-4.1JqM -T -
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%SMTPPORT' ne '9005' );"
-</precheck>
 </client>
 
 #
@@ -56,7 +51,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 <protocol>
 EHLO 948
 AUTH OAUTHBEARER
-bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwNQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+%b64[n,a=user,%01host=127.0.0.1%01port=%SMTPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 AQ==
 </protocol>
 </verify>

--- a/tests/data/test949
+++ b/tests/data/test949
@@ -36,11 +36,6 @@ mail body
  <command>
 smtp://%HOSTIP:%SMTPPORT/949 --mail-rcpt recipient@example.com --mail-from sender@example.com -u user --oauth2-bearer mF_9.B5f-4.1JqM --sasl-ir -T -
 </command>
-# The protocol section doesn't support ways of specifying the raw data in the
-# base64 encoded message so we must assert this
-<precheck>
-perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' ne '127.0.0.1' || '%SMTPPORT' ne '9005' );"
-</precheck>
 </client>
 
 #
@@ -55,7 +50,7 @@ perl -e "print 'Test requires default test server host and port' if ( '%HOSTIP' 
 # transfer and such a connection will not get a "QUIT"
 <protocol>
 EHLO 949
-AUTH OAUTHBEARER bixhPXVzZXIsAWhvc3Q9MTI3LjAuMC4xAXBvcnQ9OTAwNQFhdXRoPUJlYXJlciBtRl85LkI1Zi00LjFKcU0BAQ==
+AUTH OAUTHBEARER %b64[n,a=user,%01host=127.0.0.1%01port=%SMTPPORT%01auth=Bearer mF_9.B5f-4.1JqM%01%01]b64%
 AQ==
 </protocol>
 </verify>


### PR DESCRIPTION
This allows us to make test cases to use base64 at run-time and still
use and verify information determined at run-time, such as the IMAP test
server's port number in test 842.

ftpserver.pl is adjusted to load test instructions and test number from
the preprocessed test file.

FILEFORMAT.md now documents the new base64 encoding syntax.

Reported-by: Marcel Raad
Fixes #5761