### PR TITLE
curl-openssl.m4: check lib64 for the pkg-config file

### DIFF
--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -330,8 +330,21 @@ if test "x$OPT_OPENSSL" != xno; then
     if test -f "$OPENSSL_PCDIR/openssl.pc"; then
       AC_MSG_NOTICE([PKG_CONFIG_LIBDIR will be set to "$OPENSSL_PCDIR"])
       PKGTEST="yes"
-    elif test ! -f "$PREFIX_OPENSSL/include/openssl/ssl.h"; then
-      AC_MSG_ERROR([$PREFIX_OPENSSL is a bad --with-openssl prefix!])
+    fi
+
+    if test "$PKGTEST" != "yes"; then
+      # try lib64 instead
+      OPENSSL_PCDIR="$OPT_OPENSSL/lib64/pkgconfig"
+      if test -f "$OPENSSL_PCDIR/openssl.pc"; then
+        AC_MSG_NOTICE([PKG_CONFIG_LIBDIR will be set to "$OPENSSL_PCDIR"])
+        PKGTEST="yes"
+      fi
+    fi
+
+    if test "$PKGTEST" != "yes"; then
+      if test ! -f "$PREFIX_OPENSSL/include/openssl/ssl.h"; then
+        AC_MSG_ERROR([$PREFIX_OPENSSL is a bad --with-openssl prefix!])
+      fi
     fi
 
     dnl in case pkg-config comes up empty, use what we got

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -242,7 +242,7 @@
         OPENSSL3: "yes"
         C: >-
           --with-openssl={{ ansible_user_dir }}/openssl3
-        LD_LIBRARY_PATH: "{{ ansible_user_dir }}/openssl3/lib:/usr/local/lib"
+        LD_LIBRARY_PATH: "{{ ansible_user_dir }}/openssl3/lib64:/usr/local/lib"
         TFLAGS: https ftps
 
 - job:


### PR DESCRIPTION
OpenSSL recently started putting the libs in $prefix/lib64 on 'make
install', so we check that directory for pkg-config data if the
'lib' check fails.