### PR TITLE
CURLOPT_SSH_AUTH_TYPES.3: fix the default

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.3
@@ -5,7 +5,7 @@
 .\" *                            | (__| |_| |  _ <| |___
 .\" *                             \___|\___/|_| \_\_____|
 .\" *
-.\" * Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+.\" * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 .\" *
 .\" * This software is licensed as described in the file COPYING, which
 .\" * you should have received as part of this distribution. The terms
@@ -39,7 +39,7 @@ CURLSSH_AUTH_HOST has no effect. If CURLSSH_AUTH_AGENT is used, libcurl
 attempts to connect to ssh-agent or pageant and let the agent attempt the
 authentication.
 .SH DEFAULT
-None
+CURLSSH_AUTH_ANY (all availables ones)
 .SH PROTOCOLS
 SFTP and SCP
 .SH EXAMPLE


### PR DESCRIPTION
The default is all possible methods.