### PR TITLE
lib: fix some misuse of curlx_convert_wchar_to_UTF8

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -104,7 +104,7 @@ int curlx_win32_open(const char *filename, int oflag, ...)
 #ifdef _UNICODE
   if(filename_w) {
     result = _wopen(filename_w, oflag, pmode);
-    free(filename_w);
+    curlx_unicodefree(filename_w);
   }
   else
     errno = EINVAL;
@@ -124,8 +124,8 @@ FILE *curlx_win32_fopen(const char *filename, const char *mode)
     result = _wfopen(filename_w, mode_w);
   else
     errno = EINVAL;
-  free(filename_w);
-  free(mode_w);
+  curlx_unicodefree(filename_w);
+  curlx_unicodefree(mode_w);
   return result;
 #else
   return (fopen)(filename, mode);
@@ -143,7 +143,7 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
 #else
     result = _wstati64(path_w, buffer);
 #endif
-    free(path_w);
+    curlx_unicodefree(path_w);
   }
   else
     errno = EINVAL;
@@ -164,7 +164,7 @@ int curlx_win32_access(const char *path, int mode)
   wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
   if(path_w) {
     result = _waccess(path_w, mode);
-    free(path_w);
+    curlx_unicodefree(path_w);
   }
   else
     errno = EINVAL;

--- a/lib/idn_win32.c
+++ b/lib/idn_win32.c
@@ -78,10 +78,10 @@ bool curl_win32_idn_to_ascii(const char *in, char **out)
     int chars = IdnToAscii(0, in_w, -1, punycode, IDN_MAX_LENGTH);
     curlx_unicodefree(in_w);
     if(chars) {
-      char *mb = curlx_convert_wchar_to_UTF8(punycode);
-      if(mb) {
-        *out = strdup(mb);
-        curlx_unicodefree(mb);
+      char *mstr = curlx_convert_wchar_to_UTF8(punycode);
+      if(mstr) {
+        *out = strdup(mstr);
+        curlx_unicodefree(mstr);
         if(*out)
           success = TRUE;
       }
@@ -103,10 +103,10 @@ bool curl_win32_ascii_to_idn(const char *in, char **out)
                              unicode, IDN_MAX_LENGTH);
     curlx_unicodefree(in_w);
     if(chars) {
-      char *mb = curlx_convert_wchar_to_UTF8(unicode);
-      if(mb) {
-        *out = strdup(mb);
-        curlx_unicodefree(mb);
+      char *mstr = curlx_convert_wchar_to_UTF8(unicode);
+      if(mstr) {
+        *out = strdup(mstr);
+        curlx_unicodefree(mstr);
         if(*out)
           success = TRUE;
       }

--- a/lib/idn_win32.c
+++ b/lib/idn_win32.c
@@ -76,11 +76,15 @@ bool curl_win32_idn_to_ascii(const char *in, char **out)
   if(in_w) {
     wchar_t punycode[IDN_MAX_LENGTH];
     int chars = IdnToAscii(0, in_w, -1, punycode, IDN_MAX_LENGTH);
-    free(in_w);
+    curlx_unicodefree(in_w);
     if(chars) {
-      *out = curlx_convert_wchar_to_UTF8(punycode);
-      if(*out)
-        success = TRUE;
+      char *mb = curlx_convert_wchar_to_UTF8(punycode);
+      if(mb) {
+        *out = strdup(mb);
+        curlx_unicodefree(mb);
+        if(*out)
+          success = TRUE;
+      }
     }
   }
 
@@ -97,11 +101,15 @@ bool curl_win32_ascii_to_idn(const char *in, char **out)
     wchar_t unicode[IDN_MAX_LENGTH];
     int chars = IdnToUnicode(0, in_w, curlx_uztosi(in_len),
                              unicode, IDN_MAX_LENGTH);
-    free(in_w);
+    curlx_unicodefree(in_w);
     if(chars) {
-      *out = curlx_convert_wchar_to_UTF8(unicode);
-      if(*out)
-        success = TRUE;
+      char *mb = curlx_convert_wchar_to_UTF8(unicode);
+      if(mb) {
+        *out = strdup(mb);
+        curlx_unicodefree(mb);
+        if(*out)
+          success = TRUE;
+      }
     }
   }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -635,12 +635,11 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 
     res_len = SearchPath(NULL, bundle_file, NULL, PATH_MAX, buf, &ptr);
     if(res_len > 0) {
+      char *mb = curlx_convert_tchar_to_UTF8(buf);
       Curl_safefree(config->cacert);
-#ifdef UNICODE
-      config->cacert = curlx_convert_wchar_to_UTF8(buf);
-#else
-      config->cacert = strdup(buf);
-#endif
+      if(mb)
+        config->cacert = strdup(mb);
+      curlx_unicodefree(mb);
       if(!config->cacert)
         result = CURLE_OUT_OF_MEMORY;
     }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -635,11 +635,11 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 
     res_len = SearchPath(NULL, bundle_file, NULL, PATH_MAX, buf, &ptr);
     if(res_len > 0) {
-      char *mb = curlx_convert_tchar_to_UTF8(buf);
+      char *mstr = curlx_convert_tchar_to_UTF8(buf);
       Curl_safefree(config->cacert);
-      if(mb)
-        config->cacert = strdup(mb);
-      curlx_unicodefree(mb);
+      if(mstr)
+        config->cacert = strdup(mstr);
+      curlx_unicodefree(mstr);
       if(!config->cacert)
         result = CURLE_OUT_OF_MEMORY;
     }


### PR DESCRIPTION
curlx_convert_wchar_to_UTF8 must be freed by curlx_unicodefree, but
prior to this change some uses mistakenly called free.

I've reviewed all other uses of curlx_convert_wchar_to_UTF8 and
curlx_convert_UTF8_to_wchar.

Ref: https://github.com/curl/curl/commit/1d5d0ae

Closes #xxxx

---

Sort of related: I find it confusing that in non-Unicode builds curlx_convert_UTF8_to_tchar and curlx_convert_tchar_to_UTF8 just duplicate the string in its current encoding, and a while ago I added a comment [here](https://github.com/curl/curl/blob/curl-7_81_0/lib/curl_multibyte.h#L42-L45) but it's still easy to forget. Since the purpose of those functions in non-unicode builds is just to use the current encoding then wouldn't it be better to call them curlx_convert_multibyte_to_tchar and curlx_convert_tchar_to_multibyte?