### PR TITLE
openldap: use a state machine and implement starttls

### DIFF
--- a/docs/cmdline-opts/ssl-reqd.d
+++ b/docs/cmdline-opts/ssl-reqd.d
@@ -1,6 +1,6 @@
 Long: ssl-reqd
 Help: Require SSL/TLS
-Protocols: FTP IMAP POP3 SMTP
+Protocols: FTP IMAP POP3 SMTP LDAP (openldap only)
 Added: 7.20.0
 Category: tls
 Example: --ssl-reqd ftp://example.com

--- a/docs/cmdline-opts/ssl.d
+++ b/docs/cmdline-opts/ssl.d
@@ -1,6 +1,6 @@
 Long: ssl
 Help: Try SSL/TLS
-Protocols: FTP IMAP POP3 SMTP
+Protocols: FTP IMAP POP3 SMTP LDAP (openldap only)
 Added: 7.20.0
 Category: tls
 Example: --ssl pop3://example.com/
@@ -9,6 +9,9 @@ See-also: insecure ciphers
 Try to use SSL/TLS for the connection.  Reverts to a non-secure connection if
 the server does not support SSL/TLS.  See also --ftp-ssl-control and --ssl-reqd
 for different levels of encryption required.
+
+Please note that a server may close the connection if the negotiation does
+not succeed.
 
 This option was formerly known as --ftp-ssl (Added in 7.11.0). That option
 name can still be used but will be removed in a future version.

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -28,15 +28,16 @@ CURLINFO_RESPONSE_CODE \- get the last response code
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RESPONSE_CODE, long *codep);
 .SH DESCRIPTION
-Pass a pointer to a long to receive the last received HTTP, FTP or SMTP
-response code. This option was previously known as CURLINFO_HTTP_CODE in
-libcurl 7.10.7 and earlier. The stored value will be zero if no server
-response code has been received. Note that a proxy's CONNECT response should
+Pass a pointer to a long to receive the last received HTTP, FTP, SMTP or
+LDAP (openldap only) response code. This option was previously known as
+CURLINFO_HTTP_CODE in libcurl 7.10.7 and earlier.
+The stored value will be zero if no server response code has been received.
+Note that a proxy's CONNECT response should
 be read with \fICURLINFO_HTTP_CONNECTCODE(3)\fP and not this.
 
-Support for SMTP responses added in 7.25.0.
+Support for SMTP responses added in 7.25.0, for OpenLDAP in x.xx.x.
 .SH PROTOCOLS
-HTTP, FTP and SMTP
+HTTP, FTP, SMTP and LDAP (OpenLDAP only)
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.3
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -38,7 +38,8 @@ This is for enabling SSL/TLS when you use FTP, SMTP, POP3, IMAP etc.
 .IP CURLUSESSL_NONE
 do not attempt to use SSL.
 .IP CURLUSESSL_TRY
-Try using SSL, proceed as normal otherwise.
+Try using SSL, proceed as normal otherwise. Note that server may close the
+connection if the negotiation does not succeed.
 .IP CURLUSESSL_CONTROL
 Require SSL for the control connection or fail with \fICURLE_USE_SSL_FAILED\fP.
 .IP CURLUSESSL_ALL
@@ -46,7 +47,7 @@ Require SSL for all communication or fail with \fICURLE_USE_SSL_FAILED\fP.
 .SH DEFAULT
 CURLUSESSL_NONE
 .SH PROTOCOLS
-FTP, SMTP, POP3, IMAP
+FTP, SMTP, POP3, IMAP, LDAP (openldap only)
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -70,6 +70,15 @@
  */
 /* #define CURL_OPENLDAP_DEBUG */
 
