### PR TITLE
github: add support for Hacktoberfest using labels

### DIFF
--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -1,0 +1,53 @@
+name: Hacktoberfest
+
+on:
+  # run for all pushes to master branch
+  push:
+    branches:
+      - master
+
+jobs:
+  # add hacktoberfest-accepted label to PRs opened starting from September 30th
+  # till November 1st which are closed via commit reference from master branch.
+  merged:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+
+      - name: Check wether repo participates in Hacktoberfest
+        run: |
+          gh config set prompt disabled && echo "::set-output name=label::$(
+            gh repo view --json repositoryTopics --jq '.repositoryTopics[].name' | grep '^hacktoberfest$')"
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Search relevant commit message lines starting with Closes/Merges
+        run: |
+          git log --format=email ${{ github.event.before }}..${{ github.event.after }} | \
+            egrep -i "^Close[sd]? " | sort | uniq | tee log
+        if: steps.check.outputs.label == 'hacktoberfest'
+
+      - name: Search for Number-based PR references
+        run: |
+          egrep -o "#([0-9]+)" log | cut -d# -f2 | sort | uniq | xargs -t -n1 -I{} \
+            gh pr view {} --json number,createdAt \
+              --jq '{number, opened: .createdAt} | [.number, .opened] | join(":")' | tee /dev/stderr | \
+            egrep -o '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
+              gh pr edit {} --add-label 'hacktoberfest-accepted'
+        if: steps.check.outputs.label == 'hacktoberfest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Search for URL-based PR references
+        run: |
+          egrep -o "github.com/(.+)/(.+)/pull/([0-9]+)" log | sort | uniq | xargs -t -n1 -I{} \
+            gh pr view "https://{}" --json number,createdAt \
+              --jq '{number, opened: .createdAt} | [.number, .opened] | join(":")' | tee /dev/stderr | \
+            egrep -o '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
+              gh pr edit {} --add-label 'hacktoberfest-accepted'
+        if: steps.check.outputs.label == 'hacktoberfest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sorry for being a little late with this, but I finally got to implementing the necessary workflows and successfully tested them in my curl repository fork with a fake "hacktober**T**est" set of labels.

If this PR is accepted/approved for merge, I will also go ahead and retroactively add the labels to all relevant PRs for this years Hacktoberfest once via the GitHub CLI.

--

Automatically add hacktoberfest-accepted label to PRs opened between
September 30th and November 1st once a commit with a close reference
to it is pushed onto the master branch.

With this workflow we can participate in Hacktoberfest while not
relying on GitHub to identify PRs as merged due to our rebasing.

Requires hacktoberfest-accepted labels to exist for PRs on the
participating repository. Also requires hacktoberfest topic on
the participating repository to avoid applying to forked repos.

Fixes #7865