### PR TITLE
docs: consistent manpage SYNOPSIS

### DIFF
--- a/docs/libcurl/curl_easy_cleanup.3
+++ b/docs/libcurl/curl_easy_cleanup.3
@@ -24,9 +24,11 @@
 .SH NAME
 curl_easy_cleanup - End a libcurl easy handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
-.BI "void curl_easy_cleanup(CURL *" handle ");"
+void curl_easy_cleanup(CURL *handle);
+.fi
 .SH DESCRIPTION
 This function must be the last function to call for an easy session. It is the
 opposite of the \fIcurl_easy_init(3)\fP function and must be called with the

--- a/docs/libcurl/curl_easy_duphandle.3
+++ b/docs/libcurl/curl_easy_duphandle.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_easy_duphandle - Clone a libcurl session handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
-.BI "CURL *curl_easy_duphandle(CURL *"handle ");"
-
+CURL *curl_easy_duphandle(CURL *handle);
+.fi
 .SH DESCRIPTION
 This function will return a new curl handle, a duplicate, using all the
 options previously set in the input curl \fIhandle\fP. Both handles can

--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -24,11 +24,11 @@
 .SH NAME
 curl_easy_escape - URL encodes the given string
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "char *curl_easy_escape( CURL *" curl ", const char *" string
-.BI ", int "length " );"
-.ad
+.nf
+#include <curl/curl.h>
+
+char *curl_easy_escape(CURL *curl, const char *string, int length);
+.fi
 .SH DESCRIPTION
 This function converts the given input \fIstring\fP to a URL encoded string
 and returns that as a new allocated string. All input characters that are not

--- a/docs/libcurl/curl_easy_getinfo.3
+++ b/docs/libcurl/curl_easy_getinfo.3
@@ -24,10 +24,11 @@
 .SH NAME
 curl_easy_getinfo - extract information from a curl handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
-.B "CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ... );"
-
+CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ... );
+.fi
 .SH DESCRIPTION
 Request internal information from the curl session with this function.  The
 third argument \fBMUST\fP be a pointer to a long, a pointer to a char *, a

--- a/docs/libcurl/curl_easy_init.3
+++ b/docs/libcurl/curl_easy_init.3
@@ -23,9 +23,11 @@
 .SH NAME
 curl_easy_init - Start a libcurl easy session
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
-.BI "CURL *curl_easy_init( );"
+CURL *curl_easy_init();
+.fi
 .SH DESCRIPTION
 This function must be the first function to call, and it returns a CURL easy
 handle that you must use as input to other functions in the easy

--- a/docs/libcurl/curl_easy_perform.3
+++ b/docs/libcurl/curl_easy_perform.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_easy_perform - perform a blocking file transfer
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_easy_perform(CURL *" easy_handle ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_easy_perform(CURL *easy_handle);
+.fi
 .SH DESCRIPTION
 Invoke this function after \fIcurl_easy_init(3)\fP and all the
 \fIcurl_easy_setopt(3)\fP calls are made, and it performs the transfer as

--- a/docs/libcurl/curl_easy_recv.3
+++ b/docs/libcurl/curl_easy_recv.3
@@ -24,11 +24,11 @@
 .SH NAME
 curl_easy_recv - receives raw data on an "easy" connection
 .SH SYNOPSIS
-.B #include <curl/easy.h>
-.sp
-.BI "CURLcode curl_easy_recv( CURL *" curl ", void *" buffer ","
-.BI "size_t " buflen ", size_t *" n ");"
-.ad
+.nf
+#include <curl/easy.h>
+
+CURLcode curl_easy_recv(CURL *curl, void *buffer, size_t buflen, size_t *n);
+.fi
 .SH DESCRIPTION
 This function receives raw data from the established connection. You may use
 it together with \fIcurl_easy_send(3)\fP to implement custom protocols using

--- a/docs/libcurl/curl_easy_reset.3
+++ b/docs/libcurl/curl_easy_reset.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_easy_reset - reset all options of a libcurl session handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
-.BI "void curl_easy_reset(CURL *"handle ");"
-
+void curl_easy_reset(CURL *handle);
+.fi
 .SH DESCRIPTION
 Re-initializes all options previously set on a specified CURL handle to the
 default values. This puts back the handle to the same state as it was in when

--- a/docs/libcurl/curl_easy_send.3
+++ b/docs/libcurl/curl_easy_send.3
@@ -24,11 +24,12 @@
 .SH NAME
 curl_easy_send - sends raw data over an "easy" connection
 .SH SYNOPSIS
-.B #include <curl/easy.h>
-.sp
-.BI "CURLcode curl_easy_send( CURL *" curl ", const void *" buffer ","
-.BI " size_t " buflen ", size_t *" n ");"
-.ad
+.nf
+#include <curl/easy.h>
+
+CURLcode curl_easy_send(CURL *curl, const void *buffer,
+                        size_t buflen, size_t *n);
+.fi
 .SH DESCRIPTION
 This function sends arbitrary data over the established connection. You may
 use it together with \fIcurl_easy_recv(3)\fP to implement custom protocols

--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -24,9 +24,11 @@
 .SH NAME
 curl_easy_setopt \- set options for a curl easy handle
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLoption option, parameter);
+.fi
 .SH DESCRIPTION
 \fIcurl_easy_setopt(3)\fP is used to tell libcurl how to behave. By setting
 the appropriate options, the application can change libcurl's behavior.  All

--- a/docs/libcurl/curl_easy_strerror.3
+++ b/docs/libcurl/curl_easy_strerror.3
@@ -23,9 +23,11 @@
 .SH NAME
 curl_easy_strerror - return string describing error code
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 const char *curl_easy_strerror(CURLcode errornum);
+.fi
 .SH DESCRIPTION
 The \fIcurl_easy_strerror(3)\fP function returns a string describing the
 CURLcode error code passed in the argument \fIerrornum\fP.

--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -24,11 +24,12 @@
 .SH NAME
 curl_easy_unescape - URL decodes the given string
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "char *curl_easy_unescape( CURL *" curl ", const char *" url
-.BI ", int "inlength ", int *" outlength " );"
-.ad
+.nf
+#include <curl/curl.h>
+
+char *curl_easy_unescape(CURL *curl, const char *url,
+                         int inlength, int *outlength);
+.fi
 .SH DESCRIPTION
 This function converts the given URL encoded input string to a "plain string"
 and returns that in an allocated memory area. All input characters that are

--- a/docs/libcurl/curl_easy_upkeep.3
+++ b/docs/libcurl/curl_easy_upkeep.3
@@ -24,9 +24,11 @@
 .SH NAME
 curl_easy_upkeep - Perform any connection upkeep checks.
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
-.BI "CURLcode curl_easy_upkeep(CURL *" handle ");"
+CURLcode curl_easy_upkeep(CURL *handle);
+.fi
 .SH DESCRIPTION
 
 Some protocols have "connection upkeep" mechanisms. These mechanisms usually

--- a/docs/libcurl/curl_escape.3
+++ b/docs/libcurl/curl_escape.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_escape - URL encodes the given string
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "char *curl_escape( const char *" url ", int "length " );"
-.ad
+.nf
+#include <curl/curl.h>
+
+char *curl_escape(const char *url, int length);
+.fi
 .SH DESCRIPTION
 Obsolete function. Use \fIcurl_easy_escape(3)\fP instead!
 

--- a/docs/libcurl/curl_formadd.3
+++ b/docs/libcurl/curl_formadd.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_formadd - add a section to a multipart/formdata HTTP POST
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLFORMcode curl_formadd(struct curl_httppost ** " firstitem,
-.BI "struct curl_httppost ** " lastitem, " ...);"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLFORMcode curl_formadd(struct curl_httppost **firstitem,
+                          struct curl_httppost **lastitem, ...);
+.fi
 .SH DESCRIPTION
 This function is deprecated. Do not use! See \fIcurl_mime_init(3)\fP instead!
 

--- a/docs/libcurl/curl_formfree.3
+++ b/docs/libcurl/curl_formfree.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_formfree - free a previously build multipart/formdata HTTP POST chain
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "void curl_formfree(struct curl_httppost *" form);
-.ad
+.nf
+#include <curl/curl.h>
+
+void curl_formfree(struct curl_httppost *form);
+.fi
 .SH DESCRIPTION
 This function is deprecated. Do not use! See \fIcurl_mime_init(3)\fP instead!
 

--- a/docs/libcurl/curl_free.3
+++ b/docs/libcurl/curl_free.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_free - reclaim memory that has been obtained through a libcurl call
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "void curl_free( char *" ptr " );"
-.ad
+.nf
+#include <curl/curl.h>
+
+void curl_free(char *ptr);
+.fi
 .SH DESCRIPTION
 curl_free reclaims memory that has been obtained through a libcurl call.  Use
 \fIcurl_free(3)\fP instead of free() to avoid anomalies that can result from

--- a/docs/libcurl/curl_getdate.3
+++ b/docs/libcurl/curl_getdate.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_getdate - Convert a date string to number of seconds
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "time_t curl_getdate(char *" datestring ", time_t *"now " );"
-.ad
+.nf
+#include <curl/curl.h>
+
+time_t curl_getdate(char *datestring, time_t *now);
+.fi
 .SH DESCRIPTION
 \fIcurl_getdate(3)\fP returns the number of seconds since the Epoch, January
 1st 1970 00:00:00 in the UTC time zone, for the date and time that the

--- a/docs/libcurl/curl_getenv.3
+++ b/docs/libcurl/curl_getenv.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_getenv - return value for environment name
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "char *curl_getenv(const char *" name ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+char *curl_getenv(const char *name);
+.fi
 .SH DESCRIPTION
 curl_getenv() is a portable wrapper for the getenv() function, meant to
 emulate its behavior and provide an identical interface for all operating

--- a/docs/libcurl/curl_global_cleanup.3
+++ b/docs/libcurl/curl_global_cleanup.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_global_cleanup - global libcurl cleanup
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "void curl_global_cleanup(void);"
-.ad
+.nf
+#include <curl/curl.h>
+
+void curl_global_cleanup(void);
+.fi
 .SH DESCRIPTION
 This function releases resources acquired by \fIcurl_global_init(3)\fP.
 

