### PR TITLE
cleanup: Constify unmodified static structs

### DIFF
--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -374,7 +374,7 @@ static void krb5_end(void *app_data)
     }
 }
 
-static struct Curl_sec_client_mech Curl_krb5_client_mech = {
+static const struct Curl_sec_client_mech Curl_krb5_client_mech = {
   "GSSAPI",
   sizeof(gss_ctx_id_t),
   krb5_init,

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3180,7 +3180,7 @@ CURLMcode curl_multi_socket_all(struct Curl_multi *multi, int *running_handles)
 static CURLMcode multi_timeout(struct Curl_multi *multi,
                                long *timeout_ms)
 {
-  static struct curltime tv_zero = {0, 0};
+  static const struct curltime tv_zero = {0, 0};
 
   if(multi->timetree) {
     /* we have a tree of expire times */

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -154,7 +154,7 @@ struct Curl_tree *Curl_splaygetbest(struct curltime i,
                                     struct Curl_tree *t,
                                     struct Curl_tree **removed)
 {
-  static struct curltime tv_zero = {0, 0};
+  static const struct curltime tv_zero = {0, 0};
   struct Curl_tree *x;
 
   if(!t) {

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -128,7 +128,7 @@ struct decc_feat_t {
 };
 
 /* Array of DECC$* feature names and their desired values. */
-static struct decc_feat_t decc_feat_array[] = {
+static const struct decc_feat_t decc_feat_array[] = {
   /* Preserve command-line case with SET PROCESS/PARSE_STYLE=EXTENDED */
   { "DECC$ARGV_PARSE_STYLE", 1 },
   /* Preserve case for file names on ODS5 disks. */

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -128,7 +128,7 @@ struct querycase {
   CURLUcode ucode;
 };
 
-static struct testcase get_parts_list[] ={
+static const struct testcase get_parts_list[] ={
   {"https://user:password@example.net/get?this=and what", "",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_MALFORMED_INPUT},
   {"https://user:password@example.net/ge t?this=and-what", "",
@@ -351,7 +351,7 @@ static struct testcase get_parts_list[] ={
   {NULL, NULL, 0, 0, CURLUE_OK},
 };
 
-static struct urltestcase get_url_list[] = {
+static const struct urltestcase get_url_list[] = {
   /* IPv4 trickeries */
   {"https://16843009", "https://1.1.1.1/", 0, 0, CURLUE_OK},
   {"https://0x7f.1", "https://127.0.0.1/", 0, 0, CURLUE_OK},
@@ -522,7 +522,7 @@ static int checkurl(const char *url, const char *out)
 }
 
 /* !checksrc! disable SPACEBEFORECOMMA 1 */
-static struct setcase set_parts_list[] = {
+static const struct setcase set_parts_list[] = {
   {"https://example.com/",
    "query=Al2cO3tDkcDZ3EWE5Lh+LX8TPHs,", /* contains '+' */
    "https://example.com/?Al2cO3tDkcDZ3EWE5Lh%2bLX8TPHs",
@@ -737,7 +737,7 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
   return CURLUE_OK;
 }
 
-static struct redircase set_url_list[] = {
+static const struct redircase set_url_list[] = {
   {"http://example.org/static/favicon/wikipedia.ico",
    "//fake.example.com/licenses/by-sa/3.0/",
    "http://fake.example.com/licenses/by-sa/3.0/",
@@ -935,7 +935,7 @@ static int get_parts(void)
   return error;
 }
 
-static struct querycase append_list[] = {
+static const struct querycase append_list[] = {
   {"HTTP://test/?s", "name=joe\x02", "http://test/?s&name=joe%02",
    0, CURLU_URLENCODE, CURLUE_OK},
   {"HTTP://test/?size=2#f", "name=joe=", "http://test/?size=2&name=joe%3d#f",

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -30,7 +30,7 @@ struct entry {
   const char *exp;
 };
 
-static struct entry preload_hosts[] = {
+static const struct entry preload_hosts[] = {
   /* curl turns 39 that day just before 31-bit time_t overflow */
   { "1.example.com", "20370320 01:02:03" },
   { "2.example.com", "20370320 03:02:01" },

--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -28,7 +28,7 @@ struct dcheck {
   time_t output;
 };
 
-static struct dcheck dates[] = {
+static const struct dcheck dates[] = {
   {"Sun, 06 Nov 1994 08:49:37 GMT", 784111777 },
   {"Sunday, 06-Nov-94 08:49:37 GMT", 784111777 },
   {"Sun Nov  6 08:49:37 1994", 784111777 },

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -179,7 +179,7 @@ static struct errmsg errmsgs[] = {
   { -1,           0 }
 };
 
-static struct formats formata[] = {
+static const struct formats formata[] = {
   { "netascii",   1 },
   { "octet",      0 },
   { NULL,         0 }
@@ -245,9 +245,9 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size);
 
 static int validate_access(struct testcase *test, const char *fname, int mode);
 
-static void sendtftp(struct testcase *test, struct formats *pf);
+static void sendtftp(struct testcase *test, const struct formats *pf);
 
-static void recvtftp(struct testcase *test, struct formats *pf);
+static void recvtftp(struct testcase *test, const struct formats *pf);
 
 static void nak(int error);
 
@@ -884,7 +884,7 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
 {
   char *cp;
   int first = 1, ecode;
-  struct formats *pf;
+  const struct formats *pf;
   char *filename, *mode = NULL;
 #ifdef USE_WINSOCK
   DWORD recvtimeout, recvtimeoutbak;
@@ -1151,7 +1151,7 @@ static int validate_access(struct testcase *test,
 /*
  * Send the requested file.
  */
-static void sendtftp(struct testcase *test, struct formats *pf)
+static void sendtftp(struct testcase *test, const struct formats *pf)
 {
   int size;
   ssize_t n;
@@ -1232,7 +1232,7 @@ static void sendtftp(struct testcase *test, struct formats *pf)
 /*
  * Receive a file.
  */
-static void recvtftp(struct testcase *test, struct formats *pf)
+static void recvtftp(struct testcase *test, const struct formats *pf)
 {
   ssize_t n, size;
   /* These are volatile to live through a siglongjmp */

--- a/tests/unit/unit1621.c
+++ b/tests/unit/unit1621.c
@@ -52,7 +52,7 @@ struct checkthis {
   const char *output;
 };
 
-static struct checkthis tests[] = {
+static const struct checkthis tests[] = {
   { "ninja://foo@example.com", "ninja://foo@example.com" },
   { "https://foo@example.com", "https://example.com/" },
   { "https://localhost:45", "https://localhost:45/" },

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -59,7 +59,7 @@ struct dohrequest {
 };
 
 
-static struct dohrequest req[] = {
+static const struct dohrequest req[] = {
   {"test.host.name", DNS_TYPE_A, DNS_Q1, sizeof(DNS_Q1)-1, 0 },
   {"test.host.name", DNS_TYPE_AAAA, DNS_Q2, sizeof(DNS_Q2)-1, 0 },
   {"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
@@ -86,7 +86,7 @@ struct dohresp {
 
 static const char full49[] = DNS_FOO_EXAMPLE_COM;
 
-static struct dohresp resp[] = {
+static const struct dohresp resp[] = {
   {"\x00\x00", 2, DNS_TYPE_A, DOH_TOO_SMALL_BUFFER, NULL },
   {"\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01", 12,
    DNS_TYPE_A, DOH_DNS_BAD_ID, NULL },


### PR DESCRIPTION
Constify a number of static structs that are never modified. Make them
const to show this.