### PR TITLE
tool_urlglob: return error when the output file name is blank

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1017,7 +1017,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             Curl_safefree(storefile);
             if(result) {
               /* bad globbing */
-              warnf(global, "bad output glob!\n");
+              errorf(global, "bad output filename\n");
+              config->synthetic_error = TRUE;
               break;
             }
           }

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -685,6 +685,8 @@ CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
     if(curlx_dyn_addn(&dyn, appendthis, appendlen))
       return CURLE_OUT_OF_MEMORY;
   }
+  if(!curlx_dyn_len(&dyn))
+    return CURLE_WRITE_ERROR;
 
 #if defined(MSDOS) || defined(WIN32)
   {


### PR DESCRIPTION
Reported-by: iblanes on github
Fixes #8606