### PR TITLE
tool_operate: ignore URL filename too long if server can set filename

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -996,9 +996,21 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             /* extract the file name from the URL */
             result = get_url_file_name(&per->outfile, per->this_url);
             if(result) {
-              errorf(global, "Failed to extract a sensible file name"
-                     " from the URL to use for storage!\n");
-              break;
+              /* If filename extraction failed but the user has allowed the
+                 server to set the filename then use an empty filename as a
+                 placeholder. */
+              if(config->content_disposition) {
+                per->outfile = strdup("");
+                if(!per->outfile) {
+                  result = CURLE_OUT_OF_MEMORY;
+                  break;
+                }
+              }
+              else {
+                errorf(global, "Failed to extract a sensible file name"
+                       " from the URL to use for storage!\n");
+                break;
+              }
             }
             if(!*per->outfile && !config->content_disposition) {
               errorf(global, "Remote file name has no length!\n");


### PR DESCRIPTION
- If extracting a filename from the URL (--remote-name) fails and the
  server can set the filename (--remote-header-name) then don't treat
  it as an error, instead use an empty filename as a placeholder.

curl already supports URL paths missing a filename by using an empty
filename as a placeholder. And in Windows curl already supports URL
filenames with invalid characters by replacing them with underscores.

Prior to this change if the filename part of the URL was too long then
an error would occur:

curl: Failed to extract a sensible file name from the URL to use for
storage!
curl: (3) URL using bad/illegal format or missing URL

Bug: https://github.com/curl/curl/issues/8461#issuecomment-1042027612
Reported-by: Illegal-Services@users.noreply.github.com

Closes #xxxx