### PR TITLE
--help: strdup the category

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1777,7 +1777,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 
     case 'h': /* h for help */
       if(toggle) {
-        global->help_category = nextarg;
+        global->help_category = strdup(nextarg);
+        if(!global->help_category)
+          return PARAM_NO_MEM;
         return PARAM_HELP_REQUESTED;
       }
       /* we now actually support --no-help too! */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1777,9 +1777,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 
     case 'h': /* h for help */
       if(toggle) {
-        global->help_category = strdup(nextarg);
-        if(!global->help_category)
-          return PARAM_NO_MEM;
+        if(nextarg) {
+          global->help_category = strdup(nextarg);
+          if(!global->help_category)
+            return PARAM_NO_MEM;
+        }
         return PARAM_HELP_REQUESTED;
       }
       /* we now actually support --no-help too! */

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -905,26 +905,21 @@ void tool_help(const char *category)
   /* If no category was provided */
   if(!category) {
     const char *category_note = "\nThis is not the full help, this "
-    "menu is stripped into categories.\nUse \"--help category\" to get "
-    "an overview of all categories.\nFor all options use the manual"
-    " or \"--help all\".";
+      "menu is stripped into categories.\nUse \"--help category\" to get "
+      "an overview of all categories.\nFor all options use the manual"
+      " or \"--help all\".";
     print_category(CURLHELP_IMPORTANT);
     puts(category_note);
-    return;
   }
   /* Lets print everything if "all" was provided */
-  if(curl_strequal(category, "all")) {
+  else if(curl_strequal(category, "all"))
     /* Print everything except hidden */
     print_category(~(CURLHELP_HIDDEN));
-    return;
-  }
   /* Lets handle the string "category" differently to not print an errormsg */
-  if(curl_strequal(category, "category")) {
+  else if(curl_strequal(category, "category"))
     get_categories();
-    return;
-  }
   /* Otherwise print category and handle the case if the cat was not found */
-  if(get_category_content(category)) {
+  else if(get_category_content(category)) {
     puts("Invalid category provided, here is a list of all categories:\n");
     get_categories();
   }

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -928,6 +928,7 @@ void tool_help(const char *category)
     puts("Invalid category provided, here is a list of all categories:\n");
     get_categories();
   }
+  free((char *)category);
 }
 
 static int

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -899,7 +899,7 @@ static void get_categories(void)
 }
 
 
-void tool_help(const char *category)
+void tool_help(char *category)
 {
   puts("Usage: curl [options...] <url>");
   /* If no category was provided */
@@ -923,7 +923,7 @@ void tool_help(const char *category)
     puts("Invalid category provided, here is a list of all categories:\n");
     get_categories();
   }
-  free((char *)category);
+  free(category);
 }
 
 static int

--- a/src/tool_help.h
+++ b/src/tool_help.h
@@ -23,7 +23,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-void tool_help(const char *category);
+void tool_help(char *category);
 void tool_list_engines(void);
 void tool_version_info(void);
 


### PR DESCRIPTION
... since it is converted and the original pointer is freed on Windows
unicode handling.

Follow-up to aa8777f63febc
Fixes #5977
Reported-by: xwxbug on github