### PR TITLE
Makefile.m32: rename -winssl option to -schannel and tidy up

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -215,7 +215,7 @@ ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
 IPV6 = 1
 endif
 ifeq ($(findstring -winssl,$(CFG)),-winssl)
-WINSSL = 1
+SCHANNEL = 1
 SSPI = 1
 endif
 ifeq ($(findstring -nghttp2,$(CFG)),-nghttp2)
@@ -230,7 +230,7 @@ endif
 
 # SSH2 and RTMP require an SSL library; assume OpenSSL if none specified
 ifneq ($(SSH2)$(RTMP),)
-  ifeq ($(SSL)$(WINSSL),)
+  ifeq ($(SSL)$(SCHANNEL),)
     SSL = 1
   endif
 endif
@@ -264,7 +264,7 @@ endif
 ifdef SSH2
   CFLAGS += -DUSE_LIBSSH2 -DHAVE_LIBSSH2_H
   curl_LDADD += -L"$(LIBSSH2_PATH)/win32" -lssh2
-  ifdef WINSSL
+  ifdef SCHANNEL
     ifndef DYN
       curl_LDADD += -lbcrypt -lcrypt32
     endif
@@ -310,7 +310,7 @@ ifdef SSL
   CFLAGS += -DUSE_OPENSSL
   curl_LDADD += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
 endif
-ifdef WINSSL
+ifdef SCHANNEL
   CFLAGS += -DUSE_SCHANNEL
   curl_LDADD += -lcrypt32
 endif

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -214,7 +214,7 @@ endif
 ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
 IPV6 = 1
 endif
-ifeq ($(findstring -winssl,$(CFG)),-winssl)
+ifneq ($(findstring -schannel,$(CFG))$(findstring -winssl,$(CFG)),)
 SCHANNEL = 1
 SSPI = 1
 endif

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -170,61 +170,61 @@ endif
 ########################################################
 ## Nothing more to do below this line!
 
-ifeq ($(findstring -dyn,$(CFG)),-dyn)
+ifneq ($(findstring -dyn,$(CFG)),)
 DYN = 1
 endif
-ifeq ($(findstring -ares,$(CFG)),-ares)
+ifneq ($(findstring -ares,$(CFG)),)
 ARES = 1
 endif
-ifeq ($(findstring -rtmp,$(CFG)),-rtmp)
+ifneq ($(findstring -rtmp,$(CFG)),)
 RTMP = 1
 ZLIB = 1
 endif
-ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
+ifneq ($(findstring -ssh2,$(CFG)),)
 SSH2 = 1
 ZLIB = 1
 endif
-ifeq ($(findstring -ssl,$(CFG)),-ssl)
+ifneq ($(findstring -ssl,$(CFG)),)
 SSL = 1
 endif
-ifeq ($(findstring -zlib,$(CFG)),-zlib)
+ifneq ($(findstring -zlib,$(CFG)),)
 ZLIB = 1
 endif
-ifeq ($(findstring -zstd,$(CFG)),-zstd)
+ifneq ($(findstring -zstd,$(CFG)),)
 ZSTD = 1
 endif
-ifeq ($(findstring -brotli,$(CFG)),-brotli)
+ifneq ($(findstring -brotli,$(CFG)),)
 BROTLI = 1
 endif
-ifeq ($(findstring -gsasl,$(CFG)),-gsasl)
+ifneq ($(findstring -gsasl,$(CFG)),)
 GSASL = 1
 endif
-ifeq ($(findstring -idn2,$(CFG)),-idn2)
+ifneq ($(findstring -idn2,$(CFG)),)
 IDN2 = 1
 endif
-ifeq ($(findstring -winidn,$(CFG)),-winidn)
+ifneq ($(findstring -winidn,$(CFG)),)
 WINIDN = 1
 endif
-ifeq ($(findstring -sspi,$(CFG)),-sspi)
+ifneq ($(findstring -sspi,$(CFG)),)
 SSPI = 1
 endif
-ifeq ($(findstring -ldaps,$(CFG)),-ldaps)
+ifneq ($(findstring -ldaps,$(CFG)),)
 LDAPS = 1
 endif
-ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
+ifneq ($(findstring -ipv6,$(CFG)),)
 IPV6 = 1
 endif
 ifneq ($(findstring -schannel,$(CFG))$(findstring -winssl,$(CFG)),)
 SCHANNEL = 1
 SSPI = 1
 endif
-ifeq ($(findstring -nghttp2,$(CFG)),-nghttp2)
+ifneq ($(findstring -nghttp2,$(CFG)),)
 NGHTTP2 = 1
 endif
-ifeq ($(findstring -nghttp3,$(CFG)),-nghttp3)
+ifneq ($(findstring -nghttp3,$(CFG)),)
 NGHTTP3 = 1
 endif
-ifeq ($(findstring -ngtcp2,$(CFG)),-ngtcp2)
+ifneq ($(findstring -ngtcp2,$(CFG)),)
 NGTCP2 = 1
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -219,7 +219,7 @@ ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
 IPV6 = 1
 endif
 ifeq ($(findstring -winssl,$(CFG)),-winssl)
-WINSSL = 1
+SCHANNEL = 1
 SSPI = 1
 endif
 ifeq ($(findstring -nghttp2,$(CFG)),-nghttp2)
@@ -237,7 +237,7 @@ endif
 
 # SSH2 and RTMP require an SSL library; assume OpenSSL if none specified
 ifneq ($(SSH2)$(RTMP),)
-  ifeq ($(SSL)$(WINSSL),)
+  ifeq ($(SSL)$(SCHANNEL),)
     SSL = 1
   endif
 endif
@@ -245,7 +245,7 @@ endif
 INCLUDES = -I. -I../include
 CFLAGS += -DBUILDING_LIBCURL
 ifdef SSL
-  ifdef WINSSL
+  ifdef SCHANNEL
     CFLAGS += -DCURL_WITH_MULTI_SSL
   endif
 endif
@@ -277,7 +277,7 @@ ifdef SSH2
   INCLUDES += -I"$(LIBSSH2_PATH)/include" -I"$(LIBSSH2_PATH)/win32"
   CFLAGS += -DUSE_LIBSSH2 -DHAVE_LIBSSH2_H
   DLL_LIBS += -L"$(LIBSSH2_PATH)/win32" -lssh2
-  ifdef WINSSL
+  ifdef SCHANNEL
     ifndef DYN
       DLL_LIBS += -lbcrypt -lcrypt32
     endif
@@ -329,7 +329,7 @@ ifdef SSL
     endif
   endif
 endif
-ifdef WINSSL
+ifdef SCHANNEL
   CFLAGS += -DUSE_SCHANNEL
   DLL_LIBS += -lcrypt32
 endif

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -168,70 +168,70 @@ endif
 ########################################################
 ## Nothing more to do below this line!
 
-ifeq ($(findstring -dyn,$(CFG)),-dyn)
+ifneq ($(findstring -dyn,$(CFG)),)
 DYN = 1
 endif
-ifeq ($(findstring -ares,$(CFG)),-ares)
+ifneq ($(findstring -ares,$(CFG)),)
 ARES = 1
 endif
-ifeq ($(findstring -sync,$(CFG)),-sync)
+ifneq ($(findstring -sync,$(CFG)),)
 SYNC = 1
 endif
-ifeq ($(findstring -rtmp,$(CFG)),-rtmp)
+ifneq ($(findstring -rtmp,$(CFG)),)
 RTMP = 1
 ZLIB = 1
 endif
-ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
+ifneq ($(findstring -ssh2,$(CFG)),)
 SSH2 = 1
 ZLIB = 1
 endif
-ifeq ($(findstring -ssl,$(CFG)),-ssl)
+ifneq ($(findstring -ssl,$(CFG)),)
 SSL = 1
 endif
-ifeq ($(findstring -srp,$(CFG)),-srp)
+ifneq ($(findstring -srp,$(CFG)),)
 SRP = 1
 endif
-ifeq ($(findstring -zlib,$(CFG)),-zlib)
+ifneq ($(findstring -zlib,$(CFG)),)
 ZLIB = 1
 endif
-ifeq ($(findstring -zstd,$(CFG)),-zstd)
+ifneq ($(findstring -zstd,$(CFG)),)
 ZSTD = 1
 endif
