### PR TITLE
multi: allow user callbacks to call curl_multi_assign

### DIFF
--- a/docs/libcurl/curl_multi_assign.3
+++ b/docs/libcurl/curl_multi_assign.3
@@ -48,6 +48,8 @@ The idea here being that this association (socket to private pointer) is
 something that just about every application that uses this API will need and
 then libcurl can just as well do it since it already has an internal hash
 table lookup for this.
+
+It is acceptable to call this function from your multi callback functions.
 .SH EXAMPLE
 .nf
  /* make our struct pointer associated with socket fd */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3571,9 +3571,6 @@ CURLMcode curl_multi_assign(struct Curl_multi *multi, curl_socket_t s,
 {
   struct Curl_sh_entry *there = NULL;
 
-  if(multi->in_callback)
-    return CURLM_RECURSIVE_API_CALL;
-
   there = sh_getentry(&multi->sockhash, s);
 
   if(!there)


### PR DESCRIPTION
Several years ago a change was made to block user callbacks from calling
back into the API when not supported (recursive calls). One of the calls
blocked was curl_multi_assign. Recently the blocking was extended to the
multi interface API, however curl_multi_assign may need to be called
from within those user callbacks (eg CURLMOPT_SOCKETFUNCTION).

I can't think of any callback where it would be unsafe to call
curl_multi_assign so I removed the restriction entirely.

Reported-by: Michael Wallner

Ref: https://github.com/curl/curl/commit/b46cfbc
Ref: https://github.com/curl/curl/commit/340bb19

Fixes https://github.com/curl/curl/issues/8480
Closes #xxxx

---

/cc @zagor