### PR TITLE
http: empty reply connection are not left intact

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1597,7 +1597,7 @@ CURLcode Curl_http_done(struct Curl_easy *data,
        return an error here */
     failf(data, "Empty reply from server");
     /* Mark it as closed to avoid the "left intact" message */
-    connclose(conn, "Empty reply from server");
+    streamclose(conn, "Empty reply from server");
     return CURLE_GOT_NOTHING;
   }
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1596,6 +1596,8 @@ CURLcode Curl_http_done(struct Curl_easy *data,
        read from the HTTP server (that counts), this can't be right so we
        return an error here */
     failf(data, "Empty reply from server");
+    /* Mark it as closed to avoid the "left intact" message */
+    connclose(conn, "Empty reply from server");
     return CURLE_GOT_NOTHING;
   }
 


### PR DESCRIPTION
... so mark the connection as closed in this condition to prevent that
verbose message to wrongly appear.

Reported-by: Matt Holt
Bug: https://twitter.com/mholt6/status/1352130240265375744