### PR TITLE
make: fix ca-bundle due to mk-ca-bundle.pl being moved

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,7 +278,7 @@ uninstall-hook:
 	(cd docs && $(MAKE) uninstall)
 	(cd docs/libcurl && $(MAKE) uninstall)
 
-ca-bundle: lib/mk-ca-bundle.pl
+ca-bundle: scripts/mk-ca-bundle.pl
 	@echo "generating a fresh ca-bundle.crt"
 	@perl $< -b -l -u lib/ca-bundle.crt
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -81,7 +81,7 @@ linux: all
 
 linux-ssl: ssl
 
-ca-bundle: lib/mk-ca-bundle.pl
+ca-bundle: scripts/mk-ca-bundle.pl
 	@echo "generate a fresh ca-bundle.crt"
 	@perl $< -b -l -u lib/ca-bundle.crt
 


### PR DESCRIPTION
the script was moved in 8e22fc68e7dda43e9f0b6857b1057d0e9131a4b2 but
the lines that called it was not changed to reflect it's new position

Signed-off-by: Christopher Degawa <ccom@randomderp.com>