### PR TITLE
curl-wolfssl.m4: without custom include path, assume /usr/include

### DIFF
--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -148,8 +148,8 @@ if test "x$OPT_WOLFSSL" != xno; then
             else
               dnl user didn't give a path, so guess/hope they installed wolfssl
               dnl headers to system default location
-              CPPFLAGS="-I$includedir/wolfssl $CPPFLAGS"
-              AC_MSG_NOTICE([Add $includedir/wolfssl to CPPFLAGS])
+              CPPFLAGS="-I/usr/include/wolfssl $CPPFLAGS"
+              AC_MSG_NOTICE([Add /usr/include/wolfssl to CPPFLAGS])
             fi
             WOLFSSL_NTLM=1
         ]


### PR DESCRIPTION
... so that we can point out the root of the OpenSSL emulation headers.
Previously this used the '$includedir' variable which is wrong since
that defaults to the dir where the current configure invoke will install
the built libcurl headers: /usr/local by default.

Fixes #7085
Reported-by: Joel Jakobsson