### PR TITLE
libcurl-errors.3: clarify two CURLUcode errors

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -326,9 +326,9 @@ The requested sharing could not be done because the library you use don't have
 that particular feature enabled. (Added in 7.23.0)
 .SH "CURLUcode"
 .IP "CURLUE_BAD_HANDLE (1)"
-An argument that should be a CURLU pointer was passed in as a NULL.
+An invalid CURLU pointer was passed as argument.
 .IP "CURLUE_BAD_PARTPOINTER (2)"
-A NULL pointer was passed to the 'part' argument of \fIcurl_url_get(3)\fP.
+An invalid 'part' argument was passed as argument.
 .IP "CURLUE_MALFORMED_INPUT (3)"
 A malformed input was passed to a URL API function.
 .IP "CURLUE_BAD_PORT_NUMBER (4)"


### PR DESCRIPTION
CURLUE_BAD_HANDLE and CURLUE_BAD_PARTPOINTER should be for "bad" or
wrong pointers in a generic sense, not just for NULL pointers.

Ref: #7605