### PR TITLE
headers_push: error out if a folded header has no previous header

### DIFF
--- a/lib/headers.c
+++ b/lib/headers.c
@@ -293,9 +293,14 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
   }
   hlen = end - header + 1;
 
-  if((header[0] == ' ') || (header[0] == '\t'))
-    /* line folding, append value to the previous header's value */
-    return unfold_value(data, header, hlen);
+  if((header[0] == ' ') || (header[0] == '\t')) {
+    if(data->state.prevhead)
+      /* line folding, append value to the previous header's value */
+      return unfold_value(data, header, hlen);
+    else
+      /* can't unfold without a previous header */
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+  }
 
   hs = calloc(1, sizeof(*hs) + hlen);
   if(!hs)


### PR DESCRIPTION
As that would indicate an illegal header. The fuzzer reached the assert
in unfold_value() proving that this case can happen.