### PR TITLE
curl_multibyte: Resurrect local encoding fallbacks

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -34,6 +34,54 @@
 
 #include "curl_multibyte.h"
 
+/* utf8_strict_codepoint_count:
+Count the number of Unicode codepoints encoded in a UTF-8 string.
+
+Note that a UTF-8 BOM is a codepoint and is counted.
+
+This function also tests for valid UTF-8 in accordance with the Unicode
+Standard, Section Conformance 3.9, Table 3-7, Well-Formed UTF-8 Byte Sequences.
+http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G7404
+
+The UTF-8 conformance in this function must remain strict, its purpose is to
+test for exactly that. Any byte sequence that is not well-formed is an error.
+
+Success: (>= 0) The number of codepoints in valid UTF-8 string 'str'.
+Failure: (-1) String 'str' is not valid UTF-8.
+*/
+curl_off_t curlx_utf8_strict_codepoint_count(const char *str)
+{
+  const unsigned char *ch = (const unsigned char *)str;
+  const curl_off_t error = -1;
+  curl_off_t count = 0;
+
+  for(; *ch; ++ch, ++count) {
+    unsigned char first = *ch; /* first byte */
+    if(count == CURL_OFF_T_MAX)
+      return error;
+    if(*ch <= 0x7F)
+      continue;
+    if(*ch < 0xC2 || *ch > 0xF4)
+      return error;
+    ++ch; /* second byte */
+    if(*ch < (first == 0xE0 ? 0xA0 : (first == 0xF0 ? 0x90 : 0x80)) ||
+       *ch > (first == 0xED ? 0x9F : (first == 0xF4 ? 0x8F : 0xBF)))
+      return error;
+    if(first <= 0xDF)
+      continue;
+    ++ch; /* third byte */
+    if(*ch < 0x80 || *ch > 0xBF)
+      return error;
+    if(first <= 0xEF)
+      continue;
+    ++ch; /* fourth byte */
+    if(*ch < 0x80 || *ch > 0xBF)
+      return error;
+  }
+
+  return count;
+}
+
 /*
  * MultiByte conversions using Windows kernel32 library.
  */
