### PR TITLE
curl: add compatibility for Amiga and GCC 6.5

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1880,11 +1880,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
 #endif
 #endif
 #ifndef HAVE_WINDOWS_H
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #elif defined(HAVE_UNISTD_H)
@@ -1892,6 +1887,11 @@ struct Library *SocketBase = NULL;
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
+#endif
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
 #endif
 #endif
     ]],[[
@@ -1945,11 +1945,6 @@ struct Library *SocketBase = NULL;
 #endif
 #endif
 #ifndef HAVE_WINDOWS_H
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
-#endif
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #elif defined(HAVE_UNISTD_H)
@@ -1957,6 +1952,11 @@ struct Library *SocketBase = NULL;
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
+#endif
+#ifdef HAVE_PROTO_BSDSOCKET_H
+#include <proto/bsdsocket.h>
+struct Library *SocketBase = NULL;
+#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
 #endif
 #define SELECTCALLCONV
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -863,24 +863,27 @@ then
   ])
 fi
 
-dnl This is for AmigaOS with bsdsocket.library - needs testing before -lnet
-AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
-AC_LINK_IFELSE([
-  AC_LANG_PROGRAM([[
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-  ]],[[
-    gethostbyname("www.dummysite.com");
-  ]])
-],[
-  AC_MSG_RESULT([yes])
-  HAVE_GETHOSTBYNAME="1"
-  HAVE_PROTO_BSDSOCKET_H="1"
-  AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
-  AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])
-],[
-  AC_MSG_RESULT([no])
-])
+if test "$HAVE_GETHOSTBYNAME" != "1" -o "${with_amissl+set}" = set
+then
+  dnl This is for AmigaOS with bsdsocket.library - needs testing before -lnet
+  AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+  #include <proto/bsdsocket.h>
+  struct Library *SocketBase = NULL;
+    ]],[[
+      gethostbyname("www.dummysite.com");
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    HAVE_GETHOSTBYNAME="1"
+    HAVE_PROTO_BSDSOCKET_H="1"
+    AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
+    AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])
+  ],[
+    AC_MSG_RESULT([no])
+  ])
+fi
 
 if test "$HAVE_GETHOSTBYNAME" != "1"
 then

--- a/configure.ac
+++ b/configure.ac
@@ -863,27 +863,24 @@ then
   ])
 fi
 
-if test "$HAVE_GETHOSTBYNAME" != "1"
-then
-  dnl This is for AmigaOS with bsdsocket.library - needs testing before -lnet
-  AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
-  AC_LINK_IFELSE([
-    AC_LANG_PROGRAM([[
+dnl This is for AmigaOS with bsdsocket.library - needs testing before -lnet
+AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
+AC_LINK_IFELSE([
+  AC_LANG_PROGRAM([[
 #include <proto/bsdsocket.h>
 struct Library *SocketBase = NULL;
-    ]],[[
-      gethostbyname("www.dummysite.com");
-    ]])
-  ],[
-    AC_MSG_RESULT([yes])
-    HAVE_GETHOSTBYNAME="1"
-    HAVE_PROTO_BSDSOCKET_H="1"
-    AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
-    AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])
-  ],[
-    AC_MSG_RESULT([no])
-  ])
-fi
+  ]],[[
+    gethostbyname("www.dummysite.com");
+  ]])
+],[
+  AC_MSG_RESULT([yes])
+  HAVE_GETHOSTBYNAME="1"
+  HAVE_PROTO_BSDSOCKET_H="1"
+  AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
+  AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])
+],[
+  AC_MSG_RESULT([no])
+])
 
 if test "$HAVE_GETHOSTBYNAME" != "1"
 then

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -74,7 +74,7 @@
 #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
     defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
-    defined(__CYGWIN__) || \
+    defined(__CYGWIN__) || defined(AMIGA) || \
    (defined(__FreeBSD_version) && (__FreeBSD_version < 800000))
 #include <sys/select.h>
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -277,10 +277,23 @@
 #  include <exec/execbase.h>
 #  include <proto/exec.h>
 #  include <proto/dos.h>
+#  include <unistd.h>
+/*
+ * pwd.h required for getpwuid but works only if __NO_NET_API is not
+ * defined so it must be defined here.
+ */
+#  ifdef HAVE_PWD_H
+#    include <pwd.h>
+#  endif
 #  ifdef HAVE_PROTO_BSDSOCKET_H
 #    include <proto/bsdsocket.h> /* ensure bsdsocket.library use */
 #    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
 #  endif
+/*
+ * In clib2 arpa/inet.h warns that some prototypes may clash
+ * with bsdsocket.library. This avoids the definition of those.
+ */
+#  define __NO_NET_API
 #endif
 
 #include <stdio.h>

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -278,13 +278,6 @@
 #  include <proto/exec.h>
 #  include <proto/dos.h>
 #  include <unistd.h>
-/*
- * pwd.h required for getpwuid but works only if __NO_NET_API is not
- * defined so it must be defined here.
- */
-#  ifdef HAVE_PWD_H
-#    include <pwd.h>
-#  endif
 #  ifdef HAVE_PROTO_BSDSOCKET_H
 #    include <proto/bsdsocket.h> /* ensure bsdsocket.library use */
 #    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)

--- a/src/tool_homedir.c
+++ b/src/tool_homedir.c
@@ -22,6 +22,7 @@
 #include "tool_setup.h"
 
 #ifdef HAVE_PWD_H
+#  undef __NO_NET_API /* required for building for AmigaOS */
 #  include <pwd.h>
 #endif
 


### PR DESCRIPTION
Changes are mainly reordering and adding of includes required
to compile with a more recent version of GCC.