### PR TITLE
http2: fix KEEP_SEND flag remaining set when there's no more data to be sent

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1446,13 +1446,15 @@ CURLcode Curl_http2_done_sending(struct Curl_easy *data,
 
       H2BUGF(infof(data, "HTTP/2 still wants to send data (easy %p)\n", data));
 
-      /* re-set KEEP_SEND to make sure we are called again */
-      k->keepon |= KEEP_SEND;
-
       /* and attempt to send the pending frames */
       rv = h2_session_send(data, h2);
       if(rv != 0)
         result = CURLE_SEND_ERROR;
+
+      if(nghttp2_session_want_write(h2)) {
+         /* re-set KEEP_SEND to make sure we are called again */
+         k->keepon |= KEEP_SEND;
+      }
     }
   }
   return result;


### PR DESCRIPTION
http2: fix KEEP_SEND flag remaining set when there's no more data to be sent

this should fix an issue where curl sometimes doesn't send out a
request with authorization info after a 401 is received over http2