### PR TITLE
runtests: make 'oldlibssh' be before 0.9.4

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -395,7 +395,7 @@ Features testable here are:
 - `ld_preload`
 - `libssh2`
 - `libssh`
-- `oldlibssh` (versions before 0.9.6)
+- `oldlibssh` (versions before 0.9.4)
 - `libz`
 - `manual`
 - `Mime`

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -271,7 +271,7 @@ my $has_mingw;      # set if built with MinGW (as opposed to MinGW-w64)
 my $has_hyper = 0;  # set if built with Hyper
 my $has_libssh2;    # set if built with libssh2
 my $has_libssh;     # set if built with libssh
-my $has_oldlibssh;  # set if built with libssh < 0.9.6
+my $has_oldlibssh;  # set if built with libssh < 0.9.4
 my $has_wolfssh;    # set if built with wolfssh
 my $has_unicode;    # set if libcurl is built with Unicode support
 
@@ -3047,8 +3047,8 @@ sub checksystem {
                 $has_libssh=1;
                 if($1 =~ /(\d+)\.(\d+).(\d+)/) {
                     my $v = $1 * 100 + $2 * 10 + $3;
-                    if($v < 95) {
-                        # before 0.9.5
+                    if($v < 94) {
+                        # before 0.9.4
                         $has_oldlibssh = 1;
                     }
                 }


### PR DESCRIPTION
The 'oldlibssh' feature indicates that the error code returned by libssh for a broken known_hosts file should be 67 rather than 60 (test1459). This feature was added as part of #8444 with 'oldlibssh' mapping to libssh versions prior to 0.9.6, and then refined as part of #8511 to map to versions prior to 0.9.5.

In Red Hat Enterprise Linux 8.5 there is a patched version of libssh version 0.9.4 (https://git.centos.org/rpms/libssh/blob/c8/f/SOURCES) in which test1459 fails because it returns the "new" value rather than the "old" one. It's plausible that one of the patches is responsible for this rather than the underlying code but I don't think so.

This change therefore drops the 'oldlibssh' version check to map to libssh versions older than 0.9.4, which fixes builds on RHEL-8.