### PR TITLE
Fix build errors when using GSKit

### DIFF
--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -1314,6 +1314,7 @@ const struct Curl_ssl Curl_ssl_gskit = {
   Curl_none_cert_status_request,  /* cert_status_request */
   gskit_connect,                  /* connect */
   gskit_connect_nonblocking,      /* connect_nonblocking */
+  Curl_ssl_getsock,               /* getsock */
   gskit_get_internals,            /* get_internals */
   gskit_close,                    /* close_one */
   Curl_none_close_all,            /* close_all */

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -28,6 +28,7 @@
 #include <qsoasync.h>
 #undef HAVE_SOCKETPAIR /* because the native one isn't good enough */
 #include "socketpair.h"
+#include "strerror.h"
 
 /* Some symbols are undefined/unsupported on OS400 versions < V7R1. */
 #ifndef GSK_SSL_EXTN_SERVERNAME_REQUEST
@@ -247,10 +248,10 @@ static CURLcode set_enum(struct Curl_easy *data, gsk_handle h,
 
 
 static CURLcode set_buffer(struct Curl_easy *data, gsk_handle h,
-                        GSK_BUF_ID id, const char *buffer, bool unsupported_ok)
+                        GSK_BUF_ID id, const char *buf, bool unsupported_ok)
 {
   char buffer[STRERROR_LEN];
-  int rc = gsk_attribute_set_buffer(h, id, buffer, 0);
+  int rc = gsk_attribute_set_buffer(h, id, buf, 0);
 
   switch(rc) {
   case GSK_OK:


### PR DESCRIPTION
Various changes in master have caused the GSKit build to break, which is used by the IBM i ILE (OS400) build.