### PR TITLE
Implemented BearSSL: CURLOPT_SSL_CTX_FUNCTION

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
@@ -116,7 +116,7 @@ int main(void)
 .fi
 .SH AVAILABILITY
 Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL, in 7.54.0 for mbedTLS,
-in 7.82.0 in BearSSL. Other SSL backends are not supported.
+in 7.83.0 in BearSSL. Other SSL backends are not supported.
 .SH RETURN VALUE
 CURLE_OK if supported; or an error such as:
 

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
@@ -115,8 +115,8 @@ int main(void)
 }
 .fi
 .SH AVAILABILITY
-Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL and in 7.54.0 for
-mbedTLS. Other SSL backends are not supported.
+Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL, in 7.54.0 for mbedTLS,
+in 7.82.0 in BearSSL. Other SSL backends are not supported.
 .SH RETURN VALUE
 CURLE_OK if supported; or an error such as:
 

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -32,8 +32,9 @@ CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr);
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_FUNCTION,
                           ssl_ctx_callback);
 .SH DESCRIPTION
-This option only works for libcurl powered by OpenSSL, wolfSSL or mbedTLS. If
-libcurl was built against another SSL library this functionality is absent.
+This option only works for libcurl powered by OpenSSL, wolfSSL, mbedTLS or
+BearSSL. If libcurl was built against another SSL library this functionality
+is absent.
 
 Pass a pointer to your callback function, which should match the prototype
 shown above.
@@ -42,8 +43,9 @@ This callback function gets called by libcurl just before the initialization
 of an SSL connection after having processed all other SSL related options to
 give a last chance to an application to modify the behavior of the SSL
 initialization. The \fIssl_ctx\fP parameter is actually a pointer to the SSL
-library's \fISSL_CTX\fP for OpenSSL or wolfSSL, and a pointer to
-\fImbedtls_ssl_config\fP for mbedTLS. If an error is returned from the
+library's \fISSL_CTX\fP for OpenSSL or wolfSSL, a pointer to
+\fImbedtls_ssl_config\fP for mbedTLS or a pointer to
+\fIbr_ssl_client_context\fP for BearSSL. If an error is returned from the
 callback no attempt to establish a connection is made and the perform
 operation will return the callback's error code. Set the \fIuserptr\fP
 argument with the \fICURLOPT_SSL_CTX_DATA(3)\fP option.

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -154,8 +154,8 @@ int main(void)
 }
 .fi
 .SH AVAILABILITY
-Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL and in 7.54.0 for
-mbedTLS. Other SSL backends are not supported.
+Added in 7.11.0 for OpenSSL, in 7.42.0 for wolfSSL, in 7.54.0 for mbedTLS,
+in 7.83.0 in BearSSL. Other SSL backends are not supported.
 .SH RETURN VALUE
 CURLE_OK if supported; or an error such as:
 


### PR DESCRIPTION
Separated from: https://github.com/curl/curl/pull/8106

Implemented the CURLOPT_SSL_CTX_FUNCTION option for BearSSL.
