### PR TITLE
lib: fix some misuse of curlx_convert_UTF8_to_tchar

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -581,7 +581,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
         result = CURLE_OUT_OF_MEMORY;
 
         goto quit;
-    }
+      }
 #else
       char *attr = attribute;
 #endif
@@ -1061,13 +1061,23 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp)
   if(!ludp)
     return;
 
+#if defined(USE_WIN32_LDAP)
+  curlx_unicodefree(ludp->lud_dn);
+  curlx_unicodefree(ludp->lud_filter);
+#else
   free(ludp->lud_dn);
   free(ludp->lud_filter);
+#endif
 
   if(ludp->lud_attrs) {
     size_t i;
-    for(i = 0; i < ludp->lud_attrs_dups; i++)
+    for(i = 0; i < ludp->lud_attrs_dups; i++) {
+#if defined(USE_WIN32_LDAP)
+      curlx_unicodefree(ludp->lud_attrs[i]);
+#else
       free(ludp->lud_attrs[i]);
+#endif
+    }
     free(ludp->lud_attrs);
   }
 

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -72,6 +72,7 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
 {
   char *utf8_spn = NULL;
   TCHAR *tchar_spn = NULL;
+  TCHAR *dupe_tchar_spn = NULL;
 
   (void) realm;
 
@@ -84,23 +85,19 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
 
   /* Generate our UTF8 based SPN */
   utf8_spn = aprintf("%s/%s", service, host);
-  if(!utf8_spn) {
+  if(!utf8_spn)
     return NULL;
-  }
 
-  /* Allocate our TCHAR based SPN */
+  /* Allocate and return a TCHAR based SPN. Since curlx_convert_UTF8_to_tchar
+     must be freed by curlx_unicodefree we'll dupe the result so that the
+     pointer this function returns can be normally free'd. */
   tchar_spn = curlx_convert_UTF8_to_tchar(utf8_spn);
-  if(!tchar_spn) {
-    free(utf8_spn);
-
+  free(utf8_spn);
+  if(!tchar_spn)
     return NULL;
-  }
-
-  /* Release the UTF8 variant when operating with Unicode */
-  curlx_unicodefree(utf8_spn);
-
-  /* Return our newly allocated SPN */
-  return tchar_spn;
+  dupe_tchar_spn = _tcsdup(tchar_spn);
+  curlx_unicodefree(tchar_spn);
+  return dupe_tchar_spn;
 }
 #endif /* USE_WINDOWS_SSPI */
 


### PR DESCRIPTION
curlx_convert_UTF8_to_tchar must be freed by curlx_unicodefree, but
prior to this change some uses mistakenly called free.

I've reviewed all other uses of curlx_convert_UTF8_to_tchar and
curlx_convert_tchar_to_UTF8.

Bug: https://github.com/curl/curl/pull/6602#issuecomment-825236763
Reported-by: sergio-nsk@users.noreply.github.com

Closes #xxxx