### PR TITLE
test897: verify delivery of IMAP post-body header content

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -106,7 +106,7 @@ test854 test855 test856 test857 test858 test859 test860 test861 test862 \
 test863 test864 test865 test866 test867 test868 test869 test870 test871 \
 test872 test873 test874 test875 test876 test877 test878 test879 test880 \
 test881 test882 test883 test884 test885 test886 test887 test888 test889 \
-test890 test891 test892 test893 test894 test895 test896 \
+test890 test891 test892 test893 test894 test895 test896 test897 \
 \
 test900 test901 test902 test903 test904 test905 test906 test907 test908 \
 test909 test910 test911 test912 test913 test914 test915 test916 test917 \

--- a/tests/data/test897
+++ b/tests/data/test897
@@ -1,0 +1,70 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+FETCH
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+body
+
+--
+  yours sincerely
+</data>
+<servercmd>
+POSTFETCH extra stuff sent in the envelope after the body
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP and envelope meta data after body transfer
+ </name>
+ <command>
+'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=123/;SECTION=1' -u user:secret -D log/head-%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+A001 CAPABILITY
+A002 LOGIN user secret
+A003 SELECT %TESTNUMBER
+A004 FETCH 123 BODY[1]
+A005 LOGOUT
+</protocol>
+<file name="log/head-%TESTNUMBER">
+        _   _ ____  _     
+    ___| | | |  _ \| |    
+   / __| | | | |_) | |    
+  | (__| |_| |  _ {| |___ 
+   \___|\___/|_| \_\_____|
+* OK curl IMAP server ready to serve
+A001 BAD Command
+A002 OK LOGIN completed
+* 172 EXISTS
+* 1 RECENT
+* OK [UNSEEN 12] Message 12 is first unseen
+* OK [UIDVALIDITY 3857529045] UIDs valid
+* OK [UIDNEXT 4392] Predicted next UID
+* FLAGS (\Answered \Flagged \Deleted \Seen \Draft)
+* OK [PERMANENTFLAGS (\Deleted \Seen \*)] Limited
+A003 OK [READ-WRITE] SELECT completed
+* 123 FETCH (BODY[1] {31}
+extra stuff sent in the envelope after the body)
+A004 OK FETCH completed
+</file>
+</verify>
+</testcase>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -146,6 +146,7 @@ my $nodataconn425; # set if ftp srvr doesn't establish data ch and replies 425
 my $nodataconn421; # set if ftp srvr doesn't establish data ch and replies 421
 my $nodataconn150; # set if ftp srvr doesn't establish data ch and replies 150
 my $storeresp;
+my $postfetch;
 my @capabilities;  # set if server supports capability commands
 my @auth_mechs;    # set if server supports authentication commands
 my %fulltextreply; #
@@ -1232,7 +1233,8 @@ sub FETCH_imap {
             sendcontrol $d;
         }
 
-        sendcontrol ")\r\n";
+        # Set the custom extra header content with POSTFETCH
+        sendcontrol "$postfetch)\r\n";
         sendcontrol "$cmdid OK FETCH completed\r\n";
     }
 
@@ -2798,6 +2800,7 @@ sub customize {
     $nodataconn421 = 0; # default is to not send 421 without data channel
     $nodataconn150 = 0; # default is to not send 150 without data channel
     $storeresp = "";    # send as ultimate STOR response
+    $postfetch = "";    # send as header after a FETCH response
     @capabilities = (); # default is to not support capability commands
     @auth_mechs = ();   # default is to not support authentication commands
     %fulltextreply = ();#
@@ -2839,6 +2842,10 @@ sub customize {
         elsif($_ =~ /DELAY ([A-Z]+) (\d*)/) {
             $delayreply{$1}=$2;
             logmsg "FTPD: delay reply for $1 with $2 seconds\n";
+        }
+        elsif($_ =~ /POSTFETCH (.*)/) {
+            logmsg "FTPD: read POSTFETCH header data\n";
+            $postfetch = $1;
         }
         elsif($_ =~ /SLOWDOWN/) {
             $ctrldelay=1;


### PR DESCRIPTION
The "content" is delivered as "body" by curl, but the envelope continues
after the body and the rest of it should be delivered as header.

The IMAP server can now get 'POSTFETCH' set to include more data to
include after the body and test 897 is done to verify that such "extra"
header data is in fact delivered by curl as header.

Ref: #7284 but fails to reproduce the bug