### PR TITLE
mime: mention CURL_DISABLE_MIME in comment

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1954,7 +1954,8 @@ void Curl_mime_unpause(curl_mimepart *part)
 }
 
 
-#else /* !CURL_DISABLE_HTTP || !CURL_DISABLE_SMTP || !CURL_DISABLE_IMAP */
+#else /* !CURL_DISABLE_HTTP && !CURL_DISABLE_MIME ||
+         !CURL_DISABLE_SMTP || !CURL_DISABLE_IMAP */
 
 /* Mime not compiled in: define stubs for externally-referenced functions. */
 curl_mime *curl_mime_init(CURL *easy)


### PR DESCRIPTION
CURL_DISABLE_MIME is not mentioned in the comment
describing the if else preprocessor directive.