### PR TITLE
Revert "ftp: Expression 'ftpc->wait_data_conn' is always false"

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3644,8 +3644,13 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
         return result;
 
       result = ftp_multi_statemach(data, &complete);
-      /* ftpc->wait_data_conn is always false here */
-      *completep = (int)complete;
+      if(ftpc->wait_data_conn)
+        /* if we reach the end of the FTP state machine here, *complete will be
+           TRUE but so is ftpc->wait_data_conn, which says we need to wait for
+           the data connection and therefore we're not actually complete */
+        *completep = 0;
+      else
+        *completep = (int)complete;
     }
     else {
       /* download */


### PR DESCRIPTION
The reverted commit introduced a logic error in code that was
correct.

The client using libcurl would notice the error since FTP file
uploads in active transfer mode would somtimes complete with
success despite no transfer having been performed and the
"uploaded" file thus not being on the remote server afterwards.

The FTP server would notice the error because it receives a
RST on the data connection it has established with the client
before any data was transferred at all.

The logic error happens if the STOR response from the server have
arrived by the time ftp_multi_statemach() in the affected code path
is called, but the incoming data connection have not arrived yet.
In that case, the processing of the STOR response will cause
'ftpc->wait_data_conn' to be set to TRUE, contradicting the comment
in the code. Since 'complete' will also be set, later logic would
believe the transfer was done.

In most cases, the STOR response will not have arrived yet when
the affected code path is executed, or the incoming connection will
also have arrived, and thus the error would not express itself.
But if the speed difference of the device using libcurl and the
FTP server is exactly right, the error may happen as often as in
one out of hundred file transfers.

This reverts commit 49f3117a238b6eac0e22a32f50699a9eddcb66ab.

Bug: https://curl.se/mail/lib-2021-07/0025.html