### PR TITLE
Curl_connect_done: handle being called twice

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -207,8 +207,9 @@ void Curl_connect_done(struct Curl_easy *data)
     Curl_dyn_free(&s->rcvbuf);
     Curl_dyn_free(&s->req);
 
-    /* restore the protocol pointer */
-    data->req.p.http = s->prot_save;
+    /* restore the protocol pointer, if not already done */
+    if(s->prot_save)
+      data->req.p.http = s->prot_save;
     s->prot_save = NULL;
     data->info.httpcode = 0; /* clear it as it might've been used for the
                                 proxy */


### PR DESCRIPTION
Follow-up to f0b7099a10d1a7c

When torture testing 1021, it turns out the Curl_connect_done function
might be called twice and that previously then wrongly cleared the HTTP
pointer in the second invoke.