### PR TITLE
Draft: Add libproxy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,13 @@ mark_as_advanced(CURL_DISABLE_TFTP)
 option(CURL_DISABLE_VERBOSE_STRINGS "disables verbose strings" OFF)
 mark_as_advanced(CURL_DISABLE_VERBOSE_STRINGS)
 
+option(ENABLE_LIBPROXY "Define if you want to enable libproxy support" ON)
+if(ENABLE_LIBPROXY)
+  find_package(libproxy REQUIRED)
+  set(ENABLE_LIBPROXY ON)
+  list(APPEND CURL_LIBS ${LIBPROXY_LIBRARIES})
+endif()
+
 # Corresponds to HTTP_ONLY in lib/curl_setup.h
 option(HTTP_ONLY "disables all protocols except HTTP (This overrides all CURL_DISABLE_* options)" OFF)
 mark_as_advanced(HTTP_ONLY)
@@ -1467,6 +1474,7 @@ _add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE)
 _add_if("MultiSSL"      CURL_WITH_MULTI_SSL)
 _add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS OR USE_NSS))
 _add_if("unicode"       ENABLE_UNICODE)
+_add_if("libproxy"      ENABLE_LIBPROXY)
 string(REPLACE ";" " " SUPPORT_FEATURES "${_items}")
 message(STATUS "Enabled features: ${SUPPORT_FEATURES}")
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,10 +23,10 @@
 #***************************************************************************
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.59)
+AC_PREREQ([2.71])
 
 dnl We don't know the version number "statically" so we use a dash here
-AC_INIT([curl], [-], [a suitable curl mailing list: https://curl.se/mail/])
+AC_INIT([curl],[-],[a suitable curl mailing list: https://curl.se/mail/])
 
 XC_OVR_ZZ50
 XC_OVR_ZZ60
@@ -1369,6 +1369,90 @@ if test X"$OPT_BROTLI" != Xno; then
     fi
   else
     dnl no brotli, revert back to clean variables
+    LDFLAGS=$CLEANLDFLAGS
+    CPPFLAGS=$CLEANCPPFLAGS
+    LIBS=$CLEANLIBS
+  fi
+fi
+
+dnl **********************************************************************
+dnl Check for the presence of LIBPROXY libraries and headers
+dnl **********************************************************************
+
+dnl Default to compiler & linker defaults for LIBPROXY files & libraries.
+OPT_LIBPROXY=off
+AC_ARG_WITH(libproxy,dnl
+AS_HELP_STRING([--with-libproxy=PATH],[Where to look for libproxy, PATH points to the LIBPROXY installation; when possible, set the PKG_CONFIG_PATH environment variable instead of using this option])
+AS_HELP_STRING([--without-libproxy],[disable LIBPROXY]),
+  OPT_LIBPROXY=$withval)
+
+if test X"$OPT_LIBPROXY" != Xno; then
+  dnl backup the pre-libproxy variables
+  CLEANLDFLAGS="$LDFLAGS"
+  CLEANCPPFLAGS="$CPPFLAGS"
+  CLEANLIBS="$LIBS"
+
+  case "$OPT_LIBPROXY" in
+  yes)
+    dnl --with-libproxy (without path) used
+    CURL_CHECK_PKGCONFIG(libproxy)
+
+    if test "$PKGCONFIG" != "no" ; then
+      LIB_PROXY=`$PKGCONFIG --libs-only-l libproxy`
+      LD_PROXY=`$PKGCONFIG --libs-only-L libproxy`
+      CPP_PROXY=`$PKGCONFIG --cflags-only-I libproxy`
+      version=`$PKGCONFIG --modversion libproxy`
+      DIR_PROXY=`echo $LD_PROXY | $SED -e 's/-L//'`
+    fi
+
+    ;;
+  off)
+    dnl no --with-libproxy option given, just check default places
+    ;;
+  *)
+    dnl use the given --with-libproxy spot
+    PREFIX_PROXY=$OPT_LIBPROXY
+    ;;
+  esac
+
+  dnl if given with a prefix, we set -L and -I based on that
+  if test -n "$PREFIX_PROXY"; then
+    LIB_PROXY="-lproxy"
+    LD_PROXY=-L${PREFIX_PROXY}/lib$libsuff
+    CPP_PROXY=-I${PREFIX_PROXY}/include
+    DIR_PROXY=${PREFIX_PROXY}/lib$libsuff
+  fi
+
+  LDFLAGS="$LDFLAGS $LD_PROXY"
+  CPPFLAGS="$CPPFLAGS $CPP_PROXY"
+  LIBS="$LIB_PROXY $LIBS"
+
+  AC_CHECK_LIB(proxy, px_proxy_factory_new)
+
+  AC_CHECK_HEADERS(proxy.h,
+    curl_libproxy_msg="enabled"
+    LIBPROXY_ENABLED=1
+  )
+
+  if test X"$OPT_LIBPROXY" != Xoff &&
+     test "$LIBPROXY_ENABLED" != "1"; then
+    AC_MSG_ERROR([libproxy libs and/or directories were not found where specified!])
+  fi
+
+  if test "$LIBPROXY_ENABLED" = "1"; then
+    if test -n "$DIR_LIBPROXY"; then
+       dnl when the libproxy shared libs were found in a path that the run-time
+       dnl linker doesn't search through, we need to add it to LD_LIBRARY_PATH
+       dnl to prevent further configure tests to fail due to this
+
+       if test "x$cross_compiling" != "xyes"; then
+         LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DIR_LIBPROXY"
+         export LD_LIBRARY_PATH
+         AC_MSG_NOTICE([Added $DIR_LIBPROXY to LD_LIBRARY_PATH])
+       fi
+    fi
+  else
+    dnl no libproxy; revert back to clean variables
     LDFLAGS=$CLEANLDFLAGS
     CPPFLAGS=$CLEANCPPFLAGS
     LIBS=$CLEANLIBS
@@ -4479,6 +4563,7 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   HTTP2:            ${curl_h2_msg}
   HTTP3:            ${curl_h3_msg}
   ECH:              ${curl_ech_msg}
+  libproxy support: ${curl_libproxy_msg}
   Protocols:        ${SUPPORT_PROTOCOLS}
   Features:         ${SUPPORT_FEATURES}
 ])

