### PR TITLE
runtests: make cleardir() erase dot files

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2747,7 +2747,7 @@ sub cleardir {
     opendir(DIR, $dir) ||
         return 0; # can't open dir
     while($file = readdir(DIR)) {
-        if(($file !~ /^\./)) {
+        if(($file !~ /^\.(|\.)$/)) {
             unlink("$dir/$file");
             $count++;
         }


### PR DESCRIPTION
Because test cases might use dot files.

(#5837 adds a test case with a dot file in there)