### PR TITLE
Fix minor typo in curl.h comment on line 2822

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2819,7 +2819,7 @@ typedef enum {
   CURLCLOSEPOLICY_LAST /* last, never use this */
 } curl_closepolicy;
 
-#define CURL_GLOBAL_SSL (1<<0) /* no purpose since since 7.57.0 */
+#define CURL_GLOBAL_SSL (1<<0) /* no purpose since 7.57.0 */
 #define CURL_GLOBAL_WIN32 (1<<1)
 #define CURL_GLOBAL_ALL (CURL_GLOBAL_SSL|CURL_GLOBAL_WIN32)
 #define CURL_GLOBAL_NOTHING 0


### PR DESCRIPTION
Fixed minor typo in comment on line 2822.