### PR TITLE
openssl: set the transfer pointer for logging early

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2588,6 +2588,7 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
     /* the SSL trace callback is only used for verbose logging */
     SSL_CTX_set_msg_callback(backend->ctx, ossl_trace);
     SSL_CTX_set_msg_callback_arg(backend->ctx, conn);
+    set_logger(conn, data);
   }
 #endif
 


### PR DESCRIPTION
Otherwise, the transfer will be NULL in the trace function when the
early handshake details arrive and then curl won't show them.

Reported-by: David Hu
Fixes #6783