### PR TITLE
ngtcp2: fix the cb_acked_stream_data_offset proto

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -603,7 +603,7 @@ static int cb_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
 
 static int
 cb_acked_stream_data_offset(ngtcp2_conn *tconn, int64_t stream_id,
-                            uint64_t offset, size_t datalen, void *user_data,
+                            uint64_t offset, uint64_t datalen, void *user_data,
                             void *stream_user_data)
 {
   struct quicsocket *qs = (struct quicsocket *)user_data;


### PR DESCRIPTION
The 'datalen' value should be 64 bit, not size_t!

Reported-by: Dmitry Karpov
Bug: https://curl.se/mail/lib-2021-05/0019.html