### PR TITLE
cmake: add CURL_ENABLE_SSL option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,29 +343,29 @@ endif()
 
 # check SSL libraries
 # TODO support GnuTLS
-option(ENABLE_SSL "Enable SSL support" ON)
+option(CURL_ENABLE_SSL "Enable SSL support" ON)
 if(CMAKE_USE_WINSSL)
   message(FATAL_ERROR "The cmake option CMAKE_USE_WINSSL was renamed to CMAKE_USE_SCHANNEL.")
 endif()
 
 if(APPLE)
-  cmake_dependent_option(CMAKE_USE_SECTRANSP "enable Apple OS native SSL/TLS" OFF ENABLE_SSL OFF)
+  cmake_dependent_option(CMAKE_USE_SECTRANSP "enable Apple OS native SSL/TLS" OFF CURL_ENABLE_SSL OFF)
 endif()
 if(WIN32)
-  cmake_dependent_option(CMAKE_USE_SCHANNEL "enable Windows native SSL/TLS" OFF ENABLE_SSL OFF)
+  cmake_dependent_option(CMAKE_USE_SCHANNEL "enable Windows native SSL/TLS" OFF CURL_ENABLE_SSL OFF)
   cmake_dependent_option(CURL_WINDOWS_SSPI "Use windows libraries to allow NTLM authentication without openssl" ON
     CMAKE_USE_SCHANNEL OFF)
 endif()
-cmake_dependent_option(CMAKE_USE_MBEDTLS "Enable mbedTLS for SSL/TLS" OFF ENABLE_SSL OFF)
-cmake_dependent_option(CMAKE_USE_BEARSSL "Enable BearSSL for SSL/TLS" OFF ENABLE_SSL OFF)
-cmake_dependent_option(CMAKE_USE_NSS "Enable NSS for SSL/TLS" OFF ENABLE_SSL OFF)
-cmake_dependent_option(CMAKE_USE_WOLFSSL "enable wolfSSL for SSL/TLS" OFF ENABLE_SSL OFF)
+cmake_dependent_option(CMAKE_USE_MBEDTLS "Enable mbedTLS for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
+cmake_dependent_option(CMAKE_USE_BEARSSL "Enable BearSSL for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
+cmake_dependent_option(CMAKE_USE_NSS "Enable NSS for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
+cmake_dependent_option(CMAKE_USE_WOLFSSL "enable wolfSSL for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
 
 set(openssl_default ON)
 if(WIN32 OR CMAKE_USE_SECTRANSP OR CMAKE_USE_SCHANNEL OR CMAKE_USE_MBEDTLS OR CMAKE_USE_NSS OR CMAKE_USE_WOLFSSL)
   set(openssl_default OFF)
 endif()
-cmake_dependent_option(CMAKE_USE_OPENSSL "Use OpenSSL code. Experimental" ${openssl_default} ENABLE_SSL OFF)
+cmake_dependent_option(CMAKE_USE_OPENSSL "Use OpenSSL code. Experimental" ${openssl_default} CURL_ENABLE_SSL OFF)
 option(CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG "Disable automatic loading of OpenSSL configuration" OFF)
 
 count_true(enabled_ssl_options_count


### PR DESCRIPTION
I came across a project building libcurl as a subproject that was trying to set `SSL_ENABLED` to `OFF` to disable SSL support in libcurl. Other than `SSL_ENABLED` being set as a local variable in libcurl and basically overriding anything that they might have set in the cache, issues would have also been encountered because `CMAKE_USE_OPENSSL` defaults to `ON`.

I think adding an `ENABLE_SSL` option (maybe renamed to match any curl cmake option naming convention) that the various SSL backends also depend on would make it much easier for projects building libcurl as a subproject to disable ssl without needing to determine which `CMAKE_USE_*` variables for SSL backends are set, and more obvious what option needs to be turned ON/OFF.

By `ENABLE_SSL` defaulting to `ON`, the behavior of existing SSL related options should remain the same and avoid breaking any existing ci setups or build scripts.

Thoughts?
