### PR TITLE
configure: do not set -Wformat=2 for mingw debug builds

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1074,9 +1074,19 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           fi
           #
           dnl only gcc 4.8 or later
-          if test "$compiler_num" -ge "408"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
-          fi
+          case $host_os in
+          mingw*)
+            dnl for mingw, switch it off!
+            if test "$compiler_num" -ge "408"; then
+              tmp_CFLAGS="$tmp_CFLAGS -Wno-format"
+            fi
+            ;;
+          *)
+            if test "$compiler_num" -ge "408"; then
+              tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
+            fi
+            ;;
+          esac
           #
           dnl Only gcc 5 or later
           if test "$compiler_num" -ge "500"; then

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1074,19 +1074,9 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           fi
           #
           dnl only gcc 4.8 or later
-          case $host_os in
-          mingw*)
-            dnl for mingw, switch it off!
-            if test "$compiler_num" -ge "408"; then
-              tmp_CFLAGS="$tmp_CFLAGS -Wno-format"
-            fi
-            ;;
-          *)
-            if test "$compiler_num" -ge "408"; then
-              tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
-            fi
-            ;;
-          esac
+          if test "$compiler_num" -ge "408"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
+          fi
           #
           dnl Only gcc 5 or later
           if test "$compiler_num" -ge "500"; then

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -29,6 +29,11 @@
 #  include <sys/utime.h>
 #endif
 
+#if defined(__GNUC__) && defined(__MINGW32__)
+/* GCC 10 on mingw has issues with this, disable */
+#pragma GCC diagnostic ignored "-Wformat"
+#endif
+
 curl_off_t getfiletime(const char *filename, FILE *error_stream)
 {
   curl_off_t result = -1;


### PR DESCRIPTION
With GCC 10 (at least) on mingw, we get false positive warnings
when using this option. Never use it for mingw.

Fixes #6079