### PR TITLE
url: fix possible use-after-free in default protocol

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1901,13 +1901,12 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
 
   if(data->set.str[STRING_DEFAULT_PROTOCOL] &&
      !Curl_is_absolute_url(data->change.url, NULL, MAX_SCHEME_LEN)) {
-    char *url;
-    if(data->change.url_alloc)
-      free(data->change.url);
-    url = aprintf("%s://%s", data->set.str[STRING_DEFAULT_PROTOCOL],
-                  data->change.url);
+    char *url = aprintf("%s://%s", data->set.str[STRING_DEFAULT_PROTOCOL],
+                        data->change.url);
     if(!url)
       return CURLE_OUT_OF_MEMORY;
+    if(data->change.url_alloc)
+      free(data->change.url);
     data->change.url = url;
     data->change.url_alloc = TRUE;
   }


### PR DESCRIPTION
Prior to this change if the user specified a default protocol and a
separately allocated non-absolute URL was used then it was freed
prematurely, before it was then used to make the replacement URL.

Bug: https://github.com/curl/curl/issues/6604#issuecomment-780138219
Reported-by: arvids-kokins-bidstack@users.noreply.github.com

Closes #xxxx