### PR TITLE
Clarify that curl will not parse multipart responses

### DIFF
--- a/docs/cmdline-opts/range.d
+++ b/docs/cmdline-opts/range.d
@@ -29,7 +29,8 @@ specifies two separate 100-byte ranges(*) (HTTP)
 .RE
 .IP
 (*) = NOTE that this will cause the server to reply with a multipart
-response!
+response, which will be retruned as-is by curl! Parsing or otherwise
+transforming this response is the responsibility of the caller.
 
 Only digit characters (0-9) are valid in the 'start' and 'stop' fields of the
 \&'start-stop' range syntax. If a non-digit character is given in the range,


### PR DESCRIPTION
Closes #6124 by clarifying that this behaviour is expected, as curl does not parse or transform responses.

It might still be necessary to add this notice in a more global place in the documentation.