### PR TITLE
BINDINGS: Fix outdated links

### DIFF
--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -16,11 +16,11 @@ libcurl bindings
 
 C++: [curlpp](https://curlpp.org/) Written by Jean-Philippe Barrette-LaPierre,
 [curlcpp](https://github.com/JosephP91/curlcpp) by Giuseppe Persico and [C++
-Requests](https://github.com/whoshuu/cpr) by Huu Nguyen
+Requests](https://github.com/libcpr/cpr) by Huu Nguyen
 
 [Ch](https://chcurl.sourceforge.io/) Written by Stephen Nestinger and Jonathan Rogado
 
-Cocoa: [BBHTTP](https://github.com/brunodecarvalho/BBHTTP) written by Bruno de Carvalho
+Cocoa: [BBHTTP](https://github.com/biasedbit/BBHTTP) written by Bruno de Carvalho
 [curlhandle](https://github.com/karelia/curlhandle) Written by Dan Wood
 
 Clojure: [clj-curl](https://github.com/lsevero/clj-curl) by Lucas Severo
@@ -31,7 +31,7 @@ Clojure: [clj-curl](https://github.com/lsevero/clj-curl) by Lucas Severo
 
 [Dylan](https://dylanlibs.sourceforge.io/) Written by Chris Double
 
-[Eiffel](https://room.eiffel.com/library/curl) Written by Eiffel Software
+[Eiffel](https://iron.eiffel.com/repository/20.11/package/ABEF6975-37AC-45FD-9C67-52D10BA0669B) Written by Eiffel Software
 
 [Euphoria](https://web.archive.org/web/20050204080544/rays-web.com/eulibcurl.htm) Written by Ray Smith
 
@@ -47,9 +47,9 @@ Go: [go-curl](https://github.com/andelf/go-curl) by ShuYu Wang
 
 [Guile](https://www.lonelycactus.com/guile-curl.html) Written by Michael L. Gran
 
-[Harbour](https://github.com/vszakats/hb/tree/master/contrib/hbcurl) Written by Viktor Szakats
+[Harbour](https://github.com/vszakats/hb/tree/main/contrib/hbcurl) Written by Viktor Szakats
 
-[Haskell](https://hackage.haskell.org/cgi-bin/hackage-scripts/package/curl) Written by Galois, Inc
+[Haskell](https://hackage.haskell.org/package/curl) Written by Galois, Inc
 
 [Java](https://github.com/pjlegato/curl-java)
 
@@ -61,7 +61,7 @@ Go: [go-curl](https://github.com/andelf/go-curl) by ShuYu Wang
 
 Lua: [luacurl](https://web.archive.org/web/20201205052437/luacurl.luaforge.net/) by Alexander Marinov, [Lua-cURL](https://github.com/Lua-cURL) by Jürgen Hötzel
 
-[Mono](https://forge.novell.com/modules/xfmod/project/?libcurl-mono) Written by Jeffrey Phillips
+[Mono](https://web.archive.org/web/20070606064500/https://forge.novell.com/modules/xfmod/project/?libcurl-mono) Written by Jeffrey Phillips
 
 [.NET](https://sourceforge.net/projects/libcurl-net/) libcurl-net by Jeffrey Phillips
 
@@ -98,7 +98,7 @@ RPG, support for ILE/RPG on OS/400 is included in source distribution
 
 Ruby: [curb](https://github.com/taf2/curb) written by Ross Bamford
 
-[Rust](https://github.com/carllerche/curl-rust) curl-rust - by Carl Lerche
+[Rust](https://github.com/alexcrichton/curl-rust) curl-rust - by Carl Lerche
 
 [Scheme](http://www.metapaper.net/lisovsky/web/curl/) Bigloo binding by Kirill Lisovsky
 


### PR DESCRIPTION
I noticed a few outdated URLs when I was checking out the bindings:

- cpr, BBHTTP, and curl-rust now live under different user/org names on GitHub
- hbcurl for Harbour has renamed their master branch to main
- Eiffel package has moved from `room.eiffel.com` to `iron.eiffel.com`
- Haskell package link has moved
- libcurl-mono package is inaccessible, url has been updated to archive.org -- though the download does not work and I have been unable to find where the package might have moved to