### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/vtls/mbedtls_threadlock.c
+++ b/lib/vtls/mbedtls_threadlock.c
@@ -55,10 +55,8 @@ int Curl_mbedtlsthreadlock_thread_setup(void)
     return 0;     /* error, no number of threads defined */
 
   for(i = 0;  i < NUMT;  i++) {
-    int ret;
 #if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
-    ret = pthread_mutex_init(&mutex_buf[i], NULL);
-    if(ret)
+    if(pthread_mutex_init(&mutex_buf[i], NULL))
       return 0; /* pthread_mutex_init failed */
 #elif defined(USE_THREADS_WIN32) && defined(HAVE_PROCESS_H)
     mutex_buf[i] = CreateMutex(0, FALSE, 0);
@@ -78,14 +76,11 @@ int Curl_mbedtlsthreadlock_thread_cleanup(void)
     return 0; /* error, no threads locks defined */
 
   for(i = 0; i < NUMT; i++) {
-    int ret;
 #if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
-    ret = pthread_mutex_destroy(&mutex_buf[i]);
-    if(ret)
+    if(pthread_mutex_destroy(&mutex_buf[i]))
       return 0; /* pthread_mutex_destroy failed */
 #elif defined(USE_THREADS_WIN32) && defined(HAVE_PROCESS_H)
-    ret = CloseHandle(mutex_buf[i]);
-    if(!ret)
+    if(!CloseHandle(mutex_buf[i]))
       return 0; /* CloseHandle failed */
 #endif /* USE_THREADS_POSIX && HAVE_PTHREAD_H */
   }
@@ -98,17 +93,14 @@ int Curl_mbedtlsthreadlock_thread_cleanup(void)
 int Curl_mbedtlsthreadlock_lock_function(int n)
 {
   if(n < NUMT) {
-    int ret;
 #if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
-    ret = pthread_mutex_lock(&mutex_buf[n]);
-    if(ret) {
+    if(pthread_mutex_lock(&mutex_buf[n])) {
       DEBUGF(fprintf(stderr,
                      "Error: mbedtlsthreadlock_lock_function failed\n"));
       return 0; /* pthread_mutex_lock failed */
     }
 #elif defined(USE_THREADS_WIN32) && defined(HAVE_PROCESS_H)
-    ret = (WaitForSingleObject(mutex_buf[n], INFINITE) == WAIT_FAILED?1:0);
-    if(ret) {
+    if(WaitForSingleObject(mutex_buf[n], INFINITE) == WAIT_FAILED) {
       DEBUGF(fprintf(stderr,
                      "Error: mbedtlsthreadlock_lock_function failed\n"));
       return 0; /* pthread_mutex_lock failed */
@@ -121,17 +113,14 @@ int Curl_mbedtlsthreadlock_lock_function(int n)
 int Curl_mbedtlsthreadlock_unlock_function(int n)
 {
   if(n < NUMT) {
-    int ret;
 #if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
-    ret = pthread_mutex_unlock(&mutex_buf[n]);
-    if(ret) {
+    if(pthread_mutex_unlock(&mutex_buf[n])) {
       DEBUGF(fprintf(stderr,
                      "Error: mbedtlsthreadlock_unlock_function failed\n"));
       return 0; /* pthread_mutex_unlock failed */
     }
 #elif defined(USE_THREADS_WIN32) && defined(HAVE_PROCESS_H)
-    ret = ReleaseMutex(mutex_buf[n]);
-    if(!ret) {
+    if(!ReleaseMutex(mutex_buf[n])) {
       DEBUGF(fprintf(stderr,
                      "Error: mbedtlsthreadlock_unlock_function failed\n"));
       return 0; /* pthread_mutex_lock failed */


### PR DESCRIPTION
Variable ret is only used in case of USE_THREADS_POSIX. Other cases will issue a warning about unused variable.