### PR TITLE
vtls: fix addsessionid for non-proxy builds

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -505,7 +505,6 @@ CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
     conn->host.name;
 #else
   /* proxy support disabled */
-  const bool isProxy = FALSE;
   struct ssl_primary_config * const ssl_config = &conn->ssl_config;
   const char *hostname = conn->host.name;
   (void)sockindex;


### PR DESCRIPTION
Follow-up to b09c8ee15771c61