### PR TITLE
check the return value of SSL_get_ex_data()

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2491,13 +2491,12 @@ static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
     return 0;
 
   conn = (struct connectdata*) SSL_get_ex_data(ssl, connectdata_idx);
-  if(!conn)
-    return 0;
-
   data = (struct Curl_easy *) SSL_get_ex_data(ssl, data_idx);
-
   /* The sockindex has been stored as a pointer to an array element */
   sockindex_ptr = (curl_socket_t*) SSL_get_ex_data(ssl, sockindex_idx);
+  if(!conn || !data || !sockindex_ptr)
+    return 0;
+
   sockindex = (int)(sockindex_ptr - conn->sock);
 
   isproxy = SSL_get_ex_data(ssl, proxy_idx) ? TRUE : FALSE;

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -85,7 +85,7 @@ struct Curl_ssl {
   CURLcode (*sha256sum)(const unsigned char *input, size_t inputlen,
                     unsigned char *sha256sum, size_t sha256sumlen);
 
-  void (*associate_connection)(struct Curl_easy *data,
+  bool (*associate_connection)(struct Curl_easy *data,
                                struct connectdata *conn,
                                int sockindex);
   void (*disassociate_connection)(struct Curl_easy *data, int sockindex);


### PR DESCRIPTION
check the return value of `SSL_get_ex_data()` to prevent potential NULL dereference.
`SSL_set_ex_data()` called by `ossl_associate_connection()` may fail, so it is better to check the return value from `SSL_get_ex_data()`, especially `data`  which will be dereferenced in the following code. And though `sockindex`  seems meaningless in `Curl_ssl_getsessionid()` or `Curl_ssl_addsessionid()`?