### PR TITLE
tool_getparam: error out on missing -K file

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1948,9 +1948,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         config->insecure_ok = toggle;
       break;
     case 'K': /* parse config file */
-      if(parseconfig(nextarg, global))
-        warnf(global, "error trying read config from the '%s' file\n",
-              nextarg);
+      if(parseconfig(nextarg, global)) {
+        errorf(global, "cannot read config from '%s'\n", nextarg);
+        return PARAM_READ_ERROR;
+      }
       break;
     case 'l':
       config->dirlistonly = toggle; /* only list the names of the FTP dir */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -68,7 +68,7 @@ test380 test381 test383 test384 test385 test386 \
 test392 test393 test394 test395 test396 test397 test398 \
 \
 test400 test401 test402 test403 test404 test405 test406 test407 test408 \
-test409 test410 \
+test409 test410 test411 \
 \
 test430 test431 test432 test433 test434 test435 test436 \
 \

--- a/tests/data/test411
+++ b/tests/data/test411
@@ -1,0 +1,39 @@
+<testcase>
+<info>
+<keywords>
+-K
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+ <name>
+-K with missing file causes error
+ </name>
+ <command>
+-K log/missing http://localhost
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stderr mode="text">
+curl: cannot read config from 'log/missing'
+curl: option -K: error encountered when reading a file
+curl: try 'curl --help' or 'curl --manual' for more information
+</stderr>
+<errorcode>
+26
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test411
+++ b/tests/data/test411
@@ -30,7 +30,11 @@ none
 <stderr mode="text">
 curl: cannot read config from 'log/missing'
 curl: option -K: error encountered when reading a file
+%if manual
 curl: try 'curl --help' or 'curl --manual' for more information
+%else
+curl: try 'curl --help' for more information
+%fi
 </stderr>
 <errorcode>
 26

--- a/tests/data/test411
+++ b/tests/data/test411
@@ -34,7 +34,7 @@ curl: option -K: error encountered when reading a file
 curl: try 'curl --help' or 'curl --manual' for more information
 %else
 curl: try 'curl --help' for more information
-%fi
+%endif
 </stderr>
 <errorcode>
 26


### PR DESCRIPTION
Add test 411 to verify.

Reported-by: Median Median Stride
Bug: https://hackerone.com/reports/1542881