### PR TITLE
runtests.pl: disable debuginfod

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -426,6 +426,7 @@ foreach $protocol (('ftp', 'http', 'ftps', 'https', 'no', 'all')) {
 
 delete $ENV{'SSL_CERT_DIR'} if($ENV{'SSL_CERT_DIR'});
 delete $ENV{'SSL_CERT_PATH'} if($ENV{'SSL_CERT_PATH'});
+delete $ENV{'DEBUGINFOD_URLS'} if($ENV{'DEBUGINFOD_URLS'});
 delete $ENV{'CURL_CA_BUNDLE'} if($ENV{'CURL_CA_BUNDLE'});
 
 #######################################################################


### PR DESCRIPTION
Valgrind and gdb implement this feature: as this highly slows down tests,
disable it.