### PR TITLE
http2: add option CURLMOPT_STREAM_WINDOW_SIZE to set stream window size

### DIFF
--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -395,6 +395,9 @@ typedef enum {
   /* maximum number of concurrent streams to support on a connection */
   CURLOPT(CURLMOPT_MAX_CONCURRENT_STREAMS, CURLOPTTYPE_LONG, 16),
 
+  /* stream window size (default 32M) */
+  CURLOPT(CURLMOPT_STREAM_WINDOW_SIZE, CURLOPTTYPE_LONG, 17),
+
   CURLMOPT_LASTENTRY /* the last unused */
 } CURLMoption;
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -56,7 +56,7 @@
 #define NGHTTP2_HAS_SET_LOCAL_WINDOW_SIZE 1
 #endif
 
-#define HTTP2_HUGE_WINDOW_SIZE (32 * 1024 * 1024) /* 32 MB */
+#define HTTP2_CONNECTION_WINDOW_SIZE (32 * 1024 * 1024) /* 32 MB */
 
 #ifdef DEBUG_HTTP2
 #define H2BUGF(x) x
@@ -1172,7 +1172,7 @@ static void populate_settings(struct Curl_easy *data,
   iv[0].value = Curl_multi_max_concurrent_streams(data->multi);
 
   iv[1].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
-  iv[1].value = HTTP2_HUGE_WINDOW_SIZE;
+  iv[1].value = conn->data->multi->stream_window_size;
 
   iv[2].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;
   iv[2].value = data->multi->push_cb != NULL;
@@ -2279,7 +2279,7 @@ CURLcode Curl_http2_switched(struct Curl_easy *data,
   }
 
   rv = nghttp2_session_set_local_window_size(httpc->h2, NGHTTP2_FLAG_NONE, 0,
-                                             HTTP2_HUGE_WINDOW_SIZE);
+                                             HTTP2_CONNECTION_WINDOW_SIZE);
   if(rv != 0) {
     failf(data, "nghttp2_session_set_local_window_size() failed: %s(%d)",
           nghttp2_strerror(rv), rv);
@@ -2325,7 +2325,7 @@ CURLcode Curl_http2_stream_pause(struct Curl_easy *data, bool pause)
   else {
     struct HTTP *stream = data->req.p.http;
     struct http_conn *httpc = &data->conn->proto.httpc;
-    uint32_t window = !pause * HTTP2_HUGE_WINDOW_SIZE;
+    uint32_t window = !pause * data->multi->stream_window_size;
     int rv = nghttp2_session_set_local_window_size(httpc->h2,
                                                    NGHTTP2_FLAG_NONE,
                                                    stream->stream_id,

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -379,6 +379,7 @@ struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
   /* -1 means it not set by user, use the default value */
   multi->maxconnects = -1;
   multi->max_concurrent_streams = 100;
+  multi->stream_window_size = 32 * 1024 * 1024; /* 32 MB */
   multi->ipv6_works = Curl_ipv6works(NULL);
 
 #ifdef ENABLE_WAKEUP
@@ -2941,6 +2942,16 @@ CURLMcode curl_multi_setopt(struct Curl_multi *multi,
       if(streams < 1)
         streams = 100;
       multi->max_concurrent_streams = curlx_sltoui(streams);
+    }
+    break;
+  case CURLMOPT_STREAM_WINDOW_SIZE:
+    {
+      long stream_window_size = va_arg(param, long);
+      if((stream_window_size > 0) &&
+         ((unsigned long)stream_window_size <= ((1UL << 31) - 1)))
+        multi->stream_window_size = stream_window_size;
+      else
+        return CURLM_BAD_FUNCTION_ARGUMENT;
     }
     break;
   default:

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -139,6 +139,7 @@ struct Curl_multi {
   struct curltime timer_lastcall; /* the fixed time for the timeout for the
                                     previous callback */
   unsigned int max_concurrent_streams;
+  long stream_window_size;
 
 #ifdef ENABLE_WAKEUP
   curl_socket_t wakeup_pair[2]; /* socketpair() used for wakeup


### PR DESCRIPTION
When pausing a stream the data is still transferred and uses CPU time. On low-end CPUs this can consume a lot of CPU and time until the 32MB buffer is filled. Add an option the set the stream window size. Default is still 32MB.
If there is a change that this PR will be merged, I am also willing to update the docs.
This is the option that was saved for another day in Issue #4939.


