### PR TITLE
enhance progressfunc example

### DIFF
--- a/docs/examples/progressfunc.c
+++ b/docs/examples/progressfunc.c
@@ -62,7 +62,8 @@ static int xferinfo(void *p,
 
   /* under certain circumstances it may be desirable for certain functionality
      to only run every N seconds, in order to do this the transaction time can
-     be used */
+     be used. Internally the curtime obtained is limited to platform dependent
+     min/max values, e.g. 0x7FFFFFFF (2147483647) (35min47s) */
   if((curtime - myp->lastruntime) >= MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL) {
     myp->lastruntime = curtime;
 #ifdef TIME_IN_US


### PR DESCRIPTION
Took me quite some time to find this internal limitation.
Despite the "long long int" type of curtime in this example and  CURL_FORMAT_CURL_OFF_T resolving as "lld", the value obtained is internally limited to int_min/int_max value.
I checked the source code and I did not find an easy fix to resolve this limitation, so the next best thing I could come up with is to amend he example to 'warn' for this limitation.