### PR TITLE
cmdline-opts/gen.pl: inhibit "added in" before 7.50

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -159,8 +159,8 @@ sub too_old {
     elsif($version =~ /^(\d+)\.(\d+)/) {
         $a = $1 * 1000 + $2 * 10;
     }
-    if($a < 7300) {
-        # we consider everything before 7.30.0 to be too old to mention
+    if($a < 7500) {
+        # we consider everything before 7.50.0 to be too old to mention
         # specific changes for
         return 1;
     }


### PR DESCRIPTION
Bump up the oldest version to consider for these texts from 7.30.0 to
7.50.0. 7.50.0 was released on Jul 21 2016.

This removes 35 mentions from the generated output.