### PR TITLE
doh: Add error for DOH_DNS_NAME_TOO_LONG

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -57,12 +57,13 @@ static const char * const errors[]={
   "Unexpected TYPE",
   "Unexpected CLASS",
   "No content",
-  "Bad ID"
+  "Bad ID",
+  "Name too long"
 };
 
 static const char *doh_strerror(DOHcode code)
 {
-  if((code >= DOH_OK) && (code <= DOH_DNS_BAD_ID))
+  if((code >= DOH_OK) && (code <= DOH_DNS_NAME_TOO_LONG))
     return errors[code];
   return "bad error code";
 }


### PR DESCRIPTION
When this error code was introduced in
b6a53fff6c1d07e8a9cb65ca1066d99490fb8132, it was forgotten to be added
in the errors array and doh_strerror function.