### PR TITLE
fix libssh double socket close

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1970,6 +1970,10 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       ssh_disconnect(sshc->ssh_session);
+      /* conn->sock[FIRSTSOCKET] is closed by ssh_disconnect behind our back,
+         explicitly mark it as closed with the memdebug macro: */
+      fake_sclose(conn->sock[FIRSTSOCKET]);
+      conn->sock[FIRSTSOCKET] = CURL_SOCKET_BAD;
 
       SSH_STRING_FREE_CHAR(sshc->homedir);
       data->state.most_recent_ftp_entrypath = NULL;


### PR DESCRIPTION
This is meant so solve issue #8708 

In myssh_connect in lib/vssh/libssh.c, the fd of conn->sock[FIRSTSOCKET] is assigned to ssh->ssh_session (line 2219). That gets closed on ssh_disconnect (line 1972). By setting conn->sock[FIRSTSOCKET] to CURL_SOCKET_BAD afterwards, we can avoid closing the fd a second time on cleanup of conn.