### PR TITLE
test3026: add missing control file

### DIFF
--- a/tests/data/test3026
+++ b/tests/data/test3026
@@ -1,0 +1,44 @@
+<testcase>
+<info>
+<keywords>
+curl_global_init
+thread-safe
+slow
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+# require the threaded resolver only because it means pthreads might
+# be used for it
+<features>
+threaded-resolver
+</features>
+<server>
+none
+</server>
+<name>
+curl_global_init thread-safety
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+<command>
+none
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Follow-up from 2ed101256414ea5

Makes the test run, makes 'make dist' work

This single test takes 24-25 seconds on my machine. I think it's too
slow to have it run unconditionally among the test... For this reason I
tag it with a "slow" keyword.