### PR TITLE
example/cookie_interface: fix scan-build printf warning

### DIFF
--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -93,7 +93,7 @@ main(void)
 #define snprintf _snprintf
 #endif
     /* Netscape format cookie */
-    snprintf(nline, sizeof(nline), "%s\t%s\t%s\t%s\t%.0lf\t%s\t%s",
+    snprintf(nline, sizeof(nline), "%s\t%s\t%s\t%s\t%.0f\t%s\t%s",
              ".example.com", "TRUE", "/", "FALSE",
              difftime(time(NULL) + 31337, (time_t)0),
              "PREF", "hello example, i like you very much!");

--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -69,7 +69,7 @@ main(void)
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   if(curl) {
-    char nline[256];
+    char nline[512];
 
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
Follow-up to 4b79c4fb565

Fixes #7497