### PR TITLE
check ptr against NULL before dereferencing it

### DIFF
--- a/tests/libtest/lib1536.c
+++ b/tests/libtest/lib1536.c
@@ -69,7 +69,7 @@ int test(char *URL)
             __FILE__, __LINE__, res, curl_easy_strerror(res));
     goto test_cleanup;
   }
-  if(memcmp(scheme, "HTTP", 5) != 0) {
+  if(scheme == NULL || memcmp(scheme, "HTTP", 5) != 0) {
     fprintf(stderr, "%s:%d scheme of http resource is incorrect; "
             "expected 'HTTP' but is %s\n",
             __FILE__, __LINE__,


### PR DESCRIPTION
This is a proposed fix for https://github.com/curl/curl/issues/6709

There is a small issue of dereferencing a pointer before checking it against NULL.

From [tests/libtest/lib1536.c : 72 - 76](https://github.com/curl/curl/blob/master/tests/libtest/lib1536.c#L72)

```C
72  if(memcmp(scheme, "HTTP", 5) != 0) {
              ^^^^^^ scheme is dereferenced here, but checked against NULL later
73    fprintf(stderr, "%s:%d scheme of http resource is incorrect; "
74            "expected 'HTTP' but is %s\n",
75            __FILE__, __LINE__,
76            (scheme == NULL ? "NULL" : "invalid"));
77    res = CURLE_HTTP_RETURNED_ERROR;
78    goto test_cleanup;
79  }
```

I propose to either:
- add a test in the if-condition, to check against NULL to avoid the potential null-dereference
- remove the check against NULL in `(scheme == NULL ? "NULL" : "invalid")` if `scheme` can never be NULL

