### PR TITLE
tests/memanalyze.pl: also count and show "total allocations"

### DIFF
--- a/tests/memanalyze.pl
+++ b/tests/memanalyze.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -56,7 +56,8 @@ while(1) {
     }
 }
 
-my $maxmem;
+my $memsum; # the total number of memory allocated over the lifetime
+my $maxmem; # the high water mark
 
 sub newtotal {
     my ($newtot)=@_;
@@ -150,6 +151,7 @@ while(<FILE>) {
 
             $sizeataddr{$addr}=$size;
             $totalmem += $size;
+            $memsum += $size;
 
             if($trace) {
                 print "MALLOC: malloc($size) at $source:$linenum",
@@ -175,6 +177,7 @@ while(<FILE>) {
 
             $sizeataddr{$addr}=$size;
             $totalmem += $size;
+            $memsum += $size;
 
             if($trace) {
                 print "CALLOC: calloc($arg1,$arg2) at $source:$linenum",
@@ -196,6 +199,7 @@ while(<FILE>) {
             $sizeataddr{$oldaddr}=0;
 
             $totalmem += $newsize;
+            $memsum += $size;
             $sizeataddr{$newaddr}=$newsize;
 
             if($trace) {
@@ -218,6 +222,7 @@ while(<FILE>) {
             $sizeataddr{$addr}=$size;
 
             $totalmem += $size;
+            $memsum += $size;
 
             if($trace) {
                 printf("STRDUP: $size bytes at %s, makes totally: %d bytes\n",
@@ -237,6 +242,7 @@ while(<FILE>) {
             $sizeataddr{$addr}=$size;
 
             $totalmem += $size;
+            $memsum += $size;
 
             if($trace) {
                 printf("WCSDUP: $size bytes at %s, makes totally: %d bytes\n",
@@ -422,4 +428,5 @@ if($verbose) {
         "Operations: ".($mallocs + $callocs + $reallocs + $strdups + $wcsdups + $sends + $recvs + $sockets)."\n";
 
     print "Maximum allocated: $maxmem\n";
+    print "Total allocated: $memsum\n";
 }


### PR DESCRIPTION
This is the total number of bytes allocated, increasing for new
allocations and never reduced when freed. The existing "Maximum
allocated" is the high water mark.