### PR TITLE
multi: do once-per-transfer inits in before_perform in DID state

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -105,8 +105,8 @@ static const char * const statename[]={
 /* function pointer called once when switching TO a state */
 typedef void (*init_multistate_func)(struct Curl_easy *data);
 
-/* called when the PERFORM state starts  */
-static void init_perform(struct Curl_easy *data)
+/* called in DID state, before PERFORMING state */
+static void before_perform(struct Curl_easy *data)
 {
   data->req.chunk = FALSE;
   Curl_pgrsTime(data, TIMER_PRETRANSFER);
@@ -142,8 +142,8 @@ static void mstate(struct Curl_easy *data, CURLMstate state
     Curl_connect_free, /* DO */
     NULL,              /* DOING */
     NULL,              /* DOING_MORE */
-    NULL,              /* DID */
-    init_perform,      /* PERFORMING */
+    before_perform,    /* DID */
+    NULL,              /* PERFORMING */
     NULL,              /* RATELIMITING */
     NULL,              /* DONE */
     init_completed,    /* COMPLETED */


### PR DESCRIPTION
... since the state machine might go to RATELIMITING and then back to
PERFORMING doing once-per-transfer inits in that function is wrong and
it caused problems with receiving chunked HTTP and it set the
PRETRANSFER time much too often...

Regression from b68dc34af341805aeb7b3715 (shipped in 7.75.0)

Reported-by: Amaury Denoyelle
Fixes #6640