### PR TITLE
quiche: update for network path aware API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2925,6 +2925,11 @@ if test X"$want_quiche" != Xno; then
           CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_QUICHE"
           export CURL_LIBRARY_PATH
           AC_MSG_NOTICE([Added $DIR_QUICHE to CURL_LIBRARY_PATH]),
+          [],
+          [
+AC_INCLUDES_DEFAULT
+#include <sys/socket.h>
+          ]
        )
       ],
         dnl not found, revert back to clean variables


### PR DESCRIPTION
Latest version of quiche requires the application to pass the peer
address of received packets, and it provides the address for outgoing
packets back.