### PR TITLE
docs: fix proselint nits

### DIFF
--- a/docs/CHECKSRC.md
+++ b/docs/CHECKSRC.md
@@ -18,11 +18,11 @@ when, for example, one of the files is generated.
 
 ## What does checksrc warn for?
 
-checksrc does not check and verify the code against the entire style guide,
-but the script is instead an effort to detect the most common mistakes and
-syntax mistakes that contributors make before they get accustomed to our code
-style. Heck, many of us regulars do the mistakes too and this script helps us
-keep the code in shape.
+checksrc does not check and verify the code against the entire style guide.
+The script is an effort to detect the most common mistakes and syntax mistakes
+that contributors make before they get accustomed to our code style. Heck,
+many of us regulars do the mistakes too and this script helps us keep the code
+in shape.
 
     checksrc.pl -h
 

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -278,9 +278,9 @@ When specifying multiple cipher names, separate them with colon (`:`).
 
 ## GSKit
 
-Ciphers are internally defined as
-[numeric codes](https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_73/apis/gsk_attribute_set_buffer.htm),
-but libcurl maps them to the following case-insensitive names.
+Ciphers are internally defined as [numeric
+codes](https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_73/apis/gsk_attribute_set_buffer.htm). libcurl
+maps them to the following case-insensitive names.
 
 ### SSL2 cipher suites (insecure: disabled by default)
 

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -103,7 +103,7 @@ archive is quite OK as well.
 ### Documentation
 
 Writing docs is dead boring and one of the big problems with many open source
-projects. But someone's gotta do it! It makes things a lot easier if you
+projects. But someone's gotta do it. It makes things a lot easier if you
 submit a small description of your fix or your new features with every
 contribution so that it can be swiftly added to the package documentation.
 

--- a/docs/FAQ
+++ b/docs/FAQ
@@ -65,19 +65,19 @@ FAQ
    4.5.6 "301 Moved Permanently"
   4.6 Can you tell me what error code 142 means?
   4.7 How do I keep user names and passwords secret in curl command lines?
-  4.8 I found a bug!
+  4.8 I found a bug
   4.9 curl cannot authenticate to the server that requires NTLM?
-  4.10 My HTTP request using HEAD, PUT or DELETE does not work!
+  4.10 My HTTP request using HEAD, PUT or DELETE does not work
   4.11 Why do my HTTP range requests return the full document?
   4.12 Why do I get "certificate verify failed" ?
   4.13 Why is curl -R on Windows one hour off?
-  4.14 Redirects work in browser but not with curl!
+  4.14 Redirects work in browser but not with curl
   4.15 FTPS does not work
-  4.16 My HTTP POST or PUT requests are slow!
+  4.16 My HTTP POST or PUT requests are slow
   4.17 Non-functional connect timeouts on Windows
   4.18 file:// URLs containing drive letters (Windows, NetWare)
   4.19 Why does not curl return an error when the network cable is unplugged?
-  4.20 curl does not return error for HTTP non-200 responses!
+  4.20 curl does not return error for HTTP non-200 responses
 
  5. libcurl Issues
   5.1 Is libcurl thread-safe?
@@ -86,7 +86,7 @@ FAQ
   5.4 Does libcurl do Winsock initialization on win32 systems?
   5.5 Does CURLOPT_WRITEDATA and CURLOPT_READDATA work on win32 ?
   5.6 What about Keep-Alive or persistent connections?
-  5.7 Link errors when building libcurl on Windows!
+  5.7 Link errors when building libcurl on Windows
   5.8 libcurl.so.X: open failed: No such file or directory
   5.9 How does libcurl resolve host names?
   5.10 How do I prevent libcurl from writing the response to stdout?
@@ -95,7 +95,7 @@ FAQ
   5.13 How do I stop an ongoing transfer?
   5.14 Using C++ non-static functions for callbacks?
   5.15 How do I get an FTP directory listing?
-  5.16 I want a different time-out!
+  5.16 I want a different time-out
   5.17 Can I write a server with libcurl?
   5.18 Does libcurl use threads?
 
@@ -134,14 +134,13 @@ FAQ
 
   libcurl
 
