### PR TITLE
netrc: support quoted strings

### DIFF
--- a/docs/libcurl/opts/CURLOPT_NETRC.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC.3
@@ -60,6 +60,39 @@ present in the URL is ignored.  The file will be scanned for the host and user
 name (to find the password only) or for the host only, to find the first user
 name and password after that \fImachine\fP, which ever information is not
 specified.
+.SH FILE FORMAT
+The \fB.netrc\fP file format is simple: you specify lines with a machine name
+and follow the login and password that are associated with that machine.
+
+Each field is provided as a sequence of letters that ends with a space or
+newline. Starting in 7.84.0, libcurl also supports quoted strings. They start
+and end with double quotes and support the escaped special letters \\\", \\n,
+\\r, and \\t. Quoted strings are the only way a space character can be used in
+a user namd or password.
+
+.IP "machine <name>"
+Provides credentials for a host called \fBname\fP. libcurl searches the .netrc
+file for a machine token that matches the host name specified in the URL. Once
+a match is made, the subsequent tokens are processed, stopping when the end of
+file is reached or another "machine" is encountered.
+.IP default
+This is the same as "machine" name except that default matches any name. There
+can be only one default token, and it must be after all machine tokens. To
+provide a default anonymous login for hosts that are not otherwise matched,
+add a line similar to this in the end:
+
+ default login anonymous password user@domain
+.IP "login <name>"
+The user name string for the remote machine.
+.IP "password <secret>"
+Supply a password. If this token is present, curl will supply the specified
+string if the remote server requires a password as part of the login process.
+Note that if this token is present in the .netrc file you really should make
+sure the file is not readable by anyone besides the user.
+.IP "macdef <name>"
+Define a macro. This feature is not supported by libcurl. In order for the
+rest of the .netrc to still work fine, libcurl will properly skip every
+definition done with "macdef" that it finds.
 .SH DEFAULT
 CURL_NETRC_IGNORED
 .SH PROTOCOLS

--- a/lib/url.c
+++ b/lib/url.c
@@ -3011,7 +3011,8 @@ static CURLcode override_login(struct Curl_easy *data,
             conn->host.name, data->set.str[STRING_NETRC_FILE]);
     }
     else if(ret < 0) {
-      return CURLE_OUT_OF_MEMORY;
+      failf(data, ".netrc parser error");
+      return CURLE_READ_ERROR;
     }
     else {
       /* set bits.netrc TRUE to remember that we got the name from a .netrc

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -95,6 +95,7 @@ test643         test645 test646 test647 test648 test649 test650 test651 \
 test652 test653 test654 test655 test656 test658 test659 test660 test661 \
 test662 test663 test664 test665 test666 test667 test668 test669 \
 test670 test671 test672 test673 test674 test675 test676 test677 test678 \
+test679 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -95,7 +95,7 @@ test643         test645 test646 test647 test648 test649 test650 test651 \
 test652 test653 test654 test655 test656 test658 test659 test660 test661 \
 test662 test663 test664 test665 test666 test667 test668 test669 \
 test670 test671 test672 test673 test674 test675 test676 test677 test678 \
-test679 \
+test679 test680 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test679
+++ b/tests/data/test679
@@ -1,0 +1,56 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+netrc
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+netrc with quoted password
+ </name>
+ <command>
+--netrc-optional --netrc-file log/netrc%TESTNUMBER http://%HOSTIP:%HTTPPORT/
+</command>
+<file name="log/netrc%TESTNUMBER" >
+machine %HOSTIP login user1 password "with spaces and \"\n\r\t\a"
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET / HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6d2l0aCBzcGFjZXMgYW5kICIKDQlh
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test680
+++ b/tests/data/test680
@@ -1,0 +1,37 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+netrc
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+ <name>
+netrc with quoted password but missing end quote
+ </name>
+ <command>
+--netrc --netrc-file log/netrc%TESTNUMBER http://user1@http.example/
+</command>
+<file name="log/netrc%TESTNUMBER" >
+machine %HOSTIP login user1 password "with spaces and \"\n\r\t\a
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+26
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
The .netrc parser now accepts strings within double-quotes in order to
deal with for example passwords containing white space - which
previously was not possible.

A password that starts with a double-quote also ends with one, and
double-quotes themselves are escaped with backslashes, like `\"`. It also
supports \n, \r and \t for newline, carriage return and tabs
respectively.

If the password does not start with a double quote, it will end at first
white space and no escaping is performed.

**WARNING**: this change is not entirely backwards compatible. If anyone
previously used a double-quote as the first letter of their password,
the parser will now get it differently compared to before. This is
highly unfortunate but hard to avoid.
