### PR TITLE
configure: provide --with-openssl, deprecate --with-ssl

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,11 +44,11 @@ jobs:
           macosx-version-min: 10.8
         - name: OpenSSL metalink
           install: nghttp2 openssl libmetalink
-          configure: --enable-debug --with-ssl=/usr/local/opt/openssl --with-libmetalink
+          configure: --enable-debug --with-openssl=/usr/local/opt/openssl --with-libmetalink
           macosx-version-min: 10.9
         - name: LibreSSL metalink
           install: nghttp2 libressl libmetalink
-          configure: --enable-debug --with-ssl=/usr/local/opt/libressl --with-libmetalink
+          configure: --enable-debug --with-openssl=/usr/local/opt/libressl --with-libmetalink
           macosx-version-min: 10.9
         - name: torture
           install: nghttp2 openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,12 +99,12 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=novalgrind BORINGSSL=yes C="--with-ssl=$HOME/boringssl" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
+    - T=novalgrind BORINGSSL=yes C="--with-openssl=$HOME/boringssl" LD_LIBRARY_PATH=/home/travis/boringssl/lib:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     before_install:
     - eval "$(gimme stable)"; gimme --list  # Install latest Go (for boringssl)
   - env:
-    - T=novalgrind QUICHE="yes" C="--with-ssl=$HOME/quiche/deps/boringssl/src --with-quiche=$HOME/quiche/target/release" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
+    - T=novalgrind QUICHE="yes" C="--with-openssl=$HOME/quiche/deps/boringssl/src --with-quiche=$HOME/quiche/target/release" LD_LIBRARY_PATH=$HOME/quiche/target/release:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:
@@ -135,10 +135,10 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=novalgrind LIBRESSL=yes C="--with-ssl=$HOME/libressl" LD_LIBRARY_PATH=/home/travis/libressl/lib:/usr/local/lib
+    - T=novalgrind LIBRESSL=yes C="--with-openssl=$HOME/libressl" LD_LIBRARY_PATH=/home/travis/libressl/lib:/usr/local/lib
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
   - env:
-    - T=novalgrind NGTCP2=yes C="--with-ssl=$HOME/ngbuild --with-ngtcp2=$HOME/ngbuild --with-nghttp3=$HOME/ngbuild" NOTESTS=
+    - T=novalgrind NGTCP2=yes C="--with-openssl=$HOME/ngbuild --with-ngtcp2=$HOME/ngbuild --with-nghttp3=$HOME/ngbuild" NOTESTS=
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:
@@ -181,7 +181,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug OPENSSL3="yes" C="--with-ssl=$HOME/openssl3" LD_LIBRARY_PATH=/home/travis/openssl3/lib:/usr/local/lib TFLAGS="https ftps"
+    - T=debug OPENSSL3="yes" C="--with-openssl=$HOME/openssl3" LD_LIBRARY_PATH=/home/travis/openssl3/lib:/usr/local/lib TFLAGS="https ftps"
     - OVERRIDE_CC="CC=gcc-8" OVERRIDE_CXX="CXX=g++-8"
     addons:
       apt:

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -25,7 +25,7 @@ all:
 	make
 
 ssl:
-	./configure --with-ssl
+	./configure --with-openssl
 	make
 
 mingw32:
@@ -66,7 +66,7 @@ cygwin:
 	make
 
 cygwin-ssl:
-	./configure --with-ssl
+	./configure --with-openssl
 	make
 
 amiga:

--- a/configure.ac
+++ b/configure.ac
@@ -1736,8 +1736,13 @@ OPT_SSL=off
 dnl Default to no CA bundle
 ca="no"
 AC_ARG_WITH(ssl,dnl
-AS_HELP_STRING([--with-ssl=PATH],[Where to look for OpenSSL, PATH points to the SSL installation (default: /usr/local/ssl); when possible, set the PKG_CONFIG_PATH environment variable instead of using this option])
-AS_HELP_STRING([--without-ssl], [disable OpenSSL]),
+AS_HELP_STRING([--with-ssl=PATH],[old version of --with-openssl])
+AS_HELP_STRING([--without-ssl], [old version of --without-openssl]),
+  OPT_SSL=$withval)
+
+AC_ARG_WITH(openssl,dnl
+AS_HELP_STRING([--with-openssl=PATH],[Where to look for OpenSSL, PATH points to the SSL installation (default: /usr/local/ssl); when possible, set the PKG_CONFIG_PATH environment variable instead of using this option])
+AS_HELP_STRING([--without-openssl], [disable OpenSSL]),
   OPT_SSL=$withval)
 
 if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
@@ -1773,18 +1778,18 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
 
   case "$OPT_SSL" in
   yes)
-    dnl --with-ssl (without path) used
+    dnl --with-openssl (without path) used
     PKGTEST="yes"
     PREFIX_OPENSSL=/usr/local/ssl
     LIB_OPENSSL="$PREFIX_OPENSSL/lib$libsuff"
     ;;
   off)
-    dnl no --with-ssl option given, just check default places
+    dnl no --with-openssl option given, just check default places
     PKGTEST="yes"
     PREFIX_OPENSSL=
     ;;
   *)
