### PR TITLE
http: fix compiler warning with `CURL_DISABLE_CRYPTO_AUTH`

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -895,7 +895,9 @@ CURLcode Curl_http_input_auth(struct Curl_easy *data, bool proxy,
   /*
    * This resource requires authentication
    */
+#ifndef CURL_DISABLE_CRYPTO_AUTH
   struct connectdata *conn = data->conn;
+#endif
 #ifdef USE_SPNEGO
   curlnegotiate *negstate = proxy ? &conn->proxy_negotiate_state :
                                     &conn->http_negotiate_state;


### PR DESCRIPTION
Declare `conn` only if `CURL_DISABLE_CRYPTO_AUTH` is not defined.
This fixes the following warning:
```
http.c:898:23: warning: unused variable 'conn' [-Wunused-variable]
898 | struct connectdata *conn = data->conn;
```