### PR TITLE
EVP_sha256() does not appear in OpenSSL until 0.9.7h, not available by default until 0.9.8

### DIFF
--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -40,7 +40,7 @@
 
 #include <openssl/opensslv.h>
 
-#if (OPENSSL_VERSION_NUMBER >= 0x0090700fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
 #define USE_OPENSSL_SHA256
 #endif
 


### PR DESCRIPTION
We can't use OpenSSL's SHA256 implementation in versions that predate it, and the `EVP_sha256()` function does not appear until OpenSSL 0.9.7h. It is possible it was not enabled by default until later, and someone else can propose moving this threshold up further, but this is the minimum lower bound for this to work.