### PR TITLE
Adjust examples and tests which use CURLOPT_READFUNCTION

### DIFF
--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -78,7 +78,7 @@ static curlioerr my_ioctl(CURL *handle, curliocmd cmd, void *userp)
 }
 
 /* read callback function, fread() look alike */
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   ssize_t retcode;
   curl_off_t nread;

--- a/docs/examples/curlgtk.c
+++ b/docs/examples/curlgtk.c
@@ -24,7 +24,7 @@ size_t my_write_func(void *ptr, size_t size, size_t nmemb, FILE *stream)
   return fwrite(ptr, size, nmemb, stream);
 }
 
-size_t my_read_func(void *ptr, size_t size, size_t nmemb, FILE *stream)
+size_t my_read_func(char *ptr, size_t size, size_t nmemb, FILE *stream)
 {
   return fread(ptr, size, nmemb, stream);
 }

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -48,7 +48,7 @@
    DLL, you MUST also provide a read callback with CURLOPT_READFUNCTION.
    Failing to do so will give you a crash since a DLL may not use the
    variable's memory when passed in to it from an app like this. */
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   curl_off_t nread;
   /* in real-world cases, this would probably get this data differently

--- a/docs/examples/ftpuploadfrommem.c
+++ b/docs/examples/ftpuploadfrommem.c
@@ -43,7 +43,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *upload = (struct WriteThis *)userp;
   size_t max = size*nmemb;

--- a/docs/examples/ftpuploadresume.c
+++ b/docs/examples/ftpuploadresume.c
@@ -51,7 +51,7 @@ static size_t discardfunc(void *ptr, size_t size, size_t nmemb, void *stream)
 }
 
 /* read data to upload */
