### PR TITLE
Use a custom implementation of wcsdup on Windows, so that malloc/free…

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -117,7 +117,7 @@ curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)system_strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
 #if defined(WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
+curl_wcsdup_callback Curl_cwcsdup = Curl_wcsdup;
 #endif
 
 #if defined(_MSC_VER) && defined(_DLL) && !defined(__POCC__)

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -24,6 +24,11 @@
 
 #include <curl/curl.h>
 
+#ifdef WIN32
+#include <stdint.h>
+#include <wchar.h>
+#endif
+
 #include "strdup.h"
 #include "curl_memory.h"
 
@@ -47,6 +52,35 @@ char *curlx_strdup(const char *str)
 
   memcpy(newstr, str, len);
   return newstr;
+}
+#endif
+
+#ifdef WIN32
+/***************************************************************************
+ *
+ * Curl_wcsdup(source)
+ *
+ * Copies the 'source' wchar string to a newly allocated buffer (that is
+ * returned).
+ *
+ * Returns the new pointer or NULL on failure.
+ *
+ ***************************************************************************/
+wchar_t *Curl_wcsdup(const wchar_t *src)
+{
+  size_t length = wcslen(src);
+  size_t lengthnul;
+  size_t lengthbytes;
+
+  if (SIZE_MAX - length < 1)
+    return (wchar_t *)NULL; /* overflow */
+  lengthnul = length + 1;
+
+  if ((SIZE_MAX / sizeof(wchar_t)) < lengthnul)
+    return (wchar_t *)NULL; /* overflow */
+  lengthbytes = lengthnul * sizeof(wchar_t);
+
+  return (wchar_t *)Curl_memdup(src, lengthbytes);
 }
 #endif
 

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -25,7 +25,6 @@
 #include <curl/curl.h>
 
 #ifdef WIN32
-#include <stdint.h>
 #include <wchar.h>
 #endif
 
@@ -69,18 +68,11 @@ char *curlx_strdup(const char *str)
 wchar_t *Curl_wcsdup(const wchar_t *src)
 {
   size_t length = wcslen(src);
-  size_t lengthnul;
-  size_t lengthbytes;
 
-  if(SIZE_MAX - length < 1)
-    return (wchar_t *)NULL; /* overflow */
-  lengthnul = length + 1;
+  if(length > (SIZE_T_MAX / sizeof(wchar_t)) - 1)
+    return (wchar_t *)NULL; /* integer overflow */
 
-  if((SIZE_MAX / sizeof(wchar_t)) < lengthnul)
-    return (wchar_t *)NULL; /* overflow */
-  lengthbytes = lengthnul * sizeof(wchar_t);
-
-  return (wchar_t *)Curl_memdup(src, lengthbytes);
+  return (wchar_t *)Curl_memdup(src, (length + 1) * sizeof(wchar_t));
 }
 #endif
 

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -72,11 +72,11 @@ wchar_t *Curl_wcsdup(const wchar_t *src)
   size_t lengthnul;
   size_t lengthbytes;
 
-  if (SIZE_MAX - length < 1)
+  if(SIZE_MAX - length < 1)
     return (wchar_t *)NULL; /* overflow */
   lengthnul = length + 1;
 
-  if ((SIZE_MAX / sizeof(wchar_t)) < lengthnul)
+  if((SIZE_MAX / sizeof(wchar_t)) < lengthnul)
     return (wchar_t *)NULL; /* overflow */
   lengthbytes = lengthnul * sizeof(wchar_t);
 

--- a/lib/strdup.h
+++ b/lib/strdup.h
@@ -26,6 +26,9 @@
 #ifndef HAVE_STRDUP
 extern char *curlx_strdup(const char *str);
 #endif
+#ifdef WIN32
+wchar_t* Curl_wcsdup(const wchar_t* src);
+#endif
 void *Curl_memdup(const void *src, size_t buffer_length);
 void *Curl_saferealloc(void *ptr, size_t size);
 


### PR DESCRIPTION
… overrides from curl_global_init are used for wcsdup correctly.