### PR TITLE
libcurl-errors.3: add CURLM_ABORTED_BY_CALLBACK

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -307,6 +307,8 @@ An API function was called from inside a callback.
 Wakeup is unavailable or failed.
 .IP "CURLM_BAD_FUNCTION_ARGUMENT (10)"
 A function was called with a bad parameter.
+.IP "CURLM_ABORTED_BY_CALLBACK (11)"
+A multi handle callback returned error.
 .SH "CURLSHcode"
 The "share" interface will return a CURLSHcode to indicate when an error has
 occurred. Also consider \fIcurl_share_strerror(3)\fP.


### PR DESCRIPTION
Follow-up to #8089 (2b3dd01)