### PR TITLE
CI: use GitHub Container Registry instead of Docker Hub

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -117,65 +117,65 @@ stages:
       matrix:
         msys2_mingw32_debug_openssl:
           name: 32-bit OpenSSL/libssh2
-          container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2 --with-openssl
           tests: ~571 ~612 ~1056 ~1299 !SCP
         msys2_mingw64_debug_openssl:
           name: 64-bit OpenSSL/libssh2
-          container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2 --with-openssl
           tests: ~571 ~612 ~1056 ~1299 !SCP
         msys1_mingw_debug:
           name: 32-bit (legacy)
-          container_img: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug --without-ssl
           tests: ~203 ~1056 ~1143
         msys1_mingw32_debug:
           name: 32-bit w/o zlib
-          container_img: mback2k/curl-docker-winbuildenv-msys1-mingw32:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw32:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --without-zlib --without-ssl
           tests: ~203 ~1056 ~1143 ~1299
         msys1_mingw64_debug:
           name: 64-bit w/o zlib
-          container_img: mback2k/curl-docker-winbuildenv-msys1-mingw64:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw64:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --without-zlib --without-ssl
           tests: ~203 ~1056 ~1143 ~1299
         msys2_mingw32_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN/libssh2
-          container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
           tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
         msys2_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN/libssh2
-          container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
           tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
         msys1_mingw_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN (legacy)
-          container_img: mback2k/curl-docker-winbuildenv-msys1-mingw:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug --enable-sspi --with-schannel --with-winidn
           tests: ~203 ~305 ~310 ~311 ~312 ~313 ~404 ~1056 ~1143 ~2034 ~2035 ~2037 ~2038 ~2041 ~2042 ~2048 ~3000 ~3001
         msys1_mingw32_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN w/o zlib
-          container_img: mback2k/curl-docker-winbuildenv-msys1-mingw32:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw32:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib
           tests: ~203 ~310 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
         msys1_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN w/o zlib
-          container_img: mback2k/curl-docker-winbuildenv-msys1-mingw64:ltsc2019
+          container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw64:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64  --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib
           tests: ~203 ~310 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,14 +82,14 @@ windows_task:
   matrix:
     - name: Windows 32-bit shared/release Schannel/SSPI/WinIDN/libssh2
       env:
-        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+        container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
         configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
         tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
     - name: Windows 32-bit static/release Schannel/SSPI/WinIDN/libssh2
       env:
-        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw32:ltsc2019
+        container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
         configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
@@ -98,14 +98,14 @@ windows_task:
         PKG_CONFIG: pkg-config --static
     - name: Windows 64-bit shared/release Schannel/SSPI/WinIDN/libssh2
       env:
-        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+        container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
         configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
         tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
     - name: Windows 64-bit static/release Schannel/SSPI/WinIDN/libssh2
       env:
-        container_img: mback2k/curl-docker-winbuildenv-msys2-mingw64:ltsc2019
+        container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
         configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static


### PR DESCRIPTION
Avoid limits on Docker Hub and potentially improve pull speed.