### PR TITLE
CURLOPT_PROGRESSFUNCTION.3: fix typo in example

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
@@ -93,7 +93,7 @@ All
                                  double ultotal,
                                  double ulnow)
  {
-   struct progress *memory = (struct progress *)userp;
+   struct progress *memory = (struct progress *)clientp;
 
    /* use the values */
 


### PR DESCRIPTION
mismatch between used variable and prototype