### PR TITLE
tftp warning fix for windows

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -218,7 +218,7 @@ static CURLcode tftp_set_timeouts(struct tftp_state_data *state)
   }
 
   /* timeout in milliseconds */
-  state->max_time = timeout_ms;
+  state->max_time = (time_t)timeout_ms;
 
   if(timeout_ms > 0)
     maxtime = (time_t)(timeout_ms + 500) / 1000;


### PR DESCRIPTION
This commit fix a warning on some windows build:

https://dev.azure.com/daniel0244/curl/_build/results?buildId=5132&view=logs&j=ea1d4c80-679f-50fc-e5c4-6cbed7e43517&t=6dc28ef7-2393-5edf-bed4-5e258baa3367&l=128


```
fix the warning
tftp.c: In function 'tftp_set_timeouts':

tftp.c:221:21: error: conversion from 'timediff_t' {aka 'long long int'} to 'time_t' {aka 'long int'} may change value [-Werror=conversion]

  221 |   state->max_time = timeout_ms;
      |                     ^~~~~~~~~~

```