### PR TITLE
libssh2: s/ssherr/sftperr/

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1256,7 +1256,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
           result = CURLE_SSH;
         sshc->actualcode = result;
         DEBUGF(infof(data, "error = %d makes libcurl = %d\n",
-                     ssherr, (int)result));
+                     sftperr, (int)result));
         state(conn, SSH_STOP);
         break;
       }


### PR DESCRIPTION
The debug output used ssherr instead of sftperr which not only outputs
the wrong error code but also casues a warning on Windows.

Follow-up to 7370b4e39f1

Reported-by: Gisle Vanem
Bug: https://github.com/curl/curl/commit/7370b4e39f1390e701f5b68d910c619151daf72b#r41334700