### PR TITLE
Lint README.md fix link layout and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/curl.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:curl)
 
 Curl is a command-line tool for transferring data specified with URL
-syntax. Find out how to use curl by reading [the curl.1 man page](https://curl.se/docs/manpage.html) or [the MANUAL document](https://curl.se/docs/manual.html). Find out how to install Curl
+syntax. Find out how to use curl by reading [the curl.1 man
+page](https://curl.se/docs/manpage.html) or [the MANUAL
+document](https://curl.se/docs/manual.html). Find out how to install Curl
 by reading [the INSTALL document](https://curl.se/docs/install.html).
 
 libcurl is the library curl is using to do its job. It is readily available to
-be used by your software. Read [the libcurl.3 man page](https://curl.se/libcurl/c/libcurl.html) to learn how.
+be used by your software. Read [the libcurl.3 man
+page](https://curl.se/libcurl/c/libcurl.html) to learn how.
 
-You can find answers to the most frequent questions we get in [the FAQ document](https://curl.se/docs/faq.html).
+You can find answers to the most frequent questions we get in [the FAQ
+document](https://curl.se/docs/faq.html).
 
 Study [the COPYING file](https://curl.se/docs/copyright.html) for
 distribution terms.
@@ -27,7 +31,8 @@ distribution terms.
 If you have problems, questions, ideas or suggestions, please contact us by
 posting to a suitable [mailing list](https://curl.se/mail/).
 
-All contributors to the project are listed in [the THANKS document](https://curl.se/docs/thanks.html).
+All contributors to the project are listed in [the THANKS
+document](https://curl.se/docs/thanks.html).
 
 ## Commercial support
 
@@ -49,7 +54,8 @@ To download the latest source from the Git server do this:
 
 ## Security problems
 
-Report suspected security problems via [our HackerOne page](https://hackerone.com/curl) and not in public!
+Report suspected security problems via [our HackerOne
+page](https://hackerone.com/curl) and not in public!
 
 ## Notice
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![curl logo](https://curl.se/logo/curl-logo.svg)
+# ![curl logo](https://curl.se/logo/curl-logo.svg)
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/63/badge)](https://bestpractices.coreinfrastructure.org/projects/63)
 [![Coverity passed](https://scan.coverity.com/projects/curl/badge.svg)](https://scan.coverity.com/projects/curl)
@@ -11,17 +11,13 @@
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/curl.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:curl)
 
 Curl is a command-line tool for transferring data specified with URL
-syntax. Find out how to use curl by reading [the curl.1 man
-page](https://curl.se/docs/manpage.html) or [the MANUAL
-document](https://curl.se/docs/manual.html). Find out how to install Curl
+syntax. Find out how to use curl by reading [the curl.1 man page](https://curl.se/docs/manpage.html) or [the MANUAL document](https://curl.se/docs/manual.html). Find out how to install Curl
 by reading [the INSTALL document](https://curl.se/docs/install.html).
 
 libcurl is the library curl is using to do its job. It is readily available to
-be used by your software. Read [the libcurl.3 man
-page](https://curl.se/libcurl/c/libcurl.html) to learn how.
+be used by your software. Read [the libcurl.3 man page](https://curl.se/libcurl/c/libcurl.html) to learn how.
 
-You can find answers to the most frequent questions we get in [the FAQ
-document](https://curl.se/docs/faq.html).
+You can find answers to the most frequent questions we get in [the FAQ document](https://curl.se/docs/faq.html).
 
 Study [the COPYING file](https://curl.se/docs/copyright.html) for
 distribution terms.
@@ -31,8 +27,7 @@ distribution terms.
 If you have problems, questions, ideas or suggestions, please contact us by
 posting to a suitable [mailing list](https://curl.se/mail/).
 
-All contributors to the project are listed in [the THANKS
-document](https://curl.se/docs/thanks.html).
+All contributors to the project are listed in [the THANKS document](https://curl.se/docs/thanks.html).
 
 ## Commercial support
 
@@ -54,8 +49,7 @@ To download the latest source from the Git server do this:
 
 ## Security problems
 
-Report suspected security problems via [our HackerOne
-page](https://hackerone.com/curl) and not in public!
+Report suspected security problems via [our HackerOne page](https://hackerone.com/curl) and not in public!
 
 ## Notice
 
@@ -67,21 +61,20 @@ distribution terms.
 
 Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/curl#backer)]
 
-<a href="https://opencollective.com/curl#backers" target="_blank"><img src="https://opencollective.com/curl/backers.svg?width=890"></a>
+[![Open Collective Backers](https://opencollective.com/curl/backers.svg?width=890)](https://opencollective.com/curl#backers)
 
 ## Sponsors
 
 Support this project by becoming a sponsor. Your logo will show up here with a
-link to your website. [[Become a
-sponsor](https://opencollective.com/curl#sponsor)]
+link to your website. [[Become a sponsor](https://opencollective.com/curl#sponsor)]
 
-<a href="https://opencollective.com/curl/sponsor/0/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/1/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/2/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/3/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/4/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/5/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/6/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/7/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/8/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/curl/sponsor/9/website" target="_blank"><img src="https://opencollective.com/curl/sponsor/9/avatar.svg"></a>
+[![Open Collective Sponsor 0](https://opencollective.com/curl/sponsor/0/avatar.svg)](https://opencollective.com/curl/sponsor/0/website)
+[![Open Collective Sponsor 1](https://opencollective.com/curl/sponsor/1/avatar.svg)](https://opencollective.com/curl/sponsor/1/website)
+[![Open Collective Sponsor 2](https://opencollective.com/curl/sponsor/2/avatar.svg)](https://opencollective.com/curl/sponsor/2/website)
+[![Open Collective Sponsor 3](https://opencollective.com/curl/sponsor/3/avatar.svg)](https://opencollective.com/curl/sponsor/3/website)
+[![Open Collective Sponsor 4](https://opencollective.com/curl/sponsor/4/avatar.svg)](https://opencollective.com/curl/sponsor/4/website)
+[![Open Collective Sponsor 5](https://opencollective.com/curl/sponsor/5/avatar.svg)](https://opencollective.com/curl/sponsor/5/website)
+[![Open Collective Sponsor 6](https://opencollective.com/curl/sponsor/6/avatar.svg)](https://opencollective.com/curl/sponsor/6/website)
+[![Open Collective Sponsor 7](https://opencollective.com/curl/sponsor/7/avatar.svg)](https://opencollective.com/curl/sponsor/7/website)
+[![Open Collective Sponsor 8](https://opencollective.com/curl/sponsor/8/avatar.svg)](https://opencollective.com/curl/sponsor/8/website)
+[![Open Collective Sponsor 9](https://opencollective.com/curl/sponsor/9/avatar.svg)](https://opencollective.com/curl/sponsor/9/website)


### PR DESCRIPTION
# This is documentation changes

## Lint Markdown

- [x] Lint README.md such as replace `<a></a>` tags and `<img></img>` tags.