### PR TITLE
BearSSL improvements (session id, bad access, verifypeer 0, cipher list, ctx function)

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
@@ -115,8 +115,8 @@ int main(void)
 }
 .fi
 .SH AVAILABILITY
-Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL and in 7.54.0 for
-mbedTLS. Other SSL backends are not supported.
+Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL, in 7.54.0 for mbedTLS,
+in 7.82.0 in BearSSL. Other SSL backends are not supported.
 .SH RETURN VALUE
 CURLE_OK if supported; or an error such as:
 

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -32,8 +32,9 @@ CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr);
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_FUNCTION,
                           ssl_ctx_callback);
 .SH DESCRIPTION
-This option only works for libcurl powered by OpenSSL, wolfSSL or mbedTLS. If
-libcurl was built against another SSL library this functionality is absent.
+This option only works for libcurl powered by OpenSSL, wolfSSL, mbedTLS or
+BearSSL. If libcurl was built against another SSL library this functionality
+is absent.
 
 Pass a pointer to your callback function, which should match the prototype
 shown above.
@@ -42,8 +43,9 @@ This callback function gets called by libcurl just before the initialization
 of an SSL connection after having processed all other SSL related options to
 give a last chance to an application to modify the behavior of the SSL
 initialization. The \fIssl_ctx\fP parameter is actually a pointer to the SSL
