### PR TITLE
connect: On linux, enable reporting of all ICMP errors on UDP sockets

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1574,6 +1574,20 @@ CURLcode Curl_socket(struct connectdata *conn,
   }
 #endif
 
+#if defined(__linux__) && defined(IP_RECVERR)
+  if(addr->socktype == SOCK_DGRAM) {
+    int one = 1;
+    switch(addr->family) {
+      case AF_INET:
+        setsockopt(*sockfd, SOL_IP, IP_RECVERR, &one, sizeof(one));
+        break;
+      case AF_INET6:
+        setsockopt(*sockfd, SOL_IPV6, IPV6_RECVERR, &one, sizeof(one));
+        break;
+    }
+  }
+#endif
+
   return CURLE_OK;
 
 }


### PR DESCRIPTION
The linux kernel does not report all ICMP errors back to userspace
due to historical reasons.
IP*_RECVERR sockopt must be turned on to have the correct behaviour
which is to pass all ICMP errors to userspace.

See
https://bugzilla.kernel.org/show_bug.cgi?id=202355<

PS: You almost certainly want this option to be set in your DNS resolver too (ares, or whatever, glibc was already fixed)