### PR TITLE
easy: during upkeep, attach Curl_easy to connections in the cache

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1213,9 +1213,16 @@ static int conn_upkeep(struct Curl_easy *data,
   /* Param is unused. */
   (void)param;
 
-  if(conn->handler->connection_check)
+  if(conn->handler->connection_check) {
+    /* briefly attach the connection to this transfer for the purpose of
+       checking it */
+    Curl_attach_connnection(data, conn);
+
     /* Do a protocol-specific keepalive check on the connection. */
     conn->handler->connection_check(data, conn, CONNCHECK_KEEPALIVE);
+    /* detach the connection again */
+    Curl_detach_connnection(data);
+  }
 
   return 0; /* continue iteration */
 }


### PR DESCRIPTION
During the protocol-specific parts of connection upkeep, some code 
assumes that the data->conn pointer already is set correctly.  However, 
there's currently no guarantee of that in the code.

This fix temporarily attaches each connection to the Curl_easy object 
before performing the protocol-specific connection check on it, in a 
similar manner to the connection checking in extract_if_dead().

Fixes #7386
Reported-by: Josie-H