### PR TITLE
docs: lots of minor language polish

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -14,7 +14,7 @@ We remove support for building curl with the NSS TLS library in August 2022.
 - NSS has very few users outside of curl as well (primarily Firefox)
 - NSS is harder than ever to find documentation for
 - NSS was always "best" used with Red Hat Linux when they provided additional
-  features on top of the regular NSS that isn't shipped by the vanilla library
+  features on top of the regular NSS that is not shipped by the vanilla library
 
 Starting in 7.82.0, building curl to use NSS configure requires the additional
 flag --with-nss-deprecated in an attempt to highlight these plans.

--- a/docs/FAQ
+++ b/docs/FAQ
@@ -56,7 +56,7 @@ FAQ
   4.2 Why do I get problems when I use & or % in the URL?
   4.3 How can I use {, }, [ or ] to specify multiple URLs?
   4.4 Why do I get downloaded data even though the web page does not exist?
-  4.5 Why do I get return code XXX from a HTTP server?
+  4.5 Why do I get return code XXX from an HTTP server?
    4.5.1 "400 Bad Request"
    4.5.2 "401 Unauthorized"
    4.5.3 "403 Forbidden"
@@ -434,7 +434,7 @@ FAQ
 
   3.1 curl: (1) SSL is disabled, https: not supported
 
-  If you get this output when trying to get anything from a https:// server,
+  If you get this output when trying to get anything from an https:// server,
   it means that the instance of curl/libcurl that you are using was built
   without support for this protocol.
 
@@ -564,8 +564,8 @@ FAQ
 
   3.12 Why do FTP-specific features over HTTP proxy fail?
 
-  Because when you use a HTTP proxy, the protocol spoken on the network will
-  be HTTP, even if you specify a FTP URL. This effectively means that you
+  Because when you use an HTTP proxy, the protocol spoken on the network will
+  be HTTP, even if you specify an FTP URL. This effectively means that you
   normally cannot use FTP-specific features such as FTP upload and FTP quote
   etc.
 
@@ -737,7 +737,7 @@ FAQ
   In normal circumstances, -X should hardly ever be used.
 
   By default you use curl without explicitly saying which request method to
-  use when the URL identifies a HTTP transfer. If you just pass in a URL like
+  use when the URL identifies an HTTP transfer. If you just pass in a URL like
   "curl http://example.com" it will use GET. If you use -d or -F curl will use
   POST, -I will cause a HEAD and -T will make it a PUT.
 
@@ -807,7 +807,7 @@ FAQ
   By using the --fail option you can tell curl explicitly to not get any data
   if the HTTP return code does not say success.
 
-  4.5 Why do I get return code XXX from a HTTP server?
+  4.5 Why do I get return code XXX from an HTTP server?
 
   RFC2616 clearly explains the return codes. This is a short transcript. Go
   read the RFC for exact details:
@@ -959,10 +959,10 @@ FAQ
   curl supports HTTP redirects well (see item 3.8). Browsers generally support
   at least two other ways to perform redirects that curl does not:
 
-  Meta tags. You can write a HTML tag that will cause the browser to redirect
+  Meta tags. You can write an HTML tag that will cause the browser to redirect
   to another given URL after a certain time.
 
-  Javascript. You can write a Javascript program embedded in a HTML page that
+  Javascript. You can write a Javascript program embedded in an HTML page that
   redirects the browser to another given URL.
 
   There is no way to make curl follow these redirects. You must either
@@ -978,7 +978,7 @@ FAQ
   the control connection and will therefore immediately connect and try to
   speak SSL. FTPS:// connections default to port 990.
 
-  To use explicit FTPS, you use a FTP:// URL and the --ftp-ssl option (or one
+  To use explicit FTPS, you use an FTP:// URL and the --ftp-ssl option (or one
   of its related flavors). This is the most common method, and the one
   mandated by RFC4217. This kind of connection will then of course use the
   standard FTP port 21 by default.
@@ -1212,7 +1212,7 @@ FAQ
   5.8 libcurl.so.X: open failed: No such file or directory
 
   This is an error message you might get when you try to run a program linked
