### PR TITLE
unit1610: init SSL library before calling SHA256 functions

### DIFF
--- a/tests/unit/unit1610.c
+++ b/tests/unit/unit1610.c
@@ -25,12 +25,14 @@
 
 static CURLcode unit_setup(void)
 {
-  return CURLE_OK;
+  int res = CURLE_OK;
+  global_init(CURL_GLOBAL_ALL);
+  return res;
 }
 
 static void unit_stop(void)
 {
-
+  curl_global_cleanup();
 }
 
 UNITTEST_START


### PR DESCRIPTION
The SSL library must be initialized (via global initialization) because
libcurl's SHA256 functions may call SHA256 functions in the SSL library.

Reported-by: Gisle Vanem

Fixes https://github.com/curl/curl/issues/8538
Closes #xxxx