### PR TITLE
cmake: fix detecting libidn2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,11 +675,12 @@ if(NOT CURL_DISABLE_LDAPS)
   check_include_file_concat("ldapssl.h"  HAVE_LDAPSSL_H)
 endif()
 
-# Check for idn
+# Check for idn2
 option(USE_LIBIDN2 "Use libidn2 for IDN support" ON)
-set(HAVE_LIBIDN2 OFF)
 if(USE_LIBIDN2)
   check_library_exists_concat("idn2" idn2_lookup_ul HAVE_LIBIDN2)
+else()
+  set(HAVE_LIBIDN2 OFF)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Without this patch, libidn2 detection doesn't even seem to be
attempted. With this patch, cmake can be configured to pick it
up and enable it. I'm not an expert, so maybe the root cause is
something else, or there is a better fix. The required
configuration is still quite unusual/manual.