### PR TITLE
http: streamclose "already downloaded"

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2927,7 +2927,7 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
       /* The resume point is at the end of file, consider this fine even if it
          doesn't allow resume from here. */
       infof(data, "The entire document is already downloaded");
-      connclose(conn, "already downloaded");
+      streamclose(conn, "already downloaded");
       /* Abort download */
       k->keepon &= ~KEEP_RECV;
       *done = TRUE;


### PR DESCRIPTION
Instead of connclose()ing, since when HTTP/2 is used it doesn't need to
close the connection as stopping the current transfer is enough.

Reported-by: Evangelos Foutras