### PR TITLE
tool_operate: --retry for HTTP 408 responses too

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -474,6 +474,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
 
         switch(response) {
+        case 408: /* Request Timeout */
         case 429: /* Too Many Requests (RFC6585) */
         case 500: /* Internal Server Error */
         case 502: /* Bad Gateway */


### PR DESCRIPTION
This was inadvertently dropped from the code when the parallel support
was added.

Regression since b88940850 (7.66.0)