### PR TITLE
Remove leftover WinSock v1 checks

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -229,10 +229,6 @@ int main () { ; return 0; }
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #endif
 
@@ -258,10 +254,6 @@ main ()
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #endif
 
@@ -285,10 +277,6 @@ main ()
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #endif
 
@@ -313,10 +301,6 @@ main ()
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #endif
 
@@ -403,10 +387,6 @@ main ()
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #endif
 /* includes start */

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -33,7 +33,6 @@ set(signature_call_conv)
 if(HAVE_WINDOWS_H)
   add_header_include(HAVE_WINSOCK2_H "winsock2.h")
   add_header_include(HAVE_WINDOWS_H "windows.h")
-  add_header_include(HAVE_WINSOCK_H "winsock.h")
   set(_source_epilogue
       "${_source_epilogue}\n#ifndef WIN32_LEAN_AND_MEAN\n#define WIN32_LEAN_AND_MEAN\n#endif")
   set(signature_call_conv "PASCAL")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,7 +910,6 @@ endif()
 # Check for header files
 if(NOT UNIX)
   check_include_file_concat("windows.h"      HAVE_WINDOWS_H)
-  check_include_file_concat("winsock.h"      HAVE_WINSOCK_H)
   check_include_file_concat("ws2tcpip.h"     HAVE_WS2TCPIP_H)
   check_include_file_concat("winsock2.h"     HAVE_WINSOCK2_H)
   check_include_file_concat("wincrypt.h"     HAVE_WINCRYPT_H)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -235,43 +235,6 @@ AC_DEFUN([CURL_CHECK_NATIVE_WINDOWS], [
 ])
 
 
-dnl CURL_CHECK_HEADER_WINSOCK
-dnl -------------------------------------------------
-dnl Check for compilable and valid winsock.h header
-
-AC_DEFUN([CURL_CHECK_HEADER_WINSOCK], [
-  AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([for winsock.h], [curl_cv_header_winsock_h], [
-    AC_COMPILE_IFELSE([
-      AC_LANG_PROGRAM([[
-#undef inline
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#include <winsock.h>
-      ]],[[
-#if defined(__CYGWIN__) || defined(__CEGCC__)
-        HAVE_WINSOCK_H shall not be defined.
-#else
-        int dummy=WSACleanup();
-#endif
-      ]])
-    ],[
-      curl_cv_header_winsock_h="yes"
-    ],[
-      curl_cv_header_winsock_h="no"
-    ])
-  ])
-  case "$curl_cv_header_winsock_h" in
-    yes)
-      AC_DEFINE_UNQUOTED(HAVE_WINSOCK_H, 1,
-        [Define to 1 if you have the winsock.h header file.])
-      ;;
-  esac
-])
-
-
 dnl CURL_CHECK_HEADER_WINSOCK2
 dnl -------------------------------------------------
 dnl Check for compilable and valid winsock2.h header
@@ -1058,10 +1021,6 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #else
 #ifdef HAVE_PROTO_BSDSOCKET_H
@@ -1106,10 +1065,6 @@ struct Library *SocketBase = NULL;
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #define RECVCALLCONV PASCAL
 #else
@@ -1187,7 +1142,6 @@ dnl return value in SEND_TYPE_RETV, and also defining the
 dnl type qualifier of second argument in SEND_QUAL_ARG2.
 
 AC_DEFUN([CURL_CHECK_FUNC_SEND], [
-  AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK])dnl
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
   AC_CHECK_HEADERS(sys/types.h sys/socket.h)
   #
@@ -1202,10 +1156,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #else
 #ifdef HAVE_PROTO_BSDSOCKET_H
@@ -1250,10 +1200,6 @@ struct Library *SocketBase = NULL;
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #define SENDCALLCONV PASCAL
 #else
@@ -1368,10 +1314,6 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #else
 #ifdef HAVE_PROTO_BSDSOCKET_H
