### PR TITLE
docs/Makefile.am: repair 'make html'

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -31,7 +31,7 @@ GENHTMLPAGES = curl.html curl-config.html mk-ca-bundle.html
 PDFPAGES = curl.pdf curl-config.pdf mk-ca-bundle.pdf
 MANDISTPAGES = curl.1.dist curl-config.1.dist
 
-HTMLPAGES = $(GENHTMLPAGES) index.html
+HTMLPAGES = $(GENHTMLPAGES)
 
 # Build targets in this file (.) before cmdline-opts to ensure that
 # the curl.1 rule below runs first


### PR DESCRIPTION
by removing index.html which isn't around anymore