### PR TITLE
alt-svc: enable by default

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
         torture:
           name: torture
           install: libnghttp2-dev
-          configure: --enable-debug --disable-shared --disable-threaded-resolver --enable-alt-svc
+          configure: --enable-debug --disable-shared --disable-threaded-resolver
           tests: -n -t --shallow=40 !FTP
     steps:
     - script: sudo apt-get update && sudo apt-get install -y stunnel4 python-impacket libzstd-dev libbrotli-dev $(install)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,7 +52,7 @@ jobs:
           macosx-version-min: 10.9
         - name: torture
           install: nghttp2 openssl
-          configure: --enable-debug --disable-shared --disable-threaded-resolver --enable-alt-svc
+          configure: --enable-debug --disable-shared --disable-threaded-resolver
           tflags: -n -t --shallow=25 !FTP
           macosx-version-min: 10.9
         - name: macOS 10.15

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
     before_install:
     - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
   - env:
-    - T=novalgrind QUICHE="yes" C="--with-ssl=$HOME/quiche/deps/boringssl/src --with-quiche=$HOME/quiche/target/release --enable-alt-svc" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
+    - T=novalgrind QUICHE="yes" C="--with-ssl=$HOME/quiche/deps/boringssl/src --with-quiche=$HOME/quiche/target/release" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:
@@ -115,7 +115,7 @@ jobs:
     - T=novalgrind LIBRESSL=yes C="--with-ssl=$HOME/libressl" LD_LIBRARY_PATH=/home/travis/libressl/lib:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
   - env:
-    - T=novalgrind NGTCP2=yes C="--with-ssl=$HOME/ngbuild --with-ngtcp2=$HOME/ngbuild --with-nghttp3=$HOME/ngbuild --enable-alt-svc" NOTESTS=
+    - T=novalgrind NGTCP2=yes C="--with-ssl=$HOME/ngbuild --with-ngtcp2=$HOME/ngbuild --with-nghttp3=$HOME/ngbuild" NOTESTS=
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:
@@ -126,7 +126,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=novalgrind NGTCP2=yes GNUTLS=yes C="PKG_CONFIG_PATH=$HOME/ngbuild --without-ssl --with-gnutls=$HOME/ngbuild --with-ngtcp2=$HOME/ngbuild --with-nghttp3=$HOME/ngbuild --enable-alt-svc" NOTESTS=
+    - T=novalgrind NGTCP2=yes GNUTLS=yes C="PKG_CONFIG_PATH=$HOME/ngbuild --without-ssl --with-gnutls=$HOME/ngbuild --with-ngtcp2=$HOME/ngbuild --with-nghttp3=$HOME/ngbuild" NOTESTS=
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:
@@ -192,7 +192,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug C="--enable-alt-svc"
+    - T=debug C="--disable-alt-svc"
     - *clang
     compiler: clang
     addons:
@@ -346,7 +346,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug C="--enable-alt-svc"
+    - T=debug C=""
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     arch: arm64
     addons:
@@ -364,7 +364,7 @@ jobs:
         - zlib1g-dev
 
   - env:
-    - T=debug C="--enable-alt-svc"
+    - T=debug C=""
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     arch: ppc64le
     addons:
@@ -382,7 +382,7 @@ jobs:
         - zlib1g-dev
 
   - env:
-    - T=debug C="--enable-alt-svc"
+    - T=debug C=""
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     arch: s390x
     addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,9 +208,10 @@ if(HTTP_ONLY)
   set(CURL_DISABLE_TFTP ON)
 endif()
 
+option(CURL_DISABLE_ALTSVC "to disable alt-svc support" OFF)
+mark_as_advanced(CURL_DISABLE_ALTSVC)
 option(CURL_DISABLE_COOKIES "to disable cookies support" OFF)
 mark_as_advanced(CURL_DISABLE_COOKIES)
