### PR TITLE
djgpp: build fixes

### DIFF
--- a/Makefile.dist
+++ b/Makefile.dist
@@ -61,6 +61,10 @@ djgpp:
 	$(MAKE) -C lib -f Makefile.dj
 	$(MAKE) -C src -f Makefile.dj
 
+djgpp-clean:
+	$(MAKE) -C lib -f Makefile.dj clean
+	$(MAKE) -C src -f Makefile.dj clean
+
 cygwin:
 	./configure
 	make

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -61,10 +61,6 @@ djgpp:
 	$(MAKE) -C lib -f Makefile.dj
 	$(MAKE) -C src -f Makefile.dj
 
-djgpp-clean:
-	$(MAKE) -C lib -f Makefile.dj clean
-	$(MAKE) -C src -f Makefile.dj clean
-
 cygwin:
 	./configure
 	make

--- a/lib/makefile.dj
+++ b/lib/makefile.dj
@@ -26,7 +26,7 @@
 #
 
 DEPEND_PREREQ = curl_config.h
-VPATH  = vtls vauth
+VPATH  = vtls vauth vquic vssh
 TOPDIR = ..
 
 include ../packages/DOS/common.dj

--- a/packages/DOS/README
+++ b/packages/DOS/README
@@ -1,10 +1,9 @@
 Gisle Vanem made curl build fine on DOS (and MingW) with djgpp, OpenSSL and his
 Watt-32 stack.
 
-'make -f Makefile.dist djgpp-clean djgpp' in the root curl dir should build it fine.
-
-(the 'djgpp-clean' target will first delete 'lib/curl_config.h' which is possibly
- from a previous incompatible Windows-build).
+'make -f Makefile.dist djgpp' in the root curl dir should build it fine.
+Or enter 'lib' and do a 'make -f Makefile.dj clean all' to first delete
+'lib/curl_config.h' which is possibly from a previous incompatible Windows-build.
 
 Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
         done properly. Use djgpp 2.03 until they fix it.

--- a/packages/DOS/README
+++ b/packages/DOS/README
@@ -1,7 +1,10 @@
 Gisle Vanem made curl build fine on DOS (and MingW) with djgpp, OpenSSL and his
 Watt-32 stack.
 
-'make djgpp' in the root curl dir should build it fine.
+'make -f Makefile.dist djgpp-clean djgpp' in the root curl dir should build it fine.
+
+(the 'djgpp-clean' target will first delete 'lib/curl_config.h' which is possibly
+ from a previous incompatible Windows-build).
 
 Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
         done properly. Use djgpp 2.03 until they fix it.

--- a/packages/DOS/README
+++ b/packages/DOS/README
@@ -11,3 +11,7 @@ Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
 Note 2: Compile Watt-32 (and OpenSSL) with the same version of djgpp.
         Otherwise things go wrong because things like FS-extensions and
         errnos have been changed between releases.
+        
+Note 3: Several 'USE_x' variables in 'common.dj' are on the 'USE_x ?= 0'
+        form (conditional variable assignment). So one can build like this:
+          c:\curl\lib> make -f makefile.dj USE_OPENSSL=1 USE_ZLIB=1 clean all

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -79,42 +79,42 @@ endif
 # with djgpp/Watt-32. Set to 0 if you don't need https URLs
 # (reduces curl.exe with approx 700 kB)
 #
-USE_OPENSSL = 0
+USE_OPENSSL ?= 0
 
 #
 # Use zlib for contents encoding. Needed for 'USE_OPENSSL=1' too.
 #
-USE_ZLIB = 0
+USE_ZLIB ?= 0
 
 #
 # Use libidn for international domain names
 #
-USE_IDNA = 0
+USE_IDNA ?= 0
 
 #
 # Use Watt-32 IPv6 stack (only IPv6 name resolution working at the moment)
 #
-USE_IPV6 = 0
+USE_IPV6 ?= 0
 
 #
 # Use C-Ares resolver library
 #
-USE_ARES = 0
+USE_ARES ?= 0
 
 #
 # Enable debug code in libcurl/curl
 #
