### PR TITLE
curl: free resource in error path

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -91,6 +91,7 @@ bool tool_create_output_file(struct OutStruct *outs,
       char *newname = malloc(len + 13); /* nul + 1-11 digits + dot */
       if(!newname) {
         errorf(global, "out of memory\n");
+        free(aname);
         return FALSE;
       }
       memcpy(newname, fname, len);


### PR DESCRIPTION
If the new filename cannot be generated due to memory pressure, free the allocated `aname` on the way out to avoid a small leak.