### PR TITLE
CURLOPT_XFERINFOFUNCTION.3: fix typo in example

### DIFF
--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -90,7 +90,7 @@ All
                                  curl_off_t ultotal,
                                  curl_off_t ulnow)
  {
-   struct memory *progress = (struct progress *)userp;
+   struct memory *progress = (struct progress *)clientp;
 
    /* use the values */
 


### PR DESCRIPTION
Reported-by: coralw on github
Fixes #8487