### PR TITLE
tests: fix some http/2 tests for older versions of nghttpx

### DIFF
--- a/tests/data/test1700
+++ b/tests/data/test1700
@@ -82,7 +82,6 @@ accept-ranges: bytes
 content-length: 6
 content-type: text/html
 funny-head: yesyes
-server: cut-out
 via: 1.1 nghttpx
 
 -foo-
@@ -90,13 +89,12 @@ HTTP/2 200
 date: Thu, 09 Nov 2010 14:49:00 GMT
 content-length: 6
 content-type: text/html
-server: cut-out
 via: 1.1 nghttpx
 
 -maa-
 </stdout>
 <stripfile>
-s/^server:.*/server: cut-out/
+s/^server: nghttpx.*\r?\n//
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1701
+++ b/tests/data/test1701
@@ -71,13 +71,12 @@ accept-ranges: bytes
 content-length: 6
 content-type: text/html
 funny-head: yesyes
-server: cut-out
 via: 1.1 nghttpx
 
 -foo-
 </stdout>
 <stripfile>
-s/^server:.*/server: cut-out/
+s/^server: nghttpx.*\r?\n//
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1702
+++ b/tests/data/test1702
@@ -67,12 +67,11 @@ accept-ranges: bytes
 content-length: 6
 content-type: text/html
 funny-head: yesyes
-server: cut-out
 via: 1.1 nghttpx
 
 </stdout>
 <stripfile>
-s/^server:.*/server: cut-out/
+s/^server: nghttpx.*\r?\n//
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test358
+++ b/tests/data/test358
@@ -65,7 +65,6 @@ content-length: 6
 content-type: text/html
 funny-head: yesyes
 alt-svc: h2=":%HTTP2PORT", ma=315360000; persist=0
-server: nghttpx
 via: 1.1 nghttpx
 
 -foo-
@@ -75,12 +74,12 @@ content-length: 6
 content-type: text/html
 funny-head: yesyes
 alt-svc: h2=":%HTTP2PORT", ma=315360000; persist=0
-server: nghttpx
 via: 1.1 nghttpx
 
 -foo-
 </stdout>
 <stripfile>
+s/^server: nghttpx.*\r?\n//
 # strip out the (dynamic) expire date from the file so that the rest
 # matches
 s/\"2([^\"]*)\"/TIMESTAMP/

--- a/tests/data/test359
+++ b/tests/data/test359
@@ -65,7 +65,6 @@ content-length: 6
 content-type: text/html
 funny-head: yesyes
 alt-svc: h2=":%HTTP2PORT", ma=315360000; persist=0
-server: nghttpx
 via: 1.1 nghttpx
 
 -foo-
@@ -75,12 +74,12 @@ content-length: 6
 content-type: text/html
 funny-head: yesyes
 alt-svc: h2=":%HTTP2PORT", ma=315360000; persist=0
-server: nghttpx
 via: 1.1 nghttpx
 
 -foo-
 </stdout>
 <stripfile>
+s/^server: nghttpx.*\r?\n//
 # strip out the (dynamic) expire date from the file so that the rest
 # matches
 s/\"2([^\"]*)\"/TIMESTAMP/


### PR DESCRIPTION
- Add regex that strips http/2 server header name to those http/2 tests
  that don't already have it.

- Improve that regex in all http/2 tests.

Tests 358 and 359 were failing for me before this change on a system
that uses an older version of nghttpx which includes its version number
in the server header.

Closes #xxxx

---

nghttpx has --server-name which would be a better choice to make a uniform server name however it's not available in some older versions that are still supported.