### PR TITLE
bearssl: remove incorrect const on variable that is modified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
   directories:
   - $HOME/wolfssl-4.7.0-stable
   - $HOME/mesalink-1.0.0
+  - $HOME/bearssl-0.6
 
 env:
   global:
@@ -126,6 +127,16 @@ jobs:
         - libzstd-dev
   - env:
     - T=debug-rustls RUSTLS_VERSION="v0.6.0" C="--with-rustls=$HOME/crust"
+    addons:
+      apt:
+        <<: *common_apt
+        packages:
+        - *common_packages
+        - libpsl-dev
+        - libbrotli-dev
+        - libzstd-dev
+  - env:
+    - T=debug-bearssl C="--with-bearssl" BEARSSL="yes"
     addons:
       apt:
         <<: *common_apt

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -840,30 +840,32 @@ static CURLcode bearssl_sha256sum(const unsigned char *input,
 }
 
 const struct Curl_ssl Curl_ssl_bearssl = {
-  { CURLSSLBACKEND_BEARSSL, "bearssl" },
+  { CURLSSLBACKEND_BEARSSL, "bearssl" }, /* info */
   0,
   sizeof(struct ssl_backend_data),
 
-  Curl_none_init,
-  Curl_none_cleanup,
-  bearssl_version,
-  Curl_none_check_cxn,
-  Curl_none_shutdown,
-  bearssl_data_pending,
-  bearssl_random,
-  Curl_none_cert_status_request,
-  bearssl_connect,
-  bearssl_connect_nonblocking,
-  Curl_ssl_getsock,
-  bearssl_get_internals,
-  bearssl_close,
-  Curl_none_close_all,
-  bearssl_session_free,
-  Curl_none_set_engine,
-  Curl_none_set_engine_default,
-  Curl_none_engines_list,
-  Curl_none_false_start,
-  bearssl_sha256sum
+  Curl_none_init,                  /* init */
+  Curl_none_cleanup,               /* cleanup */
+  bearssl_version,                 /* version */
+  Curl_none_check_cxn,             /* check_cxn */
+  Curl_none_shutdown,              /* shutdown */
+  bearssl_data_pending,            /* data_pending */
+  bearssl_random,                  /* random */
+  Curl_none_cert_status_request,   /* cert_status_request */
+  bearssl_connect,                 /* connect */
+  bearssl_connect_nonblocking,     /* connect_nonblocking */
+  Curl_ssl_getsock,                /* getsock */
+  bearssl_get_internals,           /* get_internals */
+  bearssl_close,                   /* close_one */
+  Curl_none_close_all,             /* close_all */
+  bearssl_session_free,            /* session_free */
+  Curl_none_set_engine,            /* set_engine */
+  Curl_none_set_engine_default,    /* set_engine_default */
+  Curl_none_engines_list,          /* engines_list */
+  Curl_none_false_start,           /* false_start */
+  bearssl_sha256sum,               /* sha256sum */
+  NULL,                            /* associate_connection */
+  NULL                             /* disassociate_connection */
 };
 
 #endif /* USE_BEARSSL */

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -300,7 +300,7 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   const char * const ssl_cafile = SSL_CONN_CONFIG(CAfile);
-  const char * const hostname = SSL_HOST_NAME();
+  const char *hostname = SSL_HOST_NAME();
   const bool verifypeer = SSL_CONN_CONFIG(verifypeer);
   const bool verifyhost = SSL_CONN_CONFIG(verifyhost);
   CURLcode ret;

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -175,4 +175,18 @@ if [ $TRAVIS_OS_NAME = linux ]; then
     sudo make install
 
   fi
+
+  if [ "$BEARSSL" = "yes" ]; then
+    if [ ! -e $HOME/bearssl-0.6/Makefile ]; then
+      cd $HOME
+      curl -LO https://bearssl.org/bearssl-0.6.tar.gz
+      tar -xzf bearssl-0.6.tar.gz
+      cd bearssl-0.6
+      make
+    fi
+    cd $HOME/bearssl-0.6
+    sudo cp inc/*.h /usr/local/include
+    sudo cp build/libbearssl.* /usr/local/lib
+  fi
+
 fi

--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -76,6 +76,12 @@ if [ "$T" = "debug-rustls" ]; then
   make "TFLAGS=HTTPS !313" test-nonflaky
 fi
 
+if [ "$T" = "debug-bearssl" ]; then
+  ./configure --enable-debug --enable-werror $C
+  make
+  make "TFLAGS=-n !313" test-nonflaky
+fi
+
 if [ "$T" = "novalgrind" ]; then
   ./configure --enable-werror $C
   make


### PR DESCRIPTION
A recent vtls cleanup accidentally made a variable const that was modified later on in the function, causing a build failure when BearSSL is enabled. To prevent this sort of thing in the future, I added BearSSL to the Travis configuration.

While testing the Travis build, I noticed a warning that it was missing explicit initializers for a couple `struct Curl_ssl` fields, so I set those to NULL.