### PR TITLE
fix configure error when using '--enable-code-coverage'

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -6562,7 +6562,7 @@ AC_DEFUN([CURL_COVERAGE],[
     fi
 
     CPPFLAGS="$CPPFLAGS -DNDEBUG"
-    CFLAGS="$CLAGS -O0 -g -fprofile-arcs -ftest-coverage"
+    CFLAGS="$CFLAGS -O0 -g -fprofile-arcs -ftest-coverage"
     LIBS="$LIBS -lgcov"
   fi
 ])


### PR DESCRIPTION
fix a spelling error that caused the compilation to fail