### PR TITLE
KNOWN_BUGS:  'no_proxy' string-matches IPv6 numerical addreses

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -104,6 +104,7 @@ problems may have been fixed or changed somewhat since this was written!
  11.9 DoH doesn't inherit all transfer options
  11.10 Blocking socket operations in non-blocking API
  11.11 A shared connection cache is not thread-safe
+ 11.12 'no_proxy' string-matches IPv6 numerical addreses
 
  12. LDAP and OpenLDAP
  12.1 OpenLDAP hangs after returning results
@@ -761,6 +762,13 @@ problems may have been fixed or changed somewhat since this was written!
  still not thread-safe when used shared.
 
  See https://github.com/curl/curl/issues/4915
+
+11.12 'no_proxy' string-matches IPv6 numerical addreses
+
+ This has the downside that "::1" for example doesn't match "::0:1" even
+ though they are in fact the same address.
+
+ See https://github.com/curl/curl/issues/5745
 
 12. LDAP and OpenLDAP
 

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -36,6 +36,10 @@ accesses the target URL through the proxy.
 
 The list of host names can also be include numerical IP addresses, and IPv6
 versions should then be given without enclosing brackets.
+
+IPv6 numerical addresses are compared as strings, so they will only match if
+the representations are the same: "::1" is the same as "::0:1" but they don't
+match.
 .IP "CURL_SSL_BACKEND <TLS backend>"
 If curl was built with support for "MultiSSL", meaning that it has built-in
 support for more than one TLS backend, this environment variable can be set to

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -48,6 +48,10 @@ Enter IPv6 numerical addresses in the list of host names without enclosing
 brackets:
 
  "example.com,::1,localhost"
+
+IPv6 numerical addresses are compared as strings, so they will only match if
+the representations are the same: "::1" is the same as "::0:1" but they don't
+match.
 
 The application does not have to keep the string around after setting this
 option.


### PR DESCRIPTION
Also: the current behavior is now documented in the curl.1 and
CURLOPT_NOPROXY.3 man pages.

Reported-by: Andrew Barnes
Closes #5745