### PR TITLE
hsts: Fix potential NULL pointer deref in errorpath

### DIFF
--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -498,7 +498,6 @@ static CURLcode hsts_load(struct hsts *h, const char *file)
 
   fail:
   Curl_safefree(h->filename);
-  free(line);
   fclose(fp);
   return CURLE_OUT_OF_MEMORY;
 }


### PR DESCRIPTION
The `line` variable will always be NULL in the error path, so remove the free call to avoid dereferencing it.