### PR TITLE
Curl_chunker: shrink the struct

### DIFF
--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -92,7 +92,6 @@ void Curl_httpchunk_init(struct Curl_easy *data)
   struct connectdata *conn = data->conn;
   struct Curl_chunker *chunk = &conn->chunk;
   chunk->hexindex = 0;      /* start at 0 */
-  chunk->dataleft = 0;      /* no data left yet! */
   chunk->state = CHUNK_HEX; /* we get hex first! */
   Curl_dyn_init(&conn->trailer, DYN_H1_TRAILER);
 }
@@ -309,7 +308,7 @@ CHUNKcode Curl_httpchunk_read(struct Curl_easy *data,
 
         /* Record the length of any data left in the end of the buffer
            even if there's no more chunks to read */
-        ch->dataleft = curlx_sotouz(length);
+        ch->datasize = curlx_sotouz(length);
 
         return CHUNKE_STOP; /* return stop */
       }

--- a/lib/http_chunks.h
+++ b/lib/http_chunks.h
@@ -48,7 +48,7 @@ typedef enum {
      big deal. */
   CHUNK_POSTLF,
 
-  /* Used to mark that we're out of the game.  NOTE: that there's a 'dataleft'
+  /* Used to mark that we're out of the game.  NOTE: that there's a 'datasize'
      field in the struct that will tell how many bytes that were not passed to
      the client in the end of the last buffer! */
   CHUNK_STOP,
@@ -83,11 +83,10 @@ typedef enum {
 const char *Curl_chunked_strerror(CHUNKcode code);
 
 struct Curl_chunker {
-  char hexbuffer[ CHUNK_MAXNUM_LEN + 1]; /* +1 for null-terminator */
-  int hexindex;
-  ChunkyState state;
   curl_off_t datasize;
-  size_t dataleft; /* untouched data amount at the end of the last buffer */
+  ChunkyState state;
+  unsigned char hexindex;
+  char hexbuffer[ CHUNK_MAXNUM_LEN + 1]; /* +1 for null-terminator */
 };
 
 /* The following functions are defined in http_chunks.c */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -752,17 +752,15 @@ static CURLcode readwrite_data(struct Curl_easy *data,
           return CURLE_RECV_ERROR;
         }
         if(CHUNKE_STOP == res) {
-          size_t dataleft;
           /* we're done reading chunks! */
           k->keepon &= ~KEEP_RECV; /* read no more */
 
-          /* There are now possibly N number of bytes at the end of the
-             str buffer that weren't written to the client.
-             Push it back to be read on the next pass. */
-
-          dataleft = conn->chunk.dataleft;
-          if(dataleft != 0) {
-            infof(data, "Leftovers after chunking: %zu bytes\n", dataleft);
+          /* N number of bytes at the end of the str buffer that weren't
+             written to the client. */
+          if(conn->chunk.datasize) {
+            infof(data, "Leftovers after chunking: % "
+                  CURL_FORMAT_CURL_OFF_T "u bytes\n",
+                  conn->chunk.datasize);
           }
         }
         /* If it returned OK, we just keep going */


### PR DESCRIPTION
... by removing a field, converting the hex index into a byte and
rearranging the order. Cuts it down from 48 bytes to 32 on x86_64.