### PR TITLE
test433: clear some home dir env variables

### DIFF
--- a/tests/data/test433
+++ b/tests/data/test433
@@ -30,6 +30,8 @@ http
 </server>
 <setenv>
 XDG_CONFIG_HOME=%PWD/log
+HOME=
+CURL_HOME=
 </setenv>
 <name>
 Verify XDG_CONFIG_HOME use to find .curlrc


### PR DESCRIPTION
Follow-up to bd6b54ba1f55b5

... so that XDG_CONFIG_HOME is the only home dir variable set and thus
used correctly in the test!

Fixes #6599