### PR TITLE
progress: Trigger the progress function at the beginning of MSTATE_DO

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2019,6 +2019,14 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       break;
 
     case MSTATE_DO:
+      /* At this point this connection is definitely connected, so trigger
+         the progress callback if it's been configured. */
+      Curl_set_in_callback(data, true);
+      if(data->set.fxferinfo != NULL) {
+        data->set.fxferinfo(data->set.progress_client, 0, 0, 0, 0);
+      }
+      Curl_set_in_callback(data, false);
+
       if(data->set.connect_only) {
         /* keep connection open for application to use the socket */
         connkeep(data->conn, "CONNECT_ONLY");


### PR DESCRIPTION
Before sending any data, trigger the progress function at the start of MSTATE_DO,
so that programs dependent on performing work before sending any data can
do that work.

---

I'm aware this probably won't get in as is 😀 I want to start a discussion on the best way to do this.

My program has a requirement to "do some work" (drop a log) before any data is sent on a connection. Unfortunately there's no callback that's called when a connection is "connected". Without creating an entirely new callback for just that, this is the next best thing.

Would appreciate thoughts on the direction this should go.