### PR TITLE
Correct gskit_send() function to match prototype

### DIFF
--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -610,7 +610,7 @@ static void close_one(struct ssl_connect_data *connssl, struct Curl_easy *data,
 }
 
 
-static ssize_t gskit_send(struct connectdata *conn, int sockindex,
+static ssize_t gskit_send(struct Curl_easy *data, int sockindex,
                           const void *mem, size_t len, CURLcode *curlcode)
 {
   struct connectdata *conn = data->conn;


### PR DESCRIPTION
gskit_send() first parameter is a pointer to Curl_easy not connectdata struct.

This should resolve https://github.com/curl/curl/issues/6569