### PR TITLE
curl_setup: include _mingw.h

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -453,9 +453,6 @@
 
 /* mingw-w64, mingw using >= MSVCR80, and visual studio >= 2005 (MSVCR80)
    all default to 64-bit time_t unless _USE_32BIT_TIME_T is defined */
-#ifdef __MINGW32__
-#  include <_mingw.h>
-#endif
 #if defined(__MINGW64_VERSION_MAJOR) || \
     (defined(__MINGW32__) && (__MSVCRT_VERSION__ >= 0x0800)) || \
     (defined(_MSC_VER) && (_MSC_VER >= 1400))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,6 +28,11 @@
 #define CURL_NO_OLDIES
 #endif
 
+/* define mingw version macros, eg __MINGW{32,64}_{MINOR,MAJOR}_VERSION */
+#ifdef __MINGW32__
+#include <_mingw.h>
+#endif
+
 /*
  * Disable Visual Studio warnings:
  * 4127 "conditional expression is constant"

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -62,7 +62,6 @@ CURLcode Curl_verify_certificate(struct Curl_easy *data,
 #ifdef EXPOSE_SCHANNEL_INTERNAL_STRUCTS
 
 #ifdef __MINGW32__
-#include <_mingw.h>
 #ifdef __MINGW64_VERSION_MAJOR
 #define HAS_MANUAL_VERIFY_API
 #endif


### PR DESCRIPTION
Prior to this change _mingw.h needed to be included in each unit before
evaluating __MINGW{32,64}_xxx_VERSION macros since it defines them. It
is included only in some mingw headers (eg stdio.h) and not others
(eg windows.h) so it's better to explicitly include it once.

Closes #xxxx