### PR TITLE
lib1564/5: verify that curl_multi_wakeup return OK

### DIFF
--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -29,6 +29,10 @@
  * be shared.
  */
 
+#include "timeval.h"
+
+struct connectdata;
+
 struct conncache {
   struct Curl_hash hash;
   size_t num_conn;

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -22,9 +22,13 @@
  *
  ***************************************************************************/
 
+#include "llist.h"
+#include "hash.h"
 #include "conncache.h"
 #include "psl.h"
 #include "socketpair.h"
+
+struct connectdata;
 
 struct Curl_message {
   struct Curl_llist_element list;

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -374,6 +374,7 @@ Features testable here are:
 - `unittest`
 - `unix-sockets`
 - `verbose-strings`
+- `wakeup`
 - `win32`
 
 as well as each protocol that curl supports.  A protocol only needs to be

--- a/tests/data/test1564
+++ b/tests/data/test1564
@@ -12,6 +12,9 @@ wakeup
 
 # Client-side
 <client>
+<features>
+wakeup
+</features>
 <server>
 none
 </server>

--- a/tests/data/test1565
+++ b/tests/data/test1565
@@ -21,6 +21,9 @@ OK
 
 # Client-side
 <client>
+<features>
+wakeup
+</features>
 <server>
 http
 </server>

--- a/tests/libtest/lib1564.c
+++ b/tests/libtest/lib1564.c
@@ -61,7 +61,7 @@ int test(char *URL)
 
   /* try a single wakeup */
 
-  multi_wakeup(multi);
+  res_multi_wakeup(multi);
 
   time_before_wait = tutil_tvnow();
   multi_poll(multi, NULL, 0, 1000, &numfds);
@@ -94,7 +94,7 @@ int test(char *URL)
   /* try lots of wakeup */
 
   for(i = 0; i < WAKEUP_NUM; ++i)
-    multi_wakeup(multi);
+    res_multi_wakeup(multi);
 
   time_before_wait = tutil_tvnow();
   multi_poll(multi, NULL, 0, 1000, &numfds);

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -70,7 +70,7 @@ static void *run_thread(void *ptr)
 
     pthread_mutex_unlock(&lock);
 
-    multi_wakeup(multi);
+    res_multi_wakeup(multi);
   }
 
 test_cleanup:

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2821,6 +2821,7 @@ sub setupfeatures {
     $feature{"shuffle-dns"} = 1;
     $feature{"typecheck"} = 1;
     $feature{"verbose-strings"} = 1;
+    $feature{"wakeup"} = 1;
 
 }
 

--- a/tests/server/disabled.c
+++ b/tests/server/disabled.c
@@ -30,6 +30,7 @@
  */
 
 #include "curl_setup.h"
+#include "multihandle.h" /* for ENABLE_WAKEUP */
 #include <stdio.h>
 
 static const char *disabled[]={
@@ -65,6 +66,9 @@ static const char *disabled[]={
 #endif
 #ifdef CURL_DISABLE_VERBOSE_STRINGS
   "verbose-strings",
+#endif
+#ifndef ENABLE_WAKEUP
+  "wakeup",
 #endif
   NULL
 };


### PR DESCRIPTION
This change should make test 1564 and 1565 fail when run in setups like #6299, with socketpair (or the equivalent) disabled.

Also makes test 1564 and 1565 only run if wakeup support is built-in.