### PR TITLE
curl.1: mention "global" flags

### DIFF
--- a/docs/cmdline-opts/libcurl.d
+++ b/docs/cmdline-opts/libcurl.d
@@ -8,5 +8,8 @@ Append this option to any ordinary curl command line, and you will get
 libcurl-using C source code written to the file that does the equivalent
 of what your command-line operation does!
 
+This option is global and does not need to be specified for each use of
+--next.
+
 If this option is used several times, the last given file name will be
 used.

--- a/docs/cmdline-opts/parallel-immediate.d
+++ b/docs/cmdline-opts/parallel-immediate.d
@@ -8,3 +8,6 @@ When doing parallel transfers, this option will instruct curl that it should
 rather prefer opening up more connections in parallel at once rather than
 waiting to see if new transfers can be added as multiplexed streams on another
 connection.
+
+This option is global and does not need to be specified for each use of
+--next.

--- a/docs/cmdline-opts/parallel-max.d
+++ b/docs/cmdline-opts/parallel-max.d
@@ -8,4 +8,7 @@ Category: connection curl
 When asked to do parallel transfers, using --parallel, this option controls
 the maximum amount of transfers to do simultaneously.
 
+This option is global and does not need to be specified for each use of
+--next.
+
 The default is 50.

--- a/docs/cmdline-opts/parallel.d
+++ b/docs/cmdline-opts/parallel.d
@@ -6,3 +6,6 @@ Category: connection curl
 ---
 Makes curl perform its transfers in parallel as compared to the regular serial
 manner.
+
+This option is global and does not need to be specified for each use of
+--next.

--- a/docs/cmdline-opts/progress-bar.d
+++ b/docs/cmdline-opts/progress-bar.d
@@ -11,3 +11,6 @@ shows a percentage if the transfer size is known. For transfers without a
 known size, there will be space ship (-=o=-) that moves back and forth but
 only while data is being transferred, with a set of flying hash sign symbols on
 top.
+
+This option is global and does not need to be specified for each use of
+--next.

--- a/docs/cmdline-opts/show-error.d
+++ b/docs/cmdline-opts/show-error.d
@@ -5,3 +5,6 @@ See-also: no-progress-meter
 Category: curl
 ---
 When used with --silent, it makes curl show an error message if it fails.
+
+This option is global and does not need to be specified for each use of
+--next.

--- a/docs/cmdline-opts/stderr.d
+++ b/docs/cmdline-opts/stderr.d
@@ -7,4 +7,7 @@ Category: verbose
 Redirect all writes to stderr to the specified file instead. If the file name
 is a plain '-', it is instead written to stdout.
 
+This option is global and does not need to be specified for each use of
+--next.
+
 If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/styled-output.d
+++ b/docs/cmdline-opts/styled-output.d
@@ -5,3 +5,6 @@ Category: verbose
 ---
 Enables the automatic use of bold font styles when writing HTTP headers to the
 terminal. Use --no-styled-output to switch them off.
+
+This option is global and does not need to be specified for each use of
+--next.

--- a/docs/cmdline-opts/trace-ascii.d
+++ b/docs/cmdline-opts/trace-ascii.d
@@ -12,4 +12,7 @@ This is very similar to --trace, but leaves out the hex part and only shows
 the ASCII part of the dump. It makes smaller output that might be easier to
 read for untrained humans.
 
+This option is global and does not need to be specified for each use of
+--next.
+
 If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/trace-time.d
+++ b/docs/cmdline-opts/trace-time.d
@@ -4,3 +4,6 @@ Added: 7.14.0
 Category: verbose
 ---
 Prepends a time stamp to each trace or verbose line that curl displays.
+
+This option is global and does not need to be specified for each use of
+--next.

--- a/docs/cmdline-opts/trace.d
+++ b/docs/cmdline-opts/trace.d
@@ -9,4 +9,7 @@ descriptive information, to the given output file. Use "-" as filename to have
 the output sent to stdout. Use "%" as filename to have the output sent to
 stderr.
 
+This option is global and does not need to be specified for each use of
+--next.
+
 If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/verbose.d
+++ b/docs/cmdline-opts/verbose.d
@@ -17,4 +17,7 @@ you're looking for.
 If you think this option still doesn't give you enough details, consider using
 --trace or --trace-ascii instead.
 
+This option is global and does not need to be specified for each use of
+--next.
+
 Use --silent to make curl really quiet.


### PR DESCRIPTION
Mention options that are "global". A global command line option is one
that doesn't get reset at --next uses and therefore don't need to be
used again.

Reported-by: Josh Soref

Fixes #7457