### PR TITLE
New protocol: gemini

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,8 @@ option(CURL_DISABLE_SMTP "to disable SMTP" OFF)
 mark_as_advanced(CURL_DISABLE_SMTP)
 option(CURL_DISABLE_GOPHER "to disable Gopher" OFF)
 mark_as_advanced(CURL_DISABLE_GOPHER)
+option(CURL_DISABLE_GEMINI "to disable Gemini" OFF)
+mark_as_advanced(CURL_DISABLE_GEMINI)
 option(CURL_DISABLE_MQTT "to disable MQTT" OFF)
 mark_as_advanced(CURL_DISABLE_MQTT)
 

--- a/configure.ac
+++ b/configure.ac
@@ -646,6 +646,22 @@ AC_HELP_STRING([--disable-gopher],[Disable Gopher support]),
        AC_MSG_RESULT(yes)
 )
 
+AC_MSG_CHECKING([whether to support gemini])
+AC_ARG_ENABLE(gemini,
+AC_HELP_STRING([--enable-gemini],[Enable Gemini support])
+AC_HELP_STRING([--disable-gemini],[Disable Gemini support]),
+[ case "$enableval" in
+  no)
+       AC_MSG_RESULT(no)
+       AC_DEFINE(CURL_DISABLE_GEMINI, 1, [to disable Gemini])
+       AC_SUBST(CURL_DISABLE_GEMINI, [1])
+       ;;
+  *)   AC_MSG_RESULT(yes)
+       ;;
+  esac ],
+       AC_MSG_RESULT(yes)
+)
+
 AC_MSG_CHECKING([whether to support mqtt])
 AC_ARG_ENABLE(mqtt,
 AC_HELP_STRING([--enable-mqtt],[Enable MQTT support])

--- a/docs/CURL-DISABLE.md
+++ b/docs/CURL-DISABLE.md
@@ -33,6 +33,10 @@ Disable the FTP (and FTPS) protocol
 Disable the `curl_easy_options` API calls that lets users get information
 about existing options to `curl_easy_setopt`.
 
+## CURL_DISABLE_GEMINI
+
+Disable the GEMINI protocol.
+
 ## CURL_DISABLE_GOPHER
 
 Disable the GOPHER protocol.

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -700,6 +700,7 @@ CURLPROTO_DICT                  7.19.4
 CURLPROTO_FILE                  7.19.4
 CURLPROTO_FTP                   7.19.4
 CURLPROTO_FTPS                  7.19.4
+CURLPROTO_GEMINI                7.75.0
 CURLPROTO_GOPHER                7.21.2
 CURLPROTO_HTTP                  7.19.4
 CURLPROTO_HTTPS                 7.19.4

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1015,6 +1015,7 @@ typedef CURLSTScode (*curl_hstswrite_callback)(CURL *easy,
 #define CURLPROTO_SMB    (1<<26)
 #define CURLPROTO_SMBS   (1<<27)
 #define CURLPROTO_MQTT   (1<<28)
+#define CURLPROTO_GEMINI (1<<29)
 #define CURLPROTO_ALL    (~0) /* enable everything */
 
 /* long may be 32 or 64 bits, but we should never depend on anything else

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -61,7 +61,7 @@ LIB_CFILES = altsvc.c amigaos.c asyn-ares.c asyn-thread.c base64.c            \
   socks_gssapi.c socks_sspi.c speedcheck.c splay.c strcase.c strdup.c         \
   strerror.c strtok.c strtoofft.c system_win32.c telnet.c tftp.c timeval.c    \
   transfer.c urlapi.c version.c warnless.c wildcard.c x509asn1.c dynbuf.c     \
-  version_win32.c easyoptions.c easygetopt.c hsts.c
+  version_win32.c easyoptions.c easygetopt.c hsts.c gemini.c
 
 LIB_HFILES = altsvc.h amigaos.h arpa_telnet.h asyn.h conncache.h connect.h    \
   content_encoding.h cookie.h curl_addrinfo.h curl_base64.h curl_ctype.h      \
@@ -80,7 +80,7 @@ LIB_HFILES = altsvc.h amigaos.h arpa_telnet.h asyn.h conncache.h connect.h    \
   smb.h smtp.h sockaddr.h socketpair.h socks.h speedcheck.h splay.h strcase.h \
   strdup.h strerror.h strtok.h strtoofft.h system_win32.h telnet.h tftp.h     \
   timeval.h transfer.h urlapi-int.h urldata.h warnless.h wildcard.h           \
-  x509asn1.h dynbuf.h version_win32.h easyoptions.h hsts.h
+  x509asn1.h dynbuf.h version_win32.h easyoptions.h hsts.h gemini.h
 
 LIB_RCFILES = libcurl.rc
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -194,6 +194,9 @@
 #  ifndef CURL_DISABLE_SMB
 #    define CURL_DISABLE_SMB
 #  endif
+#  ifndef CURL_DISABLE_GEMINI
+#    define CURL_DISABLE_GEMINI
+#  endif
 #endif
 
 /*

--- a/lib/gemini.c
+++ b/lib/gemini.c
@@ -1,0 +1,279 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#if !defined CURL_DISABLE_GEMINI && defined USE_SSL
+
+#include <ctype.h>
+#include <string.h>
+#include "gemini.h"
+#include "urldata.h"
+#include "vtls/vtls.h"
+#include "transfer.h"
+#include "sendf.h"
+#include "multiif.h"
+#include "select.h"
+#include "strdup.h"
+#include "url.h"
+#include "curl_printf.h"
+/* The last #include file should be: */
+#include "memdebug.h"
+
+static CURLcode gemini_setup_connection(struct connectdata *conn)
+{
+  struct GEMINI *gemini;
+  struct Curl_easy *data = conn->data;
+  DEBUGASSERT(data->req.p.gemini == NULL);
+
+  gemini = calloc(1, sizeof(struct GEMINI));
+  if(!gemini)
+    return CURLE_OUT_OF_MEMORY;
+  data->req.p.gemini = gemini;
+  return CURLE_OK;
+}
+
+static CURLcode gemini_connecting(struct connectdata *conn, bool *done)
+{
+  return Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, done);
+}
+
+static CURLcode gemini_do_it(struct connectdata *conn, bool *done)
+{
+  struct GEMINI *gemini;
+  struct Curl_easy *data;
+  char *request;
+
+  data = conn->data;
+  request = aprintf("%s\r\n", data->change.url);
+
+  if(!request)
+    return CURLE_OUT_OF_MEMORY;
+
+  gemini = data->req.p.gemini;
+  gemini->request.memory = request;
+  gemini->request.amount_total = strlen(request);
+  gemini->request.amount_sent = 0;
+
+  /* Real work happens in gemini_doing, so we can use non-blocking
+   * functions and avoid busy loops.
+   */
+
+  return CURLE_OK;
+}
+
+static CURLcode gemini_doing_finish(struct connectdata *, bool *);
+static CURLcode gemini_doing(struct connectdata *conn, bool *done)
+{
+  CURLcode result;
+  curl_socket_t sockfd;
+  struct Curl_easy *data;
+  struct GEMINI *gemini;
+  size_t more;
+  size_t sent;
+  size_t amount;
+
+  data = conn->data;
+  gemini = conn->data->req.p.gemini;
+  sockfd = conn->sock[FIRSTSOCKET];
+
+  /* stage1: send request */
+  sent = gemini->request.amount_sent;
+  more = gemini->request.amount_total - sent;
+  if(more) {
+    char *from;
+
+    from = gemini->request.memory + sent;
+    result = Curl_write(conn, sockfd, from, more, &amount);
+    if(result)
+      return result;
+
+    gemini->request.amount_sent += amount;
+    more -= amount;
+
+    if(more)
+      return CURLE_OK;
+  }
+
+  /* stage2: read block big enough to contain header */
+  if(!gemini->block.done) {
+    char *into;
+
+    into = gemini->block.memory + gemini->block.amount;
+    more = GEMINI_RESPONSE_BUFSIZE - gemini->block.amount;
+
+    if(SOCKET_READABLE(sockfd, 0) <= 0)
+      return CURLE_OK;
+
+    result = Curl_read(conn, sockfd, into, more, &amount);
+
+    if(result)
+      return result;
+
+    gemini->block.amount += amount;
+    more -= amount;
+
+    /* !more means that we succesfully read GEMINI_RESPONSE_BUFSIZE bytes.
+     * !amount means that there is no more data. It is quite possible
+     * for whole response, header + body combined to be less than
+     * GEMINI_RESPONSE_BUFSIZE bytes big.
+     */
+
+    if(!amount || !more)
+      gemini->block.done = TRUE;
+
+    /* Optimization: We check for LF, and skip reading more when it is
+     * found. Curl main engine adds noticable delays between
+     * invokactions of "doing" function, so it is desirable to get
+     * things done in as little calls to "doing" function, as possible,
+     * but without busy looping on socket that is not yet ready.
+     *
+     * For many servers first read returns exacly header, because it is
+     * natural thing to do on server side, although we can't rely on it.
+     * This is the reason why it does not worth to optimize search by
+     * keeping track of old {amount} value and searching only in bytes
+     * just read.
+     */
+    gemini->block.lf = memchr(gemini->block.memory, '\n',
+                              gemini->block.amount);
+    if(!gemini->block.lf && gemini->block.done) {
+      /* Distinguish between header being too big and response lacking LF */
+      if(more) {
+        failf(data, "Response did not contain LF character");
+      }
+      else {
+        failf(data, "Server returned header too big");
+      }
+
+      return CURLE_WEIRD_SERVER_REPLY;
+    }
+
+    if(gemini->block.lf)
+      gemini->block.done = TRUE;
+
+    if(!gemini->block.done)
+      return CURLE_OK;
+  }
+
+  return gemini_doing_finish(conn, done);
+}
+
+static CURLcode gemini_doing_finish(struct connectdata *conn, bool *done)
+{
+  CURLcode result;
+  struct GEMINI *gemini;
+  char *block;
+  struct Curl_easy *data;
+  size_t amount;
+  size_t hsize;
+  char status;
+  char *lf;
+
+  data = conn->data;
+  gemini = data->req.p.gemini;
+  block = gemini->block.memory;
+  amount = gemini->block.amount;
+  lf = gemini->block.lf;
+
+  if(!amount)
+    return CURLE_GOT_NOTHING;
+
+  /* Two digit status, space, empty meta string and \r\n at least. */
+  if(amount < 5) {
+    failf(data, "Response is too short");
+    return CURLE_WEIRD_SERVER_REPLY;
+  }
+
+  if(block[2] != ' ' || !isdigit(block[0]) || !isdigit(block[1])) {
+    failf(data, "First 3 bytes of response violate specification");
+    return CURLE_WEIRD_SERVER_REPLY;
+  }
+
+  /* We already checked that first byte is digit, so {lf} can't point to
+   * first byte of buffer and {cr} can't undresultun buffer.
+   */
+  if(*(lf - 1) != '\r') {
+    failf(data, "Next-to-last character in response header is not CR");
+    return CURLE_WEIRD_SERVER_REPLY;
+  }
+
+  hsize = lf - block + 1;
+  result = Curl_client_write(conn, CLIENTWRITE_HEADER, block, hsize);
+  if(result)
+    return result;
+
+  status = block[0];
+  if(status != '2') { /* TODO: handle redirects */
+    *done = TRUE;
+    return CURLE_OK;
+  }
+
+  result = Curl_client_write(conn, CLIENTWRITE_BODY, block + hsize,
+                          amount - hsize);
+  if(result)
+    return result;
+
+  *done = TRUE;
+  Curl_setup_transfer(data, FIRSTSOCKET, -1, FALSE, -1);
+  return CURLE_OK;
+}
+
+static int gemini_doing_getsock(struct connectdata *conn, curl_socket_t *socks)
+{
+  socks[0] = conn->sock[FIRSTSOCKET];
+  return GETSOCK_WRITESOCK(0);
+}
+
+static CURLcode gemini_disconnect(struct connectdata *conn, bool _ignored)
+{
+  struct GEMINI *gemini;
+
+  /* Curl engine will free GEMINI structure itself */
+  gemini = conn->data->req.p.gemini;
+  free(gemini->request.memory);
+
+  return CURLE_OK;
+}
+
+const struct Curl_handler Curl_handler_gemini = {
+  "GEMINI",                             /* scheme */
+  gemini_setup_connection,              /* setup_connection */
+  gemini_do_it,                         /* do_it */
+  ZERO_NULL,                            /* done */
+  ZERO_NULL,                            /* do_more */
+  gemini_connecting,                    /* connect_it */
+  gemini_connecting,                    /* connecting */
+  gemini_doing,                         /* doing */
+  Curl_ssl_getsock,                     /* proto_getsock */
+  gemini_doing_getsock,                 /* doing_getsock */
+  ZERO_NULL,                            /* domore_getsock */
+  ZERO_NULL,                            /* perform_getsock */
+  gemini_disconnect,                    /* disconnect */
+  ZERO_NULL,                            /* readwrite */
+  ZERO_NULL,                            /* connection_check */
+  PORT_GEMINI,                          /* defport */
+  CURLPROTO_GEMINI,                     /* protocol */
+  CURLPROTO_GEMINI,                     /* family */
+  PROTOPT_SSL                           /* flags */
+};
+
+#endif /*CURL_DISABLE_GEMINI*/

--- a/lib/gemini.h
+++ b/lib/gemini.h
@@ -50,6 +50,7 @@ struct GEMINI {
     size_t amount_total; /* How many bytes in {data} */
     size_t amount_sent; /* How many bytes of it we already sent */
   } request;
+  bool redirect;
 };
 
 #endif /* HEADER_CURL_GEMINI_H */

