### PR TITLE
Fix windows libraries discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,8 +310,21 @@ endif()
 check_function_exists(gethostname HAVE_GETHOSTNAME)
 
 if(WIN32)
-  check_library_exists_concat("ws2_32" socket       HAVE_LIBWS2_32)
-  check_library_exists_concat("winmm"  timeGetTime  HAVE_LIBWINMM)
+  check_library_exists_concat("ws2_32" getch HAVE_LIBWS2_32_getch)
+  if(HAVE_LIBWS2_32_getch)
+     set(HAVE_LIBWS2_32 1)
+  else()
+    check_library_exists_concat("ws2_32" socket HAVE_LIBWS2_32_socket)
+    set(HAVE_LIBWS2_32 ${HAVE_LIBWS2_32_socket})
+  endif()
+
+  check_library_exists_concat("winmm" getch HAVE_LIBWINMM_getch)
+  if(HAVE_LIBWINMM_getch)
+    set(HAVE_LIBWINMM 1)
+  else()
+    check_library_exists_concat("winmm" timeGetTime HAVE_LIBWINMM_timeGetTime)
+    set(HAVE_LIBWINMM ${HAVE_LIBWINMM_timeGetTime})
+  endif()
 endif()
 
 # check SSL libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,8 +310,8 @@ endif()
 check_function_exists(gethostname HAVE_GETHOSTNAME)
 
 if(WIN32)
-  check_library_exists_concat("ws2_32" getch        HAVE_LIBWS2_32)
-  check_library_exists_concat("winmm"  getch        HAVE_LIBWINMM)
+  check_library_exists_concat("ws2_32" socket       HAVE_LIBWS2_32)
+  check_library_exists_concat("winmm"  timeGetTime  HAVE_LIBWINMM)
 endif()
 
 # check SSL libraries


### PR DESCRIPTION
This is second approach for #6946

I've found similar case in my build system. It's weird: check_library_exists works with getch but not for socket for some configurations, for another works for socket but not for getch. I've also found one configuration where check_library_exists works for both getch and socket.