### PR TITLE
add link to GitHub sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: curl
 open_collective: curl


### PR DESCRIPTION
This PR adds a link to the GitHub sponsor profile, enabling the sponsor button to link to https://github.com/sponsors/curl as well. 

Optionally to this, creating a single `.github` repository in the organization and moving the `FUNDING.yml` there would render the button (with links to GitHub sponsors and open collective) in all curl repositories. For details on that, please check [this](https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository).