### PR TITLE
curl.1: remove mentions of really old version changes

### DIFF
--- a/docs/cmdline-opts/anyauth.d
+++ b/docs/cmdline-opts/anyauth.d
@@ -4,6 +4,7 @@ Protocols: HTTP
 See-also: proxy-anyauth basic digest
 Category: http proxy auth
 Example: --anyauth --user me:pwd $URL
+Added: 7.10.6
 ---
 Tells curl to figure out authentication method by itself, and use the most
 secure one the remote site claims to support. This is done by first doing a

--- a/docs/cmdline-opts/append.d
+++ b/docs/cmdline-opts/append.d
@@ -4,6 +4,7 @@ Help: Append to target file when uploading
 Protocols: FTP SFTP
 Category: ftp sftp
 Example: --upload-file local --append ftp://example.com/
+Added: 4.8
 ---
 When used in an upload, this makes curl append to the target file instead of
 overwriting it. If the remote file doesn't exist, it will be created.  Note

--- a/docs/cmdline-opts/basic.d
+++ b/docs/cmdline-opts/basic.d
@@ -4,6 +4,7 @@ See-also: proxy-basic
 Protocols: HTTP
 Category: auth
 Example: -u name:password --basic $URL
+Added: 7.10.6
 ---
 Tells curl to use HTTP Basic authentication with the remote host. This is the
 default and this option is usually pointless, unless you use it to override a

--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -4,6 +4,7 @@ Help: CA certificate to verify peer against
 Protocols: TLS
 Category: tls
 Example: --cacert CA-file.txt $URL
+Added: 7.5
 ---
 Tells curl to use the specified certificate file to verify the peer. The file
 may contain multiple CA certificates. The certificate(s) must be in PEM

--- a/docs/cmdline-opts/capath.d
+++ b/docs/cmdline-opts/capath.d
@@ -4,6 +4,7 @@ Help: CA directory to verify peer against
 Protocols: TLS
 Category: tls
 Example: --capath /local/directory $URL
+Added: 7.9.8
 ---
 Tells curl to use the specified certificate directory to verify the
 peer. Multiple paths can be provided by separating them with ":" (e.g.

--- a/docs/cmdline-opts/cert-type.d
+++ b/docs/cmdline-opts/cert-type.d
@@ -5,6 +5,7 @@ Help: Certificate type (DER/PEM/ENG)
 See-also: cert key key-type
 Category: tls
 Example: --cert-type PEM --cert file $URL
+Added: 7.9.3
 ---
 Tells curl what type the provided client certificate is using. PEM, DER, ENG
 and P12 are recognized types.  If not specified, PEM is assumed.

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -6,6 +6,7 @@ Protocols: TLS
 See-also: cert-type key key-type
 Category: tls
 Example: --cert certfile --key keyfile $URL
+Added: 5.0
 ---
 Tells curl to use the specified client certificate file when getting a file
 with HTTPS, FTPS or another SSL-based protocol. The certificate must be in

--- a/docs/cmdline-opts/ciphers.d
+++ b/docs/cmdline-opts/ciphers.d
@@ -4,6 +4,7 @@ Help: SSL ciphers to use
 Protocols: TLS
 Category: tls
 Example: --ciphers ECDHE-ECDSA-AES256-CCM8 $URL
+Added: 7.9
 ---
 Specifies which ciphers to use in the connection. The list of ciphers must
 specify valid ciphers. Read up on SSL cipher list details on this URL:

--- a/docs/cmdline-opts/compressed.d
+++ b/docs/cmdline-opts/compressed.d
@@ -3,6 +3,7 @@ Help: Request compressed response
 Protocols: HTTP
 Category: http
 Example: --compressed $URL
+Added: 7.10
 ---
 Request a compressed response using one of the algorithms curl supports, and
 automatically decompress the content. Headers are not modified.

--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -4,8 +4,8 @@ Help: Read config from a file
 Short: K
 Category: curl
 Example: --config file.txt $URL
+Added: 4.10
 ---
-
 Specify a text file to read curl arguments from. The command line arguments
 found in the text file will be used as if they were provided on the command
 line.

--- a/docs/cmdline-opts/connect-timeout.d
+++ b/docs/cmdline-opts/connect-timeout.d
@@ -5,6 +5,7 @@ See-also: max-time
 Category: connection
 Example: --connect-timeout 20 $URL
 Example: --connect-timeout 3.14 $URL
+Added: 7.7
 ---
 Maximum time in seconds that you allow curl's connection to take.  This only
 limits the connection phase, so if curl connects within the given period it

--- a/docs/cmdline-opts/continue-at.d
+++ b/docs/cmdline-opts/continue-at.d
@@ -6,6 +6,7 @@ See-also: range
 Category: connection
 Example: -C - $URL
 Example: -C 400 $URL
+Added: 4.8
 ---
 Continue/Resume a previous file transfer at the given offset. The given offset
 is the exact number of bytes that will be skipped, counting from the beginning

--- a/docs/cmdline-opts/cookie-jar.d
+++ b/docs/cmdline-opts/cookie-jar.d
@@ -6,6 +6,7 @@ Help: Write cookies to <filename> after operation
 Category: http
 Example: -c store-here.txt $URL
 Example: -c store-here.txt -b read-these $URL
+Added: 7.9
 ---
 Specify to which file you want curl to write all cookies after a completed
 operation. Curl writes all cookies from its in-memory cookie storage to the

--- a/docs/cmdline-opts/cookie.d
+++ b/docs/cmdline-opts/cookie.d
@@ -6,6 +6,7 @@ Help: Send cookies from string/file
 Category: http
 Example: -b cookiefile $URL
 Example: -b cookiefile -c cookiefile $URL
+Added: 4.9
 ---
 Pass the data to the HTTP server in the Cookie header. It is supposedly
 the data previously received from the server in a "Set-Cookie:" line.  The

--- a/docs/cmdline-opts/create-dirs.d
+++ b/docs/cmdline-opts/create-dirs.d
@@ -2,6 +2,7 @@ Long: create-dirs
 Help: Create necessary local directory hierarchy
 Category: curl
 Example: --create-dirs --output local/dir/file $URL
+Added: 7.10.3
 ---
 When used in conjunction with the --output option, curl will create the
 necessary local directory hierarchy as needed. This option creates the

--- a/docs/cmdline-opts/crlf.d
+++ b/docs/cmdline-opts/crlf.d
@@ -3,6 +3,7 @@ Help: Convert LF to CRLF in upload
 Protocols: FTP SMTP
 Category: ftp smtp
 Example: --crlf -T file ftp://example.com/
+Added: 5.7
 ---
 Convert LF to CRLF in upload. Useful for MVS (OS/390).
 

--- a/docs/cmdline-opts/data-ascii.d
+++ b/docs/cmdline-opts/data-ascii.d
@@ -4,5 +4,6 @@ Help: HTTP POST ASCII data
 Protocols: HTTP
 Category: http post upload
 Example: --data-ascii @file $URL
+Added: 7.2
 ---
 This is just an alias for --data.

--- a/docs/cmdline-opts/data-binary.d
+++ b/docs/cmdline-opts/data-binary.d
@@ -4,6 +4,7 @@ Help: HTTP POST binary data
 Protocols: HTTP
 Category: http post upload
 Example: --data-binary @filename $URL
+Added: 7.2
 ---
 This posts data exactly as specified with no extra processing whatsoever.
 

--- a/docs/cmdline-opts/data.d
+++ b/docs/cmdline-opts/data.d
@@ -9,6 +9,7 @@ Category: important http post upload
 Example: -d "name=curl" $URL
 Example: -d "name=curl" -d "tool=cmdline" $URL
 Example: -d @filename $URL
+Added: 4.0
 ---
 Sends the specified data in a POST request to the HTTP server, in the same way
 that a browser does when a user has filled in an HTML form and presses the

--- a/docs/cmdline-opts/delegation.d
+++ b/docs/cmdline-opts/delegation.d
@@ -4,6 +4,7 @@ Help: GSS-API delegation permission
 Protocols: GSS/kerberos
 Category: auth
 Example: --delegation "none" $URL
+Added: 7.22.0
 ---
 Set LEVEL to tell the server what it is allowed to delegate when it
 comes to user credentials.

--- a/docs/cmdline-opts/digest.d
+++ b/docs/cmdline-opts/digest.d
@@ -5,6 +5,7 @@ Mutexed: basic ntlm negotiate
 See-also: user proxy-digest anyauth
 Category: proxy auth http
 Example: -u name:password --digest $URL
+Added: 7.10.6
 ---
 Enables HTTP Digest authentication. This is an authentication scheme that
 prevents the password from being sent over the wire in clear text. Use this in

--- a/docs/cmdline-opts/disable-eprt.d
+++ b/docs/cmdline-opts/disable-eprt.d
@@ -3,6 +3,7 @@ Help: Inhibit using EPRT or LPRT
 Protocols: FTP
 Category: ftp
 Example: --disable-eprt ftp://example.com/
+Added: 7.10.5
 ---
 Tell curl to disable the use of the EPRT and LPRT commands when doing active
 FTP transfers. Curl will normally always first attempt to use EPRT, then LPRT

--- a/docs/cmdline-opts/disable-epsv.d
+++ b/docs/cmdline-opts/disable-epsv.d
@@ -3,6 +3,7 @@ Help: Inhibit using EPSV
 Protocols: FTP
 Category: ftp
 Example: --disable-epsv ftp://example.com/
+Added: 7.9.2
 ---
 Tell curl to disable the use of the EPSV command when doing passive FTP
 transfers. Curl will normally always first attempt to use EPSV before

--- a/docs/cmdline-opts/disable.d
+++ b/docs/cmdline-opts/disable.d
@@ -3,6 +3,7 @@ Short: q
 Help: Disable .curlrc
 Category: curl
 Example: -q $URL
+Added: 5.0
 ---
 If used as the first parameter on the command line, the *curlrc* config
 file will not be read and used. See the --config for details on the default

--- a/docs/cmdline-opts/dump-header.d
+++ b/docs/cmdline-opts/dump-header.d
@@ -6,6 +6,7 @@ Protocols: HTTP FTP
 See-also: output
 Category: http ftp
 Example: --dump-header store.txt $URL
+Added: 5.7
 ---
 Write the received protocol headers to the specified file. If no headers are
 received, the use of this option will create an empty file.

--- a/docs/cmdline-opts/egd-file.d
+++ b/docs/cmdline-opts/egd-file.d
@@ -5,6 +5,7 @@ Protocols: TLS
 See-also: random-file
 Category: tls
 Example: --egd-file /random/here $URL
+Added: 7.7
 ---
 Specify the path name to the Entropy Gathering Daemon socket. The socket is
 used to seed the random engine for SSL connections.

--- a/docs/cmdline-opts/engine.d
+++ b/docs/cmdline-opts/engine.d
@@ -4,6 +4,7 @@ Help: Crypto engine to use
 Protocols: TLS
 Category: tls
 Example: --engine flavor $URL
+Added: 7.9.3
 ---
 Select the OpenSSL crypto engine to use for cipher operations. Use --engine
 list to print a list of build-time supported engines. Note that not all (and

--- a/docs/cmdline-opts/fail.d
+++ b/docs/cmdline-opts/fail.d
@@ -5,6 +5,7 @@ Help: Fail silently (no output at all) on HTTP errors
 See-also: fail-with-body
 Category: important http
 Example: --fail $URL
+Added: 4.0
 ---
 Fail silently (no output at all) on server errors. This is mostly done to
 enable scripts etc to better deal with failed attempts. In normal cases

--- a/docs/cmdline-opts/form-string.d
+++ b/docs/cmdline-opts/form-string.d
@@ -5,6 +5,7 @@ Arg: <name=string>
 See-also: form
 Category: http upload
 Example: --form-string "data" $URL
+Added: 7.13.2
 ---
 Similar to --form except that the value string for the named parameter is used
 literally. Leading \&'@' and \&'<' characters, and the \&';type=' string in

--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -6,6 +6,7 @@ Protocols: HTTP SMTP IMAP
 Mutexed: data head upload-file
 Category: http upload
 Example: --form "name=curl" --form "file=@loadthis" $URL
+Added: 5.0
 ---
 For HTTP protocol family, this lets curl emulate a filled-in form in which a
 user has pressed the submit button. This causes curl to POST data using the

--- a/docs/cmdline-opts/ftp-create-dirs.d
+++ b/docs/cmdline-opts/ftp-create-dirs.d
@@ -4,6 +4,7 @@ Help: Create the remote dirs if not present
 See-also: create-dirs
 Category: ftp sftp curl
 Example: --ftp-create-dirs -T file ftp://example.com/remote/path/file
+Added: 7.10.7
 ---
 When an FTP or SFTP URL/operation uses a path that doesn't currently exist on
 the server, the standard behavior of curl is to fail. Using this option, curl

--- a/docs/cmdline-opts/ftp-port.d
+++ b/docs/cmdline-opts/ftp-port.d
@@ -30,7 +30,8 @@ If this option is used several times, the last one will be used. Disable the
 use of PORT with --ftp-pasv. Disable the attempt to use the EPRT command
 instead of PORT by using --disable-eprt. EPRT is really PORT++.
 
-Since 7.19.5, you can append \&":[start]-[end]\&" to the right of the address,
-to tell curl what TCP port range to use. That means you specify a port range,
-from a lower to a higher number. A single number works as well, but do note
-that it increases the risk of failure since the port may not be available.
+You can also append \&":[start]-[end]\&" to the right of the address, to tell
+curl what TCP port range to use. That means you specify a port range, from a
+lower to a higher number. A single number works as well, but do note that it
+increases the risk of failure since the port may not be available.
+(Added in 7.19.5)

--- a/docs/cmdline-opts/ftp-port.d
+++ b/docs/cmdline-opts/ftp-port.d
@@ -8,6 +8,7 @@ Category: ftp
 Example: -P - ftp:/example.com
 Example: -P eth0 ftp:/example.com
 Example: -P 192.168.0.2 ftp:/example.com
+Added: 4.0
 ---
 Reverses the default initiator/listener roles when connecting with FTP. This
 option makes curl use active mode. curl then tells the server to connect back

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -79,7 +79,7 @@ sub printdesc {
         if($d =~ /\(Added in ([0-9.]+)\)/i) {
             my $ver = $1;
             if(too_old($ver)) {
-                $d =~ s/\(Added in $ver\)//gi;
+                $d =~ s/ *\(Added in $ver\)//gi;
             }
         }
         if($d !~ /^.\\"/) {

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -135,13 +135,17 @@ sub protocols {
 
 sub too_old {
     my ($version)=@_;
+    my $a = 999999;
     if($version =~ /^(\d+)\.(\d+)\.(\d+)/) {
-        my $a = $1 * 1000 + $2 * 10 + $3;
-        if($a < 7300) {
-            # we consider everything before 7.30.0 to be too old to mention
-            # specific changes for
-            return 1;
-        }
+        $a = $1 * 1000 + $2 * 10 + $3;
+    }
+    elsif($version =~ /^(\d+)\.(\d+)/) {
+        $a = $1 * 1000 + $2 * 10;
+    }
+    if($a < 7300) {
+        # we consider everything before 7.30.0 to be too old to mention
+        # specific changes for
+        return 1;
     }
     return 0;
 }
@@ -229,6 +233,10 @@ sub single {
             }
             if(!$examples[0]) {
                 print STDERR "$f:$line:1:ERROR: no 'Example:' present\n";
+                exit 2;
+            }
+            if(!$added) {
+                print STDERR "$f:$line:1:ERROR: no 'Added:' version present\n";
                 exit 2;
             }
             last;

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -76,6 +76,12 @@ sub manpageify {
 sub printdesc {
     my @desc = @_;
     for my $d (@desc) {
+        if($d =~ /\(Added in ([0-9.]+)\)/i) {
+            my $ver = $1;
+            if(too_old($ver)) {
+                $d =~ s/\(Added in $ver\)//gi;
+            }
+        }
         if($d !~ /^.\\"/) {
             # **bold**
             $d =~ s/\*\*([^ ]*)\*\*/\\fB$1\\fP/g;
@@ -127,8 +133,25 @@ sub protocols {
     }
 }
 
+sub too_old {
+    my ($version)=@_;
+    if($version =~ /^(\d+)\.(\d+)\.(\d+)/) {
+        my $a = $1 * 1000 + $2 * 10 + $3;
+        if($a < 7300) {
+            # we consider everything before 7.30.0 to be too old to mention
+            # specific changes for
+            return 1;
+        }
+    }
+    return 0;
+}
+
 sub added {
     my ($standalone, $data)=@_;
+    if(too_old($data)) {
+        # don't mention ancient additions
+        return "";
+    }
     if($standalone) {
         return ".SH \"ADDED\"\nAdded in curl version $data\n";
     }

--- a/docs/cmdline-opts/get.d
+++ b/docs/cmdline-opts/get.d
@@ -5,6 +5,7 @@ Category: http upload
 Example: --get $URL
 Example: --get -d "tool=curl" -d "age=old" $URL
 Example: --get -I -d "tool=curl" $URL
+Added: 7.8.1
 ---
 When used, this option will make all data specified with --data, --data-binary
 or --data-urlencode to be used in an HTTP GET request instead of the POST

--- a/docs/cmdline-opts/globoff.d
+++ b/docs/cmdline-opts/globoff.d
@@ -3,6 +3,7 @@ Short: g
 Help: Disable URL sequences and ranges using {} and []
 Category: curl
 Example: -g "https://example.com/{[]}}}}"
+Added: 7.6
 ---
 This option switches off the "URL globbing parser". When you set this option,
 you can specify URLs that contain the letters {}[] without having curl itself

--- a/docs/cmdline-opts/head.d
+++ b/docs/cmdline-opts/head.d
@@ -4,6 +4,7 @@ Help: Show document info only
 Protocols: HTTP FTP FILE
 Category: http ftp file
 Example: -I $URL
+Added: 4.0
 ---
 Fetch the headers only! HTTP-servers feature the command HEAD which this uses
 to get nothing but the header of a document. When used on an FTP or FILE file,

--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -8,6 +8,7 @@ See-also: user-agent referer
 Example: -H "X-First-Name: Joe" $URL
 Example: -H "User-Agent: yes-please/2000" $URL
 Example: -H "Host:" $URL
+Added: 5.0
 ---
 Extra header to include in the request when sending HTTP to a server. You may
 specify any number of extra headers. Note that if you should add a custom

--- a/docs/cmdline-opts/help.d
+++ b/docs/cmdline-opts/help.d
@@ -4,6 +4,7 @@ Short: h
 Help: Get help for commands
 Category: important curl
 Example: --help all
+Added: 4.0
 ---
 Usage help. This lists all commands of the <category>.
 If no arg was provided, curl will display the most important

--- a/docs/cmdline-opts/http0.9.d
+++ b/docs/cmdline-opts/http0.9.d
@@ -1,10 +1,10 @@
 Long: http0.9
 Tags: Versions
 Protocols: HTTP
-Added:
 Help: Allow HTTP 0.9 responses
 Category: http
 Example: --http0.9 $URL
+Added: 7.64.0
 ---
 Tells curl to be fine with HTTP version 0.9 response.
 

--- a/docs/cmdline-opts/http1.0.d
+++ b/docs/cmdline-opts/http1.0.d
@@ -2,7 +2,7 @@ Short: 0
 Long: http1.0
 Tags: Versions
 Protocols: HTTP
-Added:
+Added: 7.9.1
 Mutexed: http1.1 http2
 Help: Use HTTP 1.0
 Category: http

--- a/docs/cmdline-opts/ignore-content-length.d
+++ b/docs/cmdline-opts/ignore-content-length.d
@@ -3,6 +3,7 @@ Help: Ignore the size of the remote resource
 Protocols: FTP HTTP
 Category: http ftp
 Example: --ignore-content-length $URL
+Added: 7.14.1
 ---
 For HTTP, Ignore the Content-Length header. This is particularly useful for
 servers running Apache 1.x, which will report incorrect Content-Length for

--- a/docs/cmdline-opts/include.d
+++ b/docs/cmdline-opts/include.d
@@ -4,6 +4,7 @@ Help: Include protocol response headers in the output
 See-also: verbose
 Category: important verbose
 Example: -i $URL
+Added: 4.8
 ---
 Include the HTTP response headers in the output. The HTTP response headers can
 include things like server name, cookies, date of the document, HTTP version

--- a/docs/cmdline-opts/insecure.d
+++ b/docs/cmdline-opts/insecure.d
@@ -5,6 +5,7 @@ Protocols: TLS
 See-also: proxy-insecure cacert
 Category: tls
 Example: --insecure $URL
+Added: 7.10
 ---
 By default, every SSL connection curl makes is verified to be secure. This
 option allows curl to proceed and operate even for server connections

--- a/docs/cmdline-opts/interface.d
+++ b/docs/cmdline-opts/interface.d
@@ -4,8 +4,8 @@ Help: Use network INTERFACE (or address)
 See-also: dns-interface
 Category: connection
 Example: --interface eth0 $URL
+Added: 7.3
 ---
-
 Perform an operation using a specified interface. You can enter interface
 name, IP address or host name. An example could look like:
 

--- a/docs/cmdline-opts/ipv4.d
+++ b/docs/cmdline-opts/ipv4.d
@@ -2,7 +2,7 @@ Short: 4
 Long: ipv4
 Tags: Versions
 Protocols:
-Added:
+Added: 7.10.8
 Mutexed: ipv6
 Requires:
 See-also: http1.1 http2

--- a/docs/cmdline-opts/ipv6.d
+++ b/docs/cmdline-opts/ipv6.d
@@ -2,7 +2,7 @@ Short: 6
 Long: ipv6
 Tags: Versions
 Protocols:
-Added:
+Added: 7.10.8
 Mutexed: ipv4
 Requires:
 See-also: http1.1 http2

--- a/docs/cmdline-opts/junk-session-cookies.d
+++ b/docs/cmdline-opts/junk-session-cookies.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 See-also: cookie cookie-jar
 Category: http
 Example: --junk-session-cookies -b cookies.txt $URL
+Added: 7.9.7
 ---
 When curl is told to read cookies from a given file, this option will make it
 discard all "session cookies". This will basically have the same effect as if

--- a/docs/cmdline-opts/key-type.d
+++ b/docs/cmdline-opts/key-type.d
@@ -4,6 +4,7 @@ Help: Private key file type (DER/PEM/ENG)
 Protocols: TLS
 Category: tls
 Example: --key-type DER --key here $URL
+Added: 7.9.3
 ---
 Private key file type. Specify which type your --key provided private key
 is. DER, PEM, and ENG are supported. If not specified, PEM is assumed.

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -4,6 +4,7 @@ Protocols: TLS SSH
 Help: Private key file name
 Category: tls ssh
 Example: --cert certificate --key here $URL
+Added: 7.9.3
 ---
 Private key file name. Allows you to provide your private key in this separate
 file. For SSH, if not specified, curl tries the following candidates in order:

--- a/docs/cmdline-opts/krb.d
+++ b/docs/cmdline-opts/krb.d
@@ -5,6 +5,7 @@ Protocols: FTP
 Requires: Kerberos
 Category: ftp
 Example: --krb clear ftp://example.com/
+Added: 7.3
 ---
 Enable Kerberos authentication and use. The level must be entered and should
 be one of 'clear', 'safe', 'confidential', or 'private'. Should you use a

--- a/docs/cmdline-opts/limit-rate.d
+++ b/docs/cmdline-opts/limit-rate.d
@@ -5,6 +5,7 @@ Category: connection
 Example: --limit-rate 100K $URL
 Example: --limit-rate 1000 $URL
 Example: --limit-rate 10M $URL
+Added: 7.10
 ---
 Specify the maximum transfer rate you want curl to use - for both downloads
 and uploads. This feature is useful if you have a limited pipe and you'd like

--- a/docs/cmdline-opts/location-trusted.d
+++ b/docs/cmdline-opts/location-trusted.d
@@ -4,6 +4,7 @@ Protocols: HTTP
 See-also: user
 Category: http auth
 Example: --location-trusted -u user:password $URL
+Added: 7.10.4
 ---
 Like --location, but will allow sending the name + password to all hosts that
 the site may redirect to. This may or may not introduce a security breach if

--- a/docs/cmdline-opts/location.d
+++ b/docs/cmdline-opts/location.d
@@ -4,6 +4,7 @@ Help: Follow redirects
 Protocols: HTTP
 Category: http
 Example: -L $URL
+Added: 4.9
 ---
 If the server reports that the requested page has moved to a different
 location (indicated with a Location: header and a 3XX response code), this

--- a/docs/cmdline-opts/manual.d
+++ b/docs/cmdline-opts/manual.d
@@ -3,5 +3,6 @@ Short: M
 Help: Display the full manual
 Category: curl
 Example: --manual
+Added: 5.2
 ---
 Manual. Display the huge help text.

--- a/docs/cmdline-opts/max-filesize.d
+++ b/docs/cmdline-opts/max-filesize.d
@@ -5,6 +5,7 @@ Protocols: FTP HTTP MQTT
 See-also: limit-rate
 Category: connection
 Example: --max-filesize 100K $URL
+Added: 7.10.2
 ---
 Specify the maximum size (in bytes) of a file to download. If the file
 requested is larger than this value, the transfer will not start and curl will

--- a/docs/cmdline-opts/max-filesize.d
+++ b/docs/cmdline-opts/max-filesize.d
@@ -5,7 +5,7 @@ Protocols: FTP HTTP MQTT
 See-also: limit-rate
 Category: connection
 Example: --max-filesize 100K $URL
-Added: 7.10.2
+Added: 7.10.8
 ---
 Specify the maximum size (in bytes) of a file to download. If the file
 requested is larger than this value, the transfer will not start and curl will

--- a/docs/cmdline-opts/max-redirs.d
+++ b/docs/cmdline-opts/max-redirs.d
@@ -4,6 +4,7 @@ Help: Maximum number of redirects allowed
 Protocols: HTTP
 Category: http
 Example: --max-redirs 3 --location $URL
+Added: 7.5
 ---
 Set maximum number of redirections to follow. When --location is used, to
 prevent curl from following too many redirects, by default, the limit is

--- a/docs/cmdline-opts/max-time.d
+++ b/docs/cmdline-opts/max-time.d
@@ -6,6 +6,7 @@ See-also: connect-timeout
 Category: connection
 Example: --max-time 10 $URL
 Example: --max-time 2.92 $URL
+Added: 4.0
 ---
 Maximum time in seconds that you allow the whole operation to take.  This is
 useful for preventing your batch jobs from hanging for hours due to slow

--- a/docs/cmdline-opts/negotiate.d
+++ b/docs/cmdline-opts/negotiate.d
@@ -4,6 +4,7 @@ Protocols: HTTP
 See-also: basic ntlm anyauth proxy-negotiate
 Category: auth http
 Example: --negotiate -u : $URL
+Added: 7.10.6
 ---
 Enables Negotiate (SPNEGO) authentication.
 

--- a/docs/cmdline-opts/netrc-optional.d
+++ b/docs/cmdline-opts/netrc-optional.d
@@ -4,6 +4,7 @@ Mutexed: netrc
 See-also: netrc-file
 Category: curl
 Example: --netrc-optional $URL
+Added: 7.9.8
 ---
 Very similar to --netrc, but this option makes the .netrc usage **optional**
 and not mandatory as the --netrc option does.

--- a/docs/cmdline-opts/netrc.d
+++ b/docs/cmdline-opts/netrc.d
@@ -3,6 +3,7 @@ Short: n
 Help: Must read .netrc for user name and password
 Category: curl
 Example: --netrc $URL
+Added: 4.6
 ---
 Makes curl scan the *.netrc* (*_netrc* on Windows) file in the user's home
 directory for login name and password. This is typically used for FTP on

--- a/docs/cmdline-opts/no-buffer.d
+++ b/docs/cmdline-opts/no-buffer.d
@@ -3,6 +3,7 @@ Short: N
 Help: Disable buffering of the output stream
 Category: curl
 Example: --no-buffer $URL
+Added: 6.5
 ---
 Disables the buffering of the output stream. In normal work situations, curl
 will use a standard buffered output stream that will have the effect that it

--- a/docs/cmdline-opts/no-keepalive.d
+++ b/docs/cmdline-opts/no-keepalive.d
@@ -2,6 +2,7 @@ Long: no-keepalive
 Help: Disable TCP keepalive on the connection
 Category: connection
 Example: --no-keepalive $URL
+Added: 7.18.0
 ---
 Disables the use of keepalive messages on the TCP connection. curl otherwise
 enables them by default.

--- a/docs/cmdline-opts/ntlm-wb.d
+++ b/docs/cmdline-opts/ntlm-wb.d
@@ -4,6 +4,7 @@ Protocols: HTTP
 See-also: ntlm proxy-ntlm
 Category: auth http
 Example: --ntlm-wb -u user:password $URL
+Added: 7.22.0
 ---
 Enables NTLM much in the style --ntlm does, but hand over the authentication
 to the separate binary ntlmauth application that is executed when needed.

--- a/docs/cmdline-opts/ntlm.d
+++ b/docs/cmdline-opts/ntlm.d
@@ -6,6 +6,7 @@ Protocols: HTTP
 Requires: TLS
 Category: auth http
 Example: --ntlm -u user:password $URL
+Added: 7.10.6
 ---
 Enables NTLM authentication. The NTLM authentication method was designed by
 Microsoft and is used by IIS web servers. It is a proprietary protocol,

--- a/docs/cmdline-opts/oauth2-bearer.d
+++ b/docs/cmdline-opts/oauth2-bearer.d
@@ -4,6 +4,7 @@ Arg: <token>
 Protocols: IMAP POP3 SMTP HTTP
 Category: auth
 Example: --oauth2-bearer "mF_9.B5f-4.1JqM" $URL
+Added: 7.33.0
 ---
 Specify the Bearer Token for OAUTH 2.0 server authentication. The Bearer Token
 is used in conjunction with the user name which can be specified as part of

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -8,6 +8,7 @@ Example: -o file $URL
 Example: "http://{one,two}.example.com" -o "file_#1.txt"
 Example: "http://{site,host}.host[1-5].com" -o "#1_#2"
 Example: -o file $URL -o file2 https://example.net
+Added: 4.0
 ---
 Write output to <file> instead of stdout. If you are using {} or [] to fetch
 multiple documents, you should quote the URL and you can use '#' followed by a

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -61,8 +61,8 @@ analyze the TLS traffic in real time using network analyzing tools such as
 Wireshark. This works with the following TLS backends: OpenSSL, libressl,
 BoringSSL, GnuTLS, NSS and wolfSSL.
 .SH "PROXY PROTOCOL PREFIXES"
-Since curl version 7.21.7, the proxy string may be specified with a
-protocol:// prefix to specify alternative proxy protocols.
+The proxy string may be specified with a protocol:// prefix to specify
+alternative proxy protocols. (Added in 7.21.7)
 
 If no protocol is specified in the proxy string or if the string doesn't match
 a supported one, the proxy will be treated as an HTTP proxy.

--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -194,6 +194,4 @@ options -O, -L and -v at once as -OLv.
 In general, all boolean options are enabled with --**option** and yet again
 disabled with --**no-**option. That is, you use the exact same option name
 but prefix it with "no-". However, in this list we mostly only list and show
-the --option version of them. (This concept with --no options was added in
-7.19.0. Previously most options were toggled on/off through repeated use of
-the same command line option.)
+the --option version of them.

--- a/docs/cmdline-opts/pass.d
+++ b/docs/cmdline-opts/pass.d
@@ -4,6 +4,7 @@ Help: Pass phrase for the private key
 Protocols: SSH TLS
 Category: ssh tls auth
 Example: --pass secret --key file $URL
+Added: 7.9.3
 ---
 Passphrase for the private key.
 

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Category: tls
 Example: --pinnedpubkey keyfile $URL
 Example: --pinnedpubkey 'sha256//ce118b51897f4452dc' $URL
+Added: 7.39.0
 ---
 Tells curl to use the specified public key file (or hashes) to verify the
 peer. This can be a path to a file which contains a single public key in PEM

--- a/docs/cmdline-opts/progress-bar.d
+++ b/docs/cmdline-opts/progress-bar.d
@@ -3,6 +3,7 @@ Long: progress-bar
 Help: Display transfer progress as a bar
 Category: verbose
 Example: -# -O $URL
+Added: 5.10
 ---
 Make curl display transfer progress as a simple progress bar instead of the
 standard, more informational, meter.

--- a/docs/cmdline-opts/proto-redir.d
+++ b/docs/cmdline-opts/proto-redir.d
@@ -13,8 +13,6 @@ Example, allow only HTTP and HTTPS on redirect:
 
  curl --proto-redir -all,http,https http://example.com
 
-By default curl will allow HTTP, HTTPS, FTP and FTPS on redirect (7.65.2).
-Older versions of curl allowed all protocols on redirect except several
-disabled for security reasons: Since 7.19.4 FILE and SCP are disabled, and
-since 7.40.0 SMB and SMBS are also disabled. Specifying *all* or *+all*
-enables all protocols on redirect, including those disabled for security.
+By default curl will only allow HTTP, HTTPS, FTP and FTPS on redirect (since
+7.65.2). Specifying *all* or *+all* enables all protocols on redirects, which
+is not good for security.

--- a/docs/cmdline-opts/proxy-basic.d
+++ b/docs/cmdline-opts/proxy-basic.d
@@ -3,6 +3,7 @@ Help: Use Basic authentication on the proxy
 See-also: proxy proxy-anyauth proxy-digest
 Category: proxy auth
 Example: --proxy-basic --proxy-user user:passwd -x proxy $URL
+Added: 7.12.0
 ---
 Tells curl to use HTTP Basic authentication when communicating with the given
 proxy. Use --basic for enabling HTTP Basic with a remote host. Basic is the

--- a/docs/cmdline-opts/proxy-digest.d
+++ b/docs/cmdline-opts/proxy-digest.d
@@ -3,6 +3,7 @@ Help: Use Digest authentication on the proxy
 See-also: proxy proxy-anyauth proxy-basic
 Category: proxy tls
 Example: --proxy-digest --proxy-user user:passwd -x proxy $URL
+Added: 7.12.0
 ---
 Tells curl to use HTTP Digest authentication when communicating with the given
 proxy. Use --digest for enabling HTTP Digest with a remote host.

--- a/docs/cmdline-opts/proxy-key.d
+++ b/docs/cmdline-opts/proxy-key.d
@@ -3,5 +3,6 @@ Help: Private key for HTTPS proxy
 Arg: <key>
 Category: proxy tls
 Example: --proxy-key here -x https://proxy $URL
+Added: 7.52.0
 ---
 Same as --key but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-ntlm.d
+++ b/docs/cmdline-opts/proxy-ntlm.d
@@ -3,6 +3,7 @@ Help: Use NTLM authentication on the proxy
 See-also: proxy-negotiate proxy-anyauth
 Category: proxy auth
 Example: --proxy-ntlm --proxy-user user:passwd -x http://proxy $URL
+Added: 7.10.7
 ---
 Tells curl to use HTTP NTLM authentication when communicating with the given
 proxy. Use --ntlm for enabling NTLM with a remote host.

--- a/docs/cmdline-opts/proxy-pinnedpubkey.d
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Category: proxy tls
 Example: --proxy-pinnedpubkey keyfile $URL
 Example: --proxy-pinnedpubkey 'sha256//ce118b51897f4452dc' $URL
+Added: 7.59.0
 ---
 Tells curl to use the specified public key file (or hashes) to verify the
 proxy. This can be a path to a file which contains a single public key in PEM

--- a/docs/cmdline-opts/proxy-tls13-ciphers.d
+++ b/docs/cmdline-opts/proxy-tls13-ciphers.d
@@ -4,6 +4,7 @@ help: TLS 1.3 proxy cipher suites
 Protocols: TLS
 Category: proxy tls
 Example: --proxy-tls13-ciphers TLS_AES_128_GCM_SHA256 -x proxy $URL
+Added: 7.61.0
 ---
 Specifies which cipher suites to use in the connection to your HTTPS proxy
 when it negotiates TLS 1.3. The list of ciphers suites must specify valid

--- a/docs/cmdline-opts/proxy-user.d
+++ b/docs/cmdline-opts/proxy-user.d
@@ -4,6 +4,7 @@ Arg: <user:password>
 Help: Proxy user and password
 Category: proxy auth
 Example: --proxy-user name:pwd -x proxy $URL
+Added: 4.0
 ---
 Specify the user name and password to use for proxy authentication.
 

--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -4,6 +4,7 @@ Arg: [protocol://]host[:port]
 Help: Use this proxy
 Category: proxy
 Example: --proxy http://proxy.example $URL
+Added: 4.0
 ---
 Use the specified proxy.
 

--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -10,7 +10,7 @@ Use the specified proxy.
 The proxy string can be specified with a protocol:// prefix. No protocol
 specified or http:// will be treated as HTTP proxy. Use socks4://, socks4a://,
 socks5:// or socks5h:// to request a specific SOCKS version to be used.
-(The protocol support was added in curl 7.21.7)
+(Added in 7.21.7)
 
 HTTPS proxy support via https:// protocol prefix was added in 7.52.0 for
 OpenSSL, GnuTLS and NSS.

--- a/docs/cmdline-opts/proxy1.0.d
+++ b/docs/cmdline-opts/proxy1.0.d
@@ -3,6 +3,7 @@ Arg: <host[:port]>
 Help: Use HTTP/1.0 proxy on given port
 Category: proxy
 Example: --proxy1.0 -x http://proxy $URL
+Added: 7.19.4
 ---
 Use the specified HTTP 1.0 proxy. If the port number is not specified, it is
 assumed at port 1080.

--- a/docs/cmdline-opts/proxytunnel.d
+++ b/docs/cmdline-opts/proxytunnel.d
@@ -4,6 +4,7 @@ Help: Operate through an HTTP proxy tunnel (using CONNECT)
 See-also: proxy
 Category: proxy
 Example: --proxytunnel -x http://proxy $URL
+Added: 7.3
 ---
 When an HTTP proxy is used --proxy, this option will make curl tunnel through
 the proxy. The tunnel approach is made with the HTTP proxy CONNECT request and

--- a/docs/cmdline-opts/pubkey.d
+++ b/docs/cmdline-opts/pubkey.d
@@ -4,6 +4,7 @@ Protocols: SFTP SCP
 Help: SSH Public key file name
 Category: sftp scp auth
 Example: --pubkey file.pub sftp://example.com/
+Added: 7.16.2
 ---
 Public key file name. Allows you to provide your public key in this separate
 file.

--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -5,6 +5,7 @@ Help: Send command(s) to server before transfer
 Protocols: FTP SFTP
 Category: ftp sftp
 Example: --quote "DELE file" ftp://example.com/foo
+Added: 5.3
 ---
 Send an arbitrary command to the remote FTP or SFTP server. Quote commands are
 sent BEFORE the transfer takes place (just after the initial PWD command in an

--- a/docs/cmdline-opts/random-file.d
+++ b/docs/cmdline-opts/random-file.d
@@ -3,6 +3,7 @@ Arg: <file>
 Help: File for reading random data from
 Category: misc
 Example: --random-file rubbish $URL
+Added: 7.7
 ---
 Specify the path name to file containing what will be considered as random
 data. The data may be used to seed the random engine for SSL connections.  See

--- a/docs/cmdline-opts/range.d
+++ b/docs/cmdline-opts/range.d
@@ -5,6 +5,7 @@ Arg: <range>
 Protocols: HTTP FTP SFTP FILE
 Category: http ftp sftp file
 Example: --range 22-44 $URL
+Added: 4.0
 ---
 Retrieve a byte range (i.e. a partial document) from an HTTP/1.1, FTP or SFTP
 server or a local FILE. Ranges can be specified in a number of ways.

--- a/docs/cmdline-opts/referer.d
+++ b/docs/cmdline-opts/referer.d
@@ -8,6 +8,7 @@ Category: http
 Example: --referer "https://fake.example" $URL
 Example: --referer "https://fake.example;auto" -L $URL
 Example: --referer ";auto" -L $URL
+Added: 4.0
 ---
 Sends the "Referrer Page" information to the HTTP server. This can also be set
 with the --header flag of course.  When used with --location you can append

--- a/docs/cmdline-opts/remote-header-name.d
+++ b/docs/cmdline-opts/remote-header-name.d
@@ -4,6 +4,7 @@ Protocols: HTTP
 Help: Use the header-provided filename
 Category: output
 Example: -OJ https://example.com/file
+Added: 7.20.0
 ---
 This option tells the --remote-name option to use the server-specified
 Content-Disposition filename instead of extracting a filename from the URL.

--- a/docs/cmdline-opts/remote-name.d
+++ b/docs/cmdline-opts/remote-name.d
@@ -3,6 +3,7 @@ Short: O
 Help: Write output to a file named as the remote file
 Category: important output
 Example: -O https://example.com/filename
+Added: 4.0
 ---
 Write output to a local file named like the remote file we get. (Only the file
 part of the remote file is used, the path is cut off.)

--- a/docs/cmdline-opts/remote-time.d
+++ b/docs/cmdline-opts/remote-time.d
@@ -3,7 +3,7 @@ Short: R
 Help: Set the remote file's time on the local output
 Category: output
 Example: --remote-time -o foo $URL
-Added: 4.9
+Added: 7.9
 ---
 When used, this will make curl attempt to figure out the timestamp of the
 remote file, and if that is available make the local file get that same

--- a/docs/cmdline-opts/remote-time.d
+++ b/docs/cmdline-opts/remote-time.d
@@ -3,6 +3,7 @@ Short: R
 Help: Set the remote file's time on the local output
 Category: output
 Example: --remote-time -o foo $URL
+Added: 4.9
 ---
 When used, this will make curl attempt to figure out the timestamp of the
 remote file, and if that is available make the local file get that same

--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -5,6 +5,7 @@ Help: Specify request command to use
 Category: connection
 Example: -X "DELETE" $URL
 Example: -X NLST ftp://example.com/
+Added: 6.0
 ---
 (HTTP) Specifies a custom request method to use when communicating with the
 HTTP server.  The specified request method will be used instead of the method

--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -30,8 +30,8 @@ Specifies a custom FTP command to use instead of LIST when doing file lists
 with FTP.
 
 (POP3)
-Specifies a custom POP3 command to use instead of LIST or RETR. (Added in
-7.26.0)
+Specifies a custom POP3 command to use instead of LIST or RETR.
+(Added in 7.26.0)
 
 (IMAP)
 Specifies a custom IMAP command to use instead of LIST. (Added in 7.30.0)

--- a/docs/cmdline-opts/show-error.d
+++ b/docs/cmdline-opts/show-error.d
@@ -4,6 +4,7 @@ Help: Show error even when -s is used
 See-also: no-progress-meter
 Category: curl
 Example: --show-error --silent $URL
+Added: 5.9
 ---
 When used with --silent, it makes curl show an error message if it fails.
 

--- a/docs/cmdline-opts/silent.d
+++ b/docs/cmdline-opts/silent.d
@@ -4,6 +4,7 @@ Help: Silent mode
 See-also: verbose stderr no-progress-meter
 Category: important verbose
 Example: -s $URL
+Added: 4.0
 ---
 Silent or quiet mode. Don't show progress meter or error messages.  Makes Curl
 mute. It will still output the data you ask for, potentially even to the

--- a/docs/cmdline-opts/socks4.d
+++ b/docs/cmdline-opts/socks4.d
@@ -12,8 +12,8 @@ and passing the address on to the proxy.
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 
-Since 7.21.7, this option is superfluous since you can specify a socks4 proxy
-with --proxy using a socks4:// protocol prefix.
+This option is superfluous since you can specify a socks4 proxy with --proxy
+using a socks4:// protocol prefix. (Added in 7.21.7)
 
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to

--- a/docs/cmdline-opts/socks4a.d
+++ b/docs/cmdline-opts/socks4a.d
@@ -11,8 +11,8 @@ assumed at port 1080. This asks the proxy to resolve the host name.
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 
-Since 7.21.7, this option is superfluous since you can specify a socks4a proxy
-with --proxy using a socks4a:// protocol prefix.
+This option is superfluous since you can specify a socks4a proxy with --proxy
+using a socks4a:// protocol prefix. (Added in 7.21.7)
 
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to

--- a/docs/cmdline-opts/socks5-hostname.d
+++ b/docs/cmdline-opts/socks5-hostname.d
@@ -11,8 +11,8 @@ the port number is not specified, it is assumed at port 1080.
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 
-Since 7.21.7, this option is superfluous since you can specify a socks5
-hostname proxy with --proxy using a socks5h:// protocol prefix.
+This option is superfluous since you can specify a socks5 hostname proxy with
+--proxy using a socks5h:// protocol prefix. (Added in 7.21.7)
 
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to

--- a/docs/cmdline-opts/socks5.d
+++ b/docs/cmdline-opts/socks5.d
@@ -11,8 +11,8 @@ port number is not specified, it is assumed at port 1080.
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 
-Since 7.21.7, this option is superfluous since you can specify a socks5 proxy
-with --proxy using a socks5:// protocol prefix.
+This option is superfluous since you can specify a socks5 proxy with --proxy
+using a socks5:// protocol prefix. (Added in 7.21.7)
 
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to

--- a/docs/cmdline-opts/speed-limit.d
+++ b/docs/cmdline-opts/speed-limit.d
@@ -4,6 +4,7 @@ Arg: <speed>
 Help: Stop transfers slower than this
 Category: connection
 Example: --speed-limit 300 --speed-time 10 $URL
+Added: 4.7
 ---
 If a download is slower than this given speed (in bytes per second) for
 speed-time seconds it gets aborted. speed-time is set with --speed-time and is

--- a/docs/cmdline-opts/speed-time.d
+++ b/docs/cmdline-opts/speed-time.d
@@ -4,6 +4,7 @@ Arg: <seconds>
 Help: Trigger 'speed-limit' abort after this time
 Category: connection
 Example: --speed-limit 300 --speed-time 10 $URL
+Added: 4.7
 ---
 If a download is slower than speed-limit bytes per second during a speed-time
 period, the download gets aborted. If speed-time is used, the default

--- a/docs/cmdline-opts/sslv2.d
+++ b/docs/cmdline-opts/sslv2.d
@@ -2,7 +2,7 @@ Short: 2
 Long: sslv2
 Tags: Versions
 Protocols: SSL
-Added:
+Added: 5.9
 Mutexed: sslv3 tlsv1 tlsv1.1 tlsv1.2
 Requires: TLS
 See-also: http1.1 http2

--- a/docs/cmdline-opts/sslv3.d
+++ b/docs/cmdline-opts/sslv3.d
@@ -2,7 +2,7 @@ Short: 3
 Long: sslv3
 Tags: Versions
 Protocols: SSL
-Added:
+Added: 5.9
 Mutexed: sslv2 tlsv1 tlsv1.1 tlsv1.2
 Requires: TLS
 See-also: http1.1 http2

--- a/docs/cmdline-opts/stderr.d
+++ b/docs/cmdline-opts/stderr.d
@@ -4,6 +4,7 @@ Help: Where to redirect stderr
 See-also: verbose silent
 Category: verbose
 Example: --stderr output.txt $URL
+Added: 6.2
 ---
 Redirect all writes to stderr to the specified file instead. If the file name
 is a plain '-', it is instead written to stdout.

--- a/docs/cmdline-opts/suppress-connect-headers.d
+++ b/docs/cmdline-opts/suppress-connect-headers.d
@@ -3,6 +3,7 @@ Help: Suppress proxy CONNECT response headers
 See-also: dump-header include proxytunnel
 Category: proxy
 Example: --suppress-connect-headers --include -x proxy $URL
+Added: 7.54.0
 ---
 When --proxytunnel is used and a CONNECT request is made don't output proxy
 CONNECT response headers. This option is meant to be used with --dump-header or

--- a/docs/cmdline-opts/telnet-option.d
+++ b/docs/cmdline-opts/telnet-option.d
@@ -4,6 +4,7 @@ Arg: <opt=val>
 Help: Set telnet option
 Category: telnet
 Example: -t TTYPE=vt100 telnet://example.com/
+Added: 7.7
 ---
 Pass options to the telnet protocol. Supported options are:
 

--- a/docs/cmdline-opts/time-cond.d
+++ b/docs/cmdline-opts/time-cond.d
@@ -7,6 +7,7 @@ Category: http ftp
 Example: -z "Wed 01 Sep 2021 12:18:00" $URL
 Example: -z "-Wed 01 Sep 2021 12:18:00" $URL
 Example: -z file $URL
+Added: 5.8
 ---
 Request a file that has been modified later than the given time and date, or
 one that has been modified before that time. The <date expression> can be all

--- a/docs/cmdline-opts/tls13-ciphers.d
+++ b/docs/cmdline-opts/tls13-ciphers.d
@@ -4,6 +4,7 @@ help: TLS 1.3 cipher suites to use
 Protocols: TLS
 Category: tls
 Example: --tls13-ciphers TLS_AES_128_GCM_SHA256 $URL
+Added: 7.61.0
 ---
 Specifies which cipher suites to use in the connection if it negotiates TLS
 1.3. The list of ciphers suites must specify valid ciphers. Read up on TLS 1.3

--- a/docs/cmdline-opts/tlsv1.d
+++ b/docs/cmdline-opts/tlsv1.d
@@ -2,7 +2,7 @@ Short: 1
 Long: tlsv1
 Tags: Versions
 Protocols: SSL
-Added:
+Added: 7.9.2
 Mutexed: tlsv1.1 tlsv1.2 tlsv1.3
 Requires: TLS
 See-also: http1.1 http2

--- a/docs/cmdline-opts/trace-ascii.d
+++ b/docs/cmdline-opts/trace-ascii.d
@@ -4,6 +4,7 @@ Help: Like --trace, but without hex output
 Mutexed: trace verbose
 Category: verbose
 Example: --trace-ascii log.txt $URL
+Added: 7.9.7
 ---
 Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have

--- a/docs/cmdline-opts/trace.d
+++ b/docs/cmdline-opts/trace.d
@@ -4,6 +4,7 @@ Help: Write a debug trace to FILE
 Mutexed: verbose trace-ascii
 Category: verbose
 Example: --trace log.txt $URL
+Added: 7.9.7
 ---
 Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have

--- a/docs/cmdline-opts/upload-file.d
+++ b/docs/cmdline-opts/upload-file.d
@@ -6,6 +6,7 @@ Category: important upload
 Example: -T file $URL
 Example: -T "img[1-1000].png" ftp://ftp.example.com/
 Example: --upload-file "{file1,file2}" $URL
+Added: 4.0
 ---
 This transfers the specified local file to the remote URL. If there is no file
 part in the specified URL, curl will append the local file name. NOTE that you

--- a/docs/cmdline-opts/url.d
+++ b/docs/cmdline-opts/url.d
@@ -3,6 +3,7 @@ Arg: <url>
 Help: URL to work with
 Category: curl
 Example: --url $URL
+Added: 7.5
 ---
 Specify a URL to fetch. This option is mostly handy when you want to specify
 URL(s) in a config file.

--- a/docs/cmdline-opts/use-ascii.d
+++ b/docs/cmdline-opts/use-ascii.d
@@ -4,6 +4,7 @@ Help: Use ASCII/text transfer
 Protocols: FTP LDAP
 Category: misc
 Example: -B ftp://example.com/README
+Added: 5.0
 ---
 Enable ASCII transfer. For FTP, this can also be enforced by using a URL that
 ends with ";type=A". This option causes data sent to stdout to be in text mode

--- a/docs/cmdline-opts/user-agent.d
+++ b/docs/cmdline-opts/user-agent.d
@@ -5,6 +5,7 @@ Help: Send User-Agent <name> to server
 Protocols: HTTP
 Category: important http
 Example: -A "Agent 007" $URL
+Added: 4.5.1
 ---
 Specify the User-Agent string to send to the HTTP server. To encode blanks in
 the string, surround the string with single quote marks. This header can also

--- a/docs/cmdline-opts/user.d
+++ b/docs/cmdline-opts/user.d
@@ -4,6 +4,7 @@ Arg: <user:password>
 Help: Server user and password
 Category: important auth
 Example: -u user:secret $URL
+Added: 4.0
 ---
 Specify the user name and password to use for server authentication. Overrides
 --netrc and --netrc-optional.

--- a/docs/cmdline-opts/verbose.d
+++ b/docs/cmdline-opts/verbose.d
@@ -5,6 +5,7 @@ Help: Make the operation more talkative
 See-also: include
 Category: important verbose
 Example: --verbose $URL
+Added: 4.0
 ---
 Makes curl verbose during the operation. Useful for debugging and seeing
 what's going on "under the hood". A line starting with '>' means "header data"

--- a/docs/cmdline-opts/version.d
+++ b/docs/cmdline-opts/version.d
@@ -3,6 +3,7 @@ Short: V
 Help: Show version number and quit
 Category: important curl
 Example: --version
+Added: 4.0
 ---
 Displays information about curl and the libcurl version it uses.
 

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -48,8 +48,7 @@ server. (Added in 7.15.4)
 .TP
 .B http_code
 The numerical response code that was found in the last retrieved HTTP(S) or
-FTP(s) transfer. In 7.18.2 the alias **response_code** was added to show the
-same info.
+FTP(s) transfer.
 .TP
 .B http_connect
 The numerical code that was found in the last response (from a proxy) to a

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -4,6 +4,7 @@ Arg: <format>
 Help: Use output FORMAT after completion
 Category: verbose
 Example: -w '%{http_code}\\n' $URL
+Added: 6.5
 ---
 Make curl display information on stdout after a completed transfer. The format
 is a string that may contain plain text mixed with any number of

--- a/docs/cmdline-opts/xattr.d
+++ b/docs/cmdline-opts/xattr.d
@@ -2,6 +2,7 @@ Long: xattr
 Help: Store metadata in extended file attributes
 Category: misc
 Example: --xattr -o storage $URL
+Added: 7.21.3
 ---
 When saving output to a file, this option tells curl to store certain file
 metadata in extended file attributes. Currently, the URL is stored in the


### PR DESCRIPTION
To make the man page more readable, this change removes all references
to changes in support/versions etc that happened before 7.30.0 from the
curl.1 output file. 7.30.0 was released on Apr 12 2013. This particular
limit is a bit arbitrary but was fairly easy to grep for.

It is handled like this: the 'Added' keyword is only used in output if
it refers to 7.30.0 or later. All occurances of "(Added in $VERSION)" in
description will be stripped out if the mentioned $VERSION is from
before 7.30.0. It is therefore important that the "Added in..."
references are always written exactly like that - and on a single line,
not split over two.

This change removes about 80 version number references from curl.1, down
to 138 from 218.