### PR TITLE
http: do not add a referrer header with empty value

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1547,7 +1547,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       else
         config->autoreferer = FALSE;
-      GetStr(&config->referer, *nextarg ? nextarg : NULL);
+      if(*nextarg)
+        GetStr(&config->referer, nextarg);
+      else
+        GetStr(&config->referer, NULL);
     }
     break;
     case 'E':

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1547,10 +1547,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       else
         config->autoreferer = FALSE;
-      if(*nextarg)
-        GetStr(&config->referer, nextarg);
-      else
-        GetStr(&config->referer, NULL);
+      ptr = *nextarg ? nextarg : NULL;
+      GetStr(&config->referer, ptr);
     }
     break;
     case 'E':

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1547,8 +1547,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       else
         config->autoreferer = FALSE;
-      if(*nextarg)
-        GetStr(&config->referer, nextarg);
+      GetStr(&config->referer, *nextarg ? nextarg : NULL);
     }
     break;
     case 'E':

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1547,7 +1547,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       else
         config->autoreferer = FALSE;
-      GetStr(&config->referer, nextarg);
+      if(*nextarg)
+        GetStr(&config->referer, nextarg);
     }
     break;
     case 'E':


### PR DESCRIPTION
Previously an empty 'Referer:' header was added to the HTTP request when passing `--referer ';auto'` or `--referer ''` on the command-line. This patch makes `--referer` work like `--header 'Referer:'` and will only add the header if it has a non-zero length value.