### PR TITLE
maketgz: return error if 'make dist' fails

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -9,7 +9,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -169,6 +169,12 @@ git log --pretty=fuller --no-color --date=short --decorate=full -1000 | ./script
 echo "make dist"
 targz="curl-$version.tar.gz"
 make -sj dist VERSION=$version
+res=$?
+
+if test "$res" != 0; then
+    echo "make dist failed"
+    exit 2
+fi
 
 ############################################################################
 #


### PR DESCRIPTION
To better detect this problem in CI jobs