### PR TITLE
vtls: remove erroneous assert

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -421,8 +421,6 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
     return TRUE;
 #endif
 
-  DEBUGASSERT(SSL_SET_OPTION(primary.sessionid));
-
   if(!SSL_SET_OPTION(primary.sessionid) || !data->state.session)
     /* session ID re-use is disabled or the session cache has not been
        setup */


### PR DESCRIPTION
As assert that required an non-zero session id cache just before the
run-time check that handles it correctly is an incorrect assert.

Reported-by: Jim Beveridge
Fixes #8472