### PR TITLE
easygetopt: pass a valid enum to avoid compiler warning

### DIFF
--- a/lib/easygetopt.c
+++ b/lib/easygetopt.c
@@ -51,7 +51,8 @@ static struct curl_easyoption *lookup(const char *name, CURLoption id)
 
 const struct curl_easyoption *curl_easy_option_by_name(const char *name)
 {
-  return lookup(name, 0);
+  /* when name is used, the id argument is ignored */
+  return lookup(name, CURLOPT_LASTENTRY);
 }
 
 const struct curl_easyoption *curl_easy_option_by_id(CURLoption id)


### PR DESCRIPTION
"integer constant not in range of enumerated type 'CURLoption'"

Reported-by: Gisle Vanem
Bug: https://github.com/curl/curl/commit/6ebe63fac23f38df911edc348e8ccc72280f9434#commitcomment-42042843