### PR TITLE
test{898,974,976}: add 'HTTP proxy' keywords

### DIFF
--- a/tests/data/test898
+++ b/tests/data/test898
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 HTTP
+HTTP proxy
 --location
 Authorization
 Cookie

--- a/tests/data/test974
+++ b/tests/data/test974
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 HTTP
+HTTP proxy
 --location
 </keywords>
 </info>

--- a/tests/data/test976
+++ b/tests/data/test976
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 HTTP
+HTTP proxy
 --location-trusted
 </keywords>
 </info>


### PR DESCRIPTION
... so the tests can be automatically skipped when
testing external HTTP proxies like Privoxy.