### PR TITLE
http2:set_transfer_url() return early on OOM

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -505,10 +505,13 @@ static int set_transfer_url(struct Curl_easy *data,
                             struct curl_pushheaders *hp)
 {
   const char *v;
-  CURLU *u = curl_url();
   CURLUcode uc;
   char *url = NULL;
   int rc = 0;
+  CURLU *u = curl_url();
+
+  if(!u)
+    return 5;
 
   v = curl_pushheader_byname(hp, ":scheme");
   if(v) {


### PR DESCRIPTION
If curl_url() returns NULL this should return early to avoid mistakes -
even if right now the subsequent function invokes are all OK.

Coverity (wrongly) pointed out this as a NULL deref.