### PR TITLE
CI/cirrus: align Windows timeout with Azure CI at 120 minutes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ freebsd_task:
 
 windows_task:
   name: Windows
-  timeout_in: 90m
+  timeout_in: 120m
   windows_container:
     image: ${container_img}
 


### PR DESCRIPTION
Make sure we use the same timeout for both (native and container-based) Windows CIs.