### PR TITLE
CI/tests: use verification curl for test reporting APIs

### DIFF
--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -34,12 +34,12 @@ sub appveyor_check_environment {
 }
 
 sub appveyor_create_test_result {
-    my ($testnum, $testname)=@_;
+    my ($curl, $testnum, $testname)=@_;
     $testname =~ s/\\/\\\\/g;
     $testname =~ s/\'/\\\'/g;
     $testname =~ s/\"/\\\"/g;
     my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`curl --silent --noproxy "*" \\
+    my $appveyor_result=`$curl --silent --noproxy "*" \\
     --header "Content-Type: application/json" \\
     --data "
         {
@@ -55,7 +55,7 @@ sub appveyor_create_test_result {
 }
 
 sub appveyor_update_test_result {
-    my ($testnum, $error, $start, $stop)=@_;
+    my ($curl, $testnum, $error, $start, $stop)=@_;
     my $testname=$APPVEYOR_TEST_NAMES{$testnum};
     if(!defined $testname) {
         return;
@@ -83,7 +83,7 @@ sub appveyor_update_test_result {
         $appveyor_category = 'Error';
     }
     my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`curl --silent --noproxy "*" --request PUT \\
+    my $appveyor_result=`$curl --silent --noproxy "*" --request PUT \\
     --header "Content-Type: application/json" \\
     --data "
         {
@@ -98,7 +98,7 @@ sub appveyor_update_test_result {
     "$appveyor_baseurl/api/tests"`;
     print "AppVeyor API result: $appveyor_result\n" if ($appveyor_result);
     if($appveyor_category eq 'Error') {
-        $appveyor_result=`curl --silent --noproxy "*" \\
+        $appveyor_result=`$curl --silent --noproxy "*" \\
         --header "Content-Type: application/json" \\
         --data "
             {

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -37,8 +37,9 @@ sub azure_check_environment {
 }
 
 sub azure_create_test_run {
+    my ($curl)=@_;
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`curl --silent --noproxy "*" \\
+    my $azure_run=`$curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -56,13 +57,13 @@ sub azure_create_test_run {
 }
 
 sub azure_create_test_result {
-    my ($azure_run_id, $testnum, $testname)=@_;
+    my ($curl, $azure_run_id, $testnum, $testname)=@_;
     $testname =~ s/\\/\\\\/g;
     $testname =~ s/\'/\\\'/g;
     $testname =~ s/\"/\\\"/g;
     my $title_testnum=sprintf("%04d", $testnum);
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`curl --silent --noproxy "*" \\
+    my $azure_result=`$curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -85,7 +86,7 @@ sub azure_create_test_result {
 }
 
 sub azure_update_test_result {
-    my ($azure_run_id, $azure_result_id, $testnum, $error, $start, $stop)=@_;
+    my ($curl, $azure_run_id, $azure_result_id, $testnum, $error, $start, $stop)=@_;
     if(!defined $stop) {
         $stop = $start;
     }
@@ -106,7 +107,7 @@ sub azure_update_test_result {
         $azure_outcome = 'Failed';
     }
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`curl --silent --noproxy "*" --request PATCH \\
+    my $azure_result=`$curl --silent --noproxy "*" --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -128,9 +129,9 @@ sub azure_update_test_result {
 }
 
 sub azure_update_test_run {
-    my ($azure_run_id)=@_;
+    my ($curl, $azure_run_id)=@_;
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`curl --silent --noproxy "*" --request PATCH \\
+    my $azure_run=`$curl --silent --noproxy "*" --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3520,10 +3520,10 @@ sub singletest {
 
     # create test result in CI services
     if(azure_check_environment() && $AZURE_RUN_ID) {
-        $AZURE_RESULT_ID = azure_create_test_result($AZURE_RUN_ID, $testnum, $testname);
+        $AZURE_RESULT_ID = azure_create_test_result($VCURL, $AZURE_RUN_ID, $testnum, $testname);
     }
     elsif(appveyor_check_environment()) {
-        appveyor_create_test_result($testnum, $testname);
+        appveyor_create_test_result($VCURL, $testnum, $testname);
     }
 
     # remove test server commands file before servers are started/verified
@@ -5683,7 +5683,7 @@ sub displaylogs {
 #
 
 if(azure_check_environment()) {
-    $AZURE_RUN_ID = azure_create_test_run();
+    $AZURE_RUN_ID = azure_create_test_run($VCURL);
     logmsg "Azure Run ID: $AZURE_RUN_ID\n" if ($verbose);
 }
 
@@ -5711,11 +5711,11 @@ foreach $testnum (@at) {
 
     # update test result in CI services
     if(azure_check_environment() && $AZURE_RUN_ID && $AZURE_RESULT_ID) {
-        $AZURE_RESULT_ID = azure_update_test_result($AZURE_RUN_ID, $AZURE_RESULT_ID, $testnum, $error,
+        $AZURE_RESULT_ID = azure_update_test_result($VCURL, $AZURE_RUN_ID, $AZURE_RESULT_ID, $testnum, $error,
                                                     $timeprepini{$testnum}, $timevrfyend{$testnum});
     }
     elsif(appveyor_check_environment()) {
-        appveyor_update_test_result($testnum, $error, $timeprepini{$testnum}, $timevrfyend{$testnum});
+        appveyor_update_test_result($VCURL, $testnum, $error, $timeprepini{$testnum}, $timevrfyend{$testnum});
     }
 
     if($error < 0) {
@@ -5760,7 +5760,7 @@ my $sofar = time() - $start;
 #
 
 if(azure_check_environment() && $AZURE_RUN_ID) {
-    $AZURE_RUN_ID = azure_update_test_run($AZURE_RUN_ID);
+    $AZURE_RUN_ID = azure_update_test_run($VCURL, $AZURE_RUN_ID);
 }
 
 # Tests done, stop the servers


### PR DESCRIPTION
Avoid using our own, potentially installed, curl for
the test reporting APIs in case it is broken.

Follow up to #6049