### PR TITLE
example/progressfunc: remove code for old libcurls

### DIFF
--- a/docs/examples/progressfunc.c
+++ b/docs/examples/progressfunc.c
@@ -27,25 +27,11 @@
 #include <stdio.h>
 #include <curl/curl.h>
 
-#if LIBCURL_VERSION_NUM >= 0x073d00
-/* In libcurl 7.61.0, support was added for extracting the time in plain
-   microseconds. Older libcurl versions are stuck in using 'double' for this
-   information so we complicate this example a bit by supporting either
-   approach. */
-#define TIME_IN_US 1 /* microseconds */
-#define TIMETYPE curl_off_t
-#define TIMEOPT CURLINFO_TOTAL_TIME_T
 #define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL     3000000
-#else
-#define TIMETYPE double
-#define TIMEOPT CURLINFO_TOTAL_TIME
-#define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL     3
-#endif
-
 #define STOP_DOWNLOAD_AFTER_THIS_MANY_BYTES         6000
 
 struct myprogress {
-  TIMETYPE lastruntime; /* type depends on version, see above */
+  curl_off_t lastruntime; /* type depends on version, see above */
   CURL *curl;
 };
 
@@ -56,21 +42,17 @@ static int xferinfo(void *p,
 {
   struct myprogress *myp = (struct myprogress *)p;
   CURL *curl = myp->curl;
-  TIMETYPE curtime = 0;
+  curl_off_t curtime = 0;
 
-  curl_easy_getinfo(curl, TIMEOPT, &curtime);
+  curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME_T, &curtime);
 
   /* under certain circumstances it may be desirable for certain functionality
      to only run every N seconds, in order to do this the transaction time can
      be used */
   if((curtime - myp->lastruntime) >= MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL) {
     myp->lastruntime = curtime;
-#ifdef TIME_IN_US
     fprintf(stderr, "TOTAL TIME: %" CURL_FORMAT_CURL_OFF_T ".%06ld\r\n",
             (curtime / 1000000), (long)(curtime % 1000000));
-#else
-    fprintf(stderr, "TOTAL TIME: %f \r\n", curtime);
-#endif
   }
 
   fprintf(stderr, "UP: %" CURL_FORMAT_CURL_OFF_T " of %" CURL_FORMAT_CURL_OFF_T
@@ -82,20 +64,6 @@ static int xferinfo(void *p,
     return 1;
   return 0;
 }
-
-#if LIBCURL_VERSION_NUM < 0x072000
-/* for libcurl older than 7.32.0 (CURLOPT_PROGRESSFUNCTION) */
-static int older_progress(void *p,
-                          double dltotal, double dlnow,
-                          double ultotal, double ulnow)
-{
-  return xferinfo(p,
-                  (curl_off_t)dltotal,
-                  (curl_off_t)dlnow,
-                  (curl_off_t)ultotal,
-                  (curl_off_t)ulnow);
-}
-#endif
 
 int main(void)
 {
@@ -110,26 +78,9 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
-#if LIBCURL_VERSION_NUM >= 0x072000
-    /* xferinfo was introduced in 7.32.0, no earlier libcurl versions will
-       compile as they will not have the symbols around.
-
-       If built with a newer libcurl, but running with an older libcurl:
-       curl_easy_setopt() will fail in run-time trying to set the new
-       callback, making the older callback get used.
-
-       New libcurls will prefer the new callback and instead use that one even
-       if both callbacks are set. */
-
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xferinfo);
-    /* pass the struct pointer into the xferinfo function, note that this is
-       an alias to CURLOPT_PROGRESSDATA */
+    /* pass the struct pointer into the xferinfo function */
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &prog);
-#else
-    curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, older_progress);
-    /* pass the struct pointer into the progress function */
-    curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &prog);
-#endif
 
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     res = curl_easy_perform(curl);


### PR DESCRIPTION
7.61.0 is over three years old now, remove all #ifdefs for handling
ancient libcurl versions so that the example gets easier to read and
understand