### PR TITLE
make pingpong's sendf() use dynbuf

### DIFF
--- a/docs/DYNBUF.md
+++ b/docs/DYNBUF.md
@@ -42,6 +42,12 @@ Append a C string to the end of the buffer.
 
 Append a `printf()`-style string to the end of the buffer.
 
+## vaddf
+
+    CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap);
+
+Append a `vprintf()`-style string to the end of the buffer.
+
 ## reset
 
     void Curl_dyn_reset(struct dynbuf *s);

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -177,24 +177,22 @@ CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
 }
 
 /*
- * Append a string printf()-style
+ * Append a string vprintf()-style
  */
-CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
+CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
 {
-  va_list ap;
 #ifdef BUILDING_LIBCURL
   int rc;
-  va_start(ap, fmt);
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
   rc = Curl_dyn_vprintf(s, fmt, ap);
-  va_end(ap);
 
   if(!rc)
     return CURLE_OK;
 #else
   char *str;
-  va_start(ap, fmt);
   str = vaprintf(fmt, ap); /* this allocs a new string to append */
-  va_end(ap);
 
   if(str) {
     CURLcode result = dyn_nappend(s, (unsigned char *)str, strlen(str));
@@ -207,7 +205,21 @@ CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
   return CURLE_OUT_OF_MEMORY;
 }
 
-
+/*
+ * Append a string printf()-style
+ */
+CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
+{
+  CURLcode result;
+  va_list ap;
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  va_start(ap, fmt);
+  result = Curl_dyn_vaddf(s, fmt, ap);
+  va_end(ap);
+  return result;
+}
 
 /*
  * Returns a pointer to the buffer.

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -29,6 +29,7 @@
 #define Curl_dyn_add(a,b) curlx_dyn_add(a,b)
 #define Curl_dyn_addn(a,b,c) curlx_dyn_addn(a,b,c)
 #define Curl_dyn_addf curlx_dyn_addf
+#define Curl_dyn_vaddf curlx_dyn_vaddf
 #define Curl_dyn_free(a) curlx_dyn_free(a)
 #define Curl_dyn_ptr(a) curlx_dyn_ptr(a)
 #define Curl_dyn_uptr(a) curlx_dyn_uptr(a)
@@ -56,6 +57,8 @@ CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
   WARN_UNUSED_RESULT;
 CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
   WARN_UNUSED_RESULT;
+CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
+  WARN_UNUSED_RESULT;
 void Curl_dyn_reset(struct dynbuf *s);
 CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail);
 char *Curl_dyn_ptr(const struct dynbuf *s);
@@ -80,4 +83,5 @@ int Curl_dyn_vprintf(struct dynbuf *dyn, const char *format, va_list ap_save);
 #define DYN_PROXY_CONNECT_HEADERS 16384
 #define DYN_QLOG_NAME       1024
 #define DYN_H1_TRAILER      4096
+#define DYN_PINGPPONG_CMD   (64*1024)
 #endif

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3112,6 +3112,7 @@ static CURLcode ftp_connect(struct connectdata *conn,
       return result;
   }
 
+  Curl_pp_setup(pp); /* once per transfer */
   Curl_pp_init(pp); /* init the generic pingpong data */
 
   /* When we connect, we start in the state where we await the 220

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1430,6 +1430,7 @@ static CURLcode imap_connect(struct connectdata *conn, bool *done)
   Curl_sasl_init(&imapc->sasl, &saslimap);
 
   /* Initialise the pingpong layer */
+  Curl_pp_setup(pp);
   Curl_pp_init(pp);
 
   /* Parse the URL options */

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -146,7 +146,11 @@ void Curl_pp_init(struct pingpong *pp)
   pp->response = Curl_now(); /* start response time-out now! */
 }
 
-
+/* setup for the coming transfer */
+void Curl_pp_setup(struct pingpong *pp)
+{
+  Curl_dyn_init(&pp->sendbuf, DYN_PINGPPONG_CMD);
+}
 
 /***********************************************************************
  *
@@ -164,8 +168,6 @@ CURLcode Curl_pp_vsendf(struct pingpong *pp,
 {
   ssize_t bytes_written = 0;
   size_t write_len;
-  char fmt_crlf[128];
-  size_t fmtlen;
   char *s;
   CURLcode result;
   struct connectdata *conn = pp->conn;
@@ -182,49 +184,42 @@ CURLcode Curl_pp_vsendf(struct pingpong *pp,
   if(!conn)
     /* can't send without a connection! */
     return CURLE_SEND_ERROR;
-
   data = conn->data;
 
-  fmtlen = strlen(fmt);
-  DEBUGASSERT(fmtlen < sizeof(fmt_crlf)-3);
-  if(fmtlen >= sizeof(fmt_crlf)-3)
-    return CURLE_BAD_FUNCTION_ARGUMENT;
-  memcpy(fmt_crlf, fmt, fmtlen);
-  /* append a trailing CRLF+null to the format string */
-  memcpy(&fmt_crlf[fmtlen], "\r\n", 3);
-  s = vaprintf(fmt_crlf, args);
-  if(!s)
-    return CURLE_OUT_OF_MEMORY;
+  Curl_dyn_reset(&pp->sendbuf);
+  result = Curl_dyn_vaddf(&pp->sendbuf, fmt, args);
+  if(result)
+    return result;
 
