### PR TITLE
curl: set CURLOPT_NEW_FILE_PERMS if requested

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2001,6 +2001,9 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->ftp_pret)
           my_setopt(curl, CURLOPT_FTP_USE_PRET, 1L);
 
+        if(config->create_file_mode)
+          my_setopt(curl, CURLOPT_NEW_FILE_PERMS, config->create_file_mode);
+
         if(config->proto_present)
           my_setopt_flags(curl, CURLOPT_PROTOCOLS, config->proto);
         if(config->proto_redir_present)


### PR DESCRIPTION
The --create-file-mode code logic accepted the value but never actually
passed it on to libcurl!

Follow-up to a7696c73436f (shipped in 7.75.0)
Reported-by: Johannes Lesr
Fixes #6657