### PR TITLE
tests: disable .curlrc in more environments

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -388,6 +388,8 @@ $ENV{'CURL_ENTROPY'}="12345678";
 $ENV{'CURL_FORCETIME'}=1; # for debug NTLM magic
 $ENV{'CURL_GLOBAL_INIT'}=1; # debug curl_global_init/cleanup use
 $ENV{'HOME'}=$pwd;
+$ENV{'CURL_HOME'}=$ENV{'HOME'};
+$ENV{'XDG_CONFIG_HOME'}=$ENV{'HOME'};
 $ENV{'COLUMNS'}=79; # screen width!
 
 sub catch_zap {


### PR DESCRIPTION
by also setting `CURL_HOME` and `XDG_CONFIG_HOME` envvar to the local directory.

Fixes #6595
