### PR TITLE
openssl: fix build for version < 1.1.0

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2409,6 +2409,7 @@ set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
 #ifdef TLS1_3_VERSION
     {
       struct ssl_connect_data *connssl = &conn->ssl[sockindex];
+      struct ssl_backend_data *backend = connssl->backend;
       SSL_CTX_set_max_proto_version(backend->ctx, TLS1_3_VERSION);
       *ctx_options |= SSL_OP_NO_TLSv1_2;
     }


### PR DESCRIPTION
Adding missing pointer to ssl backend.