### PR TITLE
curl: improve error message for --head with -J

### DIFF
--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -69,7 +69,7 @@ const char *param2text(int res)
   case PARAM_NO_NOT_BOOLEAN:
     return "used '--no-' for option that isn't a boolean";
   case PARAM_CONTDISP_SHOW_HEADER:
-    return "--include and --remote-header-name cannot be combined";
+    return "showing headers and --remote-header-name cannot be combined";
   case PARAM_CONTDISP_RESUME_FROM:
     return "--continue-at and --remote-header-name cannot be combined";
   default:


### PR DESCRIPTION
... it now focuses on the "output of headers" combined with the
--remote-header-name option, as that is actually the problem. Both
--head and --include can output headers.

Reported-by: nimaje on github
Fixes #7987