### PR TITLE
tests/server/tftpd.c: close upload file after transfer

### DIFF
--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -821,11 +821,6 @@ int main(int argc, char **argv)
     sclose(peer);
     peer = CURL_SOCKET_BAD;
 
-    if(test.ofile > 0) {
-      close(test.ofile);
-      test.ofile = 0;
-    }
-
     if(got_exit_signal)
       break;
 
@@ -1304,6 +1299,10 @@ send_ack:
     }
   } while(size == SEGSIZE);
   write_behind(test, pf->f_convert);
+  if(test->ofile > 0) {
+    close(test->ofile);
+    test->ofile = 0;
+  }
 
   rap->th_opcode = htons((unsigned short)opcode_ACK);  /* send the "final"
                                                           ack */


### PR DESCRIPTION
Make sure uploaded file is not locked after transfer.

Bug: #6058