### PR TITLE
win32: disable output buffering since line-buffering is broken

### DIFF
--- a/src/tool_binmode.c
+++ b/src/tool_binmode.c
@@ -46,6 +46,11 @@ void set_binmode(FILE *stream)
 #else
   (void)stream;
 #endif
+
+#if defined(HAVE_SETVBUF) && defined(_IONBF) && defined(WIN32)
+  (void)setvbuf(stdout, NULL, _IONBF, 0);
+  (void)setvbuf(stderr, NULL, _IONBF, 0);
+#endif
 }
 
 #endif /* HAVE_SETMODE */

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -138,8 +138,13 @@ int main(int argc, char **argv)
 #  ifdef __HIGHC__
   _setmode(stdout, O_BINARY);
 #  else
-  setmode(fileno(stdout), O_BINARY);
+  (void)setmode(fileno(stdout), O_BINARY);
 #  endif
+#endif
+
+#if defined(HAVE_SETVBUF) && defined(_IONBF) && defined(WIN32)
+  (void)setvbuf(stdout, NULL, _IONBF, 0);
+  (void)setvbuf(stderr, NULL, _IONBF, 0);
 #endif
 
   memory_tracking_init();


### PR DESCRIPTION
Related to the missing/incomplete output issues being troubleshooted with #6049 and #5904.