### PR TITLE
fix bold font style

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -47,7 +47,7 @@ if(something_is_true) {
 ## Comments
 
 Since we write C89 code, **//** comments are not allowed. They weren't
-introduced in the C standard until C99. We use only **/* comments */**.
+introduced in the C standard until C99. We use only __/* comments */__.
 
 ```c
 /* this is a comment */


### PR DESCRIPTION
Markdown gets confused with abundance of asterisks, so use underscores instead.