+/* Machine states. */
+typedef enum {
+  OLDAP_STOP,           /* Do nothing state, stops the state machine */
+  OLDAP_SSL,            /* Performing SSL handshake. */
+  OLDAP_BIND,           /* Simple bind reply. */
+  OLDAP_BINDV2,         /* Simple bind reply in protocol version 2. */
+  OLDAP_LAST            /* Never used */
+} ldapstate;
+
 #ifndef _LDAP_PVT_H
 extern int ldap_pvt_url_scheme2proto(const char *);
 extern int ldap_init_fd(ber_socket_t fd, int proto, const char *url,
@@ -158,20 +167,65 @@ static const char *url_errs[] = {
 };
 
 struct ldapconninfo {
-  LDAP *ld;
-  Curl_recv *recv;  /* for stacking SSL handler */
+  LDAP *ld;                  /* Openldap connection handle. */
+  Curl_recv *recv;           /* For stacking SSL handler */
   Curl_send *send;
-  int proto;
-  int msgid;
-  bool ssldone;
-  bool sslinst;
-  bool didbind;
+  ldapstate state;           /* Current machine state. */
+  int proto;                 /* LDAP_PROTO_TCP/LDAP_PROTO_UDP/LDAP_PROTO_IPC */
+  int msgid;                 /* Current message id. */
 };
 
 struct ldapreqinfo {
   int msgid;
   int nument;
 };
+
+/*
+ * state()
+ *
+ * This is the ONLY way to change LDAP state!
+ */
+static void state(struct Curl_easy *data, ldapstate newstate)
+{
+  struct ldapconninfo *ldapc = data->conn->proto.ldapc;
+
+#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+  /* for debug purposes */
+  static const char * const names[] = {
+    "STOP",
+    "SSL",
+    "BIND",
+    "BINDV2",
+    /* LAST */
+  };
+
+  if(ldapc->state != newstate)
+    infof(data, "LDAP %p state change from %s to %s\n",
+          (void *)ldapc, names[ldapc->state], names[newstate]);
+#endif
+
+  ldapc->state = newstate;
+}
+
+/* Map some particular LDAP error codes to CURLcode values. */
+static CURLcode oldap_map_error(int rc, CURLcode result)
+{
+  switch(rc) {
+  case LDAP_NO_MEMORY:
+    result = CURLE_OUT_OF_MEMORY;
+    break;
+  case LDAP_INVALID_CREDENTIALS:
+    result = CURLE_LOGIN_DENIED;
+    break;
+  case LDAP_PROTOCOL_ERROR:
+    result = CURLE_UNSUPPORTED_PROTOCOL;
+    break;
+  case LDAP_INSUFFICIENT_ACCESS:
+    result = CURLE_REMOTE_ACCESS_DENIED;
+    break;
+  }
+  return result;
+}
 
 static CURLcode oldap_setup_connection(struct Curl_easy *data,
                                        struct connectdata *conn)
@@ -205,8 +259,68 @@ static CURLcode oldap_setup_connection(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+/* Starts LDAP simple bind. */
+static CURLcode oldap_perform_bind(struct Curl_easy *data, ldapstate newstate)
+{
+  CURLcode result = CURLE_OK;
+  struct connectdata *conn = data->conn;
+  struct ldapconninfo *li = conn->proto.ldapc;
+  char *binddn = NULL;
+  struct berval passwd;
+  int rc;
+
+  passwd.bv_val = NULL;
+  passwd.bv_len = 0;
+
+  if(conn->bits.user_passwd) {
+    binddn = conn->user;
+    passwd.bv_val = conn->passwd;
+    passwd.bv_len = strlen(passwd.bv_val);
+  }
+
+  rc = ldap_sasl_bind(li->ld, binddn, LDAP_SASL_SIMPLE, &passwd,
+                      NULL, NULL, &li->msgid);
+  if(rc == LDAP_SUCCESS)
+    state(data, newstate);
+  else
+    result = oldap_map_error(rc, conn->bits.user_passwd?
+                                 CURLE_LOGIN_DENIED: CURLE_LDAP_CANNOT_BIND);
+  return result;
+}
+
 #ifdef USE_SSL
 static Sockbuf_IO ldapsb_tls;
+
+static bool ssl_installed(struct connectdata *conn)
+{
+  return conn->proto.ldapc->recv != NULL;
+}
+
+static CURLcode oldap_ssl_connect(struct Curl_easy *data)
+{
+  CURLcode result = CURLE_OK;
+  struct connectdata *conn = data->conn;
+  struct ldapconninfo *li = conn->proto.ldapc;
+  bool ssldone = 0;
+
+  result = Curl_ssl_connect_nonblocking(data, conn, FALSE,
+                                        FIRSTSOCKET, &ssldone);
+  if(!result) {
+    state(data, OLDAP_SSL);
+
+    if(ssldone) {
+      Sockbuf *sb;
+
+      /* Install the libcurl SSL handlers into the sockbuf. */
+      ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb);
+      ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data);
+      li->recv = conn->recv[FIRSTSOCKET];
+      li->send = conn->send[FIRSTSOCKET];
+    }
+  }
+
+  return result;
+}
 #endif
 
 static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
@@ -230,9 +344,8 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   static int do_trace = 0;
   const char *env = getenv("CURL_OPENLDAP_TRACE");
   do_trace = (env && strtol(env, NULL, 10) > 0);
-  if(do_trace) {
+  if(do_trace)
     ldap_set_option(li->ld, LDAP_OPT_DEBUG_LEVEL, &do_trace);
-  }
 #endif
 
   rc = ldap_init_fd(conn->sock[FIRSTSOCKET], li->proto, hosturl, &li->ld);
@@ -245,122 +358,106 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   ldap_set_option(li->ld, LDAP_OPT_PROTOCOL_VERSION, &proto);
 
 #ifdef USE_SSL
