### PR TITLE
remove the unnecessary use of ternary operator

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -199,7 +199,7 @@ static bool conncache_add_bundle(struct conncache *connc,
 {
   void *p = Curl_hash_add(&connc->hash, key, strlen(key), bundle);
 
-  return p?TRUE:FALSE;
+  return p;
 }
 
 static void conncache_remove_bundle(struct conncache *connc,


### PR DESCRIPTION
It's look like it return a bool value and it's obvious if the `p` is not null it is treated as true value and if null then treated as false. So, I don't think we need a ternary operator here.