### PR TITLE
test1459: disable for oldlibssh

### DIFF
--- a/tests/data/test1459
+++ b/tests/data/test1459
@@ -17,6 +17,7 @@ mkdir -p %PWD/log/test%TESTNUMBER.dir/.ssh
 </precheck>
 <features>
 sftp
+!oldlibssh
 </features>
  <name>
 SFTP with corrupted known_hosts


### PR DESCRIPTION
This test with libssh 0.9.3 works fine on github but fails on circleci.
Might as well disable this test for oldlibssh installations.