### PR TITLE
help: Make "output" description less confusing

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -87,7 +87,7 @@ static const struct category_descriptors categories[] = {
   {"imap", "IMAP protocol options", CURLHELP_IMAP},
   /* important is left out because it is the default help page */
   {"misc", "Options that don't fit into any other category", CURLHELP_MISC},
-  {"output", "The output of curl", CURLHELP_OUTPUT},
+  {"output", "Filesystem output", CURLHELP_OUTPUT},
   {"pop3", "POP3 protocol options", CURLHELP_POP3},
   {"post", "HTTP Post specific options", CURLHELP_POST},
   {"proxy", "All options related to proxies", CURLHELP_PROXY},

--- a/tests/data/test1462
+++ b/tests/data/test1462
@@ -43,7 +43,7 @@ Invalid category provided, here is a list of all categories:
  http        HTTP and HTTPS protocol options
  imap        IMAP protocol options
  misc        Options that don't fit into any other category
- output      The output of curl
+ output      Filesystem output
  pop3        POP3 protocol options
  post        HTTP Post specific options
  proxy       All options related to proxies


### PR DESCRIPTION
Currently the description of "output" is misleading when
comparing it "verbose".