### PR TITLE
spnego_gssapi: implement TLS channel bindings for openssl

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -443,6 +443,8 @@ struct negotiatedata {
   gss_ctx_id_t context;
   gss_name_t spn;
   gss_buffer_desc output_token;
+  char *channel_binding_data;
+  size_t channel_binding_data_len;
 #else
 #ifdef USE_WINDOWS_SSPI
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -91,6 +91,8 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   gss_buffer_desc spn_token = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc input_token = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+  gss_channel_bindings_t chan_bindings = GSS_C_NO_CHANNEL_BINDINGS;
+  struct gss_channel_bindings_struct chan;
 
   (void) user;
   (void) password;
@@ -148,13 +150,21 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     input_token.length = chlglen;
   }
 
+  /* Set channel binding data */
+  if(nego->channel_binding_data) {
+    memset(&chan, 0, sizeof(struct gss_channel_bindings_struct));
+    chan.application_data.length = nego->channel_binding_data_len;
+    chan.application_data.value = nego->channel_binding_data;
+    chan_bindings = &chan;
+  }
+
   /* Generate our challenge-response message */
   major_status = Curl_gss_init_sec_context(data,
                                            &minor_status,
                                            &nego->context,
                                            nego->spn,
                                            &Curl_spnego_mech_oid,
-                                           GSS_C_NO_CHANNEL_BINDINGS,
+                                           chan_bindings,
                                            &input_token,
                                            &output_token,
                                            TRUE,

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1208,7 +1208,8 @@ const struct Curl_ssl Curl_ssl_bearssl = {
   Curl_none_false_start,           /* false_start */
   bearssl_sha256sum,               /* sha256sum */
   NULL,                            /* associate_connection */
-  NULL                             /* disassociate_connection */
+  NULL,                            /* disassociate_connection */
+  NULL                             /* get_tls_server_end_point */
 };
 
 #endif /* USE_BEARSSL */

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1323,7 +1323,8 @@ const struct Curl_ssl Curl_ssl_gskit = {
   Curl_none_false_start,          /* false_start */
   NULL,                           /* sha256sum */
   NULL,                           /* associate_connection */
-  NULL                            /* disassociate_connection */
+  NULL,                           /* disassociate_connection */
+  NULL                            /* get_tls_server_end_point */
 };
 
 #endif /* USE_GSKIT */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1699,7 +1699,8 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   Curl_none_false_start,         /* false_start */
   gtls_sha256sum,                /* sha256sum */
   NULL,                          /* associate_connection */
-  NULL                           /* disassociate_connection */
+  NULL,                          /* disassociate_connection */
+  NULL                           /* get_tls_server_end_point */
 };
 
 #endif /* USE_GNUTLS */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1267,7 +1267,8 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   Curl_none_false_start,            /* false_start */
   mbedtls_sha256sum,                /* sha256sum */
   NULL,                             /* associate_connection */
-  NULL                              /* disassociate_connection */
+  NULL,                             /* disassociate_connection */
+  NULL                              /* get_tls_server_end_point */
 };
 
 #endif /* USE_MBEDTLS */

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2531,7 +2531,8 @@ const struct Curl_ssl Curl_ssl_nss = {
   nss_false_start,              /* false_start */
   nss_sha256sum,                /* sha256sum */
   NULL,                         /* associate_connection */
-  NULL                          /* disassociate_connection */
+  NULL,                         /* disassociate_connection */
+  NULL                          /* get_tls_server_end_point */
 };
 
 #endif /* USE_NSS */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4571,6 +4571,75 @@ static void ossl_disassociate_connection(struct Curl_easy *data,
   }
 }
 
