### PR TITLE
http: fix the check for 'Authorization' with Bearer

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -740,7 +740,7 @@ output_auth_headers(struct Curl_easy *data,
   if(authstatus->picked == CURLAUTH_BEARER) {
     /* Bearer */
     if((!proxy && data->set.str[STRING_BEARER] &&
-        !Curl_checkheaders(data, "Authorization:"))) {
+        !Curl_checkheaders(data, "Authorization"))) {
       auth = "Bearer";
       result = http_output_bearer(data);
       if(result)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -99,6 +99,8 @@ char *Curl_checkheaders(const struct Curl_easy *data,
 {
   struct curl_slist *head;
   size_t thislen = strlen(thisheader);
+  DEBUGASSERT(thislen);
+  DEBUGASSERT(thisheader[thislen-1] != ':');
 
   for(head = data->set.headers; head; head = head->next) {
     if(strncasecompare(head->data, thisheader, thislen) &&


### PR DESCRIPTION
The code would wrongly check for it using an additional colon.

Reported-by: Blake Burkhart