-    A free and easy-to-use client-side URL transfer library, supporting DICT,
-    FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS,
-    MQTT, POP3, POP3S, RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SMBS, SMTP, SMTPS,
-    TELNET and TFTP.
+    A client-side URL transfer library, supporting DICT, FILE, FTP, FTPS,
+    GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS, MQTT, POP3, POP3S,
+    RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SMBS, SMTP, SMTPS, TELNET and TFTP.
 
     libcurl supports HTTPS certificates, HTTP POST, HTTP PUT, FTP uploading,
     Kerberos, SPNEGO, HTTP form based upload, proxies, cookies, user+password
-    authentication, file transfer resume, http proxy tunneling and more!
+    authentication, file transfer resume, http proxy tunneling and more.
 
     libcurl is highly portable, it builds and works identically on numerous
     platforms, including Solaris, NetBSD, FreeBSD, OpenBSD, Darwin, HP-UX,
@@ -175,7 +174,7 @@ FAQ
   libcurl is a reliable and portable library for doing Internet data transfers
   using one or more of its supported Internet protocols.
 
-  You can use libcurl for free in your application, be it open source,
+  You can use libcurl freely in your application, be it open source,
   commercial or closed-source.
 
   libcurl is most probably the most portable, most powerful and most often
@@ -184,7 +183,7 @@ FAQ
 
   1.3 What is curl not?
 
-  curl is not a wget clone. That is a common misconception.  Never, during
+  curl is not a wget clone. That is a common misconception. Never, during
   curl's development, have we intended curl to replace wget or compete on its
   market. curl is targeted at single-shot file transfers.
 
@@ -247,9 +246,8 @@ FAQ
   1.6 What do you get for making curl?
 
   Project cURL is entirely free and open. We do this voluntarily, mostly in
-  our spare time.  Companies may pay individual developers to work on curl,
-  but that is up to each company and developer. This is not controlled by nor
-  supervised in any way by the curl project.
+  our spare time. Companies may pay individual developers to work on curl.
+  This is not controlled by nor supervised in any way by the curl project.
 
   We get help from companies. Haxx provides website, bandwidth, mailing lists
   etc, GitHub hosts the primary git repository and other services like the bug
@@ -538,14 +536,14 @@ FAQ
   about bindings on the curl-library list too, but be prepared that people on
   that list may not know anything about bindings.
 
-  In February 2019, there were interfaces available for the following
+  In December 2021, there were interfaces available for the following
   languages: Ada95, Basic, C, C++, Ch, Cocoa, D, Delphi, Dylan, Eiffel,
   Euphoria, Falcon, Ferite, Gambas, glib/GTK+, Go, Guile, Harbour, Haskell,
   Java, Julia, Lisp, Lua, Mono, .NET, node.js, Object-Pascal, OCaml, Pascal,
   Perl, PHP, PostgreSQL, Python, R, Rexx, Ring, RPG, Ruby, Rust, Scheme,
   Scilab, S-Lang, Smalltalk, SP-Forth, SPL, Tcl, Visual Basic, Visual FoxPro,
   Q, wxwidgets, XBLite and Xoho. By the time you read this, additional ones
-  may have appeared!
+  may have appeared.
 
   3.10 What about SOAP, WebDAV, XML-RPC or similar protocols over HTTP?
 
@@ -640,7 +638,7 @@ FAQ
   CLIENT CERTIFICATE
 
   The server you communicate with may require that you can provide this in
-  order to prove that you actually are who you claim to be.  If the server
+  order to prove that you actually are who you claim to be. If the server
   does not require this, you do not need a client certificate.
 
   A client certificate is always used together with a private key, and the
@@ -686,7 +684,7 @@ FAQ
 
   No.
 
-  But you could easily write your own program using libcurl to do such stunts.
+  You can easily write your own program using libcurl to do such stunts.
 
   3.19 How do I get HTTP from a host using a specific IP address?
 
