### PR TITLE
bearssl: support CURLOPT_CAINFO_BLOB

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
@@ -58,8 +58,8 @@ if(curl) {
 .SH AVAILABILITY
 Added in 7.77.0.
 
-This option is supported by the OpenSSL, Secure
-Transport and Schannel backends.
+This option is supported by the BearSSL (since 7.79.0),
+OpenSSL, Secure Transport and Schannel backends.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.


### PR DESCRIPTION
Just implement support to use `CURLOPT_CAINFO_BLOB` with bearssl.
Also fixed bearssl support building error on `hostname = NULL;` while having `const char * const hostname = SSL_HOST_NAME();`

There are four ways to implement support:
- have one function with parsing cert file from the buffer and two ways to get buffer. I don't want to read an entire file into memory so denied
- have two big functions with similar code buf from different sources. Too big code repeat so denied
- parse cert file iteratively while having state struct. Need to split function into some struct, init(), dispose() and update(). Denied because of complexity
- have some switches in the cert parsing function. The easiest way with a minimum amount of modification. Implemented this way