### PR TITLE
http: strip default port from URL sent to proxy

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2189,7 +2189,7 @@ CURLcode Curl_http_target(struct Curl_easy *data,
     /* Extract the URL to use in the request. Store in STRING_TEMP_URL for
        clean-up reasons if the function returns before the free() further
        down. */
-    uc = curl_url_get(h, CURLUPART_URL, &url, 0);
+    uc = curl_url_get(h, CURLUPART_URL, &url, CURLU_NO_DEFAULT_PORT);
     if(uc) {
       curl_url_cleanup(h);
       return CURLE_OUT_OF_MEMORY;

--- a/tests/data/test659
+++ b/tests/data/test659
@@ -43,7 +43,7 @@ proxy
 
 <verify>
 <protocol>
-GET http://www.example.com:80/ HTTP/1.1
+GET http://www.example.com/ HTTP/1.1
 Host: www.example.com
 Accept: */*
 Proxy-Connection: Keep-Alive


### PR DESCRIPTION
To make sure the Host: header and the URL provide the same authority
portion when sent to the proxy, strip the default port number from the
URL if one was provided.

Reported-by: Michael Brown
Fixes #6769
Closes #[fill in]