### PR TITLE
Fix 3 typos

### DIFF
--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -3,7 +3,7 @@ libcurl bindings
 
  Creative people have written bindings or interfaces for various environments
  and programming languages. Using one of these allows you to take advantage of
- curl powers from within your favourite language or system.
+ curl powers from within your favorite language or system.
 
  This is a list of all known interfaces as of this writing.
 

--- a/docs/SSL-PROBLEMS.md
+++ b/docs/SSL-PROBLEMS.md
@@ -33,7 +33,7 @@
 
   Browsers work around this problem in two ways: they cache intermediate
   certificates from previous transfers and some implement the TLS "AIA"
-  extension that lets the client explicitly download such cerfificates on
+  extension that lets the client explicitly download such certificates on
   demand.
 
 ## Protocol version

--- a/projects/README
+++ b/projects/README
@@ -145,7 +145,7 @@ Notes
    find bugs in the project files that need correcting, and would like to
    submit updated files back then please note that, whilst the solution files
    can be edited directly, the templates for the project files (which are
-   stored in the git repositoty) will need to be modified rather than the
+   stored in the git repository) will need to be modified rather than the
    generated project files that Visual Studio uses.
 
 Legacy Windows and SSL


### PR DESCRIPTION
Hi,
I wanted to contribute to curl, an amazing tool that always works fine !

I know nothing about C code but I was sure I could fix some typos by manually having a look to all the documentation files.
Using https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker

How I did:
- open file
- read all the lines with a blue mark
- distinguish between technical things and typos
- fix typos
- push

All the `docs/*.md` where checked manually, I did open some other ones but found nothing