### PR TITLE
curl_mime_headers.3: fix the example's use of curl_slist_append

### DIFF
--- a/docs/libcurl/curl_mime_headers.3
+++ b/docs/libcurl/curl_mime_headers.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -50,7 +50,7 @@ CURLE_OK or a CURL error code upon failure.
 .nf
  struct curl_slist *headers = NULL;
 
- headers = curl_slist_append("Custom-Header: mooo", headers);
+ headers = curl_slist_append(headers, "Custom-Header: mooo");
 
  /* use these headers, please take ownership */
  curl_mime_headers(part, headers, TRUE);


### PR DESCRIPTION
Reported-by: sofaboss on github
Fixes #5942