### PR TITLE
github: Use new issue template feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!-- Only file bugs here! Ask questions on the mailing lists https://curl.haxx.se/mail/
 
      SECURITY RELATED? Post it here: https://hackerone.com/curl

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature request
+    url: https://curl.haxx.se/mail/
+    about: To propose new features or enhancements, please bring that discussion to a suitable curl mailing list.
+  - name: Security vulnerability
+    url: https://hackerone.com/curl
+    about: Please report security problems or just suspected security problems to the curl-security team, to allow us to assess and work on it privately before we release a fix and inform the public.
+  - name: Question
+    url: https://curl.haxx.se/mail/
+    about: Questions should go to the mailing list
+  - name: Commercial support
+    url: https://curl.haxx.se/support.html
+    about: Several companies are offering paid support for curl/libcurl


### PR DESCRIPTION
This helps us to avoid getting feature requests as well as security
bugs reported into the issue tracker.