-static size_t readfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t readfunc(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   FILE *f = stream;
   size_t n;

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -159,7 +159,7 @@ int my_trace(CURL *handle, curl_infotype type,
   return 0;
 }
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct input *i = userp;
   size_t retcode = fread(ptr, size, nmemb, i->in);

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -38,7 +38,7 @@
  * http://www.apacheweek.com/features/put
  */
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t retcode;
   curl_off_t nread;

--- a/docs/examples/imap-append.c
+++ b/docs/examples/imap-append.c
@@ -59,7 +59,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t payload_source(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/docs/examples/post-callback.c
+++ b/docs/examples/post-callback.c
@@ -41,7 +41,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(void *dest, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *dest, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *wt = (struct WriteThis *)userp;
   size_t buffer_size = size*nmemb;

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -29,7 +29,7 @@
 #include <curl/curl.h>
 
 /* read data to upload */
-static size_t readfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t readfunc(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   FILE *f = (FILE *)stream;
   size_t n;

--- a/docs/examples/smtp-authzid.c
+++ b/docs/examples/smtp-authzid.c
@@ -67,7 +67,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t payload_source(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/docs/examples/smtp-mail.c
+++ b/docs/examples/smtp-mail.c
@@ -64,7 +64,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t payload_source(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/docs/examples/smtp-multi.c
+++ b/docs/examples/smtp-multi.c
@@ -61,7 +61,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t payload_source(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/docs/examples/smtp-ssl.c
+++ b/docs/examples/smtp-ssl.c
@@ -61,7 +61,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t payload_source(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/docs/examples/smtp-tls.c
+++ b/docs/examples/smtp-tls.c
@@ -61,7 +61,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t payload_source(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.3
@@ -75,7 +75,7 @@ The default internal read callback is fread().
 This is used for all protocols when doing uploads.
 .SH EXAMPLE
 .nf
-size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
+size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
   FILE *readhere = (FILE *)userdata;
   curl_off_t nread;

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -35,7 +35,7 @@
 ** callback for CURLOPT_READFUNCTION
 */
 
-size_t tool_read_cb(void *buffer, size_t sz, size_t nmemb, void *userdata)
+size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 {
   ssize_t rc;
   struct InStruct *in = userdata;

--- a/src/tool_cb_rea.h
+++ b/src/tool_cb_rea.h
@@ -27,7 +27,7 @@
 ** callback for CURLOPT_READFUNCTION
 */
 
-size_t tool_read_cb(void *buffer, size_t sz, size_t nmemb, void *userdata);
+size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata);
 
 /*
 ** callback for CURLOPT_XFERINFOFUNCTION used to unpause busy reads

--- a/tests/libtest/lib1507.c
+++ b/tests/libtest/lib1507.c
@@ -35,7 +35,7 @@
 
 #define MULTI_PERFORM_HANG_TIMEOUT 60 * 1000
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   (void)ptr;
   (void)size;

--- a/tests/libtest/lib1514.c
+++ b/tests/libtest/lib1514.c
@@ -35,7 +35,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *pooh = (struct WriteThis *)userp;
 
@@ -43,7 +43,7 @@ static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
     return 0;
 
   if(pooh->sizeleft) {
-    *(char *)ptr = pooh->readptr[0]; /* copy one single byte */
+    *ptr = pooh->readptr[0]; /* copy one single byte */
     pooh->readptr++;                 /* advance pointer */
     pooh->sizeleft--;                /* less data left */
     return 1;                        /* we return 1 byte at a time! */

--- a/tests/libtest/lib1517.c
+++ b/tests/libtest/lib1517.c
@@ -30,7 +30,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *pooh = (struct WriteThis *)userp;
   size_t tocopy = size * nmemb;

--- a/tests/libtest/lib1520.c
+++ b/tests/libtest/lib1520.c
@@ -47,7 +47,7 @@ struct upload_status {
   int lines_read;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;

--- a/tests/libtest/lib1525.c
+++ b/tests/libtest/lib1525.c
@@ -32,7 +32,7 @@
 
 static char data [] = "Hello Cloud!\n";
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
   if(amount < strlen(data)) {

--- a/tests/libtest/lib1526.c
+++ b/tests/libtest/lib1526.c
@@ -31,7 +31,7 @@
 
 static char data [] = "Hello Cloud!\n";
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
   if(amount < strlen(data)) {

--- a/tests/libtest/lib1527.c
+++ b/tests/libtest/lib1527.c
@@ -31,7 +31,7 @@
 
 static char data [] = "Hello Cloud!\n";
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
   if(amount < strlen(data)) {

--- a/tests/libtest/lib1533.c
+++ b/tests/libtest/lib1533.c
@@ -48,7 +48,7 @@ static void reset_data(struct cb_data *data, CURL *curl)
 }
 
 
-static size_t read_callback(void *ptr, size_t size, size_t nitems,
+static size_t read_callback(char *ptr, size_t size, size_t nitems,
                             void *userdata)
 {
   struct cb_data *data = (struct cb_data *)userdata;

--- a/tests/libtest/lib1591.c
+++ b/tests/libtest/lib1591.c
@@ -32,7 +32,7 @@
 static char data [] = "Hello Cloud!\r\n";
 static size_t consumed = 0;
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
 

--- a/tests/libtest/lib508.c
+++ b/tests/libtest/lib508.c
@@ -30,7 +30,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *pooh = (struct WriteThis *)userp;
 
@@ -38,7 +38,7 @@ static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
     return 0;
 
   if(pooh->sizeleft) {
-    *(char *)ptr = pooh->readptr[0]; /* copy one single byte */
+    *ptr = pooh->readptr[0]; /* copy one single byte */
     pooh->readptr++;                 /* advance pointer */
     pooh->sizeleft--;                /* less data left */
     return 1;                        /* we return 1 byte at a time! */

--- a/tests/libtest/lib510.c
+++ b/tests/libtest/lib510.c
@@ -36,7 +36,7 @@ struct WriteThis {
   int counter;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *pooh = (struct WriteThis *)userp;
   const char *data;

--- a/tests/libtest/lib513.c
+++ b/tests/libtest/lib513.c
@@ -23,7 +23,7 @@
 
 #include "memdebug.h"
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   (void)ptr;
   (void)size;

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -38,7 +38,7 @@
 #endif
 
 #ifndef LIB548
-static size_t readcallback(void  *ptr,
+static size_t readcallback(char  *ptr,
                            size_t size,
                            size_t nmemb,
                            void *clientp)

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -127,7 +127,7 @@ static size_t current_offset = 0;
 static char databuf[70000]; /* MUST be more than 64k OR
                                MAX_INITIAL_POST_SIZE */
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
   size_t  available = sizeof(databuf) - current_offset; /* What we have to

--- a/tests/libtest/lib553.c
+++ b/tests/libtest/lib553.c
@@ -30,7 +30,7 @@
 
 #define POSTLEN 40960
 
-static size_t myreadfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t myreadfunc(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   static size_t total = POSTLEN;
   static char buf[1024];

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -38,7 +38,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
 #ifdef LIB587
   (void)ptr;
@@ -54,7 +54,7 @@ static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
     return 0;
 
   if(pooh->sizeleft) {
-    *(char *)ptr = pooh->readptr[0]; /* copy one single byte */
+    *ptr = pooh->readptr[0]; /* copy one single byte */
     pooh->readptr++;                 /* advance pointer */
     pooh->sizeleft--;                /* less data left */
     return 1;                        /* we return 1 byte at a time! */

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -45,7 +45,7 @@ static const char uploadthis[] =
   "this is the blurb we want to upload\n";
 #endif
 
-static size_t readcallback(void  *ptr,
+static size_t readcallback(char  *ptr,
                            size_t size,
                            size_t nmemb,
                            void *clientp)

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -64,7 +64,7 @@ static int progress_callback(void *clientp, double dltotal, double dlnow,
   return 0;
 }
 
-static size_t read_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *pooh = (struct WriteThis *)userp;
   const char *data;


### PR DESCRIPTION
The type of the buffer in curl_read_callback is 'char *', not 'void *'.

Signed-off-by: Olaf Hering <olaf@aepfle.de>