### PR TITLE
tool_operate: fix potential memory-leak

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -668,15 +668,17 @@ static long url_proto(char *url)
 {
   CURLU *uh = curl_url();
   long proto = 0;
-  if(url) {
-    if(!curl_url_set(uh, CURLUPART_URL, url,
-                     CURLU_GUESS_SCHEME | CURLU_NON_SUPPORT_SCHEME)) {
-      char *schemep = NULL;
-      if(!curl_url_get(uh, CURLUPART_SCHEME, &schemep,
-                       CURLU_DEFAULT_SCHEME) &&
-         schemep) {
-        proto = scheme2protocol(schemep);
-        curl_free(schemep);
+  if(uh) {
+    if(url) {
+      if(!curl_url_set(uh, CURLUPART_URL, url,
+                       CURLU_GUESS_SCHEME | CURLU_NON_SUPPORT_SCHEME)) {
+        char *schemep = NULL;
+        if(!curl_url_get(uh, CURLUPART_SCHEME, &schemep,
+                         CURLU_DEFAULT_SCHEME) &&
+           schemep) {
+          proto = scheme2protocol(schemep);
+          curl_free(schemep);
+        }
       }
     }
     curl_url_cleanup(uh);


### PR DESCRIPTION
A 'CURLU *' would leak if url_proto() is called with no URL.

Detected by Coverity. CID 1494643.
Follow-up to 18270893abdb19