### PR TITLE
man pages: switch to https://example.com URLs

### DIFF
--- a/docs/libcurl/curl_easy_cleanup.3
+++ b/docs/libcurl/curl_easy_cleanup.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms

--- a/docs/libcurl/curl_easy_cleanup.3
+++ b/docs/libcurl/curl_easy_cleanup.3
@@ -60,7 +60,7 @@ None
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/curl_easy_init.3
+++ b/docs/libcurl/curl_easy_init.3
@@ -49,7 +49,7 @@ other curl functions.
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/curl_easy_perform.3
+++ b/docs/libcurl/curl_easy_perform.3
@@ -63,7 +63,7 @@ the error buffer when non-zero is returned.
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -655,7 +655,7 @@ the option was disabled at compile-time, it will return
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/curl_mime_init.3
+++ b/docs/libcurl/curl_mime_init.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms

--- a/docs/libcurl/curl_mime_init.3
+++ b/docs/libcurl/curl_mime_init.3
@@ -56,7 +56,7 @@ A mime struct handle, or NULL upon failure.
 
  /* Post and send it. */
  curl_easy_setopt(easy, CURLOPT_MIMEPOST, mime);
- curl_easy_setopt(easy, CURLOPT_URL, "http://example.com");
+ curl_easy_setopt(easy, CURLOPT_URL, "https://example.com");
  curl_easy_perform(easy);
 
  /* Clean-up. */

--- a/docs/libcurl/libcurl-env.3
+++ b/docs/libcurl/libcurl-env.3
@@ -30,7 +30,7 @@ supports a set of additional environment variables independently of this.
 .IP "[scheme]_proxy"
 When libcurl is given a URL to use in a transfer, it first extracts the
 "scheme" part from the URL and checks if there is a given proxy set for that
-in its corresponding environment variable. A URL like "http://example.com"
+in its corresponding environment variable. A URL like "https://example.com"
 will hence use the "http_proxy" variable, while a URL like "ftp://example.com"
 will use the "ftp_proxy" variable.
 

--- a/docs/libcurl/libcurl-env.3
+++ b/docs/libcurl/libcurl-env.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms

--- a/docs/libcurl/libcurl-security.3
+++ b/docs/libcurl/libcurl-security.3
@@ -154,7 +154,7 @@ behind a firewall.  Applications can mitigate against this by using the
 \fICURLOPT_FTP_SKIP_PASV_IP(3)\fP option or \fICURLOPT_FTPPORT(3)\fP.
 
 Local servers sometimes assume local access comes from friends and trusted
-users. An application that expects http://example.com/file_to_read that and
+users. An application that expects https://example.com/file_to_read that and
 instead gets http://192.168.0.1/my_router_config might print a file that would
 otherwise be protected by the firewall.
 

--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.3
@@ -47,7 +47,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   curl_socket_t sockfd;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Do not do the transfer - only connect to host */
   curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
@@ -41,7 +41,7 @@ HTTP and some
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* January 1, 2020 is 1577833200 */
   curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
@@ -41,7 +41,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
@@ -38,7 +38,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.3
@@ -40,7 +40,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the upload */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.3
@@ -37,7 +37,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the upload */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.3
@@ -42,7 +42,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   res = curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.3
@@ -43,7 +43,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* enable the cookie engine */
   curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.3
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.3
@@ -47,7 +47,7 @@ HTTP(S)
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "data");
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.3
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.3
@@ -43,7 +43,7 @@ HTTP(S)
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.3
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.3
@@ -40,7 +40,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     long size;

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.3
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.3
@@ -38,7 +38,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   res = curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLINFO_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLINFO_HTTP_VERSION.3
@@ -39,7 +39,7 @@ HTTP
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     long http_version;

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
@@ -47,7 +47,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   long sockfd; /* doesn't work on win64! */
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Do not do the transfer - only connect to host */
   curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
