### PR TITLE
tests/data/test1940: use binary mode for expected stdout

### DIFF
--- a/tests/data/test1940
+++ b/tests/data/test1940
@@ -47,7 +47,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 
 # Verify data after the test has been "shot"
 <verify>
-<stdout mode="text">
+<stdout>
  Date == Thu, 09 Nov 2010 14:49:00 GMT
  Server == test with trailing space
  Content-Type == text/html


### PR DESCRIPTION
The generated stdout data is written in binary mode with [LF]
line endings, therefore we also need to do a binary comparison.

Assisted-by: Jay Satiro
Assisted-by: Daniel Stenberg

Follow up to c9b60f005358a364cbcddbebd8d12593acffdd84
Fixes #8920