### PR TITLE
docs/INTERNALS: remove reference to Curl_sendf()

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -236,11 +236,9 @@ multi_do()
    The functions are named after the protocols they handle.
 
    The protocol-specific functions of course deal with protocol-specific
-   negotiations and setup. They have access to the `Curl_sendf()` (from
-   `lib/sendf.c`) function to send printf-style formatted data to the remote
-   host and when they're ready to make the actual file transfer they call the
-   `Curl_setup_transfer()` function (in `lib/transfer.c`) to setup the
-   transfer and returns.
+   negotiations and setup. When they're ready to start the actual file
+   transfer they call the `Curl_setup_transfer()` function (in
+   `lib/transfer.c`) to setup the transfer and returns.
 
    If this DO function fails and the connection is being re-used, libcurl will
    then close this connection, setup a new connection and re-issue the DO

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -124,8 +124,6 @@ static CURLcode gopher_do(struct connectdata *conn, bool *done)
     sel_org = sel;
   }
 
-  /* We use Curl_write instead of Curl_sendf to make sure the entire buffer is
-     sent, which could be sizeable with long selectors. */
   k = curlx_uztosz(len);
 
   for(;;) {


### PR DESCRIPTION
The function has been removed from common usage. Also removed comment in
gopher.c that still referenced it.

Reported-by: Rikard Falkeborn
Fixes #6242