### PR TITLE
http2: fix resource leaks detected by Coverity

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -581,6 +581,7 @@ static int push_promise(struct Curl_easy *data,
 
     rv = set_transfer_url(newhandle, &heads);
     if(rv) {
+      (void)Curl_close(&newhandle);
       rv = CURL_PUSH_DENY;
       goto fail;
     }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -500,32 +500,42 @@ static int set_transfer_url(struct Curl_easy *data,
   CURLU *u = curl_url();
   CURLUcode uc;
   char *url;
+  int rc = 0;
 
   v = curl_pushheader_byname(hp, ":scheme");
   if(v) {
     uc = curl_url_set(u, CURLUPART_SCHEME, v, 0);
-    if(uc)
-      return 1;
+    if(uc) {
+      rc = 1;
+      goto fail;
+    }
   }
 
   v = curl_pushheader_byname(hp, ":authority");
   if(v) {
     uc = curl_url_set(u, CURLUPART_HOST, v, 0);
-    if(uc)
-      return 2;
+    if(uc) {
+      rc = 2;
+      goto fail;
+    }
   }
 
   v = curl_pushheader_byname(hp, ":path");
   if(v) {
     uc = curl_url_set(u, CURLUPART_PATH, v, 0);
-    if(uc)
-      return 3;
+    if(uc) {
+      rc = 3;
+      goto fail;
+    }
   }
 
   uc = curl_url_get(u, CURLUPART_URL, &url, 0);
   if(uc)
-    return 4;
+    rc = 4;
+  fail:
   curl_url_cleanup(u);
+  if(rc)
+    return rc;
 
   if(data->state.url_alloc)
     free(data->state.url);


### PR DESCRIPTION
```
Error: RESOURCE_LEAK (CWE-772):
lib/http2.c:480: alloc_fn: Storage is returned from allocation function "curl_url". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:480: var_assign: Assigning: "u" = storage returned from "curl_url()".
lib/http2.c:486: noescape: Resource "u" is not freed or pointed-to in "curl_url_set". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:488: leaked_storage: Variable "u" going out of scope leaks the storage it points to. 

Error: RESOURCE_LEAK (CWE-772):
lib/http2.c:480: alloc_fn: Storage is returned from allocation function "curl_url". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:480: var_assign: Assigning: "u" = storage returned from "curl_url()".
lib/http2.c:493: noescape: Resource "u" is not freed or pointed-to in "curl_url_set". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:495: leaked_storage: Variable "u" going out of scope leaks the storage it points to. 

Error: RESOURCE_LEAK (CWE-772):
lib/http2.c:480: alloc_fn: Storage is returned from allocation function "curl_url". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:480: var_assign: Assigning: "u" = storage returned from "curl_url()".
lib/http2.c:500: noescape: Resource "u" is not freed or pointed-to in "curl_url_set". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:502: leaked_storage: Variable "u" going out of scope leaks the storage it points to. 

Error: RESOURCE_LEAK (CWE-772):
lib/http2.c:480: alloc_fn: Storage is returned from allocation function "curl_url". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:480: var_assign: Assigning: "u" = storage returned from "curl_url()".
lib/http2.c:505: noescape: Resource "u" is not freed or pointed-to in "curl_url_get". [Note: The source code implementation of the function has been overridden by a builtin model.]
lib/http2.c:507: leaked_storage: Variable "u" going out of scope leaks the storage it points to.

Error: RESOURCE_LEAK (CWE-772):
lib/http2.c:532: alloc_fn: Storage is returned from allocation function "duphandle".
lib/http2.c:532: var_assign: Assigning: "newhandle" = storage returned from "duphandle(data)".
lib/http2.c:552: noescape: Resource "newhandle" is not freed or pointed-to in "set_transfer_url".
lib/http2.c:555: leaked_storage: Variable "newhandle" going out of scope leaks the storage it points to. 
```