### PR TITLE
Check for connection being dead before reuse.

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1121,6 +1121,12 @@ ConnectionExists(struct Curl_easy *data,
         /* connect-only or to-be-closed connections will not be reused */
         continue;
 
+      if(extract_if_dead(check, data)) {
+        /* disconnect it */
+        (void)Curl_disconnect(data, check, /* dead_connection */TRUE);
+        continue;
+      }
+
       if(bundle->multiuse == BUNDLE_MULTIPLEX)
         multiplexed = CONN_INUSE(check);
 


### PR DESCRIPTION
Prevents incorrect reuse of an HTTP connection that has been prematurely shutdown() by the server.

Partial revert of 755083d00deb167667882e775b0885da0e63d034
    conn_maxage: move the check to prune_dead_connections()

Fixes #5884

Note that although this fixes the issue for me, I haven't considered it in the context of the original commit that it partially reverts. 