### PR TITLE
aws-sigv4: fix potentional NULL pointer arithmetic

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -202,12 +202,12 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   if(!service) {
     tmp0 = hostname;
     tmp1 = strchr(tmp0, '.');
-    len = tmp1 - tmp0;
-    if(!tmp1 || len < 1) {
+    if(!tmp1) {
       infof(data, "service missing in parameters or hostname");
       ret = CURLE_URL_MALFORMAT;
       goto fail;
     }
+    len = tmp1 - tmp0;
     service = Curl_memdup(tmp0, len + 1);
     if(!service) {
       goto fail;
@@ -217,12 +217,12 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
     if(!region) {
       tmp0 = tmp1 + 1;
       tmp1 = strchr(tmp0, '.');
-      len = tmp1 - tmp0;
-      if(!tmp1 || len < 1) {
+      if(!tmp1) {
         infof(data, "region missing in parameters or hostname");
         ret = CURLE_URL_MALFORMAT;
         goto fail;
       }
+      len = tmp1 - tmp0;
       region = Curl_memdup(tmp0, len + 1);
       if(!region) {
         goto fail;


### PR DESCRIPTION
We need to check if the strchr call returns NULL (due to missing char) before we use the returned value in arithmetic.

There is no live bug here, but this isn't good hygiene nevertheless IMHO.