### PR TITLE
examples/libtest: add .checksrc to dist

### DIFF
--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -23,7 +23,7 @@
 AUTOMAKE_OPTIONS = foreign nostdinc
 
 EXTRA_DIST = README.md Makefile.example Makefile.inc Makefile.m32 \
-  Makefile.netware makefile.dj $(COMPLICATED_EXAMPLES)
+  Makefile.netware makefile.dj $(COMPLICATED_EXAMPLES) .checksrc
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -44,8 +44,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/lib
 endif
 
-EXTRA_DIST = test307.pl test610.pl test613.pl test1013.pl \
-  test1022.pl Makefile.inc notexists.pl CMakeLists.txt mk-lib1521.pl
+EXTRA_DIST = test307.pl test610.pl test613.pl test1013.pl test1022.pl   \
+  Makefile.inc notexists.pl CMakeLists.txt mk-lib1521.pl .checksrc
 
 CFLAG_CURL_SYMBOL_HIDING = @CFLAG_CURL_SYMBOL_HIDING@
 


### PR DESCRIPTION
... so that (auto)builds from tarballs also get the correct instructions.

Fixes #6176