-USE_DEBUG = 0
+USE_DEBUG ?= 0
 
 #
 # Enable memory tracking code in libcurl/curl
 #
-USE_CURLDEBUG = 0
+USE_CURLDEBUG ?= 0
 
 #
 # Generate a .map file in 'link_EXE' macro
 #
-MAKE_MAP_FILE ?= 1
+MAKE_MAP_FILE ?= 0
 
 default: all
 

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -135,10 +135,9 @@ ifeq ($(USE_OPENSSL),1)
   CFLAGS += -DUSE_OPENSSL -I$(OPENSSL_ROOT)/include
 
   #
-  # Squelch the warnings from '$(OPENSSL_ROOT)/include/openssl/opensslconf.h'
-  # and use of deprecated functions.
+  # Squelch the warnings on deprecated functions.
   #
-  CFLAGS += -D__AFL_LOOP -DOPENSSL_SUPPRESS_DEPRECATED
+  CFLAGS += -DOPENSSL_SUPPRESS_DEPRECATED
 
   #
   # Use some of these too?

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -104,7 +104,7 @@ USE_ARES = 0
 #
 # Enable debug code in libcurl/curl
 #
-USE_DEBUG = 1
+USE_DEBUG = 0
 
 #
 # Enable memory tracking code in libcurl/curl

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -24,11 +24,9 @@
 #
 # Assumes you've unpacked curl with long-file names
 # I.e use "set LFN=y" before untaring on Win9x/XP.
-# Requires sed, yacc, rm and the usual stuff.
+# Requires sed, rm and the usual stuff.
 #
 # Define TOPDIR before including this file.
-
-.SUFFIXES: .exe .y
 
 MAKEFILE = Makefile.dj
 OBJ_DIR = djgpp
@@ -61,17 +59,32 @@ else
   DS     = \$(NOTHING)
 endif
 
+ifeq ($(OS),Windows_NT)
+  #
+  # Windows hosted djgpp cross compiler. Get it from:
+  #   https://github.com/andrewwutw/build-djgpp/releases
+  #
+  DJ_PREFIX ?= c:/some-path/djgpp/bin/i586-pc-msdosdjgpp-
+  CC = $(DJ_PREFIX)gcc
+
+else
+  #
+  # The normal djgpp 'gcc' for MSDOS.
+  #
+  CC = gcc
+endif
+
 #
 # OpenSSL is available from www.openssl.org and builds okay
 # with djgpp/Watt-32. Set to 0 if you don't need https URLs
 # (reduces curl.exe with approx 700 kB)
 #
-USE_SSL = 0
+USE_OPENSSL = 1
 
 #
-# Use zlib for contents encoding
+# Use zlib for contents encoding. Needed for 'USE_OPENSSL=1' too.
 #
-USE_ZLIB = 0
+USE_ZLIB = 1
 
 #
 # Use libidn for international domain names
@@ -81,7 +94,7 @@ USE_IDNA = 0
 #
 # Use Watt-32 IPv6 stack (only IPv6 name resolution working at the moment)
 #
-USE_IPV6 = 0
+USE_IPV6 = 1
 
 #
 # Use C-Ares resolver library
@@ -91,12 +104,17 @@ USE_ARES = 0
 #
 # Enable debug code in libcurl/curl
 #
-USE_DEBUG = 0
+USE_DEBUG = 1
 
 #
 # Enable memory tracking code in libcurl/curl
 #
-USE_CURLDEBUG = 0
+USE_CURLDEBUG = 1
+
+#
+# Generate a .map file in 'link_EXE' macro
+#
+MAKE_MAP_FILE ?= 1
 
 default: all
 
@@ -104,20 +122,41 @@ default: all
 # Root directory for Waterloo tcp/ip etc. Change to suite.
 # WATT_ROOT should be set during Watt-32 install.
 #
