### PR TITLE
tests: add Schannel-specific tests or disable unsupported ones

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -121,64 +121,64 @@ stages:
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2 --with-openssl
-          tests: ~571 ~612 ~1056 ~1299
+          tests: "~571"
         msys2_mingw64_debug_openssl:
           name: 64-bit OpenSSL/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2 --with-openssl
-          tests: ~571 ~612 ~1056 ~1299
+          tests: "~571"
         msys1_mingw_debug:
           name: 32-bit (legacy)
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug --without-ssl
-          tests: ~203 ~1056 ~1143
+          tests: "!203 !1143"
         msys1_mingw32_debug:
           name: 32-bit w/o zlib
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw32:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --without-zlib --without-ssl
-          tests: ~203 ~1056 ~1143 ~1299
+          tests: "!203 !1143"
         msys1_mingw64_debug:
           name: 64-bit w/o zlib
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw64:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --without-zlib --without-ssl
-          tests: ~203 ~1056 ~1143 ~1299
+          tests: "!203 !1143"
         msys2_mingw32_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
+          tests: "~571"
         msys2_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN/libssh2
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
           container_cmd: C:\msys64\usr\bin\sh
           prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-          tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
+          tests: "~571"
         msys1_mingw_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN (legacy)
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-pc-mingw32 --build=i686-pc-mingw32 --prefix=/mingw --enable-debug --enable-sspi --with-schannel --with-winidn
-          tests: ~203 ~305 ~310 ~311 ~312 ~313 ~404 ~1056 ~1143 ~2034 ~2035 ~2037 ~2038 ~2041 ~2042 ~2048 ~3000 ~3001
+          tests: "!203 !305 !311 !312 !313 !404 !1143 !2033 !2035 !2038 !2041 !2042 !2048 !2070 !2079 !2087 !3023 !3024"
         msys1_mingw32_debug_schannel:
           name: 32-bit Schannel/SSPI/WinIDN w/o zlib
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw32:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib
-          tests: ~203 ~310 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
+          tests: "!203 !1143"
         msys1_mingw64_debug_schannel:
           name: 64-bit Schannel/SSPI/WinIDN w/o zlib
           container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys1-mingw64:ltsc2019
           container_cmd: C:\MinGW\msys\1.0\bin\sh
           configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64  --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib
-          tests: ~203 ~310 ~1056 ~1143 ~1299 ~2034 ~2037 ~2041 ~3000 ~3001
+          tests: "!203 !1143"
     container:
       image: $(container_img)
       env:
@@ -203,4 +203,4 @@ stages:
       displayName: 'test'
       env:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-        TFLAGS: "!SCP $(tests)"
+        TFLAGS: "!IDN !SCP ~612 ~1056 $(tests)"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,14 +85,14 @@ windows_task:
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
         configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
+        tests: "~571"
     - name: Windows 32-bit static/release Schannel/SSPI/WinIDN/libssh2
       env:
         container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
         configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32 --prefix=/mingw32 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
+        tests: "~571"
         curl_LDFLAGS: -all-static
         PKG_CONFIG: pkg-config --static
     - name: Windows 64-bit shared/release Schannel/SSPI/WinIDN/libssh2
@@ -101,14 +101,14 @@ windows_task:
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
         configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
+        tests: "~571"
     - name: Windows 64-bit static/release Schannel/SSPI/WinIDN/libssh2
       env:
         container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
         container_cmd: C:\msys64\usr\bin\sh
         prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
         configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --disable-shared --enable-static
-        tests: ~165 ~310 ~571 ~612 ~1056 ~1299 ~1448 ~2034 ~2037 ~2041 ~2046 ~2047 ~3000 ~3001
+        tests: "~571"
         curl_LDFLAGS: -all-static
         PKG_CONFIG: pkg-config --static
 
@@ -126,4 +126,4 @@ windows_task:
   install_script: |
     %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
   test_script: |
-    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='!SCP %tests%' test-ci"
+    %container_cmd% -l -c "cd $(echo '%cd%') && make V=1 TFLAGS='!IDN !SCP ~612 ~1056 %tests%' test-ci"

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -222,15 +222,13 @@ test2000 test2001 test2002 test2003 test2004 \
 \
                                                                test2023 \
 test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \
-test2032          test2034 test2035 test2036 test2037 test2038 test2039 \
+test2032 test2033 test2034 test2035 test2036 test2037 test2038 test2039 \
 test2040 test2041 test2042 test2043 test2044 test2045 test2046 test2047 \
 test2048 test2049 test2050 test2051 test2052 test2053 test2054 test2055 \
 test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
-test2064 test2065 test2066 test2067 test2068 test2069 \
-test2064 test2065 test2066 test2067 test2068 test2069 test2070 \
-         test2071 test2072 test2073 test2074 test2075 test2076 test2077 \
-test2078 \
-test2080 test2081 test2082 test2083 test2084 test2085 test2086 \
+test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
+test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
+test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 \
 test2100 \
 \
@@ -238,4 +236,5 @@ test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
-test3016 test3017 test3018 test3019 test3020 test3021 test3022
+test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
+test3024

--- a/tests/data/test2033
+++ b/tests/data/test2033
@@ -25,16 +25,21 @@ MooMoo
 <client>
 <features>
 SSL
