### PR TITLE
internals: use more const *

### DIFF
--- a/docs/DYNBUF.md
+++ b/docs/DYNBUF.md
@@ -78,25 +78,34 @@ Keep `length` bytes of the buffer tail (the last `length` bytes of the
 buffer). The rest of the buffer is dropped. The specified `length` must not be
 larger than the buffer length.
 
+## trunc
+
+```c
+CURLcode Curl_dyn_trunc(struct dynbuf *s, size_t length);
+```
+
+Keep the first `length` bytes of the buffer. The rest of the buffer is
+dropped. The specified `length` must not be larger than the buffer length.
+
 ## ptr
 
 ```c
-char *Curl_dyn_ptr(const struct dynbuf *s);
+const char *Curl_dyn_ptr(const struct dynbuf *s);
 ```
 
-Returns a `char *` to the buffer if it has a length, otherwise a NULL. Since
-the buffer may be reallocated, this pointer should not be trusted or used
-anymore after the next buffer manipulation call.
+Returns a `const char *` to the buffer if it has a length, otherwise a
+NULL. Since the buffer may be reallocated, this pointer should not be trusted
+or used anymore after the next buffer manipulation call.
 
 ## uptr
 
 ```c
-unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
+const unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
 ```
 
-Returns an `unsigned char *` to the buffer if it has a length, otherwise a
-NULL. Since the buffer may be reallocated, this pointer should not be trusted
-or used anymore after the next buffer manipulation call.
+Returns an `const unsigned char *` to the buffer if it has a length, otherwise
+a NULL. Since the buffer may be reallocated, this pointer should not be
+trusted or used anymore after the next buffer manipulation call.
 
 ## len
 

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -122,7 +122,7 @@ static int hyper_each_header(void *userdata,
 {
   struct Curl_easy *data = (struct Curl_easy *)userdata;
   size_t len;
-  char *headp;
+  const char *headp;
   CURLcode result;
   int writetype;
 

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -902,7 +902,7 @@ static CURLcode client_unencode_write(struct Curl_easy *data,
   if(!nbytes || k->ignorebody)
     return CURLE_OK;
 
-  return Curl_client_write(data, CLIENTWRITE_BODY, (char *) buf, nbytes);
+  return Curl_client_write(data, CLIENTWRITE_BODY, buf, nbytes);
 }
 
 static void client_close_writer(struct Curl_easy *data,

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -450,7 +450,7 @@ Curl_cookie_add(struct Curl_easy *data,
                 struct CookieInfo *c,
                 bool httpheader, /* TRUE if HTTP header-style line */
                 bool noexpire, /* if TRUE, skip remove_expired() */
-                char *lineptr,   /* first character of the line */
+                const char *lineptr, /* first character of the line */
                 const char *domain, /* default domain */
                 const char *path,   /* full path used when this cookie is set,
                                        used to get default path for the cookie
@@ -846,7 +846,8 @@ Curl_cookie_add(struct Curl_easy *data,
     if(ptr)
       *ptr = 0; /* clear it */
 
-    firstptr = strtok_r(lineptr, "\t", &tok_buf); /* tokenize it on the TAB */
+    /* tokenize it on the TAB */
+    firstptr = strtok_r((char *)lineptr, "\t", &tok_buf);
 
     /*
      * Now loop through the fields and init the struct we already have

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -93,7 +93,7 @@ struct Curl_easy;
 
 struct Cookie *Curl_cookie_add(struct Curl_easy *data,
                                struct CookieInfo *c, bool header,
-                               bool noexpiry, char *lineptr,
+                               bool noexpiry, const char *lineptr,
                                const char *domain, const char *path,
                                bool secure);
 

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -263,7 +263,7 @@ static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
 {
   size_t len_in = strlen(input), len_out = 0;
   struct dynbuf b;
-  char *ptr = NULL;
+  const char *ptr = NULL;
   unsigned char *buf = (unsigned char *)data->state.buffer;
   Curl_dyn_init(&b, MAX_NTLM_WB_RESPONSE);
 
@@ -297,7 +297,7 @@ static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
     len_out = Curl_dyn_len(&b);
     ptr = Curl_dyn_ptr(&b);
     if(len_out && ptr[len_out - 1] == '\n') {
-      ptr[len_out - 1] = '\0';
+      Curl_dyn_trunc(&b, --len_out);
       break; /* done! */
     }
     /* loop */
@@ -309,7 +309,7 @@ static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
      ptr[0] == 'P' && ptr[1] == 'W')
     goto done;
   /* invalid response */
-  if(len_out < 4)
+  if(len_out < 3)
     goto done;
   if(state == NTLMSTATE_TYPE1 &&
      (ptr[0]!='Y' || ptr[1]!='R' || ptr[2]!=' '))

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2020, 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -153,6 +153,31 @@ CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail)
 }
 #endif
 
