### PR TITLE
strerror: use sys_errlist instead of strerror on Windows

### DIFF
--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -731,12 +731,11 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   max = buflen - 1;
   *buf = '\0';
 
-  /* !checksrc! disable STRERROR 2 */
 #if defined(WIN32) || defined(_WIN32_WCE)
 #if defined(WIN32)
   /* 'sys_nerr' is the maximum errno number, it is not widely portable */
   if(err >= 0 && err < sys_nerr)
-    strncpy(buf, strerror(err), max);
+    strncpy(buf, sys_errlist[err], max);
   else
 #endif
   {
@@ -787,6 +786,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   }
 #else
   {
+    /* !checksrc! disable STRERROR 1 */
     const char *msg = strerror(err);
     if(msg)
       strncpy(buf, msg, max);


### PR DESCRIPTION
- Change Curl_strerror to use sys_errlist[errnum] instead of strerror to
  retrieve the error message on Windows.

Windows' strerror writes to a static buffer and is not thread-safe.

Follow-up to 2f0bb86 which removed most instances of strerror in favor
of calling Curl_strerror (which calls strerror_r for other platforms).

Ref: https://github.com/curl/curl/pull/7685
Ref: https://github.com/curl/curl/commit/2f0bb86

Closes #xxxx