### PR TITLE
CURLINFO_CAINFO/PATH.3: clarify the multiple TLS situation

### DIFF
--- a/docs/libcurl/opts/CURLINFO_CAINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.3
@@ -34,6 +34,10 @@ Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the default built-in path used for the \fICURLOPT_CAINFO(3)\fP
 option unless set by the user.
 
+Note that in a situation where libcurl has been built to support multiple TLS
+libraries, this option might return a string even if the specific TLS library
+currently set to be used does not support \fICURLOPT_CAINFO(3)\fP.
+
 This is a path identifying a single file containing CA certificates.
 
 The \fBpath\fP pointer will be NULL if there is no default path.

--- a/docs/libcurl/opts/CURLINFO_CAPATH.3
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.3
@@ -34,6 +34,10 @@ Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the default built-in path used for the \fICURLOPT_CAPATH(3)\fP
 option unless set by the user.
 
+Note that in a situation where libcurl has been built to support multiple TLS
+libraries, this option might return a string even if the specific TLS library
+currently set to be used does not support \fICURLOPT_CAPATH(3)\fP.
+
 This is a path identifying a directory.
 
 The \fBpath\fP pointer will be NULL if there is no default path.


### PR DESCRIPTION
Spell out the multi-TLS situation.

Fixes #8926
Reported-by: Dan Fandrich