### PR TITLE
CURLE_SETOPT_OPTION_SYNTAX: new return code for wrong setopt syntax

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -160,8 +160,9 @@ An option passed to libcurl is not recognized/known. Refer to the appropriate
 documentation. This is most likely a problem in the program that uses
 libcurl. The error buffer might contain more specific information about which
 exact option it concerns.
-.IP "CURLE_TELNET_OPTION_SYNTAX (49)"
-A telnet option string was Illegally formatted.
+.IP "CURLE_SETOPT_OPTION_SYNTAX (49)"
+An option passed in to a setopt was wrongly formatted. See error message for
+details about what option.
 .IP "CURLE_GOT_NOTHING (52)"
 Nothing was returned from the server, and under the circumstances, getting
 nothing is considered an error.

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -120,6 +120,7 @@ CURLE_RTSP_CSEQ_ERROR           7.20.0
 CURLE_RTSP_SESSION_ERROR        7.20.0
 CURLE_SEND_ERROR                7.10
 CURLE_SEND_FAIL_REWIND          7.12.3
+CURLE_SETOPT_OPTION_SYNTAX      7.78.0
 CURLE_SHARE_IN_USE              7.9.6         7.17.0
 CURLE_SSH                       7.16.1
 CURLE_SSL_CACERT                7.10          7.62.0

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -541,7 +541,7 @@ typedef enum {
   CURLE_OBSOLETE46,              /* 46 - NOT USED */
   CURLE_TOO_MANY_REDIRECTS,      /* 47 - catch endless re-direct loops */
   CURLE_UNKNOWN_OPTION,          /* 48 - User specified an unknown option */
-  CURLE_TELNET_OPTION_SYNTAX,    /* 49 - Malformed telnet option */
+  CURLE_SETOPT_OPTION_SYNTAX,    /* 49 - Malformed setopt option */
   CURLE_OBSOLETE50,              /* 50 - NOT USED */
   CURLE_OBSOLETE51,              /* 51 - NOT USED */
   CURLE_GOT_NOTHING,             /* 52 - when this is a specific error */
@@ -635,6 +635,9 @@ typedef enum {
 
 /* The following were added in 7.21.5, April 2011 */
 #define CURLE_UNKNOWN_TELNET_OPTION CURLE_UNKNOWN_OPTION
+
+/* Added for 7.78.0 */
+#define CURLE_TELNET_OPTION_SYNTAX CURLE_SETOPT_OPTION_SYNTAX
 
 /* The following were added in 7.17.1 */
 /* These are scheduled to disappear by 2009 */

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -188,8 +188,8 @@ curl_easy_strerror(CURLcode error)
   case CURLE_UNKNOWN_OPTION:
     return "An unknown option was passed in to libcurl";
 
-  case CURLE_TELNET_OPTION_SYNTAX :
-    return "Malformed telnet option";
+  case CURLE_SETOPT_OPTION_SYNTAX :
+    return "Malformed option provided in a setopt";
 
   case CURLE_GOT_NOTHING:
     return "Server returned nothing (no headers, no data)";

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -834,7 +834,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data)
           tn->us_preferred[CURL_TELOPT_NAWS] = CURL_YES;
         else {
           failf(data, "Syntax error in telnet option: %s", head->data);
-          result = CURLE_TELNET_OPTION_SYNTAX;
+          result = CURLE_SETOPT_OPTION_SYNTAX;
           break;
         }
         continue;
@@ -855,7 +855,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data)
       break;
     }
     failf(data, "Syntax error in telnet option: %s", head->data);
-    result = CURLE_TELNET_OPTION_SYNTAX;
+    result = CURLE_SETOPT_OPTION_SYNTAX;
     break;
   }
 

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -81,7 +81,7 @@ e45: Failed binding local connection end
 e46: Unknown error
 e47: Number of redirects hit maximum amount
 e48: An unknown option was passed in to libcurl
-e49: Malformed telnet option
+e49: Malformed option provided in a setopt
 e50: Unknown error
 e51: Unknown error
 e52: Server returned nothing (no headers, no data)


### PR DESCRIPTION
For options that pass in lists or strings that are subsequently parsed
and must be correct. This broadens the scope for the option previously
known as CURLE_TELNET_OPTION_SYNTAX but the old name is of course still
provided as a #define for existing applications.

Maybe for #7174 for example?