### PR TITLE
digest: reject broken header with session protocol and without qop

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -637,6 +637,10 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
   if(!digest->nonce)
     return CURLE_BAD_CONTENT_ENCODING;
 
+  /* "<algo>-sess" protocol versions require "auth" or "auth-int" qop */
+  if(!digest->qop && (digest->algo & SESSION_ALGO))
+    return CURLE_BAD_CONTENT_ENCODING;
+
   return CURLE_OK;
 }
 


### PR DESCRIPTION
Session algorithms require use of `cnonce`.
`cnonce` could be used only when `qop=auth` or `qop=auth-int`. `cnonce` is not used when `qop` is empty or missing (missing `qop` triggers [RFC2069](https://datatracker.ietf.org/doc/html/rfc2069) compatibility mode, which does not use `cnonce`).
When `qop` is empty, `cnonce` is not sent by curl so there is no way for the server to check calculations where `cnonce` is involved, like `H(A1)`.

Cherry-picked from PR #9074 