### PR TITLE
zuul: fix quiche build pointing to wrong Cargo file

### DIFF
--- a/scripts/zuul/before_script.sh
+++ b/scripts/zuul/before_script.sh
@@ -123,7 +123,7 @@ if [ "$TRAVIS_OS_NAME" = linux -a "$QUICHE" ]; then
 
   #### Work-around https://github.com/curl/curl/issues/7927 #######
   #### See https://github.com/alexcrichton/cmake-rs/issues/131 ####
-  sed -i -e 's/cmake = "0.1"/cmake = "=0.1.45"/' Cargo.toml
+  sed -i -e 's/cmake = "0.1"/cmake = "=0.1.45"/' quiche/Cargo.toml
 
   cargo build -v --package quiche --release --features ffi,pkg-config-meta,qlog
   mkdir -v quiche/deps/boringssl/src/lib


### PR DESCRIPTION
This PR should fix #8184 

The quiche team seems to have extracted everything related to quiche from the [root Cargo.toml](https://github.com/cloudflare/quiche/commit/bbe6e2ab22126773bb63e4605ac4c8e7594f002a#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) file to a dedicated [quiche/Cargo.toml](https://github.com/cloudflare/quiche/commit/bbe6e2ab22126773bb63e4605ac4c8e7594f002a#diff-b3709efd909b098c8dcacb6c23cdb62ebd83a537bcb1ed1156d26cdf6e0bdb36) file.

The PR is in draft state as I would like to have some advice to help me testing this on zuul... 🙇🏼 

