### PR TITLE
test269: disable for hyper

### DIFF
--- a/docs/cmdline-opts/ignore-content-length.d
+++ b/docs/cmdline-opts/ignore-content-length.d
@@ -9,3 +9,5 @@ files larger than 2 gigabytes.
 
 For FTP (since 7.46.0), skip the RETR command to figure out the size before
 downloading a file.
+
+This option doesn't work if libcurl was built to use hyper for HTTP.

--- a/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.3
+++ b/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -60,7 +60,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.14.1. Support for FTP added in 7.46.0.
+Added in 7.14.1. Support for FTP added in 7.46.0. This option is not working
+for the hyper backend.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2370,8 +2370,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
 
   case CURLOPT_IGNORE_CONTENT_LENGTH:
+#ifndef USE_HYPER
     data->set.ignorecl = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
+#else
+    return CURLE_NOT_BUILT_IN;
+#endif
 
   case CURLOPT_CONNECT_ONLY:
     /*

--- a/tests/data/test269
+++ b/tests/data/test269
@@ -26,6 +26,9 @@ muahahaha
 #
 # Client-side
 <client>
+<features>
+!hyper
+</features>
 <server>
 http
 </server>


### PR DESCRIPTION
--ignore-content-length / CURLOPT_IGNORE_CONTENT_LENGTH doesn't work
with hyper.