### PR TITLE
also check %USERPROFILE% variable to find .netrc file on Windows

### DIFF
--- a/docs/libcurl/libcurl-env.3
+++ b/docs/libcurl/libcurl-env.3
@@ -54,6 +54,10 @@ nss, openssl, rustls, schannel, secure-transport, wolfssl
 When the netrc feature is used (\fICURLOPT_NETRC(3)\fP), this variable is
 checked as the primary way to find the "current" home directory in which
 the .netrc file is likely to exist.
+.IP USERPROFILE
+When the netrc feature is used (\fICURLOPT_NETRC(3)\fP), this variable is
+checked as the secondary way to find the "current" home directory (on Windows
+only) in which the .netrc file is likely to exist.
 .IP LOGNAME
 User name to use when invoking the ntlm-wb tool, if NTLMUSER was not set.
 .IP NO_PROXY

--- a/docs/libcurl/libcurl-tutorial.3
+++ b/docs/libcurl/libcurl-tutorial.3
@@ -361,9 +361,11 @@ similar to the \fICURLOPT_USERPWD(3)\fP option like this:
  curl_easy_setopt(easyhandle, CURLOPT_PROXYUSERPWD, "myname:thesecret");
 
 There's a long time Unix "standard" way of storing FTP user names and
-passwords, namely in the $HOME/.netrc file. The file should be made private
-so that only the user may read it (see also the "Security Considerations"
-chapter), as it might contain the password in plain text. libcurl has the
+passwords, namely in the $HOME/.netrc file (on Windows, libcurl also checks
+the %USERPROFILE% environment variable if %HOME% is unset, and tries
+_netrc as name). The file should be made private so that only the user may
+read it (see also the "Security Considerations" chapter),
+as it might contain the password in plain text. libcurl has the
 ability to use this file to figure out what set of user name and password to
 use for a particular host. As an extension to the normal functionality,
 libcurl also supports this file for non-FTP protocols such as HTTP. To make

--- a/docs/libcurl/opts/CURLOPT_NETRC.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC.3
@@ -33,7 +33,8 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NETRC, long level);
 This parameter controls the preference \fIlevel\fP of libcurl between using
 user names and passwords from your \fI~/.netrc\fP file, relative to user names
 and passwords in the URL supplied with \fICURLOPT_URL(3)\fP. On Windows,
-libcurl will use the file as \fI%HOME%/_netrc\fP, but you can also tell
+libcurl will use the file as \fI%HOME%/_netrc\fP. IF \fI%HOME%\fP is not set on Windows,
+libcurl falls back to \fI%USERPROFILE%\fP. You can also tell
 libcurl a different file name to use with \fICURLOPT_NETRC_FILE(3)\fP.
 
 libcurl uses a user name (and supplied or prompted password) supplied with

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -258,7 +258,7 @@ int Curl_parsenetrc(const char *host,
       if(pw) {
         home = pw->pw_dir;
       }
-#elif defined(CURL_WIN32)
+#elif defined(_WIN32)
     }
     else {
       homea = curl_getenv("USERPROFILE");

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -258,6 +258,13 @@ int Curl_parsenetrc(const char *host,
       if(pw) {
         home = pw->pw_dir;
       }
+#elif defined(CURL_WIN32)
+    }
+    else {
+      homea = curl_getenv("USERPROFILE");
+      if(homea) {
+        home = homea;
+      }
 #endif
     }
 


### PR DESCRIPTION
It seems that `%HOME%` isn't always set on Windows. 
However, `%USERPROFILE%` seems to be a standard variable on Windows. So I just added another branch of the if condition to look in there for the `.netrc` file if `%HOME%` is not set.

Ref: https://github.com/mamba-org/mamba/issues/870