### PR TITLE
curl_url_strerror() for CURLUcode

### DIFF
--- a/docs/examples/urlapi.c
+++ b/docs/examples/urlapi.c
@@ -26,8 +26,8 @@
 #include <stdio.h>
 #include <curl/curl.h>
 
-#if !CURL_AT_LEAST_VERSION(7, 62, 0)
-#error "this example requires curl 7.62.0 or later"
+#if !CURL_AT_LEAST_VERSION(7, 79, 0)
+#error "this example requires curl 7.79.0 or later"
 #endif
 
 int main(void)
@@ -47,7 +47,7 @@ int main(void)
                     "http://example.com/path/index.html", 0);
 
   if(uc) {
-    fprintf(stderr, "curl_url_set() failed: %in", uc);
+    fprintf(stderr, "curl_url_set() failed: %s", curl_url_strerror(uc));
     goto cleanup;
   }
 

--- a/docs/libcurl/Makefile.inc
+++ b/docs/libcurl/Makefile.inc
@@ -95,6 +95,7 @@ man_MANS = \
  curl_url_dup.3 \
  curl_url_get.3 \
  curl_url_set.3 \
+ curl_url_strerror.3 \
  curl_version.3 \
  curl_version_info.3 \
  libcurl-easy.3 \

--- a/docs/libcurl/curl_easy_strerror.3
+++ b/docs/libcurl/curl_easy_strerror.3
@@ -37,4 +37,5 @@ This function was added in libcurl 7.12.0
 .SH RETURN VALUE
 A pointer to a null-terminated string.
 .SH "SEE ALSO"
-.BR libcurl-errors "(3), " curl_multi_strerror "(3), " curl_share_strerror "(3)"
+.BR libcurl-errors "(3), " curl_multi_strerror "(3), "
+.BR curl_share_strerror "(3), " curl_url_strerror "(3)"

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -34,4 +34,5 @@ This function was added in libcurl 7.12.0
 .SH RETURN VALUE
 A pointer to a null-terminated string.
 .SH "SEE ALSO"
-.BR libcurl-errors "(3), " curl_multi_strerror "(3), " curl_easy_strerror "(3)"
+.BR libcurl-errors "(3), " curl_multi_strerror "(3), "
+.BR curl_easy_strerror "(3), " curl_url_strerror "(3)"

--- a/docs/libcurl/curl_url.3
+++ b/docs/libcurl/curl_url.3
@@ -50,4 +50,4 @@ Returns a \fBCURLU *\fP if successful, or NULL if out of memory.
 Added in curl 7.62.0
 .SH "SEE ALSO"
 .BR curl_url_cleanup "(3), " curl_url_get "(3), " curl_url_set "(3), "
-.BR curl_url_dup "(3), " CURLOPT_CURLU "(3), "
+.BR curl_url_dup "(3), " curl_url_strerror "(3), " CURLOPT_CURLU "(3)"

--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -99,7 +99,8 @@ decode on get with the CURLU_URLDECODE bit.
 .IP CURLUPART_FRAGMENT
 .SH RETURN VALUE
 Returns a CURLUcode error value, which is CURLUE_OK (0) if everything went
-fine.
+fine.  See the \fIlibcurl-errors(3)\fP man page for the full list with
+descriptions.
 
 If this function returns an error, no URL part is returned.
 .SH EXAMPLE
@@ -121,4 +122,4 @@ If this function returns an error, no URL part is returned.
 Added in curl 7.62.0. CURLUPART_ZONEID was added in 7.65.0.
 .SH "SEE ALSO"
 .BR curl_url_cleanup "(3), " curl_url "(3), " curl_url_set "(3), "
-.BR curl_url_dup "(3), " CURLOPT_CURLU "(3), "
+.BR curl_url_dup "(3), " curl_url_strerror "(3), " CURLOPT_CURLU "(3)"

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -136,7 +136,8 @@ space before stored. This affects how the URL will be constructed when
 individual parts.
 .SH RETURN VALUE
 Returns a CURLUcode error value, which is CURLUE_OK (0) if everything went
-fine.
+fine.  See the \fIlibcurl-errors(3)\fP man page for the full list with
+descriptions.
 
 A URL string passed on to \fIcurl_url_set(3)\fP for the \fBCURLUPART_URL\fP
 part, must be shorter than 8000000 bytes otherwise it returns
