### PR TITLE
pinnedpubkey.d: fix formatting for version support lists

### DIFF
--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -15,12 +15,19 @@ if it does not exactly match the public key provided to this option, curl will
 abort the connection before sending or receiving any data.
 
 PEM/DER support:
-  7.39.0: OpenSSL, GnuTLS and GSKit
-  7.43.0: NSS and wolfSSL
-  7.47.0: mbedtls
+
+7.39.0: OpenSSL, GnuTLS and GSKit
+
+7.43.0: NSS and wolfSSL
+
+7.47.0: mbedtls
+
 sha256 support:
-  7.44.0: OpenSSL, GnuTLS, NSS and wolfSSL
-  7.47.0: mbedtls
+
+7.44.0: OpenSSL, GnuTLS, NSS and wolfSSL
+
+7.47.0: mbedtls
+
 Other SSL backends not supported.
 
 If this option is used several times, the last one will be used.


### PR DESCRIPTION
Closes #xxxx

---

before: manpage.html
![Capture](https://user-images.githubusercontent.com/965580/124367111-88612a00-dc22-11eb-9ff2-2561e7a33db0.PNG)

after: manpage.html
![Capture6](https://user-images.githubusercontent.com/965580/124367050-1ab4fe00-dc22-11eb-8c39-9581e7b4755d.PNG)


---
alternately:

I'm not sure how to get it more compact without the vertical space and I get inconsistent results with .RS/.RE depending on whether I'm viewing the manpage generated by nroff or the manpage html generated by roffit

![Capture7a](https://user-images.githubusercontent.com/965580/124367196-19380580-dc23-11eb-9f35-50928449689b.PNG)
![Capture7b](https://user-images.githubusercontent.com/965580/124367197-1ccb8c80-dc23-11eb-8af9-daa5e09139b8.PNG)
~~~man
PEM/DER support:
.RS
7.39.0: OpenSSL, GnuTLS and GSKit
.RE
.RS
7.43.0: NSS and wolfSSL
.RE
.RS
7.47.0: mbedtls
.RE
.IP
sha256 support:
.RS
7.44.0: OpenSSL, GnuTLS, NSS and wolfSSL
.RE
.RS
7.47.0: mbedtls
.RE
.IP
Other SSL backends not supported.
~~~

