### PR TITLE
cookies: Support multiple -b parameters

### DIFF
--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -56,9 +56,9 @@ static void free_config_fields(struct OperationConfig *config)
   Curl_safefree(config->useragent);
   Curl_safefree(config->altsvc);
   Curl_safefree(config->hsts);
-  Curl_safefree(config->cookie);
+  curl_slist_free_all(config->cookies);
   Curl_safefree(config->cookiejar);
-  Curl_safefree(config->cookiefile);
+  curl_slist_free_all(config->cookiefiles);
 
   Curl_safefree(config->postfields);
   Curl_safefree(config->referer);

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -54,9 +54,9 @@ struct OperationConfig {
   char *random_file;
   char *egd_file;
   char *useragent;
-  char *cookie;             /* single line with specified cookies */
+  struct curl_slist *cookies;  /* cookies to serialize into a single line */
   char *cookiejar;          /* write to this file */
-  char *cookiefile;         /* read from this file */
+  struct curl_slist *cookiefiles;  /* file(s) to load cookies from */
   char *altsvc;             /* alt-svc cache file name */
   char *hsts;               /* HSTS cache file name */
   bool cookiesession;       /* new session? */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1320,11 +1320,15 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         }
         else if(strchr(nextarg, '=')) {
           /* A cookie string must have a =-letter */
-          GetStr(&config->cookie, nextarg);
+          err = add2list(&config->cookies, nextarg);
+          if(err)
+            return err;
           break;
         }
         /* We have a cookie file to read from! */
-        GetStr(&config->cookiefile, nextarg);
+        err = add2list(&config->cookiefiles, nextarg);
+        if(err)
+          return err;
       }
       break;
     case 'B':

--- a/tests/data/test329
+++ b/tests/data/test329
@@ -33,6 +33,9 @@ moo
 <file name="log/jar329.txt" mode="text">
 .host.foo.com	TRUE	/we/want/	FALSE	2147483647	test	no
 </file>
+<file name="log/jar329-2.txt" mode="text">
+.host.foo.com	TRUE	/we/want/	FALSE	2147483647	tester	yes
+</file>
 <server>
 http
 </server>
@@ -46,7 +49,7 @@ HTTP cookie with Max-Age=0
 TZ=GMT
 </setenv>
  <command>
-http://%HOSTIP:%HTTPPORT/we/want/329 -b log/jar329.txt -H "Host: host.foo.com" http://%HOSTIP:%HTTPPORT/we/want/3290002
+http://%HOSTIP:%HTTPPORT/we/want/329 -b log/jar329.txt -b log/jar329-2.txt -H "Host: host.foo.com" http://%HOSTIP:%HTTPPORT/we/want/3290002
 </command>
 </client>
 
@@ -57,12 +60,13 @@ GET /we/want/329 HTTP/1.1
 Host: host.foo.com
 User-Agent: curl/%VERSION
 Accept: */*
-Cookie: test=no
+Cookie: tester=yes; test=no
 
 GET /we/want/3290002 HTTP/1.1
 Host: host.foo.com
 User-Agent: curl/%VERSION
 Accept: */*
+Cookie: tester=yes
 
 </protocol>
 </verify>

--- a/tests/data/test6
+++ b/tests/data/test6
@@ -29,7 +29,7 @@ http
 HTTP with simple cookie send
  </name>
  <command>
-http://%HOSTIP:%HTTPPORT/we/want/that/page/6 -b "name=contents;name2=content2"
+http://%HOSTIP:%HTTPPORT/we/want/that/page/6 -b "name=contents;name2=content2" -b name3=content3
 </command>
 </client>
 
@@ -40,7 +40,7 @@ GET /we/want/that/page/6 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Cookie: name=contents;name2=content2
+Cookie: name=contents;name2=content2;name3=content3
 
 </protocol>
 </verify>


### PR DESCRIPTION
Previously only a single -b cookie parameter was supported with the last one winning. This adds support for supplying multiple -b params to have them serialized semicolon separated.

~~This is bit of a draft PR so far which lacks tests.~~ 