### PR TITLE
tests/server/*.c: align handling of portfile argument and file

### DIFF
--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -997,6 +997,7 @@ int main(int argc, char *argv[])
            " --version\n"
            " --logfile [file]\n"
            " --pidfile [file]\n"
+           " --portfile [file]\n"
            " --ipv4\n"
            " --ipv6\n"
            " --port [port]\n");
@@ -1048,7 +1049,7 @@ int main(int argc, char *argv[])
     goto mqttd_cleanup;
   }
 
-  wroteportfile = write_portfile(portname, (int)port);
+  wroteportfile = write_portfile(portname, port);
   if(!wroteportfile) {
     goto mqttd_cleanup;
   }
@@ -1067,6 +1068,8 @@ mqttd_cleanup:
 
   if(wrotepidfile)
     unlink(pidname);
+  if(wroteportfile)
+    unlink(portname);
 
   restore_signal_handlers(FALSE);
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1045,10 +1045,11 @@ int main(int argc, char *argv[])
   curl_socket_t sock = CURL_SOCKET_BAD;
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
+  int wroteportfile = 0;
   int flag;
   unsigned short port = DEFAULT_PORT;
   const char *pidname = ".rtsp.pid";
-  const char *portfile = NULL;
+  const char *portname = NULL; /* none by default */
   struct httprequest req;
   int rc;
   int error;
@@ -1077,7 +1078,7 @@ int main(int argc, char *argv[])
     else if(!strcmp("--portfile", argv[arg])) {
       arg++;
       if(argc>arg)
-        portfile = argv[arg++];
+        portname = argv[arg++];
     }
     else if(!strcmp("--logfile", argv[arg])) {
       arg++;
@@ -1248,9 +1249,9 @@ int main(int argc, char *argv[])
   if(!wrotepidfile)
     goto server_cleanup;
 
-  if(portfile) {
-    wrotepidfile = write_portfile(portfile, port);
-    if(!wrotepidfile)
+  if(portname) {
+    wroteportfile = write_portfile(portname, port);
+    if(!wroteportfile)
       goto server_cleanup;
   }
 
@@ -1364,6 +1365,8 @@ server_cleanup:
 
   if(wrotepidfile)
     unlink(pidname);
+  if(wroteportfile)
+    unlink(portname);
 
   if(serverlogslocked) {
     serverlogslocked = 0;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1320,8 +1320,9 @@ int main(int argc, char *argv[])
   curl_socket_t sock = CURL_SOCKET_BAD;
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
+  int wroteportfile = 0;
   const char *pidname = ".sockfilt.pid";
-  const char *portfile = NULL; /* none by default */
+  const char *portname = NULL; /* none by default */
   bool juggle_again;
   int rc;
   int error;
@@ -1352,7 +1353,7 @@ int main(int argc, char *argv[])
     else if(!strcmp("--portfile", argv[arg])) {
       arg++;
       if(argc > arg)
-        portfile = argv[arg++];
+        portname = argv[arg++];
     }
     else if(!strcmp("--logfile", argv[arg])) {
       arg++;
@@ -1418,6 +1419,7 @@ int main(int argc, char *argv[])
            " --verbose\n"
            " --logfile [file]\n"
            " --pidfile [file]\n"
+           " --portfile [file]\n"
            " --ipv4\n"
            " --ipv6\n"
            " --bindonly\n"
@@ -1518,9 +1520,9 @@ int main(int argc, char *argv[])
     write_stdout("FAIL\n", 5);
     goto sockfilt_cleanup;
   }
-  if(portfile) {
-    wrotepidfile = write_portfile(portfile, port);
-    if(!wrotepidfile) {
+  if(portname) {
+    wroteportfile = write_portfile(portname, port);
+    if(!wroteportfile) {
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;
     }
@@ -1540,6 +1542,8 @@ sockfilt_cleanup:
 
   if(wrotepidfile)
     unlink(pidname);
+  if(wroteportfile)
+    unlink(portname);
 
   restore_signal_handlers(false);
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -882,8 +882,9 @@ int main(int argc, char *argv[])
   curl_socket_t sock = CURL_SOCKET_BAD;
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
+  int wroteportfile = 0;
   const char *pidname = ".socksd.pid";
-  const char *portfile = NULL;
+  const char *portname = NULL; /* none by default */
   bool juggle_again;
   int error;
   int arg = 1;
@@ -907,7 +908,7 @@ int main(int argc, char *argv[])
     else if(!strcmp("--portfile", argv[arg])) {
       arg++;
       if(argc>arg)
-        portfile = argv[arg++];
+        portname = argv[arg++];
     }
     else if(!strcmp("--config", argv[arg])) {
       arg++;
@@ -1014,9 +1015,9 @@ int main(int argc, char *argv[])
     goto socks5_cleanup;
   }
 
-  if(portfile) {
-    wrotepidfile = write_portfile(portfile, port);
-    if(!wrotepidfile) {
+  if(portname) {
+    wroteportfile = write_portfile(portname, port);
+    if(!wroteportfile) {
       goto socks5_cleanup;
     }
   }
@@ -1035,6 +1036,8 @@ socks5_cleanup:
 
   if(wrotepidfile)
     unlink(pidname);
+  if(wroteportfile)
+    unlink(portname);
 
   restore_signal_handlers(false);
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1869,6 +1869,7 @@ int main(int argc, char *argv[])
   srvr_sockaddr_union_t me;
   curl_socket_t sock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
+  int wroteportfile = 0;
   int flag;
   unsigned short port = DEFAULT_PORT;
 #ifdef USE_UNIX_SOCKETS
@@ -2200,8 +2201,8 @@ int main(int argc, char *argv[])
   if(!wrotepidfile)
     goto sws_cleanup;
 
-  wrotepidfile = write_portfile(portname, port);
-  if(!wrotepidfile)
+  wroteportfile = write_portfile(portname, port);
+  if(!wroteportfile)
     goto sws_cleanup;
 
   /* initialization of httprequest struct is done before get_request(), but
@@ -2353,6 +2354,8 @@ sws_cleanup:
 
   if(wrotepidfile)
     unlink(pidname);
+  if(wroteportfile)
+    unlink(portname);
 
   if(serverlogslocked) {
     serverlogslocked = 0;

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -212,9 +212,10 @@ static const char *ipv_inuse = "IPv4";
 
 const  char *serverlogfile = DEFAULT_LOGFILE;
 static const char *pidname = ".tftpd.pid";
-static const char *portfile = NULL;
+static const char *portname = NULL; /* none by default */
 static int serverlogslocked = 0;
 static int wrotepidfile = 0;
+static int wroteportfile = 0;
 
 #ifdef HAVE_SIGSETJMP
 static sigjmp_buf timeoutbuf;
@@ -288,6 +289,10 @@ static void timer(int signum)
     if(wrotepidfile) {
       wrotepidfile = 0;
       unlink(pidname);
+    }
+    if(wroteportfile) {
+      wroteportfile = 0;
+      unlink(portname);
     }
     if(serverlogslocked) {
       serverlogslocked = 0;
@@ -579,7 +584,7 @@ int main(int argc, char **argv)
     else if(!strcmp("--portfile", argv[arg])) {
       arg++;
       if(argc>arg)
-        portfile = argv[arg++];
+        portname = argv[arg++];
     }
     else if(!strcmp("--logfile", argv[arg])) {
       arg++;
@@ -621,6 +626,7 @@ int main(int argc, char **argv)
            " --version\n"
            " --logfile [file]\n"
            " --pidfile [file]\n"
+           " --portfile [file]\n"
            " --ipv4\n"
            " --ipv6\n"
            " --port [port]\n"
@@ -739,9 +745,9 @@ int main(int argc, char **argv)
     goto tftpd_cleanup;
   }
 
-  if(portfile) {
-    wrotepidfile = write_portfile(portfile, port);
-    if(!wrotepidfile) {
+  if(portname) {
+    wroteportfile = write_portfile(portname, port);
+    if(!wroteportfile) {
       result = 1;
       goto tftpd_cleanup;
     }
@@ -846,8 +852,8 @@ tftpd_cleanup:
 
   if(wrotepidfile)
     unlink(pidname);
-  if(portfile)
-    unlink(portfile);
+  if(wroteportfile)
+    unlink(portname);
 
   if(serverlogslocked) {
     serverlogslocked = 0;


### PR DESCRIPTION
1. Call the internal variable portname (like pidname) everywhere.
2. Have a variable wroteportfile (like wrotepidfile) everywhere.
3. Make sure the file is cleaned up on exit (like pidfile).

Replaces #7523