@@ -771,7 +769,7 @@ FAQ
   runs the specified command in the background. To safely send the & as a part
   of a URL, you should quote the entire URL by using single (') or double (")
   quotes around it. Similar problems can also occur on some shells with other
-  characters, including ?*!$~(){}<>\|;`.  When in doubt, quote the URL.
+  characters, including ?*!$~(){}<>\|;`. When in doubt, quote the URL.
 
   An example that would invoke a remote CGI that uses &-symbols could be:
 
@@ -858,7 +856,7 @@ FAQ
   Error codes that are larger than the highest documented error code means
   that curl has exited due to a crash. This is a serious error, and we
   appreciate a detailed bug report from you that describes how we could go
-  ahead and repeat this!
+  ahead and repeat this.
 
   4.7 How do I keep user names and passwords secret in curl command lines?
 
@@ -882,10 +880,10 @@ FAQ
   authentication methods (like Digest, Negotiate or even NTLM) or consider the
   SSL-based alternatives HTTPS and FTPS.
 
-  4.8 I found a bug!
+  4.8 I found a bug
 
   It is not a bug if the behavior is documented. Read the docs first.
-  Especially check out the KNOWN_BUGS file, it may be a documented bug!
+  Especially check out the KNOWN_BUGS file, it may be a documented bug.
 
   If it is a problem with a binary you have downloaded or a package for your
   particular platform, try contacting the person who built the package/archive
@@ -902,7 +900,7 @@ FAQ
   NTLM is a Microsoft proprietary protocol. Proprietary formats are evil. You
   should not use such ones.
 
-  4.10 My HTTP request using HEAD, PUT or DELETE does not work!
+  4.10 My HTTP request using HEAD, PUT or DELETE does not work
 
   Many web servers allow or demand that the administrator configures the
   server properly for these requests to work on the web server.
@@ -956,7 +954,7 @@ FAQ
   times and it is not easily worked around. For more details read this:
   https://www.codeproject.com/Articles/1144/Beating-the-Daylight-Savings-Time-bug-and-getting
 
-  4.14 Redirects work in browser but not with curl!
+  4.14 Redirects work in browser but not with curl
 
   curl supports HTTP redirects well (see item 3.8). Browsers generally support
   at least two other ways to perform redirects that curl does not:
@@ -985,7 +983,7 @@ FAQ
   mandated by RFC4217. This kind of connection will then of course use the
   standard FTP port 21 by default.
 
-  4.16 My HTTP POST or PUT requests are slow!
+  4.16 My HTTP POST or PUT requests are slow
 
   libcurl makes all POST and PUT requests (except for POST requests with a
   tiny request body) use the "Expect: 100-continue" header. This header
@@ -1005,7 +1003,7 @@ FAQ
   In most Windows setups having a timeout longer than 21 seconds make no
   difference, as it will only send 3 TCP SYN packets and no more. The second
   packet sent three seconds after the first and the third six seconds after
-  the second.  No more than three packets are sent, no matter how long the
+  the second. No more than three packets are sent, no matter how long the
   timeout is set.
 
   See option TcpMaxConnectRetransmissions on this page:
@@ -1049,32 +1047,32 @@ FAQ
   Unplugging a cable is not an error situation. The TCP/IP protocol stack
   was designed to be fault tolerant, so even though there may be a physical
   break somewhere the connection should not be affected, just possibly
-  delayed.  Eventually, the physical break will be fixed or the data will be
+  delayed. Eventually, the physical break will be fixed or the data will be
   re-routed around the physical problem through another path.
 
   In such cases, the TCP/IP stack is responsible for detecting when the
   network connection is irrevocably lost. Since with some protocols it is
   perfectly legal for the client to wait indefinitely for data, the stack may
   never report a problem, and even when it does, it can take up to 20 minutes
-  for it to detect an issue.  The curl option --keepalive-time enables
+  for it to detect an issue. The curl option --keepalive-time enables
   keep-alive support in the TCP/IP stack which makes it periodically probe the
   connection to make sure it is still available to send data. That should
   reliably detect any TCP/IP network failure.
 
-  But even that will not detect the network going down before the TCP/IP
+  TCP keep alive will not detect the network going down before the TCP/IP
   connection is established (e.g. during a DNS lookup) or using protocols that
-  do not use TCP.  To handle those situations, curl offers a number of timeouts
+  do not use TCP. To handle those situations, curl offers a number of timeouts
   on its own. --speed-limit/--speed-time will abort if the data transfer rate
   falls too low, and --connect-timeout and --max-time can be used to put an
   overall timeout on the connection phase or the entire transfer.
 
   A libcurl-using application running in a known physical environment (e.g.
   an embedded device with only a single network connection) may want to act
-  immediately if its lone network connection goes down.  That can be achieved
+  immediately if its lone network connection goes down. That can be achieved
   by having the application monitor the network connection on its own using an
   OS-specific mechanism, then signaling libcurl to abort (see also item 5.13).
 
-  4.20 curl does not return error for HTTP non-200 responses!
+  4.20 curl does not return error for HTTP non-200 responses
 
   Correct. Unless you use -f (--fail).
 
@@ -1106,7 +1104,7 @@ FAQ
 
   We have written the libcurl code specifically adjusted for multi-threaded
   programs. libcurl will use thread-safe functions instead of non-safe ones if
-  your system has such.  Note that you must never share the same handle in
+  your system has such. Note that you must never share the same handle in
   multiple threads.
 
   There may be some exceptions to thread safety depending on how libcurl was
@@ -1183,7 +1181,7 @@ FAQ
   kept within the multi handle and will be shared among all the easy handles
   that are used within the same multi handle.
 
-  5.7 Link errors when building libcurl on Windows!
+  5.7 Link errors when building libcurl on Windows
 
   You need to make sure that your project, and all the libraries (both static
   and dynamic) that it links against, are compiled/linked against the same run
@@ -1199,7 +1197,7 @@ FAQ
   add CURL_STATICLIB in the "Preprocessor Definitions" section.
 
   If you get linker error like "unknown symbol __imp__curl_easy_init ..." you
-  have linked against the wrong (static) library.  If you want to use the
+  have linked against the wrong (static) library. If you want to use the
   libcurl.dll and import lib, you do not need any extra CFLAGS, but use one of
   the import libraries below. These are the libraries produced by the various
   lib/Makefile.* files:
@@ -1219,8 +1217,8 @@ FAQ
   current libcurl ABI, typically 3 or 4).
 
   You need to make sure that ld.so finds libcurl.so.X. You can do that
