### PR TITLE
Makefile.m32: fix to not require OpenSSL with options -libssh2 and -rtmp

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -178,12 +178,10 @@ ARES = 1
 endif
 ifeq ($(findstring -rtmp,$(CFG)),-rtmp)
 RTMP = 1
-SSL = 1
 ZLIB = 1
 endif
 ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
 SSH2 = 1
-SSL = 1
 ZLIB = 1
 endif
 ifeq ($(findstring -ssl,$(CFG)),-ssl)
@@ -228,6 +226,13 @@ NGHTTP3 = 1
 endif
 ifeq ($(findstring -ngtcp2,$(CFG)),-ngtcp2)
 NGTCP2 = 1
+endif
+
+# SSH2 and RTMP require an SSL library; assume OpenSSL if none specified
+ifneq ($(SSH2)$(RTMP),)
+  ifeq ($(SSL)$(WINSSL),)
+    SSL = 1
+  endif
 endif
 
 INCLUDES = -I. -I$(PROOT) -I$(PROOT)/include -I$(PROOT)/lib
@@ -284,7 +289,7 @@ ifdef SSL
     endif
   endif
   ifneq "$(wildcard $(OPENSSL_INCLUDE)/openssl/opensslv.h)" "$(OPENSSL_INCLUDE)/openssl/opensslv.h"
-  $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
+    $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
   endif
   ifndef OPENSSL_LIBPATH
     OPENSSL_LIBS = -lssl -lcrypto

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -179,12 +179,10 @@ SYNC = 1
 endif
 ifeq ($(findstring -rtmp,$(CFG)),-rtmp)
 RTMP = 1
-SSL = 1
 ZLIB = 1
 endif
 ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
 SSH2 = 1
-SSL = 1
 ZLIB = 1
 endif
 ifeq ($(findstring -ssl,$(CFG)),-ssl)
@@ -235,6 +233,13 @@ NGTCP2 = 1
 endif
 ifeq ($(findstring -unicode,$(CFG)),-unicode)
 UNICODE = 1
+endif
+
+# SSH2 and RTMP require an SSL library; assume OpenSSL if none specified
+ifneq ($(SSH2)$(RTMP),)
+  ifeq ($(SSL)$(WINSSL),)
+    SSL = 1
+  endif
 endif
 
 INCLUDES = -I. -I../include
@@ -299,7 +304,7 @@ ifdef SSL
     endif
   endif
   ifneq "$(wildcard $(OPENSSL_INCLUDE)/openssl/opensslv.h)" "$(OPENSSL_INCLUDE)/openssl/opensslv.h"
-  $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
+    $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
   endif
   ifndef OPENSSL_LIBPATH
     ifeq "$(wildcard $(OPENSSL_PATH)/out)" "$(OPENSSL_PATH)/out"

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -187,12 +187,10 @@ SYNC = 1
 endif
 ifeq ($(findstring -rtmp,$(CFG)),-rtmp)
 RTMP = 1
-SSL = 1
 ZLIB = 1
 endif
 ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
 SSH2 = 1
-SSL = 1
 ZLIB = 1
 endif
 ifeq ($(findstring -ssl,$(CFG)),-ssl)
@@ -240,6 +238,13 @@ NGTCP2 = 1
 endif
 ifeq ($(findstring -unicode,$(CFG)),-unicode)
 UNICODE = 1
+endif
+
+# SSH2 and RTMP require an SSL library; assume OpenSSL if none specified
+ifneq ($(SSH2)$(RTMP),)
+  ifeq ($(SSL)$(WINSSL),)
+    SSL = 1
+  endif
 endif
 
 INCLUDES = -I. -I../include -I../lib
@@ -309,7 +314,7 @@ ifdef SSL
     endif
   endif
   ifneq "$(wildcard $(OPENSSL_INCLUDE)/openssl/opensslv.h)" "$(OPENSSL_INCLUDE)/openssl/opensslv.h"
-  $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
+    $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
   endif
   ifndef OPENSSL_LIBPATH
     OPENSSL_LIBS = -lssl -lcrypto


### PR DESCRIPTION
Previously, -libssh2/-rtmp options assumed that OpenSSL is also enabled (and then failed with an error when not finding expected OpenSSL headers), but this isn't necessarly true, e.g. when building both libssh2 and curl against Schannel. This patch makes sure to only enable the OpenSSL backend with -libssh2/-rtmp, when there was no SSL option explicitly selected.

- Re-implement the logic as a single block of script.
- Also fix an indentation while there.

Assisted-by: Jay Satiro

Closes #

---

This has been tested locally and as part of curl-for-win.
