### PR TITLE
nss: Remove unused flag in context initialization

### DIFF
--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1368,10 +1368,14 @@ static CURLcode nss_init_core(struct Curl_easy *data, const char *cert_dir)
     infof(data, "Unable to initialize NSS database: %d (%s)", err, err_name);
   }
 
+  /*
+   * NSS sets NSS_INIT_NOROOTINIT when creating the context regardless of
+   * flags passed in.
+   */
   infof(data, "Initializing NSS with certpath: none");
   nss_context = NSS_InitContext("", "", "", "", &initparams, NSS_INIT_READONLY
-         | NSS_INIT_NOCERTDB   | NSS_INIT_NOMODDB       | NSS_INIT_FORCEOPEN
-         | NSS_INIT_NOROOTINIT | NSS_INIT_OPTIMIZESPACE | NSS_INIT_PK11RELOAD);
+         | NSS_INIT_NOCERTDB      | NSS_INIT_NOMODDB      | NSS_INIT_FORCEOPEN
+         | NSS_INIT_OPTIMIZESPACE | NSS_INIT_PK11RELOAD);
   if(nss_context != NULL)
     return CURLE_OK;
 


### PR DESCRIPTION
When calling `NSS_InitContext()`, NSS explicitly sets `NSS_INIT_NOROOTINIT` without checking for it's presence among the passed flags (ref https://github.com/nss-dev/nss/blob/master/lib/nss/nssinit.c#L915). While it's not incorrect per se to pass it in, remove and document it for clarity to avoid implying that removing it and recompiling curl would alter its behavior.