### PR TITLE
docs/MQTT: update state of username/password support

### DIFF
--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -21,9 +21,7 @@ payload.
 ## Caveats
 
 Remaining limitations:
- - No username support
  - Only QoS level 0 is implemented for publish
  - No way to set retain flag for publish
- - No username/password support
  - No TLS (mqtts) support
  - Naive EAGAIN handling won't handle split messages


### PR DESCRIPTION
PR #7243 implemented username/password support for MQTT, so let's drop these items from the caveats.