### PR TITLE
travis/before_script.sh: cd into the new rustls directory

### DIFF
--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -3,24 +3,24 @@
 [Rustls is a TLS backend written in Rust.](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.7.0 of crustls.
+version of curl depends on version v0.7.0 of rustls-ffi.
 
 # Building with rustls
 
 First, [install Rust](https://rustup.rs/).
 
-Next, check out, build, and install the appropriate version of crustls:
+Next, check out, build, and install the appropriate version of rustls-ffi:
 
     % cargo install cbindgen
     % git clone https://github.com/rustls/rustls-ffi -b v0.7.0
-    % cd crustls
+    % cd rustls-ffi
     % make
-    % make DESTDIR=${HOME}/crustls-built/ install
+    % make DESTDIR=${HOME}/rustls-ffi-built/ install
 
 Now configure and build curl with rustls:
 
     % git clone https://github.com/curl/curl
     % cd curl
     % ./buildconf
-    % ./configure --with-rustls=${HOME}/crustls-built
+    % ./configure --with-rustls=${HOME}/rustls-ffi-built
     % make

--- a/scripts/zuul/before_script.sh
+++ b/scripts/zuul/before_script.sh
@@ -123,7 +123,7 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS_VERSION" ]; then
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
   cargo install cbindgen
-  cd $HOME/crustls
+  cd $HOME/rustls-ffi
   make
   make DESTDIR=$HOME/crust install
 fi

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -130,7 +130,7 @@
         - libzstd-dev
       curl_env:
         T: debug-rustls
-        RUSTLS_VERSION: v0.7.0
+        RUSTLS_VERSION: v0.7.1
         C: >-
           --with-rustls={{ ansible_user_dir }}/crust
 


### PR DESCRIPTION
Follow-up to 6d972c8b1cbb3 which missed updating this directory name.