### PR TITLE
examples/curlx: support building with OpenSSL 1.1.0+

### DIFF
--- a/docs/examples/curlx.c
+++ b/docs/examples/curlx.c
@@ -191,24 +191,29 @@ static int ssl_app_verify_callback(X509_STORE_CTX *ctx, void *arg)
 {
   sslctxparm * p = (sslctxparm *) arg;
   int ok;
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+  X509 *cert = X509_STORE_CTX_get0_cert(ctx);
+#else
+  X509 *cert = ctx->cert;
+#endif
 
   if(p->verbose > 2)
     BIO_printf(p->errorbio, "entering ssl_app_verify_callback\n");
 
   ok = X509_verify_cert(ctx);
-  if(ok && ctx->cert) {
+  if(ok && cert) {
     unsigned char *accessinfo;
     if(p->verbose > 1)
-      X509_print_ex(p->errorbio, ctx->cert, 0, 0);
+      X509_print_ex(p->errorbio, cert, 0, 0);
 
-    accessinfo = my_get_ext(ctx->cert, p->accesstype, NID_sinfo_access);
+    accessinfo = my_get_ext(cert, p->accesstype, NID_sinfo_access);
     if(accessinfo) {
       if(p->verbose)
         BIO_printf(p->errorbio, "Setting URL from SIA to: %s\n", accessinfo);
 
       curl_easy_setopt(p->curl, CURLOPT_URL, accessinfo);
     }
-    else if(accessinfo = my_get_ext(ctx->cert, p->accesstype,
+    else if(accessinfo = my_get_ext(cert, p->accesstype,
                                     NID_info_access)) {
       if(p->verbose)
         BIO_printf(p->errorbio, "Setting URL from AIA to: %s\n", accessinfo);


### PR DESCRIPTION
- Access members of X509_STORE_CTX in OpenSSL 1.1.0+ by using API
  functions.

The X509_STORE_CTX struct has been opaque since OpenSSL 1.1.0.

Ref: https://curl.se/mail/lib-2022-03/0004.html

Closes #xxxx