### PR TITLE
Add -vV to include "configure" flags in version output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ AC_PREREQ(2.59)
 
 dnl We don't know the version number "statically" so we use a dash here
 AC_INIT([curl], [-], [a suitable curl mailing list: https://curl.se/mail/])
+config_flags="$*"
+AC_DEFINE_UNQUOTED([CONFIG_FLAGS],["$config_flags"],[Flags passed to configure])
 
 XC_OVR_ZZ50
 XC_OVR_ZZ60

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -965,7 +965,7 @@ featcomp(const void *p1, const void *p2)
 #endif
 }
 
-void tool_version_info(void)
+void tool_version_info(int verbose)
 {
   const char *const *proto;
 
@@ -1000,6 +1000,9 @@ void tool_version_info(void)
   if(strcmp(CURL_VERSION, curlinfo->version)) {
     printf("WARNING: curl and libcurl versions do not match. "
            "Functionality may be affected.\n");
+  }
+  if(verbose) {
+    printf("Configure flags: %s\n", CONFIG_FLAGS);
   }
 }
 

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -1001,9 +1001,13 @@ void tool_version_info(int verbose)
     printf("WARNING: curl and libcurl versions do not match. "
            "Functionality may be affected.\n");
   }
+#ifdef CONFIG_FLAGS
   if(verbose) {
     printf("Configure flags: %s\n", CONFIG_FLAGS);
   }
+#else
+  (void)verbose;
+#endif
 }
 
 void tool_list_engines(void)

--- a/src/tool_help.h
+++ b/src/tool_help.h
@@ -25,6 +25,6 @@
 
 void tool_help(char *category);
 void tool_list_engines(void);
-void tool_version_info(void);
+void tool_version_info(int);
 
 #endif /* HEADER_CURL_TOOL_HELP_H */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2563,7 +2563,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
         hugehelp();
       /* Check if we were asked for the version information */
       else if(res == PARAM_VERSION_INFO_REQUESTED)
-        tool_version_info();
+        tool_version_info(global->tracetype != TRACE_NONE);
       /* Check if we were asked to list the SSL engines */
       else if(res == PARAM_ENGINES_REQUESTED)
         tool_list_engines();


### PR DESCRIPTION
When upgrading an installed version of cURL, it can be difficult to
determine how it was configured, especially if it was installed from
a binary distribution kit.

This patch appends the `configure` flags used to build the `curl` tool
when `tool_version_info()` is invoked as `-vV`, but not if invoked
as `-V`.  This ensures that the new output, which is only of interest to
people (and scripts) who build from source, won't confuse any current
consumer of `-V`.

Example:
````sh
src/curl -vV
curl 7.80.0-DEV (i686-pc-linux-gnu) libcurl/7.80.0-DEV OpenSSL/1.1.1d zlib/1.2.11 brotli/1.0.7 zstd/1.4.9 c-ares/1.15.0 libssh2/1.8.2 nghttp2/1.37.0 OpenLDAP/2.4.47
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL TLS-SRP UnixSockets zstd
Configure flags: --cache-file=../curl.cache --prefix=/usr --with-nghttp2=/usr/local --with-libssh2=/usr/local --enable-ares --with-openssl

src/curl -V
curl 7.80.0-DEV (i686-pc-linux-gnu) libcurl/7.80.0-DEV OpenSSL/1.1.1d zlib/1.2.11 brotli/1.0.7 zstd/1.4.9 c-ares/1.15.0 libssh2/1.8.2 nghttp2/1.37.0 OpenLDAP/2.4.47
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL TLS-SRP UnixSockets zstd
````