### PR TITLE
test1140: compare stdout

### DIFF
--- a/tests/data/test1140
+++ b/tests/data/test1140
@@ -23,4 +23,10 @@ Verify the nroff of man pages
 </command>
 </client>
 
+<verify>
+<stdout>
+OK
+</stdout>
+</verify>
+
 </testcase>

--- a/tests/nroff-scan.pl
+++ b/tests/nroff-scan.pl
@@ -63,23 +63,23 @@ sub file {
         while($l =~ s/\\f(.)([^ ]*)\\f(.)//) {
             my ($pre, $str, $post)=($1, $2, $3);
             if($post ne "P") {
-                print STDERR "error: $f:$line: missing \\fP after $str\n";
+                print "error: $f:$line: missing \\fP after $str\n";
                 $errors++;
             }
             if($str =~ /((libcurl|curl)([^ ]*))\(3\)/i) {
                 my $man = "$1.3";
                 if(!manpresent($man)) {
-                    print STDERR "error: $f:$line: referring to non-existing man page $man\n";
+                    print "error: $f:$line: referring to non-existing man page $man\n";
                     $errors++;
                 }
                 if($pre ne "I") {
-                    print STDERR "error: $f:$line: use \\fI before $str\n";
+                    print "error: $f:$line: use \\fI before $str\n";
                     $errors++;
                 }
             }
         }
         if($l =~ /(curl([^ ]*)\(3\))/i) {
-            print STDERR "error: $f:$line: non-referencing $1\n";
+            print "error: $f:$line: non-referencing $1\n";
             $errors++;
         }
         if($l =~ /^\.BR (.*)/) {
@@ -87,7 +87,7 @@ sub file {
             while($i =~ s/((lib|)curl([^ ]*)) *\"\(3\)(,|) *\" *//i ) {
                 my $man = "$1.3";
                 if(!manpresent($man)) {
-                    print STDERR "error: $f:$line: referring to non-existing man page $man\n";
+                    print "error: $f:$line: referring to non-existing man page $man\n";
                     $errors++;
                 }
             }
@@ -100,5 +100,7 @@ sub file {
 foreach my $f (@f) {
     file($f);
 }
+
+print "OK\n" if(!$errors);
 
 exit $errors?1:0;


### PR DESCRIPTION
To make problems more immediately obvious when tests fail.