### PR TITLE
test3026: add support for Windows using native Win32 threads

### DIFF
--- a/tests/data/test3026
+++ b/tests/data/test3026
@@ -20,7 +20,6 @@ slow
 <features>
 threadsafe
 threaded-resolver
-!win32
 </features>
 <server>
 none

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -26,11 +26,69 @@
 #include "testutil.h"
 #include "warnless.h"
 
-#ifdef HAVE_PTHREAD_H
+#define NUM_THREADS 100
+
+#ifdef WIN32
+static DWORD WINAPI run_thread(LPVOID ptr)
+{
+  CURLcode *result = ptr;
+
+  *result = curl_global_init(CURL_GLOBAL_ALL);
+  if(*result == CURLE_OK)
+    curl_global_cleanup();
+
+  return 0;
+}
+
+int test(char *URL)
+{
+  CURLcode results[NUM_THREADS];
+  HANDLE ths[NUM_THREADS];
+  unsigned tid_count = NUM_THREADS, i;
+  int test_failure = 0;
+  curl_version_info_data *ver;
+  (void) URL;
+
+  ver = curl_version_info(CURLVERSION_NOW);
+  if((ver->features & CURL_VERSION_THREADSAFE) == 0) {
+    fprintf(stderr, "%s:%d On Windows but the "
+            "CURL_VERSION_THREADSAFE feature flag is not set\n",
+            __FILE__, __LINE__);
+    return -1;
+  }
+
+  for(i = 0; i < tid_count; i++) {
+    HANDLE th;
+    results[i] = CURL_LAST; /* initialize with invalid value */
+    th = CreateThread(NULL, 0, run_thread, &results[i], 0, NULL);
+    if(!th) {
+      fprintf(stderr, "%s:%d Couldn't create thread, errno %d\n",
+              __FILE__, __LINE__, GetLastError());
+      tid_count = i;
+      test_failure = -1;
+      goto cleanup;
+    }
+    ths[i] = th;
+  }
+
+cleanup:
+  for(i = 0; i < tid_count; i++) {
+    WaitForSingleObject(ths[i], INFINITE);
+    CloseHandle(ths[i]);
+    if(results[i] != CURLE_OK) {
+      fprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
+              "with code %d (%s)\n", __FILE__, __LINE__,
+              i, (int) results[i], curl_easy_strerror(results[i]));
+      test_failure = -1;
+    }
+  }
+
+  return test_failure;
+}
+
+#elif defined(HAVE_PTHREAD_H)
 #include <pthread.h>
 #include <unistd.h>
-
-#define NUM_THREADS 100
 
 static void *run_thread(void *ptr)
 {
@@ -61,7 +119,9 @@ int test(char *URL)
   }
 
   for(i = 0; i < tid_count; i++) {
-    int res = pthread_create(&tids[i], NULL, run_thread, &results[i]);
+    int res;
+    results[i] = CURL_LAST; /* initialize with invalid value */
+    res = pthread_create(&tids[i], NULL, run_thread, &results[i]);
     if(res) {
       fprintf(stderr, "%s:%d Couldn't create thread, errno %d\n",
               __FILE__, __LINE__, res);
@@ -85,7 +145,7 @@ cleanup:
   return test_failure;
 }
 
-#else /* without pthread, this test doesn't work */
+#else /* without pthread or Windows, this test doesn't work */
 int test(char *URL)
 {
   curl_version_info_data *ver;


### PR DESCRIPTION
Also make sure the result is initialized to an invalid value (`CURL_LAST`) before the corresponding thread is launched.

Follow up to #8996