### PR TITLE
retry.d: Clarify transient 5xx HTTP response codes

### DIFF
--- a/docs/cmdline-opts/retry.d
+++ b/docs/cmdline-opts/retry.d
@@ -7,7 +7,8 @@ Category: curl
 If a transient error is returned when curl tries to perform a transfer, it
 will retry this number of times before giving up. Setting the number to 0
 makes curl do no retries (which is the default). Transient error means either:
-a timeout, an FTP 4xx response code or an HTTP 408, 429 or 5xx response code.
+a timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503 or 504
+response code.
 
 When curl is about to retry a transfer, it will first wait one second and then
 for all forthcoming retries it will double the waiting time until it reaches


### PR DESCRIPTION
- Clarify the only 5xx response codes that are treated as transient are
  500, 502, 503 and 504.

Prior to this change it said it treated all 5xx as transient, but the
code says otherwise.

Ref: https://github.com/curl/curl/blob/curl-7_75_0/src/tool_operate.c#L462-L495

Closes #xxxx