### PR TITLE
curl: better error message when -O fails to get a good name

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -950,8 +950,11 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           if(!per->outfile) {
             /* extract the file name from the URL */
             result = get_url_file_name(&per->outfile, per->this_url);
-            if(result)
+            if(result) {
+              errorf(global, "Failed to extract a sensible file name"
+                     " from the URL to use for storage!\n");
               break;
+            }
             if(!*per->outfile && !config->content_disposition) {
               errorf(global, "Remote file name has no length!\n");
               result = CURLE_WRITE_ERROR;


### PR DESCRIPTION
Fixes #7628