### PR TITLE
libcurl option manpages consistency cleanup

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -28,26 +28,27 @@ CURLOPT_ABSTRACT_UNIX_SOCKET \- set an abstract Unix domain socket
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ABSTRACT_UNIX_SOCKET, char *path);
 .SH DESCRIPTION
-Enables the use of an abstract Unix domain socket instead of establishing a TCP
-connection to a host. The parameter should be a char * to a null-terminated string
-holding the path of the socket. The path will be set to \fIpath\fP prefixed by a
-NULL byte (this is the convention for abstract sockets, however it should be stressed
-that the path passed to this function should not contain a leading NULL).
+Enables the use of an abstract Unix domain socket instead of establishing a
+TCP connection to a host. The parameter should be a char * to a
+null-terminated string holding the path of the socket. The path will be set to
+\fIpath\fP prefixed by a NULL byte (this is the convention for abstract
+sockets, however it should be stressed that the path passed to this function
+should not contain a leading NULL).
 
-On non-supporting platforms, the abstract address will be interpreted as an empty
-string and fail gracefully, generating a run-time error.
+On non-supporting platforms, the abstract address will be interpreted as an
+empty string and fail gracefully, generating a run-time error.
 
-This option shares the same semantics as
-.BR CURLOPT_UNIX_SOCKET_PATH "(3)
-in which documentation more details can be found. Internally, these two options share
-the same storage and therefore only one of them can be set per handle.
-
+This option shares the same semantics as \fICURLOPT_UNIX_SOCKET_PATH(3)\fP in
+which documentation more details can be found. Internally, these two options
+share the same storage and therefore only one of them can be set per handle.
 .SH DEFAULT
 Default is NULL.
+.SH PROTOCOLS
+All
 .SH EXAMPLE
 .nf
-    curl_easy_setopt(curl_handle, CURLOPT_ABSTRACT_UNIX_SOCKET, "/tmp/foo.sock");
-    curl_easy_setopt(curl_handle, CURLOPT_URL, "http://localhost/");
+  curl_easy_setopt(curl_handle, CURLOPT_ABSTRACT_UNIX_SOCKET, "/tmp/foo.sock");
+  curl_easy_setopt(curl_handle, CURLOPT_URL, "http://localhost/");
 .fi
 
 .SH AVAILABILITY

--- a/docs/libcurl/opts/CURLOPT_DEBUGDATA.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGDATA.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -36,7 +36,31 @@ NULL
 .SH PROTOCOLS
 All
 .SH EXAMPLE
-https://curl.se/libcurl/c/debug.html
+.nf
+int main(void)
+{
+  CURL *curl;
+  CURLcode res;
+  struct data my_tracedata;
+
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, my_trace);
+
+    curl_easy_setopt(curl, CURLOPT_DEBUGDATA, &my_tracedata);
+
+    /* the DEBUGFUNCTION has no effect until we enable VERBOSE */
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+    res = curl_easy_perform(curl);
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  return 0;
+}
+.fi
 .SH AVAILABILITY
 Always
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -39,6 +39,22 @@ necessary then.
 .SH DEFAULT
 .SH PROTOCOLS
 .SH EXAMPLE
+.nf
+CURL *curl = curl_easy_init();
+if(curl) {
+  curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/file.txt");
+
+  /* contact us back, aka "active" FTP */
+  curl_easy_setopt(curl, CURLOPT_FTPPORT, "-");
+
+  /* FTP the way the neanderthals did it */
+  curl_easy_setopt(curl, CURLOPT_FTP_USE_EPRT, 0L);
+
+  ret = curl_easy_perform(curl);
+
+  curl_easy_cleanup(curl);
+}
+.fi
 .SH AVAILABILITY
 Added in 7.10.5
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -40,6 +40,8 @@ Eyeballs RFC 6555 says "It is RECOMMENDED that connection attempts be paced
 currently defaults to 200 ms. Firefox and Chrome currently default to 300 ms.
 .SH DEFAULT
 CURL_HET_DEFAULT (currently defined as 200L)
