### PR TITLE
Remove rustls comment about checking handshaking

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -416,9 +416,6 @@ cr_connect_nonblocking(struct Curl_easy *data, struct connectdata *conn,
     /*
     * Connection has been established according to rustls. Set send/recv
     * handlers, and update the state machine.
-    * This check has to come last because is_handshaking starts out false,
-    * then becomes true when we first write data, then becomes false again
-    * once the handshake is done.
     */
     if(!rustls_connection_is_handshaking(rconn)) {
       infof(data, "Done handshaking");


### PR DESCRIPTION
The comment is incorrect in two ways:
 - It says the check needs to be last, but the check is actually first.
 - is_handshaking actually starts out true.
 
Prompted by https://github.com/rustls/rustls-ffi/issues/134.