### PR TITLE
tool_operate: bail out proper on errors for parallel setup

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2174,7 +2174,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
 
     result = pre_transfer(global, per);
     if(result)
-      break;
+      return result;
 
     /* parallel connect means that we don't set PIPEWAIT since pipewait
        will make libcurl prefer multiplexing */


### PR DESCRIPTION
... otherwise for example trying to upload a missing file just causes a
loop.

Reported-by: BrumBrum on hackerone