### PR TITLE
libcurl: expose CMAKE_OPENSSL_AUTO_LOAD_CONFIG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ if(WIN32 OR CMAKE_USE_SECTRANSP OR CMAKE_USE_SCHANNEL OR CMAKE_USE_MBEDTLS OR CM
   set(openssl_default OFF)
 endif()
 option(CMAKE_USE_OPENSSL "Use OpenSSL code. Experimental" ${openssl_default})
+option(CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG "Disable automatic loading of OpenSSL configuration" OFF)
 
 count_true(enabled_ssl_options_count
   CMAKE_USE_SCHANNEL

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -1002,6 +1002,9 @@ ${SIZEOF_TIME_T_CODE}
 /* if OpenSSL is in use */
 #cmakedefine USE_OPENSSL 1
 
+/* Define if you don't want the OpenSSL configuration to be loaded automatically */
+#cmakedefine CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG 1
+
 /* to enable NGHTTP2  */
 #cmakedefine USE_NGHTTP2 1
 


### PR DESCRIPTION
This does for cmake builds what --enable-openssl-auto-load-config
does for autoconf builds.