### PR TITLE
ftp: make a 552 response return CURLE_REMOTE_DISK_FULL

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3292,9 +3292,18 @@ static CURLcode ftp_done(struct connectdata *conn, CURLcode status,
 
     if(!ftpc->dont_check) {
       /* 226 Transfer complete, 250 Requested file action okay, completed. */
-      if((ftpcode != 226) && (ftpcode != 250)) {
+      switch(ftpcode) {
+      case 226:
+      case 250:
+        break;
+      case 552:
+        failf(data, "Exceeded storage allocation");
+        result = CURLE_REMOTE_DISK_FULL;
+        break;
+      default:
         failf(data, "server did not report OK, got %d", ftpcode);
         result = CURLE_PARTIAL_FILE;
+        break;
       }
     }
   }

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -237,6 +237,7 @@ about to issue.
    POP3 `CAPA` and SMTP `EHLO` commands
 - `AUTH [mechanisms]` - Enables support for SASL authentication and specifies
    a list of space separated mechanisms for IMAP, POP3 and SMTP
+- `STOR [num]` respond with this instead of a 226 after `STOR`
 
 #### For HTTP/HTTPS
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -58,7 +58,7 @@ test307 test308 test309 test310 test311 test312 test313 test314 test315 \
 test316 test317 test318 test319 test320 test321 test322 test323 test324 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
-test343 test344 test345 test346 test347 \
+test343 test344 test345 test346 test347 test348 \
 test350 test351 test352 test353 test354 test355 test356 test357 test358 \
 test359 \
 test393 test394 test395 test396 test397 \

--- a/tests/data/test348
+++ b/tests/data/test348
@@ -1,0 +1,61 @@
+<testcase>
+<info>
+<keywords>
+FTP
+EPSV
+STOR
+</keywords>
+</info>
+
+<reply>
+<servercmd>
+STOR 552 disk full
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+FTP upload file with 552 disk full response
+ </name>
+<file name="log/test348.txt">
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</file>
+ <command>
+ftp://%HOSTIP:%FTPPORT/348 -T log/test348.txt
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<upload>
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</upload>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+TYPE I
+STOR 348
+QUIT
+</protocol>
+# 70 - CURLE_REMOTE_DISK_FULL
+<errorcode>
+70
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Added test 348 to verify. Added a 'STOR' command to the test FTP
server to enable test 348. Documented the command in FILEFORMAT.md

Reported-by: Duncan Wilcox
Fixes #6016