### PR TITLE
avoid static for sock_opt in nss_set_blocking

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1830,7 +1830,7 @@ static CURLcode nss_set_blocking(struct ssl_connect_data *connssl,
                                  struct Curl_easy *data,
                                  bool blocking)
 {
-  static PRSocketOptionData sock_opt;
+  PRSocketOptionData sock_opt;
   struct ssl_backend_data *backend = connssl->backend;
   sock_opt.option = PR_SockOpt_Nonblocking;
   sock_opt.value.non_blocking = !blocking;


### PR DESCRIPTION
using static data can lead to confusion of the blocking status between simultaneous calls