### PR TITLE
CI/azure: show runtime stats to investigate slowness

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
     variables:
       install: ''
       configure: ''
-      tflags: ''
+      tests: ''
     timeoutInMinutes: 60
     pool:
       vmImage: 'ubuntu-latest'
@@ -74,7 +74,7 @@ stages:
           name: torture
           install: libnghttp2-dev
           configure: --enable-debug --disable-shared --disable-threaded-resolver --enable-alt-svc
-          tflags: -n -t --shallow=40 !FTP
+          tests: -n -t --shallow=40 !FTP
     steps:
     - script: sudo apt-get update && sudo apt-get install -y stunnel4 python-impacket libzstd-dev libbrotli-dev $(install)
       displayName: 'apt install'
@@ -89,7 +89,7 @@ stages:
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "$(tflags)"
+        TFLAGS: "-r $(tests)"
 
 ##########################################
 ### Windows jobs below
@@ -106,7 +106,7 @@ stages:
       container_img: ''
       container_cmd: ''
       configure: ''
-      tflags: ''
+      tests: ''
     timeoutInMinutes: 120
     pool:
       vmImage: 'windows-2019'
@@ -118,64 +118,64 @@ stages:
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-mqtt --with-libssh2
-          tflags: ~612 ~1056 ~1299 !SCP
+          tests: ~612 ~1056 ~1299 !SCP
         msys2_mingw64_debug_openssl:
           name: 64-bit OpenSSL and MQTT
           container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-mqtt --with-libssh2
-          tflags: ~612 ~1056 ~1299 !SCP
+          tests: ~612 ~1056 ~1299 !SCP
         msys1_mingw_debug_openssl:
           name: 32-bit OpenSSL (legacy)
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug
-          tflags: ~203 ~1056 ~1143
+          tests: ~203 ~1056 ~1143
         msys1_mingw32_debug_openssl:
           name: 32-bit OpenSSL w/o zlib
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw32:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --without-zlib
-          tflags: ~203 ~1056 ~1143 ~1299
+          tests: ~203 ~1056 ~1143 ~1299
         msys1_mingw64_debug_openssl:
           name: 64-bit OpenSSL w/o zlib
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw64:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --without-zlib
-          tflags: ~203 ~1056 ~1143 ~1299
+          tests: ~203 ~1056 ~1143 ~1299
         msys2_mingw32_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN
           container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --with-libssh2
-          tflags: ~165 ~310 ~612 ~1013 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+          tests: ~165 ~310 ~612 ~1013 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
         msys2_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN
           container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --with-libssh2
-          tflags: ~165 ~310 ~612 ~1013 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+          tests: ~165 ~310 ~612 ~1013 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
         msys1_mingw_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN (legacy)
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug --enable-sspi --without-ssl --with-schannel --with-winidn
-          tflags: ~203 ~305 ~310 ~311 ~312 ~313 ~404 ~1013 ~1056 ~1143 ~2034 ~2035 ~2037 ~2038 ~2041 ~2042 ~2048 ~3000 ~3001
+          tests: ~203 ~305 ~310 ~311 ~312 ~313 ~404 ~1013 ~1056 ~1143 ~2034 ~2035 ~2037 ~2038 ~2041 ~2042 ~2048 ~3000 ~3001
         msys1_mingw32_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN w/o zlib
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw32:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --without-zlib
-          tflags: ~203 ~310 ~1013 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
+          tests: ~203 ~310 ~1013 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
         msys1_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN w/o zlib
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw64:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64  --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --without-zlib
-          tflags: ~203 ~310 ~1013 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
+          tests: ~203 ~310 ~1013 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
     container:
       image: $(container_img)
       env:
@@ -195,4 +195,4 @@ stages:
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "$(tflags)"
+        TFLAGS: "-r $(tests)"


### PR DESCRIPTION
Also avoid naming conflict of TFLAGS env and tflags variables.