### PR TITLE
cmake: with OpenSSL, define OPENSSL_SUPPRESS_DEPRECATED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,8 @@ if(CMAKE_USE_OPENSSL)
   check_symbol_exists(RAND_status "${CURL_INCLUDES}" HAVE_RAND_STATUS)
   check_symbol_exists(RAND_screen "${CURL_INCLUDES}" HAVE_RAND_SCREEN)
   check_symbol_exists(RAND_egd    "${CURL_INCLUDES}" HAVE_RAND_EGD)
+
+  set(CMAKE_REQUIRED_FLAGS "-DOPENSSL_SUPPRESS_DEPRECATED")
 endif()
 
 if(CMAKE_USE_MBEDTLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ if(CMAKE_USE_OPENSSL)
   check_symbol_exists(RAND_screen "${CURL_INCLUDES}" HAVE_RAND_SCREEN)
   check_symbol_exists(RAND_egd    "${CURL_INCLUDES}" HAVE_RAND_EGD)
 
-  set(CMAKE_REQUIRED_FLAGS "-DOPENSSL_SUPPRESS_DEPRECATED")
+  add_definitions(-DOPENSSL_SUPPRESS_DEPRECATED)
 endif()
 
 if(CMAKE_USE_MBEDTLS)


### PR DESCRIPTION
To avoid the "... is deprecated" warnings brought by OpenSSL v3.
(We need to address the underlying code at some point of course.)