### PR TITLE
zuul: explicit disable openssl for quic job with gnutls

### DIFF
--- a/scripts/zuul/before_script.sh
+++ b/scripts/zuul/before_script.sh
@@ -63,7 +63,7 @@ if [ "$NGTCP2" = yes ]; then
   cd ngtcp2
   autoreconf -i
   if test -n "$GNUTLS"; then
-      WITHGNUTLS="--with-gnutls"
+      WITHGNUTLS="--with-gnutls --without-openssl"
   fi
   ./configure PKG_CONFIG_PATH=$HOME/ngbuild/lib/pkgconfig LDFLAGS="-Wl,-rpath,$HOME/ngbuild/lib" --prefix=$HOME/ngbuild --enable-lib-only $WITHGNUTLS
   make


### PR DESCRIPTION
It is something wrong with curl-novalgrind-ngtcp2-gnutls build. The logs shows that:

```
checking for OPENSSL... yes
checking for SSL_is_quic... no
```

so I assumed openssl will not be compiled. But on the end we can see:

`libngtcp2_crypto_openssl:   yes`

and ngtcp2 build project with openssl. So try explicity disable openssl.