### PR TITLE
include: updated definition macro for MCST-LCC compiler

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -121,7 +121,7 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__LCC__)
-#  if defined(__e2k__) /* MCST eLbrus C Compiler */
+#  if defined(__MCST__) /* MCST eLbrus Compiler Collection */
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"


### PR DESCRIPTION
in mcst-lcc compiler => 1.25 added a new macro definition to determine compiler

enhancement of the previous patch - https://github.com/curl/curl/pull/4576