### PR TITLE
cirrus: switch to openldap24-client

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,9 +32,6 @@ freebsd_task:
     - name: FreeBSD 12.2
       freebsd_instance:
         image_family: freebsd-12-2
-    - name: FreeBSD 11.4
-      freebsd_instance:
-        image_family: freebsd-11-4
 
   env:
     CIRRUS_CLONE_DEPTH: 10


### PR DESCRIPTION
... as it seems openldap-client doesn't exist anymore.

Reported-by: Jay Satiro
Fixes #7868