### PR TITLE
Makefile.m32: add support for UNICODE builds

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -226,6 +226,9 @@ endif
 ifeq ($(findstring -ngtcp2,$(CFG)),-ngtcp2)
 NGTCP2 = 1
 endif
+ifeq ($(findstring -unicode,$(CFG)),-unicode)
+UNICODE = 1
+endif
 
 INCLUDES = -I. -I../include
 CFLAGS += -DBUILDING_LIBCURL
@@ -233,6 +236,9 @@ ifdef SSL
   ifdef WINSSL
     CFLAGS += -DCURL_WITH_MULTI_SSL
   endif
+endif
+ifdef UNICODE
+  CFLAGS += -DUNICODE -D_UNICODE
 endif
 
 ifdef SYNC

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -238,12 +238,19 @@ endif
 ifeq ($(findstring -ngtcp2,$(CFG)),-ngtcp2)
 NGTCP2 = 1
 endif
+ifeq ($(findstring -unicode,$(CFG)),-unicode)
+UNICODE = 1
+endif
 
 INCLUDES = -I. -I../include -I../lib
 ifdef SSL
   ifdef WINSSL
     CFLAGS += -DCURL_WITH_MULTI_SSL
   endif
+endif
+ifdef UNICODE
+  CFLAGS += -DUNICODE -D_UNICODE
+  LDFLAGS += -municode
 endif
 
 ifdef DYN


### PR DESCRIPTION
It requires the linker to support the `-municode` option.