### PR TITLE
travis: restrict the openssl3 job to only run https tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,7 +170,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug OPENSSL3="yes" C="--with-ssl=$HOME/openssl3" LD_LIBRARY_PATH=/home/travis/openssl3/lib:/usr/local/lib
+    - T=debug OPENSSL3="yes" C="--with-ssl=$HOME/openssl3" LD_LIBRARY_PATH=/home/travis/openssl3/lib:/usr/local/lib TFLAGS="https"
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,7 +170,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug OPENSSL3="yes" C="--with-ssl=$HOME/openssl3" LD_LIBRARY_PATH=/home/travis/openssl3/lib:/usr/local/lib TFLAGS="https"
+    - T=debug OPENSSL3="yes" C="--with-ssl=$HOME/openssl3" LD_LIBRARY_PATH=/home/travis/openssl3/lib:/usr/local/lib TFLAGS="https ftps"
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:


### PR DESCRIPTION
... as it is just too slow and virtually never completes in 50 minutes
when running all tests.