--- a/docs/libcurl/curl_global_init.3
+++ b/docs/libcurl/curl_global_init.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_global_init - Global libcurl initialisation
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_global_init(long " flags ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_global_init(long flags);
+.fi
 .SH DESCRIPTION
 This function sets up the program environment that libcurl needs.  Think of it
 as an extension of the library loader.

--- a/docs/libcurl/curl_global_init_mem.3
+++ b/docs/libcurl/curl_global_init_mem.3
@@ -23,14 +23,16 @@
 .SH NAME
 curl_global_init_mem - Global libcurl initialisation with memory callbacks
 .SH SYNOPSIS
-.B #include <curl/curl.h>
 .nf
-.B "CURLcode curl_global_init_mem(long " flags,
-.B " curl_malloc_callback "m,
-.B " curl_free_callback "f,
-.B " curl_realloc_callback "r,
-.B " curl_strdup_callback "s,
-.B " curl_calloc_callback "c ");"
+#include <curl/curl.h>
+
+CURLcode curl_global_init_mem(long flags,
+                              curl_malloc_callback m,
+                              curl_free_callback f,
+                              curl_realloc_callback r,
+                              curl_strdup_callback s,
+                              curl_calloc_callback c);
+.fi
 .SH DESCRIPTION
 This function works exactly as \fIcurl_global_init(3)\fP with one addition: it
 allows the application to set callbacks to replace the otherwise used internal

--- a/docs/libcurl/curl_global_sslset.3
+++ b/docs/libcurl/curl_global_sslset.3
@@ -23,8 +23,8 @@
 .SH NAME
 curl_global_sslset - Select SSL backend to use with libcurl
 .SH SYNOPSIS
-.B #include <curl/curl.h>
 .nf
+#include <curl/curl.h>
 
 typedef struct {
   curl_sslbackend id;
@@ -47,9 +47,9 @@ typedef enum {
   CURLSSLBACKEND_BEARSSL = 13
 } curl_sslbackend;
 
-.B "CURLsslset curl_global_sslset(curl_sslbackend " id,
-.B "                              const char *" name,
-.B "                              curl_ssl_backend ***" avail ");"
+CURLsslset curl_global_sslset(curl_sslbackend id,
+                              const char *name,
+                              curl_ssl_backend ***avail);
 .fi
 .SH DESCRIPTION
 This function configures at runtime which SSL backend to use with

--- a/docs/libcurl/curl_mime_addpart.3
+++ b/docs/libcurl/curl_mime_addpart.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_mime_addpart - append a new empty part to a mime structure
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "curl_mimepart * curl_mime_addpart(curl_mime * " mime ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+curl_mimepart *curl_mime_addpart(curl_mime *mime);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_addpart(3)\fP creates and appends a new empty part to the given
 mime structure and returns a handle to it.  The returned part handle can

--- a/docs/libcurl/curl_mime_data.3
+++ b/docs/libcurl/curl_mime_data.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_mime_data - set a mime part's body data from memory
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_data(curl_mimepart * " part ", const char * " data
-.BI ", size_t " datasize ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_data(curl_mimepart *part, const char *data,
+                        size_t datasize);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_data(3)\fP sets a mime part's body content from memory data.
 

--- a/docs/libcurl/curl_mime_data_cb.3
+++ b/docs/libcurl/curl_mime_data_cb.3
@@ -23,20 +23,20 @@
 .SH NAME
 curl_mime_data_cb - set a callback-based data source for a mime part's body
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
+.nf
+#include <curl/curl.h>
+
 size_t readfunc(char *buffer, size_t size, size_t nitems, void *arg);
-.br
+
 int seekfunc(void *arg, curl_off_t offset, int origin);
-.br
+
 void freefunc(void *arg);
-.sp
-.BI "CURLcode curl_mime_data_cb(curl_mimepart * " part ", curl_off_t " datasize ,
-.br
-.BI "        curl_read_callback " readfunc ", curl_seek_callback " seekfunc ,
-.br
-.BI "        curl_free_callback " freefunc ", void * " arg ");"
-.ad
+
+CURLcode curl_mime_data_cb(curl_mimepart *part, curl_off_t datasize,
+                           curl_read_callback readfunc,
+                           curl_seek_callback seekfunc,
+                           curl_free_callback freefunc, void *arg);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_data_cb(3)\fP sets the data source of a mime part's body content
 from a data read callback function.

--- a/docs/libcurl/curl_mime_encoder.3
+++ b/docs/libcurl/curl_mime_encoder.3
@@ -23,11 +23,11 @@
 .SH NAME
 curl_mime_encoder - set a mime part's encoder and content transfer encoding
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_encoder(curl_mimepart * " part ,
-.BI "const char * " encoding ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_encoder(curl_mimepart *part, const char *encoding);
+.fi
 .SH DESCRIPTION
 curl_mime_encoder() requests a mime part's content to be encoded before being
 transmitted.

--- a/docs/libcurl/curl_mime_filedata.3
+++ b/docs/libcurl/curl_mime_filedata.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_mime_filedata - set a mime part's body data from a file contents
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_filedata(curl_mimepart * " part ,
-.BI " const char * " filename ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_filedata(curl_mimepart *part,
+                            const char *filename);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_filedata(3)\fP sets a mime part's body content from the named
 file's contents. This is an alternative to \fIcurl_mime_data(3)\fP for setting

--- a/docs/libcurl/curl_mime_filename.3
+++ b/docs/libcurl/curl_mime_filename.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_mime_filename - set a mime part's remote file name
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_filename(curl_mimepart * " part ,
-.BI "const char * " filename ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_filename(curl_mimepart *part,
+                            const char *filename);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_filename(3)\fP sets a mime part's remote file name. When remote
 file name is set, content data is processed as a file, whatever is the part's

--- a/docs/libcurl/curl_mime_free.3
+++ b/docs/libcurl/curl_mime_free.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_mime_free - free a previously built mime structure
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "void curl_mime_free(curl_mime *" mime);
-.ad
+.nf
+#include <curl/curl.h>
+
+void curl_mime_free(curl_mime *mime);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_free(3)\fP is used to clean up data previously built/appended
 with \fIcurl_mime_addpart(3)\fP and other mime-handling functions.  This must

--- a/docs/libcurl/curl_mime_headers.3
+++ b/docs/libcurl/curl_mime_headers.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_mime_headers - set a mime part's custom headers
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_headers(curl_mimepart * " part ,
-.BI "struct curl_slist * " headers ", int " take_ownership ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_headers(curl_mimepart *part,
+                           struct curl_slist *headers, int take_ownership);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_headers(3)\fP sets a mime part's custom headers.
 

--- a/docs/libcurl/curl_mime_name.3
+++ b/docs/libcurl/curl_mime_name.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_mime_name - set a mime part's name
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_name(curl_mimepart * " part ", const char * " name ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_name(curl_mimepart *part, const char *name);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_name(3)\fP sets a mime part's name. This is the way HTTP form
 fields are named.

--- a/docs/libcurl/curl_mime_subparts.3
+++ b/docs/libcurl/curl_mime_subparts.3
@@ -23,11 +23,11 @@
 .SH NAME
 curl_mime_subparts - set subparts of a multipart mime part
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_subparts(curl_mimepart * " part ,
-.BI "curl_mime * " subparts ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_subparts(curl_mimepart *part, curl_mime *subparts);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_subparts(3)\fP sets a multipart mime part's content from a mime
 structure.

--- a/docs/libcurl/curl_mime_type.3
+++ b/docs/libcurl/curl_mime_type.3
@@ -23,11 +23,11 @@
 .SH NAME
 curl_mime_type - set a mime part's content type
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLcode curl_mime_type(curl_mimepart * " part ,
-.BI "const char * " mimetype ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype);
+.fi
 .SH DESCRIPTION
 \fIcurl_mime_type(3)\fP sets a mime part's content type.
 

--- a/docs/libcurl/curl_mprintf.3
+++ b/docs/libcurl/curl_mprintf.3
@@ -25,27 +25,21 @@ curl_maprintf, curl_mfprintf, curl_mprintf, curl_msnprintf, curl_msprintf
 curl_mvaprintf, curl_mvfprintf, curl_mvprintf, curl_mvsnprintf,
 curl_mvsprintf - formatted output conversion
 .SH SYNOPSIS
-.B #include <curl/mprintf.h>
-.sp
-.BI "int curl_mprintf(const char *" format ", ...);"
-.br
-.BI "int curl_mfprintf(FILE *" fd ", const char *" format ", ...);"
-.br
-.BI "int curl_msprintf(char *" buffer ", const char *" format ", ...);"
-.br
-.BI "int curl_msnprintf(char *" buffer ", size_t " maxlength ", const char *" format ", ...);"
-.br
-.BI "int curl_mvprintf(const char *" format ", va_list " args ");"
-.br
-.BI "int curl_mvfprintf(FILE *" fd ", const char *" format ", va_list " args ");"
-.br
-.BI "int curl_mvsprintf(char *" buffer ", const char *" format ", va_list " args ");"
-.br
-.BI "int curl_mvsnprintf(char *" buffer ", size_t " maxlength ", const char *" format ", va_list " args ");"
-.br
-.BI "char *curl_maprintf(const char *" format ", ...);"
-.br
-.BI "char *curl_mvaprintf(const char *" format ", va_list " args ");"
+.nf
+#include <curl/mprintf.h>
+
+int curl_mprintf(const char *format, ...);
+int curl_mfprintf(FILE *fd, const char *format, ...);
+int curl_msprintf(char *buffer, const char *format, ...);
+int curl_msnprintf(char *buffer, size_t maxlength, const char *format, ...);
+int curl_mvprintf(const char *format, va_list args);
+int curl_mvfprintf(FILE *fd, const char *format, va_list args);
+int curl_mvsprintf(char *buffer, const char *format, va_list args);
+int curl_mvsnprintf(char *buffer, size_t maxlength, const char *format,
+                    va_list args);
+char *curl_maprintf(const char *format , ...);
+char *curl_mvaprintf(const char *format, va_list args);
+.fi
 .SH DESCRIPTION
 These functions produce output according to the format string and given
 arguments. They are mostly clones of the well-known C-style functions but

--- a/docs/libcurl/curl_multi_add_handle.3
+++ b/docs/libcurl/curl_multi_add_handle.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_multi_add_handle - add an easy handle to a multi session
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_add_handle(CURLM *multi_handle, CURL *easy_handle);
-.ad
+.fi
 .SH DESCRIPTION
 Adds a standard easy handle to the multi stack. This function call will make
 this \fImulti_handle\fP control the specified \fIeasy_handle\fP.

--- a/docs/libcurl/curl_multi_assign.3
+++ b/docs/libcurl/curl_multi_assign.3
@@ -23,10 +23,12 @@
 .SH NAME
 curl_multi_assign \- set data to associate with an internal socket
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_assign(CURLM *multi_handle, curl_socket_t sockfd,
                             void *sockptr);
+.fi
 .SH DESCRIPTION
 This function creates an association in the multi handle between the given
 socket and a private pointer of the application. This is designed for

--- a/docs/libcurl/curl_multi_cleanup.3
+++ b/docs/libcurl/curl_multi_cleanup.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_multi_cleanup - close down a multi session
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLMcode curl_multi_cleanup( CURLM *multi_handle );"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLMcode curl_multi_cleanup(CURLM *multi_handle);
+.fi
 .SH DESCRIPTION
 Cleans up and removes a whole multi stack. It does not free or touch any
 individual easy handles in any way - they still need to be closed

--- a/docs/libcurl/curl_multi_info_read.3
+++ b/docs/libcurl/curl_multi_info_read.3
@@ -23,11 +23,11 @@
 .SH NAME
 curl_multi_info_read - read multi stack informationals
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMsg *curl_multi_info_read( CURLM *multi_handle,
-                               int *msgs_in_queue);
-.ad
+CURLMsg *curl_multi_info_read(CURLM *multi_handle, int *msgs_in_queue);
+.fi
 .SH DESCRIPTION
 Ask the multi handle if there are any messages/informationals from the
 individual transfers. Messages may include informationals such as an error

--- a/docs/libcurl/curl_multi_init.3
+++ b/docs/libcurl/curl_multi_init.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_multi_init - create a multi handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLM *curl_multi_init( );"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLM *curl_multi_init();
+.fi
 .SH DESCRIPTION
 This function returns a CURLM handle to be used as input to all the other
 multi-functions, sometimes referred to as a multi handle in some places in the

--- a/docs/libcurl/curl_multi_perform.3
+++ b/docs/libcurl/curl_multi_perform.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_multi_perform - reads/writes available data from each easy handle
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_perform(CURLM *multi_handle, int *running_handles);
-.ad
+.fi
 .SH DESCRIPTION
 This function performs transfers on all the added handles that need attention
 in an non-blocking fashion. The easy handles have previously been added to the

--- a/docs/libcurl/curl_multi_remove_handle.3
+++ b/docs/libcurl/curl_multi_remove_handle.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_multi_remove_handle - remove an easy handle from a multi session
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_remove_handle(CURLM *multi_handle, CURL *easy_handle);
-.ad
+.fi
 .SH DESCRIPTION
 Removes a given \fIeasy_handle\fP from the \fImulti_handle\fP. This will make
 the specified easy handle be removed from this multi handle's control.

--- a/docs/libcurl/curl_multi_setopt.3
+++ b/docs/libcurl/curl_multi_setopt.3
@@ -23,9 +23,11 @@
 .SH NAME
 curl_multi_setopt \- set options for a curl multi handle
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_setopt(CURLM *multi_handle, CURLMoption option, param);
+.fi
 .SH DESCRIPTION
 \fIcurl_multi_setopt(3)\fP is used to tell a libcurl multi handle how to
 behave. By using the appropriate options to \fIcurl_multi_setopt(3)\fP, you

--- a/docs/libcurl/curl_multi_timeout.3
+++ b/docs/libcurl/curl_multi_timeout.3
@@ -23,9 +23,11 @@
 .SH NAME
 curl_multi_timeout \- how long to wait for action before proceeding
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_timeout(CURLM *multi_handle, long *timeout);
+.fi
 .SH DESCRIPTION
 
 An application using the libcurl multi interface should call

--- a/docs/libcurl/curl_multi_wakeup.3
+++ b/docs/libcurl/curl_multi_wakeup.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_multi_wakeup - wakes up a sleeping curl_multi_poll call
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_wakeup(CURLM *multi_handle);
-.ad
+.fi
 .SH DESCRIPTION
 This function can be called from any thread and it wakes up a
 sleeping \fIcurl_multi_poll(3)\fP call that is currently (or will be)

--- a/docs/libcurl/curl_share_cleanup.3
+++ b/docs/libcurl/curl_share_cleanup.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_share_cleanup - Clean up a shared object
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLSHcode curl_share_cleanup(CURLSH *" share_handle ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLSHcode curl_share_cleanup(CURLSH *share_handle);
+.fi
 .SH DESCRIPTION
 This function deletes a shared object. The share handle cannot be used anymore
 when this function has been called.

--- a/docs/libcurl/curl_share_init.3
+++ b/docs/libcurl/curl_share_init.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_share_init - Create a shared object
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "CURLSH *curl_share_init( );"
-.ad
+.nf
+#include <curl/curl.h>
+
+CURLSH *curl_share_init();
+.fi
 .SH DESCRIPTION
 This function returns a CURLSH handle to be used as input to all the other
 share-functions, sometimes referred to as a share handle in some places in the

--- a/docs/libcurl/curl_share_setopt.3
+++ b/docs/libcurl/curl_share_setopt.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_share_setopt - Set options for a shared object
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
+.nf
+#include <curl/curl.h>
+
 CURLSHcode curl_share_setopt(CURLSH *share, CURLSHoption option, parameter);
-.ad
+.fi
 .SH DESCRIPTION
 Set the \fIoption\fP to \fIparameter\fP for the given \fIshare\fP.
 .SH OPTIONS

--- a/docs/libcurl/curl_slist_append.3
+++ b/docs/libcurl/curl_slist_append.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_slist_append - add a string to an slist
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "struct curl_slist *curl_slist_append(struct curl_slist *" list,
-.BI "const char * "string ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+struct curl_slist *curl_slist_append(struct curl_slist *list,
+                                     const char *string);
+.fi
 .SH DESCRIPTION
 \fIcurl_slist_append(3)\fP appends a string to a linked list of strings. The
 existing \fBlist\fP should be passed as the first argument and the new list is

--- a/docs/libcurl/curl_slist_free_all.3
+++ b/docs/libcurl/curl_slist_free_all.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_slist_free_all - free an entire curl_slist list
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "void curl_slist_free_all(struct curl_slist *" list);
-.ad
+.nf
+#include <curl/curl.h>
+
+void curl_slist_free_all(struct curl_slist *list);
+.fi
 .SH DESCRIPTION
 curl_slist_free_all() removes all traces of a previously built curl_slist
 linked list.

--- a/docs/libcurl/curl_strequal.3
+++ b/docs/libcurl/curl_strequal.3
@@ -23,11 +23,12 @@
 .SH NAME
 curl_strequal, curl_strnequal - case insensitive string comparisons
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "int curl_strequal(char *" str1 ", char *" str2 ");"
-.sp
-.BI "int curl_strnequal(char *" str1 ", char *" str2 ", size_t " len ");"
+.nf
+#include <curl/curl.h>
+
+int curl_strequal(char *str1, char *str2);
+int curl_strnequal(char *str1, char *str2, size_t length);
+.fi
 .SH DESCRIPTION
 The
 .B curl_strequal()
@@ -36,7 +37,7 @@ of the characters. It returns a non-zero (TRUE) integer if the strings are
 identical.
 .sp
 The \fBcurl_strnequal()\fP function is similar, except it only compares the
-first \fIlen\fP characters of \fIstr1\fP.
+first \fIlenght\fP characters of \fIstr1\fP.
 .sp
 These functions are provided by libcurl to enable applications to compare
 strings in a truly portable manner. There are no standard portable case

--- a/docs/libcurl/curl_unescape.3
+++ b/docs/libcurl/curl_unescape.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_unescape - URL decodes the given string
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "char *curl_unescape( const char *" url ", int "length " );"
-.ad
+.nf
+#include <curl/curl.h>
+
+char *curl_unescape( const char *url, int length);
+.fi
 .SH DESCRIPTION
 Obsolete function. Use \fIcurl_easy_unescape(3)\fP instead!
 

--- a/docs/libcurl/curl_url.3
+++ b/docs/libcurl/curl_url.3
@@ -23,9 +23,11 @@
 .SH NAME
 curl_url - returns a new CURLU handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
 CURLU *curl_url();
+.fi
 .SH DESCRIPTION
 This function will allocates and returns a pointer to a fresh CURLU handle, to
 be used for further use of the URL API.

--- a/docs/libcurl/curl_url_cleanup.3
+++ b/docs/libcurl/curl_url_cleanup.3
@@ -23,7 +23,8 @@
 .SH NAME
 curl_url_cleanup - free a CURLU handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
 void curl_url_cleanup(CURLU *handle);
 .fi

--- a/docs/libcurl/curl_url_dup.3
+++ b/docs/libcurl/curl_url_dup.3
@@ -23,7 +23,8 @@
 .SH NAME
 curl_url_dup - duplicate a CURLU handle
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
 CURLU *curl_url_dup(CURLU *inhandle);
 .fi

--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -23,9 +23,9 @@
 .SH NAME
 curl_url_get - extract a part from a URL
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-
 .nf
+#include <curl/curl.h>
+
 CURLUcode curl_url_get(CURLU *url,
                        CURLUPart what,
                        char **part,

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -23,7 +23,8 @@
 .SH NAME
 curl_url_set - set a URL part
 .SH SYNOPSIS
-.B #include <curl/curl.h>
+.nf
+#include <curl/curl.h>
 
 CURLUcode curl_url_set(CURLU *url,
                        CURLUPart part,

--- a/docs/libcurl/curl_version.3
+++ b/docs/libcurl/curl_version.3
@@ -23,10 +23,11 @@
 .SH NAME
 curl_version - returns the libcurl version string
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "char *curl_version( );"
-.ad
+.nf
+#include <curl/curl.h>
+
+char *curl_version();
+.fi
 .SH DESCRIPTION
 Returns a human readable string with the version number of libcurl and some of
 its important components (like OpenSSL version).

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -24,10 +24,11 @@
 .SH NAME
 curl_version_info - returns run-time libcurl version info
 .SH SYNOPSIS
-.B #include <curl/curl.h>
-.sp
-.BI "curl_version_info_data *curl_version_info( CURLversion "age ");"
-.ad
+.nf
+#include <curl/curl.h>
+
+curl_version_info_data *curl_version_info( CURLversion age);
+.fi
 .SH DESCRIPTION
 Returns a pointer to a filled in static struct with information about various
 features in the running version of libcurl. \fIage\fP should be set to the
@@ -36,9 +37,9 @@ libcurl will always return a proper struct that your program understands,
 while programs in the future might get a different
 struct. \fBCURLVERSION_NOW\fP will be the most recent one for the library you
 have installed:
-
-        data = curl_version_info(CURLVERSION_NOW);
-
+.nf
+  data = curl_version_info(CURLVERSION_NOW);
+.fi
 Applications should use this information to judge if things are possible to do
 or not, instead of using compile-time checks, as dynamic/DLL libraries can be
 changed independent of applications.
@@ -56,7 +57,7 @@ typedef struct {
   char *ssl_version;        /* human readable string */
   long ssl_version_num;     /* not used, always zero */
   const char *libz_version; /* human readable string */
-  const char * const *protocols; /* protocols */
+  const char *const *protocols; /* protocols */
 
   /* when 'age' is CURLVERSION_SECOND or higher, the members below exist */
   const char *ares;         /* human readable string */

--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_ACTIVESOCKET \- get the active socket
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_ACTIVESOCKET,
                            curl_socket_t *socket);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_socket_t to receive the most recently active socket
 used for the transfer connection by this curl session. If the socket is no

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_APPCONNECT_TIME \- get the time until the SSL/SSH handshake is completed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_APPCONNECT_TIME, double *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_APPCONNECT_TIME,
+                           double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the time, in seconds, it took from the
 start until the SSL/SSH connect/handshake to the remote host was completed.

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_APPCONNECT_TIME_T \- get the time until the SSL/SSH handshake is completed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_APPCONNECT_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_APPCONNECT_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the time, in microseconds, it took
 from the start until the SSL/SSH connect/handshake to the remote host was

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_CERTINFO \- get the TLS certificate chain
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CERTINFO,
                            struct curl_certinfo **chainp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a 'struct curl_certinfo *' and you will get it set to point to
 a struct that holds a number of linked lists with info about the certificate

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_CONDITION_UNMET \- get info on unmet time conditional or 304 HTTP response.
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONDITION_UNMET, long *unmet);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONDITION_UNMET,
+                           long *unmet);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the number 1 if the condition provided in
 the previous request did not match (see \fICURLOPT_TIMECONDITION(3)\fP). Alas,

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_CONNECT_TIME \- get the time until connect
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONNECT_TIME, double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total time in seconds from the start
 until the connection to the remote host (or proxy) was completed.

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,12 +24,15 @@
 .SH NAME
 CURLINFO_CONNECT_TIME_T \- get the time until connect
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONNECT_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONNECT_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
-Pass a pointer to a curl_off_t to receive the total time in microseconds
-from the start until the connection to the remote host (or proxy) was completed.
+Pass a pointer to a curl_off_t to receive the total time in microseconds from
+the start until the connection to the remote host (or proxy) was completed.
 
 When a redirect is followed, the time from each request is added together.
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_CONTENT_LENGTH_DOWNLOAD \- get content-length of download
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD,
                            double *content_length);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the content-length of the download. This
 is the value read from the Content-Length: field. Since 7.19.4, this returns

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_CONTENT_LENGTH_DOWNLOAD_T \- get content-length of download
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                            curl_off_t *content_length);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a \fIcurl_off_t\fP to receive the content-length of the
 download. This is the value read from the Content-Length: field. Stores -1 if

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_CONTENT_LENGTH_UPLOAD \- get the specified size of the upload
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_LENGTH_UPLOAD,
                            double *content_length);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the specified size of the upload.  Since
 7.19.4, this returns -1 if the size is not known.

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_CONTENT_LENGTH_UPLOAD_T \- get the specified size of the upload
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_LENGTH_UPLOAD_T,
                            curl_off_t *content_length);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a \fIcurl_off_t\fP to receive the specified size of the
 upload. Stores -1 if the size is not known.

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_CONTENT_TYPE \- get Content-Type
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_TYPE, char **ct);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive the content-type of the downloaded
 object. This is the value read from the Content-Type: field. If you get NULL,

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_COOKIELIST \- get all known cookies
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_COOKIELIST,
                            struct curl_slist **cookies);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a 'struct curl_slist *' to receive a linked-list of all
 cookies curl knows (expired ones, too). do not forget to call

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.3
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_EFFECTIVE_URL \- get the last used URL
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_EFFECTIVE_URL, char **urlp);
+.fi
 .SH DESCRIPTION
 Pass in a pointer to a char pointer and get the last used effective URL.
 

--- a/docs/libcurl/opts/CURLINFO_FILETIME.3
+++ b/docs/libcurl/opts/CURLINFO_FILETIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_FILETIME \- get the remote time of the retrieved document
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_FILETIME, long *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the remote time of the retrieved document
 (in number of seconds since 1 jan 1970 in the GMT/UTC time zone). If you get

--- a/docs/libcurl/opts/CURLINFO_FILETIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_FILETIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_FILETIME_T \- get the remote time of the retrieved document
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_FILETIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_FILETIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the remote time of the retrieved
 document (in number of seconds since 1 jan 1970 in the GMT/UTC time zone). If

--- a/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.3
+++ b/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_FTP_ENTRY_PATH \- get entry path in FTP server
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_FTP_ENTRY_PATH, char **path);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive a pointer to a string holding the
 path of the entry path. That is the initial path libcurl ended up in when

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.3
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_HEADER_SIZE \- get size of retrieved headers
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HEADER_SIZE, long *sizep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the total size of all the headers
 received. Measured in number of bytes.

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.3
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_HTTPAUTH_AVAIL \- get available HTTP authentication methods
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HTTPAUTH_AVAIL, long *authp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive a bitmask indicating the authentication
 method(s) available according to the previous response. The meaning of the

