### PR TITLE
tool_homedir: Fix GetEnv for Windows Unicode builds

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -36,6 +36,7 @@
 #include "warnless.h"
 #include "rand.h"
 #include "rename.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -420,10 +421,11 @@ static void altsvc_flush(struct altsvcinfo *asi, enum alpnid srcalpnid,
    return */
 static time_t debugtime(void *unused)
 {
-  char *timestr = getenv("CURL_TIME");
+  char *timestr = Curl_getenv("CURL_TIME");
   (void)unused;
   if(timestr) {
     unsigned long val = strtol(timestr, NULL, 10);
+    Curl_safefree(timestr);
     return (time_t)val;
   }
   return time(NULL);

--- a/lib/checksrc.pl
+++ b/lib/checksrc.pl
@@ -358,7 +358,7 @@ sub nostrings {
 
 sub scanfile {
     my ($file) = @_;
-
+    my $istoolsrc = ($file =~ /(^|[\\\/])(src[\\\/]|tool_)[^\\\/]+$/) ? 1 : 0;
     my $line = 1;
     my $prevl="";
     my $l;
@@ -631,7 +631,8 @@ sub scanfile {
                     strtok|
                     v?sprintf|
                     (str|_mbs|_tcs|_wcs)n?cat|
-                    LoadLibrary(Ex)?(A|W)?)
+                    LoadLibrary(Ex)?(A|W)?|
+                    (?<!\$)(curlx?_)?getenv) # banned in favor of Curl_getenv
                    \s*\(
                  /x) {
             checkwarn("BANNEDFUNC",

--- a/lib/curl_gethostname.c
+++ b/lib/curl_gethostname.c
@@ -23,6 +23,7 @@
 #include "curl_setup.h"
 
 #include "curl_gethostname.h"
+#include "getenv.h"
 
 /*
  * Curl_gethostname() is a wrapper around gethostname() which allows
@@ -64,10 +65,11 @@ int Curl_gethostname(char * const name, GETHOSTNAME_TYPE_ARG2 namelen)
 #ifdef DEBUGBUILD
 
   /* Override host name when environment variable CURL_GETHOSTNAME is set */
-  const char *force_hostname = getenv("CURL_GETHOSTNAME");
+  char *force_hostname = Curl_getenv("CURL_GETHOSTNAME");
   if(force_hostname) {
     strncpy(name, force_hostname, namelen);
     err = 0;
+    free(force_hostname);
   }
   else {
     name[0] = '\0';

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -82,6 +82,88 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
   return str_utf8;
 }
 
+wchar_t *curlx_convert_ANSI_to_wchar(const char *str_ansi)
+{
+  wchar_t *str_w = NULL;
+
+  if(str_ansi) {
+    int str_w_len = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS,
+                                        str_ansi, -1, NULL, 0);
+    if(str_w_len > 0) {
+      str_w = malloc(str_w_len * sizeof(wchar_t));
+      if(str_w) {
+        if(MultiByteToWideChar(CP_ACP, 0, str_ansi, -1, str_w,
+                               str_w_len) == 0) {
+          free(str_w);
+          return NULL;
+        }
+      }
+    }
+  }
+
+  return str_w;
+}
+
+char *curlx_convert_wchar_to_ANSI(const wchar_t *str_w)
+{
+  char *str_ansi = NULL;
+
+  if(str_w) {
+    int bytes = WideCharToMultiByte(CP_ACP, MB_ERR_INVALID_CHARS, str_w, -1,
+                                    NULL, 0, NULL, NULL);
+    if(bytes > 0) {
+      str_ansi = malloc(bytes);
+      if(str_ansi) {
+        if(WideCharToMultiByte(CP_ACP, 0, str_w, -1, str_ansi, bytes,
+                               NULL, NULL) == 0) {
+          free(str_ansi);
+          return NULL;
+        }
+      }
+    }
+  }
+
+  return str_ansi;
+}
+
+char *curlx_convert_UTF8_to_ANSI(const char *str_utf8)
+{
+  char *str_ansi = NULL;
+  wchar_t *str_w = curlx_convert_UTF8_to_wchar(str_utf8);
+
+  if(str_w) {
+    str_ansi = curlx_convert_wchar_to_ANSI(str_w);
+    free(str_w);
+  }
+
+  return str_ansi;
+}
+
+char *curlx_convert_ANSI_to_UTF8(const char *str_ansi)
+{
+  char *str_utf8 = NULL;
+  wchar_t *str_w = curlx_convert_ANSI_to_wchar(str_ansi);
+
+  if(str_w) {
+    str_utf8 = curlx_convert_wchar_to_UTF8(str_w);
+    free(str_w);
+  }
+
+  return str_utf8;
+}
+
+bool curlx_is_str_utf8(const char *str)
+{
+  if(MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                         str, strlen(str), NULL, 0) > 0) {
+    return true;
+  }
+  else {
+    DEBUGASSERT(GetLastError() == ERROR_NO_UNICODE_TRANSLATION);
+    return false;
+  }
+}
+
 #endif /* WIN32 */
 
 #if defined(USE_WIN32_LARGE_FILES) || defined(USE_WIN32_SMALL_FILES)

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -31,6 +31,15 @@
 
 wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8);
 char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
+
+wchar_t *curlx_convert_ANSI_to_wchar(const char *str_ansi);
+char *curlx_convert_wchar_to_ANSI(const wchar_t *str_w);
+
+char *curlx_convert_UTF8_to_ANSI(const char *str_utf8);
+char *curlx_convert_ANSI_to_UTF8(const char *str_ansi);
+
+bool curlx_is_str_utf8(const char *str);
+
 #endif /* WIN32 */
 
 /*
@@ -54,8 +63,15 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
 
 #if defined(UNICODE) && defined(WIN32)
 
+#ifndef _UNICODE
+#error "UNICODE is defined but _UNICODE is not"
+#endif
+
 #define curlx_convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
 #define curlx_convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
+
+#define curlx_convert_ANSI_to_tchar(ptr) curlx_convert_ANSI_to_wchar(ptr)
+#define curlx_convert_tchar_to_ANSI(ptr) curlx_convert_wchar_to_ANSI(ptr)
 
 typedef union {
   unsigned short       *tchar_ptr;
@@ -68,6 +84,9 @@ typedef union {
 
 #define curlx_convert_UTF8_to_tchar(ptr) (strdup)(ptr)
 #define curlx_convert_tchar_to_UTF8(ptr) (strdup)(ptr)
+
+#define curlx_convert_ANSI_to_tchar(ptr) (strdup)(ptr)
+#define curlx_convert_tchar_to_ANSI(ptr) (strdup)(ptr)
 
 typedef union {
   char                *tchar_ptr;

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -111,6 +111,7 @@
 #include "curl_endian.h"
 #include "curl_des.h"
 #include "curl_md4.h"
+#include "getenv.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -639,8 +640,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
 
   /* Calculate the timestamp */
 #ifdef DEBUGBUILD
-  char *force_timestamp = getenv("CURL_FORCETIME");
-  if(force_timestamp)
+  if(Curl_env_exist("CURL_FORCETIME"))
     time2filetime(&tw, (time_t) 0);
   else
 #endif

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -80,6 +80,7 @@
 #include "dynbuf.h"
 #include "altsvc.h"
 #include "hsts.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -195,7 +196,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
   init_flags = flags;
 
 #ifdef DEBUGBUILD
-  if(getenv("CURL_GLOBAL_INIT"))
+  if(Curl_env_exist("CURL_GLOBAL_INIT"))
     /* alloc data that will leak if *cleanup() is not called! */
     leakpointer = malloc(1);
 #endif

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -23,28 +23,58 @@
 #include "curl_setup.h"
 
 #include <curl/curl.h>
-#include "curl_memory.h"
 
+#include "getenv.h"
+#include "curlx.h"
+
+#ifdef BUILDING_LIBCURL
+#include "curl_memory.h"
+#endif
 #include "memdebug.h"
 
-static char *GetEnv(const char *variable)
+#ifdef WIN32
+/*
+This function returns the environment variable value in the current locale or
+Unicode UTF-8.
+
+If 'utf8' is true then 'variable' and the returned value are Unicode UTF-8
+instead of the current locale. That should only be true for Windows Unicode
+builds, since Windows does not allow setting the current locale to UTF-8.
+
+Windows API GetEnvironmentVariableW is used instead of C runtime getenv()
+since some changes aren't always visible to the latter (#4774) and also
+because getenv cannot retrieve Unicode.
+
+The API function is called in a loop because the environment can be
+modified by a different thread and have a different size between calls.
+*/
+static char *win32_getenv(const char *variable, bool utf8)
 {
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
-  (void)variable;
-  return NULL;
-#elif defined(WIN32)
-  /* This uses Windows API instead of C runtime getenv() to get the environment
-     variable since some changes aren't always visible to the latter. #4774 */
-  char *buf = NULL;
-  char *tmp;
-  DWORD bufsize;
-  DWORD rc = 1;
-  const DWORD max = 32768; /* max env var size from MSCRT source */
+  WCHAR *tmp;
+  WCHAR *w_var = NULL;
+  WCHAR *buf = NULL;
+  DWORD bufsize; /* size of buf in chars */
+  DWORD rc = 256; /* number of chars to resize buf, 256 to start */
+  const DWORD maxsize = 32768; /* max env var chars from MSCRT source */
+
+#ifndef _UNICODE
+  /* utf-8 in non-unicode builds is unexpected, assume it's a mistake */
+  DEBUGASSERT(!utf8);
+#endif
+
+  if(utf8)
+    w_var = curlx_convert_UTF8_to_wchar(variable);
+  else
+    w_var = curlx_convert_ANSI_to_wchar(variable);
+
+  if(!w_var)
+    return NULL;
 
   for(;;) {
-    tmp = realloc(buf, rc);
+    tmp = realloc(buf, rc * sizeof(WCHAR));
     if(!tmp) {
       free(buf);
+      curlx_unicodefree(w_var);
       return NULL;
     }
 
@@ -53,25 +83,76 @@ static char *GetEnv(const char *variable)
 
     /* It's possible for rc to be 0 if the variable was found but empty.
        Since getenv doesn't make that distinction we ignore it as well. */
-    rc = GetEnvironmentVariableA(variable, buf, bufsize);
-    if(!rc || rc == bufsize || rc > max) {
+    rc = GetEnvironmentVariableW(w_var, buf, bufsize);
+    if(!rc || rc == bufsize || rc > maxsize) {
       free(buf);
+      curlx_unicodefree(w_var);
       return NULL;
     }
 
-    /* if rc < bufsize then rc is bytes written not including null */
-    if(rc < bufsize)
-      return buf;
+    /* if rc < bufsize then rc is chars written not including null */
+    if(rc < bufsize) {
+      char *convbuf;
+      char *dupe = NULL;
 
-    /* else rc is bytes needed, try again */
+      if(utf8)
+        convbuf = curlx_convert_wchar_to_UTF8(buf);
+      else
+        convbuf = curlx_convert_wchar_to_ANSI(buf);
+
+      if(convbuf)
+        dupe = strdup(convbuf);
+
+      free(buf);
+      curlx_unicodefree(w_var);
+      curlx_unicodefree(convbuf);
+
+      return dupe;
+    }
+
+    /* else rc is chars needed, try again */
   }
+}
+
+#ifdef _UNICODE
+char *Curl_getenv_utf8(const char *variable)
+{
+  return win32_getenv(variable, true);
+}
+bool Curl_env_exist_utf8(const char *variable)
+{
+  char *p = Curl_getenv_utf8(variable);
+  free(p);
+  return p ? true : false;
+}
+#endif /* _UNICODE */
+#endif /* WIN32 */
+
+char *Curl_getenv_local(const char *variable)
+{
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+  (void)variable;
+  return NULL;
+#elif defined(WIN32)
+  return win32_getenv(variable, false);
 #else
+  /* !checksrc! disable BANNEDFUNC 1 */
   char *env = getenv(variable);
   return (env && env[0])?strdup(env):NULL;
 #endif
 }
 
+bool Curl_env_exist_local(const char *variable)
+{
+  char *p = Curl_getenv_local(variable);
+  free(p);
+  return p ? true : false;
+}
+
+#ifdef BUILDING_LIBCURL
+/* !checksrc! disable BANNEDFUNC 1 */
 char *curl_getenv(const char *v)
 {
-  return GetEnv(v);
+  return Curl_getenv_local(v);
 }
+#endif

--- a/lib/getenv.h
+++ b/lib/getenv.h
@@ -1,0 +1,76 @@
+#ifndef HEADER_CURLX_GETENV_H
+#define HEADER_CURLX_GETENV_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+/*
+curlx getenv replacements for libcurl and curl tool.
+
+These functions are needed to better support Windows builds.
+
+Windows does not use or support UTF-8 as the current locale (or, not really).
+The Windows Unicode builds of curl/libcurl use the current locale, but expect
+Unicode UTF-8 encoded paths for internal use such as open, access and stat.
+
+Dependencies in Windows, which may or may not be Unicode builds, may or may not
+expect UTF-8 encoded Unicode for char * string pathnames. For example, libcurl
+can use libssh or libssh2 as an SSH library and pathnames always need to be
+passed in the local encoding AFAICS.
+
+Basically, for Windows Unicode builds we need access to environment variables
+in both UTF-8 and current locale encoding. In order to make this obvious in the
+code I've banned getenv, curlx_getenv and curl_getenv (via checksrc) in favor
+of Curl_getenv_local, Curl_getenv_utf8 and Curl_getenv. For Windows Unicode
+builds Curl_getenv maps to Curl_getenv_utf8, and Curl_getenv_local otherwise.
+
+Continuing the SSH example, something like CURLOPT_SSH_KNOWNHOSTS which is
+passed to the SSH library and always needs the local encoding (in other words,
+even if it's a Windows Unicode build) can now be retrieved in the tool by
+calling homedir_local (-> Curl_getenv_local). And in contrast, a home path
+for internal use like .curlrc would be retrieved by calling homedir,
+which maps to homedir_utf8 (-> Curl_getenv_utf8) for Windows Unicode and
+homedir_local (-> Curl_getenv_local) otherwise.
+*/
+
+/* environment variable and the returned value in current locale encoding */
+char *Curl_getenv_local(const char *variable);
+
+/* returns true if variable exists */
+bool Curl_env_exist_local(const char *variable);
+
+#if defined(WIN32) && defined(_UNICODE)
+/* environment variable and the returned value in Unicode UTF-8 encoding */
+char *Curl_getenv_utf8(const char *variable);
+/* Windows Unicode builds of curl/libcurl always expect UTF-8 strings for
+   internal file paths, regardless of current locale. For paths (or other
+   values) passed to a dependency that will always expect local encoding, call
+   Curl_getenv_local directly instead.*/
+#define Curl_getenv(variable) Curl_getenv_utf8(variable)
+/* returns true if variable exists */
+bool Curl_env_exist_utf8(const char *variable);
+#define Curl_env_exist(variable) Curl_env_exist_utf8(variable)
+#else
+#define Curl_getenv(variable) Curl_getenv_local(variable)
+#define Curl_env_exist(variable) Curl_env_exist_local(variable)
+#endif
+
+#endif /* HEADER_CURLX_GETENV_H */

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -30,6 +30,7 @@
 #include "vtls/vtls.h"
 #include "connect.h" /* Curl_getconnectinfo() */
 #include "progress.h"
+#include "getenv.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -183,9 +184,10 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
   } lptr;
 
 #ifdef DEBUGBUILD
-  char *timestr = getenv("CURL_TIME");
+  char *timestr = Curl_getenv("CURL_TIME");
   if(timestr) {
     unsigned long val = strtol(timestr, NULL, 10);
+    Curl_safefree(timestr);
     switch(info) {
     case CURLINFO_LOCAL_PORT:
       *param_longp = (long)val;
@@ -195,9 +197,10 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
     }
   }
   /* use another variable for this to allow different values */
-  timestr = getenv("CURL_DEBUG_SIZE");
+  timestr = Curl_getenv("CURL_DEBUG_SIZE");
   if(timestr) {
     unsigned long val = strtol(timestr, NULL, 10);
+    Curl_safefree(timestr);
     switch(info) {
     case CURLINFO_HEADER_SIZE:
     case CURLINFO_REQUEST_SIZE:
@@ -329,9 +332,10 @@ static CURLcode getinfo_offt(struct Curl_easy *data, CURLINFO info,
                              curl_off_t *param_offt)
 {
 #ifdef DEBUGBUILD
-  char *timestr = getenv("CURL_TIME");
+  char *timestr = Curl_getenv("CURL_TIME");
   if(timestr) {
     unsigned long val = strtol(timestr, NULL, 10);
+    Curl_safefree(timestr);
     switch(info) {
     case CURLINFO_TOTAL_TIME_T:
     case CURLINFO_NAMELOOKUP_TIME_T:
@@ -408,9 +412,10 @@ static CURLcode getinfo_double(struct Curl_easy *data, CURLINFO info,
                                double *param_doublep)
 {
 #ifdef DEBUGBUILD
-  char *timestr = getenv("CURL_TIME");
+  char *timestr = Curl_getenv("CURL_TIME");
   if(timestr) {
     unsigned long val = strtol(timestr, NULL, 10);
+    Curl_safefree(timestr);
     switch(info) {
     case CURLINFO_TOTAL_TIME:
     case CURLINFO_NAMELOOKUP_TIME:

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -38,6 +38,7 @@
 #include "rand.h"
 #include "rename.h"
 #include "strtoofft.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -56,12 +57,12 @@
 time_t deltatime; /* allow for "adjustments" for unit test purposes */
 static time_t debugtime(void *unused)
 {
-  char *timestr = getenv("CURL_TIME");
+  char *timestr = Curl_getenv("CURL_TIME");
   (void)unused;
   if(timestr) {
     curl_off_t val;
     (void)curlx_strtoofft(timestr, NULL, 10, &val);
-
+    Curl_safefree(timestr);
     val += (curl_off_t)deltatime;
     return (time_t)val;
   }

--- a/lib/http.c
+++ b/lib/http.c
@@ -84,6 +84,7 @@
 #include "altsvc.h"
 #include "hsts.h"
 #include "c-hyper.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -1304,13 +1305,14 @@ CURLcode Curl_buffer_send(struct dynbuf *in,
     /* Allow debug builds to override this logic to force short initial
        sends
      */
-    char *p = getenv("CURL_SMALLREQSEND");
+    char *p = Curl_getenv("CURL_SMALLREQSEND");
     if(p) {
       size_t altsize = (size_t)strtoul(p, NULL, 10);
       if(altsize)
         sendsize = CURLMIN(size, altsize);
       else
         sendsize = size;
+      free(p);
     }
     else
 #endif
@@ -3667,7 +3669,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
           ((conn->handler->flags & PROTOPT_SSL) ||
 #ifdef CURLDEBUG
            /* allow debug builds to circumvent the HTTPS restriction */
-           getenv("CURL_ALTSVC_HTTP")
+           Curl_env_exist("CURL_ALTSVC_HTTP")
 #else
            0
 #endif

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -32,10 +32,10 @@
 #include "http_aws_sigv4.h"
 #include "curl_sha256.h"
 #include "transfer.h"
-
 #include "strcase.h"
 #include "parsedate.h"
 #include "sendf.h"
+#include "getenv.h"
 
 #include <time.h>
 
@@ -80,9 +80,6 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   char *region = NULL;
   char *service = NULL;
   const char *hostname = conn->host.name;
-#ifdef DEBUGBUILD
-  char *force_timestamp;
-#endif
   time_t clock;
   struct tm tm;
   char timestamp[17];
@@ -231,11 +228,12 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   }
 
 #ifdef DEBUGBUILD
-  force_timestamp = getenv("CURL_FORCETIME");
-  if(force_timestamp)
-    clock = 0;
-  else
-    time(&clock);
+  {
+    if(Curl_env_exist("CURL_FORCETIME"))
+      clock = 0;
+    else
+      time(&clock);
+  }
 #else
   time(&clock);
 #endif

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -66,6 +66,7 @@
 #include "curl_multibyte.h"
 #include "curl_base64.h"
 #include "connect.h"
+#include "getenv.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -744,8 +745,9 @@ static void _ldap_trace(const char *fmt, ...)
   va_list args;
 
   if(do_trace == -1) {
-    const char *env = getenv("CURL_TRACE");
+    char *env = Curl_getenv("CURL_TRACE");
     do_trace = (env && strtol(env, NULL, 10) > 0);
+    free(env);
   }
   if(!do_trace)
     return;

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -31,6 +31,7 @@
 #include "netrc.h"
 #include "strtok.h"
 #include "strcase.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -236,7 +237,7 @@ int Curl_parsenetrc(const char *host,
 
   if(!netrcfile) {
     char *home = NULL;
-    char *homea = curl_getenv("HOME"); /* portable environment reader */
+    char *homea = Curl_getenv("HOME"); /* portable environment reader */
     if(homea) {
       home = homea;
 #if defined(HAVE_GETPWUID_R) && defined(HAVE_GETEUID)

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -46,6 +46,7 @@
 #include "curl_ldap.h"
 #include "curl_base64.h"
 #include "connect.h"
+#include "getenv.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -228,8 +229,9 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
 
 #ifdef CURL_OPENLDAP_DEBUG
   static int do_trace = 0;
-  const char *env = getenv("CURL_OPENLDAP_TRACE");
+  char *env = Curl_getenv("CURL_OPENLDAP_TRACE");
   do_trace = (env && strtol(env, NULL, 10) > 0);
+  free(env);
   if(do_trace) {
     ldap_set_option(li->ld, LDAP_OPT_DEBUG_LEVEL, &do_trace);
   }

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -30,6 +30,7 @@
 #include "vtls/vtls.h"
 #include "sendf.h"
 #include "rand.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -44,7 +45,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
   static bool seeded = FALSE;
 
 #ifdef CURLDEBUG
-  char *force_entropy = getenv("CURL_ENTROPY");
+  char *force_entropy = Curl_getenv("CURL_ENTROPY");
   if(force_entropy) {
     if(!seeded) {
       unsigned int seed = 0;
@@ -58,6 +59,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
     else
       randseed++;
     *rnd = randseed;
+    free(force_entropy);
     return CURLE_OK;
   }
 #endif

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -46,6 +46,7 @@
 #include "select.h"
 #include "strdup.h"
 #include "http2.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -305,11 +306,12 @@ CURLcode Curl_write(struct Curl_easy *data,
   {
     /* Allow debug builds to override this logic to force short sends
     */
-    char *p = getenv("CURL_SMALLSENDS");
+    char *p = Curl_getenv("CURL_SMALLSENDS");
     if(p) {
       size_t altsize = (size_t)strtoul(p, NULL, 10);
       if(altsize)
         len = CURLMIN(len, altsize);
+      free(p);
     }
   }
 #endif

--- a/lib/url.c
+++ b/lib/url.c
@@ -104,6 +104,7 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
 #include "urlapi-int.h"
 #include "system_win32.h"
 #include "hsts.h"
+#include "getenv.h"
 
 /* And now for the protocols */
 #include "ftp.h"
@@ -2316,7 +2317,7 @@ static char *detect_proxy(struct Curl_easy *data,
   strcpy(envp, "_proxy");
 
   /* read the protocol proxy: */
-  prox = curl_getenv(proxy_env);
+  prox = Curl_getenv(proxy_env);
 
   /*
    * We don't try the uppercase version of HTTP_PROXY because of
@@ -2333,7 +2334,7 @@ static char *detect_proxy(struct Curl_easy *data,
   if(!prox && !strcasecompare("http_proxy", proxy_env)) {
     /* There was no lowercase variable, try the uppercase version: */
     Curl_strntoupper(proxy_env, proxy_env, sizeof(proxy_env));
-    prox = curl_getenv(proxy_env);
+    prox = Curl_getenv(proxy_env);
   }
 
   envp = proxy_env;
@@ -2342,10 +2343,10 @@ static char *detect_proxy(struct Curl_easy *data,
   }
   else {
     envp = (char *)"all_proxy";
-    proxy = curl_getenv(envp); /* default proxy to use */
+    proxy = Curl_getenv(envp); /* default proxy to use */
     if(!proxy) {
       envp = (char *)"ALL_PROXY";
-      proxy = curl_getenv(envp);
+      proxy = Curl_getenv(envp);
     }
   }
   if(proxy)
@@ -2586,10 +2587,10 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
 
   if(!data->set.str[STRING_NOPROXY]) {
     const char *p = "no_proxy";
-    no_proxy = curl_getenv(p);
+    no_proxy = Curl_getenv(p);
     if(!no_proxy) {
       p = "NO_PROXY";
-      no_proxy = curl_getenv(p);
+      no_proxy = Curl_getenv(p);
     }
     if(no_proxy) {
       infof(data, "Uses proxy env variable %s == '%s'", p, no_proxy);
@@ -3221,7 +3222,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
      ((conn->handler->protocol == CURLPROTO_HTTPS) ||
 #ifdef CURLDEBUG
       /* allow debug builds to circumvent the HTTPS restriction */
-      getenv("CURL_ALTSVC_HTTP")
+      Curl_env_exist("CURL_ALTSVC_HTTP")
 #else
       0
 #endif

--- a/lib/version.c
+++ b/lib/version.c
@@ -29,6 +29,7 @@
 #include "vssh/ssh.h"
 #include "quic.h"
 #include "curl_printf.h"
+#include "getenv.h"
 
 #ifdef USE_ARES
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
@@ -164,10 +165,11 @@ char *curl_version(void)
 
 #ifdef DEBUGBUILD
   /* Override version string when environment variable CURL_VERSION is set */
-  const char *debugversion = getenv("CURL_VERSION");
+  char *debugversion = Curl_getenv("CURL_VERSION");
   if(debugversion) {
     strncpy(out, debugversion, sizeof(out)-1);
     out[sizeof(out)-1] = '\0';
+    free(debugversion);
     return out;
   }
 #endif

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -31,6 +31,7 @@
 #include "dynbuf.h"
 #include "curl_printf.h"
 #include "vquic.h"
+#include "getenv.h"
 
 #ifdef O_BINARY
 #define QLOGMODE O_WRONLY|O_CREAT|O_BINARY
@@ -51,7 +52,7 @@ CURLcode Curl_qlogdir(struct Curl_easy *data,
                       size_t scidlen,
                       int *qlogfdp)
 {
-  const char *qlog_dir = getenv("QLOGDIR");
+  char *qlog_dir = Curl_getenv("QLOGDIR");
   *qlogfdp = -1;
   if(qlog_dir) {
     struct dynbuf fname;
@@ -76,6 +77,7 @@ CURLcode Curl_qlogdir(struct Curl_easy *data,
         *qlogfdp = qlogfd;
     }
     Curl_dyn_free(&fname);
+    Curl_safefree(qlog_dir);
     if(result)
       return result;
   }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -82,6 +82,7 @@
 #include "select.h"
 #include "warnless.h"
 #include "curl_path.h"
+#include "getenv.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -911,7 +912,8 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
         else {
           /* To ponder about: should really the lib be messing about with the
              HOME environment variable etc? */
-          char *home = curl_getenv("HOME");
+          /* $HOME is passed to libssh2 in current locale encoding */
+          char *home = Curl_getenv_local("HOME");
 
           /* If no private key file is specified, try some common paths. */
           if(home) {

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -22,6 +22,7 @@
 #include "curl_setup.h"
 
 #include "keylog.h"
+#include "getenv.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -48,7 +49,7 @@ Curl_tls_keylog_open(void)
   char *keylog_file_name;
 
   if(!keylog_file_fp) {
-    keylog_file_name = curl_getenv("SSLKEYLOGFILE");
+    keylog_file_name = Curl_getenv("SSLKEYLOGFILE");
     if(keylog_file_name) {
       keylog_file_fp = fopen(keylog_file_name, FOPEN_APPENDTEXT);
       if(keylog_file_fp) {

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -228,7 +228,16 @@ static CURLcode add_certs_file_to_store(HCERTSTORE trust_store,
   size_t ca_file_bufsize = 0;
   DWORD total_bytes_read = 0;
 
-  ca_file_tstr = curlx_convert_UTF8_to_tchar((char *)ca_file);
+  if(curlx_is_str_utf8(ca_file)) {
+#ifdef UNICODE
+    ca_file_tstr = curlx_convert_UTF8_to_wchar(ca_file);
+#else
+    ca_file_tstr = curlx_convert_UTF8_to_ANSI(ca_file);
+#endif
+  }
+  else
+    ca_file_tstr = curlx_convert_ANSI_to_tchar(ca_file);
+
   if(!ca_file_tstr) {
     char buffer[STRERROR_LEN];
     failf(data,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -64,6 +64,7 @@
 #include "curl_base64.h"
 #include "curl_printf.h"
 #include "strdup.h"
+#include "getenv.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -1377,7 +1378,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
   if(!available_backends[0])
     return 1;
 
-  env = env_tmp = curl_getenv("CURL_SSL_BACKEND");
+  env = env_tmp = Curl_getenv("CURL_SSL_BACKEND");
 #ifdef CURL_DEFAULT_SSL_BACKEND
   if(!env)
     env = CURL_DEFAULT_SSL_BACKEND;

--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -288,6 +288,7 @@ rem
       call :element %1 lib "curl_multibyte.c" %3
       call :element %1 lib "version_win32.c" %3
       call :element %1 lib "dynbuf.c" %3
+      call :element %1 lib "getenv.c" %3
     ) else if "!var!" == "CURL_SRC_X_H_FILES" (
       call :element %1 lib "config-win32.h" %3
       call :element %1 lib "curl_setup.h" %3
@@ -298,6 +299,7 @@ rem
       call :element %1 lib "curl_multibyte.h" %3
       call :element %1 lib "version_win32.h" %3
       call :element %1 lib "dynbuf.h" %3
+      call :element %1 lib "getenv.h" %3
     ) else if "!var!" == "CURL_LIB_C_FILES" (
       for /f "delims=" %%c in ('dir /b ..\lib\*.c') do call :element %1 lib "%%c" %3
     ) else if "!var!" == "CURL_LIB_H_FILES" (

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -37,7 +37,8 @@ CURLX_CFILES = \
   ../lib/curl_ctype.c \
   ../lib/curl_multibyte.c \
   ../lib/version_win32.c \
-  ../lib/dynbuf.c
+  ../lib/dynbuf.c \
+  ../lib/getenv.c
 
 CURLX_HFILES = \
   ../lib/curl_setup.h \
@@ -47,7 +48,8 @@ CURLX_HFILES = \
   ../lib/curl_ctype.h \
   ../lib/curl_multibyte.h \
   ../lib/version_win32.h \
-  ../lib/dynbuf.h
+  ../lib/dynbuf.h \
+  ../lib/getenv.h
 
 CURL_CFILES = \
   slist_wc.c \

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -33,6 +33,7 @@
 #include "tool_cb_hdr.h"
 #include "tool_cb_wrt.h"
 #include "tool_operate.h"
+#include "getenv.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -295,7 +296,7 @@ static char *parse_filename(const char *ptr, size_t len)
    */
 #ifdef DEBUGBUILD
   {
-    char *tdir = curlx_getenv("CURL_TESTDIR");
+    char *tdir = Curl_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
       msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, copy);
@@ -304,7 +305,7 @@ static char *parse_filename(const char *ptr, size_t len)
                                 aprintf() or similar since we want to use the
                                 same memory code as the "real" parse_filename
                                 function */
-      curl_free(tdir);
+      free(tdir);
     }
   }
 #endif

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -33,6 +33,7 @@
 #include "tool_cb_prg.h"
 #include "tool_util.h"
 #include "tool_operate.h"
+#include "getenv.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -221,14 +222,14 @@ void progressbarinit(struct ProgressData *bar,
   if(config->use_resume)
     bar->initial_size = config->resume_from;
 
-  colp = curlx_getenv("COLUMNS");
+  colp = Curl_getenv("COLUMNS");
   if(colp) {
     char *endptr;
     long num = strtol(colp, &endptr, 10);
     if((endptr != colp) && (endptr == colp + strlen(colp)) && (num > 20) &&
        (num < 10000))
       bar->width = (int)num;
-    curl_free(colp);
+    free(colp);
   }
 
   if(!bar->width) {

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -36,6 +36,7 @@
 #include "tool_msgs.h"
 #include "tool_cb_wrt.h"
 #include "tool_operate.h"
+#include "getenv.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -126,13 +127,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   const size_t failure = bytes ? 0 : 1;
 
 #ifdef DEBUGBUILD
-  {
-    char *tty = curlx_getenv("CURL_ISATTY");
-    if(tty) {
-      is_tty = TRUE;
-      curl_free(tty);
-    }
-  }
+  is_tty = Curl_env_exist("CURL_ISATTY");
 
   if(config->show_headers) {
     if(bytes > (size_t)CURL_MAX_HTTP_HEADER) {

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -58,7 +58,6 @@ char **__crt0_glob_function(char *arg);
 #ifdef WIN32
 
 CURLcode FindWin32CACert(struct OperationConfig *config,
-                         curl_sslbackend backend,
                          const TCHAR *bundle_file);
 struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);

--- a/src/tool_homedir.c
+++ b/src/tool_homedir.c
@@ -33,24 +33,11 @@
 #include <fcntl.h>
 #endif
 
-#include <curl/mprintf.h>
-
 #include "tool_homedir.h"
+#include "curlx.h"
+#include "getenv.h"
 
 #include "memdebug.h" /* keep this as LAST include */
-
-static char *GetEnv(const char *variable)
-{
-  char *dupe, *env;
-
-  env = curl_getenv(variable);
-  if(!env)
-    return NULL;
-
-  dupe = strdup(env);
-  curl_free(env);
-  return dupe;
-}
 
 /* return the home directory of the current user as an allocated string */
 
@@ -71,18 +58,26 @@ static char *GetEnv(const char *variable)
  * 4. Non-windows: use getpwuid
  * 5. Windows: use APPDATA if set
  * 6. Windows: use "USERPROFILE\Application Data" is set
+ *
+ * funcptr_getenv is a function pointer to the getenv to use, either Unicode
+ * UTF-8 encoding (Curl_getenv_utf8) or the current locale encoding
+ * (Curl_getenv_local). The former is only available in Windows Unicode builds
+ * since in those builds curl/libcurl uses UTF-8 for internal file paths
+ * regardless of the current locale. However, even in that case some
+ * dependencies may still expect file paths in the current locale.
  */
 
-char *homedir(const char *fname)
+static char *gethomedir(const char *fname,
+                        char *(*funcptr_getenv)(const char *))
 {
   char *home;
 
-  home = GetEnv("CURL_HOME");
+  home = funcptr_getenv("CURL_HOME");
   if(home)
     return home;
 
   if(fname) {
-    home = GetEnv("XDG_CONFIG_HOME");
+    home = funcptr_getenv("XDG_CONFIG_HOME");
     if(home) {
       char *c = curl_maprintf("%s" DIR_CHAR "%s", home, fname);
       if(c) {
@@ -97,7 +92,7 @@ char *homedir(const char *fname)
     }
   }
 
-  home = GetEnv("HOME");
+  home = funcptr_getenv("HOME");
   if(home)
     return home;
 
@@ -115,9 +110,9 @@ char *homedir(const char *fname)
  }
 #endif /* PWD-stuff */
 #ifdef WIN32
-  home = GetEnv("APPDATA");
+  home = funcptr_getenv("APPDATA");
   if(!home) {
-    char *env = GetEnv("USERPROFILE");
+    char *env = funcptr_getenv("USERPROFILE");
     if(env) {
       char *path = curl_maprintf("%s\\Application Data", env);
       if(path) {
@@ -130,3 +125,15 @@ char *homedir(const char *fname)
 #endif /* WIN32 */
   return home;
 }
+
+char *homedir_local(const char *fname)
+{
+  return gethomedir(fname, Curl_getenv_local);
+}
+
+#if defined(WIN32) && defined(_UNICODE)
+char *homedir_utf8(const char *fname)
+{
+  return gethomedir(fname, Curl_getenv_utf8);
+}
+#endif

--- a/src/tool_homedir.h
+++ b/src/tool_homedir.h
@@ -23,6 +23,20 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-char *homedir(const char *fname);
+/* returns home directory in current locale encoding.
+   windows unicode builds expect filename param 'fname' in UTF-8 encoding. */
+char *homedir_local(const char *fname);
+
+#if defined(WIN32) && defined(_UNICODE)
+/* returns home directory in unicode utf-8 encoding */
+char *homedir_utf8(const char *fname);
+/* Windows Unicode builds of curl/libcurl always expect UTF-8 strings for
+   internal file paths, regardless of current locale. For paths passed to a
+   dependency that always expects local encoding, call homedir_local directly
+   instead. */
+#define homedir(variable) homedir_utf8(variable)
+#else
+#define homedir(variable) homedir_local(variable)
+#endif
 
 #endif /* HEADER_CURL_TOOL_HOMEDIR_H */

--- a/src/tool_libinfo.h
+++ b/src/tool_libinfo.h
@@ -27,6 +27,11 @@
 
 extern curl_version_info_data *curlinfo;
 extern long built_in_protos;
+extern curl_sslbackend ssl_backend;
+
+#ifdef WIN32
+extern bool ssl_paths_use_utf8;
+#endif
 
 CURLcode get_libcurl_info(void);
 

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -49,6 +49,7 @@
 #include "tool_vms.h"
 #include "tool_main.h"
 #include "tool_libinfo.h"
+#include "getenv.h"
 
 /*
  * This is low-level hard-hacking memory leak tracking and similar. Using
@@ -108,27 +109,27 @@ static void memory_tracking_init(void)
 {
   char *env;
   /* if CURL_MEMDEBUG is set, this starts memory tracking message logging */
-  env = curlx_getenv("CURL_MEMDEBUG");
+  env = Curl_getenv("CURL_MEMDEBUG");
   if(env) {
     /* use the value as file name */
     char fname[CURL_MT_LOGFNAME_BUFSIZE];
     if(strlen(env) >= CURL_MT_LOGFNAME_BUFSIZE)
       env[CURL_MT_LOGFNAME_BUFSIZE-1] = '\0';
     strcpy(fname, env);
-    curl_free(env);
+    free(env);
     curl_dbg_memdebug(fname);
     /* this weird stuff here is to make curl_free() get called before
        curl_gdb_memdebug() as otherwise memory tracking will log a free()
        without an alloc! */
   }
   /* if CURL_MEMLIMIT is set, this enables fail-on-alloc-number-N feature */
-  env = curlx_getenv("CURL_MEMLIMIT");
+  env = Curl_getenv("CURL_MEMLIMIT");
   if(env) {
     char *endptr;
     long num = strtol(env, &endptr, 10);
     if((endptr != env) && (endptr == env + strlen(env)) && (num > 0))
       curl_dbg_memlimit(num);
-    curl_free(env);
+    free(env);
   }
 }
 #else
@@ -280,7 +281,7 @@ int main(int argc, char *argv[])
   }
 
 #ifdef __NOVELL_LIBC__
-  if(getenv("_IN_NETWARE_BASH_") == NULL)
+  if(!Curl_getenv_exist("_IN_NETWARE_BASH_"))
     tool_pressanykey();
 #endif
 

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -31,6 +31,7 @@
 #include "tool_convert.h"
 #include "tool_doswin.h"
 #include "tool_operhlp.h"
+#include "getenv.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -179,13 +180,13 @@ CURLcode get_url_file_name(char **filename, const char *url)
    */
 #ifdef DEBUGBUILD
   {
-    char *tdir = curlx_getenv("CURL_TESTDIR");
+    char *tdir = Curl_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
       msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, *filename);
       Curl_safefree(*filename);
       *filename = strdup(buffer); /* clone the buffer */
-      curl_free(tdir);
+      free(tdir);
       if(!*filename)
         return CURLE_OUT_OF_MEMORY;
     }

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -32,6 +32,7 @@
 #include "curlx.h"
 
 #include "curlmsg_vms.h"
+#include "getenv.h"
 #include "tool_vms.h"
 
 #include "memdebug.h" /* keep this as LAST include */
@@ -53,7 +54,7 @@ int is_vms_shell(void)
   if(vms_shell >= 0)
     return vms_shell;
 
-  shell = getenv("SHELL");
+  shell = Curl_getenv("SHELL");
 
   /* No shell, means DCL */
   if(!shell) {
@@ -63,10 +64,12 @@ int is_vms_shell(void)
 
   /* Have to make sure some one did not set shell to DCL */
   if(strcmp(shell, "DCL") == 0) {
+    free(shell);
     vms_shell = 1;
     return 1;
   }
 
+  free(shell);
   vms_shell = 0;
   return 0;
 }

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -31,7 +31,8 @@ CURLX_SRCS = \
  ../../lib/curl_ctype.c \
  ../../lib/dynbuf.c \
  ../../lib/strdup.c \
- ../../lib/curl_multibyte.c
+ ../../lib/curl_multibyte.c \
+ ../../lib/getenv.c
 
 CURLX_HDRS = \
  ../../lib/curlx.h \
@@ -41,7 +42,8 @@ CURLX_HDRS = \
  ../../lib/curl_ctype.h \
  ../../lib/dynbuf.h \
  ../../lib/strdup.h \
- ../../lib/curl_multibyte.h
+ ../../lib/curl_multibyte.h \
+ ../../lib/getenv.h
 
 USEFUL = \
  getpart.c \

--- a/tests/server/fake_ntlm.c
+++ b/tests/server/fake_ntlm.c
@@ -31,6 +31,8 @@
 
 #define ENABLE_CURLX_PRINTF
 #include "curlx.h" /* from the private lib dir */
+#include "getenv.h"
+
 #include "getpart.h"
 #include "util.h"
 
@@ -110,6 +112,7 @@ static char *printable(char *inbuf, size_t inlength)
 int main(int argc, char *argv[])
 {
   char buf[1024];
+  char pathbuf[256];
   char logfilename[256];
   FILE *stream;
   int error;
@@ -157,7 +160,7 @@ int main(int argc, char *argv[])
     }
   }
 
-  env = getenv("CURL_NTLM_AUTH_TESTNUM");
+  env = Curl_getenv("CURL_NTLM_AUTH_TESTNUM");
   if(env) {
     char *endptr;
     long lnum = strtol(env, &endptr, 10);
@@ -166,6 +169,7 @@ int main(int argc, char *argv[])
       exit(1);
     }
     testnum = lnum;
+    Curl_safefree(env);
   }
   else {
     fprintf(stderr, "Test number not specified in CURL_NTLM_AUTH_TESTNUM");
@@ -180,9 +184,16 @@ int main(int argc, char *argv[])
          helper_user, helper_proto, helper_domain,
          (use_cached_creds) ? "yes" : "no");
 
-  env = getenv("CURL_NTLM_AUTH_SRCDIR");
+  env = Curl_getenv("CURL_NTLM_AUTH_SRCDIR");
   if(env) {
-    path = env;
+    if(strlen(env) >= sizeof(pathbuf)) {
+      logmsg("CURL_NTLM_AUTH_SRCDIR path too long");
+      exit(1);
+    }
+    strncpy(pathbuf, env, sizeof(pathbuf));
+    pathbuf[sizeof(pathbuf)-1] = '\0';
+    path = pathbuf;
+    Curl_safefree(env);
   }
 
   stream = test2fopen(testnum);

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -606,7 +606,8 @@ CURL_FROM_LIBCURL=$(CURL_DIROBJ)\tool_hugehelp.obj \
  $(CURL_DIROBJ)\curl_ctype.obj \
  $(CURL_DIROBJ)\curl_multibyte.obj \
  $(CURL_DIROBJ)\version_win32.obj \
- $(CURL_DIROBJ)\dynbuf.obj
+ $(CURL_DIROBJ)\dynbuf.obj \
+ $(CURL_DIROBJ)\getenv.obj
 
 $(PROGRAM_NAME): $(CURL_DIROBJ) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
 	$(CURL_LINK) $(CURL_LFLAGS) $(CURL_LIBCURL_LIBNAME) $(WIN_LIBS) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
@@ -631,6 +632,8 @@ $(CURL_DIROBJ)\version_win32.obj: ../lib/version_win32.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/version_win32.c
 $(CURL_DIROBJ)\dynbuf.obj: ../lib/dynbuf.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/dynbuf.c
+$(CURL_DIROBJ)\getenv.obj: ../lib/getenv.c
+	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/getenv.c
 $(CURL_DIROBJ)\curl.res: $(CURL_SRC_DIR)\curl.rc
 	rc $(CURL_RC_FLAGS)
 


### PR DESCRIPTION
- For Windows Unicode builds retrieve the homedir in UTF-8 encoded
  Unicode instead of ANSI local character encoding.

Fixes https://github.com/curl/curl/pull/7252
Closes #xxxx

---

/cc @dEajL3kA 