### PR TITLE
build: fix `IoctlSocket` `FIONBIO` check

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -298,7 +298,7 @@ main ()
 
 /* IoctlSocket source code */
         long flags = 0;
-        if(0 != ioctlsocket(0, FIONBIO, &flags))
+        if(0 != IoctlSocket(0, FIONBIO, &flags))
           return 1;
   ;
   return 0;

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3915,7 +3915,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL_FIONBIO], [
         $curl_includes_stropts
       ]],[[
         long flags = 0;
-        if(0 != ioctlsocket(0, FIONBIO, &flags))
+        if(0 != IoctlSocket(0, FIONBIO, &flags))
           return 1;
       ]])
     ],[


### PR DESCRIPTION
`HAVE_IOCTLSOCKET_CAMEL_FIONBIO` should get defined if `IoctlSocket` with `FIONBIO` is available, but the current check uses the (lowercase) `ioctlsocket` function, resulting in the same check that is done for `HAVE_IOCTLSOCKET_FIONBIO`.

But... Does this make sense? This doesn't really check that `ioctlsocket` supports the `FIONBIO` mode, but it just makes sure that the code compiles; so in reality this just checks if `FIONBIO` is defined, since the `ioctlsocket` check is already made when setting `HAVE_IOCTLSOCKET`. But maybe I'm missing something, I'm not really familiar with the Win32 API (or Amiga, since this seems the only system that has a camelcase `IoctlSocket` function).