### PR TITLE
doh: remove UNITTEST macro definition

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -69,12 +69,6 @@ static const char *doh_strerror(DOHcode code)
 }
 #endif
 
-#ifdef DEBUGBUILD
-#define UNITTEST
-#else
-#define UNITTEST static
-#endif
-
 /* @unittest 1655
  */
 UNITTEST DOHcode doh_encode(const char *host,


### PR DESCRIPTION
The UNITTEST macro is defined by curl_setup.h so there is no use in carry a local copy of the logic.