### PR TITLE
Fixes compile errors in `Curl_conninfo_local` function in `connect.c`…

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -737,8 +737,9 @@ void Curl_conninfo_local(struct Curl_easy *data, curl_socket_t sockfd,
   }
 #else
   (void)data;
-  (void)conn;
   (void)sockfd;
+  (void)local_ip;
+  (void)local_port;
 #endif
 }
 


### PR DESCRIPTION
…… `#else` (`!HAVE_GETSOCKNAME`) case

Fix for https://github.com/curl/curl/issues/6548

Signed-off-by: Layla <layla@insightfulvr.com>