### PR TITLE
CI/azure: disable flaky tests in the msys2 builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -118,14 +118,14 @@ stages:
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2
-          tests: ~612 ~1056 ~1299 !SCP
+          tests: ~571 ~612 ~1056 ~1299 !SCP
         msys2_mingw64_debug_openssl:
           name: 64-bit OpenSSL and MQTT
           container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2
-          tests: ~612 ~1056 ~1299 !SCP
+          tests: ~571 ~612 ~1056 ~1299 !SCP
         msys1_mingw_debug_openssl:
           name: 32-bit OpenSSL (legacy)
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
@@ -150,14 +150,14 @@ stages:
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --with-libssh2
-          tests: ~165 ~310 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
         msys2_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN
           container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --without-ssl --with-schannel --with-winidn --with-libssh2
-          tests: ~165 ~310 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
         msys1_mingw_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN (legacy)
           container_img: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019


### PR DESCRIPTION
They fail almost every CI job.