### PR TITLE
Schannel: plug a memory-leak

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -522,7 +522,7 @@ static CURLcode verify_host(struct Curl_easy *data,
     failf(data, "schannel: server certificate name verification failed");
 
 cleanup:
-  curlx_unicodefree(cert_hostname_buff);
+  curl_safefree(cert_hostname_buff);
 
   return result;
 }


### PR DESCRIPTION
Building with `DEBUGBUILD` and issuing these commands:
```
c:\> set CURL_SSL_BACKEND=schannel
c:\> curl.exe https://www.vg.no > NUL
c:\> perl tests\memanalyze.pl \gv\tmp\memdebug.curl
```

This tool reports:
```
Leak detected: memory still allocated: 379 bytes
At d354420, there's 379 bytes.
 allocated by vtls/schannel_verify.c:446
```
I did **not** build with `-DUNICODE`. Hence that `curlx_unicodefree(cert_hostname_buff)` was a no-op and 
responsible for the leak. Surely it should be `free()`'d regardless of `-DUNICODE`. No?