### PR TITLE
multibyte: turn the unicodefree macro into uppercase

### DIFF
--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -36,7 +36,7 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
 
 /*
  * Macros curlx_convert_UTF8_to_tchar(), curlx_convert_tchar_to_UTF8()
- * and curlx_unicodefree() main purpose is to minimize the number of
+ * and CURLX_UNICODEFREE() main purpose is to minimize the number of
  * preprocessor conditional directives needed by code using these
  * to differentiate UNICODE from non-UNICODE builds.
  *
@@ -44,22 +44,24 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
  * curlx_convert_UTF8_to_tchar() and curlx_convert_tchar_to_UTF8()
  * return a pointer to a newly allocated memory area holding result.
  * When the result is no longer needed, allocated memory is intended
- * to be free'ed with curlx_unicodefree().
+ * to be free'ed with CURLX_UNICODEFREE().
  *
  * When building without UNICODE defined, this macros
  * curlx_convert_UTF8_to_tchar() and curlx_convert_tchar_to_UTF8()
- * return the pointer received as argument. curlx_unicodefree() does
- * no actual free'ing of this pointer it is simply set to NULL.
+ * return the pointer received as argument.
+ *
+ * CURLX_UNICODEFREE() does no actual free'ing of this pointer it is simply
+ * set to NULL.
  */
 
 #if defined(UNICODE) && defined(WIN32)
 
 #define curlx_convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
 #define curlx_convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
-#define curlx_unicodefree(ptr)                          \
+#define CURLX_UNICODEFREE(ptr)                          \
   do {                                                  \
     if(ptr) {                                           \
-      (free)(ptr);                                        \
+      (free)(ptr);                                      \
       (ptr) = NULL;                                     \
     }                                                   \
   } while(0)
