### PR TITLE
docs: cookies from HTTP headers need domain set

### DIFF
--- a/docs/cmdline-opts/cookie.d
+++ b/docs/cmdline-opts/cookie.d
@@ -22,14 +22,10 @@ The file format of the file to read cookies from should be plain HTTP headers
 The file specified with --cookie is only used as input. No cookies will be
 written to the file. To store cookies, use the --cookie-jar option.
 
-Exercise caution if you are using this option and multiple transfers may
-occur.  If you use the NAME1=VALUE1; format, or in a file use the Set-Cookie
-format and don't specify a domain, then the cookie is sent for any domain
-(even after redirects are followed) and cannot be modified by a server-set
-cookie. If the cookie engine is enabled and a server sets a cookie of the same
-name then both will be sent on a future transfer to that server, likely not
-what you intended.  To address these issues set a domain in Set-Cookie (doing
-that will include sub domains) or use the Netscape format.
+If you use the Set-Cookie file format and don't specify a domain then the
+cookie is not sent since the domain will never match. To address this, set a
+domain in Set-Cookie line (doing that will include sub-domains) or preferably:
+use the Netscape format.
 
 This option can be used multiple times.
 

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
@@ -44,13 +44,10 @@ libcurl will instead read from stdin.
 This option only \fBreads\fP cookies. To make libcurl write cookies to file,
 see \fICURLOPT_COOKIEJAR(3)\fP.
 
-Exercise caution if you are using this option and multiple transfers may occur.
-If you use the Set-Cookie format and don't specify a domain then the cookie is
-sent for any domain (even after redirects are followed) and cannot be modified
-by a server-set cookie. If a server sets a cookie of the same name then both
-will be sent on a future transfer to that server, likely not what you intended.
-To address these issues set a domain in Set-Cookie (doing that will include
-sub-domains) or use the Netscape format.
+If you use the Set-Cookie file format and don't specify a domain then the
+cookie is not sent since the domain will never match. To address this, set a
+domain in Set-Cookie line (doing that will include sub-domains) or preferably:
+use the Netscape format.
 
 If you use this option multiple times, you just add more files to read.
 Subsequent files will add more cookies.


### PR DESCRIPTION
... or the cookies won't get sent. Push users to using the "Netscape"
format instead, which curl uses when saving a cookie "jar".

Reported-by: Martin Dorey
Fixes #6723