### PR TITLE
copyright cleanup

### DIFF
--- a/.mailmap.license
+++ b/.mailmap.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2017 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
-
-SPDX-License-Identifier: curl

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -99,3 +99,7 @@ License: curl
 FILES: .github/ISSUE_TEMPLATE/bug_report.md
 Copyright: 2020 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
+
+FILES: .mailmap
+Copyright: 2017 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+License: curl

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,7 @@ Upstream-Contact: Daniel Stenberg <daniel@haxx.se>
 Source: https://curl.se
 
 # Tests
-Files: tests/*
+Files: tests/data/test* tests/certs/* tests/stunnel.pem tests/valgrind.supp
 Copyright: 2000 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
@@ -14,7 +14,7 @@ Copyright: 2000 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
 # Docs in docs/
-Files: docs/FAQ docs/INSTALL docs/INSTALL.cmake docs/KNOWN_BUGS docs/MAIL-ETIQUETTE docs/THANKS docs/TODO docs/cmdline-opts/page-footer docs/examples/.checksrc docs/libcurl/curl_multi_socket_all.3 docs/libcurl/curl_strnequal.3 docs/libcurl/symbols-in-versions docs/options-in-versions
+Files: docs/FAQ docs/INSTALL docs/INSTALL.cmake docs/KNOWN_BUGS docs/MAIL-ETIQUETTE docs/THANKS docs/TODO docs/cmdline-opts/page-footer docs/libcurl/curl_multi_socket_all.3 docs/libcurl/curl_strnequal.3 docs/libcurl/symbols-in-versions docs/options-in-versions
 Copyright: 2000 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
@@ -36,7 +36,8 @@ Files: RELEASE-NOTES
 Copyright: 2003 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-Files: lib/.checksrc
+# checksrc control files
+Files: lib/.checksrc docs/examples/.checksrc tests/libtest/.checksrc
 Copyright: 2021 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
@@ -96,10 +97,10 @@ Files: README
 Copyright: 1999 - 2021 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-FILES: .github/ISSUE_TEMPLATE/bug_report.md
+Files: .github/ISSUE_TEMPLATE/bug_report.md
 Copyright: 2020 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-FILES: .mailmap
+Files: .mailmap
 Copyright: 2017 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2016 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 
 SPDX-License-Identifier: curl
 -->

--- a/buildconf.bat
+++ b/buildconf.bat
@@ -6,7 +6,7 @@ rem *                             / __| | | | |_) | |
 rem *                            | (__| |_| |  _ <| |___
 rem *                             \___|\___/|_| \_\_____|
 rem *
-rem * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
+rem * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
 rem *
 rem * This software is licensed as described in the file COPYING, which
 rem * you should have received as part of this distribution. The terms

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # libcurl examples
 
 This directory is for libcurl programming examples. They are meant to show

--- a/docs/libcurl/ABI.md
+++ b/docs/libcurl/ABI.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 ABI - Application Binary Interface
 ==================================
 

--- a/scripts/copyright.pl
+++ b/scripts/copyright.pl
@@ -29,64 +29,27 @@
 # Usage: copyright.pl [file]
 #
 
-# regexes of files to not scan
-my @skiplist=(
-    '^tests\/data\/test(\d+)$', # test case data
+my %skips;
 
-    # all uppercase file name, possibly with dot and dash. But do not exclude
-    # the man pages:
-    '(\/|^)[A-Z0-9_.-]+[^31]$',
-    '(\/|^)[A-Z0-9_-]+\.md$', # all uppercase file name with .md extension
-    '^tests/certs/.*', # generated certs
-    '^tests/stunnel.pem', # generated cert
-    '^tests/valgrind.supp', # valgrind suppressions
-    '^projects/Windows/.*.dsw$', # generated MSVC file
-    '^projects/Windows/.*.sln$', # generated MSVC file
-    '^projects/Windows/.*.tmpl$', # generated MSVC file
-    '^projects/Windows/.*.vcxproj.filters$', # generated MSVC file
-    '^m4/ax_compile_check_sizeof.m4$', # imported, leave be
-    '^.mailmap', # git control file
-    '\/readme',
-    "buildconf", # its nothing to copyright
+# file names
+my %skiplist = (
+    # REUSE-specific file
+    ".reuse/dep5" => "<built-in>",
 
-    # docs/ files we're okay with without copyright
-    'INSTALL.cmake',
-    'TheArtOfHttpScripting',
-    'page-footer',
-    'curl_multi_socket_all.3',
-    'curl_strnequal.3',
-    'symbols-in-versions',
-    'options-in-versions',
+    # License texts
+    "LICENSES/BSD-3-Clause.txt" => "<built-in>",
+    "LICENSES/BSD-4-Clause-UC.txt" => "<built-in>",
+    "LICENSES/GPL-3.0-or-later.txt" => "<built-in>",
+    "LICENSES/ISC.txt" => "<built-in>",
+    "LICENSES/LicenseRef-OpenEvidence.txt" => "<built-in>",
+    "LICENSES/curl.txt" => "<built-in>",
+    "COPYING" => "<built-in>",
 
-    # macos-framework files
-    '^lib\/libcurl.plist.in',
-    '^lib\/libcurl.vers.in',
-
-    # vms files
-    '^packages\/vms\/build_vms.com',
-    '^packages\/vms\/curl_release_note_start.txt',
-    '^packages\/vms\/curlmsg.sdl',
-    '^packages\/vms\/macro32_exactcase.patch',
-
-    # XML junk
-    '^projects\/wolfssl_override.props',
-
-    # checksrc control files
-    '\.checksrc$',
+    # imported, leave be
+    'm4/ax_compile_check_sizeof.m4' => "<built-in>",
 
     # an empty control file
-    "^zuul.d/playbooks/.zuul.ignore",
-
-    # markdown linkchecker config
-    "mlc_config.json",
-
-    # github template file
-    "^.github/ISSUE_TEMPLATE/bug_report.md",
-
-    # License texts and REUSE-specific files
-    ".reuse/dep5",
-    "LICENSES/.*"
-
+    "zuul.d/playbooks/.zuul.ignore" => "<built-in>",
     );
 
 sub scanfile {
@@ -122,13 +85,18 @@ sub scanfile {
 }
 
 sub checkfile {
-    my ($file) = @_;
+    my ($file, $skipped, $pattern) = @_;
     my $fine = 0;
     @copyright=();
     $spdx = 0;
     my $found = scanfile($file);
 
     if($found < 1) {
+        if($skipped) {
+            # just move on
+            $skips{$pattern}++;
+            return 0;
+        }
         if(!$found) {
             print "$file:1: missing copyright range\n";
             return 2;
@@ -138,6 +106,11 @@ sub checkfile {
         return 1;
     }
     if(!$spdx) {
+        if($skipped) {
+            # move on
+            $skips{$pattern}++;
+            return 0;
+        }
         print "$file:1: missing SPDX-License-Identifier\n";
         return 2;
     }
@@ -162,13 +135,55 @@ sub checkfile {
        $copyright[0]{year} != $commityear) {
         printf "$file:%d: copyright year out of date, should be $commityear, " .
             "is $copyright[0]{year}\n",
-            $copyright[0]{line};
+            $copyright[0]{line} if(!$skipped || $verbose);
+        $skips{$pattern}++ if($skipped);
     }
     else {
         $fine = 1;
     }
+    if($skipped && $fine) {
+        print "$file:1: ignored superfluously by $pattern\n" if($verbose);
+        $superf{$pattern}++;
+    }
+
     return $fine;
 }
+
+sub dep5 {
+    my ($file) = @_;
+    my @files;
+    my $copy;
+    open(F, "<$file") || die "can't open $file";
+    my $line = 0;
+    while(<F>) {
+        $line++;
+        if(/^Files: (.*)/i) {
+            push @files, `git ls-files $1`;
+        }
+        elsif(/^Copyright: (.*)/i) {
+            $copy = $1;
+        }
+        elsif(/^License: (.*)/i) {
+            my $license = $1;
+            for my $f (@files) {
+                chomp $f;
+                if($f =~ /\.gitignore\z/) {
+                    # ignore .gitignore
+                }
+                else {
+                    if($skiplist{$f}) {
+                        print STDERR "$f already skipped at $skiplist{$f}\n";
+                    }
+                    $skiplist{$f} = "dep5:$line";
+                }
+            }
+            undef @files;
+        }
+    }
+    close(F);
+}
+
+dep5(".reuse/dep5");
 
 my @all;
 my $verbose;
@@ -182,22 +197,26 @@ if($ARGV[0]) {
 else {
     @all = `git ls-files`;
 }
+
 for my $f (@all) {
     chomp $f;
     my $skipped = 0;
-    for my $skip (@skiplist) {
-        #print "$f matches $skip ?\n";
-        if($f =~ /$skip/) {
-            $skiplisted++;
-            $skipped = 1;
-            #print "$f: SKIPPED ($skip)\n";
-            last;
-        }
+    my $miss;
+    my $wro;
+    my $pattern;
+    if($skiplist{$f}) {
+        $pattern = $skip;
+        $skiplisted++;
+        $skipped = 1;
     }
+
+    my $r = checkfile($f, $skipped, $pattern);
+    $mis=1 if($r == 2);
+    $wro=1 if(!$r);
+
     if(!$skipped) {
-        my $r = checkfile($f);
-        $missing++ if($r == 2);
-        $wrong++ if(!$r);
+        $missing += $mis;
+        $wrong += $wro;
     }
 }
 
@@ -205,6 +224,16 @@ if($verbose) {
     print STDERR "$missing files have no copyright\n" if($missing);
     print STDERR "$wrong files have wrong copyright year\n" if ($wrong);
     print STDERR "$skiplisted files are skipped\n" if ($skiplisted);
+
+    for my $s (@skiplist) {
+        if(!$skips{$s}) {
+            printf ("Never skipped pattern: %s\n", $s);
+        }
+        if($superf{$s}) {
+            printf ("%s was skipped superfluously %u times and legitimately %u times\n",
+                    $s, $superf{$s}, $skips{$s});
+        }
+    }
 }
 
 exit 1 if($missing || $wrong);

--- a/tests/CI.md
+++ b/tests/CI.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Continuous Integration for curl
 
 Curl runs in many different environments, so every change is run against a large

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl test suite file format
 
 The curl test suite's file format is very simple and extensible, closely

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # The curl Test Suite
 
 # Running

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -1,3 +1,27 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
 # This file can be used to specify test cases that should not run when all
 # test cases are run by runtests.pl. Just add the plain test case numbers, one
 # per line.

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 Fuzz tests
 ==========
 

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 1998 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Unit tests
 
 The goal is to add tests for *all* functions in libcurl. If functions are too


### PR DESCRIPTION
Primarily, make the `.reuse/dep5` the canonical source for what files to "skip" when looking for copyright info in them but also update dep5 to use less sweeping wildcards.