### PR TITLE
cmdline-opts/gen.pl: fix option matching to improve references

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -104,7 +104,7 @@ sub printdesc {
         if($d =~ /^[^ ]/) {
             for my $k (keys %optlong) {
                 my $l = manpageify($k);
-                $d =~ s/--$k([^a-z0-9_-])/$l$1/;
+                $d =~ s/--$k([^a-z0-9_-])(\W)/$l$1$2/;
             }
         }
         # quote "bare" minuses in the output


### PR DESCRIPTION
Previously it could mistakenly match partial names when there are
options that start with the same prefix, leading to the wrong references
used.