### PR TITLE
Update Lift config to match requirements of curl build

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,3 +1,3 @@
 ignore = [ "DEAD_STORE" ]
 build = "make"
-setup = ".muse/setup.sh"
+setup = ".lift/setup.sh"

--- a/.lift/setup.sh
+++ b/.lift/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+./buildconf
+./configure --with-openssl
+echo "Ran the setup script for Lift including autoconf and executing ./configure --with-openssl"

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-./buildconf
-./configure
-echo "Ran the setup script for muse including autoconf and executing ./configure"


### PR DESCRIPTION
Fix lift configuration to understand how to compile modern curl.

The Lift tool wasn't getting the better analysis results - the ones that require compilation and call graphs.  The cause is the compilation of curl changed a little bit.  Also renamed Muse -> Lift, the new tool name.