### PR TITLE
Remove conn->data occurrences from vtls subdirectory files

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -443,7 +443,7 @@ static CURLcode InitiateTransfer(struct Curl_easy *data)
     /* since we only have a plaintext TCP connection here, we must now
      * do the TLS stuff */
     infof(data, "Doing the SSL/TLS handshake on the data stream\n");
-    result = Curl_ssl_connect(conn, SECONDARYSOCKET);
+    result = Curl_ssl_connect(data, conn, SECONDARYSOCKET);
     if(result)
       return result;
   }
@@ -2734,7 +2734,7 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
 
       if((ftpcode == 234) || (ftpcode == 334)) {
         /* Curl_ssl_connect is BLOCKING */
-        result = Curl_ssl_connect(conn, FIRSTSOCKET);
+        result = Curl_ssl_connect(data, conn, FIRSTSOCKET);
         if(!result) {
           conn->bits.ftp_use_data_ssl = FALSE; /* clear-text data */
           conn->bits.ftp_use_control_ssl = TRUE; /* SSL on control */
@@ -2800,7 +2800,7 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
     case FTP_CCC:
       if(ftpcode < 500) {
         /* First shut down the SSL layer (note: this call will block) */
-        result = Curl_ssl_shutdown(conn, FIRSTSOCKET);
+        result = Curl_ssl_shutdown(data, conn, FIRSTSOCKET);
 
         if(result)
           failf(data, "Failed to clear the command channel (CCC)");
@@ -3138,7 +3138,7 @@ static CURLcode ftp_connect(struct Curl_easy *data,
 
   if(conn->handler->flags & PROTOPT_SSL) {
     /* BLOCKING */
-    result = Curl_ssl_connect(conn, FIRSTSOCKET);
+    result = Curl_ssl_connect(data, conn, FIRSTSOCKET);
     if(result)
       return result;
     conn->bits.ftp_use_control_ssl = TRUE;
@@ -3284,7 +3284,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
     if(conn->ssl[SECONDARYSOCKET].use) {
       /* The secondary socket is using SSL so we must close down that part
          first before we close the socket for real */
-      Curl_ssl_close(conn, SECONDARYSOCKET);
+      Curl_ssl_close(data, conn, SECONDARYSOCKET);
 
       /* Note that we keep "use" set to TRUE since that (next) connection is
          still requested to use SSL */

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -113,7 +113,7 @@ static CURLcode gopher_connect(struct Curl_easy *data, bool *done)
 static CURLcode gopher_connecting(struct Curl_easy *data, bool *done)
 {
   struct connectdata *conn = data->conn;
-  CURLcode result = Curl_ssl_connect(conn, FIRSTSOCKET);
+  CURLcode result = Curl_ssl_connect(data, conn, FIRSTSOCKET);
   if(result)
     connclose(conn, "Failed TLS connection");
   *done = TRUE;

--- a/lib/http.c
+++ b/lib/http.c
@@ -1532,7 +1532,7 @@ static CURLcode https_connecting(struct Curl_easy *data, bool *done)
 #endif
 
   /* perform SSL initialization for this socket */
-  result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, done);
+  result = Curl_ssl_connect_nonblocking(data, conn, FIRSTSOCKET, done);
   if(result)
     connclose(conn, "Failed HTTPS connection");
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -58,7 +58,7 @@ static CURLcode https_proxy_connect(struct connectdata *conn, int sockindex)
   if(!conn->bits.proxy_ssl_connected[sockindex]) {
     /* perform SSL initialization for this socket */
     result =
-      Curl_ssl_connect_nonblocking(conn, sockindex,
+      Curl_ssl_connect_nonblocking(conn->data, conn, sockindex,
                                    &conn->bits.proxy_ssl_connected[sockindex]);
     if(result)
       /* a failed connection is marked for closure to prevent (bad) re-use or

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -473,7 +473,7 @@ static CURLcode imap_perform_upgrade_tls(struct Curl_easy *data,
 {
   /* Start the SSL connection */
   struct imap_conn *imapc = &conn->proto.imapc;
-  CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+  CURLcode result = Curl_ssl_connect_nonblocking(data, conn, FIRSTSOCKET,
                                                  &imapc->ssldone);
 
   if(!result) {
@@ -1366,7 +1366,8 @@ static CURLcode imap_multi_statemach(struct Curl_easy *data, bool *done)
   struct imap_conn *imapc = &conn->proto.imapc;
 
   if((conn->handler->flags & PROTOPT_SSL) && !imapc->ssldone) {
-    result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &imapc->ssldone);
+    result = Curl_ssl_connect_nonblocking(data, conn,
+                                          FIRSTSOCKET, &imapc->ssldone);
     if(result || !imapc->ssldone)
       return result;
   }

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -245,7 +245,8 @@ static CURLcode ldap_connect(struct Curl_easy *data, bool *done)
 #ifdef USE_SSL
   if(conn->handler->flags & PROTOPT_SSL) {
     CURLcode result;
-    result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &li->ssldone);
+    result = Curl_ssl_connect_nonblocking(data, conn,
+                                          FIRSTSOCKET, &li->ssldone);
     if(result)
       return result;
   }
@@ -267,7 +268,7 @@ static CURLcode ldap_connecting(struct Curl_easy *data, bool *done)
   if(conn->handler->flags & PROTOPT_SSL) {
     /* Is the SSL handshake complete yet? */
     if(!li->ssldone) {
-      CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+      CURLcode result = Curl_ssl_connect_nonblocking(data, conn, FIRSTSOCKET,
                                                      &li->ssldone);
       if(result || !li->ssldone)
         return result;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -368,7 +368,7 @@ static CURLcode pop3_perform_upgrade_tls(struct Curl_easy *data,
 {
   /* Start the SSL connection */
   struct pop3_conn *pop3c = &conn->proto.pop3c;
-  CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+  CURLcode result = Curl_ssl_connect_nonblocking(data, conn, FIRSTSOCKET,
                                                  &pop3c->ssldone);
 
   if(!result) {
@@ -1029,7 +1029,8 @@ static CURLcode pop3_multi_statemach(struct Curl_easy *data, bool *done)
   struct pop3_conn *pop3c = &conn->proto.pop3c;
 
   if((conn->handler->flags & PROTOPT_SSL) && !pop3c->ssldone) {
-    result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &pop3c->ssldone);
+    result = Curl_ssl_connect_nonblocking(data, conn,
+                                          FIRSTSOCKET, &pop3c->ssldone);
     if(result || !pop3c->ssldone)
       return result;
   }

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -669,7 +669,8 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
 #ifdef USE_SSL
     if((conn->handler->flags & PROTOPT_SSL)) {
       bool ssl_done = FALSE;
-      result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &ssl_done);
+      result = Curl_ssl_connect_nonblocking(data, conn,
+                                            FIRSTSOCKET, &ssl_done);
       if(result && result != CURLE_AGAIN)
         return result;
       if(!ssl_done)

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -395,7 +395,7 @@ static CURLcode smtp_perform_upgrade_tls(struct Curl_easy *data)
   /* Start the SSL connection */
   struct connectdata *conn = data->conn;
   struct smtp_conn *smtpc = &conn->proto.smtpc;
-  CURLcode result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET,
+  CURLcode result = Curl_ssl_connect_nonblocking(data, conn, FIRSTSOCKET,
                                                  &smtpc->ssldone);
 
   if(!result) {
@@ -1256,7 +1256,8 @@ static CURLcode smtp_multi_statemach(struct Curl_easy *data, bool *done)
   struct smtp_conn *smtpc = &conn->proto.smtpc;
 
   if((conn->handler->flags & PROTOPT_SSL) && !smtpc->ssldone) {
-    result = Curl_ssl_connect_nonblocking(conn, FIRSTSOCKET, &smtpc->ssldone);
+    result = Curl_ssl_connect_nonblocking(data, conn,
+                                          FIRSTSOCKET, &smtpc->ssldone);
     if(result || !smtpc->ssldone)
       return result;
   }

--- a/lib/url.c
+++ b/lib/url.c
@@ -723,8 +723,8 @@ static void conn_shutdown(struct Curl_easy *data, struct connectdata *conn)
 
   /* close the SSL stuff before we close any sockets since they will/may
      write to the sockets */
-  Curl_ssl_close(conn, FIRSTSOCKET);
-  Curl_ssl_close(conn, SECONDARYSOCKET);
+  Curl_ssl_close(data, conn, FIRSTSOCKET);
+  Curl_ssl_close(data, conn, SECONDARYSOCKET);
 
   /* close possibly still open sockets */
   if(CURL_SOCKET_BAD != conn->sock[SECONDARYSOCKET])

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -776,12 +776,13 @@ static CURLcode bearssl_random(struct Curl_easy *data UNUSED_PARAM,
   return CURLE_OK;
 }
 
-static CURLcode bearssl_connect(struct connectdata *conn, int sockindex)
+static CURLcode bearssl_connect(struct Curl_easy *data,
+                                struct connectdata *conn, int sockindex)
 {
   CURLcode ret;
   bool done = FALSE;
 
-  ret = bearssl_connect_common(conn->data, conn, sockindex, FALSE, &done);
+  ret = bearssl_connect_common(data, conn, sockindex, FALSE, &done);
   if(ret)
     return ret;
 
@@ -790,10 +791,11 @@ static CURLcode bearssl_connect(struct connectdata *conn, int sockindex)
   return CURLE_OK;
 }
 
-static CURLcode bearssl_connect_nonblocking(struct connectdata *conn,
+static CURLcode bearssl_connect_nonblocking(struct Curl_easy *data,
+                                            struct connectdata *conn,
                                             int sockindex, bool *done)
 {
-  return bearssl_connect_common(conn->data, conn, sockindex, TRUE, done);
+  return bearssl_connect_common(data, conn, sockindex, TRUE, done);
 }
 
 static void *bearssl_get_internals(struct ssl_connect_data *connssl,
@@ -803,8 +805,8 @@ static void *bearssl_get_internals(struct ssl_connect_data *connssl,
   return &backend->ctx;
 }
 
-static void real_bearssl_close(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex)
+static void bearssl_close(struct Curl_easy *data,
+                          struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -817,11 +819,6 @@ static void real_bearssl_close(struct Curl_easy *data,
   for(i = 0; i < backend->anchors_len; ++i)
     free(backend->anchors[i].dn.data);
   free(backend->anchors);
-}
-
-static void bearssl_close(struct connectdata *conn, int sockindex)
-{
-  real_bearssl_close(conn->data, conn, sockindex);
 }
 
 static void bearssl_session_free(void *ptr)

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -374,12 +374,12 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
   if(SSL_SET_OPTION(primary.sessionid)) {
     void *session;
 
-    Curl_ssl_sessionid_lock(conn);
-    if(!Curl_ssl_getsessionid(conn, &session, NULL, sockindex)) {
+    Curl_ssl_sessionid_lock(data);
+    if(!Curl_ssl_getsessionid(data, conn, &session, NULL, sockindex)) {
       br_ssl_engine_set_session_parameters(&backend->ctx.eng, session);
       infof(data, "BearSSL: re-using session ID\n");
     }
-    Curl_ssl_sessionid_unlock(conn);
+    Curl_ssl_sessionid_unlock(data);
   }
 
   if(conn->bits.tls_enable_alpn) {
@@ -569,12 +569,13 @@ static CURLcode bearssl_connect_step3(struct Curl_easy *data,
     if(!session)
       return CURLE_OUT_OF_MEMORY;
     br_ssl_engine_get_session_parameters(&backend->ctx.eng, session);
-    Curl_ssl_sessionid_lock(conn);
-    incache = !(Curl_ssl_getsessionid(conn, &oldsession, NULL, sockindex));
+    Curl_ssl_sessionid_lock(data);
+    incache = !(Curl_ssl_getsessionid(data, conn,
+                                      &oldsession, NULL, sockindex));
     if(incache)
-      Curl_ssl_delsessionid(conn, oldsession);
-    ret = Curl_ssl_addsessionid(conn, session, 0, sockindex);
-    Curl_ssl_sessionid_unlock(conn);
+      Curl_ssl_delsessionid(data, oldsession);
+    ret = Curl_ssl_addsessionid(data, conn, session, 0, sockindex);
+    Curl_ssl_sessionid_unlock(data);
     if(ret) {
       free(session);
       return CURLE_OUT_OF_MEMORY;

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1125,9 +1125,9 @@ static CURLcode gskit_connect_common(struct Curl_easy *data,
 }
 
 
-static CURLcode real_gskit_connect_nonblocking(struct Curl_easy *data,
-                                               struct connectdata *conn,
-                                               int sockindex, bool *done)
+static CURLcode gskit_connect_nonblocking(struct Curl_easy *data,
+                                          struct connectdata *conn,
+                                          int sockindex, bool *done)
 {
   CURLcode result;
 
@@ -1137,15 +1137,9 @@ static CURLcode real_gskit_connect_nonblocking(struct Curl_easy *data,
   return result;
 }
 
-static CURLcode gskit_connect_nonblocking(struct connectdata *conn,
-                                          int sockindex, bool *done)
-{
-  return real_gskit_connect_nonblocking(conn->data, conn, sockindex, done);
-}
 
-
-static CURLcode real_gskit_connect(struct Curl_easy *data,
-                                   struct connectdata *conn, int sockindex)
+static CURLcode gskit_connect(struct Curl_easy *data,
+                              struct connectdata *conn, int sockindex)
 {
   CURLcode result;
   bool done;
@@ -1160,27 +1154,17 @@ static CURLcode real_gskit_connect(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode gskit_connect(struct connectdata *conn, int sockindex)
-{
-  return real_gskit_connect(conn->data, conn, sockindex);
-}
 
-
-static void real_gskit_close(struct Curl_easy *data, struct connectdata *conn,
-                             int sockindex)
+static void gskit_close(struct Curl_easy *data, struct connectdata *conn,
+                        int sockindex)
 {
   close_one(&conn->ssl[sockindex], data, conn, sockindex);
   close_one(&conn->proxy_ssl[sockindex], data, conn, sockindex);
 }
 
-static void gskit_close(struct connectdata *conn, int sockindex)
-{
-  real_gskit_close(conn->data, conn, sockindex);
-}
 
-
-static int real_gskit_shutdown(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex)
+static int gskit_shutdown(struct Curl_easy *data,
+                          struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   int what;
@@ -1233,11 +1217,6 @@ static int real_gskit_shutdown(struct Curl_easy *data,
   }
 
   return rc;
-}
-
-static int gskit_shutdown(struct connectdata *conn, int sockindex)
-{
-  return real_gskit_shutdown(conn->data, conn, sockindex);
 }
 
 

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -610,10 +610,10 @@ static void close_one(struct ssl_connect_data *connssl, struct Curl_easy *data,
 }
 
 
-static ssize_t real_gskit_send(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex,
-                               const void *mem, size_t len, CURLcode *curlcode)
+static ssize_t gskit_send(struct connectdata *conn, int sockindex,
+                          const void *mem, size_t len, CURLcode *curlcode)
 {
+  struct connectdata *conn = data->conn;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   CURLcode cc = CURLE_SEND_ERROR;
   int written;
@@ -634,17 +634,11 @@ static ssize_t real_gskit_send(struct Curl_easy *data,
   return (ssize_t) written; /* number of bytes */
 }
 
-static ssize_t gskit_send(struct connectdata *conn, int sockindex,
-                          const void *mem, size_t len, CURLcode *curlcode)
-{
-  return real_gskit_send(conn->data, conn, sockindex, mem, len, curlcode);
-}
 
-
-static ssize_t real_gskit_recv(struct Curl_easy *data,
-                               struct connectdata *conn, int num, char *buf,
+static ssize_t gskit_recv(struct Curl_easy *data, int num, char *buf,
                                size_t buffersize, CURLcode *curlcode)
 {
+  struct connectdata *conn = data->conn;
   struct ssl_connect_data *connssl = &conn->ssl[num];
   int nread;
   CURLcode cc = CURLE_RECV_ERROR;
@@ -666,12 +660,6 @@ static ssize_t real_gskit_recv(struct Curl_easy *data,
     break;
   }
   return (ssize_t) nread;
-}
-
-static ssize_t gskit_recv(struct connectdata *conn, int num, char *buf,
-                          size_t buffersize, CURLcode *curlcode)
-{
-  return real_gskit_recv(conn->data, conn, num, buf, buffersize, curlcode);
 }
 
 static CURLcode

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -200,12 +200,12 @@ static void unload_file(gnutls_datum_t data)
 
 
 /* this function does a SSL/TLS (re-)handshake */
-static CURLcode handshake(struct connectdata *conn,
+static CURLcode handshake(struct Curl_easy *data,
+                          struct connectdata *conn,
                           int sockindex,
                           bool duringconnect,
                           bool nonblocking)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   gnutls_session_t session = backend->session;
@@ -314,9 +314,9 @@ static gnutls_x509_crt_fmt_t do_file_type(const char *type)
 #define GNUTLS_SRP "+SRP"
 
 static CURLcode
-set_ssl_version_min_max(const char **prioritylist, struct connectdata *conn)
+set_ssl_version_min_max(const char **prioritylist, struct Curl_easy *data)
 {
-  struct Curl_easy *data = conn->data;
+  struct connectdata *conn = data->conn;
   long ssl_version = SSL_CONN_CONFIG(version);
   long ssl_version_max = SSL_CONN_CONFIG(version_max);
 
@@ -379,10 +379,10 @@ set_ssl_version_min_max(const char **prioritylist, struct connectdata *conn)
 }
 
 static CURLcode
-gtls_connect_step1(struct connectdata *conn,
+gtls_connect_step1(struct Curl_easy *data,
+                   struct connectdata *conn,
                    int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   unsigned int init_flags;
@@ -568,7 +568,7 @@ gtls_connect_step1(struct connectdata *conn,
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
       {
-        CURLcode result = set_ssl_version_min_max(&prioritylist, conn);
+        CURLcode result = set_ssl_version_min_max(&prioritylist, data);
         if(result != CURLE_OK)
           return result;
         break;
@@ -807,7 +807,8 @@ static Curl_recv gtls_recv;
 static Curl_send gtls_send;
 
 static CURLcode
-gtls_connect_step3(struct connectdata *conn,
+gtls_connect_step3(struct Curl_easy *data,
+                   struct connectdata *conn,
                    int sockindex)
 {
   unsigned int cert_list_size;
@@ -820,7 +821,6 @@ gtls_connect_step3(struct connectdata *conn,
   size_t size;
   time_t certclock;
   const char *ptr;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   gnutls_session_t session = backend->session;
@@ -1326,7 +1326,8 @@ gtls_connect_step3(struct connectdata *conn,
    'ssl_connect_2_writing' (waiting to be able to write).
  */
 static CURLcode
-gtls_connect_common(struct connectdata *conn,
+gtls_connect_common(struct Curl_easy *data,
+                    struct connectdata *conn,
                     int sockindex,
                     bool nonblocking,
                     bool *done)
@@ -1336,19 +1337,19 @@ gtls_connect_common(struct connectdata *conn,
 
   /* Initiate the connection, if not already done */
   if(ssl_connect_1 == connssl->connecting_state) {
-    rc = gtls_connect_step1(conn, sockindex);
+    rc = gtls_connect_step1(data, conn, sockindex);
     if(rc)
       return rc;
   }
 
-  rc = handshake(conn, sockindex, TRUE, nonblocking);
+  rc = handshake(data, conn, sockindex, TRUE, nonblocking);
   if(rc)
     /* handshake() sets its own error message with failf() */
     return rc;
 
   /* Finish connecting once the handshake is done */
   if(ssl_connect_1 == connssl->connecting_state) {
-    rc = gtls_connect_step3(conn, sockindex);
+    rc = gtls_connect_step3(data, conn, sockindex);
     if(rc)
       return rc;
   }
@@ -1361,7 +1362,7 @@ gtls_connect_common(struct connectdata *conn,
 static CURLcode gtls_connect_nonblocking(struct connectdata *conn,
                                          int sockindex, bool *done)
 {
-  return gtls_connect_common(conn, sockindex, TRUE, done);
+  return gtls_connect_common(conn->data, conn, sockindex, TRUE, done);
 }
 
 static CURLcode gtls_connect(struct connectdata *conn, int sockindex)
@@ -1369,7 +1370,7 @@ static CURLcode gtls_connect(struct connectdata *conn, int sockindex)
   CURLcode result;
   bool done = FALSE;
 
-  result = gtls_connect_common(conn, sockindex, FALSE, &done);
+  result = gtls_connect_common(conn->data, conn, sockindex, FALSE, &done);
   if(result)
     return result;
 
@@ -1441,24 +1442,31 @@ static void close_one(struct ssl_connect_data *connssl)
 #endif
 }
 
-static void gtls_close(struct connectdata *conn, int sockindex)
+static void real_gtls_close(struct Curl_easy *data, struct connectdata *conn,
+                            int sockindex)
 {
+  (void) data;
   close_one(&conn->ssl[sockindex]);
 #ifndef CURL_DISABLE_PROXY
   close_one(&conn->proxy_ssl[sockindex]);
 #endif
 }
 
+static void gtls_close(struct connectdata *conn, int sockindex)
+{
+  real_gtls_close(conn->data, conn, sockindex);
+}
+
 /*
  * This function is called to shut down the SSL layer but keep the
  * socket open (CCC - Clear Command Channel)
  */
-static int gtls_shutdown(struct connectdata *conn, int sockindex)
+static int real_gtls_shutdown(struct Curl_easy *data, struct connectdata *conn,
+                              int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   int retval = 0;
-  struct Curl_easy *data = conn->data;
 
 #ifndef CURL_DISABLE_FTP
   /* This has only been tested on the proftpd server, and the mod_tls code
@@ -1527,6 +1535,11 @@ static int gtls_shutdown(struct connectdata *conn, int sockindex)
   return retval;
 }
 
+static int gtls_shutdown(struct connectdata *conn, int sockindex)
+{
+  return real_gtls_shutdown(conn->data, conn, sockindex);
+}
+
 static ssize_t gtls_recv(struct Curl_easy *data, /* connection data */
                          int num,                  /* socketindex */
                          char *buf,                /* store read data here */
@@ -1547,7 +1560,7 @@ static ssize_t gtls_recv(struct Curl_easy *data, /* connection data */
   if(ret == GNUTLS_E_REHANDSHAKE) {
     /* BLOCKING call, this is bad but a work-around for now. Fixing this "the
        proper way" takes a whole lot of work. */
-    CURLcode result = handshake(conn, num, FALSE, FALSE);
+    CURLcode result = handshake(data, conn, num, FALSE, FALSE);
     if(result)
       /* handshake() writes error message on its own */
       *curlcode = result;
@@ -1557,7 +1570,7 @@ static ssize_t gtls_recv(struct Curl_easy *data, /* connection data */
   }
 
   if(ret < 0) {
-    failf(conn->data, "GnuTLS recv error (%d): %s",
+    failf(data, "GnuTLS recv error (%d): %s",
 
           (int)ret, gnutls_strerror((int)ret));
     *curlcode = CURLE_RECV_ERROR;
@@ -1606,7 +1619,7 @@ static CURLcode gtls_random(struct Curl_easy *data,
   return rc?CURLE_FAILED_INIT:CURLE_OK;
 #elif defined(USE_GNUTLS)
   if(data)
-    Curl_gtls_seed(data); /* Initiate the seed if not already done */
+    gtls_seed(data); /* Initiate the seed if not already done */
   gcry_randomize(entropy, length, GCRY_STRONG_RANDOM);
 #endif
   return CURLE_OK;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -785,8 +785,8 @@ static void mbedtls_close_all(struct Curl_easy *data)
   (void)data;
 }
 
-static void real_mbedtls_close(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex)
+static void mbedtls_close(struct Curl_easy *data,
+                          struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -802,11 +802,6 @@ static void real_mbedtls_close(struct Curl_easy *data,
 #ifndef THREADING_SUPPORT
   mbedtls_entropy_free(&backend->entropy);
 #endif /* THREADING_SUPPORT */
-}
-
-static void mbedtls_close(struct connectdata *conn, int sockindex)
-{
-  real_mbedtls_close(conn->data, conn, sockindex);
 }
 
 static ssize_t mbed_recv(struct Curl_easy *data, int num,
@@ -1016,19 +1011,21 @@ mbed_connect_common(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode mbedtls_connect_nonblocking(struct connectdata *conn,
+static CURLcode mbedtls_connect_nonblocking(struct Curl_easy *data,
+                                            struct connectdata *conn,
                                             int sockindex, bool *done)
 {
-  return mbed_connect_common(conn->data, conn, sockindex, TRUE, done);
+  return mbed_connect_common(data, conn, sockindex, TRUE, done);
 }
 
 
-static CURLcode mbedtls_connect(struct connectdata *conn, int sockindex)
+static CURLcode mbedtls_connect(struct Curl_easy *data,
+                                struct connectdata *conn, int sockindex)
 {
   CURLcode retcode;
   bool done = FALSE;
 
-  retcode = mbed_connect_common(conn->data, conn, sockindex, FALSE, &done);
+  retcode = mbed_connect_common(data, conn, sockindex, FALSE, &done);
   if(retcode)
     return retcode;
 

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -408,8 +408,7 @@ mesalink_send(struct Curl_easy *data, int sockindex, const void *mem,
 }
 
 static void
-real_mesalink_close(struct Curl_easy *data,
-                    struct connectdata *conn, int sockindex)
+mesalink_close(struct Curl_easy *data, struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 
@@ -424,12 +423,6 @@ real_mesalink_close(struct Curl_easy *data,
     SSL_CTX_free(BACKEND->ctx);
     BACKEND->ctx = NULL;
   }
-}
-
-static void
-mesalink_close(struct connectdata *conn, int sockindex)
-{
-  real_mesalink_close(conn->data, conn, sockindex);
 }
 
 static ssize_t
@@ -483,8 +476,8 @@ mesalink_init(void)
  * socket open (CCC - Clear Command Channel)
  */
 static int
-real_mesalink_shutdown(struct Curl_easy *data,
-                       struct connectdata *conn, int sockindex)
+mesalink_shutdown(struct Curl_easy *data,
+                  struct connectdata *conn, int sockindex)
 {
   int retval = 0;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
@@ -496,12 +489,6 @@ real_mesalink_shutdown(struct Curl_easy *data,
     BACKEND->handle = NULL;
   }
   return retval;
-}
-
-static int
-mesalink_shutdown(struct connectdata *conn, int sockindex)
-{
-  return real_mesalink_shutdown(conn->data, conn, sockindex);
 }
 
 static CURLcode
@@ -619,19 +606,20 @@ mesalink_connect_common(struct Curl_easy *data, struct connectdata *conn,
 }
 
 static CURLcode
-mesalink_connect_nonblocking(struct connectdata *conn, int sockindex,
-                             bool *done)
+mesalink_connect_nonblocking(struct Curl_easy *data, struct connectdata *conn,
+                             int sockindex, bool *done)
 {
-  return mesalink_connect_common(conn->data, conn, sockindex, TRUE, done);
+  return mesalink_connect_common(data, conn, sockindex, TRUE, done);
 }
 
 static CURLcode
-mesalink_connect(struct connectdata *conn, int sockindex)
+mesalink_connect(struct Curl_easy *data, struct connectdata *conn,
+                 int sockindex)
 {
   CURLcode result;
   bool done = FALSE;
 
-  result = mesalink_connect_common(conn->data, conn, sockindex, FALSE, &done);
+  result = mesalink_connect_common(data, conn, sockindex, FALSE, &done);
   if(result)
     return result;
 

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1546,9 +1546,8 @@ static void close_one(struct ssl_connect_data *connssl)
 /*
  * This function is called when an SSL connection is closed.
  */
-static void real_nss_close(struct Curl_easy *data,
-                           struct connectdata *conn,
-                           int sockindex)
+static void nss_close(struct Curl_easy *data, struct connectdata *conn,
+                      int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 #ifndef CURL_DISABLE_PROXY
@@ -1578,11 +1577,6 @@ static void real_nss_close(struct Curl_easy *data,
   close_one(connssl_proxy);
 #endif
   close_one(connssl);
-}
-
-static void nss_close(struct connectdata *conn, int sockindex)
-{
-  real_nss_close(conn->data, conn, sockindex);
 }
 
 /* return true if NSS can provide error code (and possibly msg) for the
@@ -2256,15 +2250,17 @@ static CURLcode nss_connect_common(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode nss_connect(struct connectdata *conn, int sockindex)
+static CURLcode nss_connect(struct Curl_easy *data, struct connectdata *conn,
+                            int sockindex)
 {
-  return nss_connect_common(conn->data, conn, sockindex, /* blocking */ NULL);
+  return nss_connect_common(data, conn, sockindex, /* blocking */ NULL);
 }
 
-static CURLcode nss_connect_nonblocking(struct connectdata *conn,
+static CURLcode nss_connect_nonblocking(struct Curl_easy *data,
+                                        struct connectdata *conn,
                                         int sockindex, bool *done)
 {
-  return nss_connect_common(conn->data, conn, sockindex, done);
+  return nss_connect_common(data, conn, sockindex, done);
 }
 
 static ssize_t nss_send(struct Curl_easy *data,    /* transfer */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -443,7 +443,7 @@ static CURLcode insert_wrapped_ptr(struct Curl_llist *list, void *ptr)
 
 /* Call PK11_CreateGenericObject() with the given obj_class and filename.  If
  * the call succeeds, append the object handle to the list of objects so that
- * the object can be destroyed in Curl_nss_close(). */
+ * the object can be destroyed in nss_close(). */
 static CURLcode nss_create_object(struct ssl_connect_data *connssl,
                                   CK_OBJECT_CLASS obj_class,
                                   const char *filename, bool cacert)
@@ -508,7 +508,7 @@ static CURLcode nss_create_object(struct ssl_connect_data *connssl,
 
 /* Destroy the NSS object whose handle is given by ptr.  This function is
  * a callback of Curl_llist_alloc() used by Curl_llist_destroy() to destroy
- * NSS objects in Curl_nss_close() */
+ * NSS objects in nss_close() */
 static void nss_destroy_object(void *user, void *ptr)
 {
   struct ptr_list_wrap *wrap = (struct ptr_list_wrap *) ptr;
@@ -665,14 +665,13 @@ fail:
   return CURLE_SSL_CRL_BADFILE;
 }
 
-static CURLcode nss_load_key(struct connectdata *conn, int sockindex,
-                             char *key_file)
+static CURLcode nss_load_key(struct Curl_easy *data, struct connectdata *conn,
+                             int sockindex, char *key_file)
 {
   PK11SlotInfo *slot, *tmp;
   SECStatus status;
   CURLcode result;
   struct ssl_connect_data *ssl = conn->ssl;
-  struct Curl_easy *data = conn->data;
 
   (void)sockindex; /* unused */
 
@@ -701,15 +700,15 @@ static CURLcode nss_load_key(struct connectdata *conn, int sockindex,
   return (SECSuccess == status) ? CURLE_OK : CURLE_SSL_CERTPROBLEM;
 }
 
-static int display_error(struct connectdata *conn, PRInt32 err,
+static int display_error(struct Curl_easy *data, PRInt32 err,
                          const char *filename)
 {
   switch(err) {
   case SEC_ERROR_BAD_PASSWORD:
-    failf(conn->data, "Unable to load client key: Incorrect password");
+    failf(data, "Unable to load client key: Incorrect password");
     return 1;
   case SEC_ERROR_UNKNOWN_CERT:
-    failf(conn->data, "Unable to load certificate %s", filename);
+    failf(data, "Unable to load certificate %s", filename);
     return 1;
   default:
     break;
@@ -717,17 +716,16 @@ static int display_error(struct connectdata *conn, PRInt32 err,
   return 0; /* The caller will print a generic error */
 }
 
-static CURLcode cert_stuff(struct connectdata *conn, int sockindex,
-                           char *cert_file, char *key_file)
+static CURLcode cert_stuff(struct Curl_easy *data, struct connectdata *conn,
+                           int sockindex, char *cert_file, char *key_file)
 {
-  struct Curl_easy *data = conn->data;
   CURLcode result;
 
   if(cert_file) {
     result = nss_load_cert(&conn->ssl[sockindex], cert_file, PR_FALSE);
     if(result) {
       const PRErrorCode err = PR_GetError();
-      if(!display_error(conn, err, cert_file)) {
+      if(!display_error(data, err, cert_file)) {
         const char *err_name = nss_error_to_name(err);
         failf(data, "unable to load client cert: %d (%s)", err, err_name);
       }
@@ -738,13 +736,13 @@ static CURLcode cert_stuff(struct connectdata *conn, int sockindex,
 
   if(key_file || (is_file(cert_file))) {
     if(key_file)
-      result = nss_load_key(conn, sockindex, key_file);
+      result = nss_load_key(data, conn, sockindex, key_file);
     else
       /* In case the cert file also has the key */
-      result = nss_load_key(conn, sockindex, cert_file);
+      result = nss_load_key(data, conn, sockindex, cert_file);
     if(result) {
       const PRErrorCode err = PR_GetError();
-      if(!display_error(conn, err, key_file)) {
+      if(!display_error(data, err, key_file)) {
         const char *err_name = nss_error_to_name(err);
         failf(data, "unable to load client key: %d (%s)", err, err_name);
       }
@@ -771,7 +769,8 @@ static char *nss_get_password(PK11SlotInfo *slot, PRBool retry, void *arg)
 static SECStatus nss_auth_cert_hook(void *arg, PRFileDesc *fd, PRBool checksig,
                                     PRBool isServer)
 {
-  struct connectdata *conn = (struct connectdata *)arg;
+  struct Curl_easy *data = (struct Curl_easy *)arg;
+  struct connectdata *conn = data->conn;
 
 #ifdef SSL_ENABLE_OCSP_STAPLING
   if(SSL_CONN_CONFIG(verifystatus)) {
@@ -779,12 +778,12 @@ static SECStatus nss_auth_cert_hook(void *arg, PRFileDesc *fd, PRBool checksig,
 
     const SECItemArray *csa = SSL_PeerStapledOCSPResponses(fd);
     if(!csa) {
-      failf(conn->data, "Invalid OCSP response");
+      failf(data, "Invalid OCSP response");
       return SECFailure;
     }
 
     if(csa->len == 0) {
-      failf(conn->data, "No OCSP response received");
+      failf(data, "No OCSP response received");
       return SECFailure;
     }
 
@@ -794,14 +793,14 @@ static SECStatus nss_auth_cert_hook(void *arg, PRFileDesc *fd, PRBool checksig,
     );
 
     if(cacheResult != SECSuccess) {
-      failf(conn->data, "Invalid OCSP response");
+      failf(data, "Invalid OCSP response");
       return cacheResult;
     }
   }
 #endif
 
   if(!SSL_CONN_CONFIG(verifypeer)) {
-    infof(conn->data, "skipping SSL peer certificate verification\n");
+    infof(data, "skipping SSL peer certificate verification\n");
     return SECSuccess;
   }
 
@@ -813,8 +812,8 @@ static SECStatus nss_auth_cert_hook(void *arg, PRFileDesc *fd, PRBool checksig,
  */
 static void HandshakeCallback(PRFileDesc *sock, void *arg)
 {
-  struct connectdata *conn = (struct connectdata*) arg;
-  struct Curl_easy *data = conn->data;
+  struct Curl_easy *data = (struct Curl_easy *)arg;
+  struct connectdata *conn = data->conn;
   unsigned int buflenmax = 50;
   unsigned char buf[50];
   unsigned int buflen;
@@ -857,7 +856,7 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
        !memcmp(ALPN_HTTP_1_1, buf, ALPN_HTTP_1_1_LENGTH)) {
       conn->negnpn = CURL_HTTP_VERSION_1_1;
     }
-    Curl_multiuse_state(conn->data, conn->negnpn == CURL_HTTP_VERSION_2 ?
+    Curl_multiuse_state(data, conn->negnpn == CURL_HTTP_VERSION_2 ?
                         BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 }
@@ -866,8 +865,7 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
 static SECStatus CanFalseStartCallback(PRFileDesc *sock, void *client_data,
                                        PRBool *canFalseStart)
 {
-  struct connectdata *conn = client_data;
-  struct Curl_easy *data = conn->data;
+  struct Curl_easy *data = (struct Curl_easy *)client_data;
 
   SSLChannelInfo channelInfo;
   SSLCipherSuiteInfo cipherInfo;
@@ -950,10 +948,9 @@ static void display_cert_info(struct Curl_easy *data,
   PR_Free(common_name);
 }
 
-static CURLcode display_conn_info(struct connectdata *conn, PRFileDesc *sock)
+static CURLcode display_conn_info(struct Curl_easy *data, PRFileDesc *sock)
 {
   CURLcode result = CURLE_OK;
-  struct Curl_easy *data = conn->data;
   SSLChannelInfo channel;
   SSLCipherSuiteInfo suite;
   CERTCertificate *cert;
@@ -1023,8 +1020,8 @@ static CURLcode display_conn_info(struct connectdata *conn, PRFileDesc *sock)
 
 static SECStatus BadCertHandler(void *arg, PRFileDesc *sock)
 {
-  struct connectdata *conn = (struct connectdata *)arg;
-  struct Curl_easy *data = conn->data;
+  struct Curl_easy *data = (struct Curl_easy *)arg;
+  struct connectdata *conn = data->conn;
   PRErrorCode err = PR_GetError();
   CERTCertificate *cert;
 
@@ -1549,7 +1546,9 @@ static void close_one(struct ssl_connect_data *connssl)
 /*
  * This function is called when an SSL connection is closed.
  */
-static void nss_close(struct connectdata *conn, int sockindex)
+static void real_nss_close(struct Curl_easy *data,
+                           struct connectdata *conn,
+                           int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 #ifndef CURL_DISABLE_PROXY
@@ -1557,6 +1556,7 @@ static void nss_close(struct connectdata *conn, int sockindex)
 #endif
   struct ssl_backend_data *backend = connssl->backend;
 
+  (void)data;
   if(backend->handle
 #ifndef CURL_DISABLE_PROXY
     || connssl_proxy->backend->handle
@@ -1578,6 +1578,11 @@ static void nss_close(struct connectdata *conn, int sockindex)
   close_one(connssl_proxy);
 #endif
   close_one(connssl);
+}
+
+static void nss_close(struct connectdata *conn, int sockindex)
+{
+  real_nss_close(conn->data, conn, sockindex);
 }
 
 /* return true if NSS can provide error code (and possibly msg) for the
@@ -1613,10 +1618,10 @@ static bool is_cc_error(PRInt32 err)
 static Curl_recv nss_recv;
 static Curl_send nss_send;
 
-static CURLcode nss_load_ca_certificates(struct connectdata *conn,
+static CURLcode nss_load_ca_certificates(struct Curl_easy *data,
+                                         struct connectdata *conn,
                                          int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   const char *cafile = SSL_CONN_CONFIG(CAfile);
   const char *capath = SSL_CONN_CONFIG(CApath);
   bool use_trust_module;
@@ -1821,14 +1826,14 @@ static CURLcode nss_set_blocking(struct ssl_connect_data *connssl,
   return CURLE_OK;
 }
 
-static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
+static CURLcode nss_setup_connect(struct Curl_easy *data,
+                                  struct connectdata *conn, int sockindex)
 {
   PRFileDesc *model = NULL;
   PRFileDesc *nspr_io = NULL;
   PRFileDesc *nspr_io_stub = NULL;
   PRBool ssl_no_cache;
   PRBool ssl_cbc_random_iv;
-  struct Curl_easy *data = conn->data;
   curl_socket_t sockfd = conn->sock[sockindex];
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -1851,11 +1856,11 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
 
   backend->data = data;
 
-  /* list of all NSS objects we need to destroy in Curl_nss_close() */
+  /* list of all NSS objects we need to destroy in nss_do_close() */
   Curl_llist_init(&backend->obj_list, nss_destroy_object);
 
   PR_Lock(nss_initlock);
-  result = nss_setup(conn->data);
+  result = nss_setup(data);
   if(result) {
     PR_Unlock(nss_initlock);
     goto error;
@@ -1935,20 +1940,20 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
 
   /* bypass the default SSL_AuthCertificate() hook in case we do not want to
    * verify peer */
-  if(SSL_AuthCertificateHook(model, nss_auth_cert_hook, conn) != SECSuccess)
+  if(SSL_AuthCertificateHook(model, nss_auth_cert_hook, data) != SECSuccess)
     goto error;
 
   /* not checked yet */
   SSL_SET_OPTION_LVALUE(certverifyresult) = 0;
 
-  if(SSL_BadCertHook(model, BadCertHandler, conn) != SECSuccess)
+  if(SSL_BadCertHook(model, BadCertHandler, data) != SECSuccess)
     goto error;
 
-  if(SSL_HandshakeCallback(model, HandshakeCallback, conn) != SECSuccess)
+  if(SSL_HandshakeCallback(model, HandshakeCallback, data) != SECSuccess)
     goto error;
 
   {
-    const CURLcode rv = nss_load_ca_certificates(conn, sockindex);
+    const CURLcode rv = nss_load_ca_certificates(data, conn, sockindex);
     if((rv == CURLE_SSL_CACERT_BADFILE) && !SSL_CONN_CONFIG(verifypeer))
       /* not a fatal error because we are not going to verify the peer */
       infof(data, "warning: CA certificates failed to load\n");
@@ -1974,7 +1979,7 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
       backend->obj_clicert = NULL;
     }
     else {
-      CURLcode rv = cert_stuff(conn, sockindex,
+      CURLcode rv = cert_stuff(data, conn, sockindex,
                                SSL_SET_OPTION(primary.clientcert),
                                SSL_SET_OPTION(key));
       if(rv) {
@@ -2073,7 +2078,7 @@ static CURLcode nss_setup_connect(struct connectdata *conn, int sockindex)
       goto error;
 
     if(SSL_SetCanFalseStartCallback(backend->handle, CanFalseStartCallback,
-        conn) != SECSuccess)
+        data) != SECSuccess)
       goto error;
   }
 #endif
@@ -2127,11 +2132,11 @@ error:
   return nss_fail_connect(connssl, data, result);
 }
 
-static CURLcode nss_do_connect(struct connectdata *conn, int sockindex)
+static CURLcode nss_do_connect(struct Curl_easy *data,
+                               struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
-  struct Curl_easy *data = conn->data;
   CURLcode result = CURLE_SSL_CONNECT_ERROR;
   PRUint32 timeout;
 
@@ -2156,7 +2161,7 @@ static CURLcode nss_do_connect(struct connectdata *conn, int sockindex)
     goto error;
   }
 
-  result = display_conn_info(conn, backend->handle);
+  result = display_conn_info(data, backend->handle);
   if(result)
     goto error;
 
@@ -2190,11 +2195,11 @@ error:
   return nss_fail_connect(connssl, data, result);
 }
 
-static CURLcode nss_connect_common(struct connectdata *conn, int sockindex,
+static CURLcode nss_connect_common(struct Curl_easy *data,
+                                   struct connectdata *conn, int sockindex,
                                    bool *done)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
-  struct Curl_easy *data = conn->data;
   const bool blocking = (done == NULL);
   CURLcode result;
 
@@ -2205,7 +2210,7 @@ static CURLcode nss_connect_common(struct connectdata *conn, int sockindex,
   }
 
   if(connssl->connecting_state == ssl_connect_1) {
-    result = nss_setup_connect(conn, sockindex);
+    result = nss_setup_connect(data, conn, sockindex);
     if(result)
       /* we do not expect CURLE_AGAIN from nss_setup_connect() */
       return result;
@@ -2218,7 +2223,7 @@ static CURLcode nss_connect_common(struct connectdata *conn, int sockindex,
   if(result)
     return result;
 
-  result = nss_do_connect(conn, sockindex);
+  result = nss_do_connect(data, conn, sockindex);
   switch(result) {
   case CURLE_OK:
     break;
@@ -2253,13 +2258,13 @@ static CURLcode nss_connect_common(struct connectdata *conn, int sockindex,
 
 static CURLcode nss_connect(struct connectdata *conn, int sockindex)
 {
-  return nss_connect_common(conn, sockindex, /* blocking */ NULL);
+  return nss_connect_common(conn->data, conn, sockindex, /* blocking */ NULL);
 }
 
 static CURLcode nss_connect_nonblocking(struct connectdata *conn,
                                         int sockindex, bool *done)
 {
-  return nss_connect_common(conn, sockindex, done);
+  return nss_connect_common(conn->data, conn, sockindex, done);
 }
 
 static ssize_t nss_send(struct Curl_easy *data,    /* transfer */
@@ -2288,7 +2293,7 @@ static ssize_t nss_send(struct Curl_easy *data,    /* transfer */
       infof(data, "SSL write: error %d (%s)\n", err, err_name);
 
       /* print a human-readable message describing the error if available */
-      nss_print_error_message(conn->data, err);
+      nss_print_error_message(data, err);
 
       *curlcode = (is_cc_error(err))
         ? CURLE_SSL_CERTPROBLEM
@@ -2303,8 +2308,8 @@ static ssize_t nss_send(struct Curl_easy *data,    /* transfer */
 
 static ssize_t nss_recv(struct Curl_easy *data,    /* transfer */
                         int sockindex,             /* socketindex */
-                        char *buf,                 /* store read data here */
-                        size_t buffersize,         /* max amount to read */
+                        char *buf,             /* store read data here */
+                        size_t buffersize,     /* max amount to read */
                         CURLcode *curlcode)
 {
   struct connectdata *conn = data->conn;
@@ -2330,7 +2335,7 @@ static ssize_t nss_recv(struct Curl_easy *data,    /* transfer */
       infof(data, "SSL read: errno %d (%s)\n", err, err_name);
 
       /* print a human-readable message describing the error if available */
-      nss_print_error_message(conn->data, err);
+      nss_print_error_message(data, err);
 
       *curlcode = (is_cc_error(err))
         ? CURLE_SSL_CERTPROBLEM

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1375,8 +1375,8 @@ static void ossl_closeone(struct ssl_connect_data *connssl)
 /*
  * This function is called when an SSL connection is closed.
  */
-static void real_ossl_close(struct Curl_easy *data,
-                            struct connectdata *conn, int sockindex)
+static void ossl_close(struct Curl_easy *data, struct connectdata *conn,
+                       int sockindex)
 {
   (void) data;
   ossl_closeone(&conn->ssl[sockindex]);
@@ -1385,17 +1385,12 @@ static void real_ossl_close(struct Curl_easy *data,
 #endif
 }
 
-static void ossl_close(struct connectdata *conn, int sockindex)
-{
-  real_ossl_close(conn->data, conn, sockindex);
-}
-
 /*
  * This function is called to shut down the SSL layer but keep the
  * socket open (CCC - Clear Command Channel)
  */
-static int real_ossl_shutdown(struct Curl_easy *data,
-                              struct connectdata *conn, int sockindex)
+static int ossl_shutdown(struct Curl_easy *data,
+                         struct connectdata *conn, int sockindex)
 {
   int retval = 0;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
@@ -1493,11 +1488,6 @@ static int real_ossl_shutdown(struct Curl_easy *data,
     backend->handle = NULL;
   }
   return retval;
-}
-
-static int ossl_shutdown(struct connectdata *conn, int sockindex)
-{
-  return real_ossl_shutdown(conn->data, conn, sockindex);
 }
 
 static void ossl_session_free(void *ptr)
@@ -4114,19 +4104,21 @@ static CURLcode ossl_connect_common(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode ossl_connect_nonblocking(struct connectdata *conn,
+static CURLcode ossl_connect_nonblocking(struct Curl_easy *data,
+                                         struct connectdata *conn,
                                          int sockindex,
                                          bool *done)
 {
-  return ossl_connect_common(conn->data, conn, sockindex, TRUE, done);
+  return ossl_connect_common(data, conn, sockindex, TRUE, done);
 }
 
-static CURLcode ossl_connect(struct connectdata *conn, int sockindex)
+static CURLcode ossl_connect(struct Curl_easy *data, struct connectdata *conn,
+                             int sockindex)
 {
   CURLcode result;
   bool done = FALSE;
 
-  result = ossl_connect_common(conn->data, conn, sockindex, FALSE, &done);
+  result = ossl_connect_common(data, conn, sockindex, FALSE, &done);
   if(result)
     return result;
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -142,7 +142,8 @@
 static Curl_recv schannel_recv;
 static Curl_send schannel_send;
 
-static CURLcode pkp_pin_peer_pubkey(struct connectdata *conn, int sockindex,
+static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
+                                    struct connectdata *conn, int sockindex,
                                     const char *pinnedpubkey);
 
 static void InitSecBuffer(SecBuffer *buffer, unsigned long BufType,
@@ -162,9 +163,9 @@ static void InitSecBufferDesc(SecBufferDesc *desc, SecBuffer *BufArr,
 }
 
 static CURLcode
-set_ssl_version_min_max(SCHANNEL_CRED *schannel_cred, struct connectdata *conn)
+set_ssl_version_min_max(SCHANNEL_CRED *schannel_cred, struct Curl_easy *data,
+                        struct connectdata *conn)
 {
-  struct Curl_easy *data = conn->data;
   long ssl_version = SSL_CONN_CONFIG(version);
   long ssl_version_max = SSL_CONN_CONFIG(version_max);
   long i = ssl_version;
@@ -405,10 +406,10 @@ get_cert_location(TCHAR *path, DWORD *store_name, TCHAR **store_path,
 #endif
 
 static CURLcode
-schannel_connect_step1(struct connectdata *conn, int sockindex)
+schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
+                       int sockindex)
 {
   ssize_t written = -1;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   SecBuffer outbuf;
   SecBufferDesc outbuf_desc;
@@ -563,7 +564,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
     {
-      result = set_ssl_version_min_max(&schannel_cred, conn);
+      result = set_ssl_version_min_max(&schannel_cred, data, conn);
       if(result != CURLE_OK)
         return result;
       break;
@@ -980,11 +981,11 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
 }
 
 static CURLcode
-schannel_connect_step2(struct connectdata *conn, int sockindex)
+schannel_connect_step2(struct Curl_easy *data, struct connectdata *conn,
+                       int sockindex)
 {
   int i;
   ssize_t nread = -1, written = -1;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   unsigned char *reallocated_buffer;
   SecBuffer outbuf[3];
@@ -1252,7 +1253,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
     data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY] :
     data->set.str[STRING_SSL_PINNEDPUBLICKEY_ORIG];
   if(pubkey_ptr) {
-    result = pkp_pin_peer_pubkey(conn, sockindex, pubkey_ptr);
+    result = pkp_pin_peer_pubkey(data, conn, sockindex, pubkey_ptr);
     if(result) {
       failf(data, "SSL: public key does not match pinned public key!");
       return result;
@@ -1261,7 +1262,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
 
 #ifdef HAS_MANUAL_VERIFY_API
   if(conn->ssl_config.verifypeer && BACKEND->use_manual_cred_validation) {
-    return Curl_verify_certificate(conn, sockindex);
+    return Curl_verify_certificate(data, conn, sockindex);
   }
 #endif
 
@@ -1328,10 +1329,10 @@ add_cert_to_certinfo(const CERT_CONTEXT *ccert_context, void *raw_arg)
 }
 
 static CURLcode
-schannel_connect_step3(struct connectdata *conn, int sockindex)
+schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
+                       int sockindex)
 {
   CURLcode result = CURLE_OK;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CERT_CONTEXT *ccert_context = NULL;
@@ -1476,11 +1477,10 @@ schannel_connect_step3(struct connectdata *conn, int sockindex)
 }
 
 static CURLcode
-schannel_connect_common(struct connectdata *conn, int sockindex,
-                        bool nonblocking, bool *done)
+schannel_connect_common(struct Curl_easy *data, struct connectdata *conn,
+                        int sockindex, bool nonblocking, bool *done)
 {
   CURLcode result;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   curl_socket_t sockfd = conn->sock[sockindex];
   timediff_t timeout_ms;
@@ -1502,7 +1502,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
       return CURLE_OPERATION_TIMEDOUT;
     }
 
-    result = schannel_connect_step1(conn, sockindex);
+    result = schannel_connect_step1(data, conn, sockindex);
     if(result)
       return result;
   }
@@ -1557,7 +1557,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
      * ensuring that a client using select() or epoll() will always
      * have a valid fdset to wait on.
      */
-    result = schannel_connect_step2(conn, sockindex);
+    result = schannel_connect_step2(data, conn, sockindex);
     if(result || (nonblocking &&
                   (ssl_connect_2 == connssl->connecting_state ||
                    ssl_connect_2_reading == connssl->connecting_state ||
@@ -1567,7 +1567,7 @@ schannel_connect_common(struct connectdata *conn, int sockindex,
   } /* repeat step2 until all transactions are done. */
 
   if(ssl_connect_3 == connssl->connecting_state) {
-    result = schannel_connect_step3(conn, sockindex);
+    result = schannel_connect_step3(data, conn, sockindex);
     if(result)
       return result;
   }
@@ -1957,7 +1957,7 @@ schannel_recv(struct Curl_easy *data, int sockindex,
         infof(data, "schannel: renegotiating SSL/TLS connection\n");
         connssl->state = ssl_connection_negotiating;
         connssl->connecting_state = ssl_connect_2_writing;
-        *err = schannel_connect_common(conn, sockindex, FALSE, &done);
+        *err = schannel_connect_common(data, conn, sockindex, FALSE, &done);
         if(*err) {
           infof(data, "schannel: renegotiation failed\n");
           goto cleanup;
@@ -2064,18 +2064,18 @@ schannel_recv(struct Curl_easy *data, int sockindex,
   return *err ? -1 : 0;
 }
 
-static CURLcode Curl_schannel_connect_nonblocking(struct connectdata *conn,
-                                                  int sockindex, bool *done)
+static CURLcode schannel_connect_nonblocking(struct connectdata *conn,
+                                             int sockindex, bool *done)
 {
-  return schannel_connect_common(conn, sockindex, TRUE, done);
+  return schannel_connect_common(conn->data, conn, sockindex, TRUE, done);
 }
 
-static CURLcode Curl_schannel_connect(struct connectdata *conn, int sockindex)
+static CURLcode schannel_connect(struct connectdata *conn, int sockindex)
 {
   CURLcode result;
   bool done = FALSE;
 
-  result = schannel_connect_common(conn, sockindex, FALSE, &done);
+  result = schannel_connect_common(conn->data, conn, sockindex, FALSE, &done);
   if(result)
     return result;
 
@@ -2084,8 +2084,8 @@ static CURLcode Curl_schannel_connect(struct connectdata *conn, int sockindex)
   return CURLE_OK;
 }
 
-static bool Curl_schannel_data_pending(const struct connectdata *conn,
-                                       int sockindex)
+static bool schannel_data_pending(const struct connectdata *conn,
+                                  int sockindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 
@@ -2096,14 +2096,22 @@ static bool Curl_schannel_data_pending(const struct connectdata *conn,
     return FALSE;
 }
 
-static void Curl_schannel_close(struct connectdata *conn, int sockindex)
+static void real_schannel_close(struct Curl_easy *data,
+                                struct connectdata *conn, int sockindex)
 {
+  (void) data;
+
   if(conn->ssl[sockindex].use)
     /* if the SSL/TLS channel hasn't been shut down yet, do that now. */
     Curl_ssl_shutdown(conn, sockindex);
 }
 
-static void Curl_schannel_session_free(void *ptr)
+static void schannel_close(struct connectdata *conn, int sockindex)
+{
+  real_schannel_close(conn->data, conn, sockindex);
+}
+
+static void schannel_session_free(void *ptr)
 {
   /* this is expected to be called under sessionid lock */
   struct Curl_schannel_cred *cred = ptr;
@@ -2115,12 +2123,12 @@ static void Curl_schannel_session_free(void *ptr)
   }
 }
 
-static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
+static int real_schannel_shutdown(struct Curl_easy *data,
+                                  struct connectdata *conn, int sockindex)
 {
   /* See https://msdn.microsoft.com/en-us/library/windows/desktop/aa380138.aspx
    * Shutting Down an Schannel Connection
    */
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 #ifndef CURL_DISABLE_PROXY
   char * const hostname = SSL_IS_PROXY() ? conn->http_proxy.host.name :
@@ -2204,12 +2212,12 @@ static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
   /* free SSPI Schannel API credential handle */
   if(BACKEND->cred) {
     /*
-     * When this function is called from Curl_schannel_close() the connection
+     * When this function is called from schannel_close() the connection
      * might not have an associated transfer so the check for conn->data is
      * necessary.
      */
     Curl_ssl_sessionid_lock(conn);
-    Curl_schannel_session_free(BACKEND->cred);
+    schannel_session_free(BACKEND->cred);
     Curl_ssl_sessionid_unlock(conn);
     BACKEND->cred = NULL;
   }
@@ -2232,25 +2240,30 @@ static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
   return CURLE_OK;
 }
 
-static int Curl_schannel_init(void)
+static int schannel_shutdown(struct connectdata *conn, int sockindex)
+{
+  return real_schannel_shutdown(conn->data, conn, sockindex);
+}
+
+static int schannel_init(void)
 {
   return (Curl_sspi_global_init() == CURLE_OK ? 1 : 0);
 }
 
-static void Curl_schannel_cleanup(void)
+static void schannel_cleanup(void)
 {
   Curl_sspi_global_cleanup();
 }
 
-static size_t Curl_schannel_version(char *buffer, size_t size)
+static size_t schannel_version(char *buffer, size_t size)
 {
   size = msnprintf(buffer, size, "Schannel");
 
   return size;
 }
 
-static CURLcode Curl_schannel_random(struct Curl_easy *data UNUSED_PARAM,
-                                     unsigned char *entropy, size_t length)
+static CURLcode schannel_random(struct Curl_easy *data UNUSED_PARAM,
+                                unsigned char *entropy, size_t length)
 {
   HCRYPTPROV hCryptProv = 0;
 
@@ -2269,10 +2282,10 @@ static CURLcode Curl_schannel_random(struct Curl_easy *data UNUSED_PARAM,
   return CURLE_OK;
 }
 
-static CURLcode pkp_pin_peer_pubkey(struct connectdata *conn, int sockindex,
+static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
+                                    struct connectdata *conn, int sockindex,
                                     const char *pinnedpubkey)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   CERT_CONTEXT *pCertContextServer = NULL;
 
@@ -2334,12 +2347,12 @@ static CURLcode pkp_pin_peer_pubkey(struct connectdata *conn, int sockindex,
   return result;
 }
 
-static void Curl_schannel_checksum(const unsigned char *input,
-                                   size_t inputlen,
-                                   unsigned char *checksum,
-                                   size_t checksumlen,
-                                   DWORD provType,
-                                   const unsigned int algId)
+static void schannel_checksum(const unsigned char *input,
+                              size_t inputlen,
+                              unsigned char *checksum,
+                              size_t checksumlen,
+                              DWORD provType,
+                              const unsigned int algId)
 {
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
@@ -2384,28 +2397,27 @@ static void Curl_schannel_checksum(const unsigned char *input,
     CryptReleaseContext(hProv, 0);
 }
 
-static CURLcode Curl_schannel_md5sum(unsigned char *input,
-                                     size_t inputlen,
-                                     unsigned char *md5sum,
-                                     size_t md5len)
+static CURLcode schannel_md5sum(unsigned char *input,
+                                size_t inputlen,
+                                unsigned char *md5sum,
+                                size_t md5len)
 {
-  Curl_schannel_checksum(input, inputlen, md5sum, md5len,
-                         PROV_RSA_FULL, CALG_MD5);
+  schannel_checksum(input, inputlen, md5sum, md5len, PROV_RSA_FULL, CALG_MD5);
   return CURLE_OK;
 }
 
-static CURLcode Curl_schannel_sha256sum(const unsigned char *input,
-                                        size_t inputlen,
-                                        unsigned char *sha256sum,
-                                        size_t sha256len)
+static CURLcode schannel_sha256sum(const unsigned char *input,
+                                   size_t inputlen,
+                                   unsigned char *sha256sum,
+                                   size_t sha256len)
 {
-  Curl_schannel_checksum(input, inputlen, sha256sum, sha256len,
-                         PROV_RSA_AES, CALG_SHA_256);
+  schannel_checksum(input, inputlen, sha256sum, sha256len,
+                    PROV_RSA_AES, CALG_SHA_256);
   return CURLE_OK;
 }
 
-static void *Curl_schannel_get_internals(struct ssl_connect_data *connssl,
-                                         CURLINFO info UNUSED_PARAM)
+static void *schannel_get_internals(struct ssl_connect_data *connssl,
+                                    CURLINFO info UNUSED_PARAM)
 {
   (void)info;
   return &BACKEND->ctxt->ctxt_handle;
@@ -2419,26 +2431,26 @@ const struct Curl_ssl Curl_ssl_schannel = {
 
   sizeof(struct ssl_backend_data),
 
-  Curl_schannel_init,                /* init */
-  Curl_schannel_cleanup,             /* cleanup */
-  Curl_schannel_version,             /* version */
+  schannel_init,                     /* init */
+  schannel_cleanup,                  /* cleanup */
+  schannel_version,                  /* version */
   Curl_none_check_cxn,               /* check_cxn */
-  Curl_schannel_shutdown,            /* shutdown */
-  Curl_schannel_data_pending,        /* data_pending */
-  Curl_schannel_random,              /* random */
+  schannel_shutdown,                 /* shutdown */
+  schannel_data_pending,             /* data_pending */
+  schannel_random,                   /* random */
   Curl_none_cert_status_request,     /* cert_status_request */
-  Curl_schannel_connect,             /* connect */
-  Curl_schannel_connect_nonblocking, /* connect_nonblocking */
-  Curl_schannel_get_internals,       /* get_internals */
-  Curl_schannel_close,               /* close_one */
+  schannel_connect,                  /* connect */
+  schannel_connect_nonblocking,      /* connect_nonblocking */
+  schannel_get_internals,            /* get_internals */
+  schannel_close,                    /* close_one */
   Curl_none_close_all,               /* close_all */
-  Curl_schannel_session_free,        /* session_free */
+  schannel_session_free,             /* session_free */
   Curl_none_set_engine,              /* set_engine */
   Curl_none_set_engine_default,      /* set_engine_default */
   Curl_none_engines_list,            /* engines_list */
   Curl_none_false_start,             /* false_start */
-  Curl_schannel_md5sum,              /* md5sum */
-  Curl_schannel_sha256sum            /* sha256sum */
+  schannel_md5sum,                   /* md5sum */
+  schannel_sha256sum                 /* sha256sum */
 };
 
 #endif /* USE_SCHANNEL */

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -8,7 +8,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2012, Marc Hoersken, <info@marc-hoersken.de>, et al.
- * Copyright (C) 2012 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -53,7 +53,8 @@
 
 extern const struct Curl_ssl Curl_ssl_schannel;
 
-CURLcode Curl_verify_certificate(struct connectdata *conn, int sockindex);
+CURLcode Curl_verify_certificate(struct Curl_easy *data,
+                                 struct connectdata *conn, int sockindex);
 
 /* structs to expose only in schannel.c and schannel_verify.c */
 #ifdef EXPOSE_SCHANNEL_INTERNAL_STRUCTS

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -79,8 +79,7 @@ static int is_cr_or_lf(char c)
 
 static CURLcode add_certs_to_store(HCERTSTORE trust_store,
                                    const char *ca_file,
-                                   struct Curl_easy *data,
-                                   struct connectdata *conn)
+                                   struct Curl_easy *data)
 {
   CURLcode result;
   HANDLE ca_file_handle = INVALID_HANDLE_VALUE;
@@ -584,7 +583,7 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
       }
       else {
         result = add_certs_to_store(trust_store, SSL_CONN_CONFIG(CAfile),
-                                    data, conn);
+                                    data);
       }
     }
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -79,10 +79,10 @@ static int is_cr_or_lf(char c)
 
 static CURLcode add_certs_to_store(HCERTSTORE trust_store,
                                    const char *ca_file,
+                                   struct Curl_easy *data,
                                    struct connectdata *conn)
 {
   CURLcode result;
-  struct Curl_easy *data = conn->data;
   HANDLE ca_file_handle = INVALID_HANDLE_VALUE;
   LARGE_INTEGER file_size;
   char *ca_file_buffer = NULL;
@@ -527,10 +527,10 @@ cleanup:
   return result;
 }
 
-CURLcode Curl_verify_certificate(struct connectdata *conn, int sockindex)
+CURLcode Curl_verify_certificate(struct Curl_easy *data,
+                                 struct connectdata *conn, int sockindex)
 {
   SECURITY_STATUS sspi_status;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   CURLcode result = CURLE_OK;
   CERT_CONTEXT *pCertContextServer = NULL;
@@ -584,7 +584,7 @@ CURLcode Curl_verify_certificate(struct connectdata *conn, int sockindex)
       }
       else {
         result = add_certs_to_store(trust_store, SSL_CONN_CONFIG(CAfile),
-                                    conn);
+                                    data, conn);
       }
     }
 
@@ -675,7 +675,7 @@ CURLcode Curl_verify_certificate(struct connectdata *conn, int sockindex)
 
   if(result == CURLE_OK) {
     if(SSL_CONN_CONFIG(verifyhost)) {
-      result = verify_host(conn->data, pCertContextServer, conn_hostname);
+      result = verify_host(data, pCertContextServer, conn_hostname);
     }
   }
 

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1952,12 +1952,12 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
     char *ssl_sessionid;
     size_t ssl_sessionid_len;
 
-    Curl_ssl_sessionid_lock(conn);
-    if(!Curl_ssl_getsessionid(conn, (void **)&ssl_sessionid,
+    Curl_ssl_sessionid_lock(data);
+    if(!Curl_ssl_getsessionid(data, conn, (void **)&ssl_sessionid,
                               &ssl_sessionid_len, sockindex)) {
       /* we got a session id, use it! */
       err = SSLSetPeerID(backend->ssl_ctx, ssl_sessionid, ssl_sessionid_len);
-      Curl_ssl_sessionid_unlock(conn);
+      Curl_ssl_sessionid_unlock(data);
       if(err != noErr) {
         failf(data, "SSL: SSLSetPeerID() failed: OSStatus %d", err);
         return CURLE_SSL_CONNECT_ERROR;
@@ -1976,14 +1976,14 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
 
       err = SSLSetPeerID(backend->ssl_ctx, ssl_sessionid, ssl_sessionid_len);
       if(err != noErr) {
-        Curl_ssl_sessionid_unlock(conn);
+        Curl_ssl_sessionid_unlock(data);
         failf(data, "SSL: SSLSetPeerID() failed: OSStatus %d", err);
         return CURLE_SSL_CONNECT_ERROR;
       }
 
-      result = Curl_ssl_addsessionid(conn, ssl_sessionid, ssl_sessionid_len,
-                                     sockindex);
-      Curl_ssl_sessionid_unlock(conn);
+      result = Curl_ssl_addsessionid(data, conn, ssl_sessionid,
+                                     ssl_sessionid_len, sockindex);
+      Curl_ssl_sessionid_unlock(data);
       if(result) {
         failf(data, "failed to store ssl session");
         return result;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1291,9 +1291,9 @@ static CURLcode sectransp_version_from_curl(SSLProtocol *darwinver,
 #endif
 
 static CURLcode
-set_ssl_version_min_max(struct connectdata *conn, int sockindex)
+set_ssl_version_min_max(struct Curl_easy *data, struct connectdata *conn,
+                        int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   long ssl_version = SSL_CONN_CONFIG(version);
@@ -1387,10 +1387,10 @@ set_ssl_version_min_max(struct connectdata *conn, int sockindex)
 }
 
 
-static CURLcode sectransp_connect_step1(struct connectdata *conn,
+static CURLcode sectransp_connect_step1(struct Curl_easy *data,
+                                        struct connectdata *conn,
                                         int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   curl_socket_t sockfd = conn->sock[sockindex];
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -1478,7 +1478,7 @@ static CURLcode sectransp_connect_step1(struct connectdata *conn,
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
       {
-        CURLcode result = set_ssl_version_min_max(conn, sockindex);
+        CURLcode result = set_ssl_version_min_max(data, conn, sockindex);
         if(result != CURLE_OK)
           return result;
         break;
@@ -1527,7 +1527,7 @@ static CURLcode sectransp_connect_step1(struct connectdata *conn,
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
       {
-        CURLcode result = set_ssl_version_min_max(conn, sockindex);
+        CURLcode result = set_ssl_version_min_max(data, conn, sockindex);
         if(result != CURLE_OK)
           return result;
         break;
@@ -2379,9 +2379,9 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
 #endif /* SECTRANSP_PINNEDPUBKEY */
 
 static CURLcode
-sectransp_connect_step2(struct connectdata *conn, int sockindex)
+sectransp_connect_step2(struct Curl_easy *data, struct connectdata *conn,
+                        int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   OSStatus err;
@@ -2418,7 +2418,7 @@ sectransp_connect_step2(struct connectdata *conn, int sockindex)
             return result;
         }
         /* the documentation says we need to call SSLHandshake() again */
-        return sectransp_connect_step2(conn, sockindex);
+        return sectransp_connect_step2(data, conn, sockindex);
 
       /* Problem with encrypt / decrypt */
       case errSSLPeerDecodeError:
@@ -2711,10 +2711,10 @@ sectransp_connect_step2(struct connectdata *conn, int sockindex)
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
 /* This should be called during step3 of the connection at the earliest */
 static void
-show_verbose_server_cert(struct connectdata *conn,
+show_verbose_server_cert(struct Curl_easy *data,
+                         struct connectdata *conn,
                          int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   CFArrayRef server_certs = NULL;
@@ -2817,10 +2817,9 @@ show_verbose_server_cert(struct connectdata *conn,
 #endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 
 static CURLcode
-sectransp_connect_step3(struct connectdata *conn,
+sectransp_connect_step3(struct Curl_easy *data, struct connectdata *conn,
                         int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
 
   /* There is no step 3!
@@ -2828,7 +2827,7 @@ sectransp_connect_step3(struct connectdata *conn,
    * server certificates. */
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
   if(data->set.verbose)
-    show_verbose_server_cert(conn, sockindex);
+    show_verbose_server_cert(data, conn, sockindex);
 #endif
 
   connssl->connecting_state = ssl_connect_done;
@@ -2839,13 +2838,13 @@ static Curl_recv sectransp_recv;
 static Curl_send sectransp_send;
 
 static CURLcode
-sectransp_connect_common(struct connectdata *conn,
+sectransp_connect_common(struct Curl_easy *data,
+                         struct connectdata *conn,
                          int sockindex,
                          bool nonblocking,
                          bool *done)
 {
   CURLcode result;
-  struct Curl_easy *data = conn->data;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   curl_socket_t sockfd = conn->sock[sockindex];
   int what;
@@ -2866,7 +2865,7 @@ sectransp_connect_common(struct connectdata *conn,
       return CURLE_OPERATION_TIMEDOUT;
     }
 
-    result = sectransp_connect_step1(conn, sockindex);
+    result = sectransp_connect_step1(data, conn, sockindex);
     if(result)
       return result;
   }
@@ -2920,7 +2919,7 @@ sectransp_connect_common(struct connectdata *conn,
      * before step2 has completed while ensuring that a client using select()
      * or epoll() will always have a valid fdset to wait on.
      */
-    result = sectransp_connect_step2(conn, sockindex);
+    result = sectransp_connect_step2(data, conn, sockindex);
     if(result || (nonblocking &&
                   (ssl_connect_2 == connssl->connecting_state ||
                    ssl_connect_2_reading == connssl->connecting_state ||
@@ -2931,7 +2930,7 @@ sectransp_connect_common(struct connectdata *conn,
 
 
   if(ssl_connect_3 == connssl->connecting_state) {
-    result = sectransp_connect_step3(conn, sockindex);
+    result = sectransp_connect_step3(data, conn, sockindex);
     if(result)
       return result;
   }
@@ -2951,18 +2950,18 @@ sectransp_connect_common(struct connectdata *conn,
   return CURLE_OK;
 }
 
-static CURLcode Curl_sectransp_connect_nonblocking(struct connectdata *conn,
-                                                   int sockindex, bool *done)
+static CURLcode sectransp_connect_nonblocking(struct connectdata *conn,
+                                              int sockindex, bool *done)
 {
-  return sectransp_connect_common(conn, sockindex, TRUE, done);
+  return sectransp_connect_common(conn->data, conn, sockindex, TRUE, done);
 }
 
-static CURLcode Curl_sectransp_connect(struct connectdata *conn, int sockindex)
+static CURLcode sectransp_connect(struct connectdata *conn, int sockindex)
 {
   CURLcode result;
   bool done = FALSE;
 
-  result = sectransp_connect_common(conn, sockindex, FALSE, &done);
+  result = sectransp_connect_common(conn->data, conn, sockindex, FALSE, &done);
 
   if(result)
     return result;
@@ -2972,10 +2971,13 @@ static CURLcode Curl_sectransp_connect(struct connectdata *conn, int sockindex)
   return CURLE_OK;
 }
 
-static void Curl_sectransp_close(struct connectdata *conn, int sockindex)
+static void real_sectransp_close(struct Curl_easy *data,
+                                 struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
+
+  (void) data;
 
   if(backend->ssl_ctx) {
     (void)SSLClose(backend->ssl_ctx);
@@ -2994,11 +2996,16 @@ static void Curl_sectransp_close(struct connectdata *conn, int sockindex)
   backend->ssl_sockfd = 0;
 }
 
-static int Curl_sectransp_shutdown(struct connectdata *conn, int sockindex)
+static void sectransp_close(struct connectdata *conn, int sockindex)
+{
+  real_sectransp_close(conn->data, conn, sockindex);
+}
+
+static int real_sectransp_shutdown(struct Curl_easy *data,
+                                   struct connectdata *conn, int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
-  struct Curl_easy *data = conn->data;
   ssize_t nread;
   int what;
   int rc;
@@ -3012,7 +3019,7 @@ static int Curl_sectransp_shutdown(struct connectdata *conn, int sockindex)
     return 0;
 #endif
 
-  Curl_sectransp_close(conn, sockindex);
+  sectransp_close(conn, sockindex);
 
   rc = 0;
 
@@ -3050,7 +3057,12 @@ static int Curl_sectransp_shutdown(struct connectdata *conn, int sockindex)
   return rc;
 }
 
-static void Curl_sectransp_session_free(void *ptr)
+static int sectransp_shutdown(struct connectdata *conn, int sockindex)
+{
+  return real_sectransp_shutdown(conn->data, conn, sockindex);
+}
+
+static void sectransp_session_free(void *ptr)
 {
   /* ST, as of iOS 5 and Mountain Lion, has no public method of deleting a
      cached session ID inside the Security framework. There is a private
@@ -3061,7 +3073,7 @@ static void Curl_sectransp_session_free(void *ptr)
   Curl_safefree(ptr);
 }
 
-static size_t Curl_sectransp_version(char *buffer, size_t size)
+static size_t sectransp_version(char *buffer, size_t size)
 {
   return msnprintf(buffer, size, "SecureTransport");
 }
@@ -3074,7 +3086,7 @@ static size_t Curl_sectransp_version(char *buffer, size_t size)
  *     0 means the connection has been closed
  *    -1 means the connection status is unknown
  */
-static int Curl_sectransp_check_cxn(struct connectdata *conn)
+static int sectransp_check_cxn(struct connectdata *conn)
 {
   struct ssl_connect_data *connssl = &conn->ssl[FIRSTSOCKET];
   struct ssl_backend_data *backend = connssl->backend;
@@ -3090,8 +3102,8 @@ static int Curl_sectransp_check_cxn(struct connectdata *conn)
   return 0;
 }
 
-static bool Curl_sectransp_data_pending(const struct connectdata *conn,
-                                        int connindex)
+static bool sectransp_data_pending(const struct connectdata *conn,
+                                   int connindex)
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -3108,8 +3120,8 @@ static bool Curl_sectransp_data_pending(const struct connectdata *conn,
     return false;
 }
 
-static CURLcode Curl_sectransp_random(struct Curl_easy *data UNUSED_PARAM,
-                                      unsigned char *entropy, size_t length)
+static CURLcode sectransp_random(struct Curl_easy *data UNUSED_PARAM,
+                                 unsigned char *entropy, size_t length)
 {
   /* arc4random_buf() isn't available on cats older than Lion, so let's
      do this manually for the benefit of the older cats. */
@@ -3128,27 +3140,27 @@ static CURLcode Curl_sectransp_random(struct Curl_easy *data UNUSED_PARAM,
   return CURLE_OK;
 }
 
-static CURLcode Curl_sectransp_md5sum(unsigned char *tmp, /* input */
-                                      size_t tmplen,
-                                      unsigned char *md5sum, /* output */
-                                      size_t md5len)
+static CURLcode sectransp_md5sum(unsigned char *tmp, /* input */
+                                 size_t tmplen,
+                                 unsigned char *md5sum, /* output */
+                                 size_t md5len)
 {
   (void)md5len;
   (void)CC_MD5(tmp, (CC_LONG)tmplen, md5sum);
   return CURLE_OK;
 }
 
-static CURLcode Curl_sectransp_sha256sum(const unsigned char *tmp, /* input */
-                                     size_t tmplen,
-                                     unsigned char *sha256sum, /* output */
-                                     size_t sha256len)
+static CURLcode sectransp_sha256sum(const unsigned char *tmp, /* input */
+                                    size_t tmplen,
+                                    unsigned char *sha256sum, /* output */
+                                    size_t sha256len)
 {
   assert(sha256len >= CURL_SHA256_DIGEST_LENGTH);
   (void)CC_SHA256(tmp, (CC_LONG)tmplen, sha256sum);
   return CURLE_OK;
 }
 
-static bool Curl_sectransp_false_start(void)
+static bool sectransp_false_start(void)
 {
 #if CURL_BUILD_MAC_10_9 || CURL_BUILD_IOS_7
   if(SSLSetSessionOption != NULL)
@@ -3198,7 +3210,7 @@ static ssize_t sectransp_send(struct Curl_easy *data,
         *curlcode = CURLE_AGAIN;
         return -1L;
       default:
-        failf(conn->data, "SSLWrite() returned error %d", err);
+        failf(data, "SSLWrite() returned error %d", err);
         *curlcode = CURLE_SEND_ERROR;
         return -1L;
     }
@@ -3262,7 +3274,7 @@ static ssize_t sectransp_recv(struct Curl_easy *data,
            Leopard's headers */
       case -9841:
         if(SSL_CONN_CONFIG(CAfile) && SSL_CONN_CONFIG(verifypeer)) {
-          CURLcode result = verify_cert(SSL_CONN_CONFIG(CAfile), conn->data,
+          CURLcode result = verify_cert(SSL_CONN_CONFIG(CAfile), data,
                                         backend->ssl_ctx);
           if(result)
             return result;
@@ -3278,8 +3290,8 @@ static ssize_t sectransp_recv(struct Curl_easy *data,
   return (ssize_t)processed;
 }
 
-static void *Curl_sectransp_get_internals(struct ssl_connect_data *connssl,
-                                          CURLINFO info UNUSED_PARAM)
+static void *sectransp_get_internals(struct ssl_connect_data *connssl,
+                                     CURLINFO info UNUSED_PARAM)
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
@@ -3299,24 +3311,24 @@ const struct Curl_ssl Curl_ssl_sectransp = {
 
   Curl_none_init,                     /* init */
   Curl_none_cleanup,                  /* cleanup */
-  Curl_sectransp_version,             /* version */
-  Curl_sectransp_check_cxn,           /* check_cxn */
-  Curl_sectransp_shutdown,            /* shutdown */
-  Curl_sectransp_data_pending,        /* data_pending */
-  Curl_sectransp_random,              /* random */
+  sectransp_version,                  /* version */
+  sectransp_check_cxn,                /* check_cxn */
+  sectransp_shutdown,                 /* shutdown */
+  sectransp_data_pending,             /* data_pending */
+  sectransp_random,                   /* random */
   Curl_none_cert_status_request,      /* cert_status_request */
-  Curl_sectransp_connect,             /* connect */
-  Curl_sectransp_connect_nonblocking, /* connect_nonblocking */
-  Curl_sectransp_get_internals,       /* get_internals */
-  Curl_sectransp_close,               /* close_one */
+  sectransp_connect,                  /* connect */
+  sectransp_connect_nonblocking,      /* connect_nonblocking */
+  sectransp_get_internals,            /* get_internals */
+  sectransp_close,                    /* close_one */
   Curl_none_close_all,                /* close_all */
-  Curl_sectransp_session_free,        /* session_free */
+  sectransp_session_free,             /* session_free */
   Curl_none_set_engine,               /* set_engine */
   Curl_none_set_engine_default,       /* set_engine_default */
   Curl_none_engines_list,             /* engines_list */
-  Curl_sectransp_false_start,         /* false_start */
-  Curl_sectransp_md5sum,              /* md5sum */
-  Curl_sectransp_sha256sum            /* sha256sum */
+  sectransp_false_start,              /* false_start */
+  sectransp_md5sum,                   /* md5sum */
+  sectransp_sha256sum                 /* sha256sum */
 };
 
 #ifdef __clang__

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -170,15 +170,19 @@ int Curl_ssl_backend(void);
 #ifdef USE_SSL
 int Curl_ssl_init(void);
 void Curl_ssl_cleanup(void);
-CURLcode Curl_ssl_connect(struct connectdata *conn, int sockindex);
-CURLcode Curl_ssl_connect_nonblocking(struct connectdata *conn,
+CURLcode Curl_ssl_connect(struct Curl_easy *data, struct connectdata *conn,
+                          int sockindex);
+CURLcode Curl_ssl_connect_nonblocking(struct Curl_easy *data,
+                                      struct connectdata *conn,
                                       int sockindex,
                                       bool *done);
 /* tell the SSL stuff to close down all open information regarding
    connections (and thus session ID caching etc) */
 void Curl_ssl_close_all(struct Curl_easy *data);
-void Curl_ssl_close(struct connectdata *conn, int sockindex);
-CURLcode Curl_ssl_shutdown(struct connectdata *conn, int sockindex);
+void Curl_ssl_close(struct Curl_easy *data, struct connectdata *conn,
+                    int sockindex);
+CURLcode Curl_ssl_shutdown(struct Curl_easy *data, struct connectdata *conn,
+                           int sockindex);
 CURLcode Curl_ssl_set_engine(struct Curl_easy *data, const char *engine);
 /* Sets engine as default for all SSL operations */
 CURLcode Curl_ssl_set_engine_default(struct Curl_easy *data);
@@ -210,10 +214,10 @@ CURLcode Curl_ssl_push_certinfo(struct Curl_easy *data, int certnum,
  * The purpose of explicitly locking SSL session cache data is to allow
  * individual SSL engines to manage session lifetime in their specific way.
  */
-void Curl_ssl_sessionid_lock(struct connectdata *conn);
+void Curl_ssl_sessionid_lock(struct Curl_easy *data);
 
 /* Unlock session cache mutex */
-void Curl_ssl_sessionid_unlock(struct connectdata *conn);
+void Curl_ssl_sessionid_unlock(struct Curl_easy *data);
 
 /* extract a session ID
  * Sessionid mutex must be locked (see Curl_ssl_sessionid_lock).
@@ -221,7 +225,8 @@ void Curl_ssl_sessionid_unlock(struct connectdata *conn);
  * is properly taken (e.g. its refcount is incremented
  * under sessionid mutex).
  */
-bool Curl_ssl_getsessionid(struct connectdata *conn,
+bool Curl_ssl_getsessionid(struct Curl_easy *data,
+                           struct connectdata *conn,
                            void **ssl_sessionid,
                            size_t *idsize, /* set 0 if unknown */
                            int sockindex);
@@ -230,7 +235,8 @@ bool Curl_ssl_getsessionid(struct connectdata *conn,
  * Caller must ensure that it has properly shared ownership of this sessionid
  * object with cache (e.g. incrementing refcount on success)
  */
-CURLcode Curl_ssl_addsessionid(struct connectdata *conn,
+CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
+                               struct connectdata *conn,
                                void *ssl_sessionid,
                                size_t idsize,
                                int sockindex);
@@ -247,7 +253,7 @@ void Curl_ssl_kill_session(struct Curl_ssl_session *session);
  * take sessionid object ownership from sessionid cache
  * (e.g. decrement refcount).
  */
-void Curl_ssl_delsessionid(struct connectdata *conn, void *ssl_sessionid);
+void Curl_ssl_delsessionid(struct Curl_easy *data, void *ssl_sessionid);
 
 /* get N random bytes into the buffer */
 CURLcode Curl_ssl_random(struct Curl_easy *data, unsigned char *buffer,
@@ -272,10 +278,10 @@ bool Curl_ssl_false_start(void);
 /* When SSL support is not present, just define away these function calls */
 #define Curl_ssl_init() 1
 #define Curl_ssl_cleanup() Curl_nop_stmt
-#define Curl_ssl_connect(x,y) CURLE_NOT_BUILT_IN
+#define Curl_ssl_connect(x,y,z) CURLE_NOT_BUILT_IN
 #define Curl_ssl_close_all(x) Curl_nop_stmt
-#define Curl_ssl_close(x,y) Curl_nop_stmt
-#define Curl_ssl_shutdown(x,y) CURLE_NOT_BUILT_IN
+#define Curl_ssl_close(x,y,z) Curl_nop_stmt
+#define Curl_ssl_shutdown(x,y,z) CURLE_NOT_BUILT_IN
 #define Curl_ssl_set_engine(x,y) CURLE_NOT_BUILT_IN
 #define Curl_ssl_set_engine_default(x) CURLE_NOT_BUILT_IN
 #define Curl_ssl_engines_list(x) NULL
@@ -285,7 +291,7 @@ bool Curl_ssl_false_start(void);
 #define Curl_ssl_data_pending(x,y) 0
 #define Curl_ssl_check_cxn(x) 0
 #define Curl_ssl_free_certinfo(x) Curl_nop_stmt
-#define Curl_ssl_connect_nonblocking(x,y,z) CURLE_NOT_BUILT_IN
+#define Curl_ssl_connect_nonblocking(x,y,z,w) CURLE_NOT_BUILT_IN
 #define Curl_ssl_kill_session(x) Curl_nop_stmt
 #define Curl_ssl_random(x,y,z) ((void)x, CURLE_NOT_BUILT_IN)
 #define Curl_ssl_cert_status_request() FALSE

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -47,7 +47,8 @@ struct Curl_ssl {
 
   size_t (*version)(char *buffer, size_t size);
   int (*check_cxn)(struct connectdata *cxn);
-  int (*shut_down)(struct connectdata *conn, int sockindex);
+  int (*shut_down)(struct Curl_easy *data, struct connectdata *conn,
+                   int sockindex);
   bool (*data_pending)(const struct connectdata *conn,
                        int connindex);
 
@@ -56,11 +57,14 @@ struct Curl_ssl {
                      size_t length);
   bool (*cert_status_request)(void);
 
-  CURLcode (*connect_blocking)(struct connectdata *conn, int sockindex);
-  CURLcode (*connect_nonblocking)(struct connectdata *conn, int sockindex,
+  CURLcode (*connect_blocking)(struct Curl_easy *data,
+                               struct connectdata *conn, int sockindex);
+  CURLcode (*connect_nonblocking)(struct Curl_easy *data,
+                                  struct connectdata *conn, int sockindex,
                                   bool *done);
   void *(*get_internals)(struct ssl_connect_data *connssl, CURLINFO info);
-  void (*close_one)(struct connectdata *conn, int sockindex);
+  void (*close_one)(struct Curl_easy *data, struct connectdata *conn,
+                    int sockindex);
   void (*close_all)(struct Curl_easy *data);
   void (*session_free)(void *ptr);
 
@@ -82,7 +86,8 @@ extern const struct Curl_ssl *Curl_ssl;
 
 int Curl_none_init(void);
 void Curl_none_cleanup(void);
-int Curl_none_shutdown(struct connectdata *conn, int sockindex);
+int Curl_none_shutdown(struct Curl_easy *data, struct connectdata *conn,
+                       int sockindex);
 int Curl_none_check_cxn(struct connectdata *conn);
 CURLcode Curl_none_random(struct Curl_easy *data, unsigned char *entropy,
                           size_t length);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -837,8 +837,8 @@ static ssize_t wolfssl_send(struct Curl_easy *data,
   return rc;
 }
 
-static void real_wolfssl_close(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex)
+static void wolfssl_close(struct Curl_easy *data, struct connectdata *conn,
+                          int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
@@ -854,11 +854,6 @@ static void real_wolfssl_close(struct Curl_easy *data,
     SSL_CTX_free(backend->ctx);
     backend->ctx = NULL;
   }
-}
-
-static void wolfssl_close(struct connectdata *conn, int sockindex)
-{
-  real_wolfssl_close(conn->data, conn, sockindex);
 }
 
 static ssize_t wolfssl_recv(struct Curl_easy *data,
@@ -947,8 +942,8 @@ static bool wolfssl_data_pending(const struct connectdata *conn,
  * This function is called to shut down the SSL layer but keep the
  * socket open (CCC - Clear Command Channel)
  */
-static int real_wolfssl_shutdown(struct Curl_easy *data,
-                                 struct connectdata *conn, int sockindex)
+static int wolfssl_shutdown(struct Curl_easy *data, struct connectdata *conn,
+                            int sockindex)
 {
   int retval = 0;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
@@ -961,11 +956,6 @@ static int real_wolfssl_shutdown(struct Curl_easy *data,
     backend->handle = NULL;
   }
   return retval;
-}
-
-static int wolfssl_shutdown(struct connectdata *conn, int sockindex)
-{
-  return real_wolfssl_shutdown(conn->data, conn, sockindex);
 }
 
 
@@ -1082,19 +1072,21 @@ wolfssl_connect_common(struct Curl_easy *data,
 }
 
 
-static CURLcode wolfssl_connect_nonblocking(struct connectdata *conn,
+static CURLcode wolfssl_connect_nonblocking(struct Curl_easy *data,
+                                            struct connectdata *conn,
                                             int sockindex, bool *done)
 {
-  return wolfssl_connect_common(conn->data, conn, sockindex, TRUE, done);
+  return wolfssl_connect_common(data, conn, sockindex, TRUE, done);
 }
 
 
-static CURLcode wolfssl_connect(struct connectdata *conn, int sockindex)
+static CURLcode wolfssl_connect(struct Curl_easy *data,
+                                struct connectdata *conn, int sockindex)
 {
   CURLcode result;
   bool done = FALSE;
 
-  result = wolfssl_connect_common(conn->data, conn, sockindex, FALSE, &done);
+  result = wolfssl_connect_common(data, conn, sockindex, FALSE, &done);
   if(result)
     return result;
 


### PR DESCRIPTION
This reduces the total reference count to 267.

Original PR: https://github.com/curl/curl/pull/6446