### PR TITLE
docs: fix inconsistencies in EGDSOCKET documentation

### DIFF
--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -29,7 +29,7 @@ CURLOPT_EGDSOCKET \- set EGD socket path
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_EGDSOCKET, char *path);
 .SH DESCRIPTION
 Pass a char * to the null-terminated path name to the Entropy Gathering Daemon
-socket. It will be used to seed the random engine for SSL.
+socket. It will be used to seed the random engine for TLS.
 
 The application does not have to keep the string around after setting this
 option.
@@ -48,7 +48,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-If built TLS enabled. Only the OpenSSL and GnuTLS backends will use this.
+If built with TLS enabled. Only the OpenSSL backend will use this.
 .SH RETURN VALUE
 Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.


### PR DESCRIPTION
Only the OpenSSL backend actually use the EGDSOCKET, or an I missing something? Also use TLS consistently rather than mixing SSL and TLS. While there, also fix a minor spelling nit.