### PR TITLE
src/Makefile.m32: fix undefined curlx_dyn_* errors

### DIFF
--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -380,10 +380,8 @@ include Makefile.inc
 curl_PROGRAMS = curl.exe
 curl_OBJECTS := $(patsubst %.c,%.o,$(strip $(CURL_CFILES)))
 curlx_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CURLX_CFILES))))
-ifdef DYN
 curl_OBJECTS += $(curlx_OBJECTS)
 vpath %.c $(PROOT)/lib
-endif
 
 RESOURCE = curl.res
 


### PR DESCRIPTION
by linking `lib/dynbuf.c` when building a static curl binary. Previously this source file was only included when building a dynamic curl binary. This was likely possibly because no functions from the `src/Makefile.inc` / `CURLX_CFILES` sources
were actually required for a curl tool build. This has recently changed with the introduction of `curlx_dyn_*()` memory functions and their use by the tool sources.