### PR TITLE
openssl: consider ALERT_CERTIFICATE_EXPIRED a failed verification

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3285,7 +3285,8 @@ static CURLcode ossl_connect_step2(struct connectdata *conn, int sockindex)
       reason = ERR_GET_REASON(errdetail);
 
       if((lib == ERR_LIB_SSL) &&
-         (reason == SSL_R_CERTIFICATE_VERIFY_FAILED)) {
+         ((reason == SSL_R_CERTIFICATE_VERIFY_FAILED) ||
+          (reason == SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED))) {
         result = CURLE_PEER_FAILED_VERIFICATION;
 
         lerr = SSL_get_verify_result(backend->handle);


### PR DESCRIPTION
If the error reason from the lib is
SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED, libcurl will return
CURLE_PEER_FAILED_VERIFICATION and not CURLE_SSL_CONNECT_ERROR.

This unifies the libcurl return code and makes libressl run test 313
(CRL testing) fine.