### PR TITLE
tests/disable-scan.pl: properly detect multiple symbols per line

### DIFF
--- a/tests/disable-scan.pl
+++ b/tests/disable-scan.pl
@@ -6,7 +6,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2010 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2010 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -63,7 +63,7 @@ sub scan_file {
     my ($source)=@_;
     open F, "<$source";
     while(<F>) {
-        if(/(CURL_DISABLE_[A-Z_]+)/g) {
+        while(s/(CURL_DISABLE_[A-Z_]+)//) {
             my ($sym)=($1);
             $file{$sym} = $source;
         }


### PR DESCRIPTION
Test 1165 would fail on some systems because it didn't detect
CURL_DISABLE_* symbols that were used to the right of another one on the
same line! The script would only detect and extract the first one.

Reported-by: Marcel Raad
Fixes #8384