### PR TITLE
libssh2: require version 1.0 or later

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3062,7 +3062,8 @@ if test X"$OPT_LIBSSH2" != Xno; then
   CPPFLAGS="$CPPFLAGS $CPP_SSH2"
   LIBS="$LIB_SSH2 $LIBS"
 
-  AC_CHECK_LIB(ssh2, libssh2_channel_open_ex)
+  dnl check for function added in libssh2 version 1.0
+  AC_CHECK_LIB(ssh2, libssh2_session_block_directions)
 
   AC_CHECK_HEADERS(libssh2.h,
     curl_ssh_msg="enabled (libSSH2)"

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -87,7 +87,7 @@ Dependencies
  - OpenSSL      0.9.7
  - GnuTLS       3.1.10
  - zlib         1.1.4
- - libssh2      0.16
+ - libssh2      1.0
  - c-ares       1.6.0
  - libidn2      2.0.0
  - wolfSSL      2.0.0


### PR DESCRIPTION
... and simplify the code accordingly. libssh2 version 1.0 was released
in April 2009.