### PR TITLE
docs/TheArtOfHttpScripting: fix example URL

### DIFF
--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -270,7 +270,7 @@
  And to use curl to post this form with the same data filled in as before, we
  could do it like:
 
-    curl --data "birthyear=1905&press=%20OK%20" http://www.example.com/when.cgi
+    curl --data "birthyear=1905&press=%20OK%20" http://www.example.com/when/junk.cgi
 
  This kind of POST will use the Content-Type
  `application/x-www-form-urlencoded` and is the most widely used POST kind.


### PR DESCRIPTION
The GET form post example URL is given as `http://www.example.com/when/junk.cgi`. The analogous POST form example uses URL `http://www.example.com/when.cgi` where it should use `http://www.example.com/when/junk.cgi` as before.