### PR TITLE
docs: clarify data replacement policy for MIME API

### DIFF
--- a/docs/libcurl/curl_mime_data.3
+++ b/docs/libcurl/curl_mime_data.3
@@ -39,8 +39,8 @@ storage may safely be reused after call.
 character string.
 \fIpart\fP is the part's to assign contents to.
 
-Setting a part's contents twice is valid: only the value set by the last call
-is retained. It is possible to unassign part's contents by setting
+Setting a part's contents multiple times is valid: only the value set by the
+last call is retained. It is possible to unassign part's contents by setting
 \fIdata\fP to NULL.
 
 Setting large data is memory consuming: one might consider using

--- a/docs/libcurl/curl_mime_encoder.3
+++ b/docs/libcurl/curl_mime_encoder.3
@@ -37,8 +37,8 @@ transmitted.
 set to NULL to disable an encoder previously attached to the part. The encoding
 scheme storage may safely be reused after this function returns.
 
-Setting a part's encoder twice is valid: only the value set by the last call is
-retained.
+Setting a part's encoder multiple times is valid: only the value set by the
+last call is retained.
 
 Upon multipart rendering, the part's content is encoded according to the
 pertaining scheme and a corresponding \fI"Content-Transfer-Encoding"\fP header

--- a/docs/libcurl/curl_mime_filedata.3
+++ b/docs/libcurl/curl_mime_filedata.3
@@ -52,8 +52,8 @@ If the file size cannot be determined before actually reading it (such as for
 a device or named pipe), the whole mime structure containing the part
 will be transferred as chunks by HTTP and rejected by IMAP.
 
-Setting a part's contents twice is valid: only the value set by the last call
-is retained.
+Setting a part's contents multiple times is valid: only the value set by the
+last call is retained.
 .SH EXAMPLE
 .nf
  curl_mime *mime;

--- a/docs/libcurl/curl_mime_filename.3
+++ b/docs/libcurl/curl_mime_filename.3
@@ -42,7 +42,7 @@ to NULL to remove a previously attached remote file name.
 
 The remote file name string is copied into the part, thus the associated
 storage may safely be released or reused after call. Setting a part's file
-name twice is valid: only the value set by the last call is retained.
+name multiple times is valid: only the value set by the last call is retained.
 .SH EXAMPLE
 .nf
  curl_mime *mime;

--- a/docs/libcurl/curl_mime_headers.3
+++ b/docs/libcurl/curl_mime_headers.3
@@ -41,8 +41,8 @@ to remove a previously attached custom header list.
 replacement or mime structure deletion; in this case the list must not be
 freed explicitly.
 
-Setting a part's custom headers list twice is valid: only the value set by
-the last call is retained.
+Setting a part's custom headers list multiple times is valid: only the value
+set by the last call is retained.
 .SH EXAMPLE
 .nf
  struct curl_slist *headers = NULL;

--- a/docs/libcurl/curl_mime_name.3
+++ b/docs/libcurl/curl_mime_name.3
@@ -37,9 +37,9 @@ fields are named.
 \fIname\fP points to the null-terminated name string.
 
 The name string is copied into the part, thus the associated storage may
-safely be released or reused after call. Setting a part's name twice is valid:
-only the value set by the last call is retained. It is possible to "unname" a
-part by setting \fIname\fP to NULL.
+safely be released or reused after call. Setting a part's name multiple times
+is valid: only the value set by the last call is retained. It is possible to
+"unname" a part by setting \fIname\fP to NULL.
 .SH EXAMPLE
 .nf
  curl_mime *mime;

--- a/docs/libcurl/curl_mime_subparts.3
+++ b/docs/libcurl/curl_mime_subparts.3
@@ -39,9 +39,9 @@ structure.
 multipart part and must not be freed explicitly. It may however be updated by
 subsequent calls to mime API functions.
 
-Setting a part's contents twice is valid: only the value set by the last call
-is retained. It is possible to unassign previous part's contents by setting
-\fIsubparts\fP to NULL.
+Setting a part's contents multiple times is valid: only the value set by the
+last call is retained. It is possible to unassign previous part's contents by
+setting \fIsubparts\fP to NULL.
 .SH EXAMPLE
 .nf
  /* The inline part is an alternative proposing the html and the text

--- a/docs/libcurl/curl_mime_type.3
+++ b/docs/libcurl/curl_mime_type.3
@@ -37,8 +37,8 @@ CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype);
 set to NULL to remove a previously attached mime type.
 
 The mime type string is copied into the part, thus the associated storage may
-safely be released or reused after call. Setting a part's type twice is valid:
-only the value set by the last call is retained.
+safely be released or reused after call. Setting a part's type multiple times
+is valid: only the value set by the last call is retained.
 
 In the absence of a mime type and if needed by the protocol specifications,
 a default mime type is determined by the context:


### PR DESCRIPTION
The API documentation for the MIME functions specify that the parts can be set twice, with the last call winning.  While true, the user can set the parts n times for n > 2, reword to specify multiple API calls instead.