### PR TITLE
libssh2: fix transport over HTTPS proxy

### DIFF
--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -182,6 +182,12 @@ struct ssh_conn {
   LIBSSH2_SFTP *sftp_session;   /* SFTP handle */
   LIBSSH2_SFTP_HANDLE *sftp_handle;
 
+#ifndef CURL_DISABLE_PROXY
+  /* for HTTPS proxy storage */
+  Curl_recv *tls_recv;
+  Curl_send *tls_send;
+#endif
+
 #ifdef HAVE_LIBSSH2_AGENT_API
   LIBSSH2_AGENT *ssh_agent;     /* proxy to ssh-agent/pageant */
   struct libssh2_agent_publickey *sshagent_identity,


### PR DESCRIPTION
The fix in #6021 was not enough. This fix makes sure SCP/SFTP content
can also be transfered over a HTTPS proxy.

Fixes #6113