### PR TITLE
docs/CONTRIBUTE.md: document the 'needs-votes' concept

### DIFF
--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -169,6 +169,11 @@ actual content changed also allows you to retrigger the tests for that commit.
 When you adjust your pull requests after review, consider squashing the
 commits so that we can review the full updated version more easily.
 
+A pull request sent to the project might get labeled `needs-votes` by a
+project maintainer. This label means that in addition to meeting all other
+checks and qualifications this pull request must also receive at least **5**
+thumbs-up reactions on GitHub to be considered for merging.
+
 ### Making quality patches
 
 Make the patch against as recent source versions as possible.

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -171,8 +171,9 @@ commits so that we can review the full updated version more easily.
 
 A pull request sent to the project might get labeled `needs-votes` by a
 project maintainer. This label means that in addition to meeting all other
-checks and qualifications this pull request must also receive at least **5**
-thumbs-up reactions on GitHub to be considered for merging.
+checks and qualifications this pull request must also receive more "votes" of
+user support. More signs that people want this to happen. It could be in the
+form of messages saying so, or thumbs-up reactions on GitHub.
 
 ### Making quality patches
 


### PR DESCRIPTION
A pull request sent to the project might get labeled `needs-votes` by a
project maintainer. This label means that in addition to meeting all
other checks and qualifications this pull request must also receive at
least **5** thumbs-up reactions on GitHub to be considered for merging.

Discussed: https://curl.se/mail/lib-2022-05/0067.html