### PR TITLE
cmake: set HAVE_LINUX_TCP_H if present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,7 @@ check_include_file_concat("net/if.h"         HAVE_NET_IF_H)
 check_include_file_concat("netdb.h"          HAVE_NETDB_H)
 check_include_file_concat("netinet/in.h"     HAVE_NETINET_IN_H)
 check_include_file_concat("netinet/tcp.h"    HAVE_NETINET_TCP_H)
+check_include_file("linux/tcp.h"      HAVE_LINUX_TCP_H)
 
 check_include_file_concat("pem.h"            HAVE_PEM_H)
 check_include_file_concat("poll.h"           HAVE_POLL_H)

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -677,7 +677,7 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
 {
   if(conn->transport == TRNSPRT_TCP) {
 #if defined(HAVE_GETPEERNAME) || defined(HAVE_GETSOCKNAME)
-    if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
+    if(!conn->bits.reuse) {
       struct Curl_easy *data = conn->data;
       char buffer[STRERROR_LEN];
       struct Curl_sockaddr_storage ssrem;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -677,7 +677,7 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
 {
   if(conn->transport == TRNSPRT_TCP) {
 #if defined(HAVE_GETPEERNAME) || defined(HAVE_GETSOCKNAME)
-      if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
+    if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
       struct Curl_easy *data = conn->data;
       char buffer[STRERROR_LEN];
       struct Curl_sockaddr_storage ssrem;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -677,7 +677,7 @@ void Curl_updateconninfo(struct connectdata *conn, curl_socket_t sockfd)
 {
   if(conn->transport == TRNSPRT_TCP) {
 #if defined(HAVE_GETPEERNAME) || defined(HAVE_GETSOCKNAME)
-    if(!conn->bits.reuse) {
+      if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
       struct Curl_easy *data = conn->data;
       char buffer[STRERROR_LEN];
       struct Curl_sockaddr_storage ssrem;

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -473,6 +473,9 @@
 /* Define to 1 if you have the <netinet/tcp.h> header file. */
 #cmakedefine HAVE_NETINET_TCP_H 1
 
+/* Define to 1 if you have the <linux/tcp.h> header file. */
+#cmakedefine HAVE_LINUX_TCP_H 1
+
 /* Define to 1 if you have the <net/if.h> header file. */
 #cmakedefine HAVE_NET_IF_H 1
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -28,6 +28,8 @@
 
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>
+#elif defined(HAVE_NETINET_TCP_H)
+#include <netinet/tcp.h>
 #endif
 
 #include <curl/curl.h>

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -30,6 +30,8 @@
 
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>
+#elif defined(HAVE_NETINET_TCP_H)
+#include <netinet/tcp.h>
 #endif
 
 #include "urldata.h"


### PR DESCRIPTION
The `HAVE_LINUX_TCP_H` constant was not set by cmake.
The variable has been used in some C-files in lib without including neither `linux/tcp.h` nor `netinet/tcp.h`
That lead to inconsistent calls wrt. `TCP_FASTOPEN`.

~Data field `conn->ip_addr_str` was not set in case of tcp_fastopen, but tried to be used later in `ftp_state_pasv_resp`.~

~Fixes #6252~