### PR TITLE
tests/getpart: use MIME::Base64 instead of home-cooked

### DIFF
--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -28,12 +28,7 @@ my $xmlfile;
 my $warning=0;
 my $trace=0;
 
-sub decode_base64 {
-  tr:A-Za-z0-9+/::cd;                   # remove non-base64 chars
-  tr:A-Za-z0-9+/: -_:;                  # convert to uuencoded format
-  my $len = pack("c", 32 + 0.75*length);   # compute length byte
-  return unpack("u", $len . $_);         # uudecode and print
-}
+use MIME::Base64;
 
 sub decode_hex {
     my $s = $_;


### PR DESCRIPTION
Since we already use the base64 package since a while back, we can just
as well switch to that here too.

It also happens to use the exact same function name, which otherwise
causes a run-time warning.

Reported-by: Marc Hörsken
Fixes #5885