### PR TITLE
Make `curl_url_set(url, CURLUPART_URL, NULL, 0)` clear all parts

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1518,6 +1518,10 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     if(storep && *storep) {
       Curl_safefree(*storep);
     }
+    else if(!storep) {
+      free_urlhandle(u);
+      memset(u, 0, sizeof(struct Curl_URL));
+    }
     return CURLUE_OK;
   }
 


### PR DESCRIPTION
As per the documentation :

> Setting a part to a NULL pointer will effectively remove that
> part's contents from the CURLU handle.

But currently clearing CURLUPART_URL does nothing and returns
CURLUE_OK. This change will clear all parts of the URL at once.