### PR TITLE
hostip: Fix for builds that disable all asynchronous DNS

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1130,6 +1130,7 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
  * resolve error
  */
 
+#ifdef USE_CURL_ASYNC
 CURLcode Curl_resolver_error(struct Curl_easy *data)
 {
   const char *host_or_proxy;
@@ -1153,3 +1154,4 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
 
   return result;
 }
+#endif /* USE_CURL_ASYNC */


### PR DESCRIPTION
- Define Curl_resolver_error function only when USE_CURL_ASYNC.

Prior to this change building curl without an asynchronous resolver
backend (c-ares or threaded) and without DoH (DNS-over-HTTPS, also
asynchronous but independent of resolver backend) would cause a build
error since Curl_resolver_error is called by and evaluates variables
only available in asynchronous builds.

Reported-by: Benbuck Nason

Fixes https://github.com/curl/curl/issues/6831
Closes #xxxx