### PR TITLE
AmigaOS: add function definitions for SHA256_Init etc.

### DIFF
--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -90,6 +90,33 @@ void Curl_amiga_X509_free(X509 *a)
 {
   X509_free(a);
 }
+
+/* AmiSSL replaces many functions with macros. Curl requires pointer
+ * to some of these functions. Thus, we have to encapsulate these macros.
+ */
+
+#include "warnless.h"
+
+int (SHA256_Init)(SHA256_CTX *c)
+{
+  return SHA256_Init(c);
+};
+
+int (SHA256_Update)(SHA256_CTX *c, const void *data, size_t len)
+{
+  return SHA256_Update(c, data, curlx_uztoui(len));
+};
+
+int (SHA256_Final)(unsigned char *md, SHA256_CTX *c)
+{
+  return SHA256_Final(md, c);
+};
+
+void (X509_INFO_free)(X509_INFO *a)
+{
+  X509_INFO_free(a);
+};
+
 #endif /* USE_AMISSL */
 #endif /* __AMIGA__ */
 


### PR DESCRIPTION
In sha256.h the struct Curl_HMAC_SHA256 requires pointer to functions SHA256_Init, SHA256_Update etc.:

https://github.com/curl/curl/blob/master/lib/sha256.c#L469-L483

However, AmiSSL (Amigas OpenSSL) defines those as macros so we need to wrap these macros in function definitions. Then we can point to them.