### PR TITLE
openldap: implement SASL authentication

### DIFF
--- a/docs/cmdline-opts/login-options.d
+++ b/docs/cmdline-opts/login-options.d
@@ -1,6 +1,6 @@
 Long: login-options
 Arg: <options>
-Protocols: IMAP POP3 SMTP
+Protocols: IMAP LDAP POP3 SMTP
 Help: Server login options
 Added: 7.34.0
 Category: imap pop3 smtp auth

--- a/docs/cmdline-opts/oauth2-bearer.d
+++ b/docs/cmdline-opts/oauth2-bearer.d
@@ -1,7 +1,7 @@
 Long: oauth2-bearer
 Help: OAuth 2 Bearer Token
 Arg: <token>
-Protocols: IMAP POP3 SMTP HTTP
+Protocols: IMAP LDAP POP3 SMTP HTTP
 Category: auth
 Example: --oauth2-bearer "mF_9.B5f-4.1JqM" $URL
 Added: 7.33.0

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -172,8 +172,8 @@ supports IPv6
 .IP CURL_VERSION_KERBEROS4
 supports Kerberos V4 (when using FTP). Legacy bit. Deprecated since 7.33.0.
 .IP CURL_VERSION_KERBEROS5
-supports Kerberos V5 authentication for FTP, IMAP, POP3, SMTP and SOCKSv5 proxy
-(Added in 7.40.0)
+supports Kerberos V5 authentication for FTP, IMAP, LDAP, POP3, SMTP and
+SOCKSv5 proxy. (Added in 7.40.0)
 .IP CURL_VERSION_LARGEFILE
 libcurl was built with support for large files. (Added in 7.11.1)
 .IP CURL_VERSION_UNICODE

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -46,7 +46,7 @@ option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS
-Only IMAP, POP3 and SMTP support login options.
+Only IMAP, LDAP, POP3 and SMTP support login options.
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -58,7 +58,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.34.0
+Added in 7.34.0. Support for OpenLDAP added in 7.82.0.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
+++ b/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -45,7 +45,7 @@ or a shared mailbox for example.
 .SH DEFAULT
 blank
 .SH PROTOCOLS
-IMAP, POP3 and SMTP
+IMAP, LDAP, POP3 and SMTP
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -59,7 +59,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.66.0
+Added in 7.66.0. Support for OpenLDAP added in 7.82.0.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"

--- a/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -32,15 +32,15 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SERVICE_NAME, char *name);
 .SH DESCRIPTION
 Pass a char * as parameter to a string holding the \fIname\fP of the service
 for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms. The default
-service names are "ftp", "HTTP", "imap", "pop" and "smtp". This option allows
-you to change them.
+service names are "ftp", "HTTP", "imap", "ldap", "pop" and "smtp". This option
+allows you to change them.
 
 The application does not have to keep the string around after setting this
 option.
 .SH DEFAULT
 See above
 .SH PROTOCOLS
-HTTP, FTP, IMAP, POP and SMTP
+HTTP, FTP, IMAP, LDAP, POP3 and SMTP
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -52,7 +52,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.43.0 for HTTP, 7.49.0 for FTP, IMAP, POP3 and SMTP.
+Added in 7.43.0 for HTTP, 7.49.0 for FTP, IMAP, POP3 and SMTP,
+7.82.0 for OpenLDAP.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -31,18 +31,18 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_XOAUTH2_BEARER, char *token);
 .fi
 .SH DESCRIPTION
 Pass a char * as parameter, which should point to the null-terminated OAuth
-2.0 Bearer Access Token for use with HTTP, IMAP, POP3 and SMTP servers
+2.0 Bearer Access Token for use with HTTP, IMAP, LDAP, POP3 and SMTP servers
 that support the OAuth 2.0 Authorization Framework.
 
-Note: For IMAP, POP3 and SMTP, the user name used to generate the Bearer Token
-should be supplied via the \fICURLOPT_USERNAME(3)\fP option.
+Note: For IMAP, LDAP, POP3 and SMTP, the user name used to generate the
+Bearer Token should be supplied via the \fICURLOPT_USERNAME(3)\fP option.
 
 The application does not have to keep the string around after setting this
 option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS
-IMAP, POP3 and SMTP
+HTTP, IMAP, LDAP, POP3 and SMTP
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();
@@ -54,7 +54,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.33.0
+Added in 7.33.0. Support for OpenLAP added in 7.82.0.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.


### PR DESCRIPTION
As credentials can be quite different depending on the mechanism used,
there are no default mechanisms for LDAP and simple bind with a DN is
then used.
The caller has to provide mechanism(s) using CURLOPT_LOGIN_OPTIONS to
enable SASL authentication and disable simple bind.

Note 10.1 in the TODO file targets this, but I left the note since ldap.c has not changed.