### PR TITLE
docs: Add SSL backend names to CURL_SSL_BACKEND

### DIFF
--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -44,8 +44,11 @@ match.
 If curl was built with support for "MultiSSL", meaning that it has built-in
 support for more than one TLS backend, this environment variable can be set to
 the case insensitive name of the particular backend to use when curl is
-invoked. Setting a name that isn't a built-in alternative, will make curl
+invoked. Setting a name that isn't a built-in alternative will make curl
 stay with the default.
+
+SSL backend names (case-insensitive): bearssl, gnutls, gskit, mbedtls,
+mesalink, nss, openssl, rustls, schannel, secure-transport, wolfssl
 .IP "QLOGDIR <directory name>"
 If curl was built with HTTP/3 support, setting this environment variable to a
 local directory will make curl produce qlogs in that directory, using file

--- a/docs/libcurl/libcurl-env.3
+++ b/docs/libcurl/libcurl-env.3
@@ -45,8 +45,11 @@ set.
 .IP CURL_SSL_BACKEND
 When libcurl is built to support multiple SSL backends, it will select a
 specific backend at first use. If no selection is done by the program using
-libcurl, this variable's selection will be used. It should be set to the full
-SSL backend name to use (case insensitive).
+libcurl, this variable's selection will be used. Setting a name that isn't a
+built-in alternative will make libcurl stay with the default.
+
+SSL backend names (case-insensitive): bearssl, gnutls, gskit, mbedtls,
+mesalink, nss, openssl, rustls, schannel, secure-transport, wolfssl
 .IP HOME
 When the netrc feature is used (\fICURLOPT_NETRC(3)\fP), this variable is
 checked as the primary way to find the "current" home directory in which


### PR DESCRIPTION
- Document the names that can be used with CURL_SSL_BACKEND:
  bearssl, gnutls, gskit, mbedtls, mesalink, nss, openssl, rustls,
  schannel, secure-transport, wolfssl

Ref: https://github.com/curl/curl/issues/2209#issuecomment-360623286
Ref: https://github.com/curl/curl/issues/6717#issuecomment-800745201

Closes #xxxx