### PR TITLE
Correct quiche build commands.

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -121,8 +121,8 @@ Build quiche and BoringSSL:
      % git clone --recursive https://github.com/cloudflare/quiche
      % cd quiche
      % cargo build --release --features ffi,pkg-config-meta,qlog
-     % mkdir deps/boringssl/src/lib
-     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) deps/boringssl/src/lib/
+     % mkdir quiche/deps/boringssl/src/lib
+     % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) quiche/deps/boringssl/src/lib/
 
 Build curl:
 
@@ -130,7 +130,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
+     % ./configure LDFLAGS="-Wl,-rpath,$PWD/../quiche/target/release" --with-openssl=$PWD/../quiche/quiche/deps/boringssl/src --with-quiche=$PWD/../quiche/target/release
      % make
      % make install
 


### PR DESCRIPTION
Tested commands with following repository versions on macOS 11.6:

https://github.com/cloudflare/quiche
0.10.0-34-g232807c

https://github.com/curl/curl
curl-7_80_0-76-gc8a304655