### PR TITLE
quiet a verbose error from rm in tests/data make filecheck

### DIFF
--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -31,7 +31,7 @@ EXTRA_DIST = $(TESTCASES) DISABLED CMakeLists.txt
 filecheck:
 	@mkdir test-place; \
 	cp "$(top_srcdir)"/tests/data/test[0-9]* test-place/; \
-	rm test-place/*~; \
+	rm -f test-place/*~; \
 	for f in $(EXTRA_DIST); do \
 	  if test -f "$(top_srcdir)/tests/data/$$f"; then \
 	    rm -f "test-place/$$f"; \


### PR DESCRIPTION
Very minor change here: makes make filecheck not show an error on rm test-place/*~ if there are no matching files present.