### PR TITLE
openldap: implement STARTTLS

### DIFF
--- a/docs/cmdline-opts/ssl-reqd.d
+++ b/docs/cmdline-opts/ssl-reqd.d
@@ -1,6 +1,6 @@
 Long: ssl-reqd
 Help: Require SSL/TLS
-Protocols: FTP IMAP POP3 SMTP
+Protocols: FTP IMAP POP3 SMTP LDAP
 Added: 7.20.0
 Category: tls
 Example: --ssl-reqd ftp://example.com
@@ -8,5 +8,9 @@ See-also: ssl insecure
 ---
 Require SSL/TLS for the connection.  Terminates the connection if the server
 does not support SSL/TLS.
+
+This option is handled in LDAP since version 7.81.0. It is fully supported
+by the openldap backend and rejected by the generic ldap backend if explicit
+TLS is required.
 
 This option was formerly known as --ftp-ssl-reqd.

--- a/docs/cmdline-opts/ssl.d
+++ b/docs/cmdline-opts/ssl.d
@@ -1,6 +1,6 @@
 Long: ssl
 Help: Try SSL/TLS
-Protocols: FTP IMAP POP3 SMTP
+Protocols: FTP IMAP POP3 SMTP LDAP
 Added: 7.20.0
 Category: tls
 Example: --ssl pop3://example.com/
@@ -9,6 +9,12 @@ See-also: insecure ciphers
 Try to use SSL/TLS for the connection. Reverts to a non-secure connection if
 the server does not support SSL/TLS. See also --ftp-ssl-control and --ssl-reqd
 for different levels of encryption required.
+
+This option is handled in LDAP since version 7.81.0. It is fully supported
+by the openldap backend and ignored by the generic ldap backend.
+
+Please note that a server may close the connection if the negotiation does
+not succeed.
 
 This option was formerly known as --ftp-ssl (Added in 7.11.0). That option
 name can still be used but will be removed in a future version.

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.3
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.3
@@ -40,7 +40,8 @@ This is for enabling SSL/TLS when you use FTP, SMTP, POP3, IMAP etc.
 .IP CURLUSESSL_NONE
 do not attempt to use SSL.
 .IP CURLUSESSL_TRY
-Try using SSL, proceed as normal otherwise.
+Try using SSL, proceed as normal otherwise. Note that server may close the
+connection if the negotiation does not succeed.
 .IP CURLUSESSL_CONTROL
 Require SSL for the control connection or fail with \fICURLE_USE_SSL_FAILED\fP.
 .IP CURLUSESSL_ALL
@@ -48,7 +49,7 @@ Require SSL for all communication or fail with \fICURLE_USE_SSL_FAILED\fP.
 .SH DEFAULT
 CURLUSESSL_NONE
 .SH PROTOCOLS
-FTP, SMTP, POP3, IMAP
+FTP, SMTP, POP3, IMAP, LDAP
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -65,6 +66,7 @@ if(curl) {
 .SH AVAILABILITY
 Added in 7.11.0. This option was known as CURLOPT_FTP_SSL up to 7.16.4, and
 the constants were known as CURLFTPSSL_*
+Handled by LDAP since 7.81.0. Fully supported by the openldap backend only.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -464,6 +464,11 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 #endif
 #endif /* CURL_LDAP_USE_SSL */
   }
+  else if(data->set.use_ssl > CURLUSESSL_TRY) {
+    failf(data, "LDAP local: explicit TLS not supported");
+    result = CURLE_NOT_BUILT_IN;
+    goto quit;
+  }
   else {
     server = ldap_init(host, (int)conn->port);
     if(!server) {


### PR DESCRIPTION
As this introduces use of `CURLOPT_USE_SSL` option for LDAP, also check this option in ldap.c as it is not supported by this backend.