### PR TITLE
Use proper function for checking ws2_32 and winmm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,8 +310,8 @@ endif()
 check_function_exists(gethostname HAVE_GETHOSTNAME)
 
 if(WIN32)
-  check_library_exists_concat("ws2_32" getch        HAVE_LIBWS2_32)
-  check_library_exists_concat("winmm"  getch        HAVE_LIBWINMM)
+  check_library_exists_concat("ws2_32" socket       HAVE_LIBWS2_32)
+  check_library_exists_concat("winmm"  timeGetTime  HAVE_LIBWINMM)
 endif()
 
 # check SSL libraries


### PR DESCRIPTION
ws2_32.lib nor winm.lib don't contain `getch` function. On some conditions this check doesn't work and compilation fails [here](https://github.com/curl/curl/blob/master/lib/nonblock.c#L83) because lack of implementation for setting nonblocking flag.

I'm still working for simple repo, because I guess the current check works just by coincidence.