### PR TITLE
multi: fix compiler warning with `CURL_DISABLE_WAKEUP`

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1100,6 +1100,9 @@ static CURLMcode multi_wait(struct Curl_multi *multi,
   WSANETWORKEVENTS wsa_events;
   DEBUGASSERT(multi->wsa_event != WSA_INVALID_EVENT);
 #endif
+#ifndef ENABLE_WAKEUP
+  (void)use_wakeup;
+#endif
 
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;


### PR DESCRIPTION
`use_wakeup` is unused in this case.