### PR TITLE
socketpair: allow CURL_DISABLE_SOCKETPAIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4687,6 +4687,24 @@ AC_HELP_STRING([--disable-cookies],[Disable cookies support]),
 )
 
 dnl ************************************************************
+dnl disable socketpair
+dnl
+AC_MSG_CHECKING([whether to support socketpair])
+AC_ARG_ENABLE(socketpair,
+AC_HELP_STRING([--enable-socketpair],[Enable socketpair support])
+AC_HELP_STRING([--disable-socketpair],[Disable socketpair support]),
+[ case "$enableval" in
+  no)
+       AC_MSG_RESULT(no)
+       AC_DEFINE(CURL_DISABLE_SOCKETPAIR, 1, [to disable socketpair support])
+       ;;
+  *)   AC_MSG_RESULT(yes)
+       ;;
+  esac ],
+       AC_MSG_RESULT(yes)
+)
+
+dnl ************************************************************
 dnl disable HTTP authentication support
 dnl
 AC_MSG_CHECKING([whether to support HTTP authentication])

--- a/docs/CURL-DISABLE.md
+++ b/docs/CURL-DISABLE.md
@@ -97,6 +97,11 @@ Disable the SMB(S) protocols
 
 Disable the SMTP(S) protocols
 
+## CURL_DISABLE_SOCKETPAIR
+
+Disable the use of socketpair internally to allow waking up and canceling
+curl_multi_poll().
+
 ## CURL_DISABLE_TELNET
 
 Disable the TELNET protocol

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -67,10 +67,10 @@ typedef enum {
 
 #define CURLPIPE_ANY (CURLPIPE_MULTIPLEX)
 
-#if defined(USE_SOCKETPAIR) && !defined(USE_BLOCKING_SOCKETS)
+#if defined(USE_SOCKETPAIR) && !defined(USE_BLOCKING_SOCKETS) &&        \
+  !defined(CURL_DISABLE_SOCKETPAIR)
 #define ENABLE_WAKEUP
 #endif
-
 
 /* value for MAXIMUM CONCURRENT STREAMS upper limit */
 #define INITIAL_MAX_CONCURRENT_STREAMS ((1U << 31) - 1)

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2019, 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,7 +23,7 @@
 #include "curl_setup.h"
 #include "socketpair.h"
 
-#ifndef HAVE_SOCKETPAIR
+#if !defined(HAVE_SOCKETPAIR) && !defined(CURL_DISABLE_SOCKETPAIR)
 #ifdef WIN32
 /*
  * This is a socketpair() implementation for Windows.


### PR DESCRIPTION
... to completely disable the use of socketpair