### PR TITLE
Factor base64 conversions out of authentication procedures

### DIFF
--- a/docs/BUFREF.md
+++ b/docs/BUFREF.md
@@ -1,0 +1,81 @@
+# bufref
+
+This is an internal module for handling buffer references. A referenced
+buffer is associated with its destructor function that is implicitly called
+when the reference is invalidated. Once referenced, a buffer cannot be
+reallocated.
+
+A data length is stored within the reference for binary data handling
+purpose; it is not used by the bufref API.
+
+The `struct bufref` is used to hold data referencing a buffer. The members of
+that structure **MUST NOT** be accessed or modified without using the dedicated
+bufref API.
+
+## init
+
+```c
+void Curl_bufref_init(struct bufref *br);
+```
+
+Initialises a `bufref` structure. This function **MUST** be called before any
+other operation is performed on the structure.
+
+Upon completion, the referenced buffer is `NULL` and length is zero.
+
+This function may also be called to bypass referenced buffer destruction while
+invalidating the current reference.
+
+## free
+
+```c
+void Curl_bufref_free(struct bufref *br);
+```
+
+Destroys the previously referenced buffer using its destructor and
+reinitialises the structure for a possible subsequent reuse.
+
+## set
+
+```c
+void Curl_bufref_set(struct bufref *br, const void *buffer, size_t length,
+                     void (*destructor)(void *));
+```
+
+Releases the previouly referenced buffer, then assigns the new `buffer` to
+the structure, associated with its `destructor` function. The later can be
+specified as `NULL`: this will be the case when the referenced buffer is
+static.
+
+if `buffer` is NULL, `length`must be zero.
+
+## memdup
+
+```c
+CURLcode Curl_bufref_memdup(struct bufref *br, const void *data, size_t length);
+```
+
+Releases the previouly referenced buffer, then duplicates the `length`-byte
+`data` into a buffer allocated via `malloc()` and references the later
+associated with destructor `curl_free()`.
+
+An additional trailing byte is allocated and set to zero as a possible
+string zero-terminator; it is not counted in the stored length.
+
+Returns `CURLE_OK` if successful, else `CURLE_OUT_OF_MEMORY`.
+
+## ptr
+
+```c
+const unsigned char *Curl_bufref_ptr(const struct bufref *br);
+```
+
+Returns a `const unsigned char *` to the referenced bufffer.
+
+## len
+
+```c
+size_t Curl_bufref_len(const struct bufref *br);
+```
+
+Returns the stored length of the referenced buffer.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -44,6 +44,7 @@ EXTRA_DIST =                                    \
  $(noinst_man_MANS)                             \
  ALTSVC.md                                      \
  BINDINGS.md                                    \
+ BUFREF.md                                      \
  BUG-BOUNTY.md                                  \
  BUGS.md                                        \
  CHECKSRC.md                                    \

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -97,6 +97,7 @@ LIB_CFILES =         \
   asyn-ares.c        \
   asyn-thread.c      \
   base64.c           \
+  bufref.c           \
   c-hyper.c          \
   conncache.c        \
   connect.c          \
@@ -217,6 +218,7 @@ LIB_HFILES =         \
   amigaos.h          \
   arpa_telnet.h      \
   asyn.h             \
+  bufref.h           \
   c-hyper.h          \
   conncache.h        \
   connect.h          \

--- a/lib/bufref.c
+++ b/lib/bufref.c
@@ -1,0 +1,127 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+#include "urldata.h"
+#include "bufref.h"
+
+#include "curl_memory.h"
+#include "memdebug.h"
+
+#define SIGNATURE 0x5c48e9b2    /* Random pattern. */
+
+/*
+ * Init a bufref struct.
+ */
+void Curl_bufref_init(struct bufref *br)
+{
+  DEBUGASSERT(br);
+  br->dtor = NULL;
+  br->ptr = NULL;
+  br->len = 0;
+
+#ifdef DEBUGBUILD
+  br->signature = SIGNATURE;
+#endif
+}
+
+/*
+ * Free the buffer and re-init the necessary fields. It doesn't touch the
+ * 'signature' field and thus this buffer reference can be reused.
+ */
+
+void Curl_bufref_free(struct bufref *br)
+{
+  DEBUGASSERT(br);
+  DEBUGASSERT(br->signature == SIGNATURE);
+  DEBUGASSERT(br->ptr || !br->len);
+
+  if(br->ptr && br->dtor)
+    br->dtor((void *) br->ptr);
+
+  br->dtor = NULL;
+  br->ptr = NULL;
+  br->len = 0;
+}
+
+/*
+ * Set the buffer reference to new values. The previously referenced buffer
+ * is released before assignment.
+ */
+void Curl_bufref_set(struct bufref *br, const void *ptr, size_t len,
+                     void (*dtor)(void *))
+{
+  DEBUGASSERT(ptr || !len);
+  DEBUGASSERT(len <= CURL_MAX_INPUT_LENGTH);
+
+  Curl_bufref_free(br);
+  br->ptr = (const unsigned char *) ptr;
+  br->len = len;
+  br->dtor = dtor;
+}
+
+/*
+ * Get a pointer to the referenced buffer.
+ */
+const unsigned char *Curl_bufref_ptr(const struct bufref *br)
+{
+  DEBUGASSERT(br);
+  DEBUGASSERT(br->signature == SIGNATURE);
+  DEBUGASSERT(br->ptr || !br->len);
+
+  return br->ptr;
+}
+
+/*
+ * Get the length of the referenced buffer data.
+ */
+size_t Curl_bufref_len(const struct bufref *br)
+{
+  DEBUGASSERT(br);
+  DEBUGASSERT(br->signature == SIGNATURE);
+  DEBUGASSERT(br->ptr || !br->len);
+
+  return br->len;
+}
+
+CURLcode Curl_bufref_memdup(struct bufref *br, const void *ptr, size_t len)
+{
+  unsigned char *cpy = NULL;
+
+  DEBUGASSERT(br);
+  DEBUGASSERT(br->signature == SIGNATURE);
+  DEBUGASSERT(br->ptr || !br->len);
+  DEBUGASSERT(ptr || !len);
+  DEBUGASSERT(len <= CURL_MAX_INPUT_LENGTH);
+
+  if(ptr) {
+    cpy = malloc(len + 1);
+    if(!cpy)
+      return CURLE_OUT_OF_MEMORY;
+    if(len)
+      memcpy(cpy, ptr, len);
+    cpy[len] = '\0';
+  }
+
+  Curl_bufref_set(br, cpy, len, curl_free);
+  return CURLE_OK;
+}

--- a/lib/bufref.h
+++ b/lib/bufref.h
@@ -1,0 +1,46 @@
+#ifndef HEADER_CURL_BUFREF_H
+#define HEADER_CURL_BUFREF_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+/*
+ * Generic buffer reference.
+ */
+struct bufref {
+  void (*dtor)(void *);         /* Associated destructor. */
+  const unsigned char *ptr;     /* Referenced data buffer. */
+  size_t len;                   /* The data size in bytes. */
+#ifdef DEBUGBUILD
+  int signature;                /* Detect API use mistakes. */
+#endif
+};
+
+
+void Curl_bufref_init(struct bufref *br);
+void Curl_bufref_set(struct bufref *br, const void *ptr, size_t len,
+                     void (*dtor)(void *));
+const unsigned char *Curl_bufref_ptr(const struct bufref *br);
+size_t Curl_bufref_len(const struct bufref *br);
+CURLcode Curl_bufref_memdup(struct bufref *br, const void *ptr, size_t len);
+void Curl_bufref_free(struct bufref *br);
+
+#endif

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -242,6 +242,49 @@ static void state(struct SASL *sasl, struct Curl_easy *data,
   sasl->state = newstate;
 }
 
