### PR TITLE
cookies: remove unused header

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -95,7 +95,6 @@ Example set of cookies:
 #include "strcase.h"
 #include "curl_get_line.h"
 #include "curl_memrchr.h"
-#include "inet_pton.h"
 #include "parsedate.h"
 #include "rand.h"
 #include "rename.h"


### PR DESCRIPTION
Commit 1c1d9f1affbd3367bcb24062e261d0ea5d185e3a removed the last use for the inet_pton.h headerfile, remove.

Closes: #xxxx