### PR TITLE
openssl: supress SSLv3 deprecation warning

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2602,7 +2602,14 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
     if(ssl_authtype == CURL_TLSAUTH_SRP)
       return CURLE_SSL_CONNECT_ERROR;
 #endif
+    /*
+     * Some OpenSSLs consider SSLv3 as deprecated but we know it better in this
+     * case!
+     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     req_method = SSLv3_client_method();
+#pragma GCC diagnostic pop
     use_sni(FALSE);
     break;
 #endif


### PR DESCRIPTION
This disables GCC and clang to output a warning when using SSLv3
functions. Of course this is a good thing as SSLv3 should no longer be
used but in our case we know explicitly what we are doing.


On my FreeBSD-12.2p5 compiling curl without it results in the following warning (clang)
```
vtls/openssl.c:2605:18: warning: 'SSLv3_client_method' is deprecated [-Wdeprecated-declarations]
    req_method = SSLv3_client_method();
                 ^
/usr/include/openssl/ssl.h:1864:1: note: 'SSLv3_client_method' has been explicitly marked deprecated here
DEPRECATEDIN_1_1_0(__owur const SSL_METHOD *SSLv3_client_method(void))
^
/usr/include/openssl/opensslconf.h:147:34: note: expanded from macro 'DEPRECATEDIN_1_1_0'
# define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
                                 ^
/usr/include/openssl/opensslconf.h:110:55: note: expanded from macro 'DECLARE_DEPRECATED'
#   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
```