### PR TITLE
url: check sasl additional parameters for connection reuse.

### DIFF
--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -131,6 +131,16 @@ void Curl_strntolower(char *dest, const char *src, size_t n)
   } while(*src++ && --n);
 }
 
+/* Compare case-sensitive NUL-terminated strings, taking care of possible
+ * null pointers. Return true if arguments match.
+ */
+bool Curl_safecmp(char *a, char *b)
+{
+  if(a && b)
+    return !strcmp(a, b);
+  return !a && !b;
+}
+
 /* --- public functions --- */
 
 int curl_strequal(const char *first, const char *second)

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -49,4 +49,6 @@ char Curl_raw_toupper(char in);
 void Curl_strntoupper(char *dest, const char *src, size_t n);
 void Curl_strntolower(char *dest, const char *src, size_t n);
 
+bool Curl_safecmp(char *a, char *b);
+
 #endif /* HEADER_CURL_STRCASE_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -984,6 +984,7 @@ struct connectdata {
   char *passwd;  /* password string, allocated */
   char *options; /* options string, allocated */
   char *sasl_authzid;     /* authorization identity string, allocated */
+  char *oauth_bearer; /* OAUTH2 bearer, allocated */
   unsigned char httpversion; /* the HTTP version*10 reported by the server */
   struct curltime now;     /* "current" time */
   struct curltime created; /* creation time */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -125,15 +125,6 @@ static bool blobcmp(struct curl_blob *first, struct curl_blob *second)
   return !memcmp(first->data, second->data, first->len); /* same data */
 }
 
-static bool safecmp(char *a, char *b)
-{
-  if(a && b)
-    return !strcmp(a, b);
-  else if(!a && !b)
-    return TRUE; /* match */
-  return FALSE; /* no match */
-}
-
 
 bool
 Curl_ssl_config_matches(struct ssl_primary_config *data,
@@ -147,12 +138,12 @@ Curl_ssl_config_matches(struct ssl_primary_config *data,
      blobcmp(data->cert_blob, needle->cert_blob) &&
      blobcmp(data->ca_info_blob, needle->ca_info_blob) &&
      blobcmp(data->issuercert_blob, needle->issuercert_blob) &&
-     safecmp(data->CApath, needle->CApath) &&
-     safecmp(data->CAfile, needle->CAfile) &&
-     safecmp(data->issuercert, needle->issuercert) &&
-     safecmp(data->clientcert, needle->clientcert) &&
-     safecmp(data->random_file, needle->random_file) &&
-     safecmp(data->egdsocket, needle->egdsocket) &&
+     Curl_safecmp(data->CApath, needle->CApath) &&
+     Curl_safecmp(data->CAfile, needle->CAfile) &&
+     Curl_safecmp(data->issuercert, needle->issuercert) &&
+     Curl_safecmp(data->clientcert, needle->clientcert) &&
+     Curl_safecmp(data->random_file, needle->random_file) &&
+     Curl_safecmp(data->egdsocket, needle->egdsocket) &&
      Curl_safe_strcasecompare(data->cipher_list, needle->cipher_list) &&
      Curl_safe_strcasecompare(data->cipher_list13, needle->cipher_list13) &&
      Curl_safe_strcasecompare(data->curves, needle->curves) &&


### PR DESCRIPTION
Also move static function safecmp() as non-static Curl_safecmp() since
its purpose is needed at several places.

Bug: https://curl.se/docs/CVE-2022-22576.html

CVE-2022-22576