### PR TITLE
openssl: Fix wincrypt symbols conflict with BoringSSL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -34,6 +34,13 @@
 /* Wincrypt must be included before anything that could include OpenSSL. */
 #if defined(USE_WIN32_CRYPTO)
 #include <wincrypt.h>
+/* Undefine wincrypt conflicting symbols for BoringSSL. */
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef PKCS7_SIGNER_INFO
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
 #endif
 
 #include "urldata.h"


### PR DESCRIPTION
OpenSSL undefines the conflicting symbols but BoringSSL does not so we
must do it ourselves.

Reported-by: Samuel Tranchet
Assisted-by: Javier Blazquez

Ref: https://bugs.chromium.org/p/boringssl/issues/detail?id=371
Ref: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1g/include/openssl/ossl_typ.h#L66-L73

Fixes https://github.com/curl/curl/issues/5669
Closes #xxxx

---

/cc @samuel-tranchet @jblazquez