### PR TITLE
Capitalize the name 'Netscape' consistently in docs

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -603,7 +603,7 @@ FAQ
   have no built-in support for that, so it will be treated just like any other
   contents.
 
-  .pac files are a netscape invention and are sometimes used by organizations
+  .pac files are a Netscape invention and are sometimes used by organizations
   to allow them to differentiate which proxies to use. The .pac contents is
   just a Javascript program that gets invoked by the browser and that returns
   the name of the proxy to connect to. Since curl does not support Javascript,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -51,7 +51,7 @@
  - maximum amount of redirects to follow
  - custom HTTP request
  - cookie get/send fully parsed
- - reads/writes the netscape cookie file format
+ - reads/writes the Netscape cookie file format
  - custom headers (replace/remove internally generated headers)
  - custom user-agent string
  - custom referrer string

--- a/docs/HTTP-COOKIES.md
+++ b/docs/HTTP-COOKIES.md
@@ -36,7 +36,7 @@
   sharing the cookies with browsers, only to see browsers move away from that
   format. Modern browsers no longer use it, while curl still does.
 
-  The netscape cookie file format stores one cookie per physical line in the
+  The Netscape cookie file format stores one cookie per physical line in the
   file with a bunch of associated meta data, each field separated with
   TAB. That file is called the cookiejar in curl terminology.
 
@@ -112,7 +112,7 @@
 
   Provide detailed information about a single cookie to add to the internal
   storage of cookies. Pass in the cookie as a HTTP header with all the details
-  set, or pass in a line from a netscape cookie file. This option can also be
+  set, or pass in a line from a Netscape cookie file. This option can also be
   used to flush the cookies etc.
 
   `CURLINFO_COOKIELIST`

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -445,7 +445,7 @@ cookies from the 'headers' file like:
 
 While saving headers to a file is a working way to store cookies, it is
 however error-prone and not the preferred way to do this. Instead, make curl
-save the incoming cookies using the well-known netscape cookie format like
+save the incoming cookies using the well-known Netscape cookie format like
 this:
 
     curl -c cookies.txt www.example.com
@@ -458,13 +458,13 @@ non-existing file to trigger the cookie awareness like:
     curl -L -b empty.txt www.example.com
 
 The file to read cookies from must be formatted using plain HTTP headers OR as
-netscape's cookie file. Curl will determine what kind it is based on the file
+Netscape's cookie file. Curl will determine what kind it is based on the file
 contents. In the above command, curl will parse the header and store the
 cookies received from www.example.com. curl will send to the server the
 stored cookies which match the request as it follows the location. The file
 "empty.txt" may be a nonexistent file.
 
-To read and write cookies from a netscape cookie file, you can set both `-b`
+To read and write cookies from a Netscape cookie file, you can set both `-b`
 and `-c` to use the same file:
 
     curl -b cookies.txt -c cookies.txt www.example.com


### PR DESCRIPTION
I notice the name "Netscape" isn't capitalized consistently throughout the documentation. This small PR addresses that.