### PR TITLE
misc: fix "warning: empty expression statement has no effect"

### DIFF
--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -49,17 +49,24 @@ struct conncache {
 #ifdef CURLDEBUG
 /* the debug versions of these macros make extra certain that the lock is
    never doubly locked or unlocked */
-#define CONNCACHE_LOCK(x) if((x)->share) {                              \
-    Curl_share_lock((x), CURL_LOCK_DATA_CONNECT, CURL_LOCK_ACCESS_SINGLE); \
-    DEBUGASSERT(!(x)->state.conncache_lock);                            \
-    (x)->state.conncache_lock = TRUE;                                   \
-  }
+#define CONNCACHE_LOCK(x)                                               \
+  do {                                                                  \
+    if((x)->share) {                                                    \
+      Curl_share_lock((x), CURL_LOCK_DATA_CONNECT,                      \
+                      CURL_LOCK_ACCESS_SINGLE);                         \
+      DEBUGASSERT(!(x)->state.conncache_lock);                          \
+      (x)->state.conncache_lock = TRUE;                                 \
+    }                                                                   \
+  } while(0)
 
-#define CONNCACHE_UNLOCK(x) if((x)->share) {                            \
-    DEBUGASSERT((x)->state.conncache_lock);                             \
-    (x)->state.conncache_lock = FALSE;                                  \
-    Curl_share_unlock((x), CURL_LOCK_DATA_CONNECT);                     \
-  }
+#define CONNCACHE_UNLOCK(x)                                             \
+  do {                                                                  \
+    if((x)->share) {                                                    \
+      DEBUGASSERT((x)->state.conncache_lock);                           \
+      (x)->state.conncache_lock = FALSE;                                \
+      Curl_share_unlock((x), CURL_LOCK_DATA_CONNECT);                   \
+    }                                                                   \
+  } while(0)
 #else
 #define CONNCACHE_LOCK(x) if((x)->share)                                \
     Curl_share_lock((x), CURL_LOCK_DATA_CONNECT, CURL_LOCK_ACCESS_SINGLE)

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -44,13 +44,15 @@
 #include "memdebug.h"
 
 #define HMAC_SHA256(k, kl, d, dl, o)                                    \
-  if(Curl_hmacit(Curl_HMAC_SHA256, (unsigned char *)k,                  \
-                 (unsigned int)kl,                                      \
-                 (unsigned char *)d,                                    \
-                 (unsigned int)dl, o) != CURLE_OK) {                    \
-    ret = CURLE_OUT_OF_MEMORY;                                          \
-    goto free_all;                                                      \
-  }
+  do {                                                                  \
+    if(Curl_hmacit(Curl_HMAC_SHA256, (unsigned char *)k,                \
+                   (unsigned int)kl,                                    \
+                   (unsigned char *)d,                                  \
+                   (unsigned int)dl, o) != CURLE_OK) {                  \
+      ret = CURLE_OUT_OF_MEMORY;                                        \
+      goto free_all;                                                    \
+    }                                                                   \
+  } while(0)
 
 #define PROVIDER_MAX_L 16
 #define REQUEST_TYPE_L (PROVIDER_MAX_L + sizeof("4_request"))

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -124,13 +124,17 @@ const struct Curl_handler Curl_handler_smbs = {
 
 /* Append a string to an SMB message */
 #define MSGCAT(str)                             \
-  strcpy(p, (str));                             \
-  p += strlen(str);
+  do {                                          \
+    strcpy(p, (str));                           \
+    p += strlen(str);                           \
+  } while(0)
 
 /* Append a null-terminated string to an SMB message */
 #define MSGCATNULL(str)                         \
-  strcpy(p, (str));                             \
-  p += strlen(str) + 1;
+  do {                                          \
+    strcpy(p, (str));                           \
+    p += strlen(str) + 1;                       \
+  } while(0)
 
 /* SMB is mostly little endian */
 #if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1232,10 +1232,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
   }
 
   k->now = Curl_now();
