### PR TITLE
macos: set .plist version in autoconf

### DIFF
--- a/MacOSX-Framework
+++ b/MacOSX-Framework
@@ -116,7 +116,7 @@ if test ! -z $SDK32; then
   mkdir -p libcurl.framework/${FRAMEWORK_VERSION}/Resources
   cp lib/.libs/libcurl.dylib libcurl.framework/${FRAMEWORK_VERSION}/libcurl
   install_name_tool -id @rpath/libcurl.framework/${FRAMEWORK_VERSION}/libcurl libcurl.framework/${FRAMEWORK_VERSION}/libcurl
-  /usr/bin/sed -e "s/7\.12\.3/$VERSION/" lib/libcurl.plist >libcurl.framework/${FRAMEWORK_VERSION}/Resources/Info.plist
+  cp lib/libcurl.plist >libcurl.framework/${FRAMEWORK_VERSION}/Resources/Info.plist
   mkdir -p libcurl.framework/${FRAMEWORK_VERSION}/Headers/curl
   cp include/curl/*.h libcurl.framework/${FRAMEWORK_VERSION}/Headers/curl
   pushd libcurl.framework

--- a/configure.ac
+++ b/configure.ac
@@ -2333,6 +2333,10 @@ AC_SUBST([CURL_LT_SHLIB_VERSIONED_FLAVOUR],
 AM_CONDITIONAL([CURL_LT_SHLIB_USE_VERSIONED_SYMBOLS],
   [test "x$versioned_symbols" = 'xyes'])
 
+dnl Update .plist file with current version
+AC_SUBST([CURL_PLIST_VERSION],
+  ["$CURLVERSION"])
+
 dnl -------------------------------------------------
 dnl check winidn option before other IDN libraries
 dnl -------------------------------------------------
@@ -4309,6 +4313,7 @@ AC_CONFIG_FILES([Makefile \
            lib/Makefile \
            scripts/Makefile \
            lib/libcurl.vers \
+           lib/libcurl.plist \
            tests/Makefile \
            tests/certs/Makefile \
            tests/certs/scripts/Makefile \

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -8,5 +8,6 @@ TAGS
 curl_config.h
 curl_config.h.in
 libcurl.plist.dist
+libcurl.plist
 libcurl.vers
 stamp-h1

--- a/lib/libcurl.plist.in
+++ b/lib/libcurl.plist.in
@@ -15,7 +15,7 @@
 	<string>se.curl.libcurl</string>
 
 	<key>CFBundleVersion</key>
-	<string>7.12.3</string>
+	<string>@CURL_PLIST_VERSION@</string>
 
 	<key>CFBundleName</key>
 	<string>libcurl</string>
@@ -27,9 +27,9 @@
 	<string>????</string>
 
 	<key>CFBundleShortVersionString</key>
-	<string>libcurl 7.12.3</string>
+	<string>libcurl @CURL_PLIST_VERSION@</string>
 
 	<key>CFBundleGetInfoString</key>
-	<string>libcurl.plist 7.12.3</string>
+	<string>libcurl.plist @CURL_PLIST_VERSION@</string>
 </dict>
 </plist>

--- a/maketgz
+++ b/maketgz
@@ -92,10 +92,6 @@ rm -f "$HEADER.bak"
 sed -i.bak 's/#define CURL_VERSION .*/#define CURL_VERSION "'$curlversion'"/g' $CHEADER
 rm -f "$CHEADER.bak"
 
-# Replace version number in plist file:
-sed -i.bak "s/7\.12\.3/$libversion/g" $PLIST
-rm -f "$PLIST.bak"
-
 if test -n "$only"; then
   # done!
   exit;

--- a/packages/vms/clean_gnv_curl.com
+++ b/packages/vms/clean_gnv_curl.com
@@ -181,6 +181,9 @@ $!
 $ file = "lcl_root:[.lib]libcurl.vers"
 $ if f$search(file) .nes. "" then delete 'file';*
 $!
+$ file = "lcl_root:[.lib]libcurl.plist"
+$ if f$search(file) .nes. "" then delete 'file';*
+$!
 $ file = "lcl_root:[]ca-bundle.h"
 $ if f$search(file) .nes. "" then delete 'file';*
 $!

--- a/scripts/copyright.pl
+++ b/scripts/copyright.pl
@@ -60,7 +60,7 @@ my @skiplist=(
     'options-in-versions',
 
     # macos-framework files
-    '^lib\/libcurl.plist',
+    '^lib\/libcurl.plist.in',
     '^lib\/libcurl.vers.in',
 
     # vms files


### PR DESCRIPTION
This sets the libcurl version in `libcurl.plist` like how `libcurl.vers`  is created. Is there a reason to special case handle this that I don't see? This doesn't support CMake, but neither does `libcurl.vers` already today so there isn't much of a change there.