### PR TITLE
http_proxy: make Curl_connect_done() work for proxy disabled builds

### DIFF
--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -39,6 +39,7 @@ CURLcode Curl_proxy_connect(struct Curl_easy *data, int sockindex);
 bool Curl_connect_complete(struct connectdata *conn);
 bool Curl_connect_ongoing(struct connectdata *conn);
 int Curl_connect_getsock(struct connectdata *conn);
+void Curl_connect_done(struct Curl_easy *data);
 
 #else
 #define Curl_proxyCONNECT(x,y,z,w) CURLE_NOT_BUILT_IN
@@ -46,10 +47,10 @@ int Curl_connect_getsock(struct connectdata *conn);
 #define Curl_connect_complete(x) CURLE_OK
 #define Curl_connect_ongoing(x) FALSE
 #define Curl_connect_getsock(x) 0
+#define Curl_connect_done(x)
 #endif
 
 void Curl_connect_free(struct Curl_easy *data);
-void Curl_connect_done(struct Curl_easy *data);
 
 /* struct for HTTP CONNECT state data */
 struct http_connect_state {


### PR DESCRIPTION
... by making it an empty macro then.

Follow-up to f0b7099a10d1a
Reported-by: Vincent Grande
Fixes #7995