### PR TITLE
curl.h: include sys/select.h for NuttX RTOS

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -74,7 +74,7 @@
 #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
     defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
-    defined(__CYGWIN__) || defined(AMIGA) || \
+    defined(__CYGWIN__) || defined(AMIGA) || defined(__NuttX__) || \
    (defined(__FreeBSD_version) && (__FreeBSD_version < 800000)) || \
     defined(__VXWORKS__)
 #include <sys/select.h>


### PR DESCRIPTION
To avoid fd_set undefine issue.