### PR TITLE
dynbuf: Add Curl_dyn_truncate to truncate end of buffer

### DIFF
--- a/docs/DYNBUF.md
+++ b/docs/DYNBUF.md
@@ -48,6 +48,13 @@ Append a `printf()`-style string to the end of the buffer.
 
 Reset the buffer length, but leave the allocation.
 
+## truncate
+
+    CURLcode Curl_dyn_truncate(struct dynbuf *s, size_t pos);
+
+Truncate the buffer starting at `pos`, which must not be larger than the buffer
+length. The new length is `pos`.
+
 ## tail
 
     CURLcode Curl_dyn_tail(struct dynbuf *s, size_t length)

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -123,6 +123,23 @@ void Curl_dyn_reset(struct dynbuf *s)
   s->leng = 0;
 }
 
+/*
+ * Truncate the buffer starting at `pos`
+ */
+CURLcode Curl_dyn_truncate(struct dynbuf *s, size_t pos)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  if(pos && pos > s->leng)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  if(pos == s->leng)
+    return CURLE_OK;
+  s->leng = pos;
+  s->bufr[s->leng] = 0;
+  return CURLE_OK;
+}
+
 #ifdef USE_NGTCP2
 /*
  * Specify the size of the tail to keep (number of bytes from the end of the

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -41,6 +41,7 @@ CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
 CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
   WARN_UNUSED_RESULT;
 void Curl_dyn_reset(struct dynbuf *s);
+CURLcode Curl_dyn_truncate(struct dynbuf *s, size_t pos);
 CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail);
 char *Curl_dyn_ptr(const struct dynbuf *s);
 unsigned char *Curl_dyn_uptr(const struct dynbuf *s);


### PR DESCRIPTION
- Allow removing the end of a dyn buffer.

Closes #xxxx

---

As an alternative I wrote [Curl_dyn_erase](https://github.com/curl/curl/compare/master...jay:Curl_dyn_erase?expand=1) but I'm not sure how useful it would be to remove from the middle of the buffer.