### PR TITLE
gen.pl: make the output date format work better

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -46,7 +46,7 @@ my %protolong;
 my %catlong;
 
 use POSIX qw(strftime);
-my $date = strftime "%b %e %Y", localtime;
+my $date = strftime "%B %d %Y", localtime;
 my $version = "unknown";
 
 open(INC, "<../../include/curl/curlver.h");


### PR DESCRIPTION
The previous strftime format used didn't work correctly on Windows, so
change to %B %d %Y which today looks like "September 29 2021".

Reported-by: Gisle Vanem
Bug: #7782