### PR TITLE
Avoid unused parameter error in Curl_resolv_check

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1220,6 +1220,7 @@ CURLcode Curl_resolv_check(struct Curl_easy *data,
                            struct Curl_dns_entry **dns)
 {
 #if defined(CURL_DISABLE_DOH) && !defined(CURLRES_ASYNCH)
+  (void)data;
   (void)dns;
 #endif
 #ifndef CURL_DISABLE_DOH


### PR DESCRIPTION
When built without DNS-over-HTTP and without asynchronous resolvers,
neither the dns nor the data parameters are used.

That is Curl_resolv_check appears to call
Curl_resolver_is_resolved(data, dns). But,
with CURL_DISABLE_DOH without CURLRES_ASYNCH, the call is actually
elided via a macro definition.

This fix resolves the resultant: "unused parameter 'data'" error.