### PR TITLE
curl_setup: provide the shutdown flags wider

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -715,13 +715,19 @@ int netware_init(void);
 #endif
 
 /*
- * Portable symbolic names for Winsock shutdown() mode flags.
+ * shutdown() flags for systems that don't define them
  */
 
-#ifdef USE_WINSOCK
-#  define SHUT_RD   0x00
-#  define SHUT_WR   0x01
-#  define SHUT_RDWR 0x02
+#ifndef SHUT_RD
+#define SHUT_RD 0x00
+#endif
+
+#ifndef SHUT_WR
+#define SHUT_WR 0x01
+#endif
+
+#ifndef SHUT_RDWR
+#define SHUT_RDWR 0x02
 #endif
 
 /* Define S_ISREG if not defined by system headers, f.e. MSVC */


### PR DESCRIPTION
By using #ifdef on the symbol names to work on anything that don't
provide them.

Reported-by: Kevin R. Bulgrien
Bug: https://curl.se/mail/lib-2021-04/0073.html