### PR TITLE
rustls: fix handling of EOF on read

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -138,11 +138,6 @@ cr_recv(struct Curl_easy *data, int sockindex,
     *err = CURLE_READ_ERROR;
     return -1;
   }
-  else if(tls_bytes_read == 0) {
-    failf(data, "connection closed without TLS close_notify alert");
-    *err = CURLE_READ_ERROR;
-    return -1;
-  }
 
   infof(data, "cr_recv read %ld bytes from the network", tls_bytes_read);
 


### PR DESCRIPTION
The update to rustls-ffi 0.8.0 changed handling of EOF and close_notify.
From the CHANGELOG:

> Handling of unclean close and the close_notify TLS alert. Mirroring upstream changes,
> a rustls_connection now tracks TCP closed state like so: rustls_connection_read_tls
> considers a 0-length read from its callback to mean "TCP stream was closed by peer."
> If that happens before the peer sent close_notify, rustls_connection_read will return
> RUSTLS_RESULT_UNEXPECTED_EOF once the available plaintext bytes are exhausted. This is
> useful to protect against truncation attacks. Note:
> some TLS implementations don't send close_notify. If you are already getting length
> information from your protocol (e.g. Content-Length in HTTP) you may choose to
> ignore UNEXPECTED_EOF so long as the number of plaintext bytes was as
> expected.

That means we don't need to check for unclean EOF in `cr_recv()`, because
`process_new_packets()` will give us an error if appropriate.

Also, we had code in cr_recv that would return immediately if we got a read of zero
bytes, but actually what we should do in that case is break out of the loop, and
return either CURLE_OK or CURLE_AGAIN depending on whether we had read
some plaintext on a previous iteration.