### PR TITLE
refactor: "Remove" duplicate function

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -227,18 +227,8 @@ static CURLcode file_done(struct connectdata *conn,
 static CURLcode file_disconnect(struct connectdata *conn,
                                 bool dead_connection)
 {
-  struct FILEPROTO *file = conn->data->req.p.file;
   (void)dead_connection; /* not used */
-
-  if(file) {
-    Curl_safefree(file->freepath);
-    file->path = NULL;
-    if(file->fd != -1)
-      close(file->fd);
-    file->fd = -1;
-  }
-
-  return CURLE_OK;
+  return file_done(conn, 0, 0);
 }
 
 #ifdef DOS_FILESYSTEM


### PR DESCRIPTION
file_disconnect() is identical with file_do() except the function header
but as the arguments are unused anyway why not just return file_do()
directly? This will make the binary smaller and the code more readable.