### PR TITLE
runtests: return error if no tests ran

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5775,11 +5775,11 @@ if($total) {
                    $ok/$total*100);
 
     if($ok != $total) {
-        logmsg "TESTFAIL: These test cases failed: $failed\n";
+        logmsg "\nTESTFAIL: These test cases failed: $failed\n\n";
     }
 }
 else {
-    logmsg "TESTFAIL: No tests were performed\n";
+    logmsg "\nTESTFAIL: No tests were performed\n\n";
 }
 
 if($all) {
@@ -5816,6 +5816,6 @@ if($skipped && !$short) {
     }
 }
 
-if($total && (($ok+$ign) != $total)) {
+if(($total && (($ok+$ign) != $total)) || !$total) {
     exit 1;
 }


### PR DESCRIPTION
... and make TESTFAIL stand out a little better by adding newlines
before and after.

Reported-by: Marc Hörsken
Issue: #6052