### PR TITLE
configure.ac: tweak nghttp2 library name fix again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2541,7 +2541,7 @@ if test X"$want_h2" != Xno; then
     LDFLAGS="$LDFLAGS $LD_H2"
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
-    LIB_H2_NAME=`echo $LIB_H2 | $SED -e 's/-l//'`
+    LIB_H2_NAME=`echo $LIB_H2 | $SED -ne 's/.*-l *\(nghttp2[^ ]*\).*/\1/p'`
 
     # use nghttp2_session_set_local_window_size to require nghttp2
     # >= 1.12.0


### PR DESCRIPTION
- Change extraction to handle multiple library names returned by
  pkg-config (eg a possible scenario with pkg-config --static).

Ref: https://github.com/curl/curl/pull/7472

Closes #xxxx