### PR TITLE
Fix compiler warnings with CURL_DISABLE_VERBOSE_STRINGS and DEBUGBUILD

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -99,24 +99,24 @@ int Curl_blockread_all(struct Curl_easy *data,   /* transfer */
 }
 #endif
 
-#ifndef DEBUGBUILD
-#define sxstate(x,y) socksstate(x,y)
-#else
+#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#define DEBUG_AND_VERBOSE
 #define sxstate(x,y) socksstate(x,y, __LINE__)
+#else
+#define sxstate(x,y) socksstate(x,y)
 #endif
-
 
 /* always use this function to change state, to make debugging easier */
 static void socksstate(struct Curl_easy *data,
                        enum connect_t state
-#ifdef DEBUGBUILD
+#ifdef DEBUG_AND_VERBOSE
                        , int lineno
 #endif
 )
 {
   struct connectdata *conn = data->conn;
   enum connect_t oldstate = conn->cnnct.state;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef DEBUG_AND_VERBOSE
   /* synced with the state list in urldata.h */
   static const char * const statename[] = {
     "INIT",
@@ -146,7 +146,7 @@ static void socksstate(struct Curl_easy *data,
 
   conn->cnnct.state = state;
 
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef DEBUG_AND_VERBOSE
   infof(data,
         "SXSTATE: %s => %s conn %p; line %d",
         statename[oldstate], statename[conn->cnnct.state], conn,

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -277,7 +277,9 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   const struct curl_blob *ssl_cert_blob = SSL_SET_OPTION(primary.cert_blob);
   const char * const ssl_crlfile = SSL_SET_OPTION(CRLfile);
   const char * const hostname = SSL_HOST_NAME();
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   const long int port = SSL_HOST_PORT();
+#endif
   int ret = -1;
   char errorbuf[128];
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1364,7 +1364,7 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CERT_CONTEXT *ccert_context = NULL;
   bool isproxy = SSL_IS_PROXY();
-#ifdef DEBUGBUILD
+#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
   const char * const hostname = SSL_HOST_NAME();
 #endif
 #ifdef HAS_ALPN


### PR DESCRIPTION
- socks.c : warning C4100: 'lineno': unreferenced formal parameter
- mbedtls.c: warning C4189: 'port': local variable is initialized but not referenced
- schannel.c: warning C4189: 'hostname': local variable is initialized but not referenced