### PR TITLE
curl_easy_escape: limit *output* string length to 3 * max input

### DIFF
--- a/lib/escape.c
+++ b/lib/escape.c
@@ -86,7 +86,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   if(inlength < 0)
     return NULL;
 
-  Curl_dyn_init(&d, CURL_MAX_INPUT_LENGTH);
+  Curl_dyn_init(&d, CURL_MAX_INPUT_LENGTH * 3);
 
   length = (inlength?(size_t)inlength:strlen(string));
   if(!length)


### PR DESCRIPTION
... instead of the limiting it to just the max input value. As every input byte can be expanded to 3 output bytes, this could limit the input string to 2.66 MB instead of 8.


Reported-by: Marc Schlatter