### PR TITLE
ngtcp2: fix declaration of ‘result’ shadows a previous local

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1676,7 +1676,6 @@ static CURLcode ng_has_connected(struct Curl_easy *data,
   if(conn->ssl_config.verifyhost) {
 #ifdef USE_OPENSSL
     X509 *server_cert;
-    CURLcode result;
     server_cert = SSL_get_peer_certificate(conn->quic->ssl);
     if(!server_cert) {
       return CURLE_PEER_FAILED_VERIFICATION;


### PR DESCRIPTION
Follow-up to 8fbd6feddfa587cfd3