### PR TITLE
build: fix ngtcp2 crypto library detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2718,7 +2718,7 @@ if test "x$NGTCP2_ENABLED" = "x1" -a "x$OPENSSL_ENABLED" = "x1"; then
     if test "x$cross_compiling" != "xyes"; then
       DIR_NGTCP2_CRYPTO_OPENSSL=`echo $LD_NGTCP2_CRYPTO_OPENSSL | $SED -e 's/^-L//'`
     fi
-    AC_CHECK_LIB(ngtcp2_crypto_openssl, ngtcp2_crypto_ctx_initial,
+    AC_CHECK_LIB(ngtcp2_crypto_openssl, ngtcp2_crypto_recv_client_initial_cb,
       [
        AC_CHECK_HEADERS(ngtcp2/ngtcp2_crypto.h,
           NGTCP2_ENABLED=1
@@ -2773,7 +2773,7 @@ if test "x$NGTCP2_ENABLED" = "x1" -a "x$GNUTLS_ENABLED" = "x1"; then
     if test "x$cross_compiling" != "xyes"; then
       DIR_NGTCP2_CRYPTO_GNUTLS=`echo $LD_NGTCP2_CRYPTO_GNUTLS | $SED -e 's/^-L//'`
     fi
-    AC_CHECK_LIB(ngtcp2_crypto_gnutls, ngtcp2_crypto_ctx_initial,
+    AC_CHECK_LIB(ngtcp2_crypto_gnutls, ngtcp2_crypto_recv_client_initial_cb,
       [
        AC_CHECK_HEADERS(ngtcp2/ngtcp2_crypto.h,
           NGTCP2_ENABLED=1


### PR DESCRIPTION
- Change library link check for ngtcp2_crypto_{gnutls,openssl} to
  to use function ngtcp2_crypto_recv_client_initial_cb instead of
  ngtcp2_crypto_ctx_initial.

The latter function is no longer external since two days ago in
ngtcp2/ngtcp2@533451f. curl HTTP/3 CI builds have been failing since
then because they would not link to the ngtcp2 crypto library.

Ref: https://github.com/ngtcp2/ngtcp2/pull/356

Closes #xxxx

---

See [this](https://curl.zuul.vexxhost.dev/build/aa6c13b3e92341739bca7fdb02a93668) zuul build of curl-novalgrind-ngtcp2-gnutls for example:

~~~
  CCLD     curl
../lib/.libs/libcurl.so: undefined reference to `ngtcp2_crypto_recv_retry_cb'
../lib/.libs/libcurl.so: undefined reference to `ngtcp2_crypto_recv_crypto_data_cb'
../lib/.libs/libcurl.so: undefined reference to `ngtcp2_crypto_decrypt_cb'
...and so on
~~~

/cc @tatsuhiro-t 