### PR TITLE
url: treat missing usernames in netrc as empty

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3041,6 +3041,12 @@ static CURLcode override_login(struct Curl_easy *data,
       /* don't update the user name below */
       userp = NULL;
     }
+    /* no user was set but a password, set a blank user */
+    if(userp && !*userp && *passwdp) {
+      *userp = strdup("");
+      if(!*userp)
+        return CURLE_OUT_OF_MEMORY;
+    }
   }
 #endif
 


### PR DESCRIPTION
- If, after parsing netrc, there is a password with no username then
  set a blank username.

This used to be the case prior to 7d600ad (precedes 7.82). Note
parseurlandfillconn already does the same thing for URLs.

Reported-by: Raivis <standsed@users.noreply.github.com>
Testing-by: Domen Kožar

Fixes https://github.com/curl/curl/issues/8653
Closes #xxxx

---

Edit: This could use a test so it doesn't happen again, so consider it a WIP for now.