### PR TITLE
dynbuf: Remove 64MB max limit on pause buffers

### DIFF
--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -63,9 +63,10 @@ unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
 size_t Curl_dyn_len(const struct dynbuf *s);
 
 /* Dynamic buffer max sizes */
+#define DYN_NO_LIMIT        ((size_t)-1)
 #define DYN_DOH_RESPONSE    3000
 #define DYN_DOH_CNAME       256
-#define DYN_PAUSE_BUFFER    (64 * 1024 * 1024)
+#define DYN_PAUSE_BUFFER    DYN_NO_LIMIT
 #define DYN_HAXPROXY        2048
 #define DYN_HTTP_REQUEST    (128*1024)
 #define DYN_H2_HEADERS      (128*1024)


### PR DESCRIPTION
- Add DYN_NO_LIMIT to represent no size limit for dyn buffer.

- Define DYN_PAUSE_BUFFER as DYN_NO_LIMIT.

Prior to this change the pause buffer limit was 64MB, but it's possible
the transfer may be paused for a long enough period of time to
accumulate that amount of data. The limit was introduced when the dynbuf
API was added in ed35d65 and prior to that change there was no limit.

Closes #xxxx