### PR TITLE
gen.pl: replace leading single quotes with \(aq

### DIFF
--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -16,7 +16,7 @@ set, and uses the given path as a path to a CA cert bundle. This option
 overrides that variable.
 
 The windows version of curl will automatically look for a CA certs file named
-\'curl-ca-bundle.crt\', either in the same directory as curl.exe, or in the
+'curl-ca-bundle.crt', either in the same directory as curl.exe, or in the
 Current Working Directory, or in any folder along your PATH.
 
 If curl is built against the NSS SSL library, the NSS PEM PKCS#11 module

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -99,6 +99,8 @@ sub printdesc {
         # quote "bare" minuses in the output
         $d =~ s/( |\\fI|^)--/$1\\-\\-/g;
         $d =~ s/([ -]|\\fI|^)-/$1\\-/g;
+        # handle single quotes first on the line
+        $d =~ s/(\s*)\'/$1\\(aq/;
         print $d;
     }
 }

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -10,7 +10,7 @@ Added: 7.39.0
 Tells curl to use the specified public key file (or hashes) to verify the
 peer. This can be a path to a file which contains a single public key in PEM
 or DER format, or any number of base64 encoded sha256 hashes preceded by
-\'sha256//\' and separated by \';\'
+'sha256//' and separated by ';'.
 
 When negotiating a TLS or SSL connection, the server sends a certificate
 indicating its identity. A public key is extracted from this certificate and

--- a/docs/cmdline-opts/proxy-pinnedpubkey.d
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.d
@@ -10,7 +10,7 @@ Added: 7.59.0
 Tells curl to use the specified public key file (or hashes) to verify the
 proxy. This can be a path to a file which contains a single public key in PEM
 or DER format, or any number of base64 encoded sha256 hashes preceded by
-\'sha256//\' and separated by \';\'
+'sha256//' and separated by ';'.
 
 When negotiating a TLS or SSL connection, the server sends a certificate
 indicating its identity. A public key is extracted from this certificate and

--- a/docs/cmdline-opts/retry-max-time.d
+++ b/docs/cmdline-opts/retry-max-time.d
@@ -9,7 +9,7 @@ The retry timer is reset before the first transfer attempt. Retries will be
 done as usual (see --retry) as long as the timer hasn't reached this given
 limit. Notice that if the timer hasn't reached the limit, the request will be
 made and while performing, it may take longer than this given time period. To
-limit a single request\'s maximum time, use --max-time.  Set this option to
+limit a single request's maximum time, use --max-time.  Set this option to
 zero to not timeout retries.
 
 If this option is used several times, the last one will be used.


### PR DESCRIPTION
... and allow single quotes to be used "normally" in the .d files.

Makes the output curl.1 use better nroff.

Reported-by: Sergio Durigan Junior
