### PR TITLE
Curl_easy: remember last connection by id, not by pointer

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -838,8 +838,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
 
   /* the connection cache is setup on demand */
   outcurl->state.conn_cache = NULL;
-
-  outcurl->state.lastconnect = NULL;
+  outcurl->state.lastconnect_id = -1;
 
   outcurl->progress.flags    = data->progress.flags;
   outcurl->progress.callback = data->progress.callback;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -810,7 +810,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
     /* Mark any connect-only connection for closure */
     Curl_conncache_foreach(data, data->state.conn_cache,
                            data, &close_connect_only);
-    data->state.lastconnect_id = -1;
   }
 
 #ifdef USE_LIBPSL

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -455,6 +455,7 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
     data->state.conn_cache = &data->share->conn_cache;
   else
     data->state.conn_cache = &multi->conn_cache;
+  data->state.lastconnect_id = -1;
 
 #ifdef USE_LIBPSL
   /* Do the same for PSL. */
@@ -677,11 +678,11 @@ static CURLcode multi_done(struct Curl_easy *data,
     CONNCACHE_UNLOCK(data);
     if(Curl_conncache_return_conn(data, conn)) {
       /* remember the most recently used connection */
-      data->state.lastconnect = conn;
+      data->state.lastconnect_id = conn->connection_id;
       infof(data, "%s\n", buffer);
     }
     else
-      data->state.lastconnect = NULL;
+      data->state.lastconnect_id = -1;
   }
 
   Curl_safefree(data->state.buffer);
@@ -693,7 +694,7 @@ static int close_connect_only(struct connectdata *conn, void *param)
 {
   struct Curl_easy *data = param;
 
-  if(data->state.lastconnect != conn)
+  if(data->state.lastconnect_id != conn->connection_id)
     return 0;
 
   if(conn->data != data)
@@ -805,10 +806,11 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   /* Remove the association between the connection and the handle */
   Curl_detach_connnection(data);
 
-  if(data->state.lastconnect) {
+  if(data->state.lastconnect_id != -1) {
     /* Mark any connect-only connection for closure */
     Curl_conncache_foreach(data, data->state.conn_cache,
                            data, &close_connect_only);
+    data->state.lastconnect_id = -1;
   }
 
 #ifdef USE_LIBPSL

--- a/lib/url.c
+++ b/lib/url.c
@@ -630,7 +630,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
     Curl_initinfo(data);
 
     /* most recent connection is not yet defined */
-    data->state.lastconnect = NULL;
+    data->state.lastconnect_id = -1;
 
     data->progress.flags |= PGRS_HIDE;
     data->state.current_speed = -1; /* init to negative == impossible */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1300,7 +1300,7 @@ struct UrlState {
   /* buffers to store authentication data in, as parsed from input options */
   struct curltime keeps_speed; /* for the progress meter really */
 
-  struct connectdata *lastconnect; /* The last connection, NULL if undefined */
+  long lastconnect_id; /* The last connection, -1 if undefined */
   struct dynbuf headerb; /* buffer to store headers in */
 
   char *buffer; /* download buffer */


### PR DESCRIPTION
CVE-2020-8231

Bug: https://curl.haxx.se/docs/CVE-2020-8231.html

Reported-by: Marc Aldorasi