### PR TITLE
travis: use ninja-build for CMake builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ addons:
     - libidn2-dev
     - gnutls-bin
     - python-impacket
+    - ninja-build
 
 jobs:
   include:
@@ -79,6 +80,7 @@ jobs:
         - gnutls-bin
         # The above list is common_packages minus impacket.
         - libssh-dev
+        - ninja-build
   - env:
     - T=normal C="--enable-ares"
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
@@ -246,7 +248,7 @@ jobs:
     - T=iconv
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
   - env:
-    - T=cmake BORINGSSL=yes QUICHE=yes C="-DUSE_QUICHE=1 -DOPENSSL_ROOT_DIR=$HOME/boringssl -DCURL_BROTLI=1 -DCURL_ZSTD=1"
+    - T=cmake BORINGSSL=yes QUICHE=yes C="-GNinja -DUSE_QUICHE=1 -DOPENSSL_ROOT_DIR=$HOME/boringssl -DCURL_BROTLI=1 -DCURL_ZSTD=1"
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     - PKG_CONFIG_PATH="$HOME/quiche/target/release"
     before_install:
@@ -260,7 +262,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=cmake NGTCP2=yes C="-DUSE_NGTCP2=ON -DCURL_BROTLI=1 -DCURL_ZSTD=1"
+    - T=cmake NGTCP2=yes C="-GNinja -DUSE_NGTCP2=ON -DCURL_BROTLI=1 -DCURL_ZSTD=1"
     - *clang
     - PKG_CONFIG_PATH="$HOME/ngbuild/lib/pkgconfig"
     compiler: clang

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -71,21 +71,16 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$BORINGSSL" ]; then
   cd $HOME
   git clone --depth=1 https://boringssl.googlesource.com/boringssl
   cd boringssl
-  mkdir build
-  cd build
-  CXX="g++" CC="gcc" cmake -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=1 ..
-  make
-  cd ..
+  CXX="g++" CC="gcc" cmake -H. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=release -DBUILD_SHARED_LIBS=1
+  cmake --build build
   mkdir lib
-  cd lib
-  cp ../build/crypto/libcrypto.so .
-  cp ../build/ssl/libssl.so .
-  echo "BoringSSL lib dir: "`pwd`
-  cd ../build
-  make clean
-  rm -f CMakeCache.txt
-  CXX="g++" CC="gcc" cmake -DCMAKE_POSITION_INDEPENDENT_CODE=on ..
-  make
+  cp ./build/crypto/libcrypto.so ./lib/
+  cp ./build/ssl/libssl.so ./lib/
+  echo "BoringSSL lib dir: "`pwd`"/lib"
+  cmake --build build --target clean
+  rm -f build/CMakeCache.txt
+  CXX="g++" CC="gcc" cmake -H. -Bbuild -GNinja -DCMAKE_POSITION_INDEPENDENT_CODE=on
+  cmake --build build
   export LIBS=-lpthread
 fi
 


### PR DESCRIPTION
Added package ninja-build to TravisCI environment
Use ninja to speed up CMake builds

Should speed up build a bit.