### PR TITLE
urlapi.c:seturl: assert URL instead of using if-check

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -770,8 +770,7 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
   size_t schemelen = 0;
   size_t urllen;
 
-  if(!url)
-    return CURLUE_MALFORMED_INPUT;
+  DEBUGASSERT(url);
 
   /*************************************************************
    * Parse the URL.


### PR DESCRIPTION
There's no code flow possible where this can happen. The assert makes
sure it also won't be introduced undetected in the future.