### PR TITLE
mqtt: free 'sendleftovers' in disconnect

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -346,7 +346,9 @@ end:
 static CURLcode mqtt_disconnect(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OK;
+  struct MQTT *mq = data->req.p.mqtt;
   result = mqtt_send(data, (char *)"\xe0\x00", 2);
+  Curl_safefree(mq->sendleftovers);
   return result;
 }
 


### PR DESCRIPTION
Fix a memory-leak

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43646