### PR TITLE
OS400 rpg include file fixes

### DIFF
--- a/packages/OS400/README.OS400
+++ b/packages/OS400/README.OS400
@@ -260,7 +260,7 @@ _ Likewise, if SCP and SFTP protocols have to be compiled in, LIBSSH2
   developent environment must be installed.
 _ Install the curl source directory in IFS. Do NOT install it in the
   installation target directory (which defaults to /curl).
-_ Enter shell (QSH)
+_ Enter Qshell (QSH, not PASE)
 _ Change current directory to the curl installation directory
 _ Change current directory to ./packages/OS400
 _ Edit file iniscript.sh. You may want to change tunable configuration
@@ -269,7 +269,7 @@ _ Edit file iniscript.sh. You may want to change tunable configuration
 _ Copy any file in the current directory to makelog (i.e.:
   cp initscript.sh makelog): this is intended to create the makelog file with
   an ASCII CCSID!
-_ Enter the command "sh makefile.sh > makelog 2>&1'
+_ Enter the command "sh makefile.sh > makelog 2>&1"
 _ Examine the makelog file to check for compilation errors.
 
   Leaving file initscript.sh unchanged, this will produce the following OS/400

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -1679,7 +1679,7 @@
      d                 c                   20
       *
      d CURLMIMEOPT_FORMESCAPE...
-     d                 c                   X'00000000'
+     d                 c                   X'00000001'
       *
      d CURLINFO        s             10i 0 based(######ptr######)               Enum
      d  CURLINFO_EFFECTIVE_URL...                                               CURLINFO_STRING + 1

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -1679,7 +1679,7 @@
      d                 c                   20
       *
      d CURLMIMEOPT_FORMESCAPE...
-     d                                     X'0000000'
+     d                 c                   X'00000000'
       *
      d CURLINFO        s             10i 0 based(######ptr######)               Enum
      d  CURLINFO_EFFECTIVE_URL...                                               CURLINFO_STRING + 1
@@ -2316,7 +2316,7 @@
      d                                     qualified
      d  name                           *                                        const char *
      d  id                                 like(CURLoption)
-     d  type                               like(curl_easytyoe)
+     d  type                               like(curl_easytype)
      d  flags                        10u 0
       *
      d curl_hstsentry...
@@ -2926,7 +2926,7 @@
       *
      d curl_easy_option_by_name...
      d                 pr              *   extproc('curl_easy_option_by_name')  curl_easyoption *
-     d  name                           *   value option(*string)
+     d  name                           *   value options(*string)
       *
      d curl_easy_option_by_id...
      d                 pr              *   extproc('curl_easy_option_by_id')    curl_easyoption *
@@ -3113,7 +3113,7 @@
      d curl_easy_option_by_name_ccsid...
      d                 pr              *   extproc(                             curl_easyoption *
      d                                      'curl_easy_option_by_name_ccsid')
-     d  name                           *   value option(*string)
+     d  name                           *   value options(*string)
      d  ccsid                        10u 0 value
       *
      d curl_easy_option_get_name_ccsid...


### PR DESCRIPTION
fixes typos within function declarations that were causing compilation errors when including the header in rpg code.