-WATT32_ROOT  = $(subst \,/,$(WATT_ROOT))
-OPENSSL_ROOT = e:/net/openssl.099
-ZLIB_ROOT    = $(DJDIR)/contrib/zlib
-LIBIDN_ROOT  = $(TOPDIR)/../IDN/libidn
-ARES_ROOT    = $(TOPDIR)/ares
-
-CC   = gcc
-YACC = bison -y
+WATT32_ROOT   = $(realpath $(WATT_ROOT))
+OPENSSL_ROOT ?= $(TOPDIR)/../crypto/OpenSSL
+ZLIB_ROOT    ?= e:/djgpp/contrib/zlib
+LIBIDN_ROOT  ?= $(TOPDIR)/../IDN/libidn
+ARES_ROOT    ?= $(TOPDIR)/../DNS/c-ares
 
 CFLAGS = -g -O2 -I. -I$(TOPDIR)/include -I$(TOPDIR)/lib \
          -I$(WATT32_ROOT)/inc -Wall -DHAVE_CONFIG_H
 
-ifeq ($(USE_SSL),1)
-  CFLAGS += -DUSE_OPENSSL -I$(OPENSSL_ROOT)
+ifeq ($(USE_OPENSSL),1)
+  CFLAGS += -DUSE_OPENSSL -I$(OPENSSL_ROOT)/include
+
+  #
+  # Squelch the warnings from '$(OPENSSL_ROOT)/include/openssl/opensslconf.h'
+  # and use of deprecated functions.
+  #
+  CFLAGS += -D__AFL_LOOP -DOPENSSL_SUPPRESS_DEPRECATED
+
+  #
+  # Use some of these too?
+  #
+  # CFLAGS += -DUSE_TLS_SRP=1                    \
+  #           -DHAVE_ENGINE_LOAD_BUILTIN_ENGINES \
+  #           -DHAVE_OPENSSL_PKCS12_H            \
+  #           -DHAVE_SSLV2_CLIENT_METHOD         \
+  #           -DOPENSSL_NO_DEPRECATED
+
+  #
+  # 'libcomm.a' is normally 'libcommon.a'. But to keep it 8+3 clean, it's
+  # shortened to 'libcomm.a'. The official OpenSSL build was recently changed
+  # and this "Common" library was added for several of the Crypto Providers.
+  #
+  OPENSSL_LIBS = $(OPENSSL_ROOT)/lib/libssl.a   \
+                 $(OPENSSL_ROOT)/lib/libcrypt.a \
+                 $(OPENSSL_ROOT)/lib/libcomm.a
 endif
 
 ifeq ($(USE_ZLIB),1)
