### PR TITLE
http3/quiche: fix invalid request when uploading big file

### DIFF
--- a/lib/vquic/quiche.h
+++ b/lib/vquic/quiche.h
@@ -43,6 +43,8 @@ struct quicsocket {
   uint8_t scid[QUICHE_MAX_CONN_ID_LEN];
   curl_socket_t sockfd;
   uint32_t version;
+  uint8_t *egress_buf;
+  ssize_t egress_buflen;
 };
 
 #endif


### PR DESCRIPTION
current [master](https://github.com/curl/curl/commit/78af8b68cfe4222057100911c50d52f3719b47d9):
```
$ curl --tlsv1.3 --http3 -vk -X POST --data-binary "@100mb-file" https://blog.cloudflare.com/

...
> POST / HTTP/3
> Host: blog.cloudflare.com
> user-agent: curl/7.74.1-DEV
> accept: */*
> content-length: 104857600
> content-type: application/x-www-form-urlencoded
>
* STATE: DO => DO_DONE handle 0x12cd128; line 1940 (connection #0)
* STATE: DO_DONE => PERFORM handle 0x12cd128; line 2061 (connection #0)
* Pass on 65536 body bytes to quiche
* Kill stream: Transfer returned error
* multi_done
* Connection #0 to host blog.cloudflare.com left intact
* Expire cleared (transfer 0x12cd128)
curl: (55) Failed sending data to the peer
```
after applying this patch:
```
 curl --tlsv1.3 --http3 -vk -X POST --data-binary "@100mb-file" https://blog.cloudflare.com/

...
* STATE: DO => DO_DONE handle 0x71f128; line 1940 (connection #0)
* STATE: DO_DONE => PERFORM handle 0x71f128; line 2061 (connection #0)
...
* We are completely uploaded and fine
* HTTP 1.1 or later with persistent connection
< HTTP/3 404
< date: Mon, 14 Dec 2020 10:03:31 GMT
< content-type: text/html; charset=utf-8
< set-cookie: __cfduid=d4cb754cb871a9c5c274c7243acba52a31607940201; expires=Wed, 13-Jan-21 10:03:21 GMT; path=/; domain=.blog.cloudflare.com; HttpOnly; SameSite=Lax; Secure
< x-powered-by: Express
< cache-control: no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
< vary: Accept-Encoding
< cf-cache-status: DYNAMIC
< cf-request-id: 07024c0fd50000237496382000000001
< expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
< server: cloudflare
< cf-ray: 601715f95e5b2374-HKG
< alt-svc: h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400
* Curl_readwrite: forcibly told to drain data
...
```