### PR TITLE
Fixes for c-ares use on macOS

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -238,7 +238,7 @@
  * interface doesn't support IPv4, but supports IPv6, NAT64, and DNS64,
  * performing this task will result in a synthesized IPv6 address.
  */
-#ifdef  __APPLE__
+#if defined(__APPLE__) && !defined(USE_ARES)
 #define USE_RESOLVE_ON_IPS 1
 #endif
 

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -771,7 +771,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
 
   case CONNECT_RESOLVING:
     /* check if we have the name resolved by now */
-    dns = Curl_fetch_addr(conn, hostname, (int)conn->port);
+    dns = Curl_fetch_addr(conn, hostname, remote_port);
 
     if(dns) {
 #ifdef CURLRES_ASYNCH

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -333,6 +333,7 @@ SKIPPED.
 Features testable here are:
 
 - `alt-svc`
+- `c-ares`
 - `cookies`
 - `crypto`
 - `debug`

--- a/tests/data/test506
+++ b/tests/data/test506
@@ -55,10 +55,11 @@ run 3: overwrite cookie 1 and 4, set cookie 6 with and without tailmatch
 <server>
 http
 </server>
-# don't run this with the threaded-resolver since the events might trigger in
-# a different order!
+# don't run this with the threaded-resolver or c-ares since the events might
+# trigger in a different order!
 <features>
 !threaded-resolver
+!c-ares
 </features>
 <name>
 HTTP with shared cookie list (and dns cache)

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2762,6 +2762,7 @@ sub compare {
 }
 
 sub setupfeatures {
+    $feature{"c-ares"} = $has_cares;
     $feature{"alt-svc"} = $has_altsvc;
     $feature{"HSTS"} = $has_hsts;
     $feature{"brotli"} = $has_brotli;


### PR DESCRIPTION
1 .`USE_RESOLVE_ON_IPS` was wrongly set for all Apple builds so even c-ares did extra resolves (in vain).
2. Due to (1) I found the mistake in socks.c that makes handle pending name resolves wrongly which could cause a memory leak with c-ares
3. Test 506 isn't designed to handle c-ares builds proper so I made it skip such builds by:
4. runtests now treats "c-ares" as a feature that tests can depend on or refuse to run with

Fixes #6247 