### PR TITLE
ldap: only set the callback ptr for TLS context when TLS is used

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -365,13 +365,14 @@ static CURLcode ldap_disconnect(struct Curl_easy *data,
 {
   struct ldapconninfo *li = conn->proto.ldapc;
   (void) dead_connection;
-  (void) data;
 
   if(li) {
     if(li->ld) {
-      Sockbuf *sb;
-      ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb);
-      ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data);
+      if(conn->ssl[FIRSTSOCKET].use) {
+        Sockbuf *sb;
+        ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb);
+        ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data);
+      }
       ldap_unbind_ext(li->ld, NULL, NULL);
       li->ld = NULL;
     }


### PR DESCRIPTION
Follow-up to a5eee22e594c2460f
Fixes #6804