@@ -45,7 +45,7 @@ All
 {
   char *ip;
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request, res will get the return code */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.3
@@ -40,7 +40,7 @@ All
 
   curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     res = curl_easy_perform(curl);
 
     if(CURLE_OK == res) {

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.3
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.3
@@ -41,7 +41,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
@@ -38,7 +38,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res != CURLE_OK) {
     long error;

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
@@ -44,7 +44,7 @@ All network based ones
 {
   char *ip;
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request, res will get the return code */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.3
@@ -37,7 +37,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     long port;

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.3
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.3
@@ -39,7 +39,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   void *pointer = 0x2345454;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* set the private pointer */
   curl_easy_setopt(curl, CURLOPT_PRIVATE, pointer);

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.3
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.3
@@ -46,7 +46,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     long protocol;

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.3
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.3
@@ -38,7 +38,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://127.0.0.1:80");
 
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.3
@@ -37,7 +37,7 @@ HTTP(S)
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_URL.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_URL.3
@@ -43,7 +43,7 @@ HTTP(S)
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     char *url = NULL;

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.3
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.3
@@ -38,7 +38,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     long req;

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
@@ -42,7 +42,7 @@ HTTP, FTP and SMTP
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     long response_code;

--- a/docs/libcurl/opts/CURLINFO_RETRY_AFTER.3
+++ b/docs/libcurl/opts/CURLINFO_RETRY_AFTER.3
@@ -44,7 +44,7 @@ HTTP(S)
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     curl_off_t wait = 0;

--- a/docs/libcurl/opts/CURLINFO_SCHEME.3
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.3
@@ -42,7 +42,7 @@ All
 CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode res;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   res = curl_easy_perform(curl);
   if(res == CURLE_OK) {
     char *scheme = NULL;

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
@@ -42,7 +42,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.3
@@ -39,7 +39,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
@@ -39,7 +39,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.3
@@ -36,7 +36,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
@@ -38,7 +38,7 @@ sensible variable type.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.3
@@ -35,7 +35,7 @@ that curl measured for the complete download. Measured in bytes/second.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
@@ -38,7 +38,7 @@ sensible variable type.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.3
@@ -35,7 +35,7 @@ curl measured for the complete upload. Measured in bytes/second.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
@@ -82,7 +82,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* enable all supported built-in compressions */
   curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
@@ -39,7 +39,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* follow redirects */
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
@@ -47,7 +47,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* complete connection within 10 seconds */
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
@@ -47,7 +47,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* complete connection within 10000 milliseconds */
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 10000L);

--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
@@ -93,7 +93,7 @@ connect_to = curl_slist_append(NULL, "example.com::server1.example.com:");
 curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLOPT_COOKIE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.3
@@ -66,7 +66,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_setopt(curl, CURLOPT_COOKIE, "tool=curl; fun=yes;");
 

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
@@ -65,7 +65,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* get cookies from an existing file */
   curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "/tmp/cookies.txt");

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
@@ -57,7 +57,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* export cookies to this file when closing the handle */
   curl_easy_setopt(curl, CURLOPT_COOKIEJAR, "/tmp/cookies.txt");

--- a/docs/libcurl/opts/CURLOPT_COOKIESESSION.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIESESSION.3
@@ -45,7 +45,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* new "session", don't load session cookies */
   curl_easy_setopt(curl, CURLOPT_COOKIESESSION, 1L);

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
@@ -50,7 +50,7 @@ HTTP(S)
 CURL *curl = curl_easy_init();
 if(curl) {
   char local_buffer[1024]="data to send";
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* size of the data to copy from the buffer and send in the request */
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 12L);

--- a/docs/libcurl/opts/CURLOPT_CURLU.3
+++ b/docs/libcurl/opts/CURLOPT_CURLU.3
@@ -50,7 +50,7 @@ CURLU *urlp = curl_url();
 int res = 0;
 if(curl) {
 
-  res = curl_url_set(urlp, CURLUPART_URL, "http://example.com", 0);
+  res = curl_url_set(urlp, CURLUPART_URL, "https://example.com", 0);
 
   curl_easy_setopt(handle, CURLOPT_CURLU, urlp);
 

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
@@ -91,7 +91,7 @@ HTTP, FTP, IMAP, POP3 and SMTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* DELETE the given path */
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
@@ -166,7 +166,7 @@ int main(void)
     /* example.com is redirected, so we tell libcurl to follow redirection */
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
-    curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     res = curl_easy_perform(curl);
     /* Check for errors */
     if(res != CURLE_OK)

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
@@ -39,7 +39,7 @@ Several
 CURL *curl = curl_easy_init();
 if(curl) {
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_DISALLOW_USERNAME_IN_URL, 1L);
 
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
@@ -50,7 +50,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* only reuse addresses for a very short time */
   curl_easy_setopt(curl, CURLOPT_DNS_CACHE_TIMEOUT, 2L);

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
@@ -42,7 +42,7 @@ NULL
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_DNS_INTERFACE, "eth0");
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
@@ -43,7 +43,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_DNS_LOCAL_IP4, "192.168.0.14");
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
@@ -43,7 +43,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_DNS_LOCAL_IP6, "fe80::a9ff:fe46:b619");
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
@@ -47,7 +47,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_DNS_SERVERS, "192.168.1.100:53,192.168.1.101");
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -53,7 +53,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_DOH_URL, "https://dns.example.com");
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
@@ -56,7 +56,7 @@ if(curl) {
   CURLcode res;
   char errbuf[CURL_ERROR_SIZE];
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* provide a buffer to store errors in */
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);

