### PR TITLE
curl: clamp --parallel-max to MAX_PARALLEL instead of resetting to default value

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2337,8 +2337,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = str2unum(&global->parallel_max, nextarg);
         if(err)
           return err;
-        if((global->parallel_max > MAX_PARALLEL) ||
-           (global->parallel_max < 1))
+        if(global->parallel_max > MAX_PARALLEL)
+          global->parallel_max = MAX_PARALLEL;
+        else if(global->parallel_max < 1)
           global->parallel_max = PARALLEL_DEFAULT;
         break;
       case 'c':   /* --parallel-connect */


### PR DESCRIPTION
Previously, `--parallel-max 300` would use 300 concurrent transfers, but `--parallel-max 301` would unexpectedly use only 50. This clamps higher values to the maximum.