### PR TITLE
curl: ignore options asking for SSLv2 or SSLv3

### DIFF
--- a/docs/cmdline-opts/sslv2.d
+++ b/docs/cmdline-opts/sslv2.d
@@ -9,6 +9,5 @@ See-also: http1.1 http2
 Help: Use SSLv2
 Category: tls
 ---
-Forces curl to use SSL version 2 when negotiating with a remote SSL
-server. Sometimes curl is built without SSLv2 support. SSLv2 is widely
-considered insecure (see RFC 6176).
+This option previously asked curl to use SSLv2, but starting in curl 7.77.0 this
+instruction is ignored. SSLv2 is widely considered insecure (see RFC 6176).

--- a/docs/cmdline-opts/sslv3.d
+++ b/docs/cmdline-opts/sslv3.d
@@ -9,6 +9,6 @@ See-also: http1.1 http2
 Help: Use SSLv3
 Category: tls
 ---
-Forces curl to use SSL version 3 when negotiating with a remote SSL
-server. Sometimes curl is built without SSLv3 support. SSLv3 is widely
-considered insecure (see RFC 7568).
+This option previously asked curl to use SSLv3, but starting in curl 7.77.0
+this instruction is ignored. SSLv3 is widely considered insecure (see RFC
+7568).

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1278,11 +1278,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case '2':
       /* SSL version 2 */
-      config->ssl_version = CURL_SSLVERSION_SSLv2;
+      warnf(global, "Ignores instruction to use SSLv2\n");
       break;
     case '3':
       /* SSL version 3 */
-      config->ssl_version = CURL_SSLVERSION_SSLv3;
+      warnf(global, "Ignores instruction to use SSLv3\n");
       break;
     case '4':
       /* IPv4 */


### PR DESCRIPTION
Instead output a warning about it and continue with the defaults.

These SSL versions are typically not supported by the TLS libraries since a
long time back already since they are inherently insecure and broken. Asking
for them to be used will just cause an error to be returned slightly later.

In the unlikely event that a user's TLS library actually still supports these
protocol versions, this change might make the request a little less insecure.