### PR TITLE
tests/util.py: fix compatibility with Python 2

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -46,6 +46,21 @@ class ClosingFileHandler(logging.StreamHandler):
             super(ClosingFileHandler, self).emit(record)
             self.setStream(None)
 
+    def setStream(self, stream):
+        setStream = getattr(super(ClosingFileHandler, self), 'setStream', None)
+        if callable(setStream):
+            return setStream(stream)
+        if stream is self.stream:
+            result = None
+        else:
+            result = self.stream
+            self.acquire()
+            try:
+                self.flush()
+                self.stream = stream
+            finally:
+                self.release()
+        return result
 
 class TestData(object):
     def __init__(self, data_folder):


### PR DESCRIPTION
Backporting the Python 3 implementation of setStream
to ClosingFileHandler as a fallback within Python 2.

Reported-by: Jay Satiro

Fixes #6259