### PR TITLE
sendf: accept zero-length data in Curl_client_write()

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -608,7 +608,7 @@ static CURLcode chop_write(struct Curl_easy *data,
 /* Curl_client_write() sends data to the write callback(s)
 
    The bit pattern defines to what "streams" to write to. Body and/or header.
-   The defines are in sendf.h of course. "len" is not allowed to be 0.
+   The defines are in sendf.h of course.
 
    If CURL_DO_LINEEND_CONV is enabled, data is converted IN PLACE to the
    local character encoding.  This is a problem and should be changed in
@@ -621,8 +621,10 @@ CURLcode Curl_client_write(struct Curl_easy *data,
 {
   struct connectdata *conn = data->conn;
 
-  DEBUGASSERT(len);
-  DEBUGASSERT(type <= 3);
+  DEBUGASSERT(!(type & ~CLIENTWRITE_BOTH));
+
+  if(!len)
+    return CURLE_OK;
 
   /* FTP data may need conversion. */
   if((type & CLIENTWRITE_BODY) &&


### PR DESCRIPTION
As Curl_client_write() rejects zero-length output data, ldap root
requests resulting in a null distinguished name currently cause curl to
abort.

This commit explicitly checks for non zero-length DN before writing it
to LDIF output.

This is the first part of splitting PR #7199 (that still allows me to run CI).