+/* Get the SASL server message and convert it to binary. */
+static CURLcode get_server_message(struct SASL *sasl, struct Curl_easy *data,
+                                   struct bufref *out)
+{
+  unsigned char *msg;
+  size_t msglen;
+  char *serverdata = NULL;
+  CURLcode result = CURLE_OK;
+
+  sasl->params->getmessage(data->state.buffer, &serverdata);
+  if(!serverdata)
+    result = CURLE_BAD_CONTENT_ENCODING;
+  else if(!*serverdata || *serverdata == '=')
+    Curl_bufref_set(out, NULL, 0, NULL);
+  else {
+    result = Curl_base64_decode(serverdata, &msg, &msglen);
+    if(!result)
+      Curl_bufref_set(out, msg, msglen, curl_free);
+  }
+  return result;
+}
+
+/* Encode the outgoing SASL message. */
+static CURLcode build_message(struct Curl_easy *data, struct bufref *msg)
+{
+  CURLcode result = CURLE_OK;
+  char *base64;
+  size_t base64len;
+
+  if(!Curl_bufref_ptr(msg))             /* Empty mesage. */
+    Curl_bufref_set(msg, "", 0, NULL);
+  else if(!Curl_bufref_len(msg))        /* Explicit empty response. */
+    Curl_bufref_set(msg, "=", 1, NULL);
+  else {
+    result = Curl_base64_encode(data, (const char *) Curl_bufref_ptr(msg),
+                                Curl_bufref_len(msg), &base64, &base64len);
+    if(!result)
+      Curl_bufref_set(msg, base64, base64len, curl_free);
+  }
+
+  return result;
+}
+
 /*
  * Curl_sasl_can_authenticate()
  *
@@ -272,8 +315,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   unsigned int enabledmechs;
   const char *mech = NULL;
-  char *resp = NULL;
-  size_t len = 0;
+  struct bufref resp;
   saslstate state1 = SASL_STOP;
   saslstate state2 = SASL_FINAL;
 #ifndef CURL_DISABLE_PROXY
@@ -290,7 +332,10 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
     sasl->params->service;
 #endif
   const char *oauth_bearer = data->set.str[STRING_BEARER];
+  struct bufref nullmsg;
 
+  Curl_bufref_init(&nullmsg);
+  Curl_bufref_init(&resp);
   sasl->force_ir = force_ir;    /* Latch for future use */
   sasl->authused = 0;           /* No mechanism used yet */
   enabledmechs = sasl->authmechs & sasl->prefmech;
@@ -304,8 +349,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
     sasl->authused = SASL_MECH_EXTERNAL;
 
     if(force_ir || data->set.sasl_ir)
-      result = Curl_auth_create_external_message(data, conn->user, &resp,
-                                                 &len);
+      result = Curl_auth_create_external_message(conn->user, &resp);
   }
   else if(conn->bits.user_passwd) {
 #if defined(USE_KERBEROS5)
@@ -321,10 +365,10 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
         result = Curl_auth_create_gssapi_user_message(data, conn->user,
                                                       conn->passwd,
                                                       service,
-                                                      data->conn->host.name,
+                                                      conn->host.name,
                                                       sasl->mutual_auth,
                                                       NULL, &conn->krb5,
-                                                      &resp, &len);
+                                                      &resp);
     }
     else
 #endif
@@ -340,8 +384,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       result = Curl_auth_gsasl_start(data, conn->user,
                                      conn->passwd, &conn->gsasl);
       if(result == CURLE_OK && (force_ir || data->set.sasl_ir))
-        result = Curl_auth_gsasl_token(data, NULL, &conn->gsasl,
-                                       &resp, &len);
+        result = Curl_auth_gsasl_token(data, &nullmsg, &conn->gsasl, &resp);
     }
     else if((enabledmechs & SASL_MECH_SCRAM_SHA_1) &&
             Curl_auth_gsasl_is_supported(data, SASL_MECH_STRING_SCRAM_SHA_1,
@@ -354,8 +397,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       result = Curl_auth_gsasl_start(data, conn->user,
                                      conn->passwd, &conn->gsasl);
       if(result == CURLE_OK && (force_ir || data->set.sasl_ir))
-        result = Curl_auth_gsasl_token(data, NULL, &conn->gsasl,
-                                       &resp, &len);
+        result = Curl_auth_gsasl_token(data, &nullmsg, &conn->gsasl, &resp);
     }
     else
 #endif
@@ -385,8 +427,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
                                                      conn->user, conn->passwd,
                                                      service,
                                                      hostname,
-                                                     &conn->ntlm, &resp,
-                                                     &len);
+                                                     &conn->ntlm, &resp);
       }
     else
 #endif
@@ -397,11 +438,11 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       sasl->authused = SASL_MECH_OAUTHBEARER;
 
       if(force_ir || data->set.sasl_ir)
-        result = Curl_auth_create_oauth_bearer_message(data, conn->user,
+        result = Curl_auth_create_oauth_bearer_message(conn->user,
                                                        hostname,
                                                        port,
                                                        oauth_bearer,
-                                                       &resp, &len);
+                                                       &resp);
     }
     else if((enabledmechs & SASL_MECH_XOAUTH2) && oauth_bearer) {
       mech = SASL_MECH_STRING_XOAUTH2;
@@ -409,9 +450,9 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       sasl->authused = SASL_MECH_XOAUTH2;
 
       if(force_ir || data->set.sasl_ir)
-        result = Curl_auth_create_xoauth_bearer_message(data, conn->user,
+        result = Curl_auth_create_xoauth_bearer_message(conn->user,
                                                         oauth_bearer,
-                                                        &resp, &len);
+                                                        &resp);
     }
     else if(enabledmechs & SASL_MECH_PLAIN) {
       mech = SASL_MECH_STRING_PLAIN;
@@ -419,9 +460,9 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       sasl->authused = SASL_MECH_PLAIN;
 
       if(force_ir || data->set.sasl_ir)
-        result = Curl_auth_create_plain_message(data, conn->sasl_authzid,
+        result = Curl_auth_create_plain_message(conn->sasl_authzid,
                                                 conn->user, conn->passwd,
-                                                &resp, &len);
+                                                &resp);
     }
     else if(enabledmechs & SASL_MECH_LOGIN) {
       mech = SASL_MECH_STRING_LOGIN;
@@ -430,26 +471,29 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       sasl->authused = SASL_MECH_LOGIN;
 
       if(force_ir || data->set.sasl_ir)
-        result = Curl_auth_create_login_message(data, conn->user, &resp, &len);
+        result = Curl_auth_create_login_message(conn->user, &resp);
     }
   }
 
   if(!result && mech) {
-    if(resp && sasl->params->maxirlen &&
-       strlen(mech) + len > sasl->params->maxirlen) {
-      free(resp);
-      resp = NULL;
-    }
+    if(Curl_bufref_ptr(&resp))
+      result = build_message(data, &resp);
 
-    result = sasl->params->sendauth(data, conn, mech, resp);
+    if(sasl->params->maxirlen &&
+       strlen(mech) + Curl_bufref_len(&resp) > sasl->params->maxirlen)
+      Curl_bufref_free(&resp);
+
+    if(!result)
+      result = sasl->params->sendauth(data, conn, mech,
+                                      (const char *) Curl_bufref_ptr(&resp));
+
     if(!result) {
       *progress = SASL_INPROGRESS;
-      state(sasl, data, resp ? state2 : state1);
+      state(sasl, data, Curl_bufref_ptr(&resp) ? state2 : state1);
     }
   }
 
-  free(resp);
-
+  Curl_bufref_free(&resp);
   return result;
 }
 
