### PR TITLE
Support socks5h proxy using unix sockets

### DIFF
--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -14,6 +14,9 @@ specified or http:// will be treated as HTTP proxy. Use socks4://, socks4a://,
 socks5:// or socks5h:// to request a specific SOCKS version to be used.
 (Added in 7.21.7)
 
+Unix domain sockets are supported for socks proxy. Set localhost for the host
+part. e.g. socks5h://localhost/path/to/socket.sock
+
 HTTPS proxy support via https:// protocol prefix was added in 7.52.0 for
 OpenSSL, GnuTLS and NSS.
 

--- a/docs/cmdline-opts/socks4.d
+++ b/docs/cmdline-opts/socks4.d
@@ -10,6 +10,9 @@ Use the specified SOCKS4 proxy. If the port number is not specified, it is
 assumed at port 1080. Using this socket type make curl resolve the host name
 and passing the address on to the proxy.
 
+To specify proxy on a unix domain socket, use localhost for host, e.g.
+socks4://localhost/path/to/socket.sock
+
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 

--- a/docs/cmdline-opts/socks4a.d
+++ b/docs/cmdline-opts/socks4a.d
@@ -9,6 +9,9 @@ See-also: socks4 socks5 socks5-hostname
 Use the specified SOCKS4a proxy. If the port number is not specified, it is
 assumed at port 1080. This asks the proxy to resolve the host name.
 
+To specify proxy on a unix domain socket, use localhost for host, e.g.
+socks4a://localhost/path/to/socket.sock
+
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 

--- a/docs/cmdline-opts/socks5-hostname.d
+++ b/docs/cmdline-opts/socks5-hostname.d
@@ -9,6 +9,9 @@ See-also: socks5 socks4a
 Use the specified SOCKS5 proxy (and let the proxy resolve the host name). If
 the port number is not specified, it is assumed at port 1080.
 
+To specify proxy on a unix domain socket, use localhost for host, e.g.
+socks5h://localhost/path/to/socket.sock
+
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 

--- a/docs/cmdline-opts/socks5.d
+++ b/docs/cmdline-opts/socks5.d
@@ -9,6 +9,9 @@ See-also: socks5-hostname socks4a
 Use the specified SOCKS5 proxy - but resolve the host name locally. If the
 port number is not specified, it is assumed at port 1080.
 
+To specify proxy on a unix domain socket, use localhost for host, e.g.
+socks5://localhost/path/to/socket.sock
+
 This option overrides any previous use of --proxy, as they are mutually
 exclusive.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -73,6 +73,9 @@ use of a proxy, even if there is an environment variable set for it.
 A proxy host string can also include protocol scheme (http://) and embedded
 user + password.
 
+Unix domain sockets are supported for socks proxy. Set localhost for the host
+part. e.g. socks5h://localhost/path/to/socket.sock
+
 The application does not have to keep the string around after setting this
 option.
 .SH "Environment variables"

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -128,6 +128,7 @@ Available substitute variables include:
 - `%HTTPTLS6PORT` - IPv6 port number of the HTTP TLS server
 - `%HTTPTLSPORT` - Port number of the HTTP TLS server
 - `%HTTPUNIXPATH` - Path to the Unix socket of the HTTP server
+- `%SOCKSUNIXPATH` - Absolute Path to the Unix socket of the SOCKS server
 - `%IMAP6PORT` - IPv6 port number of the IMAP server
 - `%IMAPPORT` - Port number of the IMAP server
 - `%MQTTPORT` - Port number of the MQTT server

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -185,7 +185,7 @@ test1432 test1433 test1434 test1435 test1436 test1437 test1438 test1439 \
 test1440 test1441 test1442 test1443 test1444 test1445 test1446 test1447 \
 test1448 test1449 test1450 test1451 test1452 test1453 test1454 test1455 \
 test1456 test1457 test1458 test1459 test1460 test1461 test1462 test1463 \
-test1464 test1465 test1466 \
+test1464 test1465 test1466 test1467 test1468 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1467
+++ b/tests/data/test1467
@@ -1,0 +1,59 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+SOCKS5
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+proxy
+unix-sockets
+</features>
+<server>
+http
+socks5unix
+</server>
+ <name>
+HTTP GET via SOCKS5 proxy via unix sockets
+ </name>
+ <command>
+--socks5 localhost%SOCKSUNIXPATH http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1468
+++ b/tests/data/test1468
@@ -1,0 +1,63 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+SOCKS5
+SOCKS5h
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+proxy
+unix-sockets
+</features>
+<server>
+http
+socks5unix
+</server>
+ <name>
+HTTP GET with host name using SOCKS5h via unix sockets
+ </name>
+ <command>
+http://this.is.a.host.name:%HTTPPORT/%TESTNUMBER --proxy socks5h://localhost%SOCKSUNIXPATH
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: this.is.a.host.name:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<socks>
+atyp 3 => this.is.a.host.name
+</socks>
+</verify>
+</testcase>


### PR DESCRIPTION
**Usage:**

    curl -x "socks5h://unix/run/tor/socks" "https://example.com"

Ref: https://curl.se/mail/archive-2021-03/0012.html

This is a proof of concept to make sure it is working. Please take over from here or guide next steps - tests, documentation etc.,