### PR TITLE
ngtcp2: fix typo in preprocessor condition

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -728,7 +728,7 @@ CURLcode Curl_quic_connect(struct Curl_easy *data,
 
   ngtcp2_connection_close_error_default(&qs->last_error);
 
-#if defined(__linux__) && defined(UDP_SEGMENT) & defined(HAVE_SENDMSG)
+#if defined(__linux__) && defined(UDP_SEGMENT) && defined(HAVE_SENDMSG)
   qs->no_gso = FALSE;
 #else
   qs->no_gso = TRUE;


### PR DESCRIPTION
Ref: https://github.com/curl/curl/pull/8981#discussion_r894312185
Ref: 927ede7edcb7b05b8e8bbf9ced6aed523ae594a7

Reported-By: Emil Engler
Closes #xxxx

/cc @tatsuhiro-t @emilengler 