+#ifdef NTLM_WB_ENABLED
+/*
+ * Truncate the string at the given size.
+ */
+CURLcode Curl_dyn_trunc(struct dynbuf *s, size_t newlen)
+{
+  DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
+  DEBUGASSERT(!s->leng || s->bufr);
+  if(newlen > s->leng)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  else if(newlen == s->leng)
+    return CURLE_OK;
+  else if(!newlen) {
+    Curl_dyn_reset(s);
+  }
+  else {
+    s->leng = newlen;
+    s->bufr[s->leng] = 0;
+  }
+  return CURLE_OK;
+
+}
+#endif
+
 /*
  * Appends a buffer with length.
  */
@@ -224,7 +249,7 @@ CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
 /*
  * Returns a pointer to the buffer.
  */
-char *Curl_dyn_ptr(const struct dynbuf *s)
+const char *Curl_dyn_ptr(const struct dynbuf *s)
 {
   DEBUGASSERT(s);
   DEBUGASSERT(s->init == DYNINIT);
@@ -235,7 +260,7 @@ char *Curl_dyn_ptr(const struct dynbuf *s)
 /*
  * Returns an unsigned pointer to the buffer.
  */
-unsigned char *Curl_dyn_uptr(const struct dynbuf *s)
+const unsigned char *Curl_dyn_uptr(const struct dynbuf *s)
 {
   DEBUGASSERT(s);
   DEBUGASSERT(s->init == DYNINIT);

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -36,6 +36,7 @@
 #define Curl_dyn_len(a) curlx_dyn_len(a)
 #define Curl_dyn_reset(a) curlx_dyn_reset(a)
 #define Curl_dyn_tail(a,b) curlx_dyn_tail(a,b)
+#define Curl_dyn_trunc(a,b) curlx_dyn_trunc(a,b)
 #define curlx_dynbuf dynbuf /* for the struct name */
 #endif
 
@@ -61,8 +62,9 @@ CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
   WARN_UNUSED_RESULT;
 void Curl_dyn_reset(struct dynbuf *s);
 CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail);
-char *Curl_dyn_ptr(const struct dynbuf *s);
-unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
+CURLcode Curl_dyn_trunc(struct dynbuf *s, size_t newlen);
+const char *Curl_dyn_ptr(const struct dynbuf *s);
+const unsigned char *Curl_dyn_uptr(const struct dynbuf *s);
 size_t Curl_dyn_len(const struct dynbuf *s);
 
 /* returns 0 on success, -1 on error */

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -117,7 +117,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
     string++;
   }
 
