### PR TITLE
manpages: Replace acute accent by single quote

### DIFF
--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -16,7 +16,7 @@ set, and uses the given path as a path to a CA cert bundle. This option
 overrides that variable.
 
 The windows version of curl will automatically look for a CA certs file named
-\'curl-ca-bundle.crt\', either in the same directory as curl.exe, or in the
+\(aqcurl-ca-bundle.crt\(aq, either in the same directory as curl.exe, or in the
 Current Working Directory, or in any folder along your PATH.
 
 If curl is built against the NSS SSL library, the NSS PEM PKCS#11 module

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -10,7 +10,7 @@ Added: 7.39.0
 Tells curl to use the specified public key file (or hashes) to verify the
 peer. This can be a path to a file which contains a single public key in PEM
 or DER format, or any number of base64 encoded sha256 hashes preceded by
-\'sha256//\' and separated by \';\'
+\(aqsha256//\(aq and separated by \(aq;\(aq
 
 When negotiating a TLS or SSL connection, the server sends a certificate
 indicating its identity. A public key is extracted from this certificate and

--- a/docs/cmdline-opts/proxy-pinnedpubkey.d
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.d
@@ -10,7 +10,7 @@ Added: 7.59.0
 Tells curl to use the specified public key file (or hashes) to verify the
 proxy. This can be a path to a file which contains a single public key in PEM
 or DER format, or any number of base64 encoded sha256 hashes preceded by
-\'sha256//\' and separated by \';\'
+\(aqsha256//\(aq and separated by \(aq;\(aq
 
 When negotiating a TLS or SSL connection, the server sends a certificate
 indicating its identity. A public key is extracted from this certificate and

--- a/docs/cmdline-opts/retry-max-time.d
+++ b/docs/cmdline-opts/retry-max-time.d
@@ -9,7 +9,7 @@ The retry timer is reset before the first transfer attempt. Retries will be
 done as usual (see --retry) as long as the timer hasn't reached this given
 limit. Notice that if the timer hasn't reached the limit, the request will be
 made and while performing, it may take longer than this given time period. To
-limit a single request\'s maximum time, use --max-time.  Set this option to
+limit a single request\(aqs maximum time, use --max-time.  Set this option to
 zero to not timeout retries.
 
 If this option is used several times, the last one will be used.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
@@ -35,7 +35,7 @@ colons. Commas or spaces are also acceptable separators but colons are
 normally used, \&!, \&- and \&+ can be used as operators.
 
 For OpenSSL and GnuTLS valid examples of cipher lists include 'RC4-SHA',
-\'SHA1+DES\', 'TLSv1' and 'DEFAULT'. The default list is normally set when you
+\(aqSHA1+DES\(aq, 'TLSv1' and 'DEFAULT'. The default list is normally set when you
 compile OpenSSL.
 
 You'll find more details about cipher lists on this URL:
@@ -43,7 +43,7 @@ You'll find more details about cipher lists on this URL:
  https://www.openssl.org/docs/apps/ciphers.html
 
 For NSS, valid examples of cipher lists include 'rsa_rc4_128_md5',
-\'rsa_aes_128_sha\', etc. With NSS you don't add/remove ciphers. If one uses
+\(aqrsa_aes_128_sha\(aq, etc. With NSS you don't add/remove ciphers. If one uses
 this option then all known ciphers are disabled and only those passed in are
 enabled.
 

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -35,7 +35,7 @@ spaces are also acceptable separators but colons are normally used, \&!, \&-
 and \&+ can be used as operators.
 
 For OpenSSL and GnuTLS valid examples of cipher lists include 'RC4-SHA',
-\'SHA1+DES\', 'TLSv1' and 'DEFAULT'. The default list is normally set when you
+\(aqSHA1+DES\(aq, 'TLSv1' and 'DEFAULT'. The default list is normally set when you
 compile OpenSSL.
 
 You'll find more details about cipher lists on this URL:
@@ -43,12 +43,12 @@ You'll find more details about cipher lists on this URL:
  https://curl.se/docs/ssl-ciphers.html
 
 For NSS, valid examples of cipher lists include 'rsa_rc4_128_md5',
-\'rsa_aes_128_sha\', etc. With NSS you don't add/remove ciphers. If one uses
+\(aqrsa_aes_128_sha\(aq, etc. With NSS you don't add/remove ciphers. If one uses
 this option then all known ciphers are disabled and only those passed in are
 enabled.
 
 For WolfSSL, valid examples of cipher lists include
-\'ECDHE-RSA-RC4-SHA\', 'AES256-SHA:AES256-SHA256', etc.
+\(aqECDHE-RSA-RC4-SHA\(aq, 'AES256-SHA:AES256-SHA256', etc.
 
 The application does not have to keep the string around after setting this
 option.


### PR DESCRIPTION
Hello,

This issue was flagged by Debian's lintian while preparing the package
there.

One should use the \(aq sequence when printing a single quote on a
manpage.  curl's manpages are currently using \', which will render as
an acute accent.  This commit fixes it.