### PR TITLE
Use TCP_KEEPALIVE only if TCP_KEEPIDLE is not defined

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -137,6 +137,14 @@ tcpkeepalive(struct Curl_easy *data,
           (void *)&optval, sizeof(optval)) < 0) {
       infof(data, "Failed to set TCP_KEEPIDLE on fd %d", sockfd);
     }
+#elif defined(TCP_KEEPALIVE)
+    /* Mac OS X style */
+    optval = curlx_sltosi(data->set.tcp_keepidle);
+    KEEPALIVE_FACTOR(optval);
+    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE,
+      (void *)&optval, sizeof(optval)) < 0) {
+      infof(data, "Failed to set TCP_KEEPALIVE on fd %d", sockfd);
+    }
 #endif
 #ifdef TCP_KEEPINTVL
     optval = curlx_sltosi(data->set.tcp_keepintvl);
@@ -144,15 +152,6 @@ tcpkeepalive(struct Curl_easy *data,
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
           (void *)&optval, sizeof(optval)) < 0) {
       infof(data, "Failed to set TCP_KEEPINTVL on fd %d", sockfd);
-    }
-#endif
-#ifdef TCP_KEEPALIVE
-    /* Mac OS X style */
-    optval = curlx_sltosi(data->set.tcp_keepidle);
-    KEEPALIVE_FACTOR(optval);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE,
-          (void *)&optval, sizeof(optval)) < 0) {
-      infof(data, "Failed to set TCP_KEEPALIVE on fd %d", sockfd);
     }
 #endif
 #endif


### PR DESCRIPTION
The change based on a comment for TCP_KEEPALIVE.

I try using a CURLOPT_TCP_KEEPALIVE option. For TCP connections my application use lwIP library. The library defines both TCP_KEEPALIVE and TCP_KEEPIDLE. Both are responsible for the same thing, but TCP_KEEPALIVE is in milliseconds and TCP_KEEPIDLE is in seconds. After set TCP_KEEPIDLE correctly, TCP_KEEPALIVE overwrites changes. In the end, the application does not work as intended.