### PR TITLE
wolfssl: when SSL_read() returns zero, check the error

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -923,7 +923,10 @@ static ssize_t wolfssl_recv(struct Curl_easy *data,
     switch(err) {
     case SSL_ERROR_ZERO_RETURN: /* no more data */
       break;
+    case SSL_ERROR_NONE:
+      /* FALLTHROUGH */
     case SSL_ERROR_WANT_READ:
+      /* FALLTHROUGH */
     case SSL_ERROR_WANT_WRITE:
       /* there's data pending, re-invoke SSL_read() */
       *curlcode = CURLE_AGAIN;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -917,7 +917,7 @@ static ssize_t wolfssl_recv(struct Curl_easy *data,
 
   nread = SSL_read(backend->handle, buf, buffsize);
 
-  if(nread < 0) {
+  if(nread <= 0) {
     int err = SSL_get_error(backend->handle, nread);
 
     switch(err) {


### PR DESCRIPTION
Returning zero typically indicates end of connection, so if there's no
data read but the connection is alive, it needs to return -1 with
CURLE_AGAIN.