### PR TITLE
winbuild: remove docs from Makefiles and refer to README.md

### DIFF
--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -35,40 +35,7 @@ CFGSET=true
 # Usage
 #
 
-!MESSAGE Usage: nmake /f Makefile.vc mode=<static or dll> <options>
-!MESSAGE where <options> is one or many of:
-!MESSAGE   VC=<6,7,8,9,10,11,12,14,15>    - VC versions
-!MESSAGE   WITH_DEVEL=<path>              - Paths for the development files (SSL, zlib, etc.)
-!MESSAGE                                    Defaults to curl's sibling directory deps: ../deps
-!MESSAGE                                    Libraries can be fetched at https://windows.php.net/downloads/php-sdk/deps/
-!MESSAGE                                    Uncompress them into the deps folder.
-!MESSAGE   WITH_PREFIX=<path>             - Installation directory path
-!MESSAGE                                    Defaults to a configuration dependent (SSL, zlib, etc.)
-!MESSAGE                                    directory inside curl's subdirectory builds: ./builds
-!MESSAGE                                    Use backslashes as path separator
-!MESSAGE   WITH_SSL=<dll or static>       - Enable OpenSSL support, DLL or static
-!MESSAGE   WITH_NGHTTP2=<dll or static>   - Enable HTTP/2 support, DLL or static
-!MESSAGE   WITH_CARES=<dll or static>     - Enable c-ares support, DLL or static
-!MESSAGE   WITH_ZLIB=<dll or static>      - Enable zlib support, DLL or static
-!MESSAGE   WITH_SSH2=<dll or static>      - Enable libSSH2 support, DLL or static
-!MESSAGE   WITH_MBEDTLS=<dll or static>   - Enable mbedTLS support, DLL or static
-!MESSAGE   ENABLE_IDN=<yes or no>         - Enable use of Windows IDN APIs, defaults to yes
-!MESSAGE                                    Requires Windows Vista or later
-!MESSAGE   ENABLE_IPV6=<yes or no>        - Enable IPv6, defaults to yes
-!MESSAGE   ENABLE_SSPI=<yes or no>        - Enable SSPI support, defaults to yes
-!MESSAGE   ENABLE_SCHANNEL=<yes or no>      - Enable native Windows SSL support, defaults to yes
-!MESSAGE   ENABLE_OPENSSL_AUTO_LOAD_CONFIG=<yes or no>
-!MESSAGE                                  - Whether the OpenSSL configuration will be loaded automatically, defaults to yes
-!MESSAGE   ENABLE_UNICODE=<yes or no>     - Enable UNICODE support, defaults to no
-!MESSAGE   GEN_PDB=<yes or no>            - Generate Program Database (debug symbols for release build)
-!MESSAGE   DEBUG=<yes or no>              - Debug builds
-!MESSAGE   MACHINE=<x86 or x64>           - Target architecture (default x64 on AMD64, x86 on others)
-!MESSAGE   CARES_PATH=<path to cares>     - Custom path for c-ares
-!MESSAGE   MBEDTLS_PATH=<path to mbedTLS> - Custom path for mbedTLS
-!MESSAGE   NGHTTP2_PATH=<path to HTTP/2>  - Custom path for nghttp2
-!MESSAGE   SSH2_PATH=<path to libSSH2>    - Custom path for libSSH2
-!MESSAGE   SSL_PATH=<path to OpenSSL>     - Custom path for OpenSSL
-!MESSAGE   ZLIB_PATH=<path to zlib>       - Custom path for zlib
+!MESSAGE See winbuild/README.md for usage
 !ERROR please choose a valid mode
 
 !ENDIF

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -22,24 +22,9 @@
 
 ###########################################################################
 #
-# Makefile for building libcurl with MSVC 6 through to 15
+# Makefile for building libcurl with MSVC
 #
