### PR TITLE
libssh: Improve fix for missing SSH_S_ stat macros

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -105,11 +105,12 @@
   } while(0)
 #endif
 
+/* These stat values may not be the same as the user's S_IFMT / S_IFLNK */
 #ifndef SSH_S_IFMT
-#define SSH_S_IFMT S_IFMT
+#define SSH_S_IFMT   00170000
 #endif
 #ifndef SSH_S_IFLNK
-#define SSH_S_IFLNK S_IFLNK
+#define SSH_S_IFLNK  0120000
 #endif
 
 /* Local functions: */


### PR DESCRIPTION
- If building libcurl against an old libssh version missing SSH_S_IFMT
  and SSH_S_IFLNK then use the values from a supported version.

Prior to this change if libssh did not define SSH_S_IFMT and SSH_S_IFLNK
then S_IFMT and S_IFLNK, respectively, were used instead. The problem
with that is the user's S_ stat macros don't have the same values across
platforms. For example Windows has values different from Linux.

Follow-up to 7b0fd39.

Ref: https://github.com/curl/curl/pull/8511#discussion_r815292391
Ref: https://github.com/curl/curl/pull/8574

Closes #xxxx