### PR TITLE
http: return error on colon-less HTTP headers

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -65,7 +65,7 @@ test370 test371 test372 test373 test374 test375 test376 \
 \
 test380 test381 test383 test384 test385 test386 \
 \
-test392 test393 test394 test395 test396 test397 \
+test392 test393 test394 test395 test396 test397 test398 \
 \
 test400 test401 test402 test403 test404 test405 test406 test407 test408 \
 test409 test410 \

--- a/tests/data/test398
+++ b/tests/data/test398
@@ -9,7 +9,7 @@ HTTP GET
 # Server-side
 <reply>
 
-<data>
+<data nocheck="yes">
 HTTP/1.1 200 OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Server test-server/fake
@@ -54,7 +54,11 @@ Accept: */*
 
 </protocol>
 <errorcode>
+%if hyper
+1
+%else
 8
+%endif
 </errorcode>
 </verify>
 </testcase>

--- a/tests/data/test398
+++ b/tests/data/test398
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+hello
+</data>
+<datacheck>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+Reject HTTP/1.1 response with colon-less header
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
It's a protocol violation and accepting them leads to no good.

Add test case 398 to verify