### PR TITLE
curl_multibyte: fall back to local code page stat/access on Windows

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -104,50 +104,38 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
   int result = -1;
 #ifdef _UNICODE
   wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
+  if(path_w) {
+#if defined(USE_WIN32_SMALL_FILES)
+    result = _wstat(path_w, buffer);
+#else
+    result = _wstati64(path_w, buffer);
+#endif
+    free(path_w);
+    if(result != -1)
+      return result;
+  }
 #endif /* _UNICODE */
 
 #if defined(USE_WIN32_SMALL_FILES)
-#if defined(_UNICODE)
-  if(path_w)
-    result = _wstat(path_w, buffer);
-  else
-#endif /* _UNICODE */
-    result = _stat(path, buffer);
-#else /* USE_WIN32_SMALL_FILES */
-#if defined(_UNICODE)
-  if(path_w)
-    result = _wstati64(path_w, buffer);
-  else
-#endif /* _UNICODE */
-    result = _stati64(path, buffer);
-#endif /* USE_WIN32_SMALL_FILES */
-
-#ifdef _UNICODE
-  free(path_w);
+  result = _stat(path, buffer);
+#else
+  result = _stati64(path, buffer);
 #endif
-
   return result;
 }
 
 int curlx_win32_access(const char *path, int mode)
 {
-    int result = -1;
-#ifdef _UNICODE
-    wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
-#endif /* _UNICODE */
-
 #if defined(_UNICODE)
-    if(path_w)
-        result = _waccess(path_w, mode);
-    else
-#endif /* _UNICODE */
-        result = _access(path, mode);
-
-#ifdef _UNICODE
+  wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
+  if(path_w) {
+    int result = _waccess(path_w, mode);
     free(path_w);
-#endif
-
-    return result;
+    if(result != -1)
+      return result;
+  }
+#endif /* _UNICODE */
+  return _access(path, mode);
 }
 
 #endif /* USE_WIN32_LARGE_FILES || USE_WIN32_SMALL_FILES */


### PR DESCRIPTION
If libcurl is built with Unicode support for Windows then it is assumed
the filename string is Unicode in UTF-8 encoding and it is converted to
UTF-16 to be passed to the wide character version of the respective
function (eg wstat). However the filename string may actually be in the
local encoding so, even if it successfully converted to UTF-16, if it
could not be stat/accessed then try again using the local code page
version of the function (eg wstat fails try stat).

We already do this with fopen (ie wfopen fails try fopen), so I think it
makes sense to extend it to stat and access functions.

Closes #xxxx