### PR TITLE
TLS: fix HTTP/2 selection

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -391,7 +391,7 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
      */
 
 #ifdef USE_NGHTTP2
-    if(data->state.httpversion >= CURL_HTTP_VERSION_2
+    if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
       && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -612,7 +612,7 @@ gtls_connect_step1(struct Curl_easy *data,
     gnutls_datum_t protocols[2];
 
 #ifdef USE_NGHTTP2
-    if(data->state.httpversion >= CURL_HTTP_VERSION_2
+    if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
        && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -497,7 +497,7 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   if(conn->bits.tls_enable_alpn) {
     const char **p = &backend->protocols[0];
 #ifdef USE_NGHTTP2
-    if(data->state.httpversion >= CURL_HTTP_VERSION_2)
+    if(data->state.httpwant >= CURL_HTTP_VERSION_2)
       *p++ = NGHTTP2_PROTO_VERSION_ID;
 #endif
     *p++ = ALPN_HTTP_1_1;

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2080,7 +2080,7 @@ static CURLcode nss_setup_connect(struct Curl_easy *data,
     unsigned char protocols[128];
 
 #ifdef USE_NGHTTP2
-    if(data->state.httpversion >= CURL_HTTP_VERSION_2
+    if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
       && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -862,7 +862,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
     list_start_index = cur;
 
 #ifdef USE_NGHTTP2
-    if(data->state.httpversion >= CURL_HTTP_VERSION_2) {
+    if(data->state.httpwant >= CURL_HTTP_VERSION_2) {
       memcpy(&alpn_buffer[cur], NGHTTP2_PROTO_ALPN, NGHTTP2_PROTO_ALPN_LEN);
       cur += NGHTTP2_PROTO_ALPN_LEN;
       infof(data, "schannel: ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1613,7 +1613,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
                                                        &kCFTypeArrayCallBacks);
 
 #ifdef USE_NGHTTP2
-      if(data->state.httpversion >= CURL_HTTP_VERSION_2
+      if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
          && (!isproxy || !conn->bits.tunnel_proxy)
 #endif

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -475,7 +475,7 @@ wolfssl_connect_step1(struct Curl_easy *data, struct connectdata *conn,
        protocols in descending order of preference, eg: "h2,http/1.1" */
 
 #ifdef USE_NGHTTP2
-    if(data->state.httpversion >= CURL_HTTP_VERSION_2) {
+    if(data->state.httpwant >= CURL_HTTP_VERSION_2) {
       strcpy(protocols + strlen(protocols), NGHTTP2_PROTO_VERSION_ID ",");
       infof(data, "ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
     }
@@ -726,7 +726,7 @@ wolfssl_connect_step2(struct Curl_easy *data, struct connectdata *conn,
          !memcmp(protocol, ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH))
         conn->negnpn = CURL_HTTP_VERSION_1_1;
 #ifdef USE_NGHTTP2
-      else if(data->state.httpversion >= CURL_HTTP_VERSION_2 &&
+      else if(data->state.httpwant >= CURL_HTTP_VERSION_2 &&
               protocol_len == NGHTTP2_PROTO_VERSION_ID_LEN &&
               !memcmp(protocol, NGHTTP2_PROTO_VERSION_ID,
                       NGHTTP2_PROTO_VERSION_ID_LEN))


### PR DESCRIPTION
Regression since 88dd1a8a115b1f5ece (shipped in 7.76.0)
Reported-by: Kenneth Davidson
Fixes #6825