### PR TITLE
mail-rcpt.d: fix grammar

### DIFF
--- a/docs/cmdline-opts/mail-rcpt.d
+++ b/docs/cmdline-opts/mail-rcpt.d
@@ -5,11 +5,8 @@ Protocols: SMTP
 Added: 7.20.0
 Category: smtp
 ---
-Specify a single address, user name or mailing list name. Repeat this
+Specify a single e-mail address, user name or mailing list name. Repeat this
 option several times to send to multiple recipients.
-
-When performing a mail transfer, the recipient should specify a valid email
-address to send the mail to.
 
 When performing an address verification (VRFY command), the recipient should be
 specified as the user name or user name and domain (as per Section 3.5 of


### PR DESCRIPTION
Remove confusing sentence that says to specify an e-mail address for
mail transfer, since that's implied.

Reported-by: Josh Soref

Fixes https://github.com/curl/curl/issues/7452
Closes #xxxx
