### PR TITLE
speedcheck: exclude paused transfers

### DIFF
--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -49,6 +49,10 @@ will get your write callback called before this function returns.
 The \fBhandle\fP argument is of course identifying the handle that operates on
 the connection you want to pause or unpause.
 
+A paused transfer is excluded from low speed cancels via the
+\fBCURLOPT_LOW_SPEED_LIMIT(3)\fP option and unpausing a transfer will reset
+the time period required for the low speed limit to be met.
+
 The \fBbitmask\fP argument is a set of bits that sets the new state of the
 connection. The following bits can be used:
 .IP CURLPAUSE_RECV

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1080,6 +1080,9 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
      (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) {
     Curl_expire(data, 0, EXPIRE_RUN_NOW); /* get this handle going again */
 
+    /* reset the too-slow time keeper */
+    data->state.keeps_speed.tv_sec = 0;
+
     if(!data->state.tempcount)
       /* if not pausing again, force a recv/send check of this connection as
          the data might've been read off the socket already */

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -39,6 +39,10 @@ void Curl_speedinit(struct Curl_easy *data)
 CURLcode Curl_speedcheck(struct Curl_easy *data,
                          struct curltime now)
 {
+  if(data->req.keepon & KEEP_RECV_PAUSE)
+    /* A paused transfer is not qualified for speed checks */
+    return CURLE_OK;
+
   if((data->progress.current_speed >= 0) && data->set.low_speed_time) {
     if(data->progress.current_speed < data->set.low_speed_limit) {
       if(!data->state.keeps_speed.tv_sec)


### PR DESCRIPTION
Paused transfers should not be stopped due to slow speed even when
CURLOPT_LOW_SPEED_LIMIT is set. Additionally, the slow speed timer is
now reset when the transfer is unpaused - as otherwise it would easily
just trigger immediately after unpausing.

Reported-by: Harry Sintonen
Fixes #6358