### PR TITLE
print_category: printf %*s needs an int argument

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -134,7 +134,7 @@ static void print_category(curlhelp_t category)
 
   for(i = 0; helptext[i].opt; ++i)
     if(helptext[i].categories & category) {
-      printf(" %-*s %s\n", longopt, helptext[i].opt, helptext[i].desc);
+      printf(" %-*s %s\n", (int)longopt, helptext[i].opt, helptext[i].desc);
     }
 }
 


### PR DESCRIPTION
... not a size_t!

Detected by Coverity: CID 1492331.