### PR TITLE
feat: add support for yaml file extension

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1729,7 +1729,9 @@ const char *Curl_mime_contenttype(const char *filename)
     {".htm",  "text/html"},
     {".html", "text/html"},
     {".pdf",  "application/pdf"},
-    {".xml",  "application/xml"}
+    {".xml",  "application/xml"},
+    {".yaml",  "application/x-yaml"},
+    {".yml",  "application/x-yaml"},
   };
 
   if(filename) {


### PR DESCRIPTION
add new content type for yaml files instead of default `HTTPPOST_CONTENTTYPE_DEFAULT=application/octet-stream`

credits goes to [How does `curl` on the command line determine the MIME type of a file being uploaded?](https://unix.stackexchange.com/questions/396385/how-does-curl-on-the-command-line-determine-the-mime-type-of-a-file-being-uplo) 