### PR TITLE
examples/multi-single: fix scan-build warning

### DIFF
--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -68,11 +68,12 @@ int main(void)
   do {
     CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
 
-    /* wait for activity, timeout or "nothing" */
-    mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+    if(!mc)
+      /* wait for activity, timeout or "nothing" */
+      mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
 
-    if(mc != CURLM_OK) {
-      fprintf(stderr, "curl_multi_wait() failed, code %d.\n", mc);
+    if(mc) {
+      fprintf(stderr, "curl_multi_poll() failed, code %d.\n", (int)mc);
       break;
     }
 


### PR DESCRIPTION
warning: Value stored to 'mc' during its initialization is never read

Follow-up to ae8e11ed5fd2ce