### PR TITLE
don't close prematurely socket of HTTPS proxy tunel

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -677,7 +677,7 @@ static CURLcode CONNECT(struct Curl_easy *data,
       /* When connecting to a remote HTTPS server via established HTTPS proxy
        * tunnel don't close the socket here, SSL have to send shutdown alert
        * before closing it */
-      if (conn->http_proxy.proxytype != CURLPROXY_HTTPS) {
+      if(conn->http_proxy.proxytype != CURLPROXY_HTTPS) {
         Curl_closesocket(data, conn, conn->sock[sockindex]);
         conn->sock[sockindex] = CURL_SOCKET_BAD;
       }

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -674,8 +674,13 @@ static CURLcode CONNECT(struct Curl_easy *data,
       data->req.newurl = NULL;
       /* failure, close this connection to avoid re-use */
       streamclose(conn, "proxy CONNECT failure");
-      Curl_closesocket(data, conn, conn->sock[sockindex]);
-      conn->sock[sockindex] = CURL_SOCKET_BAD;
+      /* When connecting to a remote HTTPS server via established HTTPS proxy
+       * tunnel don't close the socket here, SSL have to send shutdown alert
+       * before closing it */
+      if (conn->http_proxy.proxytype != CURLPROXY_HTTPS) {
+        Curl_closesocket(data, conn, conn->sock[sockindex]);
+        conn->sock[sockindex] = CURL_SOCKET_BAD;
+      }
     }
 
     /* to back to init state */


### PR DESCRIPTION
In case the remote host is unreachable, the SSL handshake between the proxy and the remote server won't happen. Curl should return "Received HTTP code 502 from proxy after CONNECT" and gracefully close the tunnel, but currently it prematurely closes the socket. This is against the design
https://github.com/curl/curl/blob/d4492b6d125d31ef5c74e4deb6786896606b70cc/lib/multi.c#L2548-L2549


In consequence the prematurely closed socket is used by the SSL clean up code
https://github.com/curl/curl/blob/d4492b6d125d31ef5c74e4deb6786896606b70cc/lib/multi.c#L2568-L2569


Ref:https://github.com/curl/curl/issues/8193