### PR TITLE
altsvc: inherit setting in curl_easy_duphandle

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -302,11 +302,12 @@ CURLcode Curl_altsvc_ctrl(struct altsvcinfo *asi, const long ctrl)
  * Curl_altsvc_cleanup() frees an altsvc cache instance and all associated
  * resources.
  */
-void Curl_altsvc_cleanup(struct altsvcinfo *altsvc)
+void Curl_altsvc_cleanup(struct altsvcinfo **altsvcp)
 {
   struct Curl_llist_element *e;
   struct Curl_llist_element *n;
-  if(altsvc) {
+  if(*altsvcp) {
+    struct altsvcinfo *altsvc = *altsvcp;
     for(e = altsvc->list.head; e; e = n) {
       struct altsvc *as = e->ptr;
       n = e->next;
@@ -314,6 +315,7 @@ void Curl_altsvc_cleanup(struct altsvcinfo *altsvc)
     }
     free(altsvc->filename);
     free(altsvc);
+    *altsvcp = NULL; /* clear the pointer */
   }
 }
 

--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -61,7 +61,7 @@ CURLcode Curl_altsvc_load(struct altsvcinfo *asi, const char *file);
 CURLcode Curl_altsvc_save(struct Curl_easy *data,
                           struct altsvcinfo *asi, const char *file);
 CURLcode Curl_altsvc_ctrl(struct altsvcinfo *asi, const long ctrl);
-void Curl_altsvc_cleanup(struct altsvcinfo *altsvc);
+void Curl_altsvc_cleanup(struct altsvcinfo **altsvc);
 CURLcode Curl_altsvc_parse(struct Curl_easy *data,
                            struct altsvcinfo *altsvc, const char *value,
                            enum alpnid srcalpn, const char *srchost,
@@ -74,5 +74,6 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
 #else
 /* disabled */
 #define Curl_altsvc_save(a,b,c)
+#define Curl_altsvc_cleanup(x)
 #endif /* CURL_DISABLE_HTTP || USE_ALTSVC */
 #endif /* HEADER_CURL_ALTSVC_H */

--- a/lib/url.c
+++ b/lib/url.c
@@ -391,11 +391,8 @@ CURLcode Curl_close(struct Curl_easy **datap)
   Curl_dyn_free(&data->state.headerb);
   Curl_safefree(data->state.ulbuf);
   Curl_flush_cookies(data, TRUE);
-#ifdef USE_ALTSVC
   Curl_altsvc_save(data, data->asi, data->set.str[STRING_ALTSVC]);
-  Curl_altsvc_cleanup(data->asi);
-  data->asi = NULL;
-#endif
+  Curl_altsvc_cleanup(&data->asi);
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
   Curl_http_auth_cleanup_digest(data);
 #endif

--- a/tests/data/test1908
+++ b/tests/data/test1908
@@ -8,7 +8,7 @@ CURLINFO_EFFECTIVE_URL
 # Server-side
 <reply>
 <data nocheck="yes">
-HTTP/1.1 200 OK
+HTTP/1.1 200 OK swsbounce
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
 Content-Type: text/html
@@ -17,6 +17,15 @@ Content-Length: 0
 alt-svc: h2="3dbbdetxoyw4nsp6c3cc456oj2ays6s43ezxzsfxxri3h5xqd.example:443"; ma=315360000; persist=1
 
 </data>
+
+# This is the second response
+<data1 nocheck="yes">
+HTTP/1.1 200 OK
+Connection: close
+Content-Length: 0
+alt-svc: h2="second.example:443"; ma=315360000;
+
+</data1>
 </reply>
 
 # Client-side
@@ -52,6 +61,10 @@ lib1908
 ^User-Agent:.*
 </strip>
 <protocol>
+GET /1908 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
 GET /1908 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*

--- a/tests/libtest/lib1908.c
+++ b/tests/libtest/lib1908.c
@@ -39,7 +39,22 @@ int test(char *URL)
     curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
     curl_easy_setopt(hnd, CURLOPT_ALTSVC, "log/altsvc-1908");
     ret = curl_easy_perform(hnd);
+
+    if(!ret) {
+      /* make a copy and check that this also has alt-svc activated */
+      CURL *also = curl_easy_duphandle(hnd);
+      if(also) {
+        ret = curl_easy_perform(also);
+        /* we close the second handle first, which makes it store the alt-svc
+           file only to get overwritten when the next handle is closed! */
+        curl_easy_cleanup(also);
+      }
+    }
+
     curl_easy_reset(hnd);
+
+    /* using the same file name for the alt-svc cache, this clobbers the
+       content just written from the 'also' handle */
     curl_easy_cleanup(hnd);
   }
   curl_global_cleanup();

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -54,7 +54,7 @@ UNITTEST_START
     return 1;
   result = Curl_altsvc_load(asi, arg);
   if(result) {
-    Curl_altsvc_cleanup(asi);
+    Curl_altsvc_cleanup(&asi);
     return result;
   }
   curl = curl_easy_init();
@@ -131,7 +131,7 @@ UNITTEST_START
 
   curl_easy_cleanup(curl);
   fail:
-  Curl_altsvc_cleanup(asi);
+  Curl_altsvc_cleanup(&asi);
   return unitfail;
 }
 UNITTEST_STOP


### PR DESCRIPTION
The cache content is not duplicated, like other caches, but the setting
and specified file name are.

Test 1908 is extended to verify this somewhat. Since the duplicated
handle gets the same file name, the test unfortunately overwrites the
same file twice (with different contents) which makes it hard to check
automatically.