### PR TITLE
rtsp: fixed Session ID comparison to refuse prefix

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -776,6 +776,8 @@ CURLcode Curl_rtsp_parseheader(struct connectdata *conn,
   }
   else if(checkprefix("Session:", header)) {
     char *start;
+    char *end;
+    size_t idlen;
 
     /* Find the first non-space letter */
     start = header + 8;
@@ -784,16 +786,21 @@ CURLcode Curl_rtsp_parseheader(struct connectdata *conn,
 
     if(!*start) {
       failf(data, "Got a blank Session ID");
+      return CURLE_RTSP_SESSION_ERROR;
     }
-    else if(data->set.str[STRING_RTSP_SESSION_ID]) {
-      char *end;
-      size_t idlen;
 
-      /* Find the end of Session ID */
-      end = start + 1;
-      while(*end && !ISSPACE(*end))
-        end++;
-      idlen = end - start;
+    /* Find the end of Session ID
+     *
+     * Allow any non whitespace content, up to the field separator or end of
+     * line. RFC 2326 isn't 100% clear on the session ID and for example
+     * gstreamer does url-encoded session ID's not covered by the standard.
+     */
+    end = start;
+    while(*end && *end != ';' && !ISSPACE(*end))
+      end++;
+    idlen = end - start;
+
+    if(data->set.str[STRING_RTSP_SESSION_ID]) {
 
       /* If the Session ID is set, then compare */
       if(strlen(data->set.str[STRING_RTSP_SESSION_ID]) != idlen ||
@@ -806,21 +813,14 @@ CURLcode Curl_rtsp_parseheader(struct connectdata *conn,
     else {
       /* If the Session ID is not set, and we find it in a response, then set
        * it.
-       *
-       * Allow any non whitespace content, up to the field separator or end of
-       * line. RFC 2326 isn't 100% clear on the session ID and for example
-       * gstreamer does url-encoded session ID's not covered by the standard.
        */
-      char *end = start;
-      while(*end && *end != ';' && !ISSPACE(*end))
-        end++;
 
       /* Copy the id substring into a new buffer */
-      data->set.str[STRING_RTSP_SESSION_ID] = malloc(end - start + 1);
+      data->set.str[STRING_RTSP_SESSION_ID] = malloc(idlen + 1);
       if(data->set.str[STRING_RTSP_SESSION_ID] == NULL)
         return CURLE_OUT_OF_MEMORY;
-      memcpy(data->set.str[STRING_RTSP_SESSION_ID], start, end - start);
-      (data->set.str[STRING_RTSP_SESSION_ID])[end - start] = '\0';
+      memcpy(data->set.str[STRING_RTSP_SESSION_ID], start, idlen);
+      (data->set.str[STRING_RTSP_SESSION_ID])[idlen] = '\0';
     }
   }
   return CURLE_OK;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -786,9 +786,18 @@ CURLcode Curl_rtsp_parseheader(struct connectdata *conn,
       failf(data, "Got a blank Session ID");
     }
     else if(data->set.str[STRING_RTSP_SESSION_ID]) {
+      char *end;
+      size_t idlen;
+
+      /* Find the end of Session ID */
+      end = start + 1;
+      while(*end && !ISSPACE(*end))
+        end++;
+      idlen = end - start;
+
       /* If the Session ID is set, then compare */
-      if(strncmp(start, data->set.str[STRING_RTSP_SESSION_ID],
-                 strlen(data->set.str[STRING_RTSP_SESSION_ID]))  != 0) {
+      if(strlen(data->set.str[STRING_RTSP_SESSION_ID]) != idlen ||
+         strncmp(start, data->set.str[STRING_RTSP_SESSION_ID], idlen) != 0) {
         failf(data, "Got RTSP Session ID Line [%s], but wanted ID [%s]",
               start, data->set.str[STRING_RTSP_SESSION_ID]);
         return CURLE_RTSP_SESSION_ERROR;

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -101,8 +101,12 @@ int test(char *URL)
   stream_uri = NULL;
 
   res = curl_easy_perform(curl);
-  if(res != CURLE_RTSP_SESSION_ERROR) {
+  if(res == CURLE_RTSP_SESSION_ERROR) {
+    res = 0;
+  }
+  else {
     fprintf(stderr, "Failed to detect a Session ID mismatch");
+    res = 1;
   }
 
 test_cleanup:


### PR DESCRIPTION
Fixes an oversight in the RTSP Session ID comparison: It would accept any Session ID from the server that is prefixed by the one specified by CURLOPT_RTSP_SESSION_ID.

Blank Session ID will now result in CURLE_RTSP_SESSION_ERROR.