### PR TITLE
runtests: enable 'hyper mode' only for HTTP tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
         - libbrotli-dev
         - libzstd-dev
   - env:
-    - T=debug HYPER="yes" C="--with-hyper=$HOME/hyper --with-openssl" LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib TFLAGS="1 to 153 220 221 222 223 224 230 232 314 315 316 396 397"
+    - T=debug HYPER="yes" C="--with-hyper=$HOME/hyper --with-openssl" LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib TFLAGS="1 to 153 220 221 222 223 224 230 232 271 314 315 316 396 397"
     addons:
       apt:
         <<: *common_apt

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -177,12 +177,14 @@ that will be checked/used if specified.
 
 ### `<keywords>`
 A newline-separated list of keywords describing what this test case uses and
-tests. Try to use an already used keyword.  These keywords will be used for
-statistical/informational purposes and for choosing or skipping classes
-of tests.  "Keywords" must begin with an alphabetic character, "-", "["
-or "{" and may actually consist of multiple words separated by spaces
-which are treated together as a single identifier.
+tests. Try to use already used keywords.  These keywords will be used for
+statistical/informational purposes and for choosing or skipping classes of
+tests.  "Keywords" must begin with an alphabetic character, "-", "[" or "{"
+and may actually consist of multiple words separated by spaces which are
+treated together as a single identifier.
 
+When using curl built with Hyper, the keywords must include HTTP or HTTPS for
+'hyper mode' to kick in and make line ending checks work for tests.
 ## `<reply>`
 
 ### `<data [nocheck="yes"] [sendzero="yes"] [base64="yes"] [hex="yes"]>`

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3524,7 +3524,8 @@ sub prepro {
         if($show) {
             subVariables(\$s, $testnum, "%");
             subBase64(\$s);
-            subNewlines(\$s) if($has_hyper);
+            subNewlines(\$s) if($has_hyper && ($keywords{"HTTP"} ||
+                                               $keywords{"HTTPS"}));
             push @out, $s;
         }
     }


### PR DESCRIPTION
The 'hyper mode' makes line-ending checks work in the test suite for
when hyper is used. Now it also requires that HTTP or HTTPS are
mentioned as keywords to be enabled so that it doesn't wrongly adjusts
tests for other protocols.

This makes test 271 (TFTP) work again in hyper enabled builds.