### PR TITLE
http2: skip immediate parsing of payload following protocol switch

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2335,8 +2335,15 @@ CURLcode Curl_http2_switched(struct Curl_easy *data,
 
   DEBUGASSERT(httpc->nread_inbuf == 0);
 
-  if(-1 == h2_process_pending_input(data, httpc, &result))
-    return CURLE_HTTP2;
+  /* Good enough to call it an end once the remaining payload is copied to the
+   * connection buffer.
+   * Some servers (e.g. nghttpx v1.43.0) may fulfill stream 1 immediately
+   * following the protocol switch other than waiting for the client-side
+   * connection preface. If h2_process_pending_input is invoked here to parse
+   * the remaining payload, stream 1 would be marked as closed too early and
+   * thus ignored in http2_recv (following 252790c53).
+   * The logic in lib/http.c and lib/transfer.c guarantees a following
+   * http2_recv would be invoked very soon. */
 
   return CURLE_OK;
 }


### PR DESCRIPTION
This is considered not harmful as a following `http2_recv` shall be called very soon.

This is considered helpful in the specific situation where some servers (e.g. nghttpx v1.43.0) may fulfill stream 1 immediately following the return of HTTP status 101, other than waiting for the client-side connection preface to arrive.

Resolves #7036.

This is an alternative attempt to #7038 -- please do not merge both of the pull requests.

At 849e8a39f my local build passes all test cases involved:

```
TESTDONE: 1426 tests were considered during 1566 seconds.
TESTDONE: 1149 tests out of 1149 reported OK: 100%
```