### PR TITLE
configure: warn about rustls being experimental

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,7 @@ AS_HELP_STRING([--with-rustls=PATH],[where to look for rustls, PATH points to th
   OPT_RUSTLS=$withval
   if test X"$withval" != Xno; then
     test -z "TLSCHOICE" || TLSCHOICE="${TLSCHOICE:+$TLSCHOICE, }rustls")
+    experimental="$experimental rustls"
   fi
 
 OPT_NSS_AWARE=no

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -21,3 +21,4 @@ Experimental support in curl means:
  - The Hyper HTTP backend
  - HTTP/3 support and options
  - `CURLSSLOPT_NATIVE_CA` (No configure option, feature built in when supported)
+ - The rustls backend


### PR DESCRIPTION
Right now a dozen test cases are disabled because they don't work with rustls