### PR TITLE
http: remove assert that breaks hyper

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2902,7 +2902,7 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
                               bool *done)
 {
   struct SingleRequest *k = &data->req;
-  DEBUGASSERT(conn->handler->protocol&(PROTO_FAMILY_HTTP|CURLPROTO_RTSP));
+
   if(data->req.ignore_cl) {
     k->size = k->maxdownload = -1;
   }


### PR DESCRIPTION
Reported-by: Jay Satiro
Fixes #7852