### PR TITLE
ngtcp2: support latest QUIC TLS RFC9001

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -303,7 +303,7 @@ static int quic_init_ssl(struct quicsocket *qs)
 
   SSL_set_app_data(qs->ssl, qs);
   SSL_set_connect_state(qs->ssl);
-  SSL_set_quic_use_legacy_codepoint(qs->ssl, 1);
+  SSL_set_quic_use_legacy_codepoint(qs->ssl, 0);
 
   alpn = (const uint8_t *)H3_ALPN_H3_29;
   alpnlen = sizeof(H3_ALPN_H3_29) - 1;


### PR DESCRIPTION
QUIC Transport Parameters Extension has been changed between draft-29
and latest RFC9001. Most notably, its identifier has been updated from
0xffa5 to 0x0039. The version is selected through the QUIC TLS library
via the legacy codepoint.

Disable the usage of legacy codepoint in curl to switch to latest
RFC9001. This is required to be able to keep up with latest QUIC
implementations.