### PR TITLE
mqtt: Adding appropiate boundary checks for username and password.

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -273,7 +273,6 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
 
   /*getting how much occupy the remain length*/
   remain_pos = mqtt_encode_len(remain, payloadlen + 10);
-  infof(data, "Remain Position: %d\n", remain_pos);
 
   /*10 length of variable header and
    * 1 the first byte of the fixed header*/
@@ -298,7 +297,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   /*adding client id*/
   rc = add_client_id(client_id, strlen(client_id), packet, pos + 1);
   if(rc) {
-    infof(data, "Client ID length mismatched: [%lu]\n", strlen(client_id));
+    failf(data, "Client ID length mismatched: [%lu]", strlen(client_id));
     result = CURLE_WEIRD_SERVER_REPLY;
     goto end;
   }
@@ -316,7 +315,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
     rc = add_user(username, ulen,
         (unsigned char *)packet, start_user, remain_pos);
     if(rc) {
-      infof(data, "Username is too large: [%lu]\n", ulen);
+      failf(data, "Username is too large: [%lu]", ulen);
       result = CURLE_WEIRD_SERVER_REPLY;
       goto end;
     }
@@ -326,7 +325,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   if(plen > 0) {
     rc = add_passwd(passwd, plen, packet, start_pwd, remain_pos);
     if(rc) {
-      infof(data, "Password is too large: [%lu]\n", plen);
+      failf(data, "Password is too large: [%lu]", plen);
       result = CURLE_WEIRD_SERVER_REPLY;
       goto end;
     }

--- a/tests/data/test2205
+++ b/tests/data/test2205
@@ -9,17 +9,8 @@ MQTT SUBSCRIBE
 #
 # Server-side
 <reply>
-<data nocheck="yes">
-hello
+<data>
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
-</datacheck>
-
-# error 5 - "Connection Refused, not authorized. Wrong data supplied"
-<servercmd>
-error-CONNACK 5
-</servercmd>
 </reply>
 
 #
@@ -35,7 +26,7 @@ mqtt
 MQTT with very long user name
 </name>
 <command option="binary-trace">
-mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u %repeat[65535 x a]%:fakepasswd
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u %repeat[65536 x a]%:fakepasswd
 </command>
 </client>
 
@@ -49,11 +40,6 @@ mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u %repeat[65535 x a]%:fakepasswd
 <strippart>
 s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
 </strippart>
-<protocol>
-client CONNECT 10028 00044d51545404c2003c000c6375726c
-server CONNACK 2 20020005
-</protocol>
-
 # 8 is CURLE_WEIRD_SERVER_REPLY
 <errorcode>
 8

--- a/tests/data/test2205
+++ b/tests/data/test2205
@@ -35,7 +35,7 @@ mqtt
 MQTT with very long user name
 </name>
 <command option="binary-trace">
-mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:fakepasswd
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u %repeat[65535 x a]%:fakepasswd
 </command>
 </client>
 
@@ -50,7 +50,7 @@ mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 s/^(.* 00044d51545404c2003c000c6375726c).*/$1/
 </strippart>
 <protocol>
-client CONNECT 2e 00044d51545404c2003c000c6375726c
+client CONNECT 10028 00044d51545404c2003c000c6375726c
 server CONNACK 2 20020005
 </protocol>
 

--- a/tests/data/test2205
+++ b/tests/data/test2205
@@ -25,8 +25,11 @@ mqtt
 <name>
 MQTT with very long user name
 </name>
+<file name="log/input%TESTNUMBER">
+user = %repeat[65536 x a]%:fakepasswd
+</file>
 <command option="binary-trace">
-mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -u %repeat[65536 x a]%:fakepasswd
+mqtt://%HOSTIP:%MQTTPORT/%TESTNUMBER -K log/input%TESTNUMBER
 </command>
 </client>
 


### PR DESCRIPTION
* This is a continuation of #7191 by @bagder and #7117 by myself. Adding boundary checks for username and password with a maximum of 65535 bytes each one, also using the appropriates number of bytes for the LSB and MSB on both cases. 
* The file `tests/server/mqttd.c` was modified in order to accept a payload greater than 10kb, with the new modification it will be able to reallocate memory as needed.
* Modified the test 2205 in order to check this new boundary of 65535. Right now the test is **FAILING**, below I expose why think it is failing.

**IMPORTANT NOTES:**
* Right now the checks of the length of username and password, is done using `DEBUGASSERT`, which I don't know if it is the best option.
* Apart from the username and password, I also checked the size of the payload packet and set it to 256mgb which is huge in my opinion, but I tried to comply with [2.2.3 Remaining Length](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023).
* Given the use of `DEBUGASSERT` on these checks, the test **2205** is **FAILING** with the following message:

```bash
********* System characteristics ******** 
* curl 7.77.1-DEV (x86_64-pc-linux-gnu) 
* libcurl/7.77.1-DEV OpenSSL/1.1.1c zlib/1.2.11 brotli/1.0.9 libidn2/2.2.0 libpsl/0.20.2 (+libidn2/2.0.5)
* Features: alt-svc AsynchDNS brotli Debug HSTS HTTPS-proxy IDN IPv6 Largefile libz NTLM NTLM_WB PSL SSL TLS-SRP TrackMemory UnixSockets
* Disabled: 
* Host: gealber-X541NA
* System: Linux gealber-X541NA 5.3.0-64-generic #58-Ubuntu SMP Fri Jul 10 19:33:51 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
* OS: linux
*
*** DISABLES memory tracking when using threaded resolver
*
* Servers: HTTP-IPv6 HTTP-unix FTP-IPv6 
* Env: Valgrind 
* Seed: 205617
***************************************** 
test 2205...[MQTT with very long user name]

 2205: protocol FAILED!
 There was no content at all in the file log/server.input.
 Server glitch? Total curl failure? Returned: 134

 - abort tests
TESTDONE: 1 tests were considered during 7 seconds.
TESTDONE: 0 tests out of 1 reported OK: 0%

TESTFAIL: These test cases failed: 2205
```
I checked with a username of **65534** bytes, and it passed. When I tried with the boundary limit it failed with the previous error, so I'm assuming that the problem is that I'm not checking appropriately, in the test case, the way `DEBUGASSERT` abort the process.

