### PR TITLE
c-hyper: make Curl_http propagate errors better

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -967,7 +967,8 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   if(!h2) {
     if(data->state.aptr.host) {
       result = Curl_hyper_header(data, headers, data->state.aptr.host);
-      goto error;
+      if(result)
+        goto error;
     }
   }
   else {


### PR DESCRIPTION
Pass on better return codes when errors occur within Curl_http instead
of insisting that CURLE_OUT_OF_MEMORY is the only possible one.