### PR TITLE
CMake: make BUILD_TESTING dependent option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1325,10 +1325,10 @@ if(BUILD_CURL_EXE)
   add_subdirectory(src)
 endif()
 
-option(BUILD_TESTING "Build tests" "${PERL_FOUND}")
-if(NOT PERL_FOUND)
-  message(STATUS "Perl not found, testing disabled.")
-elseif(BUILD_TESTING)
+cmake_dependent_option(BUILD_TESTING "Build tests"
+  ON "PERL_FOUND;NOT CURL_DISABLE_TESTS"
+  OFF)
+if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
Make BUILD_TESTING option dependant on PERL_FOUND and CURL_DISABLE_TESTS

The main idea that Curl testing should be enabled in the following case
PERL_FOUND is True AND CURL_DISABLE_TESTS is False

CURL_DISABLE_TESTS can be used to explicitly disable tests when libcurl is included as a subproject/subdirectory when BUILD_TESTING is enabled for the parent project.

Ref: #6036