### PR TITLE
git: Ignore libtests in 3XXX area

### DIFF
--- a/tests/libtest/.gitignore
+++ b/tests/libtest/.gitignore
@@ -1,6 +1,6 @@
 chkdecimalpoint
 chkhostname
-lib[12][0-9][0-9][0-9]
+lib[123][0-9][0-9][0-9]
 lib[56][0-9][0-9]
 lib1521.c
 libauthretry


### PR DESCRIPTION
Currently the file tests/libtest/lib3010 is not getting
ignored by git. This fixes it by adding the 3XXX area to
the according .gitignore file.