### PR TITLE
tests/server/util.h: align WIN32 condition with util.c

### DIFF
--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -360,7 +360,7 @@ curl_socket_t curlx_sitosk(int i)
 
 #endif /* USE_WINSOCK */
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(WIN32)
 
 ssize_t curlx_read(int fd, void *buf, size_t count)
 {
@@ -372,7 +372,7 @@ ssize_t curlx_write(int fd, const void *buf, size_t count)
   return (ssize_t)write(fd, buf, curlx_uztoui(count));
 }
 
-#endif /* WIN32 || _WIN32 */
+#endif /* WIN32 */
 
 #if defined(__INTEL_COMPILER) && defined(__unix__)
 

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -22,6 +22,8 @@
  *
  ***************************************************************************/
 
+#include "curl_setup.h"
+
 #ifdef USE_WINSOCK
 #include <curl/curl.h> /* for curl_socket_t */
 #endif
@@ -65,7 +67,7 @@ curl_socket_t curlx_sitosk(int i);
 
 #endif /* USE_WINSOCK */
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(WIN32)
 
 ssize_t curlx_read(int fd, void *buf, size_t count);
 
@@ -78,7 +80,7 @@ ssize_t curlx_write(int fd, const void *buf, size_t count);
 #  define write(fd, buf, count) curlx_write(fd, buf, count)
 #endif
 
-#endif /* WIN32 || _WIN32 */
+#endif /* WIN32 */
 
 #if defined(__INTEL_COMPILER) && defined(__unix__)
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -40,7 +40,7 @@ extern const char *serverlogfile;
 
 extern const char *cmdfile;
 
-#if defined(WIN32) || defined(_WIN32)
+#ifdef WIN32
 #include <process.h>
 #include <fcntl.h>
 
@@ -49,9 +49,7 @@ extern const char *cmdfile;
 #undef perror
 #define perror(m) win32_perror(m)
 void win32_perror(const char *msg);
-#endif  /* WIN32 or _WIN32 */
 
-#ifdef WIN32
 void win32_init(void);
 void win32_cleanup(void);
 #endif  /* WIN32 */


### PR DESCRIPTION
-   tests/server/util.h: align WIN32 condition with util.c

    There is no need to test for both _WIN32 and WIN32 as curl_setup.h
    automatically defines the later if the first one is defined.

    Also tests/server/util.c is only checking for WIN32 arouund the
    implementation of win32_perror, so just defining _WIN32
    would not be sufficient for a successful compilation.

-   lib/warnless.[ch]: only check for WIN32 and ignore _WIN32

    curl_setup.h automatically defines WIN32 if just _WIN32 is defined.