### PR TITLE
version: free the openldap info correctly

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -267,6 +267,8 @@ char *curl_version(void)
       msnprintf(ldap_buf, sizeof(ldap_buf), "%s/%u.%u.%u",
                 api.ldapai_vendor_name, major, minor, patch);
       src[i++] = ldap_buf;
+      ldap_memfree(api.ldapai_vendor_name);
+      ber_memvfree((void **)api.ldapai_extensions);
     }
   }
 #endif

--- a/tests/mem-include-scan.pl
+++ b/tests/mem-include-scan.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2010 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2010 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -43,7 +43,7 @@ sub scanfile {
 
     open(F, "<$file");
     while(<F>) {
-        if($_ =~ /(free|alloc|strdup)\(/) {
+        if($_ =~ /\W(free|alloc|strdup)\(/) {
             $memfunc++;
         }
         elsif($_ =~ /^ *# *include \"memdebug.h\"/) {


### PR DESCRIPTION
... to avoid memory leaks.

Follow-up to: bf0feae7768d9