### PR TITLE
http_proxy: use enum with state names for 'keepon'

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -802,7 +802,11 @@ struct proxy_info {
 /* struct for HTTP CONNECT state data */
 struct http_connect_state {
   struct dynbuf rcvbuf;
-  int keepon;
+  enum keeponval {
+    KEEPON_DONE,
+    KEEPON_CONNECT,
+    KEEPON_IGNORE
+  } keepon;
   curl_off_t cl; /* size of content to read and ignore */
   enum {
     TUNNEL_INIT,    /* init/default/no tunnel state */


### PR DESCRIPTION
To make the code clearer, change the 'keepon' from an int to an enum
with better state names.

Reported-by: Niranjan Hasabnis
Bug: https://curl.se/mail/lib-2020-11/0026.html