-  with a shared version of libcurl and your run-time linker (ld.so) could not
+  with a shared version of libcurl and your runtime linker (ld.so) could not
   find the shared library named libcurl.so.X. (Where X is the number of the
   current libcurl ABI, typically 3 or 4).
 
@@ -1221,7 +1221,7 @@ FAQ
   They are usually:
 
   * Add an option to the linker command line that specify the hard-coded path
-    the run-time linker should check for the lib (usually -R)
+    the runtime linker should check for the lib (usually -R)
 
   * Set an environment variable (LD_LIBRARY_PATH for example) where ld.so
     should check for libs
@@ -1368,7 +1368,7 @@ FAQ
   5.17 Can I write a server with libcurl?
 
   No. libcurl offers no functions or building blocks to build any kind of
-  internet protocol server. libcurl is only a client-side library. For server
+  Internet protocol server. libcurl is only a client-side library. For server
   libraries, you need to continue your search elsewhere but there exist many
   good open source ones out there for most protocols you could want a server
   for. There are also really good stand-alone servers that have been tested
@@ -1535,5 +1535,5 @@ FAQ
  stable, we will never risk anything by rewriting a lot of things in one go.
  That said, we can certainly offer more and more optional backends written in
  other languages, as long as those backends can be plugged in at build-time.
- Back-ends can be written in any language, but should probably provide APIs
+ Backends can be written in any language, but should probably provide APIs
  usable from C to ease integration and transition.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -198,7 +198,7 @@
 
 ## MQTT
 
- - Subscribe to and publish topics using url scheme `mqtt://broker/topic`
+ - Subscribe to and publish topics using URL scheme `mqtt://broker/topic`
 
 ## Footnotes
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -411,7 +411,7 @@ April: added the cyassl backend (later renamed to WolfSSL)
 2021
 ----
 
- February 3: curl 7.75.0 ships with support for Hyper is a HTTP backend
+ February 3: curl 7.75.0 ships with support for Hyper as an HTTP backend
 
  March 31: curl 7.76.0 ships with support for rustls
 

--- a/docs/HTTP-COOKIES.md
+++ b/docs/HTTP-COOKIES.md
@@ -2,7 +2,7 @@
 
 ## Cookie overview
 
-  Cookies are `name=contents` pairs that a HTTP server tells the client to
+  Cookies are `name=contents` pairs that an HTTP server tells the client to
   hold and then the client sends back those to the server on subsequent
   requests to the same domains and paths for which the cookies were set.
 
@@ -111,9 +111,9 @@
   `CURLOPT_COOKIELIST`
 
   Provide detailed information about a single cookie to add to the internal
-  storage of cookies. Pass in the cookie as a HTTP header with all the details
-  set, or pass in a line from a Netscape cookie file. This option can also be
-  used to flush the cookies etc.
+  storage of cookies. Pass in the cookie as an HTTP header with all the
+  details set, or pass in a line from a Netscape cookie file. This option can
+  also be used to flush the cookies etc.
 
   `CURLINFO_COOKIELIST`
 

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -77,7 +77,7 @@ To take advantage of multiplexing, you need to use the multi interface and set
 attempt to re-use existing HTTP/2 connections and just add a new stream over
 that when doing subsequent parallel requests.
 
-While libcurl sets up a connection to a HTTP server there is a period during
+While libcurl sets up a connection to an HTTP server there is a period during
 which it does not know if it can pipeline or do multiplexing and if you add new
 transfers in that period, libcurl will default to start new connections for
 those transfers. With the new option `CURLOPT_PIPEWAIT` (added in 7.43.0), you

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -161,14 +161,14 @@ development and experimenting.
 
 An existing local HTTP/1.1 server that hosts files. Preferably also a few huge
 ones.  You can easily create huge local files like `truncate -s=8G 8GB` - they
-are huge but do not occupy that much space on disk since they're just a big
-hole.
+are huge but do not occupy that much space on disk since they are just big
+holes.
 
 In my Debian setup I just installed **apache2**. It runs on port 80 and has a
 document root in `/var/www/html`. I can get the 8GB file from it with `curl
 localhost/8GB -o dev/null`
 
