### PR TITLE
CI: bump FreeBSD 13.0 to 13.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,9 +26,9 @@ freebsd_task:
   name: FreeBSD
 
   matrix:
-    - name: FreeBSD 13.0
+    - name: FreeBSD 13.1
       freebsd_instance:
-        image_family: freebsd-13-0
+        image_family: freebsd-13-1
     - name: FreeBSD 12.3
       freebsd_instance:
         image_family: freebsd-12-3


### PR DESCRIPTION
https://github.com/curl/curl/pull/8813
removed the repo on my cleanup :/

We should mention the org pr https://github.com/curl/curl/pull/8813 on the commit

- use MAKE_FLAGS: -j ${nporc} instead  MAKE_FLAGS: -j 2 (reason: if cirrus-ci changes the core count we use them all)
btw, freebsd 13.1 is in use at vim, thanks to me ;) and it's been running for a few weeks without any problems excluding build / test errors.