--- a/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.3
+++ b/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_HTTP_CONNECTCODE \- get the CONNECT response code
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HTTP_CONNECTCODE, long *p);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the last received HTTP proxy response code
 to a CONNECT request. The returned value will be zero if no such response code

--- a/docs/libcurl/opts/CURLINFO_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLINFO_HTTP_VERSION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_HTTP_VERSION \- get the http version used in the connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HTTP_VERSION, long *p);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the version used in the last http
 connection.  The returned value will be CURL_HTTP_VERSION_1_0,

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_LASTSOCKET \- get the last socket used
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_LASTSOCKET, long *socket);
+.fi
 .SH DESCRIPTION
 Deprecated since 7.45.0. Use \fICURLINFO_ACTIVESOCKET(3)\fP instead.
 

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_LOCAL_IP \- get local IP address of last connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_LOCAL_IP, char **ip);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the IP address of the local end of most recent connection done

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2015, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_LOCAL_PORT \- get the latest local port number
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_LOCAL_PORT, long *portp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the local port number of the most recent
 connection done with this \fBcurl\fP handle.

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_NAMELOOKUP_TIME \- get the name lookup time
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_NAMELOOKUP_TIME, double *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_NAMELOOKUP_TIME,
+                           double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total time in seconds from the start
 until the name resolving was completed.

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_NAMELOOKUP_TIME_T \- get the name lookup time in microseconds
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_NAMELOOKUP_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_NAMELOOKUP_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the total time in microseconds
 from the start until the name resolving was completed.

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.3
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_NUM_CONNECTS \- get number of created connections
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_NUM_CONNECTS, long *nump);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive how many new connections libcurl had to
 create to achieve the previous transfer (only the successful connects are

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_OS_ERRNO \- get errno number from last connect failure
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_OS_ERRNO, long *errnop);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the errno variable from a connect failure.
 Note that the value is only set on failure, it is not reset upon a successful

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_PRETRANSFER_TIME \- get the time until the file transfer start
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRETRANSFER_TIME, double *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRETRANSFER_TIME,
+                           double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the time, in seconds, it took from the
 start until the file transfer is just about to begin.

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_PRETRANSFER_TIME_T \- get the time until the file transfer start
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRETRANSFER_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRETRANSFER_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the time, in microseconds,
 it took from the

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2015, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_PRIMARY_IP \- get IP address of last connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRIMARY_IP, char **ip);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the IP address of the most recent connection done with this

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_PRIMARY_PORT \- get the latest destination port number
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRIMARY_PORT, long *portp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the destination port of the most recent
 connection done with this \fBcurl\fP handle.

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.3
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_PRIVATE \- get the private pointer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRIVATE, char **private);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive the pointer to the private data
 associated with the curl handle (set with the \fICURLOPT_PRIVATE(3)\fP).

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.3
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_PROTOCOL \- get the protocol used in the connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PROTOCOL, long *p);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the version used in the last http
 connection.  The returned value will be exactly one of the CURLPROTO_* values:

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.3
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_PROXYAUTH_AVAIL \- get available HTTP proxy authentication methods
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PROXYAUTH_AVAIL, long *authp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PROXYAUTH_AVAIL,
+                           long *authp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive a bitmask indicating the authentication
 method(s) available according to the previous response. The meaning of the

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.3
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_PROXY_SSL_VERIFYRESULT \- get the result of the proxy certificate verification
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PROXY_SSL_VERIFYRESULT, long *result);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PROXY_SSL_VERIFYRESULT,
+                           long *result);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the result of the certificate verification
 that was requested (using the \fICURLOPT_PROXY_SSL_VERIFYPEER(3)\fP

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_REDIRECT_COUNT \- get the number of redirects
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_COUNT, long *countp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_COUNT,
+                           long *countp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the total number of redirections that were
 actually followed.

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_REDIRECT_TIME \- get the time for all redirection steps
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_TIME, double *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_TIME,
+                           double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total time, in seconds, it took for
 all redirection steps include name lookup, connect, pretransfer and transfer

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_REDIRECT_TIME_T \- get the time for all redirection steps
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the total time, in microseconds,
 it took for

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_URL.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_URL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_REDIRECT_URL \- get the URL a redirect would go to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_URL, char **urlp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive the URL a redirect \fIwould\fP
 take you to if you would enable \fICURLOPT_FOLLOWLOCATION(3)\fP. This can come

--- a/docs/libcurl/opts/CURLINFO_REFERER.3
+++ b/docs/libcurl/opts/CURLINFO_REFERER.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_REFERER \- get the referrer header
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REFERER, char **hdrp);
+.fi
 .SH DESCRIPTION
 Pass in a pointer to a char pointer and get the referrer header.
 

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.3
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_REQUEST_SIZE \- get size of sent request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REQUEST_SIZE, long *sizep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the total size of the issued
 requests. This is so far only for HTTP requests. Note that this may be more

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_RESPONSE_CODE \- get the last response code
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RESPONSE_CODE, long *codep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the last received HTTP, FTP or SMTP
 response code. This option was previously known as CURLINFO_HTTP_CODE in

--- a/docs/libcurl/opts/CURLINFO_RETRY_AFTER.3
+++ b/docs/libcurl/opts/CURLINFO_RETRY_AFTER.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_RETRY_AFTER \- returns the Retry-After retry delay
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RETRY_AFTER, curl_off_t *retry);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RETRY_AFTER,
+                           curl_off_t *retry);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t variable to receive the number of seconds the
 HTTP server suggests the client should wait until the next request is

--- a/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_RTSP_CLIENT_CSEQ \- get the next RTSP client CSeq
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_CLIENT_CSEQ, long *cseq);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_CLIENT_CSEQ,
+                           long *cseq);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the next CSeq that will be used by the
 application.

--- a/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_RTSP_CSEQ_RECV \- get the recently received CSeq
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_CSEQ_RECV, long *cseq);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the most recently received CSeq from the
 server. If your application encounters a \fICURLE_RTSP_CSEQ_ERROR\fP then you

