### PR TITLE
gen.pl: improve example output format

### DIFF
--- a/docs/cmdline-opts/MANPAGE.md
+++ b/docs/cmdline-opts/MANPAGE.md
@@ -40,6 +40,9 @@ correct markup that shows both short and long version.
 Text written within `*asterisks*` will get shown using italics. Text within
 two `**asterisks**` will get shown using bold.
 
+Text that is prefixed with a space will be treated like an "example" and will
+be output in monospace.
+
 ## Header and footer
 
 `page-header` is the file that will be output before the generated options

--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -91,15 +91,11 @@ carriage-returns and trailing spaces are stripped.
 Here is an example of a header file contents:
 
   # This file contain two headers.
-.br
   X-header-1: this is a header
 
   # The following header is folded.
-.br
   X-header-2: this is
-.br
    another header
-
 
 To support sending multipart mail messages, the syntax is extended as follows:
 .br
@@ -115,11 +111,8 @@ inline part in two alternative formats: plain text and HTML. It attaches a
 text file:
 
  curl -F '=(;type=multipart/alternative' \\
-.br
-         -F '=plain text message' \\
-.br
-         -F '= <body>HTML message</body>;type=text/html' \\
-.br
+      -F '=plain text message' \\
+      -F '= <body>HTML message</body>;type=text/html' \\
       -F '=)' -F '=@textfile.txt' ...  smtp://example.com
 
 Data can be encoded for transfer using encoder=. Available encodings are
@@ -133,7 +126,6 @@ Example: send multipart mail with a quoted-printable text message and a
 base64 attached file:
 
  curl -F '=text message;encoder=quoted-printable' \\
-.br
       -F '=@localfile;encoder=base64' ... smtp://example.com
 
 See further examples and details in the MANUAL.

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -76,6 +76,7 @@ sub manpageify {
 
 sub printdesc {
     my @desc = @_;
+    my $exam = 0;
     for my $d (@desc) {
         if($d =~ /\(Added in ([0-9.]+)\)/i) {
             my $ver = $1;
@@ -88,6 +89,16 @@ sub printdesc {
             $d =~ s/\*\*([^ ]*)\*\*/\\fB$1\\fP/g;
             # *italics*
             $d =~ s/\*([^ ]*)\*/\\fI$1\\fP/g;
+        }
+        if(!$exam && ($d =~ /^ /)) {
+            # start of example
+            $exam = 1;
+            print ".nf\n"; # no-fill
+        }
+        elsif($exam && ($d !~ /^ /)) {
+            # end of example
+            $exam = 0;
+            print ".fi\n"; # fill-in
         }
         # skip lines starting with space (examples)
         if($d =~ /^[^ ]/) {


### PR DESCRIPTION
Treat consecutive lines that start with a space to be "examples". They
are output enclosed by .nf and .fi

Updated form.d to use this new fanciness