### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/bearssl.yml
+++ b/.github/workflows/bearssl.yml
@@ -44,7 +44,7 @@ jobs:
 
       name: 'get, build and install bearssl'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && LDFLAGS="-Wl,-rpath,$HOME/bear/lib" ./configure --enable-warnings --enable-werror --enable-headers-api ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: cpp
         queries: security-extended
@@ -33,7 +33,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -47,4 +47,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/event-based.yml
+++ b/.github/workflows/event-based.yml
@@ -31,7 +31,7 @@ jobs:
         sudo python3 -m pip install impacket
       name: install prereqs and impacket
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && ./configure ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,7 +29,7 @@ jobs:
         dry-run: false
 
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -17,7 +17,7 @@ jobs:
   merged:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 100
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,7 +17,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/linux-hyper.yml
+++ b/.github/workflows/linux-hyper.yml
@@ -41,7 +41,7 @@ jobs:
         RUSTFLAGS="--cfg hyper_unstable_ffi" cargo +nightly rustc --features client,http1,http2,ffi -Z unstable-options --crate-type cdylib)
       name: 'install hyper'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
     - run: python3 -m pip install impacket
       name: 'pip3 install'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && ./configure --enable-warnings --enable-werror --enable-headers-api ${{ matrix.build.configure }}
       name: 'configure and build'
@@ -137,7 +137,7 @@ jobs:
     - run: python3 -m pip install impacket
       name: 'pip3 install'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: cmake -H. -Bbuild -DCURL_WERROR=ON -DPICKY_COMPILER=ON ${{ matrix.build.generate }}
       name: 'cmake generate'

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -40,7 +40,7 @@ jobs:
         make DESTDIR=$HOME/mbed install
       name: 'install mbedtls'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && LDFLAGS="-Wl,-rpath,$HOME/mbed/lib" ./configure --enable-warnings --enable-werror --enable-headers-api ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'

--- a/.github/workflows/msh3.yml
+++ b/.github/workflows/msh3.yml
@@ -46,7 +46,7 @@ jobs:
         cmake --install .
       name: 'build and install msh3'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && LDFLAGS="-Wl,-rpath,$HOME/msh3/lib -Wl,-rpath,$HOME/quictls/lib" ./configure --enable-warnings --enable-werror --enable-headers-api ${{ matrix.build.configure }} && make V=1
       name: 'configure and build curl'

--- a/.github/workflows/nss.yml
+++ b/.github/workflows/nss.yml
@@ -31,7 +31,7 @@ jobs:
         sudo python3 -m pip install impacket
       name: install prereqs and impacket
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi
       name: 'autoreconf'

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -40,7 +40,7 @@ jobs:
         make && make install_sw
       name: 'build and install openssl3'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib64" ./configure --enable-warnings --enable-werror --enable-headers-api ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'

--- a/.github/workflows/rustls.yml
+++ b/.github/workflows/rustls.yml
@@ -39,7 +39,7 @@ jobs:
         make DESTDIR=$HOME/rustls install
       name: 'install rustls'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }} && make V=1
       name: 'configure and build'

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -44,7 +44,7 @@ jobs:
         make && make install
       name: 'install wolfssl'
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: autoreconf -fi && LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" ./configure --enable-warnings --enable-werror --enable-headers-api ${{ matrix.build.curl-configure }} && make V=1
       name: 'configure and build'


### PR DESCRIPTION
This PR updates GitHub Actions to their latest major versions. Main change is they are all now using Node 16 instead of 12 internally, which was EOL at the end of April.

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/upload-artifact` can be [found here](https://github.com/actions/upload-artifact/releases)
- Changelog from `github/codeql-actions` can be [found here](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)

This PR also changes the `actions/checkout` action in `linkcheck.yml` to reference the action by a tag/release rather than the master branch. This change protects from unintentional changes to the master branch of that action, see the [related GitHub Security blog post](https://securitylab.github.com/research/github-actions-building-blocks/). 