### PR TITLE
make Curl_getconnectinfo work with connection cache from share handle

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -74,6 +74,7 @@
 #include "warnless.h"
 #include "conncache.h"
 #include "multihandle.h"
+#include "share.h"
 #include "version_win32.h"
 #include "quic.h"
 #include "socks.h"
@@ -1487,7 +1488,11 @@ curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
     find.id_tofind = data->state.lastconnect_id;
     find.found = NULL;
 
-    Curl_conncache_foreach(data, data->multi_easy?
+    Curl_conncache_foreach(data,
+                           data->share && (data->share->specifier
+                           & (1<< CURL_LOCK_DATA_CONNECT))?
+                           &data->share->conn_cache:
+                           data->multi_easy?
                            &data->multi_easy->conn_cache:
                            &data->multi->conn_cache, &find, conn_is_conn);
 


### PR DESCRIPTION
I experienced that curl_easy_getinfo() with CURLINFO_ACTIVESOCKET does not return a socket, if I use a easy_handle with a share_handle set (curl_easy_setopt() with CURLOPT_SHARE).
The reason is that in the curl function Curl_getconnectinfo() does not check if the connection cache from the share_handle was used.
I propose the following pull request to address this issue.

BTW: A long time ago [1], I also proposed a patch in the same function to not only retrieve the last used connection of an easy_handle but also the currently active connection. If the above PR is acceptable I could also create a PR with this extended behavior. We use this for years now ;-).

[1] https://curl.se/mail/lib-2015-08/0116.html