### PR TITLE
curl: use dynbuf instead of custom realloc code

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -413,6 +413,7 @@ ParameterError str2offset(curl_off_t *val, const char *str)
   return PARAM_BAD_NUMERIC;
 }
 
+#define MAX_USERPWDLENGTH (100*1024)
 static CURLcode checkpasswd(const char *kind, /* for what purpose */
                             const size_t i,   /* operation index */
                             const bool last,  /* TRUE if last operation */
@@ -432,12 +433,11 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
 
   if(!psep && **userpwd != ';') {
     /* no password present, prompt for one */
-    char passwd[256] = "";
+    char passwd[2048] = "";
     char prompt[256];
-    size_t passwdlen;
-    size_t userlen = strlen(*userpwd);
-    char *passptr;
+    struct curlx_dynbuf dyn;
 
+    curlx_dyn_init(&dyn, MAX_USERPWDLENGTH);
     if(osep)
       *osep = '\0';
 
@@ -453,22 +453,15 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
 
     /* get password */
     getpass_r(prompt, passwd, sizeof(passwd));
-    passwdlen = strlen(passwd);
-
     if(osep)
       *osep = ';';
 
-    /* extend the allocated memory area to fit the password too */
-    passptr = realloc(*userpwd,
-                      passwdlen + 1 + /* an extra for the colon */
-                      userlen + 1);   /* an extra for the zero */
-    if(!passptr)
+    if(curlx_dyn_addf(&dyn, "%s:%s", *userpwd, passwd))
       return CURLE_OUT_OF_MEMORY;
 
-    /* append the password separated with a colon */
-    passptr[userlen] = ':';
-    memcpy(&passptr[userlen + 1], passwd, passwdlen + 1);
-    *userpwd = passptr;
+    /* return the new string */
+    free(*userpwd);
+    *userpwd = curlx_dyn_ptr(&dyn);
   }
 
   return CURLE_OK;

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -34,6 +34,7 @@
 #include "tool_msgs.h"
 #include "tool_paramhlp.h"
 #include "tool_version.h"
+#include "dynbuf.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -56,51 +57,27 @@ struct getout *new_getout(struct OperationConfig *config)
   return node;
 }
 
+#define MAX_FILE2STRING (256*1024*1024) /* big enough ? */
+
 ParameterError file2string(char **bufp, FILE *file)
 {
-  char *string = NULL;
+  struct curlx_dynbuf dyn;
+  curlx_dyn_init(&dyn, MAX_FILE2STRING);
   if(file) {
-    char *ptr;
-    size_t alloc = 512;
-    size_t alloc_needed;
     char buffer[256];
-    size_t stringlen = 0;
-    string = calloc(1, alloc);
-    if(!string)
-      return PARAM_NO_MEM;
 
     while(fgets(buffer, sizeof(buffer), file)) {
-      size_t buflen;
-      ptr = strchr(buffer, '\r');
+      char *ptr = strchr(buffer, '\r');
       if(ptr)
         *ptr = '\0';
       ptr = strchr(buffer, '\n');
       if(ptr)
         *ptr = '\0';
-      buflen = strlen(buffer);
-      alloc_needed = stringlen + buflen + 1;
-      if(alloc < alloc_needed) {
-#if SIZEOF_SIZE_T < 8
-        if(alloc >= (size_t)SIZE_T_MAX/2) {
-          Curl_safefree(string);
-          return PARAM_NO_MEM;
-        }
-#endif
-        /* doubling is enough since the string to add is always max 256 bytes
-           and the alloc size start at 512 */
-        alloc *= 2;
-        ptr = realloc(string, alloc);
-        if(!ptr) {
-          Curl_safefree(string);
-          return PARAM_NO_MEM;
-        }
-        string = ptr;
-      }
-      strcpy(string + stringlen, buffer);
-      stringlen += buflen;
+      if(curlx_dyn_add(&dyn, buffer))
+        return PARAM_NO_MEM;
     }
   }
-  *bufp = string;
+  *bufp = curlx_dyn_ptr(&dyn);
   return PARAM_OK;
 }
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -28,6 +28,7 @@
 #include "tool_doswin.h"
 #include "tool_urlglob.h"
 #include "tool_vms.h"
+#include "dynbuf.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -607,26 +608,21 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
   return CURLE_OK;
 }
 
+#define MAX_OUTPUT_GLOB_LENGTH (10*1024)
+
 CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
 {
-  char *target;
-  size_t allocsize;
   char numbuf[18];
   char *appendthis = (char *)"";
   size_t appendlen = 0;
-  size_t stringlen = 0;
+  struct curlx_dynbuf dyn;
 
   *result = NULL;
 
-  /* We cannot use the glob_buffer for storage here since the filename may
-   * be longer than the URL we use. We allocate a good start size, then
-   * we need to realloc in case of need.
+  /* We cannot use the glob_buffer for storage since the filename may be
+   * longer than the URL we use.
    */
-  allocsize = strlen(filename) + 1; /* make it at least one byte to store the
-                                       trailing zero */
-  target = malloc(allocsize);
-  if(!target)
-    return CURLE_OUT_OF_MEMORY;
+  curlx_dyn_init(&dyn, MAX_OUTPUT_GLOB_LENGTH);
 
   while(*filename) {
     if(*filename == '#' && ISDIGIT(filename[1])) {
@@ -671,7 +667,7 @@ CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
         default:
           fprintf(stderr, "internal error: invalid pattern type (%d)\n",
                   (int)pat->type);
-          Curl_safefree(target);
+          curlx_dyn_free(&dyn);
           return CURLE_FAILED_INIT;
         }
       }
@@ -686,36 +682,24 @@ CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
       appendthis = filename++;
       appendlen = 1;
     }
-    if(appendlen + stringlen >= allocsize) {
-      char *newstr;
-      /* we append a single byte to allow for the trailing byte to be appended
-         at the end of this function outside the while() loop */
-      allocsize = (appendlen + stringlen) * 2;
-      newstr = realloc(target, allocsize + 1);
-      if(!newstr) {
-        Curl_safefree(target);
-        return CURLE_OUT_OF_MEMORY;
-      }
-      target = newstr;
-    }
-    memcpy(&target[stringlen], appendthis, appendlen);
-    stringlen += appendlen;
+    if(curlx_dyn_addn(&dyn, appendthis, appendlen))
+      return CURLE_OUT_OF_MEMORY;
   }
-  target[stringlen]= '\0';
 
 #if defined(MSDOS) || defined(WIN32)
   {
     char *sanitized;
-    SANITIZEcode sc = sanitize_file_name(&sanitized, target,
+    SANITIZEcode sc = sanitize_file_name(&sanitized, curlx_dyn_ptr(&dyn),
                                          (SANITIZE_ALLOW_PATH |
                                           SANITIZE_ALLOW_RESERVED));
-    Curl_safefree(target);
+    curlx_dyn_free(&dyn);
     if(sc)
       return CURLE_URL_MALFORMAT;
-    target = sanitized;
+    *result = sanitized;
+    return CURLE_OK;
   }
 #endif /* MSDOS || WIN32 */
 
-  *result = target;
+  *result = curlx_dyn_ptr(&dyn);
   return CURLE_OK;
 }


### PR DESCRIPTION
Switch more custom realloc functionality over to using dynbuf instead. For unified treatment and better reliability.