### PR TITLE
runtests: skip starting the ssh server if user name is lacking

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2195,6 +2195,11 @@ sub runsshserver {
     my $logfile;
     my $port = 20000; # no lower port
 
+    if(!$USER) {
+        logmsg "Can't start ssh server due to lack of USER name";
+        return (0,0,0);
+    }
+
     $server = servername_id($proto, $ipvnum, $idnum);
 
     $pidfile = $serverpidfile{$server};


### PR DESCRIPTION
Because the ssh server startup script *requires* a user name there's no
point in invoking it if no name was found.

Reported-by: Ricardo M. Correia
Fixes #9007