### PR TITLE
cookie_interface: avoid printing time_t directly

### DIFF
--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -93,9 +93,9 @@ main(void)
 #define snprintf _snprintf
 #endif
     /* Netscape format cookie */
-    snprintf(nline, sizeof(nline), "%s\t%s\t%s\t%s\t%lu\t%s\t%s",
+    snprintf(nline, sizeof(nline), "%s\t%s\t%s\t%s\t%.0lf\t%s\t%s",
              ".example.com", "TRUE", "/", "FALSE",
-             (unsigned long)time(NULL) + 31337UL,
+             difftime(time(NULL) + 31337, (time_t)0),
              "PREF", "hello example, i like you very much!");
     res = curl_easy_setopt(curl, CURLOPT_COOKIELIST, nline);
     if(res != CURLE_OK) {


### PR DESCRIPTION
time_t representation is undefined and varies on bitsize and signedness,
and as of C11 could be even non integer.

instead of casting to unsigned long (which would truncate in systems with
a 32bit long after 2106) use difftime to get the elapsed time as a double
and print that (without decimals) instead.

alternatively a cast to curl_off_t and its corresponding print formatting
could have been used (at least in POSIX) but portability and curl agnostic
code was prioritized.