### PR TITLE
tool_operate: don't make a failed etag save a fatal error

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -60,7 +60,8 @@ test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \
 test352 test353 test354 test355 test356 test357 test358 test359 test360 \
-test361 test362 test363 test364 test365 test366 test367 test368 \
+test361 test362 test363 test364 test365 test366 test367 test368 test369 \
+test370 \
 \
 test392 test393 test394 test395 test396 test397 \
 \

--- a/tests/data/test369
+++ b/tests/data/test369
@@ -1,0 +1,47 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+etag
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Content-Length: 4
+Content-Type: text/html
+
+hej
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+--etag-save with bad path then working transfer
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --etag-save log/nowhere/etag%TESTNUMBER --next http://%HOSTIP:%HTTPPORT/%TESTNUMBER --include --output log/curl%TESTNUMBER.out
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test370
+++ b/tests/data/test370
@@ -1,0 +1,36 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+etag
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+--etag-save with bad path - no transfer
+</name>
+<command>
+http://%HOSTIP:%NOLISTENPORT/%TESTNUMBER --etag-save log/nowhere/etag%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+26
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
When failing to create the output file for saving an etag, only fail
that particular single transfer and allow others to follow.

In a serial transfer setup, if no transfer at all is done due to them
all being skipped because of this error, curl will output an error
message and return exit code 26.

Reported-by: Earnestly on github
Ref: #7942