### PR TITLE
pop3/smtp: return *WEIRD_SERVER_REPLY when not understood

### DIFF
--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -293,7 +293,7 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
        */
       if((ptr + pp->cache_size) > (buf + data->set.buffer_size + 1)) {
         failf(data, "cached response data too big to handle");
-        return CURLE_RECV_ERROR;
+        return CURLE_WEIRD_SERVER_REPLY;
       }
       memcpy(ptr, pp->cache, pp->cache_size);
       gotbytes = (ssize_t)pp->cache_size;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -924,7 +924,7 @@ static CURLcode pop3_state_command_resp(struct Curl_easy *data,
 
   if(pop3code != '+') {
     state(data, POP3_STOP);
-    return CURLE_RECV_ERROR;
+    return CURLE_WEIRD_SERVER_REPLY;
   }
 
   /* This 'OK' line ends with a CR LF pair which is the two first bytes of the

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1037,7 +1037,7 @@ static CURLcode smtp_state_command_resp(struct Curl_easy *data, int smtpcode,
   if((smtp->rcpt && smtpcode/100 != 2 && smtpcode != 553 && smtpcode != 1) ||
      (!smtp->rcpt && smtpcode/100 != 2 && smtpcode != 1)) {
     failf(data, "Command failed: %d", smtpcode);
-    result = CURLE_RECV_ERROR;
+    result = CURLE_WEIRD_SERVER_REPLY;
   }
   else {
     /* Temporarily add the LF character back and send as body to the client */
@@ -1182,7 +1182,7 @@ static CURLcode smtp_state_postdata_resp(struct Curl_easy *data,
   (void)instate; /* no use for this yet */
 
   if(smtpcode != 250)
-    result = CURLE_RECV_ERROR;
+    result = CURLE_WEIRD_SERVER_REPLY;
 
   /* End of DONE phase */
   state(data, SMTP_STOP);

--- a/tests/data/test852
+++ b/tests/data/test852
@@ -34,7 +34,7 @@ pop3://%HOSTIP:%POP3PORT/%TESTNUMBER -l -u user:secret
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
-56
+8
 </errorcode>
 <protocol>
 CAPA

--- a/tests/data/test855
+++ b/tests/data/test855
@@ -34,7 +34,7 @@ pop3://%HOSTIP:%POP3PORT/%TESTNUMBER -u user:secret
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
-56
+8
 </errorcode>
 <protocol>
 CAPA

--- a/tests/data/test926
+++ b/tests/data/test926
@@ -31,9 +31,9 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt recipient
 #
 # Verify data after the test has been "shot"
 <verify>
-# 56 - CURLE_RECV_ERROR
+# 8 - CURLE_WEIRD_SERVER_REPLY
 <errorcode>
-56
+8
 </errorcode>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test957
+++ b/tests/data/test957
@@ -38,9 +38,9 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt Användaren
 #
 # Verify data after the test has been "shot"
 <verify>
-# 56 - CURLE_RECV_ERROR
+# 8 - CURLE_WEIRD_SERVER_REPLY
 <errorcode>
-56
+8
 </errorcode>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test958
+++ b/tests/data/test958
@@ -38,9 +38,9 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt Användaren@example.com
 #
 # Verify data after the test has been "shot"
 <verify>
-# 56 - CURLE_RECV_ERROR
+# 8 - CURLE_WEIRD_SERVER_REPLY
 <errorcode>
-56
+8
 </errorcode>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test961
+++ b/tests/data/test961
@@ -39,9 +39,9 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt user@åäö.se
 #
 # Verify data after the test has been "shot"
 <verify>
-# 56 - CURLE_RECV_ERROR
+# 8 - CURLE_WEIRD_SERVER_REPLY
 <errorcode>
-56
+8
 </errorcode>
 <protocol>
 EHLO %TESTNUMBER


### PR DESCRIPTION
This leaves the CURLE_RECV_ERROR error code for explicit failure to
receive network data and allows users to better separate the problems.

Fixes #8356
Reported-by: Rianov Viacheslav