### PR TITLE
etag: save and use the full received contents

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -103,48 +103,23 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
   if(per->config->etag_save_file && etag_save->stream) {
     /* match only header that start with etag (case insensitive) */
     if(curl_strnequal(str, "etag:", 5)) {
-      char *etag_h = NULL;
-      char *first = NULL;
-      char *last = NULL;
-      size_t etag_length = 0;
+      const char *etag_h = &str[5];
+      const char *eot = memchr(etag_h, '\n', cb);
+      if(eot) {
+        while(ISSPACE(*etag_h) && (etag_h < eot))
+          etag_h++;
+        while(ISSPACE(*eot))
+          eot--;
 
-      etag_h = ptr;
-      /* point to first occurrence of double quote */
-      first = memchr(etag_h, '\"', cb);
-
-      /*
-       * if server side messed with the etag header and doesn't include
-       * double quotes around the etag, kindly exit with a warning
-       */
-
-      if(!first) {
-        warnf(per->config->global,
-              "Received header etag is missing double quote/s\n");
-        return failure;
+        if(eot >= etag_h) {
+          size_t etag_length = eot - etag_h + 1;
+          fwrite(etag_h, size, etag_length, etag_save->stream);
+          /* terminate with new line */
+          fputc('\n', etag_save->stream);
+          (void)fflush(etag_save->stream);
+        }
       }
-      else {
-        /* discard first double quote */
-        first++;
-      }
-
-      /* point to last occurrence of double quote */
-      last = memchr(first, '\"', cb);
-
-      if(!last) {
-        warnf(per->config->global,
-              "Received header etag is missing double quote/s\n");
-        return failure;
-      }
-
-      /* get length of desired etag */
-      etag_length = (size_t)last - (size_t)first;
-
-      fwrite(first, size, etag_length, etag_save->stream);
-      /* terminate with new line */
-      fputc('\n', etag_save->stream);
     }
-
-    (void)fflush(etag_save->stream);
   }
 
   /*

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -98,7 +98,6 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
   /*
    * Write etag to file when --etag-save option is given.
-   * etag string that we want is enveloped in double quotes
    */
   if(per->config->etag_save_file && etag_save->stream) {
     /* match only header that start with etag (case insensitive) */
@@ -114,7 +113,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
         if(eot >= etag_h) {
           size_t etag_length = eot - etag_h + 1;
           fwrite(etag_h, size, etag_length, etag_save->stream);
-          /* terminate with new line */
+          /* terminate with newline */
           fputc('\n', etag_save->stream);
           (void)fflush(etag_save->stream);
         }

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -104,8 +104,8 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
     /* match only header that start with etag (case insensitive) */
     if(curl_strnequal(str, "etag:", 5)) {
       const char *etag_h = &str[5];
-      const char *eot = memchr(etag_h, '\n', cb);
-      if(eot) {
+      const char *eot = end - 1;
+      if(*eot == '\n') {
         while(ISSPACE(*etag_h) && (etag_h < eot))
           etag_h++;
         while(ISSPACE(*eot))

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -922,7 +922,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
           if((PARAM_OK == file2string(&etag_from_file, file)) &&
              etag_from_file) {
-            header = aprintf("If-None-Match: \"%s\"", etag_from_file);
+            header = aprintf("If-None-Match: %s", etag_from_file);
             Curl_safefree(etag_from_file);
           }
           else

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -58,7 +58,7 @@ test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
-test343 test344 test345 test346 \
+test343 test344 test345 test346 test347 \
 test350 test351 test352 test353 test354 test355 test356 test357 test358 \
 test359 \
 test393 test394 test395 test396 test397 \

--- a/tests/data/test1566
+++ b/tests/data/test1566
@@ -35,7 +35,7 @@ http
 http://%HOSTIP:%HTTPPORT/1566 -o log/output1566 --etag-compare log/etag1566
 </command>
 <file name="log/etag1566">
-123456
+"123456"
 </file>
 <file1 name="log/output1566">
 downloaded already

--- a/tests/data/test342
+++ b/tests/data/test342
@@ -34,7 +34,7 @@ http
 Check if --etag-compare set correct etag in header
 </name>
 <file name="log/etag342">
-21025-dc7-39462498
+"21025-dc7-39462498"
 </file>
 <command>
 http://%HOSTIP:%HTTPPORT/342 --etag-compare log/etag342

--- a/tests/data/test343
+++ b/tests/data/test343
@@ -34,7 +34,7 @@ http
 Both --etag-compare and --etag-save to save new Etag
 </name>
 <file name="log/etag343">
-21025-dc7-39462498
+"21025-dc7-39462498"
 </file>
 <command>
 http://%HOSTIP:%HTTPPORT/343 --etag-compare log/etag343 --etag-save log/out343
@@ -55,7 +55,7 @@ If-None-Match: "21025-dc7-39462498"
 
 </protocol>
 <file name="log/out343">
-21025-dc7-11111
+"21025-dc7-11111"
 </file>
 </verify>
 </testcase>

--- a/tests/data/test344
+++ b/tests/data/test344
@@ -52,7 +52,7 @@ If-None-Match: ""
 
 </protocol>
 <file name="log/etag344">
-21025-dc7-11111
+"21025-dc7-11111"
 </file>
 </verify>
 </testcase>

--- a/tests/data/test345
+++ b/tests/data/test345
@@ -34,7 +34,7 @@ http
 Both --etag-compare and -save store new Etag using one pre-existing file
 </name>
 <file name="log/etag345">
-21025-dc7-39462498
+"21025-dc7-39462498"
 </file>
 <command>
 http://%HOSTIP:%HTTPPORT/345 --etag-compare log/etag345 --etag-save log/etag345
@@ -55,7 +55,7 @@ If-None-Match: "21025-dc7-39462498"
 
 </protocol>
 <file name="log/etag345">
-21025-dc7-11111
+"21025-dc7-11111"
 </file>
 </verify>
 </testcase>

--- a/tests/data/test347
+++ b/tests/data/test347
@@ -14,7 +14,7 @@ Server: fakeit/0.9 fakeitbad/1.0
 Transfer-Encoding: chunked
 Trailer: chunky-trailer
 Connection: mooo
-ETag: W/"asdf"
+ETag:  
 
 40
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -36,10 +36,10 @@ chunky-trailer: header data
 http
 </server>
 <name>
-Check if --etag-save saved correct etag to a file
+--etag-save with blank incoming header
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/339 --etag-save log/etag339
+http://%HOSTIP:%HTTPPORT/347 --etag-save log/etag347
 </command>
 </client>
 
@@ -50,13 +50,12 @@ http://%HOSTIP:%HTTPPORT/339 --etag-save log/etag339
 ^User-Agent:.*
 </strip>
 <protocol>
-GET /339 HTTP/1.1
+GET /347 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
 
 </protocol>
-<file name="log/etag339">
-W/"asdf"
+<file name="log/etag347">
 </file>
 </verify>
 


### PR DESCRIPTION
... which makes it support weak tags and non-standard etags too!

This is a simpler take on the issue than #5700, includes updated test cases.