### PR TITLE
curl.1: require "see also" for every documented option

### DIFF
--- a/docs/cmdline-opts/abstract-unix-socket.d
+++ b/docs/cmdline-opts/abstract-unix-socket.d
@@ -4,6 +4,7 @@ Help: Connect via abstract Unix domain socket
 Added: 7.53.0
 Protocols: HTTP
 Category: connection
+See-also: unix-socket
 Example: --abstract-unix-socket socketpath $URL
 ---
 Connect through an abstract Unix domain socket, instead of using the network.

--- a/docs/cmdline-opts/alt-svc.d
+++ b/docs/cmdline-opts/alt-svc.d
@@ -4,6 +4,7 @@ Protocols: HTTPS
 Help: Enable alt-svc with this cache file
 Added: 7.64.1
 Category: http
+See-also: resolve connect-to
 Example: --alt-svc svc.txt $URL
 ---
 This option enables the alt-svc parser in curl. If the file name points to an

--- a/docs/cmdline-opts/append.d
+++ b/docs/cmdline-opts/append.d
@@ -3,6 +3,7 @@ Long: append
 Help: Append to target file when uploading
 Protocols: FTP SFTP
 Category: ftp sftp
+See-also: range continue-at
 Example: --upload-file local --append ftp://example.com/
 Added: 4.8
 ---

--- a/docs/cmdline-opts/aws-sigv4.d
+++ b/docs/cmdline-opts/aws-sigv4.d
@@ -3,6 +3,7 @@ Arg: <provider1[:provider2[:region[:service]]]>
 Help: Use AWS V4 signature authentication
 Category: auth http
 Added: 7.75.0
+See-also: basic user
 Example: --aws-sigv4 "aws:amz:east-2:es" --user "key:secret" $URL
 ---
 Use AWS V4 signature authentication in the transfer.

--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -3,6 +3,7 @@ Arg: <file>
 Help: CA certificate to verify peer against
 Protocols: TLS
 Category: tls
+See-also: capath insecure
 Example: --cacert CA-file.txt $URL
 Added: 7.5
 ---

--- a/docs/cmdline-opts/capath.d
+++ b/docs/cmdline-opts/capath.d
@@ -3,6 +3,7 @@ Arg: <dir>
 Help: CA directory to verify peer against
 Protocols: TLS
 Category: tls
+See-also: cacert insecure
 Example: --capath /local/directory $URL
 Added: 7.9.8
 ---

--- a/docs/cmdline-opts/cert-status.d
+++ b/docs/cmdline-opts/cert-status.d
@@ -3,6 +3,7 @@ Protocols: TLS
 Added: 7.41.0
 Help: Verify the status of the server cert via OCSP-staple
 Category: tls
+See-also: pinnedpubkey
 Example: --cert-status $URL
 ---
 Tells curl to verify the status of the server certificate by using the

--- a/docs/cmdline-opts/ciphers.d
+++ b/docs/cmdline-opts/ciphers.d
@@ -3,6 +3,7 @@ Arg: <list of ciphers>
 Help: SSL ciphers to use
 Protocols: TLS
 Category: tls
+See-also: tlsv1.3
 Example: --ciphers ECDHE-ECDSA-AES256-CCM8 $URL
 Added: 7.9
 ---

--- a/docs/cmdline-opts/compressed-ssh.d
+++ b/docs/cmdline-opts/compressed-ssh.d
@@ -3,6 +3,7 @@ Help: Enable SSH compression
 Protocols: SCP SFTP
 Added: 7.56.0
 Category: scp ssh
+See-also: compressed
 Example: --compressed-ssh sftp://example.com/
 ---
 Enables built-in SSH compression.

--- a/docs/cmdline-opts/compressed.d
+++ b/docs/cmdline-opts/compressed.d
@@ -3,6 +3,7 @@ Help: Request compressed response
 Protocols: HTTP
 Category: http
 Example: --compressed $URL
+See-also: compressed-ssh
 Added: 7.10
 ---
 Request a compressed response using one of the algorithms curl supports, and

--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -5,6 +5,7 @@ Short: K
 Category: curl
 Example: --config file.txt $URL
 Added: 4.10
+See-also: disable
 ---
 Specify a text file to read curl arguments from. The command line arguments
 found in the text file will be used as if they were provided on the command

--- a/docs/cmdline-opts/cookie-jar.d
+++ b/docs/cmdline-opts/cookie-jar.d
@@ -7,6 +7,7 @@ Category: http
 Example: -c store-here.txt $URL
 Example: -c store-here.txt -b read-these $URL
 Added: 7.9
+See-also: cookie
 ---
 Specify to which file you want curl to write all cookies after a completed
 operation. Curl writes all cookies from its in-memory cookie storage to the

--- a/docs/cmdline-opts/cookie.d
+++ b/docs/cmdline-opts/cookie.d
@@ -6,6 +6,7 @@ Help: Send cookies from string/file
 Category: http
 Example: -b cookiefile $URL
 Example: -b cookiefile -c cookiefile $URL
+See-also: cookie-jar junk-session-cookies
 Added: 4.9
 ---
 Pass the data to the HTTP server in the Cookie header. It is supposedly

--- a/docs/cmdline-opts/create-dirs.d
+++ b/docs/cmdline-opts/create-dirs.d
@@ -3,6 +3,7 @@ Help: Create necessary local directory hierarchy
 Category: curl
 Example: --create-dirs --output local/dir/file $URL
 Added: 7.10.3
+See-also: ftp-create-dirs output-dir
 ---
 When used in conjunction with the --output option, curl will create the
 necessary local directory hierarchy as needed. This option creates the

--- a/docs/cmdline-opts/crlf.d
+++ b/docs/cmdline-opts/crlf.d
@@ -4,6 +4,7 @@ Protocols: FTP SMTP
 Category: ftp smtp
 Example: --crlf -T file ftp://example.com/
 Added: 5.7
+See-also: use-ascii
 ---
 Convert LF to CRLF in upload. Useful for MVS (OS/390).
 

--- a/docs/cmdline-opts/crlfile.d
+++ b/docs/cmdline-opts/crlfile.d
@@ -5,6 +5,7 @@ Help: Use this CRL list
 Added: 7.19.7
 Category: tls
 Example: --crlfile rejects.txt $URL
+See-also: cacert capath
 ---
 Provide a file using PEM format with a Certificate Revocation List that may
 specify peer certificates that are to be considered revoked.

--- a/docs/cmdline-opts/curves.d
+++ b/docs/cmdline-opts/curves.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Added: 7.73.0
 Category: tls
 Example: --curves X25519 $URL
+See-also: ciphers
 ---
 Tells curl to request specific curves to use during SSL session establishment
 according to RFC 8422, 5.1.  Multiple algorithms can be provided by separating

--- a/docs/cmdline-opts/data-ascii.d
+++ b/docs/cmdline-opts/data-ascii.d
@@ -5,5 +5,6 @@ Protocols: HTTP
 Category: http post upload
 Example: --data-ascii @file $URL
 Added: 7.2
+See-also: data-binary data-raw data-urlencode
 ---
 This is just an alias for --data.

--- a/docs/cmdline-opts/data-binary.d
+++ b/docs/cmdline-opts/data-binary.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 Category: http post upload
 Example: --data-binary @filename $URL
 Added: 7.2
+See-also: data-ascii
 ---
 This posts data exactly as specified with no extra processing whatsoever.
 

--- a/docs/cmdline-opts/delegation.d
+++ b/docs/cmdline-opts/delegation.d
@@ -5,6 +5,7 @@ Protocols: GSS/kerberos
 Category: auth
 Example: --delegation "none" $URL
 Added: 7.22.0
+See-also: insecure ssl
 ---
 Set LEVEL to tell the server what it is allowed to delegate when it
 comes to user credentials.

--- a/docs/cmdline-opts/disable-eprt.d
+++ b/docs/cmdline-opts/disable-eprt.d
@@ -4,6 +4,7 @@ Protocols: FTP
 Category: ftp
 Example: --disable-eprt ftp://example.com/
 Added: 7.10.5
+See-also: disable-epsv ftp-port
 ---
 Tell curl to disable the use of the EPRT and LPRT commands when doing active
 FTP transfers. Curl will normally always first attempt to use EPRT, then LPRT

--- a/docs/cmdline-opts/disable-epsv.d
+++ b/docs/cmdline-opts/disable-epsv.d
@@ -4,6 +4,7 @@ Protocols: FTP
 Category: ftp
 Example: --disable-epsv ftp://example.com/
 Added: 7.9.2
+See-also: disable-eprt ftp-port
 ---
 Tell curl to disable the use of the EPSV command when doing passive FTP
 transfers. Curl will normally always first attempt to use EPSV before

--- a/docs/cmdline-opts/disable.d
+++ b/docs/cmdline-opts/disable.d
@@ -4,6 +4,7 @@ Help: Disable .curlrc
 Category: curl
 Example: -q $URL
 Added: 5.0