--- a/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_RTSP_SERVER_CSEQ \- get the next RTSP server CSeq
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_SERVER_CSEQ, long *cseq);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_SERVER_CSEQ,
+                           long *cseq);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the next CSeq that will be expected by the
 application.

--- a/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_RTSP_SESSION_ID \- get RTSP session ID
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_SESSION_ID, char **id);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive a pointer to a string holding the
 most recent RTSP Session ID.

--- a/docs/libcurl/opts/CURLINFO_SCHEME.3
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_SCHEME \- get the URL scheme (sometimes called protocol) used in the connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SCHEME, char **scheme);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the URL scheme used for the most recent connection done with

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_SIZE_DOWNLOAD \- get the number of downloaded bytes
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_DOWNLOAD, double *dlp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total amount of bytes that were
 downloaded.  The amount is only for the latest transfer and will be reset

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SIZE_DOWNLOAD_T \- get the number of downloaded bytes
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_DOWNLOAD_T, curl_off_t *dlp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_DOWNLOAD_T,
+                           curl_off_t *dlp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a \fIcurl_off_t\fP to receive the total amount of bytes that
 were downloaded.  The amount is only for the latest transfer and will be reset

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SIZE_UPLOAD \- get the number of uploaded bytes
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_UPLOAD, double *uploadp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_UPLOAD,
+                           double *uploadp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total amount of bytes that were
 uploaded.

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SIZE_UPLOAD_T \- get the number of uploaded bytes
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_UPLOAD_T, curl_off_t *uploadp);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SIZE_UPLOAD_T,
+                           curl_off_t *uploadp);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a \fIcurl_off_t\fP to receive the total amount of bytes that
 were uploaded.

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SPEED_DOWNLOAD \- get download speed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_DOWNLOAD, double *speed);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_DOWNLOAD,
+                           double *speed);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the average download speed that curl
 measured for the complete download. Measured in bytes/second.

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SPEED_DOWNLOAD_T \- get download speed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_DOWNLOAD_T, curl_off_t *speed);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_DOWNLOAD_T,
+                           curl_off_t *speed);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a \fIcurl_off_t\fP to receive the average download speed
 that curl measured for the complete download. Measured in bytes/second.

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_SPEED_UPLOAD \- get upload speed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_UPLOAD, double *speed);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the average upload speed that curl
 measured for the complete upload. Measured in bytes/second.

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SPEED_UPLOAD_T \- get upload speed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_UPLOAD_T, curl_off_t *speed);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SPEED_UPLOAD_T,
+                           curl_off_t *speed);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a \fIcurl_off_t\fP to receive the average upload speed that
 curl measured for the complete upload. Measured in bytes/second.

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.3
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLINFO_SSL_ENGINES \- get an slist of OpenSSL crypto-engines
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SSL_ENGINES,
                            struct curl_slist **engine_list);
+.fi
 .SH DESCRIPTION
 Pass the address of a 'struct curl_slist *' to receive a linked-list of
 OpenSSL crypto-engines supported. Note that engines are normally implemented

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.3
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_SSL_VERIFYRESULT \- get the result of the certificate verification
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SSL_VERIFYRESULT, long *result);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SSL_VERIFYRESULT,
+                           long *result);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a long to receive the result of the server SSL certificate
 verification that was requested (using the \fICURLOPT_SSL_VERIFYPEER(3)\fP

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_STARTTRANSFER_TIME \- get the time until the first byte is received
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_STARTTRANSFER_TIME, double *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_STARTTRANSFER_TIME,
+                           double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the time, in seconds, it took from the
 start until the first byte is received by libcurl. This includes

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_STARTTRANSFER_TIME_T \- get the time until the first byte is received
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_STARTTRANSFER_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_STARTTRANSFER_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the time, in microseconds,
 it took from the

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLINFO_TOTAL_TIME \- get total time of previous transfer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_TOTAL_TIME, double *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a double to receive the total time in seconds for the
 previous transfer, including name resolving, TCP connect etc. The double

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLINFO_TOTAL_TIME_T \- get total time of previous transfer in microseconds
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_TOTAL_TIME_T, curl_off_t *timep);
+CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_TOTAL_TIME_T,
+                           curl_off_t *timep);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_off_t to receive the total time in microseconds
 for the previous transfer, including name resolving, TCP connect etc.

--- a/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.3
+++ b/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE \- chunk length threshold for pipelining
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE, long size);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE,
+                            long size);
+.fi
 .SH DESCRIPTION
 No function since pipelining was removed in 7.62.0.
 

--- a/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.3
+++ b/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE \- size threshold for pipelining penalty
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE, long size);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE,
+                            long size);
+.fi
 .SH DESCRIPTION
 No function since pipelining was removed in 7.62.0.
 

--- a/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLMOPT_MAXCONNECTS \- size of connection cache
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAXCONNECTS, long max);
+.fi
 .SH DESCRIPTION
 Pass a long indicating the \fBmax\fP. The set number will be used as the
 maximum amount of simultaneously open connections that libcurl may keep in its

--- a/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_MAX_HOST_CONNECTIONS \- max number of connections to a single host
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_HOST_CONNECTIONS, long max);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_HOST_CONNECTIONS,
+                            long max);
+.fi
 .SH DESCRIPTION
 Pass a long to indicate \fBmax\fP. The set number will be used as the maximum
 amount of simultaneously open connections to a single host (a host being the

--- a/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_MAX_PIPELINE_LENGTH \- maximum number of requests in a pipeline
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_PIPELINE_LENGTH, long max);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_PIPELINE_LENGTH,
+                            long max);
+.fi
 .SH DESCRIPTION
 No function since pipelining was removed in 7.62.0.
 

--- a/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_MAX_TOTAL_CONNECTIONS \- max simultaneously open connections
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_TOTAL_CONNECTIONS, long amount);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_TOTAL_CONNECTIONS,
+                            long amount);
+.fi
 .SH DESCRIPTION
 Pass a long for the \fBamount\fP. The set number will be used as the maximum
 number of simultaneously open connections in total using this multi

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLMOPT_PIPELINING \- enable HTTP pipelining and multiplexing
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PIPELINING, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass in the \fBbitmask\fP parameter to instruct libcurl to enable HTTP
 pipelining and/or HTTP/2 multiplexing for this multi handle.

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_PIPELINING_SERVER_BL \- pipelining server block list
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PIPELINING_SERVER_BL, char **servers);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PIPELINING_SERVER_BL,
+                            char **servers);
+.fi
 .SH DESCRIPTION
 No function since pipelining was removed in 7.62.0.
 

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLMOPT_PIPELINING_SITE_BL \- pipelining host block list
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PIPELINING_SITE_BL, char **hosts);
+CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PIPELINING_SITE_BL,
+                            char **hosts);
+.fi
 .SH DESCRIPTION
 No function since pipelining was removed in 7.62.0.
 

--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_ABSTRACT_UNIX_SOCKET \- abstract Unix domain socket
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ABSTRACT_UNIX_SOCKET, char *path);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ABSTRACT_UNIX_SOCKET,
+                          char *path);
+.fi
 .SH DESCRIPTION
 Enables the use of an abstract Unix domain socket instead of establishing a
 TCP connection to a host. The parameter should be a char * to a

--- a/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_ACCEPTTIMEOUT_MS \- timeout waiting for FTP server to connect back
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ACCEPTTIMEOUT_MS, long ms);
+.fi
 .SH DESCRIPTION
 Pass a long telling libcurl the maximum number of milliseconds to wait for a
 server to connect back to libcurl when an active FTP connection is used.

--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_ACCEPT_ENCODING \- automatic decompression of HTTP downloads
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ACCEPT_ENCODING, char *enc);
+.fi
 .SH DESCRIPTION
 Pass a char * argument specifying what encoding you would like.
 

--- a/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.3
+++ b/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_ADDRESS_SCOPE \- scope id for IPv6 addresses
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ADDRESS_SCOPE, long scope);
+.fi
 .SH DESCRIPTION
 Pass a long specifying the scope id value to use when connecting to IPv6 addresses.
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_APPEND.3
+++ b/docs/libcurl/opts/CURLOPT_APPEND.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_APPEND \- append to the remote file
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_APPEND, long append);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells the library to append to the remote file
 instead of overwrite it. This is only useful when uploading to an FTP site.

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_AUTOREFERER \- automatically update the referer header
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_AUTOREFERER, long autorefer);
+.fi
 .SH DESCRIPTION
 Pass a parameter set to 1 to enable this. When enabled, libcurl will
 automatically set the Referer: header field in HTTP requests to the full URL

--- a/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_BUFFERSIZE \- receive buffer size
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_BUFFERSIZE, long size);
+.fi
 .SH DESCRIPTION
 Pass a long specifying your preferred \fIsize\fP (in bytes) for the receive
 buffer in libcurl.  The main point of this would be that the write callback

--- a/docs/libcurl/opts/CURLOPT_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CAINFO \- path to Certificate Authority (CA) bundle
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CAINFO, char *path);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated string naming a file holding one or more
 certificates to verify the peer with.

--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_CAINFO_BLOB \- Certificate Authority (CA) bundle in PEM format
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CAINFO_BLOB, struct curl_blob *stblob);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CAINFO_BLOB,
+                          struct curl_blob *stblob);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains information (pointer
 and size) about a memory block with binary data of PEM encoded content holding

--- a/docs/libcurl/opts/CURLOPT_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_CAPATH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CAPATH \- directory holding CA certificates
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CAPATH, char *capath);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated string naming a directory holding multiple
 CA certificates to verify the peer with. If libcurl is built against OpenSSL,

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CERTINFO \- request SSL certificate information
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CERTINFO, long certinfo);
+.fi
 .SH DESCRIPTION
 Pass a long set to 1 to enable libcurl's certificate chain info gatherer. With
 this enabled, libcurl will extract lots of information and data about the

--- a/docs/libcurl/opts/CURLOPT_CHUNK_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_DATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CHUNK_DATA \- pointer passed to the FTP chunk callbacks
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CHUNK_DATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the ptr
 argument to the \fICURLOPT_CHUNK_BGN_FUNCTION(3)\fP and

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.3
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_CLOSESOCKETDATA \- pointer passed to the socket close callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CLOSESOCKETDATA, void *pointer);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CLOSESOCKETDATA,
+                          void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the first
 argument in the closesocket callback set with

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.3
@@ -24,11 +24,14 @@
 .SH NAME
 CURLOPT_CLOSESOCKETFUNCTION \- callback to socket close replacement
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 int closesocket_callback(void *clientp, curl_socket_t item);
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CLOSESOCKETFUNCTION, closesocket_callback);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CLOSESOCKETFUNCTION,
+                          closesocket_callback);
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, which should match the prototype
 shown above.

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CONNECTTIMEOUT \- timeout for the connect phase
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CONNECTTIMEOUT, long timeout);
+.fi
 .SH DESCRIPTION
 Pass a long. It should contain the maximum time in seconds that you allow the
 connection phase to the server to take.  This only limits the connection

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_CONNECTTIMEOUT_MS \- timeout for the connect phase
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CONNECTTIMEOUT_MS, long timeout);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CONNECTTIMEOUT_MS,
+                          long timeout);
+.fi
 .SH DESCRIPTION
 Pass a long. It should contain the maximum time in milliseconds that you allow
 the connection phase to the server to take.  This only limits the connection

--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CONNECT_ONLY \- stop when connected to target server
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CONNECT_ONLY, long only);
+.fi
 .SH DESCRIPTION
 Pass a long. If the parameter equals 1, it tells the library to perform all
 the required proxy authentication and connection setup, but no data transfer,

--- a/docs/libcurl/opts/CURLOPT_COOKIE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_COOKIE \- HTTP Cookie header
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIE, char *cookie);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It will be used to
 set a cookie in the HTTP request. The format of the string should be

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_COOKIEFILE \- file name to read cookies from
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIEFILE, char *filename);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It should point to
 the file name of your file holding cookie data to read. The cookie data can be

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_COOKIEJAR \- file name to store cookies to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIEJAR, char *filename);
+.fi
 .SH DESCRIPTION
 Pass a \fIfilename\fP as char *, null-terminated. This will make libcurl write
 all internally known cookies to the specified file when

--- a/docs/libcurl/opts/CURLOPT_COOKIESESSION.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIESESSION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_COOKIESESSION \- start a new cookie session
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIESESSION, long init);
+.fi
 .SH DESCRIPTION
 Pass a long set to 1 to mark this as a new cookie "session". It will force
 libcurl to ignore all cookies it is about to load that are "session cookies"

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_COPYPOSTFIELDS \- have libcurl copy data to POST
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COPYPOSTFIELDS, char *data);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should be the full \fIdata\fP to post in a
 HTTP POST operation. It behaves as the \fICURLOPT_POSTFIELDS(3)\fP option, but

--- a/docs/libcurl/opts/CURLOPT_CRLF.3
+++ b/docs/libcurl/opts/CURLOPT_CRLF.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CRLF \- CRLF conversion
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CRLF, long conv);
+.fi
 .SH DESCRIPTION
 Pass a long. If the value is set to 1 (one), libcurl converts Unix newlines to
 CRLF newlines on transfers. Disable this option again by setting the value to

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CRLFILE \- Certificate Revocation List file
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CRLFILE, char *file);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated string naming a \fIfile\fP with the
 concatenation of CRL (in PEM format) to use in the certificate validation that

--- a/docs/libcurl/opts/CURLOPT_CURLU.3
+++ b/docs/libcurl/opts/CURLOPT_CURLU.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CURLU \- URL in CURLU * format
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CURLU, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass in a pointer to the \fIURL\fP to work with. The parameter should be a
 CURLU *. Setting \fICURLOPT_CURLU(3)\fP will explicitly override

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_CUSTOMREQUEST \- custom request method
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CUSTOMREQUEST, char *request);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter.
 

--- a/docs/libcurl/opts/CURLOPT_DEBUGDATA.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DEBUGDATA \- pointer passed to the debug callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DEBUGDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP to whatever you want passed in to your
 \fICURLOPT_DEBUGFUNCTION(3)\fP in the last void * argument. This pointer is

