### PR TITLE
Update base64.c

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -273,7 +273,7 @@ static CURLcode base64_encode(const char *table64,
   free(convbuf);
 
   /* Return the length of the new data */
-  *outlen = strlen(base64data);
+  *outlen = output - base64data;
 
   return CURLE_OK;
 }


### PR DESCRIPTION
Removed an unnecessary call to strlen in base64.c