### PR TITLE
docs/cmdline-opts: don't say "protocols: all"

### DIFF
--- a/docs/cmdline-opts/doh-cert-status.d
+++ b/docs/cmdline-opts/doh-cert-status.d
@@ -1,6 +1,5 @@
 Long: doh-cert-status
 Help: Verify the status of the DoH server cert via OCSP-staple
-Protocols: all
 Added: 7.76.0
 Category: dns tls
 Example: --doh-cert-status --doh-url https://doh.example $URL

--- a/docs/cmdline-opts/doh-insecure.d
+++ b/docs/cmdline-opts/doh-insecure.d
@@ -1,6 +1,5 @@
 Long: doh-insecure
 Help: Allow insecure DoH server connections
-Protocols: all
 Added: 7.76.0
 Category: dns tls
 Example: --doh-insecure --doh-url https://doh.example $URL

--- a/docs/cmdline-opts/doh-url.d
+++ b/docs/cmdline-opts/doh-url.d
@@ -1,7 +1,6 @@
 Long: doh-url
 Arg: <URL>
 Help: Resolve host names over DoH
-Protocols: all
 Added: 7.62.0
 Category: dns
 Example: --doh-url https://doh.example $URL


### PR DESCRIPTION
Removed the lines saying "protocols: all". It makes the output in the
manpage look funny, and the expectation is probably by default that if
not anything is mentioned about protocols the option apply to them all.