### PR TITLE
netrc: skip 'macdef' definitions

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -69,7 +69,7 @@ test409 test410 \
 \
 test430 test431 test432 test433 test434 \
 \
-test490 test491 test492 test493 \
+test490 test491 test492 test493 test494 \
 \
 test500 test501 test502 test503 test504 test505 test506 test507 test508 \
 test509 test510 test511 test512 test513 test514 test515 test516 test517 \

--- a/tests/data/test494
+++ b/tests/data/test494
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+FTP
+EPSV
+netrc
+macdef
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+blipp
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+skip 'macdef' when parsing netrc
+ </name>
+ <command>
+--netrc --netrc-file log/netrc%TESTNUMBER ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
+</command>
+<file name="log/netrc%TESTNUMBER" >
+
+macdef testmacro
+	bin
+	cd default
+	cd login
+	put login.bin
+	cd ..
+	cd password
+	put password.bin
+	quit
+
+machine %HOSTIP login user1 password passwd1
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER user1
+PASS passwd1
+PWD
+EPSV
+TYPE I
+SIZE %TESTNUMBER
+RETR %TESTNUMBER
+QUIT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Add test 494 to verify

Reported-by: Harry Sintonen
Fixes #7238