### PR TITLE
mailmap: Daniel Hwang

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -72,3 +72,4 @@ SecuritySense on github <si@securitysense.co.uk>
 Mipsters on github <tomaviv57@gmail.com>
 Pavel Novikov <paul.skeptic@yandex.ru>
 apique13 on github <apique@PC42.isdom.isoft.fr>
+Daniel Hwang <danielleehwang@gmail.com>


### PR DESCRIPTION
Add Daniel Hwang to the mailmap to cover the alternative spelling
Daniel Lee Hwang which was used in one commit.