### PR TITLE
Fix build with ngtcp2 and nghttp3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2677,7 +2677,7 @@ if test X"$want_tcp2" != Xno; then
     if test "x$cross_compiling" != "xyes"; then
       DIR_TCP2=`echo $LD_TCP2 | $SED -e 's/^-L//'`
     fi
-    AC_CHECK_LIB(ngtcp2, ngtcp2_conn_client_new,
+    AC_CHECK_LIB(ngtcp2, ngtcp2_conn_client_new_versioned,
       [
        AC_CHECK_HEADERS(ngtcp2/ngtcp2.h,
           NGTCP2_ENABLED=1
@@ -2876,7 +2876,7 @@ if test X"$want_nghttp3" != Xno; then
     if test "x$cross_compiling" != "xyes"; then
       DIR_NGHTTP3=`echo $LD_NGHTTP3 | $SED -e 's/^-L//'`
     fi
-    AC_CHECK_LIB(nghttp3, nghttp3_conn_client_new,
+    AC_CHECK_LIB(nghttp3, nghttp3_conn_client_new_versioned,
       [
        AC_CHECK_HEADERS(nghttp3/nghttp3.h,
           curl_h3_msg="enabled (ngtcp2 + nghttp3)"

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -559,8 +559,8 @@ cb_acked_stream_data_offset(ngtcp2_conn *tconn, int64_t stream_id,
   return 0;
 }
 
-static int cb_stream_close(ngtcp2_conn *tconn, int64_t stream_id,
-                           uint64_t app_error_code,
+static int cb_stream_close(ngtcp2_conn *tconn, uint32_t flags,
+                           int64_t stream_id, uint64_t app_error_code,
                            void *user_data, void *stream_user_data)
 {
   struct quicsocket *qs = (struct quicsocket *)user_data;
@@ -568,6 +568,10 @@ static int cb_stream_close(ngtcp2_conn *tconn, int64_t stream_id,
   (void)tconn;
   (void)stream_user_data;
   /* stream is closed... */
+
+  if(!(flags & NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET)) {
+    app_error_code = NGHTTP3_H3_NO_ERROR;
+  }
 
   rv = nghttp3_conn_close_stream(qs->h3conn, stream_id,
                                  app_error_code);


### PR DESCRIPTION
ngtcp2_conn_client_new and nghttp3_conn_client_new are now macros.
Check the wrapped functions instead.

ngtcp2_stream_close callback now takes flags parameter.