@@ -90,11 +138,6 @@ int curlx_win32_open(const char *filename, int oflag, ...)
 {
   int pmode = 0;
 
-#ifdef _UNICODE
-  int result = -1;
-  wchar_t *filename_w = curlx_convert_UTF8_to_wchar(filename);
-#endif
-
   va_list param;
   va_start(param, oflag);
   if(oflag & O_CREAT)
@@ -102,76 +145,88 @@ int curlx_win32_open(const char *filename, int oflag, ...)
   va_end(param);
 
 #ifdef _UNICODE
-  if(filename_w) {
-    result = _wopen(filename_w, oflag, pmode);
-    free(filename_w);
+  if(curlx_is_str_utf8(filename)) {
+    int result = -1;
+    wchar_t *filename_w = curlx_convert_UTF8_to_wchar(filename);
+    if(filename_w) {
+      result = _wopen(filename_w, oflag, pmode);
+      free(filename_w);
+    }
+    else
+      errno = EINVAL;
+    return result;
   }
   else
-    errno = EINVAL;
-  return result;
-#else
-  return (_open)(filename, oflag, pmode);
 #endif
+    return (_open)(filename, oflag, pmode);
 }
 
 FILE *curlx_win32_fopen(const char *filename, const char *mode)
 {
 #ifdef _UNICODE
-  FILE *result = NULL;
-  wchar_t *filename_w = curlx_convert_UTF8_to_wchar(filename);
-  wchar_t *mode_w = curlx_convert_UTF8_to_wchar(mode);
-  if(filename_w && mode_w)
-    result = _wfopen(filename_w, mode_w);
+  if(curlx_is_str_utf8(filename)) {
+    FILE *result = NULL;
+    wchar_t *filename_w = curlx_convert_UTF8_to_wchar(filename);
+    wchar_t *mode_w = curlx_convert_UTF8_to_wchar(mode);
+    if(filename_w && mode_w)
+      result = _wfopen(filename_w, mode_w);
+    else
+      errno = EINVAL;
+    free(filename_w);
+    free(mode_w);
+    return result;
+  }
   else
-    errno = EINVAL;
-  free(filename_w);
-  free(mode_w);
-  return result;
-#else
-  return (fopen)(filename, mode);
 #endif
+    return (fopen)(filename, mode);
 }
 
 int curlx_win32_stat(const char *path, struct_stat *buffer)
 {
 #ifdef _UNICODE
-  int result = -1;
-  wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
-  if(path_w) {
+  if(curlx_is_str_utf8(path)) {
+    int result = -1;
+    wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
+    if(path_w) {
 #if defined(USE_WIN32_SMALL_FILES)
-    result = _wstat(path_w, buffer);
+      result = _wstat(path_w, buffer);
 #else
-    result = _wstati64(path_w, buffer);
+      result = _wstati64(path_w, buffer);
 #endif
-    free(path_w);
+      free(path_w);
+    }
+    else
+      errno = EINVAL;
+    return result;
   }
   else
-    errno = EINVAL;
-  return result;
-#else
+#endif
+  {
 #if defined(USE_WIN32_SMALL_FILES)
-  return _stat(path, buffer);
+    return _stat(path, buffer);
 #else
-  return _stati64(path, buffer);
+    return _stati64(path, buffer);
 #endif
-#endif
+  }
 }
 
 int curlx_win32_access(const char *path, int mode)
 {
 #if defined(_UNICODE)
-  int result = -1;
-  wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
-  if(path_w) {
-    result = _waccess(path_w, mode);
-    free(path_w);
+  if(curlx_is_str_utf8(path)) {
+    int result = -1;
+    wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
+    if(path_w) {
+      result = _waccess(path_w, mode);
+      free(path_w);
+    }
+    else
+      errno = EINVAL;
+    return result;
   }
   else
-    errno = EINVAL;
-  return result;
-#else
-  return _access(path, mode);
 #endif
+    return _access(path, mode);
 }
 
 #endif /* USE_WIN32_LARGE_FILES || USE_WIN32_SMALL_FILES */

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -25,12 +25,16 @@
 
 #if defined(WIN32)
 
+curl_off_t curlx_utf8_strict_codepoint_count(const char *str);
+#define curlx_is_str_utf8(str) (curlx_utf8_strict_codepoint_count(str) >= 0)
+
  /*
   * MultiByte conversions using Windows kernel32 library.
   */
 
 wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8);
 char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
+
 #endif /* WIN32 */
 
 /*


### PR DESCRIPTION
This is an undo of 765e060 which removed local encoding fallbacks in
Windows Unicode builds.

Briefly, Windows Unicode builds are expected to use UTF-8 for file paths
internally however the user may pass paths in the current locale. Though
that is not expected for paths that are opened internally it may be
necessary for paths passed to dependencies that expect current locale
encoding. It is not documented which paths are expected to be passed in
UTF-8 encoding in Windows Unicode builds.

Prior to 765e060 the behavior was to convert the passed in string from
UTF-8 to UTF-16 and then pass that to the respective wide character file
function (eg _wfopen). If the conversion or the file function failed
then as a fallback it would try the passed in string with the regular
file function (eg fopen).

In comparison, the behavior in this change is check explicitly to see if
the string is valid UTF-8 before the conversion and only if it is not
then fall back on the respective file function that uses the current
locale.

The main difference is the file function failing no longer causes a
fallback to occur. That removes what could be considered a slight
security or stability issue since it could fail for any reason, such
as file does not exist.

Comments I made in 765e060 describing a security issue are incorrect.
Regardless of any fallback it is possible for the user to pass a string
in the current locale that is also valid UTF-8. The security issue IMO
is that it is not documented or well known which strings should be in
which encoding, except that as developers we know UTF-8 is used for file
paths internally (ie files opened by curl/libcurl) when Windows Unicode.

Closes #xxxx