### PR TITLE
max-time.d: clarify max-time sets max transfer time

### DIFF
--- a/docs/cmdline-opts/max-time.d
+++ b/docs/cmdline-opts/max-time.d
@@ -2,16 +2,20 @@ Long: max-time
 Short: m
 Arg: <fractional seconds>
 Help: Maximum time allowed for transfer
-See-also: connect-timeout
+See-also: connect-timeout retry-max-time
 Category: connection
 Example: --max-time 10 $URL
 Example: --max-time 2.92 $URL
 Added: 4.0
 ---
-Maximum time in seconds that you allow the whole operation to take.  This is
+Maximum time in seconds that you allow each transfer to take.  This is
 useful for preventing your batch jobs from hanging for hours due to slow
 networks or links going down.  Since 7.32.0, this option accepts decimal
 values, but the actual timeout will decrease in accuracy as the specified
 timeout increases in decimal precision.
+
+If you enable retrying the transfer (--retry) then the maximum time counter is
+reset each time the transfer is retried. You can use --retry-max-time to limit
+the retry time.
 
 If this option is used several times, the last one will be used.


### PR DESCRIPTION
Prior to this change the doc said --max-time set the maximum time of the
'whole operation' which is not accurate. The option maps to
CURLOPT_TIMEOUT_MS which sets maximum transfer time.

For example, the maximum time on a transfer is reset if the transfer is
retried (--retry).

Reported-by: Nuru@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/8877
Closes #xxxx