### PR TITLE
lib: use int type for more port variables

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -611,7 +611,7 @@ static CURLcode trynextip(struct Curl_easy *data,
 /* Copies connection info into the transfer handle to make it available when
    the transfer handle is no longer associated with the connection. */
 void Curl_persistconninfo(struct Curl_easy *data, struct connectdata *conn,
-                          char *local_ip, long local_port)
+                          char *local_ip, int local_port)
 {
   memcpy(data->info.conn_primary_ip, conn->primary_ip, MAX_IPADR_LEN);
   if(local_ip && local_ip[0])
@@ -627,7 +627,7 @@ void Curl_persistconninfo(struct Curl_easy *data, struct connectdata *conn,
 /* retrieves ip address and port from a sockaddr structure.
    note it calls Curl_inet_ntop which sets errno on fail, not SOCKERRNO. */
 bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
-                      char *addr, long *port)
+                      char *addr, int *port)
 {
   struct sockaddr_in *si = NULL;
 #ifdef ENABLE_IPV6
@@ -690,7 +690,7 @@ void Curl_conninfo_remote(struct Curl_easy *data,
   char buffer[STRERROR_LEN];
   struct Curl_sockaddr_storage ssrem;
   curl_socklen_t plen;
-  long port;
+  int port;
   plen = sizeof(struct Curl_sockaddr_storage);
   memset(&ssrem, 0, sizeof(ssrem));
   if(getpeername(sockfd, (struct sockaddr*) &ssrem, &plen)) {
@@ -715,7 +715,7 @@ void Curl_conninfo_remote(struct Curl_easy *data,
 /* retrieves the start/end point information of a socket of an established
    connection */
 void Curl_conninfo_local(struct Curl_easy *data, curl_socket_t sockfd,
-                         char *local_ip, long *local_port)
+                         char *local_ip, int *local_port)
 {
 #ifdef HAVE_GETSOCKNAME
   char buffer[STRERROR_LEN];
@@ -752,7 +752,7 @@ void Curl_updateconninfo(struct Curl_easy *data, struct connectdata *conn,
      ip address and port number whenever an outgoing connection is
      **established** from the primary socket to a remote address. */
   char local_ip[MAX_IPADR_LEN] = "";
-  long local_port = -1;
+  int local_port = -1;
 
   if(conn->transport == TRNSPRT_TCP) {
     if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
@@ -1158,7 +1158,7 @@ static CURLcode singleipconnect(struct Curl_easy *data,
   curl_socket_t sockfd;
   CURLcode result;
   char ipaddress[MAX_IPADR_LEN];
-  long port;
+  int port;
   bool is_tcp;
 #ifdef TCP_FASTOPEN_CONNECT
   int optval = 1;
@@ -1180,7 +1180,7 @@ static CURLcode singleipconnect(struct Curl_easy *data,
     Curl_closesocket(data, conn, sockfd);
     return CURLE_OK;
   }
-  infof(data, "  Trying %s:%ld...\n", ipaddress, port);
+  infof(data, "  Trying %s:%d...\n", ipaddress, port);
 
 #ifdef ENABLE_IPV6
   is_tcp = (addr.family == AF_INET || addr.family == AF_INET6) &&

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -54,7 +54,7 @@ curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
                                   struct connectdata **connp);
 
 bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
-                      char *addr, long *port);
+                      char *addr, int *port);
 
 /*
  * Check if a connection seems to be alive.
@@ -81,9 +81,9 @@ void Curl_updateconninfo(struct Curl_easy *data, struct connectdata *conn,
 void Curl_conninfo_remote(struct Curl_easy *data, struct connectdata *conn,
                           curl_socket_t sockfd);
 void Curl_conninfo_local(struct Curl_easy *data, curl_socket_t sockfd,
-                         char *local_ip, long *local_port);
+                         char *local_ip, int *local_port);
 void Curl_persistconninfo(struct Curl_easy *data, struct connectdata *conn,
-                          char *local_ip, long local_port);
+                          char *local_ip, int local_port);
 int Curl_closesocket(struct Curl_easy *data, struct connectdata *conn,
                      curl_socket_t sock);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1500,7 +1500,7 @@ static CURLcode add_haproxy_protocol_header(struct Curl_easy *data)
 
   msnprintf(proxy_header,
             sizeof(proxy_header),
-            "PROXY %s %s %s %li %li\r\n",
+            "PROXY %s %s %s %i %i\r\n",
             tcp_version,
             data->info.conn_local_ip,
             data->info.conn_primary_ip,

--- a/lib/url.c
+++ b/lib/url.c
@@ -3367,7 +3367,7 @@ static void reuse_conn(struct Curl_easy *data,
      ip address and port number whenever an outgoing connection is
      **established** from the primary socket to a remote address. */
   char local_ip[MAX_IPADR_LEN] = "";
-  long local_port = -1;
+  int local_port = -1;
 #ifndef CURL_DISABLE_PROXY
   Curl_free_idnconverted_hostname(&old_conn->http_proxy.host);
   Curl_free_idnconverted_hostname(&old_conn->socks_proxy.host);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1157,9 +1157,9 @@ struct PureInfo {
      reused, in the connection cache. */
 
   char conn_primary_ip[MAX_IPADR_LEN];
-  long conn_primary_port;
+  int conn_primary_port;
   char conn_local_ip[MAX_IPADR_LEN];
-  long conn_local_port;
+  int conn_local_port;
   const char *conn_scheme;
   unsigned int conn_protocol;
   struct curl_certinfo certs; /* info about the certs, only populated in

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -758,7 +758,7 @@ CURLcode Curl_quic_connect(struct Curl_easy *data,
   ngtcp2_path path; /* TODO: this must be initialized properly */
   struct quicsocket *qs = &conn->hequic[sockindex];
   char ipbuf[40];
-  long port;
+  int port;
   int qfd;
 
   if(qs->conn)
@@ -773,7 +773,7 @@ CURLcode Curl_quic_connect(struct Curl_easy *data,
     return CURLE_BAD_FUNCTION_ARGUMENT;
   }
 
-  infof(data, "Connect socket %d over QUIC to %s:%ld\n",
+  infof(data, "Connect socket %d over QUIC to %s:%d\n",
         sockfd, ipbuf, port);
 
   qs->version = NGTCP2_PROTO_VER_MAX;

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -145,7 +145,7 @@ UNITTEST_START
     addr = dns ? dns->addr : NULL;
 
     for(j = 0; j < addressnum; ++j) {
-      long port = 0;
+      int port = 0;
       char ipaddress[MAX_IPADR_LEN] = {0};
 
       if(!addr && !tests[i].address[j])

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -147,7 +147,7 @@ UNITTEST_START
     addr = dns ? dns->addr : NULL;
 
     for(j = 0; j < addressnum; ++j) {
-      long port = 0;
+      int port = 0;
       char ipaddress[MAX_IPADR_LEN] = {0};
 
       if(!addr && !tests[i].address[j])


### PR DESCRIPTION
This is a follow-up to 764c6bd. Prior to that change port variables
were usually type long.

Closes #xxxx

---

Note that 764c6bd changed Curl_conninfo_remote to use a local port variable and not assign to conn->port... I'm not sure why that is, I think it should be conn->port shouldn't it?