### PR TITLE
Curl_ssl_getsessionid: survive a missing session id cache

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -638,6 +638,8 @@ static int push_promise(struct Curl_easy *data,
       rv = CURL_PUSH_DENY;
       goto fail;
     }
+    Curl_dyn_init(&newstream->header_recvbuf, DYN_H2_HEADERS);
+    Curl_dyn_init(&newstream->trailer_recvbuf, DYN_H2_TRAILERS);
   }
   else {
     H2BUGF(infof(data, "Got PUSH_PROMISE, ignore it!\n"));

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -407,8 +407,9 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
 
   DEBUGASSERT(SSL_SET_OPTION(primary.sessionid));
 
-  if(!SSL_SET_OPTION(primary.sessionid))
-    /* session ID re-use is disabled */
+  if(!SSL_SET_OPTION(primary.sessionid) || !data->state.session)
+    /* session ID re-use is disabled or the session cache has not been
+       setup */
     return TRUE;
 
   /* Lock if shared */


### PR DESCRIPTION
(Regression probably introduced in 7f4a9a9b2a)

Fixes #7148 