### PR TITLE
tool_getparam: handle failure of curlx_convert_tchar_to_UTF8()

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2355,6 +2355,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
   for(i = 1, stillflags = TRUE; i < argc && !result; i++) {
     orig_opt = curlx_convert_tchar_to_UTF8(argv[i]);
+    if(!orig_opt)
+      return PARAM_NO_MEM;
 
     if(stillflags && ('-' == orig_opt[0])) {
       bool passarg;


### PR DESCRIPTION
Reported by GCC analyzer:
```
Error: GCC_ANALYZER_WARNING (CWE-476):
src/tool_getparam.c: scope_hint: In function 'parse_args'
src/tool_getparam.c:2318:38: warning[-Wanalyzer-possible-null-dereference]: dereference of possibly-NULL 'orig_opt'
lib/curlx.h:56: included_from: Included from here.
src/tool_getparam.c:28: included_from: Included from here.
lib/curl_multibyte.h:70:51: note: in definition of macro 'curlx_convert_tchar_to_UTF8'
src/tool_getparam.c:2316:16: note: in expansion of macro 'curlx_convert_tchar_to_UTF8'
```