-library's \fISSL_CTX\fP for OpenSSL or wolfSSL, and a pointer to
-\fImbedtls_ssl_config\fP for mbedTLS. If an error is returned from the
+library's \fISSL_CTX\fP for OpenSSL or wolfSSL, a pointer to
+\fImbedtls_ssl_config\fP for mbedTLS or a pointer to
+\fIbr_ssl_client_context\fP for BearSSL. If an error is returned from the
 callback no attempt to establish a connection is made and the perform
 operation will return the callback's error code. Set the \fIuserptr\fP
 argument with the \fICURLOPT_SSL_CTX_DATA(3)\fP option.

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -159,6 +159,18 @@ static CURLcode load_cafile(struct cafile_source *source,
         if(strcmp(name, "CERTIFICATE") && strcmp(name, "X509 CERTIFICATE"))
           break;
         br_x509_decoder_init(&ca.xc, append_dn, &ca);
+        ca.in_cert = TRUE;
+        ca.dn_len = 0;
+        break;
+      case BR_PEM_END_OBJ:
+        if(!ca.in_cert)
+          break;
+        ca.in_cert = FALSE;
+        if(br_x509_decoder_last_error(&ca.xc)) {
+          ca.err = CURLE_SSL_CACERT_BADFILE;
+          goto fail;
+        }
+        /* add trust anchor */
         if(ca.anchors_len == SIZE_MAX / sizeof(ca.anchors[0])) {
           ca.err = CURLE_OUT_OF_MEMORY;
           goto fail;
@@ -172,19 +184,8 @@ static CURLcode load_cafile(struct cafile_source *source,
         }
         ca.anchors = new_anchors;
         ca.anchors_len = new_anchors_len;
-        ca.in_cert = TRUE;
-        ca.dn_len = 0;
         ta = &ca.anchors[ca.anchors_len - 1];
         ta->dn.data = NULL;
-        break;
-      case BR_PEM_END_OBJ:
-        if(!ca.in_cert)
-          break;
-        ca.in_cert = FALSE;
-        if(br_x509_decoder_last_error(&ca.xc)) {
-          ca.err = CURLE_SSL_CACERT_BADFILE;
-          goto fail;
-        }
         ta->flags = 0;
         if(br_x509_decoder_isCA(&ca.xc))
           ta->flags |= BR_X509_TA_CA;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -35,6 +35,7 @@
 #include "multiif.h"
 #include "curl_printf.h"
 #include "curl_memory.h"
+#include "strcase.h"
 
 struct x509_context {
   const br_x509_class *vtable;
@@ -351,6 +352,214 @@ static const br_x509_class x509_vtable = {
   x509_get_pkey
 };
 
+struct st_cipher {
+  const char *name; /* Cipher suite IANA name. It starts with "TLS_" prefix */
+  const char *alias_name; /* Alias name is the same as OpenSSL cipher name */
+  uint16_t num; /* BearSSL cipher suite */
+};
+
+/* Macro to initialize st_cipher data structure */
+#define CIPHER_DEF(num, alias) { #num, alias, BR_##num }
+
+static const struct st_cipher ciphertable[] = {
+  /* RFC 2246 TLS 1.0 */
+  CIPHER_DEF(TLS_RSA_WITH_3DES_EDE_CBC_SHA,                        /* 0x000A */
+             "DES-CBC3-SHA"),
+
+  /* RFC 3268 TLS 1.0 AES */
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_CBC_SHA,                         /* 0x002F */
+             "AES128-SHA"),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_CBC_SHA,                         /* 0x0035 */
+             "AES256-SHA"),
+
+  /* RFC 5246 TLS 1.2 */
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_CBC_SHA256,                      /* 0x003C */
+             "AES128-SHA256"),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_CBC_SHA256,                      /* 0x003D */
+             "AES256-SHA256"),
+
+  /* RFC 5288 TLS 1.2 AES GCM */
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_GCM_SHA256,                      /* 0x009C */
+             "AES128-GCM-SHA256"),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_GCM_SHA384,                      /* 0x009D */
+             "AES256-GCM-SHA384"),
+
+  /* RFC 4492 TLS 1.0 ECC */
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA,                 /* 0xC003 */
+             "ECDH-ECDSA-DES-CBC3-SHA"),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,                  /* 0xC004 */
+             "ECDH-ECDSA-AES128-SHA"),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,                  /* 0xC005 */
+             "ECDH-ECDSA-AES256-SHA"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,                /* 0xC008 */
+             "ECDHE-ECDSA-DES-CBC3-SHA"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,                 /* 0xC009 */
+             "ECDHE-ECDSA-AES128-SHA"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,                 /* 0xC00A */
+             "ECDHE-ECDSA-AES256-SHA"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA,                   /* 0xC00D */
+             "ECDH-RSA-DES-CBC3-SHA"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,                    /* 0xC00E */
+             "ECDH-RSA-AES128-SHA"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,                    /* 0xC00F */
+             "ECDH-RSA-AES256-SHA"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,                  /* 0xC012 */
+             "ECDHE-RSA-DES-CBC3-SHA"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,                   /* 0xC013 */
+             "ECDHE-RSA-AES128-SHA"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,                   /* 0xC014 */
+             "ECDHE-RSA-AES256-SHA"),
+
+  /* RFC 5289 TLS 1.2 ECC HMAC SHA256/384 */
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,              /* 0xC023 */
+             "ECDHE-ECDSA-AES128-SHA256"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,              /* 0xC024 */
+             "ECDHE-ECDSA-AES256-SHA384"),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,               /* 0xC025 */
+             "ECDH-ECDSA-AES128-SHA256"),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,               /* 0xC026 */
+             "ECDH-ECDSA-AES256-SHA384"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,                /* 0xC027 */
+             "ECDHE-RSA-AES128-SHA256"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,                /* 0xC028 */
+             "ECDHE-RSA-AES256-SHA384"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,                 /* 0xC029 */
+             "ECDH-RSA-AES128-SHA256"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,                 /* 0xC02A */
+             "ECDH-RSA-AES256-SHA384"),
+
+  /* RFC 5289 TLS 1.2 GCM */
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,              /* 0xC02B */
+             "ECDHE-ECDSA-AES128-GCM-SHA256"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,              /* 0xC02C */
+             "ECDHE-ECDSA-AES256-GCM-SHA384"),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,               /* 0xC02D */
+             "ECDH-ECDSA-AES128-GCM-SHA256"),
+  CIPHER_DEF(TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,               /* 0xC02E */
+             "ECDH-ECDSA-AES256-GCM-SHA384"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,                /* 0xC02F */
+             "ECDHE-RSA-AES128-GCM-SHA256"),
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,                /* 0xC030 */
+             "ECDHE-RSA-AES256-GCM-SHA384"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,                 /* 0xC031 */
+             "ECDH-RSA-AES128-GCM-SHA256"),
+  CIPHER_DEF(TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,                 /* 0xC032 */
+             "ECDH-RSA-AES256-GCM-SHA384"),
+#ifdef BR_TLS_RSA_WITH_AES_128_CCM
+
+    /* RFC 6655 TLS 1.2 CCM */
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_CCM,                             /* 0xC09C */
+             "AES128-CCM"),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_CCM,                             /* 0xC09D */
+             "AES256-CCM"),
+  CIPHER_DEF(TLS_RSA_WITH_AES_128_CCM_8,                           /* 0xC0A0 */
+             "AES128-CCM8"),
+  CIPHER_DEF(TLS_RSA_WITH_AES_256_CCM_8,                           /* 0xC0A1 */
+             "AES256-CCM8"),
+
+  /* RFC 7251 TLS 1.2 ECC CCM */
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_CCM,                     /* 0xC0AC */
+             "ECDHE-ECDSA-AES128-CCM"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_CCM,                     /* 0xC0AD */
+             "ECDHE-ECDSA-AES256-CCM"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,                   /* 0xC0AE */
+             "ECDHE-ECDSA-AES128-CCM8"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,                   /* 0xC0AF */
+             "ECDHE-ECDSA-AES256-CCM8"),
+#endif
+#ifdef BR_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+
+  /* RFC 7905 TLS 1.2 ChaCha20-Poly1305 */
+  CIPHER_DEF(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,          /* 0xCCA8 */
+             "ECDHE-RSA-CHACHA20-POLY1305"),
+  CIPHER_DEF(TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,        /* 0xCCA9 */
+             "ECDHE-ECDSA-CHACHA20-POLY1305"),
+#endif
+};
+
+#define NUM_OF_CIPHERS (sizeof(ciphertable) / sizeof(ciphertable[0]))
+#define CIPHER_NAME_BUF_LEN 64
+
+static bool is_separator(char c)
+{
+  /* Return whether character is a cipher list separator. */
+  switch(c) {
+    case ' ':
+    case '\t':
+    case ':':
+    case ',':
+    case ';':
+      return true;
+  }
+  return false;
+}
+
+static CURLcode bearssl_set_selected_ciphers(struct Curl_easy *data,
+                                             br_ssl_engine_context *ssl_eng,
+                                             const char *ciphers)
+{
+  uint16_t selected_ciphers[NUM_OF_CIPHERS];
+  size_t selected_count = 0;
+  char cipher_name[CIPHER_NAME_BUF_LEN];
+  const char *cipher_start = ciphers;
+  const char *cipher_end;
+  size_t i, j;
+
+  if(!cipher_start)
+    return CURLE_SSL_CIPHER;
+
+  while(true) {
+    /* Extract the next cipher name from the ciphers string */
+    while(is_separator(*cipher_start))
+      ++cipher_start;
+    if (*cipher_start == '\0')
+      break;
+    cipher_end = cipher_start;
+    while(*cipher_end != '\0' && !is_separator(*cipher_end))
+      ++cipher_end;
+    j = cipher_end - cipher_start < CIPHER_NAME_BUF_LEN - 1 ?
+        cipher_end - cipher_start : CIPHER_NAME_BUF_LEN - 1;
+    strncpy(cipher_name, cipher_start, j);
+    cipher_name[j] = '\0';
+    cipher_start = cipher_end;
+
+    /* Lookup the cipher name in the table of available ciphers. If the cipher
+       name starts with "TLS_" we do the lookup by IANA name. Otherwise, we try
+       to match cipher name by an (OpenSSL) alias. */
+    if(strncasecompare(cipher_name, "TLS_", 4)) {
+      for(i = 0; i < NUM_OF_CIPHERS &&
+                 !strcasecompare(cipher_name, ciphertable[i].name); ++i);
+    }
+    else {
+      for(i = 0; i < NUM_OF_CIPHERS &&
+                 !strcasecompare(cipher_name, ciphertable[i].alias_name); ++i);
+    }
+    if(i == NUM_OF_CIPHERS) {
+      infof(data, "BearSSL: unknown cipher in list: %s", cipher_name);
+      continue;
+    }
+
+    /* No duplicates allowed */
+    for(j = 0; j < selected_count; j++) {
+      if(selected_ciphers[j] == ciphertable[i].num) {
+        failf(data, "BearSSL: duplicate cipher in list: %s", cipher_name);
+        return CURLE_SSL_CIPHER;
+      }
+    }
+
+    selected_ciphers[selected_count] = ciphertable[i].num;
+    ++selected_count;
+  }
+
+  if(selected_count == 0) {
+    failf(data, "BearSSL: no supported cipher in list");
+    return CURLE_SSL_CIPHER;
+  }
+
+  br_ssl_engine_set_suites(ssl_eng, selected_ciphers, selected_count);
+  return CURLE_OK;
+}
+
 static CURLcode bearssl_connect_step1(struct Curl_easy *data,
                                       struct connectdata *conn, int sockindex)
 {
@@ -441,6 +650,15 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
   br_ssl_engine_set_versions(&backend->ctx.eng, version_min, version_max);
   br_ssl_engine_set_buffer(&backend->ctx.eng, backend->buf,
                            sizeof(backend->buf), 1);
+
+  if(SSL_CONN_CONFIG(cipher_list)) {
+    /* Override the ciphers as specified. For the default cipher list see the
+       BearSSL source code of br_ssl_client_init_full() */
+    ret = bearssl_set_selected_ciphers(data, &backend->ctx.eng,
+                                       SSL_CONN_CONFIG(cipher_list));
+    if(ret)
+      return ret;
+  }
 
   /* initialize X.509 context */
   backend->x509.vtable = &x509_vtable;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -716,6 +716,18 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
     hostname = NULL;
   }
 
