### PR TITLE
http2: avoid degenerative upload behavior

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1818,7 +1818,9 @@ static CURLcode smtp_parse_address(struct Curl_easy *data, const char *fqma,
   return result;
 }
 
-CURLcode Curl_smtp_escape_eob(struct Curl_easy *data, const ssize_t nread)
+CURLcode Curl_smtp_escape_eob(struct Curl_easy *data,
+                              const ssize_t nread,
+                              const ssize_t offset)
 {
   /* When sending a SMTP payload we must detect CRLF. sequences making sure
      they are sent as CRLF.. instead, as a . on the beginning of a line will
@@ -1852,7 +1854,9 @@ CURLcode Curl_smtp_escape_eob(struct Curl_easy *data, const ssize_t nread)
 
   /* This loop can be improved by some kind of Boyer-Moore style of
      approach but that is saved for later... */
-  for(i = 0, si = 0; i < nread; i++) {
+  if(offset)
+    memcpy(scratch, data->req.upload_fromhere, offset);
+  for(i = offset, si = offset; i < nread; i++) {
     if(SMTP_EOB[smtp->eob] == data->req.upload_fromhere[i]) {
       smtp->eob++;
 

--- a/lib/smtp.h
+++ b/lib/smtp.h
@@ -91,6 +91,8 @@ extern const struct Curl_handler Curl_handler_smtps;
 #define SMTP_EOB_REPL "\x0d\x0a\x2e\x2e"
 #define SMTP_EOB_REPL_LEN 4
 
-CURLcode Curl_smtp_escape_eob(struct Curl_easy *data, const ssize_t nread);
+CURLcode Curl_smtp_escape_eob(struct Curl_easy *data,
+                              const ssize_t nread,
+                              const ssize_t offset);
 
 #endif /* HEADER_CURL_SMTP_H */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -897,6 +897,9 @@ static void win_update_buffer_size(curl_socket_t sockfd)
 #define win_update_buffer_size(x)
 #endif
 
+#define curl_upload_refill_watermark(data) \
+        ((ssize_t)((data)->set.upload_buffer_size >> 5))
+
 /*
  * Send data to upload to the server, when the socket is writable.
  */
@@ -918,13 +921,25 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
 
   do {
     curl_off_t nbody;
+    ssize_t offset = 0;
+
+    if(0 != k->upload_present &&
+       k->upload_present < curl_upload_refill_watermark(data) &&
+       !k->upload_chunky &&/*(variable sized chunked header; append not safe)*/
+       !k->upload_done &&  /*!(k->upload_done once k->upload_present sent)*/
+       !(k->writebytecount + k->upload_present - k->pendingheader ==
+         data->state.infilesize)) {
+      offset = k->upload_present;
+    }
 
     /* only read more data if there's no upload data already
-       present in the upload buffer */
-    if(0 == k->upload_present) {
+       present in the upload buffer, or if appending to upload buffer */
+    if(0 == k->upload_present || offset) {
       result = Curl_get_upload_buffer(data);
       if(result)
         return result;
+      if(offset && k->upload_fromhere != data->state.ulbuf)
+        memmove(data->state.ulbuf, k->upload_fromhere, offset);
       /* init the "upload from here" pointer */
       k->upload_fromhere = data->state.ulbuf;
 
@@ -957,12 +972,14 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
             sending_http_headers = FALSE;
         }
 
-        result = Curl_fillreadbuffer(data, data->set.upload_buffer_size,
+        k->upload_fromhere += offset;
+        result = Curl_fillreadbuffer(data, data->set.upload_buffer_size-offset,
                                      &fillcount);
+        k->upload_fromhere -= offset;
         if(result)
           return result;
 
-        nread = fillcount;
+        nread = offset + fillcount;
       }
       else
         nread = 0; /* we're done uploading/reading */
@@ -1004,7 +1021,9 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
          * That means the hex values for ASCII CR (0x0d) & LF (0x0a)
          * must be used instead of the escape sequences \r & \n.
          */
-        for(i = 0, si = 0; i < nread; i++, si++) {
+        if(offset)
+          memcpy(data->state.scratch, k->upload_fromhere, offset);
+        for(i = offset, si = offset; i < nread; i++, si++) {
           if(k->upload_fromhere[i] == 0x0a) {
             data->state.scratch[si++] = 0x0d;
             data->state.scratch[si] = 0x0a;
@@ -1034,12 +1053,12 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_SMTP
       if(conn->handler->protocol & PROTO_FAMILY_SMTP) {
-        result = Curl_smtp_escape_eob(data, nread);
+        result = Curl_smtp_escape_eob(data, nread, offset);
         if(result)
           return result;
       }
 #endif /* CURL_DISABLE_SMTP */
-    } /* if 0 == k->upload_present */
+    } /* if 0 == k->upload_present or appended to upload buffer */
     else {
       /* We have a partial buffer left from a previous "round". Use
          that instead of reading more data */


### PR DESCRIPTION
http2: avoid degenerative upload behavior

avoid degenerative upload behavior which might cause curl to send
mostly 1-byte DATA frames after exhausing the h2 send window size

related discussion: https://github.com/nghttp2/nghttp2/issues/1722

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

Description
---------------
curl degenerative behavior possible when HTTP/2 window size exhausted

curl using libnghttp2 to upload a file over HTTP/2 may in some scenarios end up sending h2 DATA frames with 1-byte each for most of the DATA frames, leading to very high CPU utilization and extremely slow uploads:

A fast client machine will quickly exhaust the h2 send window (default SETTINGS_INITIAL_WINDOW_SIZE 65535 (64k-1)) by sending large DATA frames (default SETTINGS_MAX_FRAME_SIZE 16384 (16k)) in a sequence of size: (16384, 16384, 16384, 16383).

As a server receives h2 DATA frames, a server will typically send h2 WINDOW_UPDATE with exactly the number of bytes received in h2 DATA frame in order to replenish the client send window size.

A fast client machine will quickly send the next block of data immediately upon receiving h2 WINDOW_UPDATE frame from server, once again exhausing the h2 send window.

Now, if the client uploading a large file always fills the window size, then h2 WINDOW_UPDATE frames from the server will also typically be large.

Unfortunately, if the fast client chooses not to fill the window size, then a smaller DATA frame is injected into the sequence, e.g. if the client uses a 64k buffer, the fast client may send DATA frames in a sequence of sizes: (16384, 16384, 16384, 16383, 1) before reusing the 64k buffer to read the next 64k block to be sent.

This can -- and, in practice, does (!) -- lead to severe degenerative behavior, e.g. one person reported a 200 MB upload which took 1-2 mins with HTTP/1.1 now took about 30 mins with HTTP/2.  https://redmine.lighttpd.net/issues/3089

The fast client continues injecting an additional 1-byte DATA frame every 64k eventually leading to almost every frame being a 1-byte DATA frame!
```
  --> (16384, 16384, 16384, 16383)
  --> (1, 16383, 16384, 16384, 16383, 1)
  --> (1, 1, 16382, 16384, 16384, 16383, 1)
  --> (1, 1, 1, 16381, 16384, 16384, 16383, 1)
  --> (1, 1, 1, 1, 16380, 16384, 16384, 16383, 1)
  --> (1, 1, 1, 1, 1, 16379, 16384, 16384, 16383, 1)
  ...
```

```
Consider the initial send from the fast client to fill the 65535 window size:
  --> (16384, 16384, 16384, 16383)
Now, when the client receives the first WINDOW_UPDATE from the server
              <-- (16384)
the fast client sends 1 byte to finish the client 64k block, and then
continues with the next 64k block.  Since the window size was 16384:
  --> (1, 16383)
The server continues sending WINDOW_UPDATE for previously sent frames
              <-- (16384)
and the client immediately sends more data
  --> (16384)
continuing
              <-- (16384)
  --> (16384)
              <-- (16383)
  --> (16383)
              <-- (1)
  --> (1)
The client still has 1 byte left to send in its 64k block and so injects
another 1-byte DATA frame upon receiving the next WINDOW_UPDATE from server
before the client starts its next 64k block, this time sending only 16382.
              <-- (16383)
  --> (1, 16382)
```

I believe there is a design flaw in the defaults chosen in RFC 7540 that SETTINGS_INITIAL_WINDOW_SIZE 65535 (64k-1) is not a multiple of SETTINGS_MAX_FRAME_SIZE 16384 (16k).  It should have been a clean multiple.

I think that client and servers would do well to unconditionally send SETTINGS_INITIAL_WINDOW_SIZE 65536 in the HTTP/2 connection preface, and to pre-emptively increase session window size by sending WINDOW_UPDATE with +1 for id 0.

Design choices aside, I have traced this issue reported here to curl's behavior in `lib/transfer.c:readwrite_upload()`.  curl completely empties the buffer before refilling it (`if(0 == k->upload_present)`) rather than having a low watermark after which the bytes at the end of the buffer are shifted to the beginning, and more data is appended to the buffer.  If the low watermark were, say, 64 bytes -- or even in this case 1-byte -- then curl on a fast client machine would be able to continually fill the available h2 send window instead of the current behavior in which curl injects a 1-byte DATA frame at the end of sending each 64k buffer.

Modifying `lib/transfer.c:readwrite_upload()` to support appending is a larger bit of work, but I might work on that if you might accept such a patch.

In the meantime, this PR implements a simple mitigation to drastically reduce the impact of the degenerative scenario described above.