### PR TITLE
https://curl.zuul.vexxhost.dev is reachable again, so remove it from …

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -2,7 +2,7 @@
   "_comment": "Config file for linkcheck: If urls have some issues we can not fix on our end past it in here. MLC will ignore this.",
   "ignorePatterns": [
     {
-      "pattern": "^https://curl.zuul.vexxhost.dev"
+      "pattern": ""
     }
   ]
 }


### PR DESCRIPTION
…ignorelist for linkcheck