### PR TITLE
cmake: don't use reserved target name 'test'

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,6 @@ function(add_runtests targetname test_flags)
   )
 endfunction()
 
-add_runtests(test           "")
 add_runtests(test-quiet     "-a -s")
 add_runtests(test-am        "-a -am")
 add_runtests(test-full      "-a -p -r")


### PR DESCRIPTION
From https://cmake.org/cmake/help/latest/policy/CMP0037.html

 > Target names associated with optional features, such as test and package, may also be reserved. CMake 3.10 and below always reserve them. CMake 3.11 and above reserve them only when the corresponding feature is enabled (e.g. by including the CTest or CPack modules).

this fixes #6257 