### PR TITLE
Fix #8292: allow building curl when wolfssl configured with --enable-opensslextra

### DIFF
--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -20,9 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         build:
-        - name: wolfssl
+        - name: wolfssl (configured with --enable-all)
           install:
-          configure: --with-wolfssl=$HOME/wssl --enable-debug --enable-werror
+          wolfssl-configure: --enable-all
+          curl-configure: --with-wolfssl=$HOME/wssl --enable-debug --enable-werror
+        - name: wolfssl (configured with --enable-opensslextra)
+          install:
+          wolfssl-configure: --enable-opensslextra
+          curl-configure: --with-wolfssl=$HOME/wssl --enable-debug --enable-werror
 
     steps:
     - run: |
@@ -35,14 +40,14 @@ jobs:
        tar -xzf v5.0.0-stable.tar.gz
        cd wolfssl-5.0.0-stable
        ./autogen.sh
-       ./configure --enable-tls13 --enable-opensslextra --enable-harden --prefix=$HOME/wssl
+       ./configure --enable-tls13 ${{ matrix.build.wolfssl-configure }} --enable-harden --prefix=$HOME/wssl
        make && make install
 
       name: 'install wolfssl'
 
     - uses: actions/checkout@v2
 
-    - run: ./buildconf && LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }} && make V=1
+    - run: ./buildconf && LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" ./configure --enable-warnings --enable-werror ${{ matrix.build.curl-configure }} && make V=1
       name: 'configure and build'
 
     - run: make V=1 test-ci

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -35,7 +35,7 @@ jobs:
        tar -xzf v5.0.0-stable.tar.gz
        cd wolfssl-5.0.0-stable
        ./autogen.sh
-       ./configure --enable-tls13 --enable-all --enable-harden --prefix=$HOME/wssl
+       ./configure --enable-tls13 --enable-opensslextra --enable-harden --prefix=$HOME/wssl
        make && make install
 
       name: 'install wolfssl'

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -32,7 +32,7 @@ extern const struct HMAC_params Curl_HMAC_SHA256[1];
 /* SHA256_DIGEST_LENGTH is an enum value in wolfSSL. Need to import it from
  * sha.h*/
 #include <wolfssl/options.h>
-#include <openssl/sha.h>
+#include <wolfssl/openssl/sha.h>
 #else
 #define SHA256_DIGEST_LENGTH 32
 #endif

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -83,7 +83,12 @@ static void MD5_Final(unsigned char *digest, MD5_CTX *ctx)
 #elif defined(USE_OPENSSL_MD5) || defined(USE_WOLFSSL_MD5)
 
 /* When OpenSSL or wolfSSL is available, we use their MD5 functions. */
+#if defined(USE_OPENSSL_MD5)
 #include <openssl/md5.h>
+#elif defined(USE_WOLFSSL_MD5)
+#include <wolfssl/openssl/md5.h>
+#endif
+
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -69,8 +69,12 @@
 
 #if defined(USE_OPENSSL_SHA256)
 
-/* When OpenSSL is available we use the SHA256-function from OpenSSL */
+/* When OpenSSL or wolfSSL is available is available we use their SHA256-function */
+#if defined(USE_OPENSSL)
 #include <openssl/evp.h>
+#elif defined(USE_WOLFSSL)
+#include <wolfssl/openssl/evp.h>
+#endif
 
 #include "curl_memory.h"
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -69,7 +69,9 @@
 
 #if defined(USE_OPENSSL_SHA256)
 
-/* When OpenSSL or wolfSSL is available is available we use their SHA256-function */
+/* When OpenSSL or wolfSSL is available is available we use their
+ * SHA256-functions.
+ */
 #if defined(USE_OPENSSL)
 #include <openssl/evp.h>
 #elif defined(USE_WOLFSSL)


### PR DESCRIPTION
This MR puts all the `#include`s of openssl files behind wolfssl `#ifdef`s so that we can use the wolfssl/ prefixed include paths. 

Without these curl only builds when wolfssl is built with enable-all. Running CI against the first commit should fail showing why the fix is useful.

fixes #8292 