### PR TITLE
Fixes related to digest authorisation

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -349,6 +349,7 @@ struct digestdata {
   char *opaque;
   char *qop;
   char *algorithm;
+  char *h_a1; /* H(A1) for "<algo>-sess" protocols */
   int nc; /* nonce count */
   unsigned char algo;
   BIT(stale); /* set true for re-negotiation */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -344,7 +344,6 @@ struct digestdata {
   char *passwd;
 #else
   char *nonce;
-  char *cnonce;
   char *realm;
   char *opaque;
   char *qop;

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -697,7 +697,7 @@ static CURLcode auth_create_digest_http_message(
   if(!digest->nc)
     digest->nc = 1;
 
-  if(!digest->cnonce) {
+  if(!digest->cnonce && digest->qop) {
     char cnoncebuf[33];
     result = Curl_rand_hex(data, (unsigned char *)cnoncebuf,
                            sizeof(cnoncebuf));


### PR DESCRIPTION
This PR fixes a few things related to "session" digest HTTP authorisation:
* remember generated `H(A1)` value and reuse it for the next requests
* always generate new `cnonce` when `cnonce` is used in calculation (for both session and non-session)

---
Some commits were moved to separate PRs:
* #9077
* #9090
* #9076
* #9094
---
I've made some investigation. 
See https://github.com/curl/curl/pull/9074#issuecomment-1177963896 and https://github.com/curl/curl/pull/9074#issuecomment-1178021367