### PR TITLE
docs: provide "RETURN VALUE" section for more func manpages

### DIFF
--- a/docs/libcurl/curl_free.3
+++ b/docs/libcurl/curl_free.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -34,5 +34,7 @@ differences in memory management between your application and libcurl.
 
 Passing in a NULL pointer in \fIptr\fP will make this function return
 immediately with no action.
+.SH RETURN VALUE
+Nothing
 .SH "SEE ALSO"
 .BR curl_easy_unescape "(3), " curl_easy_escape "(3) "

--- a/docs/libcurl/curl_global_cleanup.3
+++ b/docs/libcurl/curl_global_cleanup.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -49,6 +49,8 @@ containing libcurl is dynamically unloaded while libcurl-created threads are
 still running then your program may crash or other corruption may occur. We
 recommend you do not run libcurl from any module that may be unloaded
 dynamically. This behavior may be addressed in the future.
+.SH RETURN VALUE
+Nothing
 .SH "SEE ALSO"
 .BR curl_global_init "(3), "
 .BR libcurl "(3), "

--- a/docs/libcurl/curl_global_init_mem.3
+++ b/docs/libcurl/curl_global_init_mem.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -59,6 +59,9 @@ to that man page for documentation.
 .SH "CAUTION"
 Manipulating these gives considerable powers to the application to severely
 screw things up for libcurl. Take care!
+.SH RETURN VALUE
+CURLE_OK (0) means everything was ok, non-zero means an error occurred as
+\fI<curl/curl.h>\fP defines - see \fIlibcurl-errors(3)\fP.
 .SH AVAILABILITY
 Added in 7.12.0
 .SH "SEE ALSO"

--- a/docs/libcurl/curl_multi_setopt.3
+++ b/docs/libcurl/curl_multi_setopt.3
@@ -69,7 +69,7 @@ See \fICURLMOPT_TIMERFUNCTION(3)\fP
 See \fICURLMOPT_TIMERDATA(3)\fP
 .IP CURLMOPT_MAX_CONCURRENT_STREAMS
 See \fICURLMOPT_MAX_CONCURRENT_STREAMS(3)\fP
-.SH RETURNS
+.SH RETURN VALUE
 The standard CURLMcode for multi interface error codes. Note that it returns a
 CURLM_UNKNOWN_OPTION if you try setting an option that this version of libcurl
 doesn't know of.


### PR DESCRIPTION
Three were missing, one used a non-standard name for the header.