### PR TITLE
hyper: rewrite executor interface

### DIFF
--- a/lib/c-hyper.h
+++ b/lib/c-hyper.h
@@ -36,14 +36,6 @@ typedef enum hyptaskud {
   HYPERUD_RESPONSE,
   /* from hyper_body_foreach(), no output */
   HYPERUD_BODY_FOREACH,
-  /* for proxy CONNECT, from hyper_clientconn_handshake(),
-   * outputs a hyper_clientconn* */
-  HYPERUD_CONNECT_HANDSHAKE,
-  /* for proxy CONNECT, from hyper_clientconn_send(),
-   * outputs a hyper_response* */
-  HYPERUD_CONNECT_RESPONSE,
-  /* for proxy CONNECT, from hyper_body_foreach(), no output */
-  HYPERUD_CONNECT_BODY_FOREACH,
 } hyptaskud;
 
 /* whether a task has completed yet, and whether it returned its output or an
@@ -74,21 +66,6 @@ struct hyptransfer {
 
   hyptaskstatus body_foreach_status;
   hyper_error *body_foreach_error;
-
-  hyptaskstatus proxy_handshake_status;
-  union {
-    hyper_clientconn *conn;
-    hyper_error *error;
-  } proxy_handshake_result;
-
-  hyptaskstatus proxy_response_status;
-  union {
-    hyper_response *response;
-    hyper_error *error;
-  } proxy_response_result;
-
-  hyptaskstatus proxy_body_foreach_status;
-  hyper_error *proxy_body_foreach_error;
 
   hyper_waker *exp100_waker;
 };

--- a/lib/c-hyper.h
+++ b/lib/c-hyper.h
@@ -31,27 +31,27 @@
  * them */
 typedef enum hyptaskud {
   /* from hyper_clientconn_handshake(), outputs a hyper_clientconn* */
-  CURL_HYPER_TASKUD_HANDSHAKE = 1,
+  HYPERUD_HANDSHAKE = 1,
   /* from hyper_clientconn_send(), outputs a hyper_response* */
-  CURL_HYPER_TASKUD_RESPONSE,
+  HYPERUD_RESPONSE,
   /* from hyper_body_foreach(), no output */
-  CURL_HYPER_TASKUD_BODY_FOREACH,
+  HYPERUD_BODY_FOREACH,
   /* for proxy CONNECT, from hyper_clientconn_handshake(),
    * outputs a hyper_clientconn* */
-  CURL_HYPER_TASKUD_CONNECT_HANDSHAKE,
+  HYPERUD_CONNECT_HANDSHAKE,
   /* for proxy CONNECT, from hyper_clientconn_send(),
    * outputs a hyper_response* */
-  CURL_HYPER_TASKUD_CONNECT_RESPONSE,
+  HYPERUD_CONNECT_RESPONSE,
   /* for proxy CONNECT, from hyper_body_foreach(), no output */
-  CURL_HYPER_TASKUD_CONNECT_BODY_FOREACH,
+  HYPERUD_CONNECT_BODY_FOREACH,
 } hyptaskud;
 
 /* whether a task has completed yet, and whether it returned its output or an
  * error */
 typedef enum hyptaskstatus {
-  CURL_HYPER_TASK_NOT_DONE = 0,
-  CURL_HYPER_TASK_COMPLETE,
-  CURL_HYPER_TASK_ERROR,
+  HYPERTASK_NOT_DONE = 0,
+  HYPERTASK_COMPLETE,
+  HYPERTASK_ERROR,
 } hyptaskstatus;
 
 /* per-transfer data for the Hyper backend */
