### PR TITLE
docs/cmdline-opts: add copyright and license identifier to each file

### DIFF
--- a/docs/cmdline-opts/MANPAGE.md
+++ b/docs/cmdline-opts/MANPAGE.md
@@ -1,3 +1,9 @@
+<!--
+  Copyright (C) 2000 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+
+  SPDX-License-Identifier: curl
+-->
+
 # curl man page generator
 
 This is the curl man page generator. It generates a single nroff man page
@@ -29,6 +35,8 @@ Each file has a set of meta-data and a body of text.
     See-also: (space separated list of related options, no dashes)
     Help: (short text for the --help output for this option)
     Example: (example command line, without "curl" and can use `$URL`)
+    c: (copyright line)
+    SPDX-License-Identifier: curl
     --- (end of meta-data)
 
 ### Body

--- a/docs/cmdline-opts/abstract-unix-socket.d
+++ b/docs/cmdline-opts/abstract-unix-socket.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: abstract-unix-socket
 Arg: <path>
 Help: Connect via abstract Unix domain socket

--- a/docs/cmdline-opts/alt-svc.d
+++ b/docs/cmdline-opts/alt-svc.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: alt-svc
 Arg: <file name>
 Protocols: HTTPS

--- a/docs/cmdline-opts/anyauth.d
+++ b/docs/cmdline-opts/anyauth.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: anyauth
 Help: Pick any authentication method
 Protocols: HTTP

--- a/docs/cmdline-opts/append.d
+++ b/docs/cmdline-opts/append.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: a
 Long: append
 Help: Append to target file when uploading

--- a/docs/cmdline-opts/aws-sigv4.d
+++ b/docs/cmdline-opts/aws-sigv4.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: aws-sigv4
 Arg: <provider1[:provider2[:region[:service]]]>
 Help: Use AWS V4 signature authentication

--- a/docs/cmdline-opts/basic.d
+++ b/docs/cmdline-opts/basic.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: basic
 Help: Use HTTP Basic Authentication
 See-also: proxy-basic

--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: cacert
 Arg: <file>
 Help: CA certificate to verify peer against

--- a/docs/cmdline-opts/capath.d
+++ b/docs/cmdline-opts/capath.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: capath
 Arg: <dir>
 Help: CA directory to verify peer against

--- a/docs/cmdline-opts/cert-status.d
+++ b/docs/cmdline-opts/cert-status.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: cert-status
 Protocols: TLS
 Added: 7.41.0

--- a/docs/cmdline-opts/cert-type.d
+++ b/docs/cmdline-opts/cert-type.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: cert-type
 Protocols: TLS
 Arg: <type>

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: E
 Long: cert
 Arg: <certificate[:password]>

--- a/docs/cmdline-opts/ciphers.d
+++ b/docs/cmdline-opts/ciphers.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ciphers
 Arg: <list of ciphers>
 Help: SSL ciphers to use

--- a/docs/cmdline-opts/compressed-ssh.d
+++ b/docs/cmdline-opts/compressed-ssh.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: compressed-ssh
 Help: Enable SSH compression
 Protocols: SCP SFTP

--- a/docs/cmdline-opts/compressed.d
+++ b/docs/cmdline-opts/compressed.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: compressed
 Help: Request compressed response
 Protocols: HTTP

--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: config
 Arg: <file>
 Help: Read config from a file

--- a/docs/cmdline-opts/connect-timeout.d
+++ b/docs/cmdline-opts/connect-timeout.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: connect-timeout
 Arg: <fractional seconds>
 Help: Maximum time allowed for connection

--- a/docs/cmdline-opts/connect-to.d
+++ b/docs/cmdline-opts/connect-to.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: connect-to
 Arg: <HOST1:PORT1:HOST2:PORT2>
 Help: Connect to host

--- a/docs/cmdline-opts/continue-at.d
+++ b/docs/cmdline-opts/continue-at.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: C
 Long: continue-at
 Arg: <offset>

--- a/docs/cmdline-opts/cookie-jar.d
+++ b/docs/cmdline-opts/cookie-jar.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: c
 Long: cookie-jar
 Arg: <filename>

--- a/docs/cmdline-opts/cookie.d
+++ b/docs/cmdline-opts/cookie.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: b
 Long: cookie
 Arg: <data|filename>

--- a/docs/cmdline-opts/create-dirs.d
+++ b/docs/cmdline-opts/create-dirs.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: create-dirs
 Help: Create necessary local directory hierarchy
 Category: curl

--- a/docs/cmdline-opts/create-file-mode.d
+++ b/docs/cmdline-opts/create-file-mode.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: create-file-mode
 Arg: <mode>
 Help: File mode for created files

--- a/docs/cmdline-opts/crlf.d
+++ b/docs/cmdline-opts/crlf.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: crlf
 Help: Convert LF to CRLF in upload
 Protocols: FTP SMTP

--- a/docs/cmdline-opts/crlfile.d
+++ b/docs/cmdline-opts/crlfile.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: crlfile
 Arg: <file>
 Protocols: TLS

--- a/docs/cmdline-opts/curves.d
+++ b/docs/cmdline-opts/curves.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: curves
 Arg: <algorithm list>
 Help: (EC) TLS key exchange algorithm(s) to request

--- a/docs/cmdline-opts/data-ascii.d
+++ b/docs/cmdline-opts/data-ascii.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: data-ascii
 Arg: <data>
 Help: HTTP POST ASCII data

--- a/docs/cmdline-opts/data-binary.d
+++ b/docs/cmdline-opts/data-binary.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: data-binary
 Arg: <data>
 Help: HTTP POST binary data

--- a/docs/cmdline-opts/data-raw.d
+++ b/docs/cmdline-opts/data-raw.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: data-raw
 Arg: <data>
 Protocols: HTTP

--- a/docs/cmdline-opts/data-urlencode.d
+++ b/docs/cmdline-opts/data-urlencode.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: data-urlencode
 Arg: <data>
 Help: HTTP POST data URL encoded

--- a/docs/cmdline-opts/data.d
+++ b/docs/cmdline-opts/data.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: data
 Short: d
 Arg: <data>

--- a/docs/cmdline-opts/delegation.d
+++ b/docs/cmdline-opts/delegation.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: delegation
 Arg: <LEVEL>
 Help: GSS-API delegation permission

