### PR TITLE
Fix typo in --json documentation (overriden -> overridden)

### DIFF
--- a/docs/cmdline-opts/json.d
+++ b/docs/cmdline-opts/json.d
@@ -29,4 +29,4 @@ from stdin. Posting data from a file named \&'foobar' would thus be done with
 If this option is used more than once on the same command line, the additional
 data pieces will be concatenated to the previous before sending.
 
-The headers this option sets can be overriden with --header as usual.
+The headers this option sets can be overridden with --header as usual.


### PR DESCRIPTION
Silly typo I caught when packaging the latest release on Debian.

Thanks