### PR TITLE
schannel: restore debug message in schannel_connect_step2

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1037,6 +1037,10 @@ schannel_connect_step2(struct Curl_easy *data, struct connectdata *conn,
 
   doread = (connssl->connecting_state != ssl_connect_2_writing) ? TRUE : FALSE;
 
+  DEBUGF(infof(data,
+               "schannel: SSL/TLS connection with %s port %hu (step 2/3)",
+               SSL_HOST_NAME(), conn->remote_port));
+
   if(!backend->cred || !backend->ctxt)
     return CURLE_SSL_CONNECT_ERROR;
 


### PR DESCRIPTION
This is a follow-up to the parent commit 2218c3a which removed the debug
message to avoid an unused variable warning. The message has been
reworked to avoid the warning.

Ref: https://github.com/curl/curl/pull/8320#issuecomment-1022957904

Closes #xxxx