### PR TITLE
check the return value of curl_url()

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2397,6 +2397,11 @@ static CURLcode parse_proxy(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   char *scheme = NULL;
 
+  if(!uhp) {
+    result = CURLE_OUT_OF_MEMORY;
+    goto error;
+  }
+
   /* When parsing the proxy, allowing non-supported schemes since we have
      these made up ones for proxies. Guess scheme for URLs without it. */
   uc = curl_url_set(uhp, CURLUPART_URL, proxy,


### PR DESCRIPTION
`curl_url() [lib/url.c:2396]` is a memory allocation function, however, the return value of it is not properly checked.
Though `curl_url_set() [lib/url.c:2402]` checks it and then returns `CURLUE_BAD_HANDLE`, this will still confuse the proper `result` of  `parse_proxy()`.