### PR TITLE
SChannel: Support SCH_USE_STRONG_CRYPTO

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -514,3 +514,9 @@ and the request will fail.
 `CALG_ECMQV`,
 `CALG_ECDSA`,
 `CALG_ECDH_EPHEM`,
+
+As of curl 7.77.0, you can also pass `USE_STRONG_CRYPTO` as a cipher to
+[constrain the set of available ciphers as specified in the schannel
+documentation](https://docs.microsoft.com/en-us/windows/win32/secauthn/tls-cipher-suites-in-windows-server-2022).
+Note that the supported ciphers in this case follows the OS version, so if you
+are running an outdated OS you might still be supporting weak ciphers.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -335,9 +335,11 @@ set_ssl_ciphers(SCHANNEL_CRED *schannel_cred, char *ciphers)
       alg = get_alg_id_by_name(startCur);
     if(alg)
       algIds[algCount++] = alg;
+#ifdef SCH_USE_STRONG_CRYPTO
     else if(strncmp(startCur, "USE_STRONG_CRYPTO",
                     sizeof("USE_STRONG_CRYPTO") - 1) == 0)
       schannel_cred->dwFlags |= SCH_USE_STRONG_CRYPTO;
+#endif
     else
       return CURLE_SSL_CIPHER;
     startCur = strchr(startCur, ':');

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -335,6 +335,8 @@ set_ssl_ciphers(SCHANNEL_CRED *schannel_cred, char *ciphers)
       alg = get_alg_id_by_name(startCur);
     if(alg)
       algIds[algCount++] = alg;
+    else if (strncmp(startCur, "USE_STRONG_CRYPTO", sizeof "USE_STRONG_CRYPTO" - 1) == 0)
+      schannel_cred->dwFlags |= SCH_USE_STRONG_CRYPTO;
     else
       return CURLE_SSL_CIPHER;
     startCur = strchr(startCur, ':');

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -117,6 +117,10 @@
 #define SP_PROT_TLS1_2_CLIENT           0x00000800
 #endif
 
+#ifndef SCH_USE_STRONG_CRYPTO
+#define SCH_USE_STRONG_CRYPTO           0x00400000
+#endif
+
 #ifndef SECBUFFER_ALERT
 #define SECBUFFER_ALERT                 17
 #endif
@@ -335,11 +339,9 @@ set_ssl_ciphers(SCHANNEL_CRED *schannel_cred, char *ciphers)
       alg = get_alg_id_by_name(startCur);
     if(alg)
       algIds[algCount++] = alg;
-#ifdef SCH_USE_STRONG_CRYPTO
     else if(strncmp(startCur, "USE_STRONG_CRYPTO",
                     sizeof("USE_STRONG_CRYPTO") - 1) == 0)
       schannel_cred->dwFlags |= SCH_USE_STRONG_CRYPTO;
-#endif
     else
       return CURLE_SSL_CIPHER;
     startCur = strchr(startCur, ':');

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -335,7 +335,8 @@ set_ssl_ciphers(SCHANNEL_CRED *schannel_cred, char *ciphers)
       alg = get_alg_id_by_name(startCur);
     if(alg)
       algIds[algCount++] = alg;
-    else if (strncmp(startCur, "USE_STRONG_CRYPTO", sizeof "USE_STRONG_CRYPTO" - 1) == 0)
+    else if(strncmp(startCur, "USE_STRONG_CRYPTO",
+                    sizeof("USE_STRONG_CRYPTO") - 1) == 0)
       schannel_cred->dwFlags |= SCH_USE_STRONG_CRYPTO;
     else
       return CURLE_SSL_CIPHER;


### PR DESCRIPTION
Feature was discussed on curl-library@cool.haxx.se; `Subject: Adding flags to SChannel cred`.

I wasn't sure about where, and to what extent, this should be documented.

Also note that I tested this by compiling curl.exe on the latest preview on windows 10. Downloading https://clienttest.ssllabs.com:8443/ssltest/viewMyClient.html with and without `--ciphers USE_STRONG_CRYPTO` and diffing the results shows that 3des is correctly disabled.