### PR TITLE
h2/h3: provide and refer to psuedo headers as defines

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1079,8 +1079,8 @@ static int cb_h3_recv_header(nghttp3_conn *conn, int64_t stream_id,
   (void)flags;
   (void)user_data;
 
-  if(h3name.len == sizeof(":status") - 1 &&
-     !memcmp(":status", h3name.base, h3name.len)) {
+  if(h3name.len == sizeof(H3_PSEUDO_STATUS) - 1 &&
+     !memcmp(H3_PSEUDO_STATUS, h3name.base, h3name.len)) {
     char line[14]; /* status line is always 13 characters long */
     size_t ncopy;
     int status = decode_status_code(h3val.base, h3val.len);
@@ -1440,8 +1440,8 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
   end = memchr(hdbuf, ' ', line_end - hdbuf);
   if(!end || end == hdbuf)
     goto fail;
-  nva[0].name = (unsigned char *)":method";
-  nva[0].namelen = strlen((char *)nva[0].name);
+  nva[0].name = (unsigned char *)H3_PSEUDO_METHOD;
+  nva[0].namelen = sizeof(H3_PSEUDO_METHOD) - 1;
   nva[0].value = (unsigned char *)hdbuf;
   nva[0].valuelen = (size_t)(end - hdbuf);
   nva[0].flags = NGHTTP3_NV_FLAG_NONE;
@@ -1458,14 +1458,14 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
   }
   if(!end || end == hdbuf)
     goto fail;
-  nva[1].name = (unsigned char *)":path";
-  nva[1].namelen = strlen((char *)nva[1].name);
+  nva[1].name = (unsigned char *)H3_PSEUDO_PATH;
+  nva[1].namelen = sizeof(H3_PSEUDO_PATH) - 1;
   nva[1].value = (unsigned char *)hdbuf;
   nva[1].valuelen = (size_t)(end - hdbuf);
   nva[1].flags = NGHTTP3_NV_FLAG_NONE;
 
-  nva[2].name = (unsigned char *)":scheme";
-  nva[2].namelen = strlen((char *)nva[2].name);
+  nva[2].name = (unsigned char *)H3_PSEUDO_SCHEME;
+  nva[2].namelen = sizeof(H3_PSEUDO_SCHEME) - 1;
   if(conn->handler->flags & PROTOPT_SSL)
     nva[2].value = (unsigned char *)"https";
   else
@@ -1499,8 +1499,8 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
 
     if(hlen == 4 && strncasecompare("host", hdbuf, 4)) {
       authority_idx = i;
-      nva[i].name = (unsigned char *)":authority";
-      nva[i].namelen = strlen((char *)nva[i].name);
+      nva[i].name = (unsigned char *)H3_PSEUDO_AUTHORITY;
+      nva[i].namelen = sizeof(H3_PSEUDO_AUTHORITY) - 1;
     }
     else {
       nva[i].namelen = (size_t)(end - hdbuf);

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -542,7 +542,7 @@ static int cb_each_header(uint8_t *name, size_t name_len,
   struct h3h1header *headers = (struct h3h1header *)argp;
   size_t olen = 0;
 
-  if((name_len == 7) && !strncmp(":status", (char *)name, 7)) {
+  if((name_len == 7) && !strncmp(H3_PSEUDO_STATUS, (char *)name, 7)) {
     msnprintf(headers->dest,
               headers->destlen, "HTTP/3 %.*s\n",
               (int) value_len, value);
@@ -759,8 +759,8 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
   end = memchr(hdbuf, ' ', line_end - hdbuf);
   if(!end || end == hdbuf)
     goto fail;
-  nva[0].name = (unsigned char *)":method";
-  nva[0].name_len = strlen((char *)nva[0].name);
+  nva[0].name = (unsigned char *)H3_PSEUDO_METHOD;
+  nva[0].name_len = sizeof(H3_PSEUDO_METHOD) - 1;
   nva[0].value = (unsigned char *)hdbuf;
   nva[0].value_len = (size_t)(end - hdbuf);
 
@@ -776,13 +776,13 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
   }
   if(!end || end == hdbuf)
     goto fail;
-  nva[1].name = (unsigned char *)":path";
-  nva[1].name_len = strlen((char *)nva[1].name);
+  nva[1].name = (unsigned char *)H3_PSEUDO_PATH;
+  nva[1].name_len = sizeof(H3_PSEUDO_PATH) - 1;
   nva[1].value = (unsigned char *)hdbuf;
   nva[1].value_len = (size_t)(end - hdbuf);
 
-  nva[2].name = (unsigned char *)":scheme";
-  nva[2].name_len = strlen((char *)nva[2].name);
+  nva[2].name = (unsigned char *)H3_PSEUDO_SCHEME;
+  nva[2].name_len = sizeof(H3_PSEUDO_SCHEME) - 1;
   if(conn->handler->flags & PROTOPT_SSL)
     nva[2].value = (unsigned char *)"https";
   else
@@ -815,8 +815,8 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
 
     if(hlen == 4 && strncasecompare("host", hdbuf, 4)) {
       authority_idx = i;
-      nva[i].name = (unsigned char *)":authority";
-      nva[i].name_len = strlen((char *)nva[i].name);
+      nva[i].name = (unsigned char *)H3_PSEUDO_AUTHORITY;
+      nva[i].name_len = sizeof(H3_PSEUDO_AUTHORITY) - 1;
     }
     else {
       nva[i].name_len = (size_t)(end - hdbuf);

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,6 +23,12 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
+
+#define H3_PSEUDO_METHOD ":method"
+#define H3_PSEUDO_SCHEME ":scheme"
+#define H3_PSEUDO_AUTHORITY ":authority"
+#define H3_PSEUDO_PATH ":path"
+#define H3_PSEUDO_STATUS ":status"
 
 #ifdef ENABLE_QUIC
 CURLcode Curl_qlogdir(struct Curl_easy *data,


### PR DESCRIPTION
... and do strlen() on the defines to allow the compiler a chance to
optimize away the strlens.