### PR TITLE
dist: provide lib/.checksrc in the tarball

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -30,7 +30,7 @@ EXTRA_DIST = Makefile.m32 config-win32.h config-win32ce.h           \
  config-os400.h setup-os400.h                                       \
  config-tpf.h mk-ca-bundle.pl mk-ca-bundle.vbs $(CMAKE_DIST)        \
  firefox-db2pem.sh config-vxworks.h Makefile.vxworks checksrc.pl    \
- setup-win32.h
+ setup-win32.h .checksrc
 
 lib_LTLIBRARIES = libcurl.la
 


### PR DESCRIPTION
So that debug builds work (checksrc really)

Reported-by: Marcel Raad
Reported-by: tawmoto on github
Fixes #7733