### PR TITLE
Allow binary zeros in tests

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -59,7 +59,7 @@ In the preprocess stage, a special instruction can be used to have runtests.pl
 generate a repetetive sequence of bytes.
 
 To insert a sequence of repeat bytes, use this syntax to make the `<string>`
-get repeated `<number>` of times. The number has to be 1 or large and the
+get repeated `<number>` of times. The number has to be 1 or larger and the
 string may contain `%HH` hexadecimal codes:
 
     %repeat[<number> x <string>]%

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -61,7 +61,7 @@ test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \
 test352 test353 test354 test355 test356 test357 test358 test359 test360 \
 test361 test362 test363 test364 test365 test366 test367 test368 test369 \
-test370 test371 test372 \
+test370 test371 test372 test373 \
 \
 test392 test393 test394 test395 test396 test397 \
 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -61,7 +61,7 @@ test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \
 test352 test353 test354 test355 test356 test357 test358 test359 test360 \
 test361 test362 test363 test364 test365 test366 test367 test368 test369 \
-test370 test371 \
+test370 test371 test372 \
 \
 test392 test393 test394 test395 test396 test397 \
 \

--- a/tests/data/test372
+++ b/tests/data/test372
@@ -1,0 +1,49 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 22 Jul 2010 11:22:33 GMT
+Connection: close
+Content-Type: text/html
+X-Control: swsclose
+Content-Length: 2
+
+%hex[%00]hex%
+</data>
+</reply>
+
+<client>
+<server>
+http
+</server>
+<name>
+Binary zero in data element.
+</name>
+<features>
+proxy
+</features>
+<command>
+--raw http://%HOSTIP:%HTTPPORT/binary-zero-in-data-section/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+<protocol>
+GET /binary-zero-in-data-section/%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test373
+++ b/tests/data/test373
@@ -1,0 +1,78 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked transfer encoding
+</keywords>
+</info>
+
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 22 Jul 2010 11:22:33 GMT
+Connection: close
+Content-Type: text/html
+Transfer-Encoding: chunked
+X-Control: swsclose
+
+100
+%repeat[255 x %00]%
+
+100
+%repeat[255 x %00]%
+
+100
+%repeat[255 x %00]%
+
+100
+%repeat[255 x %00]%
+
+0
+
+</data>
+
+<datacheck>
+HTTP/1.1 200 OK
+Date: Thu, 22 Jul 2010 11:22:33 GMT
+Connection: close
+Content-Type: text/html
+Transfer-Encoding: chunked
+X-Control: swsclose
+
+%repeat[255 x %00]%
+%repeat[255 x %00]%
+%repeat[255 x %00]%
+%repeat[255 x %00]%
+</datacheck>
+
+</reply>
+
+<client>
+<server>
+http
+</server>
+<name>
+Chunked transfer encoding - Multple valid chunks with binary zeros.
+</name>
+<features>
+proxy
+</features>
+<command>
+http://%HOSTIP:%HTTPPORT/chunked-transfer-encoding/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+<protocol>
+GET /chunked-transfer-encoding/%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3762,7 +3762,9 @@ sub singletest {
 
     # save the new version
     open(D, ">$otest");
-    print D @entiretest;
+    foreach my $bytes (@entiretest) {
+        print D pack('a*', $bytes) or die "Failed to print '$bytes': $!";
+    }
     close(D);
 
     # in case the process changed the file, reload it

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -96,6 +96,33 @@ CURLcode Curl_convert_clone(struct Curl_easy *data,
 }
 
 /*
+ * line_length()
+ *
+ * Counts the number of characters in a line including a new line.
+ * Unlike strlen() it does not stop at nul bytes.
+ *
+ */
+static size_t line_length(const char *buffer, int bytestocheck)
+{
+  size_t length = 1;
+
+  while(*buffer != '\n' && --bytestocheck) {
+    length++;
+    buffer++;
+  }
+  if(*buffer != '\n') {
+    /*
+     * We didn't find a new line so the last byte must be a
+     * '\0' character inserted by fgets() which we should not
+     * count.
+     */
+    length--;
+  }
+
+  return length;
+}
+
+/*
  * readline()
  *
  * Reads a complete line from a file into a dynamically allocated buffer.
@@ -113,7 +140,8 @@ CURLcode Curl_convert_clone(struct Curl_easy *data,
  *   GPE_OK
  */
 
-static int readline(char **buffer, size_t *bufsize, FILE *stream)
+static int readline(char **buffer, size_t *bufsize, size_t *length,
+                    FILE *stream)
 {
   size_t offset = 0;
   char *newptr;
@@ -126,17 +154,16 @@ static int readline(char **buffer, size_t *bufsize, FILE *stream)
   }
 
   for(;;) {
-    size_t length;
     int bytestoread = curlx_uztosi(*bufsize - offset);
 
     if(!fgets(*buffer + offset, bytestoread, stream))
       return (offset != 0) ? GPE_OK : GPE_END_OF_FILE;
 
-    length = offset + strlen(*buffer + offset);
-    if(*(*buffer + length - 1) == '\n')
+    *length = offset + line_length(*buffer + offset, bytestoread);
+    if(*(*buffer + *length - 1) == '\n')
       break;
-    offset = length;
-    if(length < *bufsize - 1)
+    offset = *length;
+    if(*length < *bufsize - 1)
       continue;
 
     newptr = realloc(*buffer, *bufsize * 2);
@@ -179,10 +206,10 @@ static int appenddata(char  **dst_buf,   /* dest buffer */
                       size_t *dst_len,   /* dest buffer data length */
                       size_t *dst_alloc, /* dest buffer allocated size */
                       char   *src_buf,   /* source buffer */
+                      size_t  src_len,   /* source buffer length */
                       int     src_b64)   /* != 0 if source is base64 encoded */
 {
   size_t need_alloc = 0;
-  size_t src_len = strlen(src_buf);
 
   if(!src_len)
     return GPE_OK;
@@ -293,6 +320,7 @@ int getpart(char **outbuf, size_t *outlen,
   } len;
   size_t bufsize = 0;
   size_t outalloc = 256;
+  size_t datalen;
   int in_wanted_part = 0;
   int base64 = 0;
   int error;
@@ -313,7 +341,7 @@ int getpart(char **outbuf, size_t *outlen,
 
   couter[0] = cmain[0] = csub[0] = ptag[0] = patt[0] = '\0';
 
-  while((error = readline(&buffer, &bufsize, stream)) == GPE_OK) {
+  while((error = readline(&buffer, &bufsize, &datalen, stream)) == GPE_OK) {
 
     ptr = buffer;
     EAT_SPACE(ptr);
@@ -321,7 +349,8 @@ int getpart(char **outbuf, size_t *outlen,
     if('<' != *ptr) {
       if(in_wanted_part) {
         show(("=> %s", buffer));
-        error = appenddata(outbuf, outlen, &outalloc, buffer, base64);
+        error = appenddata(outbuf, outlen, &outalloc, buffer, datalen,
+                           base64);
         if(error)
           break;
       }
@@ -459,7 +488,7 @@ int getpart(char **outbuf, size_t *outlen,
 
     if(in_wanted_part) {
       show(("=> %s", buffer));
-      error = appenddata(outbuf, outlen, &outalloc, buffer, base64);
+      error = appenddata(outbuf, outlen, &outalloc, buffer, datalen, base64);
       if(error)
         break;
     }


### PR DESCRIPTION
This patch set allows to use binary zeros in tests.

I mainly needed binary zeros for Privoxy tests but it doesn't hurt
to explicitly confirm that curl can deal with them as well.