### PR TITLE
c-hyper: mark status line as status for Curl_client_write()

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -288,7 +288,7 @@ static CURLcode status_line(struct Curl_easy *data,
              len);
 
   if(!data->state.hconnect || !data->set.suppress_connect_headers) {
-    writetype = CLIENTWRITE_HEADER;
+    writetype = CLIENTWRITE_HEADER|CLIENTWRITE_STATUS;
     if(data->set.include_header)
       writetype |= CLIENTWRITE_BODY;
     result = Curl_client_write(data, writetype,

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -49,10 +49,16 @@
 671
 672
 673
+1117
+1274
 1417
 1533
 1540
 1591
+1940
+1941
+1942
+1943
 %endif
 2043
 # Tests that are disabled here for rustls are SUPPOSED to work


### PR DESCRIPTION
To make sure the headers API can filter it out as not a regular header.

Reported-by: Gisle Vanem
Fixes #8894