### PR TITLE
unit1620: call global_init before calling Curl_open

### DIFF
--- a/tests/unit/unit1620.c
+++ b/tests/unit/unit1620.c
@@ -28,11 +28,14 @@
 
 static CURLcode unit_setup(void)
 {
-  return CURLE_OK;
+  int res = CURLE_OK;
+  global_init(CURL_GLOBAL_ALL);
+  return res;
 }
 
 static void unit_stop(void)
 {
+  curl_global_cleanup();
 }
 
 UNITTEST_START


### PR DESCRIPTION
Curl_open calls the resolver init and on Windows if the resolver backend
is c-ares then the Windows sockets library (winsock) must already have
been initialized (via global init).

Ref: https://github.com/curl/curl/pull/8540#issuecomment-1059771800

Closes #xxxx

--

/cc @gvanem 