### PR TITLE
github: inhibit deprecated declarations for clang on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,7 +98,7 @@ jobs:
         compiler:
         - CC: clang
           CXX: clang++
-          CFLAGS: "-mmacosx-version-min=10.15"
+          CFLAGS: "-mmacosx-version-min=10.15 -Wno-deprecated-declarations"
         - CC: gcc-8
           CXX: g++-8
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"


### PR DESCRIPTION
... as they otherwise cause ldap build errors in the CI.

Fixes #7081