### PR TITLE
hyper: no h2c support

### DIFF
--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -56,8 +56,9 @@ The hyper backend does not support
 - `CURLOPT_IGNORE_CONTENT_LENGTH`
 - `--raw` and disabling `CURLOPT_HTTP_TRANSFER_DECODING`
 - RTSP
-- hyper is much stricter about what HTTP header contents it allow in requests
+- hyper is much stricter about what HTTP header contents it allows
 - HTTP/0.9
+- HTTP/2 upgrade using HTTP:// URLs. Aka 'h2c'
 
 ## Remaining issues
 

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -384,6 +384,7 @@ Features testable here are:
 - `getrlimit`
 - `GnuTLS`
 - `GSS-API`
+- `h2c`
 - `HSTS`
 - `HTTP-auth`
 - `http/2`

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -43,8 +43,6 @@
 265
 266
 357
-358
-359
 565
 579
 580
@@ -60,10 +58,6 @@
 1533
 1540
 1591
-1700
-1701
-1702
-1800
 %endif
 2043
 # Tests that are disabled here for rustls are SUPPOSED to work

--- a/tests/data/test1700
+++ b/tests/data/test1700
@@ -38,6 +38,9 @@ Content-Type: text/html
 #
 # Client-side
 <client>
+<features>
+h2c
+</features>
 <server>
 http
 http/2

--- a/tests/data/test1701
+++ b/tests/data/test1701
@@ -29,6 +29,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+h2c
+</features>
 <server>
 http
 http/2

--- a/tests/data/test1702
+++ b/tests/data/test1702
@@ -28,6 +28,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+h2c
+</features>
 <server>
 http
 http/2

--- a/tests/data/test1800
+++ b/tests/data/test1800
@@ -23,6 +23,9 @@ Content-Type: text/html
 
 # Client-side
 <client>
+<features>
+h2c
+</features>
 <server>
 http
 </server>

--- a/tests/data/test358
+++ b/tests/data/test358
@@ -30,6 +30,7 @@ Alt-Svc: h2=":%HTTP2PORT", ma=315360000; persist=0
 <features>
 alt-svc
 debug
+h2c
 </features>
 <server>
 http

--- a/tests/data/test359
+++ b/tests/data/test359
@@ -30,6 +30,7 @@ Alt-Svc: h2=":%HTTP2PORT", ma=315360000; persist=0
 <features>
 alt-svc
 debug
+h2c
 </features>
 <server>
 https

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -256,6 +256,7 @@ my $has_spnego;     # set if libcurl is built with SPNEGO support
 my $has_charconv;   # set if libcurl is built with CharConv support
 my $has_tls_srp;    # set if libcurl is built with TLS-SRP support
 my $has_http2;      # set if libcurl is built with HTTP2 support
+my $has_h2c;        # set if libcurl is built with h2c support
 my $has_httpsproxy; # set if libcurl is built with HTTPS-proxy support
 my $has_crypto;     # set if libcurl is built with cryptographic support
 my $has_cares;      # set if built with c-ares
@@ -2864,38 +2865,37 @@ sub compare {
 }
 
 sub setupfeatures {
-    $feature{"hyper"} = $has_hyper;
-    $feature{"c-ares"} = $has_cares;
     $feature{"alt-svc"} = $has_altsvc;
-    $feature{"HSTS"} = $has_hsts;
     $feature{"brotli"} = $has_brotli;
+    $feature{"c-ares"} = $has_cares;
     $feature{"crypto"} = $has_crypto;
     $feature{"debug"} = $debug_build;
     $feature{"getrlimit"} = $has_getrlimit;
     $feature{"GnuTLS"} = $has_gnutls;
     $feature{"GSS-API"} = $has_gssapi;
+    $feature{"h2c"} = $has_h2c;
+    $feature{"HSTS"} = $has_hsts;
     $feature{"http/2"} = $has_http2;
     $feature{"https-proxy"} = $has_httpsproxy;
+    $feature{"hyper"} = $has_hyper;
     $feature{"idn"} = $has_idn;
     $feature{"ipv6"} = $has_ipv6;
     $feature{"Kerberos"} = $has_kerberos;
     $feature{"large_file"} = $has_largefile;
     $feature{"ld_preload"} = ($has_ldpreload && !$debug_build);
-    $feature{"libz"} = $has_libz;
-    $feature{"libssh2"} = $has_libssh2;
     $feature{"libssh"} = $has_libssh;
-    $feature{"oldlibssh"} = $has_oldlibssh;
-    $feature{"rustls"} = $has_rustls;
-    $feature{"wolfssh"} = $has_wolfssh;
-    $feature{"wolfssl"} = $has_wolfssl;
+    $feature{"libssh2"} = $has_libssh2;
+    $feature{"libz"} = $has_libz;
     $feature{"manual"} = $has_manual;
     $feature{"MinGW"} = $has_mingw;
     $feature{"MultiSSL"} = $has_multissl;
     $feature{"NSS"} = $has_nss;
     $feature{"NTLM"} = $has_ntlm;
     $feature{"NTLM_WB"} = $has_ntlm_wb;
+    $feature{"oldlibssh"} = $has_oldlibssh;
     $feature{"OpenSSL"} = $has_openssl || $has_libressl || $has_boringssl;
     $feature{"PSL"} = $has_psl;
+    $feature{"rustls"} = $has_rustls;
     $feature{"Schannel"} = $has_schannel;
     $feature{"sectransp"} = $has_sectransp;
     $feature{"SPNEGO"} = $has_spnego;
@@ -2909,6 +2909,8 @@ sub setupfeatures {
     $feature{"unittest"} = $debug_build;
     $feature{"unix-sockets"} = $has_unix;
     $feature{"win32"} = $has_win32;
+    $feature{"wolfssh"} = $has_wolfssh;
+    $feature{"wolfssl"} = $has_wolfssl;
     $feature{"zstd"} = $has_zstd;
 
     # make each protocol an enabled "feature"
@@ -3040,6 +3042,10 @@ sub checksystem {
            if ($libcurl =~ /Hyper/i) {
                $has_hyper=1;
            }
+            if ($libcurl =~ /nghttp2/i) {
+                # nghttp2 supports h2c, hyper does not
+                $has_h2c=1;
+            }
             if ($libcurl =~ /libssh2/i) {
                 $has_libssh2=1;
             }


### PR DESCRIPTION
Make tests require h2c feature present to run, and only set h2c if
nghttp2 is used in the build. Hyper does not support it.

Remove those tests from DISABLED

Ref: #8605