### PR TITLE
base64: also build for pop3 and imap

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -27,6 +27,8 @@
 #if !defined(CURL_DISABLE_HTTP_AUTH) || defined(USE_SSH) || \
   !defined(CURL_DISABLE_LDAP) || \
   !defined(CURL_DISABLE_SMTP) || \
+  !defined(CURL_DISABLE_POP3) || \
+  !defined(CURL_DISABLE_IMAP) || \
   !defined(CURL_DISABLE_DOH) || defined(USE_SSL)
 
 #include "urldata.h" /* for the Curl_easy definition */


### PR DESCRIPTION
Follow-up to the fix in 20417a13fb8f83

Reported-by: Michael Olbrich
Fixes #5937