### PR TITLE
ftp: fix error message for partial file upload

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3381,7 +3381,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
        (ftp->transfer == PPTRANSFER_BODY)) {
       failf(data, "Uploaded unaligned file size (%" CURL_FORMAT_CURL_OFF_T
             " out of %" CURL_FORMAT_CURL_OFF_T " bytes)",
-            data->req.bytecount, data->state.infilesize);
+            data->req.writebytecount, data->state.infilesize);
       result = CURLE_PARTIAL_FILE;
     }
   }


### PR DESCRIPTION
- Show the count of bytes written on partial file upload.

Prior to this change the error message mistakenly showed the count of
bytes read, not written.

Bug: https://github.com/curl/curl/discussions/8637
Reported-by: Taras Kushnir

Closes #xxxx