### PR TITLE
hsts: ignore numberical IP address hosts

### DIFF
--- a/lib/hostcheck.c
+++ b/lib/hostcheck.c
@@ -36,7 +36,7 @@
 
 #include "hostcheck.h"
 #include "strcase.h"
-#include "inet_pton.h"
+#include "hostip.h"
 
 #include "curl_memory.h"
 /* The last #include file should be: */
@@ -67,10 +67,6 @@ static int hostmatch(char *hostname, char *pattern)
   const char *pattern_label_end, *pattern_wildcard, *hostname_label_end;
   int wildcard_enabled;
   size_t prefixlen, suffixlen;
-  struct in_addr ignored;
-#ifdef ENABLE_IPV6
-  struct sockaddr_in6 si6;
-#endif
 
   /* normalize pattern and hostname by stripping off trailing dots */
   size_t len = strlen(hostname);
@@ -86,12 +82,8 @@ static int hostmatch(char *hostname, char *pattern)
       CURL_HOST_MATCH : CURL_HOST_NOMATCH;
 
   /* detect IP address as hostname and fail the match if so */
-  if(Curl_inet_pton(AF_INET, hostname, &ignored) > 0)
+  if(Curl_host_is_ipnum(hostname))
     return CURL_HOST_NOMATCH;
-#ifdef ENABLE_IPV6
-  if(Curl_inet_pton(AF_INET6, hostname, &si6.sin6_addr) > 0)
-    return CURL_HOST_NOMATCH;
-#endif
 
   /* We require at least 2 dots in pattern to avoid too wide wildcard
      match. */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -461,6 +461,25 @@ Curl_cache_addr(struct Curl_easy *data,
 }
 
 /*
+ * Curl_host_is_ipnum() returns TRUE if the given string is a numerical IPv4
+ * (or IPv6 if supported) address.
+ */
+bool Curl_host_is_ipnum(const char *hostname)
+{
+  struct in_addr in;
+#ifdef ENABLE_IPV6
+  struct in6_addr in6;
+#endif
+  if(Curl_inet_pton(AF_INET, hostname, &in) > 0
+#ifdef ENABLE_IPV6
+     || Curl_inet_pton(AF_INET6, hostname, &in6) > 0
+#endif
+    )
+    return TRUE;
+  return FALSE;
+}
+
+/*
  * Curl_resolv() is the main name resolve function within libcurl. It resolves
  * a name and returns a pointer to the entry in the 'entry' argument (if one
  * is provided). This function might return immediately if we're using asynch

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -71,6 +71,8 @@ struct Curl_dns_entry {
   long inuse;
 };
 
+bool Curl_host_is_ipnum(const char *hostname);
+
 /*
  * Curl_resolv() returns an entry with the info for the specified host
  * and port.

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -138,6 +138,11 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
   struct stsentry *sts;
   time_t now = time(NULL);
 
+  if(Curl_host_is_ipnum(hostname))
+    /* "explicit IP address identification of all forms is excluded."
+       / RFC 6797 */
+    return CURLE_OK;
+
   do {
     while(*p && ISSPACE(*p))
       p++;

--- a/lib/url.c
+++ b/lib/url.c
@@ -92,7 +92,6 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
 #include "speedcheck.h"
 #include "warnless.h"
 #include "non-ascii.h"
-#include "inet_pton.h"
 #include "getinfo.h"
 #include "urlapi-int.h"
 #include "system_win32.h"


### PR DESCRIPTION
Also, use a single function library-wide for detecting if a given hostname is
a numerical IP address.

Reported-by: Harry Sintonen
Fixes #7146