### PR TITLE
CI/makefiles: introduce dedicated test target

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -199,8 +199,8 @@ stages:
     - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
       displayName: 'install'
 
-    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 test-nonflaky"
+    - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 test-ci"
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "-r -rm -u !SCP $(tests)"
+        TFLAGS: "!SCP $(tests)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
 
   test:
     steps:
-      - run: make test-nonflaky
+      - run: make test-ci
 
 executors:
   ubuntu:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -129,4 +129,4 @@ windows_task:
   install_script: |
     %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
   test_script: |
-    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='-r -rm -u !SCP %tests%' test-nonflaky"
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='!SCP %tests%' test-ci"

--- a/.github/workflows/linux-hyper.yml
+++ b/.github/workflows/linux-hyper.yml
@@ -41,7 +41,7 @@ jobs:
     - run: ./buildconf && LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }} && make
       name: 'configure and build'
 
-    - run: make test-nonflaky
+    - run: make test-ci
       name: 'test'
       env:
         LD_LIBRARY_PATH: $HOME/hyper/target/debug:/usr/local/lib

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,7 +84,7 @@ jobs:
     - run: make
       name: 'make'
 
-    - run: make test-nonflaky
+    - run: make test-ci
       name: 'test'
       env:
         TFLAGS: "${{ matrix.build.tflags }} ~1452"

--- a/Makefile.am
+++ b/Makefile.am
@@ -248,6 +248,9 @@ test-event:
 test-am:
 	@(cd tests; $(MAKE) all am-test)
 
+test-ci:
+	@(cd tests; $(MAKE) all ci-test)
+
 endif
 
 examples:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -299,11 +299,11 @@ build_script:
 test_script:
     - if %TESTING%==ON (
         if %BUILD_SYSTEM%==CMake (
-          set TFLAGS=-r -rm -u %DISABLED_TESTS% &&
-          cmake --build . --config %PRJ_CFG% --target test-nonflaky
+          set TFLAGS=%DISABLED_TESTS% &&
+          cmake --build . --config %PRJ_CFG% --target test-ci
         ) else (
         if %BUILD_SYSTEM%==autotools (
-          bash.exe -e -l -c "cd /c/projects/curl && make V=1 TFLAGS='-r -rm -u %DISABLED_TESTS%' test-nonflaky"
+          bash.exe -e -l -c "cd /c/projects/curl && make V=1 TFLAGS='%DISABLED_TESTS%' test-ci"
         ) else (
           bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm -u %DISABLED_TESTS%"
         ))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,5 +46,6 @@ add_runtests(test-am        "-a -am")
 add_runtests(test-full      "-a -p -r")
 # !flaky means that it'll skip all tests using the flaky keyword
 add_runtests(test-nonflaky  "-a -p !flaky")
+add_runtests(test-ci        "-a -p !flaky -r -rm -u")
 add_runtests(test-torture   "-a -t")
 add_runtests(test-event     "-a -e")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,9 @@ TEST_E = -a -e
 
 # !flaky means that it'll skip all tests using the flaky keyword
 TEST_NF = -a -p !flaky
+
+# special CI target derived from nonflaky with CI-specific flags
+TEST_CI = $(TEST_NF) -r -rm -u
 endif
 
 # make sure that PERL is pointing to an executable
@@ -85,6 +88,9 @@ quiet-test: perlcheck all
 
 am-test: perlcheck all
 	$(TEST) $(TEST_AM) $(TFLAGS)
+
+ci-test: perlcheck all
+	$(TEST) $(TEST_CI) $(TFLAGS)
 
 full-test: perlcheck all
 	$(TEST) $(TEST_F) $(TFLAGS)


### PR DESCRIPTION
Make it easy to use the same set of test flags
throughout all current and future CI builds.

Follow up to #7690