### PR TITLE
lib/vtls/sectransp.c: Specify cipher name for Mac Secure Transport back-end

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -67,6 +67,7 @@
 #define CURL_BUILD_IOS_7 0
 #define CURL_BUILD_IOS_9 0
 #define CURL_BUILD_IOS_11 0
+#define CURL_BUILD_IOS_13 0
 #define CURL_BUILD_MAC 1
 /* This is the maximum API level we are allowed to use when building: */
 #define CURL_BUILD_MAC_10_5 MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
@@ -76,6 +77,7 @@
 #define CURL_BUILD_MAC_10_9 MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
 #define CURL_BUILD_MAC_10_11 MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
 #define CURL_BUILD_MAC_10_13 MAC_OS_X_VERSION_MAX_ALLOWED >= 101300
+#define CURL_BUILD_MAC_10_15 MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
 /* These macros mean "the following code is present to allow runtime backward
    compatibility with at least this cat or earlier":
    (You set this at build-time using the compiler command line option
@@ -91,6 +93,7 @@
 #define CURL_BUILD_IOS_7 __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
 #define CURL_BUILD_IOS_9 __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 #define CURL_BUILD_IOS_11 __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+#define CURL_BUILD_IOS_13 __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 #define CURL_BUILD_MAC 0
 #define CURL_BUILD_MAC_10_5 0
 #define CURL_BUILD_MAC_10_6 0
@@ -99,6 +102,7 @@
 #define CURL_BUILD_MAC_10_9 0
 #define CURL_BUILD_MAC_10_11 0
 #define CURL_BUILD_MAC_10_13 0
+#define CURL_BUILD_MAC_10_15 0
 #define CURL_SUPPORT_MAC_10_5 0
 #define CURL_SUPPORT_MAC_10_6 0
 #define CURL_SUPPORT_MAC_10_7 0
@@ -137,6 +141,636 @@ struct ssl_backend_data {
   bool ssl_direction; /* true if writing, false if reading */
   size_t ssl_write_buffered_length;
 };
