### PR TITLE
openssl: avoid static variable for seed flag

### DIFF
--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -153,6 +153,9 @@ struct Curl_multi {
   bool recheckstate; /* see Curl_multi_connchanged */
   bool in_callback;            /* true while executing a callback */
   bool ipv6_works;
+#ifdef USE_OPENSSL
+  bool ssl_seeded;
+#endif
 };
 
 #endif /* HEADER_CURL_MULTIHANDLE_H */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -435,17 +435,16 @@ static bool rand_enough(void)
 
 static CURLcode ossl_seed(struct Curl_easy *data)
 {
-  /* we have the "SSL is seeded" boolean static to prevent multiple
-     time-consuming seedings in vain */
-  static bool ssl_seeded = FALSE;
   char fname[256];
 
-  if(ssl_seeded)
+  /* This might get called before it has been added to a multi handle */
+  if(data->multi && data->multi->ssl_seeded)
     return CURLE_OK;
 
   if(rand_enough()) {
     /* OpenSSL 1.1.0+ will return here */
-    ssl_seeded = TRUE;
+    if(data->multi)
+      data->multi->ssl_seeded = TRUE;
     return CURLE_OK;
   }
 


### PR DESCRIPTION
Avoid the race condition risk by instead storing the "seeded" flag in
the multi handle. Modern OpenSSL versions handle the seeding itself so
doing the seeding once per multi-handle instead of once per process is
less of an issue.

Reported-by: Gerrit Renker
Fixes #7296