### PR TITLE
c-hyper: remove the hyper_executor_poll() loop from Curl_http

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -341,8 +341,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
     hyper_task_free(task);
 
     if(t == HYPER_TASK_ERROR) {
-      hyper_code errnum = hyper_error_code(hypererr);
-      if(errnum == HYPERE_ABORTED_BY_CALLBACK) {
+      if(data->state.hresult) {
         /* override Hyper's view, might not even be an error */
         result = data->state.hresult;
         infof(data, "hyperstream is done (by early callback)");

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -351,7 +351,9 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
         size_t errlen = hyper_error_print(hypererr, errbuf, sizeof(errbuf));
         hyper_code code = hyper_error_code(hypererr);
         failf(data, "Hyper: [%d] %.*s", (int)code, (int)errlen, errbuf);
-        if((code == HYPERE_UNEXPECTED_EOF) && !data->req.bytecount)
+        if(code == HYPERE_ABORTED_BY_CALLBACK)
+          result = CURLE_OK;
+        else if((code == HYPERE_UNEXPECTED_EOF) && !data->req.bytecount)
           result = CURLE_GOT_NOTHING;
         else if(code == HYPERE_INVALID_PEER_MESSAGE)
           result = CURLE_UNSUPPORTED_PROTOCOL; /* maybe */


### PR DESCRIPTION
1. it's superfluous
2. it didn't work identically to the Curl_hyper_stream one which could
   cause problems like #7486

Pointed-out-by: David Cook