### PR TITLE
mqtt: extend the error message for no topic

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -378,21 +378,13 @@ fail:
 static CURLcode mqtt_get_topic(struct Curl_easy *data,
                                char **topic, size_t *topiclen)
 {
-  CURLcode result = CURLE_OK;
   char *path = data->state.up.path;
-
-  if(strlen(path) > 1) {
-    result = Curl_urldecode(data, path + 1, 0, topic, topiclen,
-                            REJECT_NADA);
-  }
-  else {
-    failf(data, "Error: No topic specified.");
-    result = CURLE_URL_MALFORMAT;
-  }
-  return result;
+  if(strlen(path) > 1)
+    return Curl_urldecode(data, path + 1, 0, topic, topiclen,
+                          REJECT_NADA);
+  failf(data, "No MQTT topic found. Forgot to URL encode it?");
+  return CURLE_URL_MALFORMAT;
 }
-
-
 
 static CURLcode mqtt_subscribe(struct Curl_easy *data)
 {


### PR DESCRIPTION
... and mention that it needs URL encoding.

Reported-by: Peter Körner
Fixes #7316