-
 option(CURL_DISABLE_CRYPTO_AUTH "to disable cryptographic authentication" OFF)
 mark_as_advanced(CURL_DISABLE_CRYPTO_AUTH)
 option(CURL_DISABLE_VERBOSE_STRINGS "to disable verbose strings" OFF)
@@ -790,8 +791,6 @@ else()
   unset(USE_UNIX_SOCKETS CACHE)
 endif()
 
-option(ENABLE_ALT_SVC "Enable alt-svc support" OFF)
-set(USE_ALTSVC ${ENABLE_ALT_SVC})
 
 #
 # CA handling
@@ -1364,7 +1363,7 @@ _add_if("Largefile"     (CURL_SIZEOF_CURL_OFF_T GREATER 4) AND
 # TODO SSP1 (Schannel) check is missing
 _add_if("SSPI"          USE_WINDOWS_SSPI)
 _add_if("GSS-API"       HAVE_GSSAPI)
-_add_if("alt-svc"       ENABLE_ALT_SVC)
+_add_if("alt-svc"       NOT CURL_DISABLE_ALTSVC)
 # TODO SSP1 missing for SPNEGO
 _add_if("SPNEGO"        NOT CURL_DISABLE_CRYPTO_AUTH AND
                         (HAVE_GSSAPI OR USE_WINDOWS_SSPI))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -232,12 +232,12 @@ environment:
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 ~1056 !1233"
-        CONFIG_ARGS: "--enable-debug --enable-werror --enable-alt-svc --disable-threaded-resolver --disable-proxy"
+        CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy"
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
-        CONFIG_ARGS: "--enable-debug --enable-werror --enable-alt-svc --disable-threaded-resolver"
+        CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver"
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
         BUILD_SYSTEM: autotools
         TESTING: ON

--- a/configure.ac
+++ b/configure.ac
@@ -176,8 +176,11 @@ curl_verbose_msg="enabled (--disable-verbose)"
    curl_rtmp_msg="no      (--with-librtmp)"
   curl_mtlnk_msg="no      (--with-libmetalink)"
     curl_psl_msg="no      (--with-libpsl)"
-
+ curl_altsvc_msg="enabled";
     ssl_backends=
+
+
+enable_altsvc="yes"
 
 dnl
 dnl Save some initial values the user might have provided
@@ -396,6 +399,10 @@ AC_HELP_STRING([--disable-http],[Disable HTTP support]),
        AC_SUBST(CURL_DISABLE_HTTP, [1])
        AC_DEFINE(CURL_DISABLE_RTSP, 1, [to disable RTSP])
        AC_SUBST(CURL_DISABLE_RTSP, [1])
+       dnl toggle off alt-svc too when HTTP is disabled
+       AC_DEFINE(CURL_DISABLE_ALTSVC, 1, [disable alt-svc])
+       curl_altsvc_msg="no";
+       enable_altsvc="no"
        ;;
   *)   AC_MSG_RESULT(yes)
        ;;
@@ -4864,7 +4871,6 @@ AC_HELP_STRING([--disable-get-easy-options],[Disable curl_easy_options]),
 dnl ************************************************************
 dnl switch on/off alt-svc
 dnl
-curl_altsvc_msg="no      (--enable-alt-svc)";
 AC_MSG_CHECKING([whether to support alt-svc])
 AC_ARG_ENABLE(alt-svc,
 AC_HELP_STRING([--enable-alt-svc],[Enable alt-svc support])
@@ -4872,19 +4878,15 @@ AC_HELP_STRING([--disable-alt-svc],[Disable alt-svc support]),
 [ case "$enableval" in
   no)
        AC_MSG_RESULT(no)
+       AC_DEFINE(CURL_DISABLE_ALTSVC, 1, [disable alt-svc])
+       curl_altsvc_msg="no";
+       enable_altsvc="no"
        ;;
   *) AC_MSG_RESULT(yes)
-       curl_altsvc_msg="enabled";
-       enable_altsvc="yes"
        ;;
   esac ],
        AC_MSG_RESULT(no)
 )
