### PR TITLE
symbols-in-versions: fix CURLSSLBACKEND_QSOSSL removed version

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -10,7 +10,7 @@
  for a few symbols the last version that featured it. The names appear in
  alphabetical order.
 
- Name                           Introduced  Deprecated  Removed
+ Name                           Introduced  Deprecated  Last
 
 CURLALTSVC_H1                   7.64.1
 CURLALTSVC_H2                   7.64.1
@@ -815,7 +815,7 @@ CURLSSLBACKEND_NSS              7.34.0
 CURLSSLBACKEND_OPENSSL          7.34.0
 CURLSSLBACKEND_POLARSSL         7.34.0       7.69.0
 CURLSSLBACKEND_RUSTLS           7.76.0
-CURLSSLBACKEND_QSOSSL           7.34.0        -           7.38.1
+CURLSSLBACKEND_QSOSSL           7.34.0        -           7.38.0
 CURLSSLBACKEND_SCHANNEL         7.34.0
 CURLSSLBACKEND_SECURETRANSPORT  7.64.1
 CURLSSLBACKEND_WOLFSSL          7.49.0


### PR DESCRIPTION
Closes #xxxx

---

IMO it might be clearer to call the [symbols-in-versions](https://github.com/curl/curl/blob/master/docs/libcurl/symbols-in-versions) 'Removed' version field as 'Last'. When someone says xxx was removed in yyy most would interpret that as xxx isn't in yyy, but in this case removed refers to last version that featured symbol. Also @bagder e765afc says you have a tool for this... don't suppose you remember from 10 years ago... could use another scan.

/cc @monnerat 