### PR TITLE
curl: make sure setopt CURLOPT_IPRESOLVE passes on a long

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1269,11 +1269,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case '4':
       /* IPv4 */
-      config->ip_version = 4;
+      config->ip_version = CURL_IPRESOLVE_V4;
       break;
     case '6':
       /* IPv6 */
-      config->ip_version = 6;
+      config->ip_version = CURL_IPRESOLVE_V6;
       break;
     case 'a':
       /* This makes the FTP sessions use APPE instead of STOR */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1855,12 +1855,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           my_setopt(curl, CURLOPT_MAXFILESIZE_LARGE,
                     config->max_filesize);
 
-        if(4 == config->ip_version)
-          my_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-        else if(6 == config->ip_version)
-          my_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
-        else
-          my_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_WHATEVER);
+        my_setopt(curl, CURLOPT_IPRESOLVE, config->ip_version);
 
         /* new in curl 7.15.5 */
         if(config->ftp_ssl_reqd)


### PR DESCRIPTION
Previously, it would pass on a define (int) which could make libcurl
read junk as a vaulue - which prevented the CURLOPT_IPRESOLVE option to
"take". This could then make test 2100 do two DoH requests instead of
one!

Fixes #6042