### PR TITLE
Change qlog file extension to `.sqlog`

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -67,7 +67,7 @@ CURLcode Curl_qlogdir(struct Curl_easy *data,
       result = Curl_dyn_add(&fname, hex);
     }
     if(!result)
-      result = Curl_dyn_add(&fname, ".qlog");
+      result = Curl_dyn_add(&fname, ".sqlog");
 
     if(!result) {
       int qlogfd = open(Curl_dyn_ptr(&fname), QLOGMODE,


### PR DESCRIPTION
quiche has just switched it's qlog serialization format to JSON-SEQ by default . The spec says this SHOULD use `.sqlog` extension.

I believe ngtcp2 also supports JSON-SEQ by default as of https://github.com/ngtcp2/ngtcp2/commit/9baf06fc3f352a1d062b6953ae1de22cae30639d

Let's update curl so that tools know what format we are using!