### PR TITLE
http2: use nghttp2_session_upgrade2 than nghttp2_session_upgrade

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2273,10 +2273,10 @@ CURLcode Curl_http2_switched(struct Curl_easy *data,
     /* stream 1 is opened implicitly on upgrade */
     stream->stream_id = 1;
     /* queue SETTINGS frame (again) */
-    rv = nghttp2_session_upgrade(httpc->h2, httpc->binsettings,
-                                 httpc->binlen, NULL);
+    rv = nghttp2_session_upgrade2(httpc->h2, httpc->binsettings, httpc->binlen,
+                                  data->state.httpreq == HTTPREQ_HEAD, NULL);
     if(rv) {
-      failf(data, "nghttp2_session_upgrade() failed: %s(%d)",
+      failf(data, "nghttp2_session_upgrade2() failed: %s(%d)",
             nghttp2_strerror(rv), rv);
       return CURLE_HTTP2;
     }


### PR DESCRIPTION
I happen to notice from the upstream that `nghttp2_session_upgrade` may be considered deprecated:
https://github.com/nghttp2/nghttp2/blob/20079b4c2f688385ba9ecf723f958d0448894879/lib/includes/nghttp2/nghttp2.h#L3660-L3663

When [searching for `nghttp2_session_upgrade` on GitHub](https://github.com/curl/curl/issues?q=nghttp2_session_upgrade2), the only result returned is #521. Also there is no result when searching in the revision history. This may rule out the possibility that `nghttp2_session_upgrade2` was once adapted but reverted due to some unexpected failure.