### PR TITLE
Fixed BearSSL bug: TLS Session Resumption (session id) not working

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -474,7 +474,7 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
     hostname = snihost;
   }
 
-  if(!br_ssl_client_reset(&backend->ctx, hostname, 0))
+  if(!br_ssl_client_reset(&backend->ctx, hostname, 1))
     return CURLE_FAILED_INIT;
   backend->active = TRUE;
 


### PR DESCRIPTION
Separated from: https://github.com/curl/curl/pull/8106

In `bearssl_connect_step1` the function `br_ssl_client_reset()` is called with `resume_session` set to 0. This will make BearSSL clear the specified session id. Setting the `resume_session` paramater to 1 fixes this.
