### PR TITLE
file: Support unicode urls on windows

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -82,6 +82,32 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
 
 #if defined(USE_WIN32_LARGE_FILES) || defined(USE_WIN32_SMALL_FILES)
 
+int curlx_win32_open(const char *filename, int oflag, ...)
+{
+  int pmode = 0;
+
+#ifdef _UNICODE
+  int result = -1;
+  wchar_t *filename_w = curlx_convert_UTF8_to_wchar(filename);
+#endif
+
+  va_list param;
+  va_start(param, oflag);
+  if(oflag & O_CREAT)
+    pmode = va_arg(param, int);
+  va_end(param);
+
+#ifdef _UNICODE
+  if(filename_w)
+    result = _wopen(filename_w, oflag, pmode);
+  free(filename_w);
+  if(result != -1)
+    return result;
+#endif
+
+  return (_open)(filename, oflag, pmode);
+}
+
 FILE *curlx_win32_fopen(const char *filename, const char *mode)
 {
 #ifdef _UNICODE

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -335,8 +335,10 @@
 #  define stat(fname,stp)            curlx_win32_stat(fname, stp)
 #  define struct_stat                struct _stati64
 #  define LSEEK_ERROR                (__int64)-1
+#  define open                       curlx_win32_open
 #  define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
 #  define access(fname,mode)         curlx_win32_access(fname, mode)
+   int curlx_win32_open(const char *filename, int oflag, ...);
    int curlx_win32_stat(const char *path, struct_stat *buffer);
    FILE *curlx_win32_fopen(const char *filename, const char *mode);
    int curlx_win32_access(const char *path, int mode);
@@ -356,9 +358,11 @@
 #    define fstat(fdes,stp)            _fstat(fdes, stp)
 #    define stat(fname,stp)            curlx_win32_stat(fname, stp)
 #    define struct_stat                struct _stat
+#    define open                       curlx_win32_open
 #    define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
 #    define access(fname,mode)         curlx_win32_access(fname, mode)
      int curlx_win32_stat(const char *path, struct_stat *buffer);
+     int curlx_win32_open(const char *filename, int oflag, ...);
      FILE *curlx_win32_fopen(const char *filename, const char *mode);
      int curlx_win32_access(const char *path, int mode);
 #  endif

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -405,6 +405,7 @@ Features testable here are:
 - `TLS-SRP`
 - `TrackMemory`
 - `typecheck`
+- `Unicode`
 - `unittest`
 - `unix-sockets`
 - `verbose-strings`

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -201,7 +201,7 @@ test1630 test1631 test1632 test1633 test1634 \
 test1650 test1651 test1652 test1653 test1654 test1655 \
 test1660 \
 \
-test1700 test1701 test1702 \
+test1700 test1701 test1702 test1703 \
 \
 test1800 test1801 \
 \

--- a/tests/data/test1703
+++ b/tests/data/test1703
@@ -1,0 +1,45 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<reply>
+<data>
+foo
+   bar
+bar
+   foo
+moo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+file
+</server>
+<features>
+Unicode
+win32
+</features>
+<name>
+basic file:// file with UTF-8 characters
+</name>
+<command option="no-include">
+file://localhost%FILE_PWD/log/%E3%83%86%E3%82%B9%E3%83%881703.txt
+</command>
+<file name="log/テスト1703.txt">
+foo
+   bar
+bar
+   foo
+moo
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -264,6 +264,7 @@ my $has_manual;     # set if built with built-in manual
 my $has_win32;      # set if built for Windows
 my $has_mingw;      # set if built with MinGW (as opposed to MinGW-w64)
 my $has_hyper = 0;  # set if built with Hyper
+my $has_unicode;    # set if libcurl is built with Unicode support
 
 # this version is decided by the particular nghttp2 library that is being used
 my $h2cver = "h2c";
@@ -2803,6 +2804,7 @@ sub setupfeatures {
     $feature{"threaded-resolver"} = $has_threadedres;
     $feature{"TLS-SRP"} = $has_tls_srp;
     $feature{"TrackMemory"} = $has_memory_tracking;
+    $feature{"Unicode"} = $has_unicode;
     $feature{"unittest"} = $debug_build;
     $feature{"unix-sockets"} = $has_unix;
     $feature{"win32"} = $has_win32;
@@ -3069,6 +3071,9 @@ sub checksystem {
 
                 # 'https-proxy' is used as "server" so consider it a protocol
                 push @protocols, 'https-proxy';
+            }
+            if($feat =~ /Unicode/i) {
+                $has_unicode = 1;
             }
         }
         #


### PR DESCRIPTION
Support file: urls with utf-8 filenames on Windows when _UNICODE is defined.