-ifeq ($(findstring -brotli,$(CFG)),-brotli)
+ifneq ($(findstring -brotli,$(CFG)),)
 BROTLI = 1
 endif
-ifeq ($(findstring -gsasl,$(CFG)),-gsasl)
+ifneq ($(findstring -gsasl,$(CFG)),)
 GSASL = 1
 endif
-ifeq ($(findstring -idn2,$(CFG)),-idn2)
+ifneq ($(findstring -idn2,$(CFG)),)
 IDN2 = 1
 endif
-ifeq ($(findstring -winidn,$(CFG)),-winidn)
+ifneq ($(findstring -winidn,$(CFG)),)
 WINIDN = 1
 endif
-ifeq ($(findstring -sspi,$(CFG)),-sspi)
+ifneq ($(findstring -sspi,$(CFG)),)
 SSPI = 1
 endif
-ifeq ($(findstring -ldaps,$(CFG)),-ldaps)
+ifneq ($(findstring -ldaps,$(CFG)),)
 LDAPS = 1
 endif
-ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
+ifneq ($(findstring -ipv6,$(CFG)),)
 IPV6 = 1
 endif
 ifneq ($(findstring -schannel,$(CFG))$(findstring -winssl,$(CFG)),)
 SCHANNEL = 1
 SSPI = 1
 endif
-ifeq ($(findstring -nghttp2,$(CFG)),-nghttp2)
+ifneq ($(findstring -nghttp2,$(CFG)),)
 NGHTTP2 = 1
 endif
-ifeq ($(findstring -nghttp3,$(CFG)),-nghttp3)
+ifneq ($(findstring -nghttp3,$(CFG)),)
 NGHTTP3 = 1
 endif
-ifeq ($(findstring -ngtcp2,$(CFG)),-ngtcp2)
+ifneq ($(findstring -ngtcp2,$(CFG)),)
 NGTCP2 = 1
 endif
-ifeq ($(findstring -unicode,$(CFG)),-unicode)
+ifneq ($(findstring -unicode,$(CFG)),)
 UNICODE = 1
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -218,7 +218,7 @@ endif
 ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
 IPV6 = 1
 endif
-ifeq ($(findstring -winssl,$(CFG)),-winssl)
+ifneq ($(findstring -schannel,$(CFG))$(findstring -winssl,$(CFG)),)
 SCHANNEL = 1
 SSPI = 1
 endif

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -224,7 +224,7 @@ ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
 IPV6 = 1
 endif
 ifeq ($(findstring -winssl,$(CFG)),-winssl)
-WINSSL = 1
+SCHANNEL = 1
 SSPI = 1
 endif
 ifeq ($(findstring -nghttp2,$(CFG)),-nghttp2)
@@ -242,14 +242,14 @@ endif
 
 # SSH2 and RTMP require an SSL library; assume OpenSSL if none specified
 ifneq ($(SSH2)$(RTMP),)
-  ifeq ($(SSL)$(WINSSL),)
+  ifeq ($(SSL)$(SCHANNEL),)
     SSL = 1
   endif
 endif
 
 INCLUDES = -I. -I../include -I../lib
 ifdef SSL
-  ifdef WINSSL
+  ifdef SCHANNEL
     CFLAGS += -DCURL_WITH_MULTI_SSL
   endif
 endif
@@ -289,7 +289,7 @@ endif
 ifdef SSH2
   CFLAGS += -DUSE_LIBSSH2 -DHAVE_LIBSSH2_H
   curl_LDADD += -L"$(LIBSSH2_PATH)/win32" -lssh2
-  ifdef WINSSL
+  ifdef SCHANNEL
     ifndef DYN
       curl_LDADD += -lbcrypt -lcrypt32
     endif
@@ -335,7 +335,7 @@ ifdef SSL
   CFLAGS += -DUSE_OPENSSL
   curl_LDADD += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
 endif
-ifdef WINSSL
+ifdef SCHANNEL
   CFLAGS += -DUSE_SCHANNEL
   curl_LDADD += -lcrypt32
 endif

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -176,67 +176,67 @@ endif
 ########################################################
 ## Nothing more to do below this line!
 
