### PR TITLE
Removes strlen() calls per SAN name in a cert-check for chained certificates

### DIFF
--- a/lib/vtls/hostcheck.c
+++ b/lib/vtls/hostcheck.c
@@ -72,14 +72,15 @@ static bool pmatch(const char *hostname, size_t hostlen,
  * Return TRUE on a match. FALSE if not.
  */
 
-static bool hostmatch(const char *hostname, const char *pattern,
+static bool hostmatch(const char *hostname,
+                      size_t hostlen,
+                      const char *pattern,
                       size_t patternlen)
 {
   const char *pattern_label_end, *wildcard, *hostname_label_end;
   size_t prefixlen, suffixlen;
 
   /* normalize pattern and hostname by stripping off trailing dots */
-  size_t hostlen = strlen(hostname);
   DEBUGASSERT(patternlen);
   if(hostname[hostlen-1]=='.')
     hostlen--;
@@ -129,10 +130,10 @@ static bool hostmatch(const char *hostname, const char *pattern,
  * Curl_cert_hostcheck() returns TRUE if a match and FALSE if not.
  */
 bool Curl_cert_hostcheck(const char *match, size_t matchlen,
-                         const char *hostname)
+                         const char *hostname, size_t hostlen)
 {
   if(match && *match && hostname && *hostname)
-    return hostmatch(hostname, match, matchlen);
+    return hostmatch(hostname, hostlen, match, matchlen);
   return FALSE;
 }
 

--- a/lib/vtls/hostcheck.h
+++ b/lib/vtls/hostcheck.h
@@ -26,6 +26,6 @@
 
 /* returns TRUE if there's a match */
 bool Curl_cert_hostcheck(const char *match_pattern, size_t matchlen,
-                         const char *hostname);
+                         const char *hostname, size_t hostlen);
 
 #endif /* HEADER_CURL_HOSTCHECK_H */

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -465,6 +465,7 @@ static CURLcode verify_host(struct Curl_easy *data,
   CURLcode result = CURLE_PEER_FAILED_VERIFICATION;
   TCHAR *cert_hostname_buff = NULL;
   size_t cert_hostname_buff_index = 0;
+  size_t hostlen = strlen(conn_hostname);
   DWORD len = 0;
   DWORD actual_len = 0;
 
@@ -521,7 +522,7 @@ static CURLcode verify_host(struct Curl_easy *data,
     }
     else {
       if(Curl_cert_hostcheck(cert_hostname, strlen(cert_hostname),
-                             conn_hostname)) {
+                             conn_hostname, hostlen)) {
         infof(data,
               "schannel: connection hostname (%s) validated "
               "against certificate name (%s)",

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1275,6 +1275,7 @@ CURLcode Curl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
   ssize_t len;
   const char * const hostname = SSL_HOST_NAME();
   const char * const dispname = SSL_HOST_DISPNAME();
+  size_t hostlen = strlen(hostname);
 #ifdef ENABLE_IPV6
   struct in6_addr addr;
 #else
@@ -1330,7 +1331,8 @@ CURLcode Curl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
           len = utf8asn1str(&dnsname, CURL_ASN1_IA5_STRING,
                             name.beg, name.end);
           if(len > 0 && (size_t)len == strlen(dnsname))
-            matched = Curl_cert_hostcheck(dnsname, (size_t)len, hostname);
+            matched = Curl_cert_hostcheck(dnsname,
+                                          (size_t)len, hostname, hostlen);
           else
             matched = 0;
           free(dnsname);
@@ -1389,7 +1391,7 @@ CURLcode Curl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
     }
     if(strlen(dnsname) != (size_t) len)         /* Nul byte in string ? */
       failf(data, "SSL: illegal cert name field");
-    else if(Curl_cert_hostcheck((const char *) dnsname, hostname)) {
+    else if(Curl_cert_hostcheck((const char *) dnsname, hostname, hostlen)) {
       infof(data, "  common name: %s (matched)", dnsname);
       free(dnsname);
       return CURLE_OK;


### PR DESCRIPTION
Further to #8418 there is for chained certificates a strlen done on the hostname for each iteration of the loop through the chain. For e.g https://curl.se this leads to zero difference since the certificate used there is "sane" but for the https://google.com case which perhaps represents a worst case scenario we can reduce a further 108 calls to strlen.