### PR TITLE
Digest auth fixes

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -695,7 +695,7 @@ static CURLcode auth_create_digest_http_message(
   }
 
   if(digest->userhash) {
-    hashthis = aprintf("%s:%s", userp, digest->realm);
+    hashthis = aprintf("%s:%s", userp, digest->realm ? digest->realm : "");
     if(!hashthis)
       return CURLE_OUT_OF_MEMORY;
 
@@ -715,7 +715,8 @@ static CURLcode auth_create_digest_http_message(
            unq(nonce-value) ":" unq(cnonce-value)
   */
 
-  hashthis = aprintf("%s:%s:%s", userp, digest->realm, passwdp);
+  hashthis = aprintf("%s:%s:%s", userp, digest->realm ? digest->realm : "",
+                     passwdp);
   if(!hashthis)
     return CURLE_OUT_OF_MEMORY;
 
@@ -804,7 +805,13 @@ static CURLcode auth_create_digest_http_message(
   userp_quoted = auth_digest_string_quoted(digest->userhash ? userh : userp);
   if(!userp_quoted)
     return CURLE_OUT_OF_MEMORY;
-  realm_quoted = auth_digest_string_quoted(digest->realm);
+  if(digest->realm)
+    realm_quoted = auth_digest_string_quoted(digest->realm);
+  else {
+    realm_quoted = malloc(1);
+    if(realm_quoted)
+      realm_quoted[0] = 0;
+  }
   if(!realm_quoted) {
     free(userp_quoted);
     return CURLE_OUT_OF_MEMORY;

--- a/tests/data/test1095
+++ b/tests/data/test1095
@@ -73,7 +73,7 @@ Accept: */*
 
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="test \"this\" realm!!", nonce="1053604145", uri="/%TESTNUMBER", response="a1c7931ece9e8617bae2715045e4f49f"
+Authorization: Digest username="testuser", realm="test \"this\" realm!!", nonce="1053604145", uri="/%TESTNUMBER", response="df3246f44d2bc8de0e9f8fc4d7cf6e95"
 User-Agent: curl/%VERSION
 Accept: */*
 


### PR DESCRIPTION
RFC 7616 (and 2617) requires values to be "unquoted" before used for digest calculations. The same mentioned in the code comments.
`realm="DOMAIN\\host"` and `realm=DOMAN\\host` are different realms, but they are processed as identical values at the moment, which is not compliant with RFC. See [RFC7616](https://datatracker.ietf.org/doc/html/rfc7616#page-8).
The only place where unquoting can be done correctly is header parsing function. 
This PR adds unquoting (de-escaping) of all values during header parsing and quoting (escaping) of the values during header forming. This approach should be most straightforward and easy to read/maintain as all values are processed in the same way as required by RFC.

The second commit adds detection of more erroneous situation during header parsing.
The third commit adds fix for NULL dereference discovered by Fuzzer. Server header may not define `realm`, so code must tolerate NULL value for `digest->realm`.

Can be squashed into single commit.