### PR TITLE
SECURITY-PROCESS: disclose on hackerone [skip ci]

### DIFF
--- a/docs/SECURITY-PROCESS.md
+++ b/docs/SECURITY-PROCESS.md
@@ -125,6 +125,14 @@ Publishing Security Advisories
 6. On security advisory release day, push the changes on the curl-www
    repository's remote master branch.
 
+Hackerone
+---------
+
+Request the issue to be disclosed. If there are sensitive details present in
+the report and discussion, those should be redacted from the disclosure. The
+default policy is to disclose as much as possible as soon as the vulnerability
+has been published.
+
 Bug Bounty
 ----------
 


### PR DESCRIPTION
Once a vulnerability has been published, the hackerone issue should be
disclosed. For tranparency.