### PR TITLE
gssapi: improve handling of errors from gss_display_status

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -89,7 +89,7 @@ static size_t display_gss_error(OM_uint32 status, int type,
   OM_uint32 maj_stat;
   OM_uint32 min_stat;
   OM_uint32 msg_ctx = 0;
-  gss_buffer_desc status_string;
+  gss_buffer_desc status_string = GSS_C_EMPTY_BUFFER;
 
   do {
     maj_stat = gss_display_status(&min_stat,
@@ -98,10 +98,12 @@ static size_t display_gss_error(OM_uint32 status, int type,
                                   GSS_C_NO_OID,
                                   &msg_ctx,
                                   &status_string);
-    if(GSS_LOG_BUFFER_LEN > len + status_string.length + 3) {
-      len += msnprintf(buf + len, GSS_LOG_BUFFER_LEN - len,
-                       "%.*s. ", (int)status_string.length,
-                       (char *)status_string.value);
+    if(maj_stat == GSS_S_COMPLETE && status_string.length > 0) {
+      if(GSS_LOG_BUFFER_LEN > len + status_string.length + 3) {
+        len += msnprintf(buf + len, GSS_LOG_BUFFER_LEN - len,
+                         "%.*s. ", (int)status_string.length,
+                         (char *)status_string.value);
+      }
     }
     gss_release_buffer(&min_stat, &status_string);
   } while(!GSS_ERROR(maj_stat) && msg_ctx);


### PR DESCRIPTION
In case gss_display_status() returns an error, avoid trying to add
it to the buffer as the message may well be a NULL pointer.  While
there, also initialize the status_string variable correctly.

Originally this fix comes from a discussion in issue #8816.

Closes: #xxxx
Reviewed-by: xxxx