### PR TITLE
Add ISC to license expression

### DIFF
--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -18,7 +18,7 @@
  * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
  * KIND, either express or implied.
  *
- * SPDX-License-Identifier: curl
+ * SPDX-License-Identifier: curl AND ISC
  *
  ***************************************************************************/
 


### PR DESCRIPTION
text of the ISC license is in this file, so the SPDX license expression should be updated

@karsten-klein pointed this out on the mailing list and forwarded to me (to give credit where credit it due)