-    dnl check the given --with-ssl spot
+    dnl check the given --with-openssl spot
     PKGTEST="no"
     PREFIX_OPENSSL=$OPT_SSL
 
@@ -1796,11 +1801,11 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
       AC_MSG_NOTICE([PKG_CONFIG_LIBDIR will be set to "$OPENSSL_PCDIR"])
       PKGTEST="yes"
     elif test ! -f "$PREFIX_OPENSSL/include/openssl/ssl.h"; then
-      AC_MSG_ERROR([$PREFIX_OPENSSL is a bad --with-ssl prefix!])
+      AC_MSG_ERROR([$PREFIX_OPENSSL is a bad --with-openssl prefix!])
     fi
 
     dnl in case pkg-config comes up empty, use what we got
-    dnl via --with-ssl
+    dnl via --with-openssl
     LIB_OPENSSL="$PREFIX_OPENSSL/lib$libsuff"
     if test "$PREFIX_OPENSSL" != "/usr" ; then
       SSL_LDFLAGS="-L$LIB_OPENSSL"
@@ -1834,7 +1839,7 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
       dnl use the values pkg-config reported.  This is here
       dnl instead of below with CPPFLAGS and LDFLAGS because we only
       dnl learn about this via pkg-config.  If we only have
-      dnl the argument to --with-ssl we don't know what
+      dnl the argument to --with-openssl we don't know what
       dnl additional libs may be necessary.  Hope that we
       dnl don't need any.
       LIBS="$SSL_LIBS $LIBS"
@@ -1856,8 +1861,9 @@ if test -z "$ssl_backends" -o "x$OPT_SSL" != xno &&
        # only set this if pkg-config wasn't used
        CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include/openssl -I$PREFIX_OPENSSL/include"
      fi
-     # Linking previously failed, try extra paths from --with-ssl or pkg-config.
-     # Use a different function name to avoid reusing the earlier cached result.
+     # Linking previously failed, try extra paths from --with-openssl or
+     # pkg-config.  Use a different function name to avoid reusing the earlier
+     # cached result.
      AC_CHECK_LIB(crypto, HMAC_Init_ex,[
        HAVECRYPTO="yes"
        LIBS="-lcrypto $LIBS"], [
@@ -2051,7 +2057,7 @@ if test X"$OPT_SSL" != Xoff &&
   test "$OPENSSL_ENABLED" != "1"; then
   AC_MSG_NOTICE([OPT_SSL: $OPT_SSL])
   AC_MSG_NOTICE([OPENSSL_ENABLED: $OPENSSL_ENABLED])
-  AC_MSG_ERROR([--with-ssl was given but OpenSSL could not be detected])
+  AC_MSG_ERROR([--with-openssl was given but OpenSSL could not be detected])
 fi
 
 dnl **********************************************************************
@@ -2925,7 +2931,7 @@ case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABL
 in
 x)
   AC_MSG_WARN([SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.])
-  AC_MSG_WARN([Use --with-ssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-nss, --with-schannel, --with-secure-transport, --with-mesalink, --with-amissl or --with-bearssl to address this.])
+  AC_MSG_WARN([Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-nss, --with-schannel, --with-secure-transport, --with-mesalink, --with-amissl, --with-bearssl or --with-rustls to address this.])
   ;;
 x1)
   # one SSL backend is enabled

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -65,7 +65,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % LDFLAGS="-Wl,-rpath,<somewhere1>/lib" ./configure --with-ssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
+     % LDFLAGS="-Wl,-rpath,<somewhere1>/lib" ./configure --with-openssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
 
 ## Build with GnuTLS
@@ -105,7 +105,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure --without-ssl --with-gnutls=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
+     % ./configure --without-openssl --with-gnutls=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
 
 # quiche version
@@ -126,7 +126,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % ./buildconf
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-ssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
      % make
 
 ## Run

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -59,21 +59,21 @@ explicitly told not to. If you have OpenSSL installed in the default search
 path for your compiler/linker, you don't need to do anything special. If you
 have OpenSSL installed in `/usr/local/ssl`, you can run configure like:
 
-    ./configure --with-ssl
+    ./configure --with-openssl
 
 If you have OpenSSL installed somewhere else (for example, `/opt/OpenSSL`) and
 you have pkg-config installed, set the pkg-config path first, like this:
 
-    env PKG_CONFIG_PATH=/opt/OpenSSL/lib/pkgconfig ./configure --with-ssl
+    env PKG_CONFIG_PATH=/opt/OpenSSL/lib/pkgconfig ./configure --with-openssl
 
 Without pkg-config installed, use this:
 
-    ./configure --with-ssl=/opt/OpenSSL
+    ./configure --with-openssl=/opt/OpenSSL
 
 If you insist on forcing a build without SSL support, even though you may
 have OpenSSL installed in your system, you can run configure like this:
 
-    ./configure --without-ssl
+    ./configure --without-openssl
 
 If you have OpenSSL installed, but with the libraries in one place and the
 header files somewhere else, you have to set the `LDFLAGS` and `CPPFLAGS`
