### PR TITLE
curl_url_set.3: most URL parts accept spaces

### DIFF
--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -39,6 +39,10 @@ below) to set or change, with \fIcontent\fP pointing to a null-terminated
 string with the new contents for that URL part. The contents should be in the
 form and encoding they'd use in a URL: URL encoded.
 
+If the \fIcontent\fP contains space (ASCII value 32), which is technically not
+legally allowed to be part of a URL at all, it will be accepted in most parts
+with the exception of the scheme, host and port.
+
 The application does not have to keep \fIcontent\fP around after a successful
 call.
 

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -129,6 +129,10 @@ struct querycase {
 };
 
 static struct testcase get_parts_list[] ={
+  {"https://u ser:pass word@example.net/ge t?this=and what",
+   "https | u ser | pass word | [13] | example.net | [15] | /ge t | "
+   "this=and what | [17]",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK },
   {"[::1]",
    "http | [11] | [12] | [13] | [::1] | [15] | / | [16] | [17]",
    CURLU_GUESS_SCHEME, 0, CURLUE_OK },


### PR DESCRIPTION
... even though they're not "legal" in URLs.