### PR TITLE
ftp: add 'prefer_ascii' to the transfer state struct

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1378,7 +1378,7 @@ static CURLcode ftp_state_prepare_transfer(struct Curl_easy *data)
         result = Curl_pp_sendf(data, &ftpc->pp, "PRET %s",
                                data->set.str[STRING_CUSTOMREQUEST]?
                                data->set.str[STRING_CUSTOMREQUEST]:
-                               (data->set.ftp_list_only?"NLST":"LIST"));
+                               (data->state.list_only?"NLST":"LIST"));
       else if(data->set.upload)
         result = Curl_pp_sendf(data, &ftpc->pp, "PRET STOR %s",
                                conn->proto.ftpc.file);
@@ -1485,7 +1485,7 @@ static CURLcode ftp_state_list(struct Curl_easy *data)
   cmd = aprintf("%s%s%s",
                 data->set.str[STRING_CUSTOMREQUEST]?
                 data->set.str[STRING_CUSTOMREQUEST]:
-                (data->set.ftp_list_only?"NLST":"LIST"),
+                (data->state.list_only?"NLST":"LIST"),
                 lstArg? " ": "",
                 lstArg? lstArg: "");
   free(lstArg);
@@ -3648,7 +3648,7 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
 
       if(result)
         ;
-      else if(data->set.ftp_list_only || !ftpc->file) {
+      else if(data->state.list_only || !ftpc->file) {
         /* The specified path ends with a slash, and therefore we think this
            is a directory that is requested, use LIST. But before that we
            need to set ASCII transfer mode. */
@@ -4356,7 +4356,7 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
       break;
 
     case 'D': /* directory mode */
-      data->set.ftp_list_only = TRUE;
+      data->state.list_only = TRUE;
       break;
 
     case 'I': /* binary mode */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1525,7 +1525,7 @@ static CURLcode ftp_state_type(struct Curl_easy *data)
      information. Which in FTP can't be much more than the file size and
      date. */
   if(data->set.opt_no_body && ftpc->file &&
-     ftp_need_type(conn, data->set.prefer_ascii)) {
+     ftp_need_type(conn, data->state.prefer_ascii)) {
     /* The SIZE command is _not_ RFC 959 specified, and therefore many servers
        may not support it! It is however the only way we have to get a file's
        size! */
@@ -1535,7 +1535,7 @@ static CURLcode ftp_state_type(struct Curl_easy *data)
 
     /* Some servers return different sizes for different modes, and thus we
        must set the proper type before we check the size */
-    result = ftp_nb_type(data, conn, data->set.prefer_ascii, FTP_TYPE);
+    result = ftp_nb_type(data, conn, data->state.prefer_ascii, FTP_TYPE);
     if(result)
       return result;
   }
@@ -1747,7 +1747,7 @@ static CURLcode ftp_state_quote(struct Curl_easy *data,
           result = ftp_state_retr(data, ftpc->known_filesize);
         }
         else {
-          if(data->set.ignorecl || data->set.prefer_ascii) {
+          if(data->set.ignorecl || data->state.prefer_ascii) {
             /* 'ignorecl' is used to support download of growing files.  It
                prevents the state machine from requesting the file size from
                the server.  With an unknown file size the download continues
@@ -2454,7 +2454,7 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
      */
 
     if((instate != FTP_LIST) &&
-       !data->set.prefer_ascii &&
+       !data->state.prefer_ascii &&
        (ftp->downloadsize < 1)) {
       /*
        * It seems directory listings either don't show the size or very
@@ -2493,7 +2493,7 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
 
     if(size > data->req.maxdownload && data->req.maxdownload > 0)
       size = data->req.size = data->req.maxdownload;
-    else if((instate != FTP_LIST) && (data->set.prefer_ascii))
+    else if((instate != FTP_LIST) && (data->state.prefer_ascii))
       size = -1; /* kludge for servers that understate ASCII mode file size */
 
     infof(data, "Maxdownload = %" CURL_FORMAT_CURL_OFF_T "\n",
@@ -3626,7 +3626,8 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
       }
     }
     else if(data->set.upload) {
-      result = ftp_nb_type(data, conn, data->set.prefer_ascii, FTP_STOR_TYPE);
+      result = ftp_nb_type(data, conn, data->state.prefer_ascii,
+                           FTP_STOR_TYPE);
       if(result)
         return result;
 
@@ -3661,7 +3662,7 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
         /* otherwise just fall through */
       }
       else {
-        result = ftp_nb_type(data, conn, data->set.prefer_ascii,
+        result = ftp_nb_type(data, conn, data->state.prefer_ascii,
                              FTP_RETR_TYPE);
         if(result)
           return result;
@@ -4351,7 +4352,7 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
 
     switch(command) {
     case 'A': /* ASCII mode */
-      data->set.prefer_ascii = TRUE;
+      data->state.prefer_ascii = TRUE;
       break;
 
     case 'D': /* directory mode */
@@ -4361,7 +4362,7 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
     case 'I': /* binary mode */
     default:
       /* switch off ASCII */
-      data->set.prefer_ascii = FALSE;
+      data->state.prefer_ascii = FALSE;
       break;
     }
   }

--- a/lib/http.c
+++ b/lib/http.c
@@ -1702,7 +1702,7 @@ CURLcode Curl_http_compile_trailers(struct curl_slist *trailers,
 
   if(
 #ifdef CURL_DO_LINEEND_CONV
-     (handle->set.prefer_ascii) ||
+     (handle->state.prefer_ascii) ||
 #endif
      (handle->set.crlf)) {
     /* \n will become \r\n later on */
@@ -2209,7 +2209,7 @@ CURLcode Curl_http_target(struct Curl_easy *data,
         }
         if(!type) {
           result = Curl_dyn_addf(r, ";type=%c",
-                                 data->set.prefer_ascii ? 'a' : 'i');
+                                 data->state.prefer_ascii ? 'a' : 'i');
           if(result)
             return result;
         }

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -571,7 +571,7 @@ static CURLcode pop3_perform_command(struct Curl_easy *data)
   const char *command = NULL;
 
   /* Calculate the default command */
-  if(pop3->id[0] == '\0' || data->set.ftp_list_only) {
+  if(pop3->id[0] == '\0' || data->set.list_only) {
     command = "LIST";
 
     if(pop3->id[0] != '\0')

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1157,7 +1157,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * An option that changes the command to one that asks for a list only, no
      * file info details. Used for FTP, POP3 and SFTP.
      */
-    data->set.ftp_list_only = (0 != va_arg(param, long)) ? TRUE : FALSE;
+    data->set.list_only = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
 
   case CURLOPT_APPEND:

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -460,7 +460,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
   CURLcode result = CURLE_OK;
 
   /* Set ascii mode if -B flag was used */
-  if(data->set.prefer_ascii)
+  if(data->state.prefer_ascii)
     mode = "netascii";
 
   switch(event) {
@@ -1420,14 +1420,14 @@ static CURLcode tftp_setup_connection(struct Curl_easy *data,
     switch(command) {
     case 'A': /* ASCII mode */
     case 'N': /* NETASCII mode */
-      data->set.prefer_ascii = TRUE;
+      data->state.prefer_ascii = TRUE;
       break;
 
     case 'O': /* octet mode */
     case 'I': /* binary mode */
     default:
       /* switch off ASCII */
-      data->set.prefer_ascii = FALSE;
+      data->state.prefer_ascii = FALSE;
       break;
     }
   }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -286,7 +286,7 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
      *        <DATA> CRLF
      */
     /* On non-ASCII platforms the <DATA> may or may not be
-       translated based on set.prefer_ascii while the protocol
+       translated based on state.prefer_ascii while the protocol
        portion must always be translated to the network encoding.
        To further complicate matters, line end conversion might be
        done later on, so we need to prevent CRLFs from becoming
@@ -301,7 +301,7 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
 
     if(
 #ifdef CURL_DO_LINEEND_CONV
-       (data->set.prefer_ascii) ||
+       (data->state.prefer_ascii) ||
 #endif
        (data->set.crlf)) {
       /* \n will become \r\n later on */
@@ -348,7 +348,7 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
     {
       CURLcode result;
       size_t length;
-      if(data->set.prefer_ascii)
+      if(data->state.prefer_ascii)
         /* translate the protocol and data */
         length = nread;
       else
@@ -389,7 +389,7 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
       nread += strlen(endofline_network); /* for the added end of line */
   }
 #ifdef CURL_DOES_CONVERSIONS
-  else if((data->set.prefer_ascii) && (!sending_http_headers)) {
+  else if((data->state.prefer_ascii) && (!sending_http_headers)) {
     CURLcode result;
     result = Curl_convert_to_network(data, data->req.upload_fromhere, nread);
     /* Curl_convert_to_network calls failf if unsuccessful */
@@ -1028,7 +1028,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
       if((!sending_http_headers) && (
 #ifdef CURL_DO_LINEEND_CONV
          /* always convert if we're FTPing in ASCII mode */
-         (data->set.prefer_ascii) ||
+         (data->state.prefer_ascii) ||
 #endif
          (data->set.crlf))) {
         /* Do we need to allocate a scratch buffer? */
@@ -1415,6 +1415,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     }
   }
 
+  data->state.prefer_ascii = data->set.prefer_ascii;
   data->state.httpreq = data->set.method;
   data->change.url = data->set.str[STRING_SET_URL];
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1416,6 +1416,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
   }
 
   data->state.prefer_ascii = data->set.prefer_ascii;
+  data->state.list_only = data->set.list_only;
   data->state.httpreq = data->set.method;
   data->change.url = data->set.str[STRING_SET_URL];
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1453,7 +1453,8 @@ struct UrlState {
   BIT(stream_depends_e); /* set or don't set the Exclusive bit */
   BIT(previouslypending); /* this transfer WAS in the multi->pending queue */
   BIT(cookie_engine);
-  BIT(prefer_ascii);     /* ASCII rather than binary */
+  BIT(prefer_ascii);   /* ASCII rather than binary */
+  BIT(list_only);      /* list directory contents */
 };
 
 
@@ -1794,7 +1795,7 @@ struct UserDefined {
   BIT(tunnel_thru_httpproxy); /* use CONNECT through a HTTP proxy */
   BIT(prefer_ascii);     /* ASCII rather than binary */
   BIT(remote_append);    /* append, not overwrite, on upload */
-  BIT(ftp_list_only);    /* switch FTP command for listing directories */
+  BIT(list_only);        /* list directory */
 #ifndef CURL_DISABLE_FTP
   BIT(ftp_use_port);     /* use the FTP PORT command */
   BIT(ftp_use_epsv);     /* if EPSV is to be attempted or not */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1453,6 +1453,7 @@ struct UrlState {
   BIT(stream_depends_e); /* set or don't set the Exclusive bit */
   BIT(previouslypending); /* this transfer WAS in the multi->pending queue */
   BIT(cookie_engine);
+  BIT(prefer_ascii);     /* ASCII rather than binary */
 };
 
 

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1413,7 +1413,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         sshc->readdir_longentry = sshc->readdir_attrs->longname;
         sshc->readdir_len = strlen(sshc->readdir_filename);
 
-        if(data->set.ftp_list_only) {
+        if(data->set.list_only) {
           char *tmpLine;
 
           tmpLine = aprintf("%s\n", sshc->readdir_filename);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2143,7 +2143,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
         readdir_len = (size_t) rc;
         sshp->readdir_filename[readdir_len] = '\0';
 
-        if(data->set.ftp_list_only) {
+        if(data->set.list_only) {
           result = Curl_client_write(data, CLIENTWRITE_BODY,
                                      sshp->readdir_filename,
                                      readdir_len);

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -859,7 +859,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
         result = CURLE_OK;
         while(name) {
           char *line = aprintf("%s\n",
-                               data->set.ftp_list_only ?
+                               data->set.list_only ?
                                name->fName : name->lName);
           if(line == NULL) {
             state(data, SSH_SFTP_CLOSE);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -187,7 +187,7 @@ test1540 \
 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 test1564 test1565 \
-test1566 test1567 test1568 \
+test1566 test1567 test1568 test1569 \
 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -187,7 +187,7 @@ test1540 \
 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 test1564 test1565 \
-test1566 test1567 test1568 test1569 \
+test1566 test1567 test1568 test1569 test1570 \
 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \

--- a/tests/data/test1569
+++ b/tests/data/test1569
@@ -1,0 +1,73 @@
+<testcase>
+<info>
+<keywords>
+FTP
+PASV
+RETR
+</keywords>
+</info>
+# Server-side
+<reply>
+<data nocheck="yes">
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</data>
+<servercmd>
+REPLY EPSV 500 no such command
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+FTP first type=A then regular URL
+ </name>
+<tool>
+lib1569
+</tool>
+<command>
+"ftp://%HOSTIP:%FTPPORT/1569;type=A" ftp://%HOSTIP:%FTPPORT/1569
+</command>
+
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+PASV
+TYPE A
+RETR 1569
+PASV
+TYPE I
+SIZE 1569
+RETR 1569
+QUIT
+</protocol>
+</verify>
+<stdout>
+data
+    to
+      see
+that FTP
+works
+  so does it?
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</stdout>
+
+</testcase>

--- a/tests/data/test1570
+++ b/tests/data/test1570
@@ -1,0 +1,73 @@
+<testcase>
+<info>
+<keywords>
+FTP
+PASV
+RETR
+</keywords>
+</info>
+# Server-side
+<reply>
+<data nocheck="yes">
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</data>
+<servercmd>
+REPLY EPSV 500 no such command
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+FTP first type=D then regular URL
+ </name>
+<tool>
+lib1569
+</tool>
+<command>
+"ftp://%HOSTIP:%FTPPORT/1570;type=D" ftp://%HOSTIP:%FTPPORT/1570
+</command>
+
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+PASV
+TYPE A
+NLST
+PASV
+TYPE I
+SIZE 1570
+RETR 1570
+QUIT
+</protocol>
+</verify>
+<stdout>
+data
+    to
+      see
+that FTP
+works
+  so does it?
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</stdout>
+
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -57,7 +57,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1534 lib1535 lib1536 lib1537 lib1538 lib1539 \
  lib1540         \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
- lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 lib1568 \
+ lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 lib1568 lib1569 \
  lib1591 lib1592 lib1593 lib1594 lib1596 \
          lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
          lib1915 lib1916 lib1917 lib1918 lib1933 lib1934 lib1935 lib1936 \
@@ -607,6 +607,9 @@ lib1567_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1568_SOURCES = lib1568.c $(SUPPORTFILES)
 lib1568_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1569_SOURCES = lib1569.c $(SUPPORTFILES)
+lib1569_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1591_SOURCES = lib1591.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1591_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1569.c
+++ b/tests/libtest/lib1569.c
@@ -1,0 +1,46 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testtrace.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+  CURLcode ret;
+  CURL *hnd;
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  hnd = curl_easy_init();
+  curl_easy_setopt(hnd, CURLOPT_URL, URL);
+  curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
+
+  ret = curl_easy_perform(hnd);
+
+  curl_easy_setopt(hnd, CURLOPT_URL, libtest_arg2);
+  ret = curl_easy_perform(hnd);
+  curl_easy_cleanup(hnd);
+
+  curl_global_cleanup();
+  return (int)ret;
+}


### PR DESCRIPTION
... and make sure the code never updates 'set.prefer_ascii' as it breaks
handle reuse which should use the setting as the user specified it.

Added test 1569 to verify: it first makes an FTP transfer with ';type=A'
and then another without type on the same handle and the second should
then use binary. Previously, curl failed this.