@@ -159,4 +160,4 @@ If this function returns an error, no URL part is set.
 Added in curl 7.62.0. CURLUPART_ZONEID was added in 7.65.0.
 .SH "SEE ALSO"
 .BR curl_url_cleanup "(3), " curl_url "(3), " curl_url_get "(3), "
-.BR curl_url_dup "(3), " CURLOPT_CURLU "(3), "
+.BR curl_url_dup "(3), " curl_url_strerror "(3), " CURLOPT_CURLU "(3)"

--- a/docs/libcurl/curl_url_strerror.3
+++ b/docs/libcurl/curl_url_strerror.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -19,20 +19,21 @@
 .\" * KIND, either express or implied.
 .\" *
 .\" **************************************************************************
-.TH curl_multi_strerror 3 "26 Apr 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_url_strerror 3 "21 Aug 2021" "libcurl 7.79" "libcurl Manual"
 .SH NAME
-curl_multi_strerror - return string describing error code
+curl_url_strerror - return string describing error code
 .SH SYNOPSIS
 .nf
 .B #include <curl/curl.h>
-.BI "const char *curl_multi_strerror(CURLMcode " errornum ");"
+.BI "const char *curl_url_strerror(CURLUcode " errornum ");"
 .SH DESCRIPTION
-The curl_multi_strerror() function returns a string describing the CURLMcode
+The curl_url_strerror() function returns a string describing the CURLUcode
 error code passed in the argument \fIerrornum\fP.
 .SH AVAILABILITY
-This function was added in libcurl 7.12.0
+This function was added in libcurl 7.79.0
 .SH RETURN VALUE
 A pointer to a null-terminated string.
 .SH "SEE ALSO"
-.BR libcurl-errors "(3), " curl_easy_strerror "(3), "
-.BR curl_share_strerror "(3), " curl_url_strerror "(3)"
+.BR libcurl-errors "(3), " curl_url_get "(3), " curl_url_set "(3), "
+.BR curl_easy_strerror "(3), " curl_multi_strerror "(3), "
+.BR curl_share_strerror "(3)"

--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -325,6 +325,8 @@ Not enough memory was available.
 The requested sharing could not be done because the library you use don't have
 that particular feature enabled. (Added in 7.23.0)
 .SH "CURLUcode"
+The URL interface will return a CURLUcode to indicate when an error has
+occurred.  Also consider \fIcurl_url_strerror(3)\fP.
 .IP "CURLUE_BAD_HANDLE (1)"
 An argument that should be a CURLU pointer was passed in as a NULL.
 .IP "CURLUE_BAD_PARTPOINTER (2)"
@@ -361,5 +363,6 @@ There is no query part in the URL.
 There is no fragment part in the URL.
 .SH "SEE ALSO"
 .BR curl_easy_strerror "(3), " curl_multi_strerror "(3), "
-.BR curl_share_strerror "(3), " CURLOPT_ERRORBUFFER "(3), "
-.BR CURLOPT_VERBOSE "(3), " CURLOPT_DEBUGFUNCTION "(3) "
+.BR curl_share_strerror "(3), " curl_url_strerror "(3), "
+.BR CURLOPT_ERRORBUFFER "(3), " CURLOPT_VERBOSE "(3), "
+.BR CURLOPT_DEBUGFUNCTION "(3)"

--- a/docs/libcurl/libcurl-url.3
+++ b/docs/libcurl/libcurl-url.3
@@ -135,4 +135,5 @@ Now the URL looks like
 The URL API was introduced in libcurl 7.62.0.
 .SH "SEE ALSO"
 .BR curl_url "(3), " curl_url_cleanup "(3), " curl_url_get "(3), "
-.BR curl_url_dup "(3), " curl_url_set "(3), " CURLOPT_URL "(3), "
+.BR curl_url_dup "(3), " curl_url_set "(3), " curl_url_strerror "(3), "
+.BR CURLOPT_URL "(3)"

--- a/docs/libcurl/opts/CURLOPT_CURLU.3
+++ b/docs/libcurl/opts/CURLOPT_CURLU.3
@@ -67,4 +67,4 @@ Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"
 .BR CURLOPT_URL "(3), "
 .BR curl_url "(3), " curl_url_get "(3), " curl_url_set "(3), "
