### PR TITLE
curl-config: ignore REQUIRE_LIB_DEPS in --libs output

### DIFF
--- a/curl-config.in
+++ b/curl-config.in
@@ -160,7 +160,7 @@ while test $# -gt 0; do
         else
            CURLLIBDIR=""
         fi
-        if test "X@ENABLE_SHARED@" = "Xno" -o "X@REQUIRE_LIB_DEPS@" = "Xyes"; then
+        if test "X@ENABLE_SHARED@" = "Xno"; then
           echo ${CURLLIBDIR}-lcurl @LIBCURL_LIBS@
         else
           echo ${CURLLIBDIR}-lcurl


### PR DESCRIPTION
Fixes a curl-config issue on cygwin by making sure REQUIRE_LIB_DEPS is
not considered for the --libs output.

Reported-by: ramsay-jones on github
Assisted-by: Brian Inglis and Ken Brown
Fixes #5793