### PR TITLE
configure: fix runtime-lib detection on macOS

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -6514,11 +6514,17 @@ dnl CURL_LIBRARY_PATH variable. It keeps the LD_LIBRARY_PATH
 dnl changes contained within this macro.
 
 AC_DEFUN([CURL_RUN_IFELSE], [
-   old=$LD_LIBRARY_PATH
-   LD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
-   export LD_LIBRARY_PATH
+   case $host_os in
+     darwin*) library_path_var=DYLD_LIBRARY_PATH ;;
+     *)       library_path_var=LD_LIBRARY_PATH ;;
+   esac
+
+   eval "old=$$library_path_var"
+   eval "$library_path_var=\$CURL_LIBRARY_PATH:\$old"
+
+   eval "export $library_path_var"
    AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
-   LD_LIBRARY_PATH=$old # restore
+   eval "$library_path_var=\$old" # restore
 ])
 
 dnl CURL_COVERAGE


### PR DESCRIPTION
With a non-standard installation of openssl we get this error:

    checking run-time libs availability... failed
    configure: error: one or more libs available at link-time are not available run-time. Libs used at link-time: -lnghttp2 -lssl -lcrypto -lssl -lcrypto -lz

There's already code to set `LD_LIBRARY_PATH` on Linux, so set `DYLD_LIBRARY_PATH` equivalent on macOS.