### PR TITLE
[Win32] Fix for USE_WATT32

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -923,7 +923,7 @@ CURLcode Curl_done_sending(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#if defined(WIN32) && !defined(USE_LWIPSOCK)
+#if defined(WIN32) && defined(USE_WINSOCK)
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif


### PR DESCRIPTION
My Watt-32 tcp/ip stack works on Windows but it does not have `WSAIoctl()`.
So call `WSAIoctl()` only when using Winsock.
