### PR TITLE
hostip: Make Curl_ipv6works function independent of getaddrinfo

### DIFF
--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -97,7 +97,7 @@ enum resolve_t Curl_resolv_timeout(struct Curl_easy *data,
                                    struct Curl_dns_entry **dnsentry,
                                    timediff_t timeoutms);
 
-#ifdef CURLRES_IPV6
+#ifdef ENABLE_IPV6
 /*
  * Curl_ipv6works() returns TRUE if IPv6 seems to work.
  */

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -60,34 +60,6 @@
 #include "memdebug.h"
 
 /*
- * Curl_ipv6works() returns TRUE if IPv6 seems to work.
- */
-bool Curl_ipv6works(struct Curl_easy *data)
-{
-  if(data) {
-    /* the nature of most system is that IPv6 status doesn't come and go
-       during a program's lifetime so we only probe the first time and then we
-       have the info kept for fast re-use */
-    DEBUGASSERT(data);
-    DEBUGASSERT(data->multi);
-    return data->multi->ipv6_works;
-  }
-  else {
-    int ipv6_works = -1;
-    /* probe to see if we have a working IPv6 stack */
-    curl_socket_t s = socket(PF_INET6, SOCK_DGRAM, 0);
-    if(s == CURL_SOCKET_BAD)
-      /* an IPv6 address was requested but we can't get/use one */
-      ipv6_works = 0;
-    else {
-      ipv6_works = 1;
-      sclose(s);
-    }
-    return (ipv6_works>0)?TRUE:FALSE;
-  }
-}
-
-/*
  * Curl_ipvalid() checks what CURL_IPRESOLVE_* requirements that might've
  * been set and returns TRUE if they are OK.
  */


### PR DESCRIPTION
- Do not assume IPv6 is not working when getaddrinfo is not present.

The check to see if IPv6 actually works is now independent of whether
there is any resolver that can potentially resolve a hostname to IPv6.

Prior to this change if getaddrinfo() was not found at compile time then
Curl_ipv6works() would be defined as a macro that returns FALSE.

When getaddrinfo is not found then libcurl is built with CURLRES_IPV4
defined instead of CURLRES_IPV6, meaning that it cannot do IPv6 lookups
in the traditional way. With this commit if libcurl is built with IPv6
support (ENABLE_IPV6) but without getaddrinfo (CURLRES_IPV6), and the
IPv6 stack is actually working, then it is possible for libcurl to
resolve IPv6 addresses by using DoH.

Ref: https://github.com/curl/curl/issues/7483#issuecomment-890765378

Closes #xxxx