### PR TITLE
Fix HTTP/3 bug: uploading payload larger than 65536 will be blocked until timeout.

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1660,7 +1660,7 @@ static ssize_t ngh3_stream_send(struct Curl_easy *data,
     return -1;
   }
 
-  // Reset post upload buffer after resumed.
+  /* Reset post upload buffer after resumed. */
   if(data->set.postfields) {
     stream->upload_mem = NULL;
     stream->upload_len = 0;

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1660,6 +1660,12 @@ static ssize_t ngh3_stream_send(struct Curl_easy *data,
     return -1;
   }
 
+  // Reset post upload buffer after resumed.
+  if(data->set.postfields) {
+    stream->upload_mem = NULL;
+    stream->upload_len = 0;
+  }
+
   *curlcode = CURLE_OK;
   return sent;
 }

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1661,7 +1661,7 @@ static ssize_t ngh3_stream_send(struct Curl_easy *data,
   }
 
   /* Reset post upload buffer after resumed. */
-  if(data->set.postfields) {
+  if(stream->upload_mem) {
     stream->upload_mem = NULL;
     stream->upload_len = 0;
   }


### PR DESCRIPTION
The upload buffer default size is 65536, if we post a payload larger than this, the first buffer is ok, but when sending the second buffer, the stream will be blocked with a curlcode CURLE_AGAIN. I supoose the cause is the upload_len was not reset.