### PR TITLE
sockfilt: handle FD_CLOSE winsock event on write socket

### DIFF
--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -700,12 +700,12 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
 
     if(FD_ISSET(wsasock, readfds)) {
       FD_SET(wsasock, &readsock);
-      wsaevents.lNetworkEvents |= FD_READ|FD_ACCEPT|FD_CLOSE;
+      wsaevents.lNetworkEvents |= (FD_READ|FD_ACCEPT|FD_CLOSE);
     }
 
     if(FD_ISSET(wsasock, writefds)) {
       FD_SET(wsasock, &writesock);
-      wsaevents.lNetworkEvents |= FD_WRITE|FD_CONNECT;
+      wsaevents.lNetworkEvents |= (FD_WRITE|FD_CONNECT|FD_CLOSE);
     }
 
     if(FD_ISSET(wsasock, exceptfds)) {
@@ -835,11 +835,11 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
             FD_CLR(wsasock, readfds);
 
           /* remove from descriptor set if not ready for write/connect */
-          if(!(wsaevents.lNetworkEvents & (FD_WRITE|FD_CONNECT)))
+          if(!(wsaevents.lNetworkEvents & (FD_WRITE|FD_CONNECT|FD_CLOSE)))
             FD_CLR(wsasock, writefds);
 
           /* remove from descriptor set if not exceptional */
-          if(!(wsaevents.lNetworkEvents & (FD_OOB)))
+          if(!(wsaevents.lNetworkEvents & FD_OOB))
             FD_CLR(wsasock, exceptfds);
         }
       }


### PR DESCRIPTION
Learn from the way Cygwin handles and maps the WinSock events
to simulate correct and complete poll and select behaviour
according to Richard W. Stevens Network Programming book.

Follow up to #5867