### PR TITLE
gitattributes: Set batch files to CRLF line endings on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,9 @@ configure.ac eol=lf
 *.am eol=lf
 *.sh eol=lf
 *.[ch] whitespace=tab-in-indent
+
+# Batch files (bat,btm,cmd) must be run with CRLF line endings.
+# Refer to #xxxx
+*.bat text eol=crlf
+*.btm text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
If a batch file is run without CRLF line endings (ie LF-only) then
arbitrary behavior may occur. I consider that a bug in Windows, however
the effects can be serious enough (eg unintended code executed) that
we're fixing it in the repo by requiring CRLF line endings for batch
files on checkout.

Prior to this change the checked-out line endings of batch files were
dependent on a user's git preferences. On Windows it is common for git
users to have automatic CRLF conversion enabled (core.autocrlf true),
but those users that don't would run into this behavior.

For example a user has reported running the Visual Studio project
generator batch file (projects/generate.bat) and it looped forever.
Output showed that the Windows OS interpreter was occasionally jumping
to arbitrary points in the batch file and executing commands. This
resulted in unintended files being removed (a removal sequence called)
and looping forever.

Ref: https://serverfault.com/q/429594
Ref: https://stackoverflow.com/q/232651
Ref: https://www.dostips.com/forum/viewtopic.php?t=8988
Ref: https://git-scm.com/docs/gitattributes#_checking_out_and_checking_in
Ref: https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf

Bug: https://github.com/curl/curl/discussions/6427
Reported-by: Ganesh Kamath

Closes #xxxx

---

/cc @bitcrazed @dscho 