### PR TITLE
github/workflows/nss: apt update first

### DIFF
--- a/.github/workflows/nss.yml
+++ b/.github/workflows/nss.yml
@@ -26,6 +26,7 @@ jobs:
 
     steps:
     - run: |
+        sudo apt-get update
         sudo apt-get install libtool autoconf automake pkg-config stunnel4 libnss3-dev clang-9 libpsl-dev libbrotli-dev libzstd-dev libnghttp2-dev nss-plugin-pem
         sudo python3 -m pip install impacket
       name: install prereqs and impacket


### PR DESCRIPTION
An attempt to fix "libnss3-dev_3.49.1-1ubuntu1.6_amd64.deb 404 Not
Found"