### PR TITLE
docs: update IETF links to use datatracker

### DIFF
--- a/docs/ALTSVC.md
+++ b/docs/ALTSVC.md
@@ -10,7 +10,7 @@ curl features support for the Alt-Svc: HTTP header.
 
 ## Standard
 
-[RFC 7838](https://tools.ietf.org/html/rfc7838)
+[RFC 7838](https://datatracker.ietf.org/doc/html/rfc7838)
 
 # Alt-Svc cache file format
 

--- a/docs/HSTS.md
+++ b/docs/HSTS.md
@@ -5,7 +5,7 @@ HTTP Strict-Transport-Security. Added as experimental in curl
 
 ## Standard
 
-[HTTP Strict Transport Security](https://tools.ietf.org/html/rfc6797)
+[HTTP Strict Transport Security](https://datatracker.ietf.org/doc/html/rfc6797)
 
 ## Behavior
 

--- a/docs/HTTP-COOKIES.md
+++ b/docs/HTTP-COOKIES.md
@@ -20,12 +20,12 @@
   In 2011, [RFC6265](https://www.ietf.org/rfc/rfc6265.txt) was finally
   published and details how cookies work within HTTP. In 2016, an update which
   added support for prefixes was
-  [proposed](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00),
+  [proposed](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-prefixes-00),
   and in 2017, another update was
-  [drafted](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-alone-01)
+  [drafted](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-alone-01)
   to deprecate modification of 'secure' cookies from non-secure origins. Both
   of these drafts have been incorporated into a proposal to
-  [replace](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02)
+  [replace](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-02)
   RFC6265. Cookie prefixes and secure cookie modification protection has been
   implemented by curl.
 

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -118,4 +118,4 @@ can use that hint to create a new connection asynchronously. For libcurl, we
 may introduce a way to bring such clues to the application and/or let a
 subsequent request use the alternate route automatically.
 
-[Detailed in RFC 7838](https://tools.ietf.org/html/rfc7838)
+[Detailed in RFC 7838](https://datatracker.ietf.org/doc/html/rfc7838)

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1092,7 +1092,7 @@ for older and later versions as things do not change drastically that often.
 [1]: https://curl.se/libcurl/c/curl_easy_setopt.html
 [2]: https://curl.se/libcurl/c/curl_easy_init.html
 [3]: https://c-ares.org/
-[4]: https://tools.ietf.org/html/rfc7230 "RFC 7230"
+[4]: https://datatracker.ietf.org/doc/html/rfc7230 "RFC 7230"
 [5]: https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html
 [6]: https://curl.se/docs/manpage.html#--compressed
 [7]: https://curl.se/libcurl/c/curl_multi_socket_action.html
@@ -1103,4 +1103,4 @@ for older and later versions as things do not change drastically that often.
 [12]: https://curl.se/libcurl/c/curl_multi_fdset.html
 [13]: https://curl.se/libcurl/c/curl_multi_add_handle.html
 [14]: https://curl.se/libcurl/c/curl_multi_info_read.html
-[15]: https://tools.ietf.org/html/rfc7231#section-3.1.2.2
+[15]: https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.2

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -196,7 +196,7 @@ problems may have been fixed or changed somewhat since this was written.
  something beyond ascii but currently libcurl will only pass in the verbatim
  string the app provides. There are several browsers that already do this
  encoding. The key seems to be the updated draft to RFC2231:
- https://tools.ietf.org/html/draft-reschke-rfc2231-in-http-02
+ https://datatracker.ietf.org/doc/html/draft-reschke-rfc2231-in-http-02
 
 1.5 Expect-100 meets 417
 
@@ -808,7 +808,7 @@ problems may have been fixed or changed somewhat since this was written.
 
  Curl sends DNS requests for hostnames with a .onion TLD. This leaks
  information about what the user is attempting to access, and violates this
- requirement of RFC7686: https://tools.ietf.org/html/rfc7686
+ requirement of RFC7686: https://datatracker.ietf.org/doc/html/rfc7686
 
  Issue: https://github.com/curl/curl/issues/543
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ eventually remove the "experimental" label from this functionality.
 
 As a DNS version of alt-svc and also a pre-requisite for ECH (see below).
 
-See: https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-02
+See: https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-02
 
 ## ECH (Encrypted Client Hello - formerly known as ESNI)
 

--- a/docs/SSL-PROBLEMS.md
+++ b/docs/SSL-PROBLEMS.md
@@ -70,7 +70,7 @@
 
   References:
 
-  https://tools.ietf.org/html/draft-popov-tls-prohibiting-rc4-01
+  https://datatracker.ietf.org/doc/html/draft-popov-tls-prohibiting-rc4-01
 
 ## Allow BEAST
 

--- a/docs/TODO
+++ b/docs/TODO
@@ -413,7 +413,7 @@
 
  https://bugzilla.mozilla.org/show_bug.cgi?id=1220810
 
- https://tools.ietf.org/html/draft-ietf-dnsop-let-localhost-be-localhost-02
+ https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-let-localhost-be-localhost-02
 
 1.28 FD_CLOEXEC
 
@@ -554,7 +554,7 @@
  HOST is a command for a client to tell which host name to use, to offer FTP
  servers named-based virtual hosting:
 
- https://tools.ietf.org/html/rfc7151
+ https://datatracker.ietf.org/doc/html/rfc7151
 
 4.2 Alter passive/active on failure and retry
 
@@ -887,7 +887,7 @@
  that previously (in older TLS version) were not set. The clienthello
  extension adds padding to avoid that size range.
 
- https://tools.ietf.org/html/rfc7685
+ https://datatracker.ietf.org/doc/html/rfc7685
  https://github.com/curl/curl/issues/2299
 
 14. GnuTLS

--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -5,7 +5,7 @@
 The official "URL syntax" is primarily defined in these two different
 specifications:
 
- - [RFC 3986](https://tools.ietf.org/html/rfc3986) (although URL is called
+ - [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) (although URL is called
    "URI" in there)
  - [The WHATWG URL Specification](https://url.spec.whatwg.org/)
 
@@ -331,7 +331,7 @@ Search for an empty DN and request information about the
     ldap://ldap.example.com/?rootDomainNamingContext
 
 For more information about the individual components of a LDAP URL please
-see [RFC 4516](https://tools.ietf.org/html/rfc4516).
+see [RFC 4516](https://datatracker.ietf.org/doc/html/rfc4516).
 
 ## POP3
 

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2019 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2019 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -21,7 +21,7 @@
  ***************************************************************************/
 /*
  * The Alt-Svc: header is defined in RFC 7838:
- * https://tools.ietf.org/html/rfc7838
+ * https://datatracker.ietf.org/doc/html/rfc7838
  */
 #include "curl_setup.h"
 

--- a/lib/dotdot.c
+++ b/lib/dotdot.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/dotdot.c
+++ b/lib/dotdot.c
@@ -32,7 +32,7 @@
 
 /*
  * "Remove Dot Segments"
- * https://tools.ietf.org/html/rfc3986#section-5.2.4
+ * https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
  */
 
 /*

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -39,7 +39,7 @@
 
 /* Portable character check (remember EBCDIC). Do not use isalnum() because
    its behavior is altered by the current locale.
-   See https://tools.ietf.org/html/rfc3986#section-2.3
+   See https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
 */
 bool Curl_isunreserved(unsigned char in)
 {

--- a/lib/hostcheck.c
+++ b/lib/hostcheck.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/hostcheck.c
+++ b/lib/hostcheck.c
@@ -48,7 +48,7 @@
  *  "foo.host.com" matches "*.host.com".
  *
  * We use the matching rule described in RFC6125, section 6.4.3.
- * https://tools.ietf.org/html/rfc6125#section-6.4.3
+ * https://datatracker.ietf.org/doc/html/rfc6125#section-6.4.3
  *
  * In addition: ignore trailing dots in the host names and wildcards, so that
  * the names are used normalized. This is what the browsers do.

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2020 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2020 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -21,7 +21,7 @@
  ***************************************************************************/
 /*
  * The Strict-Transport-Security header is defined in RFC 6797:
- * https://tools.ietf.org/html/rfc6797
+ * https://datatracker.ietf.org/doc/html/rfc6797
  */
 #include "curl_setup.h"
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/http.c
+++ b/lib/http.c
@@ -4212,7 +4212,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
 
       if(conn->handler->protocol & PROTO_FAMILY_HTTP) {
         /*
-         * https://tools.ietf.org/html/rfc7230#section-3.1.2
+         * https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.2
          *
          * The response code is always a three-digit number in HTTP as the spec
          * says. We allow any three-digit number here, but we cannot make

--- a/lib/url.c
+++ b/lib/url.c
@@ -948,7 +948,7 @@ socks_proxy_info_matches(const struct proxy_info *data,
 
   /* the user information is case-sensitive
      or at least it is not defined as case-insensitive
-     see https://tools.ietf.org/html/rfc3986#section-3.2.1 */
+     see https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1 */
   if(!data->user != !needle->user)
     return FALSE;
   /* curl_strequal does a case insentive comparison, so do not use it here! */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2739,7 +2739,7 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
 
      The "-no_ticket" option was introduced in OpenSSL 0.9.8j. It's a flag to
      disable "rfc4507bis session ticket support".  rfc4507bis was later turned
-     into the proper RFC5077 it seems: https://tools.ietf.org/html/rfc5077
+     into the proper RFC5077 it seems: https://datatracker.ietf.org/doc/html/rfc5077
 
      The enabled extension concerns the session management. I wonder how often
      libcurl stops a connection and then resumes a TLS session. Also, sending
@@ -2944,7 +2944,7 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
   /* Import certificates from the Windows root certificate store if requested.
      https://stackoverflow.com/questions/9507184/
      https://github.com/d3x0r/SACK/blob/master/src/netlib/ssl_layer.c#L1037
-     https://tools.ietf.org/html/rfc5280 */
+     https://datatracker.ietf.org/doc/html/rfc5280 */
   if((SSL_CONN_CONFIG(verifypeer) || SSL_CONN_CONFIG(verifyhost)) &&
      (SSL_SET_OPTION(native_ca_store))) {
     X509_STORE *store = SSL_CTX_get_cert_store(backend->ctx);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2738,8 +2738,8 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
      implementations is desired."
 
      The "-no_ticket" option was introduced in OpenSSL 0.9.8j. It's a flag to
-     disable "rfc4507bis session ticket support".  rfc4507bis was later turned
-     into the proper RFC5077 it seems: https://datatracker.ietf.org/doc/html/rfc5077
+     disable "rfc4507bis session ticket support". rfc4507bis was later turned
+     into the proper RFC5077: https://datatracker.ietf.org/doc/html/rfc5077
 
      The enabled extension concerns the session management. I wonder how often
      libcurl stops a connection and then resumes a TLS session. Also, sending


### PR DESCRIPTION
The tools.ietf.org domain has been deprecated a while now, with the
links being redirected to datatracker.ietf.org.

Rather than make people eat that redirect time, this change switches the
URL to a more canonical source.
