### PR TITLE
runtests.pl: kill processes locking test log files

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -198,4 +198,4 @@ stages:
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "-vc /usr/bin/curl.exe -r $(tests)"
+        TFLAGS: "-vc /usr/bin/curl.exe -r -rm $(tests)"

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -372,7 +372,15 @@ sub sys_native_abs_path {
         # Path is in relative form. Resolve relative directories in Unix form
         # *BEFORE* converting to Win32 form otherwise paths like
         # '../../../cygdrive/c/windows' will not be resolved.
-        my $cur_dir = `pwd -L`;
+
+        my $cur_dir;
+        # MSys shell has built-in command.
+        if($^O eq 'msys') {
+            $cur_dir = `bash -c 'pwd -L'`;
+        }
+        else {
+            $cur_dir = `pwd -L`;
+        }
         if($? != 0) {
             warn "Can't determine current working directory.\n";
             return undef;
@@ -440,7 +448,13 @@ sub build_sys_abs_path {
         # Path is empty string. Return current directory.
         # Empty string processed correctly by 'cygpath'.
 
-        chomp($path = `pwd -L`);
+        # MSys shell has built-in command.
+        if($^O eq 'msys') {
+            chomp($path = `bash -c 'pwd -L'`);
+        }
+        else {
+            chomp($path = `pwd -L`);
+        }
         if($? != 0) {
             warn "Can't determine Unix-style current working directory.\n";
             return undef;
@@ -510,7 +524,15 @@ sub build_sys_abs_path {
         # Path in relative form. Resolve relative directories in Unix form
         # *BEFORE* converting to Win32 form otherwise paths like
         # '../../../cygdrive/c/windows' will not be resolved.
-        my $cur_dir = `pwd -L`;
+
+        my $cur_dir;
+        # MSys shell has built-in command.
+        if($^O eq 'msys') {
+            $cur_dir = `bash -c 'pwd -L'`;
+        }
+        else {
+            $cur_dir = `pwd -L`;
+        }
         if($? != 0) {
             warn "Can't determine current working directory.\n";
             return undef;

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -113,6 +113,9 @@ The random seed initially set for this is fixed per month and can be set with
 Display run time statistics. (Requires Perl Time::HiRes module)
 .IP "-rf"
 Display full run time statistics. (Requires Perl Time::HiRes module)
+.IP "-rm"
+Force removal of files by killing locking processes. (Windows only,
+requires Sysinternals handle[64].exe to be on PATH)
 .IP "--repeat=[num]"
 This will repeat the given set of test numbers this many times. If no test
 numbers are given, it will repeat ALL tests this many times. It iteratively


### PR DESCRIPTION
For now only required and implemented for Windows.

Ref: #6058