### PR TITLE
Make curl_getenv() work correctly in Unicode build.

### DIFF
--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -27,7 +27,7 @@
 
 #include "memdebug.h"
 
-#ifdef(WIN32)
+#ifdef WIN32
 static TCHAR GetEnvWin32(const TCHAR *variable)
 {
   /* This uses Windows API instead of C runtime getenv() to get the environment

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -27,22 +27,19 @@
 
 #include "memdebug.h"
 
-static char *GetEnv(const char *variable)
+#ifdef(WIN32)
+static TCHAR GetEnvWin32(const TCHAR *variable)
 {
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
-  (void)variable;
-  return NULL;
-#elif defined(WIN32)
   /* This uses Windows API instead of C runtime getenv() to get the environment
      variable since some changes aren't always visible to the latter. #4774 */
-  char *buf = NULL;
-  char *tmp;
+  TCHAR *buf = NULL;
+  TCHAR *tmp;
   DWORD bufsize;
   DWORD rc = 1;
   const DWORD max = 32768; /* max env var size from MSCRT source */
 
   for(;;) {
-    tmp = realloc(buf, rc);
+    tmp = (TCHAR*)realloc(buf, rc * sizeof(TCHAR));
     if(!tmp) {
       free(buf);
       return NULL;
@@ -53,18 +50,42 @@ static char *GetEnv(const char *variable)
 
     /* It's possible for rc to be 0 if the variable was found but empty.
        Since getenv doesn't make that distinction we ignore it as well. */
-    rc = GetEnvironmentVariableA(variable, buf, bufsize);
+    rc = GetEnvironmentVariable(variable, buf, bufsize);
     if(!rc || rc == bufsize || rc > max) {
       free(buf);
       return NULL;
     }
 
     /* if rc < bufsize then rc is bytes written not including null */
-    if(rc < bufsize)
+    if(rc < bufsize) {
       return buf;
-
+    }
     /* else rc is bytes needed, try again */
   }
+}
+#endif
+
+static char *GetEnv(const char *variable)
+{
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+  (void)variable;
+  return NULL;
+#elif defined(WIN32)
+#ifdef UNICODE
+  char *value = NULL;
+  wchar_t *variable_w = curlx_convert_UTF8_to_wchar(variable);
+  if(variable_w) {
+    wchar_t *value_w = GetEnvWin32(variable_w);
+    if(value_w) {
+      value = curlx_convert_wchar_to_UTF8(value_w);
+      free(value_w);
+    }
+    free(variable_w);
+  }
+  return value;
+#else
+  return GetEnvWin32(variable);
+#endif
 #else
   char *env = getenv(variable);
   return (env && env[0])?strdup(env):NULL;

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -28,7 +28,7 @@
 #include "memdebug.h"
 
 #ifdef WIN32
-static TCHAR GetEnvWin32(const TCHAR *variable)
+static TCHAR *GetEnvWin32(const TCHAR *variable)
 {
   /* This uses Windows API instead of C runtime getenv() to get the environment
      variable since some changes aren't always visible to the latter. #4774 */


### PR DESCRIPTION
Until now, `curl_getenv()` internally uses `GetEnvironmentVariableA()` on Windows, even in Unicode build. This does **not** work correctly, if the environment variable contains characters that cannot be represented in the system's ANSI codepage. A typical exampel would be the `HOME` environment variable. It contains a string like `C:\Users\Βαρουφάκης`, depending on user name.