### PR TITLE
connect: fix wrong format specifier in connect error string

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1038,7 +1038,8 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
     else
       hostname = conn->host.name;
 
-    failf(data, "Failed to connect to %s port %u after %ld ms: %s",
+    failf(data, "Failed to connect to %s port %u after "
+                "%" CURL_FORMAT_TIMEDIFF_T " ms: %s",
         hostname, conn->port,
         Curl_timediff(now, data->progress.t_startsingle),
         Curl_strerror(error, buffer, sizeof(buffer)));


### PR DESCRIPTION
0842175 (not in any release) used the wrong format specifier (long int)
for timediff_t. On an OS such as Windows libcurl's timediff_t (usually
64-bit) is bigger than long int (32-bit). In 32-bit Windows builds the
upper 32-bits of the timediff_t were erroneously then used by the next
format specifier. Usually since the timeout isn't larger than 32-bits
this would result in null as a pointer to the string with the reason for
the connection failing. On other OSes or maybe other compilers it could
probably result in garbage values (ie crash on deref).

Before:
Failed to connect to localhost port 12345 after 1201 ms: (nil)

After:
Failed to connect to localhost port 12345 after 1203 ms: Connection refused

Closes #xxxx