-  if(conn->handler->flags & PROTOPT_SSL) {
-    CURLcode result;
-    result = Curl_ssl_connect_nonblocking(data, conn, FALSE,
-                                          FIRSTSOCKET, &li->ssldone);
-    if(result)
-      return result;
-  }
+  if(conn->handler->flags & PROTOPT_SSL)
+    return oldap_ssl_connect(data);
 #endif
 
-  return CURLE_OK;
+  /* Force bind even if anonymous bind is not needed in protocol version 3
+     to detect missing version 3 support. */
+  return oldap_perform_bind(data, OLDAP_BIND);
+}
+
+/* Handle a simple bind response. */
+static CURLcode oldap_state_bind_resp(struct Curl_easy *data, LDAPMessage *msg,
+                                      int code)
+{
+  struct connectdata *conn = data->conn;
+  struct ldapconninfo *li = conn->proto.ldapc;
+  CURLcode result = CURLE_OK;
+  struct berval *bv = NULL;
+  int rc;
+
+  if(code != LDAP_SUCCESS)
+    return oldap_map_error(code, CURLE_LDAP_CANNOT_BIND);
+
+  rc = ldap_parse_sasl_bind_result(li->ld, msg, &bv, 0);
+  if(rc != LDAP_SUCCESS) {
+    failf(data, "LDAP local: bind ldap_parse_sasl_bind_result %s",
+          ldap_err2string(rc));
+    result = oldap_map_error(rc, CURLE_LDAP_CANNOT_BIND);
+  }
+  else
+    state(data, OLDAP_STOP);
+
+  if(bv)
+    ber_bvfree(bv);
+  return result;
 }
 
 static CURLcode oldap_connecting(struct Curl_easy *data, bool *done)
 {
+  CURLcode result = CURLE_OK;
   struct connectdata *conn = data->conn;
   struct ldapconninfo *li = conn->proto.ldapc;
   LDAPMessage *msg = NULL;
-  struct timeval tv = {0, 1}, *tvp;
-  int rc, err;
-  char *info = NULL;
+  struct timeval tv = {0, 0};
+  int code = LDAP_SUCCESS;
+  int rc;
+
+  if(li->state != OLDAP_SSL) {
+    /* Get response to last command. */
+    rc = ldap_result(li->ld, li->msgid, LDAP_MSG_ONE, &tv, &msg);
+    if(!rc)
+      return CURLE_OK;                    /* Timed out. */
+    if(rc < 0) {
+      failf(data, "LDAP local: connecting ldap_result %s",
+            ldap_err2string(rc));
+      return oldap_map_error(rc, CURLE_COULDNT_CONNECT);
+    }
+
+    /* Get error code from message. */
+    rc = ldap_parse_result(li->ld, msg, &code, NULL, NULL, NULL, NULL, 0);
+    if(rc)
+      code = rc;
+
+    /* If protocol version 3 is not supported, fallback to version 2. */
+    if(code == LDAP_PROTOCOL_ERROR && li->state != OLDAP_BINDV2) {
+      static const int version = LDAP_VERSION2;
+
+      ldap_set_option(li->ld, LDAP_OPT_PROTOCOL_VERSION, &version);
+      ldap_msgfree(msg);
+      return oldap_perform_bind(data, OLDAP_BINDV2);
+    }
+  }
+
+  /* Handle response message according to current state. */
+  switch(li->state) {
 
 #ifdef USE_SSL
-  if(conn->handler->flags & PROTOPT_SSL) {
-    /* Is the SSL handshake complete yet? */
-    if(!li->ssldone) {
-      CURLcode result = Curl_ssl_connect_nonblocking(data, conn, FALSE,
-                                                     FIRSTSOCKET,
-                                                     &li->ssldone);
-      if(result || !li->ssldone)
-        return result;
-    }
-
-    /* Have we installed the libcurl SSL handlers into the sockbuf yet? */
-    if(!li->sslinst) {
-      Sockbuf *sb;
-      ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb);
-      ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data);
-      li->sslinst = TRUE;
-      li->recv = conn->recv[FIRSTSOCKET];
-      li->send = conn->send[FIRSTSOCKET];
-    }
-  }
+  case OLDAP_SSL:
+    result = oldap_ssl_connect(data);
+    if(!result && ssl_installed(conn))
+      result = oldap_perform_bind(data, OLDAP_BIND);
+    break;
 #endif
 
