### PR TITLE
tests/server: declare variable 'reqlogfile' static

### DIFF
--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -140,7 +140,7 @@ struct configurable {
 static struct configurable config;
 
 const char *serverlogfile = DEFAULT_LOGFILE;
-const char *reqlogfile = DEFAULT_REQFILE;
+static const char *reqlogfile = DEFAULT_REQFILE;
 static const char *configfile = DEFAULT_CONFIG;
 
 static const char *socket_type = "IPv4";


### PR DESCRIPTION
Silences the warning:

     CC       socksd-socksd.o
   socksd.c:143:13: warning: no previous extern declaration for
    non-static variable 'reqlogfile' [-Wmissing-variable-declarations]
   const char *reqlogfile = DEFAULT_REQFILE;
               ^
   socksd.c:143:7: note: declare 'static' if the variable is not
    intended to be used outside of this translation unit
   const char *reqlogfile = DEFAULT_REQFILE;
         ^
   1 warning generated.

... when compiling with clang 13.