### PR TITLE
CI/cirrus: simplify logic for disabled tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,15 +64,8 @@ task:
     # Some tests won't run if run as root so run them as another user.
     # Make directories world writable so the test step can write wherever it needs.
     - find . -type d -exec chmod 777 {} \;
-    # TODO: A number of tests are failing on different FreeBSD versions and so
-    # are disabled.  This should be investigated.
-    - SKIP_TESTS=''
-    - uname -r
-    - case `uname -r` in
-        13.0*) SKIP_TESTS='!SFTP !SCP';;
-        12.1*) SKIP_TESTS='!SFTP !SCP';;
-        11.*) SKIP_TESTS='!SFTP !SCP';;
-      esac
-    - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky ${SKIP_TESTS}" test-nonflaky
+    # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
+    # therefore the SFTP and SCP tests are disabled right away from the beginning.
+    - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky !SFTP !SCP" test-nonflaky
   install_script:
     - make V=1 install


### PR DESCRIPTION
The OpenSSH server instance for the testsuite cannot
be started on FreeBSD, therefore the SFTP and SCP
tests are disabled right away from the beginning.

The previous OS version specific logic for SKIP_TESTS
is no longer needed/used and can therefore be removed.

Follow up to #6211