### PR TITLE
http_proxy: do not crash with HTTPS_PROXY and NO_PROXY set

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2556,6 +2556,9 @@ static CURLcode create_conn_helper_init_proxy(struct connectdata *conn)
     conn->bits.socksproxy = FALSE;
     conn->bits.proxy_user_passwd = FALSE;
     conn->bits.tunnel_proxy = FALSE;
+    /* CURLPROXY_HTTPS does not have its own flag in conn->bits, yet we need
+       to signal that CURLPROXY_HTTPS is not used for this connection */
+    conn->http_proxy.proxytype = CURLPROXY_HTTP;
   }
 
 out:


### PR DESCRIPTION
... in case NO_PROXY takes an effect

Without this patch, the following command crashes:

    $ GIT_CURL_VERBOSE=1 NO_PROXY=github.com HTTPS_PROXY=https://example.com \
        git clone https://github.com/curl/curl.git

Minimal libcurl-based reproducer:

    #include <curl/curl.h>

    int main() {
      CURL *curl = curl_easy_init();
      if(curl) {
        CURLcode ret;
        curl_easy_setopt(curl, CURLOPT_URL, "https://github.com/");
        curl_easy_setopt(curl, CURLOPT_PROXY, "example.com");
        /* set the proxy type */
        curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTPS);
        curl_easy_setopt(curl, CURLOPT_NOPROXY, "github.com");
        curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
        ret = curl_easy_perform(curl);
        curl_easy_cleanup(curl);
        return ret;
      }
      return -1;
    }

Assisted-by: Kamil Dudka
Bug: https://bugzilla.redhat.com/1873327