### PR TITLE
urlapi: accept port number zero

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -605,9 +605,7 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname,
 
     port = strtol(portptr + 1, &rest, 10);  /* Port number must be decimal */
 
-    if((port <= 0) || (port > 0xffff))
-      /* Single unix standard says port numbers are 16 bits long, but we don't
-         treat port zero as OK. */
+    if(port > 0xffff)
       return CURLUE_BAD_PORT_NUMBER;
 
     if(rest[0])

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -308,9 +308,13 @@ static const struct testcase get_parts_list[] ={
   {"https://example.com:65536",
    "",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_BAD_PORT_NUMBER},
-  {"https://example.com:0#moo",
+  {"https://example.com:-1#moo",
    "",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_BAD_PORT_NUMBER},
+  {"https://example.com:0#moo",
+   "https | [11] | [12] | [13] | example.com | 0 | / | "
+   "[16] | moo",
+   CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},
   {"https://example.com:01#moo",
    "https | [11] | [12] | [13] | example.com | 1 | / | "
    "[16] | moo",


### PR DESCRIPTION
This is a regression since 7.62.0 (fb30ac5a2d).

Updated test 1560 accordingly

Reported-by: Brad Fitzpatrick
Fixes #8090