### PR TITLE
digest: provide a special bit for "sess" algos

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -318,11 +318,11 @@ struct digestdata {
   char *nonce;
   char *cnonce;
   char *realm;
-  int algo;
   char *opaque;
   char *qop;
   char *algorithm;
   int nc; /* nonce count */
+  unsigned char algo;
   BIT(stale); /* set true for re-negotiation */
   BIT(userhash);
 #endif

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -945,28 +945,18 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                               struct digestdata *digest,
                                               char **outptr, size_t *outlen)
 {
-  switch(digest->algo) {
-  case ALGO_MD5:
-  case ALGO_MD5SESS:
+  if(digest->algo <= ALGO_MD5SESS)
     return auth_create_digest_http_message(data, userp, passwdp,
                                            request, uripath, digest,
                                            outptr, outlen,
                                            auth_digest_md5_to_ascii,
                                            Curl_md5it);
-
-  case ALGO_SHA256:
-  case ALGO_SHA256SESS:
-  case ALGO_SHA512_256:
-  case ALGO_SHA512_256SESS:
-    return auth_create_digest_http_message(data, userp, passwdp,
-                                           request, uripath, digest,
-                                           outptr, outlen,
-                                           auth_digest_sha256_to_ascii,
-                                           Curl_sha256it);
-
-  default:
-    return CURLE_UNSUPPORTED_PROTOCOL;
-  }
+  DEBUGASSERT(digest->algo <= ALGO_SHA512_256SESS);
+  return auth_create_digest_http_message(data, userp, passwdp,
+                                         request, uripath, digest,
+                                         outptr, outlen,
+                                         auth_digest_sha256_to_ascii,
+                                         Curl_sha256it);
 }
 
 /*

--- a/lib/vauth/digest.h
+++ b/lib/vauth/digest.h
@@ -31,15 +31,6 @@
 #define DIGEST_MAX_VALUE_LENGTH           256
 #define DIGEST_MAX_CONTENT_LENGTH         1024
 
-enum {
-  CURLDIGESTALGO_MD5,
-  CURLDIGESTALGO_MD5SESS,
-  CURLDIGESTALGO_SHA256,
-  CURLDIGESTALGO_SHA256SESS,
-  CURLDIGESTALGO_SHA512_256,
-  CURLDIGESTALGO_SHA512_256SESS
-};
-
 /* This is used to extract the realm from a challenge message */
 bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
                                const char **endptr);


### PR DESCRIPTION
Also shortened the names and moved them to the .c file since they are
private for this source file only. Also made them #defines instead of
enum.