### PR TITLE
curl_gssapi: fix build warnings by removing const

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -33,10 +33,10 @@
 #include "memdebug.h"
 
 gss_OID_desc Curl_spnego_mech_oid = {
-  6, "\x2b\x06\x01\x05\x05\x02"
+  6, (char *)"\x2b\x06\x01\x05\x05\x02"
 };
 gss_OID_desc Curl_krb5_mech_oid = {
-  9, "\x2a\x86\x48\x86\xf7\x12\x01\x02\x02"
+  9, (char *)"\x2a\x86\x48\x86\xf7\x12\x01\x02\x02"
 };
 
 OM_uint32 Curl_gss_init_sec_context(


### PR DESCRIPTION
In #7875 these inits were modified but I get two warnings that these new
typecasts are necessary for.