### PR TITLE
cmake: do not add `libcurl.rc` to the static libcurl library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,7 +40,7 @@ list(APPEND HHEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/curl_config.h
   )
 
-if(WIN32)
+if(WIN32 AND NOT CURL_STATICLIB)
   list(APPEND CSOURCES libcurl.rc)
 endif()
 


### PR DESCRIPTION
Ref: https://github.com/curl/curl/pull/8918#issuecomment-1138263855