### PR TITLE
cmake: fix leftover CURL_USE_SCHANNEL mistake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,16 @@ if(WIN32)
   check_library_exists_concat("winmm"  getch        HAVE_LIBWINMM)
 endif()
 
+foreach(_LIB GSSAPI OPENLDAP LIBSSH LIBSSH2 BEARSSL MBEDTLS NSS OPENSSL
+        SCHANNEL SECTRANSP WOLFSSL)
+  if(CMAKE_USE_${_LIB})
+    message(FATAL_ERROR "The option CMAKE_USE_${_LIB} is now CURL_USE_${_LIB}.")
+  endif()
+endforeach()
+if(CMAKE_USE_WINSSL)
+  message(FATAL_ERROR "The option CMAKE_USE_WINSSL was renamed to CURL_USE_SCHANNEL.")
+endif()
+
 # check SSL libraries
 # TODO support GnuTLS
 option(CURL_ENABLE_SSL "Enable SSL support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,14 +352,20 @@ if(WIN32)
   check_library_exists_concat("winmm"  getch        HAVE_LIBWINMM)
 endif()
 
+set(CURL_RECONFIG_REQUIRED 0)
 foreach(_LIB GSSAPI OPENLDAP LIBSSH LIBSSH2 BEARSSL MBEDTLS NSS OPENSSL
         SCHANNEL SECTRANSP WOLFSSL)
   if(CMAKE_USE_${_LIB})
-    message(FATAL_ERROR "The option CMAKE_USE_${_LIB} is now CURL_USE_${_LIB}.")
+    set(CURL_RECONFIG_REQUIRED 1)
+    message(SEND_ERROR "The option CMAKE_USE_${_LIB} was renamed to CURL_USE_${_LIB}.")
   endif()
 endforeach()
 if(CMAKE_USE_WINSSL)
-  message(FATAL_ERROR "The option CMAKE_USE_WINSSL was renamed to CURL_USE_SCHANNEL.")
+  set(CURL_RECONFIG_REQUIRED 1)
+  message(SEND_ERROR "The option CMAKE_USE_WINSSL was renamed to CURL_USE_SCHANNEL.")
+endif()
+if(CURL_RECONFIG_REQUIRED)
+  message(FATAL_ERROR "Reconfig required")
 endif()
 
 # check SSL libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,9 +355,6 @@ endif()
 # check SSL libraries
 # TODO support GnuTLS
 option(CURL_ENABLE_SSL "Enable SSL support" ON)
-if(CURL_USE_SCHANNEL)
-  message(FATAL_ERROR "The cmake option CURL_USE_SCHANNEL was renamed to CURL_USE_SCHANNEL.")
-endif()
 
 if(APPLE)
   cmake_dependent_option(CURL_USE_SECTRANSP "enable Apple OS native SSL/TLS" OFF CURL_ENABLE_SSL OFF)


### PR DESCRIPTION
CURL_USE_SCHANNEL is the proper new name.

Follow-up to 9108da2c26d