### PR TITLE
Free returned memory of SCDynamicStoreCopyProxies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,28 +372,29 @@ if(CMAKE_USE_DARWINSSL)
   message(FATAL_ERROR "The cmake option CMAKE_USE_DARWINSSL was renamed to CMAKE_USE_SECTRANSP.")
 endif()
 
-if(CMAKE_USE_SECTRANSP)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   find_library(COREFOUNDATION_FRAMEWORK "CoreFoundation")
   if(NOT COREFOUNDATION_FRAMEWORK)
       message(FATAL_ERROR "CoreFoundation framework not found")
   endif()
 
-  find_library(SECURITY_FRAMEWORK "Security")
-  if(NOT SECURITY_FRAMEWORK)
-     message(FATAL_ERROR "Security framework not found")
-  endif()
-
-  set(SSL_ENABLED ON)
-  set(USE_SECTRANSP ON)
-  list(APPEND CURL_LIBS "-framework CoreFoundation" "-framework Security")
-endif()
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   find_library(SYSTEMCONFIGURATION_FRAMEWORK "SystemConfiguration")
   if(NOT SYSTEMCONFIGURATION_FRAMEWORK)
      message(FATAL_ERROR "SystemConfiguration framework not found")
   endif()
-  list(APPEND CURL_LIBS "-framework SystemConfiguration")
+
+  list(APPEND CURL_LIBS "-framework CoreFoundation" "-framework SystemConfiguration")
+
+  if(CMAKE_USE_SECTRANSP)
+    find_library(SECURITY_FRAMEWORK "Security")
+    if(NOT SECURITY_FRAMEWORK)
+       message(FATAL_ERROR "Security framework not found")
+    endif()
+
+    set(SSL_ENABLED ON)
+    set(USE_SECTRANSP ON)
+    list(APPEND CURL_LIBS "-framework Security")
+  endif()
 endif()
 
 if(CMAKE_USE_OPENSSL)

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -636,9 +636,8 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
      * IPv4-only builds, hence the conditions above.
      */
     CFDictionaryRef dict = SCDynamicStoreCopyProxies(NULL);
-    if (dict) {
+    if(dict)
         CFRelease(dict);
-    }
 #endif
 
 #ifndef USE_RESOLVE_ON_IPS

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -635,7 +635,10 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
      * This function is only available on a macOS and is not needed for
      * IPv4-only builds, hence the conditions above.
      */
-    SCDynamicStoreCopyProxies(NULL);
+    CFDictionaryRef dict = SCDynamicStoreCopyProxies(NULL);
+    if (dict) {
+        CFRelease(dict);
+    }
 #endif
 
 #ifndef USE_RESOLVE_ON_IPS

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -21,7 +21,7 @@
 #***************************************************************************
 
 AC_DEFUN([CURL_DARWIN_SYSTEMCONFIGURATION], [
-AC_MSG_CHECKING([whether to link macOS SystemConfiguration framework])
+AC_MSG_CHECKING([whether to link macOS CoreFoundation and SystemConfiguration framework])
 case $host_os in
   darwin*)
     AC_COMPILE_IFELSE([
@@ -41,7 +41,7 @@ case $host_os in
     ])
     if test "x$build_for_macos" != xno; then
       AC_MSG_RESULT(yes)
-      LDFLAGS="$LDFLAGS -framework SystemConfiguration"
+      LDFLAGS="$LDFLAGS -framework CoreFoundation -framework SystemConfiguration"
     else
       AC_MSG_RESULT(no)
     fi


### PR DESCRIPTION
From Apples documentation on SCDynamicStoreCopyProxies, 
"Return Value: A dictionary of key-value pairs that represent the current internet proxy settings, or NULL if no proxy settings have been defined or if an error occurred. You must release the returned value."

The use of SCDynamicStoreCopyProxies without releasing the returned memory has resulted in a memory leak in curl 7.77.0. 

Source: https://developer.apple.com/documentation/systemconfiguration/1517088-scdynamicstorecopyproxies