@@ -62,33 +62,33 @@ struct hyptransfer {
 
   hyptaskstatus handshake_status;
   union {
-    hyper_clientconn* output;
-    hyper_error* error;
+    hyper_clientconn *conn;
+    hyper_error *error;
   } handshake_result;
 
   hyptaskstatus response_status;
   union {
-    hyper_response* output;
-    hyper_error* error;
+    hyper_response *response;
+    hyper_error *error;
   } response_result;
 
   hyptaskstatus body_foreach_status;
-  hyper_error* body_foreach_error;
+  hyper_error *body_foreach_error;
 
-  hyptaskstatus connect_handshake_status;
+  hyptaskstatus proxy_handshake_status;
   union {
-    hyper_clientconn* output;
-    hyper_error* error;
-  } connect_handshake_result;
+    hyper_clientconn *conn;
+    hyper_error *error;
+  } proxy_handshake_result;
 
-  hyptaskstatus connect_response_status;
+  hyptaskstatus proxy_response_status;
   union {
-    hyper_response* output;
-    hyper_error* error;
-  } connect_response_result;
+    hyper_response *response;
+    hyper_error *error;
+  } proxy_response_result;
 
-  hyptaskstatus connect_body_foreach_status;
-  hyper_error* connect_body_foreach_error;
+  hyptaskstatus proxy_body_foreach_status;
+  hyper_error *proxy_body_foreach_error;
 
   hyper_waker *exp100_waker;
 };
@@ -106,7 +106,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
 CURLcode Curl_hyper_header(struct Curl_easy *data, hyper_headers *headers,
                            const char *line);
 void Curl_hyper_done(struct Curl_easy *);
-bool Curl_hyper_poll_executor(struct hyptransfer *h);
+bool Curl_hyper_poll(struct hyptransfer *h);
 
 #else
 #define Curl_hyper_done(x)

