### PR TITLE
lib/h2h3: #ifdef on ENABLE_QUIC, not the wrong define

### DIFF
--- a/lib/h2h3.c
+++ b/lib/h2h3.c
@@ -37,7 +37,7 @@
  * used in a HTTP/2 or HTTP/3 request.
  */
 
-#if defined(USE_NGHTTP2) || defined(USE_HTTP3)
+#if defined(USE_NGHTTP2) || defined(ENABLE_QUIC)
 
 /* Index where :authority header field will appear in request header
    field list. */


### PR DESCRIPTION
Otherwise the build fails when H3 is enabled but the build doesn't
include nghttp2.