### PR TITLE
libssh: avoid plain free() of libssh-memory

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -532,10 +532,10 @@ static int myssh_is_known(struct connectdata *conn)
 
 cleanup:
   if(found_base64) {
-    free(found_base64);
+    (free)(found_base64);
   }
   if(known_base64) {
-    free(known_base64);
+    (free)(known_base64);
   }
   if(hash)
     ssh_clean_pubkey_hash(&hash);


### PR DESCRIPTION
Since curl's own memory debugging system redefines free() calls to track
and fiddle with memory, it cannot be used on memory allocated by 3rd
party libraries.

Third party libraries SHOULD NOT require free() to release allocated
resources for this reason - and libs can use separate healp allocators
on some systems (like Windows) so free() doesn't necessarily work
anyway.

Filed as an issue with libssh: https://bugs.libssh.org/T268