### PR TITLE
Relax UndefinedBehavior sanitizer

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -228,7 +228,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
  */
 bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
 {
-  size_t i;
+  int i;
   DEBUGASSERT(!buf || (buflen > MAX_SCHEME_LEN));
   (void)buflen; /* only used in debug-builds */
   if(buf)


### PR DESCRIPTION
`while(i--)` causes runtime error: unsigned integer overflow: 0 - 1 cannot be
represented in type 'size_t' (aka 'unsigned long')