+static CURLcode ossl_get_tls_server_end_point(struct Curl_easy *data,
+                                              int sockindex, char **binding,
+                                              size_t *len)
+{
+  /* required for X509_get_signature_nid support */
+#if OPENSSL_VERSION_NUMBER > 0x10100000L
+  struct connectdata *conn = data->conn;
+  struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+  struct ssl_backend_data *backend = connssl->backend;
+  const char prefix[] = "tls-server-end-point:";
+
+  X509 *cert;
+  int algo_nid;
+  const EVP_MD *algo_type;
+  const char *algo_name;
+  unsigned int length;
+  u_char buf[EVP_MAX_MD_SIZE];
+
+  cert = SSL_get_peer_certificate(backend->handle);
+  if(!cert) {
+    /* No server certificate, don't do channel binding */
+    *binding = NULL;
+    *len = 0;
+    return CURLE_OK;
+  }
+
+  if(!OBJ_find_sigid_algs(X509_get_signature_nid(cert), &algo_nid, NULL)) {
+    failf(data,
+          "Unable to find digest NID for certificate signature algorithm");
+    return CURLE_SSL_INVALIDCERTSTATUS;
+  }
+
+  /* https://datatracker.ietf.org/doc/html/rfc5929#section-4.1 */
+  if(algo_nid == NID_md5 || algo_nid == NID_sha1) {
+    algo_type = EVP_sha256();
+  }
+  else {
+    algo_type = EVP_get_digestbynid(algo_nid);
+    if(!algo_type) {
+      algo_name = OBJ_nid2sn(algo_nid);
+      failf(data, "Could not find digest algorithm %s (NID %d)",
+            algo_name ? algo_name : "(null)", algo_nid);
+      return CURLE_SSL_INVALIDCERTSTATUS;
+    }
+  }
+
+  if(!X509_digest(cert, algo_type, buf, &length)) {
+    failf(data, "X509_digest() failed");
+    return CURLE_SSL_INVALIDCERTSTATUS;
+  }
+
+  *binding = malloc(sizeof(prefix) - 1 + length);
+  if(!*binding)
+    return CURLE_OUT_OF_MEMORY;
+  memcpy(*binding, prefix, sizeof(prefix) - 1);
+  memcpy(*binding + sizeof(prefix) - 1, buf, length);
+  *len = sizeof(prefix) - 1 + length;
+
+  return CURLE_OK;
+#else
+  /* No X509_get_signature_nid support */
+  (void)data; /* unused */
+  (void)sockindex; /* unused */
+  *binding = NULL;
+  *len = 0;
+  return CURLE_OK;
+#endif
+}
+
 const struct Curl_ssl Curl_ssl_openssl = {
   { CURLSSLBACKEND_OPENSSL, "openssl" }, /* info */
 
@@ -4611,7 +4680,8 @@ const struct Curl_ssl Curl_ssl_openssl = {
   NULL,                     /* sha256sum */
 #endif
   ossl_associate_connection, /* associate_connection */
-  ossl_disassociate_connection /* disassociate_connection */
+  ossl_disassociate_connection, /* disassociate_connection */
+  ossl_get_tls_server_end_point /* get_tls_server_end_point */
 };
 
 #endif /* USE_OPENSSL */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -630,7 +630,8 @@ const struct Curl_ssl Curl_ssl_rustls = {
   Curl_none_false_start,           /* false_start */
   NULL,                            /* sha256sum */
   NULL,                            /* associate_connection */
-  NULL                             /* disassociate_connection */
+  NULL,                            /* disassociate_connection */
+  NULL                             /* get_tls_server_end_point */
 };
 
 #endif /* USE_RUSTLS */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2809,7 +2809,8 @@ const struct Curl_ssl Curl_ssl_schannel = {
   Curl_none_false_start,             /* false_start */
   schannel_sha256sum,                /* sha256sum */
   NULL,                              /* associate_connection */
-  NULL                               /* disassociate_connection */
+  NULL,                              /* disassociate_connection */
+  NULL                               /* get_tls_server_end_point */
 };
 
 #endif /* USE_SCHANNEL */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3532,7 +3532,8 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   sectransp_false_start,              /* false_start */
   sectransp_sha256sum,                /* sha256sum */
   NULL,                               /* associate_connection */
-  NULL                                /* disassociate_connection */
+  NULL,                               /* disassociate_connection */
+  NULL                                /* get_tls_server_end_point */
 };
 
 #ifdef __clang__

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -655,6 +655,17 @@ void Curl_ssl_detach_conn(struct Curl_easy *data,
   }
 }
 
+CURLcode Curl_ssl_get_tls_server_end_point(struct Curl_easy *data,
+                                           int sockindex, char **binding,
+                                           size_t *len)
+{
+  if(Curl_ssl->get_tls_server_end_point)
+    return Curl_ssl->get_tls_server_end_point(data, sockindex, binding, len);
+  *binding = NULL;
+  *len = 0;
+  return CURLE_OK;
+}
+
 void Curl_ssl_close_all(struct Curl_easy *data)
 {
   /* kill the session ID cache if not shared */
@@ -1310,7 +1321,8 @@ static const struct Curl_ssl Curl_ssl_multi = {
   Curl_none_false_start,             /* false_start */
   NULL,                              /* sha256sum */
   NULL,                              /* associate_connection */
-  NULL                               /* disassociate_connection */
+  NULL,                              /* disassociate_connection */
+  NULL                               /* get_tls_server_end_point */
 };
 
 const struct Curl_ssl *Curl_ssl =

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -102,6 +102,9 @@ struct Curl_ssl {
                                struct connectdata *conn,
                                int sockindex);
   void (*disassociate_connection)(struct Curl_easy *data, int sockindex);
+
+  CURLcode (*get_tls_server_end_point)(struct Curl_easy *data, int sockindex,
+                                       char **binding, size_t *len);
 };
 
 #ifdef USE_SSL
@@ -310,6 +313,17 @@ void Curl_ssl_associate_conn(struct Curl_easy *data,
                              struct connectdata *conn);
 void Curl_ssl_detach_conn(struct Curl_easy *data,
                           struct connectdata *conn);
+
+/* Return the tls-server-end-point channel binding, including the
+ * 'tls-server-end-point:' prefix.
+ * If successful, a pointer to the data is stored in *binding and the length of
+ * the data is stored in *len. The caller must free the data with free().
+ * If getting the channel binding is not supported, *binding will be set to
+ * NULL.
+ */
+CURLcode Curl_ssl_get_tls_server_end_point(struct Curl_easy *data,
+                                           int sockindex, char **binding,
+                                           size_t *len);
 
 #define SSL_SHUTDOWN_TIMEOUT 10000 /* ms */
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1241,7 +1241,8 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   Curl_none_false_start,           /* false_start */
   wolfssl_sha256sum,               /* sha256sum */
   NULL,                            /* associate_connection */
-  NULL                             /* disassociate_connection */
+  NULL,                            /* disassociate_connection */
+  NULL                             /* get_tls_server_end_point */
 };
 
 #endif


### PR DESCRIPTION
This requires krb5 >= 1.19 because otherwise channel bindings won't be
forwarded through SPNEGO.