### PR TITLE
asyn-thread: fix build for when getaddrinfo missing

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -696,7 +696,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
                                                 int port,
                                                 int *waitp)
 {
-  struct resdata *reslv = (struct resdata *)data->state.resolver;
+  struct resdata *reslv = (struct resdata *)data->state.async.resolver;
 
   *waitp = 0; /* default to synchronous response */
 


### PR DESCRIPTION
This is a follow-up to 8315343 which several days ago moved the resolver
pointer into the async struct but did not update the code that uses it
when getaddrinfo is not present.

Closes #xxxx

---

https://dev.azure.com/daniel0244/5571c33c-81e1-43d7-93ee-d3d4152f27b2/_apis/build/builds/4479/logs/82