### PR TITLE
openssl: ensure to check SSL_CTX_set_alpn_protos return values

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2749,7 +2749,10 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
     /* expects length prefixed preference ordered list of protocols in wire
      * format
      */
-    SSL_CTX_set_alpn_protos(backend->ctx, protocols, cur);
+    if(SSL_CTX_set_alpn_protos(backend->ctx, protocols, cur) != 0) {
+      failf(data, "Error setting ALPN");
+      return CURLE_SSL_CONNECT_ERROR;
+    }
   }
 #endif
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2749,7 +2749,7 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
     /* expects length prefixed preference ordered list of protocols in wire
      * format
      */
-    if(SSL_CTX_set_alpn_protos(backend->ctx, protocols, cur) != 0) {
+    if(SSL_CTX_set_alpn_protos(backend->ctx, protocols, cur)) {
       failf(data, "Error setting ALPN");
       return CURLE_SSL_CONNECT_ERROR;
     }


### PR DESCRIPTION
SSL_CTX_set_alpn_protos() return 0 on success, and non-0 on failure

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>