--- a/docs/cmdline-opts/digest.d
+++ b/docs/cmdline-opts/digest.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: digest
 Help: Use HTTP Digest Authentication
 Protocols: HTTP

--- a/docs/cmdline-opts/disable-eprt.d
+++ b/docs/cmdline-opts/disable-eprt.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: disable-eprt
 Help: Inhibit using EPRT or LPRT
 Protocols: FTP

--- a/docs/cmdline-opts/disable-epsv.d
+++ b/docs/cmdline-opts/disable-epsv.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: disable-epsv
 Help: Inhibit using EPSV
 Protocols: FTP

--- a/docs/cmdline-opts/disable.d
+++ b/docs/cmdline-opts/disable.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: disable
 Short: q
 Help: Disable .curlrc

--- a/docs/cmdline-opts/disallow-username-in-url.d
+++ b/docs/cmdline-opts/disallow-username-in-url.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: disallow-username-in-url
 Help: Disallow username in URL
 Protocols: HTTP

--- a/docs/cmdline-opts/dns-interface.d
+++ b/docs/cmdline-opts/dns-interface.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: dns-interface
 Arg: <interface>
 Help: Interface to use for DNS requests

--- a/docs/cmdline-opts/dns-ipv4-addr.d
+++ b/docs/cmdline-opts/dns-ipv4-addr.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: dns-ipv4-addr
 Arg: <address>
 Help: IPv4 address to use for DNS requests

--- a/docs/cmdline-opts/dns-ipv6-addr.d
+++ b/docs/cmdline-opts/dns-ipv6-addr.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: dns-ipv6-addr
 Arg: <address>
 Help: IPv6 address to use for DNS requests

--- a/docs/cmdline-opts/dns-servers.d
+++ b/docs/cmdline-opts/dns-servers.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: dns-servers
 Arg: <addresses>
 Help: DNS server addrs to use

--- a/docs/cmdline-opts/doh-cert-status.d
+++ b/docs/cmdline-opts/doh-cert-status.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: doh-cert-status
 Help: Verify the status of the DoH server cert via OCSP-staple
 Added: 7.76.0

--- a/docs/cmdline-opts/doh-insecure.d
+++ b/docs/cmdline-opts/doh-insecure.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: doh-insecure
 Help: Allow insecure DoH server connections
 Added: 7.76.0

--- a/docs/cmdline-opts/doh-url.d
+++ b/docs/cmdline-opts/doh-url.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: doh-url
 Arg: <URL>
 Help: Resolve host names over DoH

--- a/docs/cmdline-opts/dump-header.d
+++ b/docs/cmdline-opts/dump-header.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: dump-header
 Short: D
 Arg: <filename>

--- a/docs/cmdline-opts/egd-file.d
+++ b/docs/cmdline-opts/egd-file.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: egd-file
 Arg: <file>
 Help: EGD socket path for random data

--- a/docs/cmdline-opts/engine.d
+++ b/docs/cmdline-opts/engine.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: engine
 Arg: <name>
 Help: Crypto engine to use

--- a/docs/cmdline-opts/etag-compare.d
+++ b/docs/cmdline-opts/etag-compare.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: etag-compare
 Arg: <file>
 Help: Pass an ETag from a file as a custom header

--- a/docs/cmdline-opts/etag-save.d
+++ b/docs/cmdline-opts/etag-save.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: etag-save
 Arg: <file>
 Help: Parse ETag from a request and save it to a file

--- a/docs/cmdline-opts/expect100-timeout.d
+++ b/docs/cmdline-opts/expect100-timeout.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: expect100-timeout
 Arg: <seconds>
 Help: How long to wait for 100-continue

--- a/docs/cmdline-opts/fail-early.d
+++ b/docs/cmdline-opts/fail-early.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: fail-early
 Help: Fail on first transfer error, do not continue
 Added: 7.52.0

--- a/docs/cmdline-opts/fail-with-body.d
+++ b/docs/cmdline-opts/fail-with-body.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: fail-with-body
 Protocols: HTTP
 Help: Fail on HTTP errors but save the body

--- a/docs/cmdline-opts/fail.d
+++ b/docs/cmdline-opts/fail.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: fail
 Short: f
 Protocols: HTTP

--- a/docs/cmdline-opts/false-start.d
+++ b/docs/cmdline-opts/false-start.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: false-start
 Help: Enable TLS False Start
 Protocols: TLS

--- a/docs/cmdline-opts/form-escape.d
+++ b/docs/cmdline-opts/form-escape.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: form-escape
 Help: Escape multipart form field/file names using backslash
 Protocols: HTTP

--- a/docs/cmdline-opts/form-string.d
+++ b/docs/cmdline-opts/form-string.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: form-string
 Help: Specify multipart MIME data
 Protocols: HTTP SMTP IMAP

--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: form
 Short: F
 Arg: <name=content>

--- a/docs/cmdline-opts/ftp-account.d
+++ b/docs/cmdline-opts/ftp-account.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-account
 Arg: <data>
 Help: Account data string

--- a/docs/cmdline-opts/ftp-alternative-to-user.d
+++ b/docs/cmdline-opts/ftp-alternative-to-user.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-alternative-to-user
 Arg: <command>
 Help: String to replace USER [name]

--- a/docs/cmdline-opts/ftp-create-dirs.d
+++ b/docs/cmdline-opts/ftp-create-dirs.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-create-dirs
 Protocols: FTP SFTP
 Help: Create the remote dirs if not present

--- a/docs/cmdline-opts/ftp-method.d
+++ b/docs/cmdline-opts/ftp-method.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-method
 Arg: <method>
 Help: Control CWD usage

--- a/docs/cmdline-opts/ftp-pasv.d
+++ b/docs/cmdline-opts/ftp-pasv.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-pasv
 Help: Use PASV/EPSV instead of PORT
 Protocols: FTP

--- a/docs/cmdline-opts/ftp-port.d
+++ b/docs/cmdline-opts/ftp-port.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-port
 Arg: <address>
 Help: Use PORT instead of PASV

--- a/docs/cmdline-opts/ftp-pret.d
+++ b/docs/cmdline-opts/ftp-pret.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-pret
 Help: Send PRET before PASV
 Protocols: FTP

