### PR TITLE
docs: sync authentication guidance in username docs

### DIFF
--- a/docs/cmdline-opts/proxy-user.d
+++ b/docs/cmdline-opts/proxy-user.d
@@ -11,9 +11,23 @@ See-also: proxy-pass
 ---
 Specify the user name and password to use for proxy authentication.
 
-If you use a Windows SSPI-enabled curl binary and do either Negotiate or NTLM
-authentication then you can tell curl to select the user name and password
-from your environment by specifying a single colon with this option: "-U :".
+When using Kerberos V5 with a Windows based server you should include the
+Windows domain name in the user name, in order for the server to successfully
+obtain a Kerberos Ticket. If you do not, then the initial authentication
+handshake may fail.
+
+When using NTLM, the user name can be specified simply as the user name,
+without the domain, if there is a single domain and forest in your setup
+for example.
+
+To specify the domain name use either Down-Level Logon Name or UPN (User
+Principal Name) formats. For example, EXAMPLE\\user and user@example.com
+respectively.
+
+If you use a Windows SSPI-enabled curl binary and perform Kerberos V5,
+Negotiate, NTLM or Digest authentication then you can tell curl to select
+the user name and password from your environment by specifying a single colon
+with this option: "-U :".
 
 On systems where it works, curl will hide the given option argument from
 process listings. This is not enough to protect credentials from possibly

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
@@ -40,6 +40,27 @@ authentication with the proxy.
 
 To specify the proxy password use the \fICURLOPT_PROXYPASSWORD(3)\fP.
 
+When using Kerberos V5 with a Windows based server you should include the
+Windows domain name in the user name, in order for the server to successfully
+obtain a Kerberos Ticket. If you do not, then the initial authentication
+handshake may fail.
+
+When using NTLM, the user name can be specified simply as the user name,
+without the domain, if there is a single domain and forest in your setup
+for example.
+
+To specify the domain name use either Down-Level Logon Name or UPN (User
+Principal Name) formats. For example, EXAMPLE\\user and user@example.com
+respectively.
+
+Some HTTP servers (on Windows) support inclusion of the domain for Basic
+authentication as well.
+
+If you use a Windows SSPI-enabled libcurl binary and perform Kerberos V5,
+Negotiate, NTLM or Digest authentication then you can tell libcurl to select
+the user name from your environment by specifying an empty string with this
+option: "".
+
 The application does not have to keep the string around after setting this
 option.
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
@@ -40,6 +40,27 @@ used - beware.)
 
 Use \fICURLOPT_PROXYAUTH(3)\fP to specify the authentication method.
 
+When using Kerberos V5 with a Windows based server you should include the
+Windows domain name in the user name, in order for the server to successfully
+obtain a Kerberos Ticket. If you do not, then the initial authentication
+handshake may fail.
+
+When using NTLM, the user name can be specified simply as the user name,
+without the domain, if there is a single domain and forest in your setup
+for example.
+
+To specify the domain name use either Down-Level Logon Name or UPN (User
+Principal Name) formats. For example, EXAMPLE\\user and user@example.com
+respectively.
+
+Some HTTP servers (on Windows) support inclusion of the domain for Basic
+authentication as well.
+
+If you use a Windows SSPI-enabled libcurl binary and perform Kerberos V5,
+Negotiate, NTLM or Digest authentication then you can tell libcurl to select
+the user name and password from your environment by specifying a single colon
+with this option: ":".
+
 The application does not have to keep the string around after setting this
 option.
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.3
@@ -39,24 +39,29 @@ user name to use for the transfer.
 authentication. You should not use this option together with the (older)
 \fICURLOPT_USERPWD(3)\fP option.
 
-When using Kerberos V5 authentication with a Windows based server, you should
-include the domain name in order for the server to successfully obtain a
-Kerberos Ticket. If you do not then the initial part of the authentication
+To specify the password and login options, along with the user name, use the
+\fICURLOPT_PASSWORD(3)\fP and \fICURLOPT_LOGIN_OPTIONS(3)\fP options.
+
+When using Kerberos V5 with a Windows based server you should include the
+Windows domain name in the user name, in order for the server to successfully
+obtain a Kerberos Ticket. If you do not, then the initial authentication
 handshake may fail.
 