-In this description we setup and run a HTTP/3 reverse-proxy in front of the
+In this description we setup and run an HTTP/3 reverse-proxy in front of the
 HTTP/1 server.
 
 ## Setup
@@ -202,7 +202,7 @@ that exists in curl's test dir.
 single binary in a separate directory if you prefer.
 
 In the same directory you put caddy, create a `Caddyfile` with the following
-content to run a HTTP/3 reverse-proxy on port 7443:
+content to run an HTTP/3 reverse-proxy on port 7443:
 ~~~
 {
     auto_https disable_redirects

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -84,9 +84,9 @@ work:
 
     CPPFLAGS="-I/path/to/ssl/include" LDFLAGS="-L/path/to/ssl/lib" ./configure
 
-If you have shared SSL libs installed in a directory where your run-time
+If you have shared SSL libs installed in a directory where your runtime
 linker does not find them (which usually causes configure failures), you can
-provide this option to gcc to set a hard-coded path to the run-time linker:
+provide this option to gcc to set a hard-coded path to the runtime linker:
 
     LDFLAGS=-Wl,-R/usr/local/ssl/lib ./configure --with-openssl
 
@@ -126,7 +126,7 @@ These options are provided to select the TLS backend to use.
 
 # Windows
 
-## Building Windows DLLs and C run-time (CRT) linkage issues
+## Building Windows DLLs and C runtime (CRT) linkage issues
 
  As a general rule, building a DLL with static CRT linkage is highly
  discouraged, and intermixing CRTs in the same app is something to avoid at

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -205,7 +205,7 @@ problems may have been fixed or changed somewhat since this was written.
 
 1.7 Deflate error after all content was received
 
- There's a situation where we can get an error in a HTTP response that is
+ There's a situation where we can get an error in an HTTP response that is
  compressed, when that error is detected after all the actual body contents
  have been received and delivered to the application. This is tricky, but is
  ultimately a broken server.
@@ -224,14 +224,13 @@ problems may have been fixed or changed somewhat since this was written.
 
 1.11 CURLOPT_SEEKFUNCTION not called with CURLFORM_STREAM
 
- I'm using libcurl to POST form data using a FILE* with the CURLFORM_STREAM
- option of curl_formadd(). I have noticed that if the connection drops at just
- the right time, the POST is reattempted without the data from the file. It
- seems like the file stream position is not getting reset to the beginning of
- the file. I found the CURLOPT_SEEKFUNCTION option and set that with a
- function that performs an fseek() on the FILE*. However, setting that did not
- seem to fix the issue or even get called. See
- https://github.com/curl/curl/issues/768
+ When using libcurl to POST form data using a FILE* with the CURLFORM_STREAM
+ option of curl_formadd(). I notice that if the connection drops at just the
+ right time, the POST is reattempted without the data from the file. It seems
+ like the file stream position is not getting reset to the beginning of the
+ file. I found the CURLOPT_SEEKFUNCTION option and set that with a function
+ that performs an fseek() on the FILE*. However, setting that did not seem to
+ fix the issue or even get called. See https://github.com/curl/curl/issues/768
 
 
 2. TLS
@@ -633,7 +632,7 @@ problems may have been fixed or changed somewhat since this was written.
 
 7.1 FTP without or slow 220 response
 
- If a connection is made to a FTP server but the server then just never sends
+ If a connection is made to an FTP server but the server then just never sends
  the 220 response or otherwise is dead slow, libcurl will not acknowledge the
  connection timeout during that phase but only the "real" timeout - which may
  surprise users as it is probably considered to be the connect phase to most

--- a/docs/MAIL-ETIQUETTE
+++ b/docs/MAIL-ETIQUETTE
@@ -45,7 +45,7 @@ MAIL ETIQUETTE
 
   1.2 Netiquette
 
-  Netiquette is a common term for how to behave on the internet. Of course, in
+  Netiquette is a common term for how to behave on the Internet. Of course, in
   each particular group and subculture there will be differences in what is
   acceptable and what is considered good manners.
 

--- a/docs/TODO
+++ b/docs/TODO
@@ -181,7 +181,7 @@
  20.5 Add support for concurrent connections
  20.6 Use the RFC6265 test suite
  20.7 Support LD_PRELOAD on macOS
- 20.8 Run web-platform-tests url tests
+ 20.8 Run web-platform-tests URL tests
 
  21. MQTT
  21.1 Support rate-limiting
@@ -307,10 +307,11 @@
  reuse purpose it is verified that it is still alive.
 
  Those connections may get closed by the server side for idleness or they may
- get a HTTP/2 ping from the peer to verify that they are still alive. By adding
- monitoring of the connections while in the pool, libcurl can detect dead
- connections (and close them) better and earlier, and it can handle HTTP/2
- pings to keep such ones alive even when not actively doing transfers on them.
+ get an HTTP/2 ping from the peer to verify that they are still alive. By
+ adding monitoring of the connections while in the pool, libcurl can detect
+ dead connections (and close them) better and earlier, and it can handle
+ HTTP/2 pings to keep such ones alive even when not actively doing transfers
+ on them.
 
 1.16 Try to URL encode given URL
 
@@ -1117,9 +1118,9 @@
 18.21 retry on the redirected-to URL
 
  When curl is told to --retry a failed transfer and follows redirects, it
- might get a HTTP 429 response from the redirected-to URL and not the original
- one, which then could make curl decide to rather retry the transfer on that
- URL only instead of the original operation to the original URL.
+ might get an HTTP 429 response from the redirected-to URL and not the
+ original one, which then could make curl decide to rather retry the transfer
+ on that URL only instead of the original operation to the original URL.
 
  Perhaps extra emphasized if the original transfer is a large POST that
  redirects to a separate GET, and that GET is what gets the 529
@@ -1261,9 +1262,9 @@
  properly. Look into making the preload support in runtests.pl portable such
  that it uses DYLD_INSERT_LIBRARIES on macOS.
 
-20.8 Run web-platform-tests url tests
+20.8 Run web-platform-tests URL tests
 
- Run web-platform-tests url tests and compare results with browsers on wpt.fyi
+ Run web-platform-tests URL tests and compare results with browsers on wpt.fyi
 
  It would help us find issues to fix and help us document where our parser
  differs from the WHATWG URL spec parsers.

--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -30,7 +30,7 @@
  request a particular action, and then the server replies a few text lines
  before the actual requested content is sent to the client.
 
- The client, curl, sends a HTTP request. The request contains a method (like
+ The client, curl, sends an HTTP request. The request contains a method (like
  GET, POST, HEAD etc), a number of request headers and sometimes a request
  body. The HTTP server responds with a status line (indicating if things went
  well), response headers and most often also a response body. The "body" part
@@ -103,7 +103,7 @@
  The port number you specify in the URL is the number that the server uses to
  offer its services. Sometimes you may use a proxy, and then you may
  need to specify that proxy's port number separately from what curl needs to
- connect to the server. Like when using a HTTP proxy on port 4321:
+ connect to the server. Like when using an HTTP proxy on port 4321:
 
     curl --proxy http://proxy.example.org:4321 http://remote.example.org/
 
@@ -207,7 +207,7 @@
 
 ## Forms explained
 
- Forms are the general way a website can present a HTML page with fields for
+ Forms are the general way a website can present an HTML page with fields for
  the user to enter data in, and then press some kind of 'OK' or 'Submit'
  button to get that data sent to the server. The server then typically uses
  the posted data to decide how to act. Like using the entered words to search
@@ -351,11 +351,11 @@
 
 ## PUT
 
- Perhaps the best way to upload data to a HTTP server is to use PUT. Then
+ Perhaps the best way to upload data to an HTTP server is to use PUT. Then
  again, this of course requires that someone put a program or script on the
- server end that knows how to receive a HTTP PUT stream.
+ server end that knows how to receive an HTTP PUT stream.
 
- Put a file to a HTTP server with curl:
+ Put a file to an HTTP server with curl:
 
     curl --upload-file uploadfile http://www.example.com/receive.cgi
 
@@ -386,8 +386,8 @@
 
 ## Proxy Authentication
 
- Sometimes your HTTP access is only available through the use of a HTTP
- proxy. This seems to be especially common at various companies. A HTTP proxy
+ Sometimes your HTTP access is only available through the use of an HTTP
+ proxy. This seems to be especially common at various companies. An HTTP proxy
  may require its own user and password to allow the client to get through to
  the Internet. To specify those with curl, run something like:
 
@@ -416,7 +416,7 @@
 
 ## Referer
 
- A HTTP request may include a 'referer' field (yes it is misspelled), which
+ An HTTP request may include a 'referer' field (yes it is misspelled), which
  can be used to tell from which URL the client got to this particular
  resource. Some programs/scripts check the referer field of requests to verify
  that this was not arriving from an external site or an unknown page. While
@@ -560,7 +560,7 @@
 
  Curl supports encrypted fetches when built to use a TLS library and it can be
  built to use one out of a fairly large set of libraries - `curl -V` will show
- which one your curl was built to use (if any!). To get a page from a HTTPS
+ which one your curl was built to use (if any!). To get a page from an HTTPS
  server, simply run curl like:
 
     curl https://secure.example.com
@@ -572,7 +572,7 @@
  side certificates. All certificates are locked with a pass phrase, which you
  need to enter before the certificate can be used by curl. The pass phrase
  can be specified on the command line or if not, entered interactively when
- curl queries for it. Use a certificate with curl on a HTTPS server like:
+ curl queries for it. Use a certificate with curl on an HTTPS server like:
 
     curl --cert mycert.pem https://secure.example.com
 

--- a/docs/cmdline-opts/data-urlencode.d
+++ b/docs/cmdline-opts/data-urlencode.d
@@ -1,6 +1,6 @@
 Long: data-urlencode
 Arg: <data>
-Help: HTTP POST data url encoded
+Help: HTTP POST data URL encoded
 Protocols: HTTP
 See-also: data data-raw
 Added: 7.18.0

--- a/docs/cmdline-opts/disallow-username-in-url.d
+++ b/docs/cmdline-opts/disallow-username-in-url.d
@@ -1,10 +1,10 @@
 Long: disallow-username-in-url
-Help: Disallow username in url
+Help: Disallow username in URL
 Protocols: HTTP
 Added: 7.61.0
 See-also: proto
 Category: curl http
 Example: --disallow-username-in-url $URL
 ---
-This tells curl to exit if passed a url containing a username. This is probably
-most useful when the URL is being provided at run-time or similar.
+This tells curl to exit if passed a URL containing a username. This is probably
+most useful when the URL is being provided at runtime or similar.

--- a/docs/cmdline-opts/engine.d
+++ b/docs/cmdline-opts/engine.d
@@ -9,4 +9,4 @@ See-also: ciphers curves
 ---
 Select the OpenSSL crypto engine to use for cipher operations. Use --engine
 list to print a list of build-time supported engines. Note that not all (and
-possibly none) of the engines may be available at run-time.
+possibly none) of the engines may be available at runtime.

--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -30,10 +30,10 @@ This option can take an argument in @filename style, which then adds a header
 for each line in the input file. Using @- will make curl read the header file
 from stdin. Added in 7.55.0.
 
-You need --proxy-header to send custom headers intended for a HTTP
+You need --proxy-header to send custom headers intended for an HTTP
 proxy. Added in 7.37.0.
 
-Passing on a "Transfer-Encoding: chunked" header when doing a HTTP request
+Passing on a "Transfer-Encoding: chunked" header when doing an HTTP request
 with a request body, will make curl send the data using chunked encoding.
 
 **WARNING**: headers set with this option will be set in all requests - even

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -164,7 +164,7 @@ failed.
 .IP 21
 FTP quote error. A quote command returned error from the server.
 .IP 22
-HTTP page not retrieved. The requested url was not found or returned another
+HTTP page not retrieved. The requested URL was not found or returned another
 error with the HTTP error code being 400 or above. This return code only
 appears if --fail is used.
 .IP 23

--- a/docs/libcurl/curl_easy_header.3
+++ b/docs/libcurl/curl_easy_header.3
@@ -21,7 +21,7 @@
 .\" **************************************************************************
 .TH curl_easy_header 3 "13 March 2022" "libcurl 7.83.0" "libcurl Manual"
 .SH NAME
-curl_easy_header - get a HTTP header
+curl_easy_header - get an HTTP header
 .SH SYNOPSIS
 .nf
 #include <curl/curl.h>
@@ -70,7 +70,7 @@ the previous calls for the same easy handle. Applications need to copy the
 data if it wants to keep it around. The memory used for the struct gets freed
 with calling \fIcurl_easy_cleanup(3)\fP of the easy handle.
 
-The first line in a HTTP response is called the status line. It is not
+The first line in an HTTP response is called the status line. It is not
 considered a header by this function. Headers are the "name: value" lines
 following the status.
 
@@ -116,12 +116,12 @@ The header arrived as a header from the server.
 The header arrived as a trailer. A header that arrives after the body.
 .IP CURLH_CONNECT
 The header arrived in a CONNECT response. A CONNECT request is being done to
-setup a transfer "through" a HTTP(S) proxy.
+setup a transfer "through" an HTTP(S) proxy.
 .IP CURLH_1XX
-The header arrived in a HTTP 1xx response. A 1xx response is an "intermediate"
+The header arrived in an HTTP 1xx response. A 1xx response is an "intermediate"
 response that might happen before the "real" response.
 .IP CURLH_PSUEDO
-The header is a HTTP/2 or HTTP/3 pseudo header
+The header is an HTTP/2 or HTTP/3 pseudo header
 .SH EXAMPLE
 .nf
 struct curl_header *type;

--- a/docs/libcurl/curl_easy_recv.3
+++ b/docs/libcurl/curl_easy_recv.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -34,7 +34,7 @@ This function receives raw data from the established connection. You may use
 it together with \fIcurl_easy_send(3)\fP to implement custom protocols using
 libcurl. This functionality can be particularly useful if you use proxies
 and/or SSL encryption: libcurl will take care of proxy negotiation and
-connection set-up.
+connection setup.
 
 \fBbuffer\fP is a pointer to your buffer that will get the received
 data. \fBbuflen\fP is the maximum amount of data you can get in that

--- a/docs/libcurl/curl_easy_send.3
+++ b/docs/libcurl/curl_easy_send.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -35,7 +35,7 @@ This function sends arbitrary data over the established connection. You may
 use it together with \fIcurl_easy_recv(3)\fP to implement custom protocols
 using libcurl. This functionality can be particularly useful if you use
 proxies and/or SSL encryption: libcurl will take care of proxy negotiation and
-connection set-up.
+connection setup.
 
 \fBbuffer\fP is a pointer to the data of length \fBbuflen\fP that you want sent.
 The variable \fBn\fP points to will receive the number of sent bytes.

--- a/docs/libcurl/curl_easy_strerror.3
+++ b/docs/libcurl/curl_easy_strerror.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -33,7 +33,7 @@ The \fIcurl_easy_strerror(3)\fP function returns a string describing the
 CURLcode error code passed in the argument \fIerrornum\fP.
 
 Typically applications also appreciate \fICURLOPT_ERRORBUFFER(3)\fP for more
-specific error descriptions generated at run-time.
+specific error descriptions generated at runtime.
 .SH EXAMPLE
 .nf
   /* Perform the request, res will get the return code */

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -22,7 +22,7 @@
 .\"
 .TH curl_version_info 3 "2 Nov 2014" "libcurl 7.40.0" "libcurl Manual"
 .SH NAME
-curl_version_info - returns run-time libcurl version info
+curl_version_info - returns runtime libcurl version info
 .SH SYNOPSIS
 .nf
 #include <curl/curl.h>

--- a/docs/libcurl/libcurl-tutorial.3
+++ b/docs/libcurl/libcurl-tutorial.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -131,8 +131,8 @@ Repeated calls to \fIcurl_global_init(3)\fP and \fIcurl_global_cleanup(3)\fP
 should be avoided. They should only be called once each.
 
 .SH "Features libcurl Provides"
-It is considered best-practice to determine libcurl features at run-time
-rather than at build-time (if possible of course). By calling
+It is considered best-practice to determine libcurl features at runtime rather
+than at build-time (if possible of course). By calling
 \fIcurl_version_info(3)\fP and checking out the details of the returned
 struct, your program can figure out exactly what the currently running libcurl
 supports.

--- a/docs/libcurl/libcurl-url.3
+++ b/docs/libcurl/libcurl-url.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -19,7 +19,7 @@
 .\" * KIND, either express or implied.
 .\" *
 .\" **************************************************************************
-.TH libcurl 3 "10 Sep 2018" "libcurl" "libcurl url interface"
+.TH libcurl 3 "10 Sep 2018" "libcurl" "libcurl URL interface"
 .SH NAME
 libcurl-url \- URL interface overview
 .SH DESCRIPTION

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.3
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -34,7 +34,7 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_SSL_ENGINES,
 Pass the address of a 'struct curl_slist *' to receive a linked-list of
 OpenSSL crypto-engines supported. Note that engines are normally implemented
 in separate dynamic libraries. Hence not all the returned engines may be
-available at run-time. \fBNOTE:\fP you must call \fIcurl_slist_free_all(3)\fP
+available at runtime. \fBNOTE:\fP you must call \fIcurl_slist_free_all(3)\fP
 on the list pointer once you are done with it, as libcurl will not free the
 data for you.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -39,7 +39,7 @@ sockets, however it should be stressed that the path passed to this function
 should not contain a leading NULL).
 
 On non-supporting platforms, the abstract address will be interpreted as an
