### PR TITLE
gnutls: don't leak the SRP credentials in redirects

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -445,11 +445,11 @@ gtls_connect_step1(struct Curl_easy *data,
   }
 
 #ifdef USE_GNUTLS_SRP
-  if(SSL_SET_OPTION(authtype) == CURL_TLSAUTH_SRP) {
+  if((SSL_SET_OPTION(authtype) == CURL_TLSAUTH_SRP) &&
+     Curl_allow_auth_to_host(data)) {
     infof(data, "Using TLS-SRP username: %s", SSL_SET_OPTION(username));
 
-    rc = gnutls_srp_allocate_client_credentials(
-           &backend->srp_client_cred);
+    rc = gnutls_srp_allocate_client_credentials(&backend->srp_client_cred);
     if(rc != GNUTLS_E_SUCCESS) {
       failf(data, "gnutls_srp_allocate_client_cred() failed: %s",
             gnutls_strerror(rc));


### PR DESCRIPTION
Follow-up to 620ea21410030 and 139a54ed0a172a

Reported-by: Harry Sintonen