### PR TITLE
cmake: support adding a suffix to the OS value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ message(STATUS "curl version=[${CURL_VERSION}]")
 # SET(PACKAGE_STRING "curl-")
 # SET(PACKAGE_BUGREPORT "a suitable curl mailing list => https://curl.se/mail/")
 set(OPERATING_SYSTEM "${CMAKE_SYSTEM_NAME}")
-set(OS "\"${CMAKE_SYSTEM_NAME}\"")
+set(OS "\"${CMAKE_SYSTEM_NAME}${CURL_OS_SUFFIX}\"")
 
 include_directories(${CURL_SOURCE_DIR}/include)
 


### PR DESCRIPTION
CMake automatically uses the `CMAKE_SYSTEM_NAME` value to fill the OS
string appearing in the `--version` output after the curl version number,
for example:

  'curl 7.83.1 (Windows)'

This patchs adds the ability to pass a suffix that is appended to this
value. It's useful to add CPU info or other platform details,
for example:

  'curl 7.83.1 (Windows-x64)'