### PR TITLE
http_proxy: clear 'sending' when the outgoing request is sent

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -390,6 +390,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
         k->upload_fromhere += bytes_written;
         return result;
       }
+      http->sending = HTTPSEND_NADA;
       /* if nothing left to send, continue */
     }
     { /* READING RESPONSE PHASE */


### PR DESCRIPTION
... so that Curl_connect_getsock() will know how to wait for the socket
to become readable and not writable after the entire CONNECT request has
been issued.

Regression added in 7.77.0

Reported-by: zloi-user on github
Assisted-by: Jay Satiro
Fixes #7155