### PR TITLE
runtests: skip disabled tests unless -f is used

### DIFF
--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -72,6 +72,8 @@ The exclusion types are \fkeyword\fP, \ftest\fP, and \ftool\fP.
 Run the test event-based (if possible). This will make runtests invoke curl
 with --test-event option. This option only works if both curl and libcurl were
 built debug-enabled.
+.IP "-f"
+Force the test to run even if mentioned in DISABLED.
 .IP "-g"
 Run the given test(s) with gdb. This is best used on a single test case and
 curl built --disable-shared. This then fires up gdb with command line set to


### PR DESCRIPTION
To make it easier to write ranges like '115 to 229' without that
explicitly enabling tests that are listed in DISABLED, this makes
runtests always skip disabled tests unless the -f command line option is
used.

Previously the code attempted to not run such tests, but didn't do it
correctly.