### PR TITLE
mbedtls: fix CURLOPT_SSLCERT_BLOB (again)

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
@@ -33,8 +33,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSLCERT_BLOB,
 .SH DESCRIPTION
 Pass a pointer to a curl_blob structure, which contains (pointer and size) a
 client certificate. The format must be "P12" on Secure Transport or
-Schannel. The format must be "P12" or "PEM" on OpenSSL. The string "P12" or
-"PEM" must be specified with \fICURLOPT_SSLCERTTYPE(3)\fP.
+Schannel. The format must be "P12" or "PEM" on OpenSSL. The format must be
+"DER" or "PEM" on mbedTLS. The format must be specified with
+\fICURLOPT_SSLCERTTYPE(3)\fP.
 
 If the blob is initialized with the flags member of struct curl_blob set to
 CURL_BLOB_COPY, the application does not have to keep the buffer around after
@@ -63,8 +64,8 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.71.0. This option is supported by the OpenSSL, Secure Transport and
-Schannel backends.
+Added in 7.71.0. This option is supported by the OpenSSL, Secure Transport,
+Schannel and mbedTLS (since 7.78.0) backends.
 .SH RETURN VALUE
 Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -388,7 +388,7 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
     memcpy(newblob, ssl_cert_blob->data, ssl_cert_blob->len);
     newblob[ssl_cert_blob->len] = 0; /* null terminate */
     ret = mbedtls_x509_crt_parse(&backend->clicert, newblob,
-                                 ssl_cert_blob->len);
+                                 ssl_cert_blob->len + 1);
     free(newblob);
 
     if(ret) {


### PR DESCRIPTION
- Increase the buffer length passed to mbedtls_x509_crt_parse to account
  for the null byte appended to the temporary blob.

Follow-up to 867ad1c which uses a null terminated copy of the
certificate blob, because mbedtls_x509_crt_parse requires PEM data
to be null terminated.

Ref: https://github.com/curl/curl/commit/867ad1c#r63439893
Ref: https://github.com/curl/curl/pull/8146

Closes #xxxx

---

Note the [documentation](https://tls.mbed.org/api/group__x509__module.html#ga033567483649030f7f859db4f4cb7e14) says null termination applies specifically to PEM data (and therefore not to DER?):

_The size of buf, including the terminating NULL byte in case of PEM encoded data._

/cc @Koromix
