### PR TITLE
src: Consistently spell whitespace without whitespace

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -661,7 +661,7 @@ dnl -------------------------------------------------
 dnl Check for libraries needed for WINLDAP support,
 dnl and prepended to LIBS any needed libraries.
 dnl This macro can take an optional parameter with a
-dnl white space separated list of libraries to check
+dnl whitespace separated list of libraries to check
 dnl before the WINLDAP default ones.
 
 AC_DEFUN([CURL_CHECK_LIBS_WINLDAP], [
@@ -755,7 +755,7 @@ dnl -------------------------------------------------
 dnl Check for libraries needed for LDAP support,
 dnl and prepended to LIBS any needed libraries.
 dnl This macro can take an optional parameter with a
-dnl white space separated list of libraries to check
+dnl whitespace separated list of libraries to check
 dnl before the default ones.
 
 AC_DEFUN([CURL_CHECK_LIBS_LDAP], [

--- a/docs/CHECKSRC.md
+++ b/docs/CHECKSRC.md
@@ -100,7 +100,7 @@ warnings are:
 
 - `TABS`: TAB characters are not allowed!
 
-- `TRAILINGSPACE`: Trailing white space on the line
+- `TRAILINGSPACE`: Trailing whitespace on the line
 
 - `TYPEDEFSTRUCT`: we frown upon (most) typedefed structs
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -556,7 +556,7 @@ Example, set default time out and proxy in a config file:
     # ... and we use a proxy for all accesses:
     proxy = proxy.our.domain.com:8080
 
-White spaces ARE significant at the end of lines, but all white spaces leading
+Whitespaces ARE significant at the end of lines, but all whitespace leading
 up to the first characters of each line are ignored.
 
 Prevent curl from reading the default file by using -q as the first command

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -52,7 +52,7 @@ my %warnings_extended = (
 my %warnings = (
     'LONGLINE'         => "Line longer than $max_column",
     'TABS'             => 'TAB characters not allowed',
-    'TRAILINGSPACE'    => 'Trailing white space on the line',
+    'TRAILINGSPACE'    => 'Trailing whitespace on the line',
     'CPPCOMMENTS'      => '// comment detected',
     'SPACEBEFOREPAREN' => 'space before an open parenthesis',
     'SPACEAFTERPAREN'  => 'space after open parenthesis',
@@ -399,7 +399,7 @@ sub scanfile {
             checkwarn("TABS",
                       $line, length($1), $file, $l, "Contains TAB character", 1);
         }
-        # detect trailing white space
+        # detect trailing whitespace
         if($l =~ /^(.*)[ \t]+\z/) {
             checkwarn("TRAILINGSPACE",
                       $line, length($1), $file, $l, "Trailing whitespace");

--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -168,7 +168,7 @@ CURLcode Curl_get_pathname(const char **cpp, char **path, char *homedir)
     *cpp = cp + i + strspn(cp + i, WHITESPACE);
   }
   else {
-    /* Read to end of filename - either to white space or terminator */
+    /* Read to end of filename - either to whitespace or terminator */
     end = strpbrk(cp, WHITESPACE);
     if(end == NULL)
       end = strchr(cp, '\0');
@@ -184,7 +184,7 @@ CURLcode Curl_get_pathname(const char **cpp, char **path, char *homedir)
       (*path)[pathLength] = '\0';
       cp += 3;
     }
-    /* Copy path name up until first "white space" */
+    /* Copy path name up until first "whitespace" */
     memcpy(&(*path)[pathLength], cp, (int)(end - cp));
     pathLength += (int)(end - cp);
     (*path)[pathLength] = '\0';

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -418,8 +418,8 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
             finfo->b_data[parser->item_length - 1] = 0;
             if(strncmp("total ", finfo->b_data, 6) == 0) {
               char *endptr = finfo->b_data + 6;
-              /* here we can deal with directory size, pass the leading white
-                 spaces and then the digits */
+              /* here we can deal with directory size, pass the leading
+                 whitespace and then the digits */
               while(ISSPACE(*endptr))
                 endptr++;
               while(ISDIGIT(*endptr))

--- a/lib/http.c
+++ b/lib/http.c
@@ -1355,7 +1355,7 @@ Curl_compareheader(const char *headerline, /* line to check */
   /* pass the header */
   start = &headerline[hlen];
 
-  /* pass all white spaces */
+  /* pass all whitespace */
   while(*start && ISSPACE(*start))
     start++;
 

--- a/scripts/contrithanks.sh
+++ b/scripts/contrithanks.sh
@@ -64,7 +64,7 @@ sed -e 's/^ //' -e 's/ $//g' -e 's/@users.noreply.github.com$/ on github/'
 
 # grep out the list of names from RELEASE-NOTES
 # split on ", "
-# remove leading white spaces
+# remove leading whitespace
 grep -a "^  [^ (]" RELEASE-NOTES| \
 sed 's/, */\n/g'| \
 sed 's/^ *//'

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -227,7 +227,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
             break;
           default:
             warnf(operation->global, "%s:%d: warning: '%s' uses unquoted "
-                  "white space in the line that may cause side-effects!\n",
+                  "whitespace in the line that may cause side-effects!\n",
                   filename, lineno, option);
           }
         }


### PR DESCRIPTION
Whitespace is spelled without a space between white and space, so make sure to consistently spell it that way across the codebase.