### PR TITLE
cleanup: use `Curl_` as prefix for internal global symbols

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -304,8 +304,8 @@ CURLcode Curl_altsvc_ctrl(struct altsvcinfo *asi, const long ctrl)
  */
 void Curl_altsvc_cleanup(struct altsvcinfo *altsvc)
 {
-  struct curl_llist_element *e;
-  struct curl_llist_element *n;
+  struct Curl_llist_element *e;
+  struct Curl_llist_element *n;
   if(altsvc) {
     for(e = altsvc->list.head; e; e = n) {
       struct altsvc *as = e->ptr;
@@ -323,8 +323,8 @@ void Curl_altsvc_cleanup(struct altsvcinfo *altsvc)
 CURLcode Curl_altsvc_save(struct Curl_easy *data,
                           struct altsvcinfo *altsvc, const char *file)
 {
-  struct curl_llist_element *e;
-  struct curl_llist_element *n;
+  struct Curl_llist_element *e;
+  struct Curl_llist_element *n;
   CURLcode result = CURLE_OK;
   FILE *out;
   char *tempstore;
@@ -399,8 +399,8 @@ static CURLcode getalnum(const char **ptr, char *alpnbuf, size_t buflen)
 static void altsvc_flush(struct altsvcinfo *asi, enum alpnid srcalpnid,
                          const char *srchost, unsigned short srcport)
 {
-  struct curl_llist_element *e;
-  struct curl_llist_element *n;
+  struct Curl_llist_element *e;
+  struct Curl_llist_element *n;
   for(e = asi->list.head; e; e = n) {
     struct altsvc *as = e->ptr;
     n = e->next;
@@ -612,8 +612,8 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
                         struct altsvc **dstentry,
                         const int versions) /* one or more bits */
 {
-  struct curl_llist_element *e;
-  struct curl_llist_element *n;
+  struct Curl_llist_element *e;
+  struct Curl_llist_element *n;
   time_t now = time(NULL);
   DEBUGASSERT(asi);
   DEBUGASSERT(srchost);

--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -46,12 +46,12 @@ struct altsvc {
   time_t expires;
   bool persist;
   int prio;
-  struct curl_llist_element node;
+  struct Curl_llist_element node;
 };
 
 struct altsvcinfo {
   char *filename;
-  struct curl_llist list; /* list of entries */
+  struct Curl_llist list; /* list of entries */
   long flags; /* the publicly set bitmask */
 };
 

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -59,7 +59,7 @@ static CURLcode bundle_create(struct connectbundle **bundlep)
   (*bundlep)->num_connections = 0;
   (*bundlep)->multiuse = BUNDLE_UNKNOWN;
 
-  Curl_llist_init(&(*bundlep)->conn_list, (curl_llist_dtor) conn_llist_dtor);
+  Curl_llist_init(&(*bundlep)->conn_list, (Curl_llist_dtor) conn_llist_dtor);
   return CURLE_OK;
 }
 
@@ -87,7 +87,7 @@ static void bundle_add_conn(struct connectbundle *bundle,
 static int bundle_remove_conn(struct connectbundle *bundle,
                               struct connectdata *conn)
 {
-  struct curl_llist_element *curr;
+  struct Curl_llist_element *curr;
 
   curr = bundle->conn_list.head;
   while(curr) {
@@ -321,7 +321,7 @@ bool Curl_conncache_foreach(struct Curl_easy *data,
                             int (*func)(struct connectdata *conn, void *param))
 {
   struct curl_hash_iterator iter;
-  struct curl_llist_element *curr;
+  struct Curl_llist_element *curr;
   struct curl_hash_element *he;
 
   if(!connc)
@@ -371,7 +371,7 @@ conncache_find_first_connection(struct conncache *connc)
 
   he = Curl_hash_next_element(&iter);
   while(he) {
-    struct curl_llist_element *curr;
+    struct Curl_llist_element *curr;
     bundle = he->ptr;
 
     curr = bundle->conn_list.head;
@@ -429,7 +429,7 @@ struct connectdata *
 Curl_conncache_extract_bundle(struct Curl_easy *data,
                               struct connectbundle *bundle)
 {
-  struct curl_llist_element *curr;
+  struct Curl_llist_element *curr;
   timediff_t highscore = -1;
   timediff_t score;
   struct curltime now;
@@ -478,7 +478,7 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
 {
   struct conncache *connc = data->state.conn_cache;
   struct curl_hash_iterator iter;
-  struct curl_llist_element *curr;
+  struct Curl_llist_element *curr;
   struct curl_hash_element *he;
   timediff_t highscore =- 1;
   timediff_t score;
@@ -572,7 +572,7 @@ void Curl_conncache_close_all_connections(struct conncache *connc)
 void Curl_conncache_print(struct conncache *connc)
 {
   struct curl_hash_iterator iter;
-  struct curl_llist_element *curr;
+  struct Curl_llist_element *curr;
   struct curl_hash_element *he;
 
   if(!connc)

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -206,8 +206,8 @@ static bool conncache_add_bundle(struct conncache *connc,
 static void conncache_remove_bundle(struct conncache *connc,
                                     struct connectbundle *bundle)
 {
-  struct curl_hash_iterator iter;
-  struct curl_hash_element *he;
+  struct Curl_hash_iterator iter;
+  struct Curl_hash_element *he;
 
   if(!connc)
     return;
@@ -320,9 +320,9 @@ bool Curl_conncache_foreach(struct Curl_easy *data,
                             void *param,
                             int (*func)(struct connectdata *conn, void *param))
 {
-  struct curl_hash_iterator iter;
+  struct Curl_hash_iterator iter;
   struct Curl_llist_element *curr;
-  struct curl_hash_element *he;
+  struct Curl_hash_element *he;
 
   if(!connc)
     return FALSE;
@@ -363,8 +363,8 @@ bool Curl_conncache_foreach(struct Curl_easy *data,
 static struct connectdata *
 conncache_find_first_connection(struct conncache *connc)
 {
-  struct curl_hash_iterator iter;
-  struct curl_hash_element *he;
+  struct Curl_hash_iterator iter;
+  struct Curl_hash_element *he;
   struct connectbundle *bundle;
 
   Curl_hash_start_iterate(&connc->hash, &iter);
@@ -477,9 +477,9 @@ struct connectdata *
 Curl_conncache_extract_oldest(struct Curl_easy *data)
 {
   struct conncache *connc = data->state.conn_cache;
-  struct curl_hash_iterator iter;
+  struct Curl_hash_iterator iter;
   struct Curl_llist_element *curr;
-  struct curl_hash_element *he;
+  struct Curl_hash_element *he;
   timediff_t highscore =- 1;
   timediff_t score;
   struct curltime now;
@@ -571,9 +571,9 @@ void Curl_conncache_close_all_connections(struct conncache *connc)
 /* Useful for debugging the connection cache */
 void Curl_conncache_print(struct conncache *connc)
 {
-  struct curl_hash_iterator iter;
+  struct Curl_hash_iterator iter;
   struct Curl_llist_element *curr;
-  struct curl_hash_element *he;
+  struct Curl_hash_element *he;
 
   if(!connc)
     return;

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -30,7 +30,7 @@
  */
 
 struct conncache {
-  struct curl_hash hash;
+  struct Curl_hash hash;
   size_t num_conn;
   long next_connection_id;
   struct curltime last_cleanup;

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -66,7 +66,7 @@ struct conncache {
 struct connectbundle {
   int multiuse;                 /* supports multi-use */
   size_t num_connections;       /* Number of connections in the bundle */
-  struct curl_llist conn_list;  /* The connectdata members of the bundle */
+  struct Curl_llist conn_list;  /* The connectdata members of the bundle */
 };
 
 /* returns 1 on error, 0 is fine */

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -41,14 +41,14 @@
 
 #if defined(USE_THREADS_POSIX)
 
-struct curl_actual_call {
+struct Curl_actual_call {
   unsigned int (*func)(void *);
   void *arg;
 };
 
 static void *curl_thread_create_thunk(void *arg)
 {
-  struct curl_actual_call *ac = arg;
+  struct Curl_actual_call *ac = arg;
   unsigned int (*func)(void *) = ac->func;
   void *real_arg = ac->arg;
 
@@ -62,7 +62,7 @@ static void *curl_thread_create_thunk(void *arg)
 curl_thread_t Curl_thread_create(unsigned int (*func) (void *), void *arg)
 {
   curl_thread_t t = malloc(sizeof(pthread_t));
-  struct curl_actual_call *ac = malloc(sizeof(struct curl_actual_call));
+  struct Curl_actual_call *ac = malloc(sizeof(struct Curl_actual_call));
   if(!(ac && t))
     goto err;
 

--- a/lib/fileinfo.h
+++ b/lib/fileinfo.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2010 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2010 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -27,7 +27,7 @@
 
 struct fileinfo {
   struct curl_fileinfo info;
-  struct curl_llist_element list;
+  struct Curl_llist_element list;
 };
 
 struct fileinfo *Curl_fileinfo_alloc(void);

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -274,7 +274,7 @@ static CURLcode ftp_pl_insert_finfo(struct connectdata *conn,
   curl_fnmatch_callback compare;
   struct WildcardData *wc = &conn->data->wildcard;
   struct ftp_wc *ftpwc = wc->protdata;
-  struct curl_llist *llist = &wc->filelist;
+  struct Curl_llist *llist = &wc->filelist;
   struct ftp_parselist_data *parser = ftpwc->parser;
   bool add = TRUE;
   struct curl_fileinfo *finfo = &infop->info;

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -34,8 +34,8 @@
 static void
 hash_element_dtor(void *user, void *element)
 {
-  struct curl_hash *h = (struct curl_hash *) user;
-  struct curl_hash_element *e = (struct curl_hash_element *) element;
+  struct Curl_hash *h = (struct Curl_hash *) user;
+  struct Curl_hash_element *e = (struct Curl_hash_element *) element;
 
   if(e->ptr) {
     h->dtor(e->ptr);
@@ -54,11 +54,11 @@ hash_element_dtor(void *user, void *element)
  * @unittest: 1603
  */
 int
-Curl_hash_init(struct curl_hash *h,
+Curl_hash_init(struct Curl_hash *h,
                int slots,
                hash_function hfunc,
                comp_function comparator,
-               curl_hash_dtor dtor)
+               Curl_hash_dtor dtor)
 {
   if(!slots || !hfunc || !comparator ||!dtor) {
     return 1; /* failure */
@@ -81,11 +81,11 @@ Curl_hash_init(struct curl_hash *h,
   return 1; /* failure */
 }
 
-static struct curl_hash_element *
+static struct Curl_hash_element *
 mk_hash_element(const void *key, size_t key_len, const void *p)
 {
   /* allocate the struct plus memory after it to store the key */
-  struct curl_hash_element *he = malloc(sizeof(struct curl_hash_element) +
+  struct Curl_hash_element *he = malloc(sizeof(struct Curl_hash_element) +
                                         key_len);
   if(he) {
     /* copy the key */
@@ -106,14 +106,14 @@ mk_hash_element(const void *key, size_t key_len, const void *p)
  * @unittest: 1603
  */
 void *
-Curl_hash_add(struct curl_hash *h, void *key, size_t key_len, void *p)
+Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p)
 {
-  struct curl_hash_element  *he;
+  struct Curl_hash_element  *he;
   struct Curl_llist_element *le;
   struct Curl_llist *l = FETCH_LIST(h, key, key_len);
 
   for(le = l->head; le; le = le->next) {
-    he = (struct curl_hash_element *) le->ptr;
+    he = (struct Curl_hash_element *) le->ptr;
     if(h->comp_func(he->key, he->key_len, key, key_len)) {
       Curl_llist_remove(l, le, (void *)h);
       --h->size;
@@ -136,13 +136,13 @@ Curl_hash_add(struct curl_hash *h, void *key, size_t key_len, void *p)
  *
  * @unittest: 1603
  */
-int Curl_hash_delete(struct curl_hash *h, void *key, size_t key_len)
+int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len)
 {
   struct Curl_llist_element *le;
   struct Curl_llist *l = FETCH_LIST(h, key, key_len);
 
   for(le = l->head; le; le = le->next) {
-    struct curl_hash_element *he = le->ptr;
+    struct Curl_hash_element *he = le->ptr;
     if(h->comp_func(he->key, he->key_len, key, key_len)) {
       Curl_llist_remove(l, le, (void *) h);
       --h->size;
@@ -157,7 +157,7 @@ int Curl_hash_delete(struct curl_hash *h, void *key, size_t key_len)
  * @unittest: 1603
  */
 void *
-Curl_hash_pick(struct curl_hash *h, void *key, size_t key_len)
+Curl_hash_pick(struct Curl_hash *h, void *key, size_t key_len)
 {
   struct Curl_llist_element *le;
   struct Curl_llist *l;
@@ -165,7 +165,7 @@ Curl_hash_pick(struct curl_hash *h, void *key, size_t key_len)
   if(h) {
     l = FETCH_LIST(h, key, key_len);
     for(le = l->head; le; le = le->next) {
-      struct curl_hash_element *he = le->ptr;
+      struct Curl_hash_element *he = le->ptr;
       if(h->comp_func(he->key, he->key_len, key, key_len)) {
         return he->ptr;
       }
@@ -177,7 +177,7 @@ Curl_hash_pick(struct curl_hash *h, void *key, size_t key_len)
 
 #if defined(DEBUGBUILD) && defined(AGGRESIVE_TEST)
 void
-Curl_hash_apply(curl_hash *h, void *user,
+Curl_hash_apply(Curl_hash *h, void *user,
                 void (*cb)(void *user, void *ptr))
 {
   struct Curl_llist_element  *le;
@@ -187,7 +187,7 @@ Curl_hash_apply(curl_hash *h, void *user,
     for(le = (h->table[i])->head;
         le;
         le = le->next) {
-      curl_hash_element *el = le->ptr;
+      Curl_hash_element *el = le->ptr;
       cb(user, el->ptr);
     }
   }
@@ -202,7 +202,7 @@ Curl_hash_apply(curl_hash *h, void *user,
  * @unittest: 1603
  */
 void
-Curl_hash_destroy(struct curl_hash *h)
+Curl_hash_destroy(struct Curl_hash *h)
 {
   int i;
 
@@ -220,14 +220,14 @@ Curl_hash_destroy(struct curl_hash *h)
  * @unittest: 1602
  */
 void
-Curl_hash_clean(struct curl_hash *h)
+Curl_hash_clean(struct Curl_hash *h)
 {
   Curl_hash_clean_with_criterium(h, NULL, NULL);
 }
 
 /* Cleans all entries that pass the comp function criteria. */
 void
-Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
+Curl_hash_clean_with_criterium(struct Curl_hash *h, void *user,
                                int (*comp)(void *, void *))
 {
   struct Curl_llist_element *le;
@@ -242,7 +242,7 @@ Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
     list = &h->table[i];
     le = list->head; /* get first list entry */
     while(le) {
-      struct curl_hash_element *he = le->ptr;
+      struct Curl_hash_element *he = le->ptr;
       lnext = le->next;
       /* ask the callback function if we shall remove this entry or not */
       if(comp == NULL || comp(user, he->ptr)) {
@@ -277,18 +277,18 @@ size_t Curl_str_key_compare(void *k1, size_t key1_len,
   return 0;
 }
 
-void Curl_hash_start_iterate(struct curl_hash *hash,
-                             struct curl_hash_iterator *iter)
+void Curl_hash_start_iterate(struct Curl_hash *hash,
+                             struct Curl_hash_iterator *iter)
 {
   iter->hash = hash;
   iter->slot_index = 0;
   iter->current_element = NULL;
 }
 
-struct curl_hash_element *
-Curl_hash_next_element(struct curl_hash_iterator *iter)
+struct Curl_hash_element *
+Curl_hash_next_element(struct Curl_hash_iterator *iter)
 {
-  struct curl_hash *h = iter->hash;
+  struct Curl_hash *h = iter->hash;
 
   /* Get the next element in the current list, if any */
   if(iter->current_element)
@@ -307,7 +307,7 @@ Curl_hash_next_element(struct curl_hash_iterator *iter)
   }
 
   if(iter->current_element) {
-    struct curl_hash_element *he = iter->current_element->ptr;
+    struct Curl_hash_element *he = iter->current_element->ptr;
     return he;
   }
   iter->current_element = NULL;
@@ -315,11 +315,11 @@ Curl_hash_next_element(struct curl_hash_iterator *iter)
 }
 
 #if 0 /* useful function for debugging hashes and their contents */
-void Curl_hash_print(struct curl_hash *h,
+void Curl_hash_print(struct Curl_hash *h,
                      void (*func)(void *))
 {
-  struct curl_hash_iterator iter;
-  struct curl_hash_element *he;
+  struct Curl_hash_iterator iter;
+  struct Curl_hash_element *he;
   int last_index = -1;
 
   if(!h)

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -70,11 +70,11 @@ Curl_hash_init(struct curl_hash *h,
   h->size = 0;
   h->slots = slots;
 
-  h->table = malloc(slots * sizeof(struct curl_llist));
+  h->table = malloc(slots * sizeof(struct Curl_llist));
   if(h->table) {
     int i;
     for(i = 0; i < slots; ++i)
-      Curl_llist_init(&h->table[i], (curl_llist_dtor) hash_element_dtor);
+      Curl_llist_init(&h->table[i], (Curl_llist_dtor) hash_element_dtor);
     return 0; /* fine */
   }
   h->slots = 0;
@@ -109,8 +109,8 @@ void *
 Curl_hash_add(struct curl_hash *h, void *key, size_t key_len, void *p)
 {
   struct curl_hash_element  *he;
-  struct curl_llist_element *le;
-  struct curl_llist *l = FETCH_LIST(h, key, key_len);
+  struct Curl_llist_element *le;
+  struct Curl_llist *l = FETCH_LIST(h, key, key_len);
 
   for(le = l->head; le; le = le->next) {
     he = (struct curl_hash_element *) le->ptr;
@@ -138,8 +138,8 @@ Curl_hash_add(struct curl_hash *h, void *key, size_t key_len, void *p)
  */
 int Curl_hash_delete(struct curl_hash *h, void *key, size_t key_len)
 {
-  struct curl_llist_element *le;
-  struct curl_llist *l = FETCH_LIST(h, key, key_len);
+  struct Curl_llist_element *le;
+  struct Curl_llist *l = FETCH_LIST(h, key, key_len);
 
   for(le = l->head; le; le = le->next) {
     struct curl_hash_element *he = le->ptr;
@@ -159,8 +159,8 @@ int Curl_hash_delete(struct curl_hash *h, void *key, size_t key_len)
 void *
 Curl_hash_pick(struct curl_hash *h, void *key, size_t key_len)
 {
-  struct curl_llist_element *le;
-  struct curl_llist *l;
+  struct Curl_llist_element *le;
+  struct Curl_llist *l;
 
   if(h) {
     l = FETCH_LIST(h, key, key_len);
@@ -180,7 +180,7 @@ void
 Curl_hash_apply(curl_hash *h, void *user,
                 void (*cb)(void *user, void *ptr))
 {
-  struct curl_llist_element  *le;
+  struct Curl_llist_element  *le;
   int                  i;
 
   for(i = 0; i < h->slots; ++i) {
@@ -230,9 +230,9 @@ void
 Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
                                int (*comp)(void *, void *))
 {
-  struct curl_llist_element *le;
-  struct curl_llist_element *lnext;
-  struct curl_llist *list;
+  struct Curl_llist_element *le;
+  struct Curl_llist_element *lnext;
+  struct Curl_llist *list;
   int i;
 
   if(!h)

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -41,9 +41,9 @@ typedef size_t (*comp_function) (void *key1,
                                  void *key2,
                                  size_t key2_len);
 
-typedef void (*curl_hash_dtor)(void *);
+typedef void (*Curl_hash_dtor)(void *);
 
-struct curl_hash {
+struct Curl_hash {
   struct Curl_llist *table;
 
   /* Hash function to be used for this hash table */
@@ -51,49 +51,49 @@ struct curl_hash {
 
   /* Comparator function to compare keys */
   comp_function comp_func;
-  curl_hash_dtor   dtor;
+  Curl_hash_dtor   dtor;
   int slots;
   size_t size;
 };
 
-struct curl_hash_element {
+struct Curl_hash_element {
   struct Curl_llist_element list;
   void   *ptr;
   size_t key_len;
   char   key[1]; /* allocated memory following the struct */
 };
 
-struct curl_hash_iterator {
-  struct curl_hash *hash;
+struct Curl_hash_iterator {
+  struct Curl_hash *hash;
   int slot_index;
   struct Curl_llist_element *current_element;
 };
 
-int Curl_hash_init(struct curl_hash *h,
+int Curl_hash_init(struct Curl_hash *h,
                    int slots,
                    hash_function hfunc,
                    comp_function comparator,
-                   curl_hash_dtor dtor);
+                   Curl_hash_dtor dtor);
 
-void *Curl_hash_add(struct curl_hash *h, void *key, size_t key_len, void *p);
-int Curl_hash_delete(struct curl_hash *h, void *key, size_t key_len);
-void *Curl_hash_pick(struct curl_hash *, void *key, size_t key_len);
-void Curl_hash_apply(struct curl_hash *h, void *user,
+void *Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p);
+int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len);
+void *Curl_hash_pick(struct Curl_hash *, void *key, size_t key_len);
+void Curl_hash_apply(struct Curl_hash *h, void *user,
                      void (*cb)(void *user, void *ptr));
 #define Curl_hash_count(h) ((h)->size)
-void Curl_hash_destroy(struct curl_hash *h);
-void Curl_hash_clean(struct curl_hash *h);
-void Curl_hash_clean_with_criterium(struct curl_hash *h, void *user,
+void Curl_hash_destroy(struct Curl_hash *h);
+void Curl_hash_clean(struct Curl_hash *h);
+void Curl_hash_clean_with_criterium(struct Curl_hash *h, void *user,
                                     int (*comp)(void *, void *));
 size_t Curl_hash_str(void *key, size_t key_length, size_t slots_num);
 size_t Curl_str_key_compare(void *k1, size_t key1_len, void *k2,
                             size_t key2_len);
-void Curl_hash_start_iterate(struct curl_hash *hash,
-                             struct curl_hash_iterator *iter);
-struct curl_hash_element *
-Curl_hash_next_element(struct curl_hash_iterator *iter);
+void Curl_hash_start_iterate(struct Curl_hash *hash,
+                             struct Curl_hash_iterator *iter);
+struct Curl_hash_element *
+Curl_hash_next_element(struct Curl_hash_iterator *iter);
 
-void Curl_hash_print(struct curl_hash *h,
+void Curl_hash_print(struct Curl_hash *h,
                      void (*func)(void *));
 
 

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -44,7 +44,7 @@ typedef size_t (*comp_function) (void *key1,
 typedef void (*curl_hash_dtor)(void *);
 
 struct curl_hash {
-  struct curl_llist *table;
+  struct Curl_llist *table;
 
   /* Hash function to be used for this hash table */
   hash_function hash_func;
@@ -57,7 +57,7 @@ struct curl_hash {
 };
 
 struct curl_hash_element {
-  struct curl_llist_element list;
+  struct Curl_llist_element list;
   void   *ptr;
   size_t key_len;
   char   key[1]; /* allocated memory following the struct */
@@ -66,7 +66,7 @@ struct curl_hash_element {
 struct curl_hash_iterator {
   struct curl_hash *hash;
   int slot_index;
-  struct curl_llist_element *current_element;
+  struct Curl_llist_element *current_element;
 };
 
 int Curl_hash_init(struct curl_hash *h,

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -206,7 +206,7 @@ hostcache_timestamp_remove(void *datap, void *hc)
  * Prune the DNS cache. This assumes that a lock has already been taken.
  */
 static void
-hostcache_prune(struct curl_hash *hostcache, long cache_timeout, time_t now)
+hostcache_prune(struct Curl_hash *hostcache, long cache_timeout, time_t now)
 {
   struct hostcache_prune_data user;
 
@@ -843,7 +843,7 @@ static void freednsentry(void *freethis)
 /*
  * Curl_mk_dnscache() inits a new DNS cache and returns success/failure.
  */
-int Curl_mk_dnscache(struct curl_hash *hash)
+int Curl_mk_dnscache(struct Curl_hash *hash)
 {
   return Curl_hash_init(hash, 7, Curl_hash_str, Curl_str_key_compare,
                         freednsentry);
@@ -857,7 +857,7 @@ int Curl_mk_dnscache(struct curl_hash *hash)
  */
 
 void Curl_hostcache_clean(struct Curl_easy *data,
-                          struct curl_hash *hash)
+                          struct Curl_hash *hash)
 {
   if(data && data->share)
     Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -59,9 +59,9 @@ struct connectdata;
  * Global DNS cache is general badness. Do not use. This will be removed in
  * a future version. Use the share interface instead!
  *
- * Returns a struct curl_hash pointer on success, NULL on failure.
+ * Returns a struct Curl_hash pointer on success, NULL on failure.
  */
-struct curl_hash *Curl_global_host_cache_init(void);
+struct Curl_hash *Curl_global_host_cache_init(void);
 
 struct Curl_dns_entry {
   struct Curl_addrinfo *addr;
@@ -128,7 +128,7 @@ void Curl_resolv_unlock(struct Curl_easy *data,
                         struct Curl_dns_entry *dns);
 
 /* init a new dns cache and return success */
-int Curl_mk_dnscache(struct curl_hash *hash);
+int Curl_mk_dnscache(struct Curl_hash *hash);
 
 /* prune old entries from the DNS cache */
 void Curl_hostcache_prune(struct Curl_easy *data);
@@ -234,7 +234,7 @@ CURLcode Curl_set_dns_local_ip6(struct Curl_easy *data,
 /*
  * Clean off entries from the cache
  */
-void Curl_hostcache_clean(struct Curl_easy *data, struct curl_hash *hash);
+void Curl_hostcache_clean(struct Curl_easy *data, struct Curl_hash *hash);
 
 /*
  * Populate the cache with specified entries from CURLOPT_RESOLVE.

--- a/lib/llist.c
+++ b/lib/llist.c
@@ -34,7 +34,7 @@
  * @unittest: 1300
  */
 void
-Curl_llist_init(struct curl_llist *l, curl_llist_dtor dtor)
+Curl_llist_init(struct Curl_llist *l, Curl_llist_dtor dtor)
 {
   l->size = 0;
   l->dtor = dtor;
@@ -54,9 +54,9 @@ Curl_llist_init(struct curl_llist *l, curl_llist_dtor dtor)
  * @unittest: 1300
  */
 void
-Curl_llist_insert_next(struct curl_llist *list, struct curl_llist_element *e,
+Curl_llist_insert_next(struct Curl_llist *list, struct Curl_llist_element *e,
                        const void *p,
-                       struct curl_llist_element *ne)
+                       struct Curl_llist_element *ne)
 {
   ne->ptr = (void *) p;
   if(list->size == 0) {
@@ -90,7 +90,7 @@ Curl_llist_insert_next(struct curl_llist *list, struct curl_llist_element *e,
  * @unittest: 1300
  */
 void
-Curl_llist_remove(struct curl_llist *list, struct curl_llist_element *e,
+Curl_llist_remove(struct Curl_llist *list, struct Curl_llist_element *e,
                   void *user)
 {
   void *ptr;
@@ -131,7 +131,7 @@ Curl_llist_remove(struct curl_llist *list, struct curl_llist_element *e,
 }
 
 void
-Curl_llist_destroy(struct curl_llist *list, void *user)
+Curl_llist_destroy(struct Curl_llist *list, void *user)
 {
   if(list) {
     while(list->size > 0)
@@ -140,7 +140,7 @@ Curl_llist_destroy(struct curl_llist *list, void *user)
 }
 
 size_t
-Curl_llist_count(struct curl_llist *list)
+Curl_llist_count(struct Curl_llist *list)
 {
   return list->size;
 }

--- a/lib/llist.h
+++ b/lib/llist.h
@@ -25,26 +25,26 @@
 #include "curl_setup.h"
 #include <stddef.h>
 
-typedef void (*curl_llist_dtor)(void *, void *);
+typedef void (*Curl_llist_dtor)(void *, void *);
 
-struct curl_llist_element {
+struct Curl_llist_element {
   void *ptr;
-  struct curl_llist_element *prev;
-  struct curl_llist_element *next;
+  struct Curl_llist_element *prev;
+  struct Curl_llist_element *next;
 };
 
-struct curl_llist {
-  struct curl_llist_element *head;
-  struct curl_llist_element *tail;
-  curl_llist_dtor dtor;
+struct Curl_llist {
+  struct Curl_llist_element *head;
+  struct Curl_llist_element *tail;
+  Curl_llist_dtor dtor;
   size_t size;
 };
 
-void Curl_llist_init(struct curl_llist *, curl_llist_dtor);
-void Curl_llist_insert_next(struct curl_llist *, struct curl_llist_element *,
-                            const void *, struct curl_llist_element *node);
-void Curl_llist_remove(struct curl_llist *, struct curl_llist_element *,
+void Curl_llist_init(struct Curl_llist *, Curl_llist_dtor);
+void Curl_llist_insert_next(struct Curl_llist *, struct Curl_llist_element *,
+                            const void *, struct Curl_llist_element *node);
+void Curl_llist_remove(struct Curl_llist *, struct Curl_llist_element *,
                        void *);
-size_t Curl_llist_count(struct curl_llist *);
-void Curl_llist_destroy(struct curl_llist *, void *);
+size_t Curl_llist_count(struct Curl_llist *);
+void Curl_llist_destroy(struct Curl_llist *, void *);
 #endif /* HEADER_CURL_LLIST_H */

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -142,7 +142,7 @@ static CURLcode mqtt_connect(struct connectdata *conn)
   const size_t client_id_offset = 14;
   const size_t packetlen = client_id_offset + MQTT_CLIENTID_LEN;
   char client_id[MQTT_CLIENTID_LEN + 1] = "curl";
-  const size_t curl_len = strlen("curl");
+  const size_t clen = strlen("curl");
   char packet[32] = {
     MQTT_MSG_CONNECT,  /* packet type */
     0x00,              /* remaining length */
@@ -156,8 +156,8 @@ static CURLcode mqtt_connect(struct connectdata *conn)
   packet[1] = (packetlen - 2) & 0x7f;
   packet[client_id_offset - 1] = MQTT_CLIENTID_LEN;
 
-  result = Curl_rand_hex(conn->data, (unsigned char *)&client_id[curl_len],
-                         MQTT_CLIENTID_LEN - curl_len + 1);
+  result = Curl_rand_hex(conn->data, (unsigned char *)&client_id[clen],
+                         MQTT_CLIENTID_LEN - clen + 1);
   memcpy(&packet[client_id_offset], client_id, MQTT_CLIENTID_LEN);
   infof(conn->data, "Using client id '%s'\n", client_id);
   if(!result)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -722,7 +722,7 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   struct Curl_easy *easy = data;
   bool premature;
   bool easy_owns_conn;
-  struct curl_llist_element *e;
+  struct Curl_llist_element *e;
 
   /* First, make some basic checks that the CURLM handle is a good handle */
   if(!GOOD_MULTI_HANDLE(multi))
@@ -2675,7 +2675,7 @@ CURLMsg *curl_multi_info_read(struct Curl_multi *multi, int *msgs_in_queue)
      !multi->in_callback &&
      Curl_llist_count(&multi->msglist)) {
     /* there is one or more messages in the list */
-    struct curl_llist_element *e;
+    struct Curl_llist_element *e;
 
     /* extract the head of the list to return */
     e = multi->msglist.head;
@@ -2905,15 +2905,15 @@ static CURLMcode add_next_timeout(struct curltime now,
                                   struct Curl_easy *d)
 {
   struct curltime *tv = &d->state.expiretime;
-  struct curl_llist *list = &d->state.timeoutlist;
-  struct curl_llist_element *e;
+  struct Curl_llist *list = &d->state.timeoutlist;
+  struct Curl_llist_element *e;
   struct time_node *node = NULL;
 
   /* move over the timeout list for this specific handle and remove all
      timeouts that are now passed tense and store the next pending
      timeout in *tv */
   for(e = list->head; e;) {
-    struct curl_llist_element *n = e->next;
+    struct Curl_llist_element *n = e->next;
     timediff_t diff;
     node = (struct time_node *)e->ptr;
     diff = Curl_timediff(node->time, now);
@@ -3267,8 +3267,8 @@ void Curl_update_timer(struct Curl_multi *multi)
 static void
 multi_deltimeout(struct Curl_easy *data, expire_id eid)
 {
-  struct curl_llist_element *e;
-  struct curl_llist *timeoutlist = &data->state.timeoutlist;
+  struct Curl_llist_element *e;
+  struct Curl_llist *timeoutlist = &data->state.timeoutlist;
   /* find and remove the specific node from the list */
   for(e = timeoutlist->head; e; e = e->next) {
     struct time_node *n = (struct time_node *)e->ptr;
@@ -3291,11 +3291,11 @@ multi_addtimeout(struct Curl_easy *data,
                  struct curltime *stamp,
                  expire_id eid)
 {
-  struct curl_llist_element *e;
+  struct Curl_llist_element *e;
   struct time_node *node;
-  struct curl_llist_element *prev = NULL;
+  struct Curl_llist_element *prev = NULL;
   size_t n;
-  struct curl_llist *timeoutlist = &data->state.timeoutlist;
+  struct Curl_llist *timeoutlist = &data->state.timeoutlist;
 
   node = &data->state.expires[eid];
 
@@ -3422,7 +3422,7 @@ void Curl_expire_clear(struct Curl_easy *data)
   if(nowp->tv_sec || nowp->tv_usec) {
     /* Since this is an cleared time, we must remove the previous entry from
        the splay tree */
-    struct curl_llist *list = &data->state.timeoutlist;
+    struct Curl_llist *list = &data->state.timeoutlist;
     int rc;
 
     rc = Curl_splayremovebyaddr(multi->timetree,
@@ -3493,7 +3493,7 @@ void Curl_multiuse_state(struct connectdata *conn,
 
 static void process_pending_handles(struct Curl_multi *multi)
 {
-  struct curl_llist_element *e = multi->pending.head;
+  struct Curl_llist_element *e = multi->pending.head;
   if(e) {
     struct Curl_easy *data = e->ptr;
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -190,7 +190,7 @@ static void mstate(struct Curl_easy *data, CURLMstate state
  */
 
 struct Curl_sh_entry {
-  struct curl_hash transfers; /* hash of transfers using this socket */
+  struct Curl_hash transfers; /* hash of transfers using this socket */
   unsigned int action;  /* what combined action READ/WRITE this socket waits
                            for */
   void *socketp; /* settable by users with curl_multi_assign() */
@@ -204,7 +204,7 @@ struct Curl_sh_entry {
 #define SH_WRITE 2
 
 /* look up a given socket in the socket hash, skip invalid sockets */
-static struct Curl_sh_entry *sh_getentry(struct curl_hash *sh,
+static struct Curl_sh_entry *sh_getentry(struct Curl_hash *sh,
                                          curl_socket_t s)
 {
   if(s != CURL_SOCKET_BAD) {
@@ -238,7 +238,7 @@ static void trhash_dtor(void *nada)
 
 
 /* make sure this socket is present in the hash for this handle */
-static struct Curl_sh_entry *sh_addentry(struct curl_hash *sh,
+static struct Curl_sh_entry *sh_addentry(struct Curl_hash *sh,
                                          curl_socket_t s)
 {
   struct Curl_sh_entry *there = sh_getentry(sh, s);
@@ -273,7 +273,7 @@ static struct Curl_sh_entry *sh_addentry(struct curl_hash *sh,
 
 /* delete the given socket + handle from the hash */
 static void sh_delentry(struct Curl_sh_entry *entry,
-                        struct curl_hash *sh, curl_socket_t s)
+                        struct Curl_hash *sh, curl_socket_t s)
 {
   Curl_hash_destroy(&entry->transfers);
 
@@ -325,7 +325,7 @@ static size_t hash_fd(void *key, size_t key_length, size_t slots_num)
  * per call."
  *
  */
-static int sh_init(struct curl_hash *hash, int hashsize)
+static int sh_init(struct Curl_hash *hash, int hashsize)
 {
   return Curl_hash_init(hash, hashsize, hash_fd, fd_key_compare,
                         sh_freeentry);
@@ -2983,8 +2983,8 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
          and just move on. */
       ;
     else {
-      struct curl_hash_iterator iter;
-      struct curl_hash_element *he;
+      struct Curl_hash_iterator iter;
+      struct Curl_hash_element *he;
 
       /* the socket can be shared by many transfers, iterate */
       Curl_hash_start_iterate(&entry->transfers, &iter);

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -27,7 +27,7 @@
 #include "socketpair.h"
 
 struct Curl_message {
-  struct curl_llist_element list;
+  struct Curl_llist_element list;
   /* the 'CURLMsg' is the part that is visible to the external user */
   struct CURLMsg extmsg;
 };
@@ -89,9 +89,9 @@ struct Curl_multi {
   int num_alive; /* amount of easy handles that are added but have not yet
                     reached COMPLETE state */
 
-  struct curl_llist msglist; /* a list of messages from completed transfers */
+  struct Curl_llist msglist; /* a list of messages from completed transfers */
 
-  struct curl_llist pending; /* Curl_easys that are in the
+  struct Curl_llist pending; /* Curl_easys that are in the
                                 CURLM_STATE_CONNECT_PEND state */
 
   /* callback function and user data pointer for the *socket() API */

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -103,7 +103,7 @@ struct Curl_multi {
   void *push_userp;
 
   /* Hostname cache */
-  struct curl_hash hostcache;
+  struct Curl_hash hostcache;
 
 #ifdef USE_LIBPSL
   /* PSL cache. */
@@ -117,7 +117,7 @@ struct Curl_multi {
   /* 'sockhash' is the lookup hash for socket descriptor => easy handles (note
      the pluralis form, there can be more than one easy handle waiting on the
      same actual socket) */
-  struct curl_hash sockhash;
+  struct Curl_hash sockhash;
 
   /* Shared connection cache (bundles)*/
   struct conncache conn_cache;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2521,9 +2521,9 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * Set the RTSP request method (OPTIONS, SETUP, PLAY, etc...)
      * Would this be better if the RTSPREQ_* were just moved into here?
      */
-    long curl_rtspreq = va_arg(param, long);
+    long in_rtspreq = va_arg(param, long);
     Curl_RtspReq rtspreq = RTSPREQ_NONE;
-    switch(curl_rtspreq) {
+    switch(in_rtspreq) {
     case CURL_RTSPREQ_OPTIONS:
       rtspreq = RTSPREQ_OPTIONS;
       break;

--- a/lib/share.c
+++ b/lib/share.c
@@ -92,7 +92,7 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       if(!share->sslsession) {
         share->max_ssl_sessions = 8;
         share->sslsession = calloc(share->max_ssl_sessions,
-                                   sizeof(struct curl_ssl_session));
+                                   sizeof(struct Curl_ssl_session));
         share->sessionage = 0;
         if(!share->sslsession)
           res = CURLSHE_NOMEM;

--- a/lib/share.h
+++ b/lib/share.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -46,7 +46,7 @@ struct Curl_share {
   curl_unlock_function unlockfunc;
   void *clientdata;
   struct conncache conn_cache;
-  struct curl_hash hostcache;
+  struct Curl_hash hostcache;
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
   struct CookieInfo *cookies;
 #endif

--- a/lib/share.h
+++ b/lib/share.h
@@ -54,7 +54,7 @@ struct Curl_share {
   struct PslCache psl;
 #endif
 
-  struct curl_ssl_session *sslsession;
+  struct Curl_ssl_session *sslsession;
   size_t max_ssl_sessions;
   long sessionage;
 };

--- a/lib/url.c
+++ b/lib/url.c
@@ -1074,7 +1074,7 @@ ConnectionExists(struct Curl_easy *data,
                                       &hostbundle);
   if(bundle) {
     /* Max pipe length is zero (unlimited) for multiplexed connections */
-    struct curl_llist_element *curr;
+    struct Curl_llist_element *curr;
 
     infof(data, "Found bundle for host %s: %p [%s]\n",
           hostbundle, (void *)bundle, (bundle->multiuse == BUNDLE_MULTIPLEX ?

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -861,7 +861,7 @@ struct connectdata {
      connection is used! */
   struct Curl_easy *data;
   struct connstate cnnct;
-  struct curl_llist_element bundle_node; /* conncache */
+  struct Curl_llist_element bundle_node; /* conncache */
 
   /* chunk is for HTTP chunked encoding, but is in the general connectdata
      struct only because we can do just about any protocol through a HTTP proxy
@@ -1025,7 +1025,7 @@ struct connectdata {
   struct kerberos5data krb5;  /* variables into the structure definition, */
 #endif                        /* however, some of them are ftp specific. */
 
-  struct curl_llist easyq;    /* List of easy handles using this connection */
+  struct Curl_llist easyq;    /* List of easy handles using this connection */
   curl_seek_callback seek_func; /* function that seeks the input */
   void *seek_client;            /* pointer to pass to the seek() above */
 
@@ -1276,7 +1276,7 @@ typedef enum {
  * One instance for each timeout an easy handle can set.
  */
 struct time_node {
-  struct curl_llist_element list;
+  struct Curl_llist_element list;
   struct curltime time;
   expire_id eid;
 };
@@ -1340,7 +1340,7 @@ struct UrlState {
 #endif /* USE_OPENSSL */
   struct curltime expiretime; /* set this with Curl_expire() only */
   struct Curl_tree timenode; /* for the splay stuff */
-  struct curl_llist timeoutlist; /* list of pending timeouts */
+  struct Curl_llist timeoutlist; /* list of pending timeouts */
   struct time_node expires[EXPIRE_LAST]; /* nodes for each expire type */
 
   /* a place to store the most recently set FTP entrypath */
@@ -1866,8 +1866,8 @@ struct Curl_easy {
   struct Curl_easy *prev;
 
   struct connectdata *conn;
-  struct curl_llist_element connect_queue;
-  struct curl_llist_element conn_queue; /* list per connectdata */
+  struct Curl_llist_element connect_queue;
+  struct Curl_llist_element conn_queue; /* list per connectdata */
 
   CURLMstate mstate;  /* the handle's state */
   CURLcode result;   /* previous result */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -272,7 +272,7 @@ struct ssl_general_config {
 };
 
 /* information stored about one single SSL session */
-struct curl_ssl_session {
+struct Curl_ssl_session {
   char *name;       /* host name for which this ID was used */
   char *conn_to_host; /* host name for the connection (may be NULL) */
   const char *scheme; /* protocol scheme used */
@@ -1316,7 +1316,7 @@ struct UrlState {
                        strdup() data.
                     */
   int first_remote_port; /* remote port of the first (not followed) request */
-  struct curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
+  struct Curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
   long sessionage;                  /* number of the most recent session */
   unsigned int tempcount; /* number of entries in use in tempwrite, 0 - 3 */
   struct tempbuf tempwrite[3]; /* BOTH, HEADER, BODY */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1842,7 +1842,7 @@ struct UserDefined {
 };
 
 struct Names {
-  struct curl_hash *hostcache;
+  struct Curl_hash *hostcache;
   enum {
     HCACHE_NONE,    /* not pointing to anything */
     HCACHE_MULTI,   /* points to a shared one in the multi handle */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -83,7 +83,7 @@ struct ssl_backend_data {
   PRFileDesc *handle;
   char *client_nickname;
   struct Curl_easy *data;
-  struct curl_llist obj_list;
+  struct Curl_llist obj_list;
   PK11GenericObject *obj_clicert;
 };
 
@@ -91,14 +91,14 @@ static PRLock *nss_initlock = NULL;
 static PRLock *nss_crllock = NULL;
 static PRLock *nss_findslot_lock = NULL;
 static PRLock *nss_trustload_lock = NULL;
-static struct curl_llist nss_crl_list;
+static struct Curl_llist nss_crl_list;
 static NSSInitContext *nss_context = NULL;
 static volatile int initialized = 0;
 
 /* type used to wrap pointers as list nodes */
 struct ptr_list_wrap {
   void *ptr;
-  struct curl_llist_element node;
+  struct Curl_llist_element node;
 };
 
 struct cipher_s {
@@ -430,7 +430,7 @@ static PK11SlotInfo* nss_find_slot_by_name(const char *slot_name)
 }
 
 /* wrap 'ptr' as list node and tail-insert into 'list' */
-static CURLcode insert_wrapped_ptr(struct curl_llist *list, void *ptr)
+static CURLcode insert_wrapped_ptr(struct Curl_llist *list, void *ptr)
 {
   struct ptr_list_wrap *wrap = malloc(sizeof(*wrap));
   if(!wrap)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -420,7 +420,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
   SCHANNEL_CRED schannel_cred;
   PCCERT_CONTEXT client_certs[1] = { NULL };
   SECURITY_STATUS sspi_status = SEC_E_OK;
-  struct curl_schannel_cred *old_cred = NULL;
+  struct Curl_schannel_cred *old_cred = NULL;
   struct in_addr addr;
 #ifdef ENABLE_IPV6
   struct in6_addr addr6;
@@ -780,8 +780,8 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
 #endif
 
     /* allocate memory for the re-usable credential handle */
-    BACKEND->cred = (struct curl_schannel_cred *)
-      calloc(1, sizeof(struct curl_schannel_cred));
+    BACKEND->cred = (struct Curl_schannel_cred *)
+      calloc(1, sizeof(struct Curl_schannel_cred));
     if(!BACKEND->cred) {
       failf(data, "schannel: unable to allocate memory");
 
@@ -895,8 +895,8 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     ISC_REQ_STREAM;
 
   /* allocate memory for the security context handle */
-  BACKEND->ctxt = (struct curl_schannel_ctxt *)
-    calloc(1, sizeof(struct curl_schannel_ctxt));
+  BACKEND->ctxt = (struct Curl_schannel_ctxt *)
+    calloc(1, sizeof(struct Curl_schannel_ctxt));
   if(!BACKEND->ctxt) {
     failf(data, "schannel: unable to allocate memory");
     return CURLE_OUT_OF_MEMORY;
@@ -1403,7 +1403,7 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
   /* save the current session data for possible re-use */
   if(SSL_SET_OPTION(primary.sessionid)) {
     bool incache;
-    struct curl_schannel_cred *old_cred = NULL;
+    struct Curl_schannel_cred *old_cred = NULL;
 
     Curl_ssl_sessionid_lock(conn);
     incache = !(Curl_ssl_getsessionid(conn, (void **)&old_cred, NULL,
@@ -1419,7 +1419,7 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
     }
     if(!incache) {
       result = Curl_ssl_addsessionid(conn, (void *)BACKEND->cred,
-                                     sizeof(struct curl_schannel_cred),
+                                     sizeof(struct Curl_schannel_cred),
                                      sockindex);
       if(result) {
         Curl_ssl_sessionid_unlock(conn);
@@ -2101,7 +2101,7 @@ static void Curl_schannel_close(struct connectdata *conn, int sockindex)
 static void Curl_schannel_session_free(void *ptr)
 {
   /* this is expected to be called under sessionid lock */
-  struct curl_schannel_cred *cred = ptr;
+  struct Curl_schannel_cred *cred = ptr;
 
   cred->refcount--;
   if(cred->refcount == 0) {

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -8,7 +8,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2012, Marc Hoersken, <info@marc-hoersken.de>, et al.
- * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -70,20 +70,20 @@ CURLcode Curl_verify_certificate(struct connectdata *conn, int sockindex);
 #endif
 #endif
 
-struct curl_schannel_cred {
+struct Curl_schannel_cred {
   CredHandle cred_handle;
   TimeStamp time_stamp;
   int refcount;
 };
 
-struct curl_schannel_ctxt {
+struct Curl_schannel_ctxt {
   CtxtHandle ctxt_handle;
   TimeStamp time_stamp;
 };
 
 struct ssl_backend_data {
-  struct curl_schannel_cred *cred;
-  struct curl_schannel_ctxt *ctxt;
+  struct Curl_schannel_cred *cred;
+  struct Curl_schannel_ctxt *ctxt;
   SecPkgContext_StreamSizes stream_sizes;
   size_t encdata_length, decdata_length;
   size_t encdata_offset, decdata_offset;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -365,7 +365,7 @@ bool Curl_ssl_getsessionid(struct connectdata *conn,
                            size_t *idsize, /* set 0 if unknown */
                            int sockindex)
 {
-  struct curl_ssl_session *check;
+  struct Curl_ssl_session *check;
   struct Curl_easy *data = conn->data;
   size_t i;
   long *general_age;
@@ -432,7 +432,7 @@ bool Curl_ssl_getsessionid(struct connectdata *conn,
 /*
  * Kill a single session ID entry in the cache.
  */
-void Curl_ssl_kill_session(struct curl_ssl_session *session)
+void Curl_ssl_kill_session(struct Curl_ssl_session *session)
 {
   if(session->sessionid) {
     /* defensive check */
@@ -459,7 +459,7 @@ void Curl_ssl_delsessionid(struct connectdata *conn, void *ssl_sessionid)
   struct Curl_easy *data = conn->data;
 
   for(i = 0; i < data->set.general_ssl.max_ssl_sessions; i++) {
-    struct curl_ssl_session *check = &data->state.session[i];
+    struct Curl_ssl_session *check = &data->state.session[i];
 
     if(check->sessionid == ssl_sessionid) {
       Curl_ssl_kill_session(check);
@@ -481,7 +481,7 @@ CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
 {
   size_t i;
   struct Curl_easy *data = conn->data; /* the mother of all structs */
-  struct curl_ssl_session *store = &data->state.session[0];
+  struct Curl_ssl_session *store = &data->state.session[0];
   long oldest_age = data->state.session[0].age; /* zero if unused */
   char *clone_host;
   char *clone_conn_to_host;
@@ -667,13 +667,13 @@ struct curl_slist *Curl_ssl_engines_list(struct Curl_easy *data)
  */
 CURLcode Curl_ssl_initsessions(struct Curl_easy *data, size_t amount)
 {
-  struct curl_ssl_session *session;
+  struct Curl_ssl_session *session;
 
   if(data->state.session)
     /* this is just a precaution to prevent multiple inits */
     return CURLE_OK;
 
-  session = calloc(amount, sizeof(struct curl_ssl_session));
+  session = calloc(amount, sizeof(struct Curl_ssl_session));
   if(!session)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -221,7 +221,7 @@ CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
  * take sessionid object ownership from sessionid cache
  * (e.g. decrement refcount).
  */
-void Curl_ssl_kill_session(struct curl_ssl_session *session);
+void Curl_ssl_kill_session(struct Curl_ssl_session *session);
 /* delete a session from the cache
  * Sessionid mutex must be locked (see Curl_ssl_sessionid_lock).
  * This will call engine-specific curlssl_session_free function, which must

--- a/lib/wildcard.h
+++ b/lib/wildcard.h
@@ -39,18 +39,18 @@ typedef enum {
   CURLWC_ERROR, /* error cases */
   CURLWC_DONE   /* if is wildcard->state == CURLWC_DONE wildcard loop
                    will end */
-} curl_wildcard_states;
+} wildcard_states;
 
-typedef void (*curl_wildcard_dtor)(void *ptr);
+typedef void (*wildcard_dtor)(void *ptr);
 
 /* struct keeping information about wildcard download process */
 struct WildcardData {
-  curl_wildcard_states state;
+  wildcard_states state;
   char *path; /* path to the directory, where we trying wildcard-match */
   char *pattern; /* wildcard pattern */
   struct Curl_llist filelist; /* llist with struct Curl_fileinfo */
   void *protdata; /* pointer to protocol specific temporary data */
-  curl_wildcard_dtor dtor;
+  wildcard_dtor dtor;
   void *customptr;  /* for CURLOPT_CHUNK_DATA pointer */
 };
 

--- a/lib/wildcard.h
+++ b/lib/wildcard.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2010 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2010 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -48,7 +48,7 @@ struct WildcardData {
   curl_wildcard_states state;
   char *path; /* path to the directory, where we trying wildcard-match */
   char *pattern; /* wildcard pattern */
-  struct curl_llist filelist; /* llist with struct Curl_fileinfo */
+  struct Curl_llist filelist; /* llist with struct Curl_fileinfo */
   void *protdata; /* pointer to protocol specific temporary data */
   curl_wildcard_dtor dtor;
   void *customptr;  /* for CURLOPT_CHUNK_DATA pointer */

--- a/tests/unit/unit1300.c
+++ b/tests/unit/unit1300.c
@@ -23,11 +23,11 @@
 
 #include "llist.h"
 
-static struct curl_llist llist;
+static struct Curl_llist llist;
 
-static struct curl_llist llist_destination;
+static struct Curl_llist llist_destination;
 
-static void test_curl_llist_dtor(void *key, void *value)
+static void test_Curl_llist_dtor(void *key, void *value)
 {
   /* used by the llist API, does nothing here */
   (void)key;
@@ -36,8 +36,8 @@ static void test_curl_llist_dtor(void *key, void *value)
 
 static CURLcode unit_setup(void)
 {
-  Curl_llist_init(&llist, test_curl_llist_dtor);
-  Curl_llist_init(&llist_destination, test_curl_llist_dtor);
+  Curl_llist_init(&llist, test_Curl_llist_dtor);
+  Curl_llist_init(&llist_destination, test_Curl_llist_dtor);
   return CURLE_OK;
 }
 
@@ -50,14 +50,14 @@ UNITTEST_START
   int unusedData_case1 = 1;
   int unusedData_case2 = 2;
   int unusedData_case3 = 3;
-  struct curl_llist_element case1_list;
-  struct curl_llist_element case2_list;
-  struct curl_llist_element case3_list;
-  struct curl_llist_element case4_list;
-  struct curl_llist_element *head;
-  struct curl_llist_element *element_next;
-  struct curl_llist_element *element_prev;
-  struct curl_llist_element *to_remove;
+  struct Curl_llist_element case1_list;
+  struct Curl_llist_element case2_list;
+  struct Curl_llist_element case3_list;
+  struct Curl_llist_element case4_list;
+  struct Curl_llist_element *head;
+  struct Curl_llist_element *element_next;
+  struct Curl_llist_element *element_prev;
+  struct Curl_llist_element *to_remove;
   size_t llist_size = Curl_llist_count(&llist);
 
   /**
@@ -74,8 +74,8 @@ UNITTEST_START
   fail_unless(llist.size == 0, "list initial size should be zero");
   fail_unless(llist.head == NULL, "list head should initiate to NULL");
   fail_unless(llist.tail == NULL, "list tail should intiate to NULL");
-  fail_unless(llist.dtor == test_curl_llist_dtor,
-               "list dtor should initiate to test_curl_llist_dtor");
+  fail_unless(llist.dtor == test_Curl_llist_dtor,
+               "list dtor should initiate to test_Curl_llist_dtor");
 
   /**
    * testing Curl_llist_insert_next

--- a/tests/unit/unit1305.c
+++ b/tests/unit/unit1305.c
@@ -40,7 +40,7 @@
 #include "memdebug.h" /* LAST include file */
 
 static struct Curl_easy *data;
-static struct curl_hash hp;
+static struct Curl_hash hp;
 static char *data_key;
 static struct Curl_dns_entry *data_node;
 

--- a/tests/unit/unit1602.c
+++ b/tests/unit/unit1602.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -28,7 +28,7 @@
 
 #include "memdebug.h" /* LAST include file */
 
-static struct curl_hash hash_static;
+static struct Curl_hash hash_static;
 
 static void mydtor(void *p)
 {

--- a/tests/unit/unit1603.c
+++ b/tests/unit/unit1603.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2015 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2015 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -28,7 +28,7 @@
 
 #include "memdebug.h" /* LAST include file */
 
-static struct curl_hash hash_static;
+static struct Curl_hash hash_static;
 static const int slots = 3;
 
 static void mydtor(void *p)


### PR DESCRIPTION
Here's a makeover to rename internally used structs that still were using `curl_` prefix, despite our policy to only use that prefix for global symbols.

One of the primary points with insisting on the distinction is to make it easier for developers to read the code and see when types/names are private or not.