### PR TITLE
[Review]Fix the potential 2038 issues

### DIFF
--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -86,7 +86,7 @@ struct timeval tvnow(void)
     (void)gettimeofday(&now, NULL);
 #else
   else {
-    now.tv_sec = (long)time(NULL);
+    now.tv_sec = time(NULL);
     now.tv_usec = 0;
   }
 #endif
@@ -115,7 +115,7 @@ struct timeval tvnow(void)
   ** time() returns the value of time in seconds since the Epoch.
   */
   struct timeval now;
-  now.tv_sec = (long)time(NULL);
+  now.tv_sec = time(NULL);
   now.tv_usec = 0;
   return now;
 }

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -67,7 +67,7 @@ struct timeval tutil_tvnow(void)
     (void)gettimeofday(&now, NULL);
 #else
   else {
-    now.tv_sec = (long)time(NULL);
+    now.tv_sec = time(NULL);
     now.tv_usec = 0;
   }
 #endif
@@ -96,7 +96,7 @@ struct timeval tutil_tvnow(void)
   ** time() returns the value of time in seconds since the Epoch.
   */
   struct timeval now;
-  now.tv_sec = (long)time(NULL);
+  now.tv_sec = time(NULL);
   now.tv_usec = 0;
   return now;
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -488,7 +488,7 @@ static struct timeval tvnow(void)
     (void)gettimeofday(&now, NULL);
 #else
   else {
-    now.tv_sec = (long)time(NULL);
+    now.tv_sec = time(NULL);
     now.tv_usec = 0;
   }
 #endif
@@ -517,7 +517,7 @@ static struct timeval tvnow(void)
   ** time() returns the value of time in seconds since the Epoch.
   */
   struct timeval now;
-  now.tv_sec = (long)time(NULL);
+  now.tv_sec = time(NULL);
   now.tv_usec = 0;
   return now;
 }


### PR DESCRIPTION
1. The length of long in a 32-bit system is 32 bits, which cannot be used to save timestamps after 2038.
Most operating systems have extended time_t to 64 bits.
2. The return type of time() is time_t,  the tv_sec type in struct timeval is time_t except windows.  
    Possible loss of data caused by the following code: 
    The code `now.tv_sec = (long)time(NULL);` 
3. This pull request don't solve the 2038 issues in windows. 

This changes is to remove the operation of casting to long.