### PR TITLE
Fix missing header when defining MBEDTLS_DEBUG

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -46,6 +46,8 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/sha256.h>
 
+#include <mbedtls/debug.h>
+
 #include "urldata.h"
 #include "sendf.h"
 #include "inet_pton.h"

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -31,6 +31,9 @@
 
 #ifdef USE_MBEDTLS
 
+/* Define this to enable lots of debugging for mbedTLS */
+#undef MBEDTLS_DEBUG
+
 #include <mbedtls/version.h>
 #if MBEDTLS_VERSION_NUMBER >= 0x02040000
 #include <mbedtls/net_sockets.h>
@@ -46,7 +49,9 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/sha256.h>
 
+#if MBEDTLS_MAJOR_VERSION >= 2
 #include <mbedtls/debug.h>
+#endif
 
 #include "urldata.h"
 #include "sendf.h"
@@ -114,9 +119,6 @@ static int entropy_func_mutex(void *data, unsigned char *output, size_t len)
 /* end of entropy_func_mutex() */
 
 #endif /* THREADING_SUPPORT */
-
-/* Define this to enable lots of debugging for mbedTLS */
-#undef MBEDTLS_DEBUG
 
 #ifdef MBEDTLS_DEBUG
 static void mbed_debug(void *context, int level, const char *f_name,

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -49,7 +49,7 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/sha256.h>
 
-#if MBEDTLS_MAJOR_VERSION >= 2
+#if MBEDTLS_VERSION_MAJOR >= 2
 #include <mbedtls/debug.h>
 #endif
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -32,7 +32,7 @@
 #ifdef USE_MBEDTLS
 
 /* Define this to enable lots of debugging for mbedTLS */
-#undef MBEDTLS_DEBUG
+//#define MBEDTLS_DEBUG
 
 #include <mbedtls/version.h>
 #if MBEDTLS_VERSION_NUMBER >= 0x02040000

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -50,7 +50,9 @@
 #include <mbedtls/sha256.h>
 
 #if MBEDTLS_VERSION_MAJOR >= 2
-#include <mbedtls/debug.h>
+#  ifdef MBEDTLS_DEBUG
+#    include <mbedtls/debug.h>
+#  endif
 #endif
 
 #include "urldata.h"


### PR DESCRIPTION
Building curl fails when defining MBEDTLS_DEBUG for mbedtls version 2.16.x because of a missing header.