### PR TITLE
multi: rename the multi transfer states

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1034,8 +1034,8 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
 
   /* Unpause parts in active mime tree. */
   if((k->keepon & ~newstate & KEEP_SEND_PAUSE) &&
-     (data->mstate == CURLM_STATE_PERFORM ||
-      data->mstate == CURLM_STATE_TOOFAST) &&
+     (data->mstate == MSTATE_PERFORMING ||
+      data->mstate == MSTATE_RATELIMITING) &&
      data->state.fread_func == (curl_read_callback) Curl_mime_read) {
     Curl_mime_unpause(data->state.in);
   }

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -40,27 +40,26 @@ struct Curl_message {
    well!
 */
 typedef enum {
-  CURLM_STATE_INIT,         /* 0 - start in this state */
-  CURLM_STATE_CONNECT_PEND, /* 1 - no connections, waiting for one */
-  CURLM_STATE_CONNECT,      /* 2 - resolve/connect has been sent off */
-  CURLM_STATE_WAITRESOLVE,  /* 3 - awaiting the resolve to finalize */
-  CURLM_STATE_WAITCONNECT,  /* 4 - awaiting the TCP connect to finalize */
-  CURLM_STATE_WAITPROXYCONNECT, /* 5 - awaiting HTTPS proxy SSL initialization
-                                   to complete and/or proxy CONNECT to
-                                   finalize */
-  CURLM_STATE_SENDPROTOCONNECT, /* 6 - initiate protocol connect procedure */
-  CURLM_STATE_PROTOCONNECT, /* 7 - completing the protocol-specific connect
-                                   phase */
-  CURLM_STATE_DO,           /* 8 - start send off the request (part 1) */
-  CURLM_STATE_DOING,        /* 9 - sending off the request (part 1) */
-  CURLM_STATE_DO_MORE,      /* 10 - send off the request (part 2) */
-  CURLM_STATE_DO_DONE,      /* 11 - done sending off request */
-  CURLM_STATE_PERFORM,      /* 12 - transfer data */
-  CURLM_STATE_TOOFAST,      /* 13 - wait because limit-rate exceeded */
-  CURLM_STATE_DONE,         /* 14 - post data transfer operation */
-  CURLM_STATE_COMPLETED,    /* 15 - operation complete */
-  CURLM_STATE_MSGSENT,      /* 16 - the operation complete message is sent */
-  CURLM_STATE_LAST          /* 17 - not a true state, never use this */
+  MSTATE_INIT,         /* 0 - start in this state */
+  MSTATE_PENDING,      /* 1 - no connections, waiting for one */
+  MSTATE_CONNECT,      /* 2 - resolve/connect has been sent off */
+  MSTATE_RESOLVING,    /* 3 - awaiting the resolve to finalize */
+  MSTATE_CONNECTING,   /* 4 - awaiting the TCP connect to finalize */
+  MSTATE_TUNNELING,    /* 5 - awaiting HTTPS proxy SSL initialization to
+                          complete and/or proxy CONNECT to finalize */
+  MSTATE_PROTOCONNECT, /* 6 - initiate protocol connect procedure */
+  MSTATE_PROTOCONNECTING, /* 7 - completing the protocol-specific connect
+                             phase */
+  MSTATE_DO,           /* 8 - start send off the request (part 1) */
+  MSTATE_DOING,        /* 9 - sending off the request (part 1) */
+  MSTATE_DOING_MORE,   /* 10 - send off the request (part 2) */
+  MSTATE_DID,          /* 11 - done sending off request */
+  MSTATE_PERFORMING,   /* 12 - transfer data */
+  MSTATE_RATELIMITING, /* 13 - wait because limit-rate exceeded */
+  MSTATE_DONE,         /* 14 - post data transfer operation */
+  MSTATE_COMPLETED,    /* 15 - operation complete */
+  MSTATE_MSGSENT,      /* 16 - the operation complete message is sent */
+  MSTATE_LAST          /* 17 - not a true state, never use this */
 } CURLMstate;
 
 /* we support N sockets per easy handle. Set the corresponding bit to what
@@ -95,7 +94,7 @@ struct Curl_multi {
   struct Curl_llist msglist; /* a list of messages from completed transfers */
 
   struct Curl_llist pending; /* Curl_easys that are in the
-                                CURLM_STATE_CONNECT_PEND state */
+                                MSTATE_PENDING state */
 
   /* callback function and user data pointer for the *socket() API */
   curl_socket_callback socket_cb;


### PR DESCRIPTION
While working on documenting the states it dawned on me that step one is to use better descriptive names on the states. This also changes prefix on them to make them shorter in the source (from `CURLM_STATE_` to `MSTATE_`).

| New name | old name |
|--------|-----|
| INIT            | INIT             |
| **PENDING**         | CONNECT_PEND     |
| CONNECT         | CONNECT          |
| **RESOLVING**       | WAITRESOLVE      |
| **CONNECTING**      | WAITCONNECT      |
| **TUNNELING**       | WAITPROXYCONNECT |
| **PROTOCONNECT**    | SENDPROTOCONNECT |
| **PROTOCONNECTING** | PROTOCONNECT     |
| DO              | DO               |
| DOING           | DOING            |
| **DOING_MORE**      | DO_MORE          |
| **DID**             | DO_DONE          |
| **PERFORMING**      | PERFORM          |
| **RATELIMITING**      | TOOFAST          |
| DONE            | DONE             |
| COMPLETED       | COMPLETED        |
| MSGSENT         | MSGSENT          |

The general rule is that `*ING` states will remain in there until a condition is met, while the others are just transitional.