+.SH PROTOCOLS
+All except FILE
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -57,3 +59,6 @@ if(curl) {
 Added in 7.59.0
 .SH RETURN VALUE
 Returns CURLE_OK
+.SH SEE ALSO
+.BR CURLOPT_CONNECTTIMEOUT_MS "(3), "
+.BR CURLOPT_TIMEOUT "(3), " CURLOPT_LOW_SPEED_LIMIT "(3), "

--- a/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.3
+++ b/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -55,3 +55,5 @@ if(curl) {
 Along with HTTP. Added in 7.60.0.
 .SH RETURN VALUE
 Returns CURLE_OK if HTTP is enabled, and CURLE_UNKNOWN_OPTION if not.
+.SH SEE ALSO
+.BR CURLOPT_PROXY "(3), "

--- a/docs/libcurl/opts/CURLOPT_HEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HEADER.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -62,6 +62,8 @@ if(curl) {
   curl_easy_perform(curl);
 }
 .fi
+.SH AVAILABILITY
+Provided in all libcurl versions.
 .SH RETURN VALUE
 Returns CURLE_OK.
 .SH "SEE ALSO"

--- a/docs/libcurl/opts/CURLOPT_MIMEPOST.3
+++ b/docs/libcurl/opts/CURLOPT_MIMEPOST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -40,13 +40,13 @@ This option is the preferred way of posting an HTTP form, replacing and
 extending the deprecated \fICURLOPT_HTTPPOST(3)\fP option.
 .SH PROTOCOLS
 HTTP, SMTP, IMAP.
-.SH AVAILABILITY
-Since 7.56.0.
-.SH RETURN VALUE
-This will return CURLE_OK.
 .SH EXAMPLE
 Using this option implies the use of several mime structure building
 functions: see https://curl.se/libcurl/c/smtp-mime.html for a complete
 example.
+.SH AVAILABILITY
+Since 7.56.0.
+.SH RETURN VALUE
+This will return CURLE_OK.
 .SH "SEE ALSO"
 .BR curl_mime_init "(3)"

--- a/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
+++ b/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -49,6 +49,19 @@ cases when they may still happen, contrary to our desire. In addition, using
 raised.
 .SH DEFAULT
 0
+.SH EXAMPLE
+.nf
+CURL *curl = curl_easy_init();
+if(curl) {
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+  ret = curl_easy_perform(curl);
+
+  curl_easy_cleanup(curl);
+}
+.fi
 .SH AVAILABILITY
 Added in 7.10
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
+++ b/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
@@ -49,6 +49,8 @@ cases when they may still happen, contrary to our desire. In addition, using
 raised.
 .SH DEFAULT
 0
+.SH PROTOCOLS
+All
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -66,3 +68,5 @@ if(curl) {
 Added in 7.10
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+.SH SEE ALSO
+.BR CURLOPT_TIMEOUT "(3), "

--- a/docs/libcurl/opts/CURLOPT_PIPEWAIT.3
+++ b/docs/libcurl/opts/CURLOPT_PIPEWAIT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -54,6 +54,15 @@ and support level.
 .SH PROTOCOLS
 HTTP(S)
 .SH EXAMPLE
+.nf
+CURL *curl = curl_easy_init();
+if(curl) {
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
+  curl_easy_setopt(curl, CURLOPT_PIPEWAIT, 1L);
+
+  /* now add this easy handle to the multi handle */
+}
+.fi
 .SH AVAILABILITY
 Added in 7.43.0
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -35,7 +35,32 @@ The default value of this parameter is NULL.
 .SH PROTOCOLS
 All
 .SH EXAMPLE
-https://curl.se/libcurl/c/progressfunc.html
+.nf
+ struct progress {
+   char *private;
+   size_t size;
+ };
+
+ static size_t progress_callback(void *clientp,
+                                 double dltotal,
+                                 double dlnow,
+                                 double ultotal,
+                                 double ulnow)
+ {
+   struct memory *progress = (struct progress *)userp;
+
+   /* use the values */
+
+   return 0; /* all is good */
+ }
+
+ struct progress data;
+
+ /* pass struct to callback  */
+ curl_easy_setopt(curl_handle, CURLOPT_PROGRESSDATA, &data);
+
+ curl_easy_setopt(curl_handle, CURLOPT_PROGRESSFUNCTION, progress_callback);
+.fi
 .SH AVAILABILITY
 Always
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -78,7 +78,32 @@ users.
 .SH PROTOCOLS
 All
 .SH EXAMPLE
-https://curl.se/libcurl/c/progressfunc.html
+.nf
+ struct progress {
+   char *private;
+   size_t size;
+ };
+
+ static size_t progress_callback(void *clientp,
+                                 double dltotal,
+                                 double dlnow,
+                                 double ultotal,
+                                 double ulnow)
+ {
+   struct memory *progress = (struct progress *)userp;
+
+   /* use the values */
+
+   return 0; /* all is good */
+ }
+
+ struct progress data;
+
+ /* pass struct to callback  */
+ curl_easy_setopt(curl_handle, CURLOPT_PROGRESSDATA, &data);
+
+ curl_easy_setopt(curl_handle, CURLOPT_PROGRESSFUNCTION, progress_callback);
+.fi
 .SH AVAILABILITY
 Always
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -67,8 +67,6 @@ could be a privacy violation and unexpected.
 0
 .SH PROTOCOLS
 All TLS-based protocols
-.SH AVAILABLE
-Added in 7.52.0
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -82,6 +80,8 @@ if(curl) {
   curl_easy_cleanup(curl);
 }
 .fi
+.SH AVAILABILITY
+Added in 7.52.0
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/docs/libcurl/opts/CURLOPT_PUT.3
+++ b/docs/libcurl/opts/CURLOPT_PUT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -38,6 +38,29 @@ This option is \fBdeprecated\fP since version 7.12.1. Use
 0, disabled
 .SH PROTOCOLS
 HTTP
+.SH EXAMPLE
+.nf
+CURL *curl = curl_easy_init();
+if(curl) {
+  /* we want to use our own read function */
+  curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+
+  /* enable PUT */
+  curl_easy_setopt(curl, CURLOPT_PUT, 1L);
+
+  /* specify target */
+  curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/dir/to/newfile");
+
+  /* now specify which pointer to pass to our callback */
+  curl_easy_setopt(curl, CURLOPT_READDATA, hd_src);
+
+  /* Set the size of the file to upload */
+  curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsize);
+
+  /* Now run off and do what you've been told! */
+  curl_easy_perform(curl);
+}
+.fi
 .SH AVAILABILITY
 Deprecated since 7.12.1. Do not use.
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -53,3 +53,5 @@ Secure Transport (on iOS 7.0 or later, or OS X 10.9 or later) TLS backends.
 .SH RETURN VALUE
 Returns CURLE_OK if false start is supported by the SSL backend, otherwise
 returns CURLE_NOT_BUILT_IN.
+.SH SEE ALSO
+.BR CURLOPT_TCP_FASTOPEN "(3), "

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -52,3 +52,5 @@ El Capitan.
 .SH RETURN VALUE
 Returns CURLE_OK if fast open is supported by the operating system, otherwise
 returns CURLE_NOT_BUILT_IN.
+.SH SEE ALSO
+.BR CURLOPT_SSL_FALSESTART "(3), "

--- a/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -69,3 +69,5 @@ if(curl) {
 Added in 7.48.0
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+.SH SEE ALSO
+.BR CURLOPT_TFTP_BLKSIZE "(3), "

--- a/docs/libcurl/opts/CURLOPT_TRAILERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERDATA.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -27,7 +27,7 @@ CURLOPT_TRAILERDATA \- Custom pointer passed to the trailing headers callback
 #include <curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRAILERDATA, void *userdata);
-.SH DESCRIPTION:
+.SH DESCRIPTION
 Data pointer to be passed to the HTTP trailer callback function.
 .SH DEFAULT
 NULL
@@ -45,5 +45,7 @@ curl_easy_setopt(hndl, CURLOPT_TRAILERDATA, &data);
 A more complete example can be found in examples/http_trailers.html
 .SH AVAILABILITY
 This option was added in curl 7.64.0 and is present if HTTP support is enabled
+.SH RETURN VALUE
+Returns CURLE_OK.
 .SH "SEE ALSO"
 .BR CURLOPT_TRAILERFUNCTION "(3), "

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -97,5 +97,7 @@ if(curl) {
 }
 .SH AVAILABILITY
 This option was added in curl 7.64.0 and is present if HTTP support is enabled
+.SH RETURN VALUE
+Returns CURLE_OK.
 .SH "SEE ALSO"
 .BR CURLOPT_TRAILERDATA "(3), "

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -40,12 +40,10 @@ curl does not need to resolve the DNS hostname in the URL.
 The maximum path length on Cygwin, Linux and Solaris is 107. On other platforms
 it might be even less.
 
-Proxy and TCP options such as
-.BR CURLOPT_TCP_NODELAY "(3)
-are not supported. Proxy options such as
-.BR CURLOPT_PROXY "(3)
-have no effect either as these are TCP-oriented, and asking a proxy server to
-connect to a certain Unix domain socket is not possible.
+Proxy and TCP options such as \fICURLOPT_TCP_NODELAY(3)\fP are not
+supported. Proxy options such as \fICURLOPT_PROXY(3)\fP have no effect either
+as these are TCP-oriented, and asking a proxy server to connect to a certain
+Unix domain socket is not possible.
 
 The application does not have to keep the string around after setting this
 option.
@@ -59,19 +57,19 @@ Given that you have an nginx server running, listening on /tmp/nginx.sock, you
 can request an HTTP resource with:
 
 .nf
-    curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, "/tmp/nginx.sock");
-    curl_easy_setopt(curl_handle, CURLOPT_URL, "http://localhost/");
+  curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, "/tmp/nginx.sock");
+  curl_easy_setopt(curl_handle, CURLOPT_URL, "http://localhost/");
 .fi
 
-If you are on Linux and somehow have a need for paths larger than 107 bytes, you
-could use the proc filesystem to bypass the limitation:
+If you are on Linux and somehow have a need for paths larger than 107 bytes,
+you could use the proc filesystem to bypass the limitation:
 
 .nf
-    int dirfd = open(long_directory_path_to_socket, O_DIRECTORY | O_RDONLY);
-    char path[108];
-    snprintf(path, sizeof(path), "/proc/self/fd/%d/nginx.sock", dirfd);
-    curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, path);
-    /* Be sure to keep dirfd valid until you discard the handle */
+  int dirfd = open(long_directory_path_to_socket, O_DIRECTORY | O_RDONLY);
+  char path[108];
+  snprintf(path, sizeof(path), "/proc/self/fd/%d/nginx.sock", dirfd);
+  curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, path);
+  /* Be sure to keep dirfd valid until you discard the handle */
 .fi
 .SH AVAILABILITY
 Since 7.40.0.

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
@@ -50,14 +50,14 @@ option.
 .SH DEFAULT
 Default is NULL, meaning that no Unix domain sockets are used.
 .SH PROTOCOLS
