### PR TITLE
headers: handle unfold of space-cleansed headers

### DIFF
--- a/lib/headers.c
+++ b/lib/headers.c
@@ -227,8 +227,8 @@ static CURLcode unfold_value(struct Curl_easy *data, const char *value,
   DEBUGASSERT(data->state.prevhead);
   hs = data->state.prevhead;
   olen = strlen(hs->value);
-  oalloc = olen + strlen(hs->name) + 1;
   offset = hs->value - hs->buffer;
+  oalloc = olen + offset + 1;
 
   /* skip all trailing space letters */
   while(vlen && ISSPACE(value[vlen - 1]))

--- a/tests/data/test1274
+++ b/tests/data/test1274
@@ -19,7 +19,8 @@ Server: test-server/
 Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
 ETag: "21025-dc7-39462498"
 Content-Length: 6
-Connection: close
+Connection:                                              
+   close
 
 -foo-
 </data>
@@ -58,7 +59,8 @@ Server: test-server/
 Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
 ETag: "21025-dc7-39462498"
 Content-Length: 6
-Connection: close
+Connection:                                              
+   close
 
 </file>
 </verify>


### PR DESCRIPTION
Detected by OSS-fuzz

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47767

Updated test 1274