### PR TITLE
buildconf: exec autoreconf to avoid additional process

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "*** Do not use buildconf. Instead, just use: autoreconf -fi" >&2
-${AUTORECONF:-autoreconf} -fi "${@}"
+exec ${AUTORECONF:-autoreconf} -fi "${@}"


### PR DESCRIPTION
Also make buildconf exit with the return code of autoreconf.

Follow up to #5853