### PR TITLE
openssl: function to set up configuration file and appname

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -3006,6 +3006,19 @@ CURL_EXTERN CURLcode curl_easy_pause(CURL *handle, int bitmask);
 #define CURLPAUSE_ALL       (CURLPAUSE_RECV|CURLPAUSE_SEND)
 #define CURLPAUSE_CONT      (CURLPAUSE_RECV_CONT|CURLPAUSE_SEND_CONT)
 
+#ifdef USE_OPENSSL
+/*
+ * NAME curl_set_ossl_config()
+ *
+ * DESCRIPTION
+ *
+ * The curl_set_ossl_config function allows to set up
+ * OpenSSL configuration file path and OpenSSL appname (config file section)
+ * to use in OpenSSL initialization functions.
+ */
+CURL_EXTERN void curl_set_ossl_config(char *conf_file, char *appname);
+#endif
+
 #ifdef  __cplusplus
 }
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1117,8 +1117,8 @@ static int x509_name_oneline(X509_NAME *a, char *buf, size_t size)
   return !rc;
 }
 
-char *ossl_conf_file = NULL;
-char *ossl_appname = NULL;
+static char *ossl_conf_file = NULL;
+static char *ossl_appname = NULL;
 
 /* Set up OpenSSL config file path and appname (config section).*/
 void curl_set_ossl_config(char *conf_file, char *appname)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1148,7 +1148,14 @@ static int ossl_init(void)
     OPENSSL_INIT_LOAD_CONFIG |
 #endif
     0;
-  OPENSSL_init_ssl(flags, NULL);
+  OPENSSL_INIT_SETTINGS *settings = OPENSSL_INIT_new();
+  OPENSSL_INIT_set_config_filename(settings,
+                                ossl_conf_file);
+  OPENSSL_INIT_set_config_file_flags(settings,
+  CONF_MFLAGS_IGNORE_MISSING_FILE | CONF_MFLAGS_IGNORE_ERRORS);
+  OPENSSL_INIT_set_config_appname(settings, ossl_appname);
+  OPENSSL_init_ssl(flags, settings);
+  OPENSSL_INIT_free(settings);
 #else
   OPENSSL_load_builtin_modules();
 
@@ -1163,7 +1170,7 @@ static int ossl_init(void)
 #endif
 
 #ifndef CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG
-  CONF_modules_load_file(NULL, NULL,
+  CONF_modules_load_file(ossl_conf_file, ossl_appname,
                          CONF_MFLAGS_DEFAULT_SECTION|
                          CONF_MFLAGS_IGNORE_MISSING_FILE);
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1117,6 +1117,16 @@ static int x509_name_oneline(X509_NAME *a, char *buf, size_t size)
   return !rc;
 }
 
+char *ossl_conf_file = NULL;
+char *ossl_appname = NULL;
+
+/* Set up OpenSSL config file path and appname (config section).*/
+void curl_set_ossl_config(char *conf_file, char *appname)
+{
+    ossl_conf_file = conf_file;
+    ossl_appname = appname;
+}
+
 /**
  * Global SSL init
  *

--- a/tests/data/test1135
+++ b/tests/data/test1135
@@ -66,6 +66,7 @@ CURL_EXTERN curl_version_info_data *curl_version_info(CURLversion);
 CURL_EXTERN const char *curl_easy_strerror(CURLcode);
 CURL_EXTERN const char *curl_share_strerror(CURLSHcode);
 CURL_EXTERN CURLcode curl_easy_pause(CURL *handle, int bitmask);
+CURL_EXTERN void curl_set_ossl_config(char *conf_file, char *appname);
 CURL_EXTERN CURL *curl_easy_init(void);
 CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...);
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);


### PR DESCRIPTION
Added a function that allows to set up OpenSSL
configuration file path and appname (config file section)
to use in OpenSSL initialization functions.
Default variable values are NULL so if the new function
didn't called, then library behaviour will be the same as before.