### PR TITLE
http2: always debug print stream id in decimal

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -643,7 +643,7 @@ static int push_promise(struct Curl_easy *data,
                                               frame->promised_stream_id,
                                               newhandle);
     if(rv) {
-      infof(data, "failed to set user_data for stream %d",
+      infof(data, "failed to set user_data for stream %u",
             frame->promised_stream_id);
       DEBUGASSERT(0);
       rv = CURL_PUSH_DENY;
@@ -713,19 +713,19 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
   data_s = nghttp2_session_get_stream_user_data(session, stream_id);
   if(!data_s) {
     H2BUGF(infof(data,
-                 "No Curl_easy associated with stream: %x",
+                 "No Curl_easy associated with stream: %u",
                  stream_id));
     return 0;
   }
 
   stream = data_s->req.p.http;
   if(!stream) {
-    H2BUGF(infof(data_s, "No proto pointer for stream: %x",
+    H2BUGF(infof(data_s, "No proto pointer for stream: %u",
                  stream_id));
     return NGHTTP2_ERR_CALLBACK_FAILURE;
   }
 
-  H2BUGF(infof(data_s, "on_frame_recv() header %x stream %x",
+  H2BUGF(infof(data_s, "on_frame_recv() header %x stream %u",
                frame->hd.type, stream_id));
 
   switch(frame->hd.type) {
@@ -913,7 +913,7 @@ static int on_stream_close(nghttp2_session *session, int32_t stream_id,
     /* remove the entry from the hash as the stream is now gone */
     rv = nghttp2_session_set_stream_user_data(session, stream_id, 0);
     if(rv) {
-      infof(data_s, "http/2: failed to clear user_data for stream %d",
+      infof(data_s, "http/2: failed to clear user_data for stream %u",
             stream_id);
       DEBUGASSERT(0);
     }
@@ -1240,13 +1240,13 @@ void Curl_http2_done(struct Curl_easy *data, bool premature)
 
   /* do this before the reset handling, as that might clear ->stream_id */
   if(http->stream_id == httpc->pause_stream_id) {
-    H2BUGF(infof(data, "DONE the pause stream (%x)", http->stream_id));
+    H2BUGF(infof(data, "DONE the pause stream (%u)", http->stream_id));
     httpc->pause_stream_id = 0;
   }
   if(premature || (!http->closed && http->stream_id)) {
     /* RST_STREAM */
     set_transfer(httpc, data); /* set the transfer */
-    H2BUGF(infof(data, "RST stream %x", http->stream_id));
+    H2BUGF(infof(data, "RST stream %u", http->stream_id));
     if(!nghttp2_submit_rst_stream(httpc->h2, NGHTTP2_FLAG_NONE,
                                   http->stream_id, NGHTTP2_STREAM_CLOSED))
       (void)nghttp2_session_send(httpc->h2);
@@ -1260,7 +1260,7 @@ void Curl_http2_done(struct Curl_easy *data, bool premature)
     int rv = nghttp2_session_set_stream_user_data(httpc->h2,
                                                   http->stream_id, 0);
     if(rv) {
-      infof(data, "http/2: failed to clear user_data for stream %d",
+      infof(data, "http/2: failed to clear user_data for stream %u",
             http->stream_id);
       DEBUGASSERT(0);
     }
@@ -1519,7 +1519,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
   /* Reset to FALSE to prevent infinite loop in readwrite_data function. */
   stream->closed = FALSE;
   if(stream->error == NGHTTP2_REFUSED_STREAM) {
-    H2BUGF(infof(data, "REFUSED_STREAM (%d), try again on a new connection",
+    H2BUGF(infof(data, "REFUSED_STREAM (%u), try again on a new connection",
                  stream->stream_id));
     connclose(conn, "REFUSED_STREAM"); /* don't use this anymore */
     data->state.refused_stream = TRUE;
@@ -1527,7 +1527,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
     return -1;
   }
   else if(stream->error != NGHTTP2_NO_ERROR) {
-    failf(data, "HTTP/2 stream %d was not closed cleanly: %s (err %u)",
+    failf(data, "HTTP/2 stream %u was not closed cleanly: %s (err %u)",
           stream->stream_id, nghttp2_http2_strerror(stream->error),
           stream->error);
     *err = CURLE_HTTP2_STREAM;
@@ -1535,7 +1535,7 @@ static ssize_t http2_handle_stream_close(struct connectdata *conn,
   }
 
   if(!stream->bodystarted) {
-    failf(data, "HTTP/2 stream %d was closed cleanly, but before getting "
+    failf(data, "HTTP/2 stream %u was closed cleanly, but before getting "
           " all response header fields, treated as error",
           stream->stream_id);
     *err = CURLE_HTTP2_STREAM;
@@ -1740,7 +1740,7 @@ static ssize_t http2_recv(struct Curl_easy *data, int sockindex,
     if(stream->closed)
       /* closed overrides paused */
       return 0;
-    H2BUGF(infof(data, "stream %x is paused, pause id: %x",
+    H2BUGF(infof(data, "stream %u is paused, pause id: %u",
                  stream->stream_id, httpc->pause_stream_id));
     *err = CURLE_AGAIN;
     return -1;
@@ -1771,7 +1771,7 @@ static ssize_t http2_recv(struct Curl_easy *data, int sockindex,
           /* This will happen when the server or proxy server is SIGKILLed
              during data transfer. We should emit an error since our data
              received may be incomplete. */
-          failf(data, "HTTP/2 stream %d was not closed cleanly before"
+          failf(data, "HTTP/2 stream %u was not closed cleanly before"
                 " end of the underlying stream",
                 stream->stream_id);
           *err = CURLE_HTTP2_STREAM;
@@ -1855,7 +1855,7 @@ static ssize_t http2_send(struct Curl_easy *data, int sockindex,
 
   if(stream->stream_id != -1) {
     if(stream->close_handled) {
-      infof(data, "stream %d closed", stream->stream_id);
+      infof(data, "stream %u closed", stream->stream_id);
       *err = CURLE_HTTP2_STREAM;
       return -1;
     }
@@ -1968,13 +1968,13 @@ static ssize_t http2_send(struct Curl_easy *data, int sockindex,
 
   if(stream_id < 0) {
     H2BUGF(infof(data,
-                 "http2_send() nghttp2_submit_request error (%s)%d",
+                 "http2_send() nghttp2_submit_request error (%s)%u",
                  nghttp2_strerror(stream_id), stream_id));
     *err = CURLE_SEND_ERROR;
     return -1;
   }
 
-  infof(data, "Using Stream ID: %x (easy handle %p)",
+  infof(data, "Using Stream ID: %u (easy handle %p)",
         stream_id, (void *)data);
   stream->stream_id = stream_id;
 
@@ -2094,7 +2094,7 @@ CURLcode Curl_http2_switched(struct Curl_easy *data,
                                               stream->stream_id,
                                               data);
     if(rv) {
-      infof(data, "http/2: failed to set user_data for stream %d",
+      infof(data, "http/2: failed to set user_data for stream %u",
             stream->stream_id);
       DEBUGASSERT(0);
     }


### PR DESCRIPTION
Sometimes the stream id is printed with %x and sometimes with %d or %u. Confusing.