### PR TITLE
tool: Rename GETOPT_USEREMOTE to GETOPT_USER_REMOTE

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1919,7 +1919,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case 'O': /* --remote-name */
       if(subletter == 'a') { /* --remote-name-all */
-        config->default_node_flags = toggle?GETOUT_USEREMOTE:0;
+        config->default_node_flags = toggle?GETOUT_USER_REMOTE:0;
         break;
       }
       else if(subletter == 'b') { /* --output-dir */
@@ -1955,14 +1955,14 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       /* fill in the outfile */
       if('o' == letter) {
         GetStr(&url->outfile, nextarg);
-        url->flags &= ~GETOUT_USEREMOTE; /* switch off */
+        url->flags &= ~GETOUT_USER_REMOTE; /* switch off */
       }
       else {
         url->outfile = NULL; /* leave it */
         if(toggle)
-          url->flags |= GETOUT_USEREMOTE;  /* switch on */
+          url->flags |= GETOUT_USER_REMOTE;  /* switch on */
         else
-          url->flags &= ~GETOUT_USEREMOTE; /* switch off */
+          url->flags &= ~GETOUT_USER_REMOTE; /* switch off */
       }
       url->flags |= GETOUT_OUTFILE;
     }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1025,7 +1025,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           }
         }
 
-        if(((urlnode->flags&GETOUT_USEREMOTE) ||
+        if(((urlnode->flags&GETOUT_USER_REMOTE) ||
             (per->outfile && strcmp("-", per->outfile))) &&
            (metalink || !config->use_metalink)) {
 
@@ -1076,7 +1076,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
               break;
           }
 
-          if((urlnode->flags & GETOUT_USEREMOTE)
+          if((urlnode->flags & GETOUT_USER_REMOTE)
              && config->content_disposition) {
             /* Our header callback MIGHT set the filename */
             DEBUGASSERT(!outs->filename);
@@ -1963,7 +1963,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           my_setopt_flags(curl, CURLOPT_REDIR_PROTOCOLS, config->proto_redir);
 
         if(config->content_disposition
-           && (urlnode->flags & GETOUT_USEREMOTE))
+           && (urlnode->flags & GETOUT_USER_REMOTE))
           hdrcbdata->honor_cd_filename = TRUE;
         else
           hdrcbdata->honor_cd_filename = FALSE;

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -107,12 +107,12 @@ struct getout {
   int            flags;     /* options - composed of GETOUT_* bits */
 };
 
-#define GETOUT_OUTFILE    (1<<0)  /* set when outfile is deemed done */
-#define GETOUT_URL        (1<<1)  /* set when URL is deemed done */
-#define GETOUT_USEREMOTE  (1<<2)  /* use remote file name locally */
-#define GETOUT_UPLOAD     (1<<3)  /* if set, -T has been used */
-#define GETOUT_NOUPLOAD   (1<<4)  /* if set, -T "" has been used */
-#define GETOUT_METALINK   (1<<5)  /* set when Metalink download */
+#define GETOUT_OUTFILE     (1<<0)  /* set when outfile is deemed done */
+#define GETOUT_URL         (1<<1)  /* set when URL is deemed done */
+#define GETOUT_USER_REMOTE (1<<2)  /* use remote file name locally */
+#define GETOUT_UPLOAD      (1<<3)  /* if set, -T has been used */
+#define GETOUT_NOUPLOAD    (1<<4)  /* if set, -T "" has been used */
+#define GETOUT_METALINK    (1<<5)  /* set when Metalink download */
 
 /*
  * 'trace' enumeration represents curl's output look'n feel possibilities.


### PR DESCRIPTION
This is a minor fix but in my opinion the old CPP name looks a bit awkward and ugly to the eye.