### PR TITLE
quiche: fix upload for bigger content-length

### DIFF
--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -682,7 +682,7 @@ static ssize_t h3_stream_send(struct Curl_easy *data,
     sent = quiche_h3_send_body(qs->h3c, qs->conn, stream->stream3_id,
                                (uint8_t *)mem, len, FALSE);
     if(sent == QUICHE_H3_ERR_DONE) {
-      sent = len;
+      sent = 0;
     }
     if(sent < 0) {
       *curlcode = CURLE_SEND_ERROR;

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -681,6 +681,9 @@ static ssize_t h3_stream_send(struct Curl_easy *data,
     H3BUGF(infof(data, "Pass on %zd body bytes to quiche", len));
     sent = quiche_h3_send_body(qs->h3c, qs->conn, stream->stream3_id,
                                (uint8_t *)mem, len, FALSE);
+    if(sent == QUICHE_H3_ERR_DONE) {
+      sent = len;
+    }
     if(sent < 0) {
       *curlcode = CURLE_SEND_ERROR;
       return -1;

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -684,7 +684,7 @@ static ssize_t h3_stream_send(struct Curl_easy *data,
     if(sent == QUICHE_H3_ERR_DONE) {
       sent = 0;
     }
-    if(sent < 0) {
+    else if(sent < 0) {
       *curlcode = CURLE_SEND_ERROR;
       return -1;
     }


### PR DESCRIPTION
When uploading files, we can hit the underlying stream capacity, which in this case will return QUICHE_H3_ERR_DONE (-1), and result in a failure to send data.

Let fix this by handling this return code.

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>