### PR TITLE
.github: retry macos "brew install" command on failure

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,7 +70,10 @@ jobs:
     - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 
-    - run: brew update && brew bundle install --no-lock --file /tmp/Brewfile
+    # Run this command with retries because of spurious failures seen
+    # while running the tests, for example
+    # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
+    - run: brew update && for i in 1 2 3; do brew bundle install --no-lock --file /tmp/Brewfile && break || sleep 1; done
       name: 'brew install'
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
Previously we saw errors attempting to run "brew install", see
https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
for an example, since this command is idempotent, it is safe to run
again.