### PR TITLE
vtls/rustls: update to compile with rustls-ffi tip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -672,7 +672,7 @@ if test X"$want_hyper" != Xno; then
     LIB_HYPER="-lhyper -ldl -lpthread -lm"
     if test X"$want_hyper" != Xdefault; then
       CPP_HYPER=-I"$want_hyper_path/capi/include"
-      LD_HYPER="-L$want_hyper_path/target/debug"
+      LD_HYPER="-L$want_hyper_path/target/release -L$want_hyper_path/target/debug"
     fi
   fi
   if test -n "$LIB_HYPER"; then

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -3,7 +3,7 @@
 [Rustls is a TLS backend written in Rust.](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.7.0 of rustls-ffi.
+version of curl depends on version v0.8.0 of rustls-ffi.
 
 # Building with rustls
 
@@ -12,7 +12,7 @@ First, [install Rust](https://rustup.rs/).
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
     % cargo install cbindgen
-    % git clone https://github.com/rustls/rustls-ffi -b v0.7.0
+    % git clone https://github.com/rustls/rustls-ffi -b v0.8.0
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -165,12 +165,13 @@ cr_recv(struct Curl_easy *data, int sockindex,
       *err = CURLE_OK;
       return 0;
     }
-    else if(rresult != RUSTLS_RESULT_OK) {
+    else if(rresult != RUSTLS_RESULT_OK &&
+            rresult != RUSTLS_RESULT_PLAINTEXT_EMPTY) {
       failf(data, "error in rustls_connection_read");
       *err = CURLE_READ_ERROR;
       return -1;
     }
-    else if(n == 0) {
+    else if(n == 0 || rresult == RUSTLS_RESULT_PLAINTEXT_EMPTY) {
       /* rustls returns 0 from connection_read to mean "all currently
         available data has been read." If we bring in more ciphertext with
         read_tls, more plaintext will become available. So don't tell curl

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -544,6 +544,12 @@ cr_close(struct Curl_easy *data, struct connectdata *conn,
   }
 }
 
+static size_t cr_version(char *buffer, size_t size)
+{
+  struct rustls_str ver = rustls_version();
+  return msnprintf(buffer, size, "%s", ver.data);
+}
+
 const struct Curl_ssl Curl_ssl_rustls = {
   { CURLSSLBACKEND_RUSTLS, "rustls" },
   SSLSUPP_TLS13_CIPHERSUITES,      /* supports */
@@ -551,7 +557,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
 
   Curl_none_init,                  /* init */
   Curl_none_cleanup,               /* cleanup */
-  rustls_version,                  /* version */
+  cr_version,                      /* version */
   Curl_none_check_cxn,             /* check_cxn */
   Curl_none_shutdown,              /* shutdown */
   cr_data_pending,                 /* data_pending */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -27,7 +27,7 @@
 #include "curl_printf.h"
 
 #include <errno.h>
-#include <crustls.h>
+#include <rustls.h>
 
 #include "inet_pton.h"
 #include "urldata.h"
@@ -309,10 +309,10 @@ cr_init_backend(struct Curl_easy *data, struct connectdata *conn,
   config_builder = rustls_client_config_builder_new();
 #ifdef USE_HTTP2
   infof(data, "offering ALPN for HTTP/1.1 and HTTP/2");
-  rustls_client_config_builder_set_protocols(config_builder, alpn, 2);
+  rustls_client_config_builder_set_alpn_protocols(config_builder, alpn, 2);
 #else
   infof(data, "offering ALPN for HTTP/1.1 only");
-  rustls_client_config_builder_set_protocols(config_builder, alpn, 1);
+  rustls_client_config_builder_set_alpn_protocols(config_builder, alpn, 1);
 #endif
   if(!verifypeer) {
     rustls_client_config_builder_dangerous_set_certificate_verifier(

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -161,7 +161,7 @@ cr_recv(struct Curl_easy *data, int sockindex,
       (uint8_t *)plainbuf + plain_bytes_copied,
       plainlen - plain_bytes_copied,
       &n);
-    if(rresult == RUSTLS_RESULT_ALERT_CLOSE_NOTIFY) {
+    if(n == 0) {
       *err = CURLE_OK;
       return 0;
     }
@@ -171,11 +171,7 @@ cr_recv(struct Curl_easy *data, int sockindex,
       *err = CURLE_READ_ERROR;
       return -1;
     }
-    else if(n == 0 || rresult == RUSTLS_RESULT_PLAINTEXT_EMPTY) {
-      /* rustls returns 0 from connection_read to mean "all currently
-        available data has been read." If we bring in more ciphertext with
-        read_tls, more plaintext will become available. So don't tell curl
-        this is an EOF. Instead, say "come back later." */
+    else if(rresult == RUSTLS_RESULT_PLAINTEXT_EMPTY) {
       infof(data, "cr_recv got 0 bytes of plaintext");
       backend->data_pending = FALSE;
       break;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -161,20 +161,20 @@ cr_recv(struct Curl_easy *data, int sockindex,
       (uint8_t *)plainbuf + plain_bytes_copied,
       plainlen - plain_bytes_copied,
       &n);
-    if(n == 0) {
-      *err = CURLE_OK;
-      return 0;
-    }
-    else if(rresult != RUSTLS_RESULT_OK &&
-            rresult != RUSTLS_RESULT_PLAINTEXT_EMPTY) {
-      failf(data, "error in rustls_connection_read");
-      *err = CURLE_READ_ERROR;
-      return -1;
-    }
-    else if(rresult == RUSTLS_RESULT_PLAINTEXT_EMPTY) {
+    if(rresult == RUSTLS_RESULT_PLAINTEXT_EMPTY) {
       infof(data, "cr_recv got 0 bytes of plaintext");
       backend->data_pending = FALSE;
       break;
+    }
+    else if(rresult != RUSTLS_RESULT_OK) {
+      /* n always equals 0 in this case, don't need to check it */
+      failf(data, "error in rustls_connection_read: %d", rresult);
+      *err = CURLE_READ_ERROR;
+      return -1;
+    }
+    else if(n == 0) {
+      *err = CURLE_OK;
+      return 0;
     }
     else {
       infof(data, "cr_recv copied out %ld bytes of plaintext", n);
@@ -543,7 +543,7 @@ cr_close(struct Curl_easy *data, struct connectdata *conn,
 static size_t cr_version(char *buffer, size_t size)
 {
   struct rustls_str ver = rustls_version();
-  return msnprintf(buffer, size, "%s", ver.data);
+  return msnprintf(buffer, size, "%.*s", (int)ver.len, ver.data);
 }
 
 const struct Curl_ssl Curl_ssl_rustls = {

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -39,8 +39,8 @@ if test "x$OPT_RUSTLS" != xno; then
     if test -z "$OPT_RUSTLS" ; then
       dnl check for lib first without setting any new path
 
-      AC_CHECK_LIB(crustls, rustls_client_session_read,
-      dnl libcrustls found, set the variable
+      AC_CHECK_LIB(rustls, rustls_client_session_read,
+      dnl librustls found, set the variable
        [
          AC_DEFINE(USE_RUSTLS, 1, [if rustls is enabled])
          AC_SUBST(USE_RUSTLS, [1])
@@ -67,7 +67,7 @@ if test "x$OPT_RUSTLS" != xno; then
          CPPFLAGS="$CPPFLAGS $addcflags"
       fi
 
-      AC_CHECK_LIB(crustls, rustls_connection_read,
+      AC_CHECK_LIB(rustls, rustls_connection_read,
        [
        AC_DEFINE(USE_RUSTLS, 1, [if rustls is enabled])
        AC_SUBST(USE_RUSTLS, [1])
@@ -84,7 +84,7 @@ if test "x$OPT_RUSTLS" != xno; then
       AC_MSG_NOTICE([detected rustls])
       check_for_ca_bundle=1
 
-      LIBS="-lcrustls -lpthread -ldl $LIBS"
+      LIBS="-lrustls -lpthread -ldl $LIBS"
 
       if test -n "$rustlslib"; then
         dnl when shared libs were found in a path that the run-time

--- a/scripts/zuul/before_script.sh
+++ b/scripts/zuul/before_script.sh
@@ -138,7 +138,7 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS_VERSION" ]; then
   cargo install cbindgen
   cd $HOME/rustls-ffi
   make
-  make DESTDIR=$HOME/crust install
+  make DESTDIR=$HOME/rustls install
 fi
 
 if [ $TRAVIS_OS_NAME = linux -a "$WOLFSSL" ]; then

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -131,10 +131,10 @@
         - libzstd-dev
       curl_env:
         T: debug-rustls
-        RUSTLS_VERSION: v0.7.2
+        RUSTLS_VERSION: v0.8.0
         LIBS: -lm
         C: >-
-          --with-rustls={{ ansible_user_dir }}/crust
+          --with-rustls={{ ansible_user_dir }}/rustls
 
 - job:
     name: curl-debug-bearssl

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -131,6 +131,7 @@
         - libzstd-dev
       curl_env:
         T: debug-rustls
+        # Keep this in sync with the version in docs/RUSTLS.md
         RUSTLS_VERSION: v0.8.0
         LIBS: -lm
         C: >-


### PR DESCRIPTION
Some method names were changed in a recent refactoring. We have no
compatibility guarantee with rustls currently, so rustls-ffi tip is
probably the best commit to target.

Fixes #7947.