### PR TITLE
aws_sigv4: use actual Host header, trim values

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -266,7 +266,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
     }
   }
 
-  canonical_host = Curl_copy_header_value(hostname);
+  canonical_host = aws_canonical_value(hostname);
   if(!canonical_host) {
     goto fail;
   }

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -81,7 +81,7 @@ static char *aws_canonical_value(const char *hdr)
   char *r;
   char *w;
 
-  r = w = v = Curl_copy_header_value(hdr)
+  r = w = v = Curl_copy_header_value(hdr);
   if(!v) {
     return NULL;
   }
@@ -112,7 +112,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   char *region = NULL;
   char *service = NULL;
   /* we need the *actual* Host header value */
-  const char *hostname = data->aptr.host;
+  const char *hostname = data->state.aptr.host;
 #ifdef DEBUGBUILD
   char *force_timestamp;
 #endif


### PR DESCRIPTION
improve compliance with AWS SigV4 spec:
* use actual Host header value in CanonicalHeaders;
* properly trim whitespace in header values

TODO: add a test