### PR TITLE
dynbuf: bump the max HTTP request to 1MB

### DIFF
--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2020, 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -74,7 +74,7 @@ int Curl_dyn_vprintf(struct dynbuf *dyn, const char *format, va_list ap_save);
 #define DYN_DOH_CNAME       256
 #define DYN_PAUSE_BUFFER    (64 * 1024 * 1024)
 #define DYN_HAXPROXY        2048
-#define DYN_HTTP_REQUEST    (128*1024)
+#define DYN_HTTP_REQUEST    (1024*1024)
 #define DYN_H2_HEADERS      (128*1024)
 #define DYN_H2_TRAILERS     (128*1024)
 #define DYN_APRINTF         8000000


### PR DESCRIPTION
Reported-by: Carl Zogheib
Fixes #6681