### PR TITLE
headers.h: make Curl_headers_push() be CURLE_OK when not built

### DIFF
--- a/lib/headers.h
+++ b/lib/headers.h
@@ -46,7 +46,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
 CURLcode Curl_headers_cleanup(struct Curl_easy *data);
 
 #else
-#define Curl_headers_push(x,y,z) CURLE_NOT_BUILT_IN
+#define Curl_headers_push(x,y,z) CURLE_OK
 #define Curl_headers_cleanup(x) Curl_nop_stmt
 #endif
 


### PR DESCRIPTION
... to avoid errors when the function isn't there.

Reported-by: Marcel Raad
Fixes #8627