--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -182,6 +182,9 @@ Proxy port to use. See \fICURLOPT_PROXYPORT(3)\fP
 Proxy type. See \fICURLOPT_PROXYTYPE(3)\fP
 .IP CURLOPT_NOPROXY
 Filter out hosts from proxy use. \fICURLOPT_NOPROXY(3)\fP
+.IP CURLOPT_LIBPROXY
+Use the libproxy API to determine which proxy, if any, to
+use. \fICURLOPT_LIBPROXY(3)\fP
 .IP CURLOPT_HTTPPROXYTUNNEL
 Tunnel through the HTTP proxy. \fICURLOPT_HTTPPROXYTUNNEL(3)\fP
 .IP CURLOPT_CONNECT_TO

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2143,6 +2143,9 @@ typedef enum {
   /* set the SSH host key callback custom pointer */
   CURLOPT(CURLOPT_SSH_HOSTKEYDATA, CURLOPTTYPE_CBPOINT, 317),
 
+  /* Use libproxy to determine which proxy to use */
+  CURLOPT(CURLOPT_LIBPROXY, CURLOPTTYPE_LONG, 318),
+
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;
 

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -117,6 +117,7 @@ LIB_CFILES =         \
   curl_get_line.c    \
   curl_gethostname.c \
   curl_gssapi.c      \
+  curl_libproxy.c    \
   curl_memrchr.c     \
   curl_multibyte.c   \
   curl_ntlm_core.c   \
@@ -243,6 +244,7 @@ LIB_HFILES =         \
   curl_hmac.h        \
   curl_krb5.h        \
   curl_ldap.h        \
+  curl_libproxy.h    \
   curl_md4.h         \
   curl_md5.h         \
   curl_memory.h      \

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -1027,3 +1027,5 @@ ${SIZEOF_TIME_T_CODE}
 
 /* to make the compiler know the prototypes of Windows IDN APIs */
 #cmakedefine WANT_IDN_PROTOTYPES 1
+
+#cmakedefine ENABLE_LIBPROXY 1

--- a/lib/curl_libproxy.c
+++ b/lib/curl_libproxy.c
@@ -1,0 +1,75 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2011 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#ifdef ENABLE_LIBPROXY
+
+#include "urldata.h"
+
+#include <proxy.h>
+/* The last 3 #include files should be in this order */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
+
+static pxProxyFactory *factory;
+
+CURLcode Curl_libproxy_global_init(void)
+{
+  factory = px_proxy_factory_new();
+  if(!factory)
+    return CURLE_OUT_OF_MEMORY;
+
+  return CURLE_OK;
+}
+
+void Curl_libproxy_global_cleanup(void)
+{
+  if(factory)
+    px_proxy_factory_free(factory);
+
+  factory = NULL;
+}
+
+char *Curl_libproxy_detect_proxy(const char *url)
+{
+  char *result = NULL;
+
+  if(factory) {
+    char **libproxy_results = px_proxy_factory_get_proxies(factory, url);
+
+    if(libproxy_results) {
+      int i;
+
+      /* We only cope with one; can't fall back on failure */
+      result = libproxy_results[0];
+      for(i=1; libproxy_results[i]; i++)
+        free(libproxy_results[i]);
+      free(libproxy_results);
+    }
+  }
+
+  return result;
+}
+
+#endif /* ENABLE_LIBPROXY */

--- a/lib/curl_libproxy.h
+++ b/lib/curl_libproxy.h
@@ -1,0 +1,37 @@
+#ifndef HEADER_CURL_LIBPROXY_H
+#define HEADER_CURL_LIBPROXY_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2011 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at http://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+#include "urldata.h"
+
+#ifdef ENABLE_LIBPROXY
+
+CURLcode Curl_libproxy_global_init(void);
+void Curl_libproxy_global_cleanup(void);
+
+char *Curl_libproxy_detect_proxy(const char *url);
+
+#endif /* ENABLE_LIBPROXY */
+
+#endif /* HEADER_CURL_LIBPROXY_H */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -194,6 +194,10 @@ static CURLcode global_init(long flags, bool memoryfuncs)
   }
 #endif
 
