### PR TITLE
examples/httpput: remove use of CURLOPT_PUT

### DIFF
--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -89,11 +89,8 @@ int main(int argc, char **argv)
     /* we want to use our own read function */
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
 
-    /* enable uploading */
+    /* enable uploading (implies PUT over HTTP) */
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
-
-    /* HTTP PUT please */
-    curl_easy_setopt(curl, CURLOPT_PUT, 1L);
 
     /* specify target URL, and note that this URL should include a file
        name, not only a directory */


### PR DESCRIPTION
It is deprecated and unnecessary since it already sets CURLOPT_UPLOAD.
Reported-by: Jeroen Ooms
Fixes #6186