### PR TITLE
checksrc: Fix misleading // comment warning

### DIFF
--- a/docs/CHECKSRC.md
+++ b/docs/CHECKSRC.md
@@ -55,7 +55,7 @@ warnings are:
 
 - `COPYRIGHT`: the file is missing a copyright statement!
 
-- `CPPCOMMENTS`: `//` comment detected, that's not C89 compliant
+- `C99COMMENTS`: `//` comment detected, that's not C89 compliant
 
 - `FOPENMODE`: `fopen()` needs a macro for the mode string, use it
 

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -53,7 +53,7 @@ my %warnings = (
     'LONGLINE'         => "Line longer than $max_column",
     'TABS'             => 'TAB characters not allowed',
     'TRAILINGSPACE'    => 'Trailing white space on the line',
-    'CPPCOMMENTS'      => '// comment detected',
+    'C99COMMENTS'      => '// comment detected',
     'SPACEBEFOREPAREN' => 'space before an open parenthesis',
     'SPACEAFTERPAREN'  => 'space after open parenthesis',
     'SPACEBEFORECLOSE' => 'space before a close parenthesis',
@@ -442,7 +442,7 @@ sub scanfile {
         # crude attempt to detect // comments without too many false
         # positives
         if($l =~ /^([^"\*]*)[^:"]\/\//) {
-            checkwarn("CPPCOMMENTS",
+            checkwarn("C99COMMENTS",
                       $line, length($1), $file, $l, "\/\/ comment");
         }
 


### PR DESCRIPTION
"CPPCOMMENTS" is misleading as CPP traditonally stands for the C
preprocessor. CXXCOMMENTS would be correct but probably even more
misleading so I think a good place in the middle is to use C99COMMENTS.