### PR TITLE
data->state.aptr.uagent can be NULL

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -321,7 +321,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
                         host?host:"",
                         data->state.aptr.proxyuserpwd?
                         data->state.aptr.proxyuserpwd:"",
-                        useragent,
+                        useragent?useragent:"",
                         proxyconn);
 
         if(!result)


### PR DESCRIPTION
After a redirect for some reason ```data->state.aptr.uagent``` becomes 0x0.

```
CONNECT consulta.jfrn.jus.br:443 HTTP/1.1
Host: consulta.jfrn.jus.br:443
Proxy-Authorization: Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
(nil)Proxy-Connection: Keep-Alive
```