### PR TITLE
digest: fix type of len passed to aprintf %*s

### DIFF
--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -146,7 +146,8 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
     tmp = strchr((char *)uripath, '?');
     if(tmp) {
       size_t urilen = tmp - (char *)uripath;
-      path = (unsigned char *) aprintf("%.*s", urilen, uripath);
+      /* typecast is fine here since the value is always less than 32 bits */
+      path = (unsigned char *) aprintf("%.*s", (int)urilen, uripath);
     }
   }
   if(!tmp)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3873,7 +3873,7 @@ static CURLcode servercert(struct Curl_easy *data,
 
     ASN1_TIME_print(mem, X509_get0_notAfter(backend->server_cert));
     len = BIO_get_mem_data(mem, (char **) &ptr);
-    infof(data, " expire date: %.*s\n", len, ptr);
+    infof(data, " expire date: %.*s\n", (int)len, ptr);
     (void)BIO_reset(mem);
   }
 #endif

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -558,7 +558,7 @@ static const char *UTime2str(const char *beg, const char *end)
   return curl_maprintf("%u%.2s-%.2s-%.2s %.2s:%.2s:%.2s %.*s",
                        20 - (*beg >= '5'), beg, beg + 2, beg + 4,
                        beg + 6, beg + 8, sec,
-                       tzl, tzp);
+                       (int)tzl, tzp);
 }
 
 /*

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -518,7 +518,7 @@ static const char *GTime2str(const char *beg, const char *end)
                        beg, beg + 4, beg + 6,
                        beg + 8, beg + 10, sec1, sec2,
                        fracl? ".": "", fracl, fracp,
-                       sep, tzl, tzp);
+                       sep, (int)tzl, tzp);
 }
 
 /*


### PR DESCRIPTION
... it needs to be 'int'. Detected by Coverity CID 1486611.