### PR TITLE
Add back setsockopt path to curlx_nonblock

### DIFF
--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -73,6 +73,12 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
   long flags = nonblock ? 1L : 0L;
   return IoctlSocket(sockfd, FIONBIO, (char *)&flags);
 
+#elif defined(HAVE_SETSOCKOPT_SO_NONBLOCK)
+
+  /* game consoles */
+  long b = nonblock ? 1L : 0L;
+  return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
+
 #else
 #  error "no non-blocking method was found/used/set"
 #endif


### PR DESCRIPTION
The implementation using setsockopt was removed when BeOS support was purged. However this functionality wasn't BeOS specific and `HAVE_SETSOCKOPT_SO_NONBLOCK` is still present in the codebase.