@@ -152,6 +191,34 @@ $(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<
 	@echo
 
+#
+# Link-EXE macro:
+#   $(1): the .exe
+#   $(2): the .o-files and libraries
+#
+ifeq ($(MAKE_MAP_FILE),1)
+  define link_EXE
+    $(CC) -o $(1) $(LDFLAGS) -Wl,--print-map,--sort-common $(2) > $(1:.exe=.map)
+  endef
+else
+  define link_EXE
+    $(CC) $(LDFLAGS) -o $(1) $(2)
+  endef
+endif
+
+$(TOPDIR)/docs/curl.1: $(wildcard $(TOPDIR)/docs/cmdline-opts/*.d)
+	cd $(TOPDIR)/docs/cmdline-opts; \
+	perl gen.pl mainpage > ../$(TOPDIR)/docs/curl.1
+
+DEP_REPLACE = sed -e 's@\(.*\)\.o: @\n$$(OBJ_DIR)\/\1.o: @' \
+                  -e 's@$(ARES_ROOT)@$$(ARES_ROOT)@g'       \
+                  -e 's@$(OPENSSL_ROOT)@$$(OPENSSL_ROOT)@g' \
+                  -e 's@$(WATT32_ROOT)@$$(WATT32_ROOT)@g'   \
+                  -e 's@$(ZLIB_ROOT)@$$(ZLIB_ROOT)@g'
+
+#
+# One may have to do 'make -f Makefile.dj clean' first in case
+# a foreign 'curl_config.h' is making trouble.
+#
 depend: $(DEPEND_PREREQ) $(MAKEFILE)
-	$(CC) -MM $(CFLAGS) $(CSOURCES) | \
-	sed -e 's/^\([a-zA-Z0-9_-]*\.o:\)/$$(OBJ_DIR)\/\1/' > depend.dj
+	$(CC) -MM $(CFLAGS) $(CSOURCES) | $(DEP_REPLACE) > depend.dj

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -79,12 +79,12 @@ endif
 # with djgpp/Watt-32. Set to 0 if you don't need https URLs
 # (reduces curl.exe with approx 700 kB)
 #
-USE_OPENSSL = 1
+USE_OPENSSL = 0
 
 #
 # Use zlib for contents encoding. Needed for 'USE_OPENSSL=1' too.
 #
-USE_ZLIB = 1
+USE_ZLIB = 0
 
 #
 # Use libidn for international domain names
@@ -94,7 +94,7 @@ USE_IDNA = 0
 #
 # Use Watt-32 IPv6 stack (only IPv6 name resolution working at the moment)
 #
-USE_IPV6 = 1
+USE_IPV6 = 0
 
 #
 # Use C-Ares resolver library
@@ -109,7 +109,7 @@ USE_DEBUG = 1
 #
 # Enable memory tracking code in libcurl/curl
 #
-USE_CURLDEBUG = 1
+USE_CURLDEBUG = 0
 
 #
 # Generate a .map file in 'link_EXE' macro

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -167,7 +167,7 @@ ifeq ($(USE_IPV6),1)
 endif
 
 ifeq ($(USE_ARES),1)
-  CFLAGS += -DUSE_ARES -I$(ARES_ROOT)
+  CFLAGS += -DUSE_ARES -I$(ARES_ROOT)/include
 endif
 
 ifeq ($(USE_IDNA),1)

--- a/src/makefile.dj
+++ b/src/makefile.dj
@@ -29,13 +29,15 @@ DEPEND_PREREQ = # tool_hugehelp.c
 
 TOPDIR = ..
 
+vpath %.c ../lib
+
 include ../packages/DOS/common.dj
 include Makefile.inc
 
-CSOURCES = $(CURL_CFILES)
+CSOURCES = $(CURL_CFILES) $(CURLX_CFILES)
 
-ifeq ($(USE_SSL),1)
-  EX_LIBS += $(OPENSSL_ROOT)/lib/libssl.a $(OPENSSL_ROOT)/lib/libcrypt.a
+ifeq ($(USE_OPENSSL),1)
+  EX_LIBS += $(OPENSSL_LIBS)
 endif
 
 ifeq ($(USE_ARES),1)
@@ -53,8 +55,8 @@ endif
 
 EX_LIBS += $(WATT32_ROOT)/lib/libwatt.a
 
-PROGRAM  = curl.exe
-OBJECTS += $(addprefix $(OBJ_DIR)/, $(CSOURCES:.c=.o))
+PROGRAM = curl.exe
+OBJECTS = $(addprefix $(OBJ_DIR)/, $(notdir $(CSOURCES:.c=.o)))
 
 all: $(OBJ_DIR) $(PROGRAM)
 	@echo Welcome to curl
@@ -64,10 +66,14 @@ $(PROGRAM): $(OBJECTS) ../lib/libcurl.a
 
 #
 # groff 1.18+ requires "-P -c"
+# If 'USE_ZLIB = 1', create a compressed help-file.
 #
-tool_hugehelp.c: ../docs/MANUAL ../docs/curl.1 mkhelp.pl
-	groff -Tascii -man ../docs/curl.1 | \
-	perl -w mkhelp.pl ../docs/MANUAL > $@
+ifeq ($(USE_ZLIB),1)
+  COMPRESS_OPT = -c
+endif
+
+tool_hugehelp.c: ../docs/curl.1 mkhelp.pl Makefile.dj
+	groff -Tascii -man $< | perl -w mkhelp.pl $(COMPRESS_OPT) $< > $@
 
 # clean generated files
 #


### PR DESCRIPTION
Here are some fixes for `lib/Makefile.dj`, `src/Makefile.dj` and some `packages/DOS/` files.
Not many are using djgpp nowadays, but I've had these changes locally for ages. So now hopefully the diffs are out of the way.
