### PR TITLE
tests/servers: remove obsolete pid variable

### DIFF
--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1053,7 +1053,6 @@ int main(int argc, char *argv[])
   int rc;
   int error;
   int arg = 1;
-  long pid;
 
   memset(&req, 0, sizeof(req));
 
@@ -1135,8 +1134,6 @@ int main(int argc, char *argv[])
 #endif
 
   install_signal_handlers(false);
-
-  pid = (long)getpid();
 
 #ifdef ENABLE_IPV6
   if(!use_ipv6)
@@ -1377,7 +1374,7 @@ server_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s rtspd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, pid, exit_signal);
+           ipv_inuse, (int)port, (long)getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1880,7 +1880,6 @@ int main(int argc, char *argv[])
   int rc = 0;
   int error;
   int arg = 1;
-  long pid;
   const char *connecthost = "127.0.0.1";
   const char *socket_type = "IPv4";
   char port_str[11];
@@ -2018,8 +2017,6 @@ int main(int argc, char *argv[])
 #endif
 
   install_signal_handlers(false);
-
-  pid = (long)getpid();
 
   sock = socket(socket_domain, SOCK_STREAM, 0);
 
@@ -2365,7 +2362,7 @@ sws_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s sws (%s pid: %ld) exits with signal (%d)",
-           socket_type, location_str, pid, exit_signal);
+           socket_type, location_str, (long)getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -555,7 +555,6 @@ int main(int argc, char **argv)
   int flag;
   int rc;
   int error;
-  long pid;
   struct testcase test;
   int result = 0;
 
@@ -636,8 +635,6 @@ int main(int argc, char **argv)
 #endif
 
   install_signal_handlers(true);
-
-  pid = (long)getpid();
 
 #ifdef ENABLE_IPV6
   if(!use_ipv6)
@@ -861,7 +858,7 @@ tftpd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s tftpd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, pid, exit_signal);
+           ipv_inuse, (int)port, (long)getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we


### PR DESCRIPTION
Variable is not used since pidfile handling moved to util.[ch]