### PR TITLE
man pages: fix backslash-n in examples

### DIFF
--- a/docs/libcurl/curl_easy_getinfo.3
+++ b/docs/libcurl/curl_easy_getinfo.3
@@ -295,7 +295,7 @@ transaction was started. So, this is zero if no redirection took place.
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &ct);
 
       if((CURLE_OK == res) && ct)
-        printf("We received Content-Type: %s\n", ct);
+        printf("We received Content-Type: %s\\n", ct);
     }
 
     /* always cleanup */

--- a/docs/libcurl/curl_easy_option_by_id.3
+++ b/docs/libcurl/curl_easy_option_by_id.3
@@ -41,7 +41,7 @@ If libcurl has no option with the given id, this function returns NULL.
 .nf
 const struct curl_easyoption *opt = curl_easy_option_by_id(CURLOPT_URL);
 if(opt) {
-  printf("This option wants type %x\n", opt->type);
+  printf("This option wants type %x\\n", opt->type);
 }
 .fi
 .SH AVAILABILITY

--- a/docs/libcurl/curl_easy_option_by_name.3
+++ b/docs/libcurl/curl_easy_option_by_name.3
@@ -39,7 +39,7 @@ If libcurl has no option with the given name, this function returns NULL.
 .nf
 const struct curl_easyoption *opt = curl_easy_option_by_name("URL");
 if(opt) {
-  printf("This option wants CURLoption %x\n", (int)opt->id);
+  printf("This option wants CURLoption %x\\n", (int)opt->id);
 }
 .fi
 .SH AVAILABILITY

--- a/docs/libcurl/curl_easy_option_next.3
+++ b/docs/libcurl/curl_easy_option_next.3
@@ -70,7 +70,7 @@ name is provided for backwards compatibility as an alias.
 const struct curl_easyoption *opt;
 opt = curl_easy_option_by_next(NULL);
 while(opt) {
-  printf("Name: %s\n", opt->name);
+  printf("Name: %s\\n", opt->name);
   opt = curl_easy_option_by_next(opt);
 }
 .fi

--- a/docs/libcurl/curl_easy_strerror.3
+++ b/docs/libcurl/curl_easy_strerror.3
@@ -38,7 +38,7 @@ specific error descriptions generated at run-time.
   res = curl_easy_perform(curl);
   /* Check for errors */
   if(res != CURLE_OK)
