### PR TITLE
avoid using SECONDARYSOCKET when FTP is not support

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1235,7 +1235,7 @@ CURLcode Curl_buffer_send(struct dynbuf *in,
   curl_socket_t sockfd;
   size_t headersize;
 
-  DEBUGASSERT(socketindex <= SECONDARYSOCKET);
+  DEBUGASSERT(socketindex < SOCKET_CNT);
 
   sockfd = conn->sock[socketindex];
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -101,14 +101,19 @@ CURLcode Curl_proxy_connect(struct Curl_easy *data, int sockindex)
 
     if(conn->bits.conn_to_host)
       hostname = conn->conn_to_host.name;
+#ifndef CURL_DISABLE_FTP
     else if(sockindex == SECONDARYSOCKET)
       hostname = conn->secondaryhostname;
+#endif
     else
       hostname = conn->host.name;
 
+#ifndef CURL_DISABLE_FTP
     if(sockindex == SECONDARYSOCKET)
       remote_port = conn->secondary_port;
-    else if(conn->bits.conn_to_port)
+    else
+#endif
+    if(conn->bits.conn_to_port)
       remote_port = conn->conn_to_port;
     else
       remote_port = conn->remote_port;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -291,6 +291,9 @@ CURLcode Curl_write(struct Curl_easy *data,
                     size_t len,
                     ssize_t *written)
 {
+#ifdef CURL_DISABLE_FTP
+  (void)sockfd;
+#endif
   ssize_t bytes_written;
   CURLcode result = CURLE_OK;
   struct connectdata *conn;
@@ -298,7 +301,11 @@ CURLcode Curl_write(struct Curl_easy *data,
   DEBUGASSERT(data);
   DEBUGASSERT(data->conn);
   conn = data->conn;
+#ifndef CURL_DISABLE_FTP
   num = (sockfd == conn->sock[SECONDARYSOCKET]);
+#else
+  num = 0;
+#endif
 
 #ifdef CURLDEBUG
   {
@@ -408,11 +415,18 @@ CURLcode Curl_write_plain(struct Curl_easy *data,
                           size_t len,
                           ssize_t *written)
 {
+#ifdef CURL_DISABLE_FTP
+  (void)sockfd;
+#endif
   CURLcode result;
   struct connectdata *conn = data->conn;
   int num;
   DEBUGASSERT(conn);
+#ifndef CURL_DISABLE_FTP
   num = (sockfd == conn->sock[SECONDARYSOCKET]);
+#else
+  num = 0;
+#endif
 
   *written = Curl_send_plain(data, num, mem, len, &result);
 
@@ -677,6 +691,9 @@ CURLcode Curl_read(struct Curl_easy *data,   /* transfer */
                    size_t sizerequested,     /* max amount to read */
                    ssize_t *n)               /* amount bytes read */
 {
+#ifdef CURL_DISABLE_FTP
+  (void)sockfd;
+#endif
   CURLcode result = CURLE_RECV_ERROR;
   ssize_t nread = 0;
   size_t bytesfromsocket = 0;
@@ -686,7 +703,11 @@ CURLcode Curl_read(struct Curl_easy *data,   /* transfer */
   /* Set 'num' to 0 or 1, depending on which socket that has been sent here.
      If it is the second socket, we set num to 1. Otherwise to 0. This lets
      us use the correct ssl handle. */
+#ifndef CURL_DISABLE_FTP
   int num = (sockfd == conn->sock[SECONDARYSOCKET]);
+#else
+  int num = 0;
+#endif
 
   *n = 0; /* reset amount to zero */
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -452,9 +452,10 @@ static int data_pending(const struct Curl_easy *data)
   if(conn->transport == TRNSPRT_QUIC)
     return Curl_quic_data_pending(data);
 #endif
-
+#ifndef CURL_DISABLE_FTP
   if(conn->handler->protocol&PROTO_FAMILY_FTP)
     return Curl_ssl_data_pending(conn, SECONDARYSOCKET);
+#endif
 
   /* in the case of libssh2, we can never be really sure that we have emptied
      its internal buffers so we MUST always try until we get EAGAIN back */

--- a/lib/url.h
+++ b/lib/url.h
@@ -73,9 +73,11 @@ void Curl_verboseconnect(struct Curl_easy *data, struct connectdata *conn);
   (conn->http_proxy.proxytype == CURLPROXY_HTTPS &&\
   !conn->bits.proxy_ssl_connected[FIRSTSOCKET])
 
+#ifndef CURL_DISABLE_FTP
 #define CONNECT_SECONDARYSOCKET_PROXY_SSL()\
   (conn->http_proxy.proxytype == CURLPROXY_HTTPS &&\
   !conn->bits.proxy_ssl_connected[SECONDARYSOCKET])
+#endif
 #endif /* !CURL_DISABLE_PROXY */
 
 #endif /* HEADER_CURL_URL_H */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -628,18 +628,25 @@ void Curl_ssl_associate_conn(struct Curl_easy *data,
 {
   if(Curl_ssl->associate_connection) {
     Curl_ssl->associate_connection(data, conn, FIRSTSOCKET);
+#ifndef CURL_DISABLE_FTP
     if(conn->sock[SECONDARYSOCKET] && conn->bits.sock_accepted)
       Curl_ssl->associate_connection(data, conn, SECONDARYSOCKET);
+#endif
   }
 }
 
 void Curl_ssl_detach_conn(struct Curl_easy *data,
                           struct connectdata *conn)
 {
+#ifdef CURL_DISABLE_FTP
+  (void)conn;
+#endif
   if(Curl_ssl->disassociate_connection) {
     Curl_ssl->disassociate_connection(data, FIRSTSOCKET);
+#ifndef CURL_DISABLE_FTP
     if(conn->sock[SECONDARYSOCKET] && conn->bits.sock_accepted)
       Curl_ssl->disassociate_connection(data, SECONDARYSOCKET);
+#endif
   }
 }
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -140,11 +140,17 @@ bool Curl_ssl_tls13_ciphersuites(void);
 /* set of helper macros for the backends to access the correct fields. For the
    proxy or for the remote host - to properly support HTTPS proxy */
 #ifndef CURL_DISABLE_PROXY
+#ifndef CURL_DISABLE_FTP
 #define SSL_IS_PROXY()                                                  \
   (CURLPROXY_HTTPS == conn->http_proxy.proxytype &&                     \
    ssl_connection_complete !=                                           \
    conn->proxy_ssl[conn->sock[SECONDARYSOCKET] ==                       \
                    CURL_SOCKET_BAD ? FIRSTSOCKET : SECONDARYSOCKET].state)
+#else
+#define SSL_IS_PROXY()                                                  \
+  (CURLPROXY_HTTPS == conn->http_proxy.proxytype &&                     \
+   ssl_connection_complete != conn->proxy_ssl[FIRSTSOCKET].state)
+#endif
 #define SSL_SET_OPTION(var)                                             \
   (SSL_IS_PROXY() ? data->set.proxy_ssl.var : data->set.ssl.var)
 #define SSL_SET_OPTION_LVALUE(var)                                      \


### PR DESCRIPTION
In additional it reduce number of allocation for ssl backend.

I'm not sure about this solution. This will make it more difficult next socket channel. Maybe it doesn't matter? I'm curious to hear your opinions.