### PR TITLE
gskit_connect_step1: fixed bogus setsockopt calls

### DIFF
--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -775,13 +775,13 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
     BACKEND->localfd = sockpair[0];
     BACKEND->remotefd = sockpair[1];
     setsockopt(BACKEND->localfd, SOL_SOCKET, SO_RCVBUF,
-               (void *) sobufsize, sizeof(sobufsize));
+               (void *) &sobufsize, sizeof(sobufsize));
     setsockopt(BACKEND->remotefd, SOL_SOCKET, SO_RCVBUF,
-               (void *) sobufsize, sizeof(sobufsize));
+               (void *) &sobufsize, sizeof(sobufsize));
     setsockopt(BACKEND->localfd, SOL_SOCKET, SO_SNDBUF,
-               (void *) sobufsize, sizeof(sobufsize));
+               (void *) &sobufsize, sizeof(sobufsize));
     setsockopt(BACKEND->remotefd, SOL_SOCKET, SO_SNDBUF,
-               (void *) sobufsize, sizeof(sobufsize));
+               (void *) &sobufsize, sizeof(sobufsize));
     curlx_nonblock(BACKEND->localfd, TRUE);
     curlx_nonblock(BACKEND->remotefd, TRUE);
   }


### PR DESCRIPTION
setsockopt takes a reference to value, not value. With the current code this just leads to -1 return value with errno EFAULT.