### PR TITLE
c_escape: escape '?' in generated --libcurl code

### DIFF
--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -273,6 +273,12 @@ static char *c_escape(const char *str, curl_off_t len)
       strcpy(e, "\\\"");
       e += 2;
     }
+    else if(c == '?') {
+      /* escape question marks as well, to prevent generating accidental
+         trigraphs */
+      strcpy(e, "\\?");
+      e += 2;
+    }
     else if(!isprint(c)) {
       msnprintf(e, 5, "\\x%02x", (unsigned)c);
       e += 4;

--- a/tests/data/test1403
+++ b/tests/data/test1403
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 
   hnd = curl_easy_init();
   curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
-  curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER?foo=bar&baz=quux");
+  curl_easy_setopt(hnd, CURLOPT_URL, "http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER\?foo=bar&baz=quux");
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "stripped");
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
In order to avoid the risk of it being used in an accidental trigraph in
the generated code.

Reported-by: Harry Sintonen