### PR TITLE
configure.ac: move -pthread CFLAGS setting back where it used to be

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3522,23 +3522,27 @@ if test "$want_pthreads" != "no"; then
          dnl it doesn't actually work without -lpthread
          USE_THREADS_POSIX=""
          ;;
-      *-ibm-aix*)
-         dnl Check if compiler is xlC
-         COMPILER_VERSION=`"$CC" -qversion 2>/dev/null`
-         if test x"$COMPILER_VERSION" = "x"; then
-           CFLAGS="$CFLAGS -pthread"
-         else
-           CFLAGS="$CFLAGS -qthreaded"
-         fi
-         ;;
       *)
-         CFLAGS="$CFLAGS -pthread"
          ;;
       esac
 
       dnl if it wasn't found without lib, search for it in pthread lib
       if test "$USE_THREADS_POSIX" != "1"
       then
+        case $host in
+        *-ibm-aix*)
+           dnl Check if compiler is xlC
+           COMPILER_VERSION=`"$CC" -qversion 2>/dev/null`
+           if test x"$COMPILER_VERSION" = "x"; then
+             CFLAGS="$CFLAGS -pthread"
+           else
+             CFLAGS="$CFLAGS -qthreaded"
+           fi
+           ;;
+        *)
+           CFLAGS="$CFLAGS -pthread"
+           ;;
+        esac
         # assign PTHREAD for pkg-config use
         PTHREAD=" -pthread"
         AC_CHECK_LIB(pthread, pthread_create,


### PR DESCRIPTION
The fix for #8276 proposed in #8374 set `CFLAGS="$CFLAGS -pthead"` earlier than it used to be set, applying it in cases where it should not have been applied.

This moves the AIX XLC check to a new `case $host in` block inside of the `if test "$USE_THREADS_POSIX" != "1"` block, where `CFLAGS="$CFLAGS -pthead"` used to happen.

I'd like to see this tested on AIX before it gets merged.