### PR TITLE
tests: use plain UTF-8 instead of en_US.UTF-8

### DIFF
--- a/tests/data/test1034
+++ b/tests/data/test1034
@@ -28,7 +28,7 @@ http
 </features>
 <setenv>
 LC_ALL=
-LC_CTYPE=en_US.UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test1035
+++ b/tests/data/test1035
@@ -26,7 +26,7 @@ http
 </features>
 <setenv>
 LC_ALL=
-LC_CTYPE=en_US.UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test1148
+++ b/tests/data/test1148
@@ -39,7 +39,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -# --stderr log/stderrlog%TESTNUMBER
 </command>
 <setenv>
 LC_ALL=
-LC_NUMERIC=en_US.UTF-8
+LC_NUMERIC=UTF-8
 </setenv>
 </client>
 

--- a/tests/data/test1448
+++ b/tests/data/test1448
@@ -42,8 +42,8 @@ http
 idn
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test165
+++ b/tests/data/test165
@@ -32,8 +32,8 @@ idn
 proxy
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test2046
+++ b/tests/data/test2046
@@ -42,8 +42,8 @@ http
 idn
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test2047
+++ b/tests/data/test2047
@@ -43,8 +43,8 @@ idn
 proxy
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test955
+++ b/tests/data/test955
@@ -23,8 +23,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test956
+++ b/tests/data/test956
@@ -20,8 +20,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test957
+++ b/tests/data/test957
@@ -21,8 +21,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test958
+++ b/tests/data/test958
@@ -21,8 +21,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test959
+++ b/tests/data/test959
@@ -24,8 +24,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test960
+++ b/tests/data/test960
@@ -21,8 +21,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test961
+++ b/tests/data/test961
@@ -22,8 +22,8 @@ smtp
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test962
+++ b/tests/data/test962
@@ -22,8 +22,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test963
+++ b/tests/data/test963
@@ -22,8 +22,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test964
+++ b/tests/data/test964
@@ -23,8 +23,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test965
+++ b/tests/data/test965
@@ -25,8 +25,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test966
+++ b/tests/data/test966
@@ -25,8 +25,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test967
+++ b/tests/data/test967
@@ -29,8 +29,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'

--- a/tests/data/test968
+++ b/tests/data/test968
@@ -26,8 +26,8 @@ idn
 !win32
 </features>
 <setenv>
-LC_ALL=en_US.UTF-8
-LC_CTYPE=en_US.UTF-8
+LC_ALL=UTF-8
+LC_CTYPE=UTF-8
 </setenv>
 <precheck>
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'


### PR DESCRIPTION
... to make the tests work on other UTF-8 locales as well.

Reported-by: Oumph on github
Fixes #6768