### PR TITLE
docs: Remove outdated curl tool limitation

### DIFF
--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -105,9 +105,8 @@ Since 7.47.0, the curl tool enables HTTP/2 by default for HTTPS connections.
 curl tool limitations
 ---------------------
 
-The command line tool also doesn't support HTTP/2 server push for the same
-reason it doesn't do multiplexing: it needs to use the multi interface for
-that so that multiplexing is supported.
+The command line tool doesn't support HTTP/2 server push. It supports
+multiplexing when the parallel transfer option is used.
 
 HTTP Alternative Services
 -------------------------


### PR DESCRIPTION
- Document that HTTP/2 multiplexing is supported by the curl tool when
  parallel transfers are used.

Supported since 7.66.0 via --parallel, but the doc wasn't updated.

Closes #xxxx