### PR TITLE
Add test with typechecks

### DIFF
--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -292,6 +292,7 @@ CURLWARNING(_curl_easy_getinfo_err_curl_off_t,
    (option) == CURLOPT_PROXY_CAINFO ||                                        \
    (option) == CURLOPT_PROXY_CAPATH ||                                        \
    (option) == CURLOPT_PROXY_CRLFILE ||                                       \
+   (option) == CURLOPT_PROXY_ISSUERCERT ||                                    \
    (option) == CURLOPT_PROXY_KEYPASSWD ||                                     \
    (option) == CURLOPT_PROXY_PINNEDPUBLICKEY ||                               \
    (option) == CURLOPT_PROXY_SERVICE_NAME ||                                  \
@@ -357,7 +358,6 @@ CURLWARNING(_curl_easy_getinfo_err_curl_off_t,
    (option) == CURLOPT_INTERLEAVEDATA ||                                      \
    (option) == CURLOPT_IOCTLDATA ||                                           \
    (option) == CURLOPT_OPENSOCKETDATA ||                                      \
-   (option) == CURLOPT_PRIVATE ||                                             \
    (option) == CURLOPT_PROGRESSDATA ||                                        \
    (option) == CURLOPT_READDATA ||                                            \
    (option) == CURLOPT_SEEKDATA ||                                            \

--- a/tests/data/test1912
+++ b/tests/data/test1912
@@ -1,0 +1,32 @@
+<testcase>
+<info>
+<keywords>
+curl_easy_option
+typecheck
+</keywords>
+</info>
+
+# Server-side
+<reply>
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+Cross validate that gcc-typecheck macros match the option types.
+</name>
+<tool>
+lib1912
+</tool>
+
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -58,7 +58,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
  lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 \
  lib1591 lib1592 lib1593 lib1594 lib1596 \
- lib1900 lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 \
+ lib1900 lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 \
  lib2033 lib3010
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
@@ -652,6 +652,10 @@ lib1910_CPPFLAGS = $(AM_CPPFLAGS)
 lib1911_SOURCES = lib1911.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1911_LDADD = $(TESTUTIL_LIBS)
 lib1911_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1912_SOURCES = lib1912.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1912_LDADD = $(TESTUTIL_LIBS)
+lib1912_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib2033_SOURCES = libntlmconnect.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib2033_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1912.c
+++ b/tests/libtest/lib1912.c
@@ -25,10 +25,8 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-static void print_err(const char *name, const char *exp)
-{
-  fprintf(stderr, "Type mismatch for 'CURLOPT_%s' (expected %s)\n", name, exp);
-}
+#define print_err(name, exp) \
+  fprintf(stderr, "Type mismatch for CURLOPT_%s (expected %s)\n", name, exp);
 
 int test(char *URL)
 {

--- a/tests/libtest/lib1912.c
+++ b/tests/libtest/lib1912.c
@@ -1,0 +1,82 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+static void print_err(const char *name, const char *exp)
+{
+  fprintf(stderr, "Type mismatch for 'CURLOPT_%s' (expected %s)\n", name, exp);
+}
+
+int test(char *URL)
+{
+/* Only test if GCC typechecking is available */
+  int error = 0;
+#ifdef CURLINC_TYPECHECK_GCC_H
+  const struct curl_easyoption *o;
+  for(o = curl_easy_option_next(NULL);
+      o;
+      o = curl_easy_option_next(o)) {
+    /* Test for mismatch OR missing typecheck macros */
+    if(curlcheck_long_option(o->id) !=
+        (o->type == CURLOT_LONG || o->type == CURLOT_VALUES)) {
+      print_err(o->name, "CURLOT_LONG or CURLOT_VALUES");
+      error++;
+    }
+    if(curlcheck_off_t_option(o->id) != (o->type == CURLOT_OFF_T)) {
+      print_err(o->name, "CURLOT_OFF_T");
+      error++;
+    }
+    if(curlcheck_string_option(o->id) != (o->type == CURLOT_STRING)) {
+      print_err(o->name, "CURLOT_STRING");
+      error++;
+    }
+    if(curlcheck_slist_option(o->id) != (o->type == CURLOT_SLIST)) {
+      print_err(o->name, "CURLOT_SLIST");
+      error++;
+    }
+    if(curlcheck_cb_data_option(o->id) != (o->type == CURLOT_CBPTR)) {
+      print_err(o->name, "CURLOT_CBPTR");
+      error++;
+    }
+    /* From here: only test that the type matches if macro is known */
+    if(curlcheck_write_cb_option(o->id) && (o->type != CURLOT_FUNCTION)) {
+      print_err(o->name, "CURLOT_FUNCTION");
+      error++;
+    }
+    if(curlcheck_conv_cb_option(o->id) && (o->type != CURLOT_FUNCTION)) {
+      print_err(o->name, "CURLOT_FUNCTION");
+      error++;
+    }
+    if(curlcheck_postfields_option(o->id) && (o->type != CURLOT_OBJECT)) {
+      print_err(o->name, "CURLOT_OBJECT");
+      error++;
+    }
+    /* Todo: no gcc typecheck for CURLOPTTYPE_BLOB types? */
+  }
+#endif
+  (void)URL;
+  return error;
+}


### PR DESCRIPTION
Cross validates that gcc-typecheck macros match the new option type api. Not sure if you find this useful, I am using these tests to migrate my old typechecking hack in the R bindings to the new API.

Note that I removed `CURLOPT_PRIVATE` from `curlcheck_cb_data_option()` to make the check pass, because according to the new API this is not a `CURLOT_CBPTR` but instead a `CURLOT_OBJECT`.
