### PR TITLE
[WIP] cmake: add threadsafe to the feature list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1466,6 +1466,8 @@ _add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE)
 _add_if("MultiSSL"      CURL_WITH_MULTI_SSL)
 _add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS OR USE_NSS))
 _add_if("unicode"       ENABLE_UNICODE)
+# TODO also enabled when built for Vista or newer
+_add_if("threadsafe"    HAVE_ATOMIC)
 string(REPLACE ";" " " SUPPORT_FEATURES "${_items}")
 message(STATUS "Enabled features: ${SUPPORT_FEATURES}")
 


### PR DESCRIPTION
Try fixing: [FAILED]
https://ci.appveyor.com/project/curlorg/curl/builds/43950780/job/245rpmlf43xod8td#L3605

Conditions don't match the actual source. Added a TODO about it.