### PR TITLE
Build curl http3 without shared libraries to prevent conflicts with existing lib curl

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -130,7 +130,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
+     % ./configure --disable-shared LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
      % make
      % make install
 


### PR DESCRIPTION
When building curl, it is safer to disable the shared library to avoid conflicts with a shared version of libcurl that could already have been installed on the system. This patch disables the shared libraries when building curl that supports http3.