### PR TITLE
configure.ac: revert three bad nghttp2 library "fixes"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2541,11 +2541,10 @@ if test X"$want_h2" != Xno; then
     LDFLAGS="$LDFLAGS $LD_H2"
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
-    LIB_H2_NAME=`echo $LIB_H2 | $SED -ne 's/.*-l *\(nghttp2[^ ]*\).*/\1/p'`
 
     # use nghttp2_session_set_local_window_size to require nghttp2
     # >= 1.12.0
-    AC_CHECK_LIB($LIB_H2_NAME, nghttp2_session_set_local_window_size,
+    AC_CHECK_LIB(nghttp2, nghttp2_session_set_local_window_size,
       [
        AC_CHECK_HEADERS(nghttp2/nghttp2.h,
           curl_h2_msg="enabled (nghttp2)"


### PR DESCRIPTION
This reverts commit b4b34db65f9f8, 673753344c5f and 29c7cf79e8b.

The logic is now back to assuming that the nghttp2 lib is called nghttp2 and
nothing else.

Reported-by: Rui Pinheiro
Reported-by: Alex Crichton
Fixes #7514

/cc @jay @t-artikov