### PR TITLE
mime: use a define instead of the magic number 24

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1280,8 +1280,9 @@ curl_mime *curl_mime_init(struct Curl_easy *easy)
     mime->firstpart = NULL;
     mime->lastpart = NULL;
 
-    memset(mime->boundary, '-', 24);
-    if(Curl_rand_hex(easy, (unsigned char *) &mime->boundary[24],
+    memset(mime->boundary, '-', MIME_BOUNDARY_DASHES);
+    if(Curl_rand_hex(easy,
+                     (unsigned char *) &mime->boundary[MIME_BOUNDARY_DASHES],
                      MIME_RAND_BOUNDARY_CHARS + 1)) {
       /* failed to get random separator, bail out */
       free(mime);

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -24,6 +24,7 @@
 
 #include "curl_setup.h"
 
+#define MIME_BOUNDARY_DASHES            24  /* leading boundary dashes */
 #define MIME_RAND_BOUNDARY_CHARS        16  /* Nb. of random boundary chars. */
 #define MAX_ENCODED_LINE_LENGTH         76  /* Maximum encoded line length. */
 #define ENCODING_BUFFER_SIZE            256 /* Encoding temp buffers size. */
@@ -92,7 +93,7 @@ struct mime_state {
 };
 
 /* minimum buffer size for the boundary string */
-#define MIME_BOUNDARY_LEN (24 + MIME_RAND_BOUNDARY_CHARS + 1)
+#define MIME_BOUNDARY_LEN (MIME_BOUNDARY_DASHES + MIME_RAND_BOUNDARY_CHARS + 1)
 
 /* A mime multipart. */
 struct curl_mime {


### PR DESCRIPTION
MIME_BOUNDARY_DASHES is now the number of leading dashes in the
generated boundary string.

@monnerat approve?