### PR TITLE
c-hyper: use hyper_request_set_uri_parts to make h2 better

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -584,17 +584,22 @@ static CURLcode request_target(struct Curl_easy *data,
   if(result)
     return result;
 
-  if(hyper_request_set_uri_parts(req,
-                                 /* scheme */
-                                 (uint8_t *)data->state.up.scheme,
-                                 strlen(data->state.up.scheme),
-                                 /* authority */
-                                 (uint8_t *)conn->host.name,
-                                 strlen(conn->host.name),
-                                 /* path_and_query */
-                                 (uint8_t *)Curl_dyn_uptr(&r),
-                                 Curl_dyn_len(&r))) {
-    failf(data, "error setting path");
+  if(h2 && hyper_request_set_uri_parts(req,
+                                       /* scheme */
+                                       (uint8_t *)data->state.up.scheme,
+                                       strlen(data->state.up.scheme),
+                                       /* authority */
+                                       (uint8_t *)conn->host.name,
+                                       strlen(conn->host.name),
+                                       /* path_and_query */
+                                       (uint8_t *)Curl_dyn_uptr(&r),
+                                       Curl_dyn_len(&r))) {
+    failf(data, "error setting uri parts to hyper");
+    result = CURLE_OUT_OF_MEMORY;
+  }
+  else if(!h2 && hyper_request_set_uri(req, (uint8_t *)Curl_dyn_uptr(&r),
+                                       Curl_dyn_len(&r))) {
+    failf(data, "error setting uri to hyper");
     result = CURLE_OUT_OF_MEMORY;
   }
   else


### PR DESCRIPTION
and make sure to not send Host: over h2.

Fixes #7679
Reported-by: David Cook