### PR TITLE
urlapi: skip a strlen(), pass in zero

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1295,8 +1295,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
         }
       }
       else if(urlencode) {
-        int hostlen = (int)strlen(u->host);
-        allochost = curl_easy_escape(NULL, u->host, hostlen);
+        allochost = curl_easy_escape(NULL, u->host, 0);
         if(!allochost)
           return CURLUE_OUT_OF_MEMORY;
       }

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -2,7 +2,7 @@
 <info>
 <keywords>
 unittest
-URL API
+URLAPI
 </keywords>
 </info>
 


### PR DESCRIPTION
... to let curl_easy_escape() itself do the strlen. This avoids a (false
positive) Coverity warning and it avoids us having to store the strlen()
return value in an int variable.