--- a/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.3
+++ b/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -25,10 +25,12 @@
 CURLOPT_DEFAULT_PROTOCOL \- default protocol to use if the URL is missing a
 scheme name
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DEFAULT_PROTOCOL, char
-*protocol);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DEFAULT_PROTOCOL,
+                          char *protocol);
+.fi
 .SH DESCRIPTION
 This option tells libcurl to use \fIprotocol\fP if the URL is missing a scheme
 name.

--- a/docs/libcurl/opts/CURLOPT_DIRLISTONLY.3
+++ b/docs/libcurl/opts/CURLOPT_DIRLISTONLY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DIRLISTONLY \- ask for names only in a directory listing
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DIRLISTONLY, long listonly);
+.fi
 .SH DESCRIPTION
 For FTP and SFTP based URLs a parameter set to 1 tells the library to list the
 names of files in a directory, rather than performing a full directory listing

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_DISALLOW_USERNAME_IN_URL \- disallow specifying username in the url
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DISALLOW_USERNAME_IN_URL, long disallow);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DISALLOW_USERNAME_IN_URL,
+                          long disallow);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells the library to not allow URLs that include a
 username.

--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DNS_CACHE_TIMEOUT \- life-time for DNS cache entries
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_CACHE_TIMEOUT, long age);
+.fi
 .SH DESCRIPTION
 Pass a long, this sets the timeout in seconds. Name resolves will be kept in
 memory and used for this number of seconds. Set to zero to completely disable

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DNS_INTERFACE \- interface to speak DNS over
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_INTERFACE, char *ifname);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter. Set the name of the network interface that the DNS
 resolver should bind to. This must be an interface name (not an address). Set

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DNS_LOCAL_IP4 \- IPv4 address to bind DNS resolves to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_LOCAL_IP4, char *address);
+.fi
 .SH DESCRIPTION
 Set the local IPv4 \fIaddress\fP that the resolver should bind to. The
 argument should be of type char * and contain a single numerical IPv4 address

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DNS_LOCAL_IP6 \- IPv6 address to bind DNS resolves to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_LOCAL_IP6, char *address);
+.fi
 .SH DESCRIPTION
 Set the local IPv6 \fIaddress\fP that the resolver should bind to. The
 argument should be of type char * and contain a single IPv6 address as a

--- a/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DNS_SERVERS \- DNS servers to use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_SERVERS, char *servers);
+.fi
 .SH DESCRIPTION
 Pass a char * that is the list of DNS servers to be used instead of the system
 default. The format of the dns servers option is:

--- a/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.3
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_DNS_USE_GLOBAL_CACHE \- global DNS cache
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_USE_GLOBAL_CACHE,
                           long enable);
+.fi
 .SH DESCRIPTION
 Has no function since 7.62.0. Do not use!
 

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_DOH_SSL_VERIFYHOST \- verify the host name in the DoH SSL certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_SSL_VERIFYHOST, long verify);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_SSL_VERIFYHOST,
+                          long verify);
+.fi
 .SH DESCRIPTION
 Pass a long set to 2L as asking curl to \fIverify\fP the DoH (DNS-over-HTTPS)
 server's certificate name fields against the host name.

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_DOH_SSL_VERIFYPEER \- verify the DoH SSL certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_SSL_VERIFYPEER, long verify);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_SSL_VERIFYPEER,
+                          long verify);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1L to enable or 0L to disable.
 

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_DOH_SSL_VERIFYSTATUS \- verify the DoH SSL certificate's status
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_SSL_VERIFYSTATUS, long verify);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_SSL_VERIFYSTATUS,
+                          long verify);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1 to enable or 0 to disable.
 

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_DOH_URL \- provide the DNS-over-HTTPS URL
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_URL, char *URL);
+.fi
 .SH DESCRIPTION
 Pass in a pointer to a \fIURL\fP for the DoH server to use for name
 resolving. The parameter should be a char * to a null-terminated string which

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_EGDSOCKET \- EGD socket path
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_EGDSOCKET, char *path);
+.fi
 .SH DESCRIPTION
 Pass a char * to the null-terminated path name to the Entropy Gathering Daemon
 socket. It will be used to seed the random engine for TLS.

--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_ERRORBUFFER \- error buffer for error messages
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ERRORBUFFER, char *buf);
+.fi
 .SH DESCRIPTION
 Pass a char * to a buffer that libcurl \fBmay\fP store human readable error
 messages on failures or problems. This may be more helpful than just the

--- a/docs/libcurl/opts/CURLOPT_FAILONERROR.3
+++ b/docs/libcurl/opts/CURLOPT_FAILONERROR.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FAILONERROR \- request failure on HTTP response >= 400
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FAILONERROR, long fail);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells the library to fail the request if the HTTP
 code returned is equal to or larger than 400. The default action would be to

--- a/docs/libcurl/opts/CURLOPT_FILETIME.3
+++ b/docs/libcurl/opts/CURLOPT_FILETIME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FILETIME \- get the modification time of the remote resource
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FILETIME, long gettime);
+.fi
 .SH DESCRIPTION
 Pass a long. If it is 1, libcurl will attempt to get the modification time of
 the remote document in this operation. This requires that the remote server

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FOLLOWLOCATION \- follow HTTP 3xx redirects
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FOLLOWLOCATION, long enable);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells the library to follow any Location: header
 that the server sends as part of an HTTP header in a 3xx response. The

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.3
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FORBID_REUSE \- make connection get closed at once after use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FORBID_REUSE, long close);
+.fi
 .SH DESCRIPTION
 Pass a long. Set \fIclose\fP to 1 to make libcurl explicitly close the
 connection when done with the transfer. Normally, libcurl keeps all

--- a/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.3
+++ b/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FRESH_CONNECT \- force a new connection to be used
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FRESH_CONNECT, long fresh);
+.fi
 .SH DESCRIPTION
 Pass a long. Set to 1 to make the next transfer use a new (fresh) connection
 by force instead of trying to re-use an existing one.  This option should be

--- a/docs/libcurl/opts/CURLOPT_FTPPORT.3
+++ b/docs/libcurl/opts/CURLOPT_FTPPORT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTPPORT \- make FTP transfer active
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTPPORT, char *spec);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It specifies that the
 FTP transfer will be made actively and the given string will be used to get

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTPSSLAUTH \- order in which to attempt TLS vs SSL
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTPSSLAUTH, long order);
+.fi
 .SH DESCRIPTION
 Pass a long using one of the values from below, to alter how libcurl issues
 \&"AUTH TLS" or "AUTH SSL" when FTP over SSL is activated. This is only

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTP_ACCOUNT \- account info for FTP
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_ACCOUNT, char *account);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string (or NULL to disable). When an FTP
 server asks for "account data" after user name and password has been provided,

--- a/docs/libcurl/opts/CURLOPT_FTP_RESPONSE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_RESPONSE_TIMEOUT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_FTP_RESPONSE_TIMEOUT \- time allowed to wait for FTP response
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_RESPONSE_TIMEOUT, long timeout);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_RESPONSE_TIMEOUT,
+                          long timeout);
+.fi
 .SH DESCRIPTION
 Pass a long.  Causes libcurl to set a \fItimeout\fP period (in seconds) on the
 amount of time that the server is allowed to take in order to send a response

--- a/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTP_SKIP_PASV_IP \- ignore the IP address in the PASV response
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_SKIP_PASV_IP, long skip);
+.fi
 .SH DESCRIPTION
 Pass a long. If \fIskip\fP is set to 1, it instructs libcurl to not use the IP
 address the server suggests in its 227-response to libcurl's PASV command when

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_FTP_SSL_CCC \- switch off SSL again with FTP after auth
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_SSL_CCC,
                           long how);
+.fi
 .SH DESCRIPTION
 If enabled, this option makes libcurl use CCC (Clear Command Channel). It
 shuts down the SSL/TLS layer after authenticating. The rest of the control

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTP_USE_EPRT \- use EPRT for FTP
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_USE_EPRT, long enabled);
+.fi
 .SH DESCRIPTION
 Pass a long. If the value is 1, it tells curl to use the EPRT command when
 doing active FTP downloads (which is enabled by

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTP_USE_EPSV \- use EPSV for FTP
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_USE_EPSV, long epsv);
+.fi
 .SH DESCRIPTION
 Pass \fIepsv\fP as a long. If the value is 1, it tells curl to use the EPSV
 command when doing passive FTP downloads (which it does by default). Using

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_FTP_USE_PRET \- use PRET for FTP
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_USE_PRET, long enable);
+.fi
 .SH DESCRIPTION
 Pass a long. If the value is 1, it tells curl to send a PRET command before
 PASV (and EPSV). Certain FTP servers, mainly drftpd, require this non-standard

--- a/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.3
+++ b/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_GSSAPI_DELEGATION \- allowed GSS-API delegation
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_GSSAPI_DELEGATION, long level);
+.fi
 .SH DESCRIPTION
 Set the long parameter \fIlevel\fP to \fBCURLGSSAPI_DELEGATION_FLAG\fP to
 allow unconditional GSSAPI credential delegation. The delegation is disabled

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS \- head start for ipv6 for happy eyeballs
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS, long timeout);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
+                          long timeout);
+.fi
 .SH DESCRIPTION
 Happy eyeballs is an algorithm that attempts to connect to both IPv4 and IPv6
 addresses for dual-stack hosts, preferring IPv6 first for \fItimeout\fP

--- a/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.3
+++ b/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.3
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_HAPROXYPROTOCOL \- send HAProxy PROXY protocol v1 header
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HAPROXYPROTOCOL,
                           long haproxy_protocol);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells the library to send an HAProxy PROXY
 protocol v1 header at beginning of the connection. The default action is not to

--- a/docs/libcurl/opts/CURLOPT_HEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HEADER.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HEADER \- pass headers to the data stream
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HEADER, long onoff);
+.fi
 .SH DESCRIPTION
 Pass the long value \fIonoff\fP set to 1 to ask libcurl to include the headers
 in the write callback (\fICURLOPT_WRITEFUNCTION(3)\fP). This option is

--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HEADERDATA \- pointer to pass to header callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HEADERDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP to be used to write the header part of the received data
 to.

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
@@ -24,6 +24,7 @@
 .SH NAME
 CURLOPT_HEADERFUNCTION \- callback that receives header data
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 size_t header_callback(char *buffer,
@@ -31,7 +32,9 @@ size_t header_callback(char *buffer,
                        size_t nitems,
                        void *userdata);
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HEADERFUNCTION, header_callback);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HEADERFUNCTION,
+                          header_callback);
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, which should match the prototype
 shown above.

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.3
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HEADEROPT \- send HTTP headers to both proxy and host or separately
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HEADEROPT, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long that is a bitmask of options of how to deal with headers. The two
 mutually exclusive options are:

--- a/docs/libcurl/opts/CURLOPT_HSTSREADDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HSTSREADDATA \- pointer passed to the HSTS read callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTSREADDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Data \fIpointer\fP to pass to the HSTS read function. If you use the
 \fICURLOPT_HSTSREADFUNCTION(3)\fP option, this is the pointer you will get as

--- a/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.3
@@ -24,11 +24,13 @@
 .SH NAME
 CURLOPT_HSTSREADFUNCTION \- read callback for HSTS hosts
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLSTScode hstsread(CURL *easy, struct curl_hstsentry *sts, void *userp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTSREADFUNCTION, hstsread);
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, as the prototype shows above.
 

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HSTSWRITEDATA \- pointer passed to the HSTS write callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTSWRITEDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Data \fIpointer\fP to pass to the HSTS write function. If you use the
 \fICURLOPT_HSTSWRITEFUNCTION(3)\fP option, this is the pointer you will get as

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
@@ -24,12 +24,14 @@
 .SH NAME
 CURLOPT_HSTSWRITEFUNCTION \- write callback for HSTS hosts
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLSTScode hstswrite(CURL *easy, struct curl_hstsentry *sts,
                       struct curl_index *count, void *userp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTSWRITEFUNCTION, hstswrite);
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, as the prototype shows above.
 

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HTTP09_ALLOWED \- allow HTTP/0.9 response
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTP09_ALLOWED, long allowed);
+.fi
 .SH DESCRIPTION
 Pass the long argument \fIallowed\fP set to 1L to allow HTTP/0.9 responses.
 

--- a/docs/libcurl/opts/CURLOPT_HTTPGET.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPGET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HTTPGET \- ask for an HTTP GET request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTPGET, long useget);
+.fi
 .SH DESCRIPTION
 Pass a long. If \fIuseget\fP is 1, this forces the HTTP request to get back to
 using GET. Usable if a POST, HEAD, PUT, etc has been used previously using the

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_HTTPHEADER \- set of HTTP headers
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTPHEADER, struct curl_slist *headers);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTPHEADER,
+                          struct curl_slist *headers);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a linked list of HTTP headers to pass to the server and/or
 proxy in your HTTP request. The same list can be used for both host and proxy

--- a/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HTTPPROXYTUNNEL \- tunnel through HTTP proxy
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTPPROXYTUNNEL, long tunnel);
+.fi
 .SH DESCRIPTION
 Set the \fBtunnel\fP parameter to 1L to make libcurl tunnel all operations
 through the HTTP proxy (set with \fICURLOPT_PROXY(3)\fP). There is a big

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_HTTP_VERSION \- HTTP protocol version to use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTP_VERSION, long version);
+.fi
 .SH DESCRIPTION
 Pass \fIversion\fP a long, set to one of the values described below. They ask
 libcurl to use the specific HTTP versions.

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE.3
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_INFILESIZE \- size of the input file to send off
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_INFILESIZE, long filesize);
+.fi
 .SH DESCRIPTION
 When uploading a file to a remote site, \fIfilesize\fP should be used to tell
 libcurl what the expected size of the input file is. This value must be passed

--- a/docs/libcurl/opts/CURLOPT_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_INTERFACE \- source interface for outgoing traffic
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_INTERFACE, char *interface);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter. This sets the \fIinterface\fP name to use as
 outgoing network interface. The name can be an interface name, an IP address,

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_INTERLEAVEDATA \- pointer passed to RTSP interleave callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_INTERLEAVEDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 This is the userdata \fIpointer\fP that will be passed to
 \fICURLOPT_INTERLEAVEFUNCTION(3)\fP when interleaved RTP data is received. If

