### PR TITLE
openldap: disconnect better

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -371,7 +371,7 @@ static CURLcode ldap_disconnect(struct Curl_easy *data,
     if(li->ld) {
       Sockbuf *sb;
       ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb);
-      ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, NULL);
+      ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data);
       ldap_unbind_ext(li->ld, NULL, NULL);
       li->ld = NULL;
     }


### PR DESCRIPTION
Instead of clearing the callback argument in disconnect, set it to the
(new) transfer to make sure the correct data is passed to the callbacks.

Follow-up to e467ea3bd937f38
Assisted-by: Patrick Monnerat