--- a/lib/gemini.h
+++ b/lib/gemini.h
@@ -1,0 +1,55 @@
+#ifndef HEADER_CURL_GEMINI_H
+#define HEADER_CURL_GEMINI_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#if defined USE_SSL && !defined CURL_DISABLE_GEMINI
+extern const struct Curl_handler Curl_handler_gemini;
+#endif
+
+/*
+ * According to specification, response has following format:
+ *
+ *     <STATUS><SPACE><META><CR><LF>
+ *
+ * and <META> is UTF-8 string up to 1024 bytes long, so buffer of
+ * size >= (2 + 1 + 1024 + 1 + 1) = 1029 is enough to read whole
+ * response header into memory. It is more efficient than reading
+ * byte-after-byte until \n is found.
+ */
+#define GEMINI_RESPONSE_BUFSIZE 1029
+
+struct GEMINI {
+  struct {
+    char memory[GEMINI_RESPONSE_BUFSIZE];
+    size_t amount; /* Count of bytes read */
+    bool done;
+    char *lf; /* Pointer to linefeed character in {data} */
+  } block;
+  struct {
+    char *memory; /* Allocated string */
+    size_t amount_total; /* How many bytes in {data} */
+    size_t amount_sent; /* How many bytes of it we already sent */
+  } request;
+};
+
+#endif /* HEADER_CURL_GEMINI_H */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -66,6 +66,7 @@
 #include "sendf.h"
 #include "speedcheck.h"
 #include "progress.h"