--- a/docs/libcurl/opts/CURLOPT_IOCTLDATA.3
+++ b/docs/libcurl/opts/CURLOPT_IOCTLDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_IOCTLDATA \- pointer passed to I/O callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_IOCTLDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass the \fIpointer\fP that will be untouched by libcurl and passed as the 3rd
 argument in the ioctl callback set with \fICURLOPT_IOCTLFUNCTION(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_IPRESOLVE \- IP protocol version to use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_IPRESOLVE, long resolve);
+.fi
 .SH DESCRIPTION
 Allows an application to select what kind of IP addresses to use when
 establishing a connection or choosing one from the connection pool. This is

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2014, 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_ISSUERCERT \- issuer SSL certificate filename
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ISSUERCERT, char *file);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated string naming a \fIfile\fP holding a CA
 certificate in PEM format. If the option is set, an additional check against

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_ISSUERCERT_BLOB \- issuer SSL certificate from memory blob
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ISSUERCERT_BLOB, struct curl_blob *stblob);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ISSUERCERT_BLOB,
+                          struct curl_blob *stblob);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains information (pointer
 and size) about a memory block with binary data of a CA certificate in PEM

--- a/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.3
+++ b/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_KEEP_SENDING_ON_ERROR \- keep sending on early HTTP response >= 300
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_KEEP_SENDING_ON_ERROR,
                           long keep_sending);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells the library to keep sending the request body
 if the HTTP code returned is equal to or larger than 300. The default action

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_KEYPASSWD \- passphrase to private key
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_KEYPASSWD, char *pwd);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It will be used as
 the password required to use the \fICURLOPT_SSLKEY(3)\fP or

--- a/docs/libcurl/opts/CURLOPT_KRBLEVEL.3
+++ b/docs/libcurl/opts/CURLOPT_KRBLEVEL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_KRBLEVEL \- FTP kerberos security level
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_KRBLEVEL, char *level);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter. Set the kerberos security level for FTP; this also
 enables kerberos awareness.  This is a string that should match one of the

--- a/docs/libcurl/opts/CURLOPT_LOCALPORT.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_LOCALPORT \- local port number to use for socket
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOCALPORT, long port);
+.fi
 .SH DESCRIPTION
 Pass a long. This sets the local port number of the socket used for the
 connection. This can be used in combination with \fICURLOPT_INTERFACE(3)\fP

--- a/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_LOCALPORTRANGE \- number of additional local ports to try
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOCALPORTRANGE,
                           long range);
+.fi
 .SH DESCRIPTION
 Pass a long. The \fIrange\fP argument is the number of attempts libcurl will
 make to find a working local port number. It starts with the given

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_LOGIN_OPTIONS \- login options
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOGIN_OPTIONS, char *options);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should be pointing to the null-terminated
 \fIoptions\fP string to use for the transfer.

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.3
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_LOW_SPEED_LIMIT \- low speed limit in bytes per second
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOW_SPEED_LIMIT, long speedlimit);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOW_SPEED_LIMIT,
+                          long speedlimit);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter. It contains the average transfer speed in bytes per
 second that the transfer should be below during

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.3
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_LOW_SPEED_TIME \- low speed limit time period
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOW_SPEED_TIME, long speedtime);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_LOW_SPEED_TIME,
+                          long speedtime);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter. It contains the time in number seconds that the
 transfer speed should be below the \fICURLOPT_LOW_SPEED_LIMIT(3)\fP for the

--- a/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MAIL_AUTH \- SMTP authentication address
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAIL_AUTH, char *auth);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. This will be used to
 specify the authentication address (identity) of a submitted message that is

--- a/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MAIL_FROM \- SMTP sender address
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAIL_FROM, char *from);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. This should be used
 to specify the sender's email address when sending SMTP mail with libcurl.

--- a/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.3
+++ b/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MAXAGE_CONN \- max idle time allowed for reusing a connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXAGE_CONN, long maxage);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter containing \fImaxage\fP - the maximum time in seconds
 that you allow an existing connection to have been idle to be considered for

--- a/docs/libcurl/opts/CURLOPT_MAXCONNECTS.3
+++ b/docs/libcurl/opts/CURLOPT_MAXCONNECTS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MAXCONNECTS \- maximum connection cache size
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXCONNECTS, long amount);
+.fi
 .SH DESCRIPTION
 Pass a long. The set \fIamount\fP will be the maximum number of simultaneously
 open persistent connections that libcurl may cache in the pool associated with

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.3
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MAXFILESIZE \- maximum file size allowed to download
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXFILESIZE, long size);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter. This allows you to specify the maximum \fIsize\fP
 (in bytes) of a file to download. If the file requested is found larger than

--- a/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.3
+++ b/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_MAXLIFETIME_CONN \- max lifetime (since creation) allowed for reusing a connection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXLIFETIME_CONN, long maxlifetime);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXLIFETIME_CONN,
+                          long maxlifetime);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter containing \fImaxlifetime\fP - the maximum time in
 seconds, since the creation of the connection, that you allow an existing

--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MAXREDIRS \- maximum number of redirects allowed
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXREDIRS, long amount);
+.fi
 .SH DESCRIPTION
 Pass a long. The set number will be the redirection limit \fIamount\fP. If
 that many redirections have been followed, the next redirect will cause an

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_MIME_OPTIONS \- set MIME option flags
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MIME_OPTIONS, long options);
+.fi
 .SH DESCRIPTION
 Pass a long that holds a bitmask of CURLMIMEOPT_* defines. Each bit is a
 Boolean flag used while encoding a MIME tree or multipart form data.

--- a/docs/libcurl/opts/CURLOPT_NETRC.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_NETRC \- enable use of .netrc
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NETRC, long level);
+.fi
 .SH DESCRIPTION
 This parameter controls the preference \fIlevel\fP of libcurl between using
 user names and passwords from your \fI~/.netrc\fP file, relative to user names

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2017, 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_NETRC_FILE \- file name to read .netrc info from
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NETRC_FILE, char *file);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, pointing to a null-terminated string containing
 the full path name to the \fIfile\fP you want libcurl to use as .netrc

--- a/docs/libcurl/opts/CURLOPT_NOBODY.3
+++ b/docs/libcurl/opts/CURLOPT_NOBODY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_NOBODY \- do the download request without getting the body
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NOBODY, long opt);
+.fi
 .SH DESCRIPTION
 A long parameter set to 1 tells libcurl to not include the body-part in the
 output when doing what would otherwise be a download. For HTTP(S), this makes

--- a/docs/libcurl/opts/CURLOPT_NOPROGRESS.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROGRESS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_NOPROGRESS \- switch off the progress meter
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NOPROGRESS, long onoff);
+.fi
 .SH DESCRIPTION
 If \fIonoff\fP is to 1, it tells the library to shut off the progress meter
 completely for requests done with this \fIhandle\fP. It will also prevent the

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_NOPROXY \- disable proxy use for specific hosts
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NOPROXY, char *noproxy);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string. The string consists of a comma
 separated list of host names that do not require a proxy to get reached, even

--- a/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
+++ b/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_NOSIGNAL \- skip all signal handling
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NOSIGNAL, long onoff);
+.fi
 .SH DESCRIPTION
 If \fIonoff\fP is 1, libcurl will not use any functions that install signal
 handlers or any functions that cause signals to be sent to the process. This

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.3
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_OPENSOCKETDATA \- pointer passed to open socket callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_OPENSOCKETDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the first
 argument in the opensocket callback set with \fICURLOPT_OPENSOCKETFUNCTION(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PASSWORD \- password to use in authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PASSWORD, char *pwd);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should be pointing to the null-terminated
 password to use for the transfer.

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.3
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PATH_AS_IS \- do not handle dot dot sequences
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PATH_AS_IS, long leaveit);
+.fi
 .SH DESCRIPTION
 Set the long \fIleaveit\fP to 1, to explicitly tell libcurl to not alter the
 given path before passing it on to the server.

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PINNEDPUBLICKEY \- pinned public key
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PINNEDPUBLICKEY, char *pinnedpubkey);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PINNEDPUBLICKEY,
+                          char *pinnedpubkey);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string can be the
 file name of your pinned public key. The file format expected is "PEM" or "DER".

--- a/docs/libcurl/opts/CURLOPT_PIPEWAIT.3
+++ b/docs/libcurl/opts/CURLOPT_PIPEWAIT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PIPEWAIT \- wait for pipelining/multiplexing
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PIPEWAIT, long wait);
+.fi
 .SH DESCRIPTION
 Set \fIwait\fP to 1L to tell libcurl to prefer to wait for a connection to
 confirm or deny that it can do pipelining or multiplexing before continuing.

--- a/docs/libcurl/opts/CURLOPT_PORT.3
+++ b/docs/libcurl/opts/CURLOPT_PORT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PORT \- remote port number to connect to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PORT, long number);
+.fi
 .SH DESCRIPTION
 This option sets \fInumber\fP to be the remote port number to connect to,
 instead of the one specified in the URL or the default port for the used

--- a/docs/libcurl/opts/CURLOPT_POST.3
+++ b/docs/libcurl/opts/CURLOPT_POST.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_POST \- make an HTTP POST
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_POST, long post);
+.fi
 .SH DESCRIPTION
 A parameter set to 1 tells libcurl to do a regular HTTP post. This will also
 make the library use a "Content-Type: application/x-www-form-urlencoded"

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_POSTFIELDS \- data to POST to server
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_POSTFIELDS, char *postdata);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, pointing to the full data to send in an HTTP POST
 operation. You must make sure that the data is formatted the way you want the

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_POSTFIELDSIZE \- size of POST data pointed to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_POSTFIELDSIZE, long size);
+.fi
 .SH DESCRIPTION
 If you want to post data to the server without having libcurl do a strlen() to
 measure the data size, this option must be used. When this option is used you

--- a/docs/libcurl/opts/CURLOPT_POSTQUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTQUOTE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_POSTQUOTE \- (S)FTP commands to run after the transfer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_POSTQUOTE, struct curl_slist *cmds);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_POSTQUOTE,
+                          struct curl_slist *cmds);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a linked list of FTP or SFTP commands to pass to the server
 after your FTP transfer request. The commands will only be run if no error

--- a/docs/libcurl/opts/CURLOPT_PREQUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_PREQUOTE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_PREQUOTE \- commands to run before an FTP transfer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PREQUOTE,
                           struct curl_slist *cmds);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a linked list of FTP commands to pass to the server after
 the transfer type is set. The linked list should be a fully valid list of

--- a/docs/libcurl/opts/CURLOPT_PREREQDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PREREQDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PREREQDATA \- pointer passed to the pre-request callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PREREQDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the first
 argument in the pre-request callback set with

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PRE_PROXY \- pre-proxy host to use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PRE_PROXY, char *preproxy);
+.fi
 .SH DESCRIPTION
 Set the \fIpreproxy\fP to use for the upcoming request. The parameter
 should be a char * to a null-terminated string holding the host name or dotted

--- a/docs/libcurl/opts/CURLOPT_PRIVATE.3
+++ b/docs/libcurl/opts/CURLOPT_PRIVATE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PRIVATE \- store a private pointer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PRIVATE, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a void * as parameter, pointing to data that should be associated with
 this curl handle.  The pointer can subsequently be retrieved using

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROGRESSDATA \- pointer passed to the progress callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROGRESSDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the first
 argument in the progress callback set with \fICURLOPT_PROGRESSFUNCTION(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
@@ -24,6 +24,7 @@
 .SH NAME
 CURLOPT_PROGRESSFUNCTION \- progress meter callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 int progress_callback(void *clientp,
@@ -32,7 +33,9 @@ int progress_callback(void *clientp,
                       double ultotal,
                       double ulnow);
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROGRESSFUNCTION, progress_callback);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROGRESSFUNCTION,
+                          progress_callback);
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, which should match the prototype
 shown above.

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.3
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROTOCOLS \- allowed protocols
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROTOCOLS, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long that holds a bitmask of CURLPROTO_* defines. If used, this bitmask
 limits what protocols libcurl may use in the transfer. This allows you to have

--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY \- proxy to use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY, char *proxy);
+.fi
 .SH DESCRIPTION
 Set the \fIproxy\fP to use for the upcoming request. The parameter should be a
 char * to a null-terminated string holding the host name or dotted numerical

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXYAUTH \- HTTP proxy authentication methods
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYAUTH, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter, which is set to a bitmask, to tell libcurl which
 HTTP authentication method(s) you want it to use for your proxy

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXYPASSWORD \- password to use with proxy authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYPASSWORD, char *pwd);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should be pointing to the null-terminated
 password to use for authentication with the proxy.

--- a/docs/libcurl/opts/CURLOPT_PROXYPORT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPORT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXYPORT \- port number the proxy listens on
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYPORT, long port);
+.fi
 .SH DESCRIPTION
 Pass a long with this option to set the proxy port to connect to unless it is
 specified in the proxy string \fICURLOPT_PROXY(3)\fP or uses 443 for https

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXYTYPE \- proxy protocol type
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYTYPE, long type);
+.fi
 .SH DESCRIPTION
 Pass one of the values below to set the type of the proxy.
 

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXYUSERPWD \- user name and password to use for proxy authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYUSERPWD, char *userpwd);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should be [user name]:[password] to use for
 the connection to the HTTP proxy. Both the name and the password will be URL

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_CAINFO \- path to proxy Certificate Authority (CA) bundle
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CAINFO, char *path);
+.fi
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_CAINFO_BLOB \- proxy Certificate Authority (CA) bundle in PEM format
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CAINFO_BLOB, struct curl_blob *stblob);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CAINFO_BLOB,
+                          struct curl_blob *stblob);
+.fi
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_CAPATH \- directory holding HTTPS proxy CA certificates
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CAPATH, char *capath);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated string naming a directory holding multiple
 CA certificates to verify the HTTPS proxy with. If libcurl is built against

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_CRLFILE \- HTTPS proxy Certificate Revocation List file
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_CRLFILE, char *file);
+.fi
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_ISSUERCERT \- proxy issuer SSL certificate filename
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_ISSUERCERT, char *file);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated string naming a \fIfile\fP holding a CA
 certificate in PEM format. If the option is set, an additional check against

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_KEYPASSWD \- passphrase for the proxy private key
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_KEYPASSWD, char *pwd);
+.fi
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_PINNEDPUBLICKEY \- pinned public key for https proxy
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_PINNEDPUBLICKEY, char *pinnedpubkey);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string can be the
 file name of your pinned public key. The file format expected is "PEM" or "DER".

