### PR TITLE
Change the HTTP writedelay unit to milliseconds

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -315,7 +315,7 @@ about to issue.
   server will NOT wait for the full request body to get sent
 - `idle` - do nothing after receiving the request, just "sit idle"
 - `stream` - continuously send data to the client, never-ending
-- `writedelay: [secs]` delay this amount between reply packets
+- `writedelay: [msecs]` delay this amount between reply packets
 - `skip: [num]` - instructs the server to ignore reading this many bytes from
   a PUT or POST request
 - `rtp: part [num] channel [num] size [num]` - stream a fake RTP packet for

--- a/tests/data/test1116
+++ b/tests/data/test1116
@@ -41,6 +41,9 @@ chunky-trailer: header data
 another-header: yes
 %endif
 </datacheck>
+<servercmd>
+writedelay: 10
+</servercmd>
 </reply>
 
 #

--- a/tests/data/test1117
+++ b/tests/data/test1117
@@ -31,7 +31,7 @@ partial body
 </data1>
 
 <servercmd>
-writedelay: 1
+writedelay: 1000
 </servercmd>
 </reply>
 

--- a/tests/data/test1238
+++ b/tests/data/test1238
@@ -10,7 +10,7 @@ TFTP RRQ
 # Server-side
 <reply>
 <servercmd>
-writedelay: 2
+writedelay: 2000
 </servercmd>
 # ~1200 bytes (so that they don't fit in two 512 byte chunks)
 <data nocheck="yes">

--- a/tests/data/test1523
+++ b/tests/data/test1523
@@ -17,7 +17,7 @@ Funny-head: yesyes
 AA
 </data>
 <servercmd>
-writedelay: 1
+writedelay: 1000
 </servercmd>
 </reply>
 #

--- a/tests/data/test1540
+++ b/tests/data/test1540
@@ -34,7 +34,9 @@ Got 4 bytes but pausing!
 datad474
 MyCoolTrailerHeader: amazingtrailer
 </datacheck>
-
+<servercmd>
+writedelay: 10
+</servercmd>
 </reply>
 # Client-side
 <client>

--- a/tests/data/test266
+++ b/tests/data/test266
@@ -37,6 +37,9 @@ Connection: mooo
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
 chunky-trailer: header data
 </datacheck>
+<servercmd>
+writedelay: 10
+</servercmd>
 </reply>
 
 #


### PR DESCRIPTION
This allows to use write delays for large responses without
resulting in the test taking an unreasonable amount of time.
    
In many cases delaying writes by a whole second or more isn't
necessary for the desired effect.