### PR TITLE
docs: the security list is reached at security at curl.se now

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -288,10 +288,14 @@ FAQ
   from having to repeat ourselves even more. Thanks for respecting this.
 
   If you have found or simply suspect a security problem in curl or libcurl,
-  mail curl-security at haxx.se (closed list of receivers, mails are not
-  disclosed) and tell. Then we can produce a fix in a timely manner before the
-  flaw is announced to the world, thus lessen the impact the problem will have
-  on existing users.
+  submit all the details at https://hackerone.one/curl. On there we keep the
+  issue private while we investigate, confirm it, work and validate a fix and
+  agree on a time schedule for publication etc. That way we produce a fix in a
+  timely manner before the flaw is announced to the world, reducing the impact
+  the problem risk having on existing users.
+
+  Security issues can also be taking to the curl security team by emailing
+  security at curl.se (closed list of receivers, mails are not disclosed).
 
   1.9 Where do I buy commercial support for curl?
 

--- a/docs/SECURITY-PROCESS.md
+++ b/docs/SECURITY-PROCESS.md
@@ -91,7 +91,7 @@ announcement.
 - The security web page on the website should get the new vulnerability
   mentioned.
 
-curl-security (at haxx dot se)
+security (at curl dot se)
 ------------------------------
 
 This is a private mailing list for discussions on and about curl security


### PR DESCRIPTION
Also update the FAQ section a bit to encourage users to rather submit
security issues on hackerone than sending email.