### PR TITLE
Use pkgconfig to find openSSL when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1767,19 +1767,13 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
   case "$OPT_SSL" in
   yes)
     dnl --with-ssl (without path) used
-    if test x$cross_compiling != xyes; then
-      dnl only do pkg-config magic when not cross-compiling
-      PKGTEST="yes"
-    fi
+    PKGTEST="yes"
     PREFIX_OPENSSL=/usr/local/ssl
     LIB_OPENSSL="$PREFIX_OPENSSL/lib$libsuff"
     ;;
   off)
     dnl no --with-ssl option given, just check default places
-    if test x$cross_compiling != xyes; then
-      dnl only do pkg-config magic when not cross-compiling
-      PKGTEST="yes"
-    fi
+    PKGTEST="yes"
     PREFIX_OPENSSL=
     ;;
   *)


### PR DESCRIPTION
This reverts 736a40fec, which doesn't explain why it was done.

Maybe in 2004 it made sense. But I fail to see why it should not use pkg-config to find openSSL when cross-compiling. My build only works after this patch.