### PR TITLE
CI/azure: fix flakiness by avoiding libtool wrappers on Windows

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -83,7 +83,7 @@ stages:
       displayName: 'configure $(name)'
 
     - script: make
-      displayName: 'make'
+      displayName: 'make && cd tests && make'
 
     - script: make test-nonflaky
       displayName: 'test'
@@ -188,11 +188,14 @@ stages:
     - script: $(container_cmd) -l -c "cd $(echo '%cd%') && ./buildconf && ./configure $(configure)"
       displayName: 'configure $(name)'
 
-    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make"
+    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make && cd tests && make"
       displayName: 'make'
+
+    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
+      displayName: 'install'
 
     - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make test-nonflaky"
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "-r $(tests)"
+        TFLAGS: "-vc /usr/bin/curl.exe -r $(tests)"


### PR DESCRIPTION
Install curl binaries into MinGW bin folder and use that
for the tests in order to avoid libtool wrapper binaries.

The libtool wrapper binaries (not scripts) on Windows seem
to be the root cause of the following issues:

1. Process output can be lost in the wrapper process chain.
2. Killing the wrapper process does not kill the real one.

Derived from #5904