### PR TITLE
ipv4/6.d: clarify that they are about using IP addresses

### DIFF
--- a/docs/cmdline-opts/ipv4.d
+++ b/docs/cmdline-opts/ipv4.d
@@ -10,5 +10,5 @@ Help: Resolve names to IPv4 addresses
 Category: connection dns
 Example: --ipv4 $URL
 ---
-This option tells curl to resolve names to IPv4 addresses only, and not for
-example try IPv6.
+This option tells curl to use IPv4 addresses only, and not for example try
+IPv6.

--- a/docs/cmdline-opts/ipv6.d
+++ b/docs/cmdline-opts/ipv6.d
@@ -10,5 +10,5 @@ Help: Resolve names to IPv6 addresses
 Category: connection dns
 Example: --ipv6 $URL
 ---
-This option tells curl to resolve names to IPv6 addresses only, and not for
-example try IPv4.
+This option tells curl to use IPv6 addresses only, and not for example try
+IPv4.


### PR DESCRIPTION
... they may still *resolve* other families, but not use those
addresses.

Ref: #8530