### PR TITLE
NTLM: use DES_set_key_unchecked with OpenSSL

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -150,7 +150,7 @@ static void setup_des_key(const unsigned char *key_56,
   DES_set_odd_parity(&key);
 
   /* Set the key */
-  DES_set_key(&key, ks);
+  DES_set_key_unchecked(&key, ks);
 }
 
 #elif defined(USE_GNUTLS)


### PR DESCRIPTION
... as the previously used function DES_set_key() will in some cases
reject using a key that it deems "weak" which will cause curl to
continue using the unitialized buffer content as key instead.

Assisted-by: Harry Sintonen
Fixes #7779