### PR TITLE
http: fix "unused parameter ‘conn’" warning

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -666,6 +666,7 @@ output_auth_headers(struct Curl_easy *data,
 {
   const char *auth = NULL;
   CURLcode result = CURLE_OK;
+  (void)conn;
 
 #ifdef CURL_DISABLE_CRYPTO_AUTH
   (void)request;


### PR DESCRIPTION
Follow-up from 7d600ad1c395

Spotted on appveyor