### PR TITLE
http: reset the header buffer when sending the request

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3120,6 +3120,10 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   /* initialize a dynamic send-buffer */
   Curl_dyn_init(&req, DYN_HTTP_REQUEST);
 
+  /* make sure the header buffer is reset - if there are leftovers from a
+     previous transfer */
+  Curl_dyn_reset(&data->state.headerb);
+
   /* add the main request stuff */
   /* GET/HEAD/POST/PUT */
   result = Curl_dyn_addf(&req, "%s ", request);


### PR DESCRIPTION
A reused transfer handle could otherwise reuse the previous buffer's and
havoc could ensue.

Reported-by: sergio-nsk on github
Fixes #7018