### PR TITLE
c-hyper: ignore case of hex numbers in tests

### DIFF
--- a/tests/data/test1072
+++ b/tests/data/test1072
@@ -63,7 +63,11 @@ Accept: */*
 Transfer-Encoding: chunked
 Expect: 100-continue
 
+%if hyper
+7A
+%else
 7a
+%endif
 This is data we upload with PUT
 it comes from stdin so MUST be sent
 with chunked encoding

--- a/tests/data/test1073
+++ b/tests/data/test1073
@@ -57,7 +57,11 @@ Accept: */*
 Transfer-Encoding: chunked
 Expect: 100-continue
 
+%if hyper
+7A
+%else
 7a
+%endif
 This is data we upload with PUT
 it comes from stdin so MUST be sent
 with chunked encoding

--- a/tests/data/test1591
+++ b/tests/data/test1591
@@ -48,7 +48,11 @@ Transfer-Encoding: chunked
 Trailer: my-super-awesome-trailer, my-other-awesome-trailer
 Expect: 100-continue
 
+%if hyper
+E
+%else
 e
+%endif
 Hello Cloud!
 
 0

--- a/tests/data/test218
+++ b/tests/data/test218
@@ -47,7 +47,11 @@ Accept: */*
 Transfer-Encoding: chunked
 Expect: 100-continue
 
+%if hyper
+1E
+%else
 1e
+%endif
 just some tiny teeny contents
 
 0

--- a/tests/data/test510
+++ b/tests/data/test510
@@ -56,7 +56,11 @@ one
 two
 5
 three
+%if hyper
+1D
+%else
 1d
+%endif
 and a final longer crap: four
 0
 

--- a/tests/data/test565
+++ b/tests/data/test565
@@ -100,7 +100,11 @@ one
 two
 5
 three
+%if hyper
+1D
+%else
 1d
+%endif
 and a final longer crap: four
 0
 

--- a/tests/data/test645
+++ b/tests/data/test645
@@ -108,7 +108,11 @@ y
 1
 
 
+%if hyper
+19A
+%else
 19a
+%endif
 
 ------------------------------
 Content-Disposition: form-data; name="filename"
@@ -169,7 +173,11 @@ y
 1
 
 
+%if hyper
+19A
+%else
 19a
+%endif
 
 ------------------------------
 Content-Disposition: form-data; name="filename"

--- a/tests/data/test650
+++ b/tests/data/test650
@@ -90,7 +90,11 @@ Content-Disposition: attachment; filename="test%TESTNUMBER.filedata"
 Content-Type: text/whatever
 
 
+%if hyper
+A5
+%else
 a5
+%endif
 This is data from a file.
 
 ------------------------------
@@ -98,7 +102,11 @@ Content-Disposition: attachment; filename="test%TESTNUMBER.filedata"
 Content-Type: text/whatever
 
 
+%if hyper
+AF
+%else
 af
+%endif
 This is data from a file.
 
 --------------------------------
@@ -107,7 +115,11 @@ This is data from a file.
 Content-Disposition: form-data; name="filecontents"
 
 
+%if hyper
+10F
+%else
 10f
+%endif
 This is data from a file.
 
 ------------------------------

--- a/tests/data/test654
+++ b/tests/data/test654
@@ -81,7 +81,11 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
+%if hyper
+1AF
+%else
 1af
+%endif
 ------------------------------
 Content-Disposition: form-data; name="greeting"
 Content-Type: application/X-Greeting

--- a/tests/data/test667
+++ b/tests/data/test667
@@ -66,7 +66,11 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
+%if hyper
+7F
+%else
 7f
+%endif
 ------------------------------
 Content-Disposition: form-data; name="field"
 Content-Transfer-Encoding: base64

--- a/tests/data/test668
+++ b/tests/data/test668
@@ -69,7 +69,11 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
+%if hyper
+C1
+%else
 c1
+%endif
 ------------------------------
 Content-Disposition: form-data; name="field1"
 


### PR DESCRIPTION
When hyper is used, it emits uppercase hexadecimal numbers for chunked encoding lengths. Without hyper, lowercase hexadecimal numbers are used. This change adds splitpart commands to tests where this is an issue, and normalizes the lengths to lower-case digits.

Nine test cases are affected here. 218 now passes when run with hyper, while 510, 645, 650, 654, 667, 668, 1073, and 1591 are only partially fixed, as they each later fail for other reasons (when run with hyper).