### PR TITLE
print_category: print help descriptions aligned

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -115,9 +115,26 @@ static const struct feat feats[] = {
 static void print_category(curlhelp_t category)
 {
   unsigned int i;
+  size_t longopt = 5;
+  size_t longdesc = 5;
+
+  for(i = 0; helptext[i].opt; ++i) {
+    size_t len;
+    if(!(helptext[i].categories & category))
+      continue;
+    len = strlen(helptext[i].opt);
+    if(len > longopt)
+      longopt = len;
+    len = strlen(helptext[i].desc);
+    if(len > longdesc)
+      longdesc = len;
+  }
+  if(longopt + longdesc > 80)
+    longopt = 80 - longdesc;
+
   for(i = 0; helptext[i].opt; ++i)
     if(helptext[i].categories & category) {
-      printf(" %-18s  %s\n", helptext[i].opt, helptext[i].desc);
+      printf(" %-*s %s\n", longopt, helptext[i].opt, helptext[i].desc);
     }
 }
 

--- a/tests/data/test1461
+++ b/tests/data/test1461
@@ -32,18 +32,18 @@ curl important --help
 </errorcode>
 <stdout mode="text">
 Usage: curl [options...] <url>
- -d, --data <data>   HTTP POST data
- -f, --fail          Fail silently (no output at all) on HTTP errors
- -h, --help <category>  Get help for commands
- -i, --include       Include protocol response headers in the output
- -o, --output <file>  Write to file instead of stdout
- -O, --remote-name   Write output to a file named as the remote file
- -s, --silent        Silent mode
- -T, --upload-file <file>  Transfer local FILE to destination
- -u, --user <user:password>  Server user and password
- -A, --user-agent <name>  Send User-Agent <name> to server
- -v, --verbose       Make the operation more talkative
- -V, --version       Show version number and quit
+ -d, --data <data>          HTTP POST data
+ -f, --fail                 Fail silently (no output at all) on HTTP errors
+ -h, --help <category>      Get help for commands
+ -i, --include              Include protocol response headers in the output
+ -o, --output <file>        Write to file instead of stdout
+ -O, --remote-name          Write output to a file named as the remote file
+ -s, --silent               Silent mode
+ -T, --upload-file <file>   Transfer local FILE to destination
+ -u, --user <user:password> Server user and password
+ -A, --user-agent <name>    Send User-Agent <name> to server
+ -v, --verbose              Make the operation more talkative
+ -V, --version              Show version number and quit
 
 This is not the full help, this menu is stripped into categories.
 Use "--help category" to get an overview of all categories.

--- a/tests/data/test1463
+++ b/tests/data/test1463
@@ -37,9 +37,9 @@ curl file category --help
 <stdout mode="text">
 Usage: curl [options...] <url>
 file: FILE protocol options
-     --create-file-mode <mode>  File mode for created files
- -I, --head          Show document info only
- -r, --range <range>  Retrieve only the bytes within RANGE
+     --create-file-mode <mode> File mode for created files
+ -I, --head                    Show document info only
+ -r, --range <range>           Retrieve only the bytes within RANGE
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test1464
+++ b/tests/data/test1464
@@ -37,9 +37,9 @@ curl file category --help with lower/upper mix
 <stdout mode="text">
 Usage: curl [options...] <url>
 file: FILE protocol options
-     --create-file-mode <mode>  File mode for created files
- -I, --head          Show document info only
- -r, --range <range>  Retrieve only the bytes within RANGE
+     --create-file-mode <mode> File mode for created files
+ -I, --head                    Show document info only
+ -r, --range <range>           Retrieve only the bytes within RANGE
 </stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
Adjust the description position to make an aligned column when doing
help listings, which is more pleasing to the eye.

Suggested-by: Gisle Vanem