### PR TITLE
docs: document the 8MB input string limit

### DIFF
--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -36,7 +36,8 @@ a-z, A-Z, 0-9, '-', '.', '_' or '~' are converted to their "URL escaped"
 version (%NN where NN is a two-digit hexadecimal number).
 
 If \fIlength\fP is set to 0 (zero), \fIcurl_easy_escape(3)\fP uses strlen() on
-the input \fIstring\fP to find out the size.
+the input \fIstring\fP to find out the size. This function does not accept
+input strings longer than \fBCURL_MAX_INPUT_LENGTH\fP (8 MB).
 
 You must \fIcurl_free(3)\fP the returned string when you're done with it.
 .SH ENCODING

--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -48,7 +48,8 @@ thus the string storage associated to the pointer argument may be overwritten
 after \fIcurl_easy_setopt(3)\fP returns. The only exception to this rule is
 really \fICURLOPT_POSTFIELDS(3)\fP, but the alternative that copies the string
 \fICURLOPT_COPYPOSTFIELDS(3)\fP has some usage characteristics you need to
-read up on.
+read up on. This function does not accept input strings longer than
+\fBCURL_MAX_INPUT_LENGTH\fP (8 MB).
 
 The order in which the options are set does not matter.
 


### PR DESCRIPTION
for curl_easy_escape and curl_easy_setopt()

The limit is there to catch mistakes and abuse. It is meant to be large
enough to allow virtually all "fine" use cases.

Reported-by: Marc Schlatter
Fixes #6190