### PR TITLE
MQTT file size improvements

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -232,4 +232,6 @@ test2100 \
 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
-test3016
+test3016 \
+\
+test3017 test3018

--- a/tests/data/test3017
+++ b/tests/data/test3017
@@ -1,0 +1,64 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+<datacheck hex="yes">
+00 04 33 30 31 37   68 65 6c 6c 6f 5b 4c 46 5d 0a
+</datacheck>
+<servercmd>
+excessive-remaining TRUE
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT SUBSCRIBE with pathological PUBLISH length
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -m 3
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d5154540402003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 18 00044d5154540402003c000c6375726c
+server CONNACK 2 20020000
+client SUBSCRIBE 9 000100043330313700
+server SUBACK 3 9003000100
+server PUBLISH c 30ffffff8000043330313768656c6c6f0a
+server DISCONNECT 0 e000
+</protocol>
+
+# 8 is CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test3017
+++ b/tests/data/test3017
@@ -47,13 +47,16 @@ mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -m 3
 <strippart>
 s/^(.* 00044d5154540402003c000c6375726c).*/$1/
 </strippart>
+# on windows the disconnect is never seen - no idea why
+<strip>
+^server DISCONNECT 0 e000
+</strip>
 <protocol>
 client CONNECT 18 00044d5154540402003c000c6375726c
 server CONNACK 2 20020000
 client SUBSCRIBE 9 000100043330313700
 server SUBACK 3 9003000100
 server PUBLISH c 30ffffff8000043330313768656c6c6f0a
-server DISCONNECT 0 e000
 </protocol>
 
 # 8 is CURLE_WEIRD_SERVER_REPLY

--- a/tests/data/test3018
+++ b/tests/data/test3018
@@ -45,13 +45,16 @@ mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER --max-filesize 11
 <strippart>
 s/^(.* 00044d5154540402003c000c6375726c).*/$1/
 </strippart>
+# on windows the disconnect is never seen - no idea why
+<strip>
+^server DISCONNECT 0 e000
+</strip>
 <protocol>
 client CONNECT 18 00044d5154540402003c000c6375726c
 server CONNACK 2 20020000
 client SUBSCRIBE 9 000100043330313800
 server SUBACK 3 9003000100
 server PUBLISH c 300c00043330313868656c6c6f0a
-server DISCONNECT 0 e000
 </protocol>
 
 # 63 is CURLE_FILESIZE_EXCEEDED

--- a/tests/data/test3018
+++ b/tests/data/test3018
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+--max-filesize
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+<datacheck hex="yes">
+00 04 33 30 31 38   68 65 6c 6c 6f 5b 4c 46 5d 0a
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT SUBSCRIBE with PUBLISH larger than --max-filesize
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER --max-filesize 11
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d5154540402003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 18 00044d5154540402003c000c6375726c
+server CONNACK 2 20020000
+client SUBSCRIBE 9 000100043330313800
+server SUBACK 3 9003000100
+server PUBLISH c 300c00043330313868656c6c6f0a
+server DISCONNECT 0 e000
+</protocol>
+
+# 63 is CURLE_FILESIZE_EXCEEDED
+<errorcode>
+63
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
- detect when reported file size is obviously illegal as per MQTT Version 5.0 section "1.5.5 Variable Byte Integer"
- return CURLE_FILESIZE_EXCEEDED  when file size would exceed limit set by CURLOPT_MAXFILESIZE_LARGE (if set)