### PR TITLE
Don't pass -fvisibility=hidden to clang-cl on Windows

### DIFF
--- a/CMake/CurlSymbolHiding.cmake
+++ b/CMake/CurlSymbolHiding.cmake
@@ -27,7 +27,7 @@ mark_as_advanced(CURL_HIDDEN_SYMBOLS)
 if(CURL_HIDDEN_SYMBOLS)
   set(SUPPORTS_SYMBOL_HIDING FALSE)
 
-  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT MSVC)
     set(SUPPORTS_SYMBOL_HIDING TRUE)
     set(_SYMBOL_EXTERN "__attribute__ ((__visibility__ (\"default\")))")
     set(_CFLAG_SYMBOLS_HIDE "-fvisibility=hidden")


### PR DESCRIPTION
When using clang-cl on windows -fvisibility=hidden is not
an known argument. Instead it behaves exactly like MSVC in
this case. So let's make sure we take that path.

In CMake clang-cl sets both CMAKE_C_COMPILER_ID=clang and
MSVC get's defined since clang-cl is basically a MSVC
emulator. So guarding like we do in this patch seems logical.