-  multiple ways, and it differs somewhat between different operating systems,
-  but they are usually:
+  multiple ways, and it differs somewhat between different operating systems.
+  They are usually:
 
   * Add an option to the linker command line that specify the hard-coded path
     the run-time linker should check for the lib (usually -R)
@@ -1235,10 +1233,10 @@ FAQ
 
   5.9 How does libcurl resolve host names?
 
-  libcurl supports a large a number of different name resolve functions. One
-  of them is picked at build-time and will be used unconditionally. Thus, if
-  you want to change name resolver function you must rebuild libcurl and tell
-  it to use a different function.
+  libcurl supports a large number of name resolve functions. One of them is
+  picked at build-time and will be used unconditionally. Thus, if you want to
+  change name resolver function you must rebuild libcurl and tell it to use a
+  different function.
 
   - The non-IPv6 resolver that can use one of four different host name resolve
   calls (depending on what your system supports):
@@ -1277,7 +1275,7 @@ FAQ
   No. libcurl operates on a higher level. Besides, faking IP address would
   imply sending IP packets with a made-up source address, and then you normally
   get a problem with receiving the packet sent back as they would then not be
-  routed to you!
+  routed to you.
 
   If you use a proxy to access remote sites, the sites will not see your local
   IP address but instead the address of the proxy.
@@ -1293,7 +1291,7 @@ FAQ
   one of the callbacks, but none of them are instant. There is no function you
   can call from another thread or similar that will stop it immediately.
   Instead, you need to make sure that one of the callbacks you use returns an
-  appropriate value that will stop the transfer.  Suitable callbacks that you
+  appropriate value that will stop the transfer. Suitable callbacks that you
   can do this with include the progress callback, the read callback and the
   write callback.
 
@@ -1351,11 +1349,11 @@ FAQ
   libcurl since 7.21.0 also provide the ability to specify a wildcard to
   download multiple files from one FTP directory.
 
-  5.16 I want a different time-out!
+  5.16 I want a different time-out
 
-  Time and time again users realize that CURLOPT_TIMEOUT and
-  CURLOPT_CONNECTIMEOUT are not sufficiently advanced or flexible to cover all
-  the various use cases and scenarios applications end up with.
+  Sometimes users realize that CURLOPT_TIMEOUT and CURLOPT_CONNECTIMEOUT are
+  not sufficiently advanced or flexible to cover all the various use cases and
+  scenarios applications end up with.
 
   libcurl offers many more ways to time-out operations. A common alternative
   is to use the CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME options to
@@ -1372,9 +1370,9 @@ FAQ
   No. libcurl offers no functions or building blocks to build any kind of
   internet protocol server. libcurl is only a client-side library. For server
   libraries, you need to continue your search elsewhere but there exist many
