### PR TITLE
easy_lock: switch to using atomic_int instead of bool

### DIFF
--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -40,8 +40,8 @@
 #include <sched.h>
 #endif
 
-#define curl_simple_lock atomic_bool
-#define CURL_SIMPLE_LOCK_INIT false
+#define curl_simple_lock atomic_int
+#define CURL_SIMPLE_LOCK_INIT 0
 
 static inline void curl_simple_lock_lock(curl_simple_lock *lock)
 {


### PR DESCRIPTION
To work with more compilers without requiring separate libs to
link. Like with gcc-12 for RISC-V on Linux.

Reported-by: Adam Sampson
Fixes #9055