### PR TITLE
Bump crustls version and use new URL.

### DIFF
--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -2,8 +2,8 @@
 
 [Rustls is a TLS backend written in Rust.](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
-the [crustls C bindings](https://github.com/abetterinternet/crustls/). This
-version of curl depends on version v0.6.0 of crustls.
+the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
+version of curl depends on version v0.7.0 of crustls.
 
 # Building with rustls
 
@@ -12,7 +12,7 @@ First, [install Rust](https://rustup.rs/).
 Next, check out, build, and install the appropriate version of crustls:
 
     % cargo install cbindgen
-    % git clone https://github.com/abetterinternet/crustls/ -b v0.6.0
+    % git clone https://github.com/rustls/rustls-ffi -b v0.7.0
     % cd crustls
     % make
     % make DESTDIR=${HOME}/crustls-built/ install
@@ -22,5 +22,5 @@ Now configure and build curl with rustls:
     % git clone https://github.com/curl/curl
     % cd curl
     % ./buildconf
-    % ./configure --without-ssl --with-rustls=${HOME}/crustls-built
+    % ./configure --with-rustls=${HOME}/crustls-built
     % make

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -119,7 +119,7 @@ fi
 
 if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS_VERSION" ]; then
   cd $HOME
-  git clone --depth=1 --recursive https://github.com/abetterinternet/crustls.git -b "$RUSTLS_VERSION"
+  git clone --depth=1 --recursive https://github.com/rustls/rustls-ffi.git -b "$RUSTLS_VERSION"
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
   cargo install cbindgen

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -109,7 +109,7 @@
         - libzstd-dev
       curl_env:
         T: debug-rustls
-        RUSTLS_VERSION: v0.6.0
+        RUSTLS_VERSION: v0.7.0
         C: >-
           --with-rustls={{ ansible_user_dir }}/crust
 


### PR DESCRIPTION
crustls moved to https://github.com/rustls/rustls-ffi. This also bumps the expected version to 0.7.0.

There are no API-breaking changes from curl's perspective in 0.7.0, but the default build profile is now "release", so people will get faster builds by default. And there will be some API-breaking changes coming down the line related to an upcoming rustls upstream release.