### PR TITLE
connect: use CURL_SA_FAMILY_T for portability

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -660,7 +660,7 @@ bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
 #endif
 #if defined(HAVE_SYS_UN_H) && defined(AF_UNIX)
     case AF_UNIX:
-      if(salen > (curl_socklen_t)sizeof(sa_family_t)) {
+      if(salen > (curl_socklen_t)sizeof(CURL_SA_FAMILY_T)) {
         su = (struct sockaddr_un*)sa;
         msnprintf(addr, MAX_IPADR_LEN, "%s", su->sun_path);
       }


### PR DESCRIPTION
Reported-by: Kevin R. Bulgrien
Bug: https://curl.se/mail/lib-2021-04/0071.html