### PR TITLE
OpenSSL: trace SSL3_MT_SUPPLEMENTAL_DATA

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2063,7 +2063,7 @@ static const char *ssl_msg_type(int ssl_ver, int msg)
 #ifdef SSL3_MT_SUPPLEMENTAL_DATA
       case SSL3_MT_SUPPLEMENTAL_DATA:
         return "Supplemental data";
-#endif      
+#endif
 #ifdef SSL3_MT_END_OF_EARLY_DATA
       case SSL3_MT_END_OF_EARLY_DATA:
         return "End of early data";

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2060,6 +2060,10 @@ static const char *ssl_msg_type(int ssl_ver, int msg)
       case SSL3_MT_ENCRYPTED_EXTENSIONS:
         return "Encrypted Extensions";
 #endif
+#ifdef SSL3_MT_SUPPLEMENTAL_DATA
+      case SSL3_MT_SUPPLEMENTAL_DATA:
+        return "Supplemental data";
+#endif      
 #ifdef SSL3_MT_END_OF_EARLY_DATA
       case SSL3_MT_END_OF_EARLY_DATA:
         return "End of early data";


### PR DESCRIPTION
I got annoyed by seeing all those `TLSv1.2 (IN), TLS header, Unknown (23):` in the `-v` trace.
So this fix is now printing:
```
* TLSv1.2 (OUT), TLS header, Supplemental data (23):
```

I hope this is a proper fix.