### PR TITLE
docs: Use correct extension for CURL-DISABLE.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -208,7 +208,7 @@ environment, therefore, you cannot use the various disable-protocol options of
 the configure utility on this platform.
 
 You can use specific defines to disable specific protocols and features. See
-[CURL-DISABLE.md](CURL-DISABLE-md) for the full list.
+[CURL-DISABLE.md](CURL-DISABLE.md) for the full list.
 
 If you want to set any of these defines you have the following options:
 


### PR DESCRIPTION
In INSTALL.MD, it's currently set to CURL-DISABLE-md instead of CURL-DISABLE.md. This generates a 404 on the cURL website as well as when viewing the docs through Github.