### PR TITLE
Improvement/convenient darwin builds

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2580,14 +2580,13 @@ TEST EINVAL TEST
 ])
 
 
-dnl CURL_MAC_CFLAGS
+dnl CURL_DARWIN_CFLAGS
 dnl
-dnl Check if -mmacosx-version-min, -miphoneos-version-min or any
-dnl similar are set manually, otherwise do. And set
-dnl -Werror=partial-availability.
+dnl Set -Werror=partial-availability to detect possible breaking code
+dnl with very low deployment targets.
 dnl
 
-AC_DEFUN([CURL_MAC_CFLAGS], [
+AC_DEFUN([CURL_DARWIN_CFLAGS], [
 
   tst_cflags="no"
   case $host_os in
@@ -2596,28 +2595,10 @@ AC_DEFUN([CURL_MAC_CFLAGS], [
       ;;
   esac
 
-  AC_MSG_CHECKING([for good-to-use Mac CFLAGS])
+  AC_MSG_CHECKING([for good-to-use Darwin CFLAGS])
   AC_MSG_RESULT([$tst_cflags]);
 
   if test "$tst_cflags" = "yes"; then
-    AC_MSG_CHECKING([for *version-min set by user])
-    min=""
-    if test -n "$IPHONEOS_DEPLOYMENT_TARGET"; then
-      var="IPHONEOS_DEPLOYMENT_TARGET"
-    elif test -n "$MACOSX_DEPLOYMENT_TARGET"; then
-      var="MACOSX_DEPLOYMENT_TARGET"
-    elif test -z "$(echo $CFLAGS $CC | grep m.*os.*-version-min)"; then
-      min="-mmacosx-version-min=10.8"
-      CFLAGS="$CFLAGS $min"
-    else
-      var="CFLAGS or CC"
-    fi
-    if test -z "$min"; then
-      AC_MSG_RESULT([set by user in $var])
-    else
-      AC_MSG_RESULT([$min set])
-    fi
-
     old_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -Werror=partial-availability"
     AC_MSG_CHECKING([whether $CC accepts -Werror=partial-availability])

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,13 +262,12 @@ no longer support the legacy handshakes and algorithms used by those
 versions. If you will be using curl in one of those earlier versions of
 Windows you should choose another SSL backend such as OpenSSL.
 
-# Apple iOS and macOS
+# Apple Platforms (macOS, iOS, tvOS, watchOS, and their simulator counterparts)
 
 On modern Apple operating systems, curl can be built to use Apple's SSL/TLS
 implementation, Secure Transport, instead of OpenSSL. To build with Secure
-Transport for SSL/TLS, use the configure option `--with-secure-transport`. (It
-is not necessary to use the option `--without-ssl`.) This feature requires iOS
-5.0 or later, or OS X 10.5 ("Leopard") or later.
+Transport for SSL/TLS, use the configure option `--with-secure-transport`
+or `--with-darwin-ssl`. (It is not necessary to use the option `--without-ssl`.)
 
 When Secure Transport is in use, the curl options `--cacert` and `--capath`
 and their libcurl equivalents, will be ignored, because Secure Transport uses
@@ -277,22 +276,51 @@ the server. This, of course, includes the root certificates that ship with the
 OS. The `--cert` and `--engine` options, and their libcurl equivalents, are
 currently unimplemented in curl with Secure Transport.
 
-For macOS users: In OS X 10.8 ("Mountain Lion"), Apple made a major overhaul
-to the Secure Transport API that, among other things, added support for the
-newer TLS 1.1 and 1.2 protocols. To get curl to support TLS 1.1 and 1.2, you
-must build curl on Mountain Lion or later, or by using the equivalent SDK. If
-you set the `MACOSX_DEPLOYMENT_TARGET` environmental variable to an earlier
-version of macOS prior to building curl, then curl will use the new Secure
-Transport API on Mountain Lion and later, and fall back on the older API when
-the same curl binary is executed on older cats. For example, running these
-commands in curl's directory in the shell will build the code such that it
-will run on cats as old as OS X 10.6 ("Snow Leopard") (using bash):
+In general, a curl build for an Apple `ARCH/SDK/DEPLOYMENT_TARGET` combination
+can be taken by providing appropriate values for `ARCH`, `SDK`, `DEPLOYMENT_TARGET`
+below and running the commands:
 
 ```bash
-export MACOSX_DEPLOYMENT_TARGET="10.6"
-./configure --with-secure-transport
-make
+# Set these three according to your needs
+export ARCH=x86_64
+export SDK=macosx
+export DEPLOYMENT_TARGET=10.8
+
+export CFLAGS="-arch $ARCH -isysroot $(xcrun -sdk $SDK --show-sdk-path) -m$SDK-version-min=$DEPLOYMENT_TARGET"
+./configure --host=$ARCH-apple-darwin --prefix $(pwd)/artifacts --with-darwin-ssl
+make -j8
+make install
 ```
+
+Above will build curl for macOS platform with `x86_64` architecture and `10.8` as deployment target.
+
+Here is an example for iOS device:
+
+```bash
+export ARCH=arm64
+export SDK=iphoneos
+export DEPLOYMENT_TARGET=11.0
+
+export CFLAGS="-arch $ARCH -isysroot $(xcrun -sdk $SDK --show-sdk-path) -m$SDK-version-min=$DEPLOYMENT_TARGET"
+./configure --host=$ARCH-apple-darwin --prefix $(pwd)/artifacts --with-darwin-ssl
+make -j8
+make install
+```
+
+Another example for watchOS simulator for macs with Apple Silicon:
+
+```bash
+export ARCH=arm64
+export SDK=watchsimulator
+export DEPLOYMENT_TARGET=5.0
+
+export CFLAGS="-arch $ARCH -isysroot $(xcrun -sdk $SDK --show-sdk-path) -m$SDK-version-min=$DEPLOYMENT_TARGET"
+./configure --host=$ARCH-apple-darwin --prefix $(pwd)/artifacts --with-darwin-ssl
+make -j8
+make install
+```
+
+In all above, the built libraries and executables can be found in `artifacts` folder.
 
 # Android
 


### PR DESCRIPTION
- Removes default deployment version setting which breaks builds for iOS, tvOS, and watchOS if no deployment target was set.
- Provides convenient steps to build curl for Apple platforms including macOS, iOS, watchOS, tvOS, and their simulator counterparts.

Fixes #6838.

@bagder, would we want to add CI jobs for iOS/tvOS/watchOS builds? I can do that too if wanted.
