### PR TITLE
url: set "k->size" -1 at start of request

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -4110,7 +4110,7 @@ CURLcode Curl_connect(struct Curl_easy *data,
   /* init the single-transfer specific data */
   Curl_free_request_state(data);
   memset(&data->req, 0, sizeof(struct SingleRequest));
-  data->req.maxdownload = -1;
+  data->req.size = data->req.maxdownload = -1;
 
   /* call the stuff that needs to be called */
   result = create_conn(data, &conn, asyncp);


### PR DESCRIPTION
As the size of the transfer is unknown at that point.

Fixes #7871