### PR TITLE
makefile.m32: add support for custom ARCH [ci skip]

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -118,7 +118,7 @@ CC = $(CURL_CC)
 CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE)
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -O coff
+RCFLAGS = --include-dir=$(PROOT)/include -O coff $(CURL_RCFLAG_EXTRAS)
 
 # Set environment var ARCH to your architecture to override autodetection.
 ifndef ARCH
@@ -129,6 +129,7 @@ ARCH = w32
 endif
 endif
 
+ifneq ($(ARCH),custom)
 ifeq ($(ARCH),w64)
 CFLAGS  += -m64
 LDFLAGS += -m64
@@ -137,6 +138,7 @@ else
 CFLAGS  += -m32
 LDFLAGS += -m32
 RCFLAGS += -F pe-i386
+endif
 endif
 
 # Platform-dependent helper tool macros

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -115,7 +115,7 @@ LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL)
 AR = $(CURL_AR)
 RANLIB = $(CURL_RANLIB)
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -O coff
+RCFLAGS = --include-dir=$(PROOT)/include -O coff $(CURL_RCFLAG_EXTRAS)
 STRIP   = $(CROSSPREFIX)strip -g
 
 # Set environment var ARCH to your architecture to override autodetection.
@@ -127,6 +127,7 @@ ARCH = w32
 endif
 endif
 
+ifneq ($(ARCH),custom)
 ifeq ($(ARCH),w64)
 CFLAGS  += -m64
 LDFLAGS += -m64
@@ -135,6 +136,7 @@ else
 CFLAGS  += -m32
 LDFLAGS += -m32
 RCFLAGS += -F pe-i386
+endif
 endif
 
 # Platform-dependent helper tool macros

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -119,7 +119,7 @@ CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE)
 AR = $(CURL_AR)
 RC = $(CROSSPREFIX)windres
-RCFLAGS = --include-dir=$(PROOT)/include -O coff -DCURL_EMBED_MANIFEST
+RCFLAGS = --include-dir=$(PROOT)/include -O coff -DCURL_EMBED_MANIFEST $(CURL_RCFLAG_EXTRAS)
 STRIP   = $(CROSSPREFIX)strip -g
 
 # We may need these someday
@@ -135,6 +135,7 @@ ARCH = w32
 endif
 endif
 
+ifneq ($(ARCH),custom)
 ifeq ($(ARCH),w64)
 CFLAGS  += -m64
 LDFLAGS += -m64
@@ -143,6 +144,7 @@ else
 CFLAGS  += -m32
 LDFLAGS += -m32
 RCFLAGS += -F pe-i386
+endif
 endif
 
 # Platform-dependent helper tool macros


### PR DESCRIPTION
When building curl for target platform other than x64 and x86, it is now
possible to pass `ARCH=custom`, that will omit all hardcoded logic for
setting up CFLAGS/LDFLAGS/RCFLAGS for these platforms, and let these be
customized via `CURL_CFLAG_EXTRAS`, `CURL_LDFLAG_EXTRAS`, and a newly
added one for the resource compiler: `CURL_RCFLAG_EXTRAS`.

This makes it possible to use `makefile.m32` to build for ARM64 for
example.