### PR TITLE
cmake: avoid poll() on macOS

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -237,6 +237,10 @@ endif()
 unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # nothing
+  else()
+
   # if not cross-compilation...
   include(CheckCSourceRuns)
   set(CMAKE_REQUIRED_FLAGS "")
@@ -279,5 +283,6 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         }
         return 0;
     }" HAVE_POLL_FINE)
+  endif()
 endif()
 

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -237,9 +237,8 @@ endif()
 unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    # nothing
-  else()
+  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # only try this on non-macOS
 
   # if not cross-compilation...
   include(CheckCSourceRuns)


### PR DESCRIPTION
... like we do in configure builds. Since poll() on macOS is not reliable enough.

Reported-by: marc-groundctl
Fixes #7595