+
+struct st_cipher {
+  const char *name; /* Cipher suite IANA name. It starts with "TLS_" prefix */
+  const char *alias_name; /* Alias name is the same as OpenSSL cipher name */
+  SSLCipherSuite num; /* Cipher suite code/number defined in IANA registry */
+  bool weak; /* Flag to mark cipher as weak based on previous implementation
+                of Secure Transport back-end by CURL */
+};
+
+/* Macro to initialize st_cipher data structure: stringify id to name, cipher
+   number/id, 'weak' suite flag
+ */
+#define CIPHER_DEF(num, alias, weak) \
+  { #num, alias, num, weak }
+
+/*
+ Macro to initialize st_cipher data structure with name, code (IANA cipher
+ number/id value), and 'weak' suite flag. The first 28 cipher suite numbers
+ have the same IANA code for both SSL and TLS standards: numbers 0x0000 to
+ 0x001B. They have different names though. The first 4 letters of the cipher
+ suite name are the protocol name: "SSL_" or "TLS_", rest of the IANA name is
+ the same for both SSL and TLS cipher suite name.
+ The second part of the problem is that macOS/iOS SDKs don't define all TLS
+ codes but only 12 of them. The SDK defines all SSL codes though, i.e. SSL_NUM
+ constant is always defined for those 28 ciphers while TLS_NUM is defined only
+ for 12 of the first 28 ciphers. Those 12 TLS cipher codes match to
+ corresponding SSL enum value and represent the same cipher suite. Therefore
+ we'll use the SSL enum value for those cipher suites because it is defined
+ for all 28 of them.
+ We make internal data consistent and based on TLS names, i.e. all st_cipher
+ item names start with the "TLS_" prefix.
+ Summarizing all the above, those 28 first ciphers are presented in our table
+ with both TLS and SSL names. Their cipher numbers are assigned based on the
+ SDK enum value for the SSL cipher, which matches to IANA TLS number.
+ */
+#define CIPHER_DEF_SSLTLS(num_wo_prefix, alias, weak) \
+  { "TLS_" #num_wo_prefix, alias, SSL_##num_wo_prefix, weak }
+
+/*
+ Cipher suites were marked as weak based on the following:
+ RC4 encryption - rfc7465, the document contains a list of deprecated ciphers.
+     Marked in the code below as weak.
+ RC2 encryption - many mentions, was found vulnerable to a relatively easy
+     attack https://link.springer.com/chapter/10.1007%2F3-540-69710-1_14
+     Marked in the code below as weak.
+ DES and IDEA encryption - rfc5469, has a list of deprecated ciphers.
+     Marked in the code below as weak.
+ Anonymous Diffie-Hellman authentication and anonymous elliptic curve
+     Diffie-Hellman - vulnerable to a man-in-the-middle attack. Deprecated by
+     RFC 4346 aka TLS 1.1 (section A.5, page 60)
+ Null bulk encryption suites - not encrypted communication
+ Export ciphers, i.e. ciphers with restrictions to be used outside the US for
+     software exported to some countries, they were excluded from TLS 1.1
+     version. More precisely, they were noted as ciphers which MUST NOT be
+     negotiated in RFC 4346 aka TLS 1.1 (section A.5, pages 60 and 61).
+     All of those filters were considered weak because they contain a weak
+     algorithm like DES, RC2 or RC4, and already considered weak by other
+     criteria.
+ 3DES - NIST deprecated it and is going to retire it by 2023
+ https://csrc.nist.gov/News/2017/Update-to-Current-Use-and-Deprecation-of-TDEA
+     OpenSSL https://www.openssl.org/blog/blog/2016/08/24/sweet32/ also
+     deprecated those ciphers. Some other libraries also consider it
+     vulnerable or at least not strong enough.
+
+ CBC ciphers are vulnerable with SSL3.0 and TLS1.0:
+ https://www.cisco.com/c/en/us/support/docs/security/email-security-appliance
+ /118518-technote-esa-00.html
+     We don't take care of this issue because it is resolved by later TLS
+     versions and for us, it requires more complicated checks, we need to
+     check a protocol version also. Vulnerability doesn't look very critical
+     and we do not filter out those cipher suites.
+ */
+
+#define CIPHER_WEAK_NOT_ENCRYPTED   TRUE
+#define CIPHER_WEAK_RC_ENCRYPTION   TRUE
+#define CIPHER_WEAK_DES_ENCRYPTION  TRUE
+#define CIPHER_WEAK_IDEA_ENCRYPTION TRUE
+#define CIPHER_WEAK_ANON_AUTH       TRUE
+#define CIPHER_WEAK_3DES_ENCRYPTION TRUE
+#define CIPHER_STRONG_ENOUGH        FALSE
+
+/* Please do not change the order of the first ciphers available for SSL.
+   Do not insert and do not delete any of them. Code below
+   depends on their order and continuity.
+   If you add a new cipher, please maintain order by number, i.e.
+   insert in between existing items to appropriate place based on
+   cipher suite IANA number
+*/
+const static struct st_cipher ciphertable[] = {
+  /* SSL version 3.0 and initial TLS 1.0 cipher suites.
+     Defined since SDK 10.2.8 */
+  CIPHER_DEF_SSLTLS(NULL_WITH_NULL_NULL,                           /* 0x0000 */
+                    NULL,
+                    CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF_SSLTLS(RSA_WITH_NULL_MD5,                             /* 0x0001 */
+                    "NULL-MD5",
+                    CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF_SSLTLS(RSA_WITH_NULL_SHA,                             /* 0x0002 */
+                    "NULL-SHA",
+                    CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF_SSLTLS(RSA_EXPORT_WITH_RC4_40_MD5,                    /* 0x0003 */
+                    "EXP-RC4-MD5",
+                    CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_WITH_RC4_128_MD5,                          /* 0x0004 */
+                    "RC4-MD5",
+                    CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_WITH_RC4_128_SHA,                          /* 0x0005 */
+                    "RC4-SHA",
+                    CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_EXPORT_WITH_RC2_CBC_40_MD5,                /* 0x0006 */
+                    "EXP-RC2-CBC-MD5",
+                    CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_WITH_IDEA_CBC_SHA,                         /* 0x0007 */
+                    "IDEA-CBC-SHA",
+                    CIPHER_WEAK_IDEA_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_EXPORT_WITH_DES40_CBC_SHA,                 /* 0x0008 */
+                    "EXP-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_WITH_DES_CBC_SHA,                          /* 0x0009 */
+                    "DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(RSA_WITH_3DES_EDE_CBC_SHA,                     /* 0x000A */
+                    "DES-CBC3-SHA",
+                    CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_DSS_EXPORT_WITH_DES40_CBC_SHA,              /* 0x000B */
+                    "EXP-DH-DSS-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_DSS_WITH_DES_CBC_SHA,                       /* 0x000C */
+                    "DH-DSS-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_DSS_WITH_3DES_EDE_CBC_SHA,                  /* 0x000D */
+                    "DH-DSS-DES-CBC3-SHA",
+                    CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_RSA_EXPORT_WITH_DES40_CBC_SHA,              /* 0x000E */
+                    "EXP-DH-RSA-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_RSA_WITH_DES_CBC_SHA,                       /* 0x000F */
+                    "DH-RSA-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_RSA_WITH_3DES_EDE_CBC_SHA,                  /* 0x0010 */
+                    "DH-RSA-DES-CBC3-SHA",
+                    CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DHE_DSS_EXPORT_WITH_DES40_CBC_SHA,             /* 0x0011 */
+                    "EXP-EDH-DSS-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DHE_DSS_WITH_DES_CBC_SHA,                      /* 0x0012 */
+                    "EDH-DSS-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DHE_DSS_WITH_3DES_EDE_CBC_SHA,                 /* 0x0013 */
+                    "DHE-DSS-DES-CBC3-SHA",
+                    CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DHE_RSA_EXPORT_WITH_DES40_CBC_SHA,             /* 0x0014 */
+                    "EXP-EDH-RSA-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DHE_RSA_WITH_DES_CBC_SHA,                      /* 0x0015 */
+                    "EDH-RSA-DES-CBC-SHA",
+                    CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DHE_RSA_WITH_3DES_EDE_CBC_SHA,                 /* 0x0016 */
+                    "DHE-RSA-DES-CBC3-SHA",
+                    CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF_SSLTLS(DH_anon_EXPORT_WITH_RC4_40_MD5,                /* 0x0017 */
+                    "EXP-ADH-RC4-MD5",
+                    CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF_SSLTLS(DH_anon_WITH_RC4_128_MD5,                      /* 0x0018 */
+                    "ADH-RC4-MD5",
+                    CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF_SSLTLS(DH_anon_EXPORT_WITH_DES40_CBC_SHA,             /* 0x0019 */
+                    "EXP-ADH-DES-CBC-SHA",
+                    CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF_SSLTLS(DH_anon_WITH_DES_CBC_SHA,                      /* 0x001A */
+                    "ADH-DES-CBC-SHA",
+                    CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF_SSLTLS(DH_anon_WITH_3DES_EDE_CBC_SHA,                 /* 0x001B */
+                    "ADH-DES-CBC3-SHA",
+                    CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(SSL_FORTEZZA_DMS_WITH_NULL_SHA,                       /* 0x001C */
+             NULL,
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA,               /* 0x001D */
+             NULL,
+             CIPHER_STRONG_ENOUGH),
+
+#if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
+  /* RFC 4785 - Pre-Shared Key (PSK) Ciphersuites with NULL Encryption */
+  CIPHER_DEF(TLS_PSK_WITH_NULL_SHA,                                /* 0x002C */
+             "PSK-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_NULL_SHA,                            /* 0x002D */
+             "DHE-PSK-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_NULL_SHA,                            /* 0x002E */
+             "RSA-PSK-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+#endif /* CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7 */
+
+  /* TLS addenda using AES, per RFC 3268. Defined since SDK 10.4u */
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_CBC_SHA,                         /* 0x002F */
+             "AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_DSS_WITH_AES_128_CBC_SHA,                      /* 0x0030 */
+             "DH-DSS-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_RSA_WITH_AES_128_CBC_SHA,                      /* 0x0031 */
+             "DH-RSA-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_DSS_WITH_AES_128_CBC_SHA,                     /* 0x0032 */
+             "DHE-DSS-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_RSA_WITH_AES_128_CBC_SHA,                     /* 0x0033 */
+             "DHE-RSA-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_anon_WITH_AES_128_CBC_SHA,                     /* 0x0034 */
+             "ADH-AES128-SHA",
+             CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_CBC_SHA,                         /* 0x0035 */
+             "AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_DSS_WITH_AES_256_CBC_SHA,                      /* 0x0036 */
+             "DH-DSS-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_RSA_WITH_AES_256_CBC_SHA,                      /* 0x0037 */
+             "DH-RSA-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_DSS_WITH_AES_256_CBC_SHA,                     /* 0x0038 */
+             "DHE-DSS-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_RSA_WITH_AES_256_CBC_SHA,                     /* 0x0039 */
+             "DHE-RSA-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_anon_WITH_AES_256_CBC_SHA,                     /* 0x003A */
+             "ADH-AES256-SHA",
+             CIPHER_WEAK_ANON_AUTH),
+
+#if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
+  /* TLS 1.2 addenda, RFC 5246 */
+  /* Server provided RSA certificate for key exchange. */
+  CIPHER_DEF(TLS_RSA_WITH_NULL_SHA256,                             /* 0x003B */
+             "NULL-SHA256",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_CBC_SHA256,                      /* 0x003C */
+             "AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_CBC_SHA256,                      /* 0x003D */
+             "AES256-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  /* Server-authenticated (and optionally client-authenticated)
+     Diffie-Hellman. */
+  CIPHER_DEF(TLS_DH_DSS_WITH_AES_128_CBC_SHA256,                   /* 0x003E */
+             "DH-DSS-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_RSA_WITH_AES_128_CBC_SHA256,                   /* 0x003F */
+             "DH-RSA-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,                  /* 0x0040 */
+             "DHE-DSS-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+
+  /* TLS 1.2 addenda, RFC 5246 */
+  CIPHER_DEF(TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,                  /* 0x0067 */
+             "DHE-RSA-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_DSS_WITH_AES_256_CBC_SHA256,                   /* 0x0068 */
+             "DH-DSS-AES256-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_RSA_WITH_AES_256_CBC_SHA256,                   /* 0x0069 */
+             "DH-RSA-AES256-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,                  /* 0x006A */
+             "DHE-DSS-AES256-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,                  /* 0x006B */
+             "DHE-RSA-AES256-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_anon_WITH_AES_128_CBC_SHA256,                  /* 0x006C */
+             "ADH-AES128-SHA256",
+             CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF(TLS_DH_anon_WITH_AES_256_CBC_SHA256,                  /* 0x006D */
+             "ADH-AES256-SHA256",
+             CIPHER_WEAK_ANON_AUTH),
+#endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
+
+#if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
+  /* Addendum from RFC 4279, TLS PSK */
+  CIPHER_DEF(TLS_PSK_WITH_RC4_128_SHA,                             /* 0x008A */
+             "PSK-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_PSK_WITH_3DES_EDE_CBC_SHA,                        /* 0x008B */
+             "PSK-3DES-EDE-CBC-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_PSK_WITH_AES_128_CBC_SHA,                         /* 0x008C */
+             "PSK-AES128-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_PSK_WITH_AES_256_CBC_SHA,                         /* 0x008D */
+             "PSK-AES256-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_RC4_128_SHA,                         /* 0x008E */
+             "DHE-PSK-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA,                    /* 0x008F */
+             "DHE-PSK-3DES-EDE-CBC-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_AES_128_CBC_SHA,                     /* 0x0090 */
+             "DHE-PSK-AES128-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_AES_256_CBC_SHA,                     /* 0x0091 */
+             "DHE-PSK-AES256-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_RC4_128_SHA,                         /* 0x0092 */
+             "RSA-PSK-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA,                    /* 0x0093 */
+             "RSA-PSK-3DES-EDE-CBC-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_AES_128_CBC_SHA,                     /* 0x0094 */
+             "RSA-PSK-AES128-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_AES_256_CBC_SHA,                     /* 0x0095 */
+             "RSA-PSK-AES256-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+#endif /* CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7 */
+
+#if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
+  /* Addenda from rfc 5288 AES Galois Counter Mode (GCM) Cipher Suites
+     for TLS. */
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_GCM_SHA256,                      /* 0x009C */
+             "AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_GCM_SHA384,                      /* 0x009D */
+             "AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,                  /* 0x009E */
+             "DHE-RSA-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,                  /* 0x009F */
+             "DHE-RSA-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_RSA_WITH_AES_128_GCM_SHA256,                   /* 0x00A0 */
+             "DH-RSA-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_RSA_WITH_AES_256_GCM_SHA384,                   /* 0x00A1 */
+             "DH-RSA-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,                  /* 0x00A2 */
+             "DHE-DSS-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,                  /* 0x00A3 */
+             "DHE-DSS-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_DSS_WITH_AES_128_GCM_SHA256,                   /* 0x00A4 */
+             "DH-DSS-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_DSS_WITH_AES_256_GCM_SHA384,                   /* 0x00A5 */
+             "DH-DSS-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DH_anon_WITH_AES_128_GCM_SHA256,                  /* 0x00A6 */
+             "ADH-AES128-GCM-SHA256",
+             CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF(TLS_DH_anon_WITH_AES_256_GCM_SHA384,                  /* 0x00A7 */
+             "ADH-AES256-GCM-SHA384",
+             CIPHER_WEAK_ANON_AUTH),
+#endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
+
+#if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
+  /* RFC 5487 - PSK with SHA-256/384 and AES GCM */
+  CIPHER_DEF(TLS_PSK_WITH_AES_128_GCM_SHA256,                      /* 0x00A8 */
+             "PSK-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_PSK_WITH_AES_256_GCM_SHA384,                      /* 0x00A9 */
+             "PSK-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_AES_128_GCM_SHA256,                  /* 0x00AA */
+             "DHE-PSK-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_AES_256_GCM_SHA384,                  /* 0x00AB */
+             "DHE-PSK-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_AES_128_GCM_SHA256,                  /* 0x00AC */
+             "RSA-PSK-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_AES_256_GCM_SHA384,                  /* 0x00AD */
+             "RSA-PSK-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_PSK_WITH_AES_128_CBC_SHA256,                      /* 0x00AE */
+             "PSK-AES128-CBC-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_PSK_WITH_AES_256_CBC_SHA384,                      /* 0x00AF */
+             "PSK-AES256-CBC-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_PSK_WITH_NULL_SHA256,                             /* 0x00B0 */
+             "PSK-NULL-SHA256",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_PSK_WITH_NULL_SHA384,                             /* 0x00B1 */
+             "PSK-NULL-SHA384",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_AES_128_CBC_SHA256,                  /* 0x00B2 */
+             "DHE-PSK-AES128-CBC-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_AES_256_CBC_SHA384,                  /* 0x00B3 */
+             "DHE-PSK-AES256-CBC-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_NULL_SHA256,                         /* 0x00B4 */
+             "DHE-PSK-NULL-SHA256",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_DHE_PSK_WITH_NULL_SHA384,                         /* 0x00B5 */
+             "DHE-PSK-NULL-SHA384",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_AES_128_CBC_SHA256,                  /* 0x00B6 */
+             "RSA-PSK-AES128-CBC-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_AES_256_CBC_SHA384,                  /* 0x00B7 */
+             "RSA-PSK-AES256-CBC-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_NULL_SHA256,                         /* 0x00B8 */
+             "RSA-PSK-NULL-SHA256",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_RSA_PSK_WITH_NULL_SHA384,                         /* 0x00B9 */
+             "RSA-PSK-NULL-SHA384",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+#endif /* CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7 */
+
+  /* RFC 5746 - Secure Renegotiation. This is not a real suite,
+     it is a response to initiate negotiation again */
+  CIPHER_DEF(TLS_EMPTY_RENEGOTIATION_INFO_SCSV,                    /* 0x00FF */
+             NULL,
+             CIPHER_STRONG_ENOUGH),
+
+#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
+  /* TLS 1.3 standard cipher suites for ChaCha20+Poly1305.
+     Note: TLS 1.3 ciphersuites do not specify the key exchange
+     algorithm -- they only specify the symmetric ciphers.
+     Cipher alias name matches to OpenSSL cipher name, and for
+     TLS 1.3 ciphers */
+  CIPHER_DEF(TLS_AES_128_GCM_SHA256,                               /* 0x1301 */
+             NULL,  /* The OpenSSL cipher name matches to the IANA name */
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_AES_256_GCM_SHA384,                               /* 0x1302 */
+             NULL,  /* The OpenSSL cipher name matches to the IANA name */
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_CHACHA20_POLY1305_SHA256,                         /* 0x1303 */
+             NULL,  /* The OpenSSL cipher name matches to the IANA name */
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_AES_128_CCM_SHA256,                               /* 0x1304 */
+             NULL,  /* The OpenSSL cipher name matches to the IANA name */
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_AES_128_CCM_8_SHA256,                             /* 0x1305 */
+             NULL,  /* The OpenSSL cipher name matches to the IANA name */
+             CIPHER_STRONG_ENOUGH),
+#endif /* CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11 */
+
+#if CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS
+  /* ECDSA addenda, RFC 4492 */
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_NULL_SHA,                         /* 0xC001 */
+             "ECDH-ECDSA-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_RC4_128_SHA,                      /* 0xC002 */
+             "ECDH-ECDSA-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,                 /* 0xC003 */
+             "ECDH-ECDSA-DES-CBC3-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,                  /* 0xC004 */
+             "ECDH-ECDSA-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,                  /* 0xC005 */
+             "ECDH-ECDSA-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_NULL_SHA,                        /* 0xC006 */
+             "ECDHE-ECDSA-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,                     /* 0xC007 */
+             "ECDHE-ECDSA-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,                /* 0xC008 */
+             "ECDHE-ECDSA-DES-CBC3-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,                 /* 0xC009 */
+             "ECDHE-ECDSA-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,                 /* 0xC00A */
+             "ECDHE-ECDSA-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_NULL_SHA,                           /* 0xC00B */
+             "ECDH-RSA-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_RC4_128_SHA,                        /* 0xC00C */
+             "ECDH-RSA-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,                   /* 0xC00D */
+             "ECDH-RSA-DES-CBC3-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,                    /* 0xC00E */
+             "ECDH-RSA-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,                    /* 0xC00F */
+             "ECDH-RSA-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_NULL_SHA,                          /* 0xC010 */
+             "ECDHE-RSA-NULL-SHA",
+             CIPHER_WEAK_NOT_ENCRYPTED),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_RC4_128_SHA,                       /* 0xC011 */
+             "ECDHE-RSA-RC4-SHA",
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,                  /* 0xC012 */
+             "ECDHE-RSA-DES-CBC3-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,                   /* 0xC013 */
+             "ECDHE-RSA-AES128-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,                   /* 0xC014 */
+             "ECDHE-RSA-AES256-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_anon_WITH_NULL_SHA,                          /* 0xC015 */
+             "AECDH-NULL-SHA",
+             CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF(TLS_ECDH_anon_WITH_RC4_128_SHA,                       /* 0xC016 */
+             "AECDH-RC4-SHA",
+             CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF(TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA,                  /* 0xC017 */
+             "AECDH-DES-CBC3-SHA",
+             CIPHER_WEAK_3DES_ENCRYPTION),
+  CIPHER_DEF(TLS_ECDH_anon_WITH_AES_128_CBC_SHA,                   /* 0xC018 */
+             "AECDH-AES128-SHA",
+             CIPHER_WEAK_ANON_AUTH),
+  CIPHER_DEF(TLS_ECDH_anon_WITH_AES_256_CBC_SHA,                   /* 0xC019 */
+             "AECDH-AES256-SHA",
+             CIPHER_WEAK_ANON_AUTH),
+#endif /* CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS */
+
+#if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
+  /* Addenda from rfc 5289  Elliptic Curve Cipher Suites with
+     HMAC SHA-256/384. */
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,              /* 0xC023 */
+             "ECDHE-ECDSA-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,              /* 0xC024 */
+             "ECDHE-ECDSA-AES256-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,               /* 0xC025 */
+             "ECDH-ECDSA-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,               /* 0xC026 */
+             "ECDH-ECDSA-AES256-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,                /* 0xC027 */
+             "ECDHE-RSA-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,                /* 0xC028 */
+             "ECDHE-RSA-AES256-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,                 /* 0xC029 */
+             "ECDH-RSA-AES128-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,                 /* 0xC02A */
+             "ECDH-RSA-AES256-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  /* Addenda from rfc 5289  Elliptic Curve Cipher Suites with
+     SHA-256/384 and AES Galois Counter Mode (GCM) */
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,              /* 0xC02B */
+             "ECDHE-ECDSA-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,              /* 0xC02C */
+             "ECDHE-ECDSA-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,               /* 0xC02D */
+             "ECDH-ECDSA-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,               /* 0xC02E */
+             "ECDH-ECDSA-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,                /* 0xC02F */
+             "ECDHE-RSA-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,                /* 0xC030 */
+             "ECDHE-RSA-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,                 /* 0xC031 */
+             "ECDH-RSA-AES128-GCM-SHA256",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,                 /* 0xC032 */
+             "ECDH-RSA-AES256-GCM-SHA384",
+             CIPHER_STRONG_ENOUGH),
+#endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
+
+#if CURL_BUILD_MAC_10_15 || CURL_BUILD_IOS_13
+  /* ECDHE_PSK Cipher Suites for Transport Layer Security (TLS), RFC 5489 */
+  CIPHER_DEF(TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA,                   /* 0xC035 */
+             "ECDHE-PSK-AES128-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA,                   /* 0xC036 */
+             "ECDHE-PSK-AES256-CBC-SHA",
+             CIPHER_STRONG_ENOUGH),
+#endif /* CURL_BUILD_MAC_10_15 || CURL_BUILD_IOS_13 */
+
+#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
+  /* Addenda from rfc 7905  ChaCha20-Poly1305 Cipher Suites for
+     Transport Layer Security (TLS). */
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,          /* 0xCCA8 */
+             "ECDHE-RSA-CHACHA20-POLY1305",
+             CIPHER_STRONG_ENOUGH),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,        /* 0xCCA9 */
+             "ECDHE-ECDSA-CHACHA20-POLY1305",
+             CIPHER_STRONG_ENOUGH),
+#endif /* CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11 */
+
+#if CURL_BUILD_MAC_10_15 || CURL_BUILD_IOS_13
+  /* ChaCha20-Poly1305 Cipher Suites for Transport Layer Security (TLS),
+     RFC 7905 */
+  CIPHER_DEF(TLS_PSK_WITH_CHACHA20_POLY1305_SHA256,                /* 0xCCAB */
+             "PSK-CHACHA20-POLY1305",
+             CIPHER_STRONG_ENOUGH),
+#endif /* CURL_BUILD_MAC_10_15 || CURL_BUILD_IOS_13 */
+
+  /* Tags for SSL 2 cipher kinds which are not specified for SSL 3.
+     Defined since SDK 10.2.8 */
+  CIPHER_DEF(SSL_RSA_WITH_RC2_CBC_MD5,                             /* 0xFF80 */
+             NULL,
+             CIPHER_WEAK_RC_ENCRYPTION),
+  CIPHER_DEF(SSL_RSA_WITH_IDEA_CBC_MD5,                            /* 0xFF81 */
+             NULL,
+             CIPHER_WEAK_IDEA_ENCRYPTION),
+  CIPHER_DEF(SSL_RSA_WITH_DES_CBC_MD5,                             /* 0xFF82 */
+             NULL,
+             CIPHER_WEAK_DES_ENCRYPTION),
+  CIPHER_DEF(SSL_RSA_WITH_3DES_EDE_CBC_MD5,                        /* 0xFF83 */
+             NULL,
+             CIPHER_WEAK_3DES_ENCRYPTION),
+};
+
+#define NUM_OF_CIPHERS sizeof(ciphertable)/sizeof(ciphertable[0])
+
 
 /* pinned public key support tests */
 
@@ -295,586 +929,23 @@ static OSStatus SocketWrite(SSLConnectionRef connection,
 }
 
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
-CF_INLINE const char *SSLCipherNameForNumber(SSLCipherSuite cipher)
-{
-  switch(cipher) {
-    /* SSL version 3.0 */
-    case SSL_RSA_WITH_NULL_MD5:
-      return "SSL_RSA_WITH_NULL_MD5";
-      break;
-    case SSL_RSA_WITH_NULL_SHA:
-      return "SSL_RSA_WITH_NULL_SHA";
-      break;
-    case SSL_RSA_EXPORT_WITH_RC4_40_MD5:
-      return "SSL_RSA_EXPORT_WITH_RC4_40_MD5";
-      break;
-    case SSL_RSA_WITH_RC4_128_MD5:
-      return "SSL_RSA_WITH_RC4_128_MD5";
-      break;
-    case SSL_RSA_WITH_RC4_128_SHA:
-      return "SSL_RSA_WITH_RC4_128_SHA";
-      break;
-    case SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5:
-      return "SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5";
-      break;
-    case SSL_RSA_WITH_IDEA_CBC_SHA:
-      return "SSL_RSA_WITH_IDEA_CBC_SHA";
-      break;
-    case SSL_RSA_EXPORT_WITH_DES40_CBC_SHA:
-      return "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA";
-      break;
-    case SSL_RSA_WITH_DES_CBC_SHA:
-      return "SSL_RSA_WITH_DES_CBC_SHA";
-      break;
-    case SSL_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "SSL_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA:
-      return "SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA";
-      break;
-    case SSL_DH_DSS_WITH_DES_CBC_SHA:
-      return "SSL_DH_DSS_WITH_DES_CBC_SHA";
-      break;
-    case SSL_DH_DSS_WITH_3DES_EDE_CBC_SHA:
-      return "SSL_DH_DSS_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA:
-      return "SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA";
-      break;
-    case SSL_DH_RSA_WITH_DES_CBC_SHA:
-      return "SSL_DH_RSA_WITH_DES_CBC_SHA";
-      break;
-    case SSL_DH_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "SSL_DH_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA:
-      return "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA";
-      break;
-    case SSL_DHE_DSS_WITH_DES_CBC_SHA:
-      return "SSL_DHE_DSS_WITH_DES_CBC_SHA";
-      break;
-    case SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA:
-      return "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA:
-      return "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA";
-      break;
-    case SSL_DHE_RSA_WITH_DES_CBC_SHA:
-      return "SSL_DHE_RSA_WITH_DES_CBC_SHA";
-      break;
-    case SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_DH_anon_EXPORT_WITH_RC4_40_MD5:
-      return "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5";
-      break;
-    case SSL_DH_anon_WITH_RC4_128_MD5:
-      return "SSL_DH_anon_WITH_RC4_128_MD5";
-      break;
-    case SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA:
-      return "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA";
-      break;
-    case SSL_DH_anon_WITH_DES_CBC_SHA:
-      return "SSL_DH_anon_WITH_DES_CBC_SHA";
-      break;
-    case SSL_DH_anon_WITH_3DES_EDE_CBC_SHA:
-      return "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_FORTEZZA_DMS_WITH_NULL_SHA:
-      return "SSL_FORTEZZA_DMS_WITH_NULL_SHA";
-      break;
-    case SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA:
-      return "SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA";
-      break;
-    /* TLS 1.0 with AES (RFC 3268)
-       (Apparently these are used in SSLv3 implementations as well.) */
-    case TLS_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DH_DSS_WITH_AES_128_CBC_SHA:
-      return "TLS_DH_DSS_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DH_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_DH_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DHE_DSS_WITH_AES_128_CBC_SHA:
-      return "TLS_DHE_DSS_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DHE_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_DHE_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DH_anon_WITH_AES_128_CBC_SHA:
-      return "TLS_DH_anon_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DH_DSS_WITH_AES_256_CBC_SHA:
-      return "TLS_DH_DSS_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DH_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_DH_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DHE_DSS_WITH_AES_256_CBC_SHA:
-      return "TLS_DHE_DSS_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DHE_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_DHE_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DH_anon_WITH_AES_256_CBC_SHA:
-      return "TLS_DH_anon_WITH_AES_256_CBC_SHA";
-      break;
-    /* SSL version 2.0 */
-    case SSL_RSA_WITH_RC2_CBC_MD5:
-      return "SSL_RSA_WITH_RC2_CBC_MD5";
-      break;
-    case SSL_RSA_WITH_IDEA_CBC_MD5:
-      return "SSL_RSA_WITH_IDEA_CBC_MD5";
-      break;
-    case SSL_RSA_WITH_DES_CBC_MD5:
-      return "SSL_RSA_WITH_DES_CBC_MD5";
-      break;
-    case SSL_RSA_WITH_3DES_EDE_CBC_MD5:
-      return "SSL_RSA_WITH_3DES_EDE_CBC_MD5";
-      break;
-  }
-  return "SSL_NULL_WITH_NULL_NULL";
-}
-
 CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
 {
-  switch(cipher) {
-    /* TLS 1.0 with AES (RFC 3268) */
-    case TLS_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DH_DSS_WITH_AES_128_CBC_SHA:
-      return "TLS_DH_DSS_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DH_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_DH_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DHE_DSS_WITH_AES_128_CBC_SHA:
-      return "TLS_DHE_DSS_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DHE_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_DHE_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DH_anon_WITH_AES_128_CBC_SHA:
-      return "TLS_DH_anon_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DH_DSS_WITH_AES_256_CBC_SHA:
-      return "TLS_DH_DSS_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DH_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_DH_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DHE_DSS_WITH_AES_256_CBC_SHA:
-      return "TLS_DHE_DSS_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DHE_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_DHE_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DH_anon_WITH_AES_256_CBC_SHA:
-      return "TLS_DH_anon_WITH_AES_256_CBC_SHA";
-      break;
-#if CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS
-    /* TLS 1.0 with ECDSA (RFC 4492) */
-    case TLS_ECDH_ECDSA_WITH_NULL_SHA:
-      return "TLS_ECDH_ECDSA_WITH_NULL_SHA";
-      break;
-    case TLS_ECDH_ECDSA_WITH_RC4_128_SHA:
-      return "TLS_ECDH_ECDSA_WITH_RC4_128_SHA";
-      break;
-    case TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA:
-      return "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA:
-      return "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_NULL_SHA:
-      return "TLS_ECDHE_ECDSA_WITH_NULL_SHA";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_RC4_128_SHA:
-      return "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:
-      return "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:
-      return "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_ECDH_RSA_WITH_NULL_SHA:
-      return "TLS_ECDH_RSA_WITH_NULL_SHA";
-      break;
-    case TLS_ECDH_RSA_WITH_RC4_128_SHA:
-      return "TLS_ECDH_RSA_WITH_RC4_128_SHA";
-      break;
-    case TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_ECDH_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_ECDH_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_ECDHE_RSA_WITH_NULL_SHA:
-      return "TLS_ECDHE_RSA_WITH_NULL_SHA";
-      break;
-    case TLS_ECDHE_RSA_WITH_RC4_128_SHA:
-      return "TLS_ECDHE_RSA_WITH_RC4_128_SHA";
-      break;
-    case TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:
-      return "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:
-      return "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_ECDH_anon_WITH_NULL_SHA:
-      return "TLS_ECDH_anon_WITH_NULL_SHA";
-      break;
-    case TLS_ECDH_anon_WITH_RC4_128_SHA:
-      return "TLS_ECDH_anon_WITH_RC4_128_SHA";
-      break;
-    case TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_ECDH_anon_WITH_AES_128_CBC_SHA:
-      return "TLS_ECDH_anon_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_ECDH_anon_WITH_AES_256_CBC_SHA:
-      return "TLS_ECDH_anon_WITH_AES_256_CBC_SHA";
-      break;
-#endif /* CURL_BUILD_MAC_10_6 || CURL_BUILD_IOS */
-#if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
-    /* TLS 1.2 (RFC 5246) */
-    case TLS_RSA_WITH_NULL_MD5:
-      return "TLS_RSA_WITH_NULL_MD5";
-      break;
-    case TLS_RSA_WITH_NULL_SHA:
-      return "TLS_RSA_WITH_NULL_SHA";
-      break;
-    case TLS_RSA_WITH_RC4_128_MD5:
-      return "TLS_RSA_WITH_RC4_128_MD5";
-      break;
-    case TLS_RSA_WITH_RC4_128_SHA:
-      return "TLS_RSA_WITH_RC4_128_SHA";
-      break;
-    case TLS_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_RSA_WITH_NULL_SHA256:
-      return "TLS_RSA_WITH_NULL_SHA256";
-      break;
-    case TLS_RSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_RSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_RSA_WITH_AES_256_CBC_SHA256:
-      return "TLS_RSA_WITH_AES_256_CBC_SHA256";
-      break;
-    case TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_DH_DSS_WITH_AES_128_CBC_SHA256:
-      return "TLS_DH_DSS_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_DH_RSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_DH_RSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_DHE_DSS_WITH_AES_128_CBC_SHA256:
-      return "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_DHE_RSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_DH_DSS_WITH_AES_256_CBC_SHA256:
-      return "TLS_DH_DSS_WITH_AES_256_CBC_SHA256";
-      break;
-    case TLS_DH_RSA_WITH_AES_256_CBC_SHA256:
-      return "TLS_DH_RSA_WITH_AES_256_CBC_SHA256";
-      break;
-    case TLS_DHE_DSS_WITH_AES_256_CBC_SHA256:
-      return "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256";
-      break;
-    case TLS_DHE_RSA_WITH_AES_256_CBC_SHA256:
-      return "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256";
-      break;
-    case TLS_DH_anon_WITH_RC4_128_MD5:
-      return "TLS_DH_anon_WITH_RC4_128_MD5";
-      break;
-    case TLS_DH_anon_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_DH_anon_WITH_AES_128_CBC_SHA256:
-      return "TLS_DH_anon_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_DH_anon_WITH_AES_256_CBC_SHA256:
-      return "TLS_DH_anon_WITH_AES_256_CBC_SHA256";
-      break;
-    /* TLS 1.2 with AES GCM (RFC 5288) */
-    case TLS_RSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_RSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_RSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_RSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_DHE_RSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_DHE_RSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_DH_RSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_DH_RSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_DH_RSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_DH_RSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_DHE_DSS_WITH_AES_128_GCM_SHA256:
-      return "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_DHE_DSS_WITH_AES_256_GCM_SHA384:
-      return "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_DH_DSS_WITH_AES_128_GCM_SHA256:
-      return "TLS_DH_DSS_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_DH_DSS_WITH_AES_256_GCM_SHA384:
-      return "TLS_DH_DSS_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_DH_anon_WITH_AES_128_GCM_SHA256:
-      return "TLS_DH_anon_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_DH_anon_WITH_AES_256_GCM_SHA384:
-      return "TLS_DH_anon_WITH_AES_256_GCM_SHA384";
-      break;
-    /* TLS 1.2 with elliptic curve ciphers (RFC 5289) */
-    case TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384:
-      return "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384:
-      return "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384:
-      return "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256:
-      return "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384:
-      return "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256:
-      return "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384:
-      return "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_EMPTY_RENEGOTIATION_INFO_SCSV:
-      return "TLS_EMPTY_RENEGOTIATION_INFO_SCSV";
-      break;
-#else
-    case SSL_RSA_WITH_NULL_MD5:
-      return "TLS_RSA_WITH_NULL_MD5";
-      break;
-    case SSL_RSA_WITH_NULL_SHA:
-      return "TLS_RSA_WITH_NULL_SHA";
-      break;
-    case SSL_RSA_WITH_RC4_128_MD5:
-      return "TLS_RSA_WITH_RC4_128_MD5";
-      break;
-    case SSL_RSA_WITH_RC4_128_SHA:
-      return "TLS_RSA_WITH_RC4_128_SHA";
-      break;
-    case SSL_RSA_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_RSA_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case SSL_DH_anon_WITH_RC4_128_MD5:
-      return "TLS_DH_anon_WITH_RC4_128_MD5";
-      break;
-    case SSL_DH_anon_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DH_anon_WITH_3DES_EDE_CBC_SHA";
-      break;
-#endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
-#if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
-    /* TLS PSK (RFC 4279): */
-    case TLS_PSK_WITH_RC4_128_SHA:
-      return "TLS_PSK_WITH_RC4_128_SHA";
-      break;
-    case TLS_PSK_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_PSK_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_PSK_WITH_AES_128_CBC_SHA:
-      return "TLS_PSK_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_PSK_WITH_AES_256_CBC_SHA:
-      return "TLS_PSK_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_DHE_PSK_WITH_RC4_128_SHA:
-      return "TLS_DHE_PSK_WITH_RC4_128_SHA";
-      break;
-    case TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_DHE_PSK_WITH_AES_128_CBC_SHA:
-      return "TLS_DHE_PSK_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_DHE_PSK_WITH_AES_256_CBC_SHA:
-      return "TLS_DHE_PSK_WITH_AES_256_CBC_SHA";
-      break;
-    case TLS_RSA_PSK_WITH_RC4_128_SHA:
-      return "TLS_RSA_PSK_WITH_RC4_128_SHA";
-      break;
-    case TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA:
-      return "TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA";
-      break;
-    case TLS_RSA_PSK_WITH_AES_128_CBC_SHA:
-      return "TLS_RSA_PSK_WITH_AES_128_CBC_SHA";
-      break;
-    case TLS_RSA_PSK_WITH_AES_256_CBC_SHA:
-      return "TLS_RSA_PSK_WITH_AES_256_CBC_SHA";
-      break;
-    /* More TLS PSK (RFC 4785): */
-    case TLS_PSK_WITH_NULL_SHA:
-      return "TLS_PSK_WITH_NULL_SHA";
-      break;
-    case TLS_DHE_PSK_WITH_NULL_SHA:
-      return "TLS_DHE_PSK_WITH_NULL_SHA";
-      break;
-    case TLS_RSA_PSK_WITH_NULL_SHA:
-      return "TLS_RSA_PSK_WITH_NULL_SHA";
-      break;
-    /* Even more TLS PSK (RFC 5487): */
-    case TLS_PSK_WITH_AES_128_GCM_SHA256:
-      return "TLS_PSK_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_PSK_WITH_AES_256_GCM_SHA384:
-      return "TLS_PSK_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_DHE_PSK_WITH_AES_128_GCM_SHA256:
-      return "TLS_DHE_PSK_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_DHE_PSK_WITH_AES_256_GCM_SHA384:
-      return "TLS_DHE_PSK_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_RSA_PSK_WITH_AES_128_GCM_SHA256:
-      return "TLS_RSA_PSK_WITH_AES_128_GCM_SHA256";
-      break;
-    case TLS_RSA_PSK_WITH_AES_256_GCM_SHA384:
-      return "TLS_PSK_WITH_AES_256_GCM_SHA384";
-      break;
-    case TLS_PSK_WITH_AES_128_CBC_SHA256:
-      return "TLS_PSK_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_PSK_WITH_AES_256_CBC_SHA384:
-      return "TLS_PSK_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_PSK_WITH_NULL_SHA256:
-      return "TLS_PSK_WITH_NULL_SHA256";
-      break;
-    case TLS_PSK_WITH_NULL_SHA384:
-      return "TLS_PSK_WITH_NULL_SHA384";
-      break;
-    case TLS_DHE_PSK_WITH_AES_128_CBC_SHA256:
-      return "TLS_DHE_PSK_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_DHE_PSK_WITH_AES_256_CBC_SHA384:
-      return "TLS_DHE_PSK_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_DHE_PSK_WITH_NULL_SHA256:
-      return "TLS_DHE_PSK_WITH_NULL_SHA256";
-      break;
-    case TLS_DHE_PSK_WITH_NULL_SHA384:
-      return "TLS_RSA_PSK_WITH_NULL_SHA384";
-      break;
-    case TLS_RSA_PSK_WITH_AES_128_CBC_SHA256:
-      return "TLS_RSA_PSK_WITH_AES_128_CBC_SHA256";
-      break;
-    case TLS_RSA_PSK_WITH_AES_256_CBC_SHA384:
-      return "TLS_RSA_PSK_WITH_AES_256_CBC_SHA384";
-      break;
-    case TLS_RSA_PSK_WITH_NULL_SHA256:
-      return "TLS_RSA_PSK_WITH_NULL_SHA256";
-      break;
-    case TLS_RSA_PSK_WITH_NULL_SHA384:
-      return "TLS_RSA_PSK_WITH_NULL_SHA384";
-      break;
-#endif /* CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7 */
-#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
-    /* New ChaCha20+Poly1305 cipher-suites used by TLS 1.3: */
-    case TLS_AES_128_GCM_SHA256:
-      return "TLS_AES_128_GCM_SHA256";
-      break;
-    case TLS_AES_256_GCM_SHA384:
-      return "TLS_AES_256_GCM_SHA384";
-      break;
-    case TLS_CHACHA20_POLY1305_SHA256:
-      return "TLS_CHACHA20_POLY1305_SHA256";
-      break;
-    case TLS_AES_128_CCM_SHA256:
-      return "TLS_AES_128_CCM_SHA256";
-      break;
-    case TLS_AES_128_CCM_8_SHA256:
-      return "TLS_AES_128_CCM_8_SHA256";
-      break;
-    case TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:
-      return "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256";
-      break;
-    case TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:
-      return "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256";
-      break;
-#endif /* CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11 */
+  /* The first ciphers in the ciphertable are continuos. Here we do small
+     optimization and instead of loop directly get SSL name by cipher number.
+   */
+  if(cipher <= SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA) {
+    return ciphertable[cipher].name;
   }
-  return "TLS_NULL_WITH_NULL_NULL";
+  /* Iterate through the rest of the ciphers */
+  for(size_t i = SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA + 1;
+      i < NUM_OF_CIPHERS;
+      ++i) {
+    if(ciphertable[i].num == cipher) {
+      return ciphertable[i].name;
+    }
+  }
+  return ciphertable[SSL_NULL_WITH_NULL_NULL].name;
 }
 #endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 
@@ -1386,6 +1457,200 @@ set_ssl_version_min_max(struct Curl_easy *data, struct connectdata *conn,
   return CURLE_SSL_CONNECT_ERROR;
 }
 
+static bool is_cipher_suite_strong(SSLCipherSuite suite_num)
+{
+  for(size_t i = 0; i < NUM_OF_CIPHERS; ++i) {
+    if(ciphertable[i].num == suite_num) {
+      return !ciphertable[i].weak;
+    }
+  }
+  /* If the cipher is not in our list, assume it is a new one
+     and therefore strong. Previous implementation was the same,
+     if cipher suite is not in the list, it was considered strong enough */
+  return true;
+}
+
+static bool is_separator(char c)
+{
+  /* Return whether character is a cipher list separator. */
+  switch(c) {
+  case ' ':
+  case '\t':
+  case ':':
+  case ',':
+  case ';':
+    return true;
+  }
+  return false;
+}
+
+static CURLcode sectransp_set_default_ciphers(struct Curl_easy *data,
+                                              SSLContextRef ssl_ctx)
+{
+  size_t all_ciphers_count = 0UL, allowed_ciphers_count = 0UL, i;
+  SSLCipherSuite *all_ciphers = NULL, *allowed_ciphers = NULL;
+  OSStatus err = noErr;
+
+#if CURL_BUILD_MAC
+  int darwinver_maj = 0, darwinver_min = 0;
+
+  GetDarwinVersionNumber(&darwinver_maj, &darwinver_min);
+#endif /* CURL_BUILD_MAC */
+
+  /* Disable cipher suites that ST supports but are not safe. These ciphers
+     are unlikely to be used in any case since ST gives other ciphers a much
+     higher priority, but it's probably better that we not connect at all than
+     to give the user a false sense of security if the server only supports
+     insecure ciphers. (Note: We don't care about SSLv2-only ciphers.) */
+  err = SSLGetNumberSupportedCiphers(ssl_ctx, &all_ciphers_count);
+  if(err != noErr) {
+    failf(data, "SSL: SSLGetNumberSupportedCiphers() failed: OSStatus %d",
+          err);
+    return CURLE_SSL_CIPHER;
+  }
+  all_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
+  if(!all_ciphers) {
+    failf(data, "SSL: Failed to allocate memory for all ciphers");
+    return CURLE_OUT_OF_MEMORY;
+  }
+  allowed_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
+  if(!allowed_ciphers) {
+    Curl_safefree(all_ciphers);
+    failf(data, "SSL: Failed to allocate memory for allowed ciphers");
+    return CURLE_OUT_OF_MEMORY;
+  }
+  err = SSLGetSupportedCiphers(ssl_ctx, all_ciphers,
+                               &all_ciphers_count);
+  if(err != noErr) {
+    Curl_safefree(all_ciphers);
+    Curl_safefree(allowed_ciphers);
+    return CURLE_SSL_CIPHER;
+  }
+  for(i = 0UL ; i < all_ciphers_count ; i++) {
+#if CURL_BUILD_MAC
+   /* There's a known bug in early versions of Mountain Lion where ST's ECC
+      ciphers (cipher suite 0xC001 through 0xC032) simply do not work.
+      Work around the problem here by disabling those ciphers if we are
+      running in an affected version of OS X. */
+    if(darwinver_maj == 12 && darwinver_min <= 3 &&
+       all_ciphers[i] >= 0xC001 && all_ciphers[i] <= 0xC032) {
+      continue;
+    }
+#endif /* CURL_BUILD_MAC */
+    if(is_cipher_suite_strong(all_ciphers[i])) {
+      allowed_ciphers[allowed_ciphers_count++] = all_ciphers[i];
+    }
+  }
+  err = SSLSetEnabledCiphers(ssl_ctx, allowed_ciphers,
+                             allowed_ciphers_count);
+  Curl_safefree(all_ciphers);
+  Curl_safefree(allowed_ciphers);
+  if(err != noErr) {
+    failf(data, "SSL: SSLSetEnabledCiphers() failed: OSStatus %d", err);
+    return CURLE_SSL_CIPHER;
+  }
+  return CURLE_OK;
+}
+
+static CURLcode sectransp_set_selected_ciphers(struct Curl_easy *data,
+                                               SSLContextRef ssl_ctx,
+                                               const char *ciphers)
+{
+  size_t ciphers_count = 0;
+  const char *cipher_start = ciphers;
+  OSStatus err = noErr;
+  SSLCipherSuite selected_ciphers[NUM_OF_CIPHERS];
+
+  if(!ciphers)
+    return CURLE_OK;
+
+  while(is_separator(*ciphers))     /* Skip initial separators. */
+    ciphers++;
+  if(!*ciphers)
+    return CURLE_OK;
+
+  cipher_start = ciphers;
+  while(*cipher_start && ciphers_count < NUM_OF_CIPHERS) {
+    bool cipher_found = FALSE;
+    size_t cipher_len = 0;
+    const char *cipher_end = NULL;
+    bool tls_name = FALSE;
+
+    /* Skip separators */
+    while(is_separator(*cipher_start))
+       cipher_start++;
+    if(*cipher_start == '\0') {
+      break;
+    }
+    /* Find last position of a cipher in the ciphers string */
+    cipher_end = cipher_start;
+    while (*cipher_end != '\0' && !is_separator(*cipher_end)) {
+      ++cipher_end;
+    }
+
+    /* IANA cipher names start with the TLS_ or SSL_ prefix.
+       If the 4th symbol of the cipher is '_' we look for a cipher in the
+       table by its (TLS) name.
+       Otherwise, we try to match cipher by an alias. */
+    if(cipher_start[3] == '_') {
+      tls_name = TRUE;
+    }
+    /* Iterate through the cipher table and look for the cipher, starting
+       the cipher number 0x01 because the 0x00 is not the real cipher */
+    cipher_len = cipher_end - cipher_start;
+    for(size_t i = 1; i < NUM_OF_CIPHERS; ++i) {
+      const char *table_cipher_name = NULL;
+      if(tls_name) {
+        table_cipher_name = ciphertable[i].name;
+      }
+      else if(ciphertable[i].alias_name != NULL) {
+        table_cipher_name = ciphertable[i].alias_name;
+      }
+      else {
+        continue;
+      }
+      /* Compare a part of the string between separators with a cipher name
+         in the table and make sure we matched the whole cipher name */
+      if(strncmp(cipher_start, table_cipher_name, cipher_len) == 0
+          && table_cipher_name[cipher_len] == '\0') {
+        selected_ciphers[ciphers_count] = ciphertable[i].num;
+        ++ciphers_count;
+        cipher_found = TRUE;
+        break;
+      }
+    }
+    if(!cipher_found) {
+      /* It would be more human-readable if we print the wrong cipher name
+         but we don't want to allocate any additional memory and copy the name
+         into it, then add it into logs.
+         Also, we do not modify an original cipher list string. We just point
+         to positions where cipher starts and ends in the cipher list string.
+         The message is a bit cryptic and longer than necessary but can be
+         understood by humans. */
+      failf(data, "SSL: cipher string \"%s\" contains unsupported cipher name"
+            " starting position %d and ending position %d",
+            ciphers,
+            cipher_start - ciphers,
+            cipher_end - ciphers);
+      return CURLE_SSL_CIPHER;
+    }
+    if(*cipher_end) {
+      cipher_start = cipher_end + 1;
+    }
+    else {
+      break;
+    }
+  }
+  /* All cipher suites in the list are found. Report to logs as-is */
+  infof(data, "SSL: Setting cipher suites list \"%s\"\n", ciphers);
+
+  err = SSLSetEnabledCiphers(ssl_ctx, selected_ciphers, ciphers_count);
+  if(err != noErr) {
+    failf(data, "SSL: SSLSetEnabledCiphers() failed: OSStatus %d", err);
+    return CURLE_SSL_CIPHER;
+  }
+  return CURLE_OK;
+}
 
 static CURLcode sectransp_connect_step1(struct Curl_easy *data,
                                         struct connectdata *conn,
@@ -1412,8 +1677,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
 #else
   struct in_addr addr;
 #endif /* ENABLE_IPV6 */
-  size_t all_ciphers_count = 0UL, allowed_ciphers_count = 0UL, i;
-  SSLCipherSuite *all_ciphers = NULL, *allowed_ciphers = NULL;
+  char *ciphers;
   OSStatus err = noErr;
 #if CURL_BUILD_MAC
   int darwinver_maj = 0, darwinver_min = 0;
@@ -1818,121 +2082,16 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
     infof(data, "WARNING: disabling hostname validation also disables SNI.\n");
   }
 
-  /* Disable cipher suites that ST supports but are not safe. These ciphers
-     are unlikely to be used in any case since ST gives other ciphers a much
-     higher priority, but it's probably better that we not connect at all than
-     to give the user a false sense of security if the server only supports
-     insecure ciphers. (Note: We don't care about SSLv2-only ciphers.) */
-  err = SSLGetNumberSupportedCiphers(backend->ssl_ctx, &all_ciphers_count);
+  ciphers = SSL_CONN_CONFIG(cipher_list);
+  if(ciphers) {
+    err = sectransp_set_selected_ciphers(data, backend->ssl_ctx, ciphers);
+  }
+  else {
+    err = sectransp_set_default_ciphers(data, backend->ssl_ctx);
+  }
   if(err != noErr) {
-    failf(data, "SSL: SSLGetNumberSupportedCiphers() failed: OSStatus %d",
-          err);
-    return CURLE_SSL_CIPHER;
-  }
-  all_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
-  if(!all_ciphers) {
-    failf(data, "SSL: Failed to allocate memory for all ciphers");
-    return CURLE_OUT_OF_MEMORY;
-  }
-  allowed_ciphers = malloc(all_ciphers_count*sizeof(SSLCipherSuite));
-  if(!allowed_ciphers) {
-    Curl_safefree(all_ciphers);
-    failf(data, "SSL: Failed to allocate memory for allowed ciphers");
-    return CURLE_OUT_OF_MEMORY;
-  }
-  err = SSLGetSupportedCiphers(backend->ssl_ctx, all_ciphers,
-                               &all_ciphers_count);
-  if(err != noErr) {
-    Curl_safefree(all_ciphers);
-    Curl_safefree(allowed_ciphers);
-    return CURLE_SSL_CIPHER;
-  }
-  for(i = 0UL ; i < all_ciphers_count ; i++) {
-#if CURL_BUILD_MAC
-   /* There's a known bug in early versions of Mountain Lion where ST's ECC
-      ciphers (cipher suite 0xC001 through 0xC032) simply do not work.
-      Work around the problem here by disabling those ciphers if we are
-      running in an affected version of OS X. */
-    if(darwinver_maj == 12 && darwinver_min <= 3 &&
-       all_ciphers[i] >= 0xC001 && all_ciphers[i] <= 0xC032) {
-      continue;
-    }
-#endif /* CURL_BUILD_MAC */
-    switch(all_ciphers[i]) {
-      /* Disable NULL ciphersuites: */
-      case SSL_NULL_WITH_NULL_NULL:
-      case SSL_RSA_WITH_NULL_MD5:
-      case SSL_RSA_WITH_NULL_SHA:
-      case 0x003B: /* TLS_RSA_WITH_NULL_SHA256 */
-      case SSL_FORTEZZA_DMS_WITH_NULL_SHA:
-      case 0xC001: /* TLS_ECDH_ECDSA_WITH_NULL_SHA */
-      case 0xC006: /* TLS_ECDHE_ECDSA_WITH_NULL_SHA */
-      case 0xC00B: /* TLS_ECDH_RSA_WITH_NULL_SHA */
-      case 0xC010: /* TLS_ECDHE_RSA_WITH_NULL_SHA */
-      case 0x002C: /* TLS_PSK_WITH_NULL_SHA */
-      case 0x002D: /* TLS_DHE_PSK_WITH_NULL_SHA */
-      case 0x002E: /* TLS_RSA_PSK_WITH_NULL_SHA */
-      case 0x00B0: /* TLS_PSK_WITH_NULL_SHA256 */
-      case 0x00B1: /* TLS_PSK_WITH_NULL_SHA384 */
-      case 0x00B4: /* TLS_DHE_PSK_WITH_NULL_SHA256 */
-      case 0x00B5: /* TLS_DHE_PSK_WITH_NULL_SHA384 */
-      case 0x00B8: /* TLS_RSA_PSK_WITH_NULL_SHA256 */
-      case 0x00B9: /* TLS_RSA_PSK_WITH_NULL_SHA384 */
-      /* Disable anonymous ciphersuites: */
-      case SSL_DH_anon_EXPORT_WITH_RC4_40_MD5:
-      case SSL_DH_anon_WITH_RC4_128_MD5:
-      case SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA:
-      case SSL_DH_anon_WITH_DES_CBC_SHA:
-      case SSL_DH_anon_WITH_3DES_EDE_CBC_SHA:
-      case TLS_DH_anon_WITH_AES_128_CBC_SHA:
-      case TLS_DH_anon_WITH_AES_256_CBC_SHA:
-      case 0xC015: /* TLS_ECDH_anon_WITH_NULL_SHA */
-      case 0xC016: /* TLS_ECDH_anon_WITH_RC4_128_SHA */
-      case 0xC017: /* TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA */
-      case 0xC018: /* TLS_ECDH_anon_WITH_AES_128_CBC_SHA */
-      case 0xC019: /* TLS_ECDH_anon_WITH_AES_256_CBC_SHA */
-      case 0x006C: /* TLS_DH_anon_WITH_AES_128_CBC_SHA256 */
-      case 0x006D: /* TLS_DH_anon_WITH_AES_256_CBC_SHA256 */
-      case 0x00A6: /* TLS_DH_anon_WITH_AES_128_GCM_SHA256 */
-      case 0x00A7: /* TLS_DH_anon_WITH_AES_256_GCM_SHA384 */
-      /* Disable weak key ciphersuites: */
-      case SSL_RSA_EXPORT_WITH_RC4_40_MD5:
-      case SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5:
-      case SSL_RSA_EXPORT_WITH_DES40_CBC_SHA:
-      case SSL_DH_DSS_EXPORT_WITH_DES40_CBC_SHA:
-      case SSL_DH_RSA_EXPORT_WITH_DES40_CBC_SHA:
-      case SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA:
-      case SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA:
-      case SSL_RSA_WITH_DES_CBC_SHA:
-      case SSL_DH_DSS_WITH_DES_CBC_SHA:
-      case SSL_DH_RSA_WITH_DES_CBC_SHA:
-      case SSL_DHE_DSS_WITH_DES_CBC_SHA:
-      case SSL_DHE_RSA_WITH_DES_CBC_SHA:
-      /* Disable IDEA: */
-      case SSL_RSA_WITH_IDEA_CBC_SHA:
-      case SSL_RSA_WITH_IDEA_CBC_MD5:
-      /* Disable RC4: */
-      case SSL_RSA_WITH_RC4_128_MD5:
-      case SSL_RSA_WITH_RC4_128_SHA:
-      case 0xC002: /* TLS_ECDH_ECDSA_WITH_RC4_128_SHA */
-      case 0xC007: /* TLS_ECDHE_ECDSA_WITH_RC4_128_SHA*/
-      case 0xC00C: /* TLS_ECDH_RSA_WITH_RC4_128_SHA */
-      case 0xC011: /* TLS_ECDHE_RSA_WITH_RC4_128_SHA */
-      case 0x008A: /* TLS_PSK_WITH_RC4_128_SHA */
-      case 0x008E: /* TLS_DHE_PSK_WITH_RC4_128_SHA */
-      case 0x0092: /* TLS_RSA_PSK_WITH_RC4_128_SHA */
-        break;
-      default: /* enable everything else */
-        allowed_ciphers[allowed_ciphers_count++] = all_ciphers[i];
-        break;
-    }
-  }
-  err = SSLSetEnabledCiphers(backend->ssl_ctx, allowed_ciphers,
-                             allowed_ciphers_count);
-  Curl_safefree(all_ciphers);
-  Curl_safefree(allowed_ciphers);
-  if(err != noErr) {
-    failf(data, "SSL: SSLSetEnabledCiphers() failed: OSStatus %d", err);
+    failf(data, "SSL: Unable to set ciphers for SSL/TLS handshake. "
+          "Error code: %d", err);
     return CURLE_SSL_CIPHER;
   }
 
@@ -2637,11 +2796,11 @@ sectransp_connect_step2(struct Curl_easy *data, struct connectdata *conn,
     switch(protocol) {
       case kSSLProtocol2:
         infof(data, "SSL 2.0 connection using %s\n",
-              SSLCipherNameForNumber(cipher));
+              TLSCipherNameForNumber(cipher));
         break;
       case kSSLProtocol3:
         infof(data, "SSL 3.0 connection using %s\n",
-              SSLCipherNameForNumber(cipher));
+              TLSCipherNameForNumber(cipher));
         break;
       case kTLSProtocol1:
         infof(data, "TLS 1.0 connection using %s\n",


### PR DESCRIPTION
Add parser for CURLOPT_SSL_CIPHER_LIST option for Secure Transport (ST)
back-end. Similar to NNS and GSKit back-ends, new code parses string
value and configures ST library to use those ciphers for communication.

Create cipher spec data structure and initialize array of specs with
cipher number, names and flag. That array allows to add/modify ciphers
in one place instead of several functions in code. The flag is binary
value for backward compatibility with an existing wrapper
implementation. It can be extended later for other purposes like
support of specific TLS version.

Code change required some analysis of macOS SDK versions, we need to
know when one or another value of enum in macOS SDK was introduced,
and some other data. I created the TLS-CIPHERS.md file to summarize
that data I found and to add some more information about ciphers
could useful for others. That document is not completely ready yet
and I just want your opinion on it.
