### PR TITLE
remove Curl_ prefix from static functions

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -133,8 +133,8 @@ void Curl_resolver_global_cleanup(void)
 }
 
 
-static void Curl_ares_sock_state_cb(void *data, ares_socket_t socket_fd,
-                                    int readable, int writable)
+static void sock_state_cb(void *data, ares_socket_t socket_fd,
+                          int readable, int writable)
 {
   struct Curl_easy *easy = data;
   if(!readable && !writable) {
@@ -155,7 +155,7 @@ CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver)
   int status;
   struct ares_options options;
   int optmask = ARES_OPT_SOCK_STATE_CB;
-  options.sock_state_cb = Curl_ares_sock_state_cb;
+  options.sock_state_cb = sock_state_cb;
   options.sock_state_cb_data = easy;
   status = ares_init_options((ares_channel*)resolver, &options, optmask);
   if(status != ARES_SUCCESS) {

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -187,7 +187,7 @@ doh_write_cb(const void *contents, size_t size, size_t nmemb, void *userp)
 }
 
 /* called from multi.c when this DOH transfer is complete */
-static int Curl_doh_done(struct Curl_easy *doh, CURLcode result)
+static int doh_done(struct Curl_easy *doh, CURLcode result)
 {
   struct Curl_easy *data = doh->set.dohfor;
   /* so one of the DOH request done for the 'data' transfer is now complete! */
@@ -354,7 +354,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
         data->set.str[STRING_SSL_EC_CURVES]);
     }
 
-    doh->set.fmultidone = Curl_doh_done;
+    doh->set.fmultidone = doh_done;
     doh->set.dohfor = data; /* identify for which transfer this is done */
     p->easy = doh;
 

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -77,14 +77,14 @@
 #ifdef CURL_DOES_CONVERSIONS
 /* Check for an ASCII hex digit.
    We avoid the use of ISXDIGIT to accommodate non-ASCII hosts. */
-static bool Curl_isxdigit_ascii(char digit)
+static bool isxdigit_ascii(char digit)
 {
   return (digit >= 0x30 && digit <= 0x39) /* 0-9 */
-        || (digit >= 0x41 && digit <= 0x46) /* A-F */
-        || (digit >= 0x61 && digit <= 0x66); /* a-f */
+    || (digit >= 0x41 && digit <= 0x46) /* A-F */
+    || (digit >= 0x61 && digit <= 0x66); /* a-f */
 }
 #else
-#define Curl_isxdigit_ascii(x) Curl_isxdigit(x)
+#define isxdigit_ascii(x) Curl_isxdigit(x)
 #endif
 
 void Curl_httpchunk_init(struct connectdata *conn)