-# Usage: see usage message below
-#        Should be invoked from winbuild directory
-#        Edit the paths and desired library name
-#        SSL path is only required if you intend compiling
-#        with SSL.
-#
-# This make file leaves the result either a .lib or .dll file
-# in the \lib directory. It should be called from the \lib
-# directory.
-#
-# An option would have been to allow the source directory to
-# be specified, but I saw no requirement.
-#
-# Another option would have been to leave the .lib and .dll
-# files in the "cfg" directory, but then the make file
-# in \src would need to be changed.
+# Usage: see README.md
 #
 ##############################################################
 
@@ -72,7 +57,7 @@ LFLAGS     = /nologo /machine:$(MACHINE)
 LNKDLL     = link.exe /DLL
 # Use lib.exe instead of link.exe as link.exe /lib has the following bad habits:
 # - optimizing options like /opt:ref raises warnings (at least in Visual Studio 2015)
-# - all (including Windows) dependencies are aggregated (as static parts) 
+# - all (including Windows) dependencies are aggregated (as static parts)
 # - link.exe /lib is not documented (anymore) at MSDN
 # Instead of id: just create an archive, that contains all objects
 LNKLIB     = lib.exe
@@ -237,8 +222,8 @@ ZLIB_INC_DIR = $(DEVEL_INCLUDE)
 ZLIB_LIB_DIR = $(DEVEL_LIB)
 !ENDIF
 
-# Depending on how zlib is built the libraries have different names, we 
-# try to handle them all. 
+# Depending on how zlib is built the libraries have different names, we
+# try to handle them all.
 !IF "$(WITH_ZLIB)"=="dll"
 !IF EXISTS("$(ZLIB_LIB_DIR)\zlibwapi.lib")
 ZLIB_LIBS = zlibwapi.lib
@@ -622,7 +607,7 @@ CURL_FROM_LIBCURL=$(CURL_DIROBJ)\tool_hugehelp.obj \
  $(CURL_DIROBJ)\curl_multibyte.obj \
  $(CURL_DIROBJ)\version_win32.obj \
  $(CURL_DIROBJ)\dynbuf.obj
- 
+
 $(PROGRAM_NAME): $(CURL_DIROBJ) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
 	$(CURL_LINK) $(CURL_LFLAGS) $(CURL_LIBCURL_LIBNAME) $(WIN_LIBS) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
 	$(MANIFESTTOOL)

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -89,7 +89,8 @@ where `<options>` is one or many of:
  - `ENABLE_IPV6=<yes/no>`        - Enable IPv6, defaults to yes
  - `ENABLE_IDN=<yes or no>`      - Enable use of Windows IDN APIs, defaults to yes
                                    Requires Windows Vista or later
- - `ENABLE_SCHANNEL=<yes/no>`    - Enable native Windows SSL support, defaults to yes
+ - `ENABLE_SCHANNEL=<yes/no>`    - Enable native Windows SSL support, defaults
+                                   to yes if SSPI and no other SSL library
  - `ENABLE_OPENSSL_AUTO_LOAD_CONFIG=<yes/no>`
                                  - Enable loading OpenSSL configuration
                                    automatically, defaults to yes

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -90,6 +90,10 @@ where `<options>` is one or many of:
  - `ENABLE_IDN=<yes or no>`      - Enable use of Windows IDN APIs, defaults to yes
                                    Requires Windows Vista or later
  - `ENABLE_SCHANNEL=<yes/no>`    - Enable native Windows SSL support, defaults to yes
+ - `ENABLE_OPENSSL_AUTO_LOAD_CONFIG=<yes/no>`
+                                 - Enable loading OpenSSL configuration
+                                   automatically, defaults to yes
+ - `ENABLE_UNICODE=<yes/no>`     - Enable UNICODE support, defaults to no
  - `GEN_PDB=<yes/no>`            - Generate Program Database (debug symbols for release build)
  - `DEBUG=<yes/no>`              - Debug builds
  - `MACHINE=<x86/x64>`           - Target architecture (default is x86)


### PR DESCRIPTION
Reduce risk for conflicting docs and makes it to a single place to fix
and polish.