### PR TITLE
misc: remove BeOS code and references

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -56,7 +56,7 @@ return 0;
 # define PLATFORM_AIX_V3
 #endif
 /* */
-#if defined(PLATFORM_SUNOS4) || defined(PLATFORM_AIX_V3) || defined(__BEOS__)
+#if defined(PLATFORM_SUNOS4) || defined(PLATFORM_AIX_V3)
 #error "O_NONBLOCK does not work on this platform"
 #endif
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -333,13 +333,6 @@ endif()
 check_library_exists_concat("${CMAKE_DL_LIBS}" dlopen HAVE_LIBDL)
 check_library_exists_concat("socket" connect      HAVE_LIBSOCKET)
 check_library_exists("c" gethostbyname "" NOT_NEED_LIBNSL)
-
-# Yellowtab Zeta needs different libraries than BeOS 5.
-if(BEOS)
-  set(NOT_NEED_LIBNSL 1)
-  check_library_exists_concat("bind" gethostbyname HAVE_LIBBIND)
-  check_library_exists_concat("bnetapi" closesocket HAVE_LIBBNETAPI)
-endif()
 
 if(NOT NOT_NEED_LIBNSL)
   check_library_exists_concat("nsl"    gethostbyname  HAVE_LIBNSL)

--- a/configure.ac
+++ b/configure.ac
@@ -1137,16 +1137,6 @@ then
                ])
 fi
 
-if test "$HAVE_GETHOSTBYNAME" != "1"
-then
-  dnl gethostbyname in the net lib - for BeOS
-  AC_CHECK_LIB(net, gethostbyname,
-               [HAVE_GETHOSTBYNAME="1"
-               LIBS="-lnet $LIBS"
-               ])
-fi
-
-
 if test "$HAVE_GETHOSTBYNAME" != "1"; then
   AC_MSG_ERROR([couldn't find libraries for gethostbyname()])
 fi

--- a/docs/FAQ
+++ b/docs/FAQ
@@ -144,9 +144,9 @@ FAQ
 
     libcurl is highly portable, it builds and works identically on numerous
     platforms, including Solaris, NetBSD, FreeBSD, OpenBSD, Darwin, HP-UX,
-    IRIX, AIX, Tru64, Linux, UnixWare, HURD, Windows, Amiga, OS/2, BeOS, Mac
-    OS X, Ultrix, QNX, OpenVMS, RISC OS, Novell NetWare, DOS, Symbian, OSF,
-    Android, Minix, IBM TPF and more...
+    IRIX, AIX, Tru64, Linux, UnixWare, HURD, Windows, Amiga, OS/2, macOS,
+    Ultrix, QNX, OpenVMS, RISC OS, Novell NetWare, DOS, Symbian, OSF, Android,
+    Minix, IBM TPF and more...
 
     libcurl is free, thread-safe, IPv6 compatible, feature rich, well
     supported and fast.
@@ -200,8 +200,8 @@ FAQ
 
   curl is not a program for a single operating system. curl exists, compiles,
   builds and runs under a wide range of operating systems, including all
-  modern Unixes (and a bunch of older ones too), Windows, Amiga, BeOS, OS/2,
-  OS X, QNX etc.
+  modern Unixes (and a bunch of older ones too), Windows, Amiga, OS/2, macOS,
+  QNX etc.
 
   1.4 When will you make curl do XXXX ?
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -86,10 +86,6 @@
 #include <sys/time.h>
 #endif
 
-#ifdef __BEOS__
-#include <support/SupportDefs.h>
-#endif
-
 /* Compatibility for non-Clang compilers */
 #ifndef __has_declspec_attribute
 #  define __has_declspec_attribute(x) 0

--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -72,12 +72,6 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
   /* Amiga */
   long flags = nonblock ? 1L : 0L;
   return IoctlSocket(sockfd, FIONBIO, (char *)&flags);
-
-#elif defined(HAVE_SETSOCKOPT_SO_NONBLOCK)
-
-  /* BeOS */
-  long b = nonblock ? 1L : 0L;
-  return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 
 #else
 #  error "no non-blocking method was found/used/set"

--- a/lib/select.c
+++ b/lib/select.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -32,11 +32,6 @@
 
 #if !defined(HAVE_SELECT) && !defined(HAVE_POLL_FINE)
 #error "We can't compile without select() or poll() support."
-#endif
-
-#if defined(__BEOS__) && !defined(__HAIKU__)
-/* BeOS has FD_SET defined in socket.h */
-#include <socket.h>
 #endif
 
 #ifdef MSDOS

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1149,7 +1149,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FCNTL_O_NONBLOCK], [
   tst_allow_fcntl_o_nonblock="unknown"
   #
   case $host_os in
-    sunos4* | aix3* | beos*)
+    sunos4* | aix3*)
       dnl O_NONBLOCK does not work on these platforms
       curl_disallow_fcntl_o_nonblock="yes"
       ;;


### PR DESCRIPTION
There has not been a mention of this OS in any commit since December
2004 (58f4af7973e3d2). The OS is also long gone.