### PR TITLE
Remove 'conn->data' completely

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -466,7 +466,6 @@ Curl_conncache_extract_bundle(struct Curl_easy *data,
     data->state.conn_cache->num_conn--;
     DEBUGF(infof(data, "The cache now contains %zu members\n",
                  data->state.conn_cache->num_conn));
-    conn_candidate->data = data; /* associate! */
   }
 
   return conn_candidate;
@@ -529,7 +528,6 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
     connc->num_conn--;
     DEBUGF(infof(data, "The cache now contains %zu members\n",
                  connc->num_conn));
-    conn_candidate->data = data; /* associate! */
   }
   CONNCACHE_UNLOCK(data);
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1448,11 +1448,9 @@ curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
     }
 
     c = find.found;
-    if(connp) {
+    if(connp)
       /* only store this if the caller cares for it */
       *connp = c;
-      c->data = data;
-    }
     return c->sock[FIRSTSOCKET];
   }
   return CURL_SOCKET_BAD;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1052,8 +1052,6 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
       unsigned int i;
       unsigned int count = data->state.tempcount;
       struct tempbuf writebuf[3]; /* there can only be three */
-      struct connectdata *conn = data->conn;
-      struct Curl_easy *saved_data = NULL;
 
       /* copy the structs to allow for immediate re-pausing */
       for(i = 0; i < data->state.tempcount; i++) {
@@ -1061,12 +1059,6 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
         Curl_dyn_init(&data->state.tempwrite[i].b, DYN_PAUSE_BUFFER);
       }
       data->state.tempcount = 0;
-
-      /* set the connection's current owner */
-      if(conn->data != data) {
-        saved_data = conn->data;
-        conn->data = data;
-      }
 
       for(i = 0; i < count; i++) {
         /* even if one function returns error, this loops through and frees
@@ -1077,10 +1069,6 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
                                      Curl_dyn_len(&writebuf[i].b));
         Curl_dyn_free(&writebuf[i].b);
       }
-
-      /* recover previous owner of the connection */
-      if(saved_data)
-        conn->data = saved_data;
 
       if(result)
         return result;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -562,8 +562,6 @@ static CURLcode multi_done(struct Curl_easy *data,
     /* Stop if multi_done() has already been called */
     return CURLE_OK;
 
-  conn->data = data; /* ensure the connection uses this transfer now */
-
   /* Stop the resolver and free its own resources (but not dns_entry yet). */
   Curl_resolver_kill(data);
 
@@ -604,16 +602,13 @@ static CURLcode multi_done(struct Curl_easy *data,
   Curl_detach_connnection(data);
   if(CONN_INUSE(conn)) {
     /* Stop if still used. */
-    /* conn->data must not remain pointing to this transfer since it is going
-       away! Find another to own it! */
-    conn->data = conn->easyq.head->ptr;
     CONNCACHE_UNLOCK(data);
     DEBUGF(infof(data, "Connection still in use %zu, "
                  "no more multi_done now!\n",
                  conn->easyq.size));
     return CURLE_OK;
   }
-  conn->data = NULL; /* the connection now has no owner */
+
   data->state.done = TRUE; /* called just now! */
 
   if(conn->dns_entry) {
@@ -718,7 +713,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
 {
   struct Curl_easy *easy = data;
   bool premature;
-  bool easy_owns_conn;
   struct Curl_llist_element *e;
 
   /* First, make some basic checks that the CURLM handle is a good handle */
@@ -741,8 +735,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
     return CURLM_RECURSIVE_API_CALL;
 
   premature = (data->mstate < CURLM_STATE_COMPLETED) ? TRUE : FALSE;
-  easy_owns_conn = (data->conn && (data->conn->data == easy)) ?
-    TRUE : FALSE;
 
   /* If the 'state' is not INIT or COMPLETED, we might need to do something
      nice to put the easy_handle in a good known state when this returns. */
@@ -757,24 +749,16 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
      data->mstate < CURLM_STATE_COMPLETED) {
     /* Set connection owner so that the DONE function closes it.  We can
        safely do this here since connection is killed. */
-    data->conn->data = easy;
     streamclose(data->conn, "Removed with partial response");
-    easy_owns_conn = TRUE;
   }
 
   if(data->conn) {
+    /* multi_done() clears the association between the easy handle and the
+       connection.
 
-    /* we must call multi_done() here (if we still own the connection) so that
-       we don't leave a half-baked one around */
-    if(easy_owns_conn) {
-
-      /* multi_done() clears the association between the easy handle and the
-         connection.
-
-         Note that this ignores the return code simply because there's
-         nothing really useful to do with it anyway! */
-      (void)multi_done(data, data->result, premature);
-    }
+       Note that this ignores the return code simply because there's
+       nothing really useful to do with it anyway! */
+    (void)multi_done(data, data->result, premature);
   }
 
   /* The timer must be shut down before data->multi is set to NULL, else the
@@ -983,12 +967,6 @@ static int multi_getsock(struct Curl_easy *data,
   */
   if(!conn)
     return 0;
-
-  if(data->mstate > CURLM_STATE_CONNECT &&
-     data->mstate < CURLM_STATE_COMPLETED) {
-    /* Set up ownership correctly */
-    data->conn->data = data;
-  }
 
   switch(data->mstate) {
   default:
@@ -1397,7 +1375,6 @@ static CURLcode multi_do(struct Curl_easy *data, bool *done)
 
   DEBUGASSERT(conn);
   DEBUGASSERT(conn->handler);
-  DEBUGASSERT(conn->data == data);
 
   if(conn->handler->do_it)
     /* generic protocol-specific function pointer set in curl_connect() */
@@ -1584,7 +1561,6 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       DEBUGASSERT(data->conn);
       if(!data->conn)
         return CURLM_INTERNAL_ERROR;
-      data->conn->data = data;
     }
 
     if(data->conn &&

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -911,10 +911,6 @@ struct connstate {
  * unique for an entire connection.
  */
 struct connectdata {
-  /* 'data' is the CURRENT Curl_easy using this connection -- take great
-     caution that this might very well vary between different times this
-     connection is used! */
-  struct Curl_easy *data;
   struct connstate cnnct;
   struct Curl_llist_element bundle_node; /* conncache */
 

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -5,7 +5,8 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2020, Jacob Hoffman-Andrews, <github@hoffman-andrews.com>
+ * Copyright (C) 2020 - 2021, Jacob Hoffman-Andrews,
+ * <github@hoffman-andrews.com>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -61,10 +62,8 @@ static CURLcode map_error(rustls_result r)
 static bool
 cr_data_pending(const struct connectdata *conn, int sockindex)
 {
-  struct Curl_easy *data = conn->data;
   const struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
-  infof(data, "rustls_data_pending %d\n", backend->data_pending);
   return backend->data_pending;
 }
 


### PR DESCRIPTION
This complete removes the `struct Curl_easy *data` struct member from the `connectdata` struct.

~~This PR contains the #6520 and #6522 commits at this point but they will be merged individually before this, so I'll remove them when that happens.~~

Wiki page about it: https://github.com/curl/curl/wiki/conn.data-considered-bad