--- a/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.3
@@ -43,7 +43,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* wait 3 seconds for 100-continue */
   curl_easy_setopt(curl, CURLOPT_EXPECT_100_TIMEOUT_MS, 3000L);

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
@@ -63,7 +63,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* example.com is redirected, so we tell libcurl to follow redirection */
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);

--- a/docs/libcurl/opts/CURLOPT_HEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HEADER.3
@@ -55,7 +55,7 @@ Most
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
 

--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.3
@@ -60,7 +60,7 @@ static size_t header_callback(char *buffer, size_t size,
 CURL *curl = curl_easy_init();
 if(curl) {
   struct my_info my = { 10, "the cookies are in the cupboard" };
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
 

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
@@ -102,7 +102,7 @@ static size_t header_callback(char *buffer, size_t size,
 
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
 

--- a/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.3
@@ -53,7 +53,7 @@ HTTP
 CURL *curl = curl_easy_init();
 if(curl) {
   struct curl_slist *list;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   list = curl_slist_append(NULL, "ICY 200 OK");
   list = curl_slist_append(list, "WEIRDO 99 FINE");

--- a/docs/libcurl/opts/CURLOPT_HTTPGET.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPGET.3
@@ -46,7 +46,7 @@ HTTP(S)
 .nf
 curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* use a GET to fetch this */
   curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
@@ -102,7 +102,7 @@ CURL *curl = curl_easy_init();
 struct curl_slist *list = NULL;
 
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   list = curl_slist_append(list, "Shoesize: 10");
   list = curl_slist_append(list, "Accept:");

--- a/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.3
+++ b/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.3
@@ -51,7 +51,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* we know the server is silly, ignore content-length */
   curl_easy_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);

--- a/docs/libcurl/opts/CURLOPT_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.3
@@ -54,7 +54,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   curl_easy_setopt(curl, CURLOPT_INTERFACE, "eth0");
 

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
@@ -45,7 +45,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   /* resolve host name using IPv6-names only */
   curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
@@ -43,7 +43,7 @@ All TLS based protocols: HTTPS, FTPS, IMAPS, POP3S, SMTPS etc.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_SSLCERT, "client.pem");
   curl_easy_setopt(curl, CURLOPT_SSLKEY, "key.pem");
   curl_easy_setopt(curl, CURLOPT_KEYPASSWD, "superman");

--- a/docs/libcurl/opts/CURLOPT_LOCALPORT.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORT.3
@@ -40,7 +40,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_LOCALPORT, 49152L);
   /* and try 20 more ports following that */
   curl_easy_setopt(curl, CURLOPT_LOCALPORTRANGE, 20L);

--- a/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
@@ -44,7 +44,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_LOCALPORT, 49152L);
   /* and try 20 more ports following that */
   curl_easy_setopt(curl, CURLOPT_LOCALPORTRANGE, 20L);

--- a/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.3
+++ b/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.3
@@ -48,7 +48,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* only allow 30 seconds idle time */
   curl_easy_setopt(curl, CURLOPT_MAXAGE_CONN, 30L);

