### PR TITLE
Fix version checking in Windows (proper backwards and forwards compatible version checking)

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1101,7 +1101,7 @@ static void nosigpipe(struct Curl_easy *data,
 #define nosigpipe(x,y) Curl_nop_stmt
 #endif
 
-#ifdef USE_WINSOCK
+#if defined(USE_WINSOCK) && defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
 /* When you run a program that uses the Windows Sockets API, you may
    experience slow performance when you copy data to a TCP server.
 
@@ -1127,7 +1127,7 @@ void Curl_sndbufset(curl_socket_t sockfd)
   static int detectOsState = DETECT_OS_NONE;
 
   if(detectOsState == DETECT_OS_NONE) {
-    if(curlx_verify_windows_version(6, 0, PLATFORM_WINNT,
+    if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
                                     VERSION_GREATER_THAN_EQUAL))
       detectOsState = DETECT_OS_VISTA_OR_LATER;
     else

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -61,9 +61,10 @@ bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
  */
 bool Curl_connalive(struct connectdata *conn);
 
-#ifdef USE_WINSOCK
-/* When you run a program that uses the Windows Sockets API, you may
-   experience slow performance when you copy data to a TCP server.
+#if defined(USE_WINSOCK) && defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
+/* When you run a program that uses the Windows Sockets API on Windows
+   prior to Vista, you may experience slow performance when you copy
+   data to a TCP server.
 
    https://support.microsoft.com/kb/823764
 

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -83,10 +83,13 @@ CURLcode Curl_sspi_global_init(void)
      * have both these DLLs (security.dll forwards calls to secur32.dll) */
 
     /* Load SSPI dll into the address space of the calling process */
-    if(curlx_verify_windows_version(4, 0, PLATFORM_WINNT, VERSION_EQUAL))
+#if WINVER <= 0x0400
+    if(curlx_verify_windows_version(4, 0, 0, PLATFORM_WINNT, VERSION_EQUAL))
       s_hSecDll = Curl_load_library(TEXT("security.dll"));
     else
+#endif
       s_hSecDll = Curl_load_library(TEXT("secur32.dll"));
+
     if(!s_hSecDll)
       return CURLE_FAILED_INIT;
 

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -63,6 +63,9 @@ CURLcode Curl_win32_init(long flags)
       /* winsock.dll.     */
       return CURLE_FAILED_INIT;
 
+    /* Windows 2000 and newer have Winsock 2.2 so this is dead
+    code if you're targeting modern Windows. */
+#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0500
     /* Confirm that the Windows Sockets DLL supports what we need.*/
     /* Note that if the DLL supports versions greater */
     /* than wVersionRequested, it will still return */
@@ -77,6 +80,7 @@ CURLcode Curl_win32_init(long flags)
       WSACleanup();
       return CURLE_FAILED_INIT;
     }
+#endif
     /* The Windows Sockets DLL is acceptable. Proceed. */
 #elif defined(USE_LWIPSOCK)
     lwip_init();
@@ -102,12 +106,16 @@ CURLcode Curl_win32_init(long flags)
       Curl_if_nametoindex = pIfNameToIndex;
   }
 
-  if(curlx_verify_windows_version(6, 0, PLATFORM_WINNT,
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
+  Curl_isVistaOrGreater = TRUE;
+#else
+  if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
                                   VERSION_GREATER_THAN_EQUAL)) {
     Curl_isVistaOrGreater = TRUE;
   }
   else
     Curl_isVistaOrGreater = FALSE;
+#endif
 
   QueryPerformanceFrequency(&Curl_freq);
   return CURLE_OK;

--- a/lib/version_win32.h
+++ b/lib/version_win32.h
@@ -45,6 +45,7 @@ typedef enum {
 /* This is used to verify if we are running on a specific windows version */
 bool curlx_verify_windows_version(const unsigned int majorVersion,
                                   const unsigned int minorVersion,
+                                  const unsigned int buildVersion,
                                   const PlatformIdentifier platform,
                                   const VersionCondition condition);
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -355,7 +355,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
   DWORD i;
 
   /* CERT_NAME_SEARCH_ALL_NAMES_FLAG is available from Windows 8 onwards. */
-  if(curlx_verify_windows_version(6, 2, PLATFORM_WINNT,
+  if(curlx_verify_windows_version(6, 2, 0, PLATFORM_WINNT,
                                   VERSION_GREATER_THAN_EQUAL)) {
 #ifdef CERT_NAME_SEARCH_ALL_NAMES_FLAG
     /* CertGetNameString will provide the 8-bit character string without
@@ -597,7 +597,7 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
      * trusted certificates. This is only supported on Windows 7+.
      */
 
-    if(curlx_verify_windows_version(6, 1, PLATFORM_WINNT, VERSION_LESS_THAN)) {
+    if(curlx_verify_windows_version(6, 1, 0, PLATFORM_WINNT, VERSION_LESS_THAN)) {
       failf(data, "schannel: this version of Windows is too old to support "
             "certificate verification via CA bundle file.");
       result = CURLE_SSL_CACERT_BADFILE;


### PR DESCRIPTION
[VerifyVersionInfo](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-verifyversioninfoa) has some of the same problems as GetVersionEx(). Specifically, the problem that we're dealing with is inaccurate version reporting if the application linking libCurl *doesn't* explicitly have an application manifest saying it's compatible with a version greater than or equal to the version we're testing.

Or to put it in MSDN parlance:


> Windows 10:  VerifyVersionInfo returns false when called by applications that do not have a compatibility manifest for Windows 8.1 or Windows 10 if the lpVersionInfo parameter is set so that it specifies Windows 8.1 or Windows 10, even when the current operating system version is Windows 8.1 or Windows 10. Specifically, VerifyVersionInfo has the following behavior:
>
> - If the application has no manifest, VerifyVersionInfo behaves as if the operation system version is Windows 8 (6.2).
> - If the application has a manifest that contains the GUID that corresponds to Windows 8.1, VerifyVersionInfo behaves as if the operation system version is Windows 8.1 (6.3).
> - If the application has a manifest that contains the GUID that corresponds to Windows 10, VerifyVersionInfo behaves as if the operation system version is Windows 10 (10.0).


Why is this a problem? With executables we release, we have full control over the manifests, and thus this isn't a problem. With libraries we release that link to our libraries that use libCurl, suddenly the version detection is broken if the end-developer doesn't know what manifests are, why they're needed, and how to implement them correctly. In short: it becomes a big hassle where features magically work if run from one executable linking the library and suddenly don't work if run from another executable on the same machine linking the exact same library.

Right now this only affects ALPN. However, TLS 1.3 support has arrived in Windows Server 2022 (their LTS server product) and Windows 11. And to detect and use TLS 1.3 proper version checking needs to be implemented (including checking build numbers).

So... what do we do? Well, luckily there's one version function that doesn't trying to outsmart developers (yet) and still reports accurate version numbers regardless of manifests the calling executable may or may not have. Namely, [RtlGetVersion()](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion)


TLDR: this fixes ALPN detection and prepares for Window Server 2022 / Windows 11 detection for TLS 1.3 support (as well as TCP fast open support on Windows).

Also, this PR reduce the code duplication in the version checking function and removes version checking when we're compiling for a later version of Windows.