### PR TITLE
hostip: fix crash in sync resolver builds that use DOH

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -521,10 +521,10 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
       int st;
       Curl_set_in_callback(data, true);
       st = data->set.resolver_start(
-#ifdef CURLRES_SYNCH
-        NULL,
-#else
+#ifdef USE_CURL_ASYNC
         data->state.async.resolver,
+#else
+        NULL,
 #endif
         NULL,
         data->set.resolver_start_client);
@@ -1108,7 +1108,7 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
   CURLcode result;
   struct connectdata *conn = data->conn;
 
-#ifndef CURLRES_SYNCH
+#ifdef USE_CURL_ASYNC
   if(data->state.async.dns) {
     conn->dns_entry = data->state.async.dns;
     data->state.async.dns = NULL;


### PR DESCRIPTION
- Guard some Curl_async accesses with USE_CURL_ASYNC instead of
  !CURLRES_SYNCH.

This is another follow-up to 8335c64 which moved the async struct from
the connectdata struct into the Curl_easy struct. A previous follow-up
6cd167a fixed building for sync resolver by guarding some async struct
accesses with !CURLRES_SYNCH. The problem is since DOH (DNS-over-HTTPS)
is available as an asyncronous secondary resolver the async struct may
be used even when libcurl is built for the sync resolver. That means
that CURLRES_SYNCH and USE_CURL_ASYNC may be defined at the same time.

Closes #xxxx

---

IMO the situation is confusing and it's easy to forget the difference. It could happen again.

caught during doh testing in a --disable-threaded-resolver build
~~~
 connect.c:1360:49: runtime error: member access within null pointer of type 'const struct Curl_dns_entry'
     #0 0x7fa0710f297e in Curl_connecthost /home/owner/curl/lib/connect.c:1360
     #1 0x7fa071282ac1 in Curl_setup_conn /home/owner/curl/lib/url.c:3992
     #2 0x7fa0711685ea in Curl_once_resolved /home/owner/curl/lib/hostip.c:1118
     #3 0x7fa0711cf6f9 in multi_runsingle /home/owner/curl/lib/multi.c:1757
     #4 0x7fa0711d30ab in curl_multi_perform /home/owner/curl/lib/multi.c:2412
     #5 0x7fa071122b06 in easy_transfer /home/owner/curl/lib/easy.c:606
     #6 0x7fa07112321f in easy_perform /home/owner/curl/lib/easy.c:696
     #7 0x7fa0711232fc in curl_easy_perform /home/owner/curl/lib/easy.c:715
     #8 0x451028 in serial_transfers /home/owner/curl/src/tool_operate.c:2338
     #9 0x452122 in run_all_transfers /home/owner/curl/src/tool_operate.c:2512
     #10 0x45295b in operate /home/owner/curl/src/tool_operate.c:2628
     #11 0x4366f4 in main /home/owner/curl/src/tool_main.c:277
     #12 0x7fa06f9b383f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
     #13 0x4039e8 in _start (/home/owner/curl/src/.libs/lt-curl+0x4039e8)
~~~
