### PR TITLE
tool_help: remove unused define

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -853,10 +853,6 @@ static const struct helptxt helptext[] = {
   { NULL, NULL, CURLHELP_HIDDEN }
 };
 
-#ifdef NETWARE
-#  define PRINT_LINES_PAUSE 23
-#endif
-
 struct feat {
   const char *name;
   int bitmask;


### PR DESCRIPTION
The PRINT_LINES_PAUSE macro is no longer used, and has been mostly cleaned out but one occurrence remained.