-!Schannel
+SSLpinning
+Schannel
 </features>
 <server>
-https Server-localhost-firstSAN-sv.pem
+https Server-localhost-sv.pem
 </server>
-<name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match
-</name>
-<command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+ <name>
+simple HTTPS GET with DER public key pinning (Schannel variant)
+ </name>
+ <setenv>
+# This test is pointless if we're not using the schannel backend
+CURL_SSL_BACKEND=schannel
+ </setenv>
+ <command>
+--cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.der --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 # Ensure that we're running on localhost because we're checking the host name
 <precheck>

--- a/tests/data/test2034
+++ b/tests/data/test2034
@@ -26,6 +26,7 @@ MooMoo
 <features>
 SSL
 SSLpinning
+!Schannel
 </features>
 <server>
 https Server-localhost-sv.pem

--- a/tests/data/test2037
+++ b/tests/data/test2037
@@ -26,6 +26,7 @@ MooMoo
 <features>
 SSL
 SSLpinning
+!Schannel
 </features>
 <server>
 https Server-localhost-sv.pem

--- a/tests/data/test2041
+++ b/tests/data/test2041
@@ -26,6 +26,7 @@ MooMoo
 <features>
 SSL
 SSLpinning
+!Schannel
 </features>
 <server>
 https Server-localhost-sv.pem

--- a/tests/data/test2070
+++ b/tests/data/test2070
@@ -24,8 +24,8 @@ MooMoo
 # Client-side
 <client>
 <features>
+SSL
 Schannel
-!MinGW
 </features>
 <server>
 https Server-localhost-sv.pem

--- a/tests/data/test2079
+++ b/tests/data/test2079
@@ -25,16 +25,21 @@ MooMoo
 <client>
 <features>
 SSL
-!Schannel
+SSLpinning
+Schannel
 </features>
 <server>
-https Server-localhost-firstSAN-sv.pem
+https Server-localhost-sv.pem
 </server>
-<name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match
-</name>
-<command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+ <name>
+simple HTTPS GET with PEM public key pinning (Schannel variant)
+ </name>
+ <setenv>
+# This test is pointless if we're not using the schannel backend
+CURL_SSL_BACKEND=schannel
+ </setenv>
+ <command>
+--cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.pem --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 # Ensure that we're running on localhost because we're checking the host name
 <precheck>

--- a/tests/data/test2087
+++ b/tests/data/test2087
@@ -25,16 +25,21 @@ MooMoo
 <client>
 <features>
 SSL
-!Schannel
+SSLpinning
+Schannel
 </features>
 <server>
-https Server-localhost-firstSAN-sv.pem
+https Server-localhost-sv.pem
 </server>
-<name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match
-</name>
-<command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+ <name>
+simple HTTPS GET with base64-sha256 public key pinning (Schannel variant)
+ </name>
+ <setenv>
+# This test is pointless if we're not using the schannel backend
+CURL_SSL_BACKEND=schannel
+ </setenv>
+ <command>
+--cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//+JYNkp2GTGRgrvZMUkOxbFJQQqYpwNE6toGmBjz00D8= --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 # Ensure that we're running on localhost because we're checking the host name
 <precheck>

--- a/tests/data/test3001
+++ b/tests/data/test3001
@@ -25,6 +25,7 @@ MooMoo
 <client>
 <features>
 SSL
+!Schannel
 </features>
 <server>
 https Server-localhost-lastSAN-sv.pem

--- a/tests/data/test3023
+++ b/tests/data/test3023
@@ -25,16 +25,20 @@ MooMoo
 <client>
 <features>
 SSL
-!Schannel
+Schannel
 </features>
 <server>
 https Server-localhost-firstSAN-sv.pem
 </server>
 <name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match
+HTTPS GET to localhost, first subject alt name matches, CN does not match (Schannel variant)
 </name>
+<setenv>
+# This test is pointless if we're not using the schannel backend
+CURL_SSL_BACKEND=schannel
+</setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+--cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 # Ensure that we're running on localhost because we're checking the host name
 <precheck>

--- a/tests/data/test3024
+++ b/tests/data/test3024
@@ -25,16 +25,20 @@ MooMoo
 <client>
 <features>
 SSL
-!Schannel
+Schannel
 </features>
 <server>
-https Server-localhost-firstSAN-sv.pem
+https Server-localhost-lastSAN-sv.pem
 </server>
 <name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match
+HTTPS GET to localhost, last subject alt name matches, CN does not match (Schannel variant)
 </name>
+<setenv>
+# This test is pointless if we're not using the schannel backend
+CURL_SSL_BACKEND=schannel
+</setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+--cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 # Ensure that we're running on localhost because we're checking the host name
 <precheck>

--- a/tests/data/test310
+++ b/tests/data/test310
@@ -25,6 +25,7 @@ MooMoo
 <client>
 <features>
 SSL
+!Schannel
 </features>
 <server>
 https Server-localhost-sv.pem


### PR DESCRIPTION
Adds Schannel variants of SSLpinning tests that include the option
--ssl-revoke-best-effort to ignore certificate revocation check
failures which is required due to our custom test CA certificate.

Disable the original variants if the Schannel backend is enabled.

Also skip all IDN tests which are broken while using an msys shell.

This is a step to simplify test exclusions for Windows and MinGW.