### PR TITLE
schannel: Ensure the security context request flags are always set

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -562,15 +562,9 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
                    "names in server certificates.\n"));
     }
 
-    /* security request flags */
-    BACKEND->req_flags = ISC_REQ_SEQUENCE_DETECT | ISC_REQ_REPLAY_DETECT |
-      ISC_REQ_CONFIDENTIALITY | ISC_REQ_ALLOCATE_MEMORY |
-      ISC_REQ_STREAM;
-
     if(!SSL_SET_OPTION(auto_client_cert)) {
       schannel_cred.dwFlags &= ~SCH_CRED_USE_DEFAULT_CREDS;
       schannel_cred.dwFlags |= SCH_CRED_NO_DEFAULT_CREDS;
-      BACKEND->req_flags |= ISC_REQ_USE_SUPPLIED_CREDS;
       infof(data, "schannel: disabled automatic use of client certificate\n");
     }
     else
@@ -908,6 +902,15 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   /* setup output buffer */
   InitSecBuffer(&outbuf, SECBUFFER_EMPTY, NULL, 0);
   InitSecBufferDesc(&outbuf_desc, &outbuf, 1);
+
+  /* security request flags */
+  BACKEND->req_flags = ISC_REQ_SEQUENCE_DETECT | ISC_REQ_REPLAY_DETECT |
+    ISC_REQ_CONFIDENTIALITY | ISC_REQ_ALLOCATE_MEMORY |
+    ISC_REQ_STREAM;
+
+  if(!SSL_SET_OPTION(auto_client_cert)) {
+    BACKEND->req_flags |= ISC_REQ_USE_SUPPLIED_CREDS;
+  }
 
   /* allocate memory for the security context handle */
   BACKEND->ctxt = (struct Curl_schannel_ctxt *)


### PR DESCRIPTION
In pull request #6673, the code which sets the request flags for the schannel context was moved so that the flags were only set when a new credential handle is used. When a cached credential handle is being re-used, the flags are not set.

For me, this manifested itself as a TLS handshake failure in the data connection of an ftps transfer. This connection would use the cached credential handle which was created for the control connection.

@jay FYI