### PR TITLE
sasl: use 'unsigned short' to store mechanism

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -58,7 +58,7 @@
 static const struct {
   const char   *name;  /* Name */
   size_t        len;   /* Name length */
-  unsigned int  bit;   /* Flag bit */
+  unsigned short bit;   /* Flag bit */
 } mechtable[] = {
   { "LOGIN",        5,  SASL_MECH_LOGIN },
   { "PLAIN",        5,  SASL_MECH_PLAIN },
@@ -128,7 +128,8 @@ void Curl_sasl_cleanup(struct connectdata *conn, unsigned int authused)
  *
  * Returns the SASL mechanism token or 0 if no match.
  */
-unsigned int Curl_sasl_decode_mech(const char *ptr, size_t maxlen, size_t *len)
+unsigned short Curl_sasl_decode_mech(const char *ptr, size_t maxlen,
+                                     size_t *len)
 {
   unsigned int i;
   char c;
@@ -173,7 +174,7 @@ CURLcode Curl_sasl_parse_url_auth_option(struct SASL *sasl,
   if(!strncmp(value, "*", len))
     sasl->prefmech = SASL_AUTH_DEFAULT;
   else {
-    unsigned int mechbit = Curl_sasl_decode_mech(value, len, &mechlen);
+    unsigned short mechbit = Curl_sasl_decode_mech(value, len, &mechlen);
     if(mechbit && mechlen == len)
       sasl->prefmech |= mechbit;
     else

--- a/lib/curl_sasl.h
+++ b/lib/curl_sasl.h
@@ -42,7 +42,7 @@ struct connectdata;
 
 /* Authentication mechanism values */
 #define SASL_AUTH_NONE          0
-#define SASL_AUTH_ANY           ~0U
+#define SASL_AUTH_ANY           0xffff
 #define SASL_AUTH_DEFAULT       (SASL_AUTH_ANY & ~SASL_MECH_EXTERNAL)
 
 /* Authentication mechanism strings */
@@ -108,9 +108,9 @@ struct SASLproto {
 struct SASL {
   const struct SASLproto *params; /* Protocol dependent parameters */
   saslstate state;         /* Current machine state */
-  unsigned int authmechs;  /* Accepted authentication mechanisms */
-  unsigned int prefmech;   /* Preferred authentication mechanism */
-  unsigned int authused;   /* Auth mechanism used for the connection */
+  unsigned short authmechs;  /* Accepted authentication mechanisms */
+  unsigned short prefmech;   /* Preferred authentication mechanism */
+  unsigned short authused;   /* Auth mechanism used for the connection */
   bool resetprefs;         /* For URL auth option parsing. */
   bool mutual_auth;        /* Mutual authentication enabled (GSSAPI only) */
   bool force_ir;           /* Protocol always supports initial response */
@@ -126,8 +126,8 @@ struct SASL {
 void Curl_sasl_cleanup(struct connectdata *conn, unsigned int authused);
 
 /* Convert a mechanism name to a token */
-unsigned int Curl_sasl_decode_mech(const char *ptr,
-                                   size_t maxlen, size_t *len);
+unsigned short Curl_sasl_decode_mech(const char *ptr,
+                                     size_t maxlen, size_t *len);
 
 /* Parse the URL login options */
 CURLcode Curl_sasl_parse_url_auth_option(struct SASL *sasl,

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -919,7 +919,7 @@ static CURLcode imap_state_capability_resp(struct Curl_easy *data,
       /* Do we have a SASL based authentication mechanism? */
       else if(wordlen > 5 && !memcmp(line, "AUTH=", 5)) {
         size_t llen;
-        unsigned int mechbit;
+        unsigned short mechbit;
 
         line += 5;
         wordlen -= 5;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -709,7 +709,7 @@ static CURLcode pop3_state_capa_resp(struct Curl_easy *data, int pop3code,
       for(;;) {
         size_t llen;
         size_t wordlen;
-        unsigned int mechbit;
+        unsigned short mechbit;
 
         while(len &&
               (*line == ' ' || *line == '\t' ||

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -894,7 +894,7 @@ static CURLcode smtp_state_ehlo_resp(struct Curl_easy *data,
       for(;;) {
         size_t llen;
         size_t wordlen;
-        unsigned int mechbit;
+        unsigned short mechbit;
 
         while(len &&
               (*line == ' ' || *line == '\t' ||


### PR DESCRIPTION
... saves a few bytes of struct size in memory and it only uses 10 bits anyway.