### PR TITLE
cmake: Add an option to disable libidn2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,7 +618,11 @@ if(NOT CURL_DISABLE_LDAPS)
 endif()
 
 # Check for idn
-check_library_exists_concat("idn2" idn2_lookup_ul HAVE_LIBIDN2)
+option(USE_LIBIDN2 "Use libidn2 for IDN support" ON)
+set(HAVE_LIBIDN2 OFF)
+if(USE_LIBIDN2)
+  check_library_exists_concat("idn2" idn2_lookup_ul HAVE_LIBIDN2)
+endif()
 
 # Check for symbol dlopen (same as HAVE_LIBDL)
 check_library_exists("${CURL_LIBS}" dlopen "" HAVE_DLOPEN)


### PR DESCRIPTION
New option USE_LIBIDN2 defaults to ON for libidn2 detection. Prior to
this change libidn2 detection could not be turned off in cmake builds.

Reported-by: William A Rowe Jr

Fixes https://github.com/curl/curl/issues/6361
Closes #xxxx
