### PR TITLE
curl/docs/libcurl/*: fix some formatting of man pages

### DIFF
--- a/docs/libcurl/curl_getdate.3
+++ b/docs/libcurl/curl_getdate.3
@@ -62,7 +62,6 @@ first three letters. This is usually not info that adds anything.
 If a decimal number of the form YYYYMMDD appears, then YYYY is read as the
 year, MM as the month number and DD as the day of the month, for the specified
 calendar date.
-.PP
 .SH EXAMPLE
 .nf
  time_t t;
@@ -110,5 +109,5 @@ On systems with 64 bit time_t: if the year is less than 1583, this function
 will return -1. (The Gregorian calendar was first introduced 1582 so no "real"
 dates in this way of doing dates existed before then.)
 .SH "SEE ALSO"
-.BR curl_easy_escape "(3), " curl_easy_unescape "(3), "
-.BR CURLOPT_TIMECONDITION "(3), " CURLOPT_TIMEVALUE "(3) "
+.BR curl_easy_escape "(3), " curl_easy_unescape "(3),"
+.BR CURLOPT_TIMECONDITION "(3), " CURLOPT_TIMEVALUE "(3)"

--- a/docs/libcurl/curl_global_init_mem.3
+++ b/docs/libcurl/curl_global_init_mem.3
@@ -73,5 +73,5 @@ Added in 7.12.0
 CURLE_OK (0) means everything was ok, non-zero means an error occurred as
 \fI<curl/curl.h>\fP defines - see \fIlibcurl-errors(3)\fP.
 .SH "SEE ALSO"
-.BR curl_global_init "(3), "
-.BR curl_global_cleanup "(3), "
+.BR curl_global_init (3),
+.BR curl_global_cleanup (3)

--- a/docs/libcurl/curl_url_cleanup.3
+++ b/docs/libcurl/curl_url_cleanup.3
@@ -27,7 +27,7 @@ curl_url_cleanup - free a CURLU handle
 #include <curl/curl.h>
 
 void curl_url_cleanup(CURLU *handle);
-.fi
+.
 .SH DESCRIPTION
 Frees all the resources associated with the given CURLU handle!
 .SH EXAMPLE

--- a/docs/libcurl/curl_url_dup.3
+++ b/docs/libcurl/curl_url_dup.3
@@ -27,7 +27,7 @@ curl_url_dup - duplicate a CURLU handle
 #include <curl/curl.h>
 
 CURLU *curl_url_dup(CURLU *inhandle);
-.fi
+.
 .SH DESCRIPTION
 Duplicates a given CURLU \fIinhandle\fP and all its contents and returns a
 pointer to a new CURLU handle. The new handle also needs to be freed with

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -30,7 +30,6 @@ CURLUcode curl_url_set(CURLU *url,
                        CURLUPart part,
                        const char *content,
                        unsigned int flags)
-.fi
 .SH DESCRIPTION
 Given the \fIurl\fP handle of an already parsed URL, this function lets the
 user set/update individual pieces of it.


### PR DESCRIPTION
Details:

 From "mandoc -Tlint":

mandoc: curl_getdate.3:64:2: WARNING: skipping paragraph macro: PP empty
mandoc: curl_global_init_mem.3:56:2: ERROR: skipping end of block that is not open: RE
mandoc: curl_url_cleanup.3:29:2: STYLE: fill mode already enabled, skipping: fi
mandoc: curl_url_dup.3:29:2: STYLE: fill mode already enabled, skipping: fi
mandoc: curl_url_set.3:32:2: STYLE: fill mode already enabled, skipping: fi

  From "test-groff -b -mandoc -T utf8 -rF0 -t -w w -z":

  [ "test-groff" is a developmental version of "groff" ]

troff: <curl_getdate.3>:108: warning: trailing space
troff: <curl_getdate.3>:109: warning: trailing space

Patch originally submitted to Debian at:
https://bugs.debian.org/963559