### PR TITLE
windows: fix comparison of mismatched types warning

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2914,7 +2914,7 @@ static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex)
               /* "If GetLastError returns CRYPT_E_NOT_FOUND, the certificate is
                  good for all uses. If it returns zero, the certificate has no
                  valid uses." */
-              if(GetLastError() != CRYPT_E_NOT_FOUND)
+              if((HRESULT)GetLastError() != CRYPT_E_NOT_FOUND)
                 continue;
             }
             else {


### PR DESCRIPTION
clang 10, mingw-w64:
```
vtls/openssl.c:2917:33: warning: comparison of integers of different signs: 'DWORD' (aka 'unsigned long') and 'HRESULT' (aka 'long')
      [-Wsign-compare]
              if(GetLastError() != CRYPT_E_NOT_FOUND)
                 ~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~
```