### PR TITLE
CI: align make and test flags in various config files

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -83,12 +83,12 @@ stages:
     - script: ./buildconf && ./configure --enable-warnings --enable-werror $(configure)
       displayName: 'configure $(name)'
 
-    - script: make V=1 && cd tests && make V=1
+    - script: make V=1 && make V=1 examples && cd tests && make V=1
       displayName: 'compile'
       env:
         MAKEFLAGS: "-j 2"
 
-    - script: make test-nonflaky
+    - script: make V=1 test-nonflaky
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
@@ -121,14 +121,14 @@ stages:
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2 --with-openssl
-          tests: ~571 ~612 ~1056 ~1299 !SCP
+          tests: ~571 ~612 ~1056 ~1299
         msys2_mingw64_debug_openssl:
           name: 64-bit OpenSSL/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2 --with-openssl
-          tests: ~571 ~612 ~1056 ~1299 !SCP
+          tests: ~571 ~612 ~1056 ~1299
         msys1_mingw_debug:
           name: 32-bit (legacy)
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw:ltsc2019
@@ -153,14 +153,14 @@ stages:
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
         msys2_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
         msys1_mingw_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN (legacy)
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw:ltsc2019
@@ -191,7 +191,7 @@ stages:
     - script: $(container_cmd) -l -c "cd $(echo '%cd%') && ./buildconf && ./configure $(configure)"
       displayName: 'configure $(name)'
 
-    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 && cd tests && make V=1"
+    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 && make V=1 examples && cd tests && make V=1"
       displayName: 'compile'
       env:
         MAKEFLAGS: "-j 2"
@@ -203,4 +203,4 @@ stages:
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "-vc /usr/bin/curl.exe -r -rm $(tests)"
+        TFLAGS: "-r -rm !SCP $(tests)"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ freebsd_task:
       esac
     - ./configure --prefix="${HOME}"/install --enable-debug --with-openssl --with-libssh2 --with-brotli --with-gssapi --with-libidn2 --enable-manual --enable-ldap --enable-ldaps --with-librtmp --with-libpsl --with-nghttp2 || { tail -300 config.log; false; }
   compile_script:
-    - make V=1 && cd tests && make V=1
+    - make V=1 && make V=1 examples && cd tests && make V=1
   test_script:
     # blackhole?
     - sysctl net.inet.tcp.blackhole
@@ -69,7 +69,7 @@ freebsd_task:
     - find . -type d -exec chmod 777 {} \;
     # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
     # therefore the SFTP and SCP tests are disabled right away from the beginning.
-    - sudo -u nobody make V=1 TFLAGS="-n -a -p !flaky !SFTP !SCP" test-nonflaky
+    - sudo -u nobody make V=1 TFLAGS="-n -r !SFTP !SCP" test-nonflaky
   install_script:
     - make V=1 install
 
@@ -86,14 +86,14 @@ windows_task:
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
         configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
     - name: Windows 32-bit static/release Schannel/SSPI/WinIDN/libssh2
       env:
         container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
         configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
         curl_LDFLAGS: -all-static
         PKG_CONFIG: pkg-config --static
     - name: Windows 64-bit shared/release Schannel/SSPI/WinIDN/libssh2
@@ -102,14 +102,14 @@ windows_task:
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
         configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
     - name: Windows 64-bit static/release Schannel/SSPI/WinIDN/libssh2
       env:
         container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
         configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001 !SCP
+        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
         curl_LDFLAGS: -all-static
         PKG_CONFIG: pkg-config --static
 
@@ -123,8 +123,8 @@ windows_task:
   configure_script: |
     %container_cmd% -l -c "cd $(echo '%cd%') && ./buildconf && ./configure %configure%"
   compile_script: |
-    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 && cd tests && make V=1"
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 && make V=1 examples && cd tests && make V=1"
   install_script: |
     %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
   test_script: |
-    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='-r -rm %tests%' test-nonflaky"
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='-r -rm !SCP %tests%' test-nonflaky"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -289,7 +289,7 @@ build_script:
         ..\builds\libcurl-vc15-x64-%PATHPART%-dll-ssl-dll-ipv6-sspi\bin\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==autotools (
-        bash.exe -e -l -c "cd /c/projects/curl && ./buildconf && ./configure %CONFIG_ARGS% && make && make examples && cd tests && make"
+        bash.exe -e -l -c "cd /c/projects/curl && ./buildconf && ./configure %CONFIG_ARGS% && make V=1 && make V=1 examples && cd tests && make V=1"
       )))))
     - if %TESTING%==ON (
         if %BUILD_SYSTEM%==CMake (
@@ -299,11 +299,15 @@ build_script:
 test_script:
     - if %TESTING%==ON (
         if %BUILD_SYSTEM%==CMake (
-          set TFLAGS=%DISABLED_TESTS% &&
+          set TFLAGS=-r -rm %DISABLED_TESTS% &&
           cmake --build . --config %PRJ_CFG% --target test-nonflaky
         ) else (
-          echo APPVEYOR_API_URL=%APPVEYOR_API_URL% &&
-          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky %DISABLED_TESTS%" ))
+        if %BUILD_SYSTEM%==autotools (
+          bash.exe -e -l -c "cd /c/projects/curl && make V=1 TFLAGS='-r -rm !SCP %DISABLED_TESTS%' test-nonflaky"
+        ) else (
+          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm %DISABLED_TESTS%"
+        ))
+      )
 
 # select branches to avoid testing feature branches twice (as branch and as pull request)
 branches:


### PR DESCRIPTION
1. Remove redundant parameters -a -p from target test-nonflaky.
2. Disable testing of SCP protocol for all Windows environments.
3. Use Makefile target to run tests in autotools builds on AppVeyor.
4. Make sure we also compile the examples on all touched CIs.
5. Don't use -vc parameter which is reserved for debugging.