### PR TITLE
http2_connisdead: handle trailing GOAWAY better

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -200,7 +200,7 @@ static bool http2_connisdead(struct Curl_easy *data, struct connectdata *conn)
               (int)nread);
         httpc->nread_inbuf = 0;
         httpc->inbuflen = nread;
-        if(h2_process_pending_input(conn, httpc, &result) < 0)
+        if(h2_process_pending_input(data, httpc, &result) < 0)
           /* immediate error, considered dead */
           dead = TRUE;
       }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -200,7 +200,9 @@ static bool http2_connisdead(struct Curl_easy *data, struct connectdata *conn)
               (int)nread);
         httpc->nread_inbuf = 0;
         httpc->inbuflen = nread;
-        (void)h2_process_pending_input(data, httpc, &result);
+        if(h2_process_pending_input(conn, httpc, &result) < 0)
+          /* immediate error, considered dead */
+          dead = TRUE;
       }
       else
         /* the read failed so let's say this is dead anyway */


### PR DESCRIPTION
_As proposed by @SharmaShikha-84 on the libcurl mailing list:_

When checking the connection the input processing returns error
immediately, we now consider that a dead connnection.

Bug: https://curl.se/mail/lib-2021-06/0001.html