### PR TITLE
auth: compute user:realm:pass digest w/o userhash

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -722,8 +722,7 @@ static CURLcode auth_create_digest_http_message(
            unq(nonce-value) ":" unq(cnonce-value)
   */
 
-  hashthis = aprintf("%s:%s:%s", digest->userhash ? userh : userp,
-                                 digest->realm, passwdp);
+  hashthis = aprintf("%s:%s:%s", userp, digest->realm, passwdp);
   if(!hashthis)
     return CURLE_OUT_OF_MEMORY;
 

--- a/tests/data/test2059
+++ b/tests/data/test2059
@@ -21,7 +21,7 @@ X-Powered-By: ASP.NET
 
 HTTP/1.1 401 authentication please swsbounce
 Server: Microsoft-IIS/6.0
-WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-512-256", nonce="1053604144", userhash=true
+WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-256", nonce="1053604144", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 0
 
@@ -43,7 +43,7 @@ X-Powered-By: ASP.NET
 
 HTTP/1.1 401 authentication please swsbounce
 Server: Microsoft-IIS/6.0
-WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-512-256", nonce="1053604144", userhash=true
+WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-256", nonce="1053604144", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 0
 
@@ -69,7 +69,7 @@ crypto
 proxy
 </features>
  <name>
-HTTP POST --digest with PUT, resumed upload, modified method, SHA-512-256 and userhash=true
+HTTP POST --digest with PUT, resumed upload, modified method, SHA-256 and userhash=true
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u auser:apasswd --digest -T log/%TESTNUMBER -x  http://%HOSTIP:%HTTPPORT -C 2 -X GET
@@ -92,7 +92,7 @@ Content-Length: 0
 
 GET http://%HOSTIP:%HTTPPORT/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="fddc3bc7b753b73ab0848fd83cb20cbbca971258eb8d20c941dd5e0b010d66be", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="fc09be8192851e284e73e8b719b32a2f6f91cca0594e68713da8c49dc2c1656e", algorithm=SHA-512-256, userhash=true
+Authorization: Digest username="fddc3bc7b753b73ab0848fd83cb20cbbca971258eb8d20c941dd5e0b010d66be", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="22d200df1fd02a9d3a7269ef5bbb5bf8f16f184a74907df9b64a3755489c0b42", algorithm=SHA-256, userhash=true
 Content-Range: bytes 2-4/5
 User-Agent: curl/%VERSION
 Accept: */*

--- a/tests/data/test2063
+++ b/tests/data/test2063
@@ -11,7 +11,7 @@ HTTP Digest auth
 <data>
 HTTP/1.1 401 Authorization Required swsclose
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2
-WWW-Authenticate: Digest realm="testrealm", nonce="1053604145", algorithm="SHA-512-256", userhash=true
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604145", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 26
 
@@ -32,7 +32,7 @@ This IS the real page!
 <datacheck>
 HTTP/1.1 401 Authorization Required swsclose
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2
-WWW-Authenticate: Digest realm="testrealm", nonce="1053604145", algorithm="SHA-512-256", userhash=true
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604145", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 26
 
@@ -56,7 +56,7 @@ http
 crypto
 </features>
  <name>
-HTTP with RFC7616 SHA-512-256 Digest authorization and userhash=true
+HTTP with RFC7616 SHA-256 Digest authorization and userhash=true
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u testuser:testpass --digest
@@ -73,7 +73,7 @@ Accept: */*
 
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="75af8a3500f771e58a52093a25e7905d6e428a511285c12ea1420c73078dfd61", realm="testrealm", nonce="1053604145", uri="/%TESTNUMBER", response="43f7ab531dff687b5dc75617daa59d1fd67d648341d6d2655ca65ef5064cfb51", algorithm=SHA-512-256, userhash=true
+Authorization: Digest username="75af8a3500f771e58a52093a25e7905d6e428a511285c12ea1420c73078dfd61", realm="testrealm", nonce="1053604145", uri="/%TESTNUMBER", response="6c470aec384ab1d4e12d3ce1f5b08303d8cad177e52ebe50ec1a3e141adb0cdc", algorithm=SHA-256, userhash=true
 User-Agent: curl/%VERSION
 Accept: */*
 

--- a/tests/data/test2066
+++ b/tests/data/test2066
@@ -11,7 +11,7 @@ HTTP Digest auth
 <data>
 HTTP/1.1 401 Authorization Required
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2
-WWW-Authenticate: Digest realm="testrealm", nonce="2053604145", algorithm="SHA-512-256", userhash=true
+WWW-Authenticate: Digest realm="testrealm", nonce="2053604145", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 26
 
@@ -32,7 +32,7 @@ This is not the real page either
 <datacheck>
 HTTP/1.1 401 Authorization Required
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2
-WWW-Authenticate: Digest realm="testrealm", nonce="2053604145", algorithm="SHA-512-256", userhash=true
+WWW-Authenticate: Digest realm="testrealm", nonce="2053604145", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 26
 
@@ -56,7 +56,7 @@ http
 crypto
 </features>
  <name>
-HTTP with RFC7616 Digest authorization with bad password, SHA-512-256 and userhash=true
+HTTP with RFC7616 Digest authorization with bad password, SHA-256 and userhash=true
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u testuser:test2pass --digest
@@ -73,7 +73,7 @@ Accept: */*
 
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="75af8a3500f771e58a52093a25e7905d6e428a511285c12ea1420c73078dfd61", realm="testrealm", nonce="2053604145", uri="/%TESTNUMBER", response="a2e2ae589f575fb132991d6f550ef14bf7ef697d2fef1242d2498f07eafc77dc", algorithm=SHA-512-256, userhash=true
+Authorization: Digest username="75af8a3500f771e58a52093a25e7905d6e428a511285c12ea1420c73078dfd61", realm="testrealm", nonce="2053604145", uri="/%TESTNUMBER", response="374a35326cc09e7d1ec3165aee9de01cae46daac33d8999aa1f483fa7882b86c", algorithm=SHA-256, userhash=true
 User-Agent: curl/%VERSION
 Accept: */*
 

--- a/tests/data/test2069
+++ b/tests/data/test2069
@@ -12,7 +12,7 @@ HTTP Digest auth
 <data>
 HTTP/1.1 401 authentication please swsbounce
 Server: Microsoft-IIS/6.0
-WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-512-256", userhash=true
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 0
 
@@ -29,7 +29,7 @@ ok
 <datacheck>
 HTTP/1.1 401 authentication please swsbounce
 Server: Microsoft-IIS/6.0
-WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-512-256", userhash=true
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
 Content-Length: 0
 
@@ -54,7 +54,7 @@ http
 crypto
 </features>
 <name>
-HTTP POST --digest with SHA-512-256, userhash=true and user-specified Content-Length header
+HTTP POST --digest with SHA-256, userhash=true and user-specified Content-Length header
 </name>
 # This test is to ensure 'Content-Length: 0' is sent while negotiating auth
 # even when there is a user-specified Content-Length header.
@@ -76,7 +76,7 @@ Content-Type: application/x-www-form-urlencoded
 
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="fddc3bc7b753b73ab0848fd83cb20cbbca971258eb8d20c941dd5e0b010d66be", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="ff13d977110a471f30de75e747976e4de78d7a3d2425cd23ff46e67f4bc9ead7", algorithm=SHA-512-256, userhash=true
+Authorization: Digest username="fddc3bc7b753b73ab0848fd83cb20cbbca971258eb8d20c941dd5e0b010d66be", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="9a29f1dab407e62daa7121185f9f12db6177415e03f35d9a881550095a83378d", algorithm=SHA-256, userhash=true
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 11


### PR DESCRIPTION
auth: compute user:realm:pass digest w/o userhash

https://datatracker.ietf.org/doc/html/rfc7616#section-3.4.4
  ... the client MUST calculate a hash of the username after
      any other hash calculation ...

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

---

I am implementing HTTP Digest Auth userhash support in lighttpd and I read RFC 7616 Section 3.4.4 differently from how it is currently implemented in cURL from 2b5b37cb9109e7c2e6bfa5ebf54016aff8a1fb48.  The patch in this PR works with my development version of lighttpd, and I am looking for confirmation on whether or not this is an issue in curl, or if I have misunderstood RFC 7616 Section 3.4.4.  Thanks.