### PR TITLE
[PellesC] fix _lseeki64() macro

### DIFF
--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -100,6 +100,7 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 /* 64-bit lseek-like function unavailable */
 #    define _lseeki64(hnd,ofs,whence) _lseek(hnd,ofs,whence)
 #  else
+#    undef _lseeki64
 #    define _lseeki64(hnd,ofs,whence) _lseek64(hnd,ofs,whence)
 #  endif
 #endif


### PR DESCRIPTION
Compilng with latest version 10.0 of PellesC gives this error:
```c
tool_cb_see.c(104): error #1050: Redefinition of macro '_lseeki64'.
```

It's `<io.h>` defines `_lseeki64()` as:
```
#define _lseeki64(h,o,m)  _lseek64(h,o,m)
```
PellesC' pre-processor seems to have an issue with redefining arguments inside the macro; using `(h,o,m)` 
also works in curl.  But a bit more elegant IMHO just to `#undef` and redefine.