@@ -75,7 +77,7 @@ typedef union {
 
 #define curlx_convert_UTF8_to_tchar(ptr) (ptr)
 #define curlx_convert_tchar_to_UTF8(ptr) (ptr)
-#define curlx_unicodefree(ptr) \
+#define CURLX_UNICODEFREE(ptr) \
   do {(ptr) = NULL;} while(0)
 
 typedef union {

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -174,7 +174,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   /* Setup the identity's user and length */
   dup_user.tchar_ptr = _tcsdup(user.tchar_ptr);
   if(!dup_user.tchar_ptr) {
-    curlx_unicodefree(useranddomain.tchar_ptr);
+    CURLX_UNICODEFREE(useranddomain.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
   }
   identity->User = dup_user.tbyte_ptr;
@@ -184,7 +184,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   /* Setup the identity's domain and length */
   dup_domain.tchar_ptr = malloc(sizeof(TCHAR) * (domlen + 1));
   if(!dup_domain.tchar_ptr) {
-    curlx_unicodefree(useranddomain.tchar_ptr);
+    CURLX_UNICODEFREE(useranddomain.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
   }
   _tcsncpy(dup_domain.tchar_ptr, domain.tchar_ptr, domlen);
@@ -193,7 +193,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   identity->DomainLength = curlx_uztoul(domlen);
   dup_domain.tchar_ptr = NULL;
 
-  curlx_unicodefree(useranddomain.tchar_ptr);
+  CURLX_UNICODEFREE(useranddomain.tchar_ptr);
 
   /* Setup the identity's password and length */
   passwd.tchar_ptr = curlx_convert_UTF8_to_tchar((char *)passwdp);
@@ -201,14 +201,14 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
     return CURLE_OUT_OF_MEMORY;
   dup_passwd.tchar_ptr = _tcsdup(passwd.tchar_ptr);
   if(!dup_passwd.tchar_ptr) {
-    curlx_unicodefree(passwd.tchar_ptr);
+    CURLX_UNICODEFREE(passwd.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
   }
   identity->Password = dup_passwd.tbyte_ptr;
   identity->PasswordLength = curlx_uztoul(_tcslen(dup_passwd.tchar_ptr));
   dup_passwd.tchar_ptr = NULL;
 
-  curlx_unicodefree(passwd.tchar_ptr);
+  CURLX_UNICODEFREE(passwd.tchar_ptr);
 
   /* Setup the identity's flags */
   identity->Flags = SECFLAG_WINNT_AUTH_IDENTITY;

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -60,7 +60,7 @@
   curlx_convert_wchar_to_UTF8()
   curlx_convert_UTF8_to_tchar()
   curlx_convert_tchar_to_UTF8()
-  curlx_unicodefree()
+  CURLX_UNICODEFREE()
 */
 
 #include "version_win32.h"

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -246,8 +246,8 @@ static int ldap_win_bind(struct connectdata *conn, LDAP *server,
 
     rc = ldap_simple_bind_s(server, inuser, inpass);
 
-    curlx_unicodefree(inuser);
-    curlx_unicodefree(inpass);
+    CURLX_UNICODEFREE(inuser);
+    CURLX_UNICODEFREE(inpass);
   }
 #if defined(USE_WINDOWS_SSPI)
   else {
@@ -260,7 +260,7 @@ static int ldap_win_bind(struct connectdata *conn, LDAP *server,
 #endif /* #if defined(USE_WIN32_LDAP) */
 
 #if defined(USE_WIN32_LDAP)
-#define FREE_ON_WINLDAP(x) curlx_unicodefree(x)
+#define FREE_ON_WINLDAP(x) CURLX_UNICODEFREE(x)
 #else
 #define FREE_ON_WINLDAP(x)
 #endif
@@ -873,7 +873,7 @@ static int _ldap_url_parse2(const struct connectdata *conn, LDAPURLDesc *ludp)
     ludp->lud_dn = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    curlx_unicodefree(unescaped);
+    CURLX_UNICODEFREE(unescaped);
 
     if(!ludp->lud_dn) {
       rc = LDAP_NO_MEMORY;
@@ -941,7 +941,7 @@ static int _ldap_url_parse2(const struct connectdata *conn, LDAPURLDesc *ludp)
       ludp->lud_attrs[i] = curlx_convert_UTF8_to_tchar(unescaped);
 
       /* Free the unescaped string as we are done with it */
-      curlx_unicodefree(unescaped);
+      CURLX_UNICODEFREE(unescaped);
 
       if(!ludp->lud_attrs[i]) {
         free(attributes);
@@ -1009,7 +1009,7 @@ static int _ldap_url_parse2(const struct connectdata *conn, LDAPURLDesc *ludp)
     ludp->lud_filter = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    curlx_unicodefree(unescaped);
+    CURLX_UNICODEFREE(unescaped);
 
     if(!ludp->lud_filter) {
       rc = LDAP_NO_MEMORY;

--- a/lib/rename.c
+++ b/lib/rename.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2020 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,14 +49,14 @@ int Curl_rename(const char *oldpath, const char *newpath)
   for(;;) {
     timediff_t diff;
     if(MoveFileEx(tchar_oldpath, tchar_newpath, MOVEFILE_REPLACE_EXISTING)) {
-      curlx_unicodefree(tchar_oldpath);
-      curlx_unicodefree(tchar_newpath);
+      CURLX_UNICODEFREE(tchar_oldpath);
+      CURLX_UNICODEFREE(tchar_newpath);
       break;
     }
     diff = Curl_timediff(Curl_now(), start);
     if(diff < 0 || diff > max_wait_ms) {
-      curlx_unicodefree(tchar_oldpath);
-      curlx_unicodefree(tchar_newpath);
+      CURLX_UNICODEFREE(tchar_oldpath);
+      CURLX_UNICODEFREE(tchar_newpath);
       return 1;
     }
     Sleep(1);

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  * Copyright (C) 2009, 2011, Markus Moeller, <markus_moeller@compuserve.com>
  *
  * This software is licensed as described in the file COPYING, which
@@ -180,7 +180,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
                                                  &sspi_ret_flags,
                                                  &expiry);
 
-    curlx_unicodefree(sname);
+    CURLX_UNICODEFREE(sname);
 
     if(sspi_recv_token.pvBuffer) {
       s_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2012 - 2016, Marc Hoersken, <info@marc-hoersken.de>
  * Copyright (C) 2012, Mark Salisbury, <mark.salisbury@hp.com>
- * Copyright (C) 2012 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -622,7 +622,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
           failf(data, "schannel: Failed to get certificate location"
                 " or file for %s",
                 data->set.ssl.primary.clientcert);
-          curlx_unicodefree(cert_path);
+          CURLX_UNICODEFREE(cert_path);
           return result;
         }
       }
@@ -632,7 +632,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
         failf(data, "schannel: certificate format compatibility error "
                 " for %s",
                 blob ? "(memory blob)" : data->set.ssl.primary.clientcert);
-        curlx_unicodefree(cert_path);
+        CURLX_UNICODEFREE(cert_path);
         return CURLE_SSL_CERTPROBLEM;
       }
 
@@ -647,7 +647,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
         int str_w_len = 0;
         const char *cert_showfilename_error = blob ?
           "(memory blob)" : data->set.ssl.primary.clientcert;
-        curlx_unicodefree(cert_path);
+        CURLX_UNICODEFREE(cert_path);
         if(fInCert) {
           long cert_tell = 0;
           bool continue_reading = fseek(fInCert, 0, SEEK_END) == 0;
@@ -736,7 +736,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
                 "last error is 0x%x",
                 cert_store_name, cert_store_path, GetLastError());
           free(cert_store_path);
-          curlx_unicodefree(cert_path);
+          CURLX_UNICODEFREE(cert_path);
           return CURLE_SSL_CERTPROBLEM;
         }
         free(cert_store_path);
@@ -750,7 +750,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
                                 cert_thumbprint_data,
                                 &cert_thumbprint.cbData,
                                 NULL, NULL)) {
-          curlx_unicodefree(cert_path);
+          CURLX_UNICODEFREE(cert_path);
           CertCloseStore(cert_store, 0);
           return CURLE_SSL_CERTPROBLEM;
         }
@@ -759,7 +759,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
           cert_store, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0,
           CERT_FIND_HASH, &cert_thumbprint, NULL);
 
-        curlx_unicodefree(cert_path);
+        CURLX_UNICODEFREE(cert_path);
 
         if(client_certs[0]) {
           schannel_cred.cCreds = 1;
@@ -920,7 +920,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     0, &BACKEND->ctxt->ctxt_handle,
     &outbuf_desc, &BACKEND->ret_flags, &BACKEND->ctxt->time_stamp);
 
-  curlx_unicodefree(host_name);
+  CURLX_UNICODEFREE(host_name);
 
   if(sspi_status != SEC_I_CONTINUE_NEEDED) {
     char buffer[STRERROR_LEN];
@@ -1118,7 +1118,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
       host_name, BACKEND->req_flags, 0, 0, &inbuf_desc, 0, NULL,
       &outbuf_desc, &BACKEND->ret_flags, &BACKEND->ctxt->time_stamp);
 
-    curlx_unicodefree(host_name);
+    CURLX_UNICODEFREE(host_name);
 
     /* free buffer for received handshake data */
     Curl_safefree(inbuf[0].pvBuffer);
@@ -2176,7 +2176,7 @@ static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
       &BACKEND->ret_flags,
       &BACKEND->ctxt->time_stamp);
 
-    curlx_unicodefree(host_name);
+    CURLX_UNICODEFREE(host_name);
 
     if((sspi_status == SEC_E_OK) || (sspi_status == SEC_I_CONTEXT_EXPIRED)) {
       /* send close message which is in output buffer */

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2012 - 2016, Marc Hoersken, <info@marc-hoersken.de>
  * Copyright (C) 2012, Mark Salisbury, <mark.salisbury@hp.com>
- * Copyright (C) 2012 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -288,7 +288,7 @@ cleanup:
     CloseHandle(ca_file_handle);
   }
   Curl_safefree(ca_file_buffer);
-  curlx_unicodefree(ca_file_tstr);
+  CURLX_UNICODEFREE(ca_file_tstr);
 
   return result;
 }
@@ -508,7 +508,7 @@ static CURLcode verify_host(struct Curl_easy *data,
 
         result = CURLE_PEER_FAILED_VERIFICATION;
       }
-      curlx_unicodefree(cert_hostname);
+      CURLX_UNICODEFREE(cert_hostname);
     }
   }
 
