### PR TITLE
docs: Fix missing semicolon in example code

### DIFF
--- a/docs/libcurl/curl_share_cleanup.3
+++ b/docs/libcurl/curl_share_cleanup.3
@@ -36,7 +36,7 @@ Passing in a NULL pointer in \fIshare_handle\fP will make this function return
 immediately with no action.
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   /* use the share, then ... */

--- a/docs/libcurl/curl_share_init.3
+++ b/docs/libcurl/curl_share_init.3
@@ -39,7 +39,7 @@ This \fIshare handle\fP is what you pass to curl using the
 specific curl handle use the data in this share.
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   if(sh)

--- a/docs/libcurl/curl_share_setopt.3
+++ b/docs/libcurl/curl_share_setopt.3
@@ -43,7 +43,7 @@ See \fICURLSHOPT_UNSHARE(3)\fP.
 See \fICURLSHOPT_USERDATA(3)\fP.
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   if(sh)

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -31,7 +31,7 @@ The curl_share_strerror() function returns a string describing the CURLSHcode
 error code passed in the argument \fIerrornum\fP.
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   if(sh)

--- a/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
@@ -53,7 +53,7 @@ This pointer is not used by libcurl itself.
 All
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_LOCKFUNC, mutex_lock);
   if(sh)

--- a/docs/libcurl/opts/CURLSHOPT_SHARE.3
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.3
@@ -80,7 +80,7 @@ multi handle will share PSL cache by default without using this option.
 All
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
   if(sh)

--- a/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
@@ -51,7 +51,7 @@ This pointer is not used by libcurl itself.
 All
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, mutex_unlock);
   if(sh)

--- a/docs/libcurl/opts/CURLSHOPT_UNSHARE.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNSHARE.3
@@ -53,7 +53,7 @@ The Public Suffix List is no longer shared.
 All
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_UNSHARE, CURL_LOCK_DATA_COOKIE);
   if(sh)

--- a/docs/libcurl/opts/CURLSHOPT_USERDATA.3
+++ b/docs/libcurl/opts/CURLSHOPT_USERDATA.3
@@ -36,7 +36,7 @@ and \fICURLSHOPT_UNLOCKFUNC(3)\fP.
 All
 .SH EXAMPLE
 .nf
-  CURLSHcode sh
+  CURLSHcode sh;
   struct secrets private_stuff;
   share = curl_share_init();
   sh = curl_share_setopt(share, CURLSHOPT_USERDATA, &private_stuff);


### PR DESCRIPTION
Multiple share examples were missing a semicolon on the line defining the CURLSHcode variable.

Closes: #xxxx
Reported-by: Michael Kaufmann <mail@michael-kaufmann.ch>