### PR TITLE
save a bit of space with some structure packing

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -160,10 +160,9 @@ static bool init_resolve_thread(struct connectdata *conn,
 struct thread_sync_data {
   curl_mutex_t *mtx;
   int done;
-
+  int port;
   char *hostname;        /* hostname to resolve, Curl_async.hostname
                             duplicate */
-  int port;
 #ifdef USE_SOCKETPAIR
   struct connectdata *conn;
   curl_socket_t sock_pair[2]; /* socket pair */

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -34,12 +34,12 @@ struct Cookie {
   char *domain;      /* domain = <this> */
   curl_off_t expires;  /* expires = <this> */
   char *expirestr;   /* the plain text version */
-  bool tailmatch;    /* whether we do tail-matching of the domain name */
 
   /* RFC 2109 keywords. Version=1 means 2109-compliant cookie sending */
   char *version;     /* Version = <value> */
   char *maxage;      /* Max-Age = <value> */
 
+  bool tailmatch;    /* whether we do tail-matching of the domain name */
   bool secure;       /* whether the 'secure' keyword was used */
   bool livecookie;   /* updated from a server, not a stored file */
   bool httponly;     /* true if the httponly directive is present */
@@ -61,8 +61,8 @@ struct CookieInfo {
   struct Cookie *cookies[COOKIE_HASH_SIZE];
 
   char *filename;  /* file we read from/write to */
-  bool running;    /* state info, for cookie adding information */
   long numcookies; /* number of cookies in the "jar" */
+  bool running;    /* state info, for cookie adding information */
   bool newsession; /* new session, discard session cookies on load */
   int lastct;      /* last creation-time used in the jar */
 };

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -29,22 +29,22 @@
 /* used by FormAdd for temporary storage */
 struct FormInfo {
   char *name;
-  bool name_alloc;
   size_t namelength;
   char *value;
-  bool value_alloc;
   curl_off_t contentslength;
   char *contenttype;
-  bool contenttype_alloc;
   long flags;
   char *buffer;      /* pointer to existing buffer used for file upload */
   size_t bufferlength;
   char *showfilename; /* The file name to show. If not set, the actual
                          file name will be used */
-  bool showfilename_alloc;
   char *userp;        /* pointer for the read callback */
   struct curl_slist *contentheader;
   struct FormInfo *more;
+  bool name_alloc;
+  bool value_alloc;
+  bool contenttype_alloc;
+  bool showfilename_alloc;
 };
 
 CURLcode Curl_getformdata(struct Curl_easy *data,

--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -116,9 +116,9 @@ struct FTP {
 struct ftp_conn {
   struct pingpong pp;
   char *entrypath; /* the PWD reply when we logged on */
+  char *file;    /* url-decoded file name (or path) */
   char **dirs;   /* realloc()ed array for path components */
   int dirdepth;  /* number of entries used in the 'dirs' array */
-  char *file;    /* url-decoded file name (or path) */
   bool dont_check;  /* Set to TRUE to prevent the final (post-transfer)
                        file size and 226/250 status check. It should still
                        read the line, just ignore the result. */
@@ -131,6 +131,10 @@ struct ftp_conn {
   bool cwdfail;     /* set TRUE if a CWD command fails, as then we must prevent
                        caching the current directory */
   bool wait_data_conn; /* this is set TRUE if data connection is waited */
+  /* newhost is the (allocated) IP addr or host name to connect the data
+     connection to */
+  unsigned short newport;
+  char *newhost;
   char *prevpath;   /* url-decoded conn->path from the previous transfer */
   char transfertype; /* set by ftp_transfertype for use by Curl_client_write()a
                         and others (A/I or zero) */
@@ -145,10 +149,6 @@ struct ftp_conn {
   curl_off_t known_filesize; /* file size is different from -1, if wildcard
                                 LIST parsing was done and wc_statemach set
                                 it */
-  /* newhost is the (allocated) IP addr or host name to connect the data
-     connection to */
-  char *newhost;          /* this is the pair to connect the DATA... */
-  unsigned short newport; /* connection to */
 };
 
 #define DEFAULT_ACCEPT_TIMEOUT   60000 /* milliseconds == one minute */

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -110,6 +110,7 @@ struct curl_mimepart {
   curl_mime *parent;               /* Parent mime structure. */
   curl_mimepart *nextpart;         /* Forward linked list. */
   enum mimekind kind;              /* The part kind. */
+  unsigned int flags;              /* Flags. */
   char *data;                      /* Memory data or file name. */
   curl_read_callback readfunc;     /* Read function. */
   curl_seek_callback seekfunc;     /* Seek function. */
@@ -122,7 +123,6 @@ struct curl_mimepart {
   char *filename;                  /* Remote file name. */
   char *name;                      /* Data name. */
   curl_off_t datasize;             /* Expected data size. */
-  unsigned int flags;              /* Flags. */
   struct mime_state state;         /* Current readback state. */
   const struct mime_encoder *encoder; /* Content data encoder. */
   struct mime_encoder_state encstate; /* Data encoder state. */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -200,8 +200,8 @@ struct Curl_sh_entry {
   struct Curl_hash transfers; /* hash of transfers using this socket */
   unsigned int action;  /* what combined action READ/WRITE this socket waits
                            for */
-  void *socketp; /* settable by users with curl_multi_assign() */
   unsigned int users; /* number of transfers using this */
+  void *socketp; /* settable by users with curl_multi_assign() */
   unsigned int readers; /* this many transfers want to read */
   unsigned int writers; /* this many transfers want to write */
 };

--- a/lib/pop3.h
+++ b/lib/pop3.h
@@ -61,6 +61,7 @@ struct pop3_conn {
   struct pingpong pp;
   pop3state state;        /* Always use pop3.c:state() to change state! */
   bool ssldone;           /* Is connect() over SSL done? */
+  bool tls_supported;     /* StartTLS capability supported by server */
   size_t eob;             /* Number of bytes of the EOB (End Of Body) that
                              have been received so far */
   size_t strip;           /* Number of bytes from the start to ignore as
@@ -69,7 +70,6 @@ struct pop3_conn {
   unsigned int authtypes; /* Accepted authentication types */
   unsigned int preftype;  /* Preferred authentication type */
   char *apoptimestamp;    /* APOP timestamp from the server greeting */
-  bool tls_supported;     /* StartTLS capability supported by server */
 };
 
 extern const struct Curl_handler Curl_handler_pop3;

--- a/lib/smtp.h
+++ b/lib/smtp.h
@@ -57,10 +57,10 @@ struct SMTP {
   struct curl_slist *rcpt; /* Recipient list */
   bool rcpt_had_ok;        /* Whether any of RCPT TO commands (depends on
                               total number of recipients) succeeded so far */
+  bool trailing_crlf;      /* Specifies if the trailing CRLF is present */
   int rcpt_last_error;     /* The last error received for RCPT TO command */
   size_t eob;              /* Number of bytes of the EOB (End Of Body) that
                               have been received so far */
-  bool trailing_crlf;      /* Specifies if the tailing CRLF is present */
 };
 
 /* smtp_conn is used for struct connection-oriented data in the connectdata

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -156,13 +156,12 @@ struct TELNET {
   char subopt_xdisploc[128];         /* Set with suboption XDISPLOC */
   unsigned short subopt_wsx;         /* Set with suboption NAWS */
   unsigned short subopt_wsy;         /* Set with suboption NAWS */
+  TelnetReceive telrcv_state;
   struct curl_slist *telnet_vars;    /* Environment variables */
 
   /* suboptions */
   unsigned char subbuffer[SUBBUFSIZE];
   unsigned char *subpointer, *subend;      /* buffer for sub-options */
-
-  TelnetReceive telrcv_state;
 };
 
 

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -132,7 +132,6 @@ struct tftp_state_data {
   time_t          start_time;
   time_t          max_time;
   time_t          rx_time;
-  unsigned short  block;
   struct Curl_sockaddr_storage   local_addr;
   struct Curl_sockaddr_storage   remote_addr;
   curl_socklen_t  remote_addrlen;
@@ -140,6 +139,7 @@ struct tftp_state_data {
   int             sbytes;
   int             blksize;
   int             requested_blksize;
+  unsigned short  block;
   struct tftp_packet rpacket;
   struct tftp_packet spacket;
 };

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -377,8 +377,8 @@ struct ntlmdata {
 #else
   unsigned int flags;
   unsigned char nonce[8];
-  void *target_info; /* TargetInfo received in the ntlm type-2 message */
   unsigned int target_info_len;
+  void *target_info; /* TargetInfo received in the ntlm type-2 message */
 
 #if defined(NTLM_WB_ENABLED)
   /* used for communication with Samba's winbind daemon helper ntlm_auth */
@@ -526,8 +526,8 @@ struct hostname {
 struct Curl_async {
   char *hostname;
   int port;
-  struct Curl_dns_entry *dns;
   int status; /* if done is TRUE, this is the status from the callback */
+  struct Curl_dns_entry *dns;
   struct thread_data *tdata;
   BIT(done);  /* set TRUE when the lookup is complete */
 };
@@ -581,8 +581,8 @@ struct dohdata {
   struct curl_slist *headers;
   struct dnsprobe probe[DOH_PROBE_SLOTS];
   unsigned int pending; /* still outstanding requests */
-  const char *host;
   int port;
+  const char *host;
 };
 
 /*
@@ -625,6 +625,7 @@ struct SingleRequest {
                                    Content-Range: header */
   int httpcode;                 /* error code from the 'HTTP/1.? XXX' or
                                    'RTSP/1.? XXX' line */
+  int keepon;
   struct curltime start100;      /* time stamp to wait for the 100 code from */
   enum expect100 exp100;        /* expect 100 continue state */
   enum upgrade101 upgr101;      /* 101 upgrade state */
@@ -633,7 +634,6 @@ struct SingleRequest {
   struct contenc_writer *writer_stack;
   time_t timeofdoc;
   long bodywrites;
-  int keepon;
   char *location;   /* This points to an allocated version of the Location:
                        header data */
   char *newurl;     /* Set to the new URL to use when a redirect or a retry is
@@ -1007,13 +1007,14 @@ struct connectdata {
 #endif
   struct ConnectBits bits;    /* various state-flags for this connection */
 
+  /* The field below gets set in Curl_connecthost */
+  int num_addr; /* number of addresses to try to connect to */
  /* connecttime: when connect() is called on the current IP address. Used to
     be able to track when to move on to try next IP - but only when the multi
     interface is used. */
   struct curltime connecttime;
-  /* The two fields below get set in Curl_connecthost */
-  int num_addr; /* number of addresses to try to connect to */
 
+  /* The field below gets set in Curl_connecthost */
   /* how long time in milliseconds to spend on trying to connect to each IP
      address, per family */
   timediff_t timeoutms_per_addr[2];
@@ -1339,10 +1340,10 @@ struct UrlState {
   int first_remote_port; /* remote port of the first (not followed) request */
   struct Curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
   long sessionage;                  /* number of the most recent session */
-  unsigned int tempcount; /* number of entries in use in tempwrite, 0 - 3 */
   struct tempbuf tempwrite[3]; /* BOTH, HEADER, BODY */
-  char *scratch; /* huge buffer[set.buffer_size*2] for upload CRLF replacing */
+  unsigned int tempcount; /* number of entries in use in tempwrite, 0 - 3 */
   int os_errno;  /* filled in with errno whenever an error occurs */
+  char *scratch; /* huge buffer[set.buffer_size*2] for upload CRLF replacing */
 #ifdef HAVE_SIGNAL
   /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
   void (*prev_signal)(int sig);
@@ -1707,6 +1708,7 @@ struct UserDefined {
   struct curl_slist *connect_to; /* list of host:port mappings to override
                                     the hostname and port to connect to */
   curl_TimeCond timecondition; /* kind of time/date comparison */
+  curl_proxytype proxytype; /* what kind of proxy that is in use */
   time_t timevalue;       /* what time to compare with */
 #if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_MQTT)
   Curl_HttpReq method;   /* what kind of HTTP request (if any) is this */
@@ -1718,7 +1720,6 @@ struct UserDefined {
   struct ssl_config_data proxy_ssl;  /* user defined SSL stuff for proxy */
 #endif
   struct ssl_general_config general_ssl; /* general user defined SSL stuff */
-  curl_proxytype proxytype; /* what kind of proxy that is in use */
   long dns_cache_timeout; /* DNS cache timeout */
   long buffer_size;      /* size of receive buffer to use */
   size_t upload_buffer_size; /* size of upload buffer to use,
@@ -1905,6 +1906,7 @@ struct Curl_easy {
   int actions[MAX_SOCKSPEREASYHANDLE]; /* action for each socket in
                                           sockets[] */
   int numsocks;
+  unsigned int magic;          /* set to a CURLEASY_MAGIC_NUMBER */
 
   struct Names dns;
   struct Curl_multi *multi;    /* if non-NULL, points to the multi handle
@@ -1947,7 +1949,6 @@ struct Curl_easy {
 #ifdef USE_HYPER
   struct hyptransfer hyp;
 #endif
-  unsigned int magic;          /* set to a CURLEASY_MAGIC_NUMBER */
 };
 
 #define LIBCURL_NAME "libcurl"

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -123,6 +123,8 @@ struct ssh_conn {
   char *rsa_pub;              /* path name */
   char *rsa;                  /* path name */
   bool authed;                /* the connection has been authenticated fine */
+  bool acceptfail;            /* used by the SFTP_QUOTE (continue if
+                                 quote command fails) */
   sshstate state;             /* always use ssh.c:state() to change state! */
   sshstate nextstate;         /* the state to goto after stopping */
   CURLcode actualcode;        /* the actual error code */
@@ -130,8 +132,6 @@ struct ssh_conn {
   char *quote_path1;          /* two generic pointers for the QUOTE stuff */
   char *quote_path2;
 
-  bool acceptfail;            /* used by the SFTP_QUOTE (continue if
-                                 quote command fails) */
   char *homedir;              /* when doing SFTP we figure out home dir in the
                                  connect phase */
   char *readdir_line;
@@ -140,9 +140,8 @@ struct ssh_conn {
   int secondCreateDirs;         /* counter use by the code to see if the
                                    second attempt has been made to change
                                    to/create a directory */
-  char *slash_pos;              /* used by the SFTP_CREATE_DIRS state */
-
   int orig_waitfor;             /* default READ/WRITE bits wait for */
+  char *slash_pos;              /* used by the SFTP_CREATE_DIRS state */
 
 #if defined(USE_LIBSSH)
   char *readdir_linkPath;


### PR DESCRIPTION
This is an attempt at saving a bit of space by packing some structs (using pahole to find the holes) where it might make sense to do so without losing readability.
I.e., I tried to avoid separating fields that seem grouped together (like the cwd... fields in `struct ftp_conn` for instance).
Also abstained from touching fields behind conditional macros as that quickly can get complicated.

If this is at all useful (and I doubt it) I'm happy to squash; kept them separate for now to easy be able any unwanted ones.
