### PR TITLE
OS400: Fix the compile errors in ccsidcurl.c

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -396,7 +396,7 @@ curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid)
   int nproto;
   curl_version_info_data *id;
   int i;
-  const char *cpp;
+  const char **cpp;
   static const size_t charfields[] = {
     offsetof(curl_version_info_data, version),
     offsetof(curl_version_info_data, host),
@@ -485,8 +485,8 @@ curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid)
 
   for(i = 0; i < sizeof(charfields) / sizeof(charfields[0]); i++) {
     cpp = (const char **) ((char *) p + charfields[i]);
-    if(*cpp)
-      if(convert_version_info_string(cpp, &cp, &n, ccsid))
+    if (*cpp && convert_version_info_string(cpp, &cp, &n, ccsid))
+      return (curl_version_info_data *) NULL;
   }
 
   return id;


### PR DESCRIPTION
Looks like the declaration of cpp pointer variable should be const char ** and return null if convert_version_info_string() fails.

This resolves https://github.com/curl/curl/issues/7134 for me.