### PR TITLE
ssl: reduce allocate space for ssl backend when FTP is not supported.

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -373,6 +373,8 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
   struct in_addr addr;
 #endif
 
+  DEBUGASSERT(backend);
+
   switch(SSL_CONN_CONFIG(version)) {
   case CURL_SSLVERSION_SSLv2:
     failf(data, "BearSSL does not support SSLv2");
@@ -530,6 +532,8 @@ static CURLcode bearssl_run_until(struct Curl_easy *data,
   ssize_t ret;
   int err;
 
+  DEBUGASSERT(backend);
+
   for(;;) {
     state = br_ssl_engine_current_state(&backend->ctx.eng);
     if(state & BR_SSL_CLOSED) {
@@ -602,6 +606,8 @@ static CURLcode bearssl_connect_step2(struct Curl_easy *data,
   struct ssl_backend_data *backend = connssl->backend;
   CURLcode ret;
 
+  DEBUGASSERT(backend);
+
   ret = bearssl_run_until(data, conn, sockindex,
                           BR_SSL_SENDAPP | BR_SSL_RECVAPP);
   if(ret == CURLE_AGAIN)
@@ -624,6 +630,7 @@ static CURLcode bearssl_connect_step3(struct Curl_easy *data,
   CURLcode ret;
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
+  DEBUGASSERT(backend);
 
   if(conn->bits.tls_enable_alpn) {
     const char *protocol;
@@ -689,6 +696,8 @@ static ssize_t bearssl_send(struct Curl_easy *data, int sockindex,
   unsigned char *app;
   size_t applen;
 
+  DEBUGASSERT(backend);
+
   for(;;) {
     *err = bearssl_run_until(data, conn, sockindex, BR_SSL_SENDAPP);
     if (*err != CURLE_OK)
@@ -721,6 +730,8 @@ static ssize_t bearssl_recv(struct Curl_easy *data, int sockindex,
   struct ssl_backend_data *backend = connssl->backend;
   unsigned char *app;
   size_t applen;
+
+  DEBUGASSERT(backend);
 
   *err = bearssl_run_until(data, conn, sockindex, BR_SSL_RECVAPP);
   if(*err != CURLE_OK)
@@ -847,6 +858,7 @@ static bool bearssl_data_pending(const struct connectdata *conn,
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   struct ssl_backend_data *backend = connssl->backend;
+  DEBUGASSERT(backend);
   return br_ssl_engine_current_state(&backend->ctx.eng) & BR_SSL_RECVAPP;
 }
 
@@ -896,6 +908,7 @@ static void *bearssl_get_internals(struct ssl_connect_data *connssl,
                                    CURLINFO info UNUSED_PARAM)
 {
   struct ssl_backend_data *backend = connssl->backend;
+  DEBUGASSERT(backend);
   return &backend->ctx;
 }
 
@@ -905,6 +918,8 @@ static void bearssl_close(struct Curl_easy *data,
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   size_t i;
+
+  DEBUGASSERT(backend);
 
   if(backend->active) {
     br_ssl_engine_close(&backend->ctx.eng);

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -202,8 +202,11 @@ static CURLcode handshake(struct Curl_easy *data,
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
-  gnutls_session_t session = backend->session;
+  gnutls_session_t session;
   curl_socket_t sockfd = conn->sock[sockindex];
+
+  DEBUGASSERT(backend);
+  session = backend->session;
 
   for(;;) {
     timediff_t timeout_ms;
@@ -405,6 +408,8 @@ gtls_connect_step1(struct Curl_easy *data,
   long * const certverifyresult = &SSL_SET_OPTION_LVALUE(certverifyresult);
   const char *tls13support;
   CURLcode result;
+
+  DEBUGASSERT(backend);
 
   if(connssl->state == ssl_connection_complete)
     /* to make us tolerant against being called more than once for the
@@ -701,7 +706,10 @@ gtls_connect_step1(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_PROXY
   if(conn->proxy_ssl[sockindex].use) {
-    transport_ptr = conn->proxy_ssl[sockindex].backend->session;
+    struct ssl_backend_data *proxy_backend;
+    proxy_backend = conn->proxy_ssl[sockindex].backend;
+    DEBUGASSERT(proxy_backend);
+    transport_ptr = proxy_backend->session;
     gnutls_transport_push = gtls_push_ssl;
     gnutls_transport_pull = gtls_pull_ssl;
   }
@@ -1356,7 +1364,9 @@ gtls_connect_common(struct Curl_easy *data,
   /* Finish connecting once the handshake is done */
   if(ssl_connect_1 == connssl->connecting_state) {
     struct ssl_backend_data *backend = connssl->backend;
-    gnutls_session_t session = backend->session;
+    gnutls_session_t session;
+    DEBUGASSERT(backend);
+    session = backend->session;
     rc = Curl_gtls_verifyserver(data, conn, session, sockindex);
     if(rc)
       return rc;
@@ -1397,6 +1407,9 @@ static bool gtls_data_pending(const struct connectdata *conn,
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   bool res = FALSE;
   struct ssl_backend_data *backend = connssl->backend;
+
+  DEBUGASSERT(backend);
+
   if(backend->session &&
      0 != gnutls_record_check_pending(backend->session))
     res = TRUE;
@@ -1404,6 +1417,7 @@ static bool gtls_data_pending(const struct connectdata *conn,
 #ifndef CURL_DISABLE_PROXY
   connssl = &conn->proxy_ssl[connindex];
   backend = connssl->backend;
+  DEBUGASSERT(backend);
   if(backend->session &&
      0 != gnutls_record_check_pending(backend->session))
     res = TRUE;
@@ -1421,7 +1435,10 @@ static ssize_t gtls_send(struct Curl_easy *data,
   struct connectdata *conn = data->conn;
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
-  ssize_t rc = gnutls_record_send(backend->session, mem, len);
+  ssize_t rc;
+
+  DEBUGASSERT(backend);
+  rc = gnutls_record_send(backend->session, mem, len);
 
   if(rc < 0) {
     *curlcode = (rc == GNUTLS_E_AGAIN)
@@ -1437,6 +1454,8 @@ static ssize_t gtls_send(struct Curl_easy *data,
 static void close_one(struct ssl_connect_data *connssl)
 {
   struct ssl_backend_data *backend = connssl->backend;
+  DEBUGASSERT(backend);
+
   if(backend->session) {
     char buf[32];
     /* Maybe the server has already sent a close notify alert.
@@ -1478,6 +1497,8 @@ static int gtls_shutdown(struct Curl_easy *data, struct connectdata *conn,
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
   int retval = 0;
+
+  DEBUGASSERT(backend);
 
 #ifndef CURL_DISABLE_FTP
   /* This has only been tested on the proftpd server, and the mod_tls code
@@ -1557,6 +1578,8 @@ static ssize_t gtls_recv(struct Curl_easy *data, /* connection data */
   struct ssl_backend_data *backend = connssl->backend;
   ssize_t ret;
 
+  DEBUGASSERT(backend);
+
   ret = gnutls_record_recv(backend->session, buf, buffersize);
   if((ret == GNUTLS_E_AGAIN) || (ret == GNUTLS_E_INTERRUPTED)) {
     *curlcode = CURLE_AGAIN;
@@ -1628,6 +1651,7 @@ static void *gtls_get_internals(struct ssl_connect_data *connssl,
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
+  DEBUGASSERT(backend);
   return backend->session;
 }
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -230,6 +230,8 @@ set_ssl_version_min_max(struct Curl_easy *data, struct connectdata *conn,
   long ssl_version_max = SSL_CONN_CONFIG(version_max);
   CURLcode result = CURLE_OK;
 
+  DEBUGASSERT(backend);
+
   switch(ssl_version) {
     case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1:
@@ -284,6 +286,8 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
 #endif
   int ret = -1;
   char errorbuf[128];
+
+  DEBUGASSERT(backend);
 
   if((SSL_CONN_CONFIG(version) == CURL_SSLVERSION_SSLv2) ||
      (SSL_CONN_CONFIG(version) == CURL_SSLVERSION_SSLv3)) {
@@ -665,6 +669,8 @@ mbed_connect_step2(struct Curl_easy *data, struct connectdata *conn,
   const mbedtls_x509_crt *peercert;
   const char * const pinnedpubkey = SSL_PINNED_PUB_KEY();
 
+  DEBUGASSERT(backend);
+
   conn->recv[sockindex] = mbed_recv;
   conn->send[sockindex] = mbed_send;
 
@@ -844,6 +850,7 @@ mbed_connect_step3(struct Curl_easy *data, struct connectdata *conn,
   struct ssl_backend_data *backend = connssl->backend;
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
+  DEBUGASSERT(backend);
 
   if(SSL_SET_OPTION(primary.sessionid)) {
     int ret;
@@ -900,6 +907,8 @@ static ssize_t mbed_send(struct Curl_easy *data, int sockindex,
   struct ssl_backend_data *backend = connssl->backend;
   int ret = -1;
 
+  DEBUGASSERT(backend);
+
   ret = mbedtls_ssl_write(&backend->ssl, (unsigned char *)mem, len);
 
   if(ret < 0) {
@@ -923,6 +932,8 @@ static void mbedtls_close(struct Curl_easy *data,
   struct ssl_backend_data *backend = connssl->backend;
   char buf[32];
   (void) data;
+
+  DEBUGASSERT(backend);
 
   /* Maybe the server has already sent a close notify alert.
      Read it to avoid an RST on the TCP connection. */
@@ -951,6 +962,8 @@ static ssize_t mbed_recv(struct Curl_easy *data, int num,
   struct ssl_backend_data *backend = connssl->backend;
   int ret = -1;
   ssize_t len = -1;
+
+  DEBUGASSERT(backend);
 
   ret = mbedtls_ssl_read(&backend->ssl, (unsigned char *)buf,
                          buffersize);
@@ -1186,6 +1199,7 @@ static bool mbedtls_data_pending(const struct connectdata *conn,
 {
   const struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
+  DEBUGASSERT(backend);
   return mbedtls_ssl_get_bytes_avail(&backend->ssl) != 0;
 }
 
@@ -1215,6 +1229,7 @@ static void *mbedtls_get_internals(struct ssl_connect_data *connssl,
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
+  DEBUGASSERT(backend);
   return &backend->ssl;
 }
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -426,6 +426,8 @@ schannel_acquire_credential_handle(struct Curl_easy *data,
   CURLcode result;
   struct ssl_backend_data *backend = connssl->backend;
 
+  DEBUGASSERT(backend);
+
   /* setup Schannel API options */
   memset(&schannel_cred, 0, sizeof(schannel_cred));
   schannel_cred.dwVersion = SCHANNEL_CRED_VERSION;
@@ -772,6 +774,8 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   char * const hostname = SSL_HOST_NAME();
   struct ssl_backend_data *backend = connssl->backend;
 
+  DEBUGASSERT(backend);
+
   DEBUGF(infof(data,
                "schannel: SSL/TLS connection with %s port %hu (step 1/3)",
                hostname, conn->remote_port));
@@ -1037,6 +1041,8 @@ schannel_connect_step2(struct Curl_easy *data, struct connectdata *conn,
   bool doread;
   const char *pubkey_ptr;
   struct ssl_backend_data *backend = connssl->backend;
+
+  DEBUGASSERT(backend);
 
   doread = (connssl->connecting_state != ssl_connect_2_writing) ? TRUE : FALSE;
 
@@ -1371,6 +1377,7 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
   struct ssl_backend_data *backend = connssl->backend;
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
+  DEBUGASSERT(backend);
 
   DEBUGF(infof(data,
                "schannel: SSL/TLS connection with %s port %hu (step 3/3)",
@@ -1611,6 +1618,7 @@ schannel_connect_common(struct Curl_easy *data, struct connectdata *conn,
      */
     {
       struct ssl_backend_data *backend = connssl->backend;
+      DEBUGASSERT(backend);
       conn->sslContext = &backend->ctxt->ctxt_handle;
     }
 #endif
@@ -1640,6 +1648,8 @@ schannel_send(struct Curl_easy *data, int sockindex,
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CURLcode result;
   struct ssl_backend_data *backend = connssl->backend;
+
+  DEBUGASSERT(backend);
 
   /* check if the maximum stream sizes were queried */
   if(backend->stream_sizes.cbMaximumMessage == 0) {
@@ -1788,6 +1798,8 @@ schannel_recv(struct Curl_easy *data, int sockindex,
      that it can hold all the bytes requested and some TLS record overhead. */
   size_t min_encdata_length = len + CURL_SCHANNEL_BUFFER_FREE_SIZE;
   struct ssl_backend_data *backend = connssl->backend;
+
+  DEBUGASSERT(backend);
 
   /****************************************************************************
    * Don't return or set backend->recv_unrecoverable_err unless in the cleanup.
@@ -2123,6 +2135,8 @@ static bool schannel_data_pending(const struct connectdata *conn,
   const struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_backend_data *backend = connssl->backend;
 
+  DEBUGASSERT(backend);
+
   if(connssl->use) /* SSL/TLS is in use */
     return (backend->decdata_offset > 0 ||
             (backend->encdata_offset > 0 && !backend->encdata_is_incomplete));
@@ -2159,6 +2173,7 @@ static int schannel_shutdown(struct Curl_easy *data, struct connectdata *conn,
   struct ssl_backend_data *backend = connssl->backend;
 
   DEBUGASSERT(data);
+  DEBUGASSERT(backend);
 
   if(connssl->use) {
     infof(data, "schannel: shutting down SSL/TLS connection with %s port %hu",
@@ -2309,6 +2324,8 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
   /* Result is returned to caller */
   CURLcode result = CURLE_SSL_PINNEDPUBKEYNOTMATCH;
 
+  DEBUGASSERT(backend);
+
   /* if a path wasn't specified, don't pin */
   if(!pinnedpubkey)
     return CURLE_OK;
@@ -2429,6 +2446,7 @@ static void *schannel_get_internals(struct ssl_connect_data *connssl,
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
+  DEBUGASSERT(backend);
   return &backend->ctxt->ctxt_handle;
 }
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -576,6 +576,8 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
   HCERTSTORE trust_store = NULL;
   const char * const conn_hostname = SSL_HOST_NAME();
 
+  DEBUGASSERT(BACKEND);
+
   sspi_status =
     s_pSecFn->QueryContextAttributes(&BACKEND->ctxt->ctxt_handle,
                                      SECPKG_ATTR_REMOTE_CERT_CONTEXT,

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -837,12 +837,14 @@ static OSStatus SocketRead(SSLConnectionRef connection,
   /*int sock = *(int *)connection;*/
   struct ssl_connect_data *connssl = (struct ssl_connect_data *)connection;
   struct ssl_backend_data *backend = connssl->backend;
-  int sock = backend->ssl_sockfd;
+  int sock;
   OSStatus rtn = noErr;
   size_t bytesRead;
   ssize_t rrtn;
   int theErr;
 
+  DEBUGASSERT(backend);
+  sock = backend->ssl_sockfd;
   *dataLength = 0;
 
   for(;;) {
@@ -898,13 +900,15 @@ static OSStatus SocketWrite(SSLConnectionRef connection,
   /*int sock = *(int *)connection;*/
   struct ssl_connect_data *connssl = (struct ssl_connect_data *)connection;
   struct ssl_backend_data *backend = connssl->backend;
-  int sock = backend->ssl_sockfd;
+  int sock;
   ssize_t length;
   size_t dataLen = *dataLength;
   const UInt8 *dataPtr = (UInt8 *)data;
   OSStatus ortn;
   int theErr;
 
+  DEBUGASSERT(backend);
+  sock = backend->ssl_sockfd;
   *dataLength = 0;
 
   do {
@@ -1376,6 +1380,8 @@ set_ssl_version_min_max(struct Curl_easy *data, struct connectdata *conn,
   long ssl_version_max = SSL_CONN_CONFIG(version_max);
   long max_supported_version_by_os;
 
+  DEBUGASSERT(backend);
+
   /* macOS 10.5-10.7 supported TLS 1.0 only.
      macOS 10.8 and later, and iOS 5 and later, added TLS 1.1 and 1.2.
      macOS 10.13 and later, and iOS 11 and later, added TLS 1.3. */
@@ -1683,6 +1689,8 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
   OSStatus err = noErr;
 #if CURL_BUILD_MAC
   int darwinver_maj = 0, darwinver_min = 0;
+
+  DEBUGASSERT(backend);
 
   GetDarwinVersionNumber(&darwinver_maj, &darwinver_min);
 #endif /* CURL_BUILD_MAC */
@@ -2547,6 +2555,7 @@ sectransp_connect_step2(struct Curl_easy *data, struct connectdata *conn,
   DEBUGASSERT(ssl_connect_2 == connssl->connecting_state
               || ssl_connect_2_reading == connssl->connecting_state
               || ssl_connect_2_writing == connssl->connecting_state);
+  DEBUGASSERT(backend);
 
   /* Here goes nothing: */
   err = SSLHandshake(backend->ssl_ctx);
@@ -2923,6 +2932,8 @@ collect_server_cert(struct Curl_easy *data,
   CFIndex i, count;
   SecTrustRef trust = NULL;
 
+  DEBUGASSERT(backend);
+
   if(!show_verbose_server_cert && !data->set.ssl.certinfo)
     return CURLE_OK;
 
@@ -3167,6 +3178,8 @@ static void sectransp_close(struct Curl_easy *data, struct connectdata *conn,
 
   (void) data;
 
+  DEBUGASSERT(backend);
+
   if(backend->ssl_ctx) {
     (void)SSLClose(backend->ssl_ctx);
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
@@ -3194,6 +3207,8 @@ static int sectransp_shutdown(struct Curl_easy *data,
   int rc;
   char buf[120];
   int loop = 10; /* avoid getting stuck */
+
+  DEBUGASSERT(backend);
 
   if(!backend->ssl_ctx)
     return 0;
@@ -3274,6 +3289,8 @@ static int sectransp_check_cxn(struct connectdata *conn)
   OSStatus err;
   SSLSessionState state;
 
+  DEBUGASSERT(backend);
+
   if(backend->ssl_ctx) {
     err = SSLGetSessionState(backend->ssl_ctx, &state);
     if(err == noErr)
@@ -3290,6 +3307,8 @@ static bool sectransp_data_pending(const struct connectdata *conn,
   struct ssl_backend_data *backend = connssl->backend;
   OSStatus err;
   size_t buffer;
+
+  DEBUGASSERT(backend);
 
   if(backend->ssl_ctx) {  /* SSL is in use */
     err = SSLGetBufferedReadSize(backend->ssl_ctx, &buffer);
@@ -3351,6 +3370,8 @@ static ssize_t sectransp_send(struct Curl_easy *data,
   struct ssl_backend_data *backend = connssl->backend;
   size_t processed = 0UL;
   OSStatus err;
+
+  DEBUGASSERT(backend);
 
   /* The SSLWrite() function works a little differently than expected. The
      fourth argument (processed) is currently documented in Apple's
@@ -3419,6 +3440,8 @@ static ssize_t sectransp_recv(struct Curl_easy *data,
   size_t processed = 0UL;
   OSStatus err;
 
+  DEBUGASSERT(backend);
+
   again:
   err = SSLRead(backend->ssl_ctx, buf, buffersize, &processed);
 
@@ -3468,6 +3491,7 @@ static void *sectransp_get_internals(struct ssl_connect_data *connssl,
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
+  DEBUGASSERT(backend);
   return backend->ssl_ctx;
 }
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -300,6 +300,8 @@ ssl_connect_init_proxy(struct connectdata *conn, int sockindex)
     pbdata = conn->proxy_ssl[sockindex].backend;
     conn->proxy_ssl[sockindex] = conn->ssl[sockindex];
 
+    DEBUGASSERT(pbdata != NULL);
+
     memset(&conn->ssl[sockindex], 0, sizeof(conn->ssl[sockindex]));
     memset(pbdata, 0, Curl_ssl->sizeof_ssl_backend_data);
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -263,6 +263,8 @@ wolfssl_connect_step1(struct Curl_easy *data, struct connectdata *conn,
 #define use_sni(x)  Curl_nop_stmt
 #endif
 
+  DEBUGASSERT(backend);
+
   if(connssl->state == ssl_connection_complete)
     return CURLE_OK;
 
@@ -598,6 +600,8 @@ wolfssl_connect_step2(struct Curl_easy *data, struct connectdata *conn,
   const char * const dispname = SSL_HOST_DISPNAME();
   const char * const pinnedpubkey = SSL_PINNED_PUB_KEY();
 
+  DEBUGASSERT(backend);
+
   ERR_clear_error();
 
   conn->recv[sockindex] = wolfssl_recv;
@@ -802,6 +806,7 @@ wolfssl_connect_step3(struct Curl_easy *data, struct connectdata *conn,
   struct ssl_backend_data *backend = connssl->backend;
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
+  DEBUGASSERT(backend);
 
   if(SSL_SET_OPTION(primary.sessionid)) {
     bool incache;
@@ -853,6 +858,8 @@ static ssize_t wolfssl_send(struct Curl_easy *data,
   int memlen = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
   int rc;
 
+  DEBUGASSERT(backend);
+
   ERR_clear_error();
 
   rc = SSL_write(backend->handle, mem, memlen);
@@ -885,6 +892,8 @@ static void wolfssl_close(struct Curl_easy *data, struct connectdata *conn,
 
   (void) data;
 
+  DEBUGASSERT(backend);
+
   if(backend->handle) {
     char buf[32];
     /* Maybe the server has already sent a close notify alert.
@@ -912,6 +921,8 @@ static ssize_t wolfssl_recv(struct Curl_easy *data,
   char error_buffer[WOLFSSL_MAX_ERROR_SZ];
   int buffsize = (buffersize > (size_t)INT_MAX) ? INT_MAX : (int)buffersize;
   int nread;
+
+  DEBUGASSERT(backend);
 
   ERR_clear_error();
 
@@ -982,6 +993,7 @@ static bool wolfssl_data_pending(const struct connectdata *conn,
 {
   const struct ssl_connect_data *connssl = &conn->ssl[connindex];
   struct ssl_backend_data *backend = connssl->backend;
+  DEBUGASSERT(backend);
   if(backend->handle)   /* SSL is in use */
     return (0 != SSL_pending(backend->handle)) ? TRUE : FALSE;
   else
@@ -1001,6 +1013,8 @@ static int wolfssl_shutdown(struct Curl_easy *data, struct connectdata *conn,
   struct ssl_backend_data *backend = connssl->backend;
 
   (void) data;
+
+  DEBUGASSERT(backend);
 
   if(backend->handle) {
     ERR_clear_error();
@@ -1181,6 +1195,7 @@ static void *wolfssl_get_internals(struct ssl_connect_data *connssl,
 {
   struct ssl_backend_data *backend = connssl->backend;
   (void)info;
+  DEBUGASSERT(backend);
   return backend->handle;
 }
 


### PR DESCRIPTION
Additionally, adding a backend check for NULL everywhere