### PR TITLE
tests: fix gcc -fanalyzer errors

### DIFF
--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2064,6 +2064,10 @@ int main(int argc, char *argv[])
   case AF_UNIX:
     memset(&me.sau, 0, sizeof(me.sau));
     me.sau.sun_family = AF_UNIX;
+    if(!unix_socket) {
+      logmsg("unix_socket is unexpectedly NULL");
+      goto sws_cleanup;
+    }
     strncpy(me.sau.sun_path, unix_socket, sizeof(me.sau.sun_path) - 1);
     rc = bind(sock, &me.sa, sizeof(me.sau));
     if(0 != rc && errno == EADDRINUSE) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -960,9 +960,14 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
   /* store input protocol */
   fclose(server);
 
-  for(pf = formata; pf->f_mode; pf++)
+  for(pf = formata; pf->f_mode; pf++) {
+    if(!mode) {
+      logmsg("mode is unexpectedly NULL");
+      return -1;
+    }
     if(strcmp(pf->f_mode, mode) == 0)
       break;
+  }
   if(!pf->f_mode) {
     nak(EBADOP);
     return 2;

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -188,6 +188,11 @@ UNITTEST_START
         break;
       }
 
+      if(!dns) {
+        fprintf(stderr, "dns variable is NULL");
+        problem = true;
+        break;
+      }
       if(dns->timestamp != 0) {
         fprintf(stderr, "%s:%d tests[%d] failed. the timestamp is not zero. "
                 "for tests[%d].address[%d\n",


### PR DESCRIPTION
GCC 10 introduces -fanalyzer CFLAGS, which seems to detect some errors
in the tests.

It seems gcc think those variables can be NULL when non NULL is expected,

I don't know if those are false positive, but gcc stop complaining after those
checks.

The error appear with gcc 10.1.0, using:
./configure CFLAGS="-g -O0 -fanalyzer" LDFLAGS="-fanalyzer" --enable-debug