### PR TITLE
http2: fail if connection terminated without END_STREAM

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1729,6 +1729,17 @@ static ssize_t http2_recv(struct Curl_easy *data, int sockindex,
       }
 
       if(nread == 0) {
+        if(!stream->closed) {
+          /* This will happen when the server or proxy server is SIGKILLed
+             during data transfer. We should emit an error since our data
+             received may be incomplete. */
+          failf(data, "HTTP/2 stream %d was not closed cleanly before"
+                " end of the underlying stream",
+                stream->stream_id);
+          *err = CURLE_HTTP2_STREAM;
+          return -1;
+        }
+
         H2BUGF(infof(data, "end of stream\n"));
         *err = CURLE_OK;
         return 0;


### PR DESCRIPTION
Emit an error if HTTP/2 stream is not correctly closed when underlying TCP/SSL connection is terminated.
In [rfc7540](https://www.rfc-editor.org/rfc/rfc7540.txt), section 8.1.  HTTP Request/Response Exchange,
> An HTTP response is complete after the server sends -- or the client
> receives -- a frame with the END_STREAM flag set (including any
> CONTINUATION frames needed to complete a header block). 

In case of the server or proxy server is SIGKILLed during data transfer, Linux kernel will terminated the TCP connection by `FIN+ACK`. And if the server doesn't provide `Content-Length` (eg. GitHub tarball archive URLs), our current behavior is to exit without error, leaving incomplete data.
The misbehavior makes downstream programs unexpectedly cache incomplete files (https://github.com/NixOS/nix/issues/4533).

Note:
1. HTTP/1.1 *CAN* correctly handle the case above (emit an error) by chunked transfer due to missing of final zero-size chunk.
2. With HTTP/2 + TLS, TLS *DO* detect the unexpected termination of TCP connection. But we unfortunately choose to explicitly ignore this error in #4624. So at least we should still check in HTTP/2 layer for the data completeness.

Reproduce misbehavior: (reproduced in master 7b2f0676c2eaaa99e8773134414769fab02c2b2d)
1. Setup any proxy server with protocol socks5 or http, and set environment variable `https_proxy`.
2. Run `curl -LO https://codeload.github.com/NixOS/nixpkgs/legacy.tar.gz/772406c2a4e22a85620854056a4cd02856fa10f0`, or any other URL without `Content-Length`. (For GitHub, it may be cached if an archive is recently downloaded. You can try different commits, or wait for minutes between two fetch, until `curl` doesn't show total bytes, which indicates missing `Content-Length`)
3. `kill -9` the proxy server.
4. The `curl` instance exited with 0 without any error, leaving the incomplete file.
