### PR TITLE
configure: let --enable-debug set -Wenum-conversion with gcc >= 10

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1119,6 +1119,10 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             fi
           fi
         fi
+        dnl Only gcc 10 or later
+        if test "$compiler_num" -ge "1000"; then
+          CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-conversion])
+        fi
         ;;
         #
       HP_UX_C)


### PR DESCRIPTION
Unfortunately, this option is not detecting the same issues as clang's
-Wassign-enum flag, but should still be useful to detect future
mistakes.