### PR TITLE
connect: zero variable on stack to silence valgrind complaint

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -680,6 +680,7 @@ void Curl_conninfo_remote(struct connectdata *conn, curl_socket_t sockfd)
   struct Curl_sockaddr_storage ssrem;
   curl_socklen_t plen;
   plen = sizeof(struct Curl_sockaddr_storage);
+  memset(&ssrem, 0, sizeof(ssrem));
   if(getpeername(sockfd, (struct sockaddr*) &ssrem, &plen)) {
     int error = SOCKERRNO;
     failf(conn->data, "getpeername() failed with errno %d: %s",


### PR DESCRIPTION
Valgrind will complain that ssrem buffer usage if not explicit
initialized, hence initialize it to zero.

This completes the change intially started in commit 2c0d7212151 ('ftp:
retry getpeername for FTP with TCP_FASTOPEN') where the ssloc buffer has
a similar memset to zero.

Signed-off-by: Hans-Christian Noren Egtvedt <hegtvedt@cisco.com>