### PR TITLE
Removed strlen calls on empty strings in dprintf_formatf

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -829,6 +829,8 @@ static int dprintf_formatf(
         }
         else if(prec != -1)
           len = (size_t)prec;
+        else if(*str == '\0')
+          len = 0;
         else
           len = strlen(str);
 


### PR DESCRIPTION
Turns out that in dprintf_formatf we did a strlen on empty strings, a bit strange is how common this actually is, 24 alone when doing a simple GET from https://curl.se