@@ -522,7 +522,7 @@ static CURLcode verify_host(struct Curl_easy *data,
     failf(data, "schannel: server certificate name verification failed");
 
 cleanup:
-  curlx_unicodefree(cert_hostname_buff);
+  CURLX_UNICODEFREE(cert_hostname_buff);
 
   return result;
 }

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,7 +49,7 @@ curl_off_t getfiletime(const char *filename, FILE *error_stream)
                       (FILE_SHARE_READ | FILE_SHARE_WRITE |
                        FILE_SHARE_DELETE),
                       NULL, OPEN_EXISTING, 0, NULL);
-  curlx_unicodefree(tchar_filename);
+  CURLX_UNICODEFREE(tchar_filename);
   if(hfile != INVALID_HANDLE_VALUE) {
     FILETIME ft;
     if(GetFileTime(hfile, NULL, NULL, &ft)) {
@@ -110,7 +110,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
       fprintf(error_stream,
               "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
               " on outfile: overflow\n", filetime);
-      curlx_unicodefree(tchar_filename);
+      CURLX_UNICODEFREE(tchar_filename);
       return;
     }
 
@@ -118,7 +118,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
                         (FILE_SHARE_READ | FILE_SHARE_WRITE |
                          FILE_SHARE_DELETE),
                         NULL, OPEN_EXISTING, 0, NULL);
-    curlx_unicodefree(tchar_filename);
+    CURLX_UNICODEFREE(tchar_filename);
     if(hfile != INVALID_HANDLE_VALUE) {
       curl_off_t converted = ((curl_off_t)filetime * 10000000) +
                              CURL_OFF_T_C(116444736000000000);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2303,7 +2303,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
           : NULL;
 
         result = getparameter(orig_opt, nextarg, &passarg, global, config);
-        curlx_unicodefree(nextarg);
+        CURLX_UNICODEFREE(nextarg);
         config = global->last;
         if(result == PARAM_NEXT_OPERATION) {
           /* Reset result as PARAM_NEXT_OPERATION is only used here and not
@@ -2344,7 +2344,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
     }
 
     if(!result)
-      curlx_unicodefree(orig_opt);
+      CURLX_UNICODEFREE(orig_opt);
   }
 
   if(result && result != PARAM_HELP_REQUESTED &&
@@ -2359,6 +2359,6 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
       helpf(global->errors, "%s\n", reason);
   }
 
-  curlx_unicodefree(orig_opt);
+  CURLX_UNICODEFREE(orig_opt);
   return result;
 }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2552,7 +2552,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
     }
   }
 
-  curlx_unicodefree(first_arg);
+  CURLX_UNICODEFREE(first_arg);
 
   if(!result) {
     /* Parse the command line arguments */


### PR DESCRIPTION
CURLX_UNICODEFREE() is the name now to make it more obvious to users
that this is a macro and not a plain or pretend-to-be function call.

Suggested-by: Gisle Vanem
Ref: #6457