### PR TITLE
transfer: Fix potential NULL pointer dereference

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1888,10 +1888,13 @@ Curl_setup_transfer(
   struct SingleRequest *k = &data->req;
   struct connectdata *conn = data->conn;
   struct HTTP *http = data->req.p.http;
-  bool httpsending = ((conn->handler->protocol&PROTO_FAMILY_HTTP) &&
-                      (http->sending == HTTPSEND_REQUEST));
+  bool httpsending;
+
   DEBUGASSERT(conn != NULL);
   DEBUGASSERT((sockindex <= 1) && (sockindex >= -1));
+
+  httpsending = ((conn->handler->protocol&PROTO_FAMILY_HTTP) &&
+                 (http->sending == HTTPSEND_REQUEST));
 
   if(conn->bits.multiplex || conn->httpversion == 20 || httpsending) {
     /* when multiplexing, the read/write sockets need to be the same! */


### PR DESCRIPTION
Commit 0ef54abf5208 accidentally used the conn variable before the
assertion for it being NULL. Fix by moving the assignment which use
conn to after the assertion.

Closes: #xxxx