### PR TITLE
docs: make the documentation for `--etag-save` match the program behaviour

### DIFF
--- a/docs/cmdline-opts/etag-compare.d
+++ b/docs/cmdline-opts/etag-compare.d
@@ -5,15 +5,14 @@ Protocols: HTTP
 Added: 7.68.0
 Category: http
 ---
-This option makes a conditional HTTP request for the specific
-ETag read from the given file by sending a custom If-None-Match
-header using the extracted ETag.
+This option makes a conditional HTTP request for the specific ETag read
+from the given file by sending a custom If-None-Match header using the
+stored ETag.
 
-For correct results, make sure that specified file contains only a single
-line with a desired ETag. An empty file is parsed as an empty ETag.
+For correct results, make sure that the specified file contains only a
+single line with the desired ETag. An empty file is parsed as an empty
+ETag.
 
 Use the option --etag-save to first save the ETag from a response, and
-then use this option to compare using the saved ETag in a subsequent request.
-
-**COMPARISON**: There are 2 types of comparison or ETags: Weak and Strong.
-This option expects, and uses a strong comparison.
+then use this option to compare against the saved ETag in a subsequent
+request.

--- a/docs/cmdline-opts/etag-save.d
+++ b/docs/cmdline-opts/etag-save.d
@@ -5,13 +5,7 @@ Protocols: HTTP
 Added: 7.68.0
 Category: http
 ---
-This option saves an HTTP ETag to the specified file. Etag is
-usually part of headers returned by a request. When server sends an
-ETag, it must be enveloped by a double quote. This option extracts the
-ETag without the double quotes and saves it into the <file>.
+This option saves an HTTP ETag to the specified file. An ETag is a
+caching related header, usually returned in a response.
 
-A server can send a weak ETag which is prefixed by "W/". This identifier
-is not considered, and only relevant ETag between quotation marks is parsed.
-
-It an ETag wasn't sent by the server or it cannot be parsed, an empty
-file is created.
+If no ETag is sent by the server, an empty file is created.


### PR DESCRIPTION
When using curl with the option `--etag-save` I expected it to save the ETag without its surrounding quotes, as stated by the documentation in the repository and by the generated man pages.

My first endeavour was to fix the program, but while investigating the history of the relevant parts, I discovered that curl once saved the ETag without the quotes.
This was undone by Daniel Stenberg (@bagder) in commit [`98c94596f5928840177b6bd3c7b0f0dd03a431af`](https://github.com/curl/curl/commit/98c94596f5928840177b6bd3c7b0f0dd03a431af), therefore I decided that in this case the documentation should be adjusted to match the behaviour of curl.

The changed save behaviour also made parts of the `--etag-compare` documentation wrong or superfluous, so I adjusted those accordingly.