### PR TITLE
configure: adjust the REQUIRE_LIB_DEPS logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,7 @@ AC_SUBST([CPPFLAG_CURL_STATICLIB])
 
 
 # Determine whether all dependent libraries must be specified when linking
-if test "X$enable_shared" = "Xyes" -a "X$link_all_deplibs" = "Xno"
+if test "X$enable_shared" = "Xyes" -a "X$link_all_deplibs" != "Xyes"
 then
     REQUIRE_LIB_DEPS=no
 else


### PR DESCRIPTION
Fixes curl-config generation on cygwin by making sure REQUIRE_LIB_DEPS
is set to 'no' there.

Assisted-by: Brian Inglis
Fixes #5793