### PR TITLE
Make tests pass until 2037

### DIFF
--- a/tests/data/test1915
+++ b/tests/data/test1915
@@ -41,10 +41,10 @@ http://%HOSTIP:%NOLISTENPORT/not-there/%TESTNUMBER
 7
 </errorcode>
 <stdout>
-[0/4] 1.example.com 20300320 01:02:03
-[1/4] 2.example.com 20300320 01:02:03
-[2/4] 3.example.com 20300320 01:02:03
-[3/4] 4.example.com 20300320 01:02:03
+[0/4] 1.example.com 20370320 01:02:03
+[1/4] 2.example.com 20370320 01:02:03
+[2/4] 3.example.com 20370320 01:02:03
+[3/4] 4.example.com 20370320 01:02:03
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test493
+++ b/tests/data/test493
@@ -33,7 +33,7 @@ https
 </features>
 
 <file name="log/input%TESTNUMBER">
-.hsts.example "20311001 04:47:41"
+.hsts.example "99991001 04:47:41"
 </file>
 
 <name>

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -49,7 +49,8 @@ static CURLSTScode hstsread(CURL *easy, struct curl_hstsentry *e,
   if(host && (strlen(host) < e->namelen)) {
     strcpy(e->name, host);
     e->includeSubDomains = FALSE;
-    strcpy(e->expire, "20300320 01:02:03"); /* curl turns 32 that day */
+    strcpy(e->expire, "20370320 01:02:03"); /* curl turns 39 that day
+                                   just before 31-bit time_t overflow */
     fprintf(stderr, "add '%s'\n", host);
   }
   else


### PR DESCRIPTION
after 2038 something in (or behind) test1915 fails on 32-bit OSes.
It will need fixing within the next years.