### PR TITLE
CI/cirrus: add shared and static Windows release builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,14 +22,18 @@
 # Cirrus CI configuration
 # https://cirrus-ci.com/github/curl/curl
 
-task:
+freebsd_task:
   name: FreeBSD
-  freebsd_instance:
-    matrix:
+
+  matrix:
       # A stable 13.0 image likely won't be available before early 2021
       # image_family: freebsd-13-0-snap
-      image_family: freebsd-12-2
-      image_family: freebsd-11-4
+    - name: FreeBSD 12.2
+      freebsd_instance:
+        image_family: freebsd-12-2
+    - name: FreeBSD 11.4
+      freebsd_instance:
+        image_family: freebsd-11-4
 
   env:
     CIRRUS_CLONE_DEPTH: 10
@@ -54,7 +58,7 @@ task:
       esac
     - ./configure --prefix="${HOME}"/install --enable-debug --with-openssl --with-libssh2 --with-brotli --with-gssapi --with-libidn2 --enable-manual --enable-ldap --enable-ldaps --with-librtmp --with-libmetalink --with-libpsl --with-nghttp2 || { tail -300 config.log; false; }
   compile_script:
-    - make V=1
+    - make V=1 && cd tests && make V=1
   test_script:
     # blackhole?
     - sysctl net.inet.tcp.blackhole
@@ -68,3 +72,58 @@ task:
     - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky !SFTP !SCP" test-nonflaky
   install_script:
     - make V=1 install
+
+windows_task:
+  name: Windows
+  timeout_in: 90m
+  windows_container:
+    image: ${container_img}
+
+  matrix:
+    - name: Windows 32-bit shared/release Schannel/SSPI/WinIDN/libssh2
+      env:
+        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+        container_cmd: C:\msys64\usr\bin\sh
+        prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
+        configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+    - name: Windows 32-bit static/release Schannel/SSPI/WinIDN/libssh2
+      env:
+        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+        container_cmd: C:\msys64\usr\bin\sh
+        prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
+        configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+        curl_LDFLAGS: -all-static
+        PKG_CONFIG: pkg-config --static
+    - name: Windows 64-bit shared/release Schannel/SSPI/WinIDN/libssh2
+      env:
+        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+        container_cmd: C:\msys64\usr\bin\sh
+        prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
+        configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+    - name: Windows 64-bit static/release Schannel/SSPI/WinIDN/libssh2
+      env:
+        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+        container_cmd: C:\msys64\usr\bin\sh
+        prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
+        configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+        curl_LDFLAGS: -all-static
+        PKG_CONFIG: pkg-config --static
+
+  env:
+    CIRRUS_CLONE_DEPTH: 10
+    MSYS2_PATH_TYPE: inherit
+
+  prepare_script: |
+    %container_cmd% -l -c "cd $(echo '%cd%') && %prepare%"
+  configure_script: |
+    %container_cmd% -l -c "cd $(echo '%cd%') && ./buildconf && ./configure %configure%"
+  compile_script: |
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 && cd tests && make V=1"
+  install_script: |
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
+  test_script: |
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='-r -rm %tests%' test-nonflaky"


### PR DESCRIPTION
Azure Pipelines is currently being used for debug builds, let's try to also run some non-debug (release) builds and make use of underutilized Cirrus CI for that.