### PR TITLE
mbedTLS: include NULL byte in blob data length for CURLOPT_CAINFO_BLOB

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -320,9 +320,13 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   mbedtls_x509_crt_init(&backend->cacert);
 
   if(ca_info_blob) {
-    const unsigned char *blob_data = (const unsigned char *)ca_info_blob->data;
+    unsigned char *blob_data = (unsigned char *)ca_info_blob->data;
+
+    /* mbedTLS expects the terminating NULL byte to be included in the length */
+    size_t blob_data_len = ca_info_blob->len + 1;
+
     ret = mbedtls_x509_crt_parse(&backend->cacert, blob_data,
-                                 ca_info_blob->len);
+                                 blob_data_len);
 
     if(ret<0) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -322,7 +322,8 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   if(ca_info_blob) {
     unsigned char *blob_data = (unsigned char *)ca_info_blob->data;
 
-    /* mbedTLS expects the terminating NULL byte to be included in the length */
+    /* mbedTLS expects the terminating NULL byte to be included in the length
+       of the data */
     size_t blob_data_len = ca_info_blob->len + 1;
 
     ret = mbedtls_x509_crt_parse(&backend->cacert, blob_data,


### PR DESCRIPTION
Fix for https://github.com/curl/curl/issues/8079

https://github.com/curl/curl/pull/8071 added support for CURLOPT_CAINFO_BLOB but broke test 678.
The issue is caused by mbedTLS requiring the terminating NULL byte to be included in the length of the data. Since a PEM string is NULL terminated, we can simply increment the length passed to `mbedtls_x509_crt_parse` to meet this requirement.

I this change locally, and now test 678 does succeed. 