### PR TITLE
asyn-ares: use consistent resolve error message

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -384,13 +384,8 @@ CURLcode Curl_resolver_is_resolved(struct Curl_easy *data,
        them */
     res->temp_ai = NULL;
 
-    if(!data->state.async.dns) {
-      failf(data, "Could not resolve: %s (%s)",
-            data->state.async.hostname,
-            ares_strerror(data->state.async.status));
-      result = data->conn->bits.proxy?CURLE_COULDNT_RESOLVE_PROXY:
-        CURLE_COULDNT_RESOLVE_HOST;
-    }
+    if(!data->state.async.dns)
+      result = Curl_resolver_error(data);
     else
       *dns = data->state.async.dns;
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -484,35 +484,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
 }
 
 /*
- * resolver_error() calls failf() with the appropriate message after a resolve
- * error
- */
-
-static CURLcode resolver_error(struct Curl_easy *data)
-{
-  const char *host_or_proxy;
-  CURLcode result;
-
-#ifndef CURL_DISABLE_PROXY
-  struct connectdata *conn = data->conn;
-  if(conn->bits.httpproxy) {
-    host_or_proxy = "proxy";
-    result = CURLE_COULDNT_RESOLVE_PROXY;
-  }
-  else
-#endif
-  {
-    host_or_proxy = "host";
-    result = CURLE_COULDNT_RESOLVE_HOST;
-  }
-
-  failf(data, "Could not resolve %s: %s", host_or_proxy,
-        data->state.async.hostname);
-
-  return result;
-}
-
-/*
  * 'entry' may be NULL and then no data is returned
  */
 static CURLcode thread_wait_resolv(struct Curl_easy *data,
@@ -542,7 +513,7 @@ static CURLcode thread_wait_resolv(struct Curl_easy *data,
 
   if(!data->state.async.dns && report)
     /* a name was not resolved, report error */
-    result = resolver_error(data);
+    result = Curl_resolver_error(data);
 
   destroy_async_data(&data->state.async);
 
@@ -616,7 +587,7 @@ CURLcode Curl_resolver_is_resolved(struct Curl_easy *data,
     getaddrinfo_complete(data);
 
     if(!data->state.async.dns) {
-      CURLcode result = resolver_error(data);
+      CURLcode result = Curl_resolver_error(data);
       destroy_async_data(&data->state.async);
       return result;
     }

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1124,3 +1124,32 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
   }
   return result;
 }
+
+/*
+ * Curl_resolver_error() calls failf() with the appropriate message after a
+ * resolve error
+ */
+
+CURLcode Curl_resolver_error(struct Curl_easy *data)
+{
+  const char *host_or_proxy;
+  CURLcode result;
+
+#ifndef CURL_DISABLE_PROXY
+  struct connectdata *conn = data->conn;
+  if(conn->bits.httpproxy) {
+    host_or_proxy = "proxy";
+    result = CURLE_COULDNT_RESOLVE_PROXY;
+  }
+  else
+#endif
+  {
+    host_or_proxy = "host";
+    result = CURLE_COULDNT_RESOLVE_HOST;
+  }
+
+  failf(data, "Could not resolve %s: %s", host_or_proxy,
+        data->state.async.hostname);
+
+  return result;
+}

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -245,4 +245,5 @@ CURLcode Curl_resolv_check(struct Curl_easy *data,
 int Curl_resolv_getsock(struct Curl_easy *data,
                         curl_socket_t *socks);
 
+CURLcode Curl_resolver_error(struct Curl_easy *data);
 #endif /* HEADER_CURL_HOSTIP_H */


### PR DESCRIPTION
... with the help of Curl_resolver_error() which now is moved from
asyn-thead.c and is provided globally for this purpose.

Follow-up to 35ca04ce1b77636

Makes test 1188 work for c-ares builds