### PR TITLE
libssh2: kdb_callback: get the right struct pointer

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -184,7 +184,7 @@ kbd_callback(const char *name, int name_len, const char *instruction,
              LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses,
              void **abstract)
 {
-  struct connectdata *conn = (struct connectdata *)*abstract;
+  struct Curl_easy *data = (struct Curl_easy *)*abstract;
 
 #ifdef CURL_LIBSSH2_DEBUG
   fprintf(stderr, "name=%s\n", name);
@@ -199,11 +199,11 @@ kbd_callback(const char *name, int name_len, const char *instruction,
   (void)instruction_len;
 #endif  /* CURL_LIBSSH2_DEBUG */
   if(num_prompts == 1) {
+    struct connectdata *conn = data->conn;
     responses[0].text = strdup(conn->passwd);
     responses[0].length = curlx_uztoui(strlen(conn->passwd));
   }
   (void)prompts;
-  (void)abstract;
 } /* kbd_callback */
 
 static CURLcode sftp_libssh2_error_to_CURLE(unsigned long err)


### PR DESCRIPTION
After the recent conn/data refactor in this source file, this function
was mistakenly still getting the old struct pointer which would lead to
crash on servers with keyboard-interactive auth enabled.

Follow-up to a304051620b92e12b (shipped in 7.75.0)

Reported-by: Christian Schmitz
Fixes #6691 