### PR TITLE
http: do not require a user name when using CURLAUTH_NEGOTIATE

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -66,7 +66,6 @@ problems may have been fixed or changed somewhat since this was written.
  6.1 NTLM authentication and unicode
  6.2 MIT Kerberos for Windows build
  6.3 NTLM in system context uses wrong name
- 6.4 Negotiate and Kerberos V5 need a fake user name
  6.5 NTLM does not support password with § character
  6.6 libcurl can fail to try alternatives with --proxy-any
  6.7 Do not clear digest for single realm
@@ -559,18 +558,6 @@ problems may have been fixed or changed somewhat since this was written.
  NTLM authentication using SSPI (on Windows) when (lib)curl is running in
  "system context" will make it use wrong(?) user name - at least when compared
  to what winhttp does. See https://curl.se/bug/view.cgi?id=535
-
-6.4 Negotiate and Kerberos V5 need a fake user name
-
- In order to get Negotiate (SPNEGO) authentication to work in HTTP or Kerberos
- V5 in the email protocols, you need to  provide a (fake) user name (this
- concerns both curl and the lib) because the code wrongly only considers
- authentication if there's a user name provided by setting
- conn->bits.user_passwd in url.c  https://curl.se/bug/view.cgi?id=440 How?
- https://curl.se/mail/lib-2004-08/0182.html A possible solution is to
- either modify this variable to be set or introduce a variable such as
- new conn->bits.want_authentication which is set when any of the authentication
- options are set.
 
 6.5 NTLM does not support password with § character
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -828,7 +828,12 @@ Curl_http_output_auth(struct Curl_easy *data,
 #ifndef CURL_DISABLE_PROXY
     (conn->bits.httpproxy && conn->bits.proxy_user_passwd) ||
 #endif
-     data->state.aptr.user || data->set.str[STRING_BEARER])
+     data->state.aptr.user ||
+#ifdef USE_SPNEGO
+     authhost->want & CURLAUTH_NEGOTIATE ||
+     authproxy->want & CURLAUTH_NEGOTIATE ||
+#endif
+     data->set.str[STRING_BEARER])
     /* continue please */;
   else {
     authhost->done = TRUE;

--- a/tests/data/test2056
+++ b/tests/data/test2056
@@ -47,7 +47,7 @@ LD_PRELOAD=%PWD/libtest/.libs/libstubgss.so
 CURL_STUB_GSS_CREDS="KRB5_Alice"
 </setenv>
 <command>
--u: --negotiate http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+--negotiate http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2057
+++ b/tests/data/test2057
@@ -63,7 +63,7 @@ LD_PRELOAD=%PWD/libtest/.libs/libstubgss.so
 CURL_STUB_GSS_CREDS="NTLM_Alice"
 </setenv>
 <command>
--u: --negotiate http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+--negotiate http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2077
+++ b/tests/data/test2077
@@ -29,7 +29,7 @@ GSS-API
 curl --fail --negotiate to unauthenticated service fails
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u : --fail --negotiate
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --fail --negotiate
 </command>
 </client>
 

--- a/tests/data/test2078
+++ b/tests/data/test2078
@@ -29,7 +29,7 @@ GSS-API
 curl --negotiate should not send empty POST request only
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u : --negotiate --data name=value
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --negotiate --data name=value
 </command>
 </client>
 


### PR DESCRIPTION
In order to get Negotiate (SPNEGO) authentication to work in HTTP or
Kerberos V5 in the email protocols, you used to be required to provide a
(fake) user name (this concerns both curl and the lib) because the code
wrongly only considered authentication if there was a user name
provided, as in:

  curl -u : --negotiate https://example.com/

This commit leverages the `struct auth` want member to figure out if the
user enabled CURLAUTH_NEGOTIATE, effectively removing the requirement of
setting a user name both in curl and the lib.

Signed-off-by: Marin Hannache <git@mareo.fr>
Reported-by: Enrico Scholz
Fixes https://sourceforge.net/p/curl/bugs/440/
Fixes #1161