### PR TITLE
vtls, gskit: fixed build with CURL_DISABLE_PROXY flag

### DIFF
--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -101,8 +101,10 @@
 struct ssl_backend_data {
   gsk_handle handle;
   int iocport;
+#ifndef CURL_DISABLE_PROXY
   int localfd;
   int remotefd;
+#endif
 };
 
 #define BACKEND connssl->backend
@@ -515,6 +517,7 @@ static void close_async_handshake(struct ssl_connect_data *connssl)
 static int pipe_ssloverssl(struct connectdata *conn, int sockindex,
                            int directions)
 {
+#ifndef CURL_DISABLE_PROXY
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_connect_data *connproxyssl = &conn->proxy_ssl[sockindex];
   fd_set fds_read;
@@ -583,6 +586,9 @@ static int pipe_ssloverssl(struct connectdata *conn, int sockindex,
   }
 
   return ret;  /* OK */
+#else
+  return 0;
+#endif
 }
 
 
@@ -596,6 +602,7 @@ static void close_one(struct ssl_connect_data *connssl, struct Curl_easy *data,
     while(pipe_ssloverssl(conn, sockindex, SOS_WRITE) > 0)
       ;
     BACKEND->handle = (gsk_handle) NULL;
+#ifndef CURL_DISABLE_PROXY
     if(BACKEND->localfd >= 0) {
       close(BACKEND->localfd);
       BACKEND->localfd = -1;
@@ -604,6 +611,7 @@ static void close_one(struct ssl_connect_data *connssl, struct Curl_easy *data,
       close(BACKEND->remotefd);
       BACKEND->remotefd = -1;
     }
+#endif
   }
   if(BACKEND->iocport >= 0)
     close_async_handshake(connssl);
@@ -709,15 +717,19 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
   const char *sni;
   unsigned int protoflags = 0;
   Qso_OverlappedIO_t commarea;
+#ifndef CURL_DISABLE_PROXY
   int sockpair[2];
   static const int sobufsize = CURL_MAX_WRITE_SIZE;
+#endif
 
   /* Create SSL environment, start (preferably asynchronous) handshake. */
 
   BACKEND->handle = (gsk_handle) NULL;
   BACKEND->iocport = -1;
+#ifndef CURL_DISABLE_PROXY
   BACKEND->localfd = -1;
   BACKEND->remotefd = -1;
+#endif
 
   /* GSKit supports two ways of specifying an SSL context: either by
    *  application identifier (that should have been defined at the system
@@ -756,6 +768,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
   if(result)
     return result;
 
+#ifndef CURL_DISABLE_PROXY
   /* Establish a pipelining socket pair for SSL over SSL. */
   if(conn->proxy_ssl[sockindex].use) {
     if(Curl_socketpair(0, 0, 0, sockpair))
@@ -773,6 +786,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
     curlx_nonblock(BACKEND->localfd, TRUE);
     curlx_nonblock(BACKEND->remotefd, TRUE);
   }
+#endif
 
   /* Determine which SSL/TLS version should be enabled. */
   sni = hostname;
@@ -825,8 +839,13 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
   if(!result)
     result = set_numeric(data, BACKEND->handle, GSK_OS400_READ_TIMEOUT, 1);
   if(!result)
+#ifndef CURL_DISABLE_PROXY
     result = set_numeric(data, BACKEND->handle, GSK_FD, BACKEND->localfd >= 0?
                          BACKEND->localfd: conn->sock[sockindex]);
+#else
+    result = set_numeric(data, BACKEND->handle, GSK_FD,
+                         conn->sock[sockindex]);
+#endif
   if(!result)
     result = set_ciphers(data, BACKEND->handle, &protoflags);
   if(!protoflags) {
@@ -895,10 +914,12 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
     else if(errno != ENOBUFS)
       result = gskit_status(data, GSK_ERROR_IO,
                             "QsoCreateIOCompletionPort()", 0);
+#ifndef CURL_DISABLE_PROXY
     else if(conn->proxy_ssl[sockindex].use) {
       /* Cannot pipeline while handshaking synchronously. */
       result = CURLE_SSL_CONNECT_ERROR;
     }
+#endif
     else {
       /* No more completion port available. Use synchronous IO. */
       result = gskit_status(data, gsk_secure_soc_init(BACKEND->handle),
@@ -1156,7 +1177,9 @@ static void gskit_close(struct Curl_easy *data, struct connectdata *conn,
                         int sockindex)
 {
   close_one(&conn->ssl[sockindex], data, conn, sockindex);
+#ifndef CURL_DISABLE_PROXY
   close_one(&conn->proxy_ssl[sockindex], data, conn, sockindex);
+#endif
 }
 
 


### PR DESCRIPTION
Removed localfd and remotefd from ssl_backend_data (ued only with proxy connection). Function pipe_ssloverssl return always 0, when proxy is not used.