### PR TITLE
GIT-INFO: suggest using autoreconf instead of buildconf following 85868537d

### DIFF
--- a/GIT-INFO
+++ b/GIT-INFO
@@ -13,7 +13,7 @@ inner sanctum.
 To build in environments that support configure, after having extracted
 everything from git, do this:
 
-./buildconf
+autoreconf -fi
 ./configure
 make
 


### PR DESCRIPTION
A minor change to resolve the conflicts in documentations.

Someone that is new to this project may, as I earlier did myself, start from `docs/INSTALL.md` and observe these lines:

https://github.com/curl/curl/blob/1763aceb0cbc14ebff425eeba3987322ac037a0e/docs/INSTALL.md#L22-L26

Then in `GIT-INFO` there are:

https://github.com/curl/curl/blob/1763aceb0cbc14ebff425eeba3987322ac037a0e/GIT-INFO#L13-L18

However `./buildconf` has been obsoleted as part of 85868537d:

https://github.com/curl/curl/blob/1763aceb0cbc14ebff425eeba3987322ac037a0e/buildconf#L3-L4

Therefore this PR attempts to update `GIT-INFO` to have the recommended approach.
