### PR TITLE
socketpair: fix potential hangs on Windows

### DIFF
--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -48,6 +48,10 @@
 #endif /* !INADDR_LOOPBACK */
 #endif /* !WIN32 */
 
+#include "nonblock.h" /* for curlx_nonblock */
+#include "timeval.h"  /* needed before select.h */
+#include "select.h"   /* for Curl_poll */
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -63,9 +67,7 @@ int Curl_socketpair(int domain, int type, int protocol,
   curl_socket_t listener;
   curl_socklen_t addrlen = sizeof(a.inaddr);
   int reuse = 1;
-  unsigned long nonblock = 1;
-  struct timeval timeout = {10, 0}; /* 10 seconds */
-  fd_set fds;
+  struct pollfd pfd[1];
   (void)domain;
   (void)type;
   (void)protocol;
@@ -98,13 +100,12 @@ int Curl_socketpair(int domain, int type, int protocol,
     goto error;
 
   /* use non-blocking accept to make sure we don't block forever */
-  if(ioctlsocket(listener, FIONBIO, &nonblock) == -1)
+  if(curlx_nonblock(listener, TRUE) < 0)
     goto error;
-  FD_ZERO(&fds);
-  FD_SET(listener, &fds);
-  /* this is Windows-only code -> using select is fine regardless
-     of the _value_ of the socket descriptor, also nfds is ignored */
-  select(0, &fds, NULL, NULL, &timeout);
+  pfd[0].fd = listener;
+  pfd[0].events = POLLIN;
+  pfd[0].revents = 0;
+  (void)Curl_poll(pfd, 1, 10*1000); /* 10 seconds */
   socks[1] = accept(listener, NULL, NULL);
   if(socks[1] == CURL_SOCKET_BAD)
     goto error;


### PR DESCRIPTION
Fixes potential hang in `accept` by using `select` + non-blocking `accept`.
Fixes potential hang in peer check by replacing the `send`/`recv` check with a `getsockname`/`getpeername` check.
Adds length check for returned `sockaddr` data.

---

We have, very rarely, seen `Curl_socketpair` hang in `accept` for more than 20 minutes (at which time our watchdog would write a minidump and restart the application). The callstacks were not always 100% identical but they all had in common that `Curl_socketpair` hangs in `accept`. Unfortunately we were not able to reproduce those hangs locally. After inspection of the code I found two weaknesses: 

1) AFAIU `accept` could block forever, for example if the OS drops the connection from the backlog for whatever reason. Also from my tests it looks like loopback connections really go through at least large parts of the TCP stack on Windows, so I think that other scenarios could also be possible. Maybe Windows drops loopback packets in certain situations? Or some kind of DoS guard in the OS kicks in even for loopback connections? IMO the easiest (and only) fix for this is to use a timeout with `accept`, so that's what I decided to do (`select` followed by non-blocking `accept`). Re. the use of `select`: Using `select` for a single socket in Windows-only code should not be an issue. The dreaded `select` issue with high FDs on POSIX systems doesn't affect Windows: the only limitation there is the _number_ of sockets in an `fd_set`, the _value_ of the socket handles doesn't matter.

2) The `send`+`recv` based peer validation could also lead to hangs. If a "foreign" socket connects first, trying to `recv` from the accepted connection could block forever. I decided to not use non-blocking IO here but replace the check with a `getsockname` + `getpeername` check instead -- because it's both easier and more secure. We have never seen hangs in `recv` but I thought if I'm already working on a patch for `Curl_socketpair` I should probably address that too.

I also thought it could make sense to add a check for the returned `addrlen` so I did that as well. (Might be a little paranoid, but I think it can't hurt.)