@@ -86,7 +86,7 @@ If you have shared SSL libs installed in a directory where your run-time
 linker doesn't find them (which usually causes configure failures), you can
 provide this option to gcc to set a hard-coded path to the run-time linker:
 
-    LDFLAGS=-Wl,-R/usr/local/ssl/lib ./configure --with-ssl
+    LDFLAGS=-Wl,-R/usr/local/ssl/lib ./configure --with-openssl
 
 ## More Options
 
@@ -112,14 +112,14 @@ want to alter it, you can select how to deal with each individual library.
 The default OpenSSL configure check will also detect and use BoringSSL or
 libressl.
 
- - GnuTLS: `--without-ssl --with-gnutls`.
- - wolfSSL: `--without-ssl --with-wolfssl`
- - NSS: `--without-ssl --with-nss`
- - mbedTLS: `--without-ssl --with-mbedtls`
- - schannel: `--without-ssl --with-schannel`
- - secure transport: `--without-ssl --with-secure-transport`
- - MesaLink: `--without-ssl --with-mesalink`
- - BearSSL: `--without-ssl --with-bearssl`
+ - GnuTLS: `--without-openssl --with-gnutls`.
+ - wolfSSL: `--without-openssl --with-wolfssl`
+ - NSS: `--without-openssl --with-nss`
+ - mbedTLS: `--without-openssl --with-mbedtls`
+ - schannel: `--without-openssl --with-schannel`
+ - secure transport: `--without-openssl --with-secure-transport`
+ - MesaLink: `--without-openssl --with-mesalink`
+ - BearSSL: `--without-openssl --with-bearssl`
 
 # Windows
 
@@ -267,7 +267,7 @@ Windows you should choose another SSL backend such as OpenSSL.
 On modern Apple operating systems, curl can be built to use Apple's SSL/TLS
 implementation, Secure Transport, instead of OpenSSL. To build with Secure
 Transport for SSL/TLS, use the configure option `--with-secure-transport`
-or `--with-darwin-ssl`. (It is not necessary to use the option `--without-ssl`.)
+or `--with-darwin-ssl`. (It is not necessary to use the option `--without-openssl`.)
 
 When Secure Transport is in use, the curl options `--cacert` and `--capath`
 and their libcurl equivalents, will be ignored, because Secure Transport uses
@@ -358,8 +358,8 @@ OpenSSL, follow the OpenSSL build instructions and then install `libssl.a` and
 `libcrypto.a` to `$TOOLCHAIN/sysroot/usr/lib` and copy `include/openssl` to
 `$TOOLCHAIN/sysroot/usr/include`. Now you can build curl for Android using
 OpenSSL like this:
-    
-    ./configure --host aarch64-linux-android --with-pic --disable-shared --with-ssl="$TOOLCHAIN/sysroot/usr"
+
+    ./configure --host aarch64-linux-android --with-pic --disable-shared --with-openssl="$TOOLCHAIN/sysroot/usr"
 
 Note, however, that you must target at least Android M (API level 23) or `configure`
 won't be able to detect OpenSSL since `stderr` (and the like) weren't defined
@@ -438,7 +438,7 @@ use, here are some other flags that can reduce the size of the library:
  - `--enable-hidden-symbols` (eliminates unneeded symbols in the shared library)
  - `--without-libidn` (disables support for the libidn DNS library)
  - `--without-librtmp` (disables support for RTMP)
- - `--without-ssl` (disables support for SSL/TLS)
+ - `--without-openssl` (disables support for SSL/TLS)
  - `--without-zlib` (disables support for on-the-fly decompression)
 
 The GNU compiler and linker have a number of options that can reduce the

--- a/docs/TODO
+++ b/docs/TODO
@@ -112,7 +112,7 @@
  13.4 Cache/share OpenSSL contexts
  13.5 Export session ids
  13.6 Provide callback for cert verification
- 13.7 improve configure --with-ssl
+ 13.7 improve configure --with-openssl
  13.8 Support DANE
  13.9 TLS record padding
  13.10 Support Authority Information Access certificate extension (AIA)
@@ -769,10 +769,12 @@
  certificate, but this doesn't seem to be exposed in the libcurl APIs. Could
  it be? There's so much that could be done if it were!
 
-13.7 improve configure --with-ssl
+13.7 improve configure --with-openssl
 
- make the configure --with-ssl option first check for OpenSSL, then GnuTLS,
- then NSS...
+ Consider making the configure script not guess which TLS library to use (as
+ it makes it harder to purposely select another library than the default).
+ Maybe require specific TLS library option(s) or an explicit no-TLS-at-all
+ option.
 
 13.8 Support DANE
 

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -306,7 +306,7 @@ if (!$desc) {
 if (!$confopts) {
   if ($infixed < 4) {
     print "please enter your additional arguments to configure\n";
-    print "examples: --with-ssl --enable-debug --enable-ipv6 --with-krb4\n";
+    print "examples: --with-openssl --enable-debug --enable-ipv6\n";
     $confopts = <>;
     chomp $confopts;
   }


### PR DESCRIPTION
Makes the option more explicit.