### PR TITLE
configure: tweak nghttp2 library name fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2541,7 +2541,7 @@ if test X"$want_h2" != Xno; then
     LDFLAGS="$LDFLAGS $LD_H2"
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
-    LIB_H2_NAME=${LIB_H2#"-l"}
+    LIB_H2_NAME=`echo $LIB_H2 | $SED -e 's/-l//'`
 
     # use nghttp2_session_set_local_window_size to require nghttp2
     # >= 1.12.0


### PR DESCRIPTION
commit 29c7cf79e8b44cf (shipped in 7.78.0) introduced a problem by
assuming that LIB_H2 does not have any leading whitespace.  At least
OpenBSD's native pkg-config can produce such whitespace, though:

    $ pkg-config --libs-only-l libnghttp2
     -lnghttp2

As a result, the configure check for libnghttp2 will erroneously fail.

Bug: https://curl.se/mail/lib-2021-07/0050.html