### PR TITLE
links: update dead links

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -5,10 +5,6 @@
 [HTTP/3 Explained](https://http3-explained.haxx.se/en/) - the online free
 book describing the protocols involved.
 
-[QUIC implementation](https://github.com/curl/curl/wiki/QUIC-implementation) -
-the wiki page describing the plan for how to support QUIC and HTTP/3 in curl
-and libcurl.
-
 [quicwg.org](https://quicwg.org/) - home of the official protocol drafts
 
 ## QUIC libraries

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -184,8 +184,7 @@ static CURLcode altsvc_add(struct altsvcinfo *asi, char *line)
 
 /*
  * Load alt-svc entries from the given file. The text based line-oriented file
- * format is documented here:
- * https://github.com/curl/curl/wiki/QUIC-implementation
+ * format is documented here: https://curl.se/docs/alt-svc.html
  *
  * This function only returns error on major problems that prevents alt-svc
  * handling to work completely. It will ignore individual syntactical errors

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -494,8 +494,7 @@ static CURLcode hsts_pull(struct Curl_easy *data, struct hsts *h)
 
 /*
  * Load the HSTS cache from the given file. The text based line-oriented file
- * format is documented here:
- * https://github.com/curl/curl/wiki/HSTS
+ * format is documented here: https://curl.se/docs/hsts.html
  *
  * This function only returns error on major problems that prevent hsts
  * handling to work completely. It will ignore individual syntactical errors


### PR DESCRIPTION
The wiki pages are gone, remove and link to more long-living docs.