### PR TITLE
tls: enable CURLOPT_SSL_EC_CURVES with BoringSSL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -208,9 +208,18 @@
      !defined(OPENSSL_IS_BORINGSSL))
 #define HAVE_SSL_CTX_SET_CIPHERSUITES
 #define HAVE_SSL_CTX_SET_POST_HANDSHAKE_AUTH
-/* SET_EC_CURVES is available under the same preconditions: see
- * https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set1_groups.html
+#endif
+
+/*
+ * Whether SSL_CTX_set1_curves_list is available.
+ * OpenSSL: supported since 1.0.2, see
+ *   https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set1_groups.html
+ * BoringSSL: supported since 5fd1807d95f7 (committed 2016-09-30)
+ * LibreSSL: not tested.
  */
+#if ((OPENSSL_VERSION_NUMBER >= 0x10002000L) && \
+     !defined(LIBRESSL_VERSION_NUMBER)) || \
+    defined(OPENSSL_IS_BORINGSSL)
 #define HAVE_SSL_CTX_SET_EC_CURVES
 #endif
 


### PR DESCRIPTION
The CURLOPT_SSL_EC_CURVES option (used by the '--curves' flag)
in libcurl was ignored when compiling with BoringSSL because
HAVE_SSL_CTX_SET_EC_CURVES was explicitly disabled if BoringSSL was
detected.  However, this feature is supported in BoringSSL since
5fd1807d. This commit enables it, and also reduces the required minimal
OpenSSL version to 1.0.2 as per OpenSSL's official documentation.

Fixes #8553.