### PR TITLE
Extra libs in auxiliary path are ignored

### DIFF
--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -138,8 +138,8 @@ if test "x$OPT_OPENSSL" != xno; then
   fi
 
   dnl finally, set flags to use SSL
-  CPPFLAGS="$CPPFLAGS $SSL_CPPFLAGS"
-  LDFLAGS="$LDFLAGS $SSL_LDFLAGS"
+  CPPFLAGS="$SSL_CPPFLAGS $CPPFLAGS"
+  LDFLAGS="$SSL_LDFLAGS $LDFLAGS"
 
   AC_CHECK_LIB(crypto, HMAC_Update,[
      HAVECRYPTO="yes"


### PR DESCRIPTION
Hello Dan,
It is a nit only but it is common the path to auxiliary libraries should prepend the standard paths.
Could it be possible to fix it?
Thanks,
Yura