### PR TITLE
writeout: fix NULL dereference for "this url"

### DIFF
--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -141,7 +141,8 @@ void ourWriteOut(CURL *curl, struct per_transfer *per, const char *writeinfo,
                       curl_easy_strerror(result), stream);
                 break;
               case VAR_INPUT_URL:
-                fputs(per->this_url, stream);
+                if(per->this_url)
+                  fputs(per->this_url, stream);
                 break;
               case VAR_URLNUM:
                 fprintf(stream, "%u", per->urlnum);


### PR DESCRIPTION
Detected by torture test 1029

Follow-up to 7a90ddf88f5a