### PR TITLE
Fix 4 problems in SASL kerberos

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -630,7 +630,9 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
       }
       else
         /* Decode the security challenge and create the response message */
-        result = Curl_auth_create_gssapi_security_message(data, &serverdata,
+        result = Curl_auth_create_gssapi_security_message(data,
+                                                          conn->sasl_authzid,
+                                                          &serverdata,
                                                           &conn->krb5,
                                                           &resp);
     }
@@ -639,7 +641,9 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
     /* Decode the security challenge and create the response message */
     result = get_server_message(sasl, data, &serverdata);
     if(!result)
-      result = Curl_auth_create_gssapi_security_message(data, &serverdata,
+      result = Curl_auth_create_gssapi_security_message(data,
+                                                        conn->sasl_authzid,
+                                                        &serverdata,
                                                         &conn->krb5,
                                                         &resp);
     break;

--- a/lib/vauth/krb5_gssapi.c
+++ b/lib/vauth/krb5_gssapi.c
@@ -247,8 +247,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
 
   /* Allocate our message */
   messagelen = 4;
-  if(authzid && *authzid)
-    messagelen += strlen(authzid) + 1;
+  if(authzid)
+    messagelen += strlen(authzid);
   message = malloc(messagelen);
   if(!message)
     return CURLE_OUT_OF_MEMORY;
@@ -260,13 +260,10 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   message[2] = (max_size >> 8) & 0xFF;
   message[3] = max_size & 0xFF;
 
-  /* If given, append the authorization identity including the 0x00 based
-     terminator. Note: Despite RFC4752 Section 3.1 stating "The authorization
-     identity is not terminated with the zero-valued (%x00) octet." it seems
-     necessary to include it. */
+  /* If given, append the authorization identity. */
 
   if(authzid && *authzid)
-    strcpy((char *) message + 4, authzid);
+    memcpy(message + 4, authzid, messagelen - 4);
 
   /* Setup the "authentication data" security buffer */
   input_token.value = message;

--- a/lib/vauth/krb5_gssapi.c
+++ b/lib/vauth/krb5_gssapi.c
@@ -257,6 +257,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
     gss_release_buffer(&unused_status, &username_token);
     return CURLE_BAD_CONTENT_ENCODING;
   }
+  sec_layer &= GSSAUTH_P_NONE;  /* We do not support a security layer */
 
   /* Process the maximum message size the server can receive */
   if(max_size > 0) {

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -338,6 +338,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
     infof(data, "GSSAPI handshake failure (invalid security layer)");
     return CURLE_BAD_CONTENT_ENCODING;
   }
+  sec_layer &= KERB_WRAP_NO_ENCRYPT;  /* We do not support a security layer */
 
   /* Process the maximum message size the server can receive */
   if(max_size > 0) {

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -344,8 +344,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
 
   /* Allocate our message */
   messagelen = 4;
-  if(authzid && *authzid)
-    messagelen += strlen(authzid) + 1;
+  if(authzid)
+    messagelen += strlen(authzid);
   message = malloc(messagelen);
   if(!message) {
     free(trailer);
@@ -360,13 +360,10 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   message[2] = (max_size >> 8) & 0xFF;
   message[3] = max_size & 0xFF;
 
-  /* If given, append the authorization identity including the 0x00 based
-     terminator. Note: Despite RFC4752 Section 3.1 stating "The authorization
-     identity is not terminated with the zero-valued (%x00) octet." it seems
-     necessary to include it. */
+  /* If given, append the authorization identity. */
 
   if(authzid && *authzid)
-    strcpy((char *) message + 4, authzid);
+    memcpy(message + 4, authzid, messagelen - 4);
 
   /* Allocate the padding */
   padding = malloc(sizes.cbBlockSize);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -194,6 +194,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
 /* This is used to generate a base64 encoded GSSAPI (Kerberos V5) security
    token message */
 CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
+                                                  const char *authzid,
                                                   const struct bufref *chlg,
                                                   struct kerberos5data *krb5,
                                                   struct bufref *out);


### PR DESCRIPTION
These are all in `Curl_auth_create_gssapi_security_message`, both in gssapi and sspi versions:

1. Byte order was not handled correctly: was bad for a big endian architecture.
2. Security layer negotiation flags were resent unchanged to the server: as we don't support such a layer (SASL is only used for authentication), mask off integrity and privacy layer flags.
3. An authorization identity was always derived from the context's user name, which is useless and a possible source of error for the server. Replace it by the provided SASL authzid or nothing.
4. The authorization identity was sent with a zero byte terminator, although RFC 4752 specifies it should not. This was justified by a comment but no reference to this need has been found. In addition, some servers include this extra byte in the real identity string causing failure of the authentication. As cyrus-sasl ang libgsasl do not include this byte, it is dropped here too.