### PR TITLE
m4: add security frameworks on Mac when compiling rustls

### DIFF
--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -63,6 +63,9 @@ if test "x$OPT_RUSTLS" != xno; then
       rustlslib=$OPT_RUSTLS/lib$libsuff
 
       LDFLAGS="$LDFLAGS $addld"
+      if (test -d "/System/Library/Frameworks/Security.framework" && test "x$cross_compiling" != "xyes"); then
+        LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
+      fi
       if test "$addcflags" != "-I/usr/include"; then
          CPPFLAGS="$CPPFLAGS $addcflags"
       fi


### PR DESCRIPTION
Previously compiling rustls on Mac would only complete if you also
compiled the SecureTransport TLS backend, which curl would prefer to
the Rust backend.

Appending these flags to LDFLAGS makes it possible to compile the
Rustls backend on Mac without the SecureTransport backend, which means
this patch will make it possible for Mac users to use the Rustls
backend for TLS.

Fixes #6955.