### PR TITLE
openldap: some tiny adjustments

### DIFF
--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
@@ -30,15 +30,14 @@ CURLINFO_RESPONSE_CODE \- get the last response code
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RESPONSE_CODE, long *codep);
 .fi
 .SH DESCRIPTION
-Pass a pointer to a long to receive the last received HTTP, FTP or SMTP
-response code. This option was previously known as CURLINFO_HTTP_CODE in
-libcurl 7.10.7 and earlier. The stored value will be zero if no server
-response code has been received. Note that a proxy's CONNECT response should
+Pass a pointer to a long to receive the last received HTTP, FTP, SMTP or
+LDAP (openldap only) response code. This option was previously known as
+CURLINFO_HTTP_CODE in libcurl 7.10.7 and earlier.
+The stored value will be zero if no server response code has been received.
+Note that a proxy's CONNECT response should
 be read with \fICURLINFO_HTTP_CONNECTCODE(3)\fP and not this.
-
-Support for SMTP responses added in 7.25.0.
 .SH PROTOCOLS
-HTTP, FTP and SMTP
+HTTP, FTP, SMTP and LDAP
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -55,6 +54,7 @@ if(curl) {
 .fi
 .SH AVAILABILITY
 Added in 7.10.8. CURLINFO_HTTP_CODE was added in 7.4.1.
+Support for SMTP responses added in 7.25.0, for OpenLDAP in 7.81.0.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"


### PR DESCRIPTION
- Early check proper LDAP URL syntax. Reject URLs with a userinfo part.
- Use dynamic memory for `ldap_init_fd`() URL rather than a
  stack-allocated buffer.
- Never chase referrals: supporting it would require additional parallel
  connections and alternate authentication credentials.
- Do not wait 1 microsecond while polling/reading query response data.
- Store last received server code for retrieval with `CURLINFO_RESPONSE_CODE`.

Maybe you will postpone pull of this as `CURLINFO_RESPONSE_CODE` for LDAP might be considered as a feature.