### PR TITLE
scripts/completion.pl: improve zsh completion

### DIFF
--- a/scripts/completion.pl
+++ b/scripts/completion.pl
@@ -102,11 +102,20 @@ sub parse_main_opts {
             $option .= '}' if defined $short;
             $option .= '\'[' . trim($desc) . ']\'' if defined $desc;
 
-            $option .= ":'$arg'" if defined $arg;
-
-            $option .= ':_files'
-                if defined $arg and ($arg eq '<file>' || $arg eq '<filename>'
-                    || $arg eq '<dir>');
+            if (defined $arg) {
+                $option .= ":'$arg'";
+                if ($arg =~ /<file ?(name)?>|<path>/) {
+                    $option .= ':_files';
+                } elsif ($arg =~ /<dir>/) {
+                    $option .= ":'_path_files -/'";
+                } elsif ($arg =~ /<url>/i) {
+                    $option .= ':_urls';
+                } elsif ($long =~ /ftp/ && $arg =~ /<method>/) {
+                    $option .= ":'(multicwd nocwd singlecwd)'";
+                } elsif ($arg =~ /<method>/) {
+                    $option .= ":'(DELETE GET HEAD POST PUT)'";
+                }
+            }
         }
 
         push @list, $option;


### PR DESCRIPTION
Some small improvements to the zsh completion, I mainly wanted to fix `--unix-socket` having no completion, but there are a few more low-hanging fruits.

```
- Detect all spellings of <file>, <file name> etc as well as <path>.
- Only complete directories for <dir>.
- Complete URLs for <URL>.
- Complete --request and --ftp-method.
```