### PR TITLE
examples/multi-single.c: remove WAITMS()

### DIFF
--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -34,15 +34,6 @@
 /* curl stuff */
 #include <curl/curl.h>
 
-#ifdef _WIN32
-#define WAITMS(x) Sleep(x)
-#else
-/* Portable sleep for platforms other than Windows. */
-#define WAITMS(x)                               \
-  struct timeval wait = { 0, (x) * 1000 };      \
-  (void)select(0, NULL, NULL, NULL, &wait)
-#endif
-
 /*
  * Simply download a HTTP file.
  */


### PR DESCRIPTION
As it isn't used.

Reported-by: Melroy van den Berg
Fixes #8200