### PR TITLE
cmake: append libcurl.rc to source files also for MSYS based system

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,7 +39,7 @@ list(APPEND HHEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/curl_config.h
   )
 
-if(MSVC)
+if(WIN32)
   list(APPEND CSOURCES libcurl.rc)
 endif()
 


### PR DESCRIPTION
On MSYS or MSYS2, windres also exists.
Tested with MSYS2 + mingw-w64 toolchain