### PR TITLE
Actually append "-" to --range

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2077,7 +2077,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
               "A specified range MUST include at least one dash (-). "
               "Appending one for you!\n");
         msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-", off);
-        GetStr(&config->range, buffer);
+        Curl_safefree(config->range);
+        config->range = strdup(buffer);
+        if(!config->range)
+          return PARAM_NO_MEM;
       }
       else {
         /* byte range requested */


### PR DESCRIPTION
Because the block is missing the `else`, it always executes and overwrites the result of the `if` block before it. So curl has been warning users that it has fixed their incorrect `--range` it but not actually fixing it.