### PR TITLE
mbedtls: remove #include <mbedtls/certs.h>

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -41,9 +41,6 @@
 #include <mbedtls/net.h>
 #endif
 #include <mbedtls/ssl.h>
-#if MBEDTLS_VERSION_NUMBER < 0x03000000
-#include <mbedtls/certs.h>
-#endif
 #include <mbedtls/x509.h>
 
 #include <mbedtls/error.h>


### PR DESCRIPTION
mbedtls/certs.h file contains only certificates example (all definitions is beginning by mbedtls_test_*). None of them is used so we can avoid include the file.