### PR TITLE
lib: avoid fallthrough cases in switch statements

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -240,7 +240,8 @@ static CURLcode inflate_stream(struct Curl_easy *data,
         }
         zp->zlib_init = ZLIB_UNINIT;    /* inflateEnd() already called. */
       }
-      /* FALLTHROUGH */
+      result = exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
+      break;
     default:
       result = exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
       break;

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -198,6 +198,12 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 #endif
 
   Curl_bufref_init(&ntlmmsg);
+
+  /* connection is already authenticated, don't send a header in future
+   * requests so go directly to NTLMSTATE_LAST */
+  if(*state == NTLMSTATE_TYPE3)
+    *state = NTLMSTATE_LAST;
+
   switch(*state) {
   case NTLMSTATE_TYPE1:
   default: /* for the weird cases we (re)start here */
@@ -246,11 +252,6 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     }
     break;
 
-  case NTLMSTATE_TYPE3:
-    /* connection is already authenticated,
-     * don't send a header in future requests */
-    *state = NTLMSTATE_LAST;
-    /* FALLTHROUGH */
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -904,7 +904,8 @@ static CURLcode CONNECT(struct Curl_easy *data,
         h->write_waker = NULL;
       }
     }
-      /* FALLTHROUGH */
+    break;
+
     default:
       break;
     }

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -462,11 +462,13 @@ static size_t encoder_base64_read(char *buffer, size_t size, bool ateof,
       /* Buffered data size can only be 0, 1 or 2. */
       ptr[2] = ptr[3] = '=';
       i = 0;
-      switch(st->bufend - st->bufbeg) {
-      case 2:
-        i = (st->buf[st->bufbeg + 1] & 0xFF) << 8;
-        /* FALLTHROUGH */
-      case 1:
+
+      /* If there is buffered data */
+      if(st->bufend != st->bufbeg) {
+
+        if(st->bufend - st->bufbeg == 2)
+          i = (st->buf[st->bufbeg + 1] & 0xFF) << 8;
+
         i |= (st->buf[st->bufbeg] & 0xFF) << 16;
         ptr[0] = base64[(i >> 18) & 0x3F];
         ptr[1] = base64[(i >> 12) & 0x3F];
@@ -476,7 +478,6 @@ static size_t encoder_base64_read(char *buffer, size_t size, bool ateof,
         }
         cursize += 4;
         st->pos += 4;
-        break;
       }
     }
   }

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1011,7 +1011,9 @@ static CURLcode pop3_statemachine(struct Curl_easy *data,
       break;
 
     case POP3_QUIT:
-      /* fallthrough, just stop! */
+      state(data, POP3_STOP);
+      break;
+
     default:
       /* internal error */
       state(data, POP3_STOP);

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -157,23 +157,23 @@ static size_t strlen_url(const char *url, bool relative)
       continue;
     }
 
-    switch(*ptr) {
-    case '?':
-      left = FALSE;
-      /* FALLTHROUGH */
-    default:
-      if(urlchar_needs_escaping(*ptr))
-        newlen += 2;
-      newlen++;
-      break;
-    case ' ':
+    if(*ptr == ' ') {
       if(left)
         newlen += 3;
       else
         newlen++;
-      break;
+      continue;
     }
+
+    if (*ptr == '?')
+      left = FALSE;
+
+    if(urlchar_needs_escaping(*ptr))
+      newlen += 2;
+
+    newlen++;
   }
+
   return newlen;
 }
 
@@ -202,19 +202,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
       continue;
     }
 
-    switch(*iptr) {
-    case '?':
-      left = FALSE;
-      /* FALLTHROUGH */
-    default:
-      if(urlchar_needs_escaping(*iptr)) {
-        msnprintf(optr, 4, "%%%02x", *iptr);
-        optr += 3;
-      }
-      else
-        *optr++=*iptr;
-      break;
-    case ' ':
+    if(*iptr == ' ') {
       if(left) {
         *optr++='%'; /* add a '%' */
         *optr++='2'; /* add a '2' */
@@ -222,8 +210,18 @@ static void strcpy_url(char *output, const char *url, bool relative)
       }
       else
         *optr++='+'; /* add a '+' here */
-      break;
+      continue;
     }
+
+    if(*iptr == '?')
+      left = FALSE;
+
+    if(urlchar_needs_escaping(*iptr)) {
+      msnprintf(optr, 4, "%%%02x", *iptr);
+      optr += 3;
+    }
+    else
+      *optr++ = *iptr;
   }
   *optr = 0; /* null-terminate output buffer */
 

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -449,7 +449,8 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
     switch(sshc->state) {
     case SSH_INIT:
       state(data, SSH_S_STARTUP);
-      /* FALLTHROUGH */
+      break;
+
     case SSH_S_STARTUP:
       rc = wolfSSH_connect(sshc->ssh_session);
       if(rc != WS_SUCCESS)
@@ -838,7 +839,8 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_SFTP_READDIR);
-      /* FALLTHROUGH */
+      break;
+
     case SSH_SFTP_READDIR:
       name = wolfSSH_SFTP_LS(sshc->ssh_session, sftp_scp->path);
       if(!name)

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -2250,10 +2250,11 @@ static CURLcode nss_connect_common(struct Curl_easy *data,
   case CURLE_OK:
     break;
   case CURLE_AGAIN:
+    /* CURLE_AGAIN in non-blocking mode is not an error */
     if(!blocking)
-      /* CURLE_AGAIN in non-blocking mode is not an error */
       return CURLE_OK;
-    /* FALLTHROUGH */
+    else
+      return result;
   default:
     return result;
   }


### PR DESCRIPTION
This patch needs a lot of exercise on the CI courts, it should be a noop functionality wise.

Commit b5a434f7f0ee4d64857f8592eced5b9007d83620 inhibits the warning
on implicit fallthrough cases, since the current coding of indicating
fallthrough with comments is falling out of fashion with new compilers.
This attempts to make the issue smaller by rewriting fallthroughs to no
longer fallthrough, via either breaking the cases or turning switch
statements into if statements.

  lib/content_encoding.c: the fallthrough codepath is simply copied
    into the case as it's a single line.
  lib/http_ntlm.c: the fallthrough case skips a state in the state-
    machine and fast-forwards to NTLMSTATE_LAST. Do this before the
    switch statement instead to set up the states that we actually
    want.
  lib/http_proxy.c: the fallthrough is just falling into exiting the
    switch statement which can be done easily enough in the case.
  lib/mime.c: switch statement rewritten as if statement.
  lib/pop3.c: the fallthrough case skips to the next state in the
    statemachine, do this explicitly instead.
  lib/urlapi.c: switch statement rewritten as if statement.
  lib/vssh/wolfssh.c: the fallthrough cases fast-forwards the state
    machine, do this by running another iteration of the switch
    statement instead.
  lib/vtls/gtls.c: switch statement rewritten as if statement.
  lib/vtls/nss.c: the fallthrough codepath is simply copied into the
    case as it's a single line. Also twiddle a comment to not be
    inside a non-brace if statement.

Closes: #xxxx
See-also: #7295