### PR TITLE
docs: clarify MAX_SEND/RECV_SPEED functionality

### DIFF
--- a/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -28,11 +28,17 @@ CURLOPT_MAX_RECV_SPEED_LARGE \- rate limit data download speed
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAX_RECV_SPEED_LARGE,
-                          curl_off_t speed);
+                          curl_off_t maxspeed);
 .SH DESCRIPTION
-Pass a curl_off_t as parameter.  If a download exceeds this \fIspeed\fP
+Pass a curl_off_t as parameter.  If a download exceeds this \fImaxspeed\fP
 (counted in bytes per second) the transfer will pause to keep the speed less
 than or equal to the parameter value. Defaults to unlimited speed.
+
+This is not an exact science. libcurl attempts to keep the average speed below
+the given threshold over a period time.
+
+If you set \fImaxspeed\fP to a value lower than \fBCURLOPT_BUFFERSIZE(3)\fP,
+libcurl might download faster than the set limit initially.
 
 This option doesn't affect transfer speeds done with FILE:// URLs.
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.3
@@ -37,7 +37,7 @@ than or equal to the parameter value. Defaults to unlimited speed.
 This is not an exact science. libcurl attempts to keep the average speed below
 the given threshold over a period time.
 
-If you set \fImaxspeed\fP to a value lower than \fBCURLOPT_BUFFERSIZE(3)\fP,
+If you set \fImaxspeed\fP to a value lower than \fICURLOPT_BUFFERSIZE(3)\fP,
 libcurl might download faster than the set limit initially.
 
 This option doesn't affect transfer speeds done with FILE:// URLs.

--- a/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.3
@@ -39,7 +39,7 @@ This is not an exact science. libcurl attempts to keep the average speed below
 the given threshold over a period time.
 
 If you set \fImaxspeed\fP to a value lower than
-\fBCURLOPT_UPLOAD_BUFFERSIZE(3)\fP, libcurl might "shoot over" the limit on
+\fICURLOPT_UPLOAD_BUFFERSIZE(3)\fP, libcurl might "shoot over" the limit on
 its first send and still send off a full buffer.
 
 This option doesn't affect transfer speeds done with FILE:// URLs.

--- a/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -34,6 +34,13 @@ Pass a curl_off_t as parameter with the \fImaxspeed\fP.  If an upload exceeds
 this speed (counted in bytes per second) the transfer will pause to keep the
 speed less than or equal to the parameter value.  Defaults to unlimited
 speed.
+
+This is not an exact science. libcurl attempts to keep the average speed below
+the given threshold over a period time.
+
+If you set \fImaxspeed\fP to a value lower than
+\fBCURLOPT_UPLOAD_BUFFERSIZE(3)\fP, libcurl might "shoot over" the limit on
+its first send and still send off a full buffer.
 
 This option doesn't affect transfer speeds done with FILE:// URLs.
 .SH DEFAULT


### PR DESCRIPTION
... in particular what happens if the maximum speed limit is set to a
value that's smaller than the transfer buffer size in use.

Reported-by: Tomas Berger
Fixes #5788