### PR TITLE
sws: #ifdef S_IFSOCK use

### DIFF
--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2092,11 +2092,13 @@ int main(int argc, char *argv[])
                unix_socket, errno, strerror(errno));
         goto sws_cleanup;
       }
+#ifdef S_IFSOCK
       if((statbuf.st_mode & S_IFSOCK) != S_IFSOCK) {
         logmsg("Error binding socket, failed to stat %s: (%d) %s",
                unix_socket, error, strerror(error));
         goto sws_cleanup;
       }
+#endif
       /* dead socket, cleanup and retry bind */
       rc = unlink(unix_socket);
       if(0 != rc) {


### PR DESCRIPTION
SCO OpenServer 5.0.7 does not define S_IFSOCK.

Reported-by: Kevin R. Bulgrien
Bug: https://curl.se/mail/lib-2021-04/0074.html