### PR TITLE
add missing SPDX-License-Identifier

### DIFF
--- a/docs/libcurl/opts/CURLINFO_CAINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.3
@@ -18,6 +18,8 @@
 .\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 .\" * KIND, either express or implied.
 .\" *
+.\" * SPDX-License-Identifier: curl
+.\" *
 .\" **************************************************************************
 .\"
 .TH CURLINFO_CAINFO 3 "20 May 2022" "libcurl 7.84.0" "curl_easy_getinfo options"

--- a/docs/libcurl/opts/CURLINFO_CAPATH.3
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.3
@@ -18,6 +18,8 @@
 .\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 .\" * KIND, either express or implied.
 .\" *
+.\" * SPDX-License-Identifier: curl
+.\" *
 .\" **************************************************************************
 .\"
 .TH CURLINFO_CAPATH 3 "20 May 2022" "libcurl 7.84.0" "curl_easy_getinfo options"

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.3
@@ -18,6 +18,8 @@
 .\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 .\" * KIND, either express or implied.
 .\" *
+.\" * SPDX-License-Identifier: curl
+.\" *
 .\" **************************************************************************
 .\"
 .TH CURLOPT_SSH_KEYDATA 3 "4 Nov 2021" "libcurl 7.84.0" "curl_easy_setopt options"

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.3
@@ -18,6 +18,8 @@
 .\" * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
 .\" * KIND, either express or implied.
 .\" *
+.\" * SPDX-License-Identifier: curl
+.\" *
 .\" **************************************************************************
 .\"
 .TH CURLOPT_SSH_HOSTKEYFUNCTION 3 "4 Nov 2021" "libcurl 7.84.0" "curl_easy_setopt options"

--- a/scripts/copyright.pl
+++ b/scripts/copyright.pl
@@ -107,6 +107,9 @@ sub scanfile {
                 $found++;
             }
         }
+        if($l =~ /SPDX-License-Identifier:/) {
+            $spdx = 1;
+        }
         # allow within the first 100 lines
         if(++$line > 100) {
             last;
@@ -120,6 +123,7 @@ sub checkfile {
     my ($file) = @_;
     my $fine = 0;
     @copyright=();
+    $spdx = 0;
     my $found = scanfile($file);
 
     if($found < 1) {
@@ -130,6 +134,10 @@ sub checkfile {
         # this means the file couldn't open - it might not exist, consider
         # that fine
         return 1;
+    }
+    if(!$spdx) {
+        print "$file:1: missing SPDX-License-Identifier\n";
+        return 2;
     }
 
     my $commityear = undef;

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -18,6 +18,8 @@
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
  * KIND, either express or implied.
  *
+ * SPDX-License-Identifier: curl
+ *
  ***************************************************************************/
 #include "test.h"
 


### PR DESCRIPTION
@mxmehl can you figure out why the REUSE CI job didn't catch these?