### PR TITLE
transfer: Check the secondary socket in the data_pending function

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -501,7 +501,6 @@ static int data_pending(const struct Curl_easy *data)
      its internal buffers so we MUST always try until we get EAGAIN back */
   return conn->handler->protocol&(CURLPROTO_SCP|CURLPROTO_SFTP) ||
 #if defined(USE_NGHTTP2)
-    Curl_ssl_data_pending(conn, FIRSTSOCKET) ||
     /* For HTTP/2, we may read up everything including response body
        with header fields in Curl_http_readwrite_headers. If no
        content-length is provided, curl waits for the connection
@@ -509,10 +508,9 @@ static int data_pending(const struct Curl_easy *data)
        TRUE. The thing is if we read everything, then http2_recv won't
        be called and we cannot signal the HTTP/2 stream has closed. As
        a workaround, we return nonzero here to call http2_recv. */
-    ((conn->handler->protocol&PROTO_FAMILY_HTTP) && conn->httpversion >= 20);
-#else
-    Curl_ssl_data_pending(conn, FIRSTSOCKET);
+    ((conn->handler->protocol&PROTO_FAMILY_HTTP) && conn->httpversion >= 20) ||
 #endif
+    Curl_ssl_data_pending(conn, FIRSTSOCKET);
 }
 
 /*

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -497,6 +497,9 @@ static int data_pending(const struct Curl_easy *data)
     return Curl_quic_data_pending(data);
 #endif
 
+  if(conn->handler->protocol&PROTO_FAMILY_FTP)
+    return Curl_ssl_data_pending(conn, SECONDARYSOCKET);
+
   /* in the case of libssh2, we can never be really sure that we have emptied
      its internal buffers so we MUST always try until we get EAGAIN back */
   return conn->handler->protocol&(CURLPROTO_SCP|CURLPROTO_SFTP) ||
@@ -510,8 +513,7 @@ static int data_pending(const struct Curl_easy *data)
        a workaround, we return nonzero here to call http2_recv. */
     ((conn->handler->protocol&PROTO_FAMILY_HTTP) && conn->httpversion >= 20) ||
 #endif
-    Curl_ssl_data_pending(conn, FIRSTSOCKET) ||
-    Curl_ssl_data_pending(conn, SECONDARYSOCKET);
+    Curl_ssl_data_pending(conn, FIRSTSOCKET);
 }
 
 /*

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -510,7 +510,8 @@ static int data_pending(const struct Curl_easy *data)
        a workaround, we return nonzero here to call http2_recv. */
     ((conn->handler->protocol&PROTO_FAMILY_HTTP) && conn->httpversion >= 20) ||
 #endif
-    Curl_ssl_data_pending(conn, FIRSTSOCKET);
+    Curl_ssl_data_pending(conn, FIRSTSOCKET) ||
+    Curl_ssl_data_pending(conn, SECONDARYSOCKET);
 }
 
 /*


### PR DESCRIPTION
Proposed fix for #7068

This adds a check for the secondary socket to the `data_pending` function. This makes libcurl notice any TLS messages (such as close_notify) which may have been received but not processed when receiving data. This is needed for FTPS transfers, which use TLS on the secondary socket.