### PR TITLE
sectransp: check for a function defined when __BLOCKS__ is undefined

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2964,7 +2964,7 @@ collect_server_cert(struct Curl_easy *data,
      private API and doesn't work as expected. So we have to look for
      a different symbol to make sure this code is only executed under
      Lion or later. */
-  if(SecTrustEvaluateAsync) {
+  if(SecTrustCopyPublicKey) {
 #pragma unused(server_certs)
     err = SSLCopyPeerTrust(backend->ssl_ctx, &trust);
     /* For some reason, SSLCopyPeerTrust() can return noErr and yet return


### PR DESCRIPTION
SecTrustEvaluateAsync() is defined in the macOS 10.7 SDK, but it
requires Grand Central Dispatch to be supported by the compiler, and
some third-party macOS compilers do not support Grand Central Dispatch.
SecTrustCopyPublicKey() is not present in macOS 10.6, so this shouldn't
adversely affect anything.

Fixes #8846
Reported-by: Egor Pugin