### PR TITLE
azure: make the "w/o HTTP/SMTP/IMAP" build disable SSL proper

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -64,7 +64,7 @@ stages:
           configure: --disable-ipv6 --with-openssl
         disable_http_smtp_imap:
           name: w/o HTTP/SMTP/IMAP
-          configure: --disable-http --disable-smtp --disable-imap --without-openssl
+          configure: --disable-http --disable-smtp --disable-imap --without-ssl
         disable_thredres:
           name: sync resolver
           configure: --disable-threaded-resolver --with-openssl


### PR DESCRIPTION
The configure line would previously depend on a configure mistake using
--without-openssl that is fixed and now this configure line needs
adjusting to use --without-ssl.

Follow-up to b589696f0312d