### PR TITLE
Add missing goto error

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -805,7 +805,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
       if(hyper_request_set_uri(req, (uint8_t *)hostheader,
                                strlen(hostheader))) {
         failf(data, "error setting path");
-        result = CURLE_OUT_OF_MEMORY;
+        goto error;
       }
       /* Setup the proxy-authorization header, if any */
       result = Curl_http_output_auth(data, conn, "CONNECT", HTTPREQ_GET,


### PR DESCRIPTION
This PR adds missing `goto error`
Without this, failure was not handled. `result` was set to `CURLE_OUT_OF_MEMORY`, but in line 811 it was changed to somethings else, so it was useless

Looks that was copy paste bug from:
https://github.com/curl/curl/blob/e8c8775eaa79fb93208c70a3c607e7e23222e4db/lib/c-hyper.c#L587-L591