### PR TITLE
wolfSSL: explicitly use compatibility layer

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -59,13 +59,18 @@
 #if defined(USE_OPENSSL_DES) || defined(USE_WOLFSSL)
 
 #ifdef USE_WOLFSSL
-#include <wolfssl/options.h>
-#endif
-
+#  include <wolfssl/options.h>
+#  include <wolfssl/openssl/des.h>
+#  include <wolfssl/openssl/md5.h>
+#  include <wolfssl/openssl/ssl.h>
+#  include <wolfssl/openssl/rand.h>
+#else
 #  include <openssl/des.h>
 #  include <openssl/md5.h>
 #  include <openssl/ssl.h>
 #  include <openssl/rand.h>
+#endif
+
 #  if (defined(OPENSSL_VERSION_NUMBER) && \
        (OPENSSL_VERSION_NUMBER < 0x00907001L)) && !defined(USE_WOLFSSL)
 #    define DES_key_schedule des_key_schedule

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -35,10 +35,10 @@
 #define NTLM_NEEDS_NSS_INIT
 #endif
 
-#if defined(USE_OPENSSL) || defined(USE_WOLFSSL)
 #ifdef USE_WOLFSSL
 #  include <wolfssl/options.h>
-#endif
+#  include <wolfssl/openssl/ssl.h>
+#elif defined(USE_OPENSSL)
 #  include <openssl/ssl.h>
 #endif
 

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -39,7 +39,7 @@
 #ifdef USE_WOLFSSL
 #include <wolfssl/options.h>
 #ifdef NO_MD4
-#define OPENSSL_NO_MD4
+#define WOLFSSL_NO_MD4
 #endif
 #endif
 
@@ -82,9 +82,11 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
   md4_digest(ctx, MD4_DIGEST_SIZE, result);
 }
 
-#elif (defined(USE_OPENSSL) || defined(USE_WOLFSSL)) && \
-      !defined(OPENSSL_NO_MD4)
 /* When OpenSSL or wolfSSL is available, we use their MD4 functions. */
+#elif defined(USE_WOLFSSL) && !defined(WOLFSSL_NO_MD4)
+#include <wolfssl/openssl/md4.h>
+
+#elif defined(USE_OPENSSL) && !defined(OPENSSL_NO_MD4)
 #include <openssl/md4.h>
 
 #elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -136,19 +136,6 @@ if test "x$OPT_WOLFSSL" != xno; then
         [
             AC_DEFINE(HAVE_WOLFSSL_DES_ECB_ENCRYPT, 1,
                       [if you have wolfSSL_DES_ecb_encrypt])
-            if test -n "$addcflags"; then
-              dnl use a for loop to strip off whitespace
-              for f in $addcflags; do
-                CPPFLAGS="$f/wolfssl $CPPFLAGS"
-                AC_MSG_NOTICE([Add $f/wolfssl to CPPFLAGS])
-                break
-              done
-            else
-              dnl user didn't give a path, so guess/hope they installed wolfssl
-              dnl headers to system default location
-              CPPFLAGS="-I/usr/include/wolfssl $CPPFLAGS"
-              AC_MSG_NOTICE([Add /usr/include/wolfssl to CPPFLAGS])
-            fi
             WOLFSSL_NTLM=1
         ]
         )


### PR DESCRIPTION
This change removes adding an include `$prefix/wolfssl` or similar to allow for openssl include aliasing. Include paths of
`wolfssl/openssl/` are used to explicitly use wolfSSL includes. This fixes cmake builds(see https://github.com/microsoft/vcpkg/pull/24348) as well as avoiding potentially using openSSL headers since include path order is not guaranteed.
