### PR TITLE
vtls: provide a unified APLN-disagree string for all backends

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -884,7 +884,7 @@ static CURLcode bearssl_connect_step3(struct Curl_easy *data,
                           BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
     }
     else
-      infof(data, "ALPN, server did not agree to a protocol");
+      infof(data, VTLS_INFOF_NO_ALPN);
   }
 
   if(SSL_SET_OPTION(primary.sessionid)) {

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1280,7 +1280,7 @@ Curl_gtls_verifyserver(struct Curl_easy *data,
       }
     }
     else
-      infof(data, "ALPN, server did not agree to a protocol");
+      infof(data, VTLS_INFOF_NO_ALPN);
 
     Curl_multiuse_state(data, conn->negnpn == CURL_HTTP_VERSION_2 ?
                         BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -828,7 +828,7 @@ mbed_connect_step2(struct Curl_easy *data, struct connectdata *conn,
         }
     }
     else {
-      infof(data, "ALPN, server did not agree to a protocol");
+      infof(data, VTLS_INFOF_NO_ALPN);
     }
     Curl_multiuse_state(data, conn->negnpn == CURL_HTTP_VERSION_2 ?
                         BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -862,7 +862,7 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
 #endif
     case SSL_NEXT_PROTO_NO_SUPPORT:
     case SSL_NEXT_PROTO_NO_OVERLAP:
-      infof(data, "ALPN/NPN, server did not agree to a protocol");
+      infof(data, VTLS_INFOF_NO_ALPN);
       return;
 #ifdef SSL_ENABLE_ALPN
     case SSL_NEXT_PROTO_SELECTED:

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3472,7 +3472,7 @@ static CURLcode ossl_connect_step2(struct Curl_easy *data,
         }
       }
       else
-        infof(data, "ALPN, server did not agree to a protocol");
+        infof(data, VTLS_INFOF_NO_ALPN);
 
       Curl_multiuse_state(data, conn->negnpn == CURL_HTTP_VERSION_2 ?
                           BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -406,7 +406,7 @@ cr_set_negotiated_alpn(struct Curl_easy *data, struct connectdata *conn,
 
   rustls_connection_get_alpn_protocol(rconn, &protocol, &len);
   if(!protocol) {
-    infof(data, "ALPN, server did not agree to a protocol");
+    infof(data, VTLS_INFOF_NO_ALPN);
     return;
   }
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1433,7 +1433,7 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
         }
     }
     else
-      infof(data, "ALPN, server did not agree to a protocol");
+      infof(data, VTLS_INFOF_NO_ALPN);
     Curl_multiuse_state(data, conn->negnpn == CURL_HTTP_VERSION_2 ?
                         BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2853,7 +2853,7 @@ sectransp_connect_step2(struct Curl_easy *data, struct connectdata *conn,
           conn->negnpn = CURL_HTTP_VERSION_1_1;
         }
         else
-          infof(data, "ALPN, server did not agree to a protocol");
+          infof(data, VTLS_INFOF_NO_ALPN);
 
         Curl_multiuse_state(data, conn->negnpn == CURL_HTTP_VERSION_2 ?
                             BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -34,6 +34,9 @@ struct ssl_connect_data;
 #define SSLSUPP_TLS13_CIPHERSUITES (1<<5) /* supports TLS 1.3 ciphersuites */
 #define SSLSUPP_CAINFO_BLOB  (1<<6)
 
+#define VTLS_INFOF_NO_ALPN                                      \
+  "ALPN: server did not agree on a protocol. Uses default."
+
 struct Curl_ssl {
   /*
    * This *must* be the first entry to allow returning the list of available

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -776,7 +776,7 @@ wolfssl_connect_step2(struct Curl_easy *data, struct connectdata *conn,
                           BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
     }
     else if(rc == SSL_ALPN_NOT_FOUND)
-      infof(data, "ALPN, server did not agree to a protocol");
+      infof(data, VTLS_INFOF_NO_ALPN);
     else {
       failf(data, "ALPN, failure getting protocol, error %d", rc);
       return CURLE_SSL_CONNECT_ERROR;


### PR DESCRIPTION
Also rephrase to make it sound less dangerous:

 "ALPN: server did not agree on a protocol. Uses default."

Reported-by: Nick Coghlan
Fixes #8643