### PR TITLE
zuul.d: update rustls-ffi to version 0.8.2

### DIFF
--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -3,7 +3,7 @@
 [Rustls is a TLS backend written in Rust.](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.8.0 of rustls-ffi.
+version of curl depends on version v0.8.2 of rustls-ffi.
 
 # Building with rustls
 
@@ -12,7 +12,7 @@ First, [install Rust](https://rustup.rs/).
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
     % cargo install cbindgen
-    % git clone https://github.com/rustls/rustls-ffi -b v0.8.0
+    % git clone https://github.com/rustls/rustls-ffi -b v0.8.2
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -132,7 +132,7 @@
       curl_env:
         T: debug-rustls
         # Keep this in sync with the version in docs/RUSTLS.md
-        RUSTLS_VERSION: v0.8.0
+        RUSTLS_VERSION: v0.8.2
         LIBS: -lm
         C: >-
           --with-rustls={{ ansible_user_dir }}/rustls


### PR DESCRIPTION
This version fixes errors with ALPN negotiation in rustls, which is
necessary for HTTP/2 support. For more information see the rustls-ffi
changelog.