### PR TITLE
CURLOPT_RESOLVE.3: change example port to 443

### DIFF
--- a/docs/libcurl/opts/CURLOPT_RESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.3
@@ -79,7 +79,7 @@ All
 .nf
 CURL *curl;
 struct curl_slist *host = NULL;
-host = curl_slist_append(NULL, "example.com:80:127.0.0.1");
+host = curl_slist_append(NULL, "example.com:443:127.0.0.1");
 
 curl = curl_easy_init();
 if(curl) {


### PR DESCRIPTION
83cc96670811cd0e6cccbf78d2b21bbeb2e4ea45 changed documentation from using
http to https. However, CURLOPT_RESOLVE being set to port 80 in the
documentation means that it isn't valid for the new URL. Update to 443.