### PR TITLE
Revert "c-hyper: handle body on HYHTASK_EMPTY"

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -331,7 +331,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
       infof(data, "hyperstream is done!\n");
       break;
     }
-    else if(t != HYPER_TASK_RESPONSE && t != HYPER_TASK_EMPTY) {
+    else if(t != HYPER_TASK_RESPONSE) {
       *didwhat = KEEP_RECV;
       break;
     }


### PR DESCRIPTION
This reverts commit c3eefa95c31f55657f0af422e8268d738f689066.

Reported-by: Kevin Burke
Fixes #7122 go