### PR TITLE
tool_cb_prg: show 100% progress bar for chunked and http2

### DIFF
--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
@@ -35,6 +35,11 @@ Pass a pointer to a double to receive the content-length of the download. This
 is the value read from the Content-Length: field. Since 7.19.4, this returns
 -1 if the size is not known.
 
+Some transfers do not have a Content-Length: and instead the server signals
+when the download is complete by using a termination marker (eg HTTP/2
+end-of-stream). In such a case the received content size is the content-length.
+(Added in 7.82.0)
+
 \fICURLINFO_CONTENT_LENGTH_DOWNLOAD_T(3)\fP is a newer replacement that returns a more
 sensible variable type.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
@@ -34,6 +34,12 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
 Pass a pointer to a \fIcurl_off_t\fP to receive the content-length of the
 download. This is the value read from the Content-Length: field. Stores -1 if
 the size is not known.
+
+Some transfers do not have a Content-Length: and instead the server signals
+when the download is complete by using a termination marker (eg HTTP/2
+end-of-stream). In such a case the received content size is the content-length.
+(Added in 7.82.0)
+
 .SH PROTOCOLS
 HTTP(S)
 .SH EXAMPLE

--- a/lib/http.c
+++ b/lib/http.c
@@ -1654,6 +1654,19 @@ CURLcode Curl_http_done(struct Curl_easy *data,
     return CURLE_GOT_NOTHING;
   }
 
+  /* Set the total download size for when it is not known until end of transfer
+     (eg successful finish of chunked encoding or HTTP/2 stream). */
+  if(status == CURLE_OK && data->req.size == -1 &&
+     !(data->progress.flags & PGRS_DL_SIZE_KNOWN) &&
+     !premature && !conn->bits.retry && !data->set.connect_only &&
+     (
+#ifdef USE_NGHTTP2
+      (conn->httpversion == 20 && http->close_handled) ||
+#endif
+      data->req.chunk)) {
+    Curl_pgrsSetDownloadSize(data, data->req.bytecount);
+  }
+
   return CURLE_OK;
 }
 

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -158,7 +158,7 @@ int tool_progress_cb(void *clientp,
   else
     point = dlnow + ulnow + bar->initial_size;
 
-  if(bar->calls) {
+  if(bar->calls && total == bar->prevtotal) {
     /* after first call... */
     if(total) {
       /* we know the total data to get... */
@@ -181,7 +181,7 @@ int tool_progress_cb(void *clientp,
   /* simply count invokes */
   bar->calls++;
 
-  if((total > 0) && (point != bar->prev)) {
+  if((total > 0) && ((point != bar->prev) || (total != bar->prevtotal))) {
     char line[MAX_BARLENGTH + 1];
     char format[40];
     double frac;
@@ -190,9 +190,10 @@ int tool_progress_cb(void *clientp,
     int num;
     if(point > total)
       /* we have got more than the expected total! */
-      total = point;
+      frac = 1;
+    else
+      frac = (double)point / (double)total;
 
-    frac = (double)point / (double)total;
     percent = frac * 100.0;
     barwidth = bar->width - 7;
     num = (int) (((double)barwidth) * frac);
@@ -206,6 +207,7 @@ int tool_progress_cb(void *clientp,
   fflush(bar->out);
   bar->prev = point;
   bar->prevtime = now;
+  bar->prevtotal = total;
 
   if(config->readbusy) {
     config->readbusy = FALSE;

--- a/src/tool_cb_prg.h
+++ b/src/tool_cb_prg.h
@@ -30,6 +30,7 @@ struct ProgressData {
   int         calls;
   curl_off_t  prev;
   struct timeval prevtime;
+  curl_off_t  prevtotal;
   int         width;
   FILE       *out;  /* where to write everything to */
   curl_off_t  initial_size;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -183,7 +183,7 @@ test1432 test1433 test1434 test1435 test1436 test1437 test1438 test1439 \
 test1440 test1441 test1442 test1443 test1444 test1445 test1446 test1447 \
 test1448 test1449 test1450 test1451 test1452 test1453 test1454 test1455 \
 test1456 test1457 test1458 test1459 test1460 test1461 test1462 test1463 \
-test1464 test1465 test1466 \
+test1464 test1465 test1466 test1467 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1467
+++ b/tests/data/test1467
@@ -1,0 +1,82 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked Transfer-Encoding
+progressbar
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Connection: mooo
+
+6
+chunk1
+7
+chunk2
+
+0
+
+</data>
+<datacheck>
+HTTP/1.1 200 OK
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Connection: mooo
+
+chunk1chunk2
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP GET with progress bar and chunked transfer
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -# --stderr log/stderrlog%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<file name="log/stderrlog%TESTNUMBER" mode="text">
+correct
+</file>
+#
+# Check that the final progress bar is 100.0%
+#
+# Chunked transfer download content size is unknown until last-chunk (0).
+# curl's progress callback receives the known download total and changes format
+# from spaceship (size unknown) to bar (size known).
+# It looks sort of like this (condensed for example):
+# -=O=-          #     #    #     #
+# \r############################ 100.0%
+#
+# Since this example is very fast it is highly likely the size is known
+# instantly and therefore the spaceship is never shown.
+#
+<stripfile>
+s/.*\r#+ 100.0%/correct/
+</stripfile>
+</verify>
+
+</testcase>

--- a/tests/data/test599
+++ b/tests/data/test599
@@ -80,7 +80,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER log/ip%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <file name="log/ip%TESTNUMBER">
-CL -1
+CL 50
 </file>
 </verify>
 </testcase>


### PR DESCRIPTION
- Update the total download size of chunked and unknown size http/2
  transfers when they complete successfully.

When the total download size is not known initially then a spaceship
type progress is used. Sometimes it may happen that the download size is
not known until the end, such as with chunked encoding or some HTTP/2
transfers. In that case it is useful to update the total download size
so that at the end the progress switches from the spaceship to the
normal progress bar to show 100% and signal the download was completed
successfully.

Before (condensed for example purpose):
 -=O=-          #     #    #     #

After (condensed for example purpose):
############################ 100.0%

Fixes https://github.com/curl/curl/issues/8302
Closes #xxxx

---

Not totally sure about the logic in http done