### PR TITLE
configure.ac: replace krb5-config with pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1677,18 +1677,17 @@ AC_ARG_WITH(gssapi,
   fi
 ])
 
-: ${KRB5CONFIG:="$GSSAPI_ROOT/bin/krb5-config"}
-
 save_CPPFLAGS="$CPPFLAGS"
 AC_MSG_CHECKING([if GSS-API support is requested])
 if test x"$want_gss" = xyes; then
   AC_MSG_RESULT(yes)
 
+  CURL_CHECK_PKGCONFIG(mit-krb5-gssapi)
   if test -z "$GSSAPI_INCS"; then
      if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
         GSSAPI_INCS=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --cflags gssapi`
-     elif test -f "$KRB5CONFIG"; then
-        GSSAPI_INCS=`$KRB5CONFIG --cflags gssapi`
+     elif test "$PKGCONFIG" != "no" ; then
+        GSSAPI_INCS=`$PKGCONFIG --cflags mit-krb5-gssapi`
      elif test "$GSSAPI_ROOT" != "yes"; then
         GSSAPI_INCS="-I$GSSAPI_ROOT/include"
      fi
@@ -1773,15 +1772,14 @@ if test x"$want_gss" = xyes; then
         LIBS="-lgssapi_krb5 -lresolv $LIBS"
         ;;
      *)
+        CURL_CHECK_PKGCONFIG(mit-krb5-gssapi)
         if test -n "$host_alias" -a -f "$GSSAPI_ROOT/bin/$host_alias-krb5-config"; then
            dnl krb5-config doesn't have --libs-only-L or similar, put everything
            dnl into LIBS
            gss_libs=`$GSSAPI_ROOT/bin/$host_alias-krb5-config --libs gssapi`
            LIBS="$gss_libs $LIBS"
-        elif test -f "$KRB5CONFIG"; then
-           dnl krb5-config doesn't have --libs-only-L or similar, put everything
-           dnl into LIBS
-           gss_libs=`$KRB5CONFIG --libs gssapi`
+        elif test "$PKGCONFIG" != "no" ; then
+           gss_libs=`$PKGCONFIG --libs mit-krb5-gssapi`
            LIBS="$gss_libs $LIBS"
         else
            case $host in


### PR DESCRIPTION
The rationale is that custom *-config tools don't work well when cross-compiling or using
sysroots (such as when using Yocto project) and require custom fixing for each of them;
pkg-config on the other hand works similarly everywhere.