-
-if test "$enable_altsvc" = "yes"; then
-  AC_DEFINE(USE_ALTSVC, 1, [to enable alt-svc])
-  experimental="$experimental alt-svc"
-fi
 
 dnl *************************************************************
 dnl check whether ECH support, if desired, is actually available

--- a/docs/ALTSVC.md
+++ b/docs/ALTSVC.md
@@ -1,10 +1,12 @@
 # Alt-Svc
 
-curl features **EXPERIMENTAL** support for the Alt-Svc: HTTP header.
+curl features support for the Alt-Svc: HTTP header.
 
 ## Enable Alt-Svc in build
 
 `./configure --enable-alt-svc`
+
+(enabled by default since 7.73.0)
 
 ## Standard
 

--- a/docs/CURL-DISABLE.md
+++ b/docs/CURL-DISABLE.md
@@ -1,5 +1,9 @@
 # Code defines to disable features and protocols
 
+## CURL_DISABLE_ALTSVC
+
+Disable support for Alt-Svc: HTTP headers.
+
 ## CURL_DISABLE_COOKIES
 
 Disable support for HTTP cookies.

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -19,5 +19,4 @@ Experimental support in curl means:
 ## Experimental features right now
 
  - HTTP/3 support and options
- - alt-svc support and options
  - CURLSSLOPT_NATIVE_CA (No configure option, feature built in when supported)

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -65,7 +65,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % LDFLAGS="-Wl,-rpath,<somewhere1>/lib" ./configure --with-ssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3> --enable-alt-svc
+     % LDFLAGS="-Wl,-rpath,<somewhere1>/lib" ./configure --with-ssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
 
 ## Build with GnuTLS
@@ -105,7 +105,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure --without-ssl --with-gnutls=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3> --enable-alt-svc
+     % ./configure --without-ssl --with-gnutls=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
 
 # quiche version
@@ -126,7 +126,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release --enable-alt-svc
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
      % make
 
 ## Run

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.3
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -29,11 +29,6 @@ CURLOPT_ALTSVC \- set alt-svc cache file name
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ALTSVC, char *filename);
 .fi
-.SH EXPERIMENTAL
-Warning: this feature is early code and is marked as experimental. It can only
-be enabled by explicitly telling configure with \fB--enable-alt-svc\fP. You are
-advised to not ship this in production before the experimental label is
-removed.
 .SH DESCRIPTION
 Pass in a pointer to a \fIfilename\fP to instruct libcurl to use that file as
 the Alt-Svc cache to read existing cache contents from and possibly also write

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.3
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.3
@@ -27,7 +27,6 @@ CURLOPT_ALTSVC_CTRL \- control alt-svc behavior
 .nf
 #include <curl/curl.h>
 
-#define CURLALTSVC_IMMEDIATELY  (1<<0)
 #define CURLALTSVC_READONLYFILE (1<<2)
 #define CURLALTSVC_H1           (1<<3)
 #define CURLALTSVC_H2           (1<<4)
@@ -35,11 +34,6 @@ CURLOPT_ALTSVC_CTRL \- control alt-svc behavior
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ALTSVC_CTRL, long bitmask);
 .fi
-.SH EXPERIMENTAL
-Warning: this feature is early code and is marked as experimental. It can only
-be enabled by explicitly telling configure with \fB--enable-alt-svc\fP. You are
-advised to not ship this in production before the experimental label is
-removed.
 .SH DESCRIPTION
 Populate the long \fIbitmask\fP with the correct set of features to instruct
 libcurl how to handle Alt-Svc for the transfers using this handle.
@@ -50,10 +44,6 @@ origin is properly hosted over HTTPS. These requirements are there to make
 sure both the source and the destination are legitimate.
 
 Setting any bit will enable the alt-svc engine.
