### PR TITLE
schannel: Fix ALPN buffer for HTTP/2

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -874,6 +874,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
 
 #ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2) {
+      alpn_buffer[cur++] = ALPN_H2_LENGTH;
       memcpy(&alpn_buffer[cur], ALPN_H2, ALPN_H2_LENGTH);
       cur += ALPN_H2_LENGTH;
       infof(data, "schannel: ALPN, offering %s\n", ALPN_H2);


### PR DESCRIPTION
After upgrading to version 7.77, I noticed that requests using HTTP/2 with SChannel were failing with an error from the InitializeSecurityContext function.

> schannel: initial InitializeSecurityContext failed: SEC_E_ILLEGAL_MESSAGE (0x80090326) - This error usually occurs when a fatal SSL/TLS` alert is received (e.g. handshake failed). More detail may be available in the Windows System event log.

In a3268eca792f1c2ff8754de3c4094ee9762b2a87 the schannel code was changed to use the ALPN_H2 constant instead of the NGHTTP2_PROTO_ALPN constant. However, these constants are not the same. The nghttp2 constant included the length of the string, like this: "\x2h2". The ALPN_H2 constant is just "h2". Therefore we need to re-add the length of the string to the ALPN buffer.

This now matches the way that the "http/1.1" string and it's associated length are added to the ALPN buffer.