### PR TITLE
Add CMake CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,52 @@
+name: CI_cmake
+
+on:
+  # Trigger the workflow on push or pull requests, but only for the
+  # master branch
+  push:
+    branches:
+    - master
+    - '*/ci'
+  pull_request:
+    branches:
+    - master
+
+jobs:
+
+  windows_msys:
+    name:  windows_msys cmake ${{ matrix.compiler.CC }} ${{ matrix.build.name }}
+    runs-on: windows-latest
+    env: ${{ matrix.compiler }}
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+        - CC: clang
+        - CC: gcc
+          CFLAGS: "-Wno-error=undef -Wno-error=conversion"
+        build:
+        - name: OpenSSL
+          generate: -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_USE_OPENSSL=on
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: >-
+          git
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-ninja
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-clang
+          mingw-w64-x86_64-perl
+          mingw-w64-x86_64-openssl
+          mingw-w64-x86_64-nghttp2
+
+    - run: echo "D:/a/_temp/msys/msys64/mingw64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - uses: actions/checkout@v2
+
+    - run: cmake -S. -Bbuild -GNinja -DBUILD_TESTING=off -DCURL_WERROR=ON -DPICKY_COMPILER=ON ${{ matrix.build.generate }}
+      name: CMake generate
+
+    - run: cmake --build build --parallel
+      name: CMake build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,13 +39,13 @@
 # (From Daniel Stenberg) The gcc command line use neither -g nor any -O options. As a developer, I also treasure our configure scripts's --enable-debug option that sets a long range of "picky" compiler options.
 cmake_minimum_required(VERSION 3.2...3.16 FATAL_ERROR)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 include(Utilities)
 include(Macros)
 include(CMakeDependentOption)
 include(CheckCCompilerFlag)
 
-project(CURL C)
+project(CURL LANGUAGES C)
 
 file(STRINGS ${CURL_SOURCE_DIR}/include/curl/curlver.h CURL_VERSION_H_CONTENTS REGEX "#define LIBCURL_VERSION( |_NUM )")
 string(REGEX MATCH "#define LIBCURL_VERSION \"[^\"]*"


### PR DESCRIPTION
Add CMake CI for Windows MSYS2 with OpenSSH build.
I implemented it as simply as possible (compare to Curl's AppVeyor MSYS implementation). It can do more than this, as desired.

Also, simple modernization of CMake 3.x syntax.

This is a starting point for a modernization of Curl's CMake in future PRs.