### PR TITLE
libssh2: clear session pointer after free

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3159,6 +3159,7 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
     sshc->kh = libssh2_knownhost_init(sshc->ssh_session);
     if(!sshc->kh) {
       libssh2_session_free(sshc->ssh_session);
+      sshc->ssh_session = NULL;
       return CURLE_FAILED_INIT;
     }
 


### PR DESCRIPTION
If libssh2_knownhost_init() returns NULL, like in an OOM situation, the
ssh session was freed but the pointer wasn't cleared which made libcurl
later call libssh2 to cleanup using the stale pointer.

Fixes #6764
Closes #