### PR TITLE
dynbuf: make dyn_ptr consistently return NULL when length is zero

### DIFF
--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2020 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -222,25 +222,25 @@ CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
 }
 
 /*
- * Returns a pointer to the buffer.
+ * Returns a pointer to the buffer if it has a length.
  */
 char *Curl_dyn_ptr(const struct dynbuf *s)
 {
   DEBUGASSERT(s);
   DEBUGASSERT(s->init == DYNINIT);
   DEBUGASSERT(!s->leng || s->bufr);
-  return s->bufr;
+  return s->leng ? s->bufr : NULL;
 }
 
 /*
- * Returns an unsigned pointer to the buffer.
+ * Returns an unsigned pointer to the buffer if it has a length.
  */
 unsigned char *Curl_dyn_uptr(const struct dynbuf *s)
 {
   DEBUGASSERT(s);
   DEBUGASSERT(s->init == DYNINIT);
   DEBUGASSERT(!s->leng || s->bufr);
-  return (unsigned char *)s->bufr;
+  return s->leng ? (unsigned char *)s->bufr : NULL;
 }
 
 /*

--- a/lib/http.c
+++ b/lib/http.c
@@ -3349,6 +3349,8 @@ static statusline
 checkprotoprefix(struct Curl_easy *data, struct connectdata *conn,
                  const char *s, size_t len)
 {
+  if(!len)
+    return STATUS_UNKNOWN;
 #ifndef CURL_DISABLE_RTSP
   if(conn->handler->protocol & CURLPROTO_RTSP)
     return checkrtspprefix(data, s, len);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -200,7 +200,7 @@ test1566 test1567 test1568 test1569 test1570 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
-test1608 test1609 test1610 test1611 test1612 test1613 \
+test1608 test1609 test1610 test1611 test1612 test1613 test1614 \
 \
 test1620 test1621 \
 \

--- a/tests/data/test1614
+++ b/tests/data/test1614
@@ -1,0 +1,22 @@
+<testcase>
+<info>
+<keywords>
+unittest
+dynbuf
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+</features>
+ <name>
+dynbuf
+ </name>
+</client>
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -32,7 +32,7 @@ UNITPROGS = unit1300 unit1301 unit1302 unit1303 unit1304 unit1305 unit1307 \
  unit1330 unit1394 unit1395 unit1396 unit1397 unit1398 \
  unit1399 \
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
- unit1608 unit1609 unit1610 unit1611 unit1612 \
+ unit1608 unit1609 unit1610 unit1611 unit1612 unit1614 \
  unit1620 unit1621 \
  unit1650 unit1651 unit1652 unit1653 unit1654 unit1655 \
  unit1660 unit1661
@@ -129,6 +129,9 @@ unit1611_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1612_SOURCES = unit1612.c $(UNITFILES)
 unit1612_CPPFLAGS = $(AM_CPPFLAGS)
+
+unit1614_SOURCES = unit1614.c $(UNITFILES)
+unit1614_CPPFLAGS = $(AM_CPPFLAGS)
 
 unit1620_SOURCES = unit1620.c $(UNITFILES)
 unit1620_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/unit/unit1614.c
+++ b/tests/unit/unit1614.c
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+#include "curl_setup.h"
+#include "dynbuf.h"
+
+static CURLcode unit_setup(void)
+{
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+
+}
+
+/* it means 10 is too much, it can only fit 9 bytes */
+#define MAX_LENGTH 10
+
+UNITTEST_START
+{
+  char *ptr;
+  struct dynbuf buf;
+  CURLcode result;
+  Curl_dyn_init(&buf, MAX_LENGTH);
+
+  ptr = Curl_dyn_ptr(&buf);
+  fail_unless(!ptr, "Curl_dyn_ptr return non-NULL");
+
+  result = Curl_dyn_add(&buf, "one  ");
+  fail_unless(result == CURLE_OK, "Curl_dyn_add return code");
+
+  result = Curl_dyn_add(&buf, "two ");
+  fail_unless(result == CURLE_OK, "Curl_dyn_add return code");
+
+  ptr = Curl_dyn_ptr(&buf);
+  fail_unless(ptr, "Curl_dyn_ptr returned NULL");
+  Curl_dyn_reset(&buf);
+
+  ptr = Curl_dyn_ptr(&buf);
+  fail_unless(!ptr, "Curl_dyn_ptr return non-NULL");
+
+  result = Curl_dyn_add(&buf, "one two 33"); /* too long */
+  fail_unless(result != CURLE_OK, "Curl_dyn_add return code");
+
+  ptr = Curl_dyn_ptr(&buf);
+  fail_unless(!ptr, "Curl_dyn_ptr return non-NULL");
+
+  result = Curl_dyn_add(&buf, "one two");
+  fail_unless(result == CURLE_OK, "Curl_dyn_add return code");
+
+  Curl_dyn_free(&buf);
+}
+UNITTEST_STOP


### PR DESCRIPTION
Previously it would return a pointer if the buffer previously had
contents. This makes the code follow the documentation.

Added test case 1614 to verify this behavior.

Spotted-by: iblanes
Ref: #8606