### PR TITLE
openssl: define HAVE_OPENSSL_VERSION for OpenSSL 1.1.0+

### DIFF
--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -535,11 +535,8 @@ if test "x$OPT_OPENSSL" != xno; then
 
   if test X"$OPENSSL_ENABLED" = X"1"; then
     dnl These can only exist if OpenSSL exists
-    dnl OpenSSL_version is introduced in 3.0.0
 
-    AC_CHECK_FUNCS( RAND_egd \
-                    SSLv2_client_method \
-                    OpenSSL_version )
+    AC_CHECK_FUNCS( RAND_egd )
 
     AC_MSG_CHECKING([for BoringSSL])
     AC_COMPILE_IFELSE([


### PR DESCRIPTION
Prior to this change OpenSSL_version was only detected in configure
builds.

Reported-by: lllaffer@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/8154
Closes #xxxx