### PR TITLE
Factor out Curl_ssl_getsock to field of Curl_ssl.

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -855,6 +855,7 @@ const struct Curl_ssl Curl_ssl_bearssl = {
   Curl_none_cert_status_request,
   bearssl_connect,
   bearssl_connect_nonblocking,
+  Curl_ssl_getsock,
   bearssl_get_internals,
   bearssl_close,
   Curl_none_close_all,

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1671,6 +1671,7 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   gtls_cert_status_request,      /* cert_status_request */
   gtls_connect,                  /* connect */
   gtls_connect_nonblocking,      /* connect_nonblocking */
+  Curl_ssl_getsock,              /* getsock */
   gtls_get_internals,            /* get_internals */
   gtls_close,                    /* close_one */
   Curl_none_close_all,           /* close_all */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1100,6 +1100,7 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   Curl_none_cert_status_request,    /* cert_status_request */
   mbedtls_connect,                  /* connect */
   mbedtls_connect_nonblocking,      /* connect_nonblocking */
+  Curl_ssl_getsock,                 /* getsock */
   mbedtls_get_internals,            /* get_internals */
   mbedtls_close,                    /* close_one */
   mbedtls_close_all,                /* close_all */

--- a/lib/vtls/mesalink.c
+++ b/lib/vtls/mesalink.c
@@ -654,6 +654,7 @@ const struct Curl_ssl Curl_ssl_mesalink = {
   Curl_none_cert_status_request, /* cert_status_request */
   mesalink_connect,              /* connect */
   mesalink_connect_nonblocking,  /* connect_nonblocking */
+  Curl_none_getsock,             /* connect_nonblocking */
   mesalink_get_internals,        /* get_internals */
   mesalink_close,                /* close_one */
   Curl_none_close_all,           /* close_all */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2435,6 +2435,7 @@ const struct Curl_ssl Curl_ssl_nss = {
   nss_cert_status_request,      /* cert_status_request */
   nss_connect,                  /* connect */
   nss_connect_nonblocking,      /* connect_nonblocking */
+  Curl_ssl_getsock,             /* getsock */
   nss_get_internals,            /* get_internals */
   nss_close,                    /* close_one */
   Curl_none_close_all,          /* close_all */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4477,6 +4477,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_cert_status_request, /* cert_status_request */
   ossl_connect,             /* connect */
   ossl_connect_nonblocking, /* connect_nonblocking */
+  Curl_ssl_getsock,         /* getsock */
   ossl_get_internals,       /* get_internals */
   ossl_close,               /* close_one */
   ossl_close_all,           /* close_all */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2418,6 +2418,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
   Curl_none_cert_status_request,     /* cert_status_request */
   schannel_connect,                  /* connect */
   schannel_connect_nonblocking,      /* connect_nonblocking */
+  Curl_ssl_getsock,                  /* getsock */
   schannel_get_internals,            /* get_internals */
   schannel_close,                    /* close_one */
   Curl_none_close_all,               /* close_all */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3301,6 +3301,7 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   Curl_none_cert_status_request,      /* cert_status_request */
   sectransp_connect,                  /* connect */
   sectransp_connect_nonblocking,      /* connect_nonblocking */
+  Curl_ssl_getsock,                   /* getsock */
   sectransp_get_internals,            /* get_internals */
   sectransp_close,                    /* close_one */
   Curl_none_close_all,                /* close_all */

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -62,6 +62,13 @@ struct Curl_ssl {
   CURLcode (*connect_nonblocking)(struct Curl_easy *data,
                                   struct connectdata *conn, int sockindex,
                                   bool *done);
+
+  /* If the SSL backend wants to read or write on this connection during a
+     handshake, set socks[0] to the connection's FIRSTSOCKET, and return
+     a bitmap indicating read or write with GETSOCK_WRITESOCK(0) or
+     GETSOCK_READSOCK(0). Otherwise return GETSOCK_BLANK. */
+  int (*getsock)(struct connectdata *conn, curl_socket_t *socks);
+
   void *(*get_internals)(struct ssl_connect_data *connssl, CURLINFO info);
   void (*close_one)(struct Curl_easy *data, struct connectdata *conn,
                     int sockindex);
@@ -88,6 +95,8 @@ int Curl_none_shutdown(struct Curl_easy *data, struct connectdata *conn,
 int Curl_none_check_cxn(struct connectdata *conn);
 CURLcode Curl_none_random(struct Curl_easy *data, unsigned char *entropy,
                           size_t length);
+int Curl_none_getsock(struct connectdata *conn, curl_socket_t *socks);
+int Curl_ssl_getsock(struct connectdata *conn, curl_socket_t *socks);
 void Curl_none_close_all(struct Curl_easy *data);
 void Curl_none_session_free(void *ptr);
 bool Curl_none_data_pending(const struct connectdata *conn, int connindex);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1152,6 +1152,7 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   Curl_none_cert_status_request,   /* cert_status_request */
   wolfssl_connect,                 /* connect */
   wolfssl_connect_nonblocking,     /* connect_nonblocking */
+  Curl_ssl_getsock,                /* getsock */
   wolfssl_get_internals,           /* get_internals */
   wolfssl_close,                   /* close_one */
   Curl_none_close_all,             /* close_all */


### PR DESCRIPTION
vtls.c offers a default implementation, used by most TLS backends, and a
none implementation, currently used by mesalink. It's possible that
mesalink should use the default implementation, but I went with the
current behavior according to the #defines.