### PR TITLE
wolfssl: use for SHA256, MD4, MD5, and setting DES odd parity

### DIFF
--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -22,7 +22,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NTLM) && !defined(USE_OPENSSL)
+#if defined(USE_NTLM) && !defined(USE_OPENSSL) && !defined(USE_WOLFSSL)
 
 #include "curl_des.h"
 

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -28,7 +28,14 @@
 
 extern const struct HMAC_params Curl_HMAC_SHA256[1];
 
+#ifdef USE_WOLFSSL
+/* SHA256_DIGEST_LENGTH is an enum value in wolfSSL. Need to import it from
+ * sha.h*/
+#include <wolfssl/options.h>
+#include <openssl/sha.h>
+#else
 #define SHA256_DIGEST_LENGTH 32
+#endif
 
 void Curl_sha256it(unsigned char *outbuffer, const unsigned char *input,
                    const size_t len);

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -27,6 +27,7 @@
 #include "curl_md4.h"
 #include "warnless.h"
 
+
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
@@ -34,6 +35,13 @@
 #define OPENSSL_NO_MD4
 #endif
 #endif /* USE_OPENSSL */
+
+#ifdef USE_WOLFSSL
+#include <wolfssl/options.h>
+#ifdef NO_MD4
+#define OPENSSL_NO_MD4
+#endif
+#endif
 
 #ifdef USE_MBEDTLS
 #include <mbedtls/version.h>
@@ -74,8 +82,9 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
   md4_digest(ctx, MD4_DIGEST_SIZE, result);
 }
 
-#elif defined(USE_OPENSSL) && !defined(OPENSSL_NO_MD4)
-/* When OpenSSL is available we use the MD4-functions from OpenSSL */
+#elif (defined(USE_OPENSSL) || defined(USE_WOLFSSL)) && \
+      !defined(OPENSSL_NO_MD4)
+/* When OpenSSL or wolfSSL is available, we use their MD4 functions. */
 #include <openssl/md4.h>
 
 #elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -65,12 +65,19 @@ static void MD5_Final(unsigned char *digest, MD5_CTX *ctx)
   md5_digest(ctx, 16, digest);
 }
 
-#elif defined(USE_OPENSSL) && !defined(USE_AMISSL)
-/* When OpenSSL is available we use the MD5-function from OpenSSL */
+#elif (defined(USE_OPENSSL) && !defined(USE_AMISSL)) || defined(USE_WOLFSSL)
+
+#ifdef USE_WOLFSSL
+#include <wolfssl/options.h>
+#endif
+
+#if defined(USE_OPENSSL) || (defined(USE_WOLFSSL) && !defined(NO_MD5))
+/* When OpenSSL or wolfSSL is available, we use their MD5 functions. */
 #include <openssl/md5.h>
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"
+#endif
 
 #elif defined(USE_MBEDTLS)
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -29,6 +29,13 @@
 #include "curl_sha256.h"
 #include "curl_hmac.h"
 
+#ifdef USE_WOLFSSL
+#include <wolfssl/options.h>
+#ifndef NO_SHA256
+#define USE_OPENSSL_SHA256
+#endif
+#endif
+
 #if defined(USE_OPENSSL)
 
 #include <openssl/opensslv.h>


### PR DESCRIPTION
Prior to this commit, OpenSSL could be used for all these functions, but
not wolfSSL. This commit makes it so wolfSSL will be used if USE_WOLFSSL
is defined.