### PR TITLE
schannel: Move the algIds array out of schannel.h

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -325,13 +325,15 @@ get_alg_id_by_name(char *name)
   return 0;
 }
 
+#define NUM_CIPHERS 47 /* There are 47 options listed above */
+
 static CURLcode
 set_ssl_ciphers(SCHANNEL_CRED *schannel_cred, char *ciphers,
                 ALG_ID *algIds)
 {
   char *startCur = ciphers;
   int algCount = 0;
-  while(startCur && (0 != *startCur) && (algCount < NUMOF_CIPHERS)) {
+  while(startCur && (0 != *startCur) && (algCount < NUM_CIPHERS)) {
     long alg = strtol(startCur, 0, 0);
     if(!alg)
       alg = get_alg_id_by_name(startCur);
@@ -418,6 +420,7 @@ schannel_acquire_credential_handle(struct Curl_easy *data,
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   SCHANNEL_CRED schannel_cred;
+  ALG_ID algIds[NUM_CIPHERS];
   PCCERT_CONTEXT client_certs[1] = { NULL };
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CURLcode result;
@@ -502,7 +505,7 @@ schannel_acquire_credential_handle(struct Curl_easy *data,
 
   if(SSL_CONN_CONFIG(cipher_list)) {
     result = set_ssl_ciphers(&schannel_cred, SSL_CONN_CONFIG(cipher_list),
-                             backend->algIds);
+                             algIds);
     if(CURLE_OK != result) {
       failf(data, "Unable to set ciphers to passed via SSL_CONN_CONFIG");
       return result;

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -71,8 +71,6 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
 #endif
 #endif
 
-#define NUMOF_CIPHERS 45 /* There are 45 listed in the MS headers */
-
 struct Curl_schannel_cred {
   CredHandle cred_handle;
   TimeStamp time_stamp;
@@ -105,7 +103,6 @@ struct ssl_backend_data {
 #ifdef HAS_MANUAL_VERIFY_API
   bool use_manual_cred_validation; /* true if manual cred validation is used */
 #endif
-  ALG_ID algIds[NUMOF_CIPHERS];
 };
 #endif /* EXPOSE_SCHANNEL_INTERNAL_STRUCTS */
 


### PR DESCRIPTION
This array is only used by the `SCHANNEL_CRED` struct in the `schannel_acquire_credential_handle` function. It can therefore be kept as a local variable. This is a minor update to bbb71507b7bab52002f9b1e0880bed6a32834511.

This change also updates the `NUM_CIPHERS` value to accurately count the number of ciphers options listed in schannel.c, which is 47 instead of 45. It is unlikely that anyone tries to set all 47 values, but if they had tried, the last two would not have been set.