### PR TITLE
tests/*server.py: remove pidfile on server termination

### DIFF
--- a/tests/dictserver.py
+++ b/tests/dictserver.py
@@ -188,5 +188,8 @@ if __name__ == '__main__':
         log.exception(e)
         rc = ScriptRC.EXCEPTION
 
+    if options.pidfile and os.path.isfile(options.pidfile):
+        os.unlink(options.pidfile)
+
     log.info("[DICT] Returning %d", rc)
     sys.exit(rc)

--- a/tests/negtelnetserver.py
+++ b/tests/negtelnetserver.py
@@ -364,5 +364,8 @@ if __name__ == '__main__':
         log.exception(e)
         rc = ScriptRC.EXCEPTION
 
+    if options.pidfile and os.path.isfile(options.pidfile):
+        os.unlink(options.pidfile)
+
     log.info("Returning %d", rc)
     sys.exit(rc)

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -391,5 +391,8 @@ if __name__ == '__main__':
         log.exception(e)
         rc = ScriptRC.EXCEPTION
 
+    if options.pidfile and os.path.isfile(options.pidfile):
+        os.unlink(options.pidfile)
+
     log.info("[SMB] Returning %d", rc)
     sys.exit(rc)


### PR DESCRIPTION
Avoid pidfile leaking/laying around after server already exited.

Discovered while working on #7180.