### PR TITLE
CI: more use of test-ci make target and verbose output

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
       env:
         MAKEFLAGS: "-j 2"
 
-    - script: make test-nonflaky
+    - script: make V=1 test-ci
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ commands:
 
   build:
     steps:
-      - run: make
+      - run: make V=1
 
   test:
     steps:
-      - run: make test-ci
+      - run: make V=1 test-ci
 
 executors:
   ubuntu:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ freebsd_task:
     - find . -type d -exec chmod 777 {} \;
     # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
     # therefore the SFTP and SCP tests are disabled right away from the beginning.
-    - sudo -u nobody make V=1 TFLAGS="-n -r -u !SFTP !SCP" test-nonflaky
+    - sudo -u nobody make V=1 TFLAGS="-n !SFTP !SCP" test-ci
   install_script:
     - make V=1 install
 

--- a/.github/workflows/linux-hyper.yml
+++ b/.github/workflows/linux-hyper.yml
@@ -38,10 +38,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - run: ./buildconf && LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }} && make
+    - run: ./buildconf && LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'
 
-    - run: make test-ci
+    - run: make V=1 test-ci
       name: 'test'
       env:
         LD_LIBRARY_PATH: $HOME/hyper/target/debug:/usr/local/lib

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,10 +81,10 @@ jobs:
         # -Wvla is caused by brotli
         CFLAGS: "-Wno-vla -mmacosx-version-min=${{ matrix.build.macosx-version-min }}"
 
-    - run: make
+    - run: make V=1
       name: 'make'
 
-    - run: make test-ci
+    - run: make V=1 test-ci
       name: 'test'
       env:
         TFLAGS: "${{ matrix.build.tflags }} ~1452"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -289,7 +289,7 @@ build_script:
         ..\builds\libcurl-vc15-x64-%PATHPART%-dll-ssl-dll-ipv6-sspi\bin\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==autotools (
-        bash.exe -e -l -c "cd /c/projects/curl && ./buildconf && ./configure %CONFIG_ARGS% && make && make examples && cd tests && make"
+        bash.exe -e -l -c "cd /c/projects/curl && ./buildconf && ./configure %CONFIG_ARGS% && make V=1 && make V=1 examples && cd tests && make V=1"
       )))))
     - if %TESTING%==ON (
         if %BUILD_SYSTEM%==CMake (


### PR DESCRIPTION
Replace test-nonflaky with test-ci and enable verbose output
in all remaining CIs except Zuul which is customized a lot.

Follow up to #7785