### PR TITLE
http2: remove conn->data use

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3155,7 +3155,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
      (data->set.httpversion == CURL_HTTP_VERSION_2)) {
     /* append HTTP2 upgrade magic stuff to the HTTP request if it isn't done
        over SSL */
-    result = Curl_http2_request_upgrade(&req, conn);
+    result = Curl_http2_request_upgrade(&req, data);
     if(result) {
       Curl_dyn_free(&req);
       return result;

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -43,7 +43,7 @@ CURLcode Curl_http2_init(struct connectdata *conn);
 void Curl_http2_init_state(struct UrlState *state);
 void Curl_http2_init_userset(struct UserDefined *set);
 CURLcode Curl_http2_request_upgrade(struct dynbuf *req,
-                                    struct connectdata *conn);
+                                    struct Curl_easy *data);
 CURLcode Curl_http2_setup(struct Curl_easy *data, struct connectdata *conn);
 CURLcode Curl_http2_switched(struct Curl_easy *data,
                              const char *ptr, size_t nread);


### PR DESCRIPTION
Starting here, the code sets the 'data' pointer as user-data even for
the connection, and the callbacks need to find the connection using
'data->conn'. Since the transfer can come and go over the life time of
the connection it thus becomes important to always set the correct
"current transfer" when calling nghttp2 so that it doesn't get the *old*
transfer that previously used the connection.