### PR TITLE
urlapi: cleanup scheme parsing

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -258,7 +258,7 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
     if(buf) {
       buf[i] = 0;
       while(i--) {
-        buf[i] = TOLOWER(url[i]);
+        buf[i] = (char)TOLOWER(url[i]);
       }
     }
     return TRUE;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -235,26 +235,31 @@ static void strcpy_url(char *output, const char *url, bool relative)
 bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
 {
   size_t i;
+  char s;
+
+  if (buf && buflen)
+    buf[0] = 0; /* always leave a defined value in buf */
 #ifdef WIN32
   if(STARTS_WITH_DRIVE_PREFIX(url))
     return FALSE;
 #endif
-  for(i = 0; i < buflen && url[i]; ++i) {
-    char s = url[i];
-    if((s == ':') && (url[i + 1] == '/')) {
-      if(buf)
+  for(i = 0; i < buflen; ++i) {
+    if((s = url[i]) &&
+      (ISALNUM(s) || (s == '+') || (s == '-') || (s == '.') )) {
+      /* RFC 3986 3.1 explains:
+        scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+      */
+    }
+    else {
+        break;
+    }
+  }
+  if(i && (url[i] == ':') && (url[i + 1] == '/')) {
+    if (buf) {
+        memcpy(buf, url, i);
         buf[i] = 0;
-      return TRUE;
     }
-    /* RFC 3986 3.1 explains:
-      scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-    */
-    else if(ISALNUM(s) || (s == '+') || (s == '-') || (s == '.') ) {
-      if(buf)
-        buf[i] = (char)TOLOWER(s);
-    }
-    else
-      break;
+    return TRUE;
   }
   return FALSE;
 }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -256,8 +256,8 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
   }
   if(i && (url[i] == ':') && (url[i + 1] == '/')) {
     if (buf) {
-        memcpy(buf, url, i);
-        buf[i] = 0;
+      memcpy(buf, url, i);
+      buf[i] = 0;
     }
     return TRUE;
   }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -251,13 +251,15 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
       */
     }
     else {
-        break;
+      break;
     }
   }
   if(i && (url[i] == ':') && (url[i + 1] == '/')) {
     if(buf) {
-      memcpy(buf, url, i);
       buf[i] = 0;
+      while(i--) {
+        buf[i] = TOLOWER(url[i]);
+      }
     }
     return TRUE;
   }
@@ -822,7 +824,7 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
   }
 
   /* handle the file: scheme */
-  if(url_has_scheme && strcasecompare(schemebuf, "file")) {
+  if(url_has_scheme && !strcmp(schemebuf, "file")) {
     /* path has been allocated large enough to hold this */
     strcpy(path, &url[5]);
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -237,15 +237,15 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
   size_t i;
   char s;
 
-  if (buf && buflen)
+  if(buf && buflen)
     buf[0] = 0; /* always leave a defined value in buf */
 #ifdef WIN32
   if(STARTS_WITH_DRIVE_PREFIX(url))
     return FALSE;
 #endif
   for(i = 0; i < buflen; ++i) {
-    if((s = url[i]) &&
-      (ISALNUM(s) || (s == '+') || (s == '-') || (s == '.') )) {
+    s = url[i];
+    if(s && (ISALNUM(s) || (s == '+') || (s == '-') || (s == '.') )) {
       /* RFC 3986 3.1 explains:
         scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
       */
@@ -255,7 +255,7 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
     }
   }
   if(i && (url[i] == ':') && (url[i + 1] == '/')) {
-    if (buf) {
+    if(buf) {
       memcpy(buf, url, i);
       buf[i] = 0;
     }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -818,7 +818,7 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
   hostname = &path[urllen + 1];
   hostname[0] = 0;
 
-  if(Curl_is_absolute_url(url, schemebuf, sizeof(schemebuf))) {
+  if(Curl_is_absolute_url(url, schemebuf, sizeof(schemebuf) - 1)) {
     url_has_scheme = TRUE;
     schemelen = strlen(schemebuf);
   }
@@ -1527,7 +1527,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     char *redired_url;
     CURLU *handle2;
 
-    if(Curl_is_absolute_url(part, NULL, MAX_SCHEME_LEN + 1)) {
+    if(Curl_is_absolute_url(part, NULL, MAX_SCHEME_LEN)) {
       handle2 = curl_url();
       if(!handle2)
         return CURLUE_OUT_OF_MEMORY;


### PR DESCRIPTION
Just a suggestion coming into my mind while thinking about #8041. Feel free to ignore.

`urlapi.c: Curl_is_absolute_url()`

  * always have a defined return in `buf`(if given)
  * only copy when scheme is detected