### PR TITLE
ntlm: remove unused feature defines

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -444,7 +444,6 @@ CURLcode Curl_ntlm_core_mk_lm_hash(const char *password,
   return CURLE_OK;
 }
 
-#ifdef USE_NTRESPONSES
 static void ascii_to_unicode_le(unsigned char *dest, const char *src,
                                 size_t srclen)
 {
@@ -455,7 +454,7 @@ static void ascii_to_unicode_le(unsigned char *dest, const char *src,
   }
 }
 
-#if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_WINDOWS_SSPI)
 
 static void ascii_uppercase_to_unicode_le(unsigned char *dest,
                                           const char *src, size_t srclen)
@@ -467,7 +466,7 @@ static void ascii_uppercase_to_unicode_le(unsigned char *dest,
   }
 }
 
-#endif /* USE_NTLM_V2 && !USE_WINDOWS_SSPI */
+#endif /* !USE_WINDOWS_SSPI */
 
 /*
  * Set up nt hashed passwords
@@ -495,7 +494,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(const char *password,
   return CURLE_OK;
 }
 
-#if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_WINDOWS_SSPI)
 
 /* Timestamp in tenths of a microsecond since January 1, 1601 00:00:00 UTC. */
 struct ms_filetime {
@@ -711,8 +710,6 @@ CURLcode  Curl_ntlm_core_mk_lmv2_resp(unsigned char *ntlmv2hash,
   return result;
 }
 
-#endif /* USE_NTLM_V2 && !USE_WINDOWS_SSPI */
-
-#endif /* USE_NTRESPONSES */
+#endif /* !USE_WINDOWS_SSPI */
 
 #endif /* USE_CURL_NTLM_CORE */

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -42,22 +42,6 @@
 #  include <openssl/ssl.h>
 #endif
 
-/* Define USE_NTRESPONSES in order to make the type-3 message include
- * the NT response message. */
-#define USE_NTRESPONSES
-
-/* Define USE_NTLM2SESSION in order to make the type-3 message include the
-   NTLM2Session response message, requires USE_NTRESPONSES defined to 1 */
-#if defined(USE_NTRESPONSES)
-#define USE_NTLM2SESSION
-#endif
-
-/* Define USE_NTLM_V2 in order to allow the type-3 message to include the
-   LMv2 and NTLMv2 response messages, requires USE_NTRESPONSES defined to 1 */
-#if defined(USE_NTRESPONSES)
-#define USE_NTLM_V2
-#endif
-
 /* Helpers to generate function byte arguments in little endian order */
 #define SHORTPAIR(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff))
 #define LONGQUARTET(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff)), \
@@ -70,11 +54,10 @@ void Curl_ntlm_core_lm_resp(const unsigned char *keys,
 CURLcode Curl_ntlm_core_mk_lm_hash(const char *password,
                                    unsigned char *lmbuffer /* 21 bytes */);
 
-#ifdef USE_NTRESPONSES
 CURLcode Curl_ntlm_core_mk_nt_hash(const char *password,
                                    unsigned char *ntbuffer /* 21 bytes */);
 
-#if defined(USE_NTLM_V2) && !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_WINDOWS_SSPI)
 
 CURLcode Curl_hmac_md5(const unsigned char *key, unsigned int keylen,
                        const unsigned char *data, unsigned int datalen,
@@ -96,9 +79,7 @@ CURLcode  Curl_ntlm_core_mk_lmv2_resp(unsigned char *ntlmv2hash,
                                       unsigned char *challenge_server,
                                       unsigned char *lmresp);
 
-#endif /* USE_NTLM_V2 && !USE_WINDOWS_SSPI */
-
-#endif /* USE_NTRESPONSES */
+#endif /* !USE_WINDOWS_SSPI */
 
 #endif /* USE_CURL_NTLM_CORE */
 

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -464,12 +464,8 @@ static CURLcode smb_send_setup(struct Curl_easy *data)
 
   Curl_ntlm_core_mk_lm_hash(conn->passwd, lm_hash);
   Curl_ntlm_core_lm_resp(lm_hash, smbc->challenge, lm);
-#ifdef USE_NTRESPONSES
   Curl_ntlm_core_mk_nt_hash(conn->passwd, nt_hash);
   Curl_ntlm_core_lm_resp(nt_hash, smbc->challenge, nt);
-#else
-  memset(nt, 0, sizeof(nt));
-#endif
 
   memset(&msg, 0, sizeof(msg));
   msg.word_count = SMB_WC_SETUP_ANDX;


### PR DESCRIPTION
They're not used anymore and always supported.