### PR TITLE
http2: Clarify 'Using HTTP2' verbose message

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2234,7 +2234,7 @@ CURLcode Curl_http2_setup(struct Curl_easy *data,
     return result;
   }
 
-  infof(data, "Using HTTP2, server supports multi-use\n");
+  infof(data, "Using HTTP2, server supports multiplexing\n");
   stream->upload_left = 0;
   stream->upload_mem = NULL;
   stream->upload_len = 0;


### PR DESCRIPTION
- Change phrasing from multi-use to multiplexing since the former may
  not be as well understood.

Before: * Using HTTP2, server supports multi-use

After: * Using HTTP2, server supports multiplexing

Bug: https://github.com/curl/curl/discussions/7255
Reported-by: David Hu

Closes #xxxx

---

/cc @D4v1dH03
