### PR TITLE
docs: improve CURLOPT_HSTSWRITEFUNCTION by making it clear that using CURLOPT_HSTS_CTRL is required

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
@@ -49,6 +49,9 @@ the syntax YYYYMMDD HH:MM:SS.
 The callback should return \fICURLSTS_OK\fP if it succeeded and is prepared to
 be called again (for another host) or \fICURLSTS_DONE\fP if there's nothing
 more to do. It can also return \fICURLSTS_FAIL\fP to signal error.
+
+This option doesn't enable HSTS, you need to use \fICURLOPT_HSTS_CTRL(3)\fP to
+do that.
 .SH DEFAULT
 NULL - no callback.
 .SH PROTOCOLS


### PR DESCRIPTION
Minor change to the documentation