### PR TITLE
cookies: Fix potential NULL pointer deref with PSL

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -951,8 +951,12 @@ Curl_cookie_add(struct Curl_easy *data,
     remove_expired(c);
 
 #ifdef USE_LIBPSL
-  /* Check if the domain is a Public Suffix and if yes, ignore the cookie. */
-  if(domain && co->domain && !isip(co->domain)) {
+  /*
+   * Check if the domain is a Public Suffix and if yes, ignore the cookie. We
+   * must also check that the data handle isn't NULL since the psl code will
+   * dereference it.
+   */
+  if(data && (domain && co->domain && !isip(co->domain))) {
     const psl_ctx_t *psl = Curl_psl_use(data);
     int acceptable;
 


### PR DESCRIPTION
Curl_cookie_init can be called with data being NULL, and this can in turn be passed to Curl_cookie_add, meaning that both functions must be careful to only use data where it's checked for being a NULL pointer.  The libpsl support code does however dereference data without checking, so if we are indeed having an unset data pointer we cannot PSL check the cookiedomain.

This is currently not a reachable dereference, as the only caller with a NULL data isn't passing a file to initialize cookies from, but since the API has this contract let's ensure we hold it.