### PR TITLE
cmake: enable curl.rc for all Windows targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include(${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake)
 
-if(MSVC)
+if(WIN32)
   list(APPEND CURL_FILES curl.rc)
 endif()
 


### PR DESCRIPTION
Before this patch, it was only enabled for MSVC. This syncs this
configuration with libcurl.rc, which was already included for all
Windows targets.