### PR TITLE
http_proxy: make hyper CONNECT() return the correct error code

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -966,6 +966,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
     }
   }
   error:
+  DEBUGASSERT(result);
   free(host);
   free(hostheader);
   if(io)


### PR DESCRIPTION
For every 'goto error', make sure the result variable holds the error
code for what went wrong.

Reported-by: Rafał Mikrut
Fixes #7825