### PR TITLE
Issue5974: Fix easy_reset retry mechanism for http

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -969,6 +969,7 @@ void curl_easy_reset(struct Curl_easy *data)
 
   data->progress.flags |= PGRS_HIDE;
   data->state.current_speed = -1; /* init to negative == impossible */
+  data->state.retrycount = 0;     /* reset the retry counter */
 
   /* zero out authentication data: */
   memset(&data->state.authhost, 0, sizeof(struct auth));


### PR DESCRIPTION
This fix the issue 5974 breaking the retry mechanism if reset is used