### PR TITLE
openssl: check if sessionid flag is enabled before retrieving session

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3226,21 +3226,23 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-  Curl_ssl_sessionid_lock(data);
-  if(!Curl_ssl_getsessionid(data, conn, SSL_IS_PROXY() ? TRUE : FALSE,
-                            &ssl_sessionid, NULL, sockindex)) {
-    /* we got a session id, use it! */
-    if(!SSL_set_session(backend->handle, ssl_sessionid)) {
-      Curl_ssl_sessionid_unlock(data);
-      failf(data, "SSL: SSL_set_session failed: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      return CURLE_SSL_CONNECT_ERROR;
+  if(SSL_SET_OPTION(primary.sessionid)) {
+    Curl_ssl_sessionid_lock(data);
+    if(!Curl_ssl_getsessionid(data, conn, SSL_IS_PROXY() ? TRUE : FALSE,
+                              &ssl_sessionid, NULL, sockindex)) {
+      /* we got a session id, use it! */
+      if(!SSL_set_session(backend->handle, ssl_sessionid)) {
+        Curl_ssl_sessionid_unlock(data);
+        failf(data, "SSL: SSL_set_session failed: %s",
+              ossl_strerror(ERR_get_error(), error_buffer,
+                            sizeof(error_buffer)));
+        return CURLE_SSL_CONNECT_ERROR;
+      }
+      /* Informational message */
+      infof(data, "SSL re-using session ID");
     }
-    /* Informational message */
-    infof(data, "SSL re-using session ID");
+    Curl_ssl_sessionid_unlock(data);
   }
-  Curl_ssl_sessionid_unlock(data);
 
 #ifndef CURL_DISABLE_PROXY
   if(conn->proxy_ssl[sockindex].use) {


### PR DESCRIPTION
Ideally, Curl_ssl_getsessionid should not be called unless sessionid
caching is enabled. There is a debug assertion in the function to help
ensure that. Therefore, the pattern in all vtls is basically:

  if(primary.sessionid) {lock(); Curl_ssl_getsessionid(...); unlock();}

There was one instance in openssl.c where sessionid was not checked
beforehand and this change fixes that.

Prior to this change an assertion would occur in openssl debug builds
during connection stage if session caching was disabled.

Reported-by: Jim Beveridge

Fixes https://github.com/curl/curl/issues/8472
Closes #xxxx