### PR TITLE
tool_getparam: replace (in-place) '%20' by '+' according to RFC1866

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -48,7 +48,6 @@ problems may have been fixed or changed somewhat since this was written!
  4.1 -J and -O with %-encoded file names
  4.2 -J with -C - fails
  4.3 --retry and transfer timeouts
- 4.4 Improve --data-urlencode space encoding
 
  5. Build and portability issues
  5.1 OS400 port requires deprecated IBM library
@@ -410,13 +409,6 @@ problems may have been fixed or changed somewhat since this was written!
  original position where it was at before the previous failed attempt. See
  https://curl.se/mail/lib-2008-01/0080.html and Mandriva bug report
  https://qa.mandriva.com/show_bug.cgi?id=22565
-
-4.4 Improve --data-urlencode space encoding
-
- ASCII space characters in --data-urlencode are currently encoded as %20
- rather than +, which RFC 1866 says should be used.
-
- See https://github.com/curl/curl/issues/3229
 
 5. Build and portability issues
 

--- a/tests/data/test1015
+++ b/tests/data/test1015
@@ -43,10 +43,10 @@ POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 133
+Content-Length: 119
 Content-Type: application/x-www-form-urlencoded
 
-my%20name%20is%20moo%5B%5D&y e s=s_i_r&v_alue=content%20to%20_%3F%21%23%24%27%7C%3C%3E%0A&content%20to%20_%3F%21%23%24%27%7C%3C%3E%0A
+my+name+is+moo%5B%5D&y e s=s_i_r&v_alue=content+to+_%3F%21%23%24%27%7C%3C%3E%0A&content+to+_%3F%21%23%24%27%7C%3C%3E%0A
 </protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
This PR addresses KNOWN_BUGS 4.5 Improve `--data-urlencode` space encoding

related to #3229