### PR TITLE
fix mem-leak of two strings in connection reuse

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3498,17 +3498,6 @@ static void reuse_conn(struct Curl_easy *data,
      **established** from the primary socket to a remote address. */
   char local_ip[MAX_IPADR_LEN] = "";
   int local_port = -1;
-#ifndef CURL_DISABLE_PROXY
-  Curl_free_idnconverted_hostname(&old_conn->http_proxy.host);
-  Curl_free_idnconverted_hostname(&old_conn->socks_proxy.host);
-
-  free(old_conn->http_proxy.host.rawalloc);
-  free(old_conn->socks_proxy.host.rawalloc);
-  Curl_free_primary_ssl_config(&old_conn->proxy_ssl_config);
-#endif
-  /* free the SSL config struct from this connection struct as this was
-     allocated in vain and is targeted for destruction */
-  Curl_free_primary_ssl_config(&old_conn->ssl_config);
 
   /* get the user+password information from the old_conn struct since it may
    * be new for this request even when we re-use an existing connection */
@@ -3539,19 +3528,11 @@ static void reuse_conn(struct Curl_easy *data,
     old_conn->http_proxy.passwd = NULL;
     old_conn->socks_proxy.passwd = NULL;
   }
-  Curl_safefree(old_conn->http_proxy.user);
-  Curl_safefree(old_conn->socks_proxy.user);
-  Curl_safefree(old_conn->http_proxy.passwd);
-  Curl_safefree(old_conn->socks_proxy.passwd);
 #endif
 
-  /* host can change, when doing keepalive with a proxy or if the case is
-     different this time etc */
-  Curl_free_idnconverted_hostname(&conn->host);
-  Curl_free_idnconverted_hostname(&conn->conn_to_host);
   Curl_safefree(conn->host.rawalloc);
-  Curl_safefree(conn->conn_to_host.rawalloc);
   conn->host = old_conn->host;
+  old_conn->host.rawalloc = NULL;
   conn->conn_to_host = old_conn->conn_to_host;
   conn->conn_to_port = old_conn->conn_to_port;
   conn->remote_port = old_conn->remote_port;
@@ -3572,15 +3553,7 @@ static void reuse_conn(struct Curl_easy *data,
   /* re-use init */
   conn->bits.reuse = TRUE; /* yes, we're re-using here */
 
-  Curl_safefree(old_conn->user);
-  Curl_safefree(old_conn->passwd);
-  Curl_safefree(old_conn->options);
-  Curl_safefree(old_conn->localdev);
-  Curl_llist_destroy(&old_conn->easyq, NULL);
-
-#ifdef USE_UNIX_SOCKETS
-  Curl_safefree(old_conn->unix_domain_socket);
-#endif
+  conn_free(old_conn);
 }
 
 /**
@@ -3930,10 +3903,6 @@ static CURLcode create_conn(struct Curl_easy *data,
      * allocated before we can move along and use the previously existing one.
      */
     reuse_conn(data, conn, conn_temp);
-#ifdef USE_SSL
-    free(conn->ssl_extra);
-#endif
-    free(conn);          /* we don't need this anymore */
     conn = conn_temp;
     *in_connect = conn;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3531,8 +3531,11 @@ static void reuse_conn(struct Curl_easy *data,
 #endif
 
   Curl_safefree(conn->host.rawalloc);
+  Curl_free_idnconverted_hostname(&conn->host);
+  Curl_free_idnconverted_hostname(&conn->conn_to_host);
   conn->host = old_conn->host;
   old_conn->host.rawalloc = NULL;
+  old_conn->host.encalloc = NULL;
   conn->conn_to_host = old_conn->conn_to_host;
   conn->conn_to_port = old_conn->conn_to_port;
   conn->remote_port = old_conn->remote_port;

--- a/lib/url.c
+++ b/lib/url.c
@@ -3538,6 +3538,7 @@ static void reuse_conn(struct Curl_easy *data,
   old_conn->host.rawalloc = NULL;
   old_conn->host.encalloc = NULL;
   conn->conn_to_host = old_conn->conn_to_host;
+  old_conn->conn_to_host.rawalloc = NULL;
   conn->conn_to_port = old_conn->conn_to_port;
   conn->remote_port = old_conn->remote_port;
   Curl_safefree(conn->hostname_resolve);

--- a/lib/url.c
+++ b/lib/url.c
@@ -3530,9 +3530,10 @@ static void reuse_conn(struct Curl_easy *data,
   }
 #endif
 
-  Curl_safefree(conn->host.rawalloc);
   Curl_free_idnconverted_hostname(&conn->host);
   Curl_free_idnconverted_hostname(&conn->conn_to_host);
+  Curl_safefree(conn->host.rawalloc);
+  Curl_safefree(conn->conn_to_host.rawalloc);
   conn->host = old_conn->host;
   old_conn->host.rawalloc = NULL;
   old_conn->host.encalloc = NULL;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -220,7 +220,7 @@ test1800 test1801 \
 \
                                     test1904 test1905 test1906 test1907 \
 test1908 test1909 test1910 test1911 test1912 test1913 test1914 test1915 \
-test1916 test1917 test1918 \
+test1916 test1917 test1918 test1919 \
 \
 test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
 test1941 test1942 test1943 test1944 test1945 test1946 \

--- a/tests/data/test1919
+++ b/tests/data/test1919
@@ -1,0 +1,51 @@
+<testcase>
+<info>
+<keywords>
+conn-reuse
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Content-Length: 6
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+
+# This created a memory leak in 7.83.1 and earlier
+<name>
+set CURLOPT_XOAUTH2_BEARER and do connection reuse
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Bearer c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca1
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Bearer c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca1
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -60,8 +60,9 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 lib1568 lib1569 \
  lib1591 lib1592 lib1593 lib1594 lib1596 \
          lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
-         lib1915 lib1916 lib1917 lib1918 lib1933 lib1934 lib1935 lib1936 \
- lib1937 lib1938 lib1939 lib1940 lib1945 lib1946 \
+         lib1915 lib1916 lib1917 lib1918 lib1919 \
+ lib1933 lib1934 lib1935 lib1936 lib1937 lib1938 lib1939 lib1940 \
+ lib1945 lib1946 \
  lib3010 lib3025
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
@@ -695,6 +696,9 @@ lib1917_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1917
 
 lib1918_SOURCES = lib1918.c $(SUPPORTFILES) $(WARNLESS)
 lib1918_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1919_SOURCES = lib1919.c $(SUPPORTFILES) $(WARNLESS)
+lib1919_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib1933_SOURCES = lib1933.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1933_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1919.c
+++ b/tests/libtest/lib1919.c
@@ -1,0 +1,51 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+  CURL *curl;
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  curl = curl_easy_init();
+  if(curl) {
+    int i;
+    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
+    curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER,
+                     "c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca1");
+    curl_easy_setopt(curl, CURLOPT_SASL_AUTHZID,
+                     "c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca2");
+    curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+    for(i = 0; i < 2; i++)
+      /* the second request needs to do connection reuse */
+      curl_easy_perform(curl);
+
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+  return 0;
+}


### PR DESCRIPTION
Better use a single function for free'ing the connectdata struct and not have a special case one for connection reuse.

Test 1919 reproduces the case without the fix.