### PR TITLE
Don't set _USRDLL on a static Windows build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -95,10 +95,6 @@ endif()
 
 target_link_libraries(${LIB_NAME} ${CURL_LIBS})
 
-if(WIN32)
-  add_definitions(-D_USRDLL)
-endif()
-
 set_target_properties(${LIB_NAME} PROPERTIES
   COMPILE_DEFINITIONS BUILDING_LIBCURL
   OUTPUT_NAME ${LIBCURL_OUTPUT_NAME}
@@ -121,6 +117,7 @@ endif()
 
 if(WIN32)
   if(BUILD_SHARED_LIBS)
+    set_property(TARGET ${LIB_NAME} APPEND PROPERTY COMPILE_DEFINITIONS "_USRDLL")
     if(MSVC)
       # Add "_imp" as a suffix before the extension to avoid conflicting with
       # the statically linked "libcurl.lib"


### PR DESCRIPTION
The `_USRDLL` macro should only be set when building a `.dll`.