### PR TITLE
Fix LIBRARY_PATH adjustment for linux which is currently breaking configure script in 7.81.0

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -6515,16 +6515,21 @@ dnl changes contained within this macro.
 
 AC_DEFUN([CURL_RUN_IFELSE], [
    case $host_os in
-     darwin*) library_path_var=DYLD_LIBRARY_PATH ;;
-     *)       library_path_var=LD_LIBRARY_PATH ;;
+     darwin*)
+      old=$DYLD_LIBRARY_PATH
+      DYLD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
+      export DYLD_LIBRARY_PATH
+      AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
+      DYLD_LIBRARY_PATH=$old # restore
+     ;;
+     *)
+      old=$LD_LIBRARY_PATH
+      LD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
+      export LD_LIBRARY_PATH
+      AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
+      LD_LIBRARY_PATH=$old # restore
+     ;;
    esac
-
-   eval "old=$$library_path_var"
-   eval "$library_path_var=\$CURL_LIBRARY_PATH:\$old"
-
-   eval "export $library_path_var"
-   AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
-   eval "$library_path_var=\$old" # restore
 ])
 
 dnl CURL_COVERAGE


### PR DESCRIPTION
Fixes #8229 

Tested-by: Satadru Pramanik <satadru@gmail.com> (in linux)

- `$$` usage in a m4 file introduces the PID in linux.
Instead, just duplicate previous working code with a case switch.

This also breaks `configure` script on `armv7l` and `i686` on ChromeOS/Chromebrew linux systems.