### PR TITLE
Makefile.m32: add ability to override zstd libs

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -298,7 +298,12 @@ endif
 ifdef ZSTD
   INCLUDES += -I"$(ZSTD_PATH)/include"
   CFLAGS += -DHAVE_ZSTD
-  DLL_LIBS += -L"$(ZSTD_PATH)/lib" -lzstd
+  DLL_LIBS += -L"$(ZSTD_PATH)/lib"
+  ifdef ZSTD_LIBS
+    DLL_LIBS += $(ZSTD_LIBS)
+  else
+    DLL_LIBS += -lzstd
+  endif
 endif
 ifdef BROTLI
   INCLUDES += -I"$(BROTLI_PATH)/include"

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -312,7 +312,12 @@ endif
 ifdef ZSTD
   INCLUDES += -I"$(ZSTD_PATH)/include"
   CFLAGS += -DHAVE_ZSTD
-  curl_LDADD += -L"$(ZSTD_PATH)/lib" -lzstd
+  curl_LDADD += -L"$(ZSTD_PATH)/lib"
+  ifdef ZSTD_LIBS
+    curl_LDADD += $(ZSTD_LIBS)
+  else
+    curl_LDADD += -lzstd
+  endif
 endif
 ifdef BROTLI
   INCLUDES += -I"$(BROTLI_PATH)/include"


### PR DESCRIPTION
Similarly to brotli, where this was already possible. It allows linking zstd statically to libcurl.dll.

Ref: https://github.com/curl/curl-for-win/issues/12
