### PR TITLE
misc: spelling fixes

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -62,7 +62,7 @@ are provided as arrays, since in the case of multiple headers there can be
 multiple values.
 
 The header names provided in lowercase, listed in order of appearance over the
-wire. Except for duplicated headers. They are grouped on the first occurance
+wire. Except for duplicated headers. They are grouped on the first occurrence
 of that header, each value is presented in the JSON array.
 .TP
 .B http_code

--- a/lib/h2h3.c
+++ b/lib/h2h3.c
@@ -114,7 +114,7 @@ static header_instruction inspect_header(const char *name, size_t namelen,
 }
 
 CURLcode Curl_pseudo_headers(struct Curl_easy *data,
-                             const char *mem, /* the requeset */
+                             const char *mem, /* the request */
                              const size_t len /* size of request */,
                              struct h2h3req **hp)
 {

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -48,10 +48,10 @@ static void copy_header_external(struct Curl_easy *data,
   h->value = hs->value;
   h->amount = amount;
   h->index = index;
-  /* this will randomly OR a reverved bit for the sole purpose of making it
-     impossible for applications to do == comparisons, as that would
-     otherwise be very tempting and then lead the reserved bits not being
-     reserved anymore. */
+  /* this will randomly OR a reserved bit for the sole purpose of making it
+     impossible for applications to do == comparisons, as that would otherwise
+     be very tempting and then lead to the reserved bits not being reserved
+     anymore. */
   h->origin = hs->type | (1<<27);
   h->anchor = e;
 }
@@ -99,7 +99,7 @@ CURLHcode curl_easy_header(CURL *easy,
     return CURLHE_BADINDEX;
 
   if(nameindex == amount - 1)
-    /* if the last or only ocurrance is what's asked for, then we know it */
+    /* if the last or only occurrence is what's asked for, then we know it */
     hs = pick;
   else {
     for(e = data->state.httphdrs.head; e; e = e->next) {

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1144,7 +1144,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
 }
 
 /*
- * Parse the URL and, if successful, replace everyting in the Curl_URL struct.
+ * Parse the URL and, if successful, replace everything in the Curl_URL struct.
  */
 static CURLUcode parseurl_and_replace(const char *url, CURLU *u,
                                       unsigned int flags)

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -938,9 +938,9 @@ static OSStatus SocketWrite(SSLConnectionRef connection,
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
 CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
 {
-  /* The first ciphers in the ciphertable are continuos. Here we do small
+  /* The first ciphers in the ciphertable are continuous. Here we do small
      optimization and instead of loop directly get SSL name by cipher number.
-   */
+  */
   if(cipher <= SSL_FORTEZZA_DMS_WITH_FORTEZZA_CBC_SHA) {
     return ciphertable[cipher].name;
   }

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -95,7 +95,7 @@ bool tool_create_output_file(struct OutStruct *outs,
       }
       memcpy(newname, fname, len);
       newname[len] = '.';
-      while(fd == -1 && /* haven't sucessfully opened a file */
+      while(fd == -1 && /* haven't successfully opened a file */
             (errno == EEXIST || errno == EISDIR) &&
             /* because we keep having files that already exist */
             next_num < 100 /* and we haven't reached the retry limit */ ) {

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -291,7 +291,7 @@ struct OperationConfig {
   bool disallow_username_in_url;  /* disallow usernames in URLs */
   char *aws_sigv4;
   enum {
-    CLOBBER_DEFAULT, /* Provides compatability with previous versions of curl,
+    CLOBBER_DEFAULT, /* Provides compatibility with previous versions of curl,
                         by using the default behavior for -o, -O, and -J.
                         If those options would have overwritten files, like
                         -o and -O would, then overwrite them. In the case of


### PR DESCRIPTION
Mostly in comments but also in the -w documentation for headers_json.