### PR TITLE
configure: fix pkg-config detecting wolfssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2474,8 +2474,12 @@ if test -z "$ssl_backends" -o "x$OPT_WOLFSSL" != xno; then
             AC_DEFINE(HAVE_WOLFSSL_DES_ECB_ENCRYPT, 1,
                       [if you have wolfSSL_DES_ecb_encrypt])
             if test -n "$addcflags"; then
-              CPPFLAGS="$addcflags/wolfssl $CPPFLAGS"
-              AC_MSG_NOTICE([Add $addcflags/wolfssl to CPPFLAGS])
+              dnl use a for loop to strip off whitespace
+              for f in $addcflags; do
+                CPPFLAGS="$f/wolfssl $CPPFLAGS"
+                AC_MSG_NOTICE([Add $f/wolfssl to CPPFLAGS])
+                break
+              done
             else
               dnl user didn't give a path, so guess/hope they installed wolfssl
               dnl headers to system default location


### PR DESCRIPTION
When amending the include path with "/wolfssl", this now properly strips
off all whitespace from the path variable! Previously this would lead to
pkg-config builds creating bad command lines.