### PR TITLE
contributors: strip off final comma

### DIFF
--- a/scripts/contributors.sh
+++ b/scripts/contributors.sh
@@ -91,7 +91,8 @@ awk '{
 }
 
  END {
-   printf("  %s\n", p);
+   pp=substr(p,1,length(p)-1);
+   printf("  %s\n", pp);
    printf("  (%d contributors)\n", num);
  }
 


### PR DESCRIPTION
The final row of contributors should not end with a comma as it's the end of the list.