### PR TITLE
Makefile.m32: delete two obsolete OpenSSL options [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -320,8 +320,7 @@ ifdef SSL
     OPENSSL_LIBS += -lgdi32 -lcrypt32
   endif
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
-  CFLAGS += -DUSE_OPENSSL -DHAVE_OPENSSL_PKCS12_H \
-            -DOPENSSL_NO_KRB5
+  CFLAGS += -DUSE_OPENSSL
   DLL_LIBS += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
   ifdef SRP
     ifeq "$(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h)" "$(OPENSSL_INCLUDE)/openssl/srp.h"


### PR DESCRIPTION
- `-DOPENSSL_NO_KRB5`: No longer used by OpenSSL 1.1.x, 3.x, or
  LibreSSL 3.5.x, yet it collides with the latter, which defines
  it unconditionally, resulting in this warning:
  ```
  ../../libressl/include/openssl/opensslfeatures.h:14:9: warning: 'OPENSSL_NO_KRB5' macro redefined [-Wmacro-redefined]
  ```
  It was originally added to curl in 2004.

- `-DHAVE_OPENSSL_PKCS12_H`: No longer used by OpenSSL 1.1.x, 3.x, or
  LibreSSL back to at least 2.5.5. Originally added in the same
  commit as the above, in 2004.