-.IP "CURLALTSVC_IMMEDIATELY"
-If an Alt-Svc: header is received, this instructs libcurl to switch to one of
-those alternatives asap rather than to save it and use for the next
-request. (Not currently supported).
 .IP "CURLALTSVC_READONLYFILE"
 Do not write the alt-svc cache back to the file specified with
 \fICURLOPT_ALTSVC(3)\fP even if it gets updated. By default a file specified

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -15,7 +15,6 @@
 CURLALTSVC_H1                   7.64.1
 CURLALTSVC_H2                   7.64.1
 CURLALTSVC_H3                   7.64.1
-CURLALTSVC_IMMEDIATELY          7.64.1
 CURLALTSVC_READONLYFILE         7.64.1
 CURLAUTH_ANY                    7.10.6
 CURLAUTH_ANYSAFE                7.10.6

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -949,8 +949,6 @@ typedef enum {
 #define CURLHEADER_SEPARATE (1<<0)
 
 /* CURLALTSVC_* are bits for the CURLOPT_ALTSVC_CTRL option */
-#define CURLALTSVC_IMMEDIATELY  (1<<0)
-
 #define CURLALTSVC_READONLYFILE (1<<2)
 #define CURLALTSVC_H1           (1<<3)
 #define CURLALTSVC_H2           (1<<4)

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -25,7 +25,7 @@
  */
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_ALTSVC)
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_ALTSVC)
 #include <curl/curl.h>
 #include "urldata.h"
 #include "altsvc.h"
@@ -457,6 +457,9 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
   struct altsvc *as;
   unsigned short dstport = srcport; /* the same by default */
   CURLcode result = getalnum(&p, alpnbuf, sizeof(alpnbuf));
+#ifdef CURL_DISABLE_VERBOSE_STRINGS
+  (void)data;
+#endif
   if(result) {
     infof(data, "Excessive alt-svc header, ignoring...\n");
     return CURLE_OK;
@@ -642,4 +645,4 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
   return FALSE;
 }
 
-#endif /* CURL_DISABLE_HTTP || USE_ALTSVC */
+#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_ALTSVC */

--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -23,7 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_ALTSVC)
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_ALTSVC)
 #include <curl/curl.h>
 #include "llist.h"
 
@@ -75,5 +75,5 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
 /* disabled */
 #define Curl_altsvc_save(a,b,c)
 #define Curl_altsvc_cleanup(x)
-#endif /* CURL_DISABLE_HTTP || USE_ALTSVC */
+#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_ALTSVC */
 #endif /* HEADER_CURL_ALTSVC_H */

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -422,9 +422,6 @@
 /* Define if you can safely include both <sys/time.h> and <time.h>. */
 #define TIME_WITH_SYS_TIME
 
-/* Define to enable alt-svc support (experimental) */
-#undef USE_ALTSVC
-
 /* Define to enable HTTP3 support (experimental, requires NGTCP2 or QUICHE) */
 #undef ENABLE_QUIC
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -1017,8 +1017,8 @@ ${SIZEOF_TIME_T_CODE}
 /* if Unix domain sockets are enabled  */
 #cmakedefine USE_UNIX_SOCKETS
 
-/* to enable alt-svc */
-#cmakedefine USE_ALTSVC 1
+/* to disable alt-svc */
+#cmakedefine CURL_DISABLE_ALTSVC 1
 
 /* Define to 1 if you are building a Windows target with large file support. */
 #cmakedefine USE_WIN32_LARGE_FILES 1

--- a/lib/curl_get_line.c
+++ b/lib/curl_get_line.c
@@ -22,7 +22,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_COOKIES) && !defined(CURL_DISABLE_ALTSVC)
+#if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC)
 
 #include "curl_get_line.h"
 #include "curl_memory.h"

--- a/lib/http.c
+++ b/lib/http.c
@@ -2518,7 +2518,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
   if(result)
     return result;
 
-#ifdef USE_ALTSVC
+#ifndef CURL_DISABLE_ALTSVC
   if(conn->bits.altused && !Curl_checkheaders(conn, "Alt-Used")) {
     altused = aprintf("Alt-Used: %s:%d\r\n",
                       conn->conn_to_host.name, conn->conn_to_port);
@@ -3992,7 +3992,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
         }
       }
     }
