### PR TITLE
select: do not return fatal error on EINTR from poll()

### DIFF
--- a/lib/select.c
+++ b/lib/select.c
@@ -310,8 +310,12 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
   else
     pending_ms = 0;
   r = poll(ufds, nfds, pending_ms);
-  if(r <= 0)
+  if(r <= 0) {
+    if((r == -1) && (SOCKERRNO == EINTR))
+      /* make EINTR from select or poll not a "lethal" error */
+      r = 0;
     return r;
+  }
 
   for(i = 0; i < nfds; i++) {
     if(ufds[i].fd == CURL_SOCKET_BAD)


### PR DESCRIPTION
The same was done for select() in 5912da253b64de3cb2a1a229558077219b2c8a35
but poll() was missed.

Downstream report: https://bugs.archlinux.org/task/75201
See #8921 and #8961