### PR TITLE
curl: use dynbuf for config file buffer management

### DIFF
--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -21,12 +21,11 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
-#include "strdup.h"
 #include "dynbuf.h"
-
-/* The last 3 #include files should be in this order */
 #include "curl_printf.h"
+#ifdef BUILDING_LIBCURL
 #include "curl_memory.h"
+#endif
 #include "memdebug.h"
 
 #define MIN_FIRST_ALLOC 32
@@ -94,11 +93,15 @@ static CURLcode dyn_nappend(struct dynbuf *s,
   }
 
   if(a != s->allc) {
-    s->bufr = Curl_saferealloc(s->bufr, a);
-    if(!s->bufr) {
+    /* this logic is not using Curl_saferealloc() to make the tool not have to
+       include that as well when it uses this code */
+    void *p = realloc(s->bufr, a);
+    if(!p) {
+      Curl_safefree(s->bufr);
       s->leng = s->allc = 0;
       return CURLE_OUT_OF_MEMORY;
     }
+    s->bufr = p;
     s->allc = a;
   }
 

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -22,6 +22,22 @@
  *
  ***************************************************************************/
 
+#ifndef BUILDING_LIBCURL
+/* this renames the functions so that the tool code can use the same code
+   without getting symbol collisions */
+#define Curl_dyn_init(a,b) curlx_dyn_init(a,b)
+#define Curl_dyn_add(a,b) curlx_dyn_add(a,b)
+#define Curl_dyn_addn(a,b,c) curlx_dyn_addn(a,b,c)
+#define Curl_dyn_addf curlx_dyn_addf
+#define Curl_dyn_free(a) curlx_dyn_free(a)
+#define Curl_dyn_ptr(a) curlx_dyn_ptr(a)
+#define Curl_dyn_uptr(a) curlx_dyn_uptr(a)
+#define Curl_dyn_len(a) curlx_dyn_len(a)
+#define Curl_dyn_reset(a) curlx_dyn_reset(a)
+#define Curl_dyn_tail(a,b) curlx_dyn_tail(a,b)
+#define curlx_dynbuf dynbuf /* for the struct name */
+#endif
+
 struct dynbuf {
   char *bufr;    /* point to a null-terminated allocated buffer */
   size_t leng;   /* number of bytes *EXCLUDING* the zero terminator */

--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -287,6 +287,7 @@ rem
       call :element %1 lib "curl_ctype.c" %3
       call :element %1 lib "curl_multibyte.c" %3
       call :element %1 lib "version_win32.c" %3
+      call :element %1 lib "dynbuf.c" %3
     ) else if "!var!" == "CURL_SRC_X_H_FILES" (
       call :element %1 lib "config-win32.h" %3
       call :element %1 lib "curl_setup.h" %3
@@ -296,6 +297,7 @@ rem
       call :element %1 lib "curl_ctype.h" %3
       call :element %1 lib "curl_multibyte.h" %3
       call :element %1 lib "version_win32.h" %3
+      call :element %1 lib "dynbuf.h" %3
     ) else if "!var!" == "CURL_LIB_C_FILES" (
       for /f "delims=" %%c in ('dir /b ..\lib\*.c') do call :element %1 lib "%%c" %3
     ) else if "!var!" == "CURL_LIB_H_FILES" (

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -36,7 +36,8 @@ CURLX_CFILES = \
   ../lib/warnless.c \
   ../lib/curl_ctype.c \
   ../lib/curl_multibyte.c \
-  ../lib/version_win32.c
+  ../lib/version_win32.c \
+  ../lib/dynbuf.c
 
 CURLX_HFILES = \
   ../lib/curl_setup.h \
@@ -45,7 +46,8 @@ CURLX_HFILES = \
   ../lib/warnless.h \
   ../lib/curl_ctype.h \
   ../lib/curl_multibyte.h \
-  ../lib/version_win32.h
+  ../lib/version_win32.h \
+  ../lib/dynbuf.h
 
 CURL_CFILES = \
   slist_wc.c \

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -356,7 +356,8 @@ static bool my_get_line(FILE *fp, struct curlx_dynbuf *db,
     /* fgets() returns s on success, and NULL on error or when end of file
        occurs while no characters have been read. */
     if(!fgets(buf, sizeof(buf), fp))
-      return FALSE; /* stop reading */
+      /* only if there's data in the line, return TRUE */
+      return curlx_dyn_len(db) ? TRUE : FALSE;
     if(curlx_dyn_add(db, buf)) {
       *error = TRUE; /* error */
       return FALSE; /* stop reading */

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -31,6 +31,7 @@
 #include "tool_homedir.h"
 #include "tool_msgs.h"
 #include "tool_parsecfg.h"
+#include "dynbuf.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -39,7 +40,9 @@
 #define ISSEP(x,dash) (!dash && (((x) == '=') || ((x) == ':')))
 
 static const char *unslashquote(const char *line, char *param);
-static char *my_get_line(FILE *fp);
+
+#define MAX_CONFIG_LINE_LENGTH (100*1024)
+static bool my_get_line(FILE *fp, struct curlx_dynbuf *, bool *error);
 
 #ifdef WIN32
 static FILE *execpath(const char *filename)
@@ -135,17 +138,23 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 
   if(file) {
     char *line;
-    char *aline;
     char *option;
     char *param;
     int lineno = 0;
     bool dashed_option;
+    struct curlx_dynbuf buf;
+    bool fileerror;
+    curlx_dyn_init(&buf, MAX_CONFIG_LINE_LENGTH);
 
-    while(NULL != (aline = my_get_line(file))) {
+    while(my_get_line(file, &buf, &fileerror)) {
       int res;
       bool alloced_param = FALSE;
       lineno++;
-      line = aline;
+      line = curlx_dyn_ptr(&buf);
+      if(!line) {
+        rc = 1; /* out of memory */
+        break;
+      }
 
       /* line with # in the first non-blank column is a comment! */
       while(*line && ISSPACE(*line))
@@ -158,7 +167,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       case '\n':
       case '*':
       case '\0':
-        Curl_safefree(aline);
+        curlx_dyn_reset(&buf);
         continue;
       }
 
@@ -190,7 +199,6 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
         param = malloc(strlen(line) + 1); /* parameter */
         if(!param) {
           /* out of memory */
-          Curl_safefree(aline);
           rc = 1;
           break;
         }
@@ -280,10 +288,13 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       if(alloced_param)
         Curl_safefree(param);
 
-      Curl_safefree(aline);
+      curlx_dyn_reset(&buf);
     }
+    curlx_dyn_free(&buf);
     if(file != stdin)
       fclose(file);
+    if(fileerror)
+      rc = 1;
   }
   else
     rc = 1; /* couldn't open the file */
@@ -335,39 +346,22 @@ static const char *unslashquote(const char *line, char *param)
 
 /*
  * Reads a line from the given file, ensuring is NUL terminated.
- * The pointer must be freed by the caller.
- * NULL is returned on an out of memory condition.
  */
-static char *my_get_line(FILE *fp)
+static bool my_get_line(FILE *fp, struct curlx_dynbuf *db,
+                        bool *error)
 {
   char buf[4096];
-  char *nl = NULL;
-  char *line = NULL;
-
+  *error = FALSE;
   do {
-    if(NULL == fgets(buf, sizeof(buf), fp))
-      break;
-    if(!line) {
-      line = strdup(buf);
-      if(!line)
-        return NULL;
+    /* fgets() returns s on success, and NULL on error or when end of file
+       occurs while no characters have been read. */
+    if(!fgets(buf, sizeof(buf), fp))
+      return FALSE; /* stop reading */
+    if(curlx_dyn_add(db, buf)) {
+      *error = TRUE; /* error */
+      return FALSE; /* stop reading */
     }
-    else {
-      char *ptr;
-      size_t linelen = strlen(line);
-      ptr = realloc(line, linelen + strlen(buf) + 1);
-      if(!ptr) {
-        Curl_safefree(line);
-        return NULL;
-      }
-      line = ptr;
-      strcpy(&line[linelen], buf);
-    }
-    nl = strchr(line, '\n');
-  } while(!nl);
+  } while(!strchr(buf, '\n'));
 
-  if(nl)
-    *nl = '\0';
-
-  return line;
+  return TRUE; /* continue */
 }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -66,7 +66,7 @@ test393 test394 test395 test396 test397 \
 test400 test401 test402 test403 test404 test405 test406 test407 test408 \
 test409 \
 \
-test430 test431 test432 test433 \
+test430 test431 test432 test433 test434 \
 \
 test490 test491 test492 \
 \

--- a/tests/data/test434
+++ b/tests/data/test434
@@ -1,0 +1,48 @@
+<testcase>
+
+<info>
+<keywords>
+--config
+</keywords>
+</info>
+
+#
+<reply>
+<data>
+HTTP/1.1 200 OK
+Content-Length: 6
+Content-Type: text/1
+
+-foo-
+</data>
+</reply>
+
+#
+<client>
+<file name="log/config434" nonewline="yes">
+url = %HOSTIP:%HTTPPORT/434
+</file>
+<server>
+http
+</server>
+<name>
+-K with a single line without newline
+</name>
+<command>
+-K log/config434
+</command>
+</client>
+
+#
+<verify>
+<strip>
+^User-Agent:.*
+</strip>
+<protocol>
+GET /434 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test558
+++ b/tests/data/test558
@@ -38,8 +38,8 @@ nothing
 <file name="log/memdump">
 MEM lib558.c: malloc()
 MEM lib558.c: free()
-MEM strdup.c: realloc()
-MEM strdup.c: realloc()
+MEM dynbuf.c: realloc()
+MEM dynbuf.c: realloc()
 MEM escape.c: free()
 </file>
 <stripfile>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -65,7 +65,7 @@ chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
  ../../lib/curl_ctype.c  ../../lib/dynbuf.c ../../lib/strdup.c
 chkdecimalpoint_LDADD =
 chkdecimalpoint_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB \
- -DCURLX_NO_MEMORY_CALLBACKS
+ -DCURLX_NO_MEMORY_CALLBACKS -DBUILDING_LIBCURL
 
 chkhostname_SOURCES = chkhostname.c ../../lib/curl_gethostname.c
 chkhostname_LDADD = @CURL_NETWORK_LIBS@

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3753,6 +3753,10 @@ sub singletest {
             subVariables(\$fileContent);
             open(OUTFILE, ">$filename");
             binmode OUTFILE; # for crapage systems, use binary
+            if($fileattr{'nonewline'}) {
+                # cut off the final newline
+                chomp($fileContent);
+            }
             print OUTFILE $fileContent;
             close(OUTFILE);
         }

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -620,7 +620,8 @@ CURL_FROM_LIBCURL=$(CURL_DIROBJ)\tool_hugehelp.obj \
  $(CURL_DIROBJ)\warnless.obj \
  $(CURL_DIROBJ)\curl_ctype.obj \
  $(CURL_DIROBJ)\curl_multibyte.obj \
- $(CURL_DIROBJ)\version_win32.obj
+ $(CURL_DIROBJ)\version_win32.obj \
+ $(CURL_DIROBJ)\dynbuf.obj
  
 $(PROGRAM_NAME): $(CURL_DIROBJ) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
 	$(CURL_LINK) $(CURL_LFLAGS) $(CURL_LIBCURL_LIBNAME) $(WIN_LIBS) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
@@ -643,6 +644,8 @@ $(CURL_DIROBJ)\curl_multibyte.obj: ../lib/curl_multibyte.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/curl_multibyte.c
 $(CURL_DIROBJ)\version_win32.obj: ../lib/version_win32.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/version_win32.c
+$(CURL_DIROBJ)\dynbuf.obj: ../lib/dynbuf.c
+	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/dynbuf.c
 $(CURL_DIROBJ)\curl.res: $(CURL_SRC_DIR)\curl.rc
 	rc $(CURL_RC_FLAGS)
 


### PR DESCRIPTION
By making the dynbuf functions available as `curlx_` verisons, the config file parser in the tool code can use that for its buffer management and for saver reallocs etc.

Once landed, we can move more curl functions over to dynbuf,

(Alternative take to #5941 )