### PR TITLE
ci: stop building on freebsd-12-1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,6 @@ task:
       # A stable 13.0 image likely won't be available before early 2021
       # image_family: freebsd-13-0-snap
       image_family: freebsd-12-2
-      image_family: freebsd-12-1
       image_family: freebsd-11-4
 
   env:


### PR DESCRIPTION
An updated freebsd-12-2 image was added a few month ago, and this older one is consistently failing to go past `pkginstall`:
```
Newer FreeBSD version for package py37-mlt:
To ignore this error set IGNORE_OSVERSION=yes
- package: 1202000
- running kernel: 1201000
Ignore the mismatch and continue? [Y/n]: pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:12:amd64
```

FreeBSD thread suggests that 12.1 is EOL, and it's best to avoid.

Ref: https://forums.freebsd.org/threads/78856/

Closes #xxxx