### PR TITLE
misc: use __fallthrough__ attribute where available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,28 @@ if(NOT CURL_DISABLE_LDAP)
   endif()
 endif()
 
+set(_SRC_STRING
+     "
+     ${_INCLUDE_STRING}
+     int main(int argc, char ** argv)
+     {
+       int i = 1;
+       switch(i) {
+         case 1:
+           __attribute__((__fallthrough__));
+         case 0:
+           break;
+       }
+       return 0;
+     }"
+   )
+
+check_c_source_compiles("${_SRC_STRING}" ATTRIBUTE_FALLTHROUGH_WORKS)
+if(ATTRIBUTE_FALLTHROUGH_WORKS)
+  set(CURL_ATTRIBUTE_FALLTHROUGH ON)
+endif()
+
+
 # No ldap, no ldaps.
 if(CURL_DISABLE_LDAP)
   if(NOT CURL_DISABLE_LDAPS)

--- a/configure.ac
+++ b/configure.ac
@@ -408,6 +408,8 @@ CURL_CHECK_COMPILER_SYMBOL_HIDING
 CURL_CHECK_CURLDEBUG
 AM_CONDITIONAL(CURLDEBUG, test x$want_curldebug = xyes)
 
+CURL_FALLTHROUGH_WORKS
+
 supports_unittests=yes
 # cross-compilation of unit tests static library/programs fails when
 # libcurl shared library is built. This might be due to a libtool or

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -240,7 +240,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
         }
         zp->zlib_init = ZLIB_UNINIT;    /* inflateEnd() already called. */
       }
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     default:
       result = exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
       break;

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -893,7 +893,7 @@ Curl_cookie_add(struct Curl_easy *data,
         if(!co->spath)
           badcookie = TRUE;
         fields++; /* add a field and fall down to secure */
-        /* FALLTHROUGH */
+        FALLTHROUGH;
       case 3:
         co->secure = FALSE;
         if(strcasecompare(ptr, "TRUE")) {

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -320,6 +320,9 @@
 /* Define to 1 if you have the lber.h header file. */
 #cmakedefine HAVE_LBER_H 1
 
+/* Define to 1 if this attribute works */
+#cmakedefine CURL_ATTRIBUTE_FALLTHROUGH 1
+
 /* Define to 1 if you have the ldapssl.h header file. */
 #cmakedefine HAVE_LDAPSSL_H 1
 

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -478,7 +478,7 @@ CURLcode Curl_output_ntlm_wb(struct Curl_easy *data, struct connectdata *conn,
     /* connection is already authenticated,
      * don't send a header in future requests */
     *state = NTLMSTATE_LAST;
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -154,6 +154,12 @@
 #  endif
 #endif
 
+#ifdef CURL_ATTRIBUTE_FALLTHROUGH
+# define FALLTHROUGH __attribute__((__fallthrough__))
+#else
+# define FALLTHROUGH do {} while
+#endif
+
 /* ================================================================ */
 /*  If you need to include a system header file for your platform,  */
 /*  please, do it beyond the point further indicated in this file.  */

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -277,7 +277,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
 #else
       current_form->flags |= HTTPPOST_PTRNAME; /* fall through */
 #endif
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     case CURLFORM_COPYNAME:
       if(current_form->name)
         return_value = CURL_FORMADD_OPTION_TWICE;
@@ -303,7 +303,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
        */
     case CURLFORM_PTRCONTENTS:
       current_form->flags |= HTTPPOST_PTRCONTENTS;
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     case CURLFORM_COPYCONTENTS:
       if(current_form->value)
         return_value = CURL_FORMADD_OPTION_TWICE;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3218,7 +3218,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
 
     /* until we cope better with prematurely ended requests, let them
      * fallback as if in complete failure */
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   default:       /* by default, an error means the control connection is
                     wedged and should not be used anymore */
     ftpc->ctl_valid = FALSE;

--- a/lib/http.c
+++ b/lib/http.c
@@ -3742,7 +3742,7 @@ CURLcode Curl_http_statusline(struct Curl_easy *data,
      * fields.  */
     if(data->set.timecondition)
       data->info.timecond = TRUE;
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case 204:
     /* (quote from RFC2616, section 10.2.5): The server has
      * fulfilled the request but does not need to return an

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -250,7 +250,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     /* connection is already authenticated,
      * don't send a header in future requests */
     *state = NTLMSTATE_LAST;
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -874,7 +874,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
         }
       } while(task);
       s->tunnel_state = TUNNEL_CONNECT;
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     case TUNNEL_CONNECT: {
       int didwhat;
       bool done = FALSE;
@@ -898,7 +898,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
         h->write_waker = NULL;
       }
     }
-      /* FALLTHROUGH */
+    FALLTHROUGH;
     default:
       break;
     }

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -465,7 +465,7 @@ static size_t encoder_base64_read(char *buffer, size_t size, bool ateof,
       switch(st->bufend - st->bufbeg) {
       case 2:
         i = (st->buf[st->bufbeg + 1] & 0xFF) << 8;
-        /* FALLTHROUGH */
+        FALLTHROUGH;
       case 1:
         i |= (st->buf[st->bufbeg] & 0xFF) << 16;
         ptr[0] = base64[(i >> 18) & 0x3F];
@@ -803,7 +803,7 @@ static size_t read_part_content(curl_mimepart *part,
     case MIMEKIND_FILE:
       if(part->fp && feof(part->fp))
         break;  /* At EOF. */
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     default:
       if(part->readfunc) {
         if(!(part->flags & MIME_FAST_READ)) {
@@ -925,7 +925,7 @@ static size_t readback_part(curl_mimepart *part,
         mimesetstate(&part->state, MIMESTATE_USERHEADERS, hdr->next);
         break;
       }
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     case MIMESTATE_CURLHEADERS:
       if(!hdr)
         mimesetstate(&part->state, MIMESTATE_USERHEADERS, part->userheaders);
@@ -967,7 +967,7 @@ static size_t readback_part(curl_mimepart *part,
           fclose(part->fp);
           part->fp = NULL;
         }
-        /* FALLTHROUGH */
+        FALLTHROUGH;
       case CURL_READFUNC_ABORT:
       case CURL_READFUNC_PAUSE:
       case READ_ERROR:

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -361,7 +361,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
         case '0':
           if(!(flags & FLAGS_LEFT))
             flags |= FLAGS_PAD_NIL;
-          /* FALLTHROUGH */
+          FALLTHROUGH;
         case '1': case '2': case '3': case '4':
         case '5': case '6': case '7': case '8': case '9':
           flags |= FLAGS_WIDTH;
@@ -397,7 +397,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
       switch (*fmt) {
       case 'S':
         flags |= FLAGS_ALT;
-        /* FALLTHROUGH */
+        FALLTHROUGH;
       case 's':
         vto[i].type = FORMAT_STRING;
         break;

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -637,7 +637,7 @@ static CURLcode mqtt_read_publish(struct Curl_easy *data, bool *done)
     data->req.bytecount = 0;
     data->req.size = remlen;
     mq->npacket = remlen; /* get this many bytes */
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case MQTT_PUB_REMAIN: {
     /* read rest of packet, but no more. Cap to buffer size */
     struct SingleRequest *k = &data->req;
@@ -729,7 +729,7 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
     /* remember the first byte */
     mq->npacket = 0;
     mqstate(data, MQTT_REMAINING_LENGTH, MQTT_NOSTATE);
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case MQTT_REMAINING_LENGTH:
     do {
       result = Curl_read(data, sockfd, (char *)&byte, 1, &nread);

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -275,7 +275,7 @@ CURLproxycode Curl_SOCKS4(const char *proxy_user,
         return CURLPX_OK;
       }
     }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     struct Curl_addrinfo *hp = NULL;
@@ -313,7 +313,7 @@ CURLproxycode Curl_SOCKS4(const char *proxy_user,
       return CURLPX_RESOLVE_HOST;
     }
   }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
     /*
@@ -358,7 +358,7 @@ CURLproxycode Curl_SOCKS4(const char *proxy_user,
       sx->outstanding = packetsize;
       sxstate(data, CONNECT_REQ_SENDING);
     }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_REQ_SENDING:
     /* Send request */
     result = Curl_write_plain(data, sockfd, (char *)sx->outp,
@@ -379,7 +379,7 @@ CURLproxycode Curl_SOCKS4(const char *proxy_user,
     sx->outp = socksreq;
     sxstate(data, CONNECT_SOCKS_READ);
 
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_SOCKS_READ:
     /* Receive response */
     result = Curl_read_plain(sockfd, (char *)sx->outp,
@@ -587,12 +587,12 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
       sx->outp += written;
       return CURLPX_OK;
     }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   CONNECT_SOCKS_READ_INIT:
   case CONNECT_SOCKS_READ_INIT:
     sx->outstanding = 2; /* expect two bytes */
     sx->outp = socksreq; /* store it here */
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_SOCKS_READ:
     result = Curl_read_plain(sockfd, (char *)sx->outp,
                              sx->outstanding, &actualread);
@@ -705,7 +705,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
     sx->outstanding = len;
     sx->outp = socksreq;
   }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_AUTH_SEND:
     result = Curl_write_plain(data, sockfd, (char *)sx->outp,
                               sx->outstanding, &written);
@@ -722,7 +722,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
     sx->outp = socksreq;
     sx->outstanding = 2;
     sxstate(data, CONNECT_AUTH_READ);
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_AUTH_READ:
     result = Curl_read_plain(sockfd, (char *)sx->outp,
                              sx->outstanding, &actualread);
@@ -750,7 +750,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
 
     /* Everything is good so far, user was authenticated! */
     sxstate(data, CONNECT_REQ_INIT);
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
     if(socks5_resolve_local) {
@@ -789,7 +789,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
         return CURLPX_OK;
       }
     }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     struct Curl_addrinfo *hp = NULL;
@@ -861,7 +861,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
       infof(data, "SOCKS5 connect to %s:%d (remotely resolved)\n",
             hostname, remote_port);
     }
-    /* FALLTHROUGH */
+    FALLTHROUGH;
 
   CONNECT_REQ_SEND:
   case CONNECT_REQ_SEND:
@@ -879,7 +879,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
     sx->outp = socksreq;
     sx->outstanding = len;
     sxstate(data, CONNECT_REQ_SENDING);
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_REQ_SENDING:
     result = Curl_write_plain(data, sockfd, (char *)sx->outp,
                               sx->outstanding, &written);
@@ -902,7 +902,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
     sx->outstanding = 10; /* minimum packet size is 10 */
     sx->outp = socksreq;
     sxstate(data, CONNECT_REQ_READ);
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_REQ_READ:
     result = Curl_read_plain(sockfd, (char *)sx->outp,
                              sx->outstanding, &actualread);
@@ -1001,7 +1001,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
     }
 #endif
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case CONNECT_REQ_READ_MORE:
     result = Curl_read_plain(sockfd, (char *)sx->outp,
                              sx->outstanding, &actualread);

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1493,7 +1493,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case 0:                     /* timeout */
       pfd[0].revents = 0;
       pfd[1].revents = 0;
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     default:                    /* read! */
       if(pfd[0].revents & POLLIN) {
         /* read data from network */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -160,7 +160,7 @@ static size_t strlen_url(const char *url, bool relative)
     switch(*ptr) {
     case '?':
       left = FALSE;
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     default:
       if(urlchar_needs_escaping(*ptr))
         newlen += 2;
@@ -205,7 +205,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
     switch(*iptr) {
     case '?':
       left = FALSE;
-      /* FALLTHROUGH */
+      FALLTHROUGH;
     default:
       if(urlchar_needs_escaping(*iptr)) {
         msnprintf(optr, 4, "%%%02x", *iptr);

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -311,10 +311,10 @@ utf8asn1str(char **to, int type, const char *from, const char *end)
       case 4:
         wc = (wc << 8) | *(const unsigned char *) from++;
         wc = (wc << 8) | *(const unsigned char *) from++;
-        /* FALLTHROUGH */
+        FALLTHROUGH;
       case 2:
         wc = (wc << 8) | *(const unsigned char *) from++;
-        /* FALLTHROUGH */
+        FALLTHROUGH;
       default: /* case 1: */
         wc = (wc << 8) | *(const unsigned char *) from++;
       }
@@ -480,7 +480,7 @@ static const char *GTime2str(const char *beg, const char *end)
     break;
   case 2:
     sec1 = fracp[-2];
-    /* FALLTHROUGH */
+    FALLTHROUGH;
   case 1:
     sec2 = fracp[-1];
     break;

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1612,3 +1612,26 @@ AC_DEFUN([CURL_ADD_COMPILER_WARNINGS], [
   [$1]="$[$1] $ac_var_added_warnings"
   squeeze [$1]
 ])
+
+AC_DEFUN([CURL_FALLTHROUGH_WORKS], [
+  AC_MSG_CHECKING([if attribute fallthrough works])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+    ]],[[
+      int i = 1;
+      switch(i) {
+        case 1:
+          __attribute__((__fallthrough__));
+        case 0:
+          break;
+      }
+    ]])
+  ],[
+    fallthrough_works="yes"
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(CURL_ATTRIBUTE_FALLTHROUGH, 1, [this attribute works])
+  ],[
+    tmp_compiler_works="no"
+    AC_MSG_RESULT([no])
+  ])
+])


### PR DESCRIPTION
Make configure/cmake check if the attribute works, then use the
FALLTHROUGH define instead of the previous comment to inhibit compiler
warnings for when a switch-case doesn't end with a break or return.

Reported-by: Younes El-karama
Fixes #7295