### PR TITLE
connect: get local port + ip also when reusing connections

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -751,10 +751,9 @@ void Curl_updateconninfo(struct Curl_easy *data, struct connectdata *conn,
   int local_port = -1;
 
   if(conn->transport == TRNSPRT_TCP) {
-    if(!conn->bits.reuse && !conn->bits.tcp_fastopen) {
+    if(!conn->bits.reuse && !conn->bits.tcp_fastopen)
       Curl_conninfo_remote(data, conn, sockfd);
-      Curl_conninfo_local(data, sockfd, local_ip, &local_port);
-    }
+    Curl_conninfo_local(data, sockfd, local_ip, &local_port);
   } /* end of TCP-only section */
 
   /* persist connection info in session handle */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -67,7 +67,7 @@ test392 test393 test394 test395 test396 test397 \
 test400 test401 test402 test403 test404 test405 test406 test407 test408 \
 test409 test410 \
 \
-test430 test431 test432 test433 test434 \
+test430 test431 test432 test433 test434 test435 \
 \
 test490 test491 test492 test493 test494 \
 \

--- a/tests/data/test435
+++ b/tests/data/test435
@@ -1,0 +1,71 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Content-Length: 0
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+verify -w local/remote port+ip after connecton re-use
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w 'local port == %{local_port}\nlocal ip == %{local_ip}\nremote_ip == %{remote_ip}\nremote_port == %{remote_port}\n'
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+
+# replace the number with a fixed string since the port number is not
+# known to the test script but it should always be a decimal number
+<stripfile>
+s/local port == (\d+)/local port == [digits]/
+</stripfile>
+<stdout>
+HTTP/1.1 200 OK
+Content-Length: 0
+
+local port == [digits]
+local ip == 127.0.0.1
+remote_ip == %HOSTIP
+remote_port == %HTTPPORT
+HTTP/1.1 200 OK
+Content-Length: 0
+
+local port == [digits]
+local ip == 127.0.0.1
+remote_ip == %HOSTIP
+remote_port == %HTTPPORT
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
In d6a37c23a3c (7.75.0) we removed the duplicated storage (connection +
easy handle), so this info needs be extract again even for re-used
connections.

Add test 435 to verify

Reported-by: Max Dymond
Fixes #7660
Closes #