### PR TITLE
tls: colons, commas and spaces are valid separators for NSS cipher list

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -337,7 +337,7 @@ static SECStatus set_ciphers(struct Curl_easy *data, PRFileDesc * model,
     while((*cipher) && (ISSPACE(*cipher)))
       ++cipher;
 
-    cipher_list = strchr(cipher, ',');
+    cipher_list = strpbrk(cipher, ":, ");
     if(cipher_list) {
       *cipher_list++ = '\0';
     }


### PR DESCRIPTION
Fixes #7110