-  good open source ones out there for most protocols you could possibly want a
-  server for. And there are really good stand-alone ones that have been tested
-  and proven for many years. There's no need for you to reinvent them!
+  good open source ones out there for most protocols you could want a server
+  for. There are also really good stand-alone servers that have been tested
+  and proven for many years. There's no need for you to reinvent them.
 
   5.18 Does libcurl use threads?
 
@@ -1382,8 +1380,8 @@ FAQ
   callbacks will be called in the same thread as the one you call libcurl in.
 
   If you want to avoid your thread to be blocked by the libcurl call, you make
-  sure you use the non-blocking API which will do transfers asynchronously -
-  but still in the same single thread.
+  sure you use the non-blocking multi API which will do transfers
+  asynchronously - still in the same single thread.
 
   libcurl will potentially internally use threads for name resolving, if it
   was built to work like that, but in those cases it will create the child
@@ -1405,36 +1403,36 @@ FAQ
 
   6.1 I have a GPL program, can I use the libcurl library?
 
-  Yes!
+  Yes
 
-  Since libcurl may be distributed under the MIT/X derivative license, it can be
-  used together with GPL in any software.
+  Since libcurl may be distributed under the MIT/X derivative license, it can
+  be used together with GPL in any software.
 
   6.2 I have a closed-source program, can I use the libcurl library?
 
-  Yes!
+  Yes
 
   libcurl does not put any restrictions on the program that uses the library.
 
   6.3 I have a BSD licensed program, can I use the libcurl library?
 
-  Yes!
+  Yes
 
   libcurl does not put any restrictions on the program that uses the library.
 
   6.4 I have a program that uses LGPL libraries, can I use libcurl?
 
-  Yes!
+  Yes
 
   The LGPL license does not clash with other licenses.
 
   6.5 Can I modify curl/libcurl for my program and keep the changes secret?
 
-  Yes!
+  Yes
 
-  The MIT/X derivative license practically allows you to do almost anything with
-  the sources, on the condition that the copyright texts in the sources are
-  left intact.
+  The MIT/X derivative license practically allows you to do almost anything
+  with the sources, on the condition that the copyright texts in the sources
+  are left intact.
 
   6.6 Can you please change the curl/libcurl license to XXXX?
 

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -7,9 +7,9 @@
                                   Known Bugs
 
 These are problems and bugs known to exist at the time of this release. Feel
-free to join in and help us correct one or more of these! Also be sure to
+free to join in and help us correct one or more of these. Also be sure to
 check the changelog of the current development status, as one or more of these
-problems may have been fixed or changed somewhat since this was written!
+problems may have been fixed or changed somewhat since this was written.
 
  1. HTTP
  1.2 Multiple methods in a single WWW-Authenticate: header
@@ -200,7 +200,7 @@ problems may have been fixed or changed somewhat since this was written!
 1.5 Expect-100 meets 417
 
  If an upload using Expect: 100-continue receives an HTTP 417 response, it
- ought to be automatically resent without the Expect:.  A workaround is for
+ ought to be automatically resent without the Expect:. A workaround is for
  the client application to redo the transfer after disabling Expect:.
  https://curl.se/mail/archive-2008-02/0043.html
 
@@ -411,9 +411,9 @@ problems may have been fixed or changed somewhat since this was written!
 4.2 -J with -C - fails
 
  When using -J (with -O), automatically resumed downloading together with "-C
- -" fails. Without -J the same command line works! This happens because the
+ -" fails. Without -J the same command line works. This happens because the
  resume logic is worked out before the target file name (and thus its
- pre-transfer size) has been figured out!
+ pre-transfer size) has been figured out.
  https://curl.se/bug/view.cgi?id=1169
 
 4.3 --retry and transfer timeouts
@@ -511,7 +511,7 @@ problems may have been fixed or changed somewhat since this was written!
 
  This can make subsequent checks for libraries wrongly detect another
  installation in a directory that was previously added to LDFLAGS by another
- library check!
+ library check.
 
  A possibly better way to do these checks would be to keep the pristine LDFLAGS
  even after successful checks and instead add those verified paths to a
@@ -676,7 +676,7 @@ problems may have been fixed or changed somewhat since this was written!
 
     The sender converts the data from an internal character representation to
     the standard 8-bit NVT-ASCII representation (see the Telnet
-    specification).  The receiver will convert the data from the standard
+    specification). The receiver will convert the data from the standard
     form to his own internal form.
 
  Since 7.15.4 at least line endings are converted.
