### PR TITLE
tool_help: Increase space between option and description

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -889,7 +889,7 @@ static void print_category(curlhelp_t category)
   unsigned int i;
   for(i = 0; helptext[i].opt; ++i)
     if(helptext[i].categories & category) {
-      printf(" %-19s %s\n", helptext[i].opt, helptext[i].desc);
+      printf(" %-18s  %s\n", helptext[i].opt, helptext[i].desc);
     }
 }
 

--- a/tests/data/test1461
+++ b/tests/data/test1461
@@ -34,14 +34,14 @@ curl important --help
 Usage: curl [options...] <url>
  -d, --data <data>   HTTP POST data
  -f, --fail          Fail silently (no output at all) on HTTP errors
- -h, --help <category> Get help for commands
+ -h, --help <category>  Get help for commands
  -i, --include       Include protocol response headers in the output
- -o, --output <file> Write to file instead of stdout
+ -o, --output <file>  Write to file instead of stdout
  -O, --remote-name   Write output to a file named as the remote file
  -s, --silent        Silent mode
- -T, --upload-file <file> Transfer local FILE to destination
- -u, --user <user:password> Server user and password
- -A, --user-agent <name> Send User-Agent <name> to server
+ -T, --upload-file <file>  Transfer local FILE to destination
+ -u, --user <user:password>  Server user and password
+ -A, --user-agent <name>  Send User-Agent <name> to server
  -v, --verbose       Make the operation more talkative
  -V, --version       Show version number and quit
 

--- a/tests/data/test1463
+++ b/tests/data/test1463
@@ -37,9 +37,9 @@ curl file category --help
 <stdout mode="text">
 Usage: curl [options...] <url>
 file: FILE protocol options
-     --create-file-mode <mode> File mode (octal) for created files
+     --create-file-mode <mode>  File mode (octal) for created files
  -I, --head          Show document info only
- -r, --range <range> Retrieve only the bytes within RANGE
+ -r, --range <range>  Retrieve only the bytes within RANGE
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test1464
+++ b/tests/data/test1464
@@ -37,9 +37,9 @@ curl file category --help with lower/upper mix
 <stdout mode="text">
 Usage: curl [options...] <url>
 file: FILE protocol options
-     --create-file-mode <mode> File mode (octal) for created files
+     --create-file-mode <mode>  File mode (octal) for created files
  -I, --head          Show document info only
- -r, --range <range> Retrieve only the bytes within RANGE
+ -r, --range <range>  Retrieve only the bytes within RANGE
 </stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
- Increase the minimum number of spaces between the option and the
  description from 1 to 2.

Before:
~~~
 -u, --user <user:password> Server user and password
 -A, --user-agent <name> Send User-Agent <name> to server
 -v, --verbose       Make the operation more talkative
 -V, --version       Show version number and quit
 -w, --write-out <format> Use output FORMAT after completion
     --xattr         Store metadata in extended file attributes
~~~

After:
~~~
 -u, --user <user:password>  Server user and password
 -A, --user-agent <name>  Send User-Agent <name> to server
 -v, --verbose       Make the operation more talkative
 -V, --version       Show version number and quit
 -w, --write-out <format>  Use output FORMAT after completion
     --xattr         Store metadata in extended file attributes
~~~

Closes #xxxx