### PR TITLE
examples: Simplify signal handler

### DIFF
--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -455,11 +455,9 @@ static void clean_fifo(GlobalInfo *g)
 
 int g_should_exit_ = 0;
 
-void SignalHandler(int signo)
+void sigint_handler(int signo)
 {
-  if(signo == SIGINT) {
-    g_should_exit_ = 1;
-  }
+  g_should_exit_ = 1;
 }
 
 int main(int argc, char **argv)
@@ -472,7 +470,7 @@ int main(int argc, char **argv)
   (void)argv;
 
   g_should_exit_ = 0;
-  signal(SIGINT, SignalHandler);
+  signal(SIGINT, sigint_handler);
 
   memset(&g, 0, sizeof(GlobalInfo));
   g.epfd = epoll_create1(EPOLL_CLOEXEC);


### PR DESCRIPTION
The signal handler registered for SIGINT is only handling SIGINT
so there isn't much need for inspecting the signo.  While there,
rename the handler to be more specific.

g_should_exit should really be of sig_atomic_t type, but relying
on autoconf in the examples seems like a bad idea so keep tjat
for now.

Closes #xxxx