@@ -464,29 +508,25 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
 {
   CURLcode result = CURLE_OK;
   saslstate newstate = SASL_FINAL;
-  char *resp = NULL;
+  struct bufref resp;
 #ifndef CURL_DISABLE_PROXY
-  const char * const hostname = SSL_IS_PROXY() ? conn->http_proxy.host.name :
-    conn->host.name;
+  const char * const hostname = SSL_HOST_NAME();
   const long int port = SSL_IS_PROXY() ? conn->port : conn->remote_port;
 #else
   const char * const hostname = conn->host.name;
   const long int port = conn->remote_port;
-#endif
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
-  char *chlg = NULL;
-  size_t chlglen = 0;
 #endif
 #if !defined(CURL_DISABLE_CRYPTO_AUTH) || defined(USE_KERBEROS5) ||     \
   defined(USE_NTLM)
   const char *service = data->set.str[STRING_SERVICE_NAME] ?
     data->set.str[STRING_SERVICE_NAME] :
     sasl->params->service;
-  char *serverdata;
 #endif
-  size_t len = 0;
   const char *oauth_bearer = data->set.str[STRING_BEARER];
+  struct bufref serverdata;
 
+  Curl_bufref_init(&serverdata);
+  Curl_bufref_init(&resp);
   *progress = SASL_INPROGRESS;
 
   if(sasl->state == SASL_FINAL) {
@@ -509,50 +549,45 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     *progress = SASL_DONE;
     return result;
   case SASL_PLAIN:
-    result = Curl_auth_create_plain_message(data, conn->sasl_authzid,
-                                            conn->user, conn->passwd,
-                                            &resp, &len);
+    result = Curl_auth_create_plain_message(conn->sasl_authzid,
+                                            conn->user, conn->passwd, &resp);
     break;
   case SASL_LOGIN:
-    result = Curl_auth_create_login_message(data, conn->user, &resp, &len);
+    result = Curl_auth_create_login_message(conn->user, &resp);
     newstate = SASL_LOGIN_PASSWD;
     break;
   case SASL_LOGIN_PASSWD:
-    result = Curl_auth_create_login_message(data, conn->passwd, &resp, &len);
+    result = Curl_auth_create_login_message(conn->passwd, &resp);
     break;
   case SASL_EXTERNAL:
-    result = Curl_auth_create_external_message(data, conn->user, &resp, &len);
+    result = Curl_auth_create_external_message(conn->user, &resp);
     break;
 #ifndef CURL_DISABLE_CRYPTO_AUTH
 #ifdef USE_GSASL
   case SASL_GSASL:
-    sasl->params->getmessage(data->state.buffer, &serverdata);
-    result = Curl_auth_gsasl_token(data, serverdata, &conn->gsasl,
-                                   &resp, &len);
-    if(len > 0)
+    result = get_server_message(sasl, data, &serverdata);
+    if(!result)
+      result = Curl_auth_gsasl_token(data, &serverdata, &conn->gsasl, &resp);
+    if(!result && Curl_bufref_len(&resp) > 0)
       newstate = SASL_GSASL;
     break;
 #endif
   case SASL_CRAMMD5:
-    sasl->params->getmessage(data->state.buffer, &serverdata);
-    result = Curl_auth_decode_cram_md5_message(serverdata, &chlg, &chlglen);
+    result = get_server_message(sasl, data, &serverdata);
     if(!result)
-      result = Curl_auth_create_cram_md5_message(data, chlg, conn->user,
-                                                 conn->passwd, &resp, &len);
-    free(chlg);
+      result = Curl_auth_create_cram_md5_message(&serverdata, conn->user,
+                                                 conn->passwd, &resp);
     break;
   case SASL_DIGESTMD5:
-    sasl->params->getmessage(data->state.buffer, &serverdata);
-    result = Curl_auth_create_digest_md5_message(data, serverdata,
-                                                 conn->user, conn->passwd,
-                                                 service,
-                                                 &resp, &len);
+    result = get_server_message(sasl, data, &serverdata);
+    if(!result)
+      result = Curl_auth_create_digest_md5_message(data, &serverdata,
+                                                   conn->user, conn->passwd,
+                                                   service, &resp);
     newstate = SASL_DIGESTMD5_RESP;
     break;
   case SASL_DIGESTMD5_RESP:
-    resp = strdup("");
-    if(!resp)
-      result = CURLE_OUT_OF_MEMORY;
+    /* Keep response NULL to output an empty line. */
     break;
 #endif
 
@@ -562,18 +597,19 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     result = Curl_auth_create_ntlm_type1_message(data,
                                                  conn->user, conn->passwd,
                                                  service, hostname,
-                                                 &conn->ntlm, &resp, &len);
+                                                 &conn->ntlm, &resp);
     newstate = SASL_NTLM_TYPE2MSG;
     break;
   case SASL_NTLM_TYPE2MSG:
     /* Decode the type-2 message */
-    sasl->params->getmessage(data->state.buffer, &serverdata);
-    result = Curl_auth_decode_ntlm_type2_message(data, serverdata,
-                                                 &conn->ntlm);
+    result = get_server_message(sasl, data, &serverdata);
+    if(!result)
+      result = Curl_auth_decode_ntlm_type2_message(data, &serverdata,
+                                                   &conn->ntlm);
     if(!result)
       result = Curl_auth_create_ntlm_type3_message(data, conn->user,
                                                    conn->passwd, &conn->ntlm,
-                                                   &resp, &len);
+                                                   &resp);
     break;
 #endif
 
@@ -582,55 +618,59 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     result = Curl_auth_create_gssapi_user_message(data, conn->user,
                                                   conn->passwd,
                                                   service,
-                                                  data->conn->host.name,
+                                                  conn->host.name,
                                                   sasl->mutual_auth, NULL,
                                                   &conn->krb5,
-                                                  &resp, &len);
+                                                  &resp);
     newstate = SASL_GSSAPI_TOKEN;
     break;
   case SASL_GSSAPI_TOKEN:
-    sasl->params->getmessage(data->state.buffer, &serverdata);
-    if(sasl->mutual_auth) {
-      /* Decode the user token challenge and create the optional response
-         message */
-      result = Curl_auth_create_gssapi_user_message(data, NULL, NULL,
-                                                    NULL, NULL,
-                                                    sasl->mutual_auth,
-                                                    serverdata, &conn->krb5,
-                                                    &resp, &len);
-      newstate = SASL_GSSAPI_NO_DATA;
+    result = get_server_message(sasl, data, &serverdata);
+    if(!result) {
+      if(sasl->mutual_auth) {
+        /* Decode the user token challenge and create the optional response
+           message */
+        result = Curl_auth_create_gssapi_user_message(data, NULL, NULL,
+                                                      NULL, NULL,
+                                                      sasl->mutual_auth,
+                                                      &serverdata,
+                                                      &conn->krb5,
+                                                      &resp);
+        newstate = SASL_GSSAPI_NO_DATA;
+      }
+      else
+        /* Decode the security challenge and create the response message */
+        result = Curl_auth_create_gssapi_security_message(data, &serverdata,
+                                                          &conn->krb5,
+                                                          &resp);
     }
-    else
-      /* Decode the security challenge and create the response message */
-      result = Curl_auth_create_gssapi_security_message(data, serverdata,
-                                                        &conn->krb5,
-                                                        &resp, &len);
     break;
   case SASL_GSSAPI_NO_DATA:
-    sasl->params->getmessage(data->state.buffer, &serverdata);
     /* Decode the security challenge and create the response message */
-    result = Curl_auth_create_gssapi_security_message(data, serverdata,
-                                                      &conn->krb5,
-                                                      &resp, &len);
+    result = get_server_message(sasl, data, &serverdata);
+    if(!result)
+      result = Curl_auth_create_gssapi_security_message(data, &serverdata,
+                                                        &conn->krb5,
+                                                        &resp);
     break;
 #endif
 
   case SASL_OAUTH2:
     /* Create the authorisation message */
     if(sasl->authused == SASL_MECH_OAUTHBEARER) {
-      result = Curl_auth_create_oauth_bearer_message(data, conn->user,
+      result = Curl_auth_create_oauth_bearer_message(conn->user,
                                                      hostname,
                                                      port,
                                                      oauth_bearer,
-                                                     &resp, &len);
+                                                     &resp);
 
       /* Failures maybe sent by the server as continuations for OAUTHBEARER */
       newstate = SASL_OAUTH2_RESP;
     }
     else
-      result = Curl_auth_create_xoauth_bearer_message(data, conn->user,
+      result = Curl_auth_create_xoauth_bearer_message(conn->user,
                                                       oauth_bearer,
-                                                      &resp, &len);
+                                                      &resp);
     break;
 
   case SASL_OAUTH2_RESP:
@@ -642,11 +682,8 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
       return result;
     }
     else if(code == sasl->params->contcode) {
-      /* Acknowledge the continuation by sending a 0x01 response base64
-         encoded */
-      resp = strdup("AQ==");
-      if(!resp)
-        result = CURLE_OUT_OF_MEMORY;
+      /* Acknowledge the continuation by sending a 0x01 response. */
+      Curl_bufref_set(&resp, "\x01", 1, NULL);
       break;
     }
     else {
@@ -660,14 +697,14 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     sasl->authmechs ^= sasl->authused;
 
     /* Start an alternative SASL authentication */
-    result = Curl_sasl_start(sasl, data, conn, sasl->force_ir, progress);
-    newstate = sasl->state;   /* Use state from Curl_sasl_start() */
-    break;
+    return Curl_sasl_start(sasl, data, conn, sasl->force_ir, progress);
   default:
     failf(data, "Unsupported SASL authentication mechanism");
     result = CURLE_UNSUPPORTED_PROTOCOL;  /* Should not happen */
     break;
   }
