### PR TITLE
Revert "src/tool_filetime: disable -Wformat on mingw for this file"

### DIFF
--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -30,11 +30,6 @@
 #  include <sys/utime.h>
 #endif
 
-#if defined(__GNUC__) && defined(__MINGW32__)
-/* GCC 10 on mingw has issues with this, disable */
-#pragma GCC diagnostic ignored "-Wformat"
-#endif
-
 curl_off_t getfiletime(const char *filename, struct GlobalConfig *global)
 {
   curl_off_t result = -1;


### PR DESCRIPTION
This reverts commit 7c88fe375b15c44d77bccc9ab733b8069d228e6f.

Follow up to #6535 as the pragma is obsolete with warnf