### PR TITLE
url: Use UTF-8 conversion for Windows Unicode libidn builds

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1585,7 +1585,13 @@ CURLcode Curl_idnconvert_hostname(struct Curl_easy *data,
 #else
       int flags = IDN2_NFC_INPUT;
 #endif
-      int rc = idn2_lookup_ul((const char *)host->name, &ace_hostname, flags);
+      int rc;
+#if defined(WIN32) && defined(UNICODE)
+      rc = idn2_lookup_u8((uint8_t *)host->name,
+                          (uint8_t **)&ace_hostname, flags);
+      if(rc != IDN2_OK)
+#endif
+        rc = idn2_lookup_ul((const char *)host->name, &ace_hostname, flags);
       if(rc != IDN2_OK)
         /* fallback to TR46 Transitional mode for better IDNA2003
            compatibility */


### PR DESCRIPTION
- For Windows Unicode builds of libcurl that use libidn, attempt to
  convert the hostname from UTF-8 and if that fails use local encoding
  as a fallback.

Prior to this change Windows Unicode builds that use libidn attempted to
convert the hostname from the local encoding only. The curl tool passes
the command-line URL (and therefore the hostname) in Unicode's UTF-8
encoding, so the conversion would fail. Since other applications may
pass locally encoded URLs to libcurl we'll keep local encoding as a
fallback.

Reported-by: dEajL3kA@users.noreply.github.com
Assisted-by: Viktor Szakats

Fixes https://github.com/curl/curl/issues/7228
Closes https://github.com/curl/curl/pull/7246
Closes #xxxx