### PR TITLE
test1188: change error from connect to resolve error

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3344,7 +3344,7 @@ static CURLcode resolve_server(struct Curl_easy *data,
         result = CURLE_OPERATION_TIMEDOUT;
 
       else if(!hostaddr) {
-        failf(data, "Couldn't resolve host '%s'", connhost->dispname);
+        failf(data, "Could not resolve host: %s", connhost->dispname);
         result = CURLE_COULDNT_RESOLVE_HOST;
         /* don't return yet, we need to clean up the timeout first */
       }

--- a/tests/data/test1188
+++ b/tests/data/test1188
@@ -27,7 +27,7 @@ http
 --write-out with %{onerror} and %{urlnum} to stderr
  </name>
 <command>
-http://%HOSTIP:%NOLISTENPORT/we/want/our/1188 http://%HOSTIP:%HTTPPORT/we/want/our/1188 -w '%{onerror}%{stderr}%{urlnum} says %{exitcode} %{errormsg}\n' -s
+http://non-existing-host.haxx.se:%NOLISTENPORT/we/want/our/1188 http://%HOSTIP:%HTTPPORT/we/want/our/1188 -w '%{onerror}%{stderr}%{urlnum} says %{exitcode} %{errormsg}\n' -s
 </command>
 </client>
 
@@ -41,7 +41,7 @@ Accept: */*
 
 </protocol>
 <stderr mode="text">
-0 says 7 Failed to connect to %HOSTIP port %NOLISTENPORT: Connection refused
+0 says 6 Could not resolve host: non-existing-host.haxx.se
 </stderr>
 </verify>
 </testcase>


### PR DESCRIPTION
Using the %NOLISTENPORT to trigger a connection failure is somewhat
"risky" (since it isn't guaranteed to not be listened to) and caused
occasional CI problems. This fix changes the infused error to be a more
reliable one but still verifies the --write-out functionality properly -
which is the purpose of this test.

Reported-by: Jay Satiro
Fixes #6621