### PR TITLE
configure: set -Wextra-semi-stmt for clang with --enable-debug

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -948,6 +948,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl clang 7 or later
           if test "$compiler_num" -ge "700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [assign-enum])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [extra-semi-stmt])
           fi
         fi
         ;;

--- a/tests/unit/curlcheck.h
+++ b/tests/unit/curlcheck.h
@@ -22,29 +22,35 @@
 #include "test.h"
 
 /* The fail macros mark the current test step as failed, and continue */
-#define fail_if(expr, msg)                              \
-  if(expr) {                                            \
-    fprintf(stderr, "%s:%d Assertion '%s' met: %s\n",   \
-            __FILE__, __LINE__, #expr, msg);            \
-    unitfail++;                                         \
-  }
+#define fail_if(expr, msg)                                \
+  do {                                                    \
+    if(expr) {                                            \
+      fprintf(stderr, "%s:%d Assertion '%s' met: %s\n",   \
+              __FILE__, __LINE__, #expr, msg);            \
+      unitfail++;                                         \
+    }                                                     \
+  } while(0)
 
-#define fail_unless(expr, msg)                           \
-  if(!(expr)) {                                          \
-    fprintf(stderr, "%s:%d Assertion '%s' failed: %s\n", \
-            __FILE__, __LINE__, #expr, msg);             \
-    unitfail++;                                          \
-  }
+#define fail_unless(expr, msg)                             \
+  do {                                                     \
+    if(!(expr)) {                                          \
+      fprintf(stderr, "%s:%d Assertion '%s' failed: %s\n", \
+              __FILE__, __LINE__, #expr, msg);             \
+      unitfail++;                                          \
+    }                                                      \
+  } while(0)
 
-#define verify_memory(dynamic, check, len)                                  \
-  if(dynamic && memcmp(dynamic, check, len)) {                              \
-    fprintf(stderr, "%s:%d Memory buffer mismatch size %d. '%s' is not\n",  \
-            __FILE__, __LINE__, len,                                        \
-            hexdump((const unsigned char *)check, len));                    \
-    fprintf(stderr, "%s:%d the same as '%s'\n", __FILE__, __LINE__,         \
-            hexdump((const unsigned char *)dynamic, len));                  \
-    unitfail++;                                                             \
-  }
+#define verify_memory(dynamic, check, len)                              \
+  do {                                                                  \
+    if(dynamic && memcmp(dynamic, check, len)) {                             \
+      fprintf(stderr, "%s:%d Memory buffer mismatch size %d. '%s' is not\n", \
+              __FILE__, __LINE__, len,                                  \
+              hexdump((const unsigned char *)check, len));              \
+      fprintf(stderr, "%s:%d the same as '%s'\n", __FILE__, __LINE__,   \
+              hexdump((const unsigned char *)dynamic, len));            \
+      unitfail++;                                                       \
+    }                                                                   \
+  } while(0)
 
 /* fail() is for when the test case figured out by itself that a check
    proved a failure */
@@ -56,29 +62,33 @@
 
 
 /* The abort macros mark the current test step as failed, and exit the test */
-#define abort_if(expr, msg)                                   \
-  if(expr) {                                                  \
-    fprintf(stderr, "%s:%d Abort assertion '%s' met: %s\n",   \
-            __FILE__, __LINE__, #expr, msg);                  \
-    unitfail++;                                               \
-    goto unit_test_abort;                                     \
-  }
+#define abort_if(expr, msg)                                     \
+  do {                                                          \
+    if(expr) {                                                  \
+      fprintf(stderr, "%s:%d Abort assertion '%s' met: %s\n",   \
+              __FILE__, __LINE__, #expr, msg);                  \
+      unitfail++;                                               \
+      goto unit_test_abort;                                     \
+    }                                                           \
+  } while(0)
 
-#define abort_unless(expr, msg)                                \
-  if(!(expr)) {                                                \
-    fprintf(stderr, "%s:%d Abort assertion '%s' failed: %s\n", \
-            __FILE__, __LINE__, #expr, msg);                   \
-    unitfail++;                                                \
-    goto unit_test_abort;                                      \
-  }
+#define abort_unless(expr, msg)                                         \
+  do {                                                                  \
+    if(!(expr)) {                                                       \
+      fprintf(stderr, "%s:%d Abort assertion '%s' failed: %s\n",        \
+              __FILE__, __LINE__, #expr, msg);                          \
+      unitfail++;                                                       \
+      goto unit_test_abort;                                             \
+    }                                                                   \
+  } while(0)
 
-#define abort_test(msg) do {                                  \
+#define abort_test(msg)                                       \
+  do {                                                        \
     fprintf(stderr, "%s:%d test aborted: '%s'\n",             \
             __FILE__, __LINE__, msg);                         \
     unitfail++;                                               \
     goto unit_test_abort;                                     \
   } while(0)
-
 
 
 extern int unitfail;


### PR DESCRIPTION
To have it properly complain on empty statements with no effect.

Ref: #6376