### PR TITLE
test328: avoid a header-looking body to make hyper mode work

### DIFF
--- a/tests/data/test328
+++ b/tests/data/test328
@@ -16,7 +16,7 @@ Content-Type: text/html
 Content-Encoding: none
 Content-Length: 38
 
-Q: What did 0 say to 8? A: Nice Belt!
+Q- What did 0 say to 8? A- Nice Belt!
 </data>
 </reply>
 


### PR DESCRIPTION
The test still works the same, just modified two bytes in the content.