### PR TITLE
http_proxy: only loop on 407 + close if we have credentials

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -358,7 +358,8 @@ static CURLcode CONNECT(struct Curl_easy *data,
           break;
         }
         else if(gotbytes <= 0) {
-          if(data->set.proxyauth && data->state.authproxy.avail) {
+          if(data->set.proxyauth && data->state.authproxy.avail &&
+             data->state.aptr.proxyuserpwd) {
             /* proxy auth was requested and there was proxy auth available,
                then deem this as "mere" proxy disconnect */
             conn->bits.proxy_connect_closed = TRUE;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -94,6 +94,7 @@ test670 test671 test672 test673 test674 test675 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \
+test718 \
 \
 test800 test801 test802 test803 test804 test805 test806 test807 test808 \
 test809 test810 test811 test812 test813 test814 test815 test816 test817 \

--- a/tests/data/test718
+++ b/tests/data/test718
@@ -1,0 +1,59 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP CONNECT
+HTTP proxy
+proxytunnel
+HTTP proxy Digest auth
+</keywords>
+</info>
+
+# Server-side
+<reply>
+
+# this is returned first since we get no proxy-auth
+<connect>
+HTTP/1.1 407 Authorization Required to proxy me swsclose
+Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
+</connect>
+
+<datacheck>
+HTTP/1.1 407 Authorization Required to proxy me swsclose
+Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+!SSPI
+crypto
+proxy
+</features>
+ <name>
+HTTP proxy CONNECT (no auth) with proxy returning 407 and closing
+ </name>
+ <command>
+http://test.remote.haxx.se.%TESTNUMBER:8990/path/%TESTNUMBER0002 --proxy http://%HOSTIP:%HTTPPORT --proxytunnel
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+CONNECT test.remote.haxx.se.%TESTNUMBER:8990 HTTP/1.1
+Host: test.remote.haxx.se.%TESTNUMBER:8990
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</protocol>
+<errorcode>
+56
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
... to fix the retry-loop.

Reported-by: Daniel Kurečka
Fixes #6828
Closes #[fill in]