### PR TITLE
configure: inhibit the implicit-fallthrough warning on gcc-12

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1033,7 +1033,10 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [alloc-zero])
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-overflow=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
-            tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough=4"
+            if test "$compiler_num" -lt "1200"; then
+              dnl gcc 12 doesn't acknowledge our comment markups
+              tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough=4"
+            fi
           fi
           #
         fi


### PR DESCRIPTION
... since it no longer acknowledges the comment markup we use for that
purpose.

Reported-by: Younes El-karama
Fixes #7295