+
+  Curl_bufref_free(&serverdata);
 
   switch(result) {
   case CURLE_BAD_CONTENT_ENCODING:
@@ -676,8 +713,10 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     newstate = SASL_CANCEL;
     break;
   case CURLE_OK:
-    if(resp)
-      result = sasl->params->sendcont(data, conn, resp);
+    result = build_message(data, &resp);
+    if(!result)
+      result = sasl->params->sendcont(data, conn,
+                                      (const char *) Curl_bufref_ptr(&resp));
     break;
   default:
     newstate = SASL_STOP;    /* Stop on error */
@@ -685,7 +724,7 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     break;
   }
 
-  free(resp);
+  Curl_bufref_free(&resp);
 
   state(sasl, data, newstate);
 

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -39,6 +39,7 @@
 #include "http_ntlm.h"
 #include "curl_ntlm_core.h"
 #include "curl_ntlm_wb.h"
+#include "curl_base64.h"
 #include "vauth/vauth.h"
 #include "url.h"
 
@@ -80,7 +81,18 @@ CURLcode Curl_input_ntlm(struct Curl_easy *data,
       header++;
 
     if(*header) {
-      result = Curl_auth_decode_ntlm_type2_message(data, header, ntlm);
+      unsigned char *hdr;
+      size_t hdrlen;
+
+      result = Curl_base64_decode(header, &hdr, &hdrlen);
+      if(!result) {
+        struct bufref hdrbuf;
+
+        Curl_bufref_init(&hdrbuf);
+        Curl_bufref_set(&hdrbuf, hdr, hdrlen, curl_free);
+        result = Curl_auth_decode_ntlm_type2_message(data, &hdrbuf, ntlm);
+        Curl_bufref_free(&hdrbuf);
+      }
       if(result)
         return result;
 
@@ -116,7 +128,8 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 {
   char *base64 = NULL;
   size_t len = 0;
-  CURLcode result;
+  CURLcode result = CURLE_OK;
+  struct bufref ntlmmsg;
 
   /* point to the address of the pointer that holds the string to send to the
      server, which is for a plain host or for a HTTP proxy */
@@ -184,50 +197,52 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 #endif
 #endif
 
+  Curl_bufref_init(&ntlmmsg);
   switch(*state) {
   case NTLMSTATE_TYPE1:
   default: /* for the weird cases we (re)start here */
     /* Create a type-1 message */
     result = Curl_auth_create_ntlm_type1_message(data, userp, passwdp,
                                                  service, hostname,
-                                                 ntlm, &base64,
-                                                 &len);
-    if(result)
-      return result;
-
-    if(base64) {
-      free(*allocuserpwd);
-      *allocuserpwd = aprintf("%sAuthorization: NTLM %s\r\n",
-                              proxy ? "Proxy-" : "",
-                              base64);
-      free(base64);
-      if(!*allocuserpwd)
-        return CURLE_OUT_OF_MEMORY;
-
-      DEBUG_OUT(fprintf(stderr, "**** Header %s\n ", *allocuserpwd));
+                                                 ntlm, &ntlmmsg);
+    if(!result) {
+      DEBUGASSERT(Curl_bufref_len(&ntlmmsg) != 0);
+      result = Curl_base64_encode(data,
+                                  (const char *) Curl_bufref_ptr(&ntlmmsg),
+                                  Curl_bufref_len(&ntlmmsg), &base64, &len);
+      if(!result) {
+        free(*allocuserpwd);
+        *allocuserpwd = aprintf("%sAuthorization: NTLM %s\r\n",
+                                proxy ? "Proxy-" : "",
+                                base64);
+        free(base64);
+        if(!*allocuserpwd)
+          result = CURLE_OUT_OF_MEMORY;
+      }
     }
     break;
 
   case NTLMSTATE_TYPE2:
     /* We already received the type-2 message, create a type-3 message */
     result = Curl_auth_create_ntlm_type3_message(data, userp, passwdp,
-                                                 ntlm, &base64, &len);
-    if(result)
-      return result;
-
-    if(base64) {
-      free(*allocuserpwd);
-      *allocuserpwd = aprintf("%sAuthorization: NTLM %s\r\n",
-                              proxy ? "Proxy-" : "",
-                              base64);
-      free(base64);
-      if(!*allocuserpwd)
-        return CURLE_OUT_OF_MEMORY;
-
-      DEBUG_OUT(fprintf(stderr, "**** %s\n ", *allocuserpwd));
-
-      *state = NTLMSTATE_TYPE3; /* we send a type-3 */
-      authp->done = TRUE;
+                                                 ntlm, &ntlmmsg);
+    if(!result && Curl_bufref_len(&ntlmmsg)) {
+      result = Curl_base64_encode(data,
+                                  (const char *) Curl_bufref_ptr(&ntlmmsg),
+                                  Curl_bufref_len(&ntlmmsg), &base64, &len);
+      if(!result) {
+        free(*allocuserpwd);
+        *allocuserpwd = aprintf("%sAuthorization: NTLM %s\r\n",
+                                proxy ? "Proxy-" : "",
+                                base64);
+        free(base64);
+        if(!*allocuserpwd)
+          result = CURLE_OUT_OF_MEMORY;
+        else {
+          *state = NTLMSTATE_TYPE3; /* we send a type-3 */
+          authp->done = TRUE;
+        }
+      }
     }
     break;
 
@@ -241,8 +256,9 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     authp->done = TRUE;
     break;
   }
+  Curl_bufref_free(&ntlmmsg);
 
-  return CURLE_OK;
+  return result;
 }
 
 void Curl_http_auth_cleanup_ntlm(struct connectdata *conn)

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -32,7 +32,6 @@
 #include "urldata.h"
 
 #include "vauth/vauth.h"
-#include "curl_base64.h"
 #include "curl_md5.h"
 #include "warnless.h"
 #include "strtok.h"
@@ -51,31 +50,24 @@
  *
  * Parameters:
  *
- * data    [in]     - The session handle.
  * authzid [in]     - The authorization identity.
  * authcid [in]     - The authentication identity.
  * passwd  [in]     - The password.
- * outptr  [in/out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen  [out]    - The length of the output message.
+ * out     [out]    - The result storage.
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
-                                        const char *authzid,
+CURLcode Curl_auth_create_plain_message(const char *authzid,
                                         const char *authcid,
                                         const char *passwd,
-                                        char **outptr, size_t *outlen)
+                                        struct bufref *out)
 {
-  CURLcode result;
   char *plainauth;
+  size_t plainlen;
   size_t zlen;
   size_t clen;
   size_t plen;
-  size_t plainlen;
 
-  *outlen = 0;
-  *outptr = NULL;
   zlen = (authzid == NULL ? 0 : strlen(authzid));
   clen = strlen(authcid);
   plen = strlen(passwd);
@@ -86,7 +78,7 @@ CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
   plainlen = zlen + clen + plen + 2;
 
-  plainauth = malloc(plainlen);
+  plainauth = malloc(plainlen + 1);
   if(!plainauth)
     return CURLE_OUT_OF_MEMORY;
 
@@ -97,12 +89,9 @@ CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
   memcpy(plainauth + zlen + 1, authcid, clen);
   plainauth[zlen + clen + 1] = '\0';
   memcpy(plainauth + zlen + clen + 2, passwd, plen);
-
-  /* Base64 encode the reply */
-  result = Curl_base64_encode(data, plainauth, plainlen, outptr, outlen);
-  free(plainauth);
-
-  return result;
+  plainauth[plainlen] = '\0';
+  Curl_bufref_set(out, plainauth, plainlen, curl_free);
+  return CURLE_OK;
 }
 
 /*
@@ -113,34 +102,15 @@ CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
  *
  * Parameters:
  *
- * data    [in]     - The session handle.
  * valuep  [in]     - The user name or user's password.
- * outptr  [in/out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen  [out]    - The length of the output message.
+ * out     [out]    - The result storage.
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_auth_create_login_message(struct Curl_easy *data,
-                                        const char *valuep, char **outptr,
-                                        size_t *outlen)
+CURLcode Curl_auth_create_login_message(const char *valuep, struct bufref *out)
 {
-  size_t vlen = strlen(valuep);
-
-  if(!vlen) {
-    /* Calculate an empty reply */
-    *outptr = strdup("=");
-    if(*outptr) {
-      *outlen = (size_t) 1;
-      return CURLE_OK;
-    }
-
-    *outlen = 0;
-    return CURLE_OUT_OF_MEMORY;
-  }
-
-  /* Base64 encode the value */
-  return Curl_base64_encode(data, valuep, vlen, outptr, outlen);
+  Curl_bufref_set(out, valuep, strlen(valuep), NULL);
+  return CURLE_OK;
 }
 
 /*
@@ -151,20 +121,16 @@ CURLcode Curl_auth_create_login_message(struct Curl_easy *data,
  *
  * Parameters:
  *
- * data    [in]     - The session handle.
  * user    [in]     - The user name.
- * outptr  [in/out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen  [out]    - The length of the output message.
+ * out     [out]    - The result storage.
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_auth_create_external_message(struct Curl_easy *data,
-                                           const char *user, char **outptr,
-                                           size_t *outlen)
+CURLcode Curl_auth_create_external_message(const char *user,
+                                           struct bufref *out)
 {
   /* This is the same formatting as the login message */
