### PR TITLE
AppVeyor: update build images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,9 +37,9 @@ environment:
         SHARED: ON
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 16 2019"
+        PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Release
         OPENSSL: ON
@@ -50,9 +50,9 @@ environment:
         SHARED: ON
         DISABLED_TESTS: ""
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 16 2019"
+        PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A ARM64"
         PRJ_CFG: Release
         OPENSSL: OFF
@@ -76,9 +76,9 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 16 2019"
+        PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Debug
         OPENSSL: OFF
@@ -89,9 +89,9 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501 "
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 16 2019"
+        PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Debug
         OPENSSL: OFF
@@ -102,9 +102,9 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501"
         COMPILER_PATH: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
-        PRJ_GEN: "Visual Studio 16 2019"
+        PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Debug
         OPENSSL: OFF
@@ -158,7 +158,7 @@ environment:
         COMPILER_PATH: "C:\\mingw-w64\\i686-6.3.0-posix-dwarf-rt_v5-rev1\\mingw32\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -228,17 +228,17 @@ environment:
         TESTING: OFF
         VC_VERSION: VC15
       # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 ~1056 !1233"
         CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy --with-schannel"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
         CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --with-schannel"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2019"
+      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"


### PR DESCRIPTION
- Update current VS 2019 images to VS 2022
- Use VS 2022 also for the classic MinGW job, which previously used VS 2015 because the VS 2017 image doesn't have it installed
- Use VS 2017 for the autotools builds as the VS 2019 and 2022 images don't have autotools

Fixes https://github.com/curl/curl/issues/8248