-.BR curl_url_dup "(3), " curl_url_cleanup "(3), "
+.BR curl_url_dup "(3), " curl_url_cleanup "(3), " curl_url_strerror "(3)"

--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
@@ -89,4 +89,4 @@ Returns CURLE_OK
 .SH "SEE ALSO"
 .BR CURLOPT_DEBUGFUNCTION "(3), " CURLOPT_VERBOSE "(3), "
 .BR curl_easy_strerror "(3), " curl_multi_strerror "(3), "
-.BR curl_share_strerror "(3) "
+.BR curl_share_strerror "(3), " curl_url_strerror "(3)"

--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -47,7 +47,8 @@ typedef enum {
   CURLUE_NO_HOST,             /* 14 */
   CURLUE_NO_PORT,             /* 15 */
   CURLUE_NO_QUERY,            /* 16 */
-  CURLUE_NO_FRAGMENT          /* 17 */
+  CURLUE_NO_FRAGMENT,         /* 17 */
+  CURLUE_LAST
 } CURLUcode;
 
 typedef enum {
@@ -118,6 +119,12 @@ CURL_EXTERN CURLUcode curl_url_get(CURLU *handle, CURLUPart what,
 CURL_EXTERN CURLUcode curl_url_set(CURLU *handle, CURLUPart what,
                                    const char *part, unsigned int flags);
 
+/*
+ * curl_url_strerror() turns a CURLUcode value into the equivalent human
+ * readable error string.  This is useful for printing meaningful error
+ * messages.
+ */
+CURL_EXTERN const char *curl_url_strerror(CURLUcode);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -462,7 +462,8 @@ curl_url_strerror(CURLUcode error)
     return "No error";
 
   case CURLUE_BAD_HANDLE:
-    return "An argument that should be a CURLU pointer was passed in as a NULL";
+    return "An argument that should be a CURLU pointer was passed in as a "
+           "NULL";
 
   case CURLUE_BAD_PARTPOINTER:
     return "A NULL pointer was passed to the 'part' argument of curl_url_get";

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -453,6 +453,78 @@ curl_share_strerror(CURLSHcode error)
 #endif
 }
 
+const char *
+curl_url_strerror(CURLUcode error)
+{
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+  switch(error) {
+  case CURLUE_OK:
+    return "No error";
+
+  case CURLUE_BAD_HANDLE:
+    return "An argument that should be a CURLU pointer was passed in as a NULL";
+
+  case CURLUE_BAD_PARTPOINTER:
+    return "A NULL pointer was passed to the 'part' argument of curl_url_get";
+
+  case CURLUE_MALFORMED_INPUT:
+    return "A malformed input was passed to a URL API function";
+
+  case CURLUE_BAD_PORT_NUMBER:
+    return "The port number was not a decimal number between 0 and 65535";
+
+  case CURLUE_UNSUPPORTED_SCHEME:
+    return "This libcurl build doesn't support the given URL scheme";
+
+  case CURLUE_URLDECODE:
+    return "URL decode error, most likely because of rubbish in the input";
+
+  case CURLUE_OUT_OF_MEMORY:
+    return "A memory function failed";
+
+  case CURLUE_USER_NOT_ALLOWED:
+    return "Credentials was passed in the URL when prohibited";
+
+  case CURLUE_UNKNOWN_PART:
+    return "An unknown part ID was passed to a URL API function";
+
+  case CURLUE_NO_SCHEME:
+    return "There is no scheme part in the URL";
+
+  case CURLUE_NO_USER:
+    return "There is no user part in the URL";
+
+  case CURLUE_NO_PASSWORD:
+    return "There is no password part in the URL";
+
+  case CURLUE_NO_OPTIONS:
+    return "There is no options part in the URL";
+
+  case CURLUE_NO_HOST:
+    return "There is no host part in the URL";
+
+  case CURLUE_NO_PORT:
+    return "There is no port part in the URL";
+
+  case CURLUE_NO_QUERY:
+    return "There is no query part in the URL";
+
+  case CURLUE_NO_FRAGMENT:
+    return "There is no fragment part in the URL";
+
+  case CURLUE_LAST:
+    break;
+  }
+
+  return "CURLUcode unknown";
+#else
+  if(error == CURLUE_OK)
+    return "No error";
+  else
+    return "Error";
+#endif
+}
+
 #ifdef USE_WINSOCK
 /* This is a helper function for Curl_strerror that converts Winsock error
  * codes (WSAGetLastError) to error messages.

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -462,11 +462,10 @@ curl_url_strerror(CURLUcode error)
     return "No error";
 
   case CURLUE_BAD_HANDLE:
-    return "An argument that should be a CURLU pointer was passed in as a "
-           "NULL";
+    return "An invalid CURLU pointer was passed as argument";
 
   case CURLUE_BAD_PARTPOINTER:
-    return "A NULL pointer was passed to the 'part' argument of curl_url_get";
+    return "An invalid 'part' argument was passed as argument";
 
   case CURLUE_MALFORMED_INPUT:
     return "A malformed input was passed to a URL API function";

--- a/lib/url.c
+++ b/lib/url.c
@@ -1950,7 +1950,8 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
                      CURLU_DISALLOW_USER : 0) |
                     (data->set.path_as_is ? CURLU_PATH_AS_IS : 0));
     if(uc) {
-      DEBUGF(infof(data, "curl_url_set rejected %s", data->state.url));
+      DEBUGF(infof(data, "curl_url_set rejected %s: %s", data->state.url,
+                   curl_url_strerror(uc)));
       return Curl_uc_to_curlcode(uc);
     }
 

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -2913,6 +2913,10 @@
      d  part                           *   value options(*string)
      d  flags                        10u 0 value
       *
+     d curl_url_strerror...
+     d                 pr              *   extproc('curl_url_strerror')         const char *
+     d  code                               value like(CURLUcode)
+      *
      d curl_easy_option_by_name...
      d                 pr              *   extproc('curl_easy_option_by_name')  curl_easyoption *
      d  name                           *   value option(*string)

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -145,6 +145,7 @@ my %api = (
     'curl_url_dup' => 'API',
     'curl_url_get' => 'API',
     'curl_url_set' => 'API',
+    'curl_url_strerror' => 'API',
     'curl_version' => 'API',
     'curl_version_info' => 'API',
 

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -153,8 +153,8 @@ s4: Out of memory
 s5: Feature not enabled in this library
 s6: CURLSHcode unknown
 u0: No error
-u1: An argument that should be a CURLU pointer was passed in as a NULL
-u2: A NULL pointer was passed to the 'part' argument of curl_url_get
+u1: An invalid CURLU pointer was passed as argument
+u2: An invalid 'part' argument was passed as argument
 u3: A malformed input was passed to a URL API function
 u4: The port number was not a decimal number between 0 and 65535
 u5: This libcurl build doesn't support the given URL scheme

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -152,6 +152,25 @@ s3: Invalid share handle
 s4: Out of memory
 s5: Feature not enabled in this library
 s6: CURLSHcode unknown
+u0: No error
+u1: An argument that should be a CURLU pointer was passed in as a NULL
+u2: A NULL pointer was passed to the 'part' argument of curl_url_get
+u3: A malformed input was passed to a URL API function
+u4: The port number was not a decimal number between 0 and 65535
+u5: This libcurl build doesn't support the given URL scheme
+u6: URL decode error, most likely because of rubbish in the input
+u7: A memory function failed
+u8: Credentials was passed in the URL when prohibited
+u9: An unknown part ID was passed to a URL API function
+u10: There is no scheme part in the URL
+u11: There is no user part in the URL
+u12: There is no password part in the URL
+u13: There is no options part in the URL
+u14: There is no host part in the URL
+u15: There is no port part in the URL
+u16: There is no query part in the URL
+u17: There is no fragment part in the URL
+u18: CURLUcode unknown
 </stdout>
 </verify>
 

--- a/tests/data/test1559
+++ b/tests/data/test1559
@@ -35,9 +35,9 @@ Set excessive URL lengths
 <stdout>
 CURLOPT_URL 10000000 bytes URL == 43
 CURLOPT_POSTFIELDS 10000000 bytes data == 0
-CURLUPART_URL 10000000 bytes URL == 3
-CURLUPART_SCHEME 10000000 bytes scheme == 3
-CURLUPART_USER 10000000 bytes user == 3
+CURLUPART_URL 10000000 bytes URL == 3 (A malformed input was passed to a URL API function)
+CURLUPART_SCHEME 10000000 bytes scheme == 3 (A malformed input was passed to a URL API function)
+CURLUPART_USER 10000000 bytes user == 3 (A malformed input was passed to a URL API function)
 </stdout>
 </verify>
 

--- a/tests/libtest/lib1538.c
+++ b/tests/libtest/lib1538.c
@@ -29,14 +29,17 @@ int test(char *URL)
   CURLcode easyret;
   CURLMcode multiret;
   CURLSHcode shareret;
+  CURLUcode urlret;
   (void)URL;
 
   curl_easy_strerror((CURLcode)INT_MAX);
   curl_multi_strerror((CURLMcode)INT_MAX);
   curl_share_strerror((CURLSHcode)INT_MAX);
+  curl_url_strerror((CURLUcode)INT_MAX);
   curl_easy_strerror((CURLcode)-INT_MAX);
   curl_multi_strerror((CURLMcode)-INT_MAX);
   curl_share_strerror((CURLSHcode)-INT_MAX);
+  curl_url_strerror((CURLUcode)-INT_MAX);
   for(easyret = CURLE_OK; easyret <= CURL_LAST; easyret++) {
     printf("e%d: %s\n", (int)easyret, curl_easy_strerror(easyret));
   }
@@ -46,6 +49,9 @@ int test(char *URL)
   }
   for(shareret = CURLSHE_OK; shareret <= CURLSHE_LAST; shareret++) {
     printf("s%d: %s\n", (int)shareret, curl_share_strerror(shareret));
+  }
+  for(urlret = CURLUE_OK; urlret <= CURLUE_LAST; urlret++) {
+    printf("u%d: %s\n", (int)urlret, curl_url_strerror(urlret));
   }
 
   return (int)res;

--- a/tests/libtest/lib1559.c
+++ b/tests/libtest/lib1559.c
@@ -54,14 +54,14 @@ int test(char *URL)
   u = curl_url();
   if(u) {
     CURLUcode uc = curl_url_set(u, CURLUPART_URL, longurl, 0);
-    printf("CURLUPART_URL %d bytes URL == %d\n",
-           EXCESSIVE, (int)uc);
+    printf("CURLUPART_URL %d bytes URL == %d (%s)\n",
+           EXCESSIVE, (int)uc, curl_url_strerror(uc));
     uc = curl_url_set(u, CURLUPART_SCHEME, longurl, CURLU_NON_SUPPORT_SCHEME);
-    printf("CURLUPART_SCHEME %d bytes scheme == %d\n",
-           EXCESSIVE, (int)uc);
+    printf("CURLUPART_SCHEME %d bytes scheme == %d (%s)\n",
+           EXCESSIVE, (int)uc, curl_url_strerror(uc));
     uc = curl_url_set(u, CURLUPART_USER, longurl, 0);
-    printf("CURLUPART_USER %d bytes user == %d\n",
-           EXCESSIVE, (int)uc);
+    printf("CURLUPART_USER %d bytes user == %d (%s)\n",
+           EXCESSIVE, (int)uc, curl_url_strerror(uc));
     curl_url_cleanup(u);
   }
 

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -785,17 +785,17 @@ static int set_url(void)
       rc = curl_url_set(urlp, CURLUPART_URL, set_url_list[i].set,
                         set_url_list[i].setflags);
       if(rc) {
-        fprintf(stderr, "%s:%d Set URL %s returned %d\n",
+        fprintf(stderr, "%s:%d Set URL %s returned %d (%s)\n",
                 __FILE__, __LINE__, set_url_list[i].set,
-                (int)rc);
+                (int)rc, curl_url_strerror(rc));
         error++;
       }
       else {
         char *url = NULL;
         rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
         if(rc) {
-          fprintf(stderr, "%s:%d Get URL returned %d\n",
-                  __FILE__, __LINE__, (int)rc);
+          fprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
           error++;
         }
         else {
@@ -847,8 +847,8 @@ static int set_parts(void)
       rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
 
       if(rc) {
-        fprintf(stderr, "%s:%d Get URL returned %d\n",
-                __FILE__, __LINE__, (int)rc);
+        fprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
+                __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
         error++;
       }
       else if(checkurl(url, set_parts_list[i].out)) {
@@ -884,8 +884,8 @@ static int get_url(void)
       rc = curl_url_get(urlp, CURLUPART_URL, &url, get_url_list[i].getflags);
 
       if(rc) {
-        fprintf(stderr, "%s:%d returned %d\n",
-                __FILE__, __LINE__, (int)rc);
+        fprintf(stderr, "%s:%d returned %d (%s)\n",
+                __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
         error++;
       }
       else {
@@ -987,8 +987,8 @@ static int append(void)
       char *url;
       rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
       if(rc) {
-        fprintf(stderr, "%s:%d Get URL returned %d\n",
-                __FILE__, __LINE__, (int)rc);
+        fprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
+                __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
         error++;
       }
       else {
@@ -1013,15 +1013,15 @@ static int scopeid(void)
   rc = curl_url_set(u, CURLUPART_URL,
                     "https://[fe80::20c:29ff:fe9c:409b%25eth0]/hello.html", 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_set returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_set returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
   rc = curl_url_get(u, CURLUPART_HOST, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_HOST returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_HOST returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1031,15 +1031,15 @@ static int scopeid(void)
 
   rc = curl_url_set(u, CURLUPART_HOST, "[::1]", 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_set CURLUPART_HOST returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
   rc = curl_url_get(u, CURLUPART_URL, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1049,15 +1049,15 @@ static int scopeid(void)
 
   rc = curl_url_set(u, CURLUPART_HOST, "example.com", 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_set CURLUPART_HOST returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
   rc = curl_url_get(u, CURLUPART_URL, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1068,15 +1068,15 @@ static int scopeid(void)
   rc = curl_url_set(u, CURLUPART_HOST,
                     "[fe80::20c:29ff:fe9c:409b%25eth0]", 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_set CURLUPART_HOST returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
   rc = curl_url_get(u, CURLUPART_URL, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1086,8 +1086,8 @@ static int scopeid(void)
 
   rc = curl_url_get(u, CURLUPART_HOST, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_HOST returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_HOST returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1097,8 +1097,8 @@ static int scopeid(void)
 
   rc = curl_url_get(u, CURLUPART_ZONEID, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_ZONEID returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_ZONEID returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1108,15 +1108,15 @@ static int scopeid(void)
 
   rc = curl_url_set(u, CURLUPART_ZONEID, "clown", 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_set CURLUPART_ZONEID returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_set CURLUPART_ZONEID returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
   rc = curl_url_get(u, CURLUPART_URL, &url, 0);
   if(rc != CURLUE_OK) {
-    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d\n",
-            __FILE__, __LINE__, (int)rc);
+    fprintf(stderr, "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
+            __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {

--- a/tests/libtest/lib658.c
+++ b/tests/libtest/lib658.c
@@ -48,7 +48,8 @@ int test(char *URL)
 
   uc = curl_url_set(urlp, CURLUPART_URL, URL, 0);
   if(uc) {
-    fprintf(stderr, "problem setting CURLUPART_URL.");
+    fprintf(stderr, "problem setting CURLUPART_URL: %s.",
+            curl_url_strerror(uc));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib674.c
+++ b/tests/libtest/lib674.c
@@ -49,7 +49,8 @@ int test(char *URL)
 
   uc = curl_url_set(urlp, CURLUPART_URL, URL, 0);
   if(uc) {
-    fprintf(stderr, "problem setting CURLUPART_URL.");
+    fprintf(stderr, "problem setting CURLUPART_URL: %s.",
+            curl_url_strerror(uc));
     goto test_cleanup;
   }
 


### PR DESCRIPTION
1. Add `curl_url_strerror()` to convert `CURLUcode` into readable string and facilitate easier troubleshooting in programs using URL API.
1. Extend `CURLUcode` with `CURLUE_LAST` for iteration in unit tests.
1. Update man pages with a mention of new function.
1. Update example code and tests with new functionality where it fits.

P.S. Target version will need to be updated since 7.79.0 is already frozen.