### PR TITLE
docs: document attach in INTERNALS.md

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1024,6 +1024,8 @@ for older and later versions as things don't change drastically that often.
   `->readwrite` gets called during transfer to allow the protocol to do extra
   reads/writes
 
+  `->attach` attaches a transfer to the connection.
+
   `->defport` is the default report TCP or UDP port this protocol uses
 
   `->protocol` is one or more bits in the `CURLPROTO_*` set. The SSL versions


### PR DESCRIPTION
The new field in the Curl_handler struct still lacks documentation. This
adds it it from the information extracted from lib/urldata.h:797