### PR TITLE
test178: adjust for hyper

### DIFF
--- a/tests/data/test178
+++ b/tests/data/test178
@@ -19,8 +19,11 @@ Funny-head: yesyes
 moooooooooooo
 </data>
 <datacheck>
+%if hyper
+%else
 HTTP/1.1 200 OK swsclose
 Date: Tue, 09 Nov 2010 14:49:00 GMT
+%endif
 </datacheck>
 </reply>
 
@@ -48,8 +51,15 @@ User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>
+
+# Hyper curl returns unsupported protocol
+# bullt-in curl returns weird_server_reply
 <errorcode>
+%if hyper
+1
+%else
 8
+%endif
 </errorcode>
 </verify>
 </testcase>


### PR DESCRIPTION
Hyper returns the same error for wrong HTTP version as for negative
content-length. Test 178 verifies that negative content-length is
rejected but the hyper backend will return a different error for it (and
without any helpful message telling why the message was bad). It will
also not return any headers at all for the response, not even the ones
that arrived before the error.