--- a/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SERVICE_NAME \- proxy authentication service name
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SERVICE_NAME, char *name);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SERVICE_NAME,
+                          char *name);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter to a string holding the \fIname\fP of the
 service. The default service name is "HTTP" for HTTP based proxies and "rcmd"

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_SSLCERT \- HTTPS proxy client certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERT, char *cert);
+.fi
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_SSLCERTTYPE \- type of the proxy client SSL certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERTTYPE, char *type);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your client certificate used when connecting to an HTTPS proxy.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SSLCERT_BLOB \- SSL proxy client certificate from memory blob
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERT_BLOB, struct curl_blob *blob);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLCERT_BLOB,
+                          struct curl_blob *blob);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains information (pointer
 and size) about a memory block with binary data of the certificate used to

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_SSLKEY \- private keyfile for HTTPS proxy client cert
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLKEY, char *keyfile);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your private key used for connecting to the HTTPS proxy. The

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PROXY_SSLKEYTYPE \- type of the proxy private key file
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLKEYTYPE, char *type);
+.fi
 .SH DESCRIPTION
 This option is for connecting to an HTTPS proxy, not an HTTPS server.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SSLVERSION \- preferred HTTPS proxy TLS version
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLVERSION, long version);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSLVERSION,
+                          long version);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter to control which version of SSL/TLS to attempt to use
 when connecting to an HTTPS proxy.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SSL_CIPHER_LIST \- ciphers to use for HTTPS proxy
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_CIPHER_LIST, char *list);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_CIPHER_LIST,
+                          char *list);
+.fi
 .SH DESCRIPTION
 Pass a char *, pointing to a null-terminated string holding the list of
 ciphers to use for the connection to the HTTPS proxy. The list must be

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SSL_OPTIONS \- HTTPS proxy SSL behavior options
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_OPTIONS, long bitmask);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_OPTIONS,
+                          long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long with a bitmask to tell libcurl about specific SSL
 behaviors. Available bits:

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SSL_VERIFYHOST \- verify the proxy certificate's name against host
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_VERIFYHOST, long verify);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_VERIFYHOST,
+                          long verify);
+.fi
 .SH DESCRIPTION
 Pass a long set to 2L as asking curl to \fIverify\fP in the HTTPS proxy's
 certificate name fields against the proxy name.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_SSL_VERIFYPEER \- verify the proxy's SSL certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_VERIFYPEER, long verify);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_VERIFYPEER,
+                          long verify);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1L to enable or 0L to disable.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_TLS13_CIPHERS \- ciphers suites for proxy TLS 1.3
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLS13_CIPHERS, char *list);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLS13_CIPHERS,
+                          char *list);
+.fi
 .SH DESCRIPTION
 Pass a char *, pointing to a null-terminated string holding the list of cipher
 suites to use for the TLS 1.3 connection to a proxy. The list must be

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_TLSAUTH_PASSWORD \- password to use for proxy TLS authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_PASSWORD, char *pwd);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_PASSWORD,
+                          char *pwd);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should point to the null-terminated password
 to use for the TLS authentication method specified with the

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_TLSAUTH_TYPE \- HTTPS proxy TLS authentication methods
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_TYPE, char *type);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_TYPE,
+                          char *type);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the method of the TLS authentication used for the HTTPS connection. Supported

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_TLSAUTH_USERNAME \- user name to use for proxy TLS authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_USERNAME, char *user);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TLSAUTH_USERNAME,
+                          char *user);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should point to the null-terminated username
 to use for the HTTPS proxy TLS authentication method specified with the

--- a/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_PROXY_TRANSFER_MODE \- append FTP transfer mode to URL for proxy
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TRANSFER_MODE, long enabled);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_TRANSFER_MODE,
+                          long enabled);
+.fi
 .SH DESCRIPTION
 Pass a long. If the value is set to 1 (one), it tells libcurl to set the
 transfer mode (binary or ASCII) for FTP transfers done via an HTTP proxy, by

--- a/docs/libcurl/opts/CURLOPT_PUT.3
+++ b/docs/libcurl/opts/CURLOPT_PUT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_PUT \- make an HTTP PUT request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PUT, long put);
+.fi
 .SH DESCRIPTION
 A parameter set to 1 tells the library to use HTTP PUT to transfer data. The
 data should be set with \fICURLOPT_READDATA(3)\fP and

--- a/docs/libcurl/opts/CURLOPT_QUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_QUOTE.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_QUOTE \- (S)FTP commands to run before transfer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_QUOTE, struct curl_slist *cmds);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_QUOTE,
+                          struct curl_slist *cmds);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a linked list of FTP or SFTP commands to pass to the server
 prior to your request. This will be done before any other commands are issued

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RANDOM_FILE \- file to read random data from
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RANDOM_FILE, char *path);
+.fi
 .SH DESCRIPTION
 Pass a char * to a null-terminated file name. The file might be used to read
 from to seed the random engine for SSL and more.

--- a/docs/libcurl/opts/CURLOPT_RANGE.3
+++ b/docs/libcurl/opts/CURLOPT_RANGE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RANGE \- byte range to request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RANGE, char *range);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should contain the specified range you want
 to retrieve. It should be in the format "X-Y", where either X or Y may be left

--- a/docs/libcurl/opts/CURLOPT_READDATA.3
+++ b/docs/libcurl/opts/CURLOPT_READDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_READDATA \- pointer passed to the read callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_READDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Data \fIpointer\fP to pass to the file read function. If you use the
 \fICURLOPT_READFUNCTION(3)\fP option, this is the pointer you will get as

--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,12 +24,13 @@
 .SH NAME
 CURLOPT_READFUNCTION \- read callback for data uploads
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 size_t read_callback(char *buffer, size_t size, size_t nitems, void *userdata);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_READFUNCTION, read_callback);
-
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, as the prototype shows above.
 

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_REDIR_PROTOCOLS \- protocols allowed to redirect to
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_REDIR_PROTOCOLS, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long that holds a bitmask of CURLPROTO_* defines. If used, this bitmask
 limits what protocols libcurl may use in a transfer that it follows to in a

--- a/docs/libcurl/opts/CURLOPT_REFERER.3
+++ b/docs/libcurl/opts/CURLOPT_REFERER.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_REFERER \- the HTTP referer header
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_REFERER, char *where);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It will be used to
 set the Referer: header in the http request sent to the remote server. This

--- a/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.3
+++ b/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_REQUEST_TARGET \- alternative target for this request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_REQUEST_TARGET, string);
+.fi
 .SH DESCRIPTION
 Pass a char * to string which libcurl uses in the upcoming request instead of
 the path as extracted from the URL.

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_RESOLVER_START_DATA \- pointer passed to the resolver start callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RESOLVER_START_DATA, void *pointer);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RESOLVER_START_DATA,
+                          void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the third
 argument in the resolver start callback set with

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM.3
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RESUME_FROM \- offset to resume transfer from
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RESUME_FROM, long from);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter. It contains the offset in number of bytes that you
 want the transfer to start from. Set this option to 0 to make the transfer

--- a/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RTSP_CLIENT_CSEQ \- RTSP client CSEQ number
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RTSP_CLIENT_CSEQ, long cseq);
+.fi
 .SH DESCRIPTION
 Pass a long to set the CSEQ number to issue for the next RTSP
 request. Useful if the application is resuming a previously broken

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RTSP_REQUEST \- RTSP request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RTSP_REQUEST, long request);
+.fi
 .SH DESCRIPTION
 Tell libcurl what kind of RTSP request to make. Pass one of the following RTSP
 enum values as a long in the \fIrequest\fP argument. Unless noted otherwise,

--- a/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RTSP_SERVER_CSEQ \- RTSP server CSEQ number
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RTSP_SERVER_CSEQ, long cseq);
+.fi
 .SH DESCRIPTION
 Pass a long to set the CSEQ number to expect for the next RTSP Server->Client
 request.  \fBNOTE\fP: this feature (listening for Server requests) is

--- a/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RTSP_SESSION_ID \- RTSP session ID
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RTSP_SESSION_ID, char *id);
+.fi
 .SH DESCRIPTION
 Pass a char * as a parameter to set the value of the current RTSP Session ID
 for the handle. Useful for resuming an in-progress session. Once this value is

--- a/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_RTSP_STREAM_URI \- RTSP stream URI
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RTSP_STREAM_URI, char *URI);
+.fi
 .SH DESCRIPTION
 Set the stream \fIURI\fP to operate on by passing a char * . For example, a
 single session may be controlling \fIrtsp://foo/twister/audio\fP and

--- a/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
+++ b/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SASL_AUTHZID \- authorisation identity (identity to act as)
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SASL_AUTHZID, char *authzid);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should be pointing to the null-terminated
 authorisation identity (authzid) for the transfer. Only applicable to the PLAIN

--- a/docs/libcurl/opts/CURLOPT_SASL_IR.3
+++ b/docs/libcurl/opts/CURLOPT_SASL_IR.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SASL_IR \- send initial response in first packet
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SASL_IR, long enable);
+.fi
 .SH DESCRIPTION
 Pass a long. If the value is 1, curl will send the initial response to the
 server in the first authentication packet in order to reduce the number of

--- a/docs/libcurl/opts/CURLOPT_SEEKDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SEEKDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SEEKDATA \- pointer passed to the seek callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SEEKDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Data \fIpointer\fP to pass to the seek callback function. If you use the
 \fICURLOPT_SEEKFUNCTION(3)\fP option, this is the pointer you will get as

--- a/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SERVICE_NAME \- authentication service name
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SERVICE_NAME, char *name);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter to a string holding the \fIname\fP of the service
 for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms. The default

--- a/docs/libcurl/opts/CURLOPT_SHARE.3
+++ b/docs/libcurl/opts/CURLOPT_SHARE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SHARE \- share handle to use
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SHARE, CURLSH *share);
+.fi
 .SH DESCRIPTION
 Pass a \fIshare\fP handle as a parameter. The share handle must have been
 created by a previous call to \fIcurl_share_init(3)\fP. Setting this option,

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SOCKOPTDATA \- pointer to pass to sockopt callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SOCKOPTDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the first
 argument in the sockopt callback set with \fICURLOPT_SOCKOPTFUNCTION(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SOCKS5_AUTH \- methods for SOCKS5 proxy authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SOCKS5_AUTH, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter, which is set to a bitmask, to tell libcurl which
 authentication method(s) are allowed for SOCKS5 proxy authentication.  The only

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SOCKS5_GSSAPI_NEC \- socks proxy gssapi negotiation protection
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SOCKS5_GSSAPI_NEC, long nec);
+.fi
 .SH DESCRIPTION
 Pass a long set to 1 to enable or 0 to disable. As part of the gssapi
 negotiation a protection mode is negotiated. The RFC1961 says in section

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_SOCKS5_GSSAPI_SERVICE \- SOCKS5 proxy authentication service name
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SOCKS5_GSSAPI_SERVICE, char *name);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SOCKS5_GSSAPI_SERVICE,
+                          char *name);
+.fi
 .SH DESCRIPTION
 Deprecated since 7.49.0. Use \fICURLOPT_PROXY_SERVICE_NAME(3)\fP instead.
 

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSH_AUTH_TYPES \- auth types for SFTP and SCP
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_AUTH_TYPES, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long set to a bitmask consisting of one or more of
 CURLSSH_AUTH_PUBLICKEY, CURLSSH_AUTH_PASSWORD, CURLSSH_AUTH_HOST,

--- a/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSH_COMPRESSION \- enable SSH compression
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_COMPRESSION, long enable);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1L to enable or 0L to disable.
 

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSH_KEYDATA \- pointer passed to the SSH key callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_KEYDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a void * as parameter. This \fIpointer\fP will be passed along verbatim
 to the callback set with \fICURLOPT_SSH_KEYFUNCTION(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSH_KNOWNHOSTS \- file name holding the SSH known hosts
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_KNOWNHOSTS, char *fname);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string holding the file name of the
 known_host file to use.  The known_hosts file should use the OpenSSH file

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLCERT \- SSL client certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERT, char *cert);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your client certificate. The default format is "P12" on

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLCERTTYPE \- type of client SSL certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERTTYPE, char *type);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your certificate. Supported formats are "PEM" and "DER", except

--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_SSLCERT_BLOB \- SSL client certificate from memory blob
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERT_BLOB, struct curl_blob *stblob);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERT_BLOB,
+                          struct curl_blob *stblob);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains (pointer and size) a
 client certificate. The format must be "P12" on Secure Transport or

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLENGINE \- SSL engine identifier
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLENGINE, char *id);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It will be used as
 the identifier for the crypto engine you want to use for your private key.

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLENGINE_DEFAULT \- make SSL engine default
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLENGINE_DEFAULT, long val);
+.fi
 .SH DESCRIPTION
 Pass a long set to 1 to make the already specified crypto engine the default
 for (asymmetric) crypto operations.

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLKEY \- private keyfile for TLS and SSL client cert
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLKEY, char *keyfile);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the file name of your private key. The default format is "PEM" and can be

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLKEYTYPE \- type of the private key file
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLKEYTYPE, char *type);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the format of your private key. Supported formats are "PEM", "DER" and "ENG".

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSLVERSION \- preferred TLS/SSL version
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLVERSION, long version);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter to control which version range of SSL/TLS versions to
 use.

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_CIPHER_LIST \- ciphers to use for TLS
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CIPHER_LIST, char *list);
+.fi
 .SH DESCRIPTION
 Pass a char *, pointing to a null-terminated string holding the list of
 ciphers to use for the SSL connection. The list must be syntactically correct,

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_CTX_DATA \- pointer passed to ssl_ctx callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_DATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Data \fIpointer\fP to pass to the ssl context callback set by the option
 \fICURLOPT_SSL_CTX_FUNCTION(3)\fP, this is the pointer you will get as third

