### PR TITLE
Get the libssh2 version at runtime if possible

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3610,7 +3610,7 @@ void Curl_ssh_cleanup(void)
 
 void Curl_ssh_version(char *buffer, size_t buflen)
 {
-  (void)msnprintf(buffer, buflen, "libssh2/%s", LIBSSH2_VERSION);
+  (void)msnprintf(buffer, buflen, "libssh2/%s", CURL_LIBSSH2_VERSION);
 }
 
 /* The SSH session is associated with the *CONNECTION* but the callback user


### PR DESCRIPTION
Previously this code used a compile time constant, meaning that libcurl always reported the libssh2 version that libcurl was built with. This could differ from the libssh2 version being used at runtime. The new code uses the `CURL_LIBSSH2_VERSION` macro, which is defined in ssh.h. The macro calls the `libssh2_version` function if it is available, otherwise it falls back to the compile time version.