### PR TITLE
Fix a hang in imap fetch

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1176,6 +1176,9 @@ static CURLcode imap_state_fetch_resp(struct connectdata *conn, int imapcode,
     else {
       /* IMAP download */
       data->req.maxdownload = size;
+      /* force a recv/send check of this connection, as the data might've been
+       read off the socket already */
+      data->conn->cselect_bits = CURL_CSELECT_IN;
       Curl_setup_transfer(data, FIRSTSOCKET, size, FALSE, -1);
     }
   }


### PR DESCRIPTION
I was testing imap downloads on windows and I noticed that curl hangs on fetch for a particular sized file on a SSL connection. The library was built against schannel, and I was testing against Outlook's imap server.

Upon debugging I saw that the size of the file was small enough that the entirety of the transfer happened in a single go and schannel buffers held entire data. However, it wasn't completely read in Curl_pp_readresp since a line break was found before that could happen. So, by the time we are in imap_state_fetch_resp - there's data in buffers that needs to be read via Curl_read but nothing to read from the socket. After we setup a transfer (Curl_setup_transfer), curl just waits on the socket state to change - which doesn't happen since no new data ever comes.

I saw CURL_CSELECT_IN was used to mark that the socket is readable, so made that change before transfer setup and it seems to fix the issue.