### PR TITLE
docs: Explain DOH transfers inherit some SSL settings

### DIFF
--- a/docs/cmdline-opts/doh-url.d
+++ b/docs/cmdline-opts/doh-url.d
@@ -8,4 +8,9 @@ Category: dns
 Specifies which DNS-over-HTTPS (DOH) server to use to resolve hostnames,
 instead of using the default name resolver mechanism. The URL must be HTTPS.
 
+Some SSL options that you set for your transfer will apply to DOH since the
+name lookups take place over SSL. However, the certificate verification
+settings are not inherited and can be controlled separately via
+--doh-insecure and --doh-cert-status.
+
 If this option is used several times, the last one will be used.

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -44,6 +44,15 @@ will use the default name lookup function. You can bootstrap that by providing
 the address for the DOH server with \fICURLOPT_RESOLVE(3)\fP.
 
 Disable DOH use again by setting this option to NULL.
+
+\fBAdvanced:\fP The DOH lookups use SSL so some SSL settings from your transfer
+are inherited. The hostname and peer certificate verification settings are not
+inherited and can be controlled separately via
+\fICURLOPT_DOH_SSL_VERIFYHOST(3)\fP and \fICURLOPT_DOH_SSL_VERIFYPEER(3)\fP.
+Note \fICURLOPT_SSL_CTX_FUNCTION(3)\fP is inherited, so if you are doing custom
+advanced verification for your transfer then you may need to distinguish it
+from the DOH transfers in your CTX callback.
+
 .SH DEFAULT
 NULL - there is no default DOH URL. If this option isn't set, libcurl will use
 the default name resolver.

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -49,10 +49,7 @@ Disable DOH use again by setting this option to NULL.
 are inherited. The hostname and peer certificate verification settings are not
 inherited and can be controlled separately via
 \fICURLOPT_DOH_SSL_VERIFYHOST(3)\fP and \fICURLOPT_DOH_SSL_VERIFYPEER(3)\fP.
-Note \fICURLOPT_SSL_CTX_FUNCTION(3)\fP is inherited, so if you are doing custom
-advanced verification for your transfer then you may need to distinguish it
-from the DOH transfers in your CTX callback.
-
+Note \fICURLOPT_SSL_CTX_FUNCTION(3)\fP is inherited.
 .SH DEFAULT
 NULL - there is no default DOH URL. If this option isn't set, libcurl will use
 the default name resolver.

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -62,6 +62,11 @@ to reach in and modify SSL details in the connection without libcurl itself
 knowing anything about it, which then subsequently can lead to libcurl
 unknowingly reusing SSL connections with different properties. To remedy this
 you may set \fICURLOPT_FORBID_REUSE(3)\fP from the callback function.
+
+WARNING: The callback is also called for each internal DNS-over-HTTPS (DOH)
+easy handle created for a DNS lookup, if you turned on DOH via
+\fICURLOPT_DOH_URL(3)\fP. You may compare the passed in handle to determine
+whether it's the handle for your transfer.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -63,10 +63,13 @@ knowing anything about it, which then subsequently can lead to libcurl
 unknowingly reusing SSL connections with different properties. To remedy this
 you may set \fICURLOPT_FORBID_REUSE(3)\fP from the callback function.
 
-WARNING: The callback is also called for each internal DNS-over-HTTPS (DOH)
-easy handle created for a DNS lookup, if you turned on DOH via
-\fICURLOPT_DOH_URL(3)\fP. You may compare the passed in handle to determine
-whether it's the handle for your transfer.
+WARNING: If you are using DNS-over-HTTPS (DOH) via \fICURLOPT_DOH_URL(3)\fP
+then the CTX callback will also be called for those transfers and the curl
+handle is set to an internal handle. \fBThis behavior is subject to change.\fP
+We recommend before performing your transfer set \fICURLOPT_PRIVATE(3)\fP on
+your curl handle so you can identify it in the CTX callback. If you have a
+reason to modify DOH SSL context please let us know on the curl-library mailing
+list because we are considering removing this capability.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -359,7 +359,12 @@ static CURLcode dohprobe(struct Curl_easy *data,
     doh->set.dohfor = data; /* identify for which transfer this is done */
     p->easy = doh;
 
-    /* add this transfer to the multi handle */
+    /* Since the DOH handles are passed to the user's SSL CTX callback, the
+       user must have a way to distinguish their transfer's handle from DOH
+       transfer handles. A documented way to do that is they set the private
+       pointer on their transfer's handle. The DOH private must be NULL. */
+    DEBUGASSERT(!data->set.private_data);
+
     if(curl_multi_add_handle(multi, doh))
       goto error;
   }


### PR DESCRIPTION
Closes #xxxx

---

Among other things this documents that CURLOPT_SSL_CTX_FUNCTION is inherited. Since that may be unexpected and it is not currently documented I am considering removing that behavior instead. This is similar to the discussion we had in #6605 about CURLOPT_DEBUGFUNCTION where the user may assume they only have to deal with their handle, and not internal DOH handles. The remedy, if there is actually demand for it, would be like I said in #6605 where we have a callback for advanced users that can be used to set DOH options.

Either way though I think we should document how CURLOPT_SSL_CTX_FUNCTION behaves, because it's possible the user may be doing some advanced verification or debugging through that function.