### PR TITLE
rtsp: don't let CSeq error override earlier errors

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -219,7 +219,7 @@ static CURLcode rtsp_done(struct Curl_easy *data,
 
   httpStatus = Curl_http_done(data, status, premature);
 
-  if(rtsp) {
+  if(rtsp && !status && !httpStatus) {
     /* Check the sequence numbers */
     long CSeq_sent = rtsp->CSeq_sent;
     long CSeq_recv = rtsp->CSeq_recv;


### PR DESCRIPTION
- When done, if an error has already occurred then don't check the
  sequence numbers for mismatch.

A sequence number may not have been received if an error occurred.

Prior to this change a sequence mismatch error would override earlier
errors. For example, a server that returns nothing would cause error
CURLE_GOT_NOTHING in Curl_http_done which was then overridden by
CURLE_RTSP_CSEQ_ERROR in rtsp_done.

Closes #xxxx

---

Before:
~~~
* multi_done: status: 0 prem: 0 done: 0
* Empty reply from server
* The CSseq of this request 1 did not match the response 0
* The cache now contains 0 members
* Closing connection 0
curl: (85) Empty reply from server
~~~

After:
~~~
* multi_done: status: 0 prem: 0 done: 0
* Empty reply from server
* The cache now contains 0 members
* Closing connection 0
curl: (52) Empty reply from server
~~~
