### PR TITLE
Handle body on HYPER_TASK_EMPTY.

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -331,7 +331,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
       infof(data, "hyperstream is done!\n");
       break;
     }
-    else if(t != HYPER_TASK_RESPONSE) {
+    else if(t != HYPER_TASK_RESPONSE && t != HYPER_TASK_EMPTY) {
       *didwhat = KEEP_RECV;
       break;
     }


### PR DESCRIPTION
Some of the time, we get a HYPER_TASK_EMPTY response before the status
line, headers, and body have been read. Previously, that would cause us
to poll again, leading to a 1 second timeout.

The HYPER_TASK_EMPTY docs say:

   The value of this task is null (does not imply an error).

So, if we receive a HYPER_TASK_EMPTY, continue on with processing the
response.

Fixes #7064 

/cc @kevinburke 