### PR TITLE
remote-header-name.d: clarify

### DIFF
--- a/docs/cmdline-opts/remote-header-name.d
+++ b/docs/cmdline-opts/remote-header-name.d
@@ -8,10 +8,15 @@ Added: 7.20.0
 See-also: remote-name
 ---
 This option tells the --remote-name option to use the server-specified
-Content-Disposition filename instead of extracting a filename from the URL.
+Content-Disposition filename instead of extracting a filename from the URL. If
+the server-provided file name contains a path, that will be stripped off
+before the file name is used.
+
+The file is saved in the current directory, or in the directory specified with
+--output-dir.
 
 If the server specifies a file name and a file with that name already exists
-in the current working directory it will not be overwritten and an error will
+in the destination directory, it will not be overwritten and an error will
 occur. If the server does not specify a file name then this option has no
 effect.
 


### PR DESCRIPTION
- it strips off the path from the server provided name
- it saves in current directory or --output-dir

Ref: https://curl.se/mail/archive-2022-01/0032.html