### PR TITLE
doh: Inherit CURLOPT_STDERR from user's easy handle

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -285,6 +285,8 @@ static CURLcode dohprobe(struct Curl_easy *data,
 #endif
     ERROR_CHECK_SETOPT(CURLOPT_TIMEOUT_MS, (long)timeout_ms);
     ERROR_CHECK_SETOPT(CURLOPT_SHARE, data->share);
+    if(data->set.err && data->set.err != stderr)
+      ERROR_CHECK_SETOPT(CURLOPT_STDERR, data->set.err);
     if(data->set.verbose)
       ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, 1L);
     if(data->set.no_signal)


### PR DESCRIPTION
Prior to this change if the user set their easy handle's error stream
to something other than stderr it was not inherited by the doh handles,
which meant that they would still write to the default standard error
stream (stderr) for verbose output.

Bug: https://github.com/curl/curl/issues/6605
Reported-by: arvids-kokins-bidstack@users.noreply.github.com

Closes #xxxx