### PR TITLE
WIP: tests: re-enable test 2086

### DIFF
--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -29,8 +29,6 @@
 # test 1801 causes problems on Mac OS X and github
 # https://github.com/curl/curl/issues/380
 1801
-# test 2086 causes issues on Windows only
-2086
 #
 #
 # Tests that are disabled here for Hyper are SUPPOSED to work but


### PR DESCRIPTION
Test 2086 experienced issues running on Windows. Reenable it to diagnose whether it's still a problem.