### PR TITLE
win32: drop support for WinSock version 1, require version 2

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -97,6 +97,7 @@ Dependencies
  - NSS          3.14.x
  - Heimdal      ?
  - nghttp2      1.12.0
+ - WinSock      2.2 (on Windows 95+ and Windows CE .NET 4.1+)
 
 Operating Systems
 -----------------
@@ -145,6 +146,8 @@ Windows vs Unix
    That's taken care of by the `curl_global_init()` call, but if other libs
    also do it etc there might be reasons for applications to alter that
    behaviour.
+
+   We require WinSock version 2.2 and load this version during global init.
 
  3. The file descriptors for network communication and file operations are
     not as easily interchangeable as in Unix.

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -560,14 +560,6 @@
 /* ---------------------------------------------------------------- */
 
 /*
- * When using WINSOCK, TELNET protocol requires WINSOCK2 API.
- */
-
-#if defined(USE_WINSOCK) && (USE_WINSOCK != 2)
-#  define CURL_DISABLE_TELNET 1
-#endif
-
-/*
  * msvc 6.0 does not have struct sockaddr_storage and
  * does not define IPPROTO_ESP in winsock2.h. But both
  * are available if PSDK is properly installed.
@@ -705,7 +697,7 @@ int netware_init(void);
      defined(HAVE_WINSOCK_H) || \
      defined(HAVE_WINSOCK2_H) || \
      defined(HAVE_WS2TCPIP_H)
-#    error "Winsock and lwIP TCP/IP stack definitions shall not coexist!"
+#    error "WinSock and lwIP TCP/IP stack definitions shall not coexist!"
 #  endif
 #endif
 

--- a/lib/setup-win32.h
+++ b/lib/setup-win32.h
@@ -60,7 +60,6 @@
 
 /*
  * Define USE_WINSOCK to 2 if we have and use WINSOCK2 API, else
- * define USE_WINSOCK to 1 if we have and use WINSOCK  API, else
  * undefine USE_WINSOCK.
  */
 
@@ -70,7 +69,7 @@
 #  define USE_WINSOCK 2
 #else
 #  ifdef HAVE_WINSOCK_H
-#    define USE_WINSOCK 1
+#    error "WinSock version 1 is no longer supported, version 2 is required!"
 #  endif
 #endif
 

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -55,12 +55,7 @@ CURLcode Curl_win32_init(long flags)
     WSADATA wsaData;
     int res;
 
-#if defined(ENABLE_IPV6) && (USE_WINSOCK < 2)
-#error IPV6_requires_winsock2
-#endif
-
-    wVersionRequested = MAKEWORD(USE_WINSOCK, USE_WINSOCK);
-
+    wVersionRequested = MAKEWORD(2, 2);
     res = WSAStartup(wVersionRequested, &wsaData);
 
     if(res != 0)
@@ -83,9 +78,9 @@ CURLcode Curl_win32_init(long flags)
       return CURLE_FAILED_INIT;
     }
     /* The Windows Sockets DLL is acceptable. Proceed. */
-  #elif defined(USE_LWIPSOCK)
+#elif defined(USE_LWIPSOCK)
     lwip_init();
-  #endif
+#endif
   } /* CURL_GLOBAL_WIN32 */
 
 #ifdef USE_WINDOWS_SSPI

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -167,8 +167,8 @@ void win32_init(void)
   WORD wVersionRequested;
   WSADATA wsaData;
   int err;
-  wVersionRequested = MAKEWORD(USE_WINSOCK, USE_WINSOCK);
 
+  wVersionRequested = MAKEWORD(2, 2);
   err = WSAStartup(wVersionRequested, &wsaData);
 
   if(err != 0) {
@@ -177,8 +177,8 @@ void win32_init(void)
     exit(1);
   }
 
-  if(LOBYTE(wsaData.wVersion) != USE_WINSOCK ||
-     HIBYTE(wsaData.wVersion) != USE_WINSOCK) {
+  if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
+     HIBYTE(wsaData.wVersion) != HIBYTE(wVersionRequested) ) {
     WSACleanup();
     perror("Winsock init failed");
     logmsg("No suitable winsock.dll found -- aborting");


### PR DESCRIPTION
**New PR content:**

IPv6, telnet and now also the multi API require WinSock
version 2 which is available starting with Windows 95.

Therefore we think it is time to drop support for version 1.

----

**Original PR content:**

While digging through the WinSock setup in the curl source code, I found out that there is actually code to handle the differences between WinSock version 1 and 2. Therefore the changes introduced with #5634 should also still support compilation against older WinSock versions.

An alternative to repeating the same check in every `#if` statement would be to define an internal variable inside `multi.c` or `multihandle.h` and just `#ifdef` on that one instead of just `USE_WINSOCK`.

--

Update the ifdef-jungle to check for WinSock version 2.

Follow up to #5634