### PR TITLE
tool_writeout: Fix output time format

### DIFF
--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -190,41 +190,48 @@ void ourWriteOut(CURL *curl, struct per_transfer *per, const char *writeinfo)
               case VAR_REDIRECT_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_REDIRECT_TIME_T, &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_TOTAL_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME_T, &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_NAMELOOKUP_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME_T,
                                      &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_CONNECT_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME_T, &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_APPCONNECT_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_APPCONNECT_TIME_T,
                                      &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_PRETRANSFER_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_PRETRANSFER_TIME_T,
                                      &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_STARTTRANSFER_TIME:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_STARTTRANSFER_TIME_T,
                                      &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%06d",
+                          offinfo / 1000000, (int)(offinfo % 1000000));
                 break;
               case VAR_SIZE_UPLOAD:
                 if(CURLE_OK ==
@@ -241,12 +248,14 @@ void ourWriteOut(CURL *curl, struct per_transfer *per, const char *writeinfo)
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD_T,
                                      &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%03d",
+                          offinfo / 1000, (int)(offinfo % 1000));
                 break;
               case VAR_SPEED_UPLOAD:
                 if(CURLE_OK ==
                    curl_easy_getinfo(curl, CURLINFO_SPEED_UPLOAD_T, &offinfo))
-                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU, offinfo);
+                  fprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ".%03d",
+                          offinfo / 1000, (int)(offinfo % 1000));
                 break;
               case VAR_CONTENT_TYPE:
                 if((CURLE_OK ==


### PR DESCRIPTION
fc813f8 (precedes 7.74.0) changed write-out to retrieve the times using
curl_off_t (microseconds) instead of double (seconds) but did not
account for that in the formatted output.

Fixes https://github.com/curl/curl/issues/6321
Closes #xxxx