### PR TITLE
rtmp: deprecate "wrong" RTMP protocol defines

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1028,17 +1028,23 @@ typedef CURLSTScode (*curl_hstswrite_callback)(CURL *easy,
 #define CURLPROTO_SMTPS  (1<<17)
 #define CURLPROTO_RTSP   (1<<18)
 #define CURLPROTO_RTMP   (1<<19)
-#define CURLPROTO_RTMPT  (1<<20)
-#define CURLPROTO_RTMPE  (1<<21)
-#define CURLPROTO_RTMPTE (1<<22)
+  /* 1<<20 */
+  /* 1<<21 */
+  /* 1<<22 */
 #define CURLPROTO_RTMPS  (1<<23)
-#define CURLPROTO_RTMPTS (1<<24)
+  /* 1<<24 */
 #define CURLPROTO_GOPHER (1<<25)
 #define CURLPROTO_SMB    (1<<26)
 #define CURLPROTO_SMBS   (1<<27)
 #define CURLPROTO_MQTT   (1<<28)
 #define CURLPROTO_GOPHERS (1<<29)
 #define CURLPROTO_ALL    (~0) /* enable everything */
+
+/* Deprecated aliases, do not use: */
+#define CURLPROTO_RTMPT  (1<<19)
+#define CURLPROTO_RTMPE  (1<<19)
+#define CURLPROTO_RTMPTE (1<<19)
+#define CURLPROTO_RTMPTS (1<<23)
 
 /* long may be 32 or 64 bits, but we should never depend on anything else
    but 32 */

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -5,7 +5,7 @@
  *                | (__| |_| |  _ <| |___
  *                 \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2021, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
  * Copyright (C) 2010, Howard Chu, <hyc@highlandsun.com>
  *
  * This software is licensed as described in the file COPYING, which
@@ -104,8 +104,8 @@ const struct Curl_handler Curl_handler_rtmpt = {
   ZERO_NULL,                            /* connection_check */
   ZERO_NULL,                            /* attach connection */
   PORT_RTMPT,                           /* defport */
-  CURLPROTO_RTMPT,                      /* protocol */
-  CURLPROTO_RTMPT,                      /* family */
+  CURLPROTO_RTMP,                       /* protocol */
+  CURLPROTO_RTMP,                       /* family */
   PROTOPT_NONE                          /* flags*/
 };
 
@@ -127,8 +127,8 @@ const struct Curl_handler Curl_handler_rtmpe = {
   ZERO_NULL,                            /* connection_check */
   ZERO_NULL,                            /* attach connection */
   PORT_RTMP,                            /* defport */
-  CURLPROTO_RTMPE,                      /* protocol */
-  CURLPROTO_RTMPE,                      /* family */
+  CURLPROTO_RTMP,                       /* protocol */
+  CURLPROTO_RTMP,                       /* family */
   PROTOPT_NONE                          /* flags*/
 };
 
@@ -150,8 +150,8 @@ const struct Curl_handler Curl_handler_rtmpte = {
   ZERO_NULL,                            /* connection_check */
   ZERO_NULL,                            /* attach connection */
   PORT_RTMPT,                           /* defport */
-  CURLPROTO_RTMPTE,                     /* protocol */
-  CURLPROTO_RTMPTE,                     /* family */
+  CURLPROTO_RTMP,                       /* protocol */
+  CURLPROTO_RTMP,                       /* family */
   PROTOPT_NONE                          /* flags*/
 };
 
@@ -196,8 +196,8 @@ const struct Curl_handler Curl_handler_rtmpts = {
   ZERO_NULL,                            /* connection_check */
   ZERO_NULL,                            /* attach connection */
   PORT_RTMPS,                           /* defport */
-  CURLPROTO_RTMPTS,                     /* protocol */
-  CURLPROTO_RTMPT,                      /* family */
+  CURLPROTO_RTMPS,                      /* protocol */
+  CURLPROTO_RTMP,                       /* family */
   PROTOPT_NONE                          /* flags*/
 };
 


### PR DESCRIPTION
The 32 bit protocol bitmask is getting full so adding new protocols
become complicated when they no longer fit.

There are 4 defines that were wrongly added to the set back in 2010 that
we now change and move out to make room for a few more protocols until
we hit the ceiling for real. I say wrongly, because they are not
separate enough protocols to warrant their own protocol bits like
this. They are:

 CURLPROTO_RTMPT
 CURLPROTO_RTMPE
 CURLPROTO_RTMPTE
 CURLPROTO_RTMPTS

Leaving CURLPROTO_RTMP and CURLPROTO_RTMPS as-is.

RTMP is extremely rarely used by curl users (1.5% use RTMP, 1.7% RTMPS),
and there's likely much fewer users who ever used one of these modified
defines.

Modifying these defines is less than ideal and involves a certain risk
to cause issues for users who are actually using them individually.