### PR TITLE
openssl: fix 7f4a9a9b2a49 commit about missing comma

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3452,7 +3452,7 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   Curl_none_set_engine_default,       /* set_engine_default */
   Curl_none_engines_list,             /* engines_list */
   sectransp_false_start,              /* false_start */
-  sectransp_sha256sum                 /* sha256sum */
+  sectransp_sha256sum,                /* sha256sum */
   NULL,                               /* associate_connection */
   NULL                                /* disassociate_connection */
 };


### PR DESCRIPTION
Fix https://github.com/curl/curl/commit/7f4a9a9b2a49547eae24d2e19bc5c346e9026479 commit about missing comma.