### PR TITLE
config/cmake: configure CURL_SA_FAMILY_T properly for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1062,6 +1062,16 @@ if(HAVE_FSETXATTR)
   endforeach()
 endif()
 
+set(CMAKE_EXTRA_INCLUDE_FILES   "sys/socket.h")
+check_type_size("sa_family_t"   SIZEOF_SA_FAMILY_T)
+set(HAVE_SA_FAMILY_T            ${HAVE_SIZEOF_SA_FAMILY_T})
+set(CMAKE_EXTRA_INCLUDE_FILES   "")
+
+set(CMAKE_EXTRA_INCLUDE_FILES   "ws2def.h")
+check_type_size("ADDRESS_FAMILY"    SIZEOF_ADDRESS_FAMILY)
+set(HAVE_ADDRESS_FAMILY         ${HAVE_SIZEOF_ADDRESS_FAMILY})
+set(CMAKE_EXTRA_INCLUDE_FILES   "")
+
 # sigaction and sigsetjmp are special. Use special mechanism for
 # detecting those, but only if previous attempt failed.
 if(HAVE_SIGNAL_H)

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -313,6 +313,12 @@
 /* Define to 1 if you have a IPv6 capable working inet_pton function. */
 #cmakedefine HAVE_INET_PTON 1
 
+/* Define to 1 if symbol `sa_family_t' exists */
+#cmakedefine HAVE_SA_FAMILY_T 1
+
+/* Define to 1 if symbol `ADDRESS_FAMILY' exists */
+#cmakedefine HAVE_ADDRESS_FAMILY 1
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #cmakedefine HAVE_INTTYPES_H 1
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -777,9 +777,16 @@ endings either CRLF or LF so 't' is appropriate.
 #  endif
 #endif /* DONT_USE_RECV_BEFORE_SEND_WORKAROUND */
 
-/* for systems that don't detect this in configure, use a sensible default */
+/* for systems that don't detect this in configure */
 #ifndef CURL_SA_FAMILY_T
-#define CURL_SA_FAMILY_T unsigned short
+#  if defined(HAVE_SA_FAMILY_T)
+#    define CURL_SA_FAMILY_T sa_family_t
+#  elif defined(HAVE_ADDRESS_FAMILY)
+#    define CURL_SA_FAMILY_T ADDRESS_FAMILY
+#  else
+/* use a sensible default */
+#    define CURL_SA_FAMILY_T unsigned short
+#  endif
 #endif
 
 /* Some convenience macros to get the larger/smaller value out of two given.


### PR DESCRIPTION
The reported issue #7049 is believed to have been triggered by the combination of these observations:

1. On macOS, `sa_family_t` is defined to be an unsigned char than short:
https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/bsd/sys/_types/_sa_family_t.h#L31
2. Currently (as of dae382a1a) the CMake configuration (`CMakeLists.txt`) does not cover the `CURL_SA_FAMILY_T` macro.
3. In `lib/curl_setup.h` the fallback handling code for `CURL_SA_FAMILY_T` uses unsigned short unconditionally:
https://github.com/curl/curl/blob/dae382a1a/lib/curl_setup.h#L781-L784

This PR attempts to better configure this macro on macOS by updating both files.

Kindly notice that I do not currently have an appropriate environment to test myself. Therefore I created a dummy PR in my fork to launch the `macos.yml` CI: https://github.com/starrify/curl/pull/1
The result looks good and the reported warning is now gone.

Resolves #7049