### PR TITLE
CI/cirrus: install impacket from PyPI instead of FreeBSD packages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,16 +37,16 @@ freebsd_task:
 
   env:
     CIRRUS_CLONE_DEPTH: 10
+    CRYPTOGRAPHY_DONT_BUILD_RUST: 1
     MAKE_FLAGS: -j 2
 
   pkginstall_script:
     - pkg update -f
     - pkg install -y autoconf automake libtool pkgconf brotli openldap-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel
-    - case `python -V` in
-        Python?3.7*) pkg install -y py37-impacket ;;
-        Python?2.7*) pkg install -y py27-impacket ;;
-      esac
     - pkg delete -y curl
+    - easy_install "cryptography<3.2"
+    - easy_install "pyOpenSSL<20.0"
+    - easy_install "impacket"
   configure_script:
     - ./buildconf
     - case `uname -r` in


### PR DESCRIPTION
Availability of impacket as FreeBSD package is too flaky.