-ifeq ($(findstring -dyn,$(CFG)),-dyn)
+ifneq ($(findstring -dyn,$(CFG)),)
 DYN = 1
 endif
-ifeq ($(findstring -ares,$(CFG)),-ares)
+ifneq ($(findstring -ares,$(CFG)),)
 ARES = 1
 endif
-ifeq ($(findstring -sync,$(CFG)),-sync)
+ifneq ($(findstring -sync,$(CFG)),)
 SYNC = 1
 endif
-ifeq ($(findstring -rtmp,$(CFG)),-rtmp)
+ifneq ($(findstring -rtmp,$(CFG)),)
 RTMP = 1
 ZLIB = 1
 endif
-ifeq ($(findstring -ssh2,$(CFG)),-ssh2)
+ifneq ($(findstring -ssh2,$(CFG)),)
 SSH2 = 1
 ZLIB = 1
 endif
-ifeq ($(findstring -ssl,$(CFG)),-ssl)
+ifneq ($(findstring -ssl,$(CFG)),)
 SSL = 1
 endif
-ifeq ($(findstring -zlib,$(CFG)),-zlib)
+ifneq ($(findstring -zlib,$(CFG)),)
 ZLIB = 1
 endif
-ifeq ($(findstring -zstd,$(CFG)),-zstd)
+ifneq ($(findstring -zstd,$(CFG)),)
 ZSTD = 1
 endif
-ifeq ($(findstring -brotli,$(CFG)),-brotli)
+ifneq ($(findstring -brotli,$(CFG)),)
 BROTLI = 1
 endif
-ifeq ($(findstring -gsasl,$(CFG)),-gsasl)
+ifneq ($(findstring -gsasl,$(CFG)),)
 GSASL = 1
 endif
-ifeq ($(findstring -idn2,$(CFG)),-idn2)
+ifneq ($(findstring -idn2,$(CFG)),)
 IDN2 = 1
 endif
-ifeq ($(findstring -winidn,$(CFG)),-winidn)
+ifneq ($(findstring -winidn,$(CFG)),)
 WINIDN = 1
 endif
-ifeq ($(findstring -sspi,$(CFG)),-sspi)
+ifneq ($(findstring -sspi,$(CFG)),)
 SSPI = 1
 endif
-ifeq ($(findstring -ldaps,$(CFG)),-ldaps)
+ifneq ($(findstring -ldaps,$(CFG)),)
 LDAPS = 1
 endif
-ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
+ifneq ($(findstring -ipv6,$(CFG)),)
 IPV6 = 1
 endif
 ifneq ($(findstring -schannel,$(CFG))$(findstring -winssl,$(CFG)),)
 SCHANNEL = 1
 SSPI = 1
 endif
-ifeq ($(findstring -nghttp2,$(CFG)),-nghttp2)
+ifneq ($(findstring -nghttp2,$(CFG)),)
 NGHTTP2 = 1
 endif
-ifeq ($(findstring -nghttp3,$(CFG)),-nghttp3)
+ifneq ($(findstring -nghttp3,$(CFG)),)
 NGHTTP3 = 1
 endif
-ifeq ($(findstring -ngtcp2,$(CFG)),-ngtcp2)
+ifneq ($(findstring -ngtcp2,$(CFG)),)
 NGTCP2 = 1
 endif
-ifeq ($(findstring -unicode,$(CFG)),-unicode)
+ifneq ($(findstring -unicode,$(CFG)),)
 UNICODE = 1
 endif
 

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -223,7 +223,7 @@ endif
 ifeq ($(findstring -ipv6,$(CFG)),-ipv6)
 IPV6 = 1
 endif
-ifeq ($(findstring -winssl,$(CFG)),-winssl)
+ifneq ($(findstring -schannel,$(CFG))$(findstring -winssl,$(CFG)),)
 SCHANNEL = 1
 SSPI = 1
 endif


### PR DESCRIPTION
- Accept `-schannel` as an alternative to `CFG` option `-winssl`. (Latter is still accepted, but deprecated)
- Rename internal variable `WINSSL` to `SCHANNEL`
- Make the `CFG` option evaluation shorter, without repeating the option name

Let me know if _dropping_ the previous, `-winssl` option name would be desirable/acceptable.