### PR TITLE
CI/tests: enable test target on TravisCI for CMake builds

### DIFF
--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -106,6 +106,7 @@ fi
 if [ "$T" = "cmake" ]; then
   cmake -H. -Bbuild -DCURL_WERROR=ON $C
   cmake --build build
+  env TFLAGS="!1139" cmake --build build --target test-nonflaky
 fi
 
 if [ "$T" = "distcheck" ]; then


### PR DESCRIPTION
Added test-nonflaky target to CMake builds

Ref: #6052