### PR TITLE
Update OS400 ccsidcurl.c to compensate for CURLOPT_AWS_SIGV4

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1112,6 +1112,7 @@ curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
 
   case CURLOPT_ABSTRACT_UNIX_SOCKET:
   case CURLOPT_ALTSVC:
+  case CURLOPT_AWS_SIGV4:
   case CURLOPT_CAINFO:
   case CURLOPT_CAPATH:
   case CURLOPT_COOKIE:

--- a/packages/OS400/chkstrings.c
+++ b/packages/OS400/chkstrings.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -36,7 +36,7 @@
  * values can be updated to match the latest enum values in urldata.h.
  */
 #define EXPECTED_STRING_LASTZEROTERMINATED  (STRING_SSL_EC_CURVES + 1)
-#define EXPECTED_STRING_LAST                (STRING_COPYPOSTFIELDS + 1)
+#define EXPECTED_STRING_LAST                (STRING_AWS_SIGV4 + 1)
 
 int main(int argc, char *argv[])
 {

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -5,7 +5,7 @@
       *                            | (__| |_| |  _ <| |___
       *                             \___|\___/|_| \_\_____|
       *
-      * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+      * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
       *
       * This software is licensed as described in the file COPYING, which
       * you should have received as part of this distribution. The terms
@@ -1456,6 +1456,8 @@
      d                 c                   40297
      d  CURLOPT_SSL_EC_CURVES...
      d                 c                   10298
+     d  CURLOPT_AWS_SIG4...
+     d                 c                   10305
       *
       /if not defined(CURL_NO_OLDIES)
      d  CURLOPT_FILE   c                   10001


### PR DESCRIPTION
chkstrings fails because a new string option that could require codepage conversion has been added. These changes should address issue https://github.com/curl/curl/issues/6560.