### PR TITLE
CURLOPT_[PROXY]_SSL_CIPHER_LIST.3: bold instead of quote

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
@@ -34,22 +34,21 @@ syntactically correct, it consists of one or more cipher strings separated by
 colons. Commas or spaces are also acceptable separators but colons are
 normally used, \&!, \&- and \&+ can be used as operators.
 
-For OpenSSL and GnuTLS valid examples of cipher lists include 'RC4-SHA',
-\'SHA1+DES\', 'TLSv1' and 'DEFAULT'. The default list is normally set when you
-compile OpenSSL.
+For OpenSSL and GnuTLS valid examples of cipher lists include \fBRC4-SHA\fP,
+\fBSHA1+DES\fP, \fBTLSv1\fP and \fBDEFAULT\fP. The default list is normally
+set when you compile OpenSSL.
 
-You'll find more details about cipher lists on this URL:
-
- https://www.openssl.org/docs/apps/ciphers.html
-
-For NSS, valid examples of cipher lists include 'rsa_rc4_128_md5',
-\'rsa_aes_128_sha\', etc. With NSS you don't add/remove ciphers. If one uses
+For NSS, valid examples of cipher lists include \fBrsa_rc4_128_md5\fP,
+\fBrsa_aes_128_sha\fP, etc. With NSS you don't add/remove ciphers. If one uses
 this option then all known ciphers are disabled and only those passed in are
 enabled.
 
-You'll find more details about the NSS cipher lists on this URL:
+For WolfSSL, valid examples of cipher lists include \fBECDHE-RSA-RC4-SHA\fP,
+\fBAES256-SHA:AES256-SHA256\fP, etc.
 
- http://git.fedorahosted.org/cgit/mod_nss.git/plain/docs/mod_nss.html#Directives
+You'll find more details about cipher lists on this URL:
+
+ https://curl.se/docs/ssl-ciphers.html
 
 The application does not have to keep the string around after setting this
 option.

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -34,21 +34,21 @@ it consists of one or more cipher strings separated by colons. Commas or
 spaces are also acceptable separators but colons are normally used, \&!, \&-
 and \&+ can be used as operators.
 
-For OpenSSL and GnuTLS valid examples of cipher lists include 'RC4-SHA',
-\'SHA1+DES\', 'TLSv1' and 'DEFAULT'. The default list is normally set when you
-compile OpenSSL.
+For OpenSSL and GnuTLS valid examples of cipher lists include \fBRC4-SHA\fP,
+\fBSHA1+DES\fP, \fBTLSv1\fP and \fBDEFAULT\fP. The default list is normally
+set when you compile OpenSSL.
+
+For NSS, valid examples of cipher lists include \fBrsa_rc4_128_md5\fP,
+\fBrsa_aes_128_sha\fP, etc. With NSS you don't add/remove ciphers. If one uses
+this option then all known ciphers are disabled and only those passed in are
+enabled.
+
+For WolfSSL, valid examples of cipher lists include \fBECDHE-RSA-RC4-SHA\fP,
+\fBAES256-SHA:AES256-SHA256\fP, etc.
 
 You'll find more details about cipher lists on this URL:
 
  https://curl.se/docs/ssl-ciphers.html
-
-For NSS, valid examples of cipher lists include 'rsa_rc4_128_md5',
-\'rsa_aes_128_sha\', etc. With NSS you don't add/remove ciphers. If one uses
-this option then all known ciphers are disabled and only those passed in are
-enabled.
-
-For WolfSSL, valid examples of cipher lists include
-\'ECDHE-RSA-RC4-SHA\', 'AES256-SHA:AES256-SHA256', etc.
 
 The application does not have to keep the string around after setting this
 option.


### PR DESCRIPTION
Bold the example ciphers instead of using single quotes, which then also
avoids the problem of how to use single quotes when first in a line.

Also rephrased the pages a little.

Reported-by: Sergio Durigan Junior
Ref: #7928