### PR TITLE
mprintf: Ignore non-literal format string

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -956,9 +956,16 @@ static int dprintf_formatf(
 
         *fptr = 0; /* and a final zero termination */
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
         /* NOTE NOTE NOTE!! Not all sprintf implementations return number of
            output characters */
         (sprintf)(work, formatbuf, p->data.dnum);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         DEBUGASSERT(strlen(work) <= sizeof(work));
         for(fptr = work; *fptr; fptr++)
           OUTCHAR(*fptr);


### PR DESCRIPTION
Using the non-literal format string here is intentional and the warning leads to noise in the best case or an error in the worst.