@@ -1408,7 +1350,6 @@ dnl -------------------------------------------------
 dnl Check for timeval struct
 
 AC_DEFUN([CURL_CHECK_STRUCT_TIMEVAL], [
-  AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK])dnl
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
   AC_CHECK_HEADERS(sys/types.h sys/time.h sys/socket.h)
   AC_CACHE_CHECK([for struct timeval], [curl_cv_struct_timeval], [
@@ -1422,10 +1363,6 @@ AC_DEFUN([CURL_CHECK_STRUCT_TIMEVAL], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #endif
 #ifdef HAVE_SYS_TYPES_H
@@ -1481,9 +1418,6 @@ AC_DEFUN([TYPE_IN_ADDR_T], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
 #endif
 #endif
 #else
@@ -1527,10 +1461,6 @@ AC_DEFUN([TYPE_IN_ADDR_T], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #else
 #ifdef HAVE_SYS_TYPES_H
@@ -1823,10 +1753,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #endif
 #ifdef HAVE_SYS_TYPES_H
@@ -1881,10 +1807,6 @@ struct Library *SocketBase = NULL;
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #define SELECTCALLCONV PASCAL
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -477,7 +477,7 @@ dnl Compilation based checks should not be done before this point.
 dnl **********************************************************************
 
 dnl **********************************************************************
-dnl Make sure that our checks for headers windows.h winsock.h winsock2.h
+dnl Make sure that our checks for headers windows.h winsock2.h
 dnl and ws2tcpip.h take precedence over any other further checks which
 dnl could be done later using AC_CHECK_HEADER or AC_CHECK_HEADERS for
 dnl this specific header files. And do them before its results are used.
@@ -487,7 +487,6 @@ CURL_CHECK_HEADER_WINDOWS
 CURL_CHECK_NATIVE_WINDOWS
 case X-"$curl_cv_native_windows" in
   X-yes)
-    CURL_CHECK_HEADER_WINSOCK
     CURL_CHECK_HEADER_WINSOCK2
     CURL_CHECK_HEADER_WS2TCPIP
     CURL_CHECK_HEADER_WINCRYPT
@@ -495,7 +494,6 @@ case X-"$curl_cv_native_windows" in
     CURL_CHECK_HEADER_WINBER
     ;;
   *)
-    curl_cv_header_winsock_h="no"
     curl_cv_header_winsock2_h="no"
     curl_cv_header_ws2tcpip_h="no"
     curl_cv_header_wincrypt_h="no"
@@ -1022,16 +1020,6 @@ if test "$HAVE_GETHOSTBYNAME" != "1"
 then
   dnl This is for winsock systems
   if test "$curl_cv_header_windows_h" = "yes"; then
-    if test "$curl_cv_header_winsock_h" = "yes"; then
-      case $host in
-        *-*-mingw32ce*)
-          winsock_LIB="-lwinsock"
-          ;;
-        *)
-          winsock_LIB="-lwsock32"
-          ;;
-      esac
-    fi
     if test "$curl_cv_header_winsock2_h" = "yes"; then
       winsock_LIB="-lws2_32"
     fi
@@ -1048,10 +1036,6 @@ then
 #include <windows.h>
 #ifdef HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#ifdef HAVE_WINSOCK_H
-#include <winsock.h>
-#endif
 #endif
 #endif
         ]],[[

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -97,7 +97,7 @@ int main(void)
 
 #ifdef WIN32
   WSADATA wsaData;
-  int initwsa = WSAStartup(MAKEWORD(2, 0), &wsaData);
+  int initwsa = WSAStartup(MAKEWORD(2, 2), &wsaData);
   if(initwsa) {
     printf("WSAStartup failed: %d\n", initwsa);
     return 1;

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -328,9 +328,6 @@
 /* Define if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H
 
-/* Define if you have the <winsock.h> header file. */
-#undef HAVE_WINSOCK_H
-
 /* Define if you have the <x509.h> header file. */
 #undef HAVE_X509_H
 

--- a/lib/config-riscos.h
+++ b/lib/config-riscos.h
@@ -305,9 +305,6 @@
 /* Define if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H
 
-/* Define if you have the <winsock.h> header file. */
-#undef HAVE_WINSOCK_H
-
 /* Define if you have the <x509.h> header file. */
 #undef HAVE_X509_H
 

--- a/lib/config-tpf.h
+++ b/lib/config-tpf.h
@@ -483,9 +483,6 @@
 /* Define to 1 if you have the <winsock2.h> header file. */
 /* #undef HAVE_WINSOCK2_H */
 
-/* Define to 1 if you have the <winsock.h> header file. */
-/* #undef HAVE_WINSOCK_H */
-
 /* Define this symbol if your OS supports changing the contents of argv */
 /* #undef HAVE_WRITABLE_ARGV */
 

--- a/lib/config-vxworks.h
+++ b/lib/config-vxworks.h
@@ -601,9 +601,6 @@
 /* Define to 1 if you have the winsock2.h header file. */
 /* #undef HAVE_WINSOCK2_H */
 
-/* Define to 1 if you have the winsock.h header file. */
-/* #undef HAVE_WINSOCK_H */
-
 /* Define this symbol if your OS supports changing the contents of argv */
 #define HAVE_WRITABLE_ARGV 1
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -132,9 +132,6 @@
 /* Define if you have the <windows.h> header file. */
 #define HAVE_WINDOWS_H 1
 
-/* Define if you have the <winsock.h> header file. */
-#define HAVE_WINSOCK_H 1
-
 /* Define if you have the <winsock2.h> header file. */
 #ifndef __SALFORDC__
 #define HAVE_WINSOCK2_H 1
@@ -381,7 +378,6 @@
 
 #ifdef USE_LWIPSOCK
 #  undef USE_WINSOCK
-#  undef HAVE_WINSOCK_H
 #  undef HAVE_WINSOCK2_H
 #  undef HAVE_WS2TCPIP_H
 #  undef HAVE_ERRNO_H
@@ -412,7 +408,6 @@
   #undef byte
   #undef word
   #undef USE_WINSOCK
-  #undef HAVE_WINSOCK_H
   #undef HAVE_WINSOCK2_H
   #undef HAVE_WS2TCPIP_H
   #define HAVE_GETADDRINFO

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -110,9 +110,6 @@
 /* Define if you have the <windows.h> header file.  */
 #define HAVE_WINDOWS_H 1
 
-/* Define if you have the <winsock.h> header file.  */
-#define HAVE_WINSOCK_H 1
-
 /* Define if you have the <winsock2.h> header file.  */
 /* #define HAVE_WINSOCK2_H 1 */
 

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -111,10 +111,10 @@
 #define HAVE_WINDOWS_H 1
 
 /* Define if you have the <winsock2.h> header file.  */
-/* #define HAVE_WINSOCK2_H 1 */
+#define HAVE_WINSOCK2_H 1
 
 /* Define if you have the <ws2tcpip.h> header file.  */
-/* #define HAVE_WS2TCPIP_H 1 */
+#define HAVE_WS2TCPIP_H 1
 
 /* ---------------------------------------------------------------- */
 /*                        OTHER HEADER INFO                         */

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -85,7 +85,7 @@
 
 static bool verifyconnect(curl_socket_t sockfd, int *error);
 
-#if defined(__DragonFly__) || defined(HAVE_WINSOCK_H)
+#if defined(__DragonFly__) || defined(HAVE_WINSOCK2_H)
 /* DragonFlyBSD and Windows use millisecond units */
 #define KEEPALIVE_FACTOR(x) (x *= 1000)
 #else

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -710,9 +710,6 @@
 /* Define to 1 if you have the winsock2.h header file. */
 #cmakedefine HAVE_WINSOCK2_H 1
 
-/* Define to 1 if you have the winsock.h header file. */
-#cmakedefine HAVE_WINSOCK_H 1
-
 /* Define this symbol if your OS supports changing the contents of argv */
 #cmakedefine HAVE_WRITABLE_ARGV 1
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -717,7 +717,6 @@ int netware_init(void);
 #if defined(__LWIP_OPT_H__) || defined(LWIP_HDR_OPT_H)
 #  if defined(SOCKET) || \
      defined(USE_WINSOCK) || \
-     defined(HAVE_WINSOCK_H) || \
      defined(HAVE_WINSOCK2_H) || \
      defined(HAVE_WS2TCPIP_H)
 #    error "WinSock and lwIP TCP/IP stack definitions shall not coexist!"

--- a/lib/setup-win32.h
+++ b/lib/setup-win32.h
@@ -25,11 +25,11 @@
 /*
  * Include header files for windows builds before redefining anything.
  * Use this preprocessor block only to include or exclude windows.h,
- * winsock2.h, ws2tcpip.h or winsock.h. Any other windows thing belongs
+ * winsock2.h or ws2tcpip.h. Any other windows thing belongs
  * to any other further and independent block.  Under Cygwin things work
  * just as under linux (e.g. <sys/socket.h>) and the winsock headers should
  * never be included when __CYGWIN__ is defined.  configure script takes
- * care of this, not defining HAVE_WINDOWS_H, HAVE_WINSOCK_H, HAVE_WINSOCK2_H,
+ * care of this, not defining HAVE_WINDOWS_H, HAVE_WINSOCK2_H,
  * neither HAVE_WS2TCPIP_H when __CYGWIN__ is defined.
  */
 
@@ -47,10 +47,6 @@
 #    ifdef HAVE_WS2TCPIP_H
 #      include <ws2tcpip.h>
 #    endif
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #  include <tchar.h>
 #  ifdef UNICODE
@@ -67,10 +63,6 @@
 
 #ifdef HAVE_WINSOCK2_H
 #  define USE_WINSOCK 2
-#else
-#  ifdef HAVE_WINSOCK_H
-#    error "WinSock version 1 is no longer supported, version 2 is required!"
-#  endif
 #endif
 
 /*

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -486,7 +486,7 @@ curl_includes_unistd="\
 dnl CURL_INCLUDES_WINSOCK2
 dnl -------------------------------------------------
 dnl Set up variable with list of headers that must be
-dnl included when winsock(2).h is to be included.
+dnl included when winsock2.h is to be included.
 
 AC_DEFUN([CURL_INCLUDES_WINSOCK2], [
 curl_includes_winsock2="\
@@ -498,15 +498,10 @@ curl_includes_winsock2="\
 #  include <windows.h>
 #  ifdef HAVE_WINSOCK2_H
 #    include <winsock2.h>
-#  else
-#    ifdef HAVE_WINSOCK_H
-#      include <winsock.h>
-#    endif
 #  endif
 #endif
 /* includes end */"
   CURL_CHECK_HEADER_WINDOWS
-  CURL_CHECK_HEADER_WINSOCK
   CURL_CHECK_HEADER_WINSOCK2
 ])
 


### PR DESCRIPTION
We require Winsock 2.2 since commit 3e4b32a3e12,