### PR TITLE
Use python3 in test 1451

### DIFF
--- a/tests/data/test1451
+++ b/tests/data/test1451
@@ -29,7 +29,7 @@ Basic SMB request
 -u 'curltest:curltest' smb://%HOSTIP:%SMBPORT/TESTS/%TESTNUMBER
 </command>
 <precheck>
-python -c "__import__('pkgutil').find_loader('impacket') or (__import__('sys').stdout.write('Test only works if Python package impacket is installed\n'), __import__('sys').exit(1))"
+python3 -c "__import__('pkgutil').find_loader('impacket') or (__import__('sys').stdout.write('Test only works if Python package impacket is installed\n'), __import__('sys').exit(1))"
 </precheck>
 </client>
 


### PR DESCRIPTION
Hello, I'm one of the new Debian maintainers for curl and I'll be updating the package and sending some patches upstream. The previous maintainer didn't have much time lately so hopefully we'll be able to improve on a few things.

 This is a continuation of commit
 ec91b5a69000bea0794bbb3f97a4d994dab2031e in which changing this test was
 missed.
 There are no other python2 leftovers now.

 Based on a Debian patch originally written by Alessandro Ghedini
 <ghedo@debian.org>