### PR TITLE
Setting Curl_resolver_getsock minimum back off time to 1

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -642,7 +642,7 @@ int Curl_resolver_getsock(struct Curl_easy *data, curl_socket_t *socks)
 #endif
     ms = Curl_timediff(Curl_now(), reslv->start);
     if(ms < 3)
-      milli = 0;
+      milli = 1;
     else if(ms <= 50)
       milli = ms/3;
     else if(ms <= 250)

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -644,7 +644,7 @@ int Curl_resolver_getsock(struct Curl_easy *data, curl_socket_t *socks)
     if(ms < 3)
       milli = 1;
     else if(ms <= 50)
-      milli = ms / 3;
+      milli = ms/3;
     else if(ms <= 250)
       milli = 50;
     else

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -644,7 +644,7 @@ int Curl_resolver_getsock(struct Curl_easy *data, curl_socket_t *socks)
     if(ms < 3)
       milli = 1;
     else if(ms <= 50)
-      milli = ms/3;
+      milli = ms / 3;
     else if(ms <= 250)
       milli = 50;
     else


### PR DESCRIPTION
- Curl calls synchronous name resolution APIs. To not block, these are called on a separate thread. The main thread then polls to see if the resolution has finished. The code that determines the poll backoff time was starting at 0 which caused a hang on Windows.

Setting this minimum backoff time to 1 ms solves the issue.