### PR TITLE
ftp: don't do ssl_shutdown instead of ssl_close

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3251,9 +3251,9 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
     }
 
     if(conn->ssl[SECONDARYSOCKET].use) {
-      /* The secondary socket used SSL so we must close down that part first
-         before we close the socket for real */
-      result = Curl_ssl_shutdown(conn, SECONDARYSOCKET);
+      /* The secondary socket is using SSL so we must close down that part
+         first before we close the socket for real */
+      Curl_ssl_close(conn, SECONDARYSOCKET);
 
       /* Note that we keep "use" set to TRUE since that (next) connection is
          still requested to use SSL */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -621,6 +621,7 @@ void Curl_ssl_close(struct connectdata *conn, int sockindex)
 {
   DEBUGASSERT((sockindex <= 1) && (sockindex >= -1));
   Curl_ssl->close_one(conn, sockindex);
+  conn->ssl[sockindex].state = ssl_connection_none;
 }
 
 CURLcode Curl_ssl_shutdown(struct connectdata *conn, int sockindex)


### PR DESCRIPTION
The shutdown function is for downgrading a connection from TLS to plain,
and this is not requested here.

This partially reverts commit f002c850d98d

Reported-by: Rasmus Melchior Jacobsen
Reported-by: Denis Goleshchikhin
Fixes #5797