### PR TITLE
tool and tests: force flush of all buffers at end of program

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -277,6 +277,11 @@ int main(int argc, char *argv[])
     main_free(&global);
   }
 
+#ifdef WIN32
+  /* Flush buffers of all streams opened in write or update mode */
+  fflush(NULL);
+#endif
+
 #ifdef __NOVELL_LIBC__
   if(!getenv("_IN_NETWARE_BASH_"))
     tool_pressanykey();

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -179,5 +179,10 @@ int main(int argc, char **argv)
     PR_Cleanup();
 #endif
 
+#ifdef WIN32
+  /* flush buffers of all streams regardless of mode */
+  _flushall();
+#endif
+
   return result;
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -159,11 +159,10 @@ void win32_perror(const char *msg)
     fprintf(stderr, "%s: ", msg);
   fprintf(stderr, "%s\n", buf);
 }
-#endif  /* WIN32 */
 
-#ifdef USE_WINSOCK
 void win32_init(void)
 {
+#ifdef USE_WINSOCK
   WORD wVersionRequested;
   WSADATA wsaData;
   int err;
@@ -184,13 +183,19 @@ void win32_init(void)
     logmsg("No suitable winsock.dll found -- aborting");
     exit(1);
   }
+#endif  /* USE_WINSOCK */
 }
 
 void win32_cleanup(void)
 {
+#ifdef USE_WINSOCK
   WSACleanup();
-}
 #endif  /* USE_WINSOCK */
+
+  /* flush buffers of all streams regardless of their mode */
+  _flushall();
+}
+#endif  /* WIN32 */
 
 /* set by the main code to point to where the test dir is */
 const char *path = ".";

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -51,10 +51,10 @@ extern const char *cmdfile;
 void win32_perror(const char *msg);
 #endif  /* WIN32 or _WIN32 */
 
-#ifdef USE_WINSOCK
+#ifdef WIN32
 void win32_init(void);
 void win32_cleanup(void);
-#endif  /* USE_WINSOCK */
+#endif  /* WIN32 */
 
 /* fopens the test case file */
 FILE *test2fopen(long testno);


### PR DESCRIPTION
On Windows data can be lost in buffers in case of abnormal program
termination, especially in process chains as seen due to flaky tests.
Therefore flushing all buffers manually should avoid this data loss.

In the curl tool we play the safe game by only flushing write buffers,
but in the testsuite where we manage all buffers, we flush everything.

This should drastically reduce the CI and testsuite flakiness.

Supersedes https://github.com/curl/curl/pull/7833 and https://github.com/curl/curl/pull/6064