### PR TITLE
runtests.pl: tolerate test directories without Makefile.inc

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -586,9 +586,11 @@ sub checkcmd {
 #######################################################################
 # Get the list of tests that the tests/data/Makefile.am knows about!
 #
-my $disttests;
+my $disttests = "";
 sub get_disttests {
-    open(D, "<$TESTDIR/Makefile.inc");
+    # If a non-default $TESTDIR is being used there may not be any
+    # Makefile.inc in which case there's nothing to do.
+    open(D, "<$TESTDIR/Makefile.inc") or return;
     while(<D>) {
         chomp $_;
         if(($_ =~ /^#/) ||($_ !~ /test/)) {


### PR DESCRIPTION
Silences the following warnings when using a Makefile.inc-free
TESTDIR using the "-o" argument:

   readline() on closed filehandle D at ./runtests.pl line 592.
   Use of uninitialized value $disttests in pattern match (m//) at ./runtests.pl line 3602.