### PR TITLE
warnless: simplify type size handling by using sizeof(T)

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -456,6 +456,15 @@
 #endif
 #endif
 
+#ifndef SSIZE_T_MAX
+/* some limits.h headers have this defined, some don't */
+#if defined(SIZEOF_SIZE_T) && (SIZEOF_SIZE_T > 4)
+#define SSIZE_T_MAX 9223372036854775807
+#else
+#define SSIZE_T_MAX 2147483647
+#endif
+#endif
+
 /*
  * Arg 2 type for gethostname in case it hasn't been defined in config file.
  */

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -37,85 +37,23 @@
 
 #include "warnless.h"
 
-#define CURL_MASK_SCHAR  0x7F
-#define CURL_MASK_UCHAR  0xFF
+#define CURL_MASK_UCHAR   ((unsigned char)~0)
+#define CURL_MASK_SCHAR   (CURL_MASK_UCHAR >> 1)
 
-#if (SIZEOF_SHORT == 2)
-#  define CURL_MASK_SSHORT  0x7FFF
-#  define CURL_MASK_USHORT  0xFFFF
-#elif (SIZEOF_SHORT == 4)
-#  define CURL_MASK_SSHORT  0x7FFFFFFF
-#  define CURL_MASK_USHORT  0xFFFFFFFF
-#elif (SIZEOF_SHORT == 8)
-#  define CURL_MASK_SSHORT  0x7FFFFFFFFFFFFFFF
-#  define CURL_MASK_USHORT  0xFFFFFFFFFFFFFFFF
-#else
-#  error "SIZEOF_SHORT not defined"
-#endif
+#define CURL_MASK_USHORT  ((unsigned short)~0)
+#define CURL_MASK_SSHORT  (CURL_MASK_USHORT >> 1)
 
-#if (SIZEOF_INT == 2)
-#  define CURL_MASK_SINT  0x7FFF
-#  define CURL_MASK_UINT  0xFFFF
-#elif (SIZEOF_INT == 4)
-#  define CURL_MASK_SINT  0x7FFFFFFF
-#  define CURL_MASK_UINT  0xFFFFFFFF
-#elif (SIZEOF_INT == 8)
-#  define CURL_MASK_SINT  0x7FFFFFFFFFFFFFFF
-#  define CURL_MASK_UINT  0xFFFFFFFFFFFFFFFF
-#elif (SIZEOF_INT == 16)
-#  define CURL_MASK_SINT  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-#  define CURL_MASK_UINT  0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-#else
-#  error "SIZEOF_INT not defined"
-#endif
+#define CURL_MASK_UINT    ((unsigned int)~0)
+#define CURL_MASK_SINT    (CURL_MASK_UINT >> 1)
 
-#if (SIZEOF_LONG == 2)
-#  define CURL_MASK_SLONG  0x7FFFL
-#  define CURL_MASK_ULONG  0xFFFFUL
-#elif (SIZEOF_LONG == 4)
-#  define CURL_MASK_SLONG  0x7FFFFFFFL
-#  define CURL_MASK_ULONG  0xFFFFFFFFUL
-#elif (SIZEOF_LONG == 8)
-#  define CURL_MASK_SLONG  0x7FFFFFFFFFFFFFFFL
-#  define CURL_MASK_ULONG  0xFFFFFFFFFFFFFFFFUL
-#elif (SIZEOF_LONG == 16)
-#  define CURL_MASK_SLONG  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL
-#  define CURL_MASK_ULONG  0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFUL
-#else
-#  error "SIZEOF_LONG not defined"
-#endif
+#define CURL_MASK_ULONG   ((unsigned long)~0)
+#define CURL_MASK_SLONG   (CURL_MASK_ULONG >> 1)
 
-#if (SIZEOF_CURL_OFF_T == 2)
-#  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFF)
-#  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFF)
-#elif (SIZEOF_CURL_OFF_T == 4)
-#  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFFFFFF)
-#  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFFFFFF)
-#elif (SIZEOF_CURL_OFF_T == 8)
-#  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
-#  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFFFFFFFFFFFFFF)
-#elif (SIZEOF_CURL_OFF_T == 16)
-#  define CURL_MASK_SCOFFT  CURL_OFF_T_C(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-#  define CURL_MASK_UCOFFT  CURL_OFF_TU_C(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-#else
-#  error "SIZEOF_CURL_OFF_T not defined"
-#endif
+#define CURL_MASK_UCOFFT  ((unsigned CURL_TYPEOF_CURL_OFF_T)~0)
+#define CURL_MASK_SCOFFT  (CURL_MASK_UCOFFT >> 1)
 