-  tvp = &tv;
-
-  retry:
-  if(!li->didbind) {
-    char *binddn;
-    struct berval passwd;
-
-    if(conn->bits.user_passwd) {
-      binddn = conn->user;
-      passwd.bv_val = conn->passwd;
-      passwd.bv_len = strlen(passwd.bv_val);
-    }
-    else {
-      binddn = NULL;
-      passwd.bv_val = NULL;
-      passwd.bv_len = 0;
-    }
-    rc = ldap_sasl_bind(li->ld, binddn, LDAP_SASL_SIMPLE, &passwd,
-                        NULL, NULL, &li->msgid);
-    if(rc)
-      return CURLE_LDAP_CANNOT_BIND;
-    li->didbind = TRUE;
-    if(tvp)
-      return CURLE_OK;
+  case OLDAP_BIND:
+  case OLDAP_BINDV2:
+    result = oldap_state_bind_resp(data, msg, code);
+    break;
+  default:
+    /* internal error */
+    result = CURLE_COULDNT_CONNECT;
+    break;
   }
 
-  rc = ldap_result(li->ld, li->msgid, LDAP_MSG_ONE, tvp, &msg);
-  if(rc < 0) {
-    failf(data, "LDAP local: bind ldap_result %s", ldap_err2string(rc));
-    return CURLE_LDAP_CANNOT_BIND;
-  }
-  if(rc == 0) {
-    /* timed out */
-    return CURLE_OK;
-  }
+  ldap_msgfree(msg);
 
-  rc = ldap_parse_result(li->ld, msg, &err, NULL, &info, NULL, NULL, 1);
-  if(rc) {
-    failf(data, "LDAP local: bind ldap_parse_result %s", ldap_err2string(rc));
-    return CURLE_LDAP_CANNOT_BIND;
-  }
+  *done = li->state == OLDAP_STOP;
+  if(*done)
+    conn->recv[FIRSTSOCKET] = oldap_recv;
 
-  /* Try to fallback to LDAPv2? */
-  if(err == LDAP_PROTOCOL_ERROR) {
-    int proto;
-    ldap_get_option(li->ld, LDAP_OPT_PROTOCOL_VERSION, &proto);
-    if(proto == LDAP_VERSION3) {
-      if(info) {
-        ldap_memfree(info);
-        info = NULL;
-      }
-      proto = LDAP_VERSION2;
-      ldap_set_option(li->ld, LDAP_OPT_PROTOCOL_VERSION, &proto);
-      li->didbind = FALSE;
-      goto retry;
-    }
-  }
-
-  if(err) {
-    failf(data, "LDAP remote: bind failed %s %s", ldap_err2string(rc),
-          info ? info : "");
-    if(info)
-      ldap_memfree(info);
-    return CURLE_LOGIN_DENIED;
-  }
-
-  if(info)
-    ldap_memfree(info);
-  conn->recv[FIRSTSOCKET] = oldap_recv;
-  *done = TRUE;
-
-  return CURLE_OK;
+  return result;
 }
 
 static CURLcode oldap_disconnect(struct Curl_easy *data,
@@ -373,7 +470,7 @@ static CURLcode oldap_disconnect(struct Curl_easy *data,
   if(li) {
     if(li->ld) {
 #ifdef USE_SSL
-      if(conn->ssl[FIRSTSOCKET].use) {
+      if(ssl_installed(conn)) {
         Sockbuf *sb;
         ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb);
         ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data);

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -608,6 +608,32 @@ static CURLcode oldap_done(struct Curl_easy *data, CURLcode res,
   return CURLE_OK;
 }
 
+static CURLcode client_write(struct Curl_easy *data, const char *prefix,
+                             const char *value, size_t len, const char *suffix)
+{
+  CURLcode result = CURLE_OK;
+  size_t l;
+
+  if(prefix) {
+    l = strlen(prefix);
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *) prefix, l);
+    if(!result)
+      data->req.bytecount += l;
+  }
+  if(!result && value) {
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *) value, len);
+    if(!result)
+      data->req.bytecount += len;
+  }
+  if(!result && suffix) {
+    l = strlen(suffix);
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *) suffix, l);
+    if(!result)
+      data->req.bytecount += l;
+  }
+  return result;
+}
+
 static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
                           size_t len, CURLcode *err)
 {
@@ -617,7 +643,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
   int rc;
   LDAPMessage *msg = NULL;
   BerElement *ber = NULL;
-  struct timeval tv = {0, 1};
+  struct timeval tv = {0, 0};
   struct berval bv, *bvals;
   int binary = 0;
   CURLcode result = CURLE_AGAIN;
@@ -674,19 +700,10 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
       result = CURLE_RECV_ERROR;
       break;
     }
-    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"DN: ", 4);
-    if(result)
-      break;
 
-    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
-                               bv.bv_len);
+    result = client_write(data, "DN: ", bv.bv_val, bv.bv_len, "\n");
     if(result)
       break;
