### PR TITLE
cmake: Avoid leaking absolute paths into exported config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,7 +383,7 @@ if(CMAKE_USE_SECTRANSP)
 
   set(SSL_ENABLED ON)
   set(USE_SECTRANSP ON)
-  list(APPEND CURL_LIBS "${COREFOUNDATION_FRAMEWORK}" "${SECURITY_FRAMEWORK}")
+  list(APPEND CURL_LIBS "-framework CoreFoundation" "-framework Security")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -391,7 +391,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   if(NOT SYSTEMCONFIGURATION_FRAMEWORK)
      message(FATAL_ERROR "SystemConfiguration framework not found")
   endif()
-  list(APPEND CURL_LIBS "${SYSTEMCONFIGURATION_FRAMEWORK}")
+  list(APPEND CURL_LIBS "-framework SystemConfiguration")
 endif()
 
 if(CMAKE_USE_OPENSSL)


### PR DESCRIPTION
The `find_libarary` command resolves the library or framework
into an absolute path. In case of system frameworks which are
located within an Xcode-provided SDK this results in the Xcode
path and SDK version being part of the library path.

Because those library paths end up in the exported CMake config
importing curl will fail once the Xcode location or SDK version
changes:

```cmake
set_target_properties(CURL::libcurl PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "lber;ldap;/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/System/Library/Frameworks/SystemConfiguration.framework;OpenSSL::SSL;OpenSSL::Crypto;ZLIB::ZLIB"
)
```

A work-around is to link against system-level frameworks with
`-framework XYZ`. In case of `SystemConfiguration` we might be able
to omit the lookup-check because we could assume the framework is
always present.