### PR TITLE
remove requirement on HAVE_SYS_UN_H for unix domain sockets on Windows

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -629,7 +629,7 @@ bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
 #ifdef ENABLE_IPV6
   struct sockaddr_in6 *si6 = NULL;
 #endif
-#if defined(HAVE_SYS_UN_H) && defined(AF_UNIX)
+#if (defined(HAVE_SYS_UN_H) || defined(WIN32_SOCKADDR_UN)) && defined(AF_UNIX)
   struct sockaddr_un *su = NULL;
 #else
   (void)salen;
@@ -656,7 +656,7 @@ bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
       }
       break;
 #endif
-#if defined(HAVE_SYS_UN_H) && defined(AF_UNIX)
+#if (defined(HAVE_SYS_UN_H) || defined(WIN32_SOCKADDR_UN)) && defined(AF_UNIX)
     case AF_UNIX:
       if(salen > (curl_socklen_t)sizeof(CURL_SA_FAMILY_T)) {
         su = (struct sockaddr_un*)sa;

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -839,6 +839,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
        ADDRESS_FAMILY sun_family;
        char sun_path[UNIX_PATH_MAX];
      } SOCKADDR_UN, *PSOCKADDR_UN;
+#    define WIN32_SOCKADDR_UN
 #  endif
 #endif
 


### PR DESCRIPTION
As described in #5162 curl with option `--unix-socket` on Windows was failing with:
```
* sa_addr inet_ntop() failed with errno 10047: Address family not supported
```

It happened because in `Curl_addr2string`'s switch statement, case with `AF_UNIX` was behind `define(HAVE_SYS_UN_H) && defined(AF_UNIX)`. There is no `sys/un.h` on Windows. On Windows `sockaddr_un` is defined in `afunix.h` (not in `sys/un.h` as it's on unix-like OSs). After this change, curl with `--unix-socket` worked for me as expected.

I'm not sure if this is the proper way to fix this, so I'd welcome some feedback. Also, I'm counting on tests that should run on this PR to see if things are OK.