--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
@@ -44,7 +44,7 @@ HTTP(S)
 .nf
 curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
   /* enable redirect following */
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);

--- a/docs/libcurl/opts/CURLOPT_NOPROGRESS.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROGRESS.3
@@ -40,7 +40,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* enable progress meter */
   curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.3
@@ -44,7 +44,7 @@ Most
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   curl_easy_setopt(curl, CURLOPT_PASSWORD, "qwerty");
 

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.3
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.3
@@ -48,7 +48,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/../../etc/password");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/../../etc/password");
 
   curl_easy_setopt(curl, CURLOPT_PATH_AS_IS, 1L);
 

--- a/docs/libcurl/opts/CURLOPT_PORT.3
+++ b/docs/libcurl/opts/CURLOPT_PORT.3
@@ -45,7 +45,7 @@ Used for all protocols that speak to a port number.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_PORT, 8080L);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_POST.3
+++ b/docs/libcurl/opts/CURLOPT_POST.3
@@ -72,7 +72,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* set up the read callback with CURLOPT_READFUNCTION */

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
@@ -69,7 +69,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   const char *data = "data to send";
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* size of the POST data */
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 12L);

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
@@ -44,7 +44,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   const char *data = "data to send";
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* size of the POST data */
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long) strlen(data));

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.3
@@ -45,7 +45,7 @@ if(curl) {
   const char *data = large_chunk;
   curl_off_t length_of_data; /* set somehow */
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* size of the POST data */
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, length_of_data);

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.3
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.3
@@ -52,7 +52,7 @@ HTTP(S)
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* a silly POST example */
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "data=true");

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
@@ -64,7 +64,7 @@ All except file://. Note that some protocols don't do very well over proxy.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/file.txt");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/file.txt");
   curl_easy_setopt(curl, CURLOPT_PREPROXY, "socks4://socks-proxy:1080");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://proxy:80");
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_PRIVATE.3
+++ b/docs/libcurl/opts/CURLOPT_PRIVATE.3
@@ -42,7 +42,7 @@ CURL *curl = curl_easy_init();
 struct private secrets;
 if(curl) {
   struct private *extracted;
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* store a pointer to our private struct */
   curl_easy_setopt(curl, CURLOPT_PRIVATE, &secrets);

--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -95,7 +95,7 @@ All except file://. Note that some protocols don't do very well over proxy.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/file.txt");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/file.txt");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://proxy:80");
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
@@ -44,7 +44,7 @@ Most
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://localhost:8080");
   curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, "mrsmith");
   curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, "qwerty");

--- a/docs/libcurl/opts/CURLOPT_PROXYPORT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPORT.3
@@ -42,7 +42,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_PROXY, "localhost");
   curl_easy_setopt(curl, CURLOPT_PROXYPORT, 8080L);
   ret = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
@@ -48,7 +48,7 @@ Most
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://localhost:8080");
   curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, "mrsmith");
   curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, "qwerty");

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
@@ -46,7 +46,7 @@ Used with all protocols that can use a proxy
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_PROXY, "http://localhost:8080");
   curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, "clark%20kent:superman");
   ret = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
@@ -45,7 +45,7 @@ Used with HTTPS proxy
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
   curl_easy_setopt(curl, CURLOPT_PROXY, "https://proxy:443");
   curl_easy_setopt(curl, CURLOPT_PROXY_KEYPASSWD, "superman");
   ret = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_RANGE.3
+++ b/docs/libcurl/opts/CURLOPT_RANGE.3
@@ -63,7 +63,7 @@ HTTP, FTP, FILE, RTSP and SFTP.
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* get the first 200 bytes */
   curl_easy_setopt(curl, CURLOPT_RANGE, "0-199");

--- a/docs/libcurl/opts/CURLOPT_READDATA.3
+++ b/docs/libcurl/opts/CURLOPT_READDATA.3
@@ -47,7 +47,7 @@ This is used for all protocols when sending data.
 CURL *curl = curl_easy_init();
 struct MyData this;
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* pass pointer that gets passed in to the
      CURLOPT_READFUNCTION callback */

