### PR TITLE
asyn-ares: call ares_freeaddrinfo() to clean up addrinfo results

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -728,6 +728,7 @@ static void addrinfo_cb(void *arg, int status, int timeouts,
   if(ARES_SUCCESS == status) {
     res->temp_ai = ares2addr(result->nodes);
     res->last_status = CURL_ASYNC_SUCCESS;
+    ares_freeaddrinfo(result);
   }
   res->num_pending--;
 }


### PR DESCRIPTION
As this leaks memory otherwise

Follow-up to ba904db0705c931