-
-    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
-    if(result)
-      break;
-    data->req.bytecount += bv.bv_len + 5;
 
     for(rc = ldap_get_attribute_ber(li->ld, msg, ber, &bv, &bvals);
         rc == LDAP_SUCCESS;
@@ -696,41 +713,22 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
       if(!bv.bv_val)
         break;
 
-      if(bv.bv_len > 7 && !strncmp(bv.bv_val + bv.bv_len - 7, ";binary", 7))
-        binary = 1;
-      else
-        binary = 0;
-
       if(!bvals) {
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\t", 1);
+        result = client_write(data, "\t", bv.bv_val, bv.bv_len, ":\n");
         if(result)
           break;
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
-                                   bv.bv_len);
-        if(result)
-          break;
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)":\n", 2);
-        if(result)
-          break;
-        data->req.bytecount += bv.bv_len + 3;
         continue;
       }
 
+      binary = bv.bv_len > 7 &&
+               !strncmp(bv.bv_val + bv.bv_len - 7, ";binary", 7);
+
       for(i = 0; bvals[i].bv_val != NULL; i++) {
         int binval = 0;
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\t", 1);
-        if(result)
-          break;
 
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
-                                   bv.bv_len);
+        result = client_write(data, "\t", bv.bv_val, bv.bv_len, ":");
         if(result)
           break;
-
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)":", 1);
-        if(result)
-          break;
-        data->req.bytecount += bv.bv_len + 2;
 
         if(!binary) {
           /* check for leading or trailing whitespace */
@@ -755,48 +753,30 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
           result = Curl_base64_encode(data, bvals[i].bv_val, bvals[i].bv_len,
                                       &val_b64, &val_b64_sz);
           if(!result)
-            result = Curl_client_write(data, CLIENTWRITE_BODY,
-                                       (char *)": ", 2);
-          if(!result && val_b64_sz > 0)
-            result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
-                                       val_b64_sz);
+            result = client_write(data, ": ", val_b64, val_b64_sz, "\n");
           free(val_b64);
-          data->req.bytecount += val_b64_sz + 2;
         }
-        else {
-          result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)" ", 1);
-          if(result)
-            break;
-
-          result = Curl_client_write(data, CLIENTWRITE_BODY, bvals[i].bv_val,
-                                     bvals[i].bv_len);
-          if(result)
-            break;
-
-          data->req.bytecount += bvals[i].bv_len + 1;
-        }
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+        else
+          result = client_write(data, " ",
+                                bvals[i].bv_val, bvals[i].bv_len, "\n");
         if(result)
           break;
-
-        data->req.bytecount++;
       }
 
       ber_memfree(bvals);
-
+      bvals = NULL;
       if(!result)
-        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+        result = client_write(data, "\n", NULL, 0, NULL);
       if(result)
         break;
-      data->req.bytecount++;
     }
 
     ber_free(ber, 0);
 
-    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+    if(!result)
+      result = client_write(data, "\n", NULL, 0, NULL);
     if(!result)
       result = CURLE_AGAIN;
-    data->req.bytecount++;
     break;
   }
 

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -204,7 +204,7 @@ static void state(struct Curl_easy *data, ldapstate newstate)
   };
 
   if(ldapc->state != newstate)
