### PR TITLE
tool_operate: avoid NULL dereference of first_arg

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2542,7 +2542,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
 
   /* Parse .curlrc if necessary */
   if((argc == 1) ||
-     (strncmp(first_arg, "-q", 2) &&
+     (first_arg && strncmp(first_arg, "-q", 2) &&
       !curl_strequal(first_arg, "--disable"))) {
     parseconfig(NULL, global); /* ignore possible failure */
 


### PR DESCRIPTION
Follow-up to 6a5e020d4d2b04a
Identified by OSS-Fuzz
Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28999