### PR TITLE
cmake: Use CMAKE_INSTALL_INCLUDEDIR indirection

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -123,7 +123,7 @@ if(WIN32)
 endif()
 
 target_include_directories(${LIB_NAME} INTERFACE
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CURL_SOURCE_DIR}/include>)
 
 install(TARGETS ${LIB_NAME}


### PR DESCRIPTION
Like the header installation uses `CMAKE_INSTALL_INCLUDEDIR`:
https://github.com/curl/curl/blob/3831043eff9ed412428150537374facb609e5b33/CMakeLists.txt#L1516-L1518

the exported CMake configuration must use it as well to lookup the installed files in the same place.