### PR TITLE
parse_args: redo the warnings for --remote-header-name combos

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2384,17 +2384,11 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
       curlx_unicodefree(orig_opt);
   }
 
-  if(config->content_disposition) {
-    if(config->show_headers) {
-      helpf(global->errors, "--include and --remote-header-name "
-            "cannot be combined.\n");
-      return PARAM_BAD_USE;
-    }
-    if(config->resume_from_current) {
-      helpf(global->errors, "--continue-at - and --remote-header-name "
-            "cannot be combined.\n");
-      return PARAM_BAD_USE;
-    }
+  if(!result && config->content_disposition) {
+    if(config->show_headers)
+      result = PARAM_CONTDISP_SHOW_HEADER;
+    else if(config->resume_from_current)
+      result = PARAM_CONTDISP_RESUME_FROM;
   }
 
   if(result && result != PARAM_HELP_REQUESTED &&

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -43,6 +43,8 @@ typedef enum {
   PARAM_NO_PREFIX,
   PARAM_NUMBER_TOO_LARGE,
   PARAM_NO_NOT_BOOLEAN,
+  PARAM_CONTDISP_SHOW_HEADER, /* --include and --remote-header-name */
+  PARAM_CONTDISP_RESUME_FROM, /* --continue-at and --remote-header-name */
   PARAM_LAST
 } ParameterError;
 

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -68,6 +68,10 @@ const char *param2text(int res)
     return "too large number";
   case PARAM_NO_NOT_BOOLEAN:
     return "used '--no-' for option that isn't a boolean";
+  case PARAM_CONTDISP_SHOW_HEADER:
+    return "--include and --remote-header-name cannot be combined";
+  case PARAM_CONTDISP_RESUME_FROM:
+    return "--continue-at and --remote-header-name cannot be combined";
   default:
     return "unknown error";
   }


### PR DESCRIPTION
... to avoid the memory leak risk pointed out by scan-build.

Follow-up from 7a3e981781d6c18a