### PR TITLE
CURLOPT_PREQUOTE.3: only works for FTP file transfers, not dirs

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -64,6 +64,7 @@
  4.1 HOST
  4.2 Alter passive/active on failure and retry
  4.3 Earlier bad letter detection
+ 4.4 Support CURLOPT_PREQUOTE for dir listings too
  4.5 ASCII support
  4.6 GSSAPI via Windows SSPI
  4.7 STAT for LIST without data connection
@@ -531,6 +532,13 @@
 
  Make the detection of (bad) %0d and %0a codes in FTP URL parts earlier in the
  process to avoid doing a resolve and connect in vain.
+
+4.4 Support CURLOPT_PREQUOTE for dir listings too
+
+ The lack of support is mostly an oversight and requires the FTP state machine
+ to get updated to get fixed.
+
+ https://github.com/curl/curl/issues/8602
 
 4.5 ASCII support
 

--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -11,10 +11,13 @@ See-also: request
 Send an arbitrary command to the remote FTP or SFTP server. Quote commands are
 sent BEFORE the transfer takes place (just after the initial PWD command in an
 FTP transfer, to be exact). To make commands take place after a successful
-transfer, prefix them with a dash '-'. To make commands be sent after curl
-has changed the working directory, just before the transfer command(s), prefix
-the command with a '+' (this is only supported for FTP). You may specify any
-number of commands.
+transfer, prefix them with a dash '-'.
+
+(FTP only) To make commands be sent after curl has changed the working
+directory, just before the file transfer command(s), prefix the command with a
+'+'. This is not performed when a directory listing is performed.
+
+You may specify any number of commands.
 
 By default curl will stop at first failure. To make curl continue even if the
 command fails, prefix the command with an asterisk (*). Otherwise, if the

--- a/docs/libcurl/opts/CURLOPT_PREQUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_PREQUOTE.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -36,6 +36,9 @@ the transfer type is set. The linked list should be a fully valid list of
 struct curl_slist structs properly filled in as described for
 \fICURLOPT_QUOTE(3)\fP. Disable this operation again by setting a NULL to this
 option.
+
+These commands are not performed when a directory listing is performed, only
+for file transfers.
 
 While \fICURLOPT_QUOTE(3)\fP and \fICURLOPT_POSTQUOTE(3)\fP work for SFTP,
 this option does not.


### PR DESCRIPTION
Also add to quote.d. Add to TODO as something to add in a future.

Reported-by: anon00000000 on github
Closes #8602