### PR TITLE
If query replaces the long switch case with the same function

### DIFF
--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -36,60 +36,8 @@ char Curl_raw_toupper(char in)
   if(in >= 'a' && in <= 'z')
     return (char)('A' + in - 'a');
 #else
-  switch(in) {
-  case 'a':
-    return 'A';
-  case 'b':
-    return 'B';
-  case 'c':
-    return 'C';
-  case 'd':
-    return 'D';
-  case 'e':
-    return 'E';
-  case 'f':
-    return 'F';
-  case 'g':
-    return 'G';
-  case 'h':
-    return 'H';
-  case 'i':
-    return 'I';
-  case 'j':
-    return 'J';
-  case 'k':
-    return 'K';
-  case 'l':
-    return 'L';
-  case 'm':
-    return 'M';
-  case 'n':
-    return 'N';
-  case 'o':
-    return 'O';
-  case 'p':
-    return 'P';
-  case 'q':
-    return 'Q';
-  case 'r':
-    return 'R';
-  case 's':
-    return 'S';
-  case 't':
-    return 'T';
-  case 'u':
-    return 'U';
-  case 'v':
-    return 'V';
-  case 'w':
-    return 'W';
-  case 'x':
-    return 'X';
-  case 'y':
-    return 'Y';
-  case 'z':
-    return 'Z';
-  }
+  if(in >= 'a' && in <= 'z')
+    return (char)(in - ' ');
 #endif
 
   return in;
@@ -104,60 +52,8 @@ static char raw_tolower(char in)
   if(in >= 'A' && in <= 'Z')
     return (char)('a' + in - 'A');
 #else
-  switch(in) {
-  case 'A':
-    return 'a';
-  case 'B':
-    return 'b';
-  case 'C':
-    return 'c';
-  case 'D':
-    return 'd';
-  case 'E':
-    return 'e';
-  case 'F':
-    return 'f';
-  case 'G':
-    return 'g';
-  case 'H':
-    return 'h';
-  case 'I':
-    return 'i';
-  case 'J':
-    return 'j';
-  case 'K':
-    return 'k';
-  case 'L':
-    return 'l';
-  case 'M':
-    return 'm';
-  case 'N':
-    return 'n';
-  case 'O':
-    return 'o';
-  case 'P':
-    return 'p';
-  case 'Q':
-    return 'q';
-  case 'R':
-    return 'r';
-  case 'S':
-    return 's';
-  case 'T':
-    return 't';
-  case 'U':
-    return 'u';
-  case 'V':
-    return 'v';
-  case 'W':
-    return 'w';
-  case 'X':
-    return 'x';
-  case 'Y':
-    return 'y';
-  case 'Z':
-    return 'z';
-  }
+  if(in >= 'a' && in <= 'z')
+    return (char)(in + ' ');
 #endif
 
   return in;


### PR DESCRIPTION
I'm happy to be proven wrong, but the switch case does exactly the same thing as this short if query. Of course, this would also be possible via switch, but would not be as nice in my opinion.
e.g.
```
case 'a': case 'b': etc...
        return (char) in - ' ';
```

Even after short performance tests, this solution is faster than using the long switch case.