### PR TITLE
curl: in retry output don't call all problems "transient"

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -512,10 +512,10 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
       static const char * const m[]={
         NULL,
         "(retrying all errors)",
-        "timeout",
-        "connection refused",
-        "HTTP error",
-        "FTP error"
+        ": timeout",
+        ": connection refused",
+        ": HTTP error",
+        ": FTP error"
       };
 
       sleeptime = per->retry_sleep;
@@ -529,7 +529,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
             sleeptime = (long)retry_after * 1000; /* milliseconds */
         }
       }
-      warnf(config->global, "Transient problem: %s "
+      warnf(config->global, "Problem %s. "
             "Will retry in %ld seconds. "
             "%ld retries left.\n",
             m[retry], sleeptime/1000L, per->retry_numretries);


### PR DESCRIPTION
... because when --retry-all-errors is used, the error isn't necessarily
transient at all.