### PR TITLE
test: Forbid valgrind on non Darwin/Linux systems

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -217,7 +217,7 @@ my $start;
 my $ftpchecktime=1; # time it took to verify our test FTP server
 my $scrambleorder;
 my $stunnel = checkcmd("stunnel4") || checkcmd("tstunnel") || checkcmd("stunnel");
-my $valgrind = checktestcmd("valgrind");
+my $valgrind = $^O eq "darwin" || $^O eq "linux" ? checktestcmd("valgrind") : 0;
 my $valgrind_logfile="--logfile";
 my $valgrind_tool;
 my $gdb = checktestcmd("gdb");


### PR DESCRIPTION
Valgrind is officially only supported on Darwin and Linux systems.
Therefore the test suite will fail horrendously when executing the test
suite on a *BSD or other exotic OS while having valgrind in the $PATH.

Fixes #6210

You might argue that when you have valgrind in your $PATH it's your own fault which is not the case. For example, OpenBSDs valgrind always reports this error in EVERY executable but works more or less fine otherwise:
```
==57064== Use of uninitialised value of size 8
==57064==    at 0x4A9C2E0: _thread_finalize (stdlib/atexit.c:131)
==57064==    by 0x4A9C2E0: __cxa_finalize (stdlib/atexit.c:153)
==57064==    by 0x4A4F7E0: exit (stdlib/exit.c:54)
```