### PR TITLE
test3026: disable on win32

### DIFF
--- a/tests/data/test3026
+++ b/tests/data/test3026
@@ -19,6 +19,7 @@ slow
 # be used for it
 <features>
 threaded-resolver
+!win32
 </features>
 <server>
 none


### PR DESCRIPTION
... as it's not likely to have working pthreads