### PR TITLE
Add method to suppress response bodies to man page

### DIFF
--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -31,3 +31,11 @@ written as
 See also the --create-dirs option to create the local directories
 dynamically. Specifying the output as '-' (a single dash) will force the
 output to be done to stdout.
+
+To suppress response bodies, you can redirect output to /dev/null:
+
+  curl -o example.com -o /dev/null
+
+Or for Windows use nul:
+
+  curl -o example.com -o nul

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -34,8 +34,8 @@ output to be done to stdout.
 
 To suppress response bodies, you can redirect output to /dev/null:
 
-  curl -o example.com -o /dev/null
+  curl example.com -o /dev/null
 
 Or for Windows use nul:
 
-  curl -o example.com -o nul
+  curl example.com -o nul


### PR DESCRIPTION
I look up [this Stack Overflow answer](https://stackoverflow.com/questions/32488162/curl-suppress-response-body) more times than I'd care to admit so thought I'd propose adding this common use case to the man page.