### PR TITLE
schannel: Evaluate CURLOPT_SSL_OPTIONS via SSL_SET_OPTION macro

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -522,14 +522,14 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
 #endif
         schannel_cred.dwFlags = SCH_CRED_AUTO_CRED_VALIDATION;
 
-      if(data->set.ssl.no_revoke) {
+      if(SSL_SET_OPTION(no_revoke)) {
         schannel_cred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
           SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 
         DEBUGF(infof(data, "schannel: disabled server certificate revocation "
                      "checks\n"));
       }
-      else if(data->set.ssl.revoke_best_effort) {
+      else if(SSL_SET_OPTION(revoke_best_effort)) {
         schannel_cred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
           SCH_CRED_IGNORE_REVOCATION_OFFLINE | SCH_CRED_REVOCATION_CHECK_CHAIN;
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -624,7 +624,7 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
                                 NULL,
                                 pCertContextServer->hCertStore,
                                 &ChainPara,
-                                (data->set.ssl.no_revoke ? 0 :
+                                (SSL_SET_OPTION(no_revoke) ? 0 :
                                  CERT_CHAIN_REVOCATION_CHECK_CHAIN),
                                 NULL,
                                 &pChainContext)) {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1941,7 +1941,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
      specifically doesn't want us doing that: */
   if(SSLSetSessionOption != NULL) {
     SSLSetSessionOption(backend->ssl_ctx, kSSLSessionOptionSendOneByteRecord,
-                      !data->set.ssl.enable_beast);
+                        !SSL_SET_OPTION(enable_beast));
     SSLSetSessionOption(backend->ssl_ctx, kSSLSessionOptionFalseStart,
                       data->set.ssl.falsestart); /* false start support */
   }


### PR DESCRIPTION
- Change use of those options from CURLOPT_SSL_OPTIONS that are not
  already evaluated via SSL_SET_OPTION in schannel and secure transport
  to use that instead of data->set.ssl.optname.

Example:

Evaluate SSL_SET_OPTION(no_revoke) instead of data->set.ssl.no_revoke.

This change is because options set via CURLOPT_SSL_OPTIONS
(data->set.ssl.optname) are separate from those set for HTTPS proxy via
CURLOPT_PROXY_SSL_OPTIONS (data->set.proxy_ssl.optname). The
SSL_SET_OPTION macro determines whether the connection is for HTTPS
proxy and based on that which option to evaluate.

Since neither Schannel nor Secure Transport backends currently support
HTTPS proxy in libcurl, this change is for posterity and has no other
effect.

Closes #xxxx