### PR TITLE
http3: fix two build errors, silence warnings

### DIFF
--- a/lib/quic.h
+++ b/lib/quic.h
@@ -41,7 +41,7 @@ CURLcode Curl_quic_connect(struct connectdata *conn,
                            const struct sockaddr *addr,
                            socklen_t addrlen);
 CURLcode Curl_quic_is_connected(struct connectdata *conn,
-                                curl_socket_t sockfd,
+                                int sockindex,
                                 bool *connected);
 int Curl_quic_ver(char *p, size_t len);
 CURLcode Curl_quic_done_sending(struct connectdata *conn);

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1715,7 +1715,8 @@ CURLcode Curl_quic_is_connected(struct connectdata *conn,
 
 }
 
-static CURLcode ng_process_ingress(struct connectdata *conn, int sockfd,
+static CURLcode ng_process_ingress(struct connectdata *conn,
+                                   curl_socket_t sockfd,
                                    struct quicsocket *qs)
 {
   ssize_t recvd;
@@ -1730,7 +1731,7 @@ static CURLcode ng_process_ingress(struct connectdata *conn, int sockfd,
 
   for(;;) {
     remote_addrlen = sizeof(remote_addr);
-    while((recvd = recvfrom(sockfd, buf, bufsize, 0,
+    while((recvd = recvfrom(sockfd, (char *)buf, bufsize, 0,
                             (struct sockaddr *)&remote_addr,
                             &remote_addrlen)) == -1 &&
           SOCKERRNO == EINTR)
@@ -1870,7 +1871,7 @@ static CURLcode ng_flush_egress(struct connectdata *conn, int sockfd,
     }
 
     memcpy(&remote_addr, ps.path.remote.addr, ps.path.remote.addrlen);
-    while((sent = send(sockfd, out, outlen, 0)) == -1 &&
+    while((sent = send(sockfd, (const char *)out, outlen, 0)) == -1 &&
           SOCKERRNO == EINTR)
       ;
 


### PR DESCRIPTION
- fix two build errors due to mismatch between function
  declarations and their definitions.
- silence two mismatched signs warnings via casts

```
vquic/ngtcp2.c:1690:10: error: conflicting types for 'Curl_quic_is_connected'
CURLcode Curl_quic_is_connected(struct connectdata *conn,
         ^
./quic.h:43:10: note: previous declaration is here
CURLcode Curl_quic_is_connected(struct connectdata *conn,
         ^
vquic/ngtcp2.c:1718:17: error: conflicting types for 'ng_process_ingress'
static CURLcode ng_process_ingress(struct connectdata *conn, int sockfd,
                ^
vquic/ngtcp2.c:90:17: note: previous declaration is here
static CURLcode ng_process_ingress(struct connectdata *conn,
                ^
vquic/ngtcp2.c:1733:37: warning: passing 'uint8_t [65536]' to parameter of type 'char *' converts between pointers to integer types with different
      sign [-Wpointer-sign]
    while((recvd = recvfrom(sockfd, buf, bufsize, 0,
                                    ^~~
/usr/local/opt/mingw-w64/toolchain-x86_64/x86_64-w64-mingw32/include/winsock2.h:1023:58: note: passing argument to parameter 'buf' here
  WINSOCK_API_LINKAGE int WSAAPI recvfrom(SOCKET s,char *buf,int len,int flags,struct sockaddr *from,int *fromlen);
                                                         ^
vquic/ngtcp2.c:1873:32: warning: passing 'uint8_t [1252]' to parameter of type 'const char *' converts between pointers to integer types with
      different sign [-Wpointer-sign]
    while((sent = send(sockfd, out, outlen, 0)) == -1 &&
                               ^~~
/usr/local/opt/mingw-w64/toolchain-x86_64/x86_64-w64-mingw32/include/winsock2.h:1027:60: note: passing argument to parameter 'buf' here
  WINSOCK_API_LINKAGE int WSAAPI send(SOCKET s,const char *buf,int len,int flags);
                                                           ^
2 warnings and 2 errors generated.
```