### PR TITLE
set a label of the link to the support document

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ document](https://curl.se/docs/thanks.html).
 ## Commercial support
 
 For commercial support, maybe private and dedicated help with your problems or
-applications using (lib)curl: https://curl.se/support.html
+applications using (lib)curl visit [the support page](https://curl.se/support.html).
 
 ## Website
 


### PR DESCRIPTION
All other links in the README.md are set accordingly to the [HTML Living Standard](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element) or [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a). The content of an a-element (anchor) should indicate the link's destination. This fixes the only link that is not done like this.