### PR TITLE
http_proxy: Fix CONNECT chunked encoding race condition

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -489,9 +489,12 @@ static CURLcode CONNECT(struct connectdata *conn,
           }
           else
             s->keepon = KEEPON_DONE;
-          if(!s->cl)
+
+          if(s->keepon == KEEPON_DONE && !s->cl)
             /* we did the full CONNECT treatment, go to COMPLETE */
             s->tunnel_state = TUNNEL_COMPLETE;
+
+          DEBUGASSERT(s->keepon == KEEPON_IGNORE || s->keepon == KEEPON_DONE);
           continue;
         }
 


### PR DESCRIPTION
- During the end-of-headers response phase do not mark the tunnel
  complete unless the response body was completely parsed/ignored.

Prior to this change if the entirety of a CONNECT response with chunked
encoding was not received by the time the final header was parsed then
the connection would be marked done prematurely, before all the chunked
data could be read in and ignored (since this is what we do with any
CONNECT response body) and the connection could not be used.

Bug: https://curl.se/mail/lib-2021-01/0033.html
Reported-by: Fabian Keil

Closes #xxxx