### PR TITLE
http_proxy: fix the User-Agent inclusion in CONNECT

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -300,32 +300,27 @@ static CURLcode CONNECT(struct Curl_easy *data,
                                      hostheader, TRUE);
 
       if(!result) {
-        const char *proxyconn = "";
-        const char *useragent = "";
         const char *httpv =
           (conn->http_proxy.proxytype == CURLPROXY_HTTP_1_0) ? "1.0" : "1.1";
-
-        if(!Curl_checkProxyheaders(data, conn, "Proxy-Connection"))
-          proxyconn = "Proxy-Connection: Keep-Alive\r\n";
-
-        if(!Curl_checkProxyheaders(data, conn, "User-Agent") &&
-           data->set.str[STRING_USERAGENT])
-          useragent = data->state.aptr.uagent;
 
         result =
           Curl_dyn_addf(req,
                         "CONNECT %s HTTP/%s\r\n"
                         "%s"  /* Host: */
-                        "%s"  /* Proxy-Authorization */
-                        "%s"  /* User-Agent */
-                        "%s", /* Proxy-Connection */
+                        "%s", /* Proxy-Authorization */
                         hostheader,
                         httpv,
                         host?host:"",
                         data->state.aptr.proxyuserpwd?
-                        data->state.aptr.proxyuserpwd:"",
-                        useragent,
-                        proxyconn);
+                        data->state.aptr.proxyuserpwd:"");
+
+        if(!result && !Curl_checkProxyheaders(data, conn, "User-Agent") &&
+           data->set.str[STRING_USERAGENT])
+          result = Curl_dyn_addf(req, "User-Agent: %s\r\n",
+                                 data->set.str[STRING_USERAGENT]);
+
+        if(!result && !Curl_checkProxyheaders(data, conn, "Proxy-Connection"))
+          result = Curl_dyn_add(req, "Proxy-Connection: Keep-Alive\r\n");
 
         if(!result)
           result = Curl_add_custom_headers(data, TRUE, req);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -141,7 +141,7 @@ test1152 test1153 test1154 test1155 test1156 test1157 test1158 test1159 \
 test1160 test1161 test1162 test1163 test1164 test1165 test1166 test1167 \
 test1168 test1169 test1170 test1171 test1172 test1173 test1174 test1175 \
 test1176 test1177 test1178 test1179 test1180 test1181 test1182 test1183 \
-\
+test1184 \
 test1188 \
 \
 test1190 test1191 test1192 test1193 test1194 test1195 test1196 test1197 \

--- a/tests/data/test1184
+++ b/tests/data/test1184
@@ -1,0 +1,108 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP CONNECT
+HTTP proxy
+proxytunnel
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<connect>
+HTTP/1.1 200 Mighty fine indeed
+Server: test tunnel 2000
+
+</connect>
+
+<data nocheck="yes">
+HTTP/1.1 302 OK
+Location: http://%HOSTIP.%TESTNUMBER:%HTTPPORT/we/want/that/page/%TESTNUMBER0002
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+Connection: close
+
+contents
+</data>
+
+<data2 nocheck="yes">
+HTTP/1.1 200 OK
+Content-Length: 7
+
+second
+</data2>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+http-proxy
+</server>
+ <name>
+HTTP 1.1 CONNECT with redirect and set -H user-agent
+ </name>
+ <command>
+-x %HOSTIP:%PROXYPORT -p http://%HOSTIP.%TESTNUMBER:%HTTPPORT/we/want/that/page/%TESTNUMBER -L -H "User-Agent: %TESTNUMBER-agent"
+</command>
+<features>
+proxy
+</features>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<proxy>
+CONNECT %HOSTIP.%TESTNUMBER:%HTTPPORT HTTP/1.1
+Host: %HOSTIP.%TESTNUMBER:%HTTPPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+CONNECT %HOSTIP.%TESTNUMBER:%HTTPPORT HTTP/1.1
+Host: %HOSTIP.%TESTNUMBER:%HTTPPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</proxy>
+<protocol>
+GET /we/want/that/page/%TESTNUMBER HTTP/1.1
+Host: %HOSTIP.%TESTNUMBER:%HTTPPORT
+Accept: */*
+User-Agent: %TESTNUMBER-agent
+
+GET /we/want/that/page/%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP.%TESTNUMBER:%HTTPPORT
+Accept: */*
+User-Agent: %TESTNUMBER-agent
+
+</protocol>
+<stdout>
+HTTP/1.1 200 Mighty fine indeed
+Server: test tunnel 2000
+
+HTTP/1.1 302 OK
+Location: http://%HOSTIP.%TESTNUMBER:%HTTPPORT/we/want/that/page/%TESTNUMBER0002
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+Connection: close
+
+HTTP/1.1 200 Mighty fine indeed
+Server: test tunnel 2000
+
+HTTP/1.1 200 OK
+Content-Length: 7
+
+second
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
It should not refer to the uagent string that is allocated and created
for the end server http request, as that pointer may be cleared on
subsequent CONNECT requests.

Added test case 1184 to verify.

Reported-by: T200proX7 on github
Fixes #7705