### PR TITLE
write-out.d: Clarify urlnum is not unique for de-globbed URLs

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -178,7 +178,8 @@ The total time, in seconds, that the full operation lasted.
 The URL that was fetched. (Added in 7.75.0)
 .TP
 .B urlnum
-The URL index number of this transfer, 0-indexed. (Added in 7.75.0)
+The URL index number of this transfer, 0-indexed. De-globbed URLs share the
+same index number as the origin globbed URL. (Added in 7.75.0)
 .TP
 .B url_effective
 The URL that was fetched last. This is most meaningful if you've told curl


### PR DESCRIPTION
Reported-by: Коваленко Анатолий Викторович

Fixes https://github.com/curl/curl/issues/7342
Closes #xxxx