-  return Curl_auth_create_login_message(data, user, outptr, outlen);
+  return Curl_auth_create_login_message(user, out);
 }
 
 #endif /* if no users */

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2014 - 2016, Steve Holme, <steve_holme@hotmail.com>.
- * Copyright (C) 2015 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2015 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -32,7 +32,6 @@
 #include "vauth/vauth.h"
 #include "vauth/digest.h"
 #include "urldata.h"
-#include "curl_base64.h"
 #include "warnless.h"
 #include "curl_multibyte.h"
 #include "sendf.h"
@@ -79,28 +78,24 @@ bool Curl_auth_is_digest_supported(void)
  * Parameters:
  *
  * data    [in]     - The session handle.
- * chlg64  [in]     - The base64 encoded challenge message.
+ * chlg    [in]     - The challenge message.
  * userp   [in]     - The user name in the format User or Domain\User.
  * passwdp [in]     - The user's password.
  * service [in]     - The service type such as http, smtp, pop or imap.
- * outptr  [in/out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen  [out]    - The length of the output message.
+ * out     [out]    - The result storage.
  *
  * Returns CURLE_OK on success.
  */
 CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
-                                             const char *chlg64,
+                                             const struct bufref *chlg,
                                              const char *userp,
                                              const char *passwdp,
                                              const char *service,
-                                             char **outptr, size_t *outlen)
+                                             struct bufref *out)
 {
   CURLcode result = CURLE_OK;
   TCHAR *spn = NULL;
-  size_t chlglen = 0;
   size_t token_max = 0;
-  unsigned char *input_token = NULL;
   unsigned char *output_token = NULL;
   CredHandle credentials;
   CtxtHandle context;
@@ -115,17 +110,9 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   unsigned long attrs;
   TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
-  /* Decode the base-64 encoded challenge message */
-  if(strlen(chlg64) && *chlg64 != '=') {
-    result = Curl_base64_decode(chlg64, &input_token, &chlglen);
-    if(result)
-      return result;
-  }
-
   /* Ensure we have a valid challenge message */
-  if(!input_token) {
+  if(!Curl_bufref_len(chlg)) {
     infof(data, "DIGEST-MD5 handshake failure (empty challenge message)\n");
-
     return CURLE_BAD_CONTENT_ENCODING;
   }
 
@@ -133,8 +120,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   status = s_pSecFn->QuerySecurityPackageInfo((TCHAR *) TEXT(SP_NAME_DIGEST),
                                               &SecurityPackage);
   if(status != SEC_E_OK) {
-    free(input_token);
-
     failf(data, "SSPI: couldn't get auth info");
     return CURLE_AUTH_ERROR;
   }
@@ -146,18 +131,13 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 
   /* Allocate our response buffer */
   output_token = malloc(token_max);
-  if(!output_token) {
-    free(input_token);
-
+  if(!output_token)
     return CURLE_OUT_OF_MEMORY;
-  }
 
   /* Generate our SPN */
   spn = Curl_auth_build_spn(service, data->conn->host.name, NULL);
   if(!spn) {
     free(output_token);
-    free(input_token);
-
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -167,8 +147,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     if(result) {
       free(spn);
       free(output_token);
-      free(input_token);
-
       return result;
     }
 
@@ -190,8 +168,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     Curl_sspi_free_identity(p_identity);
     free(spn);
     free(output_token);
-    free(input_token);
-
     return CURLE_LOGIN_DENIED;
   }
 
@@ -200,8 +176,8 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   chlg_desc.cBuffers  = 1;
   chlg_desc.pBuffers  = &chlg_buf;
   chlg_buf.BufferType = SECBUFFER_TOKEN;
-  chlg_buf.pvBuffer   = input_token;
-  chlg_buf.cbBuffer   = curlx_uztoul(chlglen);
+  chlg_buf.pvBuffer   = (void *) Curl_bufref_ptr(chlg);
+  chlg_buf.cbBuffer   = curlx_uztoul(Curl_bufref_len(chlg));
 
   /* Setup the response "output" security buffer */
   resp_desc.ulVersion = SECBUFFER_VERSION;
@@ -227,7 +203,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     Curl_sspi_free_identity(p_identity);
     free(spn);
     free(output_token);
-    free(input_token);
 
     if(status == SEC_E_INSUFFICIENT_MEMORY)
       return CURLE_OUT_OF_MEMORY;
@@ -238,9 +213,8 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     return CURLE_AUTH_ERROR;
   }
 
-  /* Base64 encode the response */
-  result = Curl_base64_encode(data, (char *) output_token, resp_buf.cbBuffer,
-                              outptr, outlen);
+  /* Return the response. */
+  Curl_bufref_set(out, output_token, resp_buf.cbBuffer, curl_free);
 
   /* Free our handles */
   s_pSecFn->DeleteSecurityContext(&context);
@@ -251,12 +225,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 
   /* Free the SPN */
   free(spn);
-
-  /* Free the response buffer */
-  free(output_token);
-
-  /* Free the decoded challenge message */
-  free(input_token);
 
   return result;
 }

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -36,7 +36,6 @@
 #include "urldata.h"
 #include "non-ascii.h"
 #include "sendf.h"
-#include "curl_base64.h"
 #include "curl_ntlm_core.h"
 #include "curl_gethostname.h"
 #include "curl_multibyte.h"
@@ -157,31 +156,30 @@ static void ntlm_print_hex(FILE *handle, const char *buf, size_t len)
  * Parameters:
  *
  * data      [in]     - The session handle.
