### PR TITLE
configure: use the SED value to invoke sed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -728,7 +728,7 @@ if test X"$want_hyper" != Xno; then
           AC_MSG_NOTICE([Added $DIR_HYPER to CURL_LIBRARY_PATH]),
        )
       ],
-      for d in `echo $DIR_HYPER | sed -e 's/:/ /'`; do
+      for d in `echo $DIR_HYPER | $SED -e 's/:/ /'`; do
         if test -f "$d/libhyper.a"; then
           AC_MSG_ERROR([hyper was found in $d but was probably built with wrong flags. See docs/HYPER.md.])
         fi


### PR DESCRIPTION
Rather than assuming sed in PATH, use the resolved $SED variable like in all other invocations of sed in configure.