### PR TITLE
badsymbols.pl: Add verbose mode -v

### DIFF
--- a/tests/badsymbols.pl
+++ b/tests/badsymbols.pl
@@ -45,6 +45,14 @@ if (!$rc) {
     $Cpreprocessor = 'cpp';
 }
 
+my $verbose=0;
+
+# verbose mode when -v is the first argument
+if($ARGV[0] eq "-v") {
+    $verbose=1;
+    shift;
+}
+
 # we may get the dir root pointed out
 my $root=$ARGV[0] || ".";
 
@@ -53,7 +61,6 @@ my $i = ($ARGV[1]) ? "-I$ARGV[1] " : '';
 
 my $incdir = "$root/include/curl";
 
-my $verbose=0;
 my $summary=0;
 my $misses=0;
 
@@ -67,6 +74,7 @@ sub scanenums {
 
     open H_IN, "-|", "$Cpreprocessor $i$file" || die "Cannot preprocess $file";
     while ( <H_IN> ) {
+        my ($line, $linenum) = ($_, $.);
         if( /^#(line|) (\d+) \"(.*)\"/) {
             # if the included file isn't in our incdir, then we skip this section
             # until next #line
@@ -90,6 +98,11 @@ sub scanenums {
                ($_ ne "typedef") &&
                ($_ ne "enum") &&
                ($_ !~ /^[ \t]*$/)) {
+                if($verbose) {
+                    print "Source: $Cpreprocessor $i$file\n";
+                    print "Symbol: $_\n";
+                    print "Line #$linenum: $line\n\n";
+                }
                 push @syms, $_;
             }
         }
@@ -102,7 +115,13 @@ sub scanheader {
     scanenums($f);
     open H, "<$f";
     while(<H>) {
+        my ($line, $linenum) = ($_, $.);
         if (/^#define +([^ \n]*)/) {
+            if($verbose) {
+                print "Source: $f\n";
+                print "Symbol: $1\n";
+                print "Line #$linenum: $line\n\n";
+            }
             push @syms, $1;
         }
     }


### PR DESCRIPTION
Use -v as the first option to enable verbose mode which will show source
input, extracted symbol and line info. For example:

Source: ./../include/curl/typecheck-gcc.h
Symbol: curlcheck_socket_info(info)
Line #423: #define curlcheck_socket_info(info)                     \

Ref: https://curl.se/mail/lib-2020-12/0084.html

Closes #xxxx