### PR TITLE
md files and scripts: use autoreconf -fi instead buildconf

### DIFF
--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -33,7 +33,7 @@ Build curl to use hyper's C API:
 
      % git clone https://github.com/curl/curl
      % cd curl
-     % ./buildconf
+     % autoreconf -fi 
      % ./configure --with-hyper=<hyper dir>
      % make
 

--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -33,7 +33,7 @@ Build curl to use hyper's C API:
 
      % git clone https://github.com/curl/curl
      % cd curl
-     % autoreconf -fi 
+     % autoreconf -fi
      % ./configure --with-hyper=<hyper dir>
      % make
 

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -21,6 +21,6 @@ Now configure and build curl with rustls:
 
     % git clone https://github.com/curl/curl
     % cd curl
-    % ./buildconf
+    % autoreconf -fi
     % ./configure --with-rustls=${HOME}/rustls-ffi-built
     % make

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -21,7 +21,7 @@
 #
 ###########################################################################
 
-/usr/bin/autoreconf -fi
+autoreconf -fi
 mkdir -p cvr
 cd cvr
 ../configure --disable-shared --enable-debug --enable-maintainer-mode --enable-code-coverage

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -21,7 +21,7 @@
 #
 ###########################################################################
 
-autoreconf -fi
+/usr/bin/autoreconf -fi
 mkdir -p cvr
 cd cvr
 ../configure --disable-shared --enable-debug --enable-maintainer-mode --enable-code-coverage

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -21,7 +21,7 @@
 #
 ###########################################################################
 
-./buildconf
+autoreconf -fi
 mkdir -p cvr
 cd cvr
 ../configure --disable-shared --enable-debug --enable-maintainer-mode --enable-code-coverage

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -467,7 +467,7 @@ if ($git) {
 
     # generate the build files
     logit "invoke buildconf";
-    open(F, "./buildconf 2>&1 |") or die;
+    open(F, "autoreconf -fi 2>&1 |") or die;
     open(LOG, ">$buildlog") or die;
     while (<F>) {
       my $ll = $_;

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -466,7 +466,7 @@ if ($git) {
     unlink "autom4te.cache";
 
     # generate the build files
-    logit "invoke buildconf";
+    logit "invoke autoreconf";
     open(F, "autoreconf -fi 2>&1 |") or die;
     open(LOG, ">$buildlog") or die;
     while (<F>) {


### PR DESCRIPTION
Signed-off-by: Philip H <47042125+pheiduck@users.noreply.github.com>