### PR TITLE
CURLOPT_RESOLVE.3: minor polish

### DIFF
--- a/docs/libcurl/opts/CURLOPT_RESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.3
@@ -36,41 +36,41 @@ list of \fBstruct curl_slist\fP structs properly filled in. Use
 \fIcurl_slist_append(3)\fP to create the list and \fIcurl_slist_free_all(3)\fP
 to clean up an entire list.
 
-Each single name resolve string should be written using the format
-[+]HOST:PORT:ADDRESS[,ADDRESS]... where HOST is the name libcurl will try
-to resolve, PORT is the port number of the service where libcurl wants
-to connect to the HOST and ADDRESS is one or more numerical IP
-addresses. If you specify multiple ip addresses they need to be
-separated by comma. If libcurl is built to support IPv6, each of the
-ADDRESS entries can of course be either IPv4 or IPv6 style addressing.
+Each resolve rule to add should be written using the format
+
+.nf
+ [+]HOST:PORT:ADDRESS[,ADDRESS]
+.fi
+
+\&... where HOST is the name libcurl will try to resolve, PORT is the port
+number of the service where libcurl wants to connect to the HOST and ADDRESS
+is one or more numerical IP addresses. If you specify multiple ip addresses
+they need to be separated by comma. If libcurl is built to support IPv6, each
+of the ADDRESS entries can of course be either IPv4 or IPv6 style addressing.
 
 This option effectively pre-populates the DNS cache with entries for the
 host+port pair so redirects and everything that operations against the
 HOST+PORT will instead use your provided ADDRESS.
 
-The optional leading "+" signifies whether the new entry should time-out or
-not. Entries added with "HOST:..." will never time-out whereas entries added
-with "+HOST:..." will time-out just like ordinary DNS cache entries.
+The optional leading "+" specifies that the new entry should time-out. Entries
+added without the leading plus character will never time-out whereas entries
+added with "+HOST:..." will time-out just like ordinary DNS cache entries.
 
-If the DNS cache already has an entry for the given host+port pair, then
-this entry will be removed and a new entry will be created. This is because
-the old entry may have have different addresses or a different time-out
-setting.
+If the DNS cache already has an entry for the given host+port pair, the new
+entry will override the former one.
 
-An ADDRESS provided by this option will only be use if not restricted by
-the setting of \fICURLOPT_IPRESOLVE(3)\fP to a different IP version.
+An ADDRESS provided by this option will only be used if not restricted by the
+setting of \fICURLOPT_IPRESOLVE(3)\fP to a different IP version.
 
-Remove names from the DNS cache again, to stop providing these fake resolves,
-by including a string in the linked list that uses the format
-\&"-HOST:PORT". The host name must be prefixed with a dash, and the host name
-and port number must exactly match what was already added previously.
+To remove names from the DNS cache again, to stop providing these fake
+resolves, include a string in the linked list that uses the format
 
-Support for providing the ADDRESS within [brackets] was added in 7.57.0.
+.nf
+  -HOST:PORT
+.fi
 
-Support for providing multiple IP addresses per entry was added in 7.59.0.
-
-Support for adding non-permanent entries by using the "+" prefix was added in
-7.75.0.
+The entry to remove must be prefixed with a dash, and the host name and port
+number must exactly match what was added previously.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS
@@ -96,7 +96,15 @@ curl_slist_free_all(host);
 .fi
 .SH AVAILABILITY
 Added in 7.21.3. Removal support added in 7.42.0.
+
+Support for providing the ADDRESS within [brackets] was added in 7.57.0.
+
+Support for providing multiple IP addresses per entry was added in 7.59.0.
+
+Support for adding non-permanent entries by using the "+" prefix was added in
+7.75.0.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"
-.BR CURLOPT_IPRESOLVE "(3), " CURLOPT_DNS_CACHE_TIMEOUT "(3), " CURLOPT_CONNECT_TO "(3), "
+.BR CURLOPT_IPRESOLVE "(3), " CURLOPT_DNS_CACHE_TIMEOUT "(3), "
+.BR CURLOPT_CONNECT_TO "(3), "


### PR DESCRIPTION
Minor rephrasing for some explanations.

Put the format strings in stand-alone lines with .nf/.fi to be easier to spot.

Move "added in" to AVAILABILITY