### PR TITLE
openssl: check SSL_get_peer_cert_chain return value

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1927,6 +1927,11 @@ static CURLcode verifystatus(struct Curl_easy *data,
   }
 
   ch = SSL_get_peer_cert_chain(backend->handle);
+  if(!ch) {
+    failf(data, "Could not get peer certificate chain");
+    result CURLE_SSL_INVALIDCERTSTATUS;
+    goto end;
+  }
   st = SSL_CTX_get_cert_store(backend->ctx);
 
 #if ((OPENSSL_VERSION_NUMBER <= 0x1000201fL) /* Fixed after 1.0.2a */ || \

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1929,7 +1929,7 @@ static CURLcode verifystatus(struct Curl_easy *data,
   ch = SSL_get_peer_cert_chain(backend->handle);
   if(!ch) {
     failf(data, "Could not get peer certificate chain");
-    result CURLE_SSL_INVALIDCERTSTATUS;
+    result = CURLE_SSL_INVALIDCERTSTATUS;
     goto end;
   }
   st = SSL_CTX_get_cert_store(backend->ctx);


### PR DESCRIPTION
Ensure to check SSL_get_peer_cert_chain return value, as it can be NULL

Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>