### PR TITLE
openssl: when creating a new context, there cannot be an old one

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2658,8 +2658,7 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-  if(backend->ctx)
-    SSL_CTX_free(backend->ctx);
+  DEBUGASSERT(!backend->ctx);
   backend->ctx = SSL_CTX_new(req_method);
 
   if(!backend->ctx) {


### PR DESCRIPTION
Remove the previous handling would call SSL_CTX_free() and instead add
an assert that will halt a debug build if there ever is a context
already set at this point.