### PR TITLE
tests: fix markdown formatting in README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -168,7 +168,7 @@
     make test-torture
 
   The graphical tool ggcov can be used to browse the source and create
-  coverage reports on *NIX hosts:
+  coverage reports on \*nix hosts:
 
     ggcov -r lib src
 


### PR DESCRIPTION
The asterisk in the abbreviation *NIX (for UNIX/Linux) needs to be escaped to not mean start of italic formatting. This is consistent with docs/RELEASE-PROCEDURE.md.

While the Github UI can handle this, editors like vim can't (see screenshot):

<img width="593" alt="Screenshot 2022-05-05 at 08 28 51" src="https://user-images.githubusercontent.com/321790/166899833-8d310159-9ba9-4d29-afff-916fb345115d.png">
