### PR TITLE
tests: fix Accept-Encoding strips to work with Hyper builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug HYPER="yes" C="--with-hyper=$HOME/hyper --with-openssl" LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib TFLAGS="1 to 153"
+    - T=debug HYPER="yes" C="--with-hyper=$HOME/hyper --with-openssl" LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib TFLAGS="1 to 153 220 221 222 223 224 230 232 314 315 316 396 397"
     addons:
       apt:
         <<: *common_apt

--- a/tests/data/test220
+++ b/tests/data/test220
@@ -55,22 +55,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-%if hyper
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
-%else
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
-%endif
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-%if hyper
 Accept-Encoding: xxx
-%else
-Accept-Encoding: xxx
-%endif
 
 </protocol>
 </verify>

--- a/tests/data/test221
+++ b/tests/data/test221
@@ -55,7 +55,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test222
+++ b/tests/data/test222
@@ -186,7 +186,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test223
+++ b/tests/data/test223
@@ -76,7 +76,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test224
+++ b/tests/data/test224
@@ -91,7 +91,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test230
+++ b/tests/data/test230
@@ -187,7 +187,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test232
+++ b/tests/data/test232
@@ -186,7 +186,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test314
+++ b/tests/data/test314
@@ -182,22 +182,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-%if hyper
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
-%else
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
-%endif
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-%if hyper
 Accept-Encoding: xxx
-%else
-Accept-Encoding: xxx
-%endif
 
 </protocol>
 </verify>

--- a/tests/data/test315
+++ b/tests/data/test315
@@ -72,7 +72,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test316
+++ b/tests/data/test316
@@ -182,7 +182,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test396
+++ b/tests/data/test396
@@ -186,7 +186,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/data/test397
+++ b/tests/data/test397
@@ -182,7 +182,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^Accept-Encoding: .*/Accept-Encoding: xxx/
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
 </strippart>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -4076,7 +4076,7 @@ sub singletest {
             $valgrindcmd .= "$valgrind_tool " if($valgrind_tool);
             $valgrindcmd .= "--quiet --leak-check=yes ";
             $valgrindcmd .= "--suppressions=$srcdir/valgrind.supp ";
-           # $valgrindcmd .= "--gen-suppressions=all ";
+            $valgrindcmd .= "--gen-suppressions=all ";
             $valgrindcmd .= "--num-callers=16 ";
             $valgrindcmd .= "${valgrind_logfile}=$LOGDIR/valgrind$testnum";
             $CMDLINE = "$valgrindcmd $CMDLINE";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -703,7 +703,7 @@ sub torture {
                 $valgrindcmd .= "$valgrind_tool " if($valgrind_tool);
                 $valgrindcmd .= "--quiet --leak-check=yes ";
                 $valgrindcmd .= "--suppressions=$srcdir/valgrind.supp ";
-                # $valgrindcmd .= "--gen-suppressions=all ";
+                $valgrindcmd .= "--gen-suppressions=all ";
                 $valgrindcmd .= "--num-callers=16 ";
                 $valgrindcmd .= "${valgrind_logfile}=$LOGDIR/valgrind$testnum";
                 $cmd = "$valgrindcmd $testcmd";

--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -1,4 +1,13 @@
 {
+   zstd_decompression-1.3.3-on-Ubuntu-18.04_with_hyper
+   Memcheck:Cond
+   fun:ZSTD_decompressStream
+   fun:zstd_unencode_write
+   fun:Curl_unencode_write
+   fun:hyper_body_chunk
+}
+
+{
    zstd_decompression-1.3.3-on-Ubuntu-18.04
    Memcheck:Cond
    fun:ZSTD_decompressStream


### PR DESCRIPTION
The previous strip also removed the CR which turned problematic.

Reported-and-analyzed-by: Kevin Burke
Fixes #7169