### PR TITLE
cookies: Improve errorhandling for reading cookiefile

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1188,12 +1188,15 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
     fp = stdin;
     fromfile = FALSE;
   }
-  else if(file && !*file) {
-    /* points to a "" string */
+  else if(!file || !*file) {
+    /* points to an empty string or NULL */
     fp = NULL;
   }
-  else
-    fp = file?fopen(file, FOPEN_READTEXT):NULL;
+  else {
+    fp = fopen(file, FOPEN_READTEXT);
+    if(!fp)
+      infof(data, "WARNING: failed to open cookie file \"%s\"", file);
+  }
 
   c->newsession = newsession; /* new session? */
 
@@ -1227,7 +1230,7 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
      */
     remove_expired(c);
 
-    if(fromfile)
+    if(fromfile && fp)
       fclose(fp);
   }
 


### PR DESCRIPTION
The existing programming had some issues with errorhandling for reading
the cookie file. If the file failed to open, we would silently ignore it
and continue as if there was no file (or stdin) passed. In this case, we
would also call fclose() on the NULL FILE pointer, which is undefined
behavior. Fix by ensuring that the FILE pointer is set before calling
fclose on it, and error out in case the cookiefile cannot be opened.

Closes: #xxxx