### PR TITLE
tests/data/test1501: kill ftp server after slow LIST response

### DIFF
--- a/tests/data/test1501
+++ b/tests/data/test1501
@@ -26,8 +26,11 @@ ftp
 <tool>
 lib%TESTNUMBER
 </tool>
+<killserver>
+ftp
+</killserver>
  <name>
-FTP with multi interface and slow LIST response 
+FTP with multi interface and slow LIST response
  </name>
  <command>
 ftp://%HOSTIP:%FTPPORT/%TESTNUMBER/


### PR DESCRIPTION
This test is contributing to flakiness on the Windows CI runs.
Killing the ftp server after the test run like other slowness
tests already do may help resolve the flakiness.