### PR TITLE
rustls: handle close_notify and enable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug RUSTLS="yes" C="--with-rustls=$HOME/crust --without-ssl" NOTESTS=1
+    - T=debug-rustls RUSTLS_VERSION="v0.4.0" C="--with-rustls=$HOME/crust --without-ssl"
     addons:
       apt:
         <<: *common_apt

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -80,6 +80,7 @@ EXTRA_DIST =                                    \
  PARALLEL-TRANSFERS.md                          \
  README.md                                      \
  RELEASE-PROCEDURE.md                           \
+ RUSTLS.md                                      \
  ROADMAP.md                                     \
  SECURITY-PROCESS.md                            \
  SSL-PROBLEMS.md                                \

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -1,0 +1,26 @@
+# Rustls
+
+[Rustls is a TLS backend written in Rust.](https://docs.rs/rustls/). Curl can
+be built to use it as an alternative to OpenSSL or other TLS backends. We use
+the [crustls C bindings](https://github.com/abetterinternet/crustls/). This
+version of curl depends on version v0.4.0 of crustls.
+
+# Building with rustls
+
+First, [install Rust](https://rustup.rs/).
+
+Next, check out, build, and install the appropriate version of crustls:
+
+    % cargo install cbindgen
+    % git clone https://github.com/abetterinternet/crustls/ -b v0.4.0
+    % cd crustls
+    % make
+    % make DESTDIR=${HOME}/crustls-built/ install
+
+Now configure and build curl with rustls:
+
+    % git clone https://github.com/curl/curl
+    % cd curl
+    % ./buildconf
+    % ./configure --without-ssl --with-rustls=${HOME}/crustls-built
+    % make

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -126,9 +126,9 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
   ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
 fi
 
-if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS" ]; then
+if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS_VERSION" ]; then
   cd $HOME
-  git clone --depth=1 --recursive https://github.com/abetterinternet/crustls.git
+  git clone --depth=1 --recursive https://github.com/abetterinternet/crustls.git -b "$RUSTLS_VERSION"
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
   cargo install cbindgen

--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -70,6 +70,12 @@ if [ "$T" = "debug-mesalink" ]; then
   make "TFLAGS=-n !313 !410 !3001" test-nonflaky
 fi
 
+if [ "$T" = "debug-rustls" ]; then
+  ./configure --enable-debug --enable-werror $C
+  make
+  make "TFLAGS=HTTPS !313" test-nonflaky
+fi
+
 if [ "$T" = "novalgrind" ]; then
   ./configure --enable-werror $C
   make


### PR DESCRIPTION
When we get a close_notify alert, treat it as EOF. If we get a TCP close, treat it as an error, because we should have ended the request, and the connection, when we got the close_notify.

Also, document the version of rustls required by this version of curl, and enable running the tests for rustls builds. Note that this only runs the HTTPS tests. The remaining tests that fail are for FTPS and Gophers; those protocols use the blocking `Curl_ssl_connect`, which is not implemented by the rustls backend.

Test 313 is disabled because it requires CRL support, which rustls does not offer.