-empty string and fail gracefully, generating a run-time error.
+empty string and fail gracefully, generating a runtime error.
 
 This option shares the same semantics as \fICURLOPT_UNIX_SOCKET_PATH(3)\fP in
 which documentation more details can be found. Internally, these two options

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 2018 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 2018 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -33,7 +33,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DOH_URL, char *URL);
 Pass in a pointer to a \fIURL\fP for the DoH server to use for name
 resolving. The parameter should be a char * to a null-terminated string which
 must be URL-encoded in the following format: "https://host:port/path". It MUST
-specify a HTTPS URL.
+specify an HTTPS URL.
 
 libcurl does not validate the syntax or use this variable until the transfer is
 issued. Even if you set a crazy value here, \fIcurl_easy_setopt(3)\fP will

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2019, 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -32,7 +32,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTP09_ALLOWED, long allowed);
 .SH DESCRIPTION
 Pass the long argument \fIallowed\fP set to 1L to allow HTTP/0.9 responses.
 
-A HTTP/0.9 response is a server response entirely without headers and only a
+An HTTP/0.9 response is a server response entirely without headers and only a
 body. You can connect to lots of random TCP services and still get a response
 that curl might consider to be HTTP/0.9!
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_PORT.3
+++ b/docs/libcurl/opts/CURLOPT_PORT.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -38,7 +38,7 @@ Usually, you just let the URL decide which port to use but this allows the
 application to override that.
 
 While this option accepts a 'long', a port number is usually a 16 bit number
-and therefore using a port number over 65535 will cause a run-time error.
+and therefore using a port number over 65535 will cause a runtime error.
 .SH DEFAULT
 By default this is 0 which makes it not used.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -52,7 +52,7 @@ if(curl) {
 .fi
 .SH AVAILABILITY
 Added in 7.80.0
-Requires the libssh2 back-end.
+Requires the libssh2 backend.
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.


### PR DESCRIPTION
Mostly based on recent language decisions from "everything curl":

- remove contractions (isn't => is not)
- *an* HTTP (consistency)
- runtime (no hyphen)
- backend (no hyphen)
- URL is uppercase