### PR TITLE
projects: Fix the third-party SSL library build paths for Visual Studio

### DIFF
--- a/projects/build-openssl.bat
+++ b/projects/build-openssl.bat
@@ -73,7 +73,7 @@ rem ***************************************************************************
       set "VC_PATH=Microsoft Visual Studio 14.0\VC"
     ) else if /i "%~1" == "vc14.1" (
       set VC_VER=14.1
-      set VC_DESC=VC14.1
+      set VC_DESC=VC14.10
 
       rem Determine the VC14.1 path based on the installed edition in descending
       rem order (Enterprise, then Professional and finally Community)
@@ -86,7 +86,7 @@ rem ***************************************************************************
       )
     ) else if /i "%~1" == "vc14.2" (
       set VC_VER=14.2
-      set VC_DESC=VC14.2
+      set VC_DESC=VC14.20
 
       rem Determine the VC14.2 path based on the installed edition in descending
       rem order (Enterprise, then Professional and finally Community)
@@ -99,7 +99,7 @@ rem ***************************************************************************
       )
     ) else if /i "%~1" == "vc14.3" (
       set VC_VER=14.3
-      set VC_DESC=VC14.3
+      set VC_DESC=VC14.30
 
       rem Determine the VC14.3 path based on the installed edition in descending
       rem order (Enterprise, then Professional and finally Community)

--- a/projects/build-wolfssl.bat
+++ b/projects/build-wolfssl.bat
@@ -76,7 +76,7 @@ rem ***************************************************************************
     set "VC_PATH=Microsoft Visual Studio 14.0\VC"
   ) else if /i "%~1" == "vc14.1" (
     set VC_VER=14.1
-    set VC_DESC=VC14.1
+    set VC_DESC=VC14.10
     set VC_TOOLSET=v141
 
     rem Determine the VC14.1 path based on the installed edition in descending
@@ -90,7 +90,7 @@ rem ***************************************************************************
     )
   ) else if /i "%~1" == "vc14.2" (
     set VC_VER=14.2
-    set VC_DESC=VC14.2
+    set VC_DESC=VC14.20
     set VC_TOOLSET=v142
 
     rem Determine the VC14.2 path based on the installed edition in descending
@@ -104,7 +104,7 @@ rem ***************************************************************************
     )
   ) else if /i "%~1" == "vc14.3" (
     set VC_VER=14.3
-    set VC_DESC=VC14.3
+    set VC_DESC=VC14.30
     set VC_TOOLSET=v143
 
     rem Determine the VC14.3 path based on the installed edition in descending


### PR DESCRIPTION
The paths used by the build batch files were inconsistent with those in
the Visual Studio project files - which means the OpenSSL and wolfSSL
builds would fail trying to link.