### PR TITLE
openssl: don't leak the SRP credentials in redirects either

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -776,10 +776,10 @@ output_auth_headers(struct Curl_easy *data,
 }
 
 /*
- * allow_auth_to_host() tells if autentication, cookies or other "sensitive
- * data" can (still) be sent to this host.
+ * Curl_allow_auth_to_host() tells if authentication, cookies or other
+ * "sensitive data" can (still) be sent to this host.
  */
-static bool allow_auth_to_host(struct Curl_easy *data)
+bool Curl_allow_auth_to_host(struct Curl_easy *data)
 {
   struct connectdata *conn = data->conn;
   return (!data->state.this_is_a_follow ||
@@ -864,7 +864,7 @@ Curl_http_output_auth(struct Curl_easy *data,
 
   /* To prevent the user+password to get sent to other than the original host
      due to a location-follow */
-  if(allow_auth_to_host(data)
+  if(Curl_allow_auth_to_host(data)
 #ifndef CURL_DISABLE_NETRC
      || conn->bits.netrc
 #endif
@@ -1917,7 +1917,7 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
                    checkprefix("Cookie:", compare)) &&
                   /* be careful of sending this potentially sensitive header to
                      other hosts */
-                  !allow_auth_to_host(data))
+                  !Curl_allow_auth_to_host(data))
             ;
           else {
 #ifdef USE_HYPER

--- a/lib/http.h
+++ b/lib/http.h
@@ -364,4 +364,10 @@ Curl_http_output_auth(struct Curl_easy *data,
                       bool proxytunnel); /* TRUE if this is the request setting
                                             up the proxy tunnel */
 
+/*
+ * Curl_allow_auth_to_host() tells if authentication, cookies or other
+ * "sensitive data" can (still) be sent to this host.
+ */
+bool Curl_allow_auth_to_host(struct Curl_easy *data);
+
 #endif /* HEADER_CURL_HTTP_H */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2924,7 +2924,8 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
 #endif
 
 #ifdef USE_OPENSSL_SRP
-  if(ssl_authtype == CURL_TLSAUTH_SRP) {
+  if((ssl_authtype == CURL_TLSAUTH_SRP) &&
+     Curl_allow_auth_to_host(data)) {
     char * const ssl_username = SSL_SET_OPTION(username);
 
     infof(data, "Using TLS-SRP username: %s", ssl_username);


### PR DESCRIPTION
Follow-up to 620ea21410030

Reported-by: Harry Sintonen