+#ifdef ENABLE_LIBPROXY
+  Curl_libproxy_global_init();
+#endif
+
 #ifdef USE_WOLFSSH
   if(WS_SUCCESS != wolfSSH_Init()) {
     DEBUGF(fprintf(stderr, "Error: wolfSSH_Init failed\n"));
@@ -308,6 +312,10 @@ void curl_global_cleanup(void)
 #endif
 #ifdef DEBUGBUILD
   free(leakpointer);
+#endif
+
+#ifdef ENABLE_LIBPROXY
+  Curl_libproxy_global_cleanup();
 #endif
 
   init_flags  = 0;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -3032,6 +3032,13 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
   case CURLOPT_PREREQDATA:
     data->set.prereq_userp = va_arg(param, void *);
     break;
+ case CURLOPT_LIBPROXY:
+#ifdef ENABLE_LIBPROXY
+    data->set.libproxy = (0 != va_arg(param, long))?TRUE:FALSE;
+#else
+    result = CURLE_NOT_BUILT_IN;
+#endif
+    break;
   default:
     /* unknown tag and its companion, just ignore: */
     result = CURLE_UNKNOWN_OPTION;

--- a/lib/url.c
+++ b/lib/url.c
@@ -2404,8 +2404,17 @@ static char *detect_proxy(struct Curl_easy *data,
       proxy = curl_getenv(envp);
     }
   }
+
   if(proxy)
     infof(data, "Uses proxy env variable %s == '%s'", envp, proxy);
+#ifdef ENABLE_LIBPROXY
+  if(/*data->set.libproxy && */!proxy) {
+    char *libproxy_proxy = Curl_libproxy_detect_proxy(data->state.url);
+    if (strcmp(libproxy_proxy, "direct://"))
+      proxy = strdup(libproxy_proxy);
+  }
+
+#endif
 
   return proxy;
 }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -162,6 +162,10 @@ typedef CURLcode (*Curl_datastream)(struct Curl_easy *data,
 #include <libssh2_sftp.h>
 #endif /* HAVE_LIBSSH2_H */
 
+#ifdef ENABLE_LIBPROXY
+#include "curl_libproxy.h"
+#endif
+
 #define READBUFFER_SIZE CURL_MAX_WRITE_SIZE
 #define READBUFFER_MAX  CURL_MAX_READ_SIZE
 #define READBUFFER_MIN  1024
@@ -1896,6 +1900,7 @@ struct UserDefined {
   BIT(path_as_is);     /* allow dotdots? */
   BIT(pipewait);       /* wait for multiplex status before starting a new
                           connection */
+  BIT(libproxy);       /* use libproxy to discover proxies */
   BIT(suppress_connect_headers); /* suppress proxy CONNECT response headers
                                     from user callbacks */
   BIT(dns_shuffle_addresses); /* whether to shuffle addresses before use */


### PR DESCRIPTION
Updated MR initially made by dwmw2 (#977)

As our company uses a pac proxy with dozens of entries such a support is necessary within curl. Let's revive this old (but updated) PR and get back to talking.

@dwmw2 
