### PR TITLE
cmake: remove scary warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ include(CheckCCompilerFlag)
 
 project(CURL C)
 
-message(WARNING "the curl cmake build system is poorly maintained. Be aware")
-
 file(STRINGS ${CURL_SOURCE_DIR}/include/curl/curlver.h CURL_VERSION_H_CONTENTS REGEX "#define LIBCURL_VERSION( |_NUM )")
 string(REGEX MATCH "#define LIBCURL_VERSION \"[^\"]*"
   CURL_VERSION ${CURL_VERSION_H_CONTENTS})


### PR DESCRIPTION
Remove the text saying

"the curl cmake build system is poorly maintained. Be aware"

... not because anything changed just now, but to perhaps encourage
users to use it and subsequently improve it.