### PR TITLE
imap: Fallback to the LOGIN command when the AUTHENTICATE command fails

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -21,7 +21,7 @@
  * RFC2195 CRAM-MD5 authentication
  * RFC2595 Using TLS with IMAP, POP3 and ACAP
  * RFC2831 DIGEST-MD5 authentication
- * RFC3501 IMAPv4 protocol
+ * RFC3501 Internet Message Access Protocol - Version 4rev1
  * RFC4422 Simple Authentication and Security Layer (SASL)
  * RFC4616 PLAIN authentication
  * RFC4752 The Kerberos V5 ("GSSAPI") SASL Mechanism
@@ -29,6 +29,7 @@
  * RFC5092 IMAP URL Scheme
  * RFC6749 OAuth 2.0 Authorization Framework
  * RFC8314 Use of TLS for Email Submission and Access
+ * RFC9051 Internet Message Access Protocol (IMAP) - Version 4rev2
  * Draft   LOGIN SASL Mechanism <draft-murchison-sasl-login-00.txt>
  *
  ***************************************************************************/
@@ -1025,6 +1026,9 @@ static CURLcode imap_state_auth_resp(struct Curl_easy *data,
     default:
       break;
     }
+  else if((!imapc->login_disabled) && (imapc->preftype & IMAP_TYPE_CLEARTEXT))
+    /* Perform clear text authentication on failure as per RFC-9051 */
+    result = imap_perform_login(data, conn);
 
   return result;
 }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -112,6 +112,7 @@ test863 test864 test865 test866 test867 test868 test869 test870 test871 \
 test872 test873 test874 test875 test876 test877 test878 test879 test880 \
 test881 test882 test883 test884 test885 test886 test887 test888 test889 \
 test890 test891 test892 test893 test894 test895 test896 test897 test898 \
+test899 \
 \
 test900 test901 test902 test903 test904 test905 test906 test907 test908 \
 test909 test910 test911 test912 test913 test914 test915 test916 test917 \

--- a/tests/data/test899
+++ b/tests/data/test899
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+SASL
+SASL AUTH PLAIN
+SASL-IR
+RFC4616
+RFC9051
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<servercmd>
+AUTH PLAIN
+CAPA SASL-IR
+REPLY AUTHENTICATE A002 NO AUTHENTICATE failed
+REPLY LOGIN A003 OK LOGIN completed
+</servercmd>
+<data>
+From: me@somewhere
+To: fake@nowhere
+
+body
+
+--
+  yours sincerely
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP plain authentication with fallback to clear text
+ </name>
+ <command>
+'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=1' -u user:secret
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+A001 CAPABILITY
+A002 AUTHENTICATE PLAIN AHVzZXIAc2VjcmV0
+A003 LOGIN user secret
+A004 SELECT %TESTNUMBER
+A005 FETCH 1 BODY[]
+A006 LOGOUT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
As per section 6.2.3 of RFC-9051 allow the fallback to a clear text
LOGIN when a SASL based AUTHENTICATE fails.