### PR TITLE
connectdata struct reorgs

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -700,7 +700,6 @@ void Curl_conninfo_remote(struct Curl_easy *data,
           errno, Curl_strerror(errno, buffer, sizeof(buffer)));
     return;
   }
-  memcpy(conn->ip_addr_str, conn->primary_ip, MAX_IPADR_LEN);
 #else
   (void)data;
   (void)conn;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -616,7 +616,7 @@ void Curl_persistconninfo(struct Curl_easy *data, struct connectdata *conn)
   memcpy(data->info.conn_local_ip, conn->local_ip, MAX_IPADR_LEN);
   data->info.conn_scheme = conn->handler->scheme;
   data->info.conn_protocol = conn->handler->protocol;
-  data->info.conn_primary_port = conn->primary_port;
+  data->info.conn_primary_port = conn->port;
   data->info.conn_local_port = conn->local_port;
 }
 
@@ -686,6 +686,7 @@ void Curl_conninfo_remote(struct Curl_easy *data,
   char buffer[STRERROR_LEN];
   struct Curl_sockaddr_storage ssrem;
   curl_socklen_t plen;
+  long port;
   plen = sizeof(struct Curl_sockaddr_storage);
   memset(&ssrem, 0, sizeof(ssrem));
   if(getpeername(sockfd, (struct sockaddr*) &ssrem, &plen)) {
@@ -695,7 +696,7 @@ void Curl_conninfo_remote(struct Curl_easy *data,
     return;
   }
   if(!Curl_addr2string((struct sockaddr*)&ssrem, plen,
-                       conn->primary_ip, &conn->primary_port)) {
+                       conn->primary_ip, &port)) {
     failf(data, "ssrem inet_ntop() failed with errno %d: %s",
           errno, Curl_strerror(errno, buffer, sizeof(buffer)));
     return;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -348,7 +348,7 @@ static CURLcode bindlocal(struct Curl_easy *data,
        * of the connection. The resolve functions should really be changed
        * to take a type parameter instead.
        */
-      long ipver = conn->ip_version;
+      unsigned char ipver = conn->ip_version;
       int rc;
 
       if(af == AF_INET)

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -80,9 +80,10 @@ void Curl_updateconninfo(struct Curl_easy *data, struct connectdata *conn,
                          curl_socket_t sockfd);
 void Curl_conninfo_remote(struct Curl_easy *data, struct connectdata *conn,
                           curl_socket_t sockfd);
-void Curl_conninfo_local(struct Curl_easy *data, struct connectdata *conn,
-                         curl_socket_t sockfd);
-void Curl_persistconninfo(struct Curl_easy *data, struct connectdata *conn);
+void Curl_conninfo_local(struct Curl_easy *data, curl_socket_t sockfd,
+                         char *local_ip, long *local_port);
+void Curl_persistconninfo(struct Curl_easy *data, struct connectdata *conn,
+                          char *local_ip, long local_port);
 int Curl_closesocket(struct Curl_easy *data, struct connectdata *conn,
                      curl_socket_t sock);
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1819,7 +1819,7 @@ static char *control_address(struct connectdata *conn)
   if(conn->bits.tunnel_proxy || conn->bits.socksproxy)
     return conn->host.name;
 #endif
-  return conn->ip_addr_str;
+  return conn->primary_ip;
 }
 
 static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -229,7 +229,7 @@ static unsigned int http2_conncheck(struct Curl_easy *data,
     struct curltime now = Curl_now();
     timediff_t elapsed = Curl_timediff(now, conn->keepalive);
 
-    if(elapsed > conn->upkeep_interval_ms) {
+    if(elapsed > data->set.upkeep_interval_ms) {
       /* Perform an HTTP/2 PING */
       rc = nghttp2_submit_ping(c->h2, 0, ZERO_NULL);
       if(!rc) {

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2271,7 +2271,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     arg = va_arg(param, long);
     if((arg < CURL_IPRESOLVE_WHATEVER) || (arg > CURL_IPRESOLVE_V6))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ipver = arg;
+    data->set.ipver = (unsigned char) arg;
     break;
 
   case CURLOPT_MAXFILESIZE_LARGE:

--- a/lib/url.c
+++ b/lib/url.c
@@ -2319,7 +2319,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
                             curl_proxytype proxytype)
 {
   char *portptr = NULL;
-  long port = -1;
+  int port = -1;
   char *proxyuser = NULL;
   char *proxypasswd = NULL;
   char *host;
@@ -2408,14 +2408,14 @@ static CURLcode parse_proxy(struct Curl_easy *data,
   curl_url_get(uhp, CURLUPART_PORT, &portptr, 0);
 
   if(portptr) {
-    port = strtol(portptr, NULL, 10);
+    port = (int)strtol(portptr, NULL, 10);
     free(portptr);
   }
   else {
     if(data->set.proxyport)
       /* None given in the proxy string, then get the default one if it is
          given */
-      port = data->set.proxyport;
+      port = (int)data->set.proxyport;
     else {
       if(proxytype == CURLPROXY_HTTPS)
         port = CURL_DEFAULT_HTTPS_PROXY_PORT;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1674,9 +1674,6 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
   /* Store current time to give a baseline to keepalive connection times. */
   conn->keepalive = Curl_now();
 
-  /* Store off the configured connection upkeep time. */
-  conn->upkeep_interval_ms = data->set.upkeep_interval_ms;
-
   conn->data = data; /* Setup the association between this connection
                         and the Curl_easy */
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -1176,9 +1176,9 @@ ConnectionExists(struct Curl_easy *data,
         }
 
         if(Curl_resolver_asynch()) {
-          /* ip_addr_str[0] is NUL only if the resolving of the name hasn't
+          /* primary_ip[0] is NUL only if the resolving of the name hasn't
              completed yet and until then we don't re-use this connection */
-          if(!check->ip_addr_str[0]) {
+          if(!check->primary_ip[0]) {
             infof(data,
                   "Connection #%ld is still name resolving, can't reuse\n",
                   check->connection_id);
@@ -1491,7 +1491,7 @@ void Curl_verboseconnect(struct Curl_easy *data,
 #endif
           conn->bits.conn_to_host ? conn->conn_to_host.dispname :
           conn->host.dispname,
-          conn->ip_addr_str, conn->port, conn->connection_id);
+          conn->primary_ip, conn->port, conn->connection_id);
 }
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -977,13 +977,6 @@ struct connectdata {
 
   char primary_ip[MAX_IPADR_LEN];
 
-  /* 'local_ip' and 'local_port' get filled with local's numerical
-     ip address and port number whenever an outgoing connection is
-     **established** from the primary socket to a remote address. */
-
-  char local_ip[MAX_IPADR_LEN];
-  long local_port;
-
   char *user;    /* user name string, allocated */
   char *passwd;  /* password string, allocated */
   char *options; /* options string, allocated */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -939,11 +939,6 @@ struct connectdata {
   struct Curl_addrinfo *ip_addr;
   struct Curl_addrinfo *tempaddr[2]; /* for happy eyeballs */
 
-  /* 'ip_addr_str' is the ip_addr data as a human readable string.
-     It remains available as long as the connection does, which is longer than
-     the ip_addr itself. */
-  char ip_addr_str[MAX_IPADR_LEN];
-
   unsigned int scope_id;  /* Scope id for IPv6 */
 
   enum {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -976,6 +976,7 @@ struct connectdata {
      these are updated with data which comes directly from the socket. */
 
   char primary_ip[MAX_IPADR_LEN];
+  unsigned char ip_version; /* copied from the Curl_easy at creation time */
 
   char *user;    /* user name string, allocated */
   char *passwd;  /* password string, allocated */
@@ -1026,8 +1027,6 @@ struct connectdata {
 
   const struct Curl_handler *handler; /* Connection's protocol handler */
   const struct Curl_handler *given;   /* The protocol first given */
-
-  long ip_version; /* copied from the Curl_easy at creation time */
 
   /* Protocols can use a custom keepalive mechanism to keep connections alive.
      This allows those protocols to track the last time the keepalive mechanism
@@ -1726,8 +1725,8 @@ struct UserDefined {
                                 keep it >= CURL_MAX_WRITE_SIZE */
   void *private_data; /* application-private data */
   struct curl_slist *http200aliases; /* linked list of aliases for http200 */
-  long ipver; /* the CURL_IPRESOLVE_* defines in the public header file
-                 0 - whatever, 1 - v2, 2 - v6 */
+  unsigned char ipver; /* the CURL_IPRESOLVE_* defines in the public header
+                          file 0 - whatever, 1 - v2, 2 - v6 */
   curl_off_t max_filesize; /* Maximum file size to download */
 #ifndef CURL_DISABLE_FTP
   curl_ftpfile ftp_filemethod; /* how to get to a file when FTP is used  */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -782,7 +782,7 @@ struct Curl_handler {
                                    struct connectdata *conn,
                                    unsigned int checks_to_perform);
 
-  long defport;           /* Default port. */
+  int defport;            /* Default port. */
   unsigned int protocol;  /* See CURLPROTO_* - this needs to be the single
                              specific protocol bit */
   unsigned int family;    /* single bit for protocol family; basically the
@@ -961,7 +961,7 @@ struct connectdata {
   struct proxy_info socks_proxy;
   struct proxy_info http_proxy;
 #endif
-  long port;       /* which port to use locally */
+  int port;        /* which port to use locally - to connect to */
   int remote_port; /* the remote port, not the proxy port! */
   int conn_to_port; /* the remote port to connect to. valid only if
                        bits.conn_to_port is set */
@@ -976,7 +976,6 @@ struct connectdata {
      these are updated with data which comes directly from the socket. */
 
   char primary_ip[MAX_IPADR_LEN];
-  long primary_port;
 
   /* 'local_ip' and 'local_port' get filled with local's numerical
      ip address and port number whenever an outgoing connection is

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1101,24 +1101,8 @@ struct connectdata {
     struct mqtt_conn mqtt;
   } proto;
 
-  int cselect_bits; /* bitmask of socket events */
-  int waitfor;      /* current READ/WRITE bits to wait for */
-
-#if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
-  int socks5_gssapi_enctype;
-#endif
-
-  /* When this connection is created, store the conditions for the local end
-     bind. This is stored before the actual bind and before any connection is
-     made and will serve the purpose of being used for comparison reasons so
-     that subsequent bound-requested connections aren't accidentally re-using
-     wrong connections. */
-  char *localdev;
-  unsigned short localport;
-  int localportrange;
   struct http_connect_state *connect_state; /* for HTTP CONNECT */
   struct connectbundle *bundle; /* The bundle we are member of */
-  int negnpn; /* APLN or NPN TLS negotiated protocol, CURL_HTTP_VERSION* */
 #ifdef USE_UNIX_SOCKETS
   char *unix_domain_socket;
 #endif
@@ -1126,6 +1110,21 @@ struct connectdata {
   /* if set, an alternative data transfer function */
   Curl_datastream datastream;
 #endif
+  /* When this connection is created, store the conditions for the local end
+     bind. This is stored before the actual bind and before any connection is
+     made and will serve the purpose of being used for comparison reasons so
+     that subsequent bound-requested connections aren't accidentally re-using
+     wrong connections. */
+  char *localdev;
+  int localportrange;
+  int cselect_bits; /* bitmask of socket events */
+  int waitfor;      /* current READ/WRITE bits to wait for */
+  int negnpn; /* APLN or NPN TLS negotiated protocol, CURL_HTTP_VERSION* */
+
+#if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
+  int socks5_gssapi_enctype;
+#endif
+  unsigned short localport;
 };
 
 /* The end of connectdata. */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1034,8 +1034,6 @@ struct connectdata {
      was used on this connection. */
   struct curltime keepalive;
 
-  long upkeep_interval_ms;      /* Time between calls for connection upkeep. */
-
   /**** curl_get() phase fields */
 
   curl_socket_t sockfd;   /* socket to read from or CURL_SOCKET_BAD */

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -255,7 +255,7 @@ CURLcode Curl_quic_connect(struct Curl_easy *data,
           SOCKERRNO, Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     return CURLE_BAD_FUNCTION_ARGUMENT;
   }
-  Curl_persistconninfo(data, conn);
+  Curl_persistconninfo(data, conn, NULL, -1);
 
   /* for connection reuse purposes: */
   conn->ssl[FIRSTSOCKET].state = ssl_connection_complete;

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -255,7 +255,6 @@ CURLcode Curl_quic_connect(struct Curl_easy *data,
           SOCKERRNO, Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     return CURLE_BAD_FUNCTION_ARGUMENT;
   }
-  memcpy(conn->ip_addr_str, conn->primary_ip, MAX_IPADR_LEN);
   Curl_persistconninfo(data, conn);
 
   /* for connection reuse purposes: */


### PR DESCRIPTION
Removes duplicate struct entries, changes struct field sizes and reorder them a bit. Cuts off 136 bytes from the `connectdata` struct with no loss of functionality and no added size in other structs.

From 1832 bytes with 5 "holes" in my build before this PR. At 1696 bytes with one hole afterward.