-    infof(data, "LDAP %p state change from %s to %s\n",
+    infof(data, "LDAP %p state change from %s to %s",
           (void *)ldapc, names[ldapc->state], names[newstate]);
 #endif
 
@@ -614,95 +614,83 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
   struct connectdata *conn = data->conn;
   struct ldapconninfo *li = conn->proto.ldapc;
   struct ldapreqinfo *lr = data->req.p.ldap;
-  int rc, ret;
+  int rc;
   LDAPMessage *msg = NULL;
-  LDAPMessage *ent;
   BerElement *ber = NULL;
   struct timeval tv = {0, 1};
+  struct berval bv, *bvals;
+  int binary = 0;
+  CURLcode result = CURLE_AGAIN;
+  int code;
+  char *info = NULL;
 
   (void)len;
   (void)buf;
   (void)sockindex;
 
-  rc = ldap_result(li->ld, lr->msgid, LDAP_MSG_RECEIVED, &tv, &msg);
+  rc = ldap_result(li->ld, lr->msgid, LDAP_MSG_ONE, &tv, &msg);
   if(rc < 0) {
     failf(data, "LDAP local: search ldap_result %s", ldap_err2string(rc));
-    *err = CURLE_RECV_ERROR;
-    return -1;
+    result = CURLE_RECV_ERROR;
   }
 
-  *err = CURLE_AGAIN;
-  ret = -1;
+  *err = result;
 
-  /* timed out */
+  /* error or timed out */
   if(!msg)
-    return ret;
+    return -1;
 
-  for(ent = ldap_first_message(li->ld, msg); ent;
-      ent = ldap_next_message(li->ld, ent)) {
-    struct berval bv, *bvals;
-    int binary = 0, msgtype;
-    CURLcode writeerr;
+  result = CURLE_OK;
 
-    msgtype = ldap_msgtype(ent);
-    if(msgtype == LDAP_RES_SEARCH_RESULT) {
-      int code;
-      char *info = NULL;
-      rc = ldap_parse_result(li->ld, ent, &code, NULL, &info, NULL, NULL, 0);
-      if(rc) {
-        failf(data, "LDAP local: search ldap_parse_result %s",
-              ldap_err2string(rc));
-        *err = CURLE_LDAP_SEARCH_FAILED;
-      }
-      else if(code && code != LDAP_SIZELIMIT_EXCEEDED) {
-        failf(data, "LDAP remote: search failed %s %s", ldap_err2string(rc),
-              info ? info : "");
-        *err = CURLE_LDAP_SEARCH_FAILED;
-      }
-      else {
-        /* successful */
-        if(code == LDAP_SIZELIMIT_EXCEEDED)
-          infof(data, "There are more than %d entries", lr->nument);
-        data->req.size = data->req.bytecount;
-        *err = CURLE_OK;
-        ret = 0;
-      }
-      lr->msgid = 0;
-      ldap_memfree(info);
+  switch(ldap_msgtype(msg)) {
+  case LDAP_RES_SEARCH_RESULT:
+    lr->msgid = 0;
+    rc = ldap_parse_result(li->ld, msg, &code, NULL, &info, NULL, NULL, 0);
+    if(rc) {
+      failf(data, "LDAP local: search ldap_parse_result %s",
+            ldap_err2string(rc));
+      result = CURLE_LDAP_SEARCH_FAILED;
       break;
     }
-    else if(msgtype != LDAP_RES_SEARCH_ENTRY)
-      continue;
 
+    switch(code) {
+    case LDAP_SIZELIMIT_EXCEEDED:
+      infof(data, "There are more than %d entries", lr->nument);
+      /* FALLTHROUGH */
+    case LDAP_SUCCESS:
+      data->req.size = data->req.bytecount;
+      break;
+    default:
+      failf(data, "LDAP remote: search failed %s %s", ldap_err2string(code),
+            info ? info : "");
+      result = CURLE_LDAP_SEARCH_FAILED;
+      break;
+    }
+    break;
+  case LDAP_RES_SEARCH_ENTRY:
     lr->nument++;
-    rc = ldap_get_dn_ber(li->ld, ent, &ber, &bv);
+    rc = ldap_get_dn_ber(li->ld, msg, &ber, &bv);
     if(rc < 0) {
-      *err = CURLE_RECV_ERROR;
-      return -1;
+      result = CURLE_RECV_ERROR;
+      break;
     }
-    writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"DN: ", 4);
-    if(writeerr) {
-      *err = writeerr;
-      return -1;
-    }
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"DN: ", 4);
+    if(result)
+      break;
 
-    writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
-                                 bv.bv_len);
-    if(writeerr) {
-      *err = writeerr;
-      return -1;
-    }
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
+                               bv.bv_len);
+    if(result)
+      break;
 
-    writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
-    if(writeerr) {
-      *err = writeerr;
-      return -1;
-    }
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+    if(result)
+      break;
     data->req.bytecount += bv.bv_len + 5;
 
