### PR TITLE
url: bad --connect-to syntax now returns error

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3057,10 +3057,11 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
     if(*host_portno) {
       long portparse = strtol(host_portno, &endp, 10);
       if((endp && *endp) || (portparse < 0) || (portparse > 65535)) {
-        infof(data, "No valid port number in connect to host string (%s)\n",
+        failf(data, "No valid port number in connect to host string (%s)",
               host_portno);
         hostptr = NULL;
         port = -1;
+        return CURLE_SETOPT_OPTION_SYNTAX;
       }
       else
         port = (int)portparse; /* we know it will fit */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -236,4 +236,4 @@ test3016 \
 \
 test3017 test3018 \
 \
-test3019
+test3019 test3020

--- a/tests/data/test3020
+++ b/tests/data/test3020
@@ -1,0 +1,36 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+--connect-to
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with invalid --connect-to syntax
+</name>
+<command>
+--connect-to ::example.com:example.com http://example.com:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+49
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
This PR address bad --connect-to syntax.

Before:

```
$ curl --connect-to ::curl.se:151.101.66.49 https://curl.se -v
* No valid port number in connect to host string (151.101.66.49)
*   Trying 151.101.194.49...
* TCP_NODELAY set
* Connected to curl.se (151.101.194.49) port 443 (#0)
```

After:

```
$ ./src/curl --connect-to ::curl.se:curl.se https://curl.se -v
* No valid port number in connect to host string (curl.se)
* Closing connection -1
curl: (49) No valid port number in connect to host string (curl.se)
```

As always I'm open to any comment.

```
$ /usr/bin/perl -I. ./runtests.pl 3020
********* System characteristics ********
* curl 7.77.1-DEV (x86_64-pc-linux-gnu)
* libcurl/7.77.1-DEV OpenSSL/1.1.1d
* Features: alt-svc AsynchDNS HSTS HTTPS-proxy IPv6 Largefile NTLM NTLM_WB SSL TLS-SRP UnixSockets
* Disabled:
* Host: debian-kernel
* System: Linux debian-kernel 4.19.0-16-amd64 #1 SMP Debian 4.19.181-1 (2021-03-19) x86_64 GNU/Linux
* OS: linux
* Servers: HTTP-IPv6 HTTP-unix FTP-IPv6
* Env:
* Seed: 231622
*****************************************
test 3020...[HTTP with invalid --connect-to syntax]
-------e--- OK (1   out of 1  , remaining: 00:00, took 1.197s, duration: 00:01)
TESTDONE: 1 tests were considered during 1 seconds.
TESTDONE: 1 tests out of 1 reported OK: 100%
```