### PR TITLE
system.h: fix mismatch between curl_off_t typeof and format

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -196,8 +196,13 @@
 
 #elif defined(__MINGW32__)
 #  define CURL_TYPEOF_CURL_OFF_T     long long
-#  define CURL_FORMAT_CURL_OFF_T     "I64d"
-#  define CURL_FORMAT_CURL_OFF_TU    "I64u"
+#  if defined(__GNUC__) && (__GNUC__ >= 10)
+#    define CURL_FORMAT_CURL_OFF_T   "lld"
+#    define CURL_FORMAT_CURL_OFF_TU  "llu"
+#  else
+#    define CURL_FORMAT_CURL_OFF_T   "I64d"
+#    define CURL_FORMAT_CURL_OFF_TU  "I64u"
+#  endif
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t


### PR DESCRIPTION
This removes the following compiler warnings:
```
tool_filetime.c: In function 'setfiletime':
tool_filetime.c:106:15: warning: ISO C does not support the 'I' printf flag [-Wformat=]
  106 |               "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
tool_filetime.c:106:15: warning: format '%d' expects argument of type 'int', but argument 3 has type 'curl_off_t' {aka 'long long int'} [-Wformat=]
In file included from ../include/curl/curl.h:38,
                 from ../lib/curl_setup.h:157,
                 from tool_setup.h:36,
                 from tool_filetime.h:24,
                 from tool_filetime.c:22:
../include/curl/system.h:199:42: note: format string is defined here
  199 | #  define CURL_FORMAT_CURL_OFF_T     "I64d"
tool_filetime.c:125:17: warning: ISO C does not support the 'I' printf flag [-Wformat=]
  125 |                 "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
tool_filetime.c:125:17: warning: format '%d' expects argument of type 'int', but argument 3 has type 'curl_off_t' {aka 'long long int'} [-Wformat=]
In file included from ../include/curl/curl.h:38,
                 from ../lib/curl_setup.h:157,
                 from tool_setup.h:36,
                 from tool_filetime.h:24,
                 from tool_filetime.c:22:
../include/curl/system.h:199:42: note: format string is defined here
  199 | #  define CURL_FORMAT_CURL_OFF_T     "I64d"
tool_filetime.c:133:15: warning: ISO C does not support the 'I' printf flag [-Wformat=]
  133 |               "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
tool_filetime.c:133:15: warning: format '%d' expects argument of type 'int', but argument 3 has type 'curl_off_t' {aka 'long long int'} [-Wformat=]
In file included from ../include/curl/curl.h:38,
                 from ../lib/curl_setup.h:157,
                 from tool_setup.h:36,
                 from tool_filetime.h:24,
                 from tool_filetime.c:22:
../include/curl/system.h:199:42: note: format string is defined here
  199 | #  define CURL_FORMAT_CURL_OFF_T     "I64d"
```