### PR TITLE
config: fix SSPI enabling NTLM if crypto auth is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1377,9 +1377,11 @@ _add_if("Kerberos"      NOT CURL_DISABLE_CRYPTO_AUTH AND
                         (HAVE_GSSAPI OR USE_WINDOWS_SSPI))
 # NTLM support requires crypto function adaptions from various SSL libs
 # TODO alternative SSL libs tests for SSP1, GNUTLS, NSS
-_add_if("NTLM"          (use_curl_ntlm_core OR USE_WINDOWS_SSPI))
+_add_if("NTLM"          NOT CURL_DISABLE_CRYPTO_AUTH AND
+                        (use_curl_ntlm_core OR USE_WINDOWS_SSPI))
 # TODO missing option (autoconf: --enable-ntlm-wb)
-_add_if("NTLM_WB"       (use_curl_ntlm_core OR USE_WINDOWS_SSPI) AND
+_add_if("NTLM_WB"       NOT CURL_DISABLE_CRYPTO_AUTH AND
+                        (use_curl_ntlm_core OR USE_WINDOWS_SSPI) AND
                         NOT CURL_DISABLE_HTTP AND NTLM_WB_ENABLED)
 # TODO missing option (--enable-tls-srp), depends on GNUTLS_SRP/OPENSSL_SRP
 _add_if("TLS-SRP"       USE_TLS_SRP)

--- a/configure.ac
+++ b/configure.ac
@@ -5225,23 +5225,25 @@ if test "x$CURL_DISABLE_CRYPTO_AUTH" != "x1" -a \
   SUPPORT_FEATURES="$SUPPORT_FEATURES Kerberos"
 fi
 
-if test "x$CURL_DISABLE_CRYPTO_AUTH" != "x1" -a \
-    \( "x$OPENSSL_ENABLED" = "x1" -o "x$MBEDTLS_ENABLED" = "x1" \
+use_curl_ntlm_core=no
+
+if test "x$CURL_DISABLE_CRYPTO_AUTH" != "x1"; then
+  if test "x$OPENSSL_ENABLED" = "x1" -o "x$MBEDTLS_ENABLED" = "x1" \
       -o "x$GNUTLS_ENABLED" = "x1" -o "x$NSS_ENABLED" = "x1" \
       -o "x$SECURETRANSPORT_ENABLED" = "x1" \
       -o "x$USE_WIN32_CRYPTO" = "x1" \
-      -o "x$WOLFSSL_NTLM" = "x1" \); then
-  use_curl_ntlm_core=yes
-else
-  use_curl_ntlm_core=no
-fi
-if test "x$use_curl_ntlm_core" = "xyes" \
-    -o "x$USE_WINDOWS_SSPI" = "x1"; then
-  SUPPORT_FEATURES="$SUPPORT_FEATURES NTLM"
+      -o "x$WOLFSSL_NTLM" = "x1"; then
+    use_curl_ntlm_core=yes
+  fi
 
-  if test "x$CURL_DISABLE_HTTP" != "x1" -a \
-      "x$NTLM_WB_ENABLED" = "x1"; then
-    SUPPORT_FEATURES="$SUPPORT_FEATURES NTLM_WB"
+  if test "x$use_curl_ntlm_core" = "xyes" \
+      -o "x$USE_WINDOWS_SSPI" = "x1"; then
+    SUPPORT_FEATURES="$SUPPORT_FEATURES NTLM"
+
+    if test "x$CURL_DISABLE_HTTP" != "x1" -a \
+        "x$NTLM_WB_ENABLED" = "x1"; then
+      SUPPORT_FEATURES="$SUPPORT_FEATURES NTLM_WB"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Avoid enabling NTLM feature based upon Windows SSPI
being enabled in case that crypto auth is disabled.

Reported-by: Marcel Raad

Follow up to #6277
Fixes #6803