### PR TITLE
gen.pl: change wording for mutexed options

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -349,7 +349,8 @@ sub single {
             my $l = manpageify($k);
             $mstr .= sprintf "%s$l", $mstr?" and ":"";
         }
-        push @foot, overrides($standalone, "This option overrides $mstr. ");
+        push @foot, overrides($standalone,
+                              "This option is mutually exclusive to $mstr. ");
     }
     if($examples[0]) {
         my $s ="";


### PR DESCRIPTION
Instead of saying "This option overrides NNN", now say "This option is
mutually exclusive to NNN" in the generated man page ouput, as the
option does not in all cases actually override the others but they are
always mutually exclusive.

Ref: #8704