### PR TITLE
urlapi: don't accept blank port number field without scheme

### DIFF
--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -28,7 +28,7 @@
 bool Curl_is_absolute_url(const char *url, char *scheme, size_t buflen);
 
 #ifdef DEBUGBUILD
-CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname);
+CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname, bool);
 #endif
 
 #endif /* HEADER_CURL_URLAPI_INT_H */

--- a/tests/data/test1653
+++ b/tests/data/test1653
@@ -14,7 +14,7 @@ none
 unittest
 </features>
 <name>
-urlapi
+urlapi port number parsing
 </name>
 </client>
 </testcase>

--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -55,7 +55,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15]");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, CURLU_NO_DEFAULT_PORT);
   fail_unless(ret != CURLUE_OK, "curl_url_get portnum returned something");
@@ -69,7 +69,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15|");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "Curl_parse_port true on error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
@@ -80,7 +80,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff;fea7:da15]:80");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "Curl_parse_port true on error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
@@ -92,7 +92,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15%25eth3]:80");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, 0);
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
@@ -108,7 +108,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15%25eth3]");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
@@ -120,7 +120,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15]:81");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, 0);
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
@@ -136,7 +136,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15];81");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "Curl_parse_port true on error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
@@ -147,19 +147,20 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15]80");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "Curl_parse_port true on error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
 
-  /* Valid IPv6 with no port after the colon, should use default */
+  /* Valid IPv6 with no port after the colon, should use default if a scheme
+     was used in the URL */
   u = curl_url();
   if(!u)
     goto fail;
   ipv6port = strdup("[fe80::250:56ff:fea7:da15]:");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, TRUE);
   fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
@@ -171,7 +172,7 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15!25eth3]:80");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "Curl_parse_port returned non-error");
   free_and_clear(ipv6port);
   curl_url_cleanup(u);
@@ -183,10 +184,25 @@ UNITTEST_START
   ipv6port = strdup("[fe80::250:56ff:fea7:da15%eth3]:80");
   if(!ipv6port)
     goto fail;
-  ret = Curl_parse_port(u, ipv6port);
+  ret = Curl_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "Curl_parse_port returned error");
+  free_and_clear(ipv6port);
+  curl_url_cleanup(u);
+
+  /* No scheme and no digits following the colon - not accepted. Because that
+     makes (a*50):// that looks like a scheme be an acceptable input. */
+  u = curl_url();
+  if(!u)
+    goto fail;
+  ipv6port = strdup("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    "aaaaaaaaaaaaaaaaaaaaaa:");
+  if(!ipv6port)
+    goto fail;
+  ret = Curl_parse_port(u, ipv6port, FALSE);
+  fail_unless(ret == CURLUE_BAD_PORT_NUMBER, "Curl_parse_port did wrong");
   fail:
   free(ipv6port);
   curl_url_cleanup(u);
+
 }
 UNITTEST_STOP


### PR DESCRIPTION
... as it makes the URL parser accept "very-long-hostname://" as a valid
host name and we don't want that. The parser now only accepts a blank
(no digits) after the colon if the URL starts with a scheme.

Reported-by: d4d on hackerone