### PR TITLE
config.d: Clarify _curlrc filename is still valid on Windows

### DIFF
--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -69,4 +69,7 @@ config file is checked for in the following places in this order:
 8) On windows, if it finds no .curlrc file in the sequence described above, it
 checks for one in the same dir the curl executable is placed.
 
+On windows two filenames are checked per location: .curlrc and _curlrc,
+preferring the former. Older versions on windows checked for _curlrc only.
+
 This option can be used multiple times to load multiple config files.


### PR DESCRIPTION
Recent changes added support for filename .curlrc on Windows, and
when it's not found curl falls back on the original Windows filename
_curlrc. _curlrc was removed from the doc, however it is still valid.

Closes #xxxx