--- a/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_EC_CURVES \- key exchange curves
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_EC_CURVES, char *alg_list);
+.fi
 .SH DESCRIPTION
 Pass a string as parameter with a colon delimited list of (EC) algorithms. This
 option defines the client's key exchange algorithms in the SSL handshake (if

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_ENABLE_ALPN \- Application Layer Protocol Negotiation
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_ENABLE_ALPN, long npn);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter, 0 or 1 where 1 is for enable and 0 for disable. This
 option enables/disables ALPN in the SSL handshake (if the SSL backend libcurl

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_ENABLE_NPN \- use NPN
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_ENABLE_NPN, long npn);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter, 0 or 1 where 1 is for enable and 0 for disable. This
 option enables/disables NPN in the SSL handshake (if the SSL backend libcurl

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_FALSESTART \- TLS false start
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_FALSESTART, long enable);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1L to enable or 0 to disable.
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_OPTIONS \- SSL behavior options
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_OPTIONS, long bitmask);
+.fi
 .SH DESCRIPTION
 Pass a long with a bitmask to tell libcurl about specific SSL
 behaviors. Available bits:

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_VERIFYHOST \- verify the certificate's name against host
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_VERIFYHOST, long verify);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter specifying what to \fIverify\fP.
 

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_VERIFYPEER \- verify the peer's SSL certificate
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_VERIFYPEER, long verify);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter to enable or disable.
 

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_SSL_VERIFYSTATUS \- verify the certificate's status
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_VERIFYSTATUS, long verify);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1 to enable or 0 to disable.
 

--- a/docs/libcurl/opts/CURLOPT_STDERR.3
+++ b/docs/libcurl/opts/CURLOPT_STDERR.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_STDERR \- redirect stderr to another stream
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STDERR, FILE *stream);
+.fi
 .SH DESCRIPTION
 Pass a FILE * as parameter. Tell libcurl to use this \fIstream\fP instead of
 stderr when showing the progress meter and displaying \fICURLOPT_VERBOSE(3)\fP

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.3
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_STREAM_DEPENDS \- stream this transfer depends on
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STREAM_DEPENDS, CURL *dephandle);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STREAM_DEPENDS,
+                          CURL *dephandle);
+.fi
 .SH DESCRIPTION
 Pass a CURL * pointer in \fIdephandle\fP to identify the stream within the
 same connection that this stream is depending upon. This option clears the

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.3
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_STREAM_DEPENDS_E \- stream this transfer depends on exclusively
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STREAM_DEPENDS_E, CURL *dephandle);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STREAM_DEPENDS_E,
+                          CURL *dephandle);
+.fi
 .SH DESCRIPTION
 Pass a CURL * pointer in \fIdephandle\fP to identify the stream within the
 same connection that this stream is depending upon exclusively. That means it

--- a/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.3
+++ b/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_STREAM_WEIGHT \- numerical stream weight
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STREAM_WEIGHT, long weight);
+.fi
 .SH DESCRIPTION
 Set the long \fIweight\fP to a number between 1 and 256.
 

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TCP_FASTOPEN \- TCP Fast Open
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TCP_FASTOPEN, long enable);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter set to 1L to enable or 0 to disable.
 

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TCP_KEEPALIVE \- TCP keep-alive probing
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TCP_KEEPALIVE, long probe);
+.fi
 .SH DESCRIPTION
 Pass a long. If set to 1, TCP keepalive probes will be sent. The delay and
 frequency of these probes can be controlled by the

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TCP_KEEPIDLE \- TCP keep-alive idle time wait
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TCP_KEEPIDLE, long delay);
+.fi
 .SH DESCRIPTION
 Pass a long. Sets the \fIdelay\fP, in seconds, that the operating system will
 wait while the connection is idle before sending keepalive probes. Not all

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TCP_KEEPINTVL \- TCP keep-alive interval
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TCP_KEEPINTVL, long interval);
+.fi
 .SH DESCRIPTION
 Pass a long. Sets the interval, in seconds, that the operating system will
 wait between sending keepalive probes. Not all operating systems support this

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TCP_NODELAY \- the TCP_NODELAY option
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TCP_NODELAY, long nodelay);
+.fi
 .SH DESCRIPTION
 Pass a long specifying whether the TCP_NODELAY option is to be set or cleared
 (1L = set, 0 = clear). The option is set by default. This will have no effect

--- a/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.3
@@ -24,10 +24,12 @@
 .SH NAME
 CURLOPT_TELNETOPTIONS \- set of telnet options
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TELNETOPTIONS,
                           struct curl_slist *cmds);
+.fi
 .SH DESCRIPTION
 Provide a pointer to a curl_slist with variables to pass to the telnet
 negotiations. The variables should be in the format <option=value>. libcurl

--- a/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TFTP_BLKSIZE \- TFTP block size
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TFTP_BLKSIZE, long blocksize);
+.fi
 .SH DESCRIPTION
 Specify \fIblocksize\fP to use for TFTP data transmission. Valid range as per
 RFC2348 is 8-65464 bytes. The default of 512 bytes will be used if this option

--- a/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TFTP_NO_OPTIONS \- send no TFTP options requests
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TFTP_NO_OPTIONS, long onoff);
+.fi
 .SH DESCRIPTION
 Set \fIonoff\fP to 1L to exclude all TFTP options defined in RFC2347, RFC2348
 and RFC2349 from read and write requests (RRQs/WRQs).

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TIMECONDITION \- select condition for a time request
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TIMECONDITION, long cond);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter. This defines how the \fICURLOPT_TIMEVALUE(3)\fP time
 value is treated. You can set this parameter to \fICURL_TIMECOND_IFMODSINCE\fP

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TIMEOUT \- maximum time the transfer is allowed to complete
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TIMEOUT, long timeout);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter containing \fItimeout\fP - the maximum time in
 seconds that you allow the libcurl transfer operation to take. Normally, name

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TIMEOUT_MS \- maximum time the transfer is allowed to complete
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TIMEOUT_MS, long timeout);
+.fi
 .SH DESCRIPTION
 Pass a long as parameter containing \fItimeout\fP - the maximum time in
 milliseconds that you allow the libcurl transfer operation to take. Normally,

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TIMEVALUE \- time value for conditional
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TIMEVALUE, long val);
+.fi
 .SH DESCRIPTION
 Pass a long \fIval\fP as parameter. This should be the time counted as seconds
 since 1 Jan 1970, and the time will be used in a condition as specified with

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_TIMEVALUE_LARGE \- time value for conditional
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TIMEVALUE_LARGE, curl_off_t val);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TIMEVALUE_LARGE,
+                          curl_off_t val);
+.fi
 .SH DESCRIPTION
 Pass a curl_off_t \fIval\fP as parameter. This should be the time counted as
 seconds since 1 Jan 1970, and the time will be used in a condition as

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TLS13_CIPHERS \- ciphers suites to use for TLS 1.3
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLS13_CIPHERS, char *list);
+.fi
 .SH DESCRIPTION
 Pass a char *, pointing to a null-terminated string holding the list of cipher
 suites to use for the TLS 1.3 connection. The list must be syntactically

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TLSAUTH_PASSWORD \- password to use for TLS authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLSAUTH_PASSWORD, char *pwd);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should point to the null-terminated password
 to use for the TLS authentication method specified with the

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TLSAUTH_TYPE \- TLS authentication methods
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLSAUTH_TYPE, char *type);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. The string should be
 the method of the TLS authentication. Supported method is "SRP".

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TLSAUTH_USERNAME \- user name to use for TLS authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TLSAUTH_USERNAME, char *user);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should point to the null-terminated username
 to use for the TLS authentication method specified with the

--- a/docs/libcurl/opts/CURLOPT_TRAILERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TRAILERDATA \- pointer passed to trailing headers callback
 .SH SYNOPSIS
+.nf
 #include <curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRAILERDATA, void *userdata);
+.fi
 .SH DESCRIPTION
 Data pointer to be passed to the HTTP trailer callback function.
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
@@ -24,11 +24,14 @@
 .SH NAME
 CURLOPT_TRAILERFUNCTION \- callback for sending trailing headers
 .SH SYNOPSIS
+.nf
 #include <curl.h>
 
 int curl_trailer_callback(struct curl_slist ** list, void *userdata);
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRAILERFUNCTION, curl_trailer_callback *func);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRAILERFUNCTION,
+                          curl_trailer_callback *func);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a callback function.
 

--- a/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.3
+++ b/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_TRANSFERTEXT \- request a text based transfer for FTP
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRANSFERTEXT, long text);
+.fi
 .SH DESCRIPTION
 A parameter set to 1 tells the library to use ASCII mode for FTP transfers,
 instead of the default binary transfer. For win32 systems it does not set the

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_TRANSFER_ENCODING \- ask for HTTP Transfer Encoding
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRANSFER_ENCODING, long enable);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TRANSFER_ENCODING,
+                          long enable);
+.fi
 .SH DESCRIPTION
 Pass a long set to 1L to \fIenable\fP or 0 to disable.
 

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_UNIX_SOCKET_PATH \- Unix domain socket
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_UNIX_SOCKET_PATH, char *path);
+.fi
 .SH DESCRIPTION
 Enables the use of Unix domain sockets as connection endpoint and sets the path
 to \fIpath\fP. If \fIpath\fP is NULL, then Unix domain sockets are disabled. An

--- a/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.3
+++ b/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.3
@@ -24,9 +24,12 @@
 .SH NAME
 CURLOPT_UPKEEP_INTERVAL_MS \- connection upkeep interval
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_UPKEEP_INTERVAL_MS, long upkeep_interval_ms);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_UPKEEP_INTERVAL_MS,
+                          long upkeep_interval_ms);
+.fi
 .SH DESCRIPTION
 Some protocols have "connection upkeep" mechanisms. These mechanisms usually
 send some traffic on existing connections in order to keep them alive; this

--- a/docs/libcurl/opts/CURLOPT_UPLOAD.3
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_UPLOAD \- data upload
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_UPLOAD, long upload);
+.fi
 .SH DESCRIPTION
 The long parameter \fIupload\fP set to 1 tells the library to prepare for and
 perform an upload. The \fICURLOPT_READDATA(3)\fP and

--- a/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_UPLOAD_BUFFERSIZE \- upload buffer size
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_UPLOAD_BUFFERSIZE, long size);
+.fi
 .SH DESCRIPTION
 Pass a long specifying your preferred \fIsize\fP (in bytes) for the upload
 buffer in libcurl. It makes libcurl uses a larger buffer that gets passed to

--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_URL \- URL for this transfer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_URL, char *URL);
+.fi
 .SH DESCRIPTION
 Pass in a pointer to the \fIURL\fP to work with. The parameter should be a
 char * to a null-terminated string which must be URL-encoded in the following

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.3
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_USERAGENT \- HTTP user-agent header
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERAGENT, char *ua);
+.fi
 .SH DESCRIPTION
 Pass a pointer to a null-terminated string as parameter. It will be used to
 set the User-Agent: header in the HTTP request sent to the remote server. This

--- a/docs/libcurl/opts/CURLOPT_USERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_USERPWD \- user name and password to use in authentication
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERPWD, char *userpwd);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, pointing to a null-terminated login details string
 for the connection. The format of which is: [user name]:[password].

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.3
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_USE_SSL \- request using SSL / TLS for the transfer
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USE_SSL, long level);
+.fi
 .SH DESCRIPTION
 Pass a long using one of the values from below, to make libcurl use your
 desired \fIlevel\fP of SSL for the transfer.

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.3
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_VERBOSE \- verbose mode
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_VERBOSE, long onoff);
+.fi
 .SH DESCRIPTION
 Set the \fIonoff\fP parameter to 1 to make the library display a lot of
 verbose information about its operations on this \fIhandle\fP. Useful for

--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_WILDCARDMATCH \- directory wildcard transfers
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_WILDCARDMATCH, long onoff);
+.fi
 .SH DESCRIPTION
 Set \fIonoff\fP to 1 if you want to transfer multiple files according to a
 file name pattern. The pattern can be specified as part of the

--- a/docs/libcurl/opts/CURLOPT_WRITEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEDATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_WRITEDATA \- pointer passed to the write callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_WRITEDATA, void *pointer);
+.fi
 .SH DESCRIPTION
 A data \fIpointer\fP to pass to the write callback. If you use the
 \fICURLOPT_WRITEFUNCTION(3)\fP option, this is the pointer you will get in that

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_XFERINFODATA \- pointer passed to the progress callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_XFERINFODATA, void *pointer);
+.fi
 .SH DESCRIPTION
 Pass a \fIpointer\fP that will be untouched by libcurl and passed as the first
 argument in the progress callback set with \fICURLOPT_XFERINFOFUNCTION(3)\fP.

--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
@@ -24,6 +24,7 @@
 .SH NAME
 CURLOPT_XFERINFOFUNCTION \- progress meter callback
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 int progress_callback(void *clientp,
@@ -32,7 +33,9 @@ int progress_callback(void *clientp,
                       curl_off_t ultotal,
                       curl_off_t ulnow);
 
-CURLcode curl_easy_setopt(CURL *handle, CURLOPT_XFERINFOFUNCTION, progress_callback);
+CURLcode curl_easy_setopt(CURL *handle, CURLOPT_XFERINFOFUNCTION,
+                          progress_callback);
+.fi
 .SH DESCRIPTION
 Pass a pointer to your callback function, which should match the prototype
 shown above.

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
@@ -24,9 +24,11 @@
 .SH NAME
 CURLOPT_XOAUTH2_BEARER \- OAuth 2.0 access token
 .SH SYNOPSIS
+.nf
 #include <curl/curl.h>
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_XOAUTH2_BEARER, char *token);
+.fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should point to the null-terminated OAuth
 2.0 Bearer Access Token for use with HTTP, IMAP, POP3 and SMTP servers


### PR DESCRIPTION
Make all libcurl related options use .nf (no fill) for the SYNOPSIS
section - for consistent look. roffit then renders that section using
`<pre>` (monospace font) in html for the website.

Extended manpage-syntax (test 1173) with a basic check for it.