### PR TITLE
curl_krb5.h: rename from krb5.h

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -68,7 +68,7 @@ LIB_HFILES = altsvc.h amigaos.h arpa_telnet.h asyn.h conncache.h connect.h    \
   curl_des.h curl_endian.h curl_fnmatch.h curl_get_line.h curl_gethostname.h  \
   curl_gssapi.h curl_hmac.h curl_ldap.h curl_md4.h curl_md5.h curl_memory.h   \
   curl_memrchr.h curl_multibyte.h curl_ntlm_core.h curl_ntlm_wb.h curl_path.h \
-  curl_printf.h curl_range.h curl_rtmp.h curl_sasl.h krb5.h     curl_setup.h  \
+  curl_printf.h curl_range.h curl_rtmp.h curl_sasl.h curl_krb5.h curl_setup.h \
   curl_setup_once.h curl_sha256.h curl_sspi.h curl_threads.h curlx.h dict.h   \
   dotdot.h easyif.h escape.h file.h fileinfo.h formdata.h ftp.h url.h         \
   ftplistparser.h getinfo.h gopher.h hash.h hostcheck.h hostip.h http.h       \

--- a/lib/curl_krb5.h
+++ b/lib/curl_krb5.h
@@ -1,5 +1,5 @@
-#ifndef HEADER_CURL_SECURITY_H
-#define HEADER_CURL_SECURITY_H
+#ifndef HEADER_CURL_KRB5_H
+#define HEADER_CURL_KRB5_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -48,4 +48,4 @@ int Curl_sec_request_prot(struct connectdata *conn, const char *level);
 #define Curl_sec_end(x)
 #endif
 
-#endif /* HEADER_CURL_SECURITY_H */
+#endif /* HEADER_CURL_KRB5_H */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -59,7 +59,7 @@
 #include "fileinfo.h"
 #include "ftplistparser.h"
 #include "curl_range.h"
-#include "krb5.h"
+#include "curl_krb5.h"
 #include "strtoofft.h"
 #include "strcase.h"
 #include "vtls/vtls.h"

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -45,7 +45,7 @@
 #include "ftp.h"
 #include "curl_gssapi.h"
 #include "sendf.h"
-#include "krb5.h"
+#include "curl_krb5.h"
 #include "warnless.h"
 #include "non-ascii.h"
 #include "strcase.h"


### PR DESCRIPTION
Follow-up from f4873ebd0be32cf

Turns out some older openssl installations go bananas otherwise.
Reported-by: Tom van der Woerdt
Fixes #5995