### PR TITLE
http: have CURLOPT_FAILONERROR fail after all headers

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -196,7 +196,7 @@ test1608 test1609 test1610 test1611 test1612 \
 \
 test1620 test1621 \
 \
-test1630 test1631 test1632 test1633 \
+test1630 test1631 test1632 test1633 test1634 \
 \
 test1650 test1651 test1652 test1653 test1654 test1655 \
 test1660 \

--- a/tests/data/test1634
+++ b/tests/data/test1634
@@ -1,0 +1,70 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 429 too many requests swsbounce
+Retry-After: 1
+Content-Length: 4
+
+moo
+</data>
+<data1>
+HTTP/1.1 200 OK
+Content-Length: 4
+Connection: close
+
+hey
+</data1>
+
+<datacheck>
+HTTP/1.1 429 too many requests swsbounce
+Retry-After: 1
+Content-Length: 4
+
+HTTP/1.1 200 OK
+Content-Length: 4
+Connection: close
+
+hey
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+--retry with a 429 response and Retry-After: and --fail
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/1634 --retry 1  --fail
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /1634 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /1634 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test194
+++ b/tests/data/test194
@@ -36,6 +36,7 @@ Content-Length: 4
 Content-Range: bytes */87
 Content-Type: image/gif
 Connection: close
+
 </datacheck>
 
 </reply>

--- a/tests/data/test281
+++ b/tests/data/test281
@@ -14,11 +14,8 @@ HTTP/1.1 401 Bad Auth swsclose
 Date: Thu, 09 Nov 2010 14:49:00 GMT
 WWW-Authenticate: Basic Realm=authenticate
 Server: test-server/fake
-</data>
-<datacheck>
-HTTP/1.1 100 Continue
 
-</datacheck>
+</data>
 
 </reply>
 


### PR DESCRIPTION
... so that Retry-After and other meta-content can still be used.

Added 1634 to verify. Adjusted test 194 and 281 since --fail now also
includes the header-terminating CRLF in the output before it exits.

Fixes #6408

---

This could possible be viewed as a minor behavior change to some users, but the documentation already allows the functionality to still return headers and this just does it a little more than before.