### PR TITLE
doc: npn document negation

### DIFF
--- a/docs/cmdline-opts/no-npn.d
+++ b/docs/cmdline-opts/no-npn.d
@@ -11,3 +11,6 @@ Category: tls http
 Disable the NPN TLS extension. NPN is enabled by default if libcurl was built
 with an SSL library that supports NPN. NPN is used by a libcurl that supports
 HTTP/2 to negotiate HTTP/2 support with the server during https sessions.
+
+Note that this is the negated option name documented. You can thus use
+--npn to enable the extension.


### PR DESCRIPTION
All of the other `no-` items have this line, I can't see any particular reason this one doesn't.

But, if it's special, it really should explain why it doesn't have a counterpart...