### PR TITLE
Fix heap over-read when parsing x509 certificates

### DIFF
--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -208,6 +208,9 @@ static const char *octet2str(const char *beg, const char *end)
   size_t n = end - beg;
   char *buf = NULL;
 
+  if(!n)
+    return NULL;
+
   if(n <= (SIZE_T_MAX - 1) / 3) {
     buf = malloc(3 * n + 1);
     if(buf)

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -208,11 +208,8 @@ static const char *octet2str(const char *beg, const char *end)
   size_t n = end - beg;
   char *buf = NULL;
 
-  if(!n)
-    return NULL;
-
   if(n <= (SIZE_T_MAX - 1) / 3) {
-    buf = malloc(3 * n + 1);
+    buf = calloc(3 * n + 1, 1);
     if(buf)
       for(n = 0; beg < end; n += 3)
         msnprintf(buf + n, 4, "%02x:", *(const unsigned char *) beg++);

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -34,6 +34,7 @@
 #include "inet_pton.h"
 #include "curl_base64.h"
 #include "x509asn1.h"
+#include "dynbuf.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -205,16 +206,16 @@ static const char *bool2str(const char *beg, const char *end)
  */
 static const char *octet2str(const char *beg, const char *end)
 {
-  size_t n = end - beg;
-  char *buf = NULL;
+  struct dynbuf buf;
+  CURLcode result;
 
-  if(n <= (SIZE_T_MAX - 1) / 3) {
-    buf = calloc(3 * n + 1, 1);
-    if(buf)
-      for(n = 0; beg < end; n += 3)
-        msnprintf(buf + n, 4, "%02x:", *(const unsigned char *) beg++);
-  }
-  return buf;
+  Curl_dyn_init(&buf, 3 * CURL_ASN1_MAX + 1);
+  result = Curl_dyn_addn(&buf, "", 0);
+
+  while(!result && beg < end)
+    result = Curl_dyn_addf(&buf, "%02x:", *beg++);
+
+  return Curl_dyn_ptr(&buf);
 }
 
 static const char *bit2str(const char *beg, const char *end)

--- a/lib/x509asn1.c
+++ b/lib/x509asn1.c
@@ -213,7 +213,7 @@ static const char *octet2str(const char *beg, const char *end)
   result = Curl_dyn_addn(&buf, "", 0);
 
   while(!result && beg < end)
-    result = Curl_dyn_addf(&buf, "%02x:", *beg++);
+    result = Curl_dyn_addf(&buf, "%02x:", (unsigned char) *beg++);
 
   return Curl_dyn_ptr(&buf);
 }


### PR DESCRIPTION
The function `encodeDN` in `lib/x509asn1.c` has a heap over-read.

Root cause:
```c
static const char *octet2str(const char *beg, const char *end)
{
  size_t n = end - beg;
  char *buf = NULL;

  if(n <= (SIZE_T_MAX - 1) / 3) {
    buf = malloc(3 * n + 1);
    if(buf)
      for(n = 0; beg < end; n += 3)
        msnprintf(buf + n, 4, "%02x:", *(const unsigned char *) beg++);
  }
  return buf;
}
```
If `beg == end`, the returned chunk will be uninitialized.

The uninitialized chunk gets returned by `ASN1tostr` in `encodeDN`:
```c
/* Generate value. */
str = ASN1tostr(&value, 0);
if(!str)
  return -1;
for(p3 = str; *p3; p3++) {
  if(l < buflen)
    buf[l] = *p3;
  l++;
}
free((char *) str);
```

If the chunk doesn't contain a NUL byte, `p3` will go over the chunk boundaries and fills `buf` with some heap metadata.

This can be triggered in two different ways:
1. Decode a zero-length octet string
2. Decode a bit string of length 1

Luckily this isn't dangerous at all since the resulting leak  is only visible to a client using libcurl.