--- a/docs/cmdline-opts/ftp-skip-pasv-ip.d
+++ b/docs/cmdline-opts/ftp-skip-pasv-ip.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-skip-pasv-ip
 Help: Skip the IP address for PASV
 Protocols: FTP

--- a/docs/cmdline-opts/ftp-ssl-ccc-mode.d
+++ b/docs/cmdline-opts/ftp-ssl-ccc-mode.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-ssl-ccc-mode
 Arg: <active/passive>
 Help: Set CCC mode

--- a/docs/cmdline-opts/ftp-ssl-ccc.d
+++ b/docs/cmdline-opts/ftp-ssl-ccc.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-ssl-ccc
 Help: Send CCC after authenticating
 Protocols: FTP

--- a/docs/cmdline-opts/ftp-ssl-control.d
+++ b/docs/cmdline-opts/ftp-ssl-control.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ftp-ssl-control
 Help: Require SSL/TLS for FTP login, clear for transfer
 Protocols: FTP

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -197,6 +197,8 @@ sub single {
     my $requires;
     my $category;
     my $seealso;
+    my $copyright;
+    my $spdx;
     my @examples; # there can be more than one
     my $magic; # cmdline special option
     my $line;
@@ -238,6 +240,12 @@ sub single {
         elsif(/^Example: *(.*)/i) {
             push @examples, $1;
         }
+        elsif(/^C: (.*)/i) {
+            $copyright=$1;
+        }
+        elsif(/^SPDX-License-Identifier: (.*)/i) {
+            $spdx=$1;
+        }
         elsif(/^Help: *(.*)/i) {
             ;
         }
@@ -260,6 +268,14 @@ sub single {
             }
             if(!$seealso) {
                 print STDERR "$f:$line:1:ERROR: no 'See-also:' field present\n";
+                return 2;
+            }
+            if(!$copyright) {
+                print STDERR "$f:$line:1:ERROR: no 'C:' field present\n";
+                return 2;
+            }
+            if(!$spdx) {
+                print STDERR "$f:$line:1:ERROR: no 'SPDX-License-Identifier:' field present\n";
                 return 2;
             }
             last;

--- a/docs/cmdline-opts/get.d
+++ b/docs/cmdline-opts/get.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: get
 Short: G
 Help: Put the post data in the URL and use GET

--- a/docs/cmdline-opts/globoff.d
+++ b/docs/cmdline-opts/globoff.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: globoff
 Short: g
 Help: Disable URL sequences and ranges using {} and []

--- a/docs/cmdline-opts/happy-eyeballs-timeout-ms.d
+++ b/docs/cmdline-opts/happy-eyeballs-timeout-ms.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: happy-eyeballs-timeout-ms
 Arg: <milliseconds>
 Help: Time for IPv6 before trying IPv4

--- a/docs/cmdline-opts/haproxy-protocol.d
+++ b/docs/cmdline-opts/haproxy-protocol.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: haproxy-protocol
 Help: Send HAProxy PROXY protocol v1 header
 Protocols: HTTP

--- a/docs/cmdline-opts/head.d
+++ b/docs/cmdline-opts/head.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: head
 Short: I
 Help: Show document info only

--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: header
 Short: H
 Arg: <header/@file>

--- a/docs/cmdline-opts/help.d
+++ b/docs/cmdline-opts/help.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: help
 Arg: <category>
 Short: h

--- a/docs/cmdline-opts/hostpubmd5.d
+++ b/docs/cmdline-opts/hostpubmd5.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: hostpubmd5
 Arg: <md5>
 Help: Acceptable MD5 hash of the host public key

--- a/docs/cmdline-opts/hostpubsha256.d
+++ b/docs/cmdline-opts/hostpubsha256.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: hostpubsha256
 Arg: <sha256>
 Help: Acceptable SHA256 hash of the host public key

--- a/docs/cmdline-opts/hsts.d
+++ b/docs/cmdline-opts/hsts.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: hsts
 Arg: <file name>
 Protocols: HTTPS

--- a/docs/cmdline-opts/http0.9.d
+++ b/docs/cmdline-opts/http0.9.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: http0.9
 Tags: Versions
 Protocols: HTTP

--- a/docs/cmdline-opts/http1.0.d
+++ b/docs/cmdline-opts/http1.0.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: 0
 Long: http1.0
 Tags: Versions

--- a/docs/cmdline-opts/http1.1.d
+++ b/docs/cmdline-opts/http1.1.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: http1.1
 Tags: Versions
 Protocols: HTTP

--- a/docs/cmdline-opts/http2-prior-knowledge.d
+++ b/docs/cmdline-opts/http2-prior-knowledge.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: http2-prior-knowledge
 Tags: Versions
 Protocols: HTTP

--- a/docs/cmdline-opts/http2.d
+++ b/docs/cmdline-opts/http2.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: http2
 Tags: Versions
 Protocols: HTTP

--- a/docs/cmdline-opts/http3.d
+++ b/docs/cmdline-opts/http3.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: http3
 Tags: Versions
 Protocols: HTTP

--- a/docs/cmdline-opts/ignore-content-length.d
+++ b/docs/cmdline-opts/ignore-content-length.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ignore-content-length
 Help: Ignore the size of the remote resource
 Protocols: FTP HTTP

--- a/docs/cmdline-opts/include.d
+++ b/docs/cmdline-opts/include.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: include
 Short: i
 Help: Include protocol response headers in the output

--- a/docs/cmdline-opts/insecure.d
+++ b/docs/cmdline-opts/insecure.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: insecure
 Short: k
 Help: Allow insecure server connections

--- a/docs/cmdline-opts/interface.d
+++ b/docs/cmdline-opts/interface.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: interface
 Arg: <name>
 Help: Use network INTERFACE (or address)

--- a/docs/cmdline-opts/ipv4.d
+++ b/docs/cmdline-opts/ipv4.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: 4
 Long: ipv4
 Tags: Versions

--- a/docs/cmdline-opts/ipv6.d
+++ b/docs/cmdline-opts/ipv6.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: 6
 Long: ipv6
 Tags: Versions

--- a/docs/cmdline-opts/json.d
+++ b/docs/cmdline-opts/json.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: json
 Arg: <data>
 Help: HTTP POST JSON

--- a/docs/cmdline-opts/junk-session-cookies.d
+++ b/docs/cmdline-opts/junk-session-cookies.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: junk-session-cookies
 Short: j
 Help: Ignore session cookies read from file

--- a/docs/cmdline-opts/keepalive-time.d
+++ b/docs/cmdline-opts/keepalive-time.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: keepalive-time
 Arg: <seconds>
 Help: Interval time for keepalive probes

--- a/docs/cmdline-opts/key-type.d
+++ b/docs/cmdline-opts/key-type.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: key-type
 Arg: <type>
 Help: Private key file type (DER/PEM/ENG)

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: key
 Arg: <key>
 Protocols: TLS SSH

--- a/docs/cmdline-opts/krb.d
+++ b/docs/cmdline-opts/krb.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: krb
 Arg: <level>
 Help: Enable Kerberos with security <level>

--- a/docs/cmdline-opts/libcurl.d
+++ b/docs/cmdline-opts/libcurl.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: libcurl
 Arg: <file>
 Help: Dump libcurl equivalent code of this command line

--- a/docs/cmdline-opts/limit-rate.d
+++ b/docs/cmdline-opts/limit-rate.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: limit-rate
 Arg: <speed>
 Help: Limit transfer speed to RATE

--- a/docs/cmdline-opts/list-only.d
+++ b/docs/cmdline-opts/list-only.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: list-only
 Short: l
 Protocols: FTP POP3

--- a/docs/cmdline-opts/local-port.d
+++ b/docs/cmdline-opts/local-port.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: local-port
 Arg: <num/range>
 Help: Force use of RANGE for local port numbers

--- a/docs/cmdline-opts/location-trusted.d
+++ b/docs/cmdline-opts/location-trusted.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: location-trusted
 Help: Like --location, and send auth to other hosts
 Protocols: HTTP

--- a/docs/cmdline-opts/location.d
+++ b/docs/cmdline-opts/location.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: location
 Short: L
 Help: Follow redirects

--- a/docs/cmdline-opts/login-options.d
+++ b/docs/cmdline-opts/login-options.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: login-options
 Arg: <options>
 Protocols: IMAP LDAP POP3 SMTP

--- a/docs/cmdline-opts/mail-auth.d
+++ b/docs/cmdline-opts/mail-auth.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: mail-auth
 Arg: <address>
 Protocols: SMTP

--- a/docs/cmdline-opts/mail-from.d
+++ b/docs/cmdline-opts/mail-from.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: mail-from
 Arg: <address>
 Help: Mail from this address

--- a/docs/cmdline-opts/mail-rcpt-allowfails.d
+++ b/docs/cmdline-opts/mail-rcpt-allowfails.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: mail-rcpt-allowfails
 Help: Allow RCPT TO command to fail for some recipients
 Protocols: SMTP

--- a/docs/cmdline-opts/mail-rcpt.d
+++ b/docs/cmdline-opts/mail-rcpt.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: mail-rcpt
 Arg: <address>
 Help: Mail to this address

--- a/docs/cmdline-opts/manual.d
+++ b/docs/cmdline-opts/manual.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: manual
 Short: M
 Help: Display the full manual

--- a/docs/cmdline-opts/max-filesize.d
+++ b/docs/cmdline-opts/max-filesize.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: max-filesize
 Arg: <bytes>
 Help: Maximum file size to download

--- a/docs/cmdline-opts/max-redirs.d
+++ b/docs/cmdline-opts/max-redirs.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: max-redirs
 Arg: <num>
 Help: Maximum number of redirects allowed

--- a/docs/cmdline-opts/max-time.d
+++ b/docs/cmdline-opts/max-time.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: max-time
 Short: m
 Arg: <fractional seconds>

--- a/docs/cmdline-opts/metalink.d
+++ b/docs/cmdline-opts/metalink.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: metalink
 Help: Process given URLs as metalink XML file
 Added: 7.27.0

--- a/docs/cmdline-opts/negotiate.d
+++ b/docs/cmdline-opts/negotiate.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: negotiate
 Help: Use HTTP Negotiate (SPNEGO) authentication
 Protocols: HTTP

--- a/docs/cmdline-opts/netrc-file.d
+++ b/docs/cmdline-opts/netrc-file.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: netrc-file
 Help: Specify FILE for netrc
 Arg: <filename>

--- a/docs/cmdline-opts/netrc-optional.d
+++ b/docs/cmdline-opts/netrc-optional.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: netrc-optional
 Help: Use either .netrc or URL
 Mutexed: netrc

--- a/docs/cmdline-opts/netrc.d
+++ b/docs/cmdline-opts/netrc.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: netrc
 Short: n
 Help: Must read .netrc for user name and password

--- a/docs/cmdline-opts/next.d
+++ b/docs/cmdline-opts/next.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: :
 Long: next
 Tags:

--- a/docs/cmdline-opts/no-alpn.d
+++ b/docs/cmdline-opts/no-alpn.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-alpn
 Tags: HTTP/2
 Protocols: HTTPS

--- a/docs/cmdline-opts/no-buffer.d
+++ b/docs/cmdline-opts/no-buffer.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-buffer
 Short: N
 Help: Disable buffering of the output stream

--- a/docs/cmdline-opts/no-clobber.d
+++ b/docs/cmdline-opts/no-clobber.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-clobber
 Help: Do not overwrite files that already exist
 Category: curl output

--- a/docs/cmdline-opts/no-keepalive.d
+++ b/docs/cmdline-opts/no-keepalive.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-keepalive
 Help: Disable TCP keepalive on the connection
 Category: connection

--- a/docs/cmdline-opts/no-npn.d
+++ b/docs/cmdline-opts/no-npn.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-npn
 Tags: Versions HTTP/2
 Protocols: HTTPS

--- a/docs/cmdline-opts/no-progress-meter.d
+++ b/docs/cmdline-opts/no-progress-meter.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-progress-meter
 Help: Do not show the progress meter
 See-also: verbose silent

--- a/docs/cmdline-opts/no-sessionid.d
+++ b/docs/cmdline-opts/no-sessionid.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: no-sessionid
 Help: Disable SSL session-ID reusing
 Protocols: TLS

--- a/docs/cmdline-opts/noproxy.d
+++ b/docs/cmdline-opts/noproxy.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: noproxy
 Arg: <no-proxy-list>
 Help: List of hosts which do not use proxy

--- a/docs/cmdline-opts/ntlm-wb.d
+++ b/docs/cmdline-opts/ntlm-wb.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ntlm-wb
 Help: Use HTTP NTLM authentication with winbind
 Protocols: HTTP

--- a/docs/cmdline-opts/ntlm.d
+++ b/docs/cmdline-opts/ntlm.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ntlm
 Help: Use HTTP NTLM authentication
 Mutexed: basic negotiate digest anyauth

--- a/docs/cmdline-opts/oauth2-bearer.d
+++ b/docs/cmdline-opts/oauth2-bearer.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: oauth2-bearer
 Help: OAuth 2 Bearer Token
 Arg: <token>

--- a/docs/cmdline-opts/output-dir.d
+++ b/docs/cmdline-opts/output-dir.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: output-dir
 Arg: <dir>
 Help: Directory to save files in

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: output
 Arg: <file>
 Short: o

--- a/docs/cmdline-opts/parallel-immediate.d
+++ b/docs/cmdline-opts/parallel-immediate.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: parallel-immediate
 Help: Do not wait for multiplexing (with --parallel)
 Added: 7.68.0

--- a/docs/cmdline-opts/parallel-max.d
+++ b/docs/cmdline-opts/parallel-max.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: parallel-max
 Arg: <num>
 Help: Maximum concurrency for parallel transfers

--- a/docs/cmdline-opts/parallel.d
+++ b/docs/cmdline-opts/parallel.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: Z
 Long: parallel
 Help: Perform transfers in parallel

--- a/docs/cmdline-opts/pass.d
+++ b/docs/cmdline-opts/pass.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: pass
 Arg: <phrase>
 Help: Pass phrase for the private key

--- a/docs/cmdline-opts/path-as-is.d
+++ b/docs/cmdline-opts/path-as-is.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: path-as-is
 Help: Do not squash .. sequences in URL path
 Added: 7.42.0

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: pinnedpubkey
 Arg: <hashes>
 Help: FILE/HASHES Public key to verify peer against

--- a/docs/cmdline-opts/post301.d
+++ b/docs/cmdline-opts/post301.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: post301
 Help: Do not switch to GET after following a 301
 Protocols: HTTP

--- a/docs/cmdline-opts/post302.d
+++ b/docs/cmdline-opts/post302.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: post302
 Help: Do not switch to GET after following a 302
 Protocols: HTTP

--- a/docs/cmdline-opts/post303.d
+++ b/docs/cmdline-opts/post303.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: post303
 Help: Do not switch to GET after following a 303
 Protocols: HTTP

--- a/docs/cmdline-opts/preproxy.d
+++ b/docs/cmdline-opts/preproxy.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: preproxy
 Arg: [protocol://]host[:port]
 Help: Use this proxy first

--- a/docs/cmdline-opts/progress-bar.d
+++ b/docs/cmdline-opts/progress-bar.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: #
 Long: progress-bar
 Help: Display transfer progress as a bar

--- a/docs/cmdline-opts/proto-default.d
+++ b/docs/cmdline-opts/proto-default.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proto-default
 Help: Use PROTOCOL for any URL missing a scheme
 Arg: <protocol>

--- a/docs/cmdline-opts/proto-redir.d
+++ b/docs/cmdline-opts/proto-redir.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proto-redir
 Arg: <protocols>
 Help: Enable/disable PROTOCOLS on redirect

--- a/docs/cmdline-opts/proto.d
+++ b/docs/cmdline-opts/proto.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proto
 Arg: <protocols>
 Help: Enable/disable PROTOCOLS

--- a/docs/cmdline-opts/proxy-anyauth.d
+++ b/docs/cmdline-opts/proxy-anyauth.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-anyauth
 Help: Pick any proxy authentication method
 Added: 7.13.2

--- a/docs/cmdline-opts/proxy-basic.d
+++ b/docs/cmdline-opts/proxy-basic.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-basic
 Help: Use Basic authentication on the proxy
 See-also: proxy proxy-anyauth proxy-digest

--- a/docs/cmdline-opts/proxy-cacert.d
+++ b/docs/cmdline-opts/proxy-cacert.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-cacert
 Help: CA certificate to verify peer against for proxy
 Arg: <file>

--- a/docs/cmdline-opts/proxy-capath.d
+++ b/docs/cmdline-opts/proxy-capath.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-capath
 Help: CA directory to verify peer against for proxy
 Arg: <dir>

--- a/docs/cmdline-opts/proxy-cert-type.d
+++ b/docs/cmdline-opts/proxy-cert-type.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-cert-type
 Arg: <type>
 Added: 7.52.0

--- a/docs/cmdline-opts/proxy-cert.d
+++ b/docs/cmdline-opts/proxy-cert.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-cert
 Arg: <cert[:passwd]>
 Help: Set client certificate for proxy

--- a/docs/cmdline-opts/proxy-ciphers.d
+++ b/docs/cmdline-opts/proxy-ciphers.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-ciphers
 Arg: <list>
 Help: SSL ciphers to use for proxy

--- a/docs/cmdline-opts/proxy-crlfile.d
+++ b/docs/cmdline-opts/proxy-crlfile.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-crlfile
 Arg: <file>
 Help: Set a CRL list for proxy

--- a/docs/cmdline-opts/proxy-digest.d
+++ b/docs/cmdline-opts/proxy-digest.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-digest
 Help: Use Digest authentication on the proxy
 See-also: proxy proxy-anyauth proxy-basic

--- a/docs/cmdline-opts/proxy-header.d
+++ b/docs/cmdline-opts/proxy-header.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-header
 Arg: <header/@file>
 Help: Pass custom header(s) to proxy

--- a/docs/cmdline-opts/proxy-insecure.d
+++ b/docs/cmdline-opts/proxy-insecure.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-insecure
 Help: Do HTTPS proxy connections without verifying the proxy
 Added: 7.52.0

--- a/docs/cmdline-opts/proxy-key-type.d
+++ b/docs/cmdline-opts/proxy-key-type.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-key-type
 Arg: <type>
 Help: Private key file type for proxy

--- a/docs/cmdline-opts/proxy-key.d
+++ b/docs/cmdline-opts/proxy-key.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-key
 Help: Private key for HTTPS proxy
 Arg: <key>

--- a/docs/cmdline-opts/proxy-negotiate.d
+++ b/docs/cmdline-opts/proxy-negotiate.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-negotiate
 Help: Use HTTP Negotiate (SPNEGO) authentication on the proxy
 Added: 7.17.1

--- a/docs/cmdline-opts/proxy-ntlm.d
+++ b/docs/cmdline-opts/proxy-ntlm.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-ntlm
 Help: Use NTLM authentication on the proxy
 See-also: proxy-negotiate proxy-anyauth

--- a/docs/cmdline-opts/proxy-pass.d
+++ b/docs/cmdline-opts/proxy-pass.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-pass
 Arg: <phrase>
 Help: Pass phrase for the private key for HTTPS proxy

--- a/docs/cmdline-opts/proxy-pinnedpubkey.d
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-pinnedpubkey
 Arg: <hashes>
 Help: FILE/HASHES public key to verify proxy with

--- a/docs/cmdline-opts/proxy-service-name.d
+++ b/docs/cmdline-opts/proxy-service-name.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-service-name
 Arg: <name>
 Help: SPNEGO proxy service name

--- a/docs/cmdline-opts/proxy-ssl-allow-beast.d
+++ b/docs/cmdline-opts/proxy-ssl-allow-beast.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-ssl-allow-beast
 Help: Allow security flaw for interop for HTTPS proxy
 Added: 7.52.0

--- a/docs/cmdline-opts/proxy-ssl-auto-client-cert.d
+++ b/docs/cmdline-opts/proxy-ssl-auto-client-cert.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-ssl-auto-client-cert
 Help: Use auto client certificate for proxy (Schannel)
 Added: 7.77.0

--- a/docs/cmdline-opts/proxy-tls13-ciphers.d
+++ b/docs/cmdline-opts/proxy-tls13-ciphers.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-tls13-ciphers
 Arg: <ciphersuite list>
 help: TLS 1.3 proxy cipher suites

--- a/docs/cmdline-opts/proxy-tlsauthtype.d
+++ b/docs/cmdline-opts/proxy-tlsauthtype.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-tlsauthtype
 Arg: <type>
 Help: TLS authentication type for HTTPS proxy

--- a/docs/cmdline-opts/proxy-tlspassword.d
+++ b/docs/cmdline-opts/proxy-tlspassword.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-tlspassword
 Arg: <string>
 Help: TLS password for HTTPS proxy

--- a/docs/cmdline-opts/proxy-tlsuser.d
+++ b/docs/cmdline-opts/proxy-tlsuser.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-tlsuser
 Arg: <name>
 Help: TLS username for HTTPS proxy

--- a/docs/cmdline-opts/proxy-tlsv1.d
+++ b/docs/cmdline-opts/proxy-tlsv1.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-tlsv1
 Help: Use TLSv1 for HTTPS proxy
 Added: 7.52.0

--- a/docs/cmdline-opts/proxy-user.d
+++ b/docs/cmdline-opts/proxy-user.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy-user
 Short: U
 Arg: <user:password>

--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy
 Short: x
 Arg: [protocol://]host[:port]

--- a/docs/cmdline-opts/proxy1.0.d
+++ b/docs/cmdline-opts/proxy1.0.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxy1.0
 Arg: <host[:port]>
 Help: Use HTTP/1.0 proxy on given port

--- a/docs/cmdline-opts/proxytunnel.d
+++ b/docs/cmdline-opts/proxytunnel.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: proxytunnel
 Short: p
 Help: Operate through an HTTP proxy tunnel (using CONNECT)

--- a/docs/cmdline-opts/pubkey.d
+++ b/docs/cmdline-opts/pubkey.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: pubkey
 Arg: <key>
 Protocols: SFTP SCP

--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: quote
 Arg: <command>
 Short: Q

--- a/docs/cmdline-opts/random-file.d
+++ b/docs/cmdline-opts/random-file.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: random-file
 Arg: <file>
 Help: File for reading random data from

--- a/docs/cmdline-opts/range.d
+++ b/docs/cmdline-opts/range.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: range
 Short: r
 Help: Retrieve only the bytes within RANGE

--- a/docs/cmdline-opts/rate.d
+++ b/docs/cmdline-opts/rate.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: rate
 Arg: <max request rate>
 Help: Request rate for serial transfers

--- a/docs/cmdline-opts/raw.d
+++ b/docs/cmdline-opts/raw.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: raw
 Help: Do HTTP "raw"; no transfer decoding
 Added: 7.16.2

--- a/docs/cmdline-opts/referer.d
+++ b/docs/cmdline-opts/referer.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: referer
 Short: e
 Arg: <URL>

--- a/docs/cmdline-opts/remote-header-name.d
+++ b/docs/cmdline-opts/remote-header-name.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: remote-header-name
 Short: J
 Protocols: HTTP

--- a/docs/cmdline-opts/remote-name-all.d
+++ b/docs/cmdline-opts/remote-name-all.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: remote-name-all
 Help: Use the remote file name for all URLs
 Added: 7.19.0

--- a/docs/cmdline-opts/remote-name.d
+++ b/docs/cmdline-opts/remote-name.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: remote-name
 Short: O
 Help: Write output to a file named as the remote file

--- a/docs/cmdline-opts/remote-time.d
+++ b/docs/cmdline-opts/remote-time.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: remote-time
 Short: R
 Help: Set the remote file's time on the local output

--- a/docs/cmdline-opts/remove-on-error.d
+++ b/docs/cmdline-opts/remove-on-error.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: remove-on-error
 Help: Remove output file on errors
 See-also: fail

--- a/docs/cmdline-opts/request-target.d
+++ b/docs/cmdline-opts/request-target.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: request-target
 Arg: <path>
 Help: Specify the target for this request

--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: request
 Short: X
 Arg: <method>

--- a/docs/cmdline-opts/resolve.d
+++ b/docs/cmdline-opts/resolve.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: resolve
 Arg: <[+]host:port:addr[,addr]...>
 Help: Resolve the host+port to this address

--- a/docs/cmdline-opts/retry-all-errors.d
+++ b/docs/cmdline-opts/retry-all-errors.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: retry-all-errors
 Help: Retry all errors (use with --retry)
 Added: 7.71.0

--- a/docs/cmdline-opts/retry-connrefused.d
+++ b/docs/cmdline-opts/retry-connrefused.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: retry-connrefused
 Help: Retry on connection refused (use with --retry)
 Added: 7.52.0

--- a/docs/cmdline-opts/retry-delay.d
+++ b/docs/cmdline-opts/retry-delay.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: retry-delay
 Arg: <seconds>
 Help: Wait time between retries

--- a/docs/cmdline-opts/retry-max-time.d
+++ b/docs/cmdline-opts/retry-max-time.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: retry-max-time
 Arg: <seconds>
 Help: Retry only within this period

--- a/docs/cmdline-opts/retry.d
+++ b/docs/cmdline-opts/retry.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: retry
 Arg: <num>
 Added: 7.12.3

--- a/docs/cmdline-opts/sasl-authzid.d
+++ b/docs/cmdline-opts/sasl-authzid.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: sasl-authzid
 Arg: <identity>
 Help: Identity for SASL PLAIN authentication

--- a/docs/cmdline-opts/sasl-ir.d
+++ b/docs/cmdline-opts/sasl-ir.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: sasl-ir
 Help: Enable initial response in SASL authentication
 Added: 7.31.0

--- a/docs/cmdline-opts/service-name.d
+++ b/docs/cmdline-opts/service-name.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: service-name
 Help: SPNEGO service name
 Arg: <name>

--- a/docs/cmdline-opts/show-error.d
+++ b/docs/cmdline-opts/show-error.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: show-error
 Short: S
 Help: Show error even when -s is used

--- a/docs/cmdline-opts/silent.d
+++ b/docs/cmdline-opts/silent.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: silent
 Short: s
 Help: Silent mode

--- a/docs/cmdline-opts/socks4.d
+++ b/docs/cmdline-opts/socks4.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks4
 Arg: <host[:port]>
 Help: SOCKS4 proxy on given host + port

--- a/docs/cmdline-opts/socks4a.d
+++ b/docs/cmdline-opts/socks4a.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks4a
 Arg: <host[:port]>
 Help: SOCKS4a proxy on given host + port

--- a/docs/cmdline-opts/socks5-basic.d
+++ b/docs/cmdline-opts/socks5-basic.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks5-basic
 Help: Enable username/password auth for SOCKS5 proxies
 Added: 7.55.0

--- a/docs/cmdline-opts/socks5-gssapi-nec.d
+++ b/docs/cmdline-opts/socks5-gssapi-nec.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks5-gssapi-nec
 Help: Compatibility with NEC SOCKS5 server
 Added: 7.19.4

--- a/docs/cmdline-opts/socks5-gssapi-service.d
+++ b/docs/cmdline-opts/socks5-gssapi-service.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks5-gssapi-service
 Arg: <name>
 Help: SOCKS5 proxy service name for GSS-API

--- a/docs/cmdline-opts/socks5-gssapi.d
+++ b/docs/cmdline-opts/socks5-gssapi.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks5-gssapi
 Help: Enable GSS-API auth for SOCKS5 proxies
 Added: 7.55.0

--- a/docs/cmdline-opts/socks5-hostname.d
+++ b/docs/cmdline-opts/socks5-hostname.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks5-hostname
 Arg: <host[:port]>
 Help: SOCKS5 proxy, pass host name to proxy

--- a/docs/cmdline-opts/socks5.d
+++ b/docs/cmdline-opts/socks5.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: socks5
 Arg: <host[:port]>
 Help: SOCKS5 proxy on given host + port

--- a/docs/cmdline-opts/speed-limit.d
+++ b/docs/cmdline-opts/speed-limit.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: speed-limit
 Short: Y
 Arg: <speed>

--- a/docs/cmdline-opts/speed-time.d
+++ b/docs/cmdline-opts/speed-time.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: speed-time
 Short: y
 Arg: <seconds>

--- a/docs/cmdline-opts/ssl-allow-beast.d
+++ b/docs/cmdline-opts/ssl-allow-beast.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ssl-allow-beast
 Help: Allow security flaw to improve interop
 Added: 7.25.0

--- a/docs/cmdline-opts/ssl-auto-client-cert.d
+++ b/docs/cmdline-opts/ssl-auto-client-cert.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ssl-auto-client-cert
 Help: Use auto client certificate (Schannel)
 Added: 7.77.0

--- a/docs/cmdline-opts/ssl-no-revoke.d
+++ b/docs/cmdline-opts/ssl-no-revoke.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ssl-no-revoke
 Help: Disable cert revocation checks (Schannel)
 Added: 7.44.0

--- a/docs/cmdline-opts/ssl-reqd.d
+++ b/docs/cmdline-opts/ssl-reqd.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ssl-reqd
 Help: Require SSL/TLS
 Protocols: FTP IMAP POP3 SMTP LDAP

--- a/docs/cmdline-opts/ssl-revoke-best-effort.d
+++ b/docs/cmdline-opts/ssl-revoke-best-effort.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ssl-revoke-best-effort
 Help: Ignore missing/offline cert CRL dist points
 Added: 7.70.0

--- a/docs/cmdline-opts/ssl.d
+++ b/docs/cmdline-opts/ssl.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: ssl
 Help: Try SSL/TLS
 Protocols: FTP IMAP POP3 SMTP LDAP

--- a/docs/cmdline-opts/sslv2.d
+++ b/docs/cmdline-opts/sslv2.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: 2
 Long: sslv2
 Tags: Versions

--- a/docs/cmdline-opts/sslv3.d
+++ b/docs/cmdline-opts/sslv3.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: 3
 Long: sslv3
 Tags: Versions

--- a/docs/cmdline-opts/stderr.d
+++ b/docs/cmdline-opts/stderr.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: stderr
 Arg: <file>
 Help: Where to redirect stderr

--- a/docs/cmdline-opts/styled-output.d
+++ b/docs/cmdline-opts/styled-output.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: styled-output
 Help: Enable styled output for HTTP headers
 Added: 7.61.0

--- a/docs/cmdline-opts/suppress-connect-headers.d
+++ b/docs/cmdline-opts/suppress-connect-headers.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: suppress-connect-headers
 Help: Suppress proxy CONNECT response headers
 See-also: dump-header include proxytunnel

--- a/docs/cmdline-opts/tcp-fastopen.d
+++ b/docs/cmdline-opts/tcp-fastopen.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tcp-fastopen
 Added: 7.49.0
 Help: Use TCP Fast Open

--- a/docs/cmdline-opts/tcp-nodelay.d
+++ b/docs/cmdline-opts/tcp-nodelay.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tcp-nodelay
 Help: Use the TCP_NODELAY option
 Added: 7.11.2

--- a/docs/cmdline-opts/telnet-option.d
+++ b/docs/cmdline-opts/telnet-option.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: telnet-option
 Short: t
 Arg: <opt=val>

--- a/docs/cmdline-opts/tftp-blksize.d
+++ b/docs/cmdline-opts/tftp-blksize.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tftp-blksize
 Arg: <value>
 Help: Set TFTP BLKSIZE option

--- a/docs/cmdline-opts/tftp-no-options.d
+++ b/docs/cmdline-opts/tftp-no-options.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tftp-no-options
 Help: Do not send any TFTP options
 Protocols: TFTP

--- a/docs/cmdline-opts/time-cond.d
+++ b/docs/cmdline-opts/time-cond.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: time-cond
 Short: z
 Arg: <time>

--- a/docs/cmdline-opts/tls-max.d
+++ b/docs/cmdline-opts/tls-max.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tls-max
 Arg: <VERSION>
 Tags: Versions

--- a/docs/cmdline-opts/tls13-ciphers.d
+++ b/docs/cmdline-opts/tls13-ciphers.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tls13-ciphers
 Arg: <ciphersuite list>
 help: TLS 1.3 cipher suites to use

--- a/docs/cmdline-opts/tlsauthtype.d
+++ b/docs/cmdline-opts/tlsauthtype.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlsauthtype
 Arg: <type>
 Help: TLS authentication type

--- a/docs/cmdline-opts/tlspassword.d
+++ b/docs/cmdline-opts/tlspassword.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlspassword
 Arg: <string>
 Help: TLS password

--- a/docs/cmdline-opts/tlsuser.d
+++ b/docs/cmdline-opts/tlsuser.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlsuser
 Arg: <name>
 Help: TLS user name

--- a/docs/cmdline-opts/tlsv1.0.d
+++ b/docs/cmdline-opts/tlsv1.0.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlsv1.0
 Help: Use TLSv1.0 or greater
 Protocols: TLS

--- a/docs/cmdline-opts/tlsv1.1.d
+++ b/docs/cmdline-opts/tlsv1.1.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlsv1.1
 Help: Use TLSv1.1 or greater
 Protocols: TLS

--- a/docs/cmdline-opts/tlsv1.2.d
+++ b/docs/cmdline-opts/tlsv1.2.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlsv1.2
 Help: Use TLSv1.2 or greater
 Protocols: TLS

--- a/docs/cmdline-opts/tlsv1.3.d
+++ b/docs/cmdline-opts/tlsv1.3.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tlsv1.3
 Help: Use TLSv1.3 or greater
 Protocols: TLS

--- a/docs/cmdline-opts/tlsv1.d
+++ b/docs/cmdline-opts/tlsv1.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: 1
 Long: tlsv1
 Tags: Versions

--- a/docs/cmdline-opts/tr-encoding.d
+++ b/docs/cmdline-opts/tr-encoding.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: tr-encoding
 Added: 7.21.6
 Help: Request compressed transfer encoding

--- a/docs/cmdline-opts/trace-ascii.d
+++ b/docs/cmdline-opts/trace-ascii.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: trace-ascii
 Arg: <file>
 Help: Like --trace, but without hex output

--- a/docs/cmdline-opts/trace-time.d
+++ b/docs/cmdline-opts/trace-time.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: trace-time
 Help: Add time stamps to trace/verbose output
 Added: 7.14.0

--- a/docs/cmdline-opts/trace.d
+++ b/docs/cmdline-opts/trace.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: trace
 Arg: <file>
 Help: Write a debug trace to FILE

--- a/docs/cmdline-opts/unix-socket.d
+++ b/docs/cmdline-opts/unix-socket.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: unix-socket
 Arg: <path>
 Help: Connect through this Unix domain socket

--- a/docs/cmdline-opts/upload-file.d
+++ b/docs/cmdline-opts/upload-file.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: upload-file
 Short: T
 Arg: <file>

--- a/docs/cmdline-opts/url.d
+++ b/docs/cmdline-opts/url.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: url
 Arg: <url>
 Help: URL to work with

--- a/docs/cmdline-opts/use-ascii.d
+++ b/docs/cmdline-opts/use-ascii.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: B
 Long: use-ascii
 Help: Use ASCII/text transfer

--- a/docs/cmdline-opts/user-agent.d
+++ b/docs/cmdline-opts/user-agent.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: A
 Long: user-agent
 Arg: <name>

--- a/docs/cmdline-opts/user.d
+++ b/docs/cmdline-opts/user.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: user
 Short: u
 Arg: <user:password>

--- a/docs/cmdline-opts/verbose.d
+++ b/docs/cmdline-opts/verbose.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Short: v
 Long: verbose
 Mutexed: trace trace-ascii

--- a/docs/cmdline-opts/version.d
+++ b/docs/cmdline-opts/version.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: version
 Short: V
 Help: Show version number and quit

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: write-out
 Short: w
 Arg: <format>

--- a/docs/cmdline-opts/xattr.d
+++ b/docs/cmdline-opts/xattr.d
@@ -1,3 +1,5 @@
+c: Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+SPDX-License-Identifier: curl
 Long: xattr
 Help: Store metadata in extended file attributes
 Category: misc

--- a/scripts/copyright.pl
+++ b/scripts/copyright.pl
@@ -32,7 +32,6 @@
 # regexes of files to not scan
 my @skiplist=(
     '^tests\/data\/test(\d+)$', # test case data
-    '^docs\/cmdline-opts\/[a-z]+(.*)\.d$', # curl.1 pieces
 
     # all uppercase file name, possibly with dot and dash. But do not exclude
     # the man pages:


### PR DESCRIPTION
gen.pl now insist on C: and SPDX-License-Identifier: fields to be
present in all files.