### PR TITLE
curl_easy_pause.3: remove explanation of progress function

### DIFF
--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -41,8 +41,7 @@ the transfer is unpaused.
 
 While it may feel tempting, take care and notice that you cannot call this
 function from another thread. To unpause, you may for example call it from the
-progress callback (\fICURLOPT_PROGRESSFUNCTION(3)\fP), which gets called at
-least once per second, even if the connection is paused.
+progress callback (\fICURLOPT_PROGRESSFUNCTION(3)\fP).
 
 When this function is called to unpause receiving, the chance is high that you
 will get your write callback called before this function returns.


### PR DESCRIPTION
- Remove misleading text that says progress function "gets called at
  least once per second, even if the connection is paused."

The progress function behavior is more nuanced and the user is better
served reading the progress function doc rather than attempt to explain
it in the curl_easy_pause doc.

The progress function can only be called at least once per second if an
appropriate multi transfer function is called (eg curl_multi_perform) in
that time. For a paused transfer there may not be such a call. Rather
than explain this in detail in the curl_easy_pause doc, rely on the user
reading the CURLOPT_PROGRESSFUNCTION doc.

Ref: https://github.com/curl/curl/issues/8983

Closes #xxxx