### PR TITLE
MINOR: fix format of #error

### DIFF
--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -80,6 +80,6 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
   return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 
 #else
-#  error "no non-blocking method was found/used/set"
+#error "no non-blocking method was found/used/set"
 #endif
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -144,7 +144,7 @@ static void conn_free(struct connectdata *conn);
  * bad things will happen.
  */
 #if READBUFFER_SIZE < READBUFFER_MIN
-# error READBUFFER_SIZE is too small
+#error READBUFFER_SIZE is too small
 #endif
 
 /*


### PR DESCRIPTION
fix spurious spaces in #error preprocessor directive