### PR TITLE
test3021: disable all msys2 path transformation

### DIFF
--- a/tests/data/test3021
+++ b/tests/data/test3021
@@ -33,7 +33,7 @@ SFTP correct sha256 host key
 <setenv>
 # Needed for MSYS2 to not treat the argument as a POSIX path list
 # that has to be converted to Windows paths
-MSYS2_ARG_CONV_EXCL=/
+MSYS2_ARG_CONV_EXCL=*
 </setenv>
 <file name="log/file%TESTNUMBER.txt">
 test

--- a/tests/data/test3022
+++ b/tests/data/test3022
@@ -33,7 +33,7 @@ SCP correct sha256 host key
 <setenv>
 # Needed for MSYS2 to not treat the argument as a POSIX path list
 # that has to be converted to Windows paths
-MSYS2_ARG_CONV_EXCL=/
+MSYS2_ARG_CONV_EXCL=*
 </setenv>
 <file name="log/file%TESTNUMBER.txt">
 test


### PR DESCRIPTION
- Disable all MSYS2 path transformation in test3021 and test3022.

Prior to this change path transformation in those tests was disabled
only for arguments that start with forward slashes. However arguments
that are in base64 contain forward slashes at any position and caused
unwanted translations.

== Info: Denied establishing ssh session: mismatch sha256 fingerprint.
Remote +/EYG2YDzDGm6yiwepEMSuExgRRMoTi8Di1UN3kixZw= is not equal to
+C:/msys64/EYG2YDzDGm6yiwepEMSuExgRRMoTi8Di1UN3kixZw

In the above example an argument containing a base64 sha256 fingerprint
was passed to curl after MSYS2 translated +/ into +C:/msys64/, and then
the fingerprint didn't match what was expected.

Ref: https://www.msys2.org/wiki/Porting/

Fixes https://github.com/curl/curl/issues/8084
Closes #xxxx