### PR TITLE
progress: reset limit_size variables at transfer start

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -241,6 +241,8 @@ void Curl_pgrsStartNow(struct Curl_easy *data)
   data->progress.is_t_startransfer_set = false;
   data->progress.ul_limit_start = data->progress.start;
   data->progress.dl_limit_start = data->progress.start;
+  data->progress.ul_limit_size = 0;
+  data->progress.dl_limit_size = 0;
   data->progress.downloaded = 0;
   data->progress.uploaded = 0;
   /* clear all bits except HIDE and HEADERS_OUT */


### PR DESCRIPTION
Otherwise the old value would linger from a previous use and would mess
up the network speed cap logic.

Reported-by: Ymir1711 on github

Fixes #7042