### PR TITLE
check ssl_config when re-use TLS proxy connection

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1298,13 +1298,12 @@ ConnectionExists(struct Curl_easy *data,
             if(check->proxy_ssl[FIRSTSOCKET].state != ssl_connection_complete)
               continue;
           }
-          else {
-            if(!Curl_ssl_config_matches(&needle->ssl_config,
-                                        &check->ssl_config))
-              continue;
-            if(check->ssl[FIRSTSOCKET].state != ssl_connection_complete)
-              continue;
-          }
+
+          if(!Curl_ssl_config_matches(&needle->ssl_config,
+                                      &check->ssl_config))
+            continue;
+          if(check->ssl[FIRSTSOCKET].state != ssl_connection_complete)
+            continue;
         }
       }
 #endif


### PR DESCRIPTION
Hi!

I'm following up [this](https://curl.se/mail/lib-2021-12/0002.html) mail list thread, ssl_config need to be checked even when proxy_ssl_config is presented. Otherwise the destination TLS connections under the same hostname could mess up when re-use a connection and HTTPs proxy is presented with TLS-over-TLS.

I tested against some of our internal integration tests with HTTPS proxy without any issue, will see how the CI goes here.