### PR TITLE
openssl: don't remove session id entry in disassociate

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4540,9 +4540,6 @@ static void ossl_disassociate_connection(struct Curl_easy *data,
     return;
 
   if(SSL_SET_OPTION(primary.sessionid)) {
-    bool isproxy = FALSE;
-    bool incache;
-    void *old_ssl_sessionid = NULL;
     int data_idx = ossl_get_ssl_data_index();
     int connectdata_idx = ossl_get_ssl_conn_index();
     int sockindex_idx = ossl_get_ssl_sockindex_index();
@@ -4550,9 +4547,6 @@ static void ossl_disassociate_connection(struct Curl_easy *data,
 
     if(data_idx >= 0 && connectdata_idx >= 0 && sockindex_idx >= 0 &&
        proxy_idx >= 0) {
-      /* Invalidate the session cache entry, if any */
-      isproxy = SSL_get_ex_data(backend->handle, proxy_idx) ? TRUE : FALSE;
-
       /* Disable references to data in "new session" callback to avoid
        * accessing a stale pointer. */
       SSL_set_ex_data(backend->handle, data_idx, NULL);
@@ -4560,13 +4554,6 @@ static void ossl_disassociate_connection(struct Curl_easy *data,
       SSL_set_ex_data(backend->handle, sockindex_idx, NULL);
       SSL_set_ex_data(backend->handle, proxy_idx, NULL);
     }
-
-    Curl_ssl_sessionid_lock(data);
-    incache = !(Curl_ssl_getsessionid(data, conn, isproxy,
-                                      &old_ssl_sessionid, NULL, sockindex));
-    if(incache)
-      Curl_ssl_delsessionid(data, old_ssl_sessionid);
-    Curl_ssl_sessionid_unlock(data);
   }
 }
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -444,6 +444,10 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
     }
   }
 
+  DEBUGF(infof(data, "%s Session ID in cache for %s %s://%s:%d\n",
+               no_match? "Didn't find": "Found",
+               isProxy ? "proxy" : "host",
+               conn->handler->scheme, name, port));
   return no_match;
 }
 
@@ -589,6 +593,9 @@ CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
   }
 
+  DEBUGF(infof(data, "Added Session ID to cache for %s://%s:%d [%s]\n",
+               store->scheme, store->name, store->remote_port,
+               isProxy ? "PROXY" : "server"));
   return CURLE_OK;
 }
 


### PR DESCRIPTION
When a connection is disassociated from a transfer, the Session ID entry
should remain.

Regression since 7f4a9a9 (shipped in libcurl 7.77.0)
Reported-by: Gergely Nagy
Reported-by: Paul Groke

Fixes #7222