-  write_len = strlen(s);
+  /* append CRLF */
+  result = Curl_dyn_addn(&pp->sendbuf, "\r\n", 2);
+  if(result)
+    return result;
 
+  write_len = Curl_dyn_len(&pp->sendbuf);
+  s = Curl_dyn_ptr(&pp->sendbuf);
   Curl_pp_init(pp);
 
   result = Curl_convert_to_network(data, s, write_len);
   /* Curl_convert_to_network calls failf if unsuccessful */
-  if(result) {
-    free(s);
+  if(result)
     return result;
-  }
 
 #ifdef HAVE_GSSAPI
   conn->data_prot = PROT_CMD;
 #endif
   result = Curl_write(conn, conn->sock[FIRSTSOCKET], s, write_len,
-                     &bytes_written);
+                      &bytes_written);
+  if(result)
+    return result;
 #ifdef HAVE_GSSAPI
   data_sec = conn->data_prot;
   DEBUGASSERT(data_sec > PROT_NONE && data_sec < PROT_LAST);
   conn->data_prot = data_sec;
 #endif
 
-  if(result) {
-    free(s);
-    return result;
-  }
-
-  if(conn->data->set.verbose)
-    Curl_debug(conn->data, CURLINFO_HEADER_OUT, s, (size_t)bytes_written);
+  if(data->set.verbose)
+    Curl_debug(data, CURLINFO_HEADER_OUT, s, (size_t)bytes_written);
 
   if(bytes_written != (ssize_t)write_len) {
     /* the whole chunk was not sent, keep it around and adjust sizes */
@@ -233,7 +228,6 @@ CURLcode Curl_pp_vsendf(struct pingpong *pp,
     pp->sendleft = write_len - bytes_written;
   }
   else {
-    free(s);
     pp->sendthis = NULL;
     pp->sendleft = pp->sendsize = 0;
     pp->response = Curl_now();
@@ -495,7 +489,6 @@ CURLcode Curl_pp_flushsend(struct pingpong *pp)
     pp->sendleft -= written;
   }
   else {
-    free(pp->sendthis);
     pp->sendthis = NULL;
     pp->sendleft = pp->sendsize = 0;
     pp->response = Curl_now();
@@ -505,15 +498,15 @@ CURLcode Curl_pp_flushsend(struct pingpong *pp)
 
 CURLcode Curl_pp_disconnect(struct pingpong *pp)
 {
-  free(pp->cache);
-  pp->cache = NULL;
+  Curl_dyn_free(&pp->sendbuf);
+  Curl_safefree(pp->cache);
   return CURLE_OK;
 }
 
 bool Curl_pp_moredata(struct pingpong *pp)
 {
   return (!pp->sendleft && pp->cache && pp->nread_resp < pp->cache_size) ?
-         TRUE : FALSE;
+    TRUE : FALSE;
 }
 
 #endif

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -64,6 +64,7 @@ struct pingpong {
                                milliseconds we await for a server response. */
   struct connectdata *conn; /* points to the connectdata struct that this
                                belongs to */
+  struct dynbuf sendbuf;
 
   /* Function pointers the protocols MUST implement and provide for the
      pingpong layer to function */
@@ -85,6 +86,9 @@ CURLcode Curl_pp_statemach(struct pingpong *pp, bool block,
 
 /* initialize stuff to prepare for reading a fresh new response */
 void Curl_pp_init(struct pingpong *pp);
+
+/* setup for the transfer */
+void Curl_pp_setup(struct pingpong *pp);
 
 /* Returns timeout in ms. 0 or negative number means the timeout has already
    triggered */

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1093,6 +1093,7 @@ static CURLcode pop3_connect(struct connectdata *conn, bool *done)
   Curl_sasl_init(&pop3c->sasl, &saslpop3);
 
   /* Initialise the pingpong layer */
+  Curl_pp_setup(pp);
   Curl_pp_init(pp);
 
   /* Parse the URL options */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1324,6 +1324,7 @@ static CURLcode smtp_connect(struct connectdata *conn, bool *done)
   Curl_sasl_init(&smtpc->sasl, &saslsmtp);
 
   /* Initialise the pingpong layer */
+  Curl_pp_setup(pp);
   Curl_pp_init(pp);
 
   /* Parse the URL options */


### PR DESCRIPTION
By having `Curl_pp_vsendf` use a dynbuf for the send buffer, we avoid frequent malloc/realloc/free series. Test case 100 (FTP dir list PASV) does 7 fewer memory allocation calls after this in my test setup (132 => 125), curl 7.72.0 needed 140 calls for this.

Test case 103 makes 9 less now (130). Down from 149 in 7.72.0.

This PR adds `Curl_dyn_vaddf` to the dynbuf API to make this possible.