### PR TITLE
lib1945: fix compiler warning 4706 on MSVC

### DIFF
--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -24,6 +24,10 @@
 
 #include "memdebug.h"
 
+#ifdef _MSC_VER
+/* warning C4706: assignment within conditional expression */
+#pragma warning(disable:4706)
+#endif
 static void showem(CURL *easy, unsigned int type)
 {
   struct curl_header *header = NULL;


### PR DESCRIPTION
Follow-up from d1e4a677340c