### PR TITLE
log2changes: do not indent empty lines [ci skip]

### DIFF
--- a/scripts/log2changes.pl
+++ b/scripts/log2changes.pl
@@ -94,7 +94,7 @@ while(<STDIN>) {
         $oldco = $co;
         $oldc = $c;
         $olddate = $date;
-        if($line++) {
+        if($line++ && $2 ne "") {
             print "  ";
         }
         print $2."\n";


### PR DESCRIPTION
This will omit two spaces of indentation from lines with no content, thus avoiding 'spaces @ EOL'.