### PR TITLE
gopher: fix broken implementation

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -149,26 +149,14 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
   if(!gopherpath)
     return CURLE_OUT_OF_MEMORY;
 
-  /* Create selector. Degenerate cases: / and /1 => convert to "" */
-  if(strlen(gopherpath) <= 2) {
-    sel = (char *)"";
-    len = strlen(sel);
-    free(gopherpath);
-  }
-  else {
-    char *newp;
+  char *newp = gopherpath;
 
-    /* Otherwise, drop / and the first character (i.e., item type) ... */
-    newp = gopherpath;
-    newp += 2;
-
-    /* ... and finally unescape */
-    result = Curl_urldecode(data, newp, 0, &sel, &len, REJECT_ZERO);
-    free(gopherpath);
-    if(result)
-      return result;
-    sel_org = sel;
-  }
+  /* Unescape URL */
+  result = Curl_urldecode(data, newp, 0, &sel, &len, REJECT_ZERO);
+  free(gopherpath);
+  if(result)
+    return result;
+  sel_org = sel;
 
   k = curlx_uztosz(len);
 

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -149,7 +149,8 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
   if(!gopherpath)
     return CURLE_OUT_OF_MEMORY;
 
-  char *newp = gopherpath;
+  char *newp;
+  newp = gopherpath;
 
   /* Unescape URL */
   result = Curl_urldecode(data, newp, 0, &sel, &len, REJECT_ZERO);

--- a/tests/data/test1200
+++ b/tests/data/test1200
@@ -25,7 +25,7 @@ gopher
 Gopher index
  </name>
  <command>
-gopher://%HOSTIP:%GOPHERPORT/1/%TESTNUMBER
+gopher://%HOSTIP:%GOPHERPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test1201
+++ b/tests/data/test1201
@@ -25,7 +25,7 @@ gopher
 Gopher selector
  </name>
  <command>
-gopher://%HOSTIP:%GOPHERPORT/1/selector/SELECTOR/%TESTNUMBER?
+gopher://%HOSTIP:%GOPHERPORT/selector/SELECTOR/%TESTNUMBER?
 </command>
 </client>
 

--- a/tests/data/test1202
+++ b/tests/data/test1202
@@ -26,7 +26,7 @@ gopher
 Gopher query
  </name>
  <command>
-"gopher://%HOSTIP:%GOPHERPORT/7/the/search/engine%09query%20succeeded/%TESTNUMBER"
+"gopher://%HOSTIP:%GOPHERPORT/the/search/engine%09query%20succeeded/%TESTNUMBER"
 </command>
 </client>
 

--- a/tests/data/test1203
+++ b/tests/data/test1203
@@ -29,7 +29,7 @@ gopher-ipv6
 Gopher IPv6 index
  </name>
  <command>
--g gopher://%HOST6IP:%GOPHER6PORT/1/moo/%TESTNUMBER
+-g gopher://%HOST6IP:%GOPHER6PORT/moo/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test1272
+++ b/tests/data/test1272
@@ -26,7 +26,7 @@ gophers
 Gophers index
  </name>
  <command>
--k gophers://%HOSTIP:%GOPHERSPORT/1/%TESTNUMBER
+-k gophers://%HOSTIP:%GOPHERSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -877,11 +877,6 @@ sub verifyhttp {
         servername_canon($proto, $ipvnum, $idnum) .'_verify.log';
     unlink($verifylog) if(-f $verifylog);
 
-    if($proto eq "gopher") {
-        # gopher is funny
-        $bonus="1/";
-    }
-
     my $flags = "--max-time $server_response_maxtime ";
     $flags .= "--output $verifyout ";
     $flags .= "--silent ";
@@ -892,7 +887,7 @@ sub verifyhttp {
     if($use_external_proxy) {
         $flags .= getexternalproxyflags();
     }
-    $flags .= "\"$proto://$ip:$port/${bonus}verifiedserver\"";
+    $flags .= "\"$proto://$ip:$port/verifiedserver\"";
 
     my $cmd = "$VCURL $flags 2>$verifylog";
 


### PR DESCRIPTION
A normal convention that Gopher implementations use is to put a letter
or number at the first directory of the path. This is used to indicate
the type of the content, which allows Gopher clients to display the
content properly. However, what is important to keep in mind is that
it's just a convension, and not a requirement in the standard. Because
of this, clients are freely allowed to ignore this part, and servers
must compensate for this if this is the case.

The current implementation of Gopher is broken in the way that it
assumes that the client is the one to compensate for this. As a result,
it breaks request paths that makes most servers unable to recognize the
request. To make matters worse, cURL *always* assumes that this is the
case, and makes no effort on validating it first.

The consequence of cURL's behavior can be seen in these messages in the
mailing list:

 * https://curl.se/mail/lib-2016-02/0129.html
 * https://curl.se/mail/archive-2011-04/0043.html

As can be seen in both cases, the two first characters in the URL path
is removed by cURL, resulting in an error indicating that the resource
doesn't exist. This PR removes this behavior, and sends the URL path to
the Gopher server as it is, without changing it.