### PR TITLE
c-hyper: support CURLOPT_HEADER

### DIFF
--- a/.github/workflows/linux-hyper.yml
+++ b/.github/workflows/linux-hyper.yml
@@ -23,7 +23,7 @@ jobs:
         - name: hyper
           install:
           configure: --with-openssl --with-hyper=$HOME/hyper
-          tflags: 1 to 153 220 221 222 223 224 230 232 271 314 315 316 396 397 433 395 394 393 347 339
+          tflags: 1 to 153 220 221 222 223 224 230 232 271 314 315 316 396 397 433 395 394 393 347 339 500 501 502 503 504 505 506 507 508 509 510 511 512
 
     steps:
     - run: sudo apt-get install libtool autoconf automake pkg-config

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -125,6 +125,10 @@ static int hyper_each_header(void *userdata,
   char *headp;
   CURLcode result;
   int writetype;
+
+  if(!data->req.bytecount)
+    Curl_pgrsTime(data, TIMER_STARTTRANSFER);
+
   Curl_dyn_reset(&data->state.headerb);
   if(name_len) {
     if(Curl_dyn_addf(&data->state.headerb, "%.*s: %.*s\r\n",

--- a/tests/data/test500
+++ b/tests/data/test500
@@ -46,7 +46,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER log/ip%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <file name="log/ip%TESTNUMBER">
-IP: %HOSTIP
+IP %HOSTIP
 </file>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1

--- a/tests/libtest/lib500.c
+++ b/tests/libtest/lib500.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -101,7 +101,7 @@ int test(char *URL)
         curl_off_t time_pretransfer;
         curl_off_t time_starttransfer;
         curl_off_t time_total;
-        fprintf(moo, "IP: %s\n", ipstr);
+        fprintf(moo, "IP %s\n", ipstr);
         curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME_T, &time_namelookup);
         curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME_T, &time_connect);
         curl_easy_getinfo(curl, CURLINFO_PRETRANSFER_TIME_T,


### PR DESCRIPTION
When enabled, the headers are passed to the body write callback as well.

Like in test 500