### PR TITLE
docs: fix line length bug in gen.pl

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -369,8 +369,11 @@ sub listhelp {
 
         my $line = sprintf "  {\"%s\",\n   \"%s\",\n   %s},\n", $opt, $desc, $bitmask;
 
-        if(length($opt) + length($desc) > 78) {
-            print STDERR "WARN: the --$long line is too long\n";
+        if(length($opt) > 78) {
+            print STDERR "WARN: the --$long name is too long\n";
+        }
+        else if(length($desc) > 78) {
+            print STDERR "WARN: the --$long description is too long\n";
         }
         print $line;
     }


### PR DESCRIPTION
The script warns if the length of $opt and $desc is > 78. However, these
two variables are on totally separate lines so the check makes no sense.
Also the $bitmask field is totally forgotten. Currently this leads to
two warnings within `--resolve` and `--aws-sigv4`.