### PR TITLE
Makefile.m32: do not set the debug flag in libcurl.rc [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -115,7 +115,7 @@ LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL)
 AR = $(CURL_AR)
 RANLIB = $(CURL_RANLIB)
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -DDEBUGBUILD=0 -O coff
+RCFLAGS = --include-dir=$(PROOT)/include -O coff
 STRIP   = $(CROSSPREFIX)strip -g
 
 # Set environment var ARCH to your architecture to override autodetection.


### PR DESCRIPTION
Delete `-DDEBUGBUILD=0` windres option. This was likely meant to
disable VS_FF_DEBUG in FILEFLAGS, but any assigned value enabled
it instead. Delete this unnecessary option and thus sync up with
how CMake compiles libcurl.rc by default.