### PR TITLE
check ptr against NULL before dereferencing it

### DIFF
--- a/tests/libtest/lib1537.c
+++ b/tests/libtest/lib1537.c
@@ -47,11 +47,11 @@ int test(char *URL)
 
   /* deprecated API */
   ptr = curl_escape((char *)a, asize);
-  printf("%s\n", ptr);
   if(!ptr) {
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
+  printf("%s\n", ptr);
 
   raw = curl_easy_unescape(NULL, ptr, (int)strlen(ptr), &outlen);
   printf("outlen == %d\n", outlen);


### PR DESCRIPTION
This is a proposed fix for https://github.com/curl/curl/issues/6707

There is a small issue of dereferencing a pointer before checking it against NULL.

From [tests/libtest/lib1537.c : 49-51](https://github.com/curl/curl/blob/master/tests/libtest/lib1537.c#L49)


```C
49  ptr = curl_escape((char *)a, asize);
50  printf("%s\n", ptr); /* <-- printf dereferences 'ptr' here before the null-check */
51  if(!ptr) {
52    res = TEST_ERR_MAJOR_BAD;
53    goto test_cleanup;
54  }
```

I propose to move the call to `printf` down after the check against NULL.




