### PR TITLE
urlapi: make sure no +/- signs are accepted in IPv4 numericals

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -686,7 +686,11 @@ static bool ipv4_normalize(const char *hostname, char *outp, size_t olen)
 
   while(!done) {
     char *endp;
-    unsigned long l = strtoul(c, &endp, 0);
+    unsigned long l;
+    if((*c < '0') || (*c > '9'))
+      /* most importantly this doesn't allow a leading plus or minus */
+      return FALSE;
+    l = strtoul(c, &endp, 0);
 
     /* overflow or nothing parsed at all */
     if(((l == ULONG_MAX) && (errno == ERANGE)) ||  (endp == c))

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -331,6 +331,9 @@ static struct urltestcase get_url_list[] = {
   {"https://0xff.0xff.0377.255", "https://255.255.255.255/", 0, 0, CURLUE_OK},
   {"https://1.0xffffff", "https://1.255.255.255/", 0, 0, CURLUE_OK},
   /* IPv4 numerical overflows or syntax errors will not normalize */
+  {"https://+127.0.0.1", "https://+127.0.0.1/", 0, 0, CURLUE_OK},
+  {"https://127.-0.0.1", "https://127.-0.0.1/", 0, 0, CURLUE_OK},
+  {"https://127.0. 1", "https://127.0.0.1/", 0, 0, CURLUE_MALFORMED_INPUT},
   {"https://1.0x1000000", "https://1.0x1000000/", 0, 0, CURLUE_OK},
   {"https://1.2.3.256", "https://1.2.3.256/", 0, 0, CURLUE_OK},
   {"https://1.2.3.4.5", "https://1.2.3.4.5/", 0, 0, CURLUE_OK},


### PR DESCRIPTION
Follow-up to 56a037cc0ad1b2. Extends test 1560 to verify.

Reported-by: Tuomas Siipola @siiptuo 
Fixes #6916
Closes #