### PR TITLE
fix for integer overflow.

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -355,6 +355,10 @@ static char *my_get_line(FILE *fp)
     else {
       char *ptr;
       size_t linelen = strlen(line);
+      if(linelen >= (size_t)(SIZE_T_MAX-sizeof(buf)-2)) {
+        Curl_safefree(line);
+        return NULL;
+      }
       ptr = realloc(line, linelen + strlen(buf) + 1);
       if(!ptr) {
         Curl_safefree(line);


### PR DESCRIPTION
my tests have shown a practical possibility of overflow implementation, so I consider it necessary to make the code more secure.
this check will eliminate the possibility of linelen integer overflow, followed by a controlled heap overflow.