### PR TITLE
configure: change output for cross-compiled alt-svc support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3924,7 +3924,7 @@ AS_HELP_STRING([--disable-alt-svc],[Disable alt-svc support]),
   *) AC_MSG_RESULT(yes)
        ;;
   esac ],
-       AC_MSG_RESULT(no)
+       AC_MSG_RESULT(yes)
 )
 
 dnl only check for HSTS if there's SSL present


### PR DESCRIPTION
It said 'no', while it actually is 'yes'