-All protocols except for file:// and FTP are supported in theory. HTTP, IMAP,
+All protocols except for FILE and FTP are supported in theory. HTTP, IMAP,
 POP3 and SMTP should in particular work (including their SSL/TLS variants).
 .SH EXAMPLE
-Given that you have an nginx server running, listening on /tmp/nginx.sock, you
+Given that you have an HTTP server running listening on /tmp/httpd.sock, you
 can request an HTTP resource with:
 
 .nf
-  curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, "/tmp/nginx.sock");
+  curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, "/tmp/httpd.sock");
   curl_easy_setopt(curl_handle, CURLOPT_URL, "http://localhost/");
 .fi
 
@@ -67,7 +67,7 @@ you could use the proc filesystem to bypass the limitation:
 .nf
   int dirfd = open(long_directory_path_to_socket, O_DIRECTORY | O_RDONLY);
   char path[108];
-  snprintf(path, sizeof(path), "/proc/self/fd/%d/nginx.sock", dirfd);
+  snprintf(path, sizeof(path), "/proc/self/fd/%d/httpd.sock", dirfd);
   curl_easy_setopt(curl_handle, CURLOPT_UNIX_SOCKET_PATH, path);
   /* Be sure to keep dirfd valid until you discard the handle */
 .fi
