### PR TITLE
mem-include-scan: Check order of debug includes

### DIFF
--- a/lib/curl_ctype.c
+++ b/lib/curl_ctype.c
@@ -22,6 +22,10 @@
 
 #include "curl_setup.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 #ifndef CURL_DOES_CONVERSIONS
 
 #undef _U

--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -26,6 +26,10 @@
 
 #include "curl_des.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * Curl_des_set_odd_parity()
  *

--- a/lib/curl_endian.c
+++ b/lib/curl_endian.c
@@ -24,6 +24,10 @@
 
 #include "curl_endian.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * Curl_read16_le()
  *

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -25,12 +25,12 @@
 #include <curl/curl.h>
 
 #include "curl_fnmatch.h"
-#include "curl_memory.h"
-
-/* The last #include file should be: */
-#include "memdebug.h"
 
 #ifndef HAVE_FNMATCH
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 #define CURLFNM_CHARSET_LEN (sizeof(char) * 256)
 #define CURLFNM_CHSET_SIZE (CURLFNM_CHARSET_LEN + 15)
@@ -361,6 +361,10 @@ int Curl_fnmatch(void *ptr, const char *pattern, const char *string)
 }
 #else
 #include <fnmatch.h>
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 /*
  * @unittest: 1307
  */

--- a/lib/curl_gethostname.c
+++ b/lib/curl_gethostname.c
@@ -24,6 +24,10 @@
 
 #include "curl_gethostname.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * Curl_gethostname() is a wrapper around gethostname() which allows
  * overriding the host name that the function would normally return.

--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -25,9 +25,11 @@
 #if defined(USE_SSH)
 
 #include <curl/curl.h>
-#include "curl_memory.h"
 #include "curl_path.h"
 #include "escape.h"
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
 #include "memdebug.h"
 
 /* figure out the path to work with in this particular request */

--- a/lib/curl_range.c
+++ b/lib/curl_range.c
@@ -26,6 +26,10 @@
 #include "sendf.h"
 #include "strtoofft.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /* Only include this function if one or more of FTP, FILE are enabled. */
 #if !defined(CURL_DISABLE_FTP) || !defined(CURL_DISABLE_FILE)
 

--- a/lib/easygetopt.c
+++ b/lib/easygetopt.c
@@ -24,6 +24,10 @@
 #include "strcase.h"
 #include "easyoptions.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 #ifndef CURL_DISABLE_GETOPTIONS
 
 /* Lookups easy options at runtime */

