### PR TITLE
tests: add missing global_init/cleanup calls

### DIFF
--- a/tests/libtest/lib1523.c
+++ b/tests/libtest/lib1523.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -56,8 +56,10 @@ static CURLcode run(CURL *hnd, long limit, long time)
 int test(char *URL)
 {
   CURLcode ret;
-  CURL *hnd = curl_easy_init();
+  CURL *hnd;
   char buffer[CURL_ERROR_SIZE];
+  curl_global_init(CURL_GLOBAL_ALL);
+  hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_URL, URL);
   curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, write_cb);
   curl_easy_setopt(hnd, CURLOPT_ERRORBUFFER, buffer);
@@ -77,6 +79,7 @@ int test(char *URL)
 
   printf("End: %d\n", time(NULL));
   curl_easy_cleanup(hnd);
+  curl_global_cleanup();
 
   return (int)ret;
 }

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -38,6 +38,7 @@ int test(char *URL)
   int error = 0;
   (void)URL;
 
+  curl_global_init(CURL_GLOBAL_ALL);
   easy = curl_easy_init();
   if(!easy)
     return 1;
@@ -83,5 +84,6 @@ int test(char *URL)
     }
   }
   curl_easy_cleanup(easy);
+  curl_global_cleanup();
   return error;
 }

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -56,6 +56,7 @@ UNITTEST_START
     Curl_altsvc_cleanup(&asi);
     return result;
   }
+  curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   if(!curl)
     goto fail;
@@ -129,6 +130,7 @@ UNITTEST_START
   Curl_altsvc_save(curl, asi, outname);
 
   curl_easy_cleanup(curl);
+  curl_global_cleanup();
   fail:
   Curl_altsvc_cleanup(&asi);
   return unitfail;


### PR DESCRIPTION
Without the cleanup call in these test files, the mbedTLS backend leaks
memory.