### PR TITLE
tool_operate: flose stream if fopened

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -881,7 +881,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           result = add_per_transfer(&per);
         if(result || !curl) {
           curl_easy_cleanup(curl);
-          if(etag_save->stream)
+          if(etag_save->fopened)
             fclose(etag_save->stream);
           result = CURLE_OUT_OF_MEMORY;
           break;


### PR DESCRIPTION
Fixes torture test failures
Follow-up to cc71d352651