### PR TITLE
Remove native_roots fallback in rustls.

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -332,15 +332,6 @@ cr_init_backend(struct Curl_easy *data, struct connectdata *conn,
       return CURLE_SSL_CACERT_BADFILE;
     }
   }
-  else {
-    result = rustls_client_config_builder_load_native_roots(config_builder);
-    if(result != RUSTLS_RESULT_OK) {
-      failf(data, "failed to load trusted certificates");
-      rustls_client_config_free(
-        rustls_client_config_builder_build(config_builder));
-      return CURLE_SSL_CACERT_BADFILE;
-    }
-  }
 
   backend->config = rustls_client_config_builder_build(config_builder);
   DEBUGASSERT(rconn == NULL);

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -63,9 +63,6 @@ if test "x$OPT_RUSTLS" != xno; then
       rustlslib=$OPT_RUSTLS/lib$libsuff
 
       LDFLAGS="$LDFLAGS $addld"
-      if (test -d "/System/Library/Frameworks/Security.framework" && test "x$cross_compiling" != "xyes"); then
-        LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
-      fi
       if test "$addcflags" != "-I/usr/include"; then
          CPPFLAGS="$CPPFLAGS $addcflags"
       fi


### PR DESCRIPTION
For the commandline tool, we expect to be passed SSL_CONN_CONFIG(CAfile);
for library use, the use should pass a set of trusted roots (like in
other TLS backends).

This also removes a dependency on Security.framework when building on
macOS.