### PR TITLE
CI/runtests.pl: restore -u flag, but remove from CI runs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -305,7 +305,7 @@ test_script:
         if %BUILD_SYSTEM%==autotools (
           bash.exe -e -l -c "cd /c/projects/curl && make V=1 TFLAGS='%DISABLED_TESTS%' test-ci"
         ) else (
-          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm -u %DISABLED_TESTS%"
+          bash.exe -e -l -c "cd /c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm %DISABLED_TESTS%"
         ))
       )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,6 @@ add_runtests(test-am        "-a -am")
 add_runtests(test-full      "-a -p -r")
 # !flaky means that it'll skip all tests using the flaky keyword
 add_runtests(test-nonflaky  "-a -p !flaky")
-add_runtests(test-ci        "-a -p !flaky -r -rm -u")
+add_runtests(test-ci        "-a -p !flaky -r -rm")
 add_runtests(test-torture   "-a -t")
 add_runtests(test-event     "-a -e")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,7 +73,7 @@ TEST_E = -a -e
 TEST_NF = -a -p !flaky
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm -u
+TEST_CI = $(TEST_NF) -r -rm
 endif
 
 # make sure that PERL is pointing to an executable

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -6173,6 +6173,6 @@ else {
     }
 }
 
-if(($total && (($ok+$ign) != $total)) || !$total) {
+if(($total && (($ok+$ign) != $total)) || !$total || $unexpected) {
     exit 1;
 }


### PR DESCRIPTION
This makes it possible to use -u again for local testing,
but removes the flag from CI config files and make targets.

Partially reverts #7841