### PR TITLE
acinclude: refine the CFLAGS *version-min grep regex

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2606,7 +2606,7 @@ AC_DEFUN([CURL_MAC_CFLAGS], [
       var="IPHONEOS_DEPLOYMENT_TARGET"
     elif test -n "$MACOSX_DEPLOYMENT_TARGET"; then
       var="MACOSX_DEPLOYMENT_TARGET"
-    elif test -z "$(echo $CFLAGS $CC | grep m.*os.*-version-min)"; then
+    elif test -z "$(echo $CFLAGS $CC | grep m.*-version-min)"; then
       min="-mmacosx-version-min=10.8"
       CFLAGS="$CFLAGS $min"
     else


### PR DESCRIPTION
To make it work with -miphonesimulator-version-min and others.

Reported-by: manuyavuz-pointr on github
Fixes #6838