### PR TITLE
Lift 'ignore' is now deprecated configuration option

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,3 +1,3 @@
-ignore = [ "DEAD_STORE" ]
+ignoreRules = [ "DEAD_STORE" ]
 build = "make"
 setup = ".lift/setup.sh"


### PR DESCRIPTION
Configuration for Lift has now deprecated the use of `ignore` and has been replaced with `ignoreRules`, https://help.sonatype.com/lift/configuration-reference#ConfigurationReference-in-repo-optionsIn-RepoOptions(The.lift.toml).

I noticed the recent PRs had been [failing](https://lift.sonatype.com/result/curl/curl/01FNV1EGQ9DAQ6TK1WAT7ZZ7AP), this PR changes to the new configuration. Lift analysis is now running successfully https://lift.sonatype.com/results/github.com/doddi/curl/01FNVA0ZNPNZG9S6X1K34XFJ4R
