### PR TITLE
connect: improve binding to local ports on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -926,6 +926,7 @@ if(NOT UNIX)
   check_include_file_concat("ws2tcpip.h"     HAVE_WS2TCPIP_H)
   check_include_file_concat("winsock2.h"     HAVE_WINSOCK2_H)
   check_include_file_concat("wincrypt.h"     HAVE_WINCRYPT_H)
+  check_include_file_concat("iphlpapi.h"     HAVE_IPHLPAPI_H)
 endif()
 
 check_include_file_concat("stdio.h"          HAVE_STDIO_H)

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -141,6 +141,9 @@
 #define HAVE_WS2TCPIP_H 1
 #endif
 
+/* Define if you have the <iphlpapi.h> header file. */
+#define HAVE_IPHLPAPI_H 1
+
 /* ---------------------------------------------------------------- */
 /*                        OTHER HEADER INFO                         */
 /* ---------------------------------------------------------------- */

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -116,6 +116,9 @@
 /* Define if you have the <ws2tcpip.h> header file.  */
 #define HAVE_WS2TCPIP_H 1
 
+/* Define if you have the <iphlpapi.h> header file. */
+#define HAVE_IPHLPAPI_H 1
+
 /* ---------------------------------------------------------------- */
 /*                        OTHER HEADER INFO                         */
 /* ---------------------------------------------------------------- */

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -238,7 +238,6 @@ timediff_t Curl_timeleft(struct Curl_easy *data,
 #ifdef HAVE_IPHLPAPI_H
 /*
 *  return the state of a given port
-*  https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-gettcptable2
 */
 static CURLcode portstate4(const unsigned short port, LPDWORD state)
 {
@@ -249,14 +248,14 @@ static CURLcode portstate4(const unsigned short port, LPDWORD state)
   DWORD res = 0;
   DWORD i;
 
-  if ((port < 0) || (port > 65535))
+  if((port < 0) || (port > 65535))
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
-  if (!state)
+  if(!state)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
   tcp_table = (PMIB_TCPTABLE2)malloc(size);
-  if (!tcp_table) {
+  if(!tcp_table) {
     fprintf(stderr, "portstate4() failed with errno %d: %s",
       errno, Curl_strerror(errno, buffer, sizeof(buffer)));
     return CURLE_OUT_OF_MEMORY;
@@ -264,10 +263,10 @@ static CURLcode portstate4(const unsigned short port, LPDWORD state)
 
   /* With the first call, we get the required size */
   res = GetTcpTable2(tcp_table, &size, TRUE);
-  if (res == ERROR_INSUFFICIENT_BUFFER) {
+  if(res == ERROR_INSUFFICIENT_BUFFER) {
     free(tcp_table);
     tcp_table = (PMIB_TCPTABLE)malloc(size);
-    if (!tcp_table) {
+    if(!tcp_table) {
       fprintf(stderr, "portstate4() failed with errno %d: %s",
         errno, Curl_strerror(errno, buffer, sizeof(buffer)));
       return CURLE_OUT_OF_MEMORY;
@@ -275,10 +274,10 @@ static CURLcode portstate4(const unsigned short port, LPDWORD state)
   }
 
   res = GetTcpTable2(tcp_table, &size, TRUE);
-  if (res == NO_ERROR) {
-    for (i = 0; i < tcp_table->dwNumEntries; i++) {
+  if(res == NO_ERROR) {
+    for(i = 0; i < tcp_table->dwNumEntries; i++) {
       lport = ntohs((unsigned short)tcp_table->table[i].dwLocalPort);
-      if (lport == port) {
+      if(lport == port) {
         *state = tcp_table->table[i].dwState;
         break;
       }
@@ -513,15 +512,15 @@ static CURLcode bindlocal(struct Curl_easy *data,
     int bind_res = -1;
 
     ccode = portstate4(port, &port_st);
-    if (ccode != CURLE_OK)
+    if(ccode != CURLE_OK)
       return ccode;
 
-    if (port_st != MIB_TCP_STATE_TIME_WAIT)
+    if(port_st != MIB_TCP_STATE_TIME_WAIT)
       bind_res = bind(sockfd, sock, sizeof_sa);
 
-    if (bind_res >= 0) {
+    if(bind_res >= 0) {
 #else
-    if (bind(sockfd, sock, sizeof_sa) >= 0) {
+    if(bind(sockfd, sock, sizeof_sa) >= 0) {
 #endif
       /* we succeeded to bind */
       struct Curl_sockaddr_storage add;

--- a/lib/setup-win32.h
+++ b/lib/setup-win32.h
@@ -47,6 +47,9 @@
 #    ifdef HAVE_WS2TCPIP_H
 #      include <ws2tcpip.h>
 #    endif
+#    ifdef HAVE_IPHLPAPI_H
+#      include <iphlpapi.h>
+#    endif
 #  endif
 #  include <tchar.h>
 #  ifdef UNICODE

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -67,7 +67,7 @@ LFLAGS_PDB = /incremental:no /opt:ref,icf /DEBUG
 
 CFLAGS_LIBCURL_STATIC  = /DCURL_STATICLIB
 
-WIN_LIBS    = ws2_32.lib wldap32.lib advapi32.lib crypt32.lib
+WIN_LIBS    = ws2_32.lib wldap32.lib advapi32.lib crypt32.lib iphlpapi.lib
 
 BASE_NAME              = libcurl
 BASE_NAME_DEBUG        = $(BASE_NAME)_debug


### PR DESCRIPTION
There is a configuration parameter in windows registry
called TcpTimedWaitDelay that determines the time that a
connection stays in the TIME_WAIT state when it is closing.
It's minimum and default value is 30 seconds.
As long as a connection is in the TIME_WAIT state, the socket pair
cannot be re-used, BUT bind() still returns 0 in this case.
curl now can detect the state of a given port using
GetTcpTable2() for IPv4 connections and avoids to bind that port
if the state is TIME_WAIT

ref: https://docs.microsoft.com/en-us/troubleshoot/windows-client/networking/tcpip-and-nbt-configuration-parameters#optional-tcpip-parameters-that-you-can-configure-by-using-registry-editor

Fixes: https://github.com/curl/curl/issues/8112
Reported-by: gclinch on github