-    for(rc = ldap_get_attribute_ber(li->ld, ent, ber, &bv, &bvals);
+    for(rc = ldap_get_attribute_ber(li->ld, msg, ber, &bv, &bvals);
         rc == LDAP_SUCCESS;
-        rc = ldap_get_attribute_ber(li->ld, ent, ber, &bv, &bvals)) {
+        rc = ldap_get_attribute_ber(li->ld, msg, ber, &bv, &bvals)) {
       int i;
 
       if(!bv.bv_val)
@@ -714,57 +702,45 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
         binary = 0;
 
       if(!bvals) {
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\t", 1);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
-                                     bv.bv_len);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)":\n", 2);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\t", 1);
+        if(result)
+          break;
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
+                                   bv.bv_len);
+        if(result)
+          break;
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)":\n", 2);
+        if(result)
+          break;
         data->req.bytecount += bv.bv_len + 3;
         continue;
       }
 
       for(i = 0; bvals[i].bv_val != NULL; i++) {
         int binval = 0;
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\t", 1);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\t", 1);
+        if(result)
+          break;
 
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
-                                     bv.bv_len);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)bv.bv_val,
+                                   bv.bv_len);
+        if(result)
+          break;
 
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)":", 1);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)":", 1);
+        if(result)
+          break;
         data->req.bytecount += bv.bv_len + 2;
 
         if(!binary) {
           /* check for leading or trailing whitespace */
           if(ISSPACE(bvals[i].bv_val[0]) ||
-             ISSPACE(bvals[i].bv_val[bvals[i].bv_len-1]))
+             ISSPACE(bvals[i].bv_val[bvals[i].bv_len - 1]))
             binval = 1;
           else {
             /* check for unprintable characters */
             unsigned int j;
-            for(j = 0; j<bvals[i].bv_len; j++)
+            for(j = 0; j < bvals[i].bv_len; j++)
               if(!ISPRINT(bvals[i].bv_val[j])) {
                 binval = 1;
                 break;
@@ -774,80 +750,60 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
         if(binary || binval) {
           char *val_b64 = NULL;
           size_t val_b64_sz = 0;
-          /* Binary value, encode to base64. */
-          CURLcode error = Curl_base64_encode(data,
-                                              bvals[i].bv_val,
-                                              bvals[i].bv_len,
-                                              &val_b64,
-                                              &val_b64_sz);
-          if(error) {
-            ber_memfree(bvals);
-            ber_free(ber, 0);
-            ldap_msgfree(msg);
-            *err = error;
-            return -1;
-          }
-          writeerr = Curl_client_write(data, CLIENTWRITE_BODY,
-                                       (char *)": ", 2);
-          if(writeerr) {
-            *err = writeerr;
-            return -1;
-          }
 
-          data->req.bytecount += 2;
-          if(val_b64_sz > 0) {
-            writeerr = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
-                                         val_b64_sz);
-            if(writeerr) {
-              *err = writeerr;
-              return -1;
-            }
-            free(val_b64);
-            data->req.bytecount += val_b64_sz;
-          }
+          /* Binary value, encode to base64. */
+          result = Curl_base64_encode(data, bvals[i].bv_val, bvals[i].bv_len,
+                                      &val_b64, &val_b64_sz);
+          if(!result)
+            result = Curl_client_write(data, CLIENTWRITE_BODY,
+                                       (char *)": ", 2);
+          if(!result && val_b64_sz > 0)
+            result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
+                                       val_b64_sz);
+          free(val_b64);
+          data->req.bytecount += val_b64_sz + 2;
         }
         else {
-          writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)" ", 1);
-          if(writeerr) {
-            *err = writeerr;
-            return -1;
-          }
+          result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)" ", 1);
+          if(result)
+            break;
 
-          writeerr = Curl_client_write(data, CLIENTWRITE_BODY, bvals[i].bv_val,
-                                       bvals[i].bv_len);
-          if(writeerr) {
-            *err = writeerr;
-            return -1;
-          }
+          result = Curl_client_write(data, CLIENTWRITE_BODY, bvals[i].bv_val,
+                                     bvals[i].bv_len);
+          if(result)
+            break;
 
           data->req.bytecount += bvals[i].bv_len + 1;
         }
-        writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
-        if(writeerr) {
-          *err = writeerr;
-          return -1;
-        }
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+        if(result)
+          break;
 
         data->req.bytecount++;
       }
+
       ber_memfree(bvals);
-      writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
-      if(writeerr) {
-        *err = writeerr;
-        return -1;
-      }
+
+      if(!result)
+        result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+      if(result)
+        break;
       data->req.bytecount++;
     }
-    writeerr = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
-    if(writeerr) {
-      *err = writeerr;
-      return -1;
-    }
-    data->req.bytecount++;
+
     ber_free(ber, 0);
+
+    result = Curl_client_write(data, CLIENTWRITE_BODY, (char *)"\n", 1);
+    if(!result)
+      result = CURLE_AGAIN;
+    data->req.bytecount++;
+    break;
   }
+
+  ldap_memfree(info);
   ldap_msgfree(msg);
