### PR TITLE
Makefile.m32: delete obsolete options, improve -On [ci skip]

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1998 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -113,10 +113,8 @@ CURL_AR := $(CROSSPREFIX)ar
 endif
 
 CC = $(CURL_CC)
-CFLAGS = $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
-CFLAGS += -fno-strict-aliasing
-# comment LDFLAGS below to keep debug info
-LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s
+CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
+LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE)
 RC = $(CROSSPREFIX)windres
 RCFLAGS = --include-dir=$(PROOT)/include -O coff
 
@@ -130,7 +128,7 @@ endif
 endif
 
 ifeq ($(ARCH),w64)
-CFLAGS  += -m64 -D_AMD64_
+CFLAGS  += -m64
 LDFLAGS += -m64
 RCFLAGS += -F pe-x86-64
 else

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1999 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1999 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -108,10 +108,8 @@ CURL_RANLIB := $(CROSSPREFIX)ranlib
 endif
 
 CC = $(CURL_CC)
-CFLAGS = $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
-CFLAGS += -fno-strict-aliasing
-# comment LDFLAGS below to keep debug info
-LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL) -s
+CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
+LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL)
 AR = $(CURL_AR)
 RANLIB = $(CURL_RANLIB)
 RC = $(CROSSPREFIX)windres
@@ -128,7 +126,7 @@ endif
 endif
 
 ifeq ($(ARCH),w64)
-CFLAGS  += -m64 -D_AMD64_
+CFLAGS  += -m64
 LDFLAGS += -m64
 RCFLAGS += -F pe-x86-64
 else

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -5,7 +5,7 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 1999 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 1999 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
@@ -113,10 +113,8 @@ CURL_AR := $(CROSSPREFIX)ar
 endif
 
 CC = $(CURL_CC)
-CFLAGS = $(CURL_CFLAG_EXTRAS) -g -O2 -Wall -W
-CFLAGS += -fno-strict-aliasing
-# comment LDFLAGS below to keep debug info
-LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE) -s
+CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
+LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE)
 AR = $(CURL_AR)
 RC = $(CROSSPREFIX)windres
 RCFLAGS = --include-dir=$(PROOT)/include -O coff -DCURL_EMBED_MANIFEST
@@ -136,7 +134,7 @@ endif
 endif
 
 ifeq ($(ARCH),w64)
-CFLAGS  += -m64 -D_AMD64_
+CFLAGS  += -m64
 LDFLAGS += -m64
 RCFLAGS += -F pe-x86-64
 else


### PR DESCRIPTION
- `-D_AMD64_` has not been necessary for mingw-w64 builds for a long time now.
- `-fno-strict-aliasing` is mentioned for Intel C compiler in autotools, and
  I used this with VxWorks in another project, but otherwise this isn't
  necessary anymore as a default. If a target still needs it, it can be
  added with `CURL_CFLAG_EXTRAS=-fno-strict-aliasing`
- bump up default optimization level to `-O3` (from `-O2`), and also rearrange
  option order so the default can now be overridden via
  `CURL_CFLAG_EXTRAS`.
- delete `-g` (generate debug info) from `CFLAGS` and `-s` from `LDFLAGS`
  (strip debug info). They were working against each other. Now, if someone
  needs debug info, it can be enabled via `CURL_CFLAG_EXTRAS=-g`
