### PR TITLE
proto.d: fix formatting for paragraphs after margin changes

### DIFF
--- a/docs/cmdline-opts/proto.d
+++ b/docs/cmdline-opts/proto.d
@@ -35,7 +35,7 @@ only enables http and https
 .B --proto =http,https
 also only enables http and https
 .RE
-
+.IP
 Unknown protocols produce a warning. This allows scripts to safely rely on
 being able to disable potentially dangerous protocols, without relying upon
 support for that protocol being built into curl to avoid an error.


### PR DESCRIPTION
Closes #xxxx

---

It seems that it's necessary to reindent after the .RS -> .RE reset so I did it using .IP. I don't know much about manpage but I read [this](https://www.gnu.org/software/groff/manual/html_node/Man-usage.html).

Before:
![Capture2](https://user-images.githubusercontent.com/965580/124367458-60bf9100-dc25-11eb-8133-da62139233ae.PNG)

After:
![Capture](https://user-images.githubusercontent.com/965580/124367460-64531800-dc25-11eb-99b5-c0d4ddfc1330.PNG)
