### PR TITLE
curl: error out if -T and -d are used for the same URL

### DIFF
--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -110,7 +110,8 @@ void customrequest_helper(struct OperationConfig *config, HttpReq req,
     "GET",
     "HEAD",
     "POST",
-    "POST"
+    "POST",
+    "PUT"
   };
 
   if(!method)

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -85,7 +85,8 @@ int SetHTTPrequest(struct OperationConfig *config, HttpReq req, HttpReq *store)
     "GET (-G, --get)",
     "HEAD (-I, --head)",
     "multipart formpost (-F, --form)",
-    "POST (-d, --data)"
+    "POST (-d, --data)",
+    "PUT (-T, --upload-file)"
   };
 
   if((*store == HTTPREQ_UNSPEC) ||

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -917,6 +917,12 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             result = CURLE_OUT_OF_MEMORY;
             break;
           }
+          if(SetHTTPrequest(config, HTTPREQ_PUT, &config->httpreq)) {
+            Curl_safefree(per->uploadfile);
+            curl_easy_cleanup(curl);
+            result = CURLE_FAILED_INIT;
+            break;
+          }
         }
         *added = TRUE;
         per->config = config;

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -127,7 +127,8 @@ typedef enum {
   HTTPREQ_GET,
   HTTPREQ_HEAD,
   HTTPREQ_MIMEPOST,
-  HTTPREQ_SIMPLEPOST
+  HTTPREQ_SIMPLEPOST,
+  HTTPREQ_PUT
 } HttpReq;
 
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -61,7 +61,7 @@ test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \
 test352 test353 test354 test355 test356 test357 test358 test359 test360 \
 test361 test362 test363 test364 test365 test366 test367 test368 test369 \
-test370 test371 test372 test373 test374 test375 test376 \
+test370 test371 test372 test373 test374 test375 test376 test378 \
 \
 test380 test381 test383 test384 test385 test386 \
 \

--- a/tests/data/test378
+++ b/tests/data/test378
@@ -1,0 +1,39 @@
+<testcase>
+<info>
+<keywords>
+HTTP PUT
+HTTP POST
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+ <name>
+Reject using -T and -d at once
+ </name>
+ <command>
+-T log/%TESTNUMBER -d input http://never-accessed
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+<stderr mode="text">
+Warning: You can only select one HTTP request method! You asked for both PUT 
+Warning: (-T, --upload-file) and POST (-d, --data).
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
As one implies PUT and the other POST, both cannot be used
simultaneously.

Add test 378 to verify.

Fixes #8704
Reported-by: Boris Verkhovskiy