### PR TITLE
azure: disable test 433 on azure-ubuntu

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -49,7 +49,7 @@ stages:
     variables:
       install: ''
       configure: ''
-      tests: ''
+      tests: '!433'
     timeoutInMinutes: 60
     pool:
       vmImage: 'ubuntu-latest'


### PR DESCRIPTION
Something in that environment sets XDG_CONFIG_HOME for us in a way that
breaks the test.

Fixes #6739