### PR TITLE
conncache: alloc "closure handle" on demand

### DIFF
--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -34,8 +34,12 @@ struct conncache {
   size_t num_conn;
   long next_connection_id;
   struct curltime last_cleanup;
-  /* handle used for closing cached connections */
-  struct Curl_easy *closure_handle;
+
+  /* settings the "closure handle" wants */
+  long timeout;
+  long server_response_timeout;
+  bool no_signal;
+  bool update_values; /* if these settings are set */
 };
 
 #define BUNDLE_NO_MULTIUSE -1
@@ -101,7 +105,8 @@ Curl_conncache_extract_bundle(struct Curl_easy *data,
                               struct connectbundle *bundle);
 struct connectdata *
 Curl_conncache_extract_oldest(struct Curl_easy *data);
-void Curl_conncache_close_all_connections(struct conncache *connc);
+void Curl_conncache_close_all_connections(struct conncache *connc,
+                                          struct Curl_easy *data);
 void Curl_conncache_print(struct conncache *connc);
 
 #endif /* HEADER_CURL_CONNCACHE_H */

--- a/lib/share.c
+++ b/lib/share.c
@@ -197,7 +197,7 @@ curl_share_cleanup(struct Curl_share *share)
     return CURLSHE_IN_USE;
   }
 
-  Curl_conncache_close_all_connections(&share->conn_cache);
+  Curl_conncache_close_all_connections(&share->conn_cache, NULL);
   Curl_conncache_destroy(&share->conn_cache);
   Curl_hash_destroy(&share->hostcache);
 

--- a/tests/data/test913
+++ b/tests/data/test913
@@ -44,7 +44,6 @@ smtp://%HOSTIP:%SMTPPORT/913 --mail-rcpt recipient@example.com --mail-from sende
 <protocol>
 EHLO 913
 MAIL FROM:<sender@example.com> SIZE=38
-QUIT
 </protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
... instead of always doing it beforehand, this now allocates it only in
time of actual need.