### PR TITLE
curl_verboseconnect: use %u instead of %ld for port number

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1038,7 +1038,7 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
     else
       hostname = conn->host.name;
 
-    failf(data, "Failed to connect to %s port %ld after %ld ms: %s",
+    failf(data, "Failed to connect to %s port %u after %ld ms: %s",
         hostname, conn->port,
         Curl_timediff(now, data->progress.t_startsingle),
         Curl_strerror(error, buffer, sizeof(buffer)));

--- a/lib/url.c
+++ b/lib/url.c
@@ -1521,7 +1521,7 @@ void Curl_verboseconnect(struct Curl_easy *data,
                          struct connectdata *conn)
 {
   if(data->set.verbose)
-    infof(data, "Connected to %s (%s) port %ld (#%ld)\n",
+    infof(data, "Connected to %s (%s) port %u (#%ld)\n",
 #ifndef CURL_DISABLE_PROXY
           conn->bits.socksproxy ? conn->socks_proxy.host.dispname :
           conn->bits.httpproxy ? conn->http_proxy.host.dispname :

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1155,7 +1155,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
       const struct Curl_handler *h =
         Curl_builtin_scheme(u->scheme);
       if(h) {
-        msnprintf(portbuf, sizeof(portbuf), "%ld", h->defport);
+        msnprintf(portbuf, sizeof(portbuf), "%u", h->defport);
         ptr = portbuf;
       }
     }
@@ -1214,7 +1214,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
         /* there's no stored port number, but asked to deliver
            a default one for the scheme */
         if(h) {
-          msnprintf(portbuf, sizeof(portbuf), "%ld", h->defport);
+          msnprintf(portbuf, sizeof(portbuf), "%u", h->defport);
           port = portbuf;
         }
       }


### PR DESCRIPTION
Follow-up to 764c6bd3bf which changed the type of the port number field.
Detected by Coverity (CID 1486624).