### PR TITLE
test375: fix line endings on Windows

### DIFF
--- a/tests/data/test375
+++ b/tests/data/test375
@@ -23,7 +23,7 @@ Disabled proxy should make curl fail with --proxy
 #
 # Verify data after the test has been "shot"
 <verify>
-<stderr>
+<stderr mode="text">
 curl: proxy support is disabled in this libcurl
 </stderr>
 <errorcode>


### PR DESCRIPTION
Fixes a test failure visible in the Windows autobuilds.