### PR TITLE
lib: Don't compare fd to FD_SETSIZE when using poll [fixes #7240]

### DIFF
--- a/lib/select.h
+++ b/lib/select.h
@@ -106,7 +106,11 @@ int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,
   } \
 } while(0)
 #else
+#ifdef HAVE_POLL_FINE
+#define VALID_SOCK(s) ((s) >= 0)  // FD_SETSIZE is irrelevant for poll
+#else
 #define VALID_SOCK(s) (((s) >= 0) && ((s) < FD_SETSIZE))
+#endif
 #define VERIFY_SOCK(x) do { \
   if(!VALID_SOCK(x)) { \
     SET_SOCKERRNO(EINVAL); \

--- a/lib/select.h
+++ b/lib/select.h
@@ -107,7 +107,7 @@ int tpf_select_libcurl(int maxfds, fd_set* reads, fd_set* writes,
 } while(0)
 #else
 #ifdef HAVE_POLL_FINE
-#define VALID_SOCK(s) ((s) >= 0)  // FD_SETSIZE is irrelevant for poll
+#define VALID_SOCK(s) ((s) >= 0)  /* FD_SETSIZE is irrelevant for poll */
 #else
 #define VALID_SOCK(s) (((s) >= 0) && ((s) < FD_SETSIZE))
 #endif


### PR DESCRIPTION
FD_SETSIZE is irrelevant when using poll. So ensuring that the file
descriptor is smaller than FD_SETSIZE in VALID_SOCK, can cause
multi_wait to ignore perfectly valid file descriptors and simply wait
for 1s to avoid hammering the CPU in a busy loop.