### PR TITLE
docs: fix typo in fail-with-body doc

### DIFF
--- a/docs/cmdline-opts/fail-with-body.d
+++ b/docs/cmdline-opts/fail-with-body.d
@@ -9,7 +9,7 @@ See-also: fail
 Return an error on server errors where the HTTP response code is 400 or
 greater). In normal cases when an HTTP server fails to deliver a document, it
 returns an HTML document stating so (which often also describes why and
-more). This flag will still allow curl to outputting and save that content but
+more). This flag will still allow curl to output and save that content but
 also to return error 22.
 
 This is an alternative option to --fail which makes curl fail for the same


### PR DESCRIPTION
This commit fixes a small typo in the documentation for the
--fail-with-body flag.