### PR TITLE
http_proxy: don't close the socket (too early)

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -674,8 +674,6 @@ static CURLcode CONNECT(struct Curl_easy *data,
       data->req.newurl = NULL;
       /* failure, close this connection to avoid re-use */
       streamclose(conn, "proxy CONNECT failure");
-      Curl_closesocket(data, conn, conn->sock[sockindex]);
-      conn->sock[sockindex] = CURL_SOCKET_BAD;
     }
 
     /* to back to init state */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1435,6 +1435,12 @@ static void ossl_closeone(struct Curl_easy *data,
   if(backend->handle) {
     char buf[32];
     set_logger(conn, data);
+    /*
+     * The conn->sock[0] socket is passed to openssl with SSL_set_fd().  Make
+     * sure the socket is not closed before calling OpenSSL functions that
+     * will use it.
+     */
+    DEBUGASSERT(conn->sock[FIRSTSOCKET] != CURL_SOCKET_BAD);
 
     /* Maybe the server has already sent a close notify alert.
        Read it to avoid an RST on the TCP connection. */


### PR DESCRIPTION
... and double-check in the OpenSSL shutdown that the socket is actually
still there before it is used.

Fixes #8193

Reported-by: Leszek Kubik