### PR TITLE
mime: make sure setting MIMEPOST to NULL resets properly

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1168,6 +1168,7 @@ static void cleanup_part_content(curl_mimepart *part)
   part->kind = MIMEKIND_NONE;
   part->flags &= ~MIME_FAST_READ;
   part->lastreadstatus = 1; /* Successful read status. */
+  part->state.state = MIMESTATE_BEGIN;
 }
 
 static void mime_subparts_free(void *ptr)

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -79,7 +79,7 @@ test545 test546 test547 test548 test549 test550 test551 test552 test553 \
 test554 test555 test556 test557 test558 test559 test560 test561 test562 \
 test563 test564 test565 test566 test567 test568 test569 test570 test571 \
 test572 test573 test574 test575 test576 test577 test578 test579 test580 \
-test581 test582 test583         test585 test586 test587 test588 test589 \
+test581 test582 test583 test584 test585 test586 test587 test588 test589 \
 test590 test591 test592 test593 test594 test595 test596 test597 test598 \
 test599 test600 test601 test602 test603 test604 test605 test606 test607 \
 test608 test609 test610 test611 test612 test613 test614 test615 test616 \

--- a/tests/data/test584
+++ b/tests/data/test584
@@ -1,0 +1,77 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+HTTP MIME
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 3
+
+OK
+</data>
+<datacheck>
+HTTP/1.1 200 OK swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 3
+
+OK
+HTTP/1.1 200 OK swsclose
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 3
+
+OK
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool to invoke
+<tool>
+lib584
+</tool>
+
+ <name>
+CURLOPT_MIMEPOST first set then set to NULL
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/584
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+POST /584 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Content-Length: 144
+Content-Type: multipart/form-data; boundary=------------------------3433323135333231
+
+--------------------------3433323135333231
+Content-Disposition: form-data; name="fake"
+
+party
+--------------------------3433323135333231--
+POST /584 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Content-Length: 0
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test584
+++ b/tests/data/test584
@@ -55,18 +55,22 @@ http://%HOSTIP:%HTTPPORT/584
 #
 # Verify data after the test has been "shot"
 <verify>
+<strippart>
+s/^--------------------------[a-z0-9]*/--------------------------/
+s/boundary=------------------------[a-z0-9]*/boundary=------------------------/
+</strippart>
 <protocol>
 POST /584 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
 Content-Length: 144
-Content-Type: multipart/form-data; boundary=------------------------3433323135333231
+Content-Type: multipart/form-data; boundary=------------------------
 
---------------------------3433323135333231
+--------------------------
 Content-Disposition: form-data; name="fake"
 
 party
---------------------------3433323135333231--
+----------------------------
 POST /584 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -44,7 +44,8 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib547 lib548 lib549 lib552 lib553 lib554 lib555 lib556 lib557 lib558   \
  lib559 lib560 lib562 lib564 lib565 lib566 lib567 lib568 lib569 lib570   \
  lib571 lib572 lib573 lib574 lib575 lib576        lib578 lib579 lib582   \
- lib583 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598 lib599   \
+ lib583 lib584 lib585 lib586 lib587 lib589 lib590 lib591 lib597 lib598   \
+ lib599 \
  lib643 lib644 lib645 lib650 lib651 lib652 lib653 lib654 lib655 lib658   \
  lib659 lib661 lib666 lib667 lib668 \
  lib670 lib671 lib672 lib673 lib674 \
@@ -301,6 +302,9 @@ lib582_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib583_SOURCES = lib583.c $(SUPPORTFILES)
 lib583_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib584_SOURCES = lib589.c $(SUPPORTFILES)
+lib584_CPPFLAGS = $(AM_CPPFLAGS) -DLIB584
 
 lib585_SOURCES = lib500.c $(SUPPORTFILES) $(TESTUTIL) $(TSTTRACE) $(MULTIBYTE)
 lib585_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib589.c
+++ b/tests/libtest/lib589.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -42,9 +42,22 @@ int test(char *URL)
 
   /* First set the URL that is about to receive our POST. */
   test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_MIMEPOST, NULL);
   test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
   test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
+
+#ifdef LIB584
+  {
+    curl_mime *mime = curl_mime_init(curl);
+    curl_mimepart *part = curl_mime_addpart(mime);
+    curl_mime_name(part, "fake");
+    curl_mime_data(part, "party", 5);
+    test_setopt(curl, CURLOPT_MIMEPOST, mime);
+    res = curl_easy_perform(curl);
+    curl_mime_free(mime);
+  }
+#endif
+
+  test_setopt(curl, CURLOPT_MIMEPOST, NULL);
 
   /* Now, we should be making a zero byte POST request */
   res = curl_easy_perform(curl);


### PR DESCRIPTION
... so that a function can first use MIMEPOST and then set it to NULL to
reset it back to a blank POST.

Added test 584 to verify the fix.

Reported-by: Christoph M. Becker

Fixes #6455