### PR TITLE
fixup: redundancy on contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -84,7 +84,7 @@ Abhinav Singh <theawless@gmail.com>
 Malik Idrees Hasan Khan <77000356+MalikIdreesHasanKhan@users.noreply.github.com>
 Yongkang Huang <hyk68691@hotmail.com>
 Xiaoke Wang <xkernel.wang@foxmail.com>
-pheiduck on github <47042125+pheiduck@users.noreply.github.com>
+Philip H <47042125+pheiduck@users.noreply.github.com>
 neutric on github <5984479+neutric@users.noreply.github.com>
 Jan-Piet Mens <jp@mens.de>
 Henrik Holst <henrik.holst@millistream.com>


### PR DESCRIPTION
pheiduck on github <47042125+pheiduck@users.noreply.github.com> thats me
Philip H <47042125+pheiduck@users.noreply.github.com> thats as well

we should use only Philip H <47042125+pheiduck@users.noreply.github.com>