### PR TITLE
conncache: include the zone id in the "bundle" hashkey

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -155,8 +155,12 @@ static void hashkey(struct connectdata *conn, char *buf,
     /* report back which name we used */
     *hostp = hostname;
 
-  /* put the number first so that the hostname gets cut off if too long */
-  msnprintf(buf, len, "%ld%s", port, hostname);
+  /* put the numbers first so that the hostname gets cut off if too long */
+#ifdef ENABLE_IPV6
+  msnprintf(buf, len, "%u/%ld/%s", conn->scope_id, port, hostname);
+#else
+  msnprintf(buf, len, "%ld/%s", port, hostname);
+#endif
   Curl_strntolower(buf, buf, len);
 }
 


### PR DESCRIPTION
Make connections to two separate IPv6 zone ids create separate
connections.

Reported-by: Harry Sintonen
Bug: https://curl.se/docs/CVE-2022-27775.html