-#if (SIZEOF_SIZE_T == SIZEOF_SHORT)
-#  define CURL_MASK_SSIZE_T  CURL_MASK_SSHORT
-#  define CURL_MASK_USIZE_T  CURL_MASK_USHORT
-#elif (SIZEOF_SIZE_T == SIZEOF_INT)
-#  define CURL_MASK_SSIZE_T  CURL_MASK_SINT
-#  define CURL_MASK_USIZE_T  CURL_MASK_UINT
-#elif (SIZEOF_SIZE_T == SIZEOF_LONG)
-#  define CURL_MASK_SSIZE_T  CURL_MASK_SLONG
-#  define CURL_MASK_USIZE_T  CURL_MASK_ULONG
-#elif (SIZEOF_SIZE_T == SIZEOF_CURL_OFF_T)
-#  define CURL_MASK_SSIZE_T  CURL_MASK_SCOFFT
-#  define CURL_MASK_USIZE_T  CURL_MASK_UCOFFT
-#else
-#  error "SIZEOF_SIZE_T not defined"
-#endif
+#define CURL_MASK_USIZE_T ((size_t)~0)
+#define CURL_MASK_SSIZE_T (CURL_MASK_USIZE_T >> 1)
 
 /*
 ** unsigned long to unsigned short
@@ -207,7 +145,7 @@ unsigned long curlx_uztoul(size_t uznum)
 # pragma warning(disable:810) /* conversion may lose significant bits */
 #endif
 
-#if (SIZEOF_LONG < SIZEOF_SIZE_T)
+#if ULONG_MAX < SIZE_T_MAX
   DEBUGASSERT(uznum <= (size_t) CURL_MASK_ULONG);
 #endif
   return (unsigned long)(uznum & (size_t) CURL_MASK_ULONG);
@@ -228,7 +166,7 @@ unsigned int curlx_uztoui(size_t uznum)
 # pragma warning(disable:810) /* conversion may lose significant bits */
 #endif
 
-#if (SIZEOF_INT < SIZEOF_SIZE_T)
+#if UINT_MAX < SIZE_T_MAX
   DEBUGASSERT(uznum <= (size_t) CURL_MASK_UINT);
 #endif
   return (unsigned int)(uznum & (size_t) CURL_MASK_UINT);
@@ -250,7 +188,7 @@ int curlx_sltosi(long slnum)
 #endif
 
   DEBUGASSERT(slnum >= 0);
-#if (SIZEOF_INT < SIZEOF_LONG)
+#if INT_MAX < LONG_MAX
   DEBUGASSERT((unsigned long) slnum <= (unsigned long) CURL_MASK_SINT);
 #endif
   return (int)(slnum & (long) CURL_MASK_SINT);
@@ -272,7 +210,7 @@ unsigned int curlx_sltoui(long slnum)
 #endif
 
   DEBUGASSERT(slnum >= 0);
-#if (SIZEOF_INT < SIZEOF_LONG)
+#if UINT_MAX < LONG_MAX
   DEBUGASSERT((unsigned long) slnum <= (unsigned long) CURL_MASK_UINT);
 #endif
   return (unsigned int)(slnum & (long) CURL_MASK_UINT);
@@ -352,7 +290,7 @@ int curlx_sztosi(ssize_t sznum)
 #endif
 
   DEBUGASSERT(sznum >= 0);
-#if (SIZEOF_INT < SIZEOF_SIZE_T)
+#if INT_MAX < SSIZE_T_MAX
   DEBUGASSERT((size_t) sznum <= (size_t) CURL_MASK_SINT);
 #endif
   return (int)(sznum & (ssize_t) CURL_MASK_SINT);


### PR DESCRIPTION
Simplify type size handling by using sizeof(T) and rely on the compiler to define the required signed/unsigned masks. 

The idea is to get rid of SIZEOF_XXX defines, which are not needed for this implementation, and a manually created masks which can be generated by the compiler at compile time. In this case type masks are created by the compiler and can never be erroneous for any type.

Such run-time checks `if (sizeof(TYPE1) < sizeof(TYPE2))` are removed by the compiler during the optimization stage because the condition is constant, so there is no overhead. MSVC throws warning regarding the constant condition used but it is suppressed by the implementation.

I am using this implementation for many years already without any issue (Linux, Android, Apple iOS, Windows Win32, Windows UWP).