### PR TITLE
FAQ: Clarify Windows double quote usage

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -588,7 +588,13 @@ FAQ
   Exactly what kind of quotes and how to do this is entirely up to the shell
   or command line interpreter that you are using. For most unix shells, you
   can more or less pick either single (') or double (") quotes. For
-  Windows/DOS prompts I believe you are forced to use double (") quotes.
+  Windows/DOS command prompts you must use double (") quotes, and if you have
+  inner double quotes you can escape them with a backslash.
+
+  For Windows powershell the arguments are not always passed on as expected
+  because curl is not a powershell script. You may or may not be able to use
+  single quotes. To escape inner double quotes seems to require a
+  backslash-backtick escape sequence and the outer quotes as double quotes.
 
   Please study the documentation for your particular environment. Examples in
   the curl docs will use a mix of both of these as shown above. You must


### PR DESCRIPTION
- Windows command prompt doesn't use literal quoting via single quotes.

- Windows command prompt inner double quotes are escaped with a
  backslash.

- Windows powershell does use single quotes but curl is not a powershell
  script so the arguments may not be passed on correctly.

- Windows powershell inner double quotes seems can be passed to curl if
  the outer quotes are double quotes and an escape of backslash-backtick
  is used.

Command prompt example:

~~~
getargs -v -d "\"a\""

argv[0]: getargs
argv[1]: -v
argv[2]: -d
argv[3]: "a"
~~~

Ref: https://github.com/curl/curl/issues/8818

Reported-by: KotlinIsland@users.noreply.github.com

Closes #xxxx