### PR TITLE
HTTP3: update quiche build instructions

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -120,9 +120,9 @@ Build quiche and BoringSSL:
 
      % git clone --recursive https://github.com/cloudflare/quiche
      % cd quiche
-     % cargo build --release --features ffi,pkg-config-meta,qlog
-     % mkdir deps/boringssl/src/lib
-     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
+     % cargo build --package quiche --release --features ffi,pkg-config-meta,qlog
+     % mkdir quiche/deps/boringssl/src/lib
+     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) quiche/deps/boringssl/src/lib/
 
 Build curl:
 
@@ -130,7 +130,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
      % make
      % make install
 

--- a/scripts/zuul/before_script.sh
+++ b/scripts/zuul/before_script.sh
@@ -125,9 +125,9 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
   #### See https://github.com/alexcrichton/cmake-rs/issues/131 ####
   sed -i -e 's/cmake = "0.1"/cmake = "=0.1.45"/' Cargo.toml
 
-  cargo build -v --release --features ffi,pkg-config-meta,qlog
-  mkdir -v deps/boringssl/src/lib
-  ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
+  cargo build -v --package quiche --release --features ffi,pkg-config-meta,qlog
+  mkdir -v quiche/deps/boringssl/src/lib
+  ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) quiche/deps/boringssl/src/lib/
 fi
 
 if [ "$TRAVIS_OS_NAME" = linux -a "$RUSTLS_VERSION" ]; then

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -122,7 +122,7 @@
         T: novalgrind
         QUICHE: "yes"
         C: >-
-          --with-openssl={{ ansible_user_dir }}/quiche/deps/boringssl/src
+          --with-openssl={{ ansible_user_dir }}/quiche/quiche/deps/boringssl/src
           --with-quiche={{ ansible_user_dir }}/quiche/target/release
         LD_LIBRARY_PATH: "{{ ansible_user_dir }}/quiche/target/release:/usr/local/lib"
 


### PR DESCRIPTION
The repo repo was re-organized a bit, so the build instructions need to
be updated.