### PR TITLE
single_transfer: ignore blank --output-dir

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -970,7 +970,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             }
           }
 
-          if(config->output_dir) {
+          if(config->output_dir && *config->output_dir) {
             char *d = aprintf("%s/%s", config->output_dir, per->outfile);
             if(!d) {
               result = CURLE_WRITE_ERROR;


### PR DESCRIPTION
... as otherwise it creates a rather unexpected target directory with a
leading slash.

Reported-by: Harry Sintonen
Fixes #7218