### PR TITLE
Fixed HTTP/3 Explained book link

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -2,7 +2,7 @@
 
 ## Resources
 
-[HTTP/3 Explained](https://daniel.haxx.se/http3-explained/) - the online free
+[HTTP/3 Explained](https://http3-explained.haxx.se/en/) - the online free
 book describing the protocols involved.
 
 [QUIC implementation](https://github.com/curl/curl/wiki/QUIC-implementation) -


### PR DESCRIPTION
Link to HTTP/3 Explained doesn't exist anymore. Replaced with a current link to the same book.