-  return Curl_dyn_ptr(&d);
+  return (char *)Curl_dyn_ptr(&d);
 }
 
 /*

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -227,7 +227,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
     failf(data, "Failed sending Gopher request");
     return result;
   }
-  result = Curl_client_write(data, CLIENTWRITE_HEADER, (char *)"\r\n", 2);
+  result = Curl_client_write(data, CLIENTWRITE_HEADER, "\r\n", 2);
   if(result)
     return result;
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -92,7 +92,7 @@ CURLcode Curl_http_target(struct Curl_easy *data, struct connectdata *conn,
 CURLcode Curl_http_statusline(struct Curl_easy *data,
                               struct connectdata *conn);
 CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
-                          char *headp);
+                          const char *headp);
 CURLcode Curl_transferencode(struct Curl_easy *data);
 CURLcode Curl_http_body(struct Curl_easy *data, struct connectdata *conn,
                         Curl_HttpReq httpreq,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1522,7 +1522,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
   }
 
   if(Curl_dyn_len(&stream->trailer_recvbuf)) {
-    char *trailp = Curl_dyn_ptr(&stream->trailer_recvbuf);
+    const char *trailp = Curl_dyn_ptr(&stream->trailer_recvbuf);
     char *lf;
 
     do {

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -108,7 +108,7 @@ void Curl_httpchunk_init(struct Curl_easy *data)
  * For example, 0x0d and 0x0a are used instead of '\r' and '\n'.
  */
 CHUNKcode Curl_httpchunk_read(struct Curl_easy *data,
-                              char *datap,
+                              const char *datap,
                               ssize_t datalen,
                               ssize_t *wrotep,
                               CURLcode *extrap)
