### PR TITLE
CI/tests: fixed tests invocation for CMake builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -291,11 +291,19 @@ build_script:
       if %BUILD_SYSTEM%==autotools (
         bash.exe -e -l -c "cd /c/projects/curl && ./buildconf && ./configure %CONFIG_ARGS% && make && make examples && cd tests && make"
       )))))
+    - if %TESTING%==ON (
+        if %BUILD_SYSTEM%==CMake (
+          cmake --build . --config %PRJ_CFG% --parallel 2 --target testdeps
+      ))
 
 test_script:
     - if %TESTING%==ON (
-        echo APPVEYOR_API_URL=%APPVEYOR_API_URL% &&
-        bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -b$(($(echo '%APPVEYOR_API_URL%' | cut -d'/' -f3 | cut -d':' -f2)+1)) -p !flaky %DISABLED_TESTS%" )
+        if %BUILD_SYSTEM%==CMake (
+          set TFLAGS=%DISABLED_TESTS% &&
+          cmake --build . --config %PRJ_CFG% --target test-nonflaky
+        ) else (
+          echo APPVEYOR_API_URL=%APPVEYOR_API_URL% &&
+          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -b$(($(echo '%APPVEYOR_API_URL%' | cut -d'/' -f3 | cut -d':' -f2)+1)) -p !flaky %DISABLED_TESTS%" ))
 
 # select branches to avoid testing feature branches twice (as branch and as pull request)
 branches:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ add_subdirectory(server)
 add_subdirectory(unit)
 
 function(add_runtests targetname test_flags)
-  # Use a special '${TFLAGS}' placeholder as last argument which will be
+  # Use a special '$TFLAGS' placeholder as last argument which will be
   # replaced by the contents of the environment variable in runtests.pl.
   # This is a workaround for CMake's limitation where commands executed by
   # 'make' or 'ninja' cannot portably reference environment variables.
@@ -35,7 +35,7 @@ function(add_runtests targetname test_flags)
     COMMAND
       "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/runtests.pl"
       ${test_flags_list}
-      "\${TFLAGS}"
+      "\$TFLAGS"
     DEPENDS testdeps
     VERBATIM USES_TERMINAL
   )

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5180,9 +5180,9 @@ disabledtests("$TESTDIR/DISABLED.local");
 # Check options to this test program
 #
 
-# Special case for CMake: replace '${TFLAGS}' by the contents of the
+# Special case for CMake: replace '$TFLAGS' by the contents of the
 # environment variable (if any).
-if(@ARGV && $ARGV[-1] eq '${TFLAGS}') {
+if(@ARGV && $ARGV[-1] eq '$TFLAGS') {
     pop @ARGV;
     push(@ARGV, split(' ', $ENV{'TFLAGS'})) if defined($ENV{'TFLAGS'});
 }


### PR DESCRIPTION
Updated appveyor.yml to set env variable TFLAGS and run tests
Removed curly braces (${TFLAGS} -> $TFLAGS). If {} used we've got following error

```
  Building Custom Rule C:/projects/curl-ckq2k/tests/CMakeLists.txt
  Unknown option: $TFLAGS
```

Closes #6052