### PR TITLE
[CMake] Use multithreaded compilation on VS 2008+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1272,6 +1272,11 @@ if(MSVC)
   else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
   endif()
+
+  # Use multithreaded compilation on VS 2008+
+  if(MSVC_VERSION GREATER_EQUAL 1500)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+  endif()
 endif()
 
 if(CURL_WERROR)


### PR DESCRIPTION
Multithreaded compilation has been supported since at least VS 2005 and
been robustly stable since at least VS 2008

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>