### PR TITLE
docs/examples: add missing binaries to gitignore

### DIFF
--- a/docs/examples/.gitignore
+++ b/docs/examples/.gitignore
@@ -16,6 +16,7 @@ ftpsget
 ftpupload
 ftpuploadfrommem
 ftpuploadresume
+getreferrer
 getinfo
 getinmemory
 getredirect
@@ -49,6 +50,7 @@ multi-app
 multi-debugcallback
 multi-double
 multi-formadd
+multi-legacy
 multi-poll
 multi-post
 multi-single


### PR DESCRIPTION
Commit f65d7889b added getreferrer, and commit ae8e11ed5 multi-legacy,
both of which missed adding .gitignore clauses for the built binaries.

Closes #xxxx
Reviewed-by: xxxx