-When using NTLM, the user name can be specified simply as the user name
-without the domain name should the server be part of a single domain and
-forest.
+When using NTLM, the user name can be specified simply as the user name,
+without the domain, if there is a single domain and forest in your setup
+for example.
 
-To include the domain name use either Down-Level Logon Name or UPN (User
+To specify the domain name use either Down-Level Logon Name or UPN (User
 Principal Name) formats. For example, EXAMPLE\\user and user@example.com
 respectively.
 
 Some HTTP servers (on Windows) support inclusion of the domain for Basic
 authentication as well.
 
-To specify the password and login options, along with the user name, use the
-\fICURLOPT_PASSWORD(3)\fP and \fICURLOPT_LOGIN_OPTIONS(3)\fP options.
+If you use a Windows SSPI-enabled libcurl binary and perform Kerberos V5,
+Negotiate, NTLM or Digest authentication then you can tell libcurl to select
+the user name from your environment by specifying an empty string with this
+option: "".
 
 The application does not have to keep the string around after setting this
 option.

--- a/docs/libcurl/opts/CURLOPT_USERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.3
@@ -35,14 +35,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERPWD, char *userpwd);
 Pass a char * as parameter, pointing to a null-terminated login details string
 for the connection. The format of which is: [user name]:[password].
 
-When using Kerberos V5 authentication with a Windows based server, you should
-specify the user name part with the domain name in order for the server to
-successfully obtain a Kerberos Ticket. If you do not then the initial part of
-the authentication handshake may fail.
+When using Kerberos V5 with a Windows based server you should include the
+Windows domain name in the user name, in order for the server to successfully
+obtain a Kerberos Ticket. If you do not, then the initial authentication
+handshake may fail.
 
-When using NTLM, the user name can be specified simply as the user name
-without the domain name should the server be part of a single domain and
-forest.
+When using NTLM, the user name can be specified simply as the user name,
+without the domain, if there is a single domain and forest in your setup
+for example.
 
 To specify the domain name use either Down-Level Logon Name or UPN (User
 Principal Name) formats. For example, EXAMPLE\\user and user@example.com
@@ -50,6 +50,11 @@ respectively.
 
 Some HTTP servers (on Windows) support inclusion of the domain for Basic
 authentication as well.
+
+If you use a Windows SSPI-enabled libcurl binary and perform Kerberos V5,
+Negotiate, NTLM or Digest authentication then you can tell libcurl to select
+the user name and password from your environment by specifying a single colon
+with this option: ":".
 
 When using HTTP and \fICURLOPT_FOLLOWLOCATION(3)\fP, libcurl might perform
 several requests to possibly different hosts. libcurl will only send this user


### PR DESCRIPTION
- Use the auth username guidance from --user, which seems to be the most
  complete, in --proxy-user, CURLOPT_USERNAME, CURLOPT_PROXYUSERNAME,
  CURLOPT_USERPWD, CURLOPT_PROXYUSERPWD.

Prior to this change the documentation was out of sync as to the
recommended ways the user can set the username for NTLM, Kerberos, etc.

Bug: https://github.com/jeroen/curl/issues/237
Reported-by: Oscar Lane

Closes #xxxx

---

@captain-caveman2k note this PR was prompted by jeroen/curl#237 where it is unclear that the username must be blank for SSPI to use the user's Windows credentials.

IMO in the proxy counterparts rather than duplicate all the info we could refer back to the non-proxy version, eg CURLOPT_PROXYUSERPWD could refer to CURLOPT_USERPWD. However they are not exactly the same. Also, there would still be copies in CURLOPT_USERNAME and CURLOPT_USERPWD. So another way to handle this could be make a libcurl-username.3 and refer to that?

---

/cc @jeroen @OscarLane