### PR TITLE
curl_multi_socket_action.3: add a "RETURN VALUE" section

### DIFF
--- a/docs/libcurl/curl_multi_socket_action.3
+++ b/docs/libcurl/curl_multi_socket_action.3
@@ -88,6 +88,9 @@ callback has been told.
 8, When activity is detected, call curl_multi_socket_action() for the
 socket(s) that got action. If no activity is detected and the timeout expires,
 call \fIcurl_multi_socket_action(3)\fP with \fICURL_SOCKET_TIMEOUT\fP.
+.SH RETURN VALUE
+CURLMcode type, general libcurl multi interface error code. See
+\fIlibcurl-errors(3)\fP
 .SH AVAILABILITY
 This function was added in libcurl 7.15.4, and is deemed stable since 7.16.0.
 .SH "SEE ALSO"


### PR DESCRIPTION
.. because it may not be immediately clear to the user what
curl_multi_socket_action returns.

Ref: https://curl.se/mail/lib-2021-10/0035.html

Closes #xxxx