### PR TITLE
CURLOPT_STDERR.3: does not work with libcurl as a win32 DLL

### DIFF
--- a/docs/libcurl/opts/CURLOPT_STDERR.3
+++ b/docs/libcurl/opts/CURLOPT_STDERR.3
@@ -33,6 +33,11 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_STDERR, FILE *stream);
 Pass a FILE * as parameter. Tell libcurl to use this \fIstream\fP instead of
 stderr when showing the progress meter and displaying \fICURLOPT_VERBOSE(3)\fP
 data.
+
+If you are using libcurl as a win32 DLL, this option will cause an exception
+and crash in the library since it cannot access a FILE * passed on from the
+application. A work-around is to instead use a the
+\fICURLOPT_DEBUGFUNCTION(3)\fP.
 .SH DEFAULT
 stderr
 .SH PROTOCOLS
@@ -54,3 +59,4 @@ Always
 Returns CURLE_OK
 .SH "SEE ALSO"
 .BR CURLOPT_VERBOSE "(3), " CURLOPT_NOPROGRESS "(3), "
+.BR CURLOPT_DEBUGFUNCTION "(3) "

--- a/docs/libcurl/opts/CURLOPT_STDERR.3
+++ b/docs/libcurl/opts/CURLOPT_STDERR.3
@@ -36,7 +36,7 @@ data.
 
 If you are using libcurl as a win32 DLL, this option will cause an exception
 and crash in the library since it cannot access a FILE * passed on from the
-application. A work-around is to instead use a the
+application. A work-around is to instead use the
 \fICURLOPT_DEBUGFUNCTION(3)\fP.
 .SH DEFAULT
 stderr


### PR DESCRIPTION
This is the exact same limitation already documented for
CURLOPT_WRITEDATA but should be clarified here. It also has a different
work-around.

Reported-by: Stephane Pellegrino
Bug: https://github.com/curl/curl/issues/8102