@@ -228,7 +228,7 @@ CHUNKcode Curl_httpchunk_read(struct Curl_easy *data,
 
     case CHUNK_TRAILER:
       if((*datap == 0x0d) || (*datap == 0x0a)) {
-        char *tr = Curl_dyn_ptr(&conn->trailer);
+        const char *tr = Curl_dyn_ptr(&conn->trailer);
         /* this is the end of a trailer, but if the trailer was zero bytes
            there was no trailer and we move on */
 

--- a/lib/http_chunks.h
+++ b/lib/http_chunks.h
@@ -91,7 +91,7 @@ struct Curl_chunker {
 
 /* The following functions are defined in http_chunks.c */
 void Curl_httpchunk_init(struct Curl_easy *data);
-CHUNKcode Curl_httpchunk_read(struct Curl_easy *data, char *datap,
+CHUNKcode Curl_httpchunk_read(struct Curl_easy *data, const char *datap,
                               ssize_t length, ssize_t *wrote,
                               CURLcode *passthru);
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -259,7 +259,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
   curl_socket_t tunnelsocket = conn->sock[sockindex];
   struct http_connect_state *s = conn->connect_state;
   struct HTTP *http = data->req.p.http;
-  char *linep;
+  const char *linep;
   size_t perline;
 
 #define SELECT_OK      0

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -8,7 +8,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -172,6 +172,6 @@ CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
  */
 
 #define Curl_safefree(ptr) \
-  do { free((ptr)); (ptr) = NULL;} while(0)
+  do { free((char *)(ptr)); (ptr) = NULL;} while(0)
 
 #endif /* HEADER_CURL_MEMDEBUG_H */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1085,7 +1085,7 @@ char *curl_mvaprintf(const char *format, va_list ap_save)
     return NULL;
   }
   if(Curl_dyn_len(info.b))
-    return Curl_dyn_ptr(info.b);
+    return (char *)Curl_dyn_ptr(info.b);
   return strdup("");
 }
 

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -169,7 +169,7 @@ CURLcode Curl_pp_vsendf(struct Curl_easy *data,
 {
   ssize_t bytes_written = 0;
   size_t write_len;
-  char *s;
+  const char *s;
   CURLcode result;
   struct connectdata *conn = data->conn;
 

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -53,8 +53,8 @@ struct pingpong {
   bool pending_resp;  /* set TRUE when a server response is pending or in
                          progress, and is cleared once the last response is
                          read */
-  char *sendthis; /* allocated pointer to a buffer that is to be sent to the
-                     server */
+  const char *sendthis; /* allocated pointer to a buffer that is to be sent to
+                           the server */
   size_t sendleft; /* number of bytes left to send from the sendthis buffer */
   size_t sendsize; /* total size of the sendthis buffer */
   struct curltime response; /* set to Curl_now() when a command has been sent

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -765,7 +765,7 @@ CURLcode rtp_client_write(struct Curl_easy *data, char *ptr, size_t len)
   return CURLE_OK;
 }
 
-CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
+CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, const char *header)
 {
   long CSeq = 0;
 
@@ -783,8 +783,8 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
     }
   }
   else if(checkprefix("Session:", header)) {
-    char *start;
-    char *end;
+    const char *start;
+    const char *end;
     size_t idlen;
 
     /* Find the first non-space letter */

--- a/lib/rtsp.h
+++ b/lib/rtsp.h
@@ -29,7 +29,7 @@
 
 extern const struct Curl_handler Curl_handler_rtsp;
 
-CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header);
+CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, const char *header);
 
 #else
 /* disabled */

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -49,7 +49,7 @@ void Curl_failf(struct Curl_easy *, const char *fmt, ...);
 #define CLIENTWRITE_HEADER (1<<1)
 #define CLIENTWRITE_BOTH   (CLIENTWRITE_BODY|CLIENTWRITE_HEADER)
 
-CURLcode Curl_client_write(struct Curl_easy *data, int type, char *ptr,
+CURLcode Curl_client_write(struct Curl_easy *data, int type, const char *ptr,
                            size_t len) WARN_UNUSED_RESULT;
 
 bool Curl_recv_has_postponed_data(struct connectdata *conn, int sockindex);
@@ -84,7 +84,7 @@ CURLcode Curl_write_plain(struct Curl_easy *data,
 
 /* the function used to output verbose information */
 int Curl_debug(struct Curl_easy *data, curl_infotype type,
-               char *ptr, size_t size);
+               const char *ptr, size_t size);
 
 
 #endif /* HEADER_CURL_SENDF_H */

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -94,7 +94,7 @@ struct OperationConfig {
   char *dns_interface; /* interface name */
   char *dns_ipv4_addr; /* dot notation */
   char *dns_ipv6_addr; /* dot notation */
-  char *userpwd;
+  const char *userpwd;
   char *login_options;
   char *tls_username;
   char *tls_password;
@@ -102,7 +102,7 @@ struct OperationConfig {
   char *proxy_tls_username;
   char *proxy_tls_password;
   char *proxy_tls_authtype;
-  char *proxyuserpwd;
+  const char *proxyuserpwd;
   char *proxy;
   int proxyver;             /* set to CURLPROXY_HTTP* define */
   char *noproxy;
@@ -188,7 +188,7 @@ struct OperationConfig {
   bool proxydigest;
   bool proxybasic;
   bool proxyanyauth;
-  char *writeout;           /* %-styled format string to output */
+  const char *writeout;           /* %-styled format string to output */
   struct curl_slist *quote;
   struct curl_slist *postquote;
   struct curl_slist *prequote;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -105,7 +105,7 @@ static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
   }
   else {        /* Standard input. */
     int fd = fileno(stdin);
-    char *data = NULL;
+    const char *data = NULL;
     curl_off_t size;
     curl_off_t origin;
     struct_stat sbuf;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -619,7 +619,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
   free(per->this_url);
   free(per->separator_err);
   free(per->separator);
-  free(per->outfile);
+  free((char *)per->outfile);
   free(per->uploadfile);
 
   return result;
@@ -846,7 +846,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         /* --etag-compare */
         if(config->etag_compare_file) {
-          char *etag_from_file = NULL;
+          const char *etag_from_file = NULL;
           char *header = NULL;
 
           /* open file for reading: */
@@ -961,7 +961,9 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           else if(state->urls) {
             /* fill '#1' ... '#9' terms from URL pattern */
             char *storefile = per->outfile;
-            result = glob_match_url(&per->outfile, storefile, state->urls);
+            const char *getit = NULL;
+            result = glob_match_url(&getit, storefile, state->urls);
+            per->outfile = (char *)getit;
             Curl_safefree(storefile);
             if(result) {
               /* bad globbing */

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -62,7 +62,7 @@ struct getout *new_getout(struct OperationConfig *config)
 
 #define MAX_FILE2STRING (256*1024*1024) /* big enough ? */
 
-ParameterError file2string(char **bufp, FILE *file)
+ParameterError file2string(const char **bufp, FILE *file)
 {
   struct curlx_dynbuf dyn;
   curlx_dyn_init(&dyn, MAX_FILE2STRING);
@@ -80,13 +80,13 @@ ParameterError file2string(char **bufp, FILE *file)
         return PARAM_NO_MEM;
     }
   }
-  *bufp = curlx_dyn_ptr(&dyn);
+  *bufp = (char *)curlx_dyn_ptr(&dyn);
   return PARAM_OK;
 }
 
 #define MAX_FILE2MEMORY (1024*1024*1024) /* big enough ? */
 
-ParameterError file2memory(char **bufp, size_t *size, FILE *file)
+ParameterError file2memory(const char **bufp, size_t *size, FILE *file)
 {
   if(file) {
     size_t nread;
@@ -437,7 +437,7 @@ ParameterError str2offset(curl_off_t *val, const char *str)
 static CURLcode checkpasswd(const char *kind, /* for what purpose */
                             const size_t i,   /* operation index */
                             const bool last,  /* TRUE if last operation */
-                            char **userpwd)   /* pointer to allocated string */
+                            const char **userpwd) /* ptr to allocated string */
 {
   char *psep;
   char *osep;
@@ -480,7 +480,7 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
       return CURLE_OUT_OF_MEMORY;
 
     /* return the new string */
-    free(*userpwd);
+    free((char *)*userpwd);
     *userpwd = curlx_dyn_ptr(&dyn);
   }
 

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -25,9 +25,9 @@
 
 struct getout *new_getout(struct OperationConfig *config);
 
-ParameterError file2string(char **bufp, FILE *file);
+ParameterError file2string(const char **bufp, FILE *file);
 
-ParameterError file2memory(char **bufp, size_t *size, FILE *file);
+ParameterError file2memory(const char **bufp, size_t *size, FILE *file);
 
 void cleanarg(char *str);
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -138,7 +138,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 
   if(file) {
     char *line;
-    char *option;
+    const char *option;
     char *param;
     int lineno = 0;
     bool dashed_option;
@@ -150,7 +150,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       int res;
       bool alloced_param = FALSE;
       lineno++;
-      line = curlx_dyn_ptr(&buf);
+      line = (char *)curlx_dyn_ptr(&buf);
       if(!line) {
         rc = 1; /* out of memory */
         break;

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -610,7 +610,8 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
 
 #define MAX_OUTPUT_GLOB_LENGTH (10*1024)
 
-CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
+CURLcode glob_match_url(const char **result, char *filename,
+                        struct URLGlob *glob)
 {
   char numbuf[18];
   char *appendthis = (char *)"";

--- a/src/tool_urlglob.h
+++ b/src/tool_urlglob.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -70,7 +70,7 @@ struct URLGlob {
 
 CURLcode glob_url(struct URLGlob**, char *, unsigned long *, FILE *);
 CURLcode glob_next_url(char **, struct URLGlob *);
-CURLcode glob_match_url(char **, char *, struct URLGlob *);
+CURLcode glob_match_url(const char **, char *, struct URLGlob *);
 void glob_cleanup(struct URLGlob *glob);
 
 #endif /* HEADER_CURL_TOOL_URLGLOB_H */


### PR DESCRIPTION
Generally use const pointers more widely where the data pointed to is
not supposed to be modified.

Curl_dyn_ptr() and Curl_dyn_uptr() now return const pointers to strongly
suggest users shouldn't modify the string directly. To help, I added
Curl_dyn_trunc() for truncating a dynbuf.

Curl_write_client() is fixed to take a const. It now allocates temporary
memory for the replacement buffer it might need for FTP transfers.