### PR TITLE
HTTP/2: revert "call the handle-closed function correctly on closed stream"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2541,7 +2541,7 @@ if test X"$want_h2" != Xno; then
     LDFLAGS="$LDFLAGS $LD_H2"
     CPPFLAGS="$CPPFLAGS $CPP_H2"
     LIBS="$LIB_H2 $LIBS"
-    LIB_H2_NAME=`echo $LIB_H2 | $SED -ne 's/.*-l *\(nghttp2[^ ]*\).*/\1/p'`
+    LIB_H2_NAME=`echo $LIB_H2 | $SED -e 's/-l//'`
 
     # use nghttp2_session_set_local_window_size to require nghttp2
     # >= 1.12.0

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1624,10 +1624,6 @@ static ssize_t http2_recv(struct Curl_easy *data, int sockindex,
     return -1;
   }
 
-  if(stream->closed)
-    /* closed overrides paused */
-    return http2_handle_stream_close(conn, data, stream, err);
-
   /* Nullify here because we call nghttp2_session_send() and they
      might refer to the old buffer. */
   stream->upload_mem = NULL;


### PR DESCRIPTION
Fixes #7400 for me. "Connection died" errors no longer happen.
https://github.com/curl/curl/issues/7400#issuecomment-891064209
@alexcrichton please verify
@badger if you know better solution then reverting previous fixes, I'm free for your suggestions.
