### PR TITLE
examples: Update .gitignore

### DIFF
--- a/docs/examples/.gitignore
+++ b/docs/examples/.gitignore
@@ -1,4 +1,5 @@
 10-at-a-time
+altsvc
 anyauthput
 certinfo
 chkspeed
@@ -23,11 +24,14 @@ http2-download
 http2-pushinmemory
 http2-serverpush
 http2-upload
+http3
+http3-present
 httpcustomheader
 httpput
+httpput-postfields
 https
-imap
 imap-append
+imap-authzid
 imap-copy
 imap-create
 imap-delete
@@ -45,10 +49,12 @@ multi-app
 multi-debugcallback
 multi-double
 multi-formadd
+multi-poll
 multi-post
 multi-single
 parseurl
 persistent
+pop3-authzid
 pop3-dele
 pop3-list
 pop3-multi
@@ -59,8 +65,6 @@ pop3-stat
 pop3-tls
 pop3-top
 pop3-uidl
-pop3s
-pop3slist
 post-callback
 postinmemory
 postit2
@@ -75,8 +79,8 @@ sftpuploadresume
 shared-connection-cache
 simple
 simplepost
-simplesmtp
 simplessl
+smtp-authzid
 smtp-expn
 smtp-mail
 smtp-mime


### PR DESCRIPTION
Add files that are generated by 'make examples' and remove some that
have been renamed.

The commits that renamed the programs are e9625c5bc6c046a (imap.c and
simplesmtp.c were renamed to imap-fetch.c and smtp-send.c) and
ad39e7ec01e7 (pop3slist.c and pop3s.c were renamed to pop3-list.c and
pop3-ssl.c).