--- a/lib/c-hyper.h
+++ b/lib/c-hyper.h
@@ -52,18 +52,21 @@ struct hyptransfer {
   hyper_waker *read_waker;
   const hyper_executor *exec;
 
+  hyptaskud handshake_task_id;
   hyptaskstatus handshake_status;
   union {
     hyper_clientconn *conn;
     hyper_error *error;
   } handshake_result;
 
+  hyptaskud response_task_id;
   hyptaskstatus response_status;
   union {
     hyper_response *response;
     hyper_error *error;
   } response_result;
 
+  hyptaskud body_foreach_task_id;
   hyptaskstatus body_foreach_status;
   hyper_error *body_foreach_error;
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -738,6 +738,9 @@ static CURLcode CONNECT(struct Curl_easy *data,
       h->handshake_status = HYPERTASK_NOT_DONE;
       h->response_status = HYPERTASK_NOT_DONE;
       h->body_foreach_status = HYPERTASK_NOT_DONE;
+      h->handshake_task_id = HYPERUD_HANDSHAKE;
+      h->response_task_id = HYPERUD_RESPONSE;
+      h->body_foreach_task_id = HYPERUD_BODY_FOREACH;
       io = hyper_io_new();
       if(!io) {
         failf(data, "Couldn't create hyper IO");
@@ -777,8 +780,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
       }
       io = NULL;
       options = NULL;
-      hyper_task_set_userdata(handshake,
-                              (void *)HYPERUD_HANDSHAKE);
+      hyper_task_set_userdata(handshake, &h->handshake_task_id);
 
       if(HYPERE_OK != hyper_executor_push(h->exec, handshake)) {
         failf(data, "Couldn't hyper_executor_push the handshake");
@@ -866,8 +868,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
         failf(data, "hyper_clientconn_send");
         goto error;
       }
-      hyper_task_set_userdata(sendtask,
-                              (void *)HYPERUD_RESPONSE);
+      hyper_task_set_userdata(sendtask, &h->response_task_id);
 
       if(HYPERE_OK != hyper_executor_push(h->exec, sendtask)) {
         failf(data, "Couldn't hyper_executor_push the send");

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -735,9 +735,9 @@ static CURLcode CONNECT(struct Curl_easy *data,
     switch(s->tunnel_state) {
     case TUNNEL_INIT:
       /* BEGIN CONNECT PHASE */
-      h->connect_handshake_status = CURL_HYPER_TASK_NOT_DONE;
-      h->connect_response_status = CURL_HYPER_TASK_NOT_DONE;
-      h->connect_body_foreach_status = CURL_HYPER_TASK_NOT_DONE;
+      h->proxy_handshake_status = HYPERTASK_NOT_DONE;
+      h->proxy_response_status = HYPERTASK_NOT_DONE;
+      h->proxy_body_foreach_status = HYPERTASK_NOT_DONE;
       io = hyper_io_new();
       if(!io) {
         failf(data, "Couldn't create hyper IO");
@@ -778,7 +778,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
       io = NULL;
       options = NULL;
       hyper_task_set_userdata(handshake,
-                              (void *)CURL_HYPER_TASKUD_CONNECT_HANDSHAKE);
+                              (void *)HYPERUD_CONNECT_HANDSHAKE);
 
       if(HYPERE_OK != hyper_executor_push(h->exec, handshake)) {
         failf(data, "Couldn't hyper_executor_push the handshake");
@@ -786,19 +786,19 @@ static CURLcode CONNECT(struct Curl_easy *data,
       }
       handshake = NULL; /* ownership passed on */
 
-      while(h->connect_handshake_status == CURL_HYPER_TASK_NOT_DONE) {
-        Curl_hyper_poll_executor(h);
+      while(h->proxy_handshake_status == HYPERTASK_NOT_DONE) {
+        Curl_hyper_poll(h);
       }
-      if(h->connect_handshake_status == CURL_HYPER_TASK_ERROR) {
+      if(h->proxy_handshake_status == HYPERTASK_ERROR) {
         failf(data, "Error from hyper_clientconn_handshake");
-        hyper_error_free(h->connect_handshake_result.error);
-        h->connect_handshake_result.error = NULL;
+        hyper_error_free(h->proxy_handshake_result.error);
+        h->proxy_handshake_result.error = NULL;
         result = CURLE_WRITE_ERROR;
         goto error;
       }
 
-      client = h->connect_handshake_result.output;
-      h->connect_handshake_result.output = NULL;
+      client = h->proxy_handshake_result.conn;
+      h->proxy_handshake_result.conn = NULL;
       req = hyper_request_new();
       if(!req) {
         failf(data, "Couldn't hyper_request_new");
@@ -867,7 +867,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
         goto error;
       }
       hyper_task_set_userdata(sendtask,
-                              (void *)CURL_HYPER_TASKUD_CONNECT_RESPONSE);
+                              (void *)HYPERUD_CONNECT_RESPONSE);
 
       if(HYPERE_OK != hyper_executor_push(h->exec, sendtask)) {
         failf(data, "Couldn't hyper_executor_push the send");
@@ -947,13 +947,13 @@ static CURLcode CONNECT(struct Curl_easy *data,
   if(handshake)
     hyper_task_free(handshake);
 
-  if(h->connect_response_status == CURL_HYPER_TASK_ERROR) {
+  if(h->proxy_response_status == HYPERTASK_ERROR) {
     uint8_t errbuf[256];
-    size_t errlen = hyper_error_print(h->connect_response_result.error,
+    size_t errlen = hyper_error_print(h->proxy_response_result.error,
                                       errbuf, sizeof(errbuf));
     failf(data, "Hyper: %.*s", (int)errlen, errbuf);
-    hyper_error_free(h->connect_response_result.error);
-    h->connect_response_result.error = NULL;
+    hyper_error_free(h->proxy_response_result.error);
+    h->proxy_response_result.error = NULL;
   }
   return result;
 }


### PR DESCRIPTION
Perform all executor polls through one common function, and identify finished tasks with the user data pointer rather than the output type.

Fixes #7486

Here's a first try at the alternate approach I laid out in the issue. I added enum and union fields to the `hyptransfer` struct for each task's result, and the new executor polling wrapper will store results in those fields as they arrive. Note that HTTP requests and HTTP CONNECT proxies both kick off two tasks in their own separate functions, and then they both pass through `Curl_hyper_stream`, which consumes the response task, starts the body foreach task, and consumes it as well.