### PR TITLE
Makefile.am: portability issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -278,13 +278,13 @@ uninstall-hook:
 	(cd docs && $(MAKE) uninstall)
 	(cd docs/libcurl && $(MAKE) uninstall)
 
-ca-bundle: scripts/mk-ca-bundle.pl
+ca-bundle: $(srcdir)/scripts/mk-ca-bundle.pl
 	@echo "generating a fresh ca-bundle.crt"
-	@perl $< -b -l -u lib/ca-bundle.crt
+	@perl $(srcdir)/scripts/mk-ca-bundle.pl -b -l -u lib/ca-bundle.crt
 
-ca-firefox: scripts/firefox-db2pem.sh
+ca-firefox: $(srcdir)/scripts/firefox-db2pem.sh
 	@echo "generating a fresh ca-bundle.crt"
-	$< lib/ca-bundle.crt
+	$(srcdir)/scripts/firefox-db2pem.sh lib/ca-bundle.crt
 
 checksrc:
 	(cd lib && $(MAKE) checksrc)


### PR DESCRIPTION
Commit a04f0b961333e1a19848d073d8c7db9c20b2a371 made me notice that
there is a portability issue in curl's top-level Makefile.am.

$< can only be used in rules that deal with .SUFFIXES.  Its use
for general prerequisites is a GNU make extension.

$< could be replaced by $?, but I think in an autotools context,
something like this is better:

Bug: https://curl.se/mail/lib-2022-05/0024.html