### PR TITLE
winbuild/README: VC should be set to 6 'or larger'

### DIFF
--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -73,7 +73,7 @@ Open a Visual Studio Command prompt:
 
 where `<options>` is one or many of:
 
- - `VC=<6,7,8,9,10,11,12,14,15>` - VC version
+ - `VC=<num>`                    - VC version. 6 or later.
  - `WITH_DEVEL=<path>`           - Paths for the development files (SSL, zlib, etc.)
                                    Defaults to sibbling directory deps: ../deps
                                    Libraries can be fetched at https://windows.php.net/downloads/php-sdk/deps/


### PR DESCRIPTION
Previously it listed all versions up to 15 (missing 16) but this new
phrasing is more open ended.

Fixes #7253
Reported-by: Hugh Macdonald