### PR TITLE
travis: ignore pinning test failures with GnuTLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -229,7 +229,7 @@ jobs:
         - libzstd-dev
         - libmbedtls-dev
   - env:
-    - T=debug C="--with-gnutls --without-ssl"
+    - T=debug C="--with-gnutls --without-ssl" TFLAGS="~2034 ~2037 ~2041"
     - *clang
     compiler: clang
     addons:


### PR DESCRIPTION
This silences the TLS cert pinning test errors on travis when the GnuTLS
backend is used.

Fixes #6339