### PR TITLE
runtests: show keywords when no tests ran

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5780,6 +5780,13 @@ if($total) {
 }
 else {
     logmsg "\nTESTFAIL: No tests were performed\n\n";
+    if(scalar(keys %enabled_keywords)) {
+        logmsg "TESTFAIL: Nothing matched these keywords: ";
+        for(keys %enabled_keywords) {
+            logmsg "$_ ";
+        }
+        logmsg "\n";
+    }
 }
 
 if($all) {


### PR DESCRIPTION
To help out future debugging, runtests now outputs the list of keywords
when it fails because no tests ran.

Ref: #6120 