### PR TITLE
ngtcp2: Add client certificate authentication for OpenSSL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1158,6 +1158,22 @@ int cert_stuff(struct Curl_easy *data,
   return 1;
 }
 
+CURLcode Curl_ossl_set_client_cert(struct Curl_easy *data, SSL_CTX *ctx,
+                                   char *cert_file,
+                                   const struct curl_blob *cert_blob,
+                                   const char *cert_type, char *key_file,
+                                   const struct curl_blob *key_blob,
+                                   const char *key_type, char *key_passwd)
+{
+  int rv = cert_stuff(data, ctx, cert_file, cert_blob, cert_type, key_file,
+                      key_blob, key_type, key_passwd);
+  if(rv != 1) {
+    return CURLE_SSL_CERTPROBLEM;
+  }
+
+  return CURLE_OK;
+}
+
 /* returns non-zero on failure */
 static int x509_name_oneline(X509_NAME *a, char *buf, size_t size)
 {

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -43,5 +43,13 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
                               struct x509_st *server_cert);
 extern const struct Curl_ssl Curl_ssl_openssl;
 
+struct ssl_ctx_st;
+CURLcode Curl_ossl_set_client_cert(struct Curl_easy *data,
+                                   struct ssl_ctx_st *ctx, char *cert_file,
+                                   const struct curl_blob *cert_blob,
+                                   const char *cert_type, char *key_file,
+                                   const struct curl_blob *key_blob,
+                                   const char *key_type, char *key_passwd);
+
 #endif /* USE_OPENSSL */
 #endif /* HEADER_CURL_SSLUSE_H */


### PR DESCRIPTION
This commit adds client certificate authentication for ngtcp2 OpenSSL backend.
See https://github.com/curl/curl/issues/7625 for the background.

Setting client private key and certificate is a bit complex and done in cert_stuff in lib/vtls/openssl.c.  I added a wrapper function around it with the proper CURLcode to expose it to the internal codebase.