### PR TITLE
docs: Add video link to docs/CONTRIBUTE.md

### DIFF
--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -275,3 +275,6 @@ For Windows:
 
  - [https://gnuwin32.sourceforge.io/packages/patch.htm](https://gnuwin32.sourceforge.io/packages/patch.htm)
  - [https://gnuwin32.sourceforge.io/packages/diffutils.htm](https://gnuwin32.sourceforge.io/packages/diffutils.htm)
+
+### Useful resources
+* [Webinar on getting code into cURL](https://www.youtube.com/watch?v=QmZ3W1d6LQI)


### PR DESCRIPTION
This adds the webinar from yesterday held by @bagder to the documentation.
It is a great resource for newcomers so I think including it into the CONTRIBUTE.md wouldn't be a bad decision.