### PR TITLE
msh3: print boolean value as text representation

### DIFF
--- a/lib/vquic/msh3.c
+++ b/lib/vquic/msh3.c
@@ -357,7 +357,7 @@ static void MSH3_CALL msh3_complete(MSH3_REQUEST *Request, void *IfContext,
   struct HTTP *stream = IfContext;
   (void)Request;
   (void)AbortError;
-  H3BUGF(printf("* msh3_complete, aborted=%hhu\n", Aborted));
+  H3BUGF(printf("* msh3_complete, aborted=%s\n", Aborted?"true":"false"));
   msh3_lock_acquire(&stream->recv_lock);
   if(Aborted) {
     stream->recv_error = CURLE_HTTP3; /* TODO - how do we pass AbortError? */


### PR DESCRIPTION
Print the boolean value as its string representation instead of with `%hhu` which isn't a format we typically use. I don't have strong feelings wrt this in case others disagree, but `%hhu` struck me as odd when skimming the code.