@@ -684,19 +684,19 @@ problems may have been fixed or changed somewhat since this was written!
 7.6 FTP with NULs in URL parts
 
  FTP URLs passed to curl may contain NUL (0x00) in the RFC 1738 <user>,
- <password>, and <fpath> components, encoded as "%00".  The problem is that
+ <password>, and <fpath> components, encoded as "%00". The problem is that
  curl_unescape does not detect this, but instead returns a shortened C string.
  From a strict FTP protocol standpoint, NUL is a valid character within RFC
  959 <string>, so the way to handle this correctly in curl would be to use a
  data structure other than a plain C string, one that can handle embedded NUL
- characters.  From a practical standpoint, most FTP servers would not
+ characters. From a practical standpoint, most FTP servers would not
  meaningfully support NUL characters within RFC 959 <string>, anyway (e.g.,
  Unix pathnames may not contain NUL).
 
 7.7 FTP and empty path parts in the URL
 
  libcurl ignores empty path parts in FTP URLs, whereas RFC1738 states that
- such parts should be sent to the server as 'CWD ' (without an argument).  The
+ such parts should be sent to the server as 'CWD ' (without an argument). The
  only exception to this rule, is that we knowingly break this if the empty
  part is first in the path, as then we use the double slashes to indicate that
  the user wants to reach the root dir (this exception SHALL remain even when
@@ -824,11 +824,11 @@ problems may have been fixed or changed somewhat since this was written!
  to potentially transcend the life-time of the initial easy handle that was
  used to drive the transfer over that connection, it uses a *separate* and
  internal easy handle when it shuts down the connection. That separate
- connection might not have the exact same settings as the original easy
- handle, and in particular it is often note-worthy that it does not have the
- same VERBOSE and debug callbacks setup so that an application will not get
- the protocol data for the disconnect phase of a transfer the same way it got
- all the other data.
+ connection might not have the same settings as the original easy handle, and
+ in particular it is often note-worthy that it does not have the same VERBOSE
+ and debug callbacks setup so that an application will not get the protocol
+ data for the disconnect phase of a transfer the same way it got all the other
+ data.
 
  This is because the original easy handle might have already been freed at that
  point and the application might not at all be prepared that the callback
@@ -1079,7 +1079,7 @@ problems may have been fixed or changed somewhat since this was written!
 15.13 CMake build with MIT Kerberos does not work
 
  Minimum CMake version was bumped in curl 7.71.0 (#5358) Since CMake 3.2
- try_compile started respecting the CMAKE_EXE_FLAGS.  The code dealing with
+ try_compile started respecting the CMAKE_EXE_FLAGS. The code dealing with
  MIT Kerberos detection sets few variables to potentially weird mix of space,
  and ;-separated flags. It had to blow up at some point. All the CMake checks
  that involve compilation are doomed from that point, the configured tree

--- a/docs/MAIL-ETIQUETTE
+++ b/docs/MAIL-ETIQUETTE
@@ -25,7 +25,7 @@ MAIL ETIQUETTE
   2.5 HTML is not for mails
   2.6 Quoting
   2.7 Digest
-  2.8 Please Tell Us How You Solved The Problem!
+  2.8 Please Tell Us How You Solved The Problem
 
 ==============================================================================
 
@@ -40,7 +40,7 @@ MAIL ETIQUETTE
   please use the one or the ones that suit you the most.
 
   Each mailing list has hundreds up to thousands of readers, meaning that each
-  mail sent will be received and read by a large number of people.  People
+  mail sent will be received and read by a large number of people. People
   from various cultures, regions, religions and continents.
 
   1.2 Netiquette
@@ -111,7 +111,7 @@ MAIL ETIQUETTE
   anything good and only puts the light even more on the offender: which was
   the entire purpose of it getting sent to the list in the first place.
 
-  Do not feed the trolls!
+  Do not feed the trolls.
 
   1.7 How to unsubscribe
 
@@ -129,8 +129,8 @@ MAIL ETIQUETTE
 
   1.8 I posted, now what?
 
-  If you are not subscribed with the exact same email address that you used to
-  send the email, your post will just be silently discarded.
+  If you are not subscribed with the same email address that you used to send
+  the email, your post will just be silently discarded.
 
   If you posted for the first time to the mailing list, you first need to wait
   for an administrator to allow your email to go through (moderated). This
@@ -138,18 +138,18 @@ MAIL ETIQUETTE
   few hours.
 
   Once your email goes through it is sent out to several hundred or even
-  thousands of recipients.  Your email may cover an area that not that many
+  thousands of recipients. Your email may cover an area that not that many
   people know about or are interested in. Or possibly the person who knows
   about it is on vacation or under a heavy work load right now. You may have
-  to wait for a response and you should not expect to get a response at all,
-  but hopefully you get an answer within a couple of days.
+  to wait for a response and you should not expect to get a response at all.
+  Ideally, you get an answer within a couple of days.
 
   You do yourself and all of us a service when you include as many details as
   possible already in your first email. Mention your operating system and
   environment. Tell us which curl version you are using and tell us what you
   did, what happened and what you expected would happen. Preferably, show us
-  what you did with details enough to allow others to help point out the problem
-  or repeat the same steps in their locations.
+  what you did with details enough to allow others to help point out the
+  problem or repeat the steps in their locations.
 
   Failing to include details will only delay responses and make people respond
   and ask for more details and you will have to send a follow-up email that
@@ -239,7 +239,7 @@ MAIL ETIQUETTE
   downwards again.
 
   When most of the quotes have been removed and you have added your own words,
-  you are done!
+  you are done.
 
   2.5 HTML is not for mails
 
@@ -268,7 +268,7 @@ MAIL ETIQUETTE
   Change the subject name to something sensible and related to the subject,
   preferably even the actual subject of the single mail you wanted to reply to
 
-  2.8 Please Tell Us How You Solved The Problem!
+  2.8 Please Tell Us How You Solved The Problem
 
   Many people mail questions to the list, people spend some of their time and
   make an effort in providing good answers to these questions.
@@ -278,7 +278,7 @@ MAIL ETIQUETTE
   feel good to know that they provided a good answer and that you fixed the
   problem. Far too often, the person who asked the question is never heard from
   again, and we never get to know if he/she is gone because the problem was
-  solved or perhaps because the problem was unsolvable!
+  solved or perhaps because the problem was unsolvable.
 
   Getting the solution posted also helps other users that experience the same
   problem(s). They get to see (possibly in the web archives) that the

--- a/docs/TODO
+++ b/docs/TODO
@@ -7,14 +7,14 @@
                 Things that could be nice to do in the future
 
  Things to do in project curl. Please tell us what you think, contribute and
- send us patches that improve things!
+ send us patches that improve things.
 
  Be aware that these are things that we could do, or have once been considered
  things we could do. If you want to work on any of these areas, please
  consider bringing it up for discussions first on the mailing list so that we
- all agree it is still a good idea for the project!
+ all agree it is still a good idea for the project.
 
- All bugs documented in the KNOWN_BUGS document are subject for fixing!
+ All bugs documented in the KNOWN_BUGS document are subject for fixing.
 
  1. libcurl
  1.1 TFO support on Windows
@@ -274,7 +274,7 @@
  We can create a system with loadable modules/plug-ins, where these modules
  would be the ones that link to 3rd party libs. That would allow us to avoid
  having to load ALL dependencies since only the necessary ones for this
- app/invoke/used protocols would be necessary to load.  See
+ app/invoke/used protocols would be necessary to load. See
  https://github.com/curl/curl/issues/349
 
 1.12 updated DNS server while running
@@ -367,7 +367,7 @@
 1.20 SRV and URI DNS records
 
  Offer support for resolving SRV and URI DNS records for libcurl to know which
- server to connect to for various protocols (including HTTP!).
+ server to connect to for various protocols (including HTTP).
 
 1.21 netrc caching and sharing
 
@@ -800,7 +800,7 @@
 
  OpenSSL supports a callback for customised verification of the peer
  certificate, but this does not seem to be exposed in the libcurl APIs. Could
- it be? There's so much that could be done if it were!
+ it be? There's so much that could be done if it were.
 
 13.8 Support DANE
 
@@ -937,7 +937,7 @@
 17.4 Support CURLOPT_PREQUOTE
 
  The two other QUOTE options are supported for SFTP, but this was left out for
- unknown reasons!
+ unknown reasons.
 
 17.5 SSH over HTTPS proxy with more backends
 
@@ -1304,4 +1304,4 @@
 21.1 Support rate-limiting
 
  The rate-limiting logic is done in the PERFORMING state in multi.c but MQTT
- is not (yet) implemented to use that!
+ is not (yet) implemented to use that.

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -122,7 +122,7 @@ URL malformed. The syntax was not correct.
 .IP 4
 A feature or option that was needed to perform the desired request was not
 enabled or was explicitly disabled at build-time. To make curl able to do
-this, you probably need another build of libcurl!
+this, you probably need another build of libcurl.
 .IP 5
 Could not resolve proxy. The given proxy host could not be resolved.
 .IP 6

--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -37,7 +37,7 @@ interaction.
 curl offers a busload of useful tricks like proxy support, user
 authentication, FTP upload, HTTP post, SSL connections, cookies, file transfer
 resume and more. As you will see below, the number of features will make your
-head spin!
+head spin.
 
 curl is powered by libcurl for all transfer-related features. See
 *libcurl(3)* for details.
@@ -90,8 +90,8 @@ based on often-used host name prefixes. For example, for host names starting
 with "ftp." curl will assume you want to speak FTP.
 
 curl will do its best to use what you pass to it as a URL. It is not trying to
-validate it as a syntactically correct URL by any means but is instead
-**very** liberal with what it accepts.
+validate it as a syntactically correct URL by any means but is fairly liberal
+with what it accepts.
 
 curl will attempt to re-use connections for multiple file transfers, so that
 getting many files from the same server will not do multiple connects /
@@ -192,6 +192,6 @@ immediately next to each other, like for example you can specify all the
 options -O, -L and -v at once as -OLv.
 
 In general, all boolean options are enabled with --**option** and yet again
-disabled with --**no-**option. That is, you use the exact same option name
-but prefix it with "no-". However, in this list we mostly only list and show
-the --option version of them.
+disabled with --**no-**option. That is, you use the same option name but
+prefix it with "no-". However, in this list we mostly only list and show the
+--option version of them.

--- a/docs/cmdline-opts/ssl-reqd.d
+++ b/docs/cmdline-opts/ssl-reqd.d
@@ -6,7 +6,7 @@ Category: tls
 Example: --ssl-reqd ftp://example.com
 See-also: ssl insecure
 ---
-Require SSL/TLS for the connection.  Terminates the connection if the server
+Require SSL/TLS for the connection. Terminates the connection if the server
 does not support SSL/TLS.
 
 This option is handled in LDAP since version 7.81.0. It is fully supported

--- a/docs/cmdline-opts/tlsv1.0.d
+++ b/docs/cmdline-opts/tlsv1.0.d
@@ -8,6 +8,6 @@ See-also: tlsv1.3
 ---
 Forces curl to use TLS version 1.0 or later when connecting to a remote TLS server.
 
-In old versions of curl this option was documented to allow _only_ TLS 1.0,
-but behavior was inconsistent depending on the TLS library. Use --tls-max if
+In old versions of curl this option was documented to allow _only_ TLS 1.0.
+That behavior was inconsistent depending on the TLS library. Use --tls-max if
 you want to set a maximum TLS version.

--- a/docs/cmdline-opts/tlsv1.1.d
+++ b/docs/cmdline-opts/tlsv1.1.d
@@ -8,6 +8,6 @@ See-also: tlsv1.3
 ---
 Forces curl to use TLS version 1.1 or later when connecting to a remote TLS server.
 
-In old versions of curl this option was documented to allow _only_ TLS 1.1,
-but behavior was inconsistent depending on the TLS library. Use --tls-max if
+In old versions of curl this option was documented to allow _only_ TLS 1.1.
+That behavior was inconsistent depending on the TLS library. Use --tls-max if
 you want to set a maximum TLS version.

--- a/docs/cmdline-opts/tlsv1.2.d
+++ b/docs/cmdline-opts/tlsv1.2.d
@@ -8,6 +8,6 @@ See-also: tlsv1.3
 ---
 Forces curl to use TLS version 1.2 or later when connecting to a remote TLS server.
 
-In old versions of curl this option was documented to allow _only_ TLS 1.2,
-but behavior was inconsistent depending on the TLS library. Use --tls-max if
+In old versions of curl this option was documented to allow _only_ TLS 1.2.
+That behavior was inconsistent depending on the TLS library. Use --tls-max if
 you want to set a maximum TLS version.


### PR DESCRIPTION
- remove a lot of exclamation marks
- use consistent spaces (1, not 2)
- use better words at some places