### PR TITLE
runtests: fix skipping tests not done event-based

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -4141,16 +4141,17 @@ sub singletest {
         $DBGCURL=$CMDLINE;
     }
 
+    if($fail_due_event_based) {
+        logmsg "This test cannot run event based\n";
+        timestampskippedevents($testnum);
+        return -1;
+    }
+
     if($gdbthis) {
         # gdb is incompatible with valgrind, so disable it when debugging
         # Perhaps a better approach would be to run it under valgrind anyway
         # with --db-attach=yes or --vgdb=yes.
         $disablevalgrind=1;
-    }
-
-    if($fail_due_event_based) {
-        logmsg "This test cannot run event based\n";
-        return -1;
     }
 
     my @stdintest = getpart("client", "stdin");


### PR DESCRIPTION
... and call timestampskippedevents() to avoid the flood of
uninitialized variable warnings.