-  if(didwhat) {
-    ;
-  }
-  else {
+  if(!didwhat) {
     /* no read no write, this is a timeout? */
     if(k->exp100 == EXP100_AWAITING_CONTINUE) {
       /* This should allow some time for the header to arrive, but only a

--- a/lib/url.c
+++ b/lib/url.c
@@ -1151,10 +1151,7 @@ ConnectionExists(struct Curl_easy *data,
       if(bundle->multiuse == BUNDLE_MULTIPLEX)
         multiplexed = CONN_INUSE(check);
 
-      if(canmultiplex) {
-        ;
-      }
-      else {
+      if(!canmultiplex) {
         if(multiplexed) {
           /* can only happen within multi handles, and means that another easy
              handle is using this connection */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -983,12 +983,14 @@ void curl_url_cleanup(CURLU *u)
   }
 }
 
-#define DUP(dest, src, name)         \
-  if(src->name) {                    \
-    dest->name = strdup(src->name);  \
-    if(!dest->name)                  \
-      goto fail;                     \
-  }
+#define DUP(dest, src, name)                    \
+  do {                                          \
+    if(src->name) {                             \
+      dest->name = strdup(src->name);           \
+      if(!dest->name)                           \
+        goto fail;                              \
+    }                                           \
+  } while(0)
 
 CURLU *curl_url_dup(CURLU *in)
 {

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -61,12 +61,14 @@
    It converts digest text to ASCII so the MD5 will be correct for
    what ultimately goes over the network.
 */
-#define CURL_OUTPUT_DIGEST_CONV(a, b) \
-  result = Curl_convert_to_network(a, b, strlen(b)); \
-  if(result) { \
-    free(b); \
-    return result; \
-  }
+#define CURL_OUTPUT_DIGEST_CONV(a, b)                  \
+  do {                                                 \
+    result = Curl_convert_to_network(a, b, strlen(b)); \
+    if(result) {                                       \
+      free(b);                                         \
+      return result;                                   \
+    }                                                  \
+  } while(0)
 #endif /* !USE_WINDOWS_SSPI */
 
 bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -75,17 +75,21 @@
                                   (1<<CURL_LOCK_DATA_SSL_SESSION)))
 
 #define CLONE_STRING(var)                    \
-  if(source->var) {                          \
-    dest->var = strdup(source->var);         \
-    if(!dest->var)                           \
-      return FALSE;                          \
-  }                                          \
-  else                                       \
-    dest->var = NULL;
+  do {                                       \
+    if(source->var) {                        \
+      dest->var = strdup(source->var);       \
+      if(!dest->var)                         \
+        return FALSE;                        \
+    }                                        \
+    else                                     \
+      dest->var = NULL;                      \
+  } while(0)
 
-#define CLONE_BLOB(var)                         \
-  if(blobdup(&dest->var, source->var))         \
-    return FALSE;
+#define CLONE_BLOB(var)                        \
+  do {                                         \
+    if(blobdup(&dest->var, source->var))       \
+      return FALSE;                            \
+  } while(0)
 
 static CURLcode blobdup(struct curl_blob **dest,
                         struct curl_blob *src)

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -720,19 +720,22 @@ static int get_param_part(struct OperationConfig *config, char endchar,
  ***************************************************************************/
 
 /* Convenience macros for null pointer check. */
-#define NULL_CHECK(ptr, init, retcode) {                                \
-  (ptr) = (init);                                                       \
-  if(!(ptr)) {                                                          \
-    warnf(config->global, "out of memory!\n");                          \
-    curl_slist_free_all(headers);                                       \
-    Curl_safefree(contents);                                            \
-    return retcode;                                                     \
-  }                                                                     \
-}
-#define SET_TOOL_MIME_PTR(m, field, retcode) {                          \
-  if(field)                                                             \
-    NULL_CHECK((m)->field, strdup(field), retcode);                     \
-}
+#define NULL_CHECK(ptr, init, retcode)                                  \
+  do {                                                                  \
+    (ptr) = (init);                                                     \
+    if(!(ptr)) {                                                        \
+      warnf(config->global, "out of memory!\n");                        \
+      curl_slist_free_all(headers);                                     \
+      Curl_safefree(contents);                                          \
+      return retcode;                                                   \
+    }                                                                   \
+  } while(0)
+
+#define SET_TOOL_MIME_PTR(m, field, retcode)                            \
+  do {                                                                  \
+    if(field)                                                           \
+      NULL_CHECK((m)->field, strdup(field), retcode);                   \
+  } while(0)
 
 int formparse(struct OperationConfig *config,
               const char *input,

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -362,10 +362,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
   }
   else
 #endif
-    if(config->synthetic_error) {
-      ;
-    }
-    else if(result && global->showerror) {
+    if(!config->synthetic_error && result && global->showerror) {
       fprintf(global->errors, "curl: (%d) %s\n", result,
               (per->errorbuffer[0]) ? per->errorbuffer :
               curl_easy_strerror(result));

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -74,7 +74,7 @@ static void jsonEscape(FILE *stream, const char *in)
         fputc(*i, stream);
       }
       break;
-    };
+    }
   }
 }
 


### PR DESCRIPTION
For the HMAC_SHA256 macro.

Bug: https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64#commitcomment-45433279
Follow-up to 08e8455dddc5e4
Reported-by: Gisle Vanem