### PR TITLE
openldap: fix compiler warning when built without SSL support

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -844,6 +844,9 @@ static CURLcode oldap_disconnect(struct Curl_easy *data,
 {
   struct ldapconninfo *li = conn->proto.ldapc;
   (void) dead_connection;
+#ifndef USE_SSL
+  (void)data;
+#endif
 
   if(li) {
     if(li->ld) {


### PR DESCRIPTION
openldap.c:841:52: error: unused parameter ‘data’ [-Werror=unused-parameter]