### PR TITLE
examples: length-limit two sscanf() uses of %s

### DIFF
--- a/docs/examples/rtsp.c
+++ b/docs/examples/rtsp.c
@@ -173,7 +173,7 @@ static void get_media_control_attribute(const char *sdp_filename,
   control[0] = '\0';
   if(sdp_fp != NULL) {
     while(fgets(s, max_len - 2, sdp_fp) != NULL) {
-      sscanf(s, " a = control: %s", control);
+      sscanf(s, " a = control: %32s", control);
     }
     fclose(sdp_fp);
   }

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -155,7 +155,7 @@ size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
                                          TmpStr1 & 2? */
         AutoSyncTime = 0;
       else {
-        int RetVal = sscanf((char *)(ptr), "Date: %s %hu %s %hu %hu:%hu:%hu",
+        int RetVal = sscanf((char *)(ptr), "Date: %25s %hu %s %hu %hu:%hu:%hu",
                             TmpStr1, &SYSTime.wDay, TmpStr2, &SYSTime.wYear,
                             &SYSTime.wHour, &SYSTime.wMinute,
                             &SYSTime.wSecond);


### PR DESCRIPTION
Reported-by: Jishan Shaikh
Fixes #7293