### PR TITLE
libssh: skip the fake-close when libssh does the right thing

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1972,7 +1972,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       ssh_disconnect(sshc->ssh_session);
-      if(!ssh_version(SSH_VERSION_INT(0,10,0))) {
+      if(!ssh_version(SSH_VERSION_INT(0, 10, 0))) {
         /* conn->sock[FIRSTSOCKET] is closed by ssh_disconnect behind our back,
            explicitly mark it as closed with the memdebug macro. This libssh
            bug is fixed in 0.10.0. */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1972,10 +1972,13 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       ssh_disconnect(sshc->ssh_session);
-      /* conn->sock[FIRSTSOCKET] is closed by ssh_disconnect behind our back,
-         explicitly mark it as closed with the memdebug macro: */
-      fake_sclose(conn->sock[FIRSTSOCKET]);
-      conn->sock[FIRSTSOCKET] = CURL_SOCKET_BAD;
+      if(!ssh_version(SSH_VERSION_INT(0,10,0))) {
+        /* conn->sock[FIRSTSOCKET] is closed by ssh_disconnect behind our back,
+           explicitly mark it as closed with the memdebug macro. This libssh
+           bug is fixed in 0.10.0. */
+        fake_sclose(conn->sock[FIRSTSOCKET]);
+        conn->sock[FIRSTSOCKET] = CURL_SOCKET_BAD;
+      }
 
       SSH_STRING_FREE_CHAR(sshc->homedir);
       data->state.most_recent_ftp_entrypath = NULL;
@@ -2958,7 +2961,7 @@ void Curl_ssh_cleanup(void)
 
 void Curl_ssh_version(char *buffer, size_t buflen)
 {
-  (void)msnprintf(buffer, buflen, "libssh/%s", CURL_LIBSSH_VERSION);
+  (void)msnprintf(buffer, buflen, "libssh/%s", ssh_version(0));
 }
 
 #endif                          /* USE_LIBSSH */

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -211,11 +211,7 @@ struct ssh_conn {
 #endif /* USE_LIBSSH */
 };
 
-#if defined(USE_LIBSSH)
-
-#define CURL_LIBSSH_VERSION ssh_version(0)
-
-#elif defined(USE_LIBSSH2)
+#if defined(USE_LIBSSH2)
 
 /* Feature detection based on version numbers to better work with
    non-configure platforms */


### PR DESCRIPTION
Starting in libssh 0.10.0 ssh_disconnect() will no longer close our
socket. Instead it will be kept alive as we want it, and it is our
responsibility to close it later.

Ref: #8718
Ref: https://gitlab.com/libssh/libssh-mirror/-/merge_requests/240