- * buffer    [in]     - The decoded type-2 message.
- * size      [in]     - The input buffer size, at least 32 bytes.
+ * type2ref  [in]     - The type-2 message.
  * ntlm      [in/out] - The NTLM data struct being used and modified.
  *
  * Returns CURLE_OK on success.
  */
 static CURLcode ntlm_decode_type2_target(struct Curl_easy *data,
-                                         unsigned char *buffer,
-                                         size_t size,
+                                         const struct bufref *type2ref,
                                          struct ntlmdata *ntlm)
 {
   unsigned short target_info_len = 0;
   unsigned int target_info_offset = 0;
+  const unsigned char *type2 = Curl_bufref_ptr(type2ref);
+  size_t type2len = Curl_bufref_len(type2ref);
 
 #if defined(CURL_DISABLE_VERBOSE_STRINGS)
   (void) data;
 #endif
 
-  if(size >= 48) {
-    target_info_len = Curl_read16_le(&buffer[40]);
-    target_info_offset = Curl_read32_le(&buffer[44]);
+  if(type2len >= 48) {
+    target_info_len = Curl_read16_le(&type2[40]);
+    target_info_offset = Curl_read32_le(&type2[44]);
     if(target_info_len > 0) {
-      if((target_info_offset >= size) ||
-         ((target_info_offset + target_info_len) > size) ||
-         (target_info_offset < 48)) {
+      if((target_info_offset + target_info_len) > type2len ||
+         target_info_offset < 48) {
         infof(data, "NTLM handshake failure (bad type-2 message). "
               "Target Info Offset Len is set incorrect by the peer\n");
         return CURLE_BAD_CONTENT_ENCODING;
@@ -192,7 +190,7 @@ static CURLcode ntlm_decode_type2_target(struct Curl_easy *data,
       if(!ntlm->target_info)
         return CURLE_OUT_OF_MEMORY;
 
-      memcpy(ntlm->target_info, &buffer[target_info_offset], target_info_len);
+      memcpy(ntlm->target_info, &type2[target_info_offset], target_info_len);
     }
   }
 
@@ -234,21 +232,20 @@ bool Curl_auth_is_ntlm_supported(void)
 /*
  * Curl_auth_decode_ntlm_type2_message()
  *
- * This is used to decode an already encoded NTLM type-2 message. The message
- * is first decoded from a base64 string into a raw NTLM message and checked
- * for validity before the appropriate data for creating a type-3 message is
- * written to the given NTLM data structure.
+ * This is used to decode an NTLM type-2 message. The raw NTLM message is
+ * checked * for validity before the appropriate data for creating a type-3
+ * message is * written to the given NTLM data structure.
  *
  * Parameters:
  *
  * data     [in]     - The session handle.
- * type2msg [in]     - The base64 encoded type-2 message.
+ * type2ref [in]     - The type-2 message.
  * ntlm     [in/out] - The NTLM data struct being used and modified.
  *
  * Returns CURLE_OK on success.
  */
 CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
-                                             const char *type2msg,
+                                             const struct bufref *type2ref,
                                              struct ntlmdata *ntlm)
 {
   static const char type2_marker[] = { 0x02, 0x00, 0x00, 0x00 };
@@ -270,8 +267,8 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   */
 
   CURLcode result = CURLE_OK;
-  unsigned char *type2 = NULL;
-  size_t type2_len = 0;
+  const unsigned char *type2 = Curl_bufref_ptr(type2ref);
+  size_t type2len = Curl_bufref_len(type2ref);
 
 #if defined(NTLM_NEEDS_NSS_INIT)
   /* Make sure the crypto backend is initialized */
@@ -282,26 +279,12 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   (void)data;
 #endif
 
-  /* Decode the base-64 encoded type-2 message */
-  if(strlen(type2msg) && *type2msg != '=') {
-    result = Curl_base64_decode(type2msg, &type2, &type2_len);
-    if(result)
-      return result;
-  }
-
-  /* Ensure we have a valid type-2 message */
-  if(!type2) {
-    infof(data, "NTLM handshake failure (empty type-2 message)\n");
-    return CURLE_BAD_CONTENT_ENCODING;
-  }
-
   ntlm->flags = 0;
 
-  if((type2_len < 32) ||
+  if((type2len < 32) ||
      (memcmp(type2, NTLMSSP_SIGNATURE, 8) != 0) ||
      (memcmp(type2 + 8, type2_marker, sizeof(type2_marker)) != 0)) {
     /* This was not a good enough type-2 message */
-    free(type2);
     infof(data, "NTLM handshake failure (bad type-2 message)\n");
     return CURLE_BAD_CONTENT_ENCODING;
   }
@@ -310,9 +293,8 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   memcpy(ntlm->nonce, &type2[24], 8);
 
   if(ntlm->flags & NTLMFLAG_NEGOTIATE_TARGET_INFO) {
-    result = ntlm_decode_type2_target(data, type2, type2_len, ntlm);
+    result = ntlm_decode_type2_target(data, type2ref, ntlm);
     if(result) {
-      free(type2);
       infof(data, "NTLM handshake failure (bad type-2 message)\n");
       return result;
     }
@@ -326,8 +308,6 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
     fprintf(stderr, "\n****\n");
     fprintf(stderr, "**** Header %s\n ", header);
   });
-
-  free(type2);
 
   return result;
 }
@@ -346,8 +326,8 @@ static void unicodecpy(unsigned char *dest, const char *src, size_t length)
 /*
  * Curl_auth_create_ntlm_type1_message()
  *
- * This is used to generate an already encoded NTLM type-1 message ready for
- * sending to the recipient using the appropriate compile time crypto API.
+ * This is used to generate an NTLM type-1 message ready for sending to the
+ * recipient using the appropriate compile time crypto API.
  *
  * Parameters:
  *
@@ -357,9 +337,7 @@ static void unicodecpy(unsigned char *dest, const char *src, size_t length)
  * service [in]     - The service type such as http, smtp, pop or imap.
  * host    [in]     - The host name.
  * ntlm    [in/out] - The NTLM data struct being used and modified.
- * outptr  [in/out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen  [out]    - The length of the output message.
+ * out     [out]    - The result storage.
  *
  * Returns CURLE_OK on success.
  */
@@ -369,7 +347,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                              const char *service,
                                              const char *hostname,
                                              struct ntlmdata *ntlm,
-                                             char **outptr, size_t *outlen)
+                                             struct bufref *out)
 {
   /* NTLM type-1 message structure:
 
@@ -387,7 +365,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 
   size_t size;
 
-  unsigned char ntlmbuf[NTLM_BUFSIZE];
+  char *ntlmbuf;
   const char *host = "";              /* empty */
   const char *domain = "";            /* empty */
   size_t hostlen = 0;
@@ -395,6 +373,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   size_t hostoff = 0;
   size_t domoff = hostoff + hostlen;  /* This is 0: remember that host and
                                          domain are empty */
+  (void)data;
   (void)userp;
   (void)passwdp;
   (void)service,
@@ -409,38 +388,40 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 #else
 #define NTLM2FLAG 0
 #endif
-  msnprintf((char *)ntlmbuf, NTLM_BUFSIZE,
-            NTLMSSP_SIGNATURE "%c"
-            "\x01%c%c%c" /* 32-bit type = 1 */
-            "%c%c%c%c"   /* 32-bit NTLM flag field */
-            "%c%c"       /* domain length */
-            "%c%c"       /* domain allocated space */
-            "%c%c"       /* domain name offset */
-            "%c%c"       /* 2 zeroes */
-            "%c%c"       /* host length */
-            "%c%c"       /* host allocated space */
-            "%c%c"       /* host name offset */
-            "%c%c"       /* 2 zeroes */
-            "%s"         /* host name */
-            "%s",        /* domain string */
-            0,           /* trailing zero */
-            0, 0, 0,     /* part of type-1 long */
+  ntlmbuf = aprintf(NTLMSSP_SIGNATURE "%c"
+                    "\x01%c%c%c" /* 32-bit type = 1 */
+                    "%c%c%c%c"   /* 32-bit NTLM flag field */
+                    "%c%c"       /* domain length */
+                    "%c%c"       /* domain allocated space */
+                    "%c%c"       /* domain name offset */
+                    "%c%c"       /* 2 zeroes */
+                    "%c%c"       /* host length */
+                    "%c%c"       /* host allocated space */
+                    "%c%c"       /* host name offset */
+                    "%c%c"       /* 2 zeroes */
+                    "%s"         /* host name */
+                    "%s",        /* domain string */
+                    0,           /* trailing zero */
+                    0, 0, 0,     /* part of type-1 long */
 
-            LONGQUARTET(NTLMFLAG_NEGOTIATE_OEM |
-                        NTLMFLAG_REQUEST_TARGET |
-                        NTLMFLAG_NEGOTIATE_NTLM_KEY |
-                        NTLM2FLAG |
-                        NTLMFLAG_NEGOTIATE_ALWAYS_SIGN),
-            SHORTPAIR(domlen),
-            SHORTPAIR(domlen),
-            SHORTPAIR(domoff),
-            0, 0,
-            SHORTPAIR(hostlen),
-            SHORTPAIR(hostlen),
-            SHORTPAIR(hostoff),
-            0, 0,
-            host,  /* this is empty */
-            domain /* this is empty */);
+                    LONGQUARTET(NTLMFLAG_NEGOTIATE_OEM |
+                                NTLMFLAG_REQUEST_TARGET |
+                                NTLMFLAG_NEGOTIATE_NTLM_KEY |
+                                NTLM2FLAG |
+                                NTLMFLAG_NEGOTIATE_ALWAYS_SIGN),
+                    SHORTPAIR(domlen),
+                    SHORTPAIR(domlen),
+                    SHORTPAIR(domoff),
+                    0, 0,
+                    SHORTPAIR(hostlen),
+                    SHORTPAIR(hostlen),
+                    SHORTPAIR(hostoff),
+                    0, 0,
+                    host,  /* this is empty */
+                    domain /* this is empty */);
+
+  if(!ntlmbuf)
+    return CURLE_OUT_OF_MEMORY;
 
   /* Initial packet length */
   size = 32 + hostlen + domlen;
@@ -467,8 +448,8 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
     fprintf(stderr, "\n****\n");
   });
 
-  /* Return with binary blob encoded into base64 */
-  return Curl_base64_encode(data, (char *)ntlmbuf, size, outptr, outlen);
+  Curl_bufref_set(out, ntlmbuf, size, curl_free);
+  return CURLE_OK;
 }
 
 /*
@@ -483,9 +464,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
  * userp   [in]     - The user name in the format User or Domain\User.
  * passwdp [in]     - The user's password.
  * ntlm    [in/out] - The NTLM data struct being used and modified.
- * outptr  [in/out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen  [out]    - The length of the output message.
+ * out     [out]    - The result storage.
  *
  * Returns CURLE_OK on success.
  */