@@ -76,4 +76,5 @@ Since 7.40.0.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"
+.BR CURLOPT_ABSTRACT_UNIX_SOCKET "(3), "
 .BR CURLOPT_OPENSOCKETFUNCTION "(3), " unix "(7), "

--- a/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.3
+++ b/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -42,6 +42,8 @@ is called, an HTTP/2 PING frame is sent on the connection.
 
 .SH DEFAULT
 CURL_UPKEEP_INTERVAL_DEFAULT (currently defined as 60000L, which is 60 seconds)
+.SH PROTOCOLS
+All
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -71,3 +73,6 @@ if(curl) {
 Added in 7.62.0
 .SH RETURN VALUE
 Returns CURLE_OK
+.SH SEE ALSO
+.BR CURLOPT_TCP_KEEPALIVE "(3), "
+

--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -78,7 +78,21 @@ Using the rules above, a file name pattern can be constructed:
 .SH PROTOCOLS
 This feature is only supported for FTP download.
 .SH EXAMPLE
-See https://curl.se/libcurl/c/ftp-wildcard.html
+.nf
+  /* initialization of easy handle */
+  handle = curl_easy_init();
+
+  /* turn on wildcard matching */
+  curl_easy_setopt(handle, CURLOPT_WILDCARDMATCH, 1L);
+
+  /* callback is called before download of concrete file started */
+  curl_easy_setopt(handle, CURLOPT_CHUNK_BGN_FUNCTION, file_is_coming);
+
+  /* callback is called after data from the file have been transferred */
+  curl_easy_setopt(handle, CURLOPT_CHUNK_END_FUNCTION, file_is_downloaded);
+
+  /* See more on https://curl.se/libcurl/c/ftp-wildcard.html */
+.fi
 .SH AVAILABILITY
 Added in 7.21.0
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -74,10 +74,6 @@ do that.
 libcurl will use 'fwrite' as a callback by default.
 .SH PROTOCOLS
 For all protocols
-.SH AVAILABILITY
-Support for the CURL_WRITEFUNC_PAUSE return code was added in version 7.18.0.
-.SH RETURN VALUE
-This will return CURLE_OK.
 .SH EXAMPLE
 .nf
  struct memory {
@@ -110,6 +106,10 @@ This will return CURLE_OK.
  /* we pass our 'chunk' struct to the callback function */
  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
 .fi
+.SH AVAILABILITY
+Support for the CURL_WRITEFUNC_PAUSE return code was added in version 7.18.0.
+.SH RETURN VALUE
+This will return CURLE_OK.
 .SH "SEE ALSO"
 .BR CURLOPT_WRITEDATA "(3), " CURLOPT_READFUNCTION "(3), "
 .BR CURLOPT_HEADERFUNCTION "(3), "

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -37,7 +37,32 @@ The default value of this parameter is NULL.
 .SH PROTOCOLS
 All
 .SH EXAMPLE
-https://curl.se/libcurl/c/progressfunc.html
+.nf
+ struct progress {
+   char *private;
+   size_t size;
+ };
+
+ static size_t progress_callback(void *clientp,
+                                 curl_off_t dltotal,
+                                 curl_off_t dlnow,
+                                 curl_off_t ultotal,
+                                 curl_off_t ulnow)
+ {
+   struct memory *progress = (struct progress *)userp;
+
+   /* use the values */
+
+   return 0; /* all is good */
+ }
+
+ struct progress data;
+
+ /* pass struct to callback  */
+ curl_easy_setopt(curl_handle, CURLOPT_XFERINFODATA, &data);
+
+ curl_easy_setopt(curl_handle, CURLOPT_XFERINFOFUNCTION, progress_callback);
+.fi
 .SH AVAILABILITY
 Added in 7.32.0
 .SH RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -75,7 +75,32 @@ users.
 .SH PROTOCOLS
 All
 .SH EXAMPLE
-https://curl.se/libcurl/c/progressfunc.html
+.nf
+ struct progress {
+   char *private;
+   size_t size;
+ };
+
+ static size_t progress_callback(void *clientp,
+                                 curl_off_t dltotal,
+                                 curl_off_t dlnow,
+                                 curl_off_t ultotal,
+                                 curl_off_t ulnow)
+ {
+   struct memory *progress = (struct progress *)userp;
+
+   /* use the values */
+
+   return 0; /* all is good */
+ }
+
+ struct progress data;
+
+ /* pass struct to callback  */
+ curl_easy_setopt(curl_handle, CURLOPT_XFERINFODATA, &data);
+
+ curl_easy_setopt(curl_handle, CURLOPT_XFERINFOFUNCTION, progress_callback);
+.fi
 .SH AVAILABILITY
 Added in 7.32.0. This callback replaces \fICURLOPT_PROGRESSFUNCTION(3)\fP
 .SH RETURN VALUE

--- a/tests/data/test1173
+++ b/tests/data/test1173
@@ -15,11 +15,11 @@ none
 </server>
 
  <name>
-Basic man page syntax check
+Man page syntax checks
  </name>
 
 <command type="perl">
-%SRCDIR/manpage-syntax.pl %SRCDIR/../docs/*.1  %SRCDIR/../docs/libcurl/*.3 %SRCDIR/../docs/libcurl/opts/*.3
+%SRCDIR/manpage-syntax.pl %SRCDIR/../docs/libcurl/symbols-in-versions %SRCDIR/../docs/*.1  %SRCDIR/../docs/libcurl/*.3 %SRCDIR/../docs/libcurl/opts/*.3
 </command>
 </client>
 

--- a/tests/manpage-syntax.pl
+++ b/tests/manpage-syntax.pl
@@ -34,11 +34,28 @@ my $errors = 0;
 
 sub scanmanpage {
     my ($file) = @_;
+    my $reqex = 0;
+    my $inex = 0;
+    my $exsize = 0;
 
     print "Check $file\n";
     open(M, "<$file") || die "no such file: $file";
+    if($file =~ /\/CURL[^\/]*.3/) {
+        # This is the man page for an libcurl option. It requires an example!
+        $reqex = 1;
+    }
     my $line = 1;
     while(<M>) {
+        if($_ =~ /^.SH EXAMPLE/) {
+            $inex = 1;
+        }
+        elsif($_ =~ /^.SH/) {
+            $inex = 0;
+        }
+        elsif($inex)  {
+            $exsize++;
+        }
+
         if($_ =~ /^\'/) {
             print STDERR "$file:$line line starts with single quote!\n";
             $errors++;
@@ -57,6 +74,11 @@ sub scanmanpage {
         $line++;
     }
     close(M);
+
+    if($reqex && ($exsize < 2)) {
+        print STDERR "$file:$line missing EXAMPLE section\n";
+        $errors++;
+    }
 }
 
 

--- a/tests/manpage-syntax.pl
+++ b/tests/manpage-syntax.pl
@@ -28,6 +28,9 @@
 use strict;
 use warnings;
 
+# get the file name first
+my $symbolsinversions=shift @ARGV;
+
 # we may get the dir roots pointed out
 my @manpages=@ARGV;
 my $errors = 0;
@@ -46,6 +49,18 @@ my @order = (
     );
 my %shline; # section => line number
 
+my %symbol;
+sub allsymbols {
+    open(F, "<$symbolsinversions") ||
+        die "$symbolsinversions: $|";
+    while(<F>) {
+        if($_ =~ /^([^ ]*)/) {
+            $symbol{$1}=$1;
+        }
+    }
+    close(F);
+}
+
 sub scanmanpage {
     my ($file) = @_;
     my $reqex = 0;
@@ -54,24 +69,24 @@ sub scanmanpage {
     my $shc = 0;
     my @sh;
 
-    print "Check $file\n";
     open(M, "<$file") || die "no such file: $file";
-    if($file =~ /\/CURL[^\/]*.3/) {
+    if($file =~ /[\/\\]CURL[^\/\\]*.3/) {
         # This is the man page for an libcurl option. It requires an example!
         $reqex = 1;
     }
     my $line = 1;
     while(<M>) {
-        if($_ =~ /^.SH EXAMPLE/i) {
+        chomp;
+        if($_ =~ /^\.SH EXAMPLE/i) {
             $inex = 1;
         }
-        elsif($_ =~ /^.SH/i) {
+        elsif($_ =~ /^\.SH/i) {
             $inex = 0;
         }
         elsif($inex)  {
             $exsize++;
         }
-        if($_ =~ /^.SH (.*)/i) {
+        if($_ =~ /^\.SH ([^\r\n]*)/i) {
             my $n = $1;
             # remove enclosing quotes
             $n =~ s/\"(.*)\"\z/$1/;
@@ -94,6 +109,16 @@ sub scanmanpage {
             print STDERR "$file:$line trailing whitespace\n";
             $errors++;
         }
+        if($_ =~ /\\f([BI])([^\\]*)\\fP/) {
+            my $r = $2;
+            if($r =~ /^(CURL.*)\(3\)/) {
+                my $rr = $1;
+                if(!$symbol{$rr}) {
+                    print STDERR "$file:$line link to non-libcurl option $rr!\n";
+                    $errors++;
+                }
+            }
+        }
         $line++;
     }
     close(M);
@@ -101,43 +126,66 @@ sub scanmanpage {
     if($reqex) {
         # only for libcurl options man-pages
 
+        my $shcount = scalar(@sh); # before @sh gets shifted
         if($exsize < 2) {
             print STDERR "$file:$line missing EXAMPLE section\n";
             $errors++;
         }
 
-        my $got;
+        if($shcount < 3) {
+            print STDERR "$file:$line too few man page sections!\n";
+            $errors++;
+            return;
+        }
+
+        my $got = "start";
         my $i = 0;
         my $shused = 1;
-        do {
+        my @shorig = @sh;
+        while($got) {
+            my $finesh;
             $got = shift(@sh);
             if($got) {
-                $i = $blessed{$got};
+                if($blessed{$got}) {
+                    $i = $blessed{$got};
+                    $finesh = $got; # a mandatory one
+                }
             }
-            if($i && $got) {
+            if($i && defined($finesh)) {
                 # mandatory section
 
                 if($i != $shused) {
-                    printf STDERR "$file:%u Got $got, when %s was expected\n",
-                        $shline{$got},
+                    printf STDERR "$file:%u Got %s, when %s was expected\n",
+                        $shline{$finesh},
+                        $finesh,
                         $order[$shused-1];
                     $errors++;
                     return;
                 }
                 $shused++;
-                if($i == 9) {
+                if($i == scalar(@order)) {
                     # last mandatory one, exit
-                    $got="";
+                    last;
                 }
             }
-        } while($got);
+        }
 
-        if($i != 8) {
+        if($i != scalar(@order)) {
             printf STDERR "$file:$line missing mandatory section: %s\n",
                 $order[$i];
+            printf STDERR "$file:$line section found at index %u: '%s'\n",
+                $i, $shorig[$i];
+            printf STDERR " Found %u used sections\n", $shcount;
             $errors++;
         }
     }
+}
+
+allsymbols();
+
+if(!$symbol{'CURLALTSVC_H1'}) {
+    print STDERR "didn't get the symbols-in-version!\n";
+    exit;
 }
 
 my $ind = 1;


### PR DESCRIPTION
All man pages for libcurl options now need to:

1. feature an example
2. feature eight mandatory sections (extra sections are fine)
3. feature those mandatory sections in the correct order

Failure to comply makes test 1173 error.

