### PR TITLE
Update CURLOPT_WRITEFUNCTION.3

### DIFF
--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -102,7 +102,7 @@ This will return CURLE_OK.
    return realsize;
  }
 
- struct memory chunk;
+ struct memory chunk = {0};
 
  /* send all data to this function  */
  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, cb);


### PR DESCRIPTION
Safely avoid chunk.size garbage value if declared non globally.
Decrease debugging time if someone initialize it with garbage value and see unexpected result!