### PR TITLE
libcurl-security.3: Fix typo on macro "SH_"

### DIFF
--- a/docs/libcurl/libcurl-security.3
+++ b/docs/libcurl/libcurl-security.3
@@ -405,7 +405,7 @@ libcurl itself uses `fork()` and `execl()` if told to use the
 `CURLAUTH_NTLM_WB` authentication method which then will invoke the helper
 command in a child process with file descriptors duplicated. Make sure that
 only the trusted and reliable helper program is invoked!
-.SH_"Secrets in memory"
+.SH "Secrets in memory"
 When applications pass user names, passwords or other sensitive data to
 libcurl to be used for upcoming transfers, those secrets will be kept around
 as-is in memory. In many cases they will be stored in heap for as long as the


### PR DESCRIPTION
During the packaging of the latest curl release for Debian, Lintian warned me about a typo which causes the section name "Secrets in memory" to not be rendered in the manpage due to "SH_" not being recognized as a header.

Thanks,