### PR TITLE
tests/*.py: support Python 2 again while preferring Python 3

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -209,14 +209,14 @@ stages:
           name: 32-bit OpenSSL/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
-          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
+          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2 mingw-w64-i686-python-pip mingw-w64-i686-python-wheel mingw-w64-i686-python-pyopenssl && python3 -m pip install --prefer-binary impacket
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2 --with-openssl
           tests: "~571"
         msys2_mingw64_debug_openssl:
           name: 64-bit OpenSSL/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
-          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
+          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2 mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-wheel mingw-w64-x86_64-python-pyopenssl && python3 -m pip install --prefer-binary impacket
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2 --with-openssl
           tests: "~571"
         msys2_mingw64_debug_libssh:
@@ -248,14 +248,14 @@ stages:
           name: 32-bit Schannel/SSPI/WinIDN/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
-          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
+          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2 mingw-w64-i686-python-pip mingw-w64-i686-python-wheel mingw-w64-i686-python-pyopenssl && python3 -m pip install --prefer-binary impacket
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
           tests: "~571"
         msys2_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
-          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
+          prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2 mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-wheel mingw-w64-x86_64-python-pyopenssl && python3 -m pip install --prefer-binary impacket
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
           tests: "~571"
         msys1_mingw_debug_schannel:

--- a/.github/workflows/linux-hyper.yml
+++ b/.github/workflows/linux-hyper.yml
@@ -28,6 +28,9 @@ jobs:
     - run: sudo apt-get install libtool autoconf automake pkg-config
       name: install prereqs
 
+    - run: python3 -m pip install impacket
+      name: 'pip3 install'
+
     - run: (cd $HOME;
         git clone --depth=1 https://github.com/hyperium/hyper.git;
         curl https://sh.rustup.rs -sSf | sh -s -- -y;

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,6 +80,9 @@ jobs:
     - run: brew update && for i in 1 2 3; do brew bundle install --no-lock --file /tmp/Brewfile && break || sleep 1; done
       name: 'brew install'
 
+    - run: python3 -m pip install impacket
+      name: 'pip3 install'
+
     - uses: actions/checkout@v2
 
     - run: ./buildconf && ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
@@ -126,6 +129,9 @@ jobs:
 
     - run: brew update && brew bundle install --no-lock --file /tmp/Brewfile
       name: 'brew install'
+
+    - run: python3 -m pip install impacket
+      name: 'pip3 install'
 
     - uses: actions/checkout@v2
 

--- a/tests/data/test1451
+++ b/tests/data/test1451
@@ -28,9 +28,6 @@ Basic SMB request
 <command>
 -u 'curltest:curltest' smb://%HOSTIP:%SMBPORT/TESTS/%TESTNUMBER
 </command>
-<precheck>
-python3 -c "__import__('pkgutil').find_loader('impacket') or (__import__('sys').stdout.write('Test only works if Python package impacket is installed\n'), __import__('sys').exit(1))"
-</precheck>
 </client>
 
 #

--- a/tests/dictserver.py
+++ b/tests/dictserver.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
+#!/bin/sh
 # -*- coding: utf-8 -*-
-#***************************************************************************
 #                                  _   _ ____  _
 #  Project                     ___| | | |  _ \| |
 #                             / __| | | | |_) | |
@@ -20,13 +19,17 @@
 # This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 # KIND, either express or implied.
 #
-###########################################################################
 #
-""" DICT server """
-
+# The following 3 lines implement a fallback from the interpreter named python3
+# to the interpreter named python. This way we prefer Python 3 over Python 2.
+# It works by executing the 2nd line using a shell which then executes Python.
+""":"
+exec "$(command -v python3 || command -v python)" "$0" "$@"
+":"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+""" DICT server"""
 import argparse
 import logging
 import os

--- a/tests/negtelnetserver.py
+++ b/tests/negtelnetserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/bin/sh
 # -*- coding: utf-8 -*-
 #
 #  Project                     ___| | | |  _ \| |
@@ -19,11 +19,17 @@
 # This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 # KIND, either express or implied.
 #
-""" A telnet server which negotiates"""
-
+#
+# The following 3 lines implement a fallback from the interpreter named python3
+# to the interpreter named python. This way we prefer Python 3 over Python 2.
+# It works by executing the 2nd line using a shell which then executes Python.
+""":"
+exec "$(command -v python3 || command -v python)" "$0" "$@"
+":"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+""" A telnet server which negotiates"""
 import argparse
 import logging
 import os

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/bin/sh
 # -*- coding: utf-8 -*-
 #
 #  Project                     ___| | | |  _ \| |
@@ -19,11 +19,17 @@
 # This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 # KIND, either express or implied.
 #
-"""Server for testing SMB"""
-
+#
+# The following 3 lines implement a fallback from the interpreter named python3
+# to the interpreter named python. This way we prefer Python 3 over Python 2.
+# It works by executing the 2nd line using a shell which then executes Python.
+""":"
+exec "$(command -v python3 || command -v python)" "$0" "$@"
+":"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+"""Server for testing SMB"""
 import argparse
 import logging
 import os

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/bin/sh
 # -*- coding: utf-8 -*-
 #
 #  Project                     ___| | | |  _ \| |
@@ -19,11 +19,17 @@
 # This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 # KIND, either express or implied.
 #
-"""Module for extracting test data from the test data folder and other utils"""
-
+#
+# The following 3 lines implement a fallback from the interpreter named python3
+# to the interpreter named python. This way we prefer Python 3 over Python 2.
+# It works by executing the 2nd line using a shell which then executes Python.
+""":"
+exec "$(command -v python3 || command -v python)" "$0" "$@"
+":"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+"""Module for extracting test data from the test data folder and other utils"""
 import logging
 import os
 import re


### PR DESCRIPTION
This makes it possible to use the Python-based test servers
again in legacy environments which do not have modern Python.

Follow up to #7602 which broke Python 2 support
Follow up to #7935 which fixed impacket support