### PR TITLE
tests/*server.pl: flush output before executing subprocess

### DIFF
--- a/tests/httpserver.pl
+++ b/tests/httpserver.pl
@@ -152,4 +152,5 @@ if($verbose) {
     print STDERR "RUN: server/sws".exe_ext('SRV')." $flags\n";
 }
 
-exec("server/sws".exe_ext('SRV')." $flags");
+$| = 1;
+exec("exec server/sws".exe_ext('SRV')." $flags");

--- a/tests/rtspserver.pl
+++ b/tests/rtspserver.pl
@@ -119,4 +119,5 @@ $flags .= "--pidfile \"$pidfile\" ".
     "--logfile \"$logfile\" ";
 $flags .= "--ipv$ipvnum --port $port --srcdir \"$srcdir\"";
 
-exec("server/rtspd".exe_ext('SRV')." $flags");
+$| = 1;
+exec("exec server/rtspd".exe_ext('SRV')." $flags");

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -496,6 +496,9 @@ sub startnew {
     if(0 == $child) {
         # Here we are the child. Run the given command.
 
+        # Flush output.
+        $| = 1;
+
         # Put an "exec" in front of the command so that the child process
         # keeps this child's process ID.
         exec("exec $cmd") || die "Can't exec() $cmd: $!";
@@ -4107,6 +4110,9 @@ sub singletest {
         print GDBCMD "source $gdbinit\n" if -e $gdbinit;
         close(GDBCMD);
     }
+
+    # Flush output.
+    $| = 1;
 
     # timestamp starting of test command
     $timetoolini{$testnum} = Time::HiRes::time();

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5717,6 +5717,10 @@ mkdir($LOGDIR, 0777);
 get_disttests();
 init_serverpidfile_hash();
 
+if(pathhelp::os_is_win()) {
+    $defpostcommanddelay = 0.1;
+}
+
 #######################################################################
 # Output curl version and host info being tested
 #

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -341,6 +341,9 @@ if($tstunnel_windows) {
         close(OUT);
     }
 
+    # Flush output.
+    $| = 1;
+
     # Put an "exec" in front of the command so that the child process
     # keeps this child's process ID by being tied to the spawned shell.
     exec("exec $cmd") || die "Can't exec() $cmd: $!";

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -1122,6 +1122,9 @@ if ($sshdid =~ /OpenSSH-Windows/) {
         close(OUT);
     }
 
+    # Flush output.
+    $| = 1;
+
     # Put an "exec" in front of the command so that the child process
     # keeps this child's process ID by being tied to the spawned shell.
     exec("exec $cmd") || die "Can't exec() $cmd: $!";

--- a/tests/tftpserver.pl
+++ b/tests/tftpserver.pl
@@ -120,4 +120,5 @@ $flags .= "--pidfile \"$pidfile\" ".
     "--logfile \"$logfile\" ";
 $flags .= "--ipv$ipvnum --port $port --srcdir \"$srcdir\"";
 
-exec("server/tftpd".exe_ext('SRV')." $flags");
+$| = 1;
+exec("exec server/tftpd".exe_ext('SRV')." $flags");


### PR DESCRIPTION
Also avoid shell processes staying around by using exec. This may solve the random Windows CI issues.