-  return ret;
+  *err = result;
+  return result? -1: 0;
 }
 
 #ifdef USE_SSL

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -74,6 +74,8 @@
 typedef enum {
   OLDAP_STOP,           /* Do nothing state, stops the state machine */
   OLDAP_SSL,            /* Performing SSL handshake. */
+  OLDAP_STARTTLS,       /* STARTTLS request sent. */
+  OLDAP_TLS,            /* Performing TLS handshake. */
   OLDAP_BIND,           /* Simple bind reply. */
   OLDAP_BINDV2,         /* Simple bind reply in protocol version 2. */
   OLDAP_LAST            /* Never used */
@@ -194,6 +196,8 @@ static void state(struct Curl_easy *data, ldapstate newstate)
   static const char * const names[] = {
     "STOP",
     "SSL",
+    "STARTTLS",
+    "TLS",
     "BIND",
     "BINDV2",
     /* LAST */
@@ -256,6 +260,10 @@ static CURLcode oldap_setup_connection(struct Curl_easy *data,
   li->proto = proto;
   conn->proto.ldapc = li;
   connkeep(conn, "OpenLDAP default");
+
+  /* Clear the TLS upgraded flag */
+  conn->bits.tls_upgraded = FALSE;
+
   return CURLE_OK;
 }
 
@@ -296,7 +304,7 @@ static bool ssl_installed(struct connectdata *conn)
   return conn->proto.ldapc->recv != NULL;
 }
 
-static CURLcode oldap_ssl_connect(struct Curl_easy *data)
+static CURLcode oldap_ssl_connect(struct Curl_easy *data, ldapstate newstate)
 {
   CURLcode result = CURLE_OK;
   struct connectdata *conn = data->conn;
@@ -306,7 +314,7 @@ static CURLcode oldap_ssl_connect(struct Curl_easy *data)
   result = Curl_ssl_connect_nonblocking(data, conn, FALSE,
                                         FIRSTSOCKET, &ssldone);
   if(!result) {
-    state(data, OLDAP_SSL);
+    state(data, newstate);
 
     if(ssldone) {
       Sockbuf *sb;
@@ -319,6 +327,20 @@ static CURLcode oldap_ssl_connect(struct Curl_easy *data)
     }
   }
 
+  return result;
+}
+
+/* Send the STARTTLS request */
+static CURLcode oldap_perform_starttls(struct Curl_easy *data)
+{
+  CURLcode result = CURLE_OK;
+  struct ldapconninfo *li = data->conn->proto.ldapc;
+  int rc = ldap_start_tls(li->ld, NULL, NULL, &li->msgid);
+
+  if(rc == LDAP_SUCCESS)
+    state(data, OLDAP_STARTTLS);
+  else
+    result = oldap_map_error(rc, CURLE_USE_SSL_FAILED);
   return result;
 }
 #endif
@@ -359,7 +381,13 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
 
 #ifdef USE_SSL
   if(conn->handler->flags & PROTOPT_SSL)
-    return oldap_ssl_connect(data);
+    return oldap_ssl_connect(data, OLDAP_SSL);
+  if(data->set.use_ssl) {
+    CURLcode result = oldap_perform_starttls(data);
+
+    if(!result || data->set.use_ssl != CURLUSESSL_TRY)
+      return result;
+  }
 #endif
 
   /* Force bind even if anonymous bind is not needed in protocol version 3
@@ -404,7 +432,7 @@ static CURLcode oldap_connecting(struct Curl_easy *data, bool *done)
   int code = LDAP_SUCCESS;
   int rc;
 
-  if(li->state != OLDAP_SSL) {
+  if(li->state != OLDAP_SSL && li->state != OLDAP_TLS) {
     /* Get response to last command. */
     rc = ldap_result(li->ld, li->msgid, LDAP_MSG_ONE, &tv, &msg);
     if(!rc)
@@ -421,7 +449,11 @@ static CURLcode oldap_connecting(struct Curl_easy *data, bool *done)
       code = rc;
 
     /* If protocol version 3 is not supported, fallback to version 2. */
-    if(code == LDAP_PROTOCOL_ERROR && li->state != OLDAP_BINDV2) {
+    if(code == LDAP_PROTOCOL_ERROR && li->state != OLDAP_BINDV2
+#ifdef USE_SSL
+       && (ssl_installed(conn) || data->set.use_ssl <= CURLUSESSL_TRY)
+#endif
+       ) {
       static const int version = LDAP_VERSION2;
 
       ldap_set_option(li->ld, LDAP_OPT_PROTOCOL_VERSION, &version);
@@ -435,9 +467,32 @@ static CURLcode oldap_connecting(struct Curl_easy *data, bool *done)
 
 #ifdef USE_SSL
   case OLDAP_SSL:
-    result = oldap_ssl_connect(data);
+    result = oldap_ssl_connect(data, OLDAP_SSL);
     if(!result && ssl_installed(conn))
       result = oldap_perform_bind(data, OLDAP_BIND);
+    break;
+  case OLDAP_STARTTLS:
+    if(code != LDAP_SUCCESS) {
+      if(data->set.use_ssl != CURLUSESSL_TRY)
+        result = oldap_map_error(code, CURLE_USE_SSL_FAILED);
+      else
+        result = oldap_perform_bind(data, OLDAP_BIND);
+      break;
+    }
+    /* FALLTHROUGH */
+  case OLDAP_TLS:
+    result = oldap_ssl_connect(data, OLDAP_TLS);
+    if(result && data->set.use_ssl != CURLUSESSL_TRY)
+      result = oldap_map_error(code, CURLE_USE_SSL_FAILED);
+    else if(ssl_installed(conn)) {
+      conn->bits.tls_upgraded = TRUE;
+      if(conn->bits.user_passwd)
+        result = oldap_perform_bind(data, OLDAP_BIND);
+      else {
+        state(data, OLDAP_STOP); /* Version 3 supported: no bind required */
+        result = CURLE_OK;
+      }
+    }
     break;
 #endif
 


### PR DESCRIPTION
Huge work on it, cleaning and fixing as well as new features: see commits comments for details.
I have also SASL ready for it, but i'll push it when #6930 will have landed in master.

Question: as the standard LDAP URL scheme does not feature a userinfo part, should we support it anyway for unification with the rest of curl ?