### PR TITLE
http2: make sure pause is done on HTTP

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2353,7 +2353,8 @@ CURLcode Curl_http2_stream_pause(struct Curl_easy *data, bool pause)
   DEBUGASSERT(data);
   DEBUGASSERT(data->conn);
   /* if it isn't HTTP/2, we're done */
-  if(!data->conn->proto.httpc.h2)
+  if(!(data->conn->handler->protocol & PROTO_FAMILY_HTTP) ||
+     !data->conn->proto.httpc.h2)
     return CURLE_OK;
 #ifdef NGHTTP2_HAS_SET_LOCAL_WINDOW_SIZE
   else {


### PR DESCRIPTION
Since the function is called for any protocol, we can't assume that the
HTTP struct is there without first making sure it is HTTP.

Reported-by: Denis Goleshchikhin
Fixes #7079