### PR TITLE
hostip: remove the debug code for LocalHost

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -466,10 +466,6 @@ Curl_cache_addr(struct Curl_easy *data,
  * function is used. You MUST call Curl_resolv_unlock() later (when you're
  * done using this struct) to decrease the counter again.
  *
- * In debug mode, we specifically test for an interface name "LocalHost"
- * and resolve "localhost" instead as a means to permit test cases
- * to connect to a local test server with any host name.
- *
  * Return codes:
  *
  * CURLRESOLV_ERROR   (-1) = error, no pointer
@@ -578,13 +574,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
         /* If Curl_getaddrinfo() returns NULL, 'respwait' might be set to a
            non-zero value indicating that we need to wait for the response to
            the resolve call */
-        addr = Curl_getaddrinfo(data,
-#ifdef DEBUGBUILD
-                                (data->set.str[STRING_DEVICE]
-                                 && !strcmp(data->set.str[STRING_DEVICE],
-                                            "LocalHost"))?"localhost":
-#endif
-                                hostname, port, &respwait);
+        addr = Curl_getaddrinfo(data, hostname, port, &respwait);
       }
     }
     if(!addr) {


### PR DESCRIPTION
The Curl_resolv() had special code (when built in debug mode) for when
resolving the host name "LocalHost" (using that exact casing). It would
then get the host name from the --interface option instead.

This development-only feature was not used by anything (anymore) and we
have the --resolve feature if we want to play similar tricks properly
going forward.