### PR TITLE
man pages: remove trailing whitespaces

### DIFF
--- a/docs/cmdline-opts/fail-with-body.d
+++ b/docs/cmdline-opts/fail-with-body.d
@@ -5,7 +5,6 @@ Category: http output
 Added: 7.76.0
 See-also: fail
 ---
-
 Return an error on server errors where the HTTP response code is 400 or
 greater). In normal cases when an HTTP server fails to deliver a document, it
 returns an HTML document stating so (which often also describes why and

--- a/docs/cmdline-opts/http3.d
+++ b/docs/cmdline-opts/http3.d
@@ -8,7 +8,6 @@ Help: Use HTTP v3
 See-also: http1.1 http2
 Category: http
 ---
-
 WARNING: this option is experimental. Do not use in production.
 
 Tells curl to use HTTP version 3 directly to the host and port number used in

--- a/docs/cmdline-opts/insecure.d
+++ b/docs/cmdline-opts/insecure.d
@@ -5,7 +5,6 @@ Protocols: TLS
 See-also: proxy-insecure cacert
 Category: tls
 ---
-
 By default, every SSL connection curl makes is verified to be secure. This
 option allows curl to proceed and operate even for server connections
 otherwise considered insecure.

--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -5,7 +5,6 @@ Help: Send command(s) to server before transfer
 Protocols: FTP SFTP
 Category: ftp sftp
 ---
-
 Send an arbitrary command to the remote FTP or SFTP server. Quote commands are
 sent BEFORE the transfer takes place (just after the initial PWD command in an
 FTP transfer, to be exact). To make commands take place after a successful

--- a/docs/cmdline-opts/ssl.d
+++ b/docs/cmdline-opts/ssl.d
@@ -4,7 +4,6 @@ Protocols: FTP IMAP POP3 SMTP
 Added: 7.20.0
 Category: tls
 ---
-
 Try to use SSL/TLS for the connection.  Reverts to a non-secure connection if
 the server doesn't support SSL/TLS.  See also --ftp-ssl-control and --ssl-reqd
 for different levels of encryption required.

--- a/docs/cmdline-opts/user-agent.d
+++ b/docs/cmdline-opts/user-agent.d
@@ -5,7 +5,6 @@ Help: Send User-Agent <name> to server
 Protocols: HTTP
 Category: important http
 ---
-
 Specify the User-Agent string to send to the HTTP server. To encode blanks in
 the string, surround the string with single quote marks. This header can also
 be set with the --header or the --proxy-header options.

--- a/docs/libcurl/libcurl-multi.3
+++ b/docs/libcurl/libcurl-multi.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -97,7 +97,7 @@ period for your select() calls.
 \fIcurl_multi_perform(3)\fP stores the number of still running transfers in
 one of its input arguments, and by reading that you can figure out when all
 the transfers in the multi handles are done. 'done' does not mean
-successful. One or more of the transfers may have failed. 
+successful. One or more of the transfers may have failed.
 
 To get information about completed transfers, to figure out success or not and
 similar, \fIcurl_multi_info_read(3)\fP should be called. It can return a

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
@@ -53,7 +53,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_PROXY, "https://localhost:443");
   blob.data = strpem;
   blob.len = strlen(strpem);
-  blob.flags = CURL_BLOB_COPY;  
+  blob.flags = CURL_BLOB_COPY;
   curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO_BLOB, &blob);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/tests/data/test1173
+++ b/tests/data/test1173
@@ -23,4 +23,10 @@ Basic man page syntax check
 </command>
 </client>
 
+<verify>
+<stderr>
+ok
+</stderr>
+</verify>
+
 </testcase>

--- a/tests/manpage-syntax.pl
+++ b/tests/manpage-syntax.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2019 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2019 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -50,6 +50,10 @@ sub scanmanpage {
                 $errors++;
             }
         }
+        if($_ =~ /[ \t]+$/) {
+            print STDERR "$file:$line trailing whitespace\n";
+            $errors++;
+        }
         $line++;
     }
     close(M);
@@ -59,5 +63,7 @@ sub scanmanpage {
 for my $m (@manpages) {
     scanmanpage($m);
 }
+
+print STDERR "ok\n" if(!$errors);
 
 exit $errors;


### PR DESCRIPTION
Extended test 1173 (via the manpage-syntax.pl script) to detect and warn
for them.

Ref: #7602
Reported-by: a1346054