### PR TITLE
configure: error out if both ngtcp2 and quiche are specified

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2893,6 +2893,11 @@ case "$OPT_QUICHE" in
 esac
 
 if test X"$want_quiche" != Xno; then
+
+  if test "$NGHTTP3_ENABLED" = 1; then
+    AC_MSG_ERROR([--with-quiche and --with-ngtcp2 are mutually exclusive])
+  fi
+
   dnl backup the pre-quiche variables
   CLEANLDFLAGS="$LDFLAGS"
   CLEANCPPFLAGS="$CPPFLAGS"


### PR DESCRIPTION
Reported-by: Vincent Grande
See #7539