--- a/docs/libcurl/opts/CURLOPT_REFERER.3
+++ b/docs/libcurl/opts/CURLOPT_REFERER.3
@@ -43,10 +43,10 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* tell it where we found the link to this place */
-  curl_easy_setopt(curl, CURLOPT_REFERER, "http://example.com/aboutme.html");
+  curl_easy_setopt(curl, CURLOPT_REFERER, "https://example.com/aboutme.html");
 
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.3
+++ b/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.3
@@ -38,7 +38,7 @@ HTTP
 .nf
 curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/*");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/*");
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
 
   /* issue an OPTIONS * request (no leading slash) */

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.3
@@ -79,7 +79,7 @@ host = curl_slist_append(NULL, "example.com:80:127.0.0.1");
 curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_RESOLVE, host);
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.3
@@ -50,7 +50,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_start_cb);
   curl_easy_setopt(curl, CURLOPT_RESOLVER_START_DATA, curl);
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.3
@@ -70,7 +70,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_start_cb);
   curl_easy_setopt(curl, CURLOPT_RESOLVER_START_DATA, curl);
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.3
@@ -48,7 +48,7 @@ curl = curl_easy_init();
 if(curl) {
   int recvbuffersize = 256 * 1024;
 
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
   /* call this function to set options for the socket */
   curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_callback);

--- a/docs/libcurl/opts/CURLOPT_STDERR.3
+++ b/docs/libcurl/opts/CURLOPT_STDERR.3
@@ -40,7 +40,7 @@ All
 CURL *curl = curl_easy_init();
 FILE *filep = fopen("dump", "wb");
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_STDERR, filep);
 
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
@@ -41,7 +41,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_TCP_FASTOPEN, 1L);
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.3
@@ -41,7 +41,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* enable TCP keep-alive for this transfer */
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.3
@@ -39,7 +39,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* enable TCP keep-alive for this transfer */
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.3
@@ -39,7 +39,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* enable TCP keep-alive for this transfer */
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.3
@@ -50,7 +50,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   /* disable Nagle */
   curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 0);
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
@@ -45,7 +45,7 @@ HTTP, FTP, RTSP, and FILE
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* January 1, 2020 is 1577833200 */
   curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.3
@@ -54,7 +54,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* complete within 20 seconds */
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 20L);

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.3
@@ -57,7 +57,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* complete within 20000 milliseconds */
   curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 20000L);

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.3
@@ -42,7 +42,7 @@ HTTP, FTP, RTSP, and FILE
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* January 1, 2020 is 1577833200 */
   curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.3
@@ -43,7 +43,7 @@ HTTP, FTP, RTSP, and FILE
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* January 1, 2020 is 1577833200 */
   curl_easy_setopt(curl, CURLOPT_TIMEVALUE_LARGE, (curl_off_t)1577833200);

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
@@ -73,7 +73,7 @@ static int trailer_cb(struct curl_slist **tr, void *data)
 CURL *curl = curl_easy_init();
 if(curl) {
   /* Set the URL of the request */
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
   /* Now set it as a put */
   curl_easy_setopt(curl, CURLOPT_PUT, 1L);
 

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.3
@@ -48,7 +48,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_TRANSFER_ENCODING, 1L);
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.3
@@ -46,7 +46,7 @@ HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -339,7 +339,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.3
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.3
@@ -43,7 +43,7 @@ HTTP, HTTPS
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   curl_easy_setopt(curl, CURLOPT_USERAGENT, "Dark Secret Ninja/1.0");
 

--- a/docs/libcurl/opts/CURLOPT_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.3
@@ -66,7 +66,7 @@ Most
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   curl_easy_setopt(curl, CURLOPT_USERNAME, "clark");
 

--- a/docs/libcurl/opts/CURLOPT_USERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.3
@@ -72,7 +72,7 @@ Most
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/foo.bin");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
   curl_easy_setopt(curl, CURLOPT_USERPWD, "clark:kent");
 

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.3
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.3
@@ -46,7 +46,7 @@ All
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* ask libcurl to show us the verbose output */
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
Since HTTPS is "the new normal", this update changes a lot of man page
examples to use https://example.com instead of the previous "http://..."