### PR TITLE
lib/Makefile.am: bump VERSIONINFO due to new functions

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -66,7 +66,7 @@ endif
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
-VERSIONINFO=-version-info 10:0:6
+VERSIONINFO=-version-info 11:0:7
 # This flag accepts an argument of the form current[:revision[:age]]. So,
 # passing -version-info 3:12:1 sets current to 3, revision to 12, and age to
 # 1.


### PR DESCRIPTION
... we're generally bad at this, but we are adding new functions for
this release.

This now produces a `libcurl.so.4.7.0` on Linux.