### PR TITLE
http: make 'authneg' also work for Hyper

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -670,7 +670,7 @@ CURLcode Curl_http(struct connectdata *conn, bool *done)
       if(!pq)
         return CURLE_OUT_OF_MEMORY;
     }
-    result = Curl_http_output_auth(conn, method,
+    result = Curl_http_output_auth(conn, method, httpreq,
                                    (pq ? pq : data->state.up.path), FALSE);
     free(pq);
     if(result)

--- a/lib/http.h
+++ b/lib/http.h
@@ -24,14 +24,12 @@
 #include "curl_setup.h"
 
 typedef enum {
-  HTTPREQ_NONE, /* first in list */
   HTTPREQ_GET,
   HTTPREQ_POST,
   HTTPREQ_POST_FORM, /* we make a difference internally */
   HTTPREQ_POST_MIME, /* we make a difference internally */
   HTTPREQ_PUT,
-  HTTPREQ_HEAD,
-  HTTPREQ_LAST /* last in list */
+  HTTPREQ_HEAD
 } Curl_HttpReq;
 
 #ifndef CURL_DISABLE_HTTP
@@ -295,6 +293,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
  *
  * @param conn all information about the current connection
  * @param request pointer to the request keyword
+ * @param httpreq is the request type
  * @param path pointer to the requested path
  * @param proxytunnel boolean if this is the request setting up a "proxy
  * tunnel"
@@ -304,6 +303,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
 CURLcode
 Curl_http_output_auth(struct connectdata *conn,
                       const char *request,
+                      Curl_HttpReq httpreq,
                       const char *path,
                       bool proxytunnel); /* TRUE if this is the request setting
                                             up the proxy tunnel */

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -263,7 +263,8 @@ static CURLcode CONNECT(struct connectdata *conn,
         return result;
 
       /* Setup the proxy-authorization header, if any */
-      result = Curl_http_output_auth(conn, "CONNECT", hostheader, TRUE);
+      result = Curl_http_output_auth(conn, "CONNECT", HTTPREQ_GET,
+                                     hostheader, TRUE);
 
       if(!result) {
         const char *proxyconn = "";
@@ -739,7 +740,8 @@ static CURLcode CONNECT(struct connectdata *conn,
         result = CURLE_OUT_OF_MEMORY;
       }
       /* Setup the proxy-authorization header, if any */
-      result = Curl_http_output_auth(conn, "CONNECT", hostheader, TRUE);
+      result = Curl_http_output_auth(conn, "CONNECT", HTTPREQ_GET,
+                                     hostheader, TRUE);
       if(result)
         goto error;
       Curl_safefree(hostheader);

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -385,7 +385,8 @@ static CURLcode rtsp_do(struct connectdata *conn, bool *done)
   }
 
   /* setup the authentication headers */
-  result = Curl_http_output_auth(conn, p_request, p_stream_uri, FALSE);
+  result = Curl_http_output_auth(conn, p_request, HTTPREQ_GET,
+                                 p_stream_uri, FALSE);
   if(result)
     return result;
 


### PR DESCRIPTION
When doing a request with a request body expecting a 401/407 back, that
initial request is sent with a zero content-length. Test 177 and more.