+  /* give application a chance to interfere with SSL set up. */
+  if(data->set.ssl.fsslctx) {
+    Curl_set_in_callback(data, true);
+    ret = (*data->set.ssl.fsslctx)(data, &backend->ctx,
+                                   data->set.ssl.fsslctxp);
+    Curl_set_in_callback(data, false);
+    if(ret) {
+      failf(data, "BearSSL: error signaled by ssl ctx callback");
+      return ret;
+    }
+  }
+
   if(!br_ssl_client_reset(&backend->ctx, hostname, 1))
     return CURLE_FAILED_INIT;
   backend->active = TRUE;
@@ -1143,7 +1155,7 @@ static CURLcode bearssl_sha256sum(const unsigned char *input,
 
 const struct Curl_ssl Curl_ssl_bearssl = {
   { CURLSSLBACKEND_BEARSSL, "bearssl" }, /* info */
-  SSLSUPP_CAINFO_BLOB,
+  SSLSUPP_CAINFO_BLOB | SSLSUPP_SSL_CTX,
   sizeof(struct ssl_backend_data),
 
   Curl_none_init,                  /* init */

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -466,7 +466,7 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
     hostname = NULL;
   }
 
-  if(!br_ssl_client_reset(&backend->ctx, hostname, 0))
+  if(!br_ssl_client_reset(&backend->ctx, hostname, 1))
     return CURLE_FAILED_INIT;
   backend->active = TRUE;
 

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -39,8 +39,10 @@
 struct x509_context {
   const br_x509_class *vtable;
   br_x509_minimal_context minimal;
+  br_x509_decoder_context decoder;
   bool verifyhost;
   bool verifypeer;
+  int cert_num;
 };
 
 struct ssl_backend_data {
@@ -261,6 +263,11 @@ static void x509_start_chain(const br_x509_class **ctx,
 {
   struct x509_context *x509 = (struct x509_context *)ctx;
 
+  if(!x509->verifypeer) {
+    x509->cert_num = 0;
+    return;
+  }
+
   if(!x509->verifyhost)
     server_name = NULL;
   x509->minimal.vtable->start_chain(&x509->minimal.vtable, server_name);
@@ -270,6 +277,13 @@ static void x509_start_cert(const br_x509_class **ctx, uint32_t length)
 {
   struct x509_context *x509 = (struct x509_context *)ctx;
 
+  if(!x509->verifypeer) {
+    /* Only decode the first cert in the chain to obtain the public key */
+    if(x509->cert_num == 0)
+      br_x509_decoder_init(&x509->decoder, NULL, NULL);
+    return;
+  }
+
   x509->minimal.vtable->start_cert(&x509->minimal.vtable, length);
 }
 
@@ -278,6 +292,12 @@ static void x509_append(const br_x509_class **ctx, const unsigned char *buf,
 {
   struct x509_context *x509 = (struct x509_context *)ctx;
 
+  if(!x509->verifypeer) {
+    if(x509->cert_num == 0)
+      br_x509_decoder_push(&x509->decoder, buf, len);
+    return;
+  }
+
   x509->minimal.vtable->append(&x509->minimal.vtable, buf, len);
 }
 
@@ -285,27 +305,38 @@ static void x509_end_cert(const br_x509_class **ctx)
 {
   struct x509_context *x509 = (struct x509_context *)ctx;
 
+  if(!x509->verifypeer) {
+    x509->cert_num++;
+    return;
+  }
+
   x509->minimal.vtable->end_cert(&x509->minimal.vtable);
 }
 
 static unsigned x509_end_chain(const br_x509_class **ctx)
 {
   struct x509_context *x509 = (struct x509_context *)ctx;
-  unsigned err;
 
-  err = x509->minimal.vtable->end_chain(&x509->minimal.vtable);
-  if(err && !x509->verifypeer) {
-    /* ignore any X.509 errors */
-    err = BR_ERR_OK;
+  if(!x509->verifypeer) {
+    return br_x509_decoder_last_error(&x509->decoder);
   }
 
-  return err;
+  return x509->minimal.vtable->end_chain(&x509->minimal.vtable);
 }
 
 static const br_x509_pkey *x509_get_pkey(const br_x509_class *const *ctx,
                                          unsigned *usages)
 {
   struct x509_context *x509 = (struct x509_context *)ctx;
+
+  if(!x509->verifypeer) {
+    /* Nothing in the chain is verified, just return the public key of the
+       first certificate and allow its usage for both TLS_RSA_* and
+       TLS_ECDHE_* */
+    if(usages)
+      *usages = BR_KEYTYPE_KEYX | BR_KEYTYPE_SIGN;
+    return br_x509_decoder_get_pkey(&x509->decoder);
+  }
 
   return x509->minimal.vtable->get_pkey(&x509->minimal.vtable, usages);
 }


### PR DESCRIPTION
I noticed some bugs and made some improvements to the BearSSL vtls code I would like to share:

### Fixed BearSSL bug: TLS Session Resumption (session id) not working

In `bearssl_connect_step1` the function `br_ssl_client_reset()` is called with `resume_session` set to 0. This will make BearSSL clear the specified session id. Setting the `resume_session` paramater to 1 fixes this.


### Fixed BearSSL bug: EXC_BAD_ACCESS on incomplete CA cert

When having a incomplete CA cert (for example missing a newline at the end) in the function `load_cafile` the code after `case BR_PEM_END_OBJ:` will not be executed. This will result in an extra `ta` (`ca.anchors`) that does not have its data set. Because `ta->dn.len` is not set (thus a random value) this will result in EXC_BAD_ACCESS in BearSSL because it expects correct values. The fix is to only add the new `ta` after `case BR_PEM_END_OBJ:`.


### Fixed BearSSL bug: CURLE_SSL_CONNECT_ERROR when CURLOPT_SSL_VERIFYPEER 0 and expired cert

The x509_minimal engine of BearSSL is used to parse the certificate chain. When verifypeer is set to 0 the result of the end_chain method (`xm_end_chain`) is overridden to return `BR_ERR_OK` so that the chain is deemed valid even if it is not. The engine is also used to extract the public key from the cert. However, because the x509_minimal engine stops parsing if any validity check fails the parsing can stop before the public key is extracted. Checking the BearSSL code in x509_minimal.t0:`decode-certificate` we can see that this can happen for example for `ERR_X509_EXPIRED`. This will mean that `x509_get_pkey` will return no key if the cert is expired and verifypeer is set to 0, what will result in `bearssl_run_until` returning `CURLE_SSL_CONNECT_ERROR`.

This is fixed by using the x509_decode engine instead of the x509_minimal engine to parse and extract the public key from the first cert of the chain.


### Implemented BearSSL: CURLOPT_SSL_CIPHER_LIST

Implemented the CURLOPT_SSL_CIPHER_LIST option for BearSSL based on the code of SecureTransport.


### Implemented BearSSL: CURLOPT_SSL_CTX_FUNCTION

Implemented the CURLOPT_SSL_CTX_FUNCTION option for BearSSL.




