### PR TITLE
docs: document HTTP/2 not insisting on TLS 1.2

### DIFF
--- a/docs/cmdline-opts/http2.d
+++ b/docs/cmdline-opts/http2.d
@@ -17,3 +17,7 @@ handshake. curl does this by default.
 
 For HTTP, this means curl will attempt to upgrade the request to HTTP/2 using
 the Upgrade: request header.
+
+When curl uses HTTP/2 over HTTPS, it does not itself insist on TLS 1.2 or
+higher even though that is required by the specification. A user can add this
+version requirement with --tlsv1.2.

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -47,6 +47,10 @@ Enforce HTTP 1.1 requests.
 .IP CURL_HTTP_VERSION_2_0
 Attempt HTTP 2 requests. libcurl will fall back to HTTP 1.1 if HTTP 2 cannot be
 negotiated with the server. (Added in 7.33.0)
+
+When libcurl uses HTTP/2 over HTTPS, it does not itself insist on TLS 1.2 or
+higher even though that is required by the specification. A user can add this
+version requirement with \fICURLOPT_SSLVERSION(3)\fP.
 
 The alias \fICURL_HTTP_VERSION_2\fP was added in 7.43.0 to better reflect the
 actual protocol name.


### PR DESCRIPTION
Both for --http2 and CURLOPT_HTTP_VERSION.

Reported-by: jhoyla on github
Fixes #8235