### PR TITLE
runtests: add option -u to error on server unexpectedly alive

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -203,4 +203,4 @@ stages:
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "-vc /usr/bin/curl.exe -r -rm $(tests)"
+        TFLAGS: "-u -vc /usr/bin/curl.exe -r -rm $(tests)"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,7 +69,7 @@ freebsd_task:
     - find . -type d -exec chmod 777 {} \;
     # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
     # therefore the SFTP and SCP tests are disabled right away from the beginning.
-    - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky !SFTP !SCP" test-nonflaky
+    - sudo -u nobody make V=1 TFLAGS="-n -a -p -u !flaky !SFTP !SCP" test-nonflaky
   install_script:
     - make V=1 install
 
@@ -127,4 +127,4 @@ windows_task:
   install_script: |
     %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
   test_script: |
-    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='-r -rm %tests%' test-nonflaky"
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='-u -r -rm %tests%' test-nonflaky"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -303,7 +303,7 @@ test_script:
           cmake --build . --config %PRJ_CFG% --target test-nonflaky
         ) else (
           echo APPVEYOR_API_URL=%APPVEYOR_API_URL% &&
-          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky %DISABLED_TESTS%" ))
+          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p -u !flaky %DISABLED_TESTS%" ))
 
 # select branches to avoid testing feature branches twice (as branch and as pull request)
 branches:

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -147,6 +147,8 @@ to fail until all allocs have been tested. By setting \fInum\fP you can force
 the allocation with that number to be set to fail at once instead of looping
 through everyone, which is very handy when debugging and then often in
 combination with \fI-g\fP.
+.IP "-u"
+Error instead of warning on server unexpectedly alive.
 .IP "-v"
 Enable verbose output. Speaks more than default.
 .IP "-vc <curl>"


### PR DESCRIPTION
Let's try to actually handle the server unexpectedly alive
case by first making them visible on CI builds as failures.