### PR TITLE
Check build version numbers on Windows.

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1127,7 +1127,7 @@ void Curl_sndbufset(curl_socket_t sockfd)
   static int detectOsState = DETECT_OS_NONE;
 
   if(detectOsState == DETECT_OS_NONE) {
-    if(curlx_verify_windows_version(6, 0, PLATFORM_WINNT,
+    if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
                                     VERSION_GREATER_THAN_EQUAL))
       detectOsState = DETECT_OS_VISTA_OR_LATER;
     else

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -83,7 +83,7 @@ CURLcode Curl_sspi_global_init(void)
      * have both these DLLs (security.dll forwards calls to secur32.dll) */
 
     /* Load SSPI dll into the address space of the calling process */
-    if(curlx_verify_windows_version(4, 0, PLATFORM_WINNT, VERSION_EQUAL))
+    if(curlx_verify_windows_version(4, 0, 0, PLATFORM_WINNT, VERSION_EQUAL))
       s_hSecDll = Curl_load_library(TEXT("security.dll"));
     else
       s_hSecDll = Curl_load_library(TEXT("secur32.dll"));

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -104,7 +104,7 @@ CURLcode Curl_win32_init(long flags)
 
   /* curlx_verify_windows_version must be called during init at least once
      because it has its own initialization routine. */
-  if(curlx_verify_windows_version(6, 0, PLATFORM_WINNT,
+  if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
                                   VERSION_GREATER_THAN_EQUAL)) {
     Curl_isVistaOrGreater = TRUE;
   }

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -270,7 +270,7 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
   if(platform != PLATFORM_DONT_CARE)
     cm = VerSetConditionMask(cm, VER_PLATFORMID, VER_EQUAL);
 
-  if(buildVersion != 0)
+  if(buildVersion)
     cm = VerSetConditionMask(cm, VER_BUILDNUMBER, buildCondition);
 
   /* Later versions of Windows have version functions that may not return the

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -271,7 +271,7 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
     cm = VerSetConditionMask(cm, VER_PLATFORMID, VER_EQUAL);
 
   if(buildVersion != 0)
-  	cm = VerSetConditionMask(cm, VER_BUILDNUMBER, buildCondition);
+    cm = VerSetConditionMask(cm, VER_BUILDNUMBER, buildCondition);
 
   /* Later versions of Windows have version functions that may not return the
      real version of Windows unless the application is so manifested. We prefer

--- a/lib/version_win32.h
+++ b/lib/version_win32.h
@@ -45,6 +45,7 @@ typedef enum {
 /* This is used to verify if we are running on a specific windows version */
 bool curlx_verify_windows_version(const unsigned int majorVersion,
                                   const unsigned int minorVersion,
+                                  const unsigned int buildVersion,
                                   const PlatformIdentifier platform,
                                   const VersionCondition condition);
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -776,7 +776,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
                "schannel: SSL/TLS connection with %s port %hu (step 1/3)",
                hostname, conn->remote_port));
 
-  if(curlx_verify_windows_version(5, 1, PLATFORM_WINNT,
+  if(curlx_verify_windows_version(5, 1, 0, PLATFORM_WINNT,
                                   VERSION_LESS_THAN_EQUAL)) {
     /* Schannel in Windows XP (OS version 5.1) uses legacy handshakes and
        algorithms that may not be supported by all servers. */
@@ -790,7 +790,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   BACKEND->use_alpn = conn->bits.tls_enable_alpn &&
     !GetProcAddress(GetModuleHandle(TEXT("ntdll")),
                     "wine_get_version") &&
-    curlx_verify_windows_version(6, 3, PLATFORM_WINNT,
+    curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
                                  VERSION_GREATER_THAN_EQUAL);
 #else
   BACKEND->use_alpn = false;
@@ -807,7 +807,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
 #else
 #ifdef HAS_MANUAL_VERIFY_API
   if(SSL_CONN_CONFIG(CAfile) || SSL_CONN_CONFIG(ca_info_blob)) {
-    if(curlx_verify_windows_version(6, 1, PLATFORM_WINNT,
+    if(curlx_verify_windows_version(6, 1, 0, PLATFORM_WINNT,
                                     VERSION_GREATER_THAN_EQUAL)) {
       BACKEND->use_manual_cred_validation = true;
     }
@@ -2049,7 +2049,7 @@ schannel_recv(struct Curl_easy *data, int sockindex,
   */
   if(len && !BACKEND->decdata_offset && BACKEND->recv_connection_closed &&
      !BACKEND->recv_sspi_close_notify) {
-    bool isWin2k = curlx_verify_windows_version(5, 0, PLATFORM_WINNT,
+    bool isWin2k = curlx_verify_windows_version(5, 0, 0, PLATFORM_WINNT,
                                                 VERSION_EQUAL);
 
     if(isWin2k && sspi_status == SEC_E_OK)

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -355,7 +355,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
   DWORD i;
 
   /* CERT_NAME_SEARCH_ALL_NAMES_FLAG is available from Windows 8 onwards. */
-  if(curlx_verify_windows_version(6, 2, PLATFORM_WINNT,
+  if(curlx_verify_windows_version(6, 2, 0, PLATFORM_WINNT,
                                   VERSION_GREATER_THAN_EQUAL)) {
 #ifdef CERT_NAME_SEARCH_ALL_NAMES_FLAG
     /* CertGetNameString will provide the 8-bit character string without
@@ -597,7 +597,8 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
      * trusted certificates. This is only supported on Windows 7+.
      */
 
-    if(curlx_verify_windows_version(6, 1, PLATFORM_WINNT, VERSION_LESS_THAN)) {
+    if(curlx_verify_windows_version(6, 1, 0, PLATFORM_WINNT,
+                                    VERSION_LESS_THAN)) {
       failf(data, "schannel: this version of Windows is too old to support "
             "certificate verification via CA bundle file.");
       result = CURLE_SSL_CACERT_BADFILE;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -768,7 +768,7 @@ CURLcode win32_init(void)
 {
   /* curlx_verify_windows_version must be called during init at least once
      because it has its own initialization routine. */
-  if(curlx_verify_windows_version(6, 0, PLATFORM_WINNT,
+  if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
                                   VERSION_GREATER_THAN_EQUAL))
     tool_isVistaOrGreater = true;
   else


### PR DESCRIPTION
Check build version numbers on Windows. Required for enabling "evergreen" Windows 10/11 features ([like TLS 1.3](https://github.com/curl/curl/pull/7784)).

Builds upon @jay 's PR: https://github.com/curl/curl/pull/7810

This is required for: https://github.com/curl/curl/pull/7784

Less controversial version of https://github.com/curl/curl/pull/7727