### PR TITLE
x509asn1: mark msnprintf return as unchecked

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -956,7 +956,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
       infof(data, "   ECC Public Key (%lu bits)", len);
     if(data->set.ssl.certinfo) {
       char q[sizeof(len) * 8 / 3 + 1];
-      msnprintf(q, sizeof(q), "%lu", len);
+      (void)msnprintf(q, sizeof(q), "%lu", len);
       if(Curl_ssl_push_certinfo(data, certnum, "ECC Public Key", q))
         return 1;
     }


### PR DESCRIPTION
We have lots of unchecked msnprintf calls, and this particular msnprintf
call isn't more interesting than the others, but this one yields a Coverity
warning to implicitly silence it.