### PR TITLE
setopt: make curl_easy_vsetopt public

### DIFF
--- a/docs/libcurl/Makefile.inc
+++ b/docs/libcurl/Makefile.inc
@@ -42,6 +42,7 @@ man_MANS = \
  curl_easy_strerror.3 \
  curl_easy_unescape.3 \
  curl_easy_upkeep.3 \
+ curl_easy_vsetopt.3 \
  curl_escape.3 \
  curl_formadd.3 \
  curl_formfree.3 \

--- a/docs/libcurl/curl_easy_vsetopt.3
+++ b/docs/libcurl/curl_easy_vsetopt.3
@@ -1,0 +1,63 @@
+.\" **************************************************************************
+.\" *                                  _   _ ____  _
+.\" *  Project                     ___| | | |  _ \| |
+.\" *                             / __| | | | |_) | |
+.\" *                            | (__| |_| |  _ <| |___
+.\" *                             \___|\___/|_| \_\_____|
+.\" *
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" *
+.\" * This software is licensed as described in the file COPYING, which
+.\" * you should have received as part of this distribution. The terms
+.\" * are also available at https://curl.se/docs/copyright.html.
+.\" *
+.\" * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+.\" * copies of the Software, and permit persons to whom the Software is
+.\" * furnished to do so, under the terms of the COPYING file.
+.\" *
+.\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+.\" * KIND, either express or implied.
+.\" *
+.\" **************************************************************************
+.\"
+.TH curl_easy_vsetopt 3 "29 Mar 2022" "libcurl 7.83.0" "libcurl Manual"
+.SH NAME
+curl_easy_vsetopt \- set options for a curl easy handle from a va_list
+.SH SYNOPSIS
+.nf
+#include <stdarg.h>
+#include <curl/curl.h>
+
+CURLcode curl_easy_vsetopt(CURL *handle, CURLoption option, va_list ap);
+.fi
+.SH DESCRIPTION
+\fIcurl_easy_vsetopt(3)\fP is used to set options for a curl easy handle from a
+variadic argument list specified by the ap parameter. In all other respects it
+is identical to \fIcurl_easy_setopt(3)\fP.
+.SH EXAMPLE
+.nf
+void run_url(CURL *curl, ...)
+{
+  CURL *curl;
+  CURLcode res;
+  va_list arg;
+  va_start(arg, curl);
+  curl = curl_easy_init();
+  res = curl_easy_vsetopt(curl, CURLOPT_URL, arg);
+  va_end(arg);
+  if (res != CURLE_OK) {
+    // handle error...
+  }
+  res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    // handle error...
+  }
+  curl_easy_cleanup(curl);
+}
+.fi
+.SH AVAILABILITY
+Added in 7.83.0
+.SH RETURN VALUE
+See \fIcurl_easy_setopt(3)\fP.
+.SH "SEE ALSO"
+.BR curl_easy_setopt "(3)"

--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -21,6 +21,8 @@
  * KIND, either express or implied.
  *
  ***************************************************************************/
+#include <stdarg.h>
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -38,6 +40,8 @@ struct curl_blob {
 
 CURL_EXTERN CURL *curl_easy_init(void);
 CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...);
+CURL_EXTERN CURLcode curl_easy_vsetopt(CURL *curl, CURLoption option,
+                                       va_list param);
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -146,11 +146,8 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
 #define C_SSLVERSION_VALUE(x) (x & 0xffff)
 #define C_SSLVERSION_MAX_VALUE(x) (x & 0xffff0000)
 
-/*
- * Do not make Curl_vsetopt() static: it is called from
- * packages/OS400/ccsidcurl.c.
- */
-CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+CURLcode curl_easy_vsetopt(struct Curl_easy *data, CURLoption option,
+                           va_list param)
 {
   char *argptr;
   CURLcode result = CURLE_OK;
@@ -159,6 +156,9 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
   unsigned long uarg;
 #endif
   curl_off_t bigsize;
+
+  if(!data)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   switch(option) {
   case CURLOPT_DNS_CACHE_TIMEOUT:
@@ -3044,12 +3044,9 @@ CURLcode curl_easy_setopt(struct Curl_easy *data, CURLoption tag, ...)
   va_list arg;
   CURLcode result;
 
-  if(!data)
-    return CURLE_BAD_FUNCTION_ARGUMENT;
-
   va_start(arg, tag);
 
-  result = Curl_vsetopt(data, tag, arg);
+  result = curl_easy_vsetopt(data, tag, arg);
 
   va_end(arg);
   return result;

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1264,7 +1264,7 @@ curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
 
   case CURLOPT_ERRORBUFFER:                     /* This is an output buffer. */
   default:
-    result = Curl_vsetopt(curl, tag, arg);
+    result = curl_easy_vsetopt(curl, tag, arg);
     break;
   }
 

--- a/tests/data/test1135
+++ b/tests/data/test1135
@@ -68,6 +68,7 @@ CURL_EXTERN const char *curl_share_strerror
 CURL_EXTERN CURLcode curl_easy_pause
 CURL_EXTERN CURL *curl_easy_init
 CURL_EXTERN CURLcode curl_easy_setopt
+CURL_EXTERN CURLcode curl_easy_vsetopt
 CURL_EXTERN CURLcode curl_easy_perform
 CURL_EXTERN void curl_easy_cleanup
 CURL_EXTERN CURLcode curl_easy_getinfo

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -62,7 +62,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
          lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
          lib1915 lib1916 lib1917 lib1918 lib1933 lib1934 lib1935 lib1936 \
  lib1937 lib1938 lib1939 lib1940 lib1945 lib1946 \
- lib3010 lib3025
+ lib3010 lib3025 lib3026
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
  ../../lib/curl_ctype.c  ../../lib/dynbuf.c ../../lib/strdup.c
@@ -743,3 +743,7 @@ lib3010_CPPFLAGS = $(AM_CPPFLAGS)
 lib3025_SOURCES = lib3025.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib3025_LDADD = $(TESTUTIL_LIBS)
 lib3025_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib3026_SOURCES = lib3026.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib3026_LDADD = $(TESTUTIL_LIBS)
+lib3026_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -1,5 +1,3 @@
-#ifndef HEADER_CURL_SETOPT_H
-#define HEADER_CURL_SETOPT_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -21,9 +19,46 @@
  * KIND, either express or implied.
  *
  ***************************************************************************/
+#include "test.h"
+#include "memdebug.h"
 
-CURLcode Curl_setstropt(char **charp, const char *s);
-CURLcode Curl_setblobopt(struct curl_blob **blobp,
-                         const struct curl_blob *blob);
+#include <stdarg.h>
 
-#endif /* HEADER_CURL_SETOPT_H */
+CURLcode test_vsetopt(CURL *curl, CURLoption opt, ...)
+{
+  va_list ap;
+  va_start(ap, opt);
+  curl_easy_vsetopt(curl, opt, ap);
+  va_end(ap);
+}
+
+int test(char *URL)
+{
+  CURLcode res;
+  CURL *curl;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  test_vsetopt(curl, CURLOPT_VERBOSE, 1L);
+  test_vsetopt(curl, CURLOPT_HEADER, 1L);
+  test_vsetopt(curl, CURLOPT_URL, URL);
+
+  res = curl_easy_perform(curl);
+
+test_cleanup:
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return (int)res;
+}


### PR DESCRIPTION
This moves the internal Curl_vsetopt function into the public API so
that users can set options with a va_list.

Signed-off-by: Drew DeVault <sir@cmpwn.com>

This is https://curl.se/mail/lib-2022-03/0089.html with 3 copyright year ranges fixed.