+See-also: config
 ---
 If used as the first parameter on the command line, the *curlrc* config
 file will not be read and used. See the --config for details on the default

--- a/docs/cmdline-opts/dns-servers.d
+++ b/docs/cmdline-opts/dns-servers.d
@@ -5,6 +5,7 @@ Requires: c-ares
 Added: 7.33.0
 Category: dns
 Example: --dns-servers 192.168.0.1,192.168.0.2 $URL
+See-also: dns-interface dns-ipv4-addr
 ---
 Set the list of DNS servers to be used instead of the system default.
 The list of IP addresses should be separated with commas. Port numbers

--- a/docs/cmdline-opts/doh-cert-status.d
+++ b/docs/cmdline-opts/doh-cert-status.d
@@ -4,5 +4,6 @@ Protocols: all
 Added: 7.76.0
 Category: dns tls
 Example: --doh-cert-status --doh-url https://doh.example $URL
+See-also: doh-insecure
 ---
 Same as --cert-status but used for DoH (DNS-over-HTTPS).

--- a/docs/cmdline-opts/doh-insecure.d
+++ b/docs/cmdline-opts/doh-insecure.d
@@ -4,5 +4,6 @@ Protocols: all
 Added: 7.76.0
 Category: dns tls
 Example: --doh-insecure --doh-url https://doh.example $URL
+See-also: doh-url
 ---
 Same as --insecure but used for DoH (DNS-over-HTTPS).

--- a/docs/cmdline-opts/doh-url.d
+++ b/docs/cmdline-opts/doh-url.d
@@ -5,6 +5,7 @@ Protocols: all
 Added: 7.62.0
 Category: dns
 Example: --doh-url https://doh.example $URL
+See-also: doh-insecure
 ---
 Specifies which DNS-over-HTTPS (DoH) server to use to resolve hostnames,
 instead of using the default name resolver mechanism. The URL must be HTTPS.

--- a/docs/cmdline-opts/engine.d
+++ b/docs/cmdline-opts/engine.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Category: tls
 Example: --engine flavor $URL
 Added: 7.9.3
