### PR TITLE
zuul: build quiche with BoringSSL built separately

### DIFF
--- a/scripts/zuul/before_script.sh
+++ b/scripts/zuul/before_script.sh
@@ -120,9 +120,7 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
   cd $HOME/quiche
-  cargo build -v --release --features ffi,pkg-config-meta,qlog
-  mkdir -v deps/boringssl/src/lib
-  ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
+  QUICHE_BSSL_PATH=$HOME/boringssl cargo build -v --release --features ffi,pkg-config-meta,qlog
 fi
 
 if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS_VERSION" ]; then

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -107,6 +107,7 @@
     name: curl-novalgrind-boringssl-with-openssl-quiche
     parent: curl-base
     vars:
+      gimme_stable: true
       curl_apt_packages:
         - libpsl-dev
         - libbrotli-dev

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -115,9 +115,10 @@
         CC: gcc-8
         CXX: g++-8
         T: novalgrind
+        BORINGSSL: "yes"
         QUICHE: "yes"
         C: >-
-          --with-openssl={{ ansible_user_dir }}/quiche/deps/boringssl/src
+          --with-openssl={{ ansible_user_dir }}/boringssl
           --with-quiche={{ ansible_user_dir }}/quiche/target/release
         LD_LIBRARY_PATH: "{{ ansible_user_dir }}/quiche/target/release:/usr/local/lib"
 


### PR DESCRIPTION
... in an attempt to avoid BoringSSL using cmake --parallel because
that's an option that doesn't exist in the cmake shipped in Ubuntu
Bionic, which is a system commonly used in our CI systems.

Fixes #7927