### PR TITLE
Add `security-extended` to CodeQL queries

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: cpp
+        queries: security-extended
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
This PR adds the `security-extended` queries to the CodeQL CI workflow.

These queries are more aggressive, which means that they _can_ raise false positives, which is why they are disabled by default. But they're also really helpful and find lots of security bugs that the standard queries don't. The standard queries don't really check much in the way of security scans, they're mostly for general code quality.