### PR TITLE
easyoptions: provide debug function when DEBUGBUILD

### DIFF
--- a/lib/easyoptions.c
+++ b/lib/easyoptions.c
@@ -334,7 +334,7 @@ struct curl_easyoption Curl_easyopts[] = {
   {NULL, 0, 0, 0} /* end of table */
 };
 
-#ifdef CURLDEBUG
+#ifdef DEBUGBUILD
 /*
  * Curl_easyopts_check() is a debug-only function that returns non-zero
  * if this source file is not in sync with the options listed in curl/curl.h

--- a/lib/easyoptions.h
+++ b/lib/easyoptions.h
@@ -29,7 +29,7 @@
 /* generated table with all easy options */
 extern struct curl_easyoption Curl_easyopts[];
 
-#ifdef CURLDEBUG
+#ifdef DEBUGBUILD
 int Curl_easyopts_check(void);
 #endif
 #endif


### PR DESCRIPTION
... not CURLDEBUG as they're not always set in conjunction.

Fixes #5877