@@ -136,7 +136,7 @@ CHUNKcode Curl_httpchunk_read(struct connectdata *conn,
   while(length) {
     switch(ch->state) {
     case CHUNK_HEX:
-      if(Curl_isxdigit_ascii(*datap)) {
+      if(isxdigit_ascii(*datap)) {
         if(ch->hexindex < MAXNUM_SIZE) {
           ch->hexbuffer[ch->hexindex] = *datap;
           datap++;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -5,7 +5,7 @@
  *                | (__| |_| |  _ <| |___
  *                 \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -126,7 +126,7 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp);
 #endif
 
 
-static CURLcode Curl_ldap(struct connectdata *conn, bool *done);
+static CURLcode ldap_do(struct connectdata *conn, bool *done);
 
 /*
  * LDAP protocol handler.
@@ -135,7 +135,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done);
 const struct Curl_handler Curl_handler_ldap = {
   "LDAP",                               /* scheme */
   ZERO_NULL,                            /* setup_connection */
-  Curl_ldap,                            /* do_it */
+  ldap_do,                              /* do_it */
   ZERO_NULL,                            /* done */
   ZERO_NULL,                            /* do_more */
   ZERO_NULL,                            /* connect_it */
@@ -162,7 +162,7 @@ const struct Curl_handler Curl_handler_ldap = {
 const struct Curl_handler Curl_handler_ldaps = {
   "LDAPS",                              /* scheme */
   ZERO_NULL,                            /* setup_connection */
-  Curl_ldap,                            /* do_it */
+  ldap_do,                              /* do_it */
   ZERO_NULL,                            /* done */
   ZERO_NULL,                            /* do_more */
   ZERO_NULL,                            /* connect_it */
@@ -266,7 +266,7 @@ static int ldap_win_bind(struct connectdata *conn, LDAP *server,
 #endif
 
 
-static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
+static CURLcode ldap_do(struct connectdata *conn, bool *done)
 {
   CURLcode result = CURLE_OK;
   int rc = 0;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -105,7 +105,7 @@ static const char * const statename[]={
 /* function pointer called once when switching TO a state */
 typedef void (*init_multistate_func)(struct Curl_easy *data);
 
-static void Curl_init_completed(struct Curl_easy *data)
+static void init_completed(struct Curl_easy *data)
 {
   /* this is a completed transfer */
 
@@ -139,7 +139,7 @@ static void mstate(struct Curl_easy *data, CURLMstate state
     NULL,              /* PERFORM */
     NULL,              /* TOOFAST */
     NULL,              /* DONE */
-    Curl_init_completed, /* COMPLETED */
+    init_completed,    /* COMPLETED */
     NULL               /* MSGSENT */
   };
 
@@ -1067,13 +1067,13 @@ CURLMcode curl_multi_fdset(struct Curl_multi *multi,
 
 #define NUM_POLLS_ON_STACK 10
 
-static CURLMcode Curl_multi_wait(struct Curl_multi *multi,
-                                 struct curl_waitfd extra_fds[],
-                                 unsigned int extra_nfds,
-                                 int timeout_ms,
-                                 int *ret,
-                                 bool extrawait, /* when no socket, wait */
-                                 bool use_wakeup)
+static CURLMcode multi_wait(struct Curl_multi *multi,
+                            struct curl_waitfd extra_fds[],
+                            unsigned int extra_nfds,
+                            int timeout_ms,
+                            int *ret,
+                            bool extrawait, /* when no socket, wait */
+                            bool use_wakeup)
 {
   struct Curl_easy *data;
   curl_socket_t sockbunch[MAX_SOCKSPEREASYHANDLE];
@@ -1281,8 +1281,8 @@ CURLMcode curl_multi_wait(struct Curl_multi *multi,
                           int timeout_ms,
                           int *ret)
 {
-  return Curl_multi_wait(multi, extra_fds, extra_nfds, timeout_ms, ret, FALSE,
-                         FALSE);
+  return multi_wait(multi, extra_fds, extra_nfds, timeout_ms, ret, FALSE,
+                    FALSE);
 }
 
 CURLMcode curl_multi_poll(struct Curl_multi *multi,
@@ -1291,8 +1291,8 @@ CURLMcode curl_multi_poll(struct Curl_multi *multi,
                           int timeout_ms,
                           int *ret)
 {
-  return Curl_multi_wait(multi, extra_fds, extra_nfds, timeout_ms, ret, TRUE,
-                         TRUE);
+  return multi_wait(multi, extra_fds, extra_nfds, timeout_ms, ret, TRUE,
+                    TRUE);
 }
 
 CURLMcode curl_multi_wakeup(struct Curl_multi *multi)
@@ -1319,7 +1319,7 @@ CURLMcode curl_multi_wakeup(struct Curl_multi *multi)
 
          The write socket is set to non-blocking, this way this function
          cannot block, making it safe to call even from the same thread
-         that will call Curl_multi_wait(). If swrite() returns that it
+         that will call curl_multi_wait(). If swrite() returns that it
          would block, it's considered successful because it means that
          previous calls to this function will wake up the poll(). */
       if(swrite(multi->wakeup_pair[1], buf, sizeof(buf)) < 0) {

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -303,7 +303,7 @@ static unsigned short getrpacketblock(const struct tftp_packet *packet)
   return (unsigned short)((packet->data[2] << 8) | packet->data[3]);
 }
 
-static size_t Curl_strnlen(const char *string, size_t maxlen)
+static size_t tftp_strnlen(const char *string, size_t maxlen)
 {
   const char *end = memchr(string, '\0', maxlen);
   return end ? (size_t) (end - string) : maxlen;
@@ -314,14 +314,14 @@ static const char *tftp_option_get(const char *buf, size_t len,
 {
   size_t loc;
 
-  loc = Curl_strnlen(buf, len);
+  loc = tftp_strnlen(buf, len);
   loc++; /* NULL term */
 
   if(loc >= len)
     return NULL;
   *option = buf;
 
-  loc += Curl_strnlen(buf + loc, len-loc);
+  loc += tftp_strnlen(buf + loc, len-loc);
   loc++; /* NULL term */
 
   if(loc > len)
@@ -1171,7 +1171,7 @@ static CURLcode tftp_receive_packet(struct connectdata *conn)
       char *str = (char *)state->rpacket.data + 4;
       size_t strn = state->rbytes - 4;
       state->error = (tftp_error_t)error;
-      if(Curl_strnlen(str, strn) < strn)
+      if(tftp_strnlen(str, strn) < strn)
         infof(data, "TFTP error: %s\n", str);
       break;
     }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -125,8 +125,8 @@ CURLcode Curl_get_upload_buffer(struct Curl_easy *data)
  * This function will be called to loop through the trailers buffer
  * until no more data is available for sending.
  */
-static size_t Curl_trailers_read(char *buffer, size_t size, size_t nitems,
-                                 void *raw)
+static size_t trailers_read(char *buffer, size_t size, size_t nitems,
+                            void *raw)
 {
   struct Curl_easy *data = (struct Curl_easy *)raw;
   struct dynbuf *trailers_buf = &data->state.trailers_buf;
@@ -142,7 +142,7 @@ static size_t Curl_trailers_read(char *buffer, size_t size, size_t nitems,
   return to_copy;
 }
 
-static size_t Curl_trailers_left(void *raw)
+static size_t trailers_left(void *raw)
 {
   struct Curl_easy *data = (struct Curl_easy *)raw;
   struct dynbuf *trailers_buf = &data->state.trailers_buf;
@@ -231,7 +231,7 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
        simply return to the previous point in the state machine as if
        nothing happened.
        */
-    readfunc = Curl_trailers_read;
+    readfunc = trailers_read;
     extra_data = (void *)data;
   }
   else
@@ -367,7 +367,7 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
 
 #ifndef CURL_DISABLE_HTTP
     if(data->state.trailers_state == TRAILERS_SENDING &&
-       !Curl_trailers_left(data)) {
+       !trailers_left(data)) {
       Curl_dyn_free(&data->state.trailers_buf);
       data->state.trailers_state = TRAILERS_DONE;
       data->set.trailer_data = NULL;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2019 - 2020, Michael Forney, <mforney@mforney.org>
+ * Copyright (C) 2019 - 2021, Michael Forney, <mforney@mforney.org>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -741,21 +741,21 @@ static CURLcode bearssl_connect_common(struct connectdata *conn,
   return CURLE_OK;
 }
 
-static size_t Curl_bearssl_version(char *buffer, size_t size)
+static size_t bearssl_version(char *buffer, size_t size)
 {
   return msnprintf(buffer, size, "BearSSL");
 }
 
-static bool Curl_bearssl_data_pending(const struct connectdata *conn,
-                                      int connindex)
+static bool bearssl_data_pending(const struct connectdata *conn,
+                                 int connindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   struct ssl_backend_data *backend = connssl->backend;
   return br_ssl_engine_current_state(&backend->ctx.eng) & BR_SSL_RECVAPP;
 }
 
-static CURLcode Curl_bearssl_random(struct Curl_easy *data UNUSED_PARAM,
-                                    unsigned char *entropy, size_t length)
+static CURLcode bearssl_random(struct Curl_easy *data UNUSED_PARAM,
+                               unsigned char *entropy, size_t length)
 {
   static br_hmac_drbg_context ctx;
   static bool seeded = FALSE;
@@ -774,7 +774,7 @@ static CURLcode Curl_bearssl_random(struct Curl_easy *data UNUSED_PARAM,
   return CURLE_OK;
 }
 
-static CURLcode Curl_bearssl_connect(struct connectdata *conn, int sockindex)
+static CURLcode bearssl_connect(struct connectdata *conn, int sockindex)
 {
   CURLcode ret;
   bool done = FALSE;
@@ -788,20 +788,20 @@ static CURLcode Curl_bearssl_connect(struct connectdata *conn, int sockindex)
   return CURLE_OK;
 }
 
-static CURLcode Curl_bearssl_connect_nonblocking(struct connectdata *conn,
-                                                 int sockindex, bool *done)
+static CURLcode bearssl_connect_nonblocking(struct connectdata *conn,
+                                            int sockindex, bool *done)
 {
   return bearssl_connect_common(conn, sockindex, TRUE, done);
 }
 
-static void *Curl_bearssl_get_internals(struct ssl_connect_data *connssl,
-                                        CURLINFO info UNUSED_PARAM)
+static void *bearssl_get_internals(struct ssl_connect_data *connssl,
+                                   CURLINFO info UNUSED_PARAM)
 {
   struct ssl_backend_data *backend = connssl->backend;
   return &backend->ctx;
 }
 
-static void Curl_bearssl_close(struct connectdata *conn, int sockindex)
+static void bearssl_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -816,15 +816,15 @@ static void Curl_bearssl_close(struct connectdata *conn, int sockindex)
   free(backend->anchors);
 }
 
-static void Curl_bearssl_session_free(void *ptr)
+static void bearssl_session_free(void *ptr)
 {
   free(ptr);
 }
 
-static CURLcode Curl_bearssl_md5sum(unsigned char *input,
-                                    size_t inputlen,
-                                    unsigned char *md5sum,
-                                    size_t md5len UNUSED_PARAM)
+static CURLcode bearssl_md5sum(unsigned char *input,
+                               size_t inputlen,
+                               unsigned char *md5sum,
+                               size_t md5len UNUSED_PARAM)
 {
   br_md5_context ctx;
 
@@ -834,10 +834,10 @@ static CURLcode Curl_bearssl_md5sum(unsigned char *input,
   return CURLE_OK;
 }
 
-static CURLcode Curl_bearssl_sha256sum(const unsigned char *input,
-                                       size_t inputlen,
-                                       unsigned char *sha256sum,
-                                       size_t sha256len UNUSED_PARAM)
+static CURLcode bearssl_sha256sum(const unsigned char *input,
+                                  size_t inputlen,
+                                  unsigned char *sha256sum,
+                                  size_t sha256len UNUSED_PARAM)
 {
   br_sha256_context ctx;
 
@@ -854,24 +854,24 @@ const struct Curl_ssl Curl_ssl_bearssl = {
 
   Curl_none_init,
   Curl_none_cleanup,
-  Curl_bearssl_version,
+  bearssl_version,
   Curl_none_check_cxn,
   Curl_none_shutdown,
-  Curl_bearssl_data_pending,
-  Curl_bearssl_random,
+  bearssl_data_pending,
+  bearssl_random,
   Curl_none_cert_status_request,
-  Curl_bearssl_connect,
-  Curl_bearssl_connect_nonblocking,
-  Curl_bearssl_get_internals,
-  Curl_bearssl_close,
+  bearssl_connect,
+  bearssl_connect_nonblocking,
+  bearssl_get_internals,
+  bearssl_close,
   Curl_none_close_all,
-  Curl_bearssl_session_free,
+  bearssl_session_free,
   Curl_none_set_engine,
   Curl_none_set_engine_default,
   Curl_none_engines_list,
   Curl_none_false_start,
-  Curl_bearssl_md5sum,
-  Curl_bearssl_sha256sum
+  bearssl_md5sum,
+  bearssl_sha256sum
 };
 
 #endif /* USE_BEARSSL */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2010 - 2011, Hoi-Ho Chan, <hoiho.chan@gmail.com>
- * Copyright (C) 2012 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -783,12 +783,12 @@ static ssize_t mbed_send(struct connectdata *conn, int sockindex,
   return ret;
 }
 
-static void Curl_mbedtls_close_all(struct Curl_easy *data)
+static void mbedtls_close_all(struct Curl_easy *data)
 {
   (void)data;
 }
 
-static void Curl_mbedtls_close(struct connectdata *conn, int sockindex)
+static void mbedtls_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -831,13 +831,13 @@ static ssize_t mbed_recv(struct connectdata *conn, int num,
   return len;
 }
 
-static void Curl_mbedtls_session_free(void *ptr)
+static void mbedtls_session_free(void *ptr)
 {
   mbedtls_ssl_session_free(ptr);
   free(ptr);
 }
 
-static size_t Curl_mbedtls_version(char *buffer, size_t size)
+static size_t mbedtls_version(char *buffer, size_t size)
 {
 #ifdef MBEDTLS_VERSION_C
   /* if mbedtls_version_get_number() is available it is better */
@@ -849,8 +849,8 @@ static size_t Curl_mbedtls_version(char *buffer, size_t size)
 #endif
 }
 
-static CURLcode Curl_mbedtls_random(struct Curl_easy *data,
-                                    unsigned char *entropy, size_t length)
+static CURLcode mbedtls_random(struct Curl_easy *data,
+                               unsigned char *entropy, size_t length)
 {
 #if defined(MBEDTLS_CTR_DRBG_C)
   int ret = -1;
@@ -1011,14 +1011,14 @@ mbed_connect_common(struct connectdata *conn,
   return CURLE_OK;
 }
 
-static CURLcode Curl_mbedtls_connect_nonblocking(struct connectdata *conn,
-                                                 int sockindex, bool *done)
+static CURLcode mbedtls_connect_nonblocking(struct connectdata *conn,
+                                            int sockindex, bool *done)
 {
   return mbed_connect_common(conn, sockindex, TRUE, done);
 }
 
 
-static CURLcode Curl_mbedtls_connect(struct connectdata *conn, int sockindex)
+static CURLcode mbedtls_connect(struct connectdata *conn, int sockindex)
 {
   CURLcode retcode;
   bool done = FALSE;
@@ -1036,28 +1036,28 @@ static CURLcode Curl_mbedtls_connect(struct connectdata *conn, int sockindex)
  * return 0 error initializing SSL
  * return 1 SSL initialized successfully
  */
-static int Curl_mbedtls_init(void)
+static int mbedtls_init(void)
 {
   return Curl_mbedtlsthreadlock_thread_setup();
 }
 
-static void Curl_mbedtls_cleanup(void)
+static void mbedtls_cleanup(void)
 {
   (void)Curl_mbedtlsthreadlock_thread_cleanup();
 }
 
-static bool Curl_mbedtls_data_pending(const struct connectdata *conn,
-                                      int sockindex)
+static bool mbedtls_data_pending(const struct connectdata *conn,
+                                 int sockindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   return mbedtls_ssl_get_bytes_avail(&backend->ssl) != 0;
 }
 
-static CURLcode Curl_mbedtls_sha256sum(const unsigned char *input,
-                                    size_t inputlen,
-                                    unsigned char *sha256sum,
-                                    size_t sha256len UNUSED_PARAM)
+static CURLcode mbedtls_sha256sum(const unsigned char *input,
+                                  size_t inputlen,
+                                  unsigned char *sha256sum,
+                                  size_t sha256len UNUSED_PARAM)
 {
   (void)sha256len;
 #if MBEDTLS_VERSION_NUMBER < 0x02070000
@@ -1070,8 +1070,8 @@ static CURLcode Curl_mbedtls_sha256sum(const unsigned char *input,
   return CURLE_OK;
 }
 
-static void *Curl_mbedtls_get_internals(struct ssl_connect_data *connssl,
-                                        CURLINFO info UNUSED_PARAM)
+static void *mbedtls_get_internals(struct ssl_connect_data *connssl,
+                                   CURLINFO info UNUSED_PARAM)
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
@@ -1087,26 +1087,26 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
 
   sizeof(struct ssl_backend_data),
 
-  Curl_mbedtls_init,                /* init */
-  Curl_mbedtls_cleanup,             /* cleanup */
-  Curl_mbedtls_version,             /* version */
+  mbedtls_init,                     /* init */
+  mbedtls_cleanup,                  /* cleanup */
+  mbedtls_version,                  /* version */
   Curl_none_check_cxn,              /* check_cxn */
   Curl_none_shutdown,               /* shutdown */
-  Curl_mbedtls_data_pending,        /* data_pending */
-  Curl_mbedtls_random,              /* random */
+  mbedtls_data_pending,             /* data_pending */
+  mbedtls_random,                   /* random */
   Curl_none_cert_status_request,    /* cert_status_request */
-  Curl_mbedtls_connect,             /* connect */
-  Curl_mbedtls_connect_nonblocking, /* connect_nonblocking */
-  Curl_mbedtls_get_internals,       /* get_internals */
-  Curl_mbedtls_close,               /* close_one */
-  Curl_mbedtls_close_all,           /* close_all */
-  Curl_mbedtls_session_free,        /* session_free */
+  mbedtls_connect,                  /* connect */
+  mbedtls_connect_nonblocking,      /* connect_nonblocking */
+  mbedtls_get_internals,            /* get_internals */
+  mbedtls_close,                    /* close_one */
+  mbedtls_close_all,                /* close_all */
+  mbedtls_session_free,             /* session_free */
   Curl_none_set_engine,             /* set_engine */
   Curl_none_set_engine_default,     /* set_engine_default */
   Curl_none_engines_list,           /* engines_list */
   Curl_none_false_start,            /* false_start */
   Curl_none_md5sum,                 /* md5sum */
-  Curl_mbedtls_sha256sum            /* sha256sum */
+  mbedtls_sha256sum                 /* sha256sum */
 };
 
 #endif /* USE_MBEDTLS */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -587,7 +587,7 @@ static CURLcode nss_cache_crl(SECItem *crl_der)
     return CURLE_SSL_CRL_BADFILE;
   }
 
-  /* store the CRL item so that we can free it in Curl_nss_cleanup() */
+  /* store the CRL item so that we can free it in nss_cleanup() */
   if(insert_wrapped_ptr(&nss_crl_list, crl_der) != CURLE_OK) {
     if(SECSuccess == CERT_UncacheCRL(db, crl_der))
       SECITEM_FreeItem(crl_der, PR_TRUE);
@@ -1335,7 +1335,7 @@ static CURLcode nss_init_core(struct Curl_easy *data, const char *cert_dir)
 
     infof(data, "Initializing NSS with certpath: %s\n", certpath);
     nss_context = NSS_InitContext(certpath, "", "", "", &initparams,
-            NSS_INIT_READONLY | NSS_INIT_PK11RELOAD);
+                                  NSS_INIT_READONLY | NSS_INIT_PK11RELOAD);
     free(certpath);
 
     if(nss_context != NULL)
@@ -1360,7 +1360,7 @@ static CURLcode nss_init_core(struct Curl_easy *data, const char *cert_dir)
 }
 
 /* data might be NULL */
-static CURLcode nss_init(struct Curl_easy *data)
+static CURLcode nss_setup(struct Curl_easy *data)
 {
   char *cert_dir;
   struct_stat st;
@@ -1369,7 +1369,7 @@ static CURLcode nss_init(struct Curl_easy *data)
   if(initialized)
     return CURLE_OK;
 
-  /* list of all CRL items we need to destroy in Curl_nss_cleanup() */
+  /* list of all CRL items we need to destroy in nss_cleanup() */
   Curl_llist_init(&nss_crl_list, nss_destroy_crl_item);
 
   /* First we check if $SSL_DIR points to a valid dir */
@@ -1423,7 +1423,7 @@ static CURLcode nss_init(struct Curl_easy *data)
  * @retval 0 error initializing SSL
  * @retval 1 SSL initialized successfully
  */
-static int Curl_nss_init(void)
+static int nss_init(void)
 {
   /* curl_global_init() is not thread-safe so this test is ok */
   if(nss_initlock == NULL) {
@@ -1451,14 +1451,14 @@ CURLcode Curl_nss_force_init(struct Curl_easy *data)
   }
 
   PR_Lock(nss_initlock);
-  result = nss_init(data);
+  result = nss_setup(data);
   PR_Unlock(nss_initlock);
 
   return result;
 }
 
 /* Global cleanup */
-static void Curl_nss_cleanup(void)
+static void nss_cleanup(void)
 {
   /* This function isn't required to be threadsafe and this is only done
    * as a safety feature.
@@ -1498,7 +1498,7 @@ static void Curl_nss_cleanup(void)
  *     0 means the connection has been closed
  *    -1 means the connection status is unknown
  */
-static int Curl_nss_check_cxn(struct connectdata *conn)
+static int nss_check_cxn(struct connectdata *conn)
 {
   struct ssl_connect_data *connssl = &conn->ssl[FIRSTSOCKET];
   struct ssl_backend_data *backend = connssl->backend;
@@ -1517,7 +1517,7 @@ static int Curl_nss_check_cxn(struct connectdata *conn)
   return -1;  /* connection status unknown */
 }
 
-static void nss_close(struct ssl_connect_data *connssl)
+static void close_one(struct ssl_connect_data *connssl)
 {
   /* before the cleanup, check whether we are using a client certificate */
   struct ssl_backend_data *backend = connssl->backend;
@@ -1547,7 +1547,7 @@ static void nss_close(struct ssl_connect_data *connssl)
 /*
  * This function is called when an SSL connection is closed.
  */
-static void Curl_nss_close(struct connectdata *conn, int sockindex)
+static void nss_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 #ifndef CURL_DISABLE_PROXY
@@ -1573,9 +1573,9 @@ static void Curl_nss_close(struct connectdata *conn, int sockindex)
        a double close leading to crash. */
     connssl_proxy->backend->handle = NULL;
 
-  nss_close(connssl_proxy);
+  close_one(connssl_proxy);
 #endif
-  nss_close(connssl);
+  close_one(connssl);
 }
 
 /* return true if NSS can provide error code (and possibly msg) for the
@@ -1853,7 +1853,7 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
   Curl_llist_init(&backend->obj_list, nss_destroy_object);
 
   PR_Lock(nss_initlock);
-  result = nss_init(conn->data);
+  result = nss_setup(conn->data);
   if(result) {
     PR_Unlock(nss_initlock);
     goto error;
@@ -2249,13 +2249,13 @@ static CURLcode nss_connect_common(struct connectdata *conn, int sockindex,
   return CURLE_OK;
 }
 
-static CURLcode Curl_nss_connect(struct connectdata *conn, int sockindex)
+static CURLcode nss_connect(struct connectdata *conn, int sockindex)
 {
   return nss_connect_common(conn, sockindex, /* blocking */ NULL);
 }
 
-static CURLcode Curl_nss_connect_nonblocking(struct connectdata *conn,
-                                             int sockindex, bool *done)
+static CURLcode nss_connect_nonblocking(struct connectdata *conn,
+                                        int sockindex, bool *done)
 {
   return nss_connect_common(conn, sockindex, done);
 }
@@ -2339,7 +2339,7 @@ static ssize_t nss_recv(struct connectdata *conn,  /* connection data */
   return nread;
 }
 
-static size_t Curl_nss_version(char *buffer, size_t size)
+static size_t nss_version(char *buffer, size_t size)
 {
   return msnprintf(buffer, size, "NSS/%s", NSS_VERSION);
 }
@@ -2352,9 +2352,9 @@ static int Curl_nss_seed(struct Curl_easy *data)
 }
 
 /* data might be NULL */
-static CURLcode Curl_nss_random(struct Curl_easy *data,
-                                unsigned char *entropy,
-                                size_t length)
+static CURLcode nss_random(struct Curl_easy *data,
+                           unsigned char *entropy,
+                           size_t length)
 {
   Curl_nss_seed(data);  /* Initiate the seed if not already done */
 
@@ -2365,10 +2365,10 @@ static CURLcode Curl_nss_random(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode Curl_nss_md5sum(unsigned char *tmp, /* input */
-                                size_t tmplen,
-                                unsigned char *md5sum, /* output */
-                                size_t md5len)
+static CURLcode nss_md5sum(unsigned char *tmp, /* input */
+                           size_t tmplen,
+                           unsigned char *md5sum, /* output */
+                           size_t md5len)
 {
   PK11Context *MD5pw = PK11_CreateDigestContext(SEC_OID_MD5);
   unsigned int MD5out;
@@ -2383,10 +2383,10 @@ static CURLcode Curl_nss_md5sum(unsigned char *tmp, /* input */
   return CURLE_OK;
 }
 
-static CURLcode Curl_nss_sha256sum(const unsigned char *tmp, /* input */
-                               size_t tmplen,
-                               unsigned char *sha256sum, /* output */
-                               size_t sha256len)
+static CURLcode nss_sha256sum(const unsigned char *tmp, /* input */
+                              size_t tmplen,
+                              unsigned char *sha256sum, /* output */
+                              size_t sha256len)
 {
   PK11Context *SHA256pw = PK11_CreateDigestContext(SEC_OID_SHA256);
   unsigned int SHA256out;
@@ -2401,7 +2401,7 @@ static CURLcode Curl_nss_sha256sum(const unsigned char *tmp, /* input */
   return CURLE_OK;
 }
 
-static bool Curl_nss_cert_status_request(void)
+static bool nss_cert_status_request(void)
 {
 #ifdef SSL_ENABLE_OCSP_STAPLING
   return TRUE;
@@ -2410,7 +2410,7 @@ static bool Curl_nss_cert_status_request(void)
 #endif
 }
 
-static bool Curl_nss_false_start(void)
+static bool nss_false_start(void)
 {
 #if NSSVERNUM >= 0x030f04 /* 3.15.4 */
   return TRUE;
@@ -2419,7 +2419,7 @@ static bool Curl_nss_false_start(void)
 #endif
 }
 
-static void *Curl_nss_get_internals(struct ssl_connect_data *connssl,
+static void *nss_get_internals(struct ssl_connect_data *connssl,
                                     CURLINFO info UNUSED_PARAM)
 {
   struct ssl_backend_data *backend = connssl->backend;
@@ -2437,28 +2437,28 @@ const struct Curl_ssl Curl_ssl_nss = {
 
   sizeof(struct ssl_backend_data),
 
-  Curl_nss_init,                /* init */
-  Curl_nss_cleanup,             /* cleanup */
-  Curl_nss_version,             /* version */
-  Curl_nss_check_cxn,           /* check_cxn */
+  nss_init,                     /* init */
+  nss_cleanup,                  /* cleanup */
+  nss_version,                  /* version */
+  nss_check_cxn,                /* check_cxn */
   /* NSS has no shutdown function provided and thus always fail */
   Curl_none_shutdown,           /* shutdown */
   Curl_none_data_pending,       /* data_pending */
-  Curl_nss_random,              /* random */
-  Curl_nss_cert_status_request, /* cert_status_request */
-  Curl_nss_connect,             /* connect */
-  Curl_nss_connect_nonblocking, /* connect_nonblocking */
-  Curl_nss_get_internals,       /* get_internals */
-  Curl_nss_close,               /* close_one */
+  nss_random,                   /* random */
+  nss_cert_status_request,      /* cert_status_request */
+  nss_connect,                  /* connect */
+  nss_connect_nonblocking,      /* connect_nonblocking */
+  nss_get_internals,            /* get_internals */
+  nss_close,                    /* close_one */
   Curl_none_close_all,          /* close_all */
   /* NSS has its own session ID cache */
   Curl_none_session_free,       /* session_free */
   Curl_none_set_engine,         /* set_engine */
   Curl_none_set_engine_default, /* set_engine_default */
   Curl_none_engines_list,       /* engines_list */
-  Curl_nss_false_start,         /* false_start */
-  Curl_nss_md5sum,              /* md5sum */
-  Curl_nss_sha256sum            /* sha256sum */
+  nss_false_start,              /* false_start */
+  nss_md5sum,                   /* md5sum */
+  nss_sha256sum                 /* sha256sum */
 };
 
 #endif /* USE_NSS */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -839,7 +839,7 @@ static ssize_t wolfssl_send(struct connectdata *conn,
   return rc;
 }
 
-static void Curl_wolfssl_close(struct connectdata *conn, int sockindex)
+static void wolfssl_close(struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -890,14 +890,14 @@ static ssize_t wolfssl_recv(struct connectdata *conn,
 }
 
 
-static void Curl_wolfssl_session_free(void *ptr)
+static void wolfssl_session_free(void *ptr)
 {
   (void)ptr;
   /* wolfSSL reuses sessions on own, no free */
 }
 
 
-static size_t Curl_wolfssl_version(char *buffer, size_t size)
+static size_t wolfssl_version(char *buffer, size_t size)
 {
 #if LIBWOLFSSL_VERSION_HEX >= 0x03006000
   return msnprintf(buffer, size, "wolfSSL/%s", wolfSSL_lib_version());
@@ -907,7 +907,7 @@ static size_t Curl_wolfssl_version(char *buffer, size_t size)
 }
 
 
-static int Curl_wolfssl_init(void)
+static int wolfssl_init(void)
 {
 #ifdef OPENSSL_EXTRA
   Curl_tls_keylog_open();
@@ -916,7 +916,7 @@ static int Curl_wolfssl_init(void)
 }
 
 
-static void Curl_wolfssl_cleanup(void)
+static void wolfssl_cleanup(void)
 {
   wolfSSL_Cleanup();
 #ifdef OPENSSL_EXTRA
@@ -925,8 +925,8 @@ static void Curl_wolfssl_cleanup(void)
 }
 
 
-static bool Curl_wolfssl_data_pending(const struct connectdata *conn,
-                                      int connindex)
+static bool wolfssl_data_pending(const struct connectdata *conn,
+                                 int connindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -941,7 +941,7 @@ static bool Curl_wolfssl_data_pending(const struct connectdata *conn,
  * This function is called to shut down the SSL layer but keep the
  * socket open (CCC - Clear Command Channel)
  */
-static int Curl_wolfssl_shutdown(struct connectdata *conn, int sockindex)
+static int wolfssl_shutdown(struct connectdata *conn, int sockindex)
 {
   int retval = 0;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
@@ -1068,14 +1068,14 @@ wolfssl_connect_common(struct connectdata *conn,
 }
 
 
-static CURLcode Curl_wolfssl_connect_nonblocking(struct connectdata *conn,
-                                                int sockindex, bool *done)
+static CURLcode wolfssl_connect_nonblocking(struct connectdata *conn,
+                                            int sockindex, bool *done)
 {
   return wolfssl_connect_common(conn, sockindex, TRUE, done);
 }
 
 
-static CURLcode Curl_wolfssl_connect(struct connectdata *conn, int sockindex)
+static CURLcode wolfssl_connect(struct connectdata *conn, int sockindex)
 {
   CURLcode result;
   bool done = FALSE;
@@ -1089,8 +1089,8 @@ static CURLcode Curl_wolfssl_connect(struct connectdata *conn, int sockindex)
   return CURLE_OK;
 }
 
-static CURLcode Curl_wolfssl_random(struct Curl_easy *data,
-                                   unsigned char *entropy, size_t length)
+static CURLcode wolfssl_random(struct Curl_easy *data,
+                               unsigned char *entropy, size_t length)
 {
   WC_RNG rng;
   (void)data;
@@ -1105,10 +1105,10 @@ static CURLcode Curl_wolfssl_random(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode Curl_wolfssl_sha256sum(const unsigned char *tmp, /* input */
-                                       size_t tmplen,
-                                       unsigned char *sha256sum /* output */,
-                                       size_t unused)
+static CURLcode wolfssl_sha256sum(const unsigned char *tmp, /* input */
+                                  size_t tmplen,
+                                  unsigned char *sha256sum /* output */,
+                                  size_t unused)
 {
   wc_Sha256 SHA256pw;
   (void)unused;
@@ -1118,7 +1118,7 @@ static CURLcode Curl_wolfssl_sha256sum(const unsigned char *tmp, /* input */
   return CURLE_OK;
 }
 
-static void *Curl_wolfssl_get_internals(struct ssl_connect_data *connssl,
+static void *wolfssl_get_internals(struct ssl_connect_data *connssl,
                                         CURLINFO info UNUSED_PARAM)
 {
   struct ssl_backend_data *backend = connssl->backend;
@@ -1136,26 +1136,26 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
 
   sizeof(struct ssl_backend_data),
 
-  Curl_wolfssl_init,                /* init */
-  Curl_wolfssl_cleanup,             /* cleanup */
-  Curl_wolfssl_version,             /* version */
+  wolfssl_init,                    /* init */
+  wolfssl_cleanup,                 /* cleanup */
+  wolfssl_version,                 /* version */
   Curl_none_check_cxn,             /* check_cxn */
-  Curl_wolfssl_shutdown,            /* shutdown */
-  Curl_wolfssl_data_pending,        /* data_pending */
-  Curl_wolfssl_random,              /* random */
+  wolfssl_shutdown,                /* shutdown */
+  wolfssl_data_pending,            /* data_pending */
+  wolfssl_random,                  /* random */
   Curl_none_cert_status_request,   /* cert_status_request */
-  Curl_wolfssl_connect,             /* connect */
-  Curl_wolfssl_connect_nonblocking, /* connect_nonblocking */
-  Curl_wolfssl_get_internals,       /* get_internals */
-  Curl_wolfssl_close,               /* close_one */
+  wolfssl_connect,                 /* connect */
+  wolfssl_connect_nonblocking,     /* connect_nonblocking */
+  wolfssl_get_internals,           /* get_internals */
+  wolfssl_close,                   /* close_one */
   Curl_none_close_all,             /* close_all */
-  Curl_wolfssl_session_free,        /* session_free */
+  wolfssl_session_free,            /* session_free */
   Curl_none_set_engine,            /* set_engine */
   Curl_none_set_engine_default,    /* set_engine_default */
   Curl_none_engines_list,          /* engines_list */
   Curl_none_false_start,           /* false_start */
   Curl_none_md5sum,                /* md5sum */
-  Curl_wolfssl_sha256sum            /* sha256sum */
+  wolfssl_sha256sum                /* sha256sum */
 };
 
 #endif


### PR DESCRIPTION
... as we reserve this prefix to library-wide functions.