### PR TITLE
lib: change curl_blob data pointer to const

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.3
@@ -26,6 +26,12 @@ CURLOPT_ISSUERCERT_BLOB \- issuer SSL certificate from memory blob
 .SH SYNOPSIS
 #include <curl/curl.h>
 
+struct curl_blob {
+  const void *data;
+  size_t len;
+  unsigned int flags;
+};
+
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ISSUERCERT_BLOB, struct curl_blob *stblob);
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains information (pointer

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.3
@@ -27,6 +27,12 @@ CURLOPT_ISSUERCERT_BLOB \- proxy issuer SSL certificate from memory blob
 .nf
 #include <curl/curl.h>
 
+struct curl_blob {
+  const void *data;
+  size_t len;
+  unsigned int flags;
+};
+
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_ISSUERCERT_BLOB,
                           struct curl_blob *blob);
 .fi

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
@@ -26,6 +26,12 @@ CURLOPT_PROXY_SSLCERT_BLOB \- SSL proxy client certificate from memory blob
 .SH SYNOPSIS
 #include <curl/curl.h>
 
+struct curl_blob {
+  const void *data;
+  size_t len;
+  unsigned int flags;
+};
+
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERT_BLOB, struct curl_blob *blob);
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains information (pointer

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.3
@@ -27,6 +27,12 @@ CURLOPT_PROXY_SSLKEY_BLOB \- private key for proxy cert from memory blob
 .nf
 #include <curl/curl.h>
 
+struct curl_blob {
+  const void *data;
+  size_t len;
+  unsigned int flags;
+};
+
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLKEY_BLOB,
                           struct curl_blob *blob);
 .fi

--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
@@ -26,6 +26,12 @@ CURLOPT_SSLCERT_BLOB \- SSL client certificate from memory blob
 .SH SYNOPSIS
 #include <curl/curl.h>
 
+struct curl_blob {
+  const void *data;
+  size_t len;
+  unsigned int flags;
+};
+
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERT_BLOB, struct curl_blob *stblob);
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains (pointer and size) a

--- a/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.3
@@ -27,6 +27,12 @@ CURLOPT_SSLKEY_BLOB \- private key for client cert from memory blob
 .nf
 #include <curl/curl.h>
 
+struct curl_blob {
+  const void *data;
+  size_t len;
+  unsigned int flags;
+};
+
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLKEY_BLOB,
                           struct curl_blob *blob);
 .fi

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -30,7 +30,7 @@ extern "C" {
 #define CURL_BLOB_NOCOPY 0 /* tell libcurl to NOT copy the data */
 
 struct curl_blob {
-  void *data;
+  const void *data;
   size_t len;
   unsigned int flags; /* bit 0 is defined, the rest are reserved and should be
                          left zeroes */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -100,8 +100,9 @@ CURLcode Curl_setblobopt(struct curl_blob **blobp,
     *nblob = *blob;
     if(blob->flags & CURL_BLOB_COPY) {
       /* put the data after the blob struct in memory */
-      nblob->data = (char *)nblob + sizeof(struct curl_blob);
-      memcpy(nblob->data, blob->data, blob->len);
+      char *p = (char *)nblob + sizeof(struct curl_blob);
+      memcpy(p, blob->data, blob->len);
+      nblob->data = p;
     }
 
     *blobp = nblob;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -98,6 +98,7 @@ static CURLcode blobdup(struct curl_blob **dest,
   DEBUGASSERT(!*dest);
   if(src) {
     /* only if there's data to dupe! */
+    char *p;
     struct curl_blob *d;
     d = malloc(sizeof(struct curl_blob) + src->len);
     if(!d)
@@ -106,8 +107,9 @@ static CURLcode blobdup(struct curl_blob **dest,
     /* Always duplicate because the connection may survive longer than the
        handle that passed in the blob. */
     d->flags = CURL_BLOB_COPY;
-    d->data = (void *)((char *)d + sizeof(struct curl_blob));
-    memcpy(d->data, src->data, src->len);
+    p = (char *)d + sizeof(struct curl_blob);
+    memcpy(p, src->data, src->len);
+    d->data = p;
     *dest = d;
   }
   return CURLE_OK;


### PR DESCRIPTION
- Change curl_blob's 'void *data' to 'const void *data'.

- Document the curl_blob struct in each _BLOB opt doc.

Prior to this change the user may have faced a compiler warning when
assigning their const blob data to the non-const curl_blob data pointer.

Bug: https://curl.se/mail/lib-2021-02/0048.html
Reported-by: Laurent Dufresne

Closes #xxxx