### PR TITLE
mbedtls: Remove unnecessary #include

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -86,7 +86,6 @@
 #elif defined(USE_MBEDTLS)
 
 #  include <mbedtls/des.h>
-#  include "curl_md4.h"
 
 #elif defined(USE_SECTRANSP)
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -659,10 +659,6 @@ int netware_init(void);
       defined(USE_OS400CRYPTO) || defined(USE_WIN32_CRYPTO) ||              \
       (defined(USE_WOLFSSL) && defined(HAVE_WOLFSSL_DES_ECB_ENCRYPT))
 #    define USE_CURL_NTLM_CORE
-#    if defined(USE_MBEDTLS)
-       /* Get definition of MBEDTLS_MD4_C */
-#      include <mbedtls/md4.h>
-#    endif
 #  endif
 #  if defined(USE_CURL_NTLM_CORE) || defined(USE_WINDOWS_SSPI)
 #    define USE_NTLM


### PR DESCRIPTION
- curl_setup.h: all references to mbedtls_md4* functions and structures are in the md4.c. This file already includes the <mbedtls/md4.h> file along with the file existence control (defined (MBEDTLS_MD4_C))
- curl_ntlm_core.c: unnecessary include - repeated below