### PR TITLE
ngtcp2: fix QUIC transport parameter version

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -440,13 +440,10 @@ static int quic_init_ssl(struct quicsocket *qs)
   gnutls_alert_set_read_function(qs->ssl, alert_read_func);
 
   rc = gnutls_session_ext_register(qs->ssl, "QUIC Transport Parameters",
-                                   NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_DRAFT,
-                                   GNUTLS_EXT_TLS,
-                                   tp_recv_func, tp_send_func,
-                                   NULL, NULL, NULL,
-                                   GNUTLS_EXT_FLAG_TLS |
-                                   GNUTLS_EXT_FLAG_CLIENT_HELLO |
-                                   GNUTLS_EXT_FLAG_EE);
+         NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_DRAFT, GNUTLS_EXT_TLS,
+         tp_recv_func, tp_send_func, NULL, NULL, NULL,
+         GNUTLS_EXT_FLAG_TLS | GNUTLS_EXT_FLAG_CLIENT_HELLO |
+         GNUTLS_EXT_FLAG_EE);
   if(rc < 0) {
     H3BUGF(fprintf(stderr, "gnutls_session_ext_register failed: %s\n",
                    gnutls_strerror(rc)));

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -303,6 +303,7 @@ static int quic_init_ssl(struct quicsocket *qs)
 
   SSL_set_app_data(qs->ssl, qs);
   SSL_set_connect_state(qs->ssl);
+  SSL_set_quic_use_legacy_codepoint(qs->ssl, 1);
 
   alpn = (const uint8_t *)H3_ALPN_H3_29;
   alpnlen = sizeof(H3_ALPN_H3_29) - 1;
@@ -439,7 +440,8 @@ static int quic_init_ssl(struct quicsocket *qs)
   gnutls_alert_set_read_function(qs->ssl, alert_read_func);
 
   rc = gnutls_session_ext_register(qs->ssl, "QUIC Transport Parameters",
-                                   0xffa5, GNUTLS_EXT_TLS,
+                                   NGTCP2_TLSEXT_QUIC_TRANSPORT_PARAMETERS_DRAFT,
+                                   GNUTLS_EXT_TLS,
                                    tp_recv_func, tp_send_func,
                                    NULL, NULL, NULL,
                                    GNUTLS_EXT_FLAG_TLS |


### PR DESCRIPTION
# Bug details

In the ngtcp2 + OpenSSL combination, the QUIC transport parameter is set to duplicate version of QUICv1 and draft, as shown below.  Some QUIC stack, for example facebook.com's mvfst, returns a parameter error for this Initial.

```
IETF QUIC
  Version: draft-29 (0xff00001d)
    .
    .
  TLSv1.3 Record Layer: Handshake Protocol: Client Hello
        Frame Type: CRYPTO (0x0000000000000006)
        Crypto Data
        Handshake Protocol: Client Hello
            Handshake Type: Client Hello (1)
            Extension: application_layer_protocol_negotiation (len=8)
      **====> Extension: quic_transport_parameters (drafts version) (len=55)**
      **====> Extension: quic_transport_parameters (len=55)**
	       .
	       .
```


As a result, curl returns `Resource temporarily unavailable`.

```
# curl --http3 -v https://www.facebook.com/
* Trying 2a03:2880:f10f:83:face:b00c:0:25de:443...
* Connect socket 5 over QUIC to 2a03:2880:f10f:83:face:b00c:0:25de:443
* connect to 2a03:2880:f10f:83:face:b00c:0:25de port 443 failed: Resource temporarily unavailable
* Trying 31.13.82.36:443...
* Connect socket 6 over QUIC to 31.13.82.36:443
* Connect to 31.13.82.36 port 443 failed: Resource temporarily unavailable
* Failed to connect to www.facebook.com port 443 after 40 ms: Resource temporarily unavailable
* Closing connection 0
curl: (7) Failed to connect to www.facebook.com port 443 after 40 ms: Resource temporarily unavailable
```

# Cause and patch

The cause is a missing call to the OpenSSL API. This patch fixes the transport parameter version to use DRAFT version. I think it is probably due to OpenSSL bug.


# Default QUIC version

This patch keeps that curl with ngtcp2 uses DRAFT version (h3-29).

I think QUICv1+h3 should be the default version in the near future. If default version is changed to QUICv1, `SSL_set_quic_use_legacy_codepoint(qs->ssl, 0);` and some modifies enables it.

