### PR TITLE
tool_operate: fix the suppression logic of some error messages

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -396,7 +396,8 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;
-      fprintf(global->errors, "(%d) Failed writing body\n", result);
+      if(global->showerror)
+        fprintf(global->errors, "curl: (%d) Failed writing body\n", result);
     }
   }
 
@@ -559,9 +560,9 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         if(ftruncate(fileno(outs->stream), outs->init)) {
           /* when truncate fails, we can't just append as then we'll
              create something strange, bail out */
-          if(!global->mute)
+          if(global->showerror)
             fprintf(global->errors,
-                    "failed to truncate, exiting\n");
+                    "curl: (23) Failed to truncate file\n");
           return CURLE_WRITE_ERROR;
         }
         /* now seek to the end of the file, the position where we
@@ -575,9 +576,9 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         rc = fseek(outs->stream, (long)outs->init, SEEK_SET);
 #endif
         if(rc) {
-          if(!global->mute)
+          if(global->showerror)
             fprintf(global->errors,
-                    "failed seeking to end of file, exiting\n");
+                    "curl: (23) Failed seeking to end of file\n");
           return CURLE_WRITE_ERROR;
         }
         outs->bytes = 0; /* clear for next round */
@@ -633,7 +634,8 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;
-      fprintf(global->errors, "(%d) Failed writing body\n", result);
+      if(global->showerror)
+        fprintf(global->errors, "curl: (%d) Failed writing body\n", result);
     }
   }
 


### PR DESCRIPTION
- Fix the failed truncation and failed writing body error messages to
  not be shown unless error messages are shown. (ie the user has
  specified -sS, or has not specified -s).

- Also prefix same error messages with "curl: ", for example:
  curl: (23) Failed to truncate, exiting

Prior to this change the failed truncation error messages would be shown
if not -s, but did not account for -sS which should show.

Prior to this change the failed writing body error messages would be
shown always.

Ref: https://curl.se/docs/manpage.html#-S

Bug: https://curl.se/mail/archive-2020-12/0017.html
Reported-by: Hongyi Zhao

Closes #xxxx
