### PR TITLE
add memory management information for curl_url_set

### DIFF
--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -39,6 +39,9 @@ below) to set or change, with \fIcontent\fP pointing to a null-terminated
 string with the new contents for that URL part. The contents should be in the
 form and encoding they'd use in a URL: URL encoded.
 
+The application does not have to keep \fIcontent\fP around after a successful
+call.
+
 Setting a part to a NULL pointer will effectively remove that part's contents
 from the CURLU handle.
 


### PR DESCRIPTION
It would be nice to know how to manage the memory of a newly set URL (part) from the documentation. From reading the respective source file `lib/urlapi.c`, I gather that the changes represent that accurately: The string that ends up being written to the URL struct is either `malloc`'ed before either [due to encoding](https://github.com/curl/curl/blob/04488851e291ea0fc3f32e87ea637afcf1c2ca28/lib/urlapi.c#L1512) or [appending a query](https://github.com/curl/curl/blob/04488851e291ea0fc3f32e87ea637afcf1c2ca28/lib/urlapi.c#L1540), or it [is `strdup`'ed](https://github.com/curl/curl/blob/04488851e291ea0fc3f32e87ea637afcf1c2ca28/lib/urlapi.c#L1516).

I made the wording similar to the man page for `CURLOPT_URL`: <https://github.com/curl/curl/blob/04488851e291ea0fc3f32e87ea637afcf1c2ca28/docs/libcurl/opts/CURLOPT_URL.3#L67-L68>