### PR TITLE
Let --remote-time work with archive.org downloads.

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3518,6 +3518,12 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
     if(data->set.get_filetime)
       data->info.filetime = k->timeofdoc;
   }
+  else if(!k->http_bodyless && checkprefix("x-archive-orig-last-modified:", headp) &&
+          (data->set.timecondition || data->set.get_filetime) ) {
+    k->timeofdoc = Curl_getdate_capped(headp + strlen("x-archive-orig-last-modified:"));
+    if(data->set.get_filetime)
+      data->info.filetime = k->timeofdoc;
+  }
   else if((checkprefix("WWW-Authenticate:", headp) &&
            (401 == k->httpcode)) ||
           (checkprefix("Proxy-authenticate:", headp) &&


### PR DESCRIPTION
Files preserved by the archive.org way back machine do not send a 'Last-modified' header, instead the value 'Last-modified' header at archival time is provided in the 'x-archive-orig-last-modified' header.
This behavior prevents the '--remote-time' and '--time-cond' flags to work correctly with files stored at archive.org.