### PR TITLE
README.md: delete Codacy UTM parameters & follow permanent redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Backers on Open Collective](https://opencollective.com/curl/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/curl/sponsors/badge.svg)](#sponsors)
 [![Language Grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/curl/curl.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/curl/curl/context:cpp)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d11483a0cc5c4ebd9da4ff9f7cd56690)](https://www.codacy.com/app/curl/curl?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=curl/curl&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d11483a0cc5c4ebd9da4ff9f7cd56690)](https://app.codacy.com/app/curl/curl)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/curl.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:curl)
 
 Curl is a command-line tool for transferring data specified with URL


### PR DESCRIPTION
[UTM parameters](https://en.wikipedia.org/wiki/UTM_parameters) leak referrer and various marketing/tracking information even if these would normally be stripped by website
or client policy. This link also works fine without them. Also took the opportunity to update the URL to the one the previous one was pointing to by a permanent redirect.