### PR TITLE
copyright: info for/ignore .github/ISSUE_TEMPLATE/bug_report.md

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -90,3 +90,7 @@ License: curl
 Files: README
 Copyright: 1999 - 2021 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
+
+FILES: .github/ISSUE_TEMPLATE/bug_report.md
+Copyright: 2020 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+License: curl

--- a/scripts/copyright.pl
+++ b/scripts/copyright.pl
@@ -81,6 +81,9 @@ my @skiplist=(
     # markdown linkchecker config
     "mlc_config.json",
 
+    # github template file
+    "^.github/ISSUE_TEMPLATE/bug_report.md",
+
     # License texts and REUSE-specific files
     ".reuse/dep5",
     "LICENSES/.*"


### PR DESCRIPTION
Follow-up from 448f7ef9ab2afb7. The adding of the copyright text in that
file broke site functionality.