### PR TITLE
ldap: use correct memory free function

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -875,7 +875,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
     ludp->lud_dn = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    curlx_unicodefree(unescaped);
+    free(unescaped);
 
     if(!ludp->lud_dn) {
       rc = LDAP_NO_MEMORY;
@@ -943,7 +943,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
       ludp->lud_attrs[i] = curlx_convert_UTF8_to_tchar(unescaped);
 
       /* Free the unescaped string as we are done with it */
-      curlx_unicodefree(unescaped);
+      free(unescaped);
 
       if(!ludp->lud_attrs[i]) {
         free(attributes);
@@ -1010,7 +1010,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
     ludp->lud_filter = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    curlx_unicodefree(unescaped);
+    free(unescaped);
 
     if(!ludp->lud_filter) {
       rc = LDAP_NO_MEMORY;


### PR DESCRIPTION
`unescaped` is coming from `Curl_urldecode` and not a unicode conversion function, so reclaiming its memory should be performed with a normal call to `free` rather than `curlx_unicodefree`.  In reality, this is the same thing as `curlx_unicodefree` is implemented as a call to `free` but that's not guaranteed to always hold (and is less readable in this case IMO).