### PR TITLE
curl-functions.m4: revert DYLD_LIBRARY_PATH tricks in CURL_RUN_IFELSE

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -6516,11 +6516,7 @@ dnl changes contained within this macro.
 AC_DEFUN([CURL_RUN_IFELSE], [
    case $host_os in
      darwin*)
-      old=$DYLD_LIBRARY_PATH
-      DYLD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
-      export DYLD_LIBRARY_PATH
       AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
-      DYLD_LIBRARY_PATH=$old # restore
      ;;
      *)
       old=$LD_LIBRARY_PATH


### PR DESCRIPTION
Mostly reverts ba0657c343f, but now instead just does nothing on darwin.

Fixes #8229
Reported-by: Ryan Schmidt