### PR TITLE
INTERNALS: bring back the "Library symbols" section

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -58,3 +58,13 @@ versions of libs, tools and operating systems.
  - perl         5.004
  - roffit       0.5
  - groff        ? (any version that supports `groff -Tps -man [in] [out]`)
+
+Library Symbols
+===============
+
+ All symbols used internally in libcurl must use a `Curl_` prefix if they are
+ used in more than a single file. Single-file symbols must be made static.
+ Public ("exported") symbols must use a `curl_` prefix. (There are exceptions,
+ but they are to be changed to follow this pattern in future versions.) Public
+ API functions are marked with `CURL_EXTERN` in the public header files so
+ that all others can be hidden on platforms where this is possible.


### PR DESCRIPTION
Most contents was moved, but this text should remain here.

Follow-up to: d324ac8
Reported-by: Viktor Szakats
Bug: https://github.com/curl/curl/pull/9027#discussion_r903382326