### PR TITLE
h2: allow 100 streams by default

### DIFF
--- a/lib/http2.h
+++ b/lib/http2.h
@@ -29,7 +29,7 @@
 
 /* value for MAX_CONCURRENT_STREAMS we use until we get an updated setting
    from the peer */
-#define DEFAULT_MAX_CONCURRENT_STREAMS 13
+#define DEFAULT_MAX_CONCURRENT_STREAMS 100
 
 /*
  * Store nghttp2 version info in this buffer, Prefix with a space.  Return


### PR DESCRIPTION
instead of 13, before the server has told how many streams it
accepts. The server can always reject new streams anyway if we go above
what it accepts.