### PR TITLE
Re-enable --no-remote-name

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -312,7 +312,7 @@ static const struct LongShort aliases[]= {
   {"N",  "buffer",                   ARG_BOOL},
          /* 'buffer' listed as --no-buffer in the help */
   {"o",  "output",                   ARG_FILENAME},
-  {"O",  "remote-name",              ARG_NONE},
+  {"O",  "remote-name",              ARG_BOOL},
   {"Oa", "remote-name-all",          ARG_BOOL},
   {"Ob", "output-dir",               ARG_STRING},
   {"Oc", "clobber",                  ARG_BOOL},


### PR DESCRIPTION
The docs for `--remote-name-all` say

> you must use "-o -" or --no-remote-name.

but with curl 7.83 on macOS I get

```
$ curl --no-remote-name
curl: option --no-remote-name: used '--no-' for option that isn't a boolean
curl: try 'curl --help' or 'curl --manual' for more information
```

So either the option should be put back (it was incorrectly marked as `ARG_NONE` instead of `ARG_BOOL`) or the docs should be updated.