### PR TITLE
openssl: fix `ctx_option_t` for OpenSSL v3+

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2424,6 +2424,8 @@ set_ssl_version_min_max(SSL_CTX *ctx, struct connectdata *conn)
 
 #ifdef OPENSSL_IS_BORINGSSL
 typedef uint32_t ctx_option_t;
+#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
+typedef uint64_t ctx_option_t;
 #else
 typedef long ctx_option_t;
 #endif


### PR DESCRIPTION
The options have been changed to `uint64_t` in
https://github.com/openssl/openssl/commit/56bd17830f2d5855b533d923d4e0649d3ed61d11.

Without this, I get the following compile errors when building curl 7.80.0 with OpenSSL 3.0.1 using GCC 10 on Linux:

```
vtls/openssl.c: In function 'ossl_connect_step1':
vtls/openssl.c:2737:17: error: overflow in conversion from 'long long unsigned int' to 'ctx_option_t' {aka 'long int'} changes value from '2147485776' to '-2147481520' [-Werror=overflow]
 2737 |   ctx_options = SSL_OP_ALL;
      |                 ^~~~~~~~~~
vtls/openssl.c:2756:20: error: conversion from 'long long unsigned int' to 'ctx_option_t' {aka 'long int'} may change value [-Werror=conversion]
 2756 |     ctx_options &= ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
      |                    ^
```