### PR TITLE
http: cap body data amount during send speed limiting

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1167,7 +1167,7 @@ static size_t readmoredata(char *buffer,
   /* make sure that a HTTP request is never sent away chunked! */
   data->req.forbidchunk = (http->sending == HTTPSEND_REQUEST)?TRUE:FALSE;
 
-  if((data->set.max_send_speed > 0) &&
+  if(data->set.max_send_speed &&
      (data->set.max_send_speed < http->postsize))
     /* speed limit */
     fullsize = (size_t)data->set.max_send_speed;

--- a/lib/http.h
+++ b/lib/http.h
@@ -58,7 +58,7 @@ char *Curl_checkProxyheaders(struct Curl_easy *data,
 CURLcode Curl_buffer_send(struct dynbuf *in,
                           struct Curl_easy *data,
                           curl_off_t *bytes_written,
-                          size_t included_body_bytes,
+                          curl_off_t included_body_bytes,
                           int socketindex);
 #else
 #define Curl_buffer_send(a,b,c,d,e) CURLE_OK

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2069,7 +2069,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       }
       else {
         send_timeout_ms = 0;
-        if(data->set.max_send_speed > 0)
+        if(data->set.max_send_speed)
           send_timeout_ms =
             Curl_pgrsLimitWaitTime(data->progress.uploaded,
                                    data->progress.ul_limit_size,
@@ -2078,7 +2078,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
                                    *nowp);
 
         recv_timeout_ms = 0;
-        if(data->set.max_recv_speed > 0)
+        if(data->set.max_recv_speed)
           recv_timeout_ms =
             Curl_pgrsLimitWaitTime(data->progress.downloaded,
                                    data->progress.dl_limit_size,
@@ -2105,7 +2105,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       DEBUGASSERT(data->state.buffer);
       /* check if over send speed */
       send_timeout_ms = 0;
-      if(data->set.max_send_speed > 0)
+      if(data->set.max_send_speed)
         send_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.uploaded,
                                                  data->progress.ul_limit_size,
                                                  data->set.max_send_speed,
@@ -2114,7 +2114,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
       /* check if over recv speed */
       recv_timeout_ms = 0;
-      if(data->set.max_recv_speed > 0)
+      if(data->set.max_recv_speed)
         recv_timeout_ms = Curl_pgrsLimitWaitTime(data->progress.downloaded,
                                                  data->progress.dl_limit_size,
                                                  data->set.max_recv_speed,

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -321,14 +321,14 @@ void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 void Curl_ratelimit(struct Curl_easy *data, struct curltime now)
 {
   /* don't set a new stamp unless the time since last update is long enough */
-  if(data->set.max_recv_speed > 0) {
+  if(data->set.max_recv_speed) {
     if(Curl_timediff(now, data->progress.dl_limit_start) >=
        MIN_RATE_LIMIT_PERIOD) {
       data->progress.dl_limit_start = now;
       data->progress.dl_limit_size = data->progress.downloaded;
     }
   }
-  if(data->set.max_send_speed > 0) {
+  if(data->set.max_send_speed) {
     if(Curl_timediff(now, data->progress.ul_limit_start) >=
        MIN_RATE_LIMIT_PERIOD) {
       data->progress.ul_limit_start = now;


### PR DESCRIPTION
By making sure never to send off more than the allowed number of bytes
per second the speed limit logic is given more room to actually work.

Reported-by: Fabian Keil
Bug: https://curl.se/mail/lib-2021-03/0042.html