### PR TITLE
pingpong: remove the 'conn' struct member

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -803,8 +803,7 @@ static int ftp_getsock(struct Curl_easy *data,
                        struct connectdata *conn,
                        curl_socket_t *socks)
 {
-  (void)data;
-  return Curl_pp_getsock(&conn->proto.ftpc.pp, socks);
+  return Curl_pp_getsock(data, &conn->proto.ftpc.pp, socks);
 }
 
 /* For the FTP "DO_MORE" phase only */
@@ -850,7 +849,7 @@ static int ftp_domore_getsock(struct Curl_easy *data,
 
     return bits;
   }
-  return Curl_pp_getsock(&conn->proto.ftpc.pp, socks);
+  return Curl_pp_getsock(data, &conn->proto.ftpc.pp, socks);
 }
 
 /* This is called after the FTP_QUOTE state is passed.

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1411,8 +1411,7 @@ static int imap_getsock(struct Curl_easy *data,
                         struct connectdata *conn,
                         curl_socket_t *socks)
 {
-  (void)data;
-  return Curl_pp_getsock(&conn->proto.imapc.pp, socks);
+  return Curl_pp_getsock(data, &conn->proto.imapc.pp, socks);
 }
 
 /***********************************************************************

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -47,7 +47,7 @@
 timediff_t Curl_pp_state_timeout(struct Curl_easy *data,
                                  struct pingpong *pp, bool disconnecting)
 {
-  struct connectdata *conn = pp->conn;
+  struct connectdata *conn = data->conn;
   timediff_t timeout_ms; /* in milliseconds */
   timediff_t response_time = (data->set.server_response_timeout)?
     data->set.server_response_timeout: pp->response_time;
@@ -81,7 +81,7 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
                            struct pingpong *pp, bool block,
                            bool disconnecting)
 {
-  struct connectdata *conn = pp->conn;
+  struct connectdata *conn = data->conn;
   curl_socket_t sock = conn->sock[FIRSTSOCKET];
   int rc;
   timediff_t interval_ms;
@@ -131,7 +131,7 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
     result = CURLE_OUT_OF_MEMORY;
   }
   else if(rc)
-    result = pp->statemachine(data, pp->conn);
+    result = pp->statemachine(data, data->conn);
 
   return result;
 }
@@ -171,7 +171,7 @@ CURLcode Curl_pp_vsendf(struct Curl_easy *data,
   size_t write_len;
   char *s;
   CURLcode result;
-  struct connectdata *conn = pp->conn;
+  struct connectdata *conn = data->conn;
 
 #ifdef HAVE_GSSAPI
   enum protection_level data_sec;
@@ -274,7 +274,7 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
   bool keepon = TRUE;
   ssize_t gotbytes;
   char *ptr;
-  struct connectdata *conn = pp->conn;
+  struct connectdata *conn = data->conn;
   char * const buf = data->state.buffer;
   CURLcode result = CURLE_OK;
 
@@ -455,9 +455,10 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
   return result;
 }
 
-int Curl_pp_getsock(struct pingpong *pp, curl_socket_t *socks)
+int Curl_pp_getsock(struct Curl_easy *data,
+                    struct pingpong *pp, curl_socket_t *socks)
 {
-  struct connectdata *conn = pp->conn;
+  struct connectdata *conn = data->conn;
   socks[0] = conn->sock[FIRSTSOCKET];
 
   if(pp->sendleft) {
@@ -473,7 +474,7 @@ CURLcode Curl_pp_flushsend(struct Curl_easy *data,
                            struct pingpong *pp)
 {
   /* we have a piece of a command still left to send */
-  struct connectdata *conn = pp->conn;
+  struct connectdata *conn = data->conn;
   ssize_t written;
   curl_socket_t sock = conn->sock[FIRSTSOCKET];
   CURLcode result = Curl_write(data, sock, pp->sendthis + pp->sendsize -

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -62,7 +62,6 @@ struct pingpong {
                                off, used to time-out response reading */
   timediff_t response_time; /* When no timeout is given, this is the amount of
                                milliseconds we await for a server response. */
-  struct connectdata *conn; /* the connection */
   struct dynbuf sendbuf;
 
   /* Function pointers the protocols MUST implement and provide for the
@@ -78,7 +77,6 @@ struct pingpong {
     pp->response_time = RESP_TIMEOUT;            \
     pp->statemachine = s;                        \
     pp->endofresp = e;                           \
-    pp->conn = conn;                             \
   } while(0)
 
 /*
@@ -149,7 +147,8 @@ CURLcode Curl_pp_flushsend(struct Curl_easy *data,
 /* call this when a pingpong connection is disconnected */
 CURLcode Curl_pp_disconnect(struct pingpong *pp);
 
-int Curl_pp_getsock(struct pingpong *pp, curl_socket_t *socks);
+int Curl_pp_getsock(struct Curl_easy *data, struct pingpong *pp,
+                    curl_socket_t *socks);
 
 
 /***********************************************************************

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1072,8 +1072,7 @@ static CURLcode pop3_init(struct Curl_easy *data)
 static int pop3_getsock(struct Curl_easy *data,
                         struct connectdata *conn, curl_socket_t *socks)
 {
-  (void)data;
-  return Curl_pp_getsock(&conn->proto.pop3c.pp, socks);
+  return Curl_pp_getsock(data, &conn->proto.pop3c.pp, socks);
 }
 
 /***********************************************************************

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1299,8 +1299,7 @@ static CURLcode smtp_init(struct Curl_easy *data)
 static int smtp_getsock(struct Curl_easy *data,
                         struct connectdata *conn, curl_socket_t *socks)
 {
-  (void)data;
-  return Curl_pp_getsock(&conn->proto.smtpc.pp, socks);
+  return Curl_pp_getsock(data, &conn->proto.smtpc.pp, socks);
 }
 
 /***********************************************************************


### PR DESCRIPTION
... as it's superfluous now when `Curl_easy` is passed in and we can
derive the connection from that instead and avoid the duplicate copy.