### PR TITLE
tests: Add checksrc exceptions for testcode

### DIFF
--- a/tests/libtest/stub_gssapi.h
+++ b/tests/libtest/stub_gssapi.h
@@ -68,6 +68,7 @@ typedef uint32_t OM_uint32;
 
 typedef OM_uint32 gss_qop_t;
 
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct gss_buffer_desc_struct {
   size_t length;
   void *value;
@@ -85,11 +86,13 @@ struct gss_name_t_desc_struct;
 typedef struct gss_name_t_desc_struct *gss_name_t;
 typedef const struct gss_name_t_desc_struct *gss_const_name_t;
 
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct gss_OID_desc_struct {
   OM_uint32 length;
   void      *elements;
 } gss_OID_desc, *gss_OID;
 
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct gss_channel_bindings_struct {
   OM_uint32 initiator_addrtype;
   gss_buffer_desc initiator_address;

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -107,6 +107,7 @@ int libtest_debug_cb(CURL *handle, curl_infotype type,
       known_offset = 1;
     }
     secs = epoch_offset + tv.tv_sec;
+    /* !checksrc! disable BANNEDFUNC 1 */
     now = localtime(&secs);  /* not thread safe but we don't care */
     msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
               now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);


### PR DESCRIPTION
The autobuilds are reporting checksrc warnings in libtest testcode on struct typedefs and the use of localtime. These are all done intentional to add exceptions to avoid warnings.