### PR TITLE
Fix various mixups of PIDs being used in the testsuite

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1691,7 +1691,6 @@ sub runhttpsserver {
     }
 
     my $pid2;
-    my $pid3;
     my $httpspid;
     my $port = 24512; # start attempt
     for (1 .. 10) {
@@ -1862,7 +1861,6 @@ sub runpingpongserver {
         $doesntrun{$pidfile} = 1;
         return (0,0);
     }
-
     $pid2 = $pid3;
 
     logmsg "RUN: $srvrname server is PID $ftppid port $port\n" if($verbose);
@@ -1957,10 +1955,9 @@ sub runftpsserver {
     $flags .= "--stunnel \"$stunnel\" --srcdir \"$srcdir\" ";
     $flags .= "--connect $FTPPORT";
 
-    my $port = 26713;
-    my $pid2;
-    my $pid3;
     my $ftpspid;
+    my $pid2;
+    my $port = 26713;
     for (1 .. 10) {
         $port += int(rand(700));
         my $options = "$flags --accept $port";
@@ -5158,7 +5155,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid SMB => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'dict'}="$pid $pid2";
+                $run{'smb'}="$pid $pid2";
             }
         }
         elsif($what eq "telnet") {
@@ -5170,7 +5167,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid neg TELNET => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'dict'}="$pid $pid2";
+                $run{'telnet'}="$pid $pid2";
             }
         }
         elsif($what eq "none") {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -810,8 +810,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */
       logmsg("Identifying ourselves as friends");
-      msnprintf(msgbuf, sizeof(msgbuf), "RTSP_SERVER WE ROOLZ: %ld\r\n",
-                (long)getpid());
+      msnprintf(msgbuf, sizeof(msgbuf), "RTSP_SERVER WE ROOLZ: %"
+                CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
       msglen = strlen(msgbuf);
       msnprintf(weare, sizeof(weare),
                 "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -994,7 +994,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */
       logmsg("Identifying ourselves as friends");
-      msnprintf(msgbuf, sizeof(msgbuf), "WE ROOLZ: %ld\r\n", (long)getpid());
+      msnprintf(msgbuf, sizeof(msgbuf), "WE ROOLZ: %"
+                CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
       msglen = strlen(msgbuf);
       if(use_gopher)
         msnprintf(weare, sizeof(weare), "%s", msgbuf);

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1065,8 +1065,8 @@ static int validate_access(struct testcase *test,
 
   if(!strncmp("verifiedserver", filename, 14)) {
     char weare[128];
-    size_t count = msnprintf(weare, sizeof(weare),
-                             "WE ROOLZ: %ld\r\n", (long)getpid());
+    size_t count = msnprintf(weare, sizeof(weare), "WE ROOLZ: %"
+                             CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
 
     logmsg("Are-we-friendly question received");
     test->buffer = strdup(weare);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -269,17 +269,11 @@ int wait_ms(int timeout_ms)
   return r;
 }
 
-int write_pidfile(const char *filename)
+curl_off_t our_getpid(void)
 {
-  FILE *pidfile;
   curl_off_t pid;
 
   pid = (curl_off_t)getpid();
-  pidfile = fopen(filename, "wb");
-  if(!pidfile) {
-    logmsg("Couldn't write pid file: %s %s", filename, strerror(errno));
-    return 0; /* fail */
-  }
 #if defined(WIN32) || defined(_WIN32)
   /* store pid + 65536 to avoid conflict with Cygwin/msys PIDs, see also:
    * - https://cygwin.com/git/?p=newlib-cygwin.git;a=commit; ↵
@@ -289,6 +283,20 @@ int write_pidfile(const char *filename)
    */
   pid += 65536;
 #endif
+  return pid;
+}
+
+int write_pidfile(const char *filename)
+{
+  FILE *pidfile;
+  curl_off_t pid;
+
+  pid = our_getpid();
+  pidfile = fopen(filename, "wb");
+  if(!pidfile) {
+    logmsg("Couldn't write pid file: %s %s", filename, strerror(errno));
+    return 0; /* fail */
+  }
   fprintf(pidfile, "%" CURL_FORMAT_CURL_OFF_T "\n", pid);
   fclose(pidfile);
   logmsg("Wrote pid %" CURL_FORMAT_CURL_OFF_T " to %s", pid, filename);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -60,6 +60,7 @@ void win32_cleanup(void);
 FILE *test2fopen(long testno);
 
 int wait_ms(int timeout_ms);
+curl_off_t our_getpid(void);
 int write_pidfile(const char *filename);
 int write_portfile(const char *filename, int port);
 void set_advisor_read_lock(const char *filename);


### PR DESCRIPTION
This PR contains these commits to fix leaking test servers while testing on Windows:

- tests/runtests.pl: cleanup copy&paste mistakes and unused code
- tests/servers: use our platform-aware pid for server verification

  The pid used for server verification is later stored as pid2 in
  the hash of running test servers and therefore used for shutdown.

  The pid used for shutdown must be the platform-aware (Win32) pid
  to avoid leaking test servers while running them using Cygwin/msys.

The issues were made visible while working on #7180.