### PR TITLE
docs: improve winbuild readme

### DIFF
--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -74,6 +74,8 @@ Open a Visual Studio Command prompt:
 where `<options>` is one or many of:
 
  - `VC=<num>`                    - VC version. 6 or later.
+ - `RTLIBCFG=<dll/static>`       - Runtime library configuration, defaults to dll
+ - `MODE=<dll/static>`           - Build static or dll
  - `WITH_DEVEL=<path>`           - Paths for the development files (SSL, zlib, etc.)
                                    Defaults to sibbling directory deps: ../deps
                                    Libraries can be fetched at https://windows.php.net/downloads/php-sdk/deps/

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -74,7 +74,7 @@ Open a Visual Studio Command prompt:
 where `<options>` is one or many of:
 
  - `VC=<num>`                    - VC version. 6 or later.
- - `RTLIBCFG=<dll/static>`       - Runtime library configuration, defaults to dll
+ - `RTLIBCFG=<dll/static>`       - **Usage of this option is discouraged!** Runtime library configuration, defaults to dll
  - `MODE=<dll/static>`           - Build static or dll
  - `WITH_DEVEL=<path>`           - Paths for the development files (SSL, zlib, etc.)
                                    Defaults to sibbling directory deps: ../deps


### PR DESCRIPTION
This PR is for winbuild document improvement.

The RTLIBCFG and MODE options of `nmake` are both necessary in my use case,
but I didn't know these options until I track down the MakefileBuild.vc.

I think this PR can help those who want to build curl in Windows like I did.