### PR TITLE
openssl: more fixes for OpenSSL v3

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1103,7 +1103,8 @@ int cert_stuff(struct Curl_easy *data,
       EVP_PKEY_free(pktmp);
     }
 
-#if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_IS_BORINGSSL) && \
+    !defined(OPENSSL_NO_DEPRECATED_3_0)
     {
       /* If RSA is used, don't check the private key if its flags indicate
        * it doesn't support it. */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -171,6 +171,10 @@
 #define OPENSSL_load_builtin_modules(x)
 #endif
 
+#if (OPENSSL_VERSION_NUMBER < 0x30000000L)
+#define SSL_get1_peer_certificate SSL_get_peer_certificate
+#endif
+
 /*
  * Whether SSL_CTX_set_keylog_callback is available.
  * OpenSSL: supported since 1.1.1 https://github.com/openssl/openssl/pull/2287
@@ -1937,7 +1941,7 @@ static CURLcode verifystatus(struct Curl_easy *data,
   }
 
   /* Compute the certificate's ID */
-  cert = SSL_get_peer_certificate(backend->handle);
+  cert = SSL_get1_peer_certificate(backend->handle);
   if(!cert) {
     failf(data, "Error getting peer certificate");
     result = CURLE_SSL_INVALIDCERTSTATUS;
@@ -3840,7 +3844,7 @@ static CURLcode servercert(struct Curl_easy *data,
     /* we've been asked to gather certificate info! */
     (void)get_cert_chain(data, connssl);
 
-  backend->server_cert = SSL_get_peer_certificate(backend->handle);
+  backend->server_cert = SSL_get1_peer_certificate(backend->handle);
   if(!backend->server_cert) {
     BIO_free(mem);
     if(!strict)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3471,10 +3471,7 @@ static void pubkey_show(struct Curl_easy *data,
                         int num,
                         const char *type,
                         const char *name,
-#ifdef HAVE_OPAQUE_RSA_DSA_DH
-                        const
-#endif
-                        BIGNUM *bn)
+                        const BIGNUM *bn)
 {
   char *ptr;
   char namebuf[32];
@@ -3659,23 +3656,20 @@ static CURLcode get_cert_chain(struct Curl_easy *data,
         rsa = pubkey->pkey.rsa;
 #endif
 
-#ifdef HAVE_OPAQUE_RSA_DSA_DH
         {
+#ifdef HAVE_OPAQUE_RSA_DSA_DH
           const BIGNUM *n;
           const BIGNUM *e;
 
           RSA_get0_key(rsa, &n, &e, NULL);
           BIO_printf(mem, "%d", BN_num_bits(n));
+#else
+          BIO_printf(mem, "%d", BN_num_bits(rsa->n));
+#endif
           push_certinfo("RSA Public Key", i);
           print_pubkey_BN(rsa, n, i);
           print_pubkey_BN(rsa, e, i);
         }
-#else
-        BIO_printf(mem, "%d", BN_num_bits(rsa->n));
-        push_certinfo("RSA Public Key", i);
-        print_pubkey_BN(rsa, n, i);
-        print_pubkey_BN(rsa, e, i);
-#endif
 
         break;
       }
@@ -3688,8 +3682,8 @@ static CURLcode get_cert_chain(struct Curl_easy *data,
 #else
         dsa = pubkey->pkey.dsa;
 #endif
-#ifdef HAVE_OPAQUE_RSA_DSA_DH
         {
+#ifdef HAVE_OPAQUE_RSA_DSA_DH
           const BIGNUM *p;
           const BIGNUM *q;
           const BIGNUM *g;
@@ -3697,18 +3691,12 @@ static CURLcode get_cert_chain(struct Curl_easy *data,
 
           DSA_get0_pqg(dsa, &p, &q, &g);
           DSA_get0_key(dsa, &pub_key, NULL);
-
+#endif
           print_pubkey_BN(dsa, p, i);
           print_pubkey_BN(dsa, q, i);
           print_pubkey_BN(dsa, g, i);
           print_pubkey_BN(dsa, pub_key, i);
         }
-#else
-        print_pubkey_BN(dsa, p, i);
-        print_pubkey_BN(dsa, q, i);
-        print_pubkey_BN(dsa, g, i);
-        print_pubkey_BN(dsa, pub_key, i);
-#endif
 #endif /* !OPENSSL_NO_DSA */
         break;
       }
@@ -3720,8 +3708,8 @@ static CURLcode get_cert_chain(struct Curl_easy *data,
 #else
         dh = pubkey->pkey.dh;
 #endif
-#ifdef HAVE_OPAQUE_RSA_DSA_DH
         {
+#ifdef HAVE_OPAQUE_RSA_DSA_DH
           const BIGNUM *p;
           const BIGNUM *q;
           const BIGNUM *g;
@@ -3731,13 +3719,12 @@ static CURLcode get_cert_chain(struct Curl_easy *data,
           print_pubkey_BN(dh, p, i);
           print_pubkey_BN(dh, q, i);
           print_pubkey_BN(dh, g, i);
+#else
+          print_pubkey_BN(dh, p, i);
+          print_pubkey_BN(dh, g, i);
+#endif
           print_pubkey_BN(dh, pub_key, i);
        }
-#else
-        print_pubkey_BN(dh, p, i);
-        print_pubkey_BN(dh, g, i);
-        print_pubkey_BN(dh, pub_key, i);
-#endif
         break;
       }
       }


### PR DESCRIPTION
- remove usage of deprecated `SSL_get_peer_certificate` in favor of `SSL_get1_peer_certificate`
- remove RSA_METHOD_FLAG_NO_CHECK handling if unavailable
- use `EVP_PKEY_get_bn_param` to read key parameters instead of using algorithm-specific functions deprecated in OpenSSL 3.0

There are two issues left after this:
- the engine API has been deprecated in favor of providers
- the autoconf check for `HAVE_OPENSSL_SRP` checks only if the SRP functions are available in the OpenSSL library, not if they're actually usable without compile errors