### PR TITLE
version_win32: fix warning for `CURL_WINDOWS_APP`

### DIFF
--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -76,6 +76,8 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
   bool matched = FALSE;
 
 #if defined(CURL_WINDOWS_APP)
+  (void)buildVersion;
+
   /* We have no way to determine the Windows version from Windows apps,
      so let's assume we're running on the target Windows version. */
   const WORD fullVersion = MAKEWORD(minorVersion, majorVersion);


### PR DESCRIPTION
The build version is not supported by the UWP code.