### PR TITLE
mk-ca-bundle.pl: deterministic output when using -t

### DIFF
--- a/lib/mk-ca-bundle.pl
+++ b/lib/mk-ca-bundle.pl
@@ -545,7 +545,7 @@ while (<TXT>) {
       print CRT @precert if($opt_m);
       my $maxStringLength = length(decode('UTF-8', $caname, Encode::FB_CROAK | Encode::LEAVE_SRC));
       if ($opt_t) {
-        foreach my $key (keys %trust_purposes_by_level) {
+        foreach my $key (sort keys %trust_purposes_by_level) {
            my $string = $key . ": " . join(", ", @{$trust_purposes_by_level{$key}});
            $maxStringLength = List::Util::max( length($string), $maxStringLength );
            print CRT $string . "\n";


### PR DESCRIPTION
Printing trust purposes are now sorted, making the output deterministic
when running on the same input certdata.txt.