+See-also: ciphers curves
 ---
 Select the OpenSSL crypto engine to use for cipher operations. Use --engine
 list to print a list of build-time supported engines. Note that not all (and

--- a/docs/cmdline-opts/etag-compare.d
+++ b/docs/cmdline-opts/etag-compare.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 Added: 7.68.0
 Category: http
 Example: --etag-compare etag.txt $URL
+See-also: etag-save time-cond
 ---
 This option makes a conditional HTTP request for the specific ETag read
 from the given file by sending a custom If-None-Match header using the

--- a/docs/cmdline-opts/etag-save.d
+++ b/docs/cmdline-opts/etag-save.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 Added: 7.68.0
 Category: http
 Example: --etag-save storetag.txt $URL
+See-also: etag-compare
 ---
 This option saves an HTTP ETag to the specified file. An ETag is a
 caching related header, usually returned in a response.

--- a/docs/cmdline-opts/fail-early.d
+++ b/docs/cmdline-opts/fail-early.d
@@ -3,6 +3,7 @@ Help: Fail on first transfer error, do not continue
 Added: 7.52.0
 Category: curl
 Example: --fail-early $URL https://two.example
+See-also: fail fail-with-body
 ---
 Fail and exit on the first detected transfer error.
 

--- a/docs/cmdline-opts/false-start.d
+++ b/docs/cmdline-opts/false-start.d
@@ -4,6 +4,7 @@ Protocols: TLS
 Added: 7.42.0
 Category: tls
 Example: --false-start $URL
+See-also: tcp-fastopen
 ---
 Tells curl to use false start during the TLS handshake. False start is a mode
 where a TLS client will start sending application data before verifying the

--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -7,6 +7,7 @@ Mutexed: data head upload-file
 Category: http upload
 Example: --form "name=curl" --form "file=@loadthis" $URL
 Added: 5.0
+See-also: data form-string form-escape
 ---
 For HTTP protocol family, this lets curl emulate a filled-in form in which a
 user has pressed the submit button. This causes curl to POST data using the

--- a/docs/cmdline-opts/ftp-account.d
+++ b/docs/cmdline-opts/ftp-account.d
@@ -5,6 +5,7 @@ Protocols: FTP
 Added: 7.13.0
 Category: ftp auth
 Example: --ftp-account "mr.robot" ftp://example.com/
+See-also: user
 ---
 When an FTP server asks for "account data" after user name and password has
 been provided, this data is sent off using the ACCT command.

--- a/docs/cmdline-opts/ftp-alternative-to-user.d
+++ b/docs/cmdline-opts/ftp-alternative-to-user.d
@@ -5,6 +5,7 @@ Protocols: FTP
 Added: 7.15.5
 Category: ftp
 Example: --ftp-alternative-to-user "U53r" ftp://example.com
+See-also: ftp-account user
 ---
 If authenticating with the USER and PASS commands fails, send this command.
 When connecting to Tumbleweed's Secure Transport server over FTPS using a

--- a/docs/cmdline-opts/ftp-method.d
+++ b/docs/cmdline-opts/ftp-method.d
@@ -7,6 +7,7 @@ Category: ftp
 Example: --ftp-method multicwd ftp://example.com/dir1/dir2/file
 Example: --ftp-method nocwd ftp://example.com/dir1/dir2/file
 Example: --ftp-method singlecwd ftp://example.com/dir1/dir2/file
+See-also: list-only
 ---
 Control what method curl should use to reach a file on an FTP(S)
 server. The method argument should be one of the following alternatives:

--- a/docs/cmdline-opts/ftp-pret.d
+++ b/docs/cmdline-opts/ftp-pret.d
@@ -4,6 +4,7 @@ Protocols: FTP
 Added: 7.20.0
 Category: ftp
 Example: --ftp-pret ftp://example.com/
+See-also: ftp-port ftp-pasv
 ---
 Tell curl to send a PRET command before PASV (and EPSV). Certain FTP servers,
 mainly drftpd, require this non-standard command for directory listings as

--- a/docs/cmdline-opts/ftp-ssl-control.d
+++ b/docs/cmdline-opts/ftp-ssl-control.d
@@ -4,6 +4,7 @@ Protocols: FTP
 Added: 7.16.0
 Category: ftp tls
 Example: --ftp-ssl-control ftp://example.com
+See-also: ssl
 ---
 Require SSL/TLS for the FTP login, clear for transfer.  Allows secure
 authentication, but non-encrypted data transfers for efficiency.  Fails the

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -228,19 +228,23 @@ sub single {
         elsif(/^---/) {
             if(!$long) {
                 print STDERR "ERROR: no 'Long:' in $f\n";
-                exit 1;
+                return 1;
             }
             if(!$category) {
                 print STDERR "ERROR: no 'Category:' in $f\n";
-                exit 2;
+                return 2;
             }
             if(!$examples[0]) {
                 print STDERR "$f:$line:1:ERROR: no 'Example:' present\n";
-                exit 2;
+                return 2;
             }
             if(!$added) {
                 print STDERR "$f:$line:1:ERROR: no 'Added:' version present\n";
-                exit 2;
+                return 2;
+            }
+            if(!$seealso) {
+                print STDERR "$f:$line:1:ERROR: no 'See-also:' field present\n";
+                return 2;
             }
             last;
         }
@@ -304,7 +308,7 @@ sub single {
         my $i = 0;
         for my $k (@m) {
             if(!$helplong{$k}) {
-                print STDERR "WARN: $f see-alsos a non-existing option: $k\n";
+                print STDERR "$f:$line:1:WARN: see-also a non-existing option: $k\n";
             }
             my $l = manpageify($k);
             my $sep = " and";
@@ -522,17 +526,17 @@ sub listcats {
 
 sub mainpage {
     my (@files) = @_;
+    my $ret;
     # show the page header
     header("page-header");
 
     # output docs for all options
     foreach my $f (sort @files) {
-        if(single($f, 0)) {
-            print STDERR "Can't read $f?\n";
-        }
+        $ret += single($f, 0);
     }
 
     header("page-footer");
+    exit $ret if($ret);
 }
 
 sub showonly {

--- a/docs/cmdline-opts/get.d
+++ b/docs/cmdline-opts/get.d
@@ -6,6 +6,7 @@ Example: --get $URL
 Example: --get -d "tool=curl" -d "age=old" $URL
 Example: --get -I -d "tool=curl" $URL
 Added: 7.8.1
+See-also: data request
 ---
 When used, this option will make all data specified with --data, --data-binary
 or --data-urlencode to be used in an HTTP GET request instead of the POST

--- a/docs/cmdline-opts/globoff.d
+++ b/docs/cmdline-opts/globoff.d
@@ -4,6 +4,7 @@ Help: Disable URL sequences and ranges using {} and []
 Category: curl
 Example: -g "https://example.com/{[]}}}}"
 Added: 7.6
+See-also: config disable
 ---
 This option switches off the "URL globbing parser". When you set this option,
 you can specify URLs that contain the letters {}[] without having curl itself

--- a/docs/cmdline-opts/happy-eyeballs-timeout-ms.d
+++ b/docs/cmdline-opts/happy-eyeballs-timeout-ms.d
@@ -4,6 +4,7 @@ Help: Time for IPv6 before trying IPv4
 Added: 7.59.0
 Category: connection
 Example: --happy-eyeballs-timeout-ms 500 $URL
+See-also: max-time connect-timeout
 ---
 Happy Eyeballs is an algorithm that attempts to connect to both IPv4 and IPv6
 addresses for dual-stack hosts, giving IPv6 a head-start of the specified

--- a/docs/cmdline-opts/haproxy-protocol.d
+++ b/docs/cmdline-opts/haproxy-protocol.d
@@ -4,6 +4,7 @@ Protocols: HTTP
 Added: 7.60.0
 Category: http proxy
 Example: --haproxy-protocol $URL
+See-also: proxy
 ---
 Send a HAProxy PROXY protocol v1 header at the beginning of the
 connection. This is used by some load balancers and reverse proxies to

--- a/docs/cmdline-opts/head.d
+++ b/docs/cmdline-opts/head.d
@@ -5,6 +5,7 @@ Protocols: HTTP FTP FILE
 Category: http ftp file
 Example: -I $URL
 Added: 4.0
+See-also: get verbose trace-ascii
 ---
 Fetch the headers only! HTTP-servers feature the command HEAD which this uses
 to get nothing but the header of a document. When used on an FTP or FILE file,

--- a/docs/cmdline-opts/help.d
+++ b/docs/cmdline-opts/help.d
@@ -5,6 +5,7 @@ Help: Get help for commands
 Category: important curl
 Example: --help all
 Added: 4.0
+See-also: verbose
 ---
 Usage help. This lists all commands of the <category>.
 If no arg was provided, curl will display the most important

--- a/docs/cmdline-opts/hostpubmd5.d
+++ b/docs/cmdline-opts/hostpubmd5.d
@@ -5,6 +5,7 @@ Protocols: SFTP SCP
 Added: 7.17.1
 Category: sftp scp
 Example: --hostpubmd5 e5c1c49020640a5ab0f2034854c321a8 sftp://example.com/
+See-also: hostpubsha256
 ---
 Pass a string containing 32 hexadecimal digits. The string should
 be the 128 bit MD5 checksum of the remote host's public key, curl will refuse

--- a/docs/cmdline-opts/hostpubsha256.d
+++ b/docs/cmdline-opts/hostpubsha256.d
@@ -5,6 +5,7 @@ Protocols: SFTP SCP
 Added: 7.80.0
 Category: sftp scp
 Example: --hostpubsha256 NDVkMTQxMGQ1ODdmMjQ3MjczYjAyOTY5MmRkMjVmNDQ= sftp://example.com/
+See-also: hostpubmd5
 ---
 Pass a string containing a Base64-encoded SHA256 hash of the remote
 host's public key. Curl will refuse the connection with the host

--- a/docs/cmdline-opts/hsts.d
+++ b/docs/cmdline-opts/hsts.d
@@ -5,6 +5,7 @@ Help: Enable HSTS with this cache file
 Added: 7.74.0
 Category: http
 Example: --hsts cache.txt $URL
+See-also: proto
 ---
 This option enables HSTS for the transfer. If the file name points to an
 existing HSTS cache file, that will be used. After a completed transfer, the

--- a/docs/cmdline-opts/http0.9.d
+++ b/docs/cmdline-opts/http0.9.d
@@ -5,6 +5,7 @@ Help: Allow HTTP 0.9 responses
 Category: http
 Example: --http0.9 $URL
 Added: 7.64.0
+See-also: http1.1 http2 http3
 ---
 Tells curl to be fine with HTTP version 0.9 response.
 

--- a/docs/cmdline-opts/http1.0.d
+++ b/docs/cmdline-opts/http1.0.d
@@ -7,6 +7,7 @@ Mutexed: http1.1 http2
 Help: Use HTTP 1.0
 Category: http
 Example: --http1.0 $URL
+See-also: http0.9 http1.1
 ---
 Tells curl to use HTTP version 1.0 instead of using its internally preferred
 HTTP version.

--- a/docs/cmdline-opts/http1.1.d
+++ b/docs/cmdline-opts/http1.1.d
@@ -6,5 +6,6 @@ Mutexed: http1.0 http2
 Help: Use HTTP 1.1
 Category: http
 Example: --http1.1 $URL
+See-also: http1.1 http0.9
 ---
 Tells curl to use HTTP version 1.1.

--- a/docs/cmdline-opts/http2-prior-knowledge.d
+++ b/docs/cmdline-opts/http2-prior-knowledge.d
@@ -7,6 +7,7 @@ Requires: HTTP/2
 Help: Use HTTP 2 without HTTP/1.1 Upgrade
 Category: http
 Example: --http2-prior-knowledge $URL
+See-also: http2 http3
 ---
 Tells curl to issue its non-TLS HTTP requests using HTTP/2 without HTTP/1.1
 Upgrade. It requires prior knowledge that the server supports HTTP/2 straight

--- a/docs/cmdline-opts/ignore-content-length.d
+++ b/docs/cmdline-opts/ignore-content-length.d
@@ -4,6 +4,7 @@ Protocols: FTP HTTP
 Category: http ftp
 Example: --ignore-content-length $URL
 Added: 7.14.1
+See-also: ftp-skip-pasv-ip
 ---
 For HTTP, Ignore the Content-Length header. This is particularly useful for
 servers running Apache 1.x, which will report incorrect Content-Length for

--- a/docs/cmdline-opts/keepalive-time.d
+++ b/docs/cmdline-opts/keepalive-time.d
@@ -4,6 +4,7 @@ Help: Interval time for keepalive probes
 Added: 7.18.0
 Category: connection
 Example: --keepalive-time 20 $URL
+See-also: no-keepalive max-time
 ---
 This option sets the time a connection needs to remain idle before sending
 keepalive probes and the time between individual keepalive probes. It is

--- a/docs/cmdline-opts/key-type.d
+++ b/docs/cmdline-opts/key-type.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Category: tls
 Example: --key-type DER --key here $URL
 Added: 7.9.3
+See-also: key
 ---
 Private key file type. Specify which type your --key provided private key
 is. DER, PEM, and ENG are supported. If not specified, PEM is assumed.

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -5,6 +5,7 @@ Help: Private key file name
 Category: tls ssh
 Example: --cert certificate --key here $URL
 Added: 7.9.3
+See-also: key-type cert
 ---
 Private key file name. Allows you to provide your private key in this separate
 file. For SSH, if not specified, curl tries the following candidates in order:

--- a/docs/cmdline-opts/krb.d
+++ b/docs/cmdline-opts/krb.d
@@ -6,6 +6,7 @@ Requires: Kerberos
 Category: ftp
 Example: --krb clear ftp://example.com/
 Added: 7.3
+See-also: delegation ssl
 ---
 Enable Kerberos authentication and use. The level must be entered and should
 be one of 'clear', 'safe', 'confidential', or 'private'. Should you use a

--- a/docs/cmdline-opts/libcurl.d
+++ b/docs/cmdline-opts/libcurl.d
@@ -4,6 +4,7 @@ Help: Dump libcurl equivalent code of this command line
 Added: 7.16.1
 Category: curl
 Example: --libcurl client.c $URL
+See-also: verbose
 ---
 Append this option to any ordinary curl command line, and you will get
 libcurl-using C source code written to the file that does the equivalent

--- a/docs/cmdline-opts/limit-rate.d
+++ b/docs/cmdline-opts/limit-rate.d
@@ -6,6 +6,7 @@ Example: --limit-rate 100K $URL
 Example: --limit-rate 1000 $URL
 Example: --limit-rate 10M $URL
 Added: 7.10
+See-also: speed-limit speed-time
 ---
 Specify the maximum transfer rate you want curl to use - for both downloads
 and uploads. This feature is useful if you have a limited pipe and you would like

--- a/docs/cmdline-opts/list-only.d
+++ b/docs/cmdline-opts/list-only.d
@@ -5,6 +5,7 @@ Help: List only mode
 Added: 4.0
 Category: ftp pop3
 Example: --list-only ftp://example.com/dir/
+See-also: quote request
 ---
 (FTP)
 When listing an FTP directory, this switch forces a name-only view. This is

--- a/docs/cmdline-opts/local-port.d
+++ b/docs/cmdline-opts/local-port.d
@@ -4,6 +4,7 @@ Help: Force use of RANGE for local port numbers
 Added: 7.15.2
 Category: connection
 Example: --local-port 1000-3000 $URL
+See-also: globoff
 ---
 Set a preferred single number or range (FROM-TO) of local port numbers to use
 for the connection(s).  Note that port numbers by nature are a scarce resource

--- a/docs/cmdline-opts/location.d
+++ b/docs/cmdline-opts/location.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 Category: http
 Example: -L $URL
 Added: 4.9
+See-also: resolve alt-svc
 ---
 If the server reports that the requested page has moved to a different
 location (indicated with a Location: header and a 3XX response code), this

--- a/docs/cmdline-opts/login-options.d
+++ b/docs/cmdline-opts/login-options.d
@@ -5,6 +5,7 @@ Help: Server login options
 Added: 7.34.0
 Category: imap pop3 smtp auth
 Example: --login-options 'AUTH=*' imap://example.com
+See-also: user
 ---
 Specify the login options to use during server authentication.
 

--- a/docs/cmdline-opts/mail-rcpt-allowfails.d
+++ b/docs/cmdline-opts/mail-rcpt-allowfails.d
@@ -4,6 +4,7 @@ Protocols: SMTP
 Added: 7.69.0
 Category: smtp
 Example: --mail-rcpt-allowfails --mail-rcpt dest@example.com smtp://example.com
+See-also: mail-rcpt
 ---
 When sending data to multiple recipients, by default curl will abort SMTP
 conversation if at least one of the recipients causes RCPT TO command to

--- a/docs/cmdline-opts/mail-rcpt.d
+++ b/docs/cmdline-opts/mail-rcpt.d
@@ -5,6 +5,7 @@ Protocols: SMTP
 Added: 7.20.0
 Category: smtp
 Example: --mail-rcpt user@example.net smtp://example.com
+See-also: mail-rcpt-allowfails
 ---
 Specify a single e-mail address, user name or mailing list name. Repeat this
 option several times to send to multiple recipients.

--- a/docs/cmdline-opts/manual.d
+++ b/docs/cmdline-opts/manual.d
@@ -4,5 +4,6 @@ Help: Display the full manual
 Category: curl
 Example: --manual
 Added: 5.2
+See-also: verbose libcurl trace
 ---
 Manual. Display the huge help text.

--- a/docs/cmdline-opts/max-redirs.d
+++ b/docs/cmdline-opts/max-redirs.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 Category: http
 Example: --max-redirs 3 --location $URL
 Added: 7.5
+See-also: location
 ---
 Set maximum number of redirections to follow. When --location is used, to
 prevent curl from following too many redirects, by default, the limit is

--- a/docs/cmdline-opts/metalink.d
+++ b/docs/cmdline-opts/metalink.d
@@ -3,6 +3,7 @@ Help: Process given URLs as metalink XML file
 Added: 7.27.0
 Category: misc
 Example: --metalink file $URL
+See-also: parallel
 ---
 This option was previously used to specify a metalink resource. Metalink
 support has been disabled in curl since 7.78.0 for security reasons.

--- a/docs/cmdline-opts/netrc-file.d
+++ b/docs/cmdline-opts/netrc-file.d
@@ -5,6 +5,7 @@ Added: 7.21.5
 Mutexed: netrc
 Category: curl
 Example: --netrc-file netrc $URL
+See-also: netrc user config
 ---
 This option is similar to --netrc, except that you provide the path (absolute
 or relative) to the netrc file that curl should use.  You can only specify one

--- a/docs/cmdline-opts/netrc.d
+++ b/docs/cmdline-opts/netrc.d
@@ -4,6 +4,7 @@ Help: Must read .netrc for user name and password
 Category: curl
 Example: --netrc $URL
 Added: 4.6
+See-also: netrc-file config user
 ---
 Makes curl scan the *.netrc* (*_netrc* on Windows) file in the user's home
 directory for login name and password. This is typically used for FTP on

--- a/docs/cmdline-opts/next.d
+++ b/docs/cmdline-opts/next.d
@@ -8,6 +8,7 @@ Help: Make next URL use its separate set of options
 Category: curl
 Example: $URL --next -d postthis www2.example.com
 Example: -I $URL --next https://example.net/
+See-also: parallel config
 ---
 Tells curl to use a separate operation for the following URL and associated
 options. This allows you to send several URL requests, each with their own

--- a/docs/cmdline-opts/no-buffer.d
+++ b/docs/cmdline-opts/no-buffer.d
@@ -4,6 +4,7 @@ Help: Disable buffering of the output stream
 Category: curl
 Example: --no-buffer $URL
 Added: 6.5
+See-also: progress-bar
 ---
 Disables the buffering of the output stream. In normal work situations, curl
 will use a standard buffered output stream that will have the effect that it

--- a/docs/cmdline-opts/no-keepalive.d
+++ b/docs/cmdline-opts/no-keepalive.d
@@ -3,6 +3,7 @@ Help: Disable TCP keepalive on the connection
 Category: connection
 Example: --no-keepalive $URL
 Added: 7.18.0
+See-also: keepalive-time
 ---
 Disables the use of keepalive messages on the TCP connection. curl otherwise
 enables them by default.

--- a/docs/cmdline-opts/no-sessionid.d
+++ b/docs/cmdline-opts/no-sessionid.d
@@ -4,6 +4,7 @@ Protocols: TLS
 Added: 7.16.0
 Category: tls
 Example: --no-sessionid $URL
+See-also: insecure
 ---
 Disable curl's use of SSL session-ID caching.  By default all transfers are
 done using the cache. Note that while nothing should ever get hurt by

--- a/docs/cmdline-opts/noproxy.d
+++ b/docs/cmdline-opts/noproxy.d
@@ -4,6 +4,7 @@ Help: List of hosts which do not use proxy
 Added: 7.19.4
 Category: proxy
 Example: --noproxy "www.example" $URL
+See-also: proxy
 ---
 Comma-separated list of hosts for which not to use a proxy, if one is
 specified. The only wildcard is a single * character, which matches all hosts,

--- a/docs/cmdline-opts/oauth2-bearer.d
+++ b/docs/cmdline-opts/oauth2-bearer.d
@@ -5,6 +5,7 @@ Protocols: IMAP POP3 SMTP HTTP
 Category: auth
 Example: --oauth2-bearer "mF_9.B5f-4.1JqM" $URL
 Added: 7.33.0
+See-also: basic ntlm digest
 ---
 Specify the Bearer Token for OAUTH 2.0 server authentication. The Bearer Token
 is used in conjunction with the user name which can be specified as part of

--- a/docs/cmdline-opts/parallel.d
+++ b/docs/cmdline-opts/parallel.d
@@ -4,6 +4,7 @@ Help: Perform transfers in parallel
 Added: 7.66.0
 Category: connection curl
 Example: --parallel $URL -o file1 $URL -o file2
+See-also: next verbose
 ---
 Makes curl perform its transfers in parallel as compared to the regular serial
 manner.

--- a/docs/cmdline-opts/pass.d
+++ b/docs/cmdline-opts/pass.d
@@ -5,6 +5,7 @@ Protocols: SSH TLS
 Category: ssh tls auth
 Example: --pass secret --key file $URL
 Added: 7.9.3
+See-also: key user
 ---
 Passphrase for the private key.
 

--- a/docs/cmdline-opts/path-as-is.d
+++ b/docs/cmdline-opts/path-as-is.d
@@ -3,6 +3,7 @@ Help: Do not squash .. sequences in URL path
 Added: 7.42.0
 Category: curl
 Example: --path-as-is https://example.com/../../etc/passwd
+See-also: request-target
 ---
 Tell curl to not handle sequences of /../ or /./ in the given URL
 path. Normally curl will squash or merge them according to standards but with

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -6,6 +6,7 @@ Category: tls
 Example: --pinnedpubkey keyfile $URL
 Example: --pinnedpubkey 'sha256//ce118b51897f4452dc' $URL
 Added: 7.39.0
+See-also: hostpubsha256
 ---
 Tells curl to use the specified public key file (or hashes) to verify the
 peer. This can be a path to a file which contains a single public key in PEM

--- a/docs/cmdline-opts/preproxy.d
+++ b/docs/cmdline-opts/preproxy.d
@@ -4,6 +4,7 @@ Help: Use this proxy first
 Added: 7.52.0
 Category: proxy
 Example: --preproxy socks5://proxy.example -x http://http.example $URL
+See-also: proxy socks5
 ---
 Use the specified SOCKS proxy before connecting to an HTTP or HTTPS --proxy. In
 such a case curl first connects to the SOCKS proxy and then connects (through

--- a/docs/cmdline-opts/progress-bar.d
+++ b/docs/cmdline-opts/progress-bar.d
@@ -4,6 +4,7 @@ Help: Display transfer progress as a bar
 Category: verbose
 Example: -# -O $URL
 Added: 5.10
+See-also: styled-output
 ---
 Make curl display transfer progress as a simple progress bar instead of the
 standard, more informational, meter.

--- a/docs/cmdline-opts/proto-default.d
+++ b/docs/cmdline-opts/proto-default.d
@@ -4,6 +4,7 @@ Arg: <protocol>
 Added: 7.45.0
 Category: connection curl
 Example: --proto-default https ftp.example.com
+See-also: proto proto-redir
 ---
 Tells curl to use *protocol* for any URL missing a scheme name.
 

--- a/docs/cmdline-opts/proto-redir.d
+++ b/docs/cmdline-opts/proto-redir.d
@@ -4,6 +4,7 @@ Help: Enable/disable PROTOCOLS on redirect
 Added: 7.20.2
 Category: connection curl
 Example: --proto-redir =http,https $URL
+See-also: proto
 ---
 Tells curl to limit what protocols it may use on redirect. Protocols denied by
 --proto are not overridden by this option. See --proto for how protocols are

--- a/docs/cmdline-opts/proxy-cert-type.d
+++ b/docs/cmdline-opts/proxy-cert-type.d
@@ -4,5 +4,6 @@ Added: 7.52.0
 Help: Client certificate type for HTTPS proxy
 Category: proxy tls
 Example: --proxy-cert-type PEM --proxy-cert file -x https://proxy $URL
+See-also: proxy-cert
 ---
 Same as --cert-type but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-cert.d
+++ b/docs/cmdline-opts/proxy-cert.d
@@ -4,5 +4,6 @@ Help: Set client certificate for proxy
 Added: 7.52.0
 Category: proxy tls
 Example: --proxy-cert file -x https://proxy $URL
+See-also: proxy-cert-type
 ---
 Same as --cert but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-ciphers.d
+++ b/docs/cmdline-opts/proxy-ciphers.d
@@ -4,5 +4,6 @@ Help: SSL ciphers to use for proxy
 Added: 7.52.0
 Category: proxy tls
 Example: --proxy-ciphers ECDHE-ECDSA-AES256-CCM8 -x https://proxy $URL
+See-also: ciphers curves proxy
 ---
 Same as --ciphers but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-crlfile.d
+++ b/docs/cmdline-opts/proxy-crlfile.d
@@ -4,5 +4,6 @@ Help: Set a CRL list for proxy
 Added: 7.52.0
 Category: proxy tls
 Example: --proxy-crlfile rejects.txt -x https://proxy $URL
+See-also: crlfile proxy
 ---
 Same as --crlfile but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-header.d
+++ b/docs/cmdline-opts/proxy-header.d
@@ -7,6 +7,7 @@ Category: proxy
 Example: --proxy-header "X-First-Name: Joe" -x http://proxy $URL
 Example: --proxy-header "User-Agent: surprise" -x http://proxy $URL
 Example: --proxy-header "Host:" -x http://proxy $URL
+See-also: proxy
 ---
 Extra header to include in the request when sending HTTP to a proxy. You may
 specify any number of extra headers. This is the equivalent option to --header

--- a/docs/cmdline-opts/proxy-insecure.d
+++ b/docs/cmdline-opts/proxy-insecure.d
@@ -3,5 +3,6 @@ Help: Do HTTPS proxy connections without verifying the proxy
 Added: 7.52.0
 Category: proxy tls
 Example: --proxy-insecure -x https://proxy $URL
+See-also: proxy insecure
 ---
 Same as --insecure but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-key-type.d
+++ b/docs/cmdline-opts/proxy-key-type.d
@@ -4,5 +4,6 @@ Help: Private key file type for proxy
 Added: 7.52.0
 Category: proxy tls
 Example: --proxy-key-type DER --proxy-key here -x https://proxy $URL
+See-also: proxy-key proxy
 ---
 Same as --key-type but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-key.d
+++ b/docs/cmdline-opts/proxy-key.d
@@ -4,5 +4,6 @@ Arg: <key>
 Category: proxy tls
 Example: --proxy-key here -x https://proxy $URL
 Added: 7.52.0
+See-also: proxy-key-type proxy
 ---
 Same as --key but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-pass.d
+++ b/docs/cmdline-opts/proxy-pass.d
@@ -4,5 +4,6 @@ Help: Pass phrase for the private key for HTTPS proxy
 Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-pass secret --proxy-key here -x https://proxy $URL
+See-also: proxy proxy-key
 ---
 Same as --pass but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-pinnedpubkey.d
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.d
@@ -6,6 +6,7 @@ Category: proxy tls
 Example: --proxy-pinnedpubkey keyfile $URL
 Example: --proxy-pinnedpubkey 'sha256//ce118b51897f4452dc' $URL
 Added: 7.59.0
+See-also: pinnedpubkey proxy
 ---
 Tells curl to use the specified public key file (or hashes) to verify the
 proxy. This can be a path to a file which contains a single public key in PEM

--- a/docs/cmdline-opts/proxy-service-name.d
+++ b/docs/cmdline-opts/proxy-service-name.d
@@ -4,5 +4,6 @@ Help: SPNEGO proxy service name
 Added: 7.43.0
 Category: proxy tls
 Example: --proxy-service-name "shrubbery" -x proxy $URL
+See-also: service-name proxy
 ---
 This option allows you to change the service name for proxy negotiation.

--- a/docs/cmdline-opts/proxy-ssl-allow-beast.d
+++ b/docs/cmdline-opts/proxy-ssl-allow-beast.d
@@ -3,5 +3,6 @@ Help: Allow security flaw for interop for HTTPS proxy
 Added: 7.52.0
 Category: proxy tls
 Example: --proxy-ssl-allow-beast -x https://proxy $URL
+See-also: ssl-allow-beast proxy
 ---
 Same as --ssl-allow-beast but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-ssl-auto-client-cert.d
+++ b/docs/cmdline-opts/proxy-ssl-auto-client-cert.d
@@ -3,5 +3,6 @@ Help: Use auto client certificate for proxy (Schannel)
 Added: 7.77.0
 Category: proxy tls
 Example: --proxy-ssl-auto-client-cert -x https://proxy $URL
+See-also: ssl-auto-client-cert proxy
 ---
 Same as --ssl-auto-client-cert but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tls13-ciphers.d
+++ b/docs/cmdline-opts/proxy-tls13-ciphers.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Category: proxy tls
 Example: --proxy-tls13-ciphers TLS_AES_128_GCM_SHA256 -x proxy $URL
 Added: 7.61.0
+See-also: tls13-ciphers curves
 ---
 Specifies which cipher suites to use in the connection to your HTTPS proxy
 when it negotiates TLS 1.3. The list of ciphers suites must specify valid

--- a/docs/cmdline-opts/proxy-tlsauthtype.d
+++ b/docs/cmdline-opts/proxy-tlsauthtype.d
@@ -4,5 +4,6 @@ Help: TLS authentication type for HTTPS proxy
 Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlsauthtype SRP -x https://proxy $URL
+See-also: proxy proxy-tlsuser
 ---
 Same as --tlsauthtype but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tlspassword.d
+++ b/docs/cmdline-opts/proxy-tlspassword.d
@@ -4,5 +4,6 @@ Help: TLS password for HTTPS proxy
 Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlspassword passwd -x https://proxy $URL
+See-also: proxy proxy-tlsuser
 ---
 Same as --tlspassword but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tlsuser.d
+++ b/docs/cmdline-opts/proxy-tlsuser.d
@@ -4,5 +4,6 @@ Help: TLS username for HTTPS proxy
 Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlsuser smith -x https://proxy $URL
+See-also: proxy proxy-tlspassword
 ---
 Same as --tlsuser but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tlsv1.d
+++ b/docs/cmdline-opts/proxy-tlsv1.d
@@ -3,5 +3,6 @@ Help: Use TLSv1 for HTTPS proxy
 Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlsv1 -x https://proxy $URL
+See-also: proxy
 ---
 Same as --tlsv1 but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-user.d
+++ b/docs/cmdline-opts/proxy-user.d
@@ -5,6 +5,7 @@ Help: Proxy user and password
 Category: proxy auth
 Example: --proxy-user name:pwd -x proxy $URL
 Added: 4.0
+See-also: proxy-pass
 ---
 Specify the user name and password to use for proxy authentication.
 

--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -5,6 +5,7 @@ Help: Use this proxy
 Category: proxy
 Example: --proxy http://proxy.example $URL
 Added: 4.0
+See-also: socks5 proxy-basic
 ---
 Use the specified proxy.
 

--- a/docs/cmdline-opts/proxy1.0.d
+++ b/docs/cmdline-opts/proxy1.0.d
@@ -4,6 +4,7 @@ Help: Use HTTP/1.0 proxy on given port
 Category: proxy
 Example: --proxy1.0 -x http://proxy $URL
 Added: 7.19.4
+See-also: proxy socks5 preproxy
 ---
 Use the specified HTTP 1.0 proxy. If the port number is not specified, it is
 assumed at port 1080.

--- a/docs/cmdline-opts/pubkey.d
+++ b/docs/cmdline-opts/pubkey.d
@@ -5,6 +5,7 @@ Help: SSH Public key file name
 Category: sftp scp auth
 Example: --pubkey file.pub sftp://example.com/
 Added: 7.16.2
+See-also: pass
 ---
 Public key file name. Allows you to provide your public key in this separate
 file.

--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -6,6 +6,7 @@ Protocols: FTP SFTP
 Category: ftp sftp
 Example: --quote "DELE file" ftp://example.com/foo
 Added: 5.3
+See-also: request
 ---
 Send an arbitrary command to the remote FTP or SFTP server. Quote commands are
 sent BEFORE the transfer takes place (just after the initial PWD command in an

--- a/docs/cmdline-opts/random-file.d
+++ b/docs/cmdline-opts/random-file.d
@@ -4,6 +4,7 @@ Help: File for reading random data from
 Category: misc
 Example: --random-file rubbish $URL
 Added: 7.7
+See-also: egd-file
 ---
 Specify the path name to file containing what will be considered as random
 data. The data may be used to seed the random engine for SSL connections.  See

--- a/docs/cmdline-opts/range.d
+++ b/docs/cmdline-opts/range.d
@@ -6,6 +6,7 @@ Protocols: HTTP FTP SFTP FILE
 Category: http ftp sftp file
 Example: --range 22-44 $URL
 Added: 4.0
+See-also: continue-at append
 ---
 Retrieve a byte range (i.e. a partial document) from an HTTP/1.1, FTP or SFTP
 server or a local FILE. Ranges can be specified in a number of ways.

--- a/docs/cmdline-opts/raw.d
+++ b/docs/cmdline-opts/raw.d
@@ -4,6 +4,7 @@ Added: 7.16.2
 Protocols: HTTP
 Category: http
 Example: --raw $URL
+See-also: tr-encoding
 ---
 When used, it disables all internal HTTP decoding of content or transfer
 encodings and instead makes them passed on unaltered, raw.

--- a/docs/cmdline-opts/remote-header-name.d
+++ b/docs/cmdline-opts/remote-header-name.d
@@ -5,6 +5,7 @@ Help: Use the header-provided filename
 Category: output
 Example: -OJ https://example.com/file
 Added: 7.20.0
+See-also: remote-name
 ---
 This option tells the --remote-name option to use the server-specified
 Content-Disposition filename instead of extracting a filename from the URL.

--- a/docs/cmdline-opts/remote-name-all.d
+++ b/docs/cmdline-opts/remote-name-all.d
@@ -3,6 +3,7 @@ Help: Use the remote file name for all URLs
 Added: 7.19.0
 Category: output
 Example: --remote-name-all ftp://example.com/file1 ftp://example.com/file2
+See-also: remote-name
 ---
 This option changes the default action for all given URLs to be dealt with as
 if --remote-name were used for each one. So if you want to disable that for a

--- a/docs/cmdline-opts/remote-name.d
+++ b/docs/cmdline-opts/remote-name.d
@@ -4,6 +4,7 @@ Help: Write output to a file named as the remote file
 Category: important output
 Example: -O https://example.com/filename
 Added: 4.0
+See-also: remote-name-all
 ---
 Write output to a local file named like the remote file we get. (Only the file
 part of the remote file is used, the path is cut off.)

--- a/docs/cmdline-opts/remote-time.d
+++ b/docs/cmdline-opts/remote-time.d
@@ -4,6 +4,7 @@ Help: Set the remote file's time on the local output
 Category: output
 Example: --remote-time -o foo $URL
 Added: 7.9
+See-also: remote-name time-cond
 ---
 When used, this will make curl attempt to figure out the timestamp of the
 remote file, and if that is available make the local file get that same

--- a/docs/cmdline-opts/request-target.d
+++ b/docs/cmdline-opts/request-target.d
@@ -5,6 +5,7 @@ Protocols: HTTP
 Added: 7.55.0
 Category: http
 Example: --request-target "*" -X OPTIONS $URL
+See-also: request
 ---
 Tells curl to use an alternative "target" (path) instead of using the path as
 provided in the URL. Particularly useful when wanting to issue HTTP requests

--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -6,6 +6,7 @@ Category: connection
 Example: -X "DELETE" $URL
 Example: -X NLST ftp://example.com/
 Added: 6.0
+See-also: request-target
 ---
 (HTTP) Specifies a custom request method to use when communicating with the
 HTTP server.  The specified request method will be used instead of the method

--- a/docs/cmdline-opts/resolve.d
+++ b/docs/cmdline-opts/resolve.d
@@ -4,6 +4,7 @@ Help: Resolve the host+port to this address
 Added: 7.21.3
 Category: connection
 Example: --resolve example.com:443:127.0.0.1 $URL
+See-also: connect-to alt-svc
 ---
 Provide a custom address for a specific host and port pair. Using this, you
 can make the curl requests(s) use a specified address and prevent the

--- a/docs/cmdline-opts/retry-all-errors.d
+++ b/docs/cmdline-opts/retry-all-errors.d
@@ -3,6 +3,7 @@ Help: Retry all errors (use with --retry)
 Added: 7.71.0
 Category: curl
 Example: --retry-all-errors $URL
+See-also: retry
 ---
 Retry on any error. This option is used together with --retry.
 

--- a/docs/cmdline-opts/retry-connrefused.d
+++ b/docs/cmdline-opts/retry-connrefused.d
@@ -3,6 +3,7 @@ Help: Retry on connection refused (use with --retry)
 Added: 7.52.0
 Category: curl
 Example: --retry-connrefused --retry $URL
+See-also: retry retry-all-errors
 ---
 In addition to the other conditions, consider ECONNREFUSED as a transient
 error too for --retry. This option is used together with --retry.

--- a/docs/cmdline-opts/retry-delay.d
+++ b/docs/cmdline-opts/retry-delay.d
@@ -4,6 +4,7 @@ Help: Wait time between retries
 Added: 7.12.3
 Category: curl
 Example: --retry-delay 5 --retry $URL
+See-also: retry
 ---
 Make curl sleep this amount of time before each retry when a transfer has
 failed with a transient error (it changes the default backoff time algorithm

--- a/docs/cmdline-opts/retry-max-time.d
+++ b/docs/cmdline-opts/retry-max-time.d
@@ -4,6 +4,7 @@ Help: Retry only within this period
 Added: 7.12.3
 Category: curl
 Example: --retry-max-time 30 --retry 10 $URL
+See-also: retry
 ---
 The retry timer is reset before the first transfer attempt. Retries will be
 done as usual (see --retry) as long as the timer has not reached this given

--- a/docs/cmdline-opts/retry.d
+++ b/docs/cmdline-opts/retry.d
@@ -4,6 +4,7 @@ Added: 7.12.3
 Help: Retry request if transient problems occur
 Category: curl
 Example: --retry 7 $URL
+See-also: retry-max-time
 ---
 If a transient error is returned when curl tries to perform a transfer, it
 will retry this number of times before giving up. Setting the number to 0

--- a/docs/cmdline-opts/sasl-authzid.d
+++ b/docs/cmdline-opts/sasl-authzid.d
@@ -4,6 +4,7 @@ Help: Identity for SASL PLAIN authentication
 Added: 7.66.0
 Category: auth
 Example: --sasl-authzid zid imap://example.com/
+See-also: login-options
 ---
 Use this authorisation identity (authzid), during SASL PLAIN authentication,
 in addition to the authentication identity (authcid) as specified by --user.

--- a/docs/cmdline-opts/sasl-ir.d
+++ b/docs/cmdline-opts/sasl-ir.d
@@ -3,5 +3,6 @@ Help: Enable initial response in SASL authentication
 Added: 7.31.0
 Category: auth
 Example: --sasl-ir imap://example.com/
+See-also: sasl-authzid
 ---
 Enable initial response in SASL authentication.

--- a/docs/cmdline-opts/service-name.d
+++ b/docs/cmdline-opts/service-name.d
@@ -4,6 +4,7 @@ Arg: <name>
 Added: 7.43.0
 Category: misc
 Example: --service-name sockd/server $URL
+See-also: negotiate proxy-service-name
 ---
 This option allows you to change the service name for SPNEGO.
 

--- a/docs/cmdline-opts/socks4.d
+++ b/docs/cmdline-opts/socks4.d
@@ -4,6 +4,7 @@ Help: SOCKS4 proxy on given host + port
 Added: 7.15.2
 Category: proxy
 Example: --socks4 hostname:4096 $URL
+See-also: socks4a socks5 socks5-hostname
 ---
 Use the specified SOCKS4 proxy. If the port number is not specified, it is
 assumed at port 1080. Using this socket type make curl resolve the host name

--- a/docs/cmdline-opts/socks4a.d
+++ b/docs/cmdline-opts/socks4a.d
@@ -4,6 +4,7 @@ Help: SOCKS4a proxy on given host + port
 Added: 7.18.0
 Category: proxy
 Example: --socks4a hostname:4096 $URL
+See-also: socks4 socks5 socks5-hostname
 ---
 Use the specified SOCKS4a proxy. If the port number is not specified, it is
 assumed at port 1080. This asks the proxy to resolve the host name.

--- a/docs/cmdline-opts/socks5-basic.d
+++ b/docs/cmdline-opts/socks5-basic.d
@@ -3,6 +3,7 @@ Help: Enable username/password auth for SOCKS5 proxies
 Added: 7.55.0
 Category: proxy auth
 Example: --socks5-basic --socks5 hostname:4096 $URL
+See-also: socks5
 ---
 Tells curl to use username/password authentication when connecting to a SOCKS5
 proxy.  The username/password authentication is enabled by default.  Use

--- a/docs/cmdline-opts/socks5-gssapi-nec.d
+++ b/docs/cmdline-opts/socks5-gssapi-nec.d
@@ -3,6 +3,7 @@ Help: Compatibility with NEC SOCKS5 server
 Added: 7.19.4
 Category: proxy auth
 Example: --socks5-gssapi-nec --socks5 hostname:4096 $URL
+See-also: socks5
 ---
 As part of the GSS-API negotiation a protection mode is negotiated. RFC 1961
 says in section 4.3/4.4 it should be protected, but the NEC reference

--- a/docs/cmdline-opts/socks5-gssapi-service.d
+++ b/docs/cmdline-opts/socks5-gssapi-service.d
@@ -4,6 +4,7 @@ Help: SOCKS5 proxy service name for GSS-API
 Added: 7.19.4
 Category: proxy auth
 Example: --socks5-gssapi-service sockd --socks5 hostname:4096 $URL
+See-also: socks5
 ---
 The default service name for a socks server is rcmd/server-fqdn. This option
 allows you to change it.

--- a/docs/cmdline-opts/socks5-gssapi.d
+++ b/docs/cmdline-opts/socks5-gssapi.d
@@ -3,6 +3,7 @@ Help: Enable GSS-API auth for SOCKS5 proxies
 Added: 7.55.0
 Category: proxy auth
 Example: --socks5-gssapi --socks5 hostname:4096 $URL
+See-also: socks5
 ---
 Tells curl to use GSS-API authentication when connecting to a SOCKS5 proxy.
 The GSS-API authentication is enabled by default (if curl is compiled with

--- a/docs/cmdline-opts/socks5-hostname.d
+++ b/docs/cmdline-opts/socks5-hostname.d
@@ -4,6 +4,7 @@ Help: SOCKS5 proxy, pass host name to proxy
 Added: 7.18.0
 Category: proxy
 Example: --socks5-hostname proxy.example:7000 $URL
+See-also: socks5 socks4a
 ---
 Use the specified SOCKS5 proxy (and let the proxy resolve the host name). If
 the port number is not specified, it is assumed at port 1080.

--- a/docs/cmdline-opts/socks5.d
+++ b/docs/cmdline-opts/socks5.d
@@ -4,6 +4,7 @@ Help: SOCKS5 proxy on given host + port
 Added: 7.18.0
 Category: proxy
 Example: --socks5 proxy.example:7000 $URL
+See-also: socks5-hostname socks4a
 ---
 Use the specified SOCKS5 proxy - but resolve the host name locally. If the
 port number is not specified, it is assumed at port 1080.

--- a/docs/cmdline-opts/speed-limit.d
+++ b/docs/cmdline-opts/speed-limit.d
@@ -5,6 +5,7 @@ Help: Stop transfers slower than this
 Category: connection
 Example: --speed-limit 300 --speed-time 10 $URL
 Added: 4.7
+See-also: speed-time limit-rate max-time
 ---
 If a download is slower than this given speed (in bytes per second) for
 speed-time seconds it gets aborted. speed-time is set with --speed-time and is

--- a/docs/cmdline-opts/speed-time.d
+++ b/docs/cmdline-opts/speed-time.d
@@ -5,6 +5,7 @@ Help: Trigger 'speed-limit' abort after this time
 Category: connection
 Example: --speed-limit 300 --speed-time 10 $URL
 Added: 4.7
+See-also: speed-limit limit-rate
 ---
 If a download is slower than speed-limit bytes per second during a speed-time
 period, the download gets aborted. If speed-time is used, the default

--- a/docs/cmdline-opts/ssl-allow-beast.d
+++ b/docs/cmdline-opts/ssl-allow-beast.d
@@ -3,6 +3,7 @@ Help: Allow security flaw to improve interop
 Added: 7.25.0
 Category: tls
 Example: --ssl-allow-beast $URL
+See-also: proxy-ssl-allow-beast insecure
 ---
 This option tells curl to not work around a security flaw in the SSL3 and
 TLS1.0 protocols known as BEAST.  If this option is not used, the SSL layer

--- a/docs/cmdline-opts/ssl-no-revoke.d
+++ b/docs/cmdline-opts/ssl-no-revoke.d
@@ -3,6 +3,7 @@ Help: Disable cert revocation checks (Schannel)
 Added: 7.44.0
 Category: tls
 Example: --ssl-no-revoke $URL
+See-also: crlfile
 ---
 (Schannel) This option tells curl to disable certificate revocation checks.
 WARNING: this option loosens the SSL security, and by using this flag you ask

--- a/docs/cmdline-opts/ssl-reqd.d
+++ b/docs/cmdline-opts/ssl-reqd.d
@@ -4,6 +4,7 @@ Protocols: FTP IMAP POP3 SMTP
 Added: 7.20.0
 Category: tls
 Example: --ssl-reqd ftp://example.com
+See-also: ssl insecure
 ---
 Require SSL/TLS for the connection.  Terminates the connection if the server
 does not support SSL/TLS.

--- a/docs/cmdline-opts/ssl-revoke-best-effort.d
+++ b/docs/cmdline-opts/ssl-revoke-best-effort.d
@@ -3,6 +3,7 @@ Help: Ignore missing/offline cert CRL dist points
 Added: 7.70.0
 Category: tls
 Example: --ssl-revoke-best-effort $URL
+See-also: crlfile insecure
 ---
 (Schannel) This option tells curl to ignore certificate revocation checks when
 they failed due to missing/offline distribution points for the revocation check

--- a/docs/cmdline-opts/ssl.d
+++ b/docs/cmdline-opts/ssl.d
@@ -4,6 +4,7 @@ Protocols: FTP IMAP POP3 SMTP
 Added: 7.20.0
 Category: tls
 Example: --ssl pop3://example.com/
+See-also: insecure ciphers
 ---
 Try to use SSL/TLS for the connection.  Reverts to a non-secure connection if
 the server does not support SSL/TLS.  See also --ftp-ssl-control and --ssl-reqd

--- a/docs/cmdline-opts/styled-output.d
+++ b/docs/cmdline-opts/styled-output.d
@@ -3,6 +3,7 @@ Help: Enable styled output for HTTP headers
 Added: 7.61.0
 Category: verbose
 Example: --styled-output -I $URL
+See-also: head verbose
 ---
 Enables the automatic use of bold font styles when writing HTTP headers to the
 terminal. Use --no-styled-output to switch them off.

--- a/docs/cmdline-opts/tcp-fastopen.d
+++ b/docs/cmdline-opts/tcp-fastopen.d
@@ -3,5 +3,6 @@ Added: 7.49.0
 Help: Use TCP Fast Open
 Category: connection
 Example: --tcp-fastopen $URL
+See-also: false-start
 ---
 Enable use of TCP Fast Open (RFC7413).

--- a/docs/cmdline-opts/tcp-nodelay.d
+++ b/docs/cmdline-opts/tcp-nodelay.d
@@ -3,6 +3,7 @@ Help: Use the TCP_NODELAY option
 Added: 7.11.2
 Category: connection
 Example: --tcp-nodelay $URL
+See-also: no-buffer
 ---
 Turn on the TCP_NODELAY option. See the *curl_easy_setopt(3)* man page for
 details about this option.

--- a/docs/cmdline-opts/telnet-option.d
+++ b/docs/cmdline-opts/telnet-option.d
@@ -5,6 +5,7 @@ Help: Set telnet option
 Category: telnet
 Example: -t TTYPE=vt100 telnet://example.com/
 Added: 7.7
+See-also: config
 ---
 Pass options to the telnet protocol. Supported options are:
 

--- a/docs/cmdline-opts/tftp-blksize.d
+++ b/docs/cmdline-opts/tftp-blksize.d
@@ -5,6 +5,7 @@ Protocols: TFTP
 Added: 7.20.0
 Category: tftp
 Example: --tftp-blksize 1024 tftp://example.com/file
+See-also: tftp-no-options
 ---
 Set TFTP BLKSIZE option (must be >512). This is the block size that curl will
 try to use when transferring data to or from a TFTP server. By default 512

--- a/docs/cmdline-opts/tftp-no-options.d
+++ b/docs/cmdline-opts/tftp-no-options.d
@@ -4,6 +4,7 @@ Protocols: TFTP
 Added: 7.48.0
 Category: tftp
 Example: --tftp-no-options tftp://192.168.0.1/
+See-also: tftp-blksize
 ---
 Tells curl not to send TFTP options requests.
 

--- a/docs/cmdline-opts/time-cond.d
+++ b/docs/cmdline-opts/time-cond.d
@@ -8,6 +8,7 @@ Example: -z "Wed 01 Sep 2021 12:18:00" $URL
 Example: -z "-Wed 01 Sep 2021 12:18:00" $URL
 Example: -z file $URL
 Added: 5.8
+See-also: etag-compare remote-time
 ---
 Request a file that has been modified later than the given time and date, or
 one that has been modified before that time. The <date expression> can be all

--- a/docs/cmdline-opts/tls13-ciphers.d
+++ b/docs/cmdline-opts/tls13-ciphers.d
@@ -5,6 +5,7 @@ Protocols: TLS
 Category: tls
 Example: --tls13-ciphers TLS_AES_128_GCM_SHA256 $URL
 Added: 7.61.0
+See-also: ciphers curves
 ---
 Specifies which cipher suites to use in the connection if it negotiates TLS
 1.3. The list of ciphers suites must specify valid ciphers. Read up on TLS 1.3

--- a/docs/cmdline-opts/tlsauthtype.d
+++ b/docs/cmdline-opts/tlsauthtype.d
@@ -4,6 +4,7 @@ Help: TLS authentication type
 Added: 7.21.4
 Category: tls auth
 Example: --tlsauthtype SRP $URL
+See-also: tlsuser
 ---
 Set TLS authentication type. Currently, the only supported option is "SRP",
 for TLS-SRP (RFC 5054). If --tlsuser and --tlspassword are specified but

--- a/docs/cmdline-opts/tlspassword.d
+++ b/docs/cmdline-opts/tlspassword.d
@@ -4,6 +4,7 @@ Help: TLS password
 Added: 7.21.4
 Category: tls auth
 Example: --tlspassword pwd --tlsuser user $URL
+See-also: tlsuser
 ---
 Set password for use with the TLS authentication method specified with
 --tlsauthtype. Requires that --tlsuser also be set.

--- a/docs/cmdline-opts/tlsuser.d
+++ b/docs/cmdline-opts/tlsuser.d
@@ -4,6 +4,7 @@ Help: TLS user name
 Added: 7.21.4
 Category: tls auth
 Example: --tlspassword pwd --tlsuser user $URL
+See-also: tlspassword
 ---
 Set username for use with the TLS authentication method specified with
 --tlsauthtype. Requires that --tlspassword also is set.

--- a/docs/cmdline-opts/tlsv1.0.d
+++ b/docs/cmdline-opts/tlsv1.0.d
@@ -4,6 +4,7 @@ Protocols: TLS
 Added: 7.34.0
 Category: tls
 Example: --tlsv1.0 $URL
+See-also: tlsv1.3
 ---
 Forces curl to use TLS version 1.0 or later when connecting to a remote TLS server.
 

--- a/docs/cmdline-opts/tlsv1.1.d
+++ b/docs/cmdline-opts/tlsv1.1.d
@@ -4,6 +4,7 @@ Protocols: TLS
 Added: 7.34.0
 Category: tls
 Example: --tlsv1.1 $URL
+See-also: tlsv1.3
 ---
 Forces curl to use TLS version 1.1 or later when connecting to a remote TLS server.
 

--- a/docs/cmdline-opts/tlsv1.2.d
+++ b/docs/cmdline-opts/tlsv1.2.d
@@ -4,6 +4,7 @@ Protocols: TLS
 Added: 7.34.0
 Category: tls
 Example: --tlsv1.2 $URL
+See-also: tlsv1.3
 ---
 Forces curl to use TLS version 1.2 or later when connecting to a remote TLS server.
 

--- a/docs/cmdline-opts/tlsv1.3.d
+++ b/docs/cmdline-opts/tlsv1.3.d
@@ -4,6 +4,7 @@ Protocols: TLS
 Added: 7.52.0
 Category: tls
 Example: --tlsv1.3 $URL
+See-also: tlsv1.2
 ---
 Forces curl to use TLS version 1.3 or later when connecting to a remote TLS
 server.

--- a/docs/cmdline-opts/tr-encoding.d
+++ b/docs/cmdline-opts/tr-encoding.d
@@ -4,6 +4,7 @@ Help: Request compressed transfer encoding
 Protocols: HTTP
 Category: http
 Example: --tr-encoding $URL
+See-also: compressed
 ---
 Request a compressed Transfer-Encoding response using one of the algorithms
 curl supports, and uncompress the data while receiving it.

--- a/docs/cmdline-opts/trace-ascii.d
+++ b/docs/cmdline-opts/trace-ascii.d
@@ -5,6 +5,7 @@ Mutexed: trace verbose
 Category: verbose
 Example: --trace-ascii log.txt $URL
 Added: 7.9.7
+See-also: verbose trace
 ---
 Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have

--- a/docs/cmdline-opts/trace-time.d
+++ b/docs/cmdline-opts/trace-time.d
@@ -3,6 +3,7 @@ Help: Add time stamps to trace/verbose output
 Added: 7.14.0
 Category: verbose
 Example: --trace-time --trace-ascii output $URL
+See-also: trace verbose
 ---
 Prepends a time stamp to each trace or verbose line that curl displays.
 

--- a/docs/cmdline-opts/trace.d
+++ b/docs/cmdline-opts/trace.d
@@ -5,6 +5,7 @@ Mutexed: verbose trace-ascii
 Category: verbose
 Example: --trace log.txt $URL
 Added: 7.9.7
+See-also: trace-ascii trace-time
 ---
 Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have

--- a/docs/cmdline-opts/unix-socket.d
+++ b/docs/cmdline-opts/unix-socket.d
@@ -4,6 +4,7 @@ Help: Connect through this Unix domain socket
 Added: 7.40.0
 Protocols: HTTP
 Category: connection
+See-also: abstract-unix-socket
 Example: --unix-socket socket-path $URL
 ---
 Connect through this Unix domain socket, instead of using the network.

--- a/docs/cmdline-opts/upload-file.d
+++ b/docs/cmdline-opts/upload-file.d
@@ -7,6 +7,7 @@ Example: -T file $URL
 Example: -T "img[1-1000].png" ftp://ftp.example.com/
 Example: --upload-file "{file1,file2}" $URL
 Added: 4.0
+See-also: get head
 ---
 This transfers the specified local file to the remote URL. If there is no file
 part in the specified URL, curl will append the local file name. NOTE that you

--- a/docs/cmdline-opts/url.d
+++ b/docs/cmdline-opts/url.d
@@ -4,6 +4,7 @@ Help: URL to work with
 Category: curl
 Example: --url $URL
 Added: 7.5
+See-also: next config
 ---
 Specify a URL to fetch. This option is mostly handy when you want to specify
 URL(s) in a config file.

--- a/docs/cmdline-opts/use-ascii.d
+++ b/docs/cmdline-opts/use-ascii.d
@@ -5,6 +5,7 @@ Protocols: FTP LDAP
 Category: misc
 Example: -B ftp://example.com/README
 Added: 5.0
+See-also: crlf data-ascii
 ---
 Enable ASCII transfer. For FTP, this can also be enforced by using a URL that
 ends with ";type=A". This option causes data sent to stdout to be in text mode

--- a/docs/cmdline-opts/user-agent.d
+++ b/docs/cmdline-opts/user-agent.d
@@ -6,6 +6,7 @@ Protocols: HTTP
 Category: important http
 Example: -A "Agent 007" $URL
 Added: 4.5.1
+See-also: header proxy-header
 ---
 Specify the User-Agent string to send to the HTTP server. To encode blanks in
 the string, surround the string with single quote marks. This header can also

--- a/docs/cmdline-opts/user.d
+++ b/docs/cmdline-opts/user.d
@@ -5,6 +5,7 @@ Help: Server user and password
 Category: important auth
 Example: -u user:secret $URL
 Added: 4.0
+See-also: netrc config
 ---
 Specify the user name and password to use for server authentication. Overrides
 --netrc and --netrc-optional.

--- a/docs/cmdline-opts/version.d
+++ b/docs/cmdline-opts/version.d
@@ -4,6 +4,7 @@ Help: Show version number and quit
 Category: important curl
 Example: --version
 Added: 4.0
+See-also: help manual
 ---
 Displays information about curl and the libcurl version it uses.
 

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -5,6 +5,7 @@ Help: Use output FORMAT after completion
 Category: verbose
 Example: -w '%{http_code}\\n' $URL
 Added: 6.5
+See-also: verbose head
 ---
 Make curl display information on stdout after a completed transfer. The format
 is a string that may contain plain text mixed with any number of

--- a/docs/cmdline-opts/xattr.d
+++ b/docs/cmdline-opts/xattr.d
@@ -3,6 +3,7 @@ Help: Store metadata in extended file attributes
 Category: misc
 Example: --xattr -o storage $URL
 Added: 7.21.3
+See-also: remote-time write-out verbose
 ---
 When saving output to a file, this option tells curl to store certain file
 metadata in extended file attributes. Currently, the URL is stored in the


### PR DESCRIPTION
gen.pl now generates a warning if the "See Also" field is not filled in for a
command line option

All command line options now provide one or more related options.