### PR TITLE
des: fix compile break for OpenSSL without DES

### DIFF
--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -22,7 +22,12 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NTLM) && !defined(USE_OPENSSL) && !defined(USE_WOLFSSL)
+#if defined(USE_CURL_NTLM_CORE) && !defined(USE_WOLFSSL) && \
+    (defined(USE_GNUTLS) || \
+     defined(USE_NSS) || \
+     defined(USE_SECTRANSP) || \
+     defined(USE_OS400CRYPTO) || \
+     defined(USE_WIN32_CRYPTO))
 
 #include "curl_des.h"
 
@@ -60,4 +65,4 @@ void Curl_des_set_odd_parity(unsigned char *bytes, size_t len)
   }
 }
 
-#endif /* USE_NTLM && !USE_OPENSSL */
+#endif

--- a/lib/curl_des.h
+++ b/lib/curl_des.h
@@ -24,11 +24,16 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NTLM) && !defined(USE_OPENSSL)
+#if defined(USE_CURL_NTLM_CORE) && !defined(USE_WOLFSSL) && \
+    (defined(USE_GNUTLS) || \
+     defined(USE_NSS) || \
+     defined(USE_SECTRANSP) || \
+     defined(USE_OS400CRYPTO) || \
+     defined(USE_WIN32_CRYPTO))
 
 /* Applies odd parity to the given byte array */
 void Curl_des_set_odd_parity(unsigned char *bytes, size_t length);
 
-#endif /* USE_NTLM && !USE_OPENSSL */
+#endif
 
 #endif /* HEADER_CURL_DES_H */


### PR DESCRIPTION
When `USE_OPENSSL` was defined but OpenSSL had no DES support and a
different crypto library was used for that, `Curl_des_set_odd_parity`
was called but not defined. This could for example happen on Windows
and macOS when using OpenSSL v3 with deprecated features disabled.

Use the same condition for the function definition as used at the
caller side, but leaving out the OpenSSL part to avoid including
OpenSSL headers.