### PR TITLE
schannel: return CURLE_PEER_FAILED_VERIFICATION for untrusted root

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1182,7 +1182,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
               Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
         return CURLE_PEER_FAILED_VERIFICATION;
       case SEC_E_UNTRUSTED_ROOT:
-        failf(data, "schannel: untrusted root: %s",
+        failf(data, "schannel: %s",
               Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
         return CURLE_PEER_FAILED_VERIFICATION;
         /*

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1181,6 +1181,10 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
         failf(data, "schannel: SNI or certificate check failed: %s",
               Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
         return CURLE_PEER_FAILED_VERIFICATION;
+      case SEC_E_UNTRUSTED_ROOT:
+        failf(data, "schannel: untrusted root: %s",
+              Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
+        return CURLE_PEER_FAILED_VERIFICATION;
         /*
           case SEC_E_INVALID_HANDLE:
           case SEC_E_INVALID_TOKEN:


### PR DESCRIPTION
This matches what is returned in other TLS backends in the same
situation.

Follow-up to 5a3efb1
Reported-by: iammrtau on github
Fixes #6003