### PR TITLE
curl: stop retrying if Retry-After: is longer than allowed for retries

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -60,7 +60,7 @@ test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \
 test352 test353 test354 test355 test356 test357 test358 test359 test360 \
-test361 test362 test363 test364 test365 \
+test361 test362 test363 test364 test365 test366 \
 \
 test392 test393 test394 test395 test396 test397 \
 \

--- a/tests/data/test366
+++ b/tests/data/test366
@@ -1,0 +1,49 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+retry
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 503 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 21
+Retry-After: 200
+
+server not available
+</data>
+
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP --retry-max-time with too long Retry-After
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --retry 2 --retry-max-time 10
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+
+</verify>
+</testcase>


### PR DESCRIPTION
If Retry-After: specifies a period that is longer than what fits within
--retry-max-time, then stop retrying immediately.

Added test 366 to verify.

Reported-by: Kari Pahula
Fixes #7675