### PR TITLE
select: minor follow-up changes to #5707

### DIFF
--- a/lib/select.c
+++ b/lib/select.c
@@ -219,6 +219,8 @@ int Curl_select(curl_socket_t maxfd,   /* highest socket number */
 #else
   r = select((int)maxfd + 1, fds_read, fds_write, fds_err, ptimeout);
 #endif
+  if(r < 0)
+    r = -1;
 
   return r;
 }
@@ -374,7 +376,6 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
   else
     pending_ms = 0;
   r = poll(ufds, nfds, pending_ms);
-
   if(r < 0)
     return -1;
   if(r == 0)
@@ -421,11 +422,8 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
      value).
   */
   r = Curl_select(maxfd, &fds_read, &fds_write, &fds_err, timeout_ms);
-
-  if(r < 0)
-    return -1;
-  if(r == 0)
-    return 0;
+  if(r <= 0)
+    return r;
 
   r = 0;
   for(i = 0; i < nfds; i++) {

--- a/lib/select.c
+++ b/lib/select.c
@@ -385,9 +385,9 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
     if(ufds[i].fd == CURL_SOCKET_BAD)
       continue;
     if(ufds[i].revents & POLLHUP)
-      ufds[i].revents |= POLLIN;
+      ufds[i].revents |= (POLLRDNORM|POLLIN);
     if(ufds[i].revents & POLLERR)
-      ufds[i].revents |= (POLLIN|POLLOUT);
+      ufds[i].revents |= (POLLRDNORM|POLLIN|POLLWRNORM|POLLOUT);
   }
 
 #else  /* HAVE_POLL_FINE */
@@ -403,7 +403,7 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
       continue;
     VERIFY_SOCK(ufds[i].fd);
     if(ufds[i].events & (POLLIN|POLLOUT|POLLPRI|
-                          POLLRDNORM|POLLWRNORM|POLLRDBAND)) {
+                         POLLRDNORM|POLLWRNORM|POLLRDBAND)) {
       if(ufds[i].fd > maxfd)
         maxfd = ufds[i].fd;
       if(ufds[i].events & (POLLRDNORM|POLLIN))
@@ -431,11 +431,11 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
     if(ufds[i].fd == CURL_SOCKET_BAD)
       continue;
     if(FD_ISSET(ufds[i].fd, &fds_read))
-      ufds[i].revents |= POLLIN;
+      ufds[i].revents |= (POLLRDNORM|POLLIN);
     if(FD_ISSET(ufds[i].fd, &fds_write))
-      ufds[i].revents |= POLLOUT;
+      ufds[i].revents |= (POLLWRNORM|POLLOUT);
     if(FD_ISSET(ufds[i].fd, &fds_err))
-      ufds[i].revents |= POLLPRI;
+      ufds[i].revents |= (POLLRDBAND|POLLPRI);
     if(ufds[i].revents != 0)
       r++;
   }


### PR DESCRIPTION
- select: align select return code handling with poll

  Handle the <0 to -1 conversion in lower-level select
  and poll wrappers so that higher-level functions can
  just use one condition with <= 0 on the return code.

- select: use short and long poll event definitions

  Since these may differ depending on the platform.