-#ifdef USE_ALTSVC
+#ifndef CURL_DISABLE_ALTSVC
     /* If enabled, the header is incoming and this is over HTTPS */
     else if(data->asi && checkprefix("Alt-Svc:", headp) &&
             ((conn->handler->flags & PROTOPT_SSL) ||

--- a/lib/rename.c
+++ b/lib/rename.c
@@ -24,8 +24,8 @@
 
 #include "curl_setup.h"
 
-#if (!defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)) ||  \
-  defined(USE_ALTSVC)
+#if (!defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_COOKIES)) || \
+  !defined(CURL_DISABLE_ALTSVC)
 
 #include "curl_multibyte.h"
 #include "timeval.h"

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2839,7 +2839,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.trailer_data = va_arg(param, void *);
 #endif
     break;
-#ifdef USE_ALTSVC
+#ifndef CURL_DISABLE_ALTSVC
   case CURLOPT_ALTSVC:
     if(!data->asi) {
       data->asi = Curl_altsvc_init();

--- a/lib/url.c
+++ b/lib/url.c
@@ -3095,7 +3095,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
     conn_to_host = conn_to_host->next;
   }
 
-#ifdef USE_ALTSVC
+#ifndef CURL_DISABLE_ALTSVC
   if(data->asi && !host && (port == -1) &&
      ((conn->handler->protocol == CURLPROTO_HTTPS) ||
 #ifdef CURLDEBUG

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1899,7 +1899,7 @@ struct Curl_easy {
                                   NOTE that the 'cookie' field in the
                                   UserDefined struct defines if the "engine"
                                   is to be used or not. */
-#ifdef USE_ALTSVC
+#ifndef CURL_DISABLE_ALTSVC
   struct altsvcinfo *asi;      /* the alt-svc cache */
 #endif
   struct Progress progress;    /* for all the progress meter data */

--- a/lib/version.c
+++ b/lib/version.c
@@ -415,7 +415,7 @@ static curl_version_info_data version_info = {
 #if defined(HAVE_ZSTD)
   | CURL_VERSION_ZSTD
 #endif
-#if defined(USE_ALTSVC)
+#ifndef CURL_DISABLE_ALTSVC
   | CURL_VERSION_ALTSVC
 #endif
   ,

--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -25,7 +25,7 @@ set -eo pipefail
 ./buildconf
 
 if [ "$T" = "coverage" ]; then
-  ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --enable-alt-svc --with-libssh2
+  ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --with-libssh2
   make
   make TFLAGS=-n test-nonflaky
   make "TFLAGS=-n -e" test-nonflaky
@@ -36,7 +36,7 @@ if [ "$T" = "coverage" ]; then
 fi
 
 if [ "$T" = "torture" ]; then
-  ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --enable-alt-svc --with-libssh2
+  ./configure --enable-debug --disable-shared --disable-threaded-resolver --enable-code-coverage --enable-werror --with-libssh2
   make
   make TFLAGS=-n test-nonflaky
   make "TFLAGS=-n -e" test-nonflaky

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -36,11 +36,10 @@ unit_stop(void)
   curl_global_cleanup();
 }
 
-#if defined(CURL_DISABLE_HTTP) || !defined(USE_ALTSVC)
+#if defined(CURL_DISABLE_HTTP) || defined(CURL_DISABLE_ALTSVC)
 UNITTEST_START
 {
-  return 0; /* nothing to do when HTTP is disabled or alt-svc support is
-               missing */
+  return 0; /* nothing to do when HTTP or alt-svc is disabled */
 }
 UNITTEST_STOP
 #else


### PR DESCRIPTION
No longer considered experimental

Checklist:

- [X] remove `CURLALTSVC_IMMEDIATELY` as it isn't implemented
- [X] works with curl_easy_duphandle() - #5923 landed

Proposal taken to the mailing list: https://curl.haxx.se/mail/lib-2020-08/0033.html