### PR TITLE
Get --request-target working with HTTP proxy

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2177,8 +2177,9 @@ CURLcode Curl_http_target(struct Curl_easy *data,
 
     curl_url_cleanup(h);
 
-    /* url */
-    result = Curl_dyn_add(r, url);
+    /* target or url */
+    result = Curl_dyn_add(r, data->set.str[STRING_TARGET]?
+      data->set.str[STRING_TARGET]:url);
     free(url);
     if(result)
       return (result);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -192,7 +192,7 @@ test1566 test1567 test1568 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
-test1608 test1609 test1610 test1611 test1612 \
+test1608 test1609 test1610 test1611 test1612 test1613 \
 \
 test1620 test1621 \
 \

--- a/tests/data/test1613
+++ b/tests/data/test1613
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+--request-target
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Sat, 29 Feb 2020 16:10:44 GMT
+Server: Blafasel/1.1
+Last-Modified: Sat, 29 Feb 2020 16:10:44 GMT
+Content-Length: 0
+Connection: close
+Content-Type: text/html
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Send "OPTIONS *" with --request-target to a proxy
+</name>
+<features>
+proxy
+</features>
+<command>
+--request-target '*' -X OPTIONS --proxy http://%HOSTIP:%HTTPPORT/ -H "Testno: 1613" http://www.example.org/
+</command>
+</client>
+
+<verify>
+<protocol>
+OPTIONS * HTTP/1.1
+Host: www.example.org
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+Testno: 1613
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Currently the --request-target is ignored when an HTTP proxy is being used.

This PR adds a test for this and includes a potential fix.