### PR TITLE
Make execpath() work correctly in Unicode build.

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -45,6 +45,14 @@ static const char *unslashquote(const char *line, char *param);
 static bool my_get_line(FILE *fp, struct curlx_dynbuf *, bool *error);
 
 #ifdef WIN32
+static TCHAR *append(TCHAR *dst, const TCHAR *src, size_t size)
+{
+  size_t len_dst = _tcslen(dst), len_src = _tcslen(src);
+  if (len_dst + len_src < size)
+    return _tcsncpy(dst + len_dst, src, size - len_dst);
+  return NULL;
+}
+
 static FILE *execpath(const TCHAR *filename)
 {
   TCHAR filebuffer[512];
@@ -54,14 +62,11 @@ static FILE *execpath(const TCHAR *filename)
   DWORD len = GetModuleFileName(NULL, filebuffer, ARRAYSIZE(filebuffer));
   if((len > 0) && (len < ARRAYSIZE(filebuffer))) {
     TCHAR *lastdirchar = _tcsrchr(filebuffer, TEXT(DIR_CHAR)[0]);
-    if(lastdirchar) {
+    if(lastdirchar)
       *lastdirchar = TEXT('\0');
-    }
-    if(lstrlen(filebuffer) + lstrlen(filename) + 1 < ARRAYSIZE(filebuffer)) {
-      lstrcat(filebuffer, TEXT(DIR_CHAR));
-      lstrcat(filebuffer, filename);
+    if(append(filebuffer, TEXT(DIR_CHAR), ARRAYSIZE(filebuffer)) &&
+       append(filebuffer, filename, ARRAYSIZE(filebuffer)))
       return _tfopen(filebuffer, TEXT(FOPEN_READTEXT));
-    }
   }
   return NULL;
 }

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -57,9 +57,9 @@ static FILE *execpath(const TCHAR *filename)
     if(lastdirchar) {
       *lastdirchar = TEXT('\0');
     }
-    if(_tcslen(filebuffer) + _tcslen(filename) + 1 < ARRAYSIZE(filebuffer)) {
-      _tcscat(filebuffer, TEXT(DIR_CHAR));
-      _tcscat(filebuffer, filename);
+    if(lstrlen(filebuffer) + lstrlen(filename) + 1 < ARRAYSIZE(filebuffer)) {
+      lstrcat(filebuffer, TEXT(DIR_CHAR));
+      lstrcat(filebuffer, filename);
       return _tfopen(filebuffer, TEXT(FOPEN_READTEXT));
     }
   }

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -52,7 +52,7 @@ static FILE *execpath(const TCHAR *filename)
    * via inclusions done in setup header file.
    */
   DWORD len = GetModuleFileName(NULL, filebuffer, ARRAYSIZE(filebuffer));
-  if ((len > 0) && (len < ARRAYSIZE(filebuffer))) {
+  if((len > 0) && (len < ARRAYSIZE(filebuffer))) {
     TCHAR *lastdirchar = _tcsrchr(filebuffer, TEXT(DIR_CHAR)[0]);
     if(lastdirchar) {
       *lastdirchar = TEXT('\0');

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -45,20 +45,19 @@ static const char *unslashquote(const char *line, char *param);
 static bool my_get_line(FILE *fp, struct curlx_dynbuf *, bool *error);
 
 #ifdef WIN32
-#define MAX_MODULE_FILE_LENGTH 512
 static FILE *execpath(const TCHAR *filename)
 {
-  TCHAR filebuffer[MAX_MODULE_FILE_LENGTH];
+  TCHAR filebuffer[512];
   /* Get the filename of our executable. GetModuleFileName is already declared
    * via inclusions done in setup header file.
    */
-  unsigned long len = GetModuleFileName(0, filebuffer, MAX_MODULE_FILE_LENGTH);
-  if ((len > 0) && (len < MAX_MODULE_FILE_LENGTH)) {
-    TCHAR *lastdirchar = _tcsrchr(filebuffer, TEXT(DIR_CHAR));
+  DWORD len = GetModuleFileName(NULL, filebuffer, ARRAYSIZE(filebuffer));
+  if ((len > 0) && (len < ARRAYSIZE(filebuffer))) {
+    TCHAR *lastdirchar = _tcsrchr(filebuffer, TEXT(DIR_CHAR)[0]);
     if(lastdirchar) {
       *lastdirchar = TEXT('\0');
     }
-    if (_tcslen(filebuffer) + _tcslen(filename) + 1U < MAX_MODULE_FILE_LENGTH) {
+    if(_tcslen(filebuffer) + _tcslen(filename) + 1 < ARRAYSIZE(filebuffer)) {
       _tcscat(filebuffer, TEXT(DIR_CHAR));
       _tcscat(filebuffer, filename);
       return _tfopen(filebuffer, TEXT(FOPEN_READTEXT));


### PR DESCRIPTION
Note:  `GetModuleFileNameA()` won't work if the path of 'curl.exe' contains any characters that cannot be represented in system's ANSI codepage. So, instead of `GetModuleFileNameA()`, we should use  `GetModuleFileName()`, which will expand to  `GetModuleFileNameW()` in Unicode builds. Also adapted code to use `TCHAR` and appropriate generic-text routine mappings.