### PR TITLE
curl_easy_setopt: tweak the string copy wording

### DIFF
--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -44,11 +44,11 @@ you must change them between the transfers. You can optionally reset all
 options back to internal default with \fIcurl_easy_reset(3)\fP.
 
 Strings passed to libcurl as 'char *' arguments, are copied by the library;
-thus the string storage associated to the pointer argument may be overwritten
-after \fIcurl_easy_setopt(3)\fP returns. The only exception to this rule is
-really \fICURLOPT_POSTFIELDS(3)\fP, but the alternative that copies the string
-\fICURLOPT_COPYPOSTFIELDS(3)\fP has some usage characteristics you need to
-read up on. This function does not accept input strings longer than
+the string storage associated to the pointer argument may be discarded or
+reused after \fIcurl_easy_setopt(3)\fP returns. The only exception to this
+rule is really \fICURLOPT_POSTFIELDS(3)\fP, but the alternative that copies
+the string \fICURLOPT_COPYPOSTFIELDS(3)\fP has some usage characteristics you
+need to read up on. This function does not accept input strings longer than
 \fBCURL_MAX_INPUT_LENGTH\fP (8 MB).
 
 The order in which the options are set does not matter.


### PR DESCRIPTION
Reported-by: Yaobin Wen
Fixes #7632