### PR TITLE
docs: fix globoff grammar

### DIFF
--- a/docs/cmdline-opts/globoff.d
+++ b/docs/cmdline-opts/globoff.d
@@ -4,6 +4,6 @@ Help: Disable URL sequences and ranges using {} and []
 Category: curl
 ---
 This option switches off the "URL globbing parser". When you set this option,
-you can specify URLs that contain the letters {}[] without having them being
-interpreted by curl itself. Note that these letters are not normal legal URL
-contents but they should be encoded according to the URI standard.
+you can specify URLs that contain the letters {}[] without having curl itself
+interpret them. Note that these letters are not normal legal URL contents but
+they should be encoded according to the URI standard.


### PR DESCRIPTION
`having them being interpreted` doesn't work (https://app.grammarly.com agrees)