@@ -493,7 +472,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *userp,
                                              const char *passwdp,
                                              struct ntlmdata *ntlm,
-                                             char **outptr, size_t *outlen)
+                                             struct bufref *out)
 {
   /* NTLM type-3 message structure:
 
@@ -847,8 +826,8 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   if(result)
     return CURLE_CONV_FAILED;
 
-  /* Return with binary blob encoded into base64 */
-  result = Curl_base64_encode(data, (char *)ntlmbuf, size, outptr, outlen);
+  /* Return the binary blob. */
+  result = Curl_bufref_memdup(out, ntlmbuf, size);
 
   Curl_auth_cleanup_ntlm(ntlm);
 

--- a/lib/vauth/oauth2.c
+++ b/lib/vauth/oauth2.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,7 +31,6 @@
 #include "urldata.h"
 
 #include "vauth/vauth.h"
-#include "curl_base64.h"
 #include "warnless.h"
 #include "curl_printf.h"
 
@@ -42,31 +41,26 @@
 /*
  * Curl_auth_create_oauth_bearer_message()
  *
- * This is used to generate an already encoded OAuth 2.0 message ready for
- * sending to the recipient.
+ * This is used to generate an OAuth 2.0 message ready for sending to the
+ * recipient.
  *
  * Parameters:
  *
- * data[in]         - The session handle.
  * user[in]         - The user name.
  * host[in]         - The host name.
  * port[in]         - The port(when not Port 80).
  * bearer[in]       - The bearer token.
- * outptr[in / out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen[out]      - The length of the output message.
+ * out[out]         - The result storage.
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_auth_create_oauth_bearer_message(struct Curl_easy *data,
-                                               const char *user,
+CURLcode Curl_auth_create_oauth_bearer_message(const char *user,
                                                const char *host,
                                                const long port,
                                                const char *bearer,
-                                               char **outptr, size_t *outlen)
+                                               struct bufref *out)
 {
-  CURLcode result = CURLE_OK;
-  char *oauth = NULL;
+  char *oauth;
 
   /* Generate the message */
   if(port == 0 || port == 80)
@@ -78,49 +72,34 @@ CURLcode Curl_auth_create_oauth_bearer_message(struct Curl_easy *data,
   if(!oauth)
     return CURLE_OUT_OF_MEMORY;
 
-  /* Base64 encode the reply */
-  result = Curl_base64_encode(data, oauth, strlen(oauth), outptr, outlen);
-
-  free(oauth);
-
-  return result;
+  Curl_bufref_set(out, oauth, strlen(oauth), curl_free);
+  return CURLE_OK;
 }
 
 /*
  * Curl_auth_create_xoauth_bearer_message()
  *
- * This is used to generate an already encoded XOAuth 2.0 message ready for
- * sending to the recipient.
+ * This is used to generate a XOAuth 2.0 message ready for * sending to the
+ * recipient.
  *
  * Parameters:
  *
- * data[in]         - The session handle.
  * user[in]         - The user name.
  * bearer[in]       - The bearer token.
- * outptr[in / out] - The address where a pointer to newly allocated memory
- *                    holding the result will be stored upon completion.
- * outlen[out]      - The length of the output message.
+ * out[out]         - The result storage.
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_auth_create_xoauth_bearer_message(struct Curl_easy *data,
-                                               const char *user,
+CURLcode Curl_auth_create_xoauth_bearer_message(const char *user,
                                                const char *bearer,
-                                               char **outptr, size_t *outlen)
+                                               struct bufref *out)
 {
-  CURLcode result = CURLE_OK;
-
   /* Generate the message */
   char *xoauth = aprintf("user=%s\1auth=Bearer %s\1\1", user, bearer);
   if(!xoauth)
     return CURLE_OUT_OF_MEMORY;
 
-  /* Base64 encode the reply */
-  result = Curl_base64_encode(data, xoauth, strlen(xoauth), outptr, outlen);
-
-  free(xoauth);
-
-  return result;
+  Curl_bufref_set(out, xoauth, strlen(xoauth), curl_free);
+  return CURLE_OK;
 }
 #endif /* disabled, no users */
-

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -24,6 +24,8 @@
 
 #include <curl/curl.h>
 
+#include "bufref.h"
+
 struct Curl_easy;
 
 #if !defined(CURL_DISABLE_CRYPTO_AUTH)
@@ -62,45 +64,37 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
 /* This is used to test if the user contains a Windows domain name */
 bool Curl_auth_user_contains_domain(const char *user);
 
-/* This is used to generate a base64 encoded PLAIN cleartext message */
-CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
-                                        const char *authzid,
+/* This is used to generate a PLAIN cleartext message */
+CURLcode Curl_auth_create_plain_message(const char *authzid,
                                         const char *authcid,
                                         const char *passwd,
-                                        char **outptr, size_t *outlen);
+                                        struct bufref *out);
 
-/* This is used to generate a base64 encoded LOGIN cleartext message */
-CURLcode Curl_auth_create_login_message(struct Curl_easy *data,
-                                        const char *valuep, char **outptr,
-                                        size_t *outlen);
+/* This is used to generate a LOGIN cleartext message */
+CURLcode Curl_auth_create_login_message(const char *value,
+                                        struct bufref *out);
 
-/* This is used to generate a base64 encoded EXTERNAL cleartext message */
-CURLcode Curl_auth_create_external_message(struct Curl_easy *data,
-                                           const char *user, char **outptr,
-                                           size_t *outlen);
+/* This is used to generate an EXTERNAL cleartext message */
+CURLcode Curl_auth_create_external_message(const char *user,
+                                           struct bufref *out);
 
 #if !defined(CURL_DISABLE_CRYPTO_AUTH)
-/* This is used to decode a CRAM-MD5 challenge message */
-CURLcode Curl_auth_decode_cram_md5_message(const char *chlg64, char **outptr,
-                                           size_t *outlen);
-
 /* This is used to generate a CRAM-MD5 response message */
