### PR TITLE
CURLOPT_XFERINFOFUNCTION.3: fix example struct assignment

### DIFF
--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
@@ -90,7 +90,7 @@ All
                                  curl_off_t ultotal,
                                  curl_off_t ulnow)
  {
-   struct memory *progress = (struct progress *)clientp;
+   struct progress *memory = (struct progress *)clientp;
 
    /* use the values */
 


### PR DESCRIPTION
modified:   docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3