### PR TITLE
Since the string from strerror should never be modified, use an appro…

### DIFF
--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -781,7 +781,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   }
 #else
   {
-    char *msg = strerror(err);
+    const char *msg = strerror(err);
     if(msg)
       strncpy(buf, msg, max);
     else


### PR DESCRIPTION
Since the string from strerror should never be modified, use an appropriate pointer type.