### PR TITLE
progress: make trspeed avoid floats

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -377,7 +377,12 @@ static curl_off_t trspeed(curl_off_t size, /* number of bytes */
 {
   if(us < 1)
     return size * 1000000;
-  return (curl_off_t)((long double)size/(long double)us * 1000000);
+  else if(size < CURL_OFF_T_MAX/1000000)
+    return (size * 1000000) / us;
+  else if(size < CURL_OFF_T_MAX/1000)
+    return (size * 1000) / (us / 1000);
+  else
+    return size / (us / 1000000);
 }
 
 /* returns TRUE if it's time to show the progress meter */

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -379,8 +379,6 @@ static curl_off_t trspeed(curl_off_t size, /* number of bytes */
     return size * 1000000;
   else if(size < CURL_OFF_T_MAX/1000000)
     return (size * 1000000) / us;
-  else if(size < CURL_OFF_T_MAX/1000)
-    return (size * 1000) / (us / 1000);
   else
     return size / (us / 1000000);
 }


### PR DESCRIPTION
and compiler warnings for data conversions.

Reported-by: Michał Antoniak @MAntoniak 
Fixes #7645