--- a/lib/easyoptions.c
+++ b/lib/easyoptions.c
@@ -25,6 +25,10 @@
 #include "curl_setup.h"
 #include "easyoptions.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /* all easy setopt options listed in alphabetical order */
 struct curl_easyoption Curl_easyopts[] = {
   {"ABSTRACT_UNIX_SOCKET", CURLOPT_ABSTRACT_UNIX_SOCKET, CURLOT_STRING, 0},

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -48,9 +48,10 @@
 #include "ftp.h"
 #include "ftplistparser.h"
 #include "curl_fnmatch.h"
-#include "curl_memory.h"
 #include "multiif.h"
-/* The last #include file should be: */
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
 #include "memdebug.h"
 
 /* allocs buffer which will contain one line of LIST command response */

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -29,10 +29,10 @@
 #include <curl/curl.h>
 
 #include "curl_hmac.h"
-#include "curl_memory.h"
 #include "warnless.h"
 
-/* The last #include file should be: */
+/* The last include files should be in this order: */
+#include "curl_memory.h"
 #include "memdebug.h"
 
 /*

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -37,6 +37,7 @@
 #include "strtoofft.h"
 #include "strdup.h"
 #include "dynbuf.h"
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -2453,6 +2454,10 @@ bool Curl_h2_http_1_1_error(struct connectdata *conn)
 
 /* Satisfy external references even if http2 is not compiled in. */
 #include <curl/curl.h>
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 char *curl_pushheader_bynum(struct curl_pushheaders *h, size_t num)
 {

--- a/lib/idn_win32.c
+++ b/lib/idn_win32.c
@@ -29,10 +29,10 @@
 #ifdef USE_WIN32_IDN
 
 #include "curl_multibyte.h"
-#include "curl_memory.h"
 #include "warnless.h"
 
-  /* The last #include file should be: */
+/* The last include files should be in this order: */
+#include "curl_memory.h"
 #include "memdebug.h"
 
 #ifdef WANT_IDN_PROTOTYPES

--- a/lib/inet_ntop.c
+++ b/lib/inet_ntop.c
@@ -33,7 +33,11 @@
 #endif
 
 #include "inet_ntop.h"
+
+/* The last include files should be in this order: */
 #include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
 
 #define IN6ADDRSZ       16
 #define INADDRSZ         4

--- a/lib/inet_pton.c
+++ b/lib/inet_pton.c
@@ -32,6 +32,10 @@
 
 #include "inet_pton.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 #define IN6ADDRSZ       16
 #define INADDRSZ         4
 #define INT16SZ          2

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -48,9 +48,8 @@
 
 #include <nettle/md4.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 typedef struct md4_ctx MD4_CTX;
@@ -74,6 +73,10 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 /* When OpenSSL is available we use the MD4-functions from OpenSSL */
 #include <openssl/md4.h>
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 #elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
               (__MAC_OS_X_VERSION_MAX_ALLOWED >= 1040) && \
        defined(__MAC_OS_X_VERSION_MIN_ALLOWED) && \
@@ -83,9 +86,8 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include <CommonCrypto/CommonDigest.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 typedef CC_MD4_CTX MD4_CTX;
@@ -109,9 +111,8 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include <wincrypt.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 struct md4_ctx {
@@ -155,9 +156,8 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #include <mbedtls/md4.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 struct md4_ctx {
@@ -239,6 +239,10 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 
 #include <string.h>
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 /* Any 32-bit or wider unsigned integer data type will do */
 typedef unsigned int MD4_u32plus;

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -1,3 +1,7 @@
+#ifdef HEADER_CURL_MEMDEBUG_H
+#error "Header memdebug.h was already included. It should be the last include."
+#endif
+
 #ifndef HEADER_CURL_MEMDEBUG_H
 #define HEADER_CURL_MEMDEBUG_H
 #ifdef CURLDEBUG

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -40,6 +40,11 @@
 #include "rand.h"
 #include "slist.h"
 #include "strcase.h"
+
+#ifdef __VMS
+#include <fabdef.h>
+#endif
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -131,8 +136,6 @@ static const char aschex[] =
 #define fopen_read fopen
 
 #else
-
-#include <fabdef.h>
 /*
  * get_vms_file_size does what it takes to get the real size of the file
  *

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -36,12 +36,12 @@
 #include "url.h"
 #include "escape.h"
 #include "warnless.h"
-#include "curl_printf.h"
-#include "curl_memory.h"
 #include "multiif.h"
 #include "rand.h"
 
-/* The last #include file should be: */
+/* The last include files should be in this order: */
+#include "curl_printf.h"
+#include "curl_memory.h"
 #include "memdebug.h"
 
 #define MQTT_MSG_CONNECT   0x10

--- a/lib/non-ascii.c
+++ b/lib/non-ascii.c
@@ -32,10 +32,6 @@
 #include "urldata.h"
 #include "multiif.h"
 
-#include "curl_memory.h"
-/* The last #include file should be: */
-#include "memdebug.h"
-
 #ifdef HAVE_ICONV
 #include <iconv.h>
 /* set default codesets for iconv */
@@ -47,6 +43,10 @@
 #endif
 #define ICONV_ERROR  (size_t)-1
 #endif /* HAVE_ICONV */
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 /*
  * Curl_convert_clone() returns a malloced copy of the source string (if

--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -39,6 +39,10 @@
 
 #include "nonblock.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * curlx_nonblock() set the given socket to either blocking or non-blocking
  * mode based on the 'nonblock' boolean argument. This function is highly

--- a/lib/nwlib.c
+++ b/lib/nwlib.c
@@ -32,8 +32,8 @@
 #include <nks/thread.h>
 #include <nks/synch.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-/* The last #include file should be: */
 #include "memdebug.h"
 
 struct libthreaddata {
@@ -304,6 +304,10 @@ void DisposeThreadData(void *data)
 #else /* __NOVELL_LIBC__ */
 /* For native CLib-based NLM seems we can do a bit more simple. */
 #include <nwthread.h>
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 int main(void)
 {

--- a/lib/nwos.c
+++ b/lib/nwos.c
@@ -45,6 +45,10 @@ NETDB_DEFINE_CONTEXT
 #include <arpa/inet.h>
 NETINET_DEFINE_CONTEXT
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 int netware_init(void)
 {
   int rc = 0;

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -82,6 +82,10 @@
 #include "warnless.h"
 #include "parsedate.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * parsedate()
  *

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -27,7 +27,11 @@
 #include "multiif.h"
 #include "progress.h"
 #include "timeval.h"
+
+/* The last include files should be in this order: */
 #include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
 
 /* check rate limits within this many recent milliseconds, at minimum. */
 #define MIN_RATE_LIMIT_PERIOD 3000

--- a/lib/rename.c
+++ b/lib/rename.c
@@ -20,9 +20,9 @@
  *
  ***************************************************************************/
 
-#include "rename.h"
-
 #include "curl_setup.h"
+
+#include "rename.h"
 
 #if (!defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_COOKIES)) || \
   !defined(CURL_DISABLE_ALTSVC)

--- a/lib/select.c
+++ b/lib/select.c
@@ -55,6 +55,10 @@
 #include "timeval.h"
 #include "warnless.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * Internal function used for waiting a specific amount of ms
  * in Curl_socket_check() and Curl_poll() when no file descriptor

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -68,9 +68,8 @@
 
 #include <nettle/sha.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 typedef struct sha256_ctx SHA256_CTX;
@@ -96,9 +95,8 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 
 #include <mbedtls/sha256.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 typedef mbedtls_sha256_context SHA256_CTX;
@@ -139,9 +137,8 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 
 #include <CommonCrypto/CommonDigest.h>
 
+/* The last include files should be in this order: */
 #include "curl_memory.h"
-
-/* The last #include file should be: */
 #include "memdebug.h"
 
 typedef CC_SHA256_CTX SHA256_CTX;
@@ -166,6 +163,10 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 #elif defined(USE_WIN32_CRYPTO)
 
 #include <wincrypt.h>
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 struct sha256_ctx {
   HCRYPTPROV hCryptProv;
@@ -208,6 +209,10 @@ static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 }
 
 #else
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 /* When no other crypto library is available we use this code segment */
 

--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -28,6 +28,10 @@
 #include "multiif.h"
 #include "speedcheck.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 void Curl_speedinit(struct Curl_easy *data)
 {
   memset(&data->state.keeps_speed, 0, sizeof(struct curltime));

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -24,6 +24,10 @@
 
 #include "splay.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 /*
  * This macro compares two node keys i and j and returns:
  *

--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -26,6 +26,10 @@
 
 #include "strcase.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 static char raw_tolower(char in);
 
 /* Portable, consistent toupper (remember EBCDIC). Do not use toupper() because

--- a/lib/strtok.c
+++ b/lib/strtok.c
@@ -27,6 +27,10 @@
 
 #include "strtok.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 char *
 Curl_strtok_r(char *ptr, const char *sep, char **end)
 {

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -20,10 +20,15 @@
  *
  ***************************************************************************/
 
-#include <errno.h>
 #include "curl_setup.h"
 
+#include <errno.h>
+
 #include "strtoofft.h"
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 /*
  * NOTE:

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -20,9 +20,15 @@
  *
  ***************************************************************************/
 
+#include "curl_setup.h"
+
 #include "timeval.h"
 
 #if defined(WIN32) && !defined(MSDOS)
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 /* set in win32_init() */
 extern LARGE_INTEGER Curl_freq;
@@ -57,6 +63,10 @@ struct curltime Curl_now(void)
 }
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC)
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 struct curltime Curl_now(void)
 {
@@ -117,6 +127,10 @@ struct curltime Curl_now(void)
 #include <stdint.h>
 #include <mach/mach_time.h>
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 struct curltime Curl_now(void)
 {
   /*
@@ -145,6 +159,10 @@ struct curltime Curl_now(void)
 
 #elif defined(HAVE_GETTIMEOFDAY)
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 struct curltime Curl_now(void)
 {
   /*
@@ -161,6 +179,10 @@ struct curltime Curl_now(void)
 }
 
 #else
+
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
 
 struct curltime Curl_now(void)
 {

--- a/lib/version.c
+++ b/lib/version.c
@@ -28,7 +28,6 @@
 #include "http2.h"
 #include "vssh/ssh.h"
 #include "quic.h"
-#include "curl_printf.h"
 
 #ifdef USE_ARES
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
@@ -65,6 +64,11 @@
 #ifdef HAVE_ZSTD
 #include <zstd.h>
 #endif
+
+/* The last include files should be in this order: */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
 
 #ifdef HAVE_BROTLI
 static size_t brotli_version(char *buf, size_t bufsz)

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -29,8 +29,12 @@
 #endif
 #include "urldata.h"
 #include "dynbuf.h"
-#include "curl_printf.h"
 #include "vquic.h"
+
+/* The last include files should be in this order: */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
 
 #ifdef O_BINARY
 #define QLOGMODE O_WRONLY|O_CREAT|O_BINARY

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -89,11 +89,12 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include "curl_path.h"
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
 #include "memdebug.h"
-#include "curl_path.h"
 
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -33,8 +33,11 @@
 #include "connect.h"
 #include "select.h"
 #include "multiif.h"
+
+/* The last include files should be in this order: */
 #include "curl_printf.h"
 #include "curl_memory.h"
+#include "memdebug.h"
 
 struct x509_context {
   const br_x509_class *vtable;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -38,6 +38,8 @@
 #include <gnutls/crypto.h>
 #include <nettle/sha2.h>
 
+# include <gnutls/ocsp.h>
+
 #include "urldata.h"
 #include "sendf.h"
 #include "inet_pton.h"
@@ -50,9 +52,10 @@
 #include "warnless.h"
 #include "x509asn1.h"
 #include "multiif.h"
+
+/* The last include files should be in this order: */
 #include "curl_printf.h"
 #include "curl_memory.h"
-/* The last #include file should be: */
 #include "memdebug.h"
 
 /* Enable GnuTLS debugging by defining GTLSDEBUG */
@@ -69,8 +72,6 @@ static bool gtls_inited = FALSE;
 #if !defined(GNUTLS_VERSION_NUMBER) || (GNUTLS_VERSION_NUMBER < 0x03010a)
 #error "too old GnuTLS version"
 #endif
-
-# include <gnutls/ocsp.h>
 
 struct ssl_backend_data {
   gnutls_session_t session;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -90,6 +90,10 @@
 #include <openssl/engine.h>
 #endif
 
+#ifdef USE_OPENSSL_ENGINE
+#include <openssl/ui.h>
+#endif
+
 #include "warnless.h"
 #include "non-ascii.h" /* for Curl_convert_from_utf8 prototype */
 
@@ -106,10 +110,6 @@
 
 #ifndef OPENSSL_VERSION_NUMBER
 #error "OPENSSL_VERSION_NUMBER not defined"
-#endif
-
-#ifdef USE_OPENSSL_ENGINE
-#include <openssl/ui.h>
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x00909000L

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -36,6 +36,10 @@
 
 #include "multiif.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 struct ssl_backend_data
 {
   const struct rustls_client_config *config;

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -37,6 +37,10 @@
 
 #include "warnless.h"
 
+/* The last include files should be in this order: */
+#include "curl_memory.h"
+#include "memdebug.h"
+
 #define CURL_MASK_SCHAR  0x7F
 #define CURL_MASK_UCHAR  0xFF
 

--- a/tests/data/test1132
+++ b/tests/data/test1132
@@ -17,9 +17,20 @@ none
 Verify memory #include files in libcurl's C source files
  </name>
 
-<command type="perl">
-%SRCDIR/mem-include-scan.pl %SRCDIR/../lib
+<command type="shell">
+log/test1132.sh
 </command>
+<file name="log/test1132.sh">
+#!/bin/sh
+find "%SRCDIR/../lib" -type d -exec \
+  perl "-I%SRCDIR" "%SRCDIR/mem-include-scan.pl" {} \;
+echo done>&2
+</file>
 </client>
 
+<verify>
+<stderr>
+done
+</stderr>
+</verify>
 </testcase>


### PR DESCRIPTION
- In each source file check that curl_setup.h or tool_setup.h is the
  first include.

- In each source file check that curl_memory.h is the 2nd to last
  include, and curl_memory.h is the last include.

- Check all source files in lib (and all its subdirectories) for the
  proper include order instead of just those that call alloc, free, etc.

- Fix new scan problems found in lib source files.

Closes #xxxx

---

This is a first take on improving the mem-include-scan by scanning lib subdirectories, and making sure the order of includes is proper. It works by reading in all a file's includes and then checking to make sure the last 2 are curl_memory and memdebug. Also, it checks all the files rather than just the ones calling alloc, free. This is because memdebug does a lot more than that so I thought rather than try to keep it in sync with memdebug it would be easier to just include them always.

The include list doesn't always work when there are some ifdefs and additional includes in each ifdef. sha256 and md4 are good examples of this. In those cases the scan doesn't really work, it only checks the last 2 includes.

One thing I've noticed is that curl_printf.h is occasionally the 3rd from last include but not always. Possibly it should always be included as well, or maybe a last.h that always must be last and includes all 3. Just ideas...