### PR TITLE
ftp: separate FTPS from "HTTPS proxy" use

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -469,6 +469,7 @@ struct ConnectBits {
                          EPRT doesn't work we disable it for the forthcoming
                          requests */
   BIT(ftp_use_data_ssl); /* Enabled SSL for the data connection */
+  BIT(ftp_use_control_ssl); /* Enabled SSL for the control connection */
 #endif
   BIT(netrc);         /* name+password provided by netrc */
   BIT(bound); /* set true if bind() has already been done on this socket/

--- a/tests/data/test1631
+++ b/tests/data/test1631
@@ -74,8 +74,6 @@ Proxy-Connection: Keep-Alive
 <protocol>
 USER anonymous
 PASS ftp@example.com
-PBSZ 0
-PROT P
 PWD
 EPSV
 TYPE I

--- a/tests/data/test1632
+++ b/tests/data/test1632
@@ -89,8 +89,6 @@ Proxy-Connection: Keep-Alive
 <protocol>
 USER anonymous
 PASS ftp@example.com
-PBSZ 0
-PROT P
 PWD
 EPSV
 TYPE I


### PR DESCRIPTION
When using HTTPS proxy, SSL is used but not in the view of the FTP
protocol handler itself so separate the connection's use of SSL from the
FTP control connection's sue.

Fixes #5523