### PR TITLE
tftp: mark as not possible to do over CONNECT

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -744,15 +744,17 @@ void Curl_conninfo_local(struct Curl_easy *data, curl_socket_t sockfd,
 void Curl_updateconninfo(struct Curl_easy *data, struct connectdata *conn,
                          curl_socket_t sockfd)
 {
-  /* 'local_ip' and 'local_port' get filled with local's numerical ip address
-     and port number whenever an outgoing connection is **established** from
-     the primary socket to a remote address. */
+  /* 'local_ip' and 'local_port' get filled with local's numerical
+     ip address and port number whenever an outgoing connection is
+     **established** from the primary socket to a remote address. */
   char local_ip[MAX_IPADR_LEN] = "";
   int local_port = -1;
 
-  if(!conn->bits.reuse && !conn->bits.tcp_fastopen)
-    Curl_conninfo_remote(data, conn, sockfd);
-  Curl_conninfo_local(data, sockfd, local_ip, &local_port);
+  if(conn->transport == TRNSPRT_TCP) {
+    if(!conn->bits.reuse && !conn->bits.tcp_fastopen)
+      Curl_conninfo_remote(data, conn, sockfd);
+    Curl_conninfo_local(data, sockfd, local_ip, &local_port);
+  } /* end of TCP-only section */
 
   /* persist connection info in session handle */
   Curl_persistconninfo(data, conn, local_ip, local_port);

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -158,6 +158,10 @@ static CURLcode connect_init(struct Curl_easy *data, bool reinit)
 {
   struct http_connect_state *s;
   struct connectdata *conn = data->conn;
+  if(conn->handler->flags & PROTOPT_NOTCPPROXY) {
+    failf(data, "%s cannot be done over CONNECT", conn->handler->scheme);
+    return CURLE_UNSUPPORTED_PROTOCOL;
+  }
   if(!reinit) {
     CURLcode result;
     DEBUGASSERT(!conn->connect_state);

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -186,7 +186,7 @@ const struct Curl_handler Curl_handler_tftp = {
   PORT_TFTP,                            /* defport */
   CURLPROTO_TFTP,                       /* protocol */
   CURLPROTO_TFTP,                       /* family */
-  PROTOPT_NONE | PROTOPT_NOURLQUERY     /* flags */
+  PROTOPT_NOTCPPROXY | PROTOPT_NOURLQUERY /* flags */
 };
 
 /**********************************************************

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -835,6 +835,7 @@ struct Curl_handler {
 #define PROTOPT_WILDCARD (1<<12) /* protocol supports wildcard matching */
 #define PROTOPT_USERPWDCTRL (1<<13) /* Allow "control bytes" (< 32 ascii) in
                                        user name and password */
+#define PROTOPT_NOTCPPROXY (1<<14) /* this protocol can't proxy over TCP */
 
 #define CONNCHECK_NONE 0                 /* No checks */
 #define CONNCHECK_ISDEAD (1<<0)          /* Check if the connection is dead. */


### PR DESCRIPTION
... and make connect_init() refusing trying to tunnel protocols marked
as not working. Avoids a double-free.

Fixes #8018
Reported-by: Even Rouault