### PR TITLE
exclude IPv6 functions for non-ipv6 builds

### DIFF
--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -60,12 +60,10 @@
 
 /* ------------------------------------------------------------------ */
 
+#ifdef ENABLE_IPV6
 /* Return the scope of the given address. */
 unsigned int Curl_ipv6_scope(const struct sockaddr *sa)
 {
-#ifndef ENABLE_IPV6
-  (void) sa;
-#else
   if(sa->sa_family == AF_INET6) {
     const struct sockaddr_in6 * sa6 = (const struct sockaddr_in6 *)(void *) sa;
     const unsigned char *b = sa6->sin6_addr.s6_addr;
@@ -88,11 +86,9 @@ unsigned int Curl_ipv6_scope(const struct sockaddr *sa)
       break;
     }
   }
-#endif
-
   return IPV6_SCOPE_GLOBAL;
 }
-
+#endif
 
 #if defined(HAVE_GETIFADDRS)
 

--- a/lib/if2ip.h
+++ b/lib/if2ip.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2020, 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -30,7 +30,11 @@
 #define IPV6_SCOPE_UNIQUELOCAL  3       /* Unique local */
 #define IPV6_SCOPE_NODELOCAL    4       /* Loopback. */
 
+#ifdef ENABLE_IPV6
 unsigned int Curl_ipv6_scope(const struct sockaddr *sa);
+#else
+#define Curl_ipv6_scope(x) 0
+#endif
 
 typedef enum {
   IF2IP_NOT_FOUND = 0, /* Interface not found */

--- a/lib/url.c
+++ b/lib/url.c
@@ -1859,6 +1859,7 @@ CURLcode Curl_uc_to_curlcode(CURLUcode uc)
   }
 }
 
+#ifdef ENABLE_IPV6
 /*
  * If the URL was set with an IPv6 numerical address with a zone id part, set
  * the scope_id based on that!
@@ -1908,6 +1909,9 @@ static void zonefrom_url(CURLU *uh, struct Curl_easy *data,
     free(zoneid);
   }
 }
+#else
+#define zonefrom_url(a,b,c) Curl_nop_stmt
+#endif
 
 /*
  * Parse URL and fill in the relevant members of the connection struct.


### PR DESCRIPTION
This offers two alternative takes to #8430. I think this way of removing functions conditionally is nicer than sprinkling #ifdefs in the code logic that uses the functions.