### PR TITLE
curl.h: add CURLPROTO_GOPHERS as own protocol identifier

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -703,6 +703,7 @@ CURLPROTO_FILE                  7.19.4
 CURLPROTO_FTP                   7.19.4
 CURLPROTO_FTPS                  7.19.4
 CURLPROTO_GOPHER                7.21.2
+CURLPROTO_GOPHERS               7.75.0
 CURLPROTO_HTTP                  7.19.4
 CURLPROTO_HTTPS                 7.19.4
 CURLPROTO_IMAP                  7.20.0

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1016,6 +1016,7 @@ typedef CURLSTScode (*curl_hstswrite_callback)(CURL *easy,
 #define CURLPROTO_SMB    (1<<26)
 #define CURLPROTO_SMBS   (1<<27)
 #define CURLPROTO_MQTT   (1<<28)
+#define CURLPROTO_GOPHERS (1<<29)
 #define CURLPROTO_ALL    (~0) /* enable everything */
 
 /* long may be 32 or 64 bits, but we should never depend on anything else

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -98,7 +98,7 @@ const struct Curl_handler Curl_handler_gophers = {
   ZERO_NULL,                            /* readwrite */
   ZERO_NULL,                            /* connection_check */
   PORT_GOPHER,                          /* defport */
-  CURLPROTO_GOPHER,                     /* protocol */
+  CURLPROTO_GOPHERS,                    /* protocol */
   CURLPROTO_GOPHER,                     /* family */
   PROTOPT_SSL                           /* flags */
 };

--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -55,15 +55,18 @@ CURLcode get_libcurl_info(void)
     { "ftp",    CURLPROTO_FTP    },
     { "ftps",   CURLPROTO_FTPS   },
     { "gopher", CURLPROTO_GOPHER },
+    { "gophers",CURLPROTO_GOPHERS},
     { "http",   CURLPROTO_HTTP   },
     { "https",  CURLPROTO_HTTPS  },
     { "imap",   CURLPROTO_IMAP   },
     { "imaps",  CURLPROTO_IMAPS  },
     { "ldap",   CURLPROTO_LDAP   },
     { "ldaps",  CURLPROTO_LDAPS  },
+    { "mqtt",   CURLPROTO_MQTT   },
     { "pop3",   CURLPROTO_POP3   },
     { "pop3s",  CURLPROTO_POP3S  },
     { "rtmp",   CURLPROTO_RTMP   },
+    { "rtmps",  CURLPROTO_RTMPS  },
     { "rtsp",   CURLPROTO_RTSP   },
     { "scp",    CURLPROTO_SCP    },
     { "sftp",   CURLPROTO_SFTP   },


### PR DESCRIPTION
To make sure it can be handled separately from plain gopher.