### PR TITLE
rand: stop detecting /dev/urandom in cross-builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1055,8 +1055,10 @@ if(HAVE_SIZEOF_LONG_LONG)
   set(HAVE_LL 1)
 endif()
 
-find_file(RANDOM_FILE urandom /dev)
-mark_as_advanced(RANDOM_FILE)
+if(NOT CMAKE_CROSSCOMPILING)
+  find_file(RANDOM_FILE urandom /dev)
+  mark_as_advanced(RANDOM_FILE)
+endif()
 
 # Check for some functions that are used
 if(HAVE_LIBWS2_32)

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -73,7 +73,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 
   /* ---- non-cryptographic version following ---- */
 
-#ifdef RANDOM_FILE
+#if defined(RANDOM_FILE) && !defined(WIN32)
   if(!seeded) {
     /* if there's a random file to read a seed from, use it */
     int fd = open(RANDOM_FILE, O_RDONLY);
@@ -108,7 +108,8 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
  * 'rndptr' points to.
  *
  * If libcurl is built without TLS support or with a TLS backend that lacks a
- * proper random API (Gskit or mbedTLS), this function will use "weak" random.
+ * proper random API (rustls, Gskit or mbedTLS), this function will use "weak"
+ * random.
  *
  * When built *with* TLS support and a backend that offers strong random, it
  * will return error if it cannot provide strong random values.


### PR DESCRIPTION
- Prevent CMake to auto-detect `/dev/urandom` when cross-building.
  Before this patch, it would detect it in a cross-build scenario on *nix
  hosts with this device present. This was a problem for example with
  Windows builds, but it could affect any target system with this device
  missing. This also syncs detection behaviour with autotools, which also
  skips it for cross-builds.
- Also, make sure to never use the file `RANDOM_FILE` as entropy for libcurl's
  fallback random number generator on Windows. Windows does not have the
  concept of reading a random stream from a filename, nor any guaranteed
  non-world-writable path on disk. With this, a manual misconfiguration or
  an overeager auto-detection can no longer result in a user-controllable
  seed source.

Closes #xxxx

---
Split off the easy (and urgent) part of #9027 into this new PR, so that we 
can merge it before the release.
