### PR TITLE
Wording of -X in docs to refer primarily to 'method' rather than 'command'

### DIFF
--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -1,7 +1,7 @@
 Long: request
 Short: X
-Arg: <command>
-Help: Specify request command to use
+Arg: <method>
+Help: Specify request method to use
 Category: connection
 Example: -X "DELETE" $URL
 Example: -X NLST ftp://example.com/


### PR DESCRIPTION
Having a poor memory, combined with the not-particularly-descriptive mnemonic (`X`) has led me to fruitlessly scan the manpage/`-h` output numerous times for `method` before falling back to Google.

**Command** feels like awkward parlance in a world where the 95% use-case is HTTP. I could be wrong, but I feel _most people_ looking for this option are looking for how to set the HTTP **method**.