### PR TITLE
curl-openssl.m4: prefer lib64 over lib

### DIFF
--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -71,16 +71,17 @@ if test "x$OPT_OPENSSL" != xno; then
 
     dnl Try pkg-config even when cross-compiling.  Since we
     dnl specify PKG_CONFIG_LIBDIR we're only looking where
-    dnl the user told us to look
-    OPENSSL_PCDIR="$OPT_OPENSSL/lib/pkgconfig"
+    dnl the user told us to look.
+
+    dnl OpenSSL 3 may use lib64 instead of lib like older versions
+    OPENSSL_PCDIR="$OPT_OPENSSL/lib64/pkgconfig"
     if test -f "$OPENSSL_PCDIR/openssl.pc"; then
       AC_MSG_NOTICE([PKG_CONFIG_LIBDIR will be set to "$OPENSSL_PCDIR"])
       PKGTEST="yes"
     fi
 
     if test "$PKGTEST" != "yes"; then
-      # try lib64 instead
-      OPENSSL_PCDIR="$OPT_OPENSSL/lib64/pkgconfig"
+      OPENSSL_PCDIR="$OPT_OPENSSL/lib/pkgconfig"
       if test -f "$OPENSSL_PCDIR/openssl.pc"; then
         AC_MSG_NOTICE([PKG_CONFIG_LIBDIR will be set to "$OPENSSL_PCDIR"])
         PKGTEST="yes"


### PR DESCRIPTION
Prior to this change if the user had two versions of OpenSSL installed
in the same folder (eg /usr/local/ssl) then the possibly older OpenSSL
in lib was preferred over OpenSSL 3 in lib64.

Ref: https://github.com/curl/curl/issues/7606
Ref: https://github.com/curl/curl/pull/7503

Closes #xxxx

---

I'm not sure about this one. I don't understand why on some systems OpenSSL 3 is using lib64 and others it's using just lib. I have OpenSSL 1.1.1 installed in /usr/local/ssl and the libraries are in lib. When I installed OpenSSL 3.0.1 in /usr/local/ssl using the same commands it put the libraries in lib64. Since only the most recent OpenSSL version may use lib64 by default I would think prefer that over lib?  This is in Ubuntu where there isn't usually (or ever?) lib64 and $libsuff is empty.