### PR TITLE
strerror: skip errnum >= 0 assertion on windows

### DIFF
--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -721,7 +721,9 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   if(!buflen)
     return NULL;
 
+#ifndef WIN32
   DEBUGASSERT(err >= 0);
+#endif
 
   max = buflen - 1;
   *buf = '\0';


### PR DESCRIPTION
On Windows an error number may be greater than INT_MAX and negative once
cast to int.

The assertion is checked only in debug builds.

Closes #xxxx