### PR TITLE
http_proxy: only wait for writable socket while sending request

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -148,7 +148,7 @@ int Curl_connect_getsock(struct connectdata *conn)
   DEBUGASSERT(conn->connect_state);
   http = &conn->connect_state->http_proxy;
 
-  if(http->sending)
+  if(http->sending == HTTPSEND_REQUEST)
     return GETSOCK_WRITESOCK(0);
 
   return GETSOCK_READSOCK(0);


### PR DESCRIPTION
Otherwise it would wait socket writability even after the entire CONNECT
request has sent and make curl basically busy-loop while waiting for a
response to come back.

The previous fix attempt in #7484 (c27a70a591a4) was inadequate.

Reported-by: zloi-user on github
Reported-by: Oleguer Llopart
Fixes #7589