### PR TITLE
libcurl.rc: include curl/curlver.h "correctly"

### DIFF
--- a/lib/libcurl.rc
+++ b/lib/libcurl.rc
@@ -20,7 +20,7 @@
  *
  ***************************************************************************/
 #include <winver.h>
-#include "../include/curl/curlver.h"
+#include <curl/curlver.h>
 
 LANGUAGE  0, 0
 


### PR DESCRIPTION
Reported-by: Vitaly Varyvdin
Fixes #7765