### PR TITLE
dynbuf: make *addf() not require extra mallocs

### DIFF
--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -181,19 +181,15 @@ CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
  */
 CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
 {
-  char *str;
   va_list ap;
+  int rc;
   va_start(ap, fmt);
-  str = vaprintf(fmt, ap); /* this allocs a new string to append */
+  rc = Curl_dyn_vprintf(s, fmt, ap);
   va_end(ap);
 
-  if(str) {
-    CURLcode result = dyn_nappend(s, (unsigned char *)str, strlen(str));
-    free(str);
-    return result;
-  }
-  /* If we failed, we cleanup the whole buffer and return error */
-  Curl_dyn_free(s);
+  if(!rc)
+    return CURLE_OK;
+
   return CURLE_OUT_OF_MEMORY;
 }
 

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -62,6 +62,10 @@ char *Curl_dyn_ptr(const struct dynbuf *s);
 unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
 size_t Curl_dyn_len(const struct dynbuf *s);
 
+/* returns 0 on success, -1 on error */
+/* The implementation of this function exists in mprintf.c */
+int Curl_dyn_vprintf(struct dynbuf *dyn, const char *format, va_list ap_save);
+
 /* Dynamic buffer max sizes */
 #define DYN_DOH_RESPONSE    3000
 #define DYN_DOH_CNAME       256


### PR DESCRIPTION
... by introducing a printf() function that appends directly into a
dynbuf: Curl_dyn_vprintf(). This avoids the mandatory extra malloc so if
the buffer is already big enough it can just printf directly into it.