### PR TITLE
configure: fix nghttp2 library name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2541,10 +2541,11 @@ if test X"$want_h2" != Xno; then
     LDFLAGS="$LDFLAGS $LD_H2"
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
+    LIB_H2_NAME=${LIB_H2#"-l"}
 
     # use nghttp2_session_set_local_window_size to require nghttp2
     # >= 1.12.0
-    AC_CHECK_LIB(nghttp2, nghttp2_session_set_local_window_size,
+    AC_CHECK_LIB($LIB_H2_NAME, nghttp2_session_set_local_window_size,
       [
        AC_CHECK_HEADERS(nghttp2/nghttp2.h,
           curl_h2_msg="enabled (nghttp2)"


### PR DESCRIPTION
Don't hardcode the nghttp2 library name, because it can vary, be "nghttp2_static" for example.

Closes #7367