### PR TITLE
docs: split comments and option-per line

### DIFF
--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -19,9 +19,12 @@ between the option and its parameter.
 If the parameter contains whitespace (or starts with : or =), the parameter
 must be enclosed within quotes. Within double quotes, the following escape
 sequences are available: \\\\, \\", \\t, \\n, \\r and \\v. A backslash
-preceding any other letter is ignored. If the first column of a config line is
-a '#' character, the rest of the line will be treated as a comment. Only write
-one option per physical line in the config file.
+preceding any other letter is ignored.
+
+If the first column of a config line is a '#' character, the rest of the line
+will be treated as a comment.
+
+Only write one option per physical line in the config file.
 
 Specify the filename to --config as '-' to make curl read the file from stdin.
 


### PR DESCRIPTION
* comments aren't related to whitespace
* one option per line is unrelated to both