-    fprintf(stderr, "curl_easy_perform() failed: %s\n",
+    fprintf(stderr, "curl_easy_perform() failed: %s\\n",
             curl_easy_strerror(res));
 .fi
 .SH AVAILABILITY

--- a/docs/libcurl/curl_global_sslset.3
+++ b/docs/libcurl/curl_global_sslset.3
@@ -92,7 +92,7 @@ This doesn't just mean no other thread that is using libcurl.
   curl_global_sslset((curl_sslbackend)-1, NULL, &list);
 
   for(i = 0; list[i]; i++)
-    printf("SSL backend #%d: '%s' (ID: %d)\n",
+    printf("SSL backend #%d: '%s' (ID: %d)\\n",
            i, list[i]->name, list[i]->id);
 .fi
 .SH AVAILABILITY

--- a/docs/libcurl/curl_mprintf.3
+++ b/docs/libcurl/curl_mprintf.3
@@ -241,8 +241,8 @@ by the corresponding argument.
 A '%' is written. No argument is converted.
 .SH EXAMPLE
 .nf
-  mprintf("My name is %s\n", name);
-  mprintf("Pi is almost %f\n", 25/8);
+  mprintf("My name is %s\\n", name);
+  mprintf("Pi is almost %f\\n", 25/8);
 .fi
 .SH AVAILABILITY
 These functions will be removed from the public libcurl API in the future. Do

--- a/docs/libcurl/curl_multi_fdset.3
+++ b/docs/libcurl/curl_multi_fdset.3
@@ -81,7 +81,7 @@ for...
  mc = curl_multi_fdset(multi_handle, &fdread, &fdwrite, &fdexcep, &maxfd);
 
  if(mc != CURLM_OK) {
-   fprintf(stderr, "curl_multi_fdset() failed, code %d.\n", mc);
+   fprintf(stderr, "curl_multi_fdset() failed, code %d.\\n", mc);
    break;
  }
 

--- a/docs/libcurl/curl_multi_perform.3
+++ b/docs/libcurl/curl_multi_perform.3
@@ -63,7 +63,7 @@ do {
     mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
 
   if(mc) {
-    fprintf(stderr, "curl_multi_poll() failed, code %d.\n", (int)mc);
+    fprintf(stderr, "curl_multi_poll() failed, code %d.\\n", (int)mc);
     break;
   }
 

--- a/docs/libcurl/curl_multi_remove_handle.3
+++ b/docs/libcurl/curl_multi_remove_handle.3
@@ -47,7 +47,7 @@ msg = curl_multi_info_read(multi_handle, &queued);
 if(msg) {
   if(msg->msg == CURLMSG_DONE) {
     /* a transfer ended */
-    fprintf(stderr, "Transfer completed\n");
+    fprintf(stderr, "Transfer completed\\n");
     curl_multi_remove_handle(multi_handle, msg->easy_handle);
   }
 }

--- a/docs/libcurl/curl_multi_strerror.3
+++ b/docs/libcurl/curl_multi_strerror.3
@@ -35,7 +35,7 @@ int still_running;
 
 CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
 if(mc)
-  printf("error: %s\n", curl_multi_strerror(mc));
+  printf("error: %s\\n", curl_multi_strerror(mc));
 .fi
 .SH AVAILABILITY
 This function was added in libcurl 7.12.0

--- a/docs/libcurl/curl_share_init.3
+++ b/docs/libcurl/curl_share_init.3
@@ -42,7 +42,7 @@ specific curl handle use the data in this share.
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   if(sh)
-    printf("Error: %s\n", curl_share_strerror(sh));
+    printf("Error: %s\\n", curl_share_strerror(sh));
 .fi
 .SH AVAILABILITY
 Added in 7.10

--- a/docs/libcurl/curl_share_setopt.3
+++ b/docs/libcurl/curl_share_setopt.3
@@ -112,7 +112,7 @@ to the lock_function and unlock_function each time it is called.
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   if(sh)
-    printf("Error: %s\n", curl_share_strerror(sh));
+    printf("Error: %s\\n", curl_share_strerror(sh));
 .fi
 .SH AVAILABILITY
 Added in 7.10

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -35,7 +35,7 @@ error code passed in the argument \fIerrornum\fP.
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   if(sh)
-    printf("Error: %s\n", curl_share_strerror(sh));
+    printf("Error: %s\\n", curl_share_strerror(sh));
 .fi
 .SH AVAILABILITY
 This function was added in libcurl 7.12.0

--- a/docs/libcurl/curl_strequal.3
+++ b/docs/libcurl/curl_strequal.3
@@ -44,9 +44,9 @@ insensitive string comparison functions. These two work on all platforms.
 .SH EXAMPLE
 .nf
 if(curl_strequal(name, input))
-  printf("Name and input matches\n");
+  printf("Name and input matches\\n");
 if(curl_strnequal(name, input, 5))
-  printf("Name and input matches in the 5 first bytes\n");
+  printf("Name and input matches in the 5 first bytes\\n");
 .fi
 .SH AVAILABILITY
 These functions will be removed from the public libcurl API in a near

--- a/docs/libcurl/curl_url_strerror.3
+++ b/docs/libcurl/curl_url_strerror.3
@@ -35,7 +35,7 @@ error code passed in the argument \fIerrornum\fP.
   CURLU *url = curl_url();
   rc = curl_url_set(url, CURLUPART_URL, "https://example.com", 0);
   if(rc)
-    printf("URL error: %s\n", curl_url_strerror(rc));
+    printf("URL error: %s\\n", curl_url_strerror(rc));
   curl_url_cleanup(url);
 .fi
 

--- a/docs/libcurl/curl_version.3
+++ b/docs/libcurl/curl_version.3
@@ -34,7 +34,7 @@ its important components (like OpenSSL version).
 We recommend using \fIcurl_version_info(3)\fP instead!
 .SH EXAMPLE
 .nf
-printf("libcurl version %s\n", curl_version());
+printf("libcurl version %s\\n", curl_version());
 .fi
 
 .SH AVAILABILITY

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -226,7 +226,7 @@ entry.
 .SH EXAMPLE
 .nf
 curl_version_info_data *ver = curl_version_info(CURLVERSION_NOW);
-printf("libcurl version %u.%u.%u\n",
+printf("libcurl version %u.%u.%u\\n",
        (ver->version_num >> 16) & 0xff,
        (ver->version_num >> 8) & 0xff,
        ver->version_num & 0xff,

--- a/docs/libcurl/opts/CURLOPT_PREREQDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PREREQDATA.3
@@ -43,7 +43,7 @@ static int prereq_callback(void *clientp,
                            int conn_primary_port,
                            int conn_local_port)
 {
-  printf("Connection made to %s:%s\n", conn_primary_ip, conn_primary_port);
+  printf("Connection made to %s:%s\\n", conn_primary_ip, conn_primary_port);
   return CURL_PREREQFUNC_OK;
 }
 

--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.3
@@ -86,7 +86,7 @@ static int prereq_callback(void *clientp,
                            int conn_primary_port,
                            int conn_local_port)
 {
-  printf("Connection made to %s:%s\n", conn_primary_ip, conn_primary_port);
+  printf("Connection made to %s:%s\\n", conn_primary_ip, conn_primary_port);
   return CURL_PREREQFUNC_OK;
 }
 

--- a/tests/manpage-syntax.pl
+++ b/tests/manpage-syntax.pl
@@ -104,6 +104,9 @@ sub scanmanpage {
         }
         elsif($inex)  {
             $exsize++;
+            if($_ =~ /[^\\]\\n/) {
+                print STDERR "$file:$line '\\n' need to be '\\\\n'!\n";
+            }
         }
         if($_ =~ /^\.SH ([^\r\n]*)/i) {
             my $n = $1;


### PR DESCRIPTION
... to be proper backslash-backslash-n sequences to render nicely in man
and on the website.

Reported-by: Sergey Markelov

Fixes https://github.com/curl/curl-www/issues/163