### PR TITLE
Add USE_HTTP2 define

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -801,6 +801,10 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define UNITTEST static
 #endif
 
+#if defined(USE_NGHTTP2) || defined(USE_HYPER)
+#define USE_HTTP2
+#endif
+
 #if defined(USE_NGTCP2) || defined(USE_QUICHE)
 #define ENABLE_QUIC
 #endif

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -385,14 +385,14 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
      * protocols array in `struct ssl_backend_data`.
      */
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
       && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
       ) {
-      backend->protocols[cur++] = NGHTTP2_PROTO_VERSION_ID;
-      infof(data, "ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
+      backend->protocols[cur++] = ALPN_H2;
+      infof(data, "ALPN, offering %s\n", ALPN_H2);
     }
 #endif
 
@@ -540,8 +540,8 @@ static CURLcode bearssl_connect_step3(struct Curl_easy *data,
     if(protocol) {
       infof(data, "ALPN, server accepted to use %s\n", protocol);
 
-#ifdef USE_NGHTTP2
-      if(!strcmp(protocol, NGHTTP2_PROTO_VERSION_ID))
+#ifdef USE_HTTP2
+      if(!strcmp(protocol, ALPN_H2))
         conn->negnpn = CURL_HTTP_VERSION_2;
       else
 #endif

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -611,16 +611,16 @@ gtls_connect_step1(struct Curl_easy *data,
     int cur = 0;
     gnutls_datum_t protocols[2];
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
        && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
        ) {
-      protocols[cur].data = (unsigned char *)NGHTTP2_PROTO_VERSION_ID;
-      protocols[cur].size = NGHTTP2_PROTO_VERSION_ID_LEN;
+      protocols[cur].data = (unsigned char *)ALPN_H2;
+      protocols[cur].size = ALPN_H2_LENGTH;
       cur++;
-      infof(data, "ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
+      infof(data, "ALPN, offering %.*s\n", ALPN_H2_LENGTH, ALPN_H2);
     }
 #endif
 
@@ -1242,10 +1242,10 @@ gtls_connect_step3(struct Curl_easy *data,
       infof(data, "ALPN, server accepted to use %.*s\n", proto.size,
           proto.data);
 
-#ifdef USE_NGHTTP2
-      if(proto.size == NGHTTP2_PROTO_VERSION_ID_LEN &&
-         !memcmp(NGHTTP2_PROTO_VERSION_ID, proto.data,
-                 NGHTTP2_PROTO_VERSION_ID_LEN)) {
+#ifdef USE_HTTP2
+      if(proto.size == ALPN_H2_LENGTH &&
+         !memcmp(ALPN_H2, proto.data,
+                 ALPN_H2_LENGTH)) {
         conn->negnpn = CURL_HTTP_VERSION_2;
       }
       else

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -870,8 +870,8 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
     }
 
 #ifdef USE_NGHTTP2
-    if(buflen == NGHTTP2_PROTO_VERSION_ID_LEN &&
-       !memcmp(NGHTTP2_PROTO_VERSION_ID, buf, NGHTTP2_PROTO_VERSION_ID_LEN)) {
+    if(buflen == ALPN_H2_LENGTH &&
+       !memcmp(ALPN_H2, buf, ALPN_H2_LENGTH)) {
       conn->negnpn = CURL_HTTP_VERSION_2;
     }
     else
@@ -2103,16 +2103,15 @@ static CURLcode nss_setup_connect(struct Curl_easy *data,
     int cur = 0;
     unsigned char protocols[128];
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
       && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
       ) {
-      protocols[cur++] = NGHTTP2_PROTO_VERSION_ID_LEN;
-      memcpy(&protocols[cur], NGHTTP2_PROTO_VERSION_ID,
-          NGHTTP2_PROTO_VERSION_ID_LEN);
-      cur += NGHTTP2_PROTO_VERSION_ID_LEN;
+      protocols[cur++] = ALPN_H2;
+      memcpy(&protocols[cur], ALPN_H2, ALPN_H2_LENGTH);
+      cur += ALPN_H2_LENGTH;
     }
 #endif
     protocols[cur++] = ALPN_HTTP_1_1_LENGTH;

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2109,7 +2109,7 @@ static CURLcode nss_setup_connect(struct Curl_easy *data,
       && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
       ) {
-      protocols[cur++] = ALPN_H2;
+      protocols[cur++] = ALPN_H2_LENGTH;
       memcpy(&protocols[cur], ALPN_H2, ALPN_H2_LENGTH);
       cur += ALPN_H2_LENGTH;
     }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -877,11 +877,11 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
 
     list_start_index = cur;
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2) {
-      memcpy(&alpn_buffer[cur], NGHTTP2_PROTO_ALPN, NGHTTP2_PROTO_ALPN_LEN);
-      cur += NGHTTP2_PROTO_ALPN_LEN;
-      infof(data, "schannel: ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
+      memcpy(&alpn_buffer[cur], ALPN_H2, ALPN_H2_LENGTH);
+      cur += ALPN_H2_LENGTH;
+      infof(data, "schannel: ALPN, offering %s\n", ALPN_H2);
     }
 #endif
 
@@ -1392,10 +1392,9 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
       infof(data, "schannel: ALPN, server accepted to use %.*s\n",
             alpn_result.ProtocolIdSize, alpn_result.ProtocolId);
 
-#ifdef USE_NGHTTP2
-      if(alpn_result.ProtocolIdSize == NGHTTP2_PROTO_VERSION_ID_LEN &&
-         !memcmp(NGHTTP2_PROTO_VERSION_ID, alpn_result.ProtocolId,
-                 NGHTTP2_PROTO_VERSION_ID_LEN)) {
+#ifdef USE_HTTP2
+      if(alpn_result.ProtocolIdSize == ALPN_H2_LENGTH &&
+         !memcmp(ALPN_H2, alpn_result.ProtocolId, ALPN_H2_LENGTH)) {
         conn->negnpn = CURL_HTTP_VERSION_2;
       }
       else

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1829,14 +1829,14 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
       CFMutableArrayRef alpnArr = CFArrayCreateMutable(NULL, 0,
                                                        &kCFTypeArrayCallBacks);
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
       if(data->state.httpwant >= CURL_HTTP_VERSION_2
 #ifndef CURL_DISABLE_PROXY
          && (!isproxy || !conn->bits.tunnel_proxy)
 #endif
         ) {
-        CFArrayAppendValue(alpnArr, CFSTR(NGHTTP2_PROTO_VERSION_ID));
-        infof(data, "ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
+        CFArrayAppendValue(alpnArr, CFSTR(ALPN_H2));
+        infof(data, "ALPN, offering %s\n", ALPN_H2);
       }
 #endif
 
@@ -2788,10 +2788,9 @@ sectransp_connect_step2(struct Curl_easy *data, struct connectdata *conn,
         if(err == noErr && alpnArr && CFArrayGetCount(alpnArr) >= 1)
           chosenProtocol = CFArrayGetValueAtIndex(alpnArr, 0);
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
         if(chosenProtocol &&
-           !CFStringCompare(chosenProtocol, CFSTR(NGHTTP2_PROTO_VERSION_ID),
-                            0)) {
+           !CFStringCompare(chosenProtocol, CFSTR(ALPN_H2), 0)) {
           conn->negnpn = CURL_HTTP_VERSION_2;
         }
         else

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -126,9 +126,11 @@ bool Curl_ssl_tls13_ciphersuites(void);
 #define CURL_SHA256_DIGEST_LENGTH 32 /* fixed size */
 #endif
 
-/* see https://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg-04 */
+/* see https://www.iana.org/assignments/tls-extensiontype-values/ */
 #define ALPN_HTTP_1_1_LENGTH 8
 #define ALPN_HTTP_1_1 "http/1.1"
+#define ALPN_H2_LENGTH 2
+#define ALPN_H2 "h2"
 
 /* set of helper macros for the backends to access the correct fields. For the
    proxy or for the remote host - to properly support HTTPS proxy */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -451,10 +451,10 @@ wolfssl_connect_step1(struct Curl_easy *data, struct connectdata *conn,
     /* wolfSSL's ALPN protocol name list format is a comma separated string of
        protocols in descending order of preference, eg: "h2,http/1.1" */
 
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2) {
-      strcpy(protocols + strlen(protocols), NGHTTP2_PROTO_VERSION_ID ",");
-      infof(data, "ALPN, offering %s\n", NGHTTP2_PROTO_VERSION_ID);
+      strcpy(protocols + strlen(protocols), ALPN_H2 ",");
+      infof(data, "ALPN, offering %s\n", ALPN_H2);
     }
 #endif
 
@@ -691,11 +691,10 @@ wolfssl_connect_step2(struct Curl_easy *data, struct connectdata *conn,
       if(protocol_len == ALPN_HTTP_1_1_LENGTH &&
          !memcmp(protocol, ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH))
         conn->negnpn = CURL_HTTP_VERSION_1_1;
-#ifdef USE_NGHTTP2
+#ifdef USE_HTTP2
       else if(data->state.httpwant >= CURL_HTTP_VERSION_2 &&
-              protocol_len == NGHTTP2_PROTO_VERSION_ID_LEN &&
-              !memcmp(protocol, NGHTTP2_PROTO_VERSION_ID,
-                      NGHTTP2_PROTO_VERSION_ID_LEN))
+              protocol_len == ALPN_H2_LENGTH &&
+              !memcmp(protocol, ALPN_H2, ALPN_H2_LENGTH))
         conn->negnpn = CURL_HTTP_VERSION_2;
 #endif
       else


### PR DESCRIPTION
This abstracts across the two HTTP/2 backends: nghttp2 and Hyper.

Add our own define for the "h2" ALPN protocol, so TLS backends can use
it without depending on a specific HTTP backend.

Fixes #6949.