### PR TITLE
Update HTTP3.md

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -95,7 +95,7 @@ Build ngtcp2
      % git clone https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -i
-     % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only
+     % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-gnutls
      % make
      % make install
 


### PR DESCRIPTION
In ngtcp2 the `with-gnutls` option is disabled by default, which will cause `curl` unable to be `make` because of lacking the libraries needed.