### PR TITLE
mksymbolsmanpage.pl: match symbols case insenitively

### DIFF
--- a/docs/libcurl/mksymbolsmanpage.pl
+++ b/docs/libcurl/mksymbolsmanpage.pl
@@ -6,7 +6,7 @@
 # *                            | (__| |_| |  _ <| |___
 # *                             \___|\___/|_| \_\_____|
 # *
-# * Copyright (C) 2015 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# * Copyright (C) 2015 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 # *
 # * This software is licensed as described in the file COPYING, which
 # * you should have received as part of this distribution. The terms
@@ -69,7 +69,7 @@ HEADER
     ;
 
 while(<STDIN>) {
-    if($_ =~ /^(CURL[A-Z0-9_.]*) *(.*)/) {
+    if($_ =~ /^(CURL[A-Z0-9_.]*) *(.*)/i) {
         my ($symbol, $rest)=($1,$2);
         my ($intro, $dep, $rem);
         if($rest =~ s/^([0-9.]*) *//) {


### PR DESCRIPTION
Follow-up to 4e53b9430c750 which made this bug show.

Reported-by: i-ky
Bug: https://github.com/curl/curl/commit/4e53b9430c7504de8984796e2a2091ec16f27136#commitcomment-55239253