### PR TITLE
misc: fix typos which repeat a word

### DIFF
--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -48,7 +48,7 @@
 /* Define if you have the <io.h> header file.  */
 #define HAVE_IO_H 1
 
-/* Define if you need the malloc.h header header file even with stdlib.h  */
+/* Define if you need the malloc.h header file even with stdlib.h  */
 #define NEED_MALLOC_H 1
 
 /* Define if you have the <netdb.h> header file.  */

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1223,7 +1223,7 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
 
     /*
      * Remove expired cookies from the hash. We must make sure to run this
-     * after reading the file, and not not on every cookie.
+     * after reading the file, and not on every cookie.
      */
     remove_expired(c);
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3621,7 +3621,7 @@ static CURLcode create_conn(struct Curl_easy *data,
   if(result)
     goto out;
 
-  /* Check for overridden login details and set them accordingly so they
+  /* Check for overridden login details and set them accordingly so that
      they are known when protocol->setup_connection is called! */
   result = override_login(data, conn);
   if(result)


### PR DESCRIPTION
Fix typos in code comments which repeat various words.  In trivial
cases, just delete the repeated word.  Reword the affected sentence in
"lib/url.c" for it to make sense.