### PR TITLE
tests/runtests.pl: use default post command delay of 100ms

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -5800,6 +5800,10 @@ mkdir($LOGDIR, 0777);
 get_disttests();
 init_serverpidfile_hash();
 
+if(pathhelp::os_is_win()) {
+    $defpostcommanddelay = 0.1;
+}
+
 #######################################################################
 # Output curl version and host info being tested
 #


### PR DESCRIPTION
Although flushing the output buffers reduced the flakiness
of the curl test suite on Windows already, some tests were
still randomly failing. This is another attempt to fix it.

Follow up to #7530