### PR TITLE
curl.1: Fix typo in the manpage

### DIFF
--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -28,7 +28,7 @@ curl \- transfer a URL
 .SH SYNOPSIS
 .B curl [options / URLs]
 .SH DESCRIPTION
-**curl** is a tool for transfering data from or to a server. It supports these
+**curl** is a tool for transferring data from or to a server. It supports these
 protocols: DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS,
 LDAP, LDAPS, MQTT, POP3, POP3S, RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SMBS, SMTP,
 SMTPS, TELNET or TFTP. The command is designed to work without user

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -113,7 +113,7 @@ The URL scheme (sometimes called protocol) that was effectively used. (Added in 
 .TP
 .B size_download
 The total amount of bytes that were downloaded. This is the size of the
-body/data that was transfered, excluding headers.
+body/data that was transferred, excluding headers.
 .TP
 .B size_header
 The total amount of bytes of the downloaded headers.
@@ -123,7 +123,7 @@ The total amount of bytes that were sent in the HTTP request.
 .TP
 .B size_upload
 The total amount of bytes that were uploaded. This is the size of the
-body/data that was transfered, excluding headers.
+body/data that was transferred, excluding headers.
 .TP
 .B speed_download
 The average download speed that curl measured for the complete download. Bytes


### PR DESCRIPTION
There are typos in the `curl.1` manpage (`transfering` instead of
`transferring`; `transfered` instead of `transferred`).  This commit
fixes them.