### PR TITLE
CI/azure: remove obsolete strategy for single builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -101,11 +101,6 @@ stages:
     timeoutInMinutes: 30
     pool:
       vmImage: 'ubuntu-latest'
-    strategy:
-      matrix:
-        default:
-          name: default
-          install:
     steps:
     - script: autoreconf -fi && ./configure --without-ssl
       displayName: 'configure $(name)'
@@ -159,12 +154,6 @@ stages:
     timeoutInMinutes: 30
     pool:
       vmImage: 'ubuntu-latest'
-    strategy:
-      matrix:
-        default:
-          name: default
-          install:
-
     steps:
     - script: sudo apt-get update && sudo apt-get install -y clang-tools-10 clang-9 libssl-dev libssh2-1-dev libpsl-dev libbrotli-dev libzstd-dev
       displayName: 'apt install'


### PR DESCRIPTION
This shortens these CI job names on GitHub even more.
Follow up to #8906 which also increased their timeout.