### PR TITLE
vtls: prepare for custom SSL session cache sizes

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2155,8 +2155,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         data->cookies = NULL;
 #endif
 
-      if(data->share->sslsession == data->state.session)
+      if(data->share->sslsession == data->state.session) {
+        data->state.session_size = 0;
         data->state.session = NULL;
+      }
 
 #ifdef USE_LIBPSL
       if(data->psl == &data->share->psl)
@@ -2192,7 +2194,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       }
 #endif   /* CURL_DISABLE_HTTP */
       if(data->share->sslsession) {
-        data->set.general_ssl.max_ssl_sessions = data->share->max_ssl_sessions;
+        data->state.session_size = data->share->max_ssl_sessions;
         data->state.session = data->share->sslsession;
       }
 #ifdef USE_LIBPSL

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1335,7 +1335,8 @@ struct UrlState {
                        strdup() data.
                     */
   int first_remote_port; /* remote port of the first (not followed) request */
-  struct Curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
+  struct Curl_ssl_session *session; /* array of 'session_size' size */
+  size_t session_size;              /* size of the array 'session' */
   long sessionage;                  /* number of the most recent session */
   struct tempbuf tempwrite[3]; /* BOTH, HEADER, BODY */
   unsigned int tempcount; /* number of entries in use in tempwrite, 0 - 3 */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -405,7 +405,7 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
   else
     general_age = &data->state.sessionage;
 
-  for(i = 0; i < data->set.general_ssl.max_ssl_sessions; i++) {
+  for(i = 0; i < data->state.session_size; i++) {
     check = &data->state.session[i];
     if(!check->sessionid)
       /* not session ID means blank entry */
@@ -462,7 +462,7 @@ void Curl_ssl_delsessionid(struct Curl_easy *data, void *ssl_sessionid)
 {
   size_t i;
 
-  for(i = 0; i < data->set.general_ssl.max_ssl_sessions; i++) {
+  for(i = 0; i < data->state.session_size; i++) {
     struct Curl_ssl_session *check = &data->state.session[i];
 
     if(check->sessionid == ssl_sessionid) {
@@ -538,14 +538,14 @@ CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
   }
 
   /* find an empty slot for us, or find the oldest */
-  for(i = 1; (i < data->set.general_ssl.max_ssl_sessions) &&
+  for(i = 1; (i < data->state.session_size) &&
         data->state.session[i].sessionid; i++) {
     if(data->state.session[i].age < oldest_age) {
       oldest_age = data->state.session[i].age;
       store = &data->state.session[i];
     }
   }
-  if(i == data->set.general_ssl.max_ssl_sessions)
+  if(i == data->state.session_size)
     /* cache is full, we must "kill" the oldest entry! */
     Curl_ssl_kill_session(store);
   else
@@ -582,11 +582,12 @@ void Curl_ssl_close_all(struct Curl_easy *data)
   /* kill the session ID cache if not shared */
   if(data->state.session && !SSLSESSION_SHARED(data)) {
     size_t i;
-    for(i = 0; i < data->set.general_ssl.max_ssl_sessions; i++)
+    for(i = 0; i < data->state.session_size; i++)
       /* the single-killer function handles empty table slots */
       Curl_ssl_kill_session(&data->state.session[i]);
 
     /* free the cache data */
+    data->state.session_size = 0;
     Curl_safefree(data->state.session);
   }
 
@@ -684,7 +685,7 @@ CURLcode Curl_ssl_initsessions(struct Curl_easy *data, size_t amount)
     return CURLE_OUT_OF_MEMORY;
 
   /* store the info in the SSL section */
-  data->set.general_ssl.max_ssl_sessions = amount;
+  data->state.session_size = amount;
   data->state.session = session;
   data->state.sessionage = 1; /* this is brand new */
   return CURLE_OK;


### PR DESCRIPTION
This change is a preparation for a possible future option that sets the SSL
session cache size.

The idea is that the user may change the desired SSL session cache size before
the cache is created. After the cache has been created, its size cannot be
changed anymore. This means that the actual cache size must be saved as long
as the cache exists, and it must not be changed by curl_easy_reset().