+#include "gemini.h"
 #include "http.h"
 #include "url.h"
 #include "getinfo.h"
@@ -1803,6 +1804,11 @@ CURLcode Curl_retry_request(struct connectdata *conn,
     data->state.refused_stream = FALSE; /* clear again */
     retry = TRUE;
   }
+  /* Here we re-use -L flag from HTTP. Is it good idea? */
+  else if((conn->handler->protocol&CURLPROTO_GEMINI) &&
+          (data->set.http_follow_location) &&
+          (conn->data->req.p.gemini->redirect))
+    retry = TRUE;
   if(retry) {
 #define CONN_MAX_RETRIES 5
     if(data->state.retrycount++ >= CONN_MAX_RETRIES) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -115,6 +115,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
 #include "http_ntlm.h"
 #include "curl_rtmp.h"
 #include "gopher.h"
+#include "gemini.h"
 #include "mqtt.h"
 #include "http_proxy.h"
 #include "conncache.h"
@@ -251,6 +252,10 @@ static const struct Curl_handler * const protocols[] = {
 
 #ifndef CURL_DISABLE_GOPHER
   &Curl_handler_gopher,
+#endif
+
+#if !defined CURL_DISABLE_GEMINI && defined USE_SSL
+  &Curl_handler_gemini,
 #endif
 
 #ifdef USE_LIBRTMP

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -49,6 +49,7 @@
 #define PORT_RTMPT PORT_HTTP
 #define PORT_RTMPS PORT_HTTPS
 #define PORT_GOPHER 70
+#define PORT_GEMINI 1965
 #define PORT_MQTT 1883
 
 #define DICT_MATCH "/MATCH:"
@@ -659,6 +660,7 @@ struct SingleRequest {
     struct SMTP *smtp;
     struct SSHPROTO *ssh;
     struct TELNET *telnet;
+    struct GEMINI *gemini;
   } p;
 #ifndef CURL_DISABLE_DOH
   struct dohdata doh; /* DoH specific data for this request */

--- a/lib/version.c
+++ b/lib/version.c
@@ -274,6 +274,9 @@ static const char * const protocols[] = {
 #ifndef CURL_DISABLE_GOPHER
   "gopher",
 #endif
+#if defined USE_SSL && !defined CURL_DISABLE_GOPHER
+  "gemini",
+#endif
 #ifndef CURL_DISABLE_HTTP
   "http",
 #endif


### PR DESCRIPTION
This patch implements gemini protocol as described in specification[^1],
with following pieces missing:

 * Redirects. 3x status codes are not handled any specially from any
   other status code that has no body, -L option has no effect on gemini
   URLs.

Other than that, things work:

	$ make
	$ ./src/curl -k -D- gemini://tilde.pink/~kaction/dist/
	20 text/gemini
	# Directory listing

	=> /~kaction ..
	=> flake-dhall/ flake-dhall/                                           Nov 22 2020

[^1]: https://gemini.circumlunar.space/docs/specification.html