### PR TITLE
sftp: Add new quote commands 'atime' and 'mtime'

### DIFF
--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -26,6 +26,10 @@ itself before sending them to the server.  File names may be quoted
 shell-style to embed spaces or special characters.  Following is the list of
 all supported SFTP quote commands:
 .RS
+.IP "atime date file"
+The atime command sets the last access time of the file named by the file
+operand. The <date expression> can be all sorts of date strings, see the
+\fIcurl_getdate(3)\fP man pages for date expression details.
 .IP "chgrp group file"
 The chgrp command sets the group ID of the file named by the file operand to
 the group ID specified by the group operand. The group operand is a decimal
@@ -42,6 +46,10 @@ The ln and symlink commands create a symbolic link at the target_file location
 pointing to the source_file location.
 .IP "mkdir directory_name"
 The mkdir command creates the directory named by the directory_name operand.
+.IP "mtime date file"
+The mtime command sets the last modification time of the file named by the file
+operand. The <date expression> can be all sorts of date strings, see the
+\fIcurl_getdate(3)\fP man pages for date expression details.
 .IP "pwd"
 The pwd command returns the absolute pathname of the current working directory.
 .IP "rename source target"


### PR DESCRIPTION
In some situations, you may have to change the modified or last accessed date of a specific file.
This PR add new quote commands for sftp only.
