### PR TITLE
transfer: Upper-case lengths in chunked encoding

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2590,7 +2590,7 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
           if(http->postsize) {
             char chunk[16];
             /* Append the POST data chunky-style */
-            msnprintf(chunk, sizeof(chunk), "%x\r\n", (int)http->postsize);
+            msnprintf(chunk, sizeof(chunk), "%X\r\n", (int)http->postsize);
             result = Curl_dyn_add(r, chunk);
             if(!result) {
               included_body = http->postsize + strlen(chunk);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -318,7 +318,7 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
     if(data->state.trailers_state != TRAILERS_SENDING) {
       char hexbuffer[11] = "";
       hexlen = msnprintf(hexbuffer, sizeof(hexbuffer),
-                         "%zx%s", nread, endofline_native);
+                         "%zX%s", nread, endofline_native);
 
       /* move buffer pointer */
       data->req.upload_fromhere -= hexlen;

--- a/tests/data/test1072
+++ b/tests/data/test1072
@@ -63,7 +63,7 @@ Accept: */*
 Transfer-Encoding: chunked
 Expect: 100-continue
 
-7a
+7A
 This is data we upload with PUT
 it comes from stdin so MUST be sent
 with chunked encoding

--- a/tests/data/test1073
+++ b/tests/data/test1073
@@ -57,7 +57,7 @@ Accept: */*
 Transfer-Encoding: chunked
 Expect: 100-continue
 
-7a
+7A
 This is data we upload with PUT
 it comes from stdin so MUST be sent
 with chunked encoding

--- a/tests/data/test1591
+++ b/tests/data/test1591
@@ -48,7 +48,7 @@ Transfer-Encoding: chunked
 Trailer: my-super-awesome-trailer, my-other-awesome-trailer
 Expect: 100-continue
 
-e
+E
 Hello Cloud!
 
 0

--- a/tests/data/test218
+++ b/tests/data/test218
@@ -47,7 +47,7 @@ Accept: */*
 Transfer-Encoding: chunked
 Expect: 100-continue
 
-1e
+1E
 just some tiny teeny contents
 
 0

--- a/tests/data/test510
+++ b/tests/data/test510
@@ -56,7 +56,7 @@ one
 two
 5
 three
-1d
+1D
 and a final longer crap: four
 0
 

--- a/tests/data/test56
+++ b/tests/data/test56
@@ -52,11 +52,7 @@ Accept: */*
 Transfer-Encoding: chunked
 Content-Type: application/x-www-form-urlencoded
 
-%if hyper
 C
-%else
-c
-%endif
 we post this
 0
 

--- a/tests/data/test565
+++ b/tests/data/test565
@@ -100,7 +100,7 @@ one
 two
 5
 three
-1d
+1D
 and a final longer crap: four
 0
 

--- a/tests/data/test645
+++ b/tests/data/test645
@@ -108,7 +108,7 @@ y
 1
 
 
-19a
+19A
 
 ------------------------------
 Content-Disposition: form-data; name="filename"
@@ -169,7 +169,7 @@ y
 1
 
 
-19a
+19A
 
 ------------------------------
 Content-Disposition: form-data; name="filename"

--- a/tests/data/test650
+++ b/tests/data/test650
@@ -90,7 +90,7 @@ Content-Disposition: attachment; filename="test%TESTNUMBER.filedata"
 Content-Type: text/whatever
 
 
-a5
+A5
 This is data from a file.
 
 ------------------------------
@@ -98,7 +98,7 @@ Content-Disposition: attachment; filename="test%TESTNUMBER.filedata"
 Content-Type: text/whatever
 
 
-af
+AF
 This is data from a file.
 
 --------------------------------
@@ -107,7 +107,7 @@ This is data from a file.
 Content-Disposition: form-data; name="filecontents"
 
 
-10f
+10F
 This is data from a file.
 
 ------------------------------

--- a/tests/data/test654
+++ b/tests/data/test654
@@ -81,7 +81,7 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-1af
+1AF
 ------------------------------
 Content-Disposition: form-data; name="greeting"
 Content-Type: application/X-Greeting

--- a/tests/data/test667
+++ b/tests/data/test667
@@ -66,7 +66,7 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-7f
+7F
 ------------------------------
 Content-Disposition: form-data; name="field"
 Content-Transfer-Encoding: base64

--- a/tests/data/test668
+++ b/tests/data/test668
@@ -69,7 +69,7 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-c1
+C1
 ------------------------------
 Content-Disposition: form-data; name="field1"
 


### PR DESCRIPTION
Emit upper-case hexadecimal lengths in chunked encoding, instead of lower-case. This matches the choice made by hyper, and so test fixtures can easily accommodate both backends.

This is an alternative to #6987, as previously discussed. Note that there was a second chunked encoding code path, which I also changed to use upper case, and three additional test fixtures had to be updated, which were previously not affected when looking at only the hyper configuration.