### PR TITLE
docs: fix wrong documentation in help.d

### DIFF
--- a/docs/cmdline-opts/help.d
+++ b/docs/cmdline-opts/help.d
@@ -6,7 +6,7 @@ Category: important curl
 ---
 Usage help. This lists all commands of the <category>.
 If no arg was provided, curl will display the most important
-command line arguments and the list of categories.
+command line arguments.
 If the argument "all" was provided, curl will display all options available.
 If the argument "category" was provided, curl will display all categories and
 their meanings.


### PR DESCRIPTION
curl does not list all categories when you invoke "--help" without any
parameters.