### PR TITLE
cmake: fix error getting LOCATION property on non-imported target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1486,12 +1486,10 @@ set(libdir                  "${CMAKE_INSTALL_PREFIX}/lib")
 foreach(_lib ${CMAKE_C_IMPLICIT_LINK_LIBRARIES} ${CURL_LIBS})
   if(TARGET "${_lib}")
     set(_libname "${_lib}")
-    get_target_property(_libtype "${_libname}" TYPE)
-    if(_libtype STREQUAL INTERFACE_LIBRARY)
-      # Interface libraries can occur when an external project embeds curl and
-      # defined targets such as ZLIB::ZLIB by themselves. Ignore these as
-      # reading the LOCATION property will error out. Assume the user won't need
-      # this information in the .pc file.
+    get_target_property(_imported "${_libname}" IMPORTED)
+    if(NOT _imported)
+      # Reading the LOCATION property on non-imported target will error out.
+      # Assume the user won't need this information in the .pc file.
       continue()
     endif()
     get_target_property(_lib "${_libname}" LOCATION)


### PR DESCRIPTION
CMake allows getting LOCATION property only on IMPORTED targets:
https://cmake.org/cmake/help/latest/prop_tgt/LOCATION.html

Currently, curl cmake avoids getting LOCATION property on INTERFACE targets only.
With this change, it will avoid getting LOCATION property on all non-imported targets, not only INTERFACE targets.

This is required when both curl and zlib are built in the same CMake project (for example, when build with CMake package manager: https://github.com/scapix-com/cmodule), in which case ZLIB::ZLIB is a normal CMake target (not IMPORTED and not INTERFACE).