### PR TITLE
tool_operate: reorder code to avoid compiler warning

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -887,6 +887,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             fclose(etag_save->stream);
           break;
         }
+        DEBUGASSERT(per); /* to show the compiler per can't be NULL here */
         per->etag_save = etag_first; /* copy the whole struct */
         if(state->uploadfile) {
           per->uploadfile = strdup(state->uploadfile);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -794,7 +794,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
                     !strcmp(state->outfiles, "-")) && urlnum > 1);
 
       if(state->up < state->infilenum) {
-        struct per_transfer *per;
+        struct per_transfer *per = NULL;
         struct OutStruct *outs;
         struct InStruct *input;
         struct OutStruct *heads;
@@ -887,7 +887,6 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             fclose(etag_save->stream);
           break;
         }
-        DEBUGASSERT(per); /* to show the compiler per can't be NULL here */
         per->etag_save = etag_first; /* copy the whole struct */
         if(state->uploadfile) {
           per->uploadfile = strdup(state->uploadfile);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -879,11 +879,12 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         curl = curl_easy_init();
         if(curl)
           result = add_per_transfer(&per);
-        if(result || !curl) {
+        else
+          result = CURLE_OUT_OF_MEMORY;
+        if(result) {
           curl_easy_cleanup(curl);
           if(etag_save->fopened)
             fclose(etag_save->stream);
-          result = CURLE_OUT_OF_MEMORY;
           break;
         }
         per->etag_save = etag_first; /* copy the whole struct */


### PR DESCRIPTION
tool_operate.c(889) : warning C4701: potentially uninitialized local
variable 'per' use

Follow-up to cc71d352651a0d95
Reported-by: Marc Hörsken
Bug: https://github.com/curl/curl/pull/7922#issuecomment-963042676