### PR TITLE
ftp: a 550 response to SIZE is now an error

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2092,7 +2092,7 @@ static CURLcode ftp_state_mdtm_resp(struct connectdata *conn,
     break;
   case 550: /* "No such file or directory" */
     failf(data, "Given file does not exist");
-    result = CURLE_FTP_COULDNT_RETR_FILE;
+    result = CURLE_REMOTE_FILE_NOT_FOUND;
     break;
   }
 
@@ -2271,6 +2271,10 @@ static CURLcode ftp_state_size_resp(struct connectdata *conn,
     /* ignores parsing errors, which will make the size remain unknown */
     (void)curlx_strtoofft(fdigit, NULL, 0, &filesize);
 
+  }
+  else if(ftpcode == 550) { /* "No such file or directory" */
+    failf(data, "The file does not exist");
+    return CURLE_REMOTE_FILE_NOT_FOUND;
   }
 
   if(instate == FTP_SIZE) {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -207,7 +207,7 @@ test1700 test1701 test1702 \
 test1800 test1801 \
 \
                                     test1904 test1905 test1906 test1907 \
-test1908 test1909 test1910 test1911 test1912 \
+test1908 test1909 test1910 test1911 test1912 test1913 test1914 \
 \
 test2000 test2001 test2002 test2003 test2004 test2005 test2006 test2007 \
 test2008 test2009 test2010 test2011 test2012 test2013 test2014 test2015 \

--- a/tests/data/test1096
+++ b/tests/data/test1096
@@ -11,6 +11,7 @@ FAILURE
 <reply>
 <servercmd>
 REPLY RETR 550 no such file!
+REPLY SIZE 500 command not understood
 </servercmd>
 </reply>
 

--- a/tests/data/test118
+++ b/tests/data/test118
@@ -12,6 +12,7 @@ FAILURE
 <servercmd>
 REPLY RETR 314 bluah you f00l!
 REPLY EPSV 314 bluah you f00l!
+REPLY SIZE 500 command not understood
 </servercmd>
 </reply>
 

--- a/tests/data/test119
+++ b/tests/data/test119
@@ -11,6 +11,7 @@ FAILURE
 <reply>
 <servercmd>
 REPLY RETR 314 bluah you f00l!
+REPLY SIZE 500 command not understood
 </servercmd>
 </reply>
 

--- a/tests/data/test138
+++ b/tests/data/test138
@@ -15,6 +15,7 @@ this is file contents
 </size>
 <servercmd>
 RETRNOSIZE
+REPLY SIZE 500 command not understood
 </servercmd>
 </reply>
 

--- a/tests/data/test1913
+++ b/tests/data/test1913
@@ -1,0 +1,41 @@
+<testcase>
+<info>
+<keywords>
+FTP
+CURLOPT_NOBODY
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<servercmd>
+REPLY SIZE 550 no such file
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+
+# require debug so that alt-svc can work over plain old HTTP
+<name>
+FTP with NOBODY set, getting a missing file
+</name>
+<tool>
+lib1913
+</tool>
+
+<command>
+ftp://%HOSTIP:%FTPPORT/not-there/1913
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+78
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1914
+++ b/tests/data/test1914
@@ -1,0 +1,42 @@
+<testcase>
+<info>
+<keywords>
+FTP
+CURLOPT_NOBODY
+CURLOPT_FILETIME
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<servercmd>
+REPLY MDTM 550 no such file
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+
+# require debug so that alt-svc can work over plain old HTTP
+<name>
+FTP with NOBODY and FILETIME set, getting a missing file
+</name>
+<tool>
+lib1913
+</tool>
+
+<command>
+ftp://%HOSTIP:%FTPPORT/not-there/1913 1
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+78
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test235
+++ b/tests/data/test235
@@ -7,6 +7,9 @@ FTP
 
 # Server-side
 <reply>
+<servercmd>
+REPLY SIZE 500 command not understood
+</servercmd>
 </reply>
 
 # Client-side

--- a/tests/data/test236
+++ b/tests/data/test236
@@ -11,6 +11,7 @@ FTP
 REPLY SIZE 550 access to this file is very much denied
 REPLY APPE 550 I said: access to this file is very much denied
 REPLY STOR 550 I said: access to this file is very much denied
+REPLY SIZE 500 command not understood
 </servercmd>
 </reply>
 

--- a/tests/data/test511
+++ b/tests/data/test511
@@ -35,9 +35,9 @@ ftp://%HOSTIP:%FTPPORT/511
 #
 # Verify data after the test has been "shot"
 <verify>
-# CURLE_FTP_COULDNT_RETR_FILE
+# CURLE_REMOTE_FILE_NOT_FOUND
 <errorcode>
-19
+78
 </errorcode>
 <protocol>
 USER anonymous

--- a/tests/data/test533
+++ b/tests/data/test533
@@ -15,7 +15,7 @@ multi
 
 <servercmd>
 REPLY RETR 550 the file doesn't exist
-REPLY SIZE 550 Can't check for file existence
+REPLY SIZE 500 Can't check for file existence
 </servercmd>
 </reply>
 

--- a/tests/data/test534
+++ b/tests/data/test534
@@ -16,7 +16,7 @@ non-existing host
 
 <servercmd>
 REPLY RETR 550 the file doesn't exist
-REPLY SIZE 550 Can't check for file existence
+REPLY SIZE 500 Can't check for file existence
 </servercmd>
 </reply>
 

--- a/tests/data/test546
+++ b/tests/data/test546
@@ -21,7 +21,7 @@ works
 <servercmd>
 REPLY RETR 550 the file doesn't exist
 COUNT RETR 1
-REPLY SIZE 550 Can't check for file existence
+REPLY SIZE 500 Can't check for file existence
 COUNT SIZE 1
 </servercmd>
 </reply>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -58,7 +58,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
  lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 \
  lib1591 lib1592 lib1593 lib1594 lib1596 \
-         lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 \
+         lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
          lib3010
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
@@ -644,6 +644,10 @@ lib1911_CPPFLAGS = $(AM_CPPFLAGS)
 lib1912_SOURCES = lib1912.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1912_LDADD = $(TESTUTIL_LIBS)
 lib1912_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1913_SOURCES = lib1913.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1913_LDADD = $(TESTUTIL_LIBS)
+lib1913_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib3010_SOURCES = lib3010.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib3010_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1913.c
+++ b/tests/libtest/lib1913.c
@@ -1,0 +1,48 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+  CURLcode ret = CURLE_OK;
+  CURL *hnd;
+  start_test_timing();
+
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  hnd = curl_easy_init();
+  if(hnd) {
+    curl_easy_setopt(hnd, CURLOPT_URL, URL);
+    curl_easy_setopt(hnd, CURLOPT_NOBODY, 1L);
+    if(libtest_arg2)
+      /* test1914 sets this extra arg */
+      curl_easy_setopt(hnd, CURLOPT_FILETIME, 1L);
+    ret = curl_easy_perform(hnd);
+    curl_easy_cleanup(hnd);
+  }
+  curl_global_cleanup();
+  return (int)ret;
+}


### PR DESCRIPTION
and returns CURLE_REMOTE_FILE_NOT_FOUND. This is primarily interesting
for cases where CURLOPT_NOBODY is set as otherwise curl would not return
an error for this case.

This is how libcurl already acts on a 550 as a MDTM response (when
CURLOPT_FILETIME is set). If CURLOPT_NOBODY is not set, the error will
happen subsequently anyway since the RETR command will also fail with
it.

Reported-by: Tomas Berger
Fixes #5953