### PR TITLE
azure-pipelines: increase timeout from 20 to 30 Minutes

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
   dependsOn: []
   jobs:
   - job: ubuntu
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     pool:
       vmImage: 'ubuntu-latest'
     strategy:
@@ -156,7 +156,7 @@ stages:
   dependsOn: []
   jobs:
   - job: ubuntu
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     pool:
       vmImage: 'ubuntu-latest'
     strategy:


### PR DESCRIPTION
the jobs will not timeout if a build run a bit longer than 20 Minutes.