### PR TITLE
c-hyper: clear NTLM auth buffer when request is issued

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug HYPER="yes" C="--with-hyper=$HOME/hyper --with-openssl" LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib TFLAGS="1 to 89"
+    - T=debug HYPER="yes" C="--with-hyper=$HOME/hyper --with-openssl" LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib TFLAGS="1 to 93"
     addons:
       apt:
         <<: *common_apt

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -881,6 +881,10 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   }
   conn->datastream = Curl_hyper_stream;
 
+  /* clear userpwd and proxyuserpwd to avoid re-using old credentials
+   * from re-used connections */
+  Curl_safefree(data->state.aptr.userpwd);
+  Curl_safefree(data->state.aptr.proxyuserpwd);
   return CURLE_OK;
   error:
 


### PR DESCRIPTION
To prevent previous ones to get reused on subsequent requests. Matches
how the built-in HTTP code works. Makes test 90 to 93 work.

Add test 90 to 93 in travis.