### PR TITLE
ngtcp2+gnutls: clear credentials when freed

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -873,8 +873,10 @@ static void qs_disconnect(struct quicsocket *qs)
 #endif
   qs->ssl = NULL;
 #ifdef USE_GNUTLS
-  if(qs->cred)
+  if(qs->cred) {
     gnutls_certificate_free_credentials(qs->cred);
+    qs->cred = NULL;
+  }
 #endif
   for(i = 0; i < 3; i++)
     Curl_safefree(qs->crypto_data[i].buf);


### PR DESCRIPTION
... to avoid double-free.

Reported-by: Kenneth Davidson
Fixes #6824
Closes #[fill in]