### PR TITLE
Fix handling of zero-byte chunk from hyper.

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -175,6 +175,8 @@ static int hyper_body_chunk(void *userdata, const hyper_buf *chunk)
   }
   if(k->ignorebody)
     return HYPER_ITER_CONTINUE;
+  if(0 == len)
+    return HYPER_ITER_CONTINUE;
   Curl_debug(data, CURLINFO_DATA_IN, buf, len);
   if(!data->set.http_ce_skip && k->writer_stack)
     /* content-encoded data */


### PR DESCRIPTION
When curl is built with Hyper, nghttp2, and most TLS backends (other than crustls), it can produce reads from uninitialized memory. This is due to Hyper providing body chunks of length 0, and hyper_body_chunk passing those to Curl_client_write. When Curl_client_write gets a buf with a len of 0, it calls strlen on buf and uses that as the len: https://github.com/curl/curl/blob/f014eeceb218200c5864ce91a8de2cc21d951c32/lib/sendf.c#L604-L620.

Fixes https://github.com/hyperium/hyper/issues/2512.

Thanks to @kevinburke for reporting.