-CURLcode Curl_auth_create_cram_md5_message(struct Curl_easy *data,
-                                           const char *chlg,
+CURLcode Curl_auth_create_cram_md5_message(const struct bufref *chlg,
                                            const char *userp,
                                            const char *passwdp,
-                                           char **outptr, size_t *outlen);
+                                           struct bufref *out);
 
 /* This is used to evaluate if DIGEST is supported */
 bool Curl_auth_is_digest_supported(void);
 
 /* This is used to generate a base64 encoded DIGEST-MD5 response message */
 CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
-                                             const char *chlg64,
+                                             const struct bufref *chlg,
                                              const char *userp,
                                              const char *passwdp,
                                              const char *service,
-                                             char **outptr, size_t *outlen);
+                                             struct bufref *out);
 
 /* This is used to decode a HTTP DIGEST challenge message */
 CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
@@ -132,9 +126,9 @@ CURLcode Curl_auth_gsasl_start(struct Curl_easy *data,
 
 /* This is used to process and generate a new SASL token */
 CURLcode Curl_auth_gsasl_token(struct Curl_easy *data,
-                               const char *chlg64,
+                               const struct bufref *chlg,
                                struct gsasldata *gsasl,
-                               char **outptr, size_t *outlen);
+                               struct bufref *out);
 
 /* This is used to clean up the gsasl specific data */
 void Curl_auth_gsasl_cleanup(struct gsasldata *digest);
@@ -151,12 +145,11 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                              const char *service,
                                              const char *host,
                                              struct ntlmdata *ntlm,
-                                             char **outptr,
-                                             size_t *outlen);
+                                             struct bufref *out);
 
 /* This is used to decode a base64 encoded NTLM type-2 message */
 CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
-                                             const char *type2msg,
+                                             const struct bufref *type2,
                                              struct ntlmdata *ntlm);
 
 /* This is used to generate a base64 encoded NTLM type-3 message */
@@ -164,25 +157,23 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *userp,
                                              const char *passwdp,
                                              struct ntlmdata *ntlm,
-                                             char **outptr, size_t *outlen);
+                                             struct bufref *out);
 
 /* This is used to clean up the NTLM specific data */
 void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm);
 #endif /* USE_NTLM */
 
 /* This is used to generate a base64 encoded OAuth 2.0 message */
-CURLcode Curl_auth_create_oauth_bearer_message(struct Curl_easy *data,
-                                               const char *user,
+CURLcode Curl_auth_create_oauth_bearer_message(const char *user,
                                                const char *host,
                                                const long port,
                                                const char *bearer,
-                                               char **outptr, size_t *outlen);
+                                               struct bufref *out);
 
 /* This is used to generate a base64 encoded XOAuth 2.0 message */
-CURLcode Curl_auth_create_xoauth_bearer_message(struct Curl_easy *data,
-                                                const char *user,
+CURLcode Curl_auth_create_xoauth_bearer_message(const char *user,
                                                 const char *bearer,
-                                                char **outptr, size_t *outlen);
+                                                struct bufref *out);
 
 #if defined(USE_KERBEROS5)
 /* This is used to evaluate if GSSAPI (Kerberos V5) is supported */
@@ -196,17 +187,16 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
                                               const char *service,
                                               const char *host,
                                               const bool mutual,
-                                              const char *chlg64,
+                                              const struct bufref *chlg,
                                               struct kerberos5data *krb5,
-                                              char **outptr, size_t *outlen);
+                                              struct bufref *out);
 
 /* This is used to generate a base64 encoded GSSAPI (Kerberos V5) security
    token message */
 CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
-                                                  const char *input,
+                                                  const struct bufref *chlg,
                                                   struct kerberos5data *krb5,
-                                                  char **outptr,
-                                                  size_t *outlen);
+                                                  struct bufref *out);
 
 /* This is used to clean up the GSSAPI specific data */
 void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -203,7 +203,7 @@ test1620 test1621 \
 test1630 test1631 test1632 test1633 test1634 \
 \
 test1650 test1651 test1652 test1653 test1654 test1655 \
-test1660 \
+test1660 test1661 \
 \
 test1700 test1701 test1702 test1703 \
 \

--- a/tests/data/test1661
+++ b/tests/data/test1661
@@ -1,0 +1,22 @@
+<testcase>
+<info>
+<keywords>
+unittest
+bufref
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+bufref unit tests
+ </name>
+</client>
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -35,7 +35,7 @@ UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307 \
  unit1608 unit1609 unit1610 unit1611 unit1612 \
  unit1620 unit1621 \
  unit1650 unit1651 unit1652 unit1653 unit1654 unit1655 \
- unit1660
+ unit1660 unit1661
 
 unit1300_SOURCES = unit1300.c $(UNITFILES)
 unit1300_CPPFLAGS = $(AM_CPPFLAGS)
@@ -157,3 +157,6 @@ unit1655_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1660_SOURCES = unit1660.c $(UNITFILES)
 unit1660_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1661_SOURCES = unit1661.c $(UNITFILES)
+unit1661_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1661.c
+++ b/tests/unit/unit1661.c
@@ -1,0 +1,113 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include "bufref.h"
+
+static struct bufref bufref;
+
+static int freecount = 0;
+
+static void test_free(void *p)
+{
+  fail_unless(p, "pointer to free may not be NULL");
+  freecount++;
+  free(p);
+}
+
+static CURLcode unit_setup(void)
+{
+  Curl_bufref_init(&bufref);
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+}
+
+UNITTEST_START
+{
+  char *buffer = NULL;
+  CURLcode result = CURLE_OK;
+
+  /**
+   * testing Curl_bufref_init.
+   * @assumptions:
+   * 1: data size will be 0
+   * 2: reference will be NULL
+   * 3: destructor will be NULL
+   */
+
+  fail_unless(!bufref.ptr, "Initial reference must be NULL");
+  fail_unless(!bufref.len, "Initial length must be NULL");
+  fail_unless(!bufref.dtor, "Destructor must be NULL");
+
+  /**
+   * testing Curl_bufref_set
+   */
+
+  buffer = malloc(13);
+  abort_unless(buffer, "Out of memory");
+  Curl_bufref_set(&bufref, buffer, 13, test_free);
+
+  fail_unless((char *) bufref.ptr == buffer, "Referenced data badly set");
+  fail_unless(bufref.len == 13, "Data size badly set");
+  fail_unless(bufref.dtor == test_free, "Destructor badly set");
+
+  /**
+   * testing Curl_bufref_ptr
+   */
+
+  fail_unless((char *) Curl_bufref_ptr(&bufref) == buffer,
+              "Wrong pointer value returned");
+
+  /**
+   * testing Curl_bufref_len
+   */
+
+  fail_unless(Curl_bufref_len(&bufref) == 13, "Wrong data size returned");
+
+  /**
+   * testing Curl_bufref_memdup
+   */
+
+  result = Curl_bufref_memdup(&bufref, "1661", 3);
+  abort_unless(result == CURLE_OK, curl_easy_strerror(result));
+  fail_unless(freecount == 1, "Destructor not called");
+  fail_unless((char *) bufref.ptr != buffer, "Returned pointer not set");
+  buffer = (char *) Curl_bufref_ptr(&bufref);
+  fail_unless(buffer, "Allocated pointer is NULL");
+  fail_unless(bufref.len == 3, "Wrong data size stored");
+  fail_unless(!buffer[3], "Duplicated data should have been truncated");
+  fail_unless(!strcmp(buffer, "166"), "Bad duplicated data");
+
+  /**
+   * testing Curl_bufref_free
+   */
+
+  Curl_bufref_free(&bufref);
+  fail_unless(freecount == 1, "Wrong destructor called");
+  fail_unless(!bufref.ptr, "Initial reference must be NULL");
+  fail_unless(!bufref.len, "Initial length must be NULL");
+  fail_unless(!bufref.dtor, "Destructor must be NULL");
+}
+UNITTEST_STOP


### PR DESCRIPTION
Input challenges and returned messages are now in binary.
Conversions from/to base64 are performed by callers (currently curl_sasl.c
and http_ntlm.c).

Binary data control structure authbuffer is introduced with associated
handling primitives. This supports any kind of memory storage, whatever
is the allocation scheme.

This is a first step towards the implementation of binary sasl that will allow full authentication features in openldap.