### PR TITLE
[PellesC] missing '_tcsnccmp'

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -143,16 +143,6 @@
 
 #define BACKEND connssl->backend
 
-/* PellesC v10 does not have this in it's <tchar.h>
- */
-#ifndef _tcsnccmp
-#  ifdef UNICODE
-#    define _tcsnccmp wcsncmp
-#  else
-#    define _tcsnccmp strncmp
-#  endif
-#endif
-
 static Curl_recv schannel_recv;
 static Curl_send schannel_send;
 
@@ -382,23 +372,23 @@ get_cert_location(TCHAR *path, DWORD *store_name, TCHAR **store_path,
 
   store_name_len = sep - path;
 
-  if(_tcsnccmp(path, TEXT("CurrentUser"), store_name_len) == 0)
+  if(_tcsncmp(path, TEXT("CurrentUser"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_USER;
-  else if(_tcsnccmp(path, TEXT("LocalMachine"), store_name_len) == 0)
+  else if(_tcsncmp(path, TEXT("LocalMachine"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE;
-  else if(_tcsnccmp(path, TEXT("CurrentService"), store_name_len) == 0)
+  else if(_tcsncmp(path, TEXT("CurrentService"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_SERVICE;
-  else if(_tcsnccmp(path, TEXT("Services"), store_name_len) == 0)
+  else if(_tcsncmp(path, TEXT("Services"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_SERVICES;
-  else if(_tcsnccmp(path, TEXT("Users"), store_name_len) == 0)
+  else if(_tcsncmp(path, TEXT("Users"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_USERS;
-  else if(_tcsnccmp(path, TEXT("CurrentUserGroupPolicy"),
+  else if(_tcsncmp(path, TEXT("CurrentUserGroupPolicy"),
                     store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY;
-  else if(_tcsnccmp(path, TEXT("LocalMachineGroupPolicy"),
+  else if(_tcsncmp(path, TEXT("LocalMachineGroupPolicy"),
                     store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY;
-  else if(_tcsnccmp(path, TEXT("LocalMachineEnterprise"),
+  else if(_tcsncmp(path, TEXT("LocalMachineEnterprise"),
                     store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE;
   else

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -143,6 +143,16 @@
 
 #define BACKEND connssl->backend
 
+/* PellesC v10 does not have this in it's <tchar.h>
+ */
+#ifndef _tcsnccmp
+#  ifdef UNICODE
+#    define _tcsnccmp wcsncmp
+#  else
+#    define _tcsnccmp strncmp
+#  endif
+#endif
+
 static Curl_recv schannel_recv;
 static Curl_send schannel_send;
 


### PR DESCRIPTION
PellesC compiler (ver. 10) does not have this macro in it's `<tchar.h>`.
But it has `_tcsncmp` which in MSVC `<tchar.h>` header is defined exactly the same for `UNICODE`:
```c
#define _tcsnccmp       wcsncmp
#define _tcsncmp        wcsncmp
```
