### PR TITLE
Curl_http2_setup: don't change connection data on repeat invokes

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2221,12 +2221,6 @@ CURLcode Curl_http2_setup(struct Curl_easy *data,
   stream->mem = data->state.buffer;
   stream->len = data->set.buffer_size;
 
-  httpc->inbuflen = 0;
-  httpc->nread_inbuf = 0;
-
-  httpc->pause_stream_id = 0;
-  httpc->drain_total = 0;
-
   multi_connchanged(data->multi);
   /* below this point only connection related inits are done, which only needs
      to be done once per connection */
@@ -2251,6 +2245,12 @@ CURLcode Curl_http2_setup(struct Curl_easy *data,
   conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   conn->httpversion = 20;
   conn->bundle->multiuse = BUNDLE_MULTIPLEX;
+
+  httpc->inbuflen = 0;
+  httpc->nread_inbuf = 0;
+
+  httpc->pause_stream_id = 0;
+  httpc->drain_total = 0;
 
   infof(data, "Connection state changed (HTTP/2 confirmed)");
 


### PR DESCRIPTION
Regression from 3cb8a748670ab88c (releasde in 7.79.0). That change moved
transfer oriented inits to before the check but also erroneously moved a
few connection oriented ones, which causes problems.

Fixes #7730
Reported-by: Evangelos Foutras