### PR TITLE
CMake: Don't complain about missing nroff if not building manuals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,10 @@ if(ENABLE_IPV6 AND NOT WIN32)
   endif()
 endif()
 
-curl_nroff_check()
+if(USE_MANUAL)
+    #nroff is currently only used when USE_MANUAL is set, so we can prevent the warning of no *NROFF if USE_MANUAL is not _FILE_OFFSET_BITS, by not even looking for NROFF..
+    curl_nroff_check()
+endif()
 find_package(Perl)
 
 cmake_dependent_option(ENABLE_MANUAL "to provide the built-in manual"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if(ENABLE_IPV6 AND NOT WIN32)
 endif()
 
 if(USE_MANUAL)
-    #nroff is currently only used when USE_MANUAL is set, so we can prevent the warning of no *NROFF if USE_MANUAL is not _FILE_OFFSET_BITS, by not even looking for NROFF..
+    #nroff is currently only used when USE_MANUAL is set, so we can prevent the warning of no *NROFF if USE_MANUAL is OFF (or not defined), by not even looking for NROFF..
     curl_nroff_check()
 endif()
 find_package(Perl)


### PR DESCRIPTION
The curl_nroff_check() was always being called, and complaining if *NROFF wasn't found, even when not making the manual.
Only check for nroff (and complain) if actually making the manual