### PR TITLE
curl/header_json: output the header names in lowercase

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -61,10 +61,9 @@ A JSON object with all HTTP response headers from the recent transfer. Values
 are provided as arrays, since in the case of multiple headers there can be
 multiple values.
 
-The header names are listed in order of appearance over the wire using the
-same case as was used over the network. Except for duplicated headers. They
-are grouped on the first occurance of that header, using the casing of the
-first header, and then each value is presented in the JSON array.
+The header names provided in lowercase, listed in order of appearance over the
+wire. Except for duplicated headers. They are grouped on the first occurance
+of that header, each value is presented in the JSON array.
 .TP
 .B http_code
 The numerical response code that was found in the last retrieved HTTP(S) or

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -220,7 +220,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
     DEBUGASSERT(strinfo);
     if(use_json) {
       fprintf(stream, "\"%s\":", wovar->name);
-      jsonWriteString(stream, strinfo);
+      jsonWriteString(stream, strinfo, FALSE);
     }
     else
       fputs(strinfo, stream);

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -29,7 +29,7 @@
 #include "tool_writeout_json.h"
 #include "tool_writeout.h"
 
-void jsonWriteString(FILE *stream, const char *in)
+void jsonWriteString(FILE *stream, const char *in, bool lowercase)
 {
   const char *i = in;
   const char *in_end = in + strlen(in);
@@ -63,7 +63,11 @@ void jsonWriteString(FILE *stream, const char *in)
         fprintf(stream, "u%04x", *i);
       }
       else {
-        fputc(*i, stream);
+        char out = *i;
+        if(lowercase && (out >= 'A' && out <= 'Z'))
+          /* do not use tolower() since that's locale specific */
+          out |= ('a' - 'A');
+        fputc(out, stream);
       }
       break;
     }
@@ -87,7 +91,7 @@ void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
   /* The variables are sorted in alphabetical order but as a special case
      curl_version (which is not actually a --write-out variable) is last. */
   fprintf(stream, "\"curl_version\":");
-  jsonWriteString(stream, curl_version());
+  jsonWriteString(stream, curl_version(), FALSE);
   fprintf(stream, "}");
 }
 
@@ -106,7 +110,7 @@ void headerJSON(FILE *stream, struct per_transfer *per)
                                        prev))) {
     if(prev)
       fputs(",\n", stream);
-    jsonWriteString(stream, header->name);
+    jsonWriteString(stream, header->name, TRUE);
     fputc(':', stream);
     prev = header;
     if(header->amount > 1) {
@@ -118,7 +122,7 @@ void headerJSON(FILE *stream, struct per_transfer *per)
         char *name = header->name;
         fputc('[', stream);
         do {
-          jsonWriteString(stream, header->value);
+          jsonWriteString(stream, header->value, FALSE);
           if(++i >= a)
             break;
           fputc(',', stream);
@@ -131,7 +135,7 @@ void headerJSON(FILE *stream, struct per_transfer *per)
     }
     else {
       fputc('[', stream);
-      jsonWriteString(stream, header->value);
+      jsonWriteString(stream, header->value, FALSE);
       fputc(']', stream);
     }
   }

--- a/src/tool_writeout_json.h
+++ b/src/tool_writeout_json.h
@@ -27,6 +27,6 @@
 void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
                      struct per_transfer *per, CURLcode per_result);
 void headerJSON(FILE *stream, struct per_transfer *per);
-void jsonWriteString(FILE *stream, const char *in);
+void jsonWriteString(FILE *stream, const char *in, bool lowercase);
 
 #endif /* HEADER_CURL_TOOL_WRITEOUT_H */

--- a/tests/data/test1671
+++ b/tests/data/test1671
@@ -58,14 +58,14 @@ Accept: */*
 
 </protocol>
 <stdout mode="text">
-{"Date":["Tue, 09 Nov 2010 14:49:00 GMT"],
-"Server":["test-server/fake"],
-"Last-Modified":["Tue, 13 Jun 2000 12:10:00 GMT"],
-"ETag":["\"21025-dc7-39462498\""],
-"Accept-Ranges":["bytes"],
-"Set-Cookie":["firstcookie=want1; path=/","2cookie=want2; path=/","cookie3=want3; path=/"],
-"Content-Length":["6"],
-"Connection":["close"]
+{"date":["Tue, 09 Nov 2010 14:49:00 GMT"],
+"server":["test-server/fake"],
+"last-modified":["Tue, 13 Jun 2000 12:10:00 GMT"],
+"etag":["\"21025-dc7-39462498\""],
+"accept-ranges":["bytes"],
+"set-cookie":["firstcookie=want1; path=/","2cookie=want2; path=/","cookie3=want3; path=/"],
+"content-length":["6"],
+"connection":["close"]
 }
 </stdout>
 </verify>


### PR DESCRIPTION
To better allow json[“header”].

Reported-by: Peter Korsgaard
Bug: https://daniel.haxx.se/blog/2022/03/24/easier-header-picking-with-curl/comment-page-1/#comment-25878