### PR TITLE
CURLOPT_RANGE.3: remove ranged upload advice

### DIFF
--- a/docs/libcurl/opts/CURLOPT_RANGE.3
+++ b/docs/libcurl/opts/CURLOPT_RANGE.3
@@ -46,12 +46,7 @@ RTSP, byte ranges are \fBnot\fP permitted. Instead, ranges should be given in
 npt, utc, or smpte formats.
 
 For HTTP PUT uploads this option should not be used, since it may conflict with
-other options. If you need to upload arbitrary parts of a file (like for
-Amazon's web services) support is limited. We suggest set resume position using
-\fICURLOPT_RESUME_FROM(3)\fP, set end (resume+size) position using
-\fICURLOPT_INFILESIZE(3)\fP and seek to the resume position before initiating
-the transfer for each part. For more information refer to
-https://curl.se/mail/lib-2019-05/0012.html
+other options.
 
 Pass a NULL to this option to disable the use of ranges.
 


### PR DESCRIPTION
The e-mail link in the advice contains instructions that are prone to
error. We need an example that works and can demonstrate how to properly
perform a ranged upload, and then we can refer to that example instead.

Bug: https://github.com/curl/curl/issues/8969
Reported-by: Simon Berger

Closes #xxxx