### PR TITLE
windows: fix compilation for Windows UWP platform

### DIFF
--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -50,6 +50,12 @@
 #  define in_addr_t unsigned long
 #endif
 
+#if defined(USE_UNIX_SOCKETS) && defined(WINAPI_FAMILY) && \
+    (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+   /* Required for sockaddr_un type */
+#  include <afunix.h>
+#endif
+
 #include <stddef.h>
 
 #include "curl_addrinfo.h"


### PR DESCRIPTION
Fix compilation for Windows UWP platform by including the `afunix.h` which is necessary for `sockaddr_un` when `USE_UNIX_SOCKETS` is defined.