### PR TITLE
ngtcp2: remove the acked_crypto_offset struct field init

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -692,7 +692,6 @@ static ngtcp2_callbacks ng_callbacks = {
   ngtcp2_crypto_decrypt_cb,
   ngtcp2_crypto_hp_mask_cb,
   cb_recv_stream_data,
-  NULL, /* acked_crypto_offset */
   cb_acked_stream_data_offset,
   NULL, /* stream_open */
   cb_stream_close,


### PR DESCRIPTION
... as it is gone from the API upstream.