### PR TITLE
mqtt: add support for username and password

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -228,12 +228,11 @@ test2064 test2065 test2066 test2067 test2068 test2069 test2070 \
          test2071 test2072 test2073 test2074 test2075 test2076 test2077 \
 test2078 \
 test2080 test2081 \
+\
 test2100 \
+\
+test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
-test3016 \
-\
-test3017 test3018 \
-\
-test3019
+test3016 test3017 test3018 test3019

--- a/tests/data/test2200
+++ b/tests/data/test2200
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+<datacheck hex="yes">
+00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+</datacheck>
+
+# error 5 - "Connection Refused, not authorized. Wrong data supplied"
+<servercmd>
+error-CONNACK 5
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT SUBSCRIBE with user and password
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u fakeuser:fakepasswd
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 2e 00044d51545404c2003c000c6375726c
+server CONNACK 2 20020005
+</protocol>
+
+# 8 is CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2201
+++ b/tests/data/test2201
@@ -1,0 +1,50 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT PUBLISH
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT PUBLISH with user and password valid
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -d something -u testuser:testpasswd
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 2e 00044d51545404c2003c000c6375726c
+server CONNACK 2 20020000
+client PUBLISH f 000432323031736f6d657468696e67
+client DISCONNECT 0 e000
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2202
+++ b/tests/data/test2202
@@ -1,0 +1,59 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT PUBLISH
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+</data>
+
+# error 5 - "Connection Refused, not authorized. Wrong data supplied"
+<servercmd>
+error-CONNACK 5
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT PUBLISH with invalid user and password
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -d something -u fakeuser:fakepasswd
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 2e 00044d51545404c2003c000c6375726c
+server CONNACK 2 20020005
+</protocol>
+
+
+# 8 is CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2203
+++ b/tests/data/test2203
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+<datacheck hex="yes">
+00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+</datacheck>
+
+# error 5 - "Connection Refused, not authorized. No user or password supplied"
+<servercmd>
+error-CONNACK 5
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT with error in CONNACK
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d5154540402003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 18 00044d5154540402003c000c6375726c
+server CONNACK 2 20020005
+</protocol>
+
+# 8 is CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2204
+++ b/tests/data/test2204
@@ -1,0 +1,56 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+<datacheck hex="yes">
+00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT SUBSCRIBE with user and password
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u testuser:testpasswd
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 2e 00044d51545404c2003c000c6375726c
+server CONNACK 2 20020000
+client SUBSCRIBE 9 000100043232303400
+server SUBACK 3 9003000100
+server PUBLISH c 300c00043232303468656c6c6f0a
+server DISCONNECT 0 e000
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2205
+++ b/tests/data/test2205
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+<datacheck hex="yes">
+00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+</datacheck>
+
+# error 5 - "Connection Refused, not authorized. Wrong data supplied"
+<servercmd>
+error-CONNACK 5
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT with very long user name
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:fakepasswd
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+#
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
+</strippart>
+<protocol>
+client CONNECT 2e 00044d51545404c2003c000c6375726c
+server CONNACK 2 20020005
+</protocol>
+
+# 8 is CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -584,7 +584,7 @@ sub get_disttests {
         if(($_ =~ /^#/) ||($_ !~ /test/)) {
             next;
         }
-        $disttests .= join("", $_);
+        $disttests .= $_;
     }
     close(D);
 }
@@ -3561,7 +3561,7 @@ sub singletest {
     # timestamp test preparation start
     $timeprepini{$testnum} = Time::HiRes::time();
 
-    if($disttests !~ /test$testnum\W/ ) {
+    if($disttests !~ /test$testnum(\W|\z)/ ) {
         logmsg "Warning: test$testnum not present in tests/data/Makefile.inc\n";
     }
     if($disabled{$testnum}) {

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -495,6 +495,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
   unsigned char byte;
   unsigned short packet_id;
   size_t payload_len;
+  size_t client_id_length;
   unsigned int topic_len;
   size_t remaining_length = 0;
   size_t bytes = 0; /* remaining length field size in bytes */
@@ -519,11 +520,19 @@ static curl_socket_t mqttit(curl_socket_t fd)
     logmsg("Found test number %ld", testno);
 
   do {
+    unsigned char usr_flag = 0x80;
+    unsigned char passwd_flag = 0x40;
+    unsigned char conn_flags;
+    const size_t client_id_offset = 12;
+    size_t start_usr;
+    size_t start_passwd;
+
     /* get the fixed header */
     rc = fixedheader(fd, &byte, &remaining_length, &bytes);
     if(rc)
       break;
     if(remaining_length) {
+      /* reading variable header and payload into buffer */
       rc = sread(fd, (char *)buffer, remaining_length);
       if(rc > 0) {
         logmsg("READ %d bytes", rc);
@@ -540,19 +549,40 @@ static curl_socket_t mqttit(curl_socket_t fd)
         goto end;
       }
       /* ignore the connect flag byte and two keepalive bytes */
-
       payload_len = (buffer[10] << 8) | buffer[11];
+      /* first part of the payload is the client ID */
+      client_id_length = payload_len;
+
+      /* checking if user and password flags were set */
+      conn_flags = buffer[7];
+
+      start_usr = client_id_offset + payload_len;
+      if(usr_flag == (unsigned char)(conn_flags & usr_flag)) {
+        logmsg("User flag is present in CONN flag");
+        payload_len += (buffer[start_usr] << 8) | buffer[start_usr + 1];
+        payload_len += 2; /* MSB and LSB for user length */
+      }
+
+      start_passwd = client_id_offset + payload_len;
+      if(passwd_flag == (char)(conn_flags & passwd_flag)) {
+        logmsg("Password flag is present in CONN flags");
+        payload_len += (buffer[start_passwd] << 8) | buffer[start_passwd + 1];
+        payload_len += 2; /* MSB and LSB for password length */
+      }
+
+      /* check the length of the payload */
       if((ssize_t)payload_len != (rc - 12)) {
         logmsg("Payload length mismatch, expected %x got %x",
                rc - 12, payload_len);
         goto end;
       }
-      else if((payload_len + 1) > MAX_CLIENT_ID_LENGTH) {
+      /* check the length of the client ID */
+      else if((client_id_length + 1) > MAX_CLIENT_ID_LENGTH) {
         logmsg("Too large client id");
         goto end;
       }
-      memcpy(client_id, &buffer[12], payload_len);
-      client_id[payload_len] = 0;
+      memcpy(client_id, &buffer[12], client_id_length);
+      client_id[client_id_length] = 0;
 
       logmsg("MQTT client connect accepted: %s", client_id);
 


### PR DESCRIPTION
Added test 2200 to 2205

This is #7117, rebased, edited, cleaned up and with an added test (2205) case that currently breaks.

/cc @Gealber