### PR TITLE
github: remove the cmake gcc-8 macOS jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -100,9 +100,6 @@ jobs:
         - CC: clang
           CXX: clang++
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-deprecated-declarations"
-        - CC: gcc-8
-          CXX: g++-8
-          CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"
         - CC: gcc-9
           CXX: g++-9
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"


### PR DESCRIPTION
They're too similar to the gcc-9 ones to be useful