### PR TITLE
curl-openssl: fix SRP check for OpenSSL 3.0

### DIFF
--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -384,11 +384,21 @@ dnl ---
 dnl We require OpenSSL with SRP support.
 dnl ---
 if test "$OPENSSL_ENABLED" = "1"; then
-  AC_CHECK_LIB(crypto, SRP_Calc_client_key,
-   [
-     AC_DEFINE(HAVE_OPENSSL_SRP, 1, [if you have the function SRP_Calc_client_key])
-     AC_SUBST(HAVE_OPENSSL_SRP, [1])
-   ])
+  AC_MSG_CHECKING([for SRP support in OpenSSL])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+#include <openssl/ssl.h>
+    ]],[[
+      SSL_CTX_set_srp_username(NULL, "");
+      SSL_CTX_set_srp_password(NULL, "");
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(HAVE_OPENSSL_SRP, 1, [if you have the functions SSL_CTX_set_srp_username and SSL_CTX_set_srp_password])
+    AC_SUBST(HAVE_OPENSSL_SRP, [1])
+  ],[
+    AC_MSG_RESULT([no])
+  ])
 fi
 
 dnl ---


### PR DESCRIPTION
When OpenSSL 3.0 is built with `--api=3.0` and `no-deprecated`, the SRP
functions exist in the library, but are disabled for user code. Check
if they are actually usable instead of only if they exist. Also check
for the functions actually required for TLS-SRP.

TLS-SRP support is still enabled if OpenSSL is configured with just
`--api=3.0` or with `--api=1.1.1 no-deprecated`.

(I'm not very familiar with autoconf and m4 - please let me know if there's a better way to do that.)