### PR TITLE
acinclude: remove use of CURL_CHECK_HEADER_WINSOCK

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1006,7 +1006,6 @@ dnl and RECV_TYPE_ARG4, defining the type of the function
 dnl return value in RECV_TYPE_RETV.
 
 AC_DEFUN([CURL_CHECK_FUNC_RECV], [
-  AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK])dnl
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
   AC_CHECK_HEADERS(sys/types.h sys/socket.h)
   #


### PR DESCRIPTION
Follow-up from c2ea04f92 that removed the macro