### PR TITLE
WIP: ci: Order clang tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,104 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
+    - T=iconv
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+  - env:
+    - T=cmake BORINGSSL=yes QUICHE=yes C="-DUSE_QUICHE=1 -DOPENSSL_ROOT_DIR=$HOME/boringssl -DCURL_BROTLI=1 -DCURL_ZSTD=1"
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    - PKG_CONFIG_PATH="$HOME/quiche/target/release"
+    before_install:
+    - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+  - env:
+    - T=torture
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - lcov
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+        - libssh2-1-dev
+  - env:
+    - T=debug C="--enable-alt-svc"
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    arch: arm64
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+        - libev-dev
+        - libssl-dev
+        - libtool
+        - pkg-config
+        - zlib1g-dev
+
+  - env:
+    - T=debug C="--enable-alt-svc"
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    arch: ppc64le
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+        - libev-dev
+        - libssl-dev
+        - libtool
+        - pkg-config
+        - zlib1g-dev
+
+  - env:
+    - T=debug C="--enable-alt-svc"
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    arch: s390x
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+        - libev-dev
+        - libssl-dev
+        - libtool
+        - pkg-config
+        - zlib1g-dev
+
+  - env:
+    - T=distcheck
+    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+
+# Begin clang section
+
+  - env:
     - T=debug
     - &clang OVERRIDE_CC="CC=clang-9" OVERRIDE_CXX="CXX=clang++-9"
     compiler: clang
@@ -241,23 +339,6 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=iconv
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-  - env:
-    - T=cmake BORINGSSL=yes QUICHE=yes C="-DUSE_QUICHE=1 -DOPENSSL_ROOT_DIR=$HOME/boringssl -DCURL_BROTLI=1 -DCURL_ZSTD=1"
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    - PKG_CONFIG_PATH="$HOME/quiche/target/release"
-    before_install:
-    - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
-    addons:
-      apt:
-        <<: *common_apt
-        packages:
-        - *common_packages
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-  - env:
     - T=cmake NGTCP2=yes C="-DUSE_NGTCP2=ON -DCURL_BROTLI=1 -DCURL_ZSTD=1"
     - *clang
     - PKG_CONFIG_PATH="$HOME/ngbuild/lib/pkgconfig"
@@ -267,30 +348,6 @@ jobs:
         <<: *common_apt
         packages:
         - *clang_packages
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-  - env:
-    - T=torture
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    addons:
-      apt:
-        <<: *common_apt
-        packages:
-        - *common_packages
-        - lcov
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-        - libssh2-1-dev
-  - env:
-    - T=distcheck
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    addons:
-      apt:
-        <<: *common_apt
-        packages:
-        - *common_packages
         - libpsl-dev
         - libbrotli-dev
         - libzstd-dev
@@ -343,59 +400,6 @@ jobs:
         - libpsl-dev
         - libbrotli-dev
         - libzstd-dev
-  - env:
-    - T=debug C="--enable-alt-svc"
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    arch: arm64
-    addons:
-      apt:
-        <<: *common_apt
-        packages:
-        - *common_packages
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-        - libev-dev
-        - libssl-dev
-        - libtool
-        - pkg-config
-        - zlib1g-dev
-
-  - env:
-    - T=debug C="--enable-alt-svc"
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    arch: ppc64le
-    addons:
-      apt:
-        <<: *common_apt
-        packages:
-        - *common_packages
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-        - libev-dev
-        - libssl-dev
-        - libtool
-        - pkg-config
-        - zlib1g-dev
-
-  - env:
-    - T=debug C="--enable-alt-svc"
-    - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
-    arch: s390x
-    addons:
-      apt:
-        <<: *common_apt
-        packages:
-        - *common_packages
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-        - libev-dev
-        - libssl-dev
-        - libtool
-        - pkg-config
-        - zlib1g-dev
 
 before_install:
 - export "${OVERRIDE_CC-blank=}"


### PR DESCRIPTION
Currently all clang tests are wildly placed into the .travis.yml file.
The purpose of this pull request is to put them into a nice order so
when looking at the travis site it's easy to find the clang entries at
one look. Also it's probably easier to add new clang test cases then.