### PR TITLE
Fixes for changed authorisation doing second request reusing handle

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1506,9 +1506,6 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     if(data->state.authhost.picked) {
       bool reset_auth = FALSE;
       bool reset_digest = FALSE;
-#ifndef CURL_DISABLE_CRYPTO_AUTH
-      bool digest_cleared = FALSE;
-#endif
       if((data->state.authhost.picked & data->state.authhost.want) == 0) {
         /* Different auth type */
         if(data->state.authhost.done) {
@@ -1516,10 +1513,10 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           data->state.authhost.done = FALSE;
         }
 #ifndef CURL_DISABLE_CRYPTO_AUTH
-        if(data->state.authhost.picked == CURLAUTH_DIGEST) {
+        if(data->state.authhost.picked == CURLAUTH_DIGEST &&
+            Curl_auth_digest_nonce_used(&data->state.digest)) {
           reset_digest = TRUE;
           Curl_auth_digest_cleanup(&data->state.digest);
-          digest_cleared = TRUE;
         }
 #endif
         if(reset_auth || reset_digest) {
@@ -1549,8 +1546,8 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           data->state.authhost.done = FALSE;
         }
 #ifndef CURL_DISABLE_CRYPTO_AUTH
-        if(!digest_cleared &&
-           data->state.authhost.picked == CURLAUTH_DIGEST) {
+        if(data->state.authhost.picked == CURLAUTH_DIGEST &&
+           Curl_auth_digest_nonce_used(&data->state.digest)) {
           reset_digest = TRUE;
           Curl_auth_digest_cleanup(&data->state.digest);
         }
@@ -1571,9 +1568,6 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     if(data->state.authproxy.picked) {
       bool reset_auth = FALSE;
       bool reset_digest = FALSE;
-#ifndef CURL_DISABLE_CRYPTO_AUTH
-      bool digest_cleared = FALSE;
-#endif
       if((data->state.authproxy.picked & data->state.authproxy.want) == 0) {
         /* Different auth type */
         if(data->state.authproxy.done) {
@@ -1581,9 +1575,9 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           data->state.authproxy.done = FALSE;
         }
 #ifndef CURL_DISABLE_CRYPTO_AUTH
-        if(data->state.authproxy.picked == CURLAUTH_DIGEST) {
+        if(data->state.authproxy.picked == CURLAUTH_DIGEST &&
+           Curl_auth_digest_nonce_used(&data->state.proxydigest)) {
           reset_digest = TRUE;
-          digest_cleared = TRUE;
           Curl_auth_digest_cleanup(&data->state.proxydigest);
         }
 #endif
@@ -1615,8 +1609,8 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           data->state.authproxy.done = FALSE;
         }
 #ifndef CURL_DISABLE_CRYPTO_AUTH
-        if(!digest_cleared &&
-           data->state.authproxy.picked == CURLAUTH_DIGEST) {
+        if(data->state.authproxy.picked == CURLAUTH_DIGEST &&
+           Curl_auth_digest_nonce_used(&data->state.proxydigest)) {
           reset_digest = TRUE;
           Curl_auth_digest_cleanup(&data->state.proxydigest);
         }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -312,8 +312,6 @@ struct digestdata {
   CtxtHandle *http_context;
   /* copy of user/passwd used to make the identity for http_context.
      either may be NULL. */
-  char *user;
-  char *passwd;
 #else
   char *nonce;
   char *cnonce;

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -849,9 +849,6 @@ static CURLcode auth_create_digest_http_message(
                        digest->nc,
                        digest->qop,
                        request_digest);
-
-    /* Increment nonce-count to use another nc value for the next request */
-    digest->nc++;
   }
   else {
     response = aprintf("username=\"%s\", "
@@ -907,6 +904,12 @@ static CURLcode auth_create_digest_http_message(
 
     response = tmp;
   }
+
+  /*
+     Increment nonce-count to use another nc value for the next request
+     and indicate that nonce has been used already.
+   */
+  digest->nc++;
 
   /* Return the output */
   *outptr = response;

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -960,6 +960,22 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                          Curl_sha256it);
 }
 
+
+/*
+ * Curl_auth_digest_nonce_used()
+ *
+ * Check whether server provided nonce has been used at least one time
+ *
+ * Parameters:
+ *
+ * digest    [in] - The digest data struct being cleaned up.
+ *
+ */
+bool Curl_auth_digest_nonce_used(const struct digestdata *digest)
+{
+  return digest->nc > 1;
+}
+
 /*
  * Curl_auth_digest_cleanup()
  *

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -600,6 +600,21 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 }
 
 /*
+ * Curl_auth_digest_nonce_used()
+ *
+ * Check whether server provided nonce has been used at least one time
+ *
+ * Parameters:
+ *
+ * digest    [in] - The digest data struct being cleaned up.
+ *
+ */
+bool Curl_auth_digest_nonce_used(const struct digestdata *digest)
+{
+  return digest->http_context != NULL;
+}
+
+/*
  * Curl_auth_digest_cleanup()
  *
  * This is used to clean up the digest specific data.

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -427,20 +427,6 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
   }
 
-  /* If the user/passwd that was used to make the identity for http_context
-     has changed then delete that context. */
-  if((userp && !digest->user) || (!userp && digest->user) ||
-     (passwdp && !digest->passwd) || (!passwdp && digest->passwd) ||
-     (userp && digest->user && strcmp(userp, digest->user)) ||
-     (passwdp && digest->passwd && strcmp(passwdp, digest->passwd))) {
-    if(digest->http_context) {
-      s_pSecFn->DeleteSecurityContext(digest->http_context);
-      Curl_safefree(digest->http_context);
-    }
-    Curl_safefree(digest->user);
-    Curl_safefree(digest->passwd);
-  }
-
   if(digest->http_context) {
     chlg_desc.ulVersion    = SECBUFFER_VERSION;
     chlg_desc.cBuffers     = 5;

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -468,10 +468,6 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
     TCHAR *spn;
 
-    /* free the copy of user/passwd used to make the previous identity */
-    Curl_safefree(digest->user);
-    Curl_safefree(digest->passwd);
-
     if(userp && *userp) {
       /* Populate our identity structure */
       if(Curl_create_sspi_identity(userp, passwdp, &identity)) {
@@ -492,25 +488,6 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     else
       /* Use the current Windows user */
       p_identity = NULL;
-
-    if(userp) {
-      digest->user = strdup(userp);
-
-      if(!digest->user) {
-        free(output_token);
-        return CURLE_OUT_OF_MEMORY;
-      }
-    }
-
-    if(passwdp) {
-      digest->passwd = strdup(passwdp);
-
-      if(!digest->passwd) {
-        free(output_token);
-        Curl_safefree(digest->user);
-        return CURLE_OUT_OF_MEMORY;
-      }
-    }
 
     /* Acquire our credentials handle */
     status = s_pSecFn->AcquireCredentialsHandle(NULL,
@@ -645,10 +622,6 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
     s_pSecFn->DeleteSecurityContext(digest->http_context);
     Curl_safefree(digest->http_context);
   }
-
-  /* Free the copy of user/passwd used to make the identity for http_context */
-  Curl_safefree(digest->user);
-  Curl_safefree(digest->passwd);
 }
 
 #endif /* USE_WINDOWS_SSPI && !CURL_DISABLE_CRYPTO_AUTH */

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -111,6 +111,9 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                               struct digestdata *digest,
                                               char **outptr, size_t *outlen);
 
+/* Check whether server provided nonce has been used at least one time */
+bool Curl_auth_digest_nonce_used(const struct digestdata *digest);
+
 /* This is used to clean up the digest specific data */
 void Curl_auth_digest_cleanup(struct digestdata *digest);
 #endif /* !CURL_DISABLE_CRYPTO_AUTH */

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -327,7 +327,8 @@ about to issue.
   a PUT or POST request
 - `rtp: part [num] channel [num] size [num]` - stream a fake RTP packet for
   the given part on a chosen channel with the given payload size
-- `connection-monitor` - When used, this will log `[DISCONNECT]` to the
+- `connection-monitor` - When used, this will log `[DISCONNECT]` (or 
+  `[DISCONNECT #x]` if `connection-number` is activated as well) to the
   `server.input` log when the connection is disconnected.
 - `connection-number` - Prefix actual input reports in the `server.input`
    with `[CONNECTION #x]` to refer the connection's number in test.

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -329,6 +329,8 @@ about to issue.
   the given part on a chosen channel with the given payload size
 - `connection-monitor` - When used, this will log `[DISCONNECT]` to the
   `server.input` log when the connection is disconnected.
+- `connection-number` - Prefix actual input reports in the `server.input`
+   with `[CONNECTION #x]` to refer the connection's number in test.
 - `upgrade` - when an HTTP upgrade header is found, the server will upgrade to
   http2
 - `swsclose` - instruct server to close connection after response

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -239,7 +239,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-test2088 test2089 test2090 test2091 test2092 \
+test2088 test2089 test2090 test2091 test2092 test2093 test2094 \
 test2100 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -239,7 +239,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-\
+test2088 test2089 test2090 test2091 test2092 \
 test2100 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \

--- a/tests/data/test2024
+++ b/tests/data/test2024
@@ -60,6 +60,18 @@ This is a bad password page!
 </data1400>
 
 <!-- Fifth request has Digest auth, right password -->
+<data500>
+HTTP/1.1 401 Sorry wrong password (4)
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 29
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="4"
+
+This is a bad password page!
+</data500>
+
+<!-- Sixth request has Digest auth, right password -->
 <data1500>
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
@@ -100,6 +112,13 @@ WWW-Authenticate: Digest realm="testrealm", nonce="3"
 WWW-Authenticate: Basic realm="testrealm"
 
 This is a bad password page!
+HTTP/1.1 401 Sorry wrong password (4)
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 29
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="4"
+
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -165,7 +184,11 @@ Accept: */*
 
 GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="3", uri="/%TESTNUMBER0500", response="5bc77ec8c2d443b27a1b55f1fd8fbb13"
+Accept: */*
+
+GET /%TESTNUMBER0500 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="4", uri="/%TESTNUMBER0500", response="04718a72eb7c0cf5217cb8d9d60360c2"
 Accept: */*
 
 </protocol>

--- a/tests/data/test2024
+++ b/tests/data/test2024
@@ -112,13 +112,6 @@ WWW-Authenticate: Digest realm="testrealm", nonce="3"
 WWW-Authenticate: Basic realm="testrealm"
 
 This is a bad password page!
-HTTP/1.1 401 Sorry wrong password (4)
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
-WWW-Authenticate: Basic realm="testrealm"
-WWW-Authenticate: Digest realm="testrealm", nonce="4"
-
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -184,11 +177,7 @@ Accept: */*
 
 GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Accept: */*
-
-GET /%TESTNUMBER0500 HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="4", uri="/%TESTNUMBER0500", response="04718a72eb7c0cf5217cb8d9d60360c2"
+Authorization: Digest username="testuser", realm="testrealm", nonce="3", uri="/%TESTNUMBER0500", response="5bc77ec8c2d443b27a1b55f1fd8fbb13"
 Accept: */*
 
 </protocol>

--- a/tests/data/test2027
+++ b/tests/data/test2027
@@ -126,12 +126,6 @@ Content-Length: 29
 WWW-Authenticate: Digest realm="testrealm", nonce="2"
 
 This is a bad password page!
-HTTP/1.1 401 Need Digest auth (2)
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 27
-WWW-Authenticate: Digest realm="testrealm", nonce="3"
-
 HTTP/1.1 200 Things are fine in server land
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -158,12 +152,6 @@ Content-Length: 29
 WWW-Authenticate: Digest realm="testrealm", nonce="7"
 
 This is a bad password page!
-HTTP/1.1 401 Need Digest auth (5)
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 27
-WWW-Authenticate: Digest realm="testrealm", nonce="8"
-
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -218,11 +206,7 @@ Accept: */*
 
 GET /%TESTNUMBER0200 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Accept: */*
-
-GET /%TESTNUMBER0200 HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="3", uri="/%TESTNUMBER0200", response="c1d5953a435c6ff0510b8a06c6c7a7ac"
+Authorization: Digest username="testuser", realm="testrealm", nonce="2", uri="/%TESTNUMBER0200", response="785ca3ef511999f7e9c178195f5b388c"
 Accept: */*
 
 GET /%TESTNUMBER0300 HTTP/1.1
@@ -241,11 +225,7 @@ Accept: */*
 
 GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Accept: */*
-
-GET /%TESTNUMBER0500 HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="8", uri="/%TESTNUMBER0500", response="a11f70a7036b3ff3a4ec7ab9c51220eb"
+Authorization: Digest username="testuser", realm="testrealm", nonce="7", uri="/%TESTNUMBER0500", response="8ef4d935fd964a46c3965c0863b52cf1"
 Accept: */*
 
 </protocol>

--- a/tests/data/test2027
+++ b/tests/data/test2027
@@ -9,17 +9,6 @@ HTTP Digest auth
 # Server-side
 <reply>
 
-<!--
-
- Explanation for the duplicate 400 requests:
-
- libcurl doesn't detect that a given Digest password is wrong already on the
- first 401 response (as the data400 gives). libcurl will instead consider the
- new response just as a duplicate and it sends another and detects the auth
- problem on the second 401 response!
-
--->
-
 <!-- First request has Digest auth, wrong password -->
 <data100>
 HTTP/1.1 401 Need Digest auth
@@ -104,6 +93,16 @@ This is a bad password page!
 </data1400>
 
 <!-- Fifth request has Digest auth, right password -->
+<data500>
+HTTP/1.1 401 Need Digest auth (5)
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="8"
+
+This is not the real page!
+</data500>
+
 <data1500>
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
@@ -127,6 +126,12 @@ Content-Length: 29
 WWW-Authenticate: Digest realm="testrealm", nonce="2"
 
 This is a bad password page!
+HTTP/1.1 401 Need Digest auth (2)
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="3"
+
 HTTP/1.1 200 Things are fine in server land
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -152,13 +157,13 @@ Content-Type: text/html; charset=iso-8859-1
 Content-Length: 29
 WWW-Authenticate: Digest realm="testrealm", nonce="7"
 
-HTTP/1.1 401 Sorry wrong password (3)
+This is a bad password page!
+HTTP/1.1 401 Need Digest auth (5)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
-WWW-Authenticate: Digest realm="testrealm", nonce="7"
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="8"
 
-This is a bad password page!
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -213,7 +218,11 @@ Accept: */*
 
 GET /%TESTNUMBER0200 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="2", uri="/%TESTNUMBER0200", response="785ca3ef511999f7e9c178195f5b388c"
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="3", uri="/%TESTNUMBER0200", response="c1d5953a435c6ff0510b8a06c6c7a7ac"
 Accept: */*
 
 GET /%TESTNUMBER0300 HTTP/1.1
@@ -230,14 +239,13 @@ Host: %HOSTIP:%HTTPPORT
 Authorization: Digest username="testuser", realm="testrealm", nonce="5", uri="/%TESTNUMBER0400", response="f5906785511fb60a2af8b1cd53008ead"
 Accept: */*
 
-GET /%TESTNUMBER0400 HTTP/1.1
+GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="5", uri="/%TESTNUMBER0400", response="f5906785511fb60a2af8b1cd53008ead"
 Accept: */*
 
 GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="7", uri="/%TESTNUMBER0500", response="8ef4d935fd964a46c3965c0863b52cf1"
+Authorization: Digest username="testuser", realm="testrealm", nonce="8", uri="/%TESTNUMBER0500", response="a11f70a7036b3ff3a4ec7ab9c51220eb"
 Accept: */*
 
 </protocol>

--- a/tests/data/test2030
+++ b/tests/data/test2030
@@ -188,13 +188,6 @@ WWW-Authenticate: NTLM
 WWW-Authenticate: Digest realm="testrealm", nonce="7"
 
 This is a bad password page!
-HTTP/1.1 401 Need Digest or NTLM auth (5)
-Server: Microsoft-IIS/5.0
-Content-Type: text/html; charset=iso-8859-1
-Content-Length: 27
-WWW-Authenticate: Digest realm="testrealm", nonce="8"
-WWW-Authenticate: NTLM
-
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -262,11 +255,7 @@ Accept: */*
 
 GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Accept: */*
-
-GET /%TESTNUMBER0500 HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="8", uri="/%TESTNUMBER0500", response="1f7e94dc3e5fa115ccecced1cde5c163"
+Authorization: Digest username="testuser", realm="testrealm", nonce="7", uri="/%TESTNUMBER0500", response="198757e61163a779cf24ed4c49c1ad7d"
 Accept: */*
 
 </protocol>

--- a/tests/data/test2030
+++ b/tests/data/test2030
@@ -14,18 +14,6 @@ NTLM
 <!-- Alternate the order that Digest and NTLM headers appear in responses to
 ensure that the order doesn't matter. -->
 
-<!--
-
- Explanation for the duplicate 400 requests:
-
- libcurl doesn't detect that a given Digest password is wrong already on the
- first 401 response (as the data400 gives). libcurl will instead consider the
- new response just as a duplicate and it sends another and detects the auth
- problem on the second 401 response!
-
--->
-
-
 <!-- First request has NTLM auth, wrong password -->
 <data100>
 HTTP/1.1 401 Need Digest or NTLM auth
@@ -199,14 +187,14 @@ Content-Length: 29
 WWW-Authenticate: NTLM
 WWW-Authenticate: Digest realm="testrealm", nonce="7"
 
-HTTP/1.1 401 Sorry wrong password (3)
+This is a bad password page!
+HTTP/1.1 401 Need Digest or NTLM auth (5)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
-Content-Length: 29
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="8"
 WWW-Authenticate: NTLM
-WWW-Authenticate: Digest realm="testrealm", nonce="7"
 
-This is a bad password page!
 HTTP/1.1 200 Things are fine in server land (2)
 Server: Microsoft-IIS/5.0
 Content-Type: text/html; charset=iso-8859-1
@@ -272,14 +260,13 @@ Host: %HOSTIP:%HTTPPORT
 Authorization: Digest username="testuser", realm="testrealm", nonce="5", uri="/%TESTNUMBER0400", response="d6262e9147db08c62ff2f53b515861e8"
 Accept: */*
 
-GET /%TESTNUMBER0400 HTTP/1.1
+GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="5", uri="/%TESTNUMBER0400", response="d6262e9147db08c62ff2f53b515861e8"
 Accept: */*
 
 GET /%TESTNUMBER0500 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="7", uri="/%TESTNUMBER0500", response="198757e61163a779cf24ed4c49c1ad7d"
+Authorization: Digest username="testuser", realm="testrealm", nonce="8", uri="/%TESTNUMBER0500", response="1f7e94dc3e5fa115ccecced1cde5c163"
 Accept: */*
 
 </protocol>

--- a/tests/data/test2088
+++ b/tests/data/test2088
@@ -1,0 +1,173 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Basic auth
+</keywords>
+</info>
+# Server-side
+<reply>
+
+<!-- Request number 1: Basic auth, user1 -->
+<data100>
+HTTP/1.1 200 Things are fine in server land (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data100>
+
+<!-- Request number 2: Basic auth, USER2 -->
+<data200>
+HTTP/1.1 200 Things are fine in server land (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data200>
+
+<!-- Requests number 3: Basic auth, user1 -->
+<data300>
+HTTP/1.1 200 Things are fine in server land (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data300>
+
+<!-- Requests number 4: Basic auth, user1 -->
+<data310>
+HTTP/1.1 200 Things are fine in server land (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data310>
+
+<!-- Requests number 5: Basic auth, USER2 -->
+<data400>
+HTTP/1.1 200 Things are fine in server land (5)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data400>
+
+<!-- Requests number 6: Basic auth, USER2 -->
+<data410>
+HTTP/1.1 200 Things are fine in server land (6)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data410>
+<datacheck>
+HTTP/1.1 200 Things are fine in server land (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (5)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (6)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP Basic auth repeat with varying user
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER basic user1-USER2
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic VVNFUjI6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic VVNFUjI6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic VVNFUjI6dGVzdHBhc3M=
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2089
+++ b/tests/data/test2089
@@ -1,0 +1,173 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Basic auth
+</keywords>
+</info>
+# Server-side
+<reply>
+
+<!-- Request number 1: Basic auth, testuser:pwd1 -->
+<data100>
+HTTP/1.1 200 Things are fine in server land (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data100>
+
+<!-- Request number 2: Basic auth, testuser:PWD2 -->
+<data200>
+HTTP/1.1 200 Things are fine in server land (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data200>
+
+<!-- Requests number 3: Basic auth, testuser:pwd1 -->
+<data300>
+HTTP/1.1 200 Things are fine in server land (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data300>
+
+<!-- Requests number 4: Basic auth, testuser:pwd1 -->
+<data310>
+HTTP/1.1 200 Things are fine in server land (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data310>
+
+<!-- Requests number 5: Basic auth, testuser:PWD2 -->
+<data400>
+HTTP/1.1 200 Things are fine in server land (5)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data400>
+
+<!-- Requests number 6: Basic auth, testuser:PWD2 -->
+<data410>
+HTTP/1.1 200 Things are fine in server land (6)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data410>
+<datacheck>
+HTTP/1.1 200 Things are fine in server land (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (5)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (6)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP Basic auth repeat with varying password
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER basic testuser pwd1-PWD2
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6cHdkMQ==
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6UFdEMg==
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6cHdkMQ==
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6cHdkMQ==
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6UFdEMg==
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6UFdEMg==
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2090
+++ b/tests/data/test2090
@@ -1,0 +1,275 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Digest auth
+</keywords>
+</info>
+# Server-side
+<reply>
+
+<!-- Request number 1: Digest auth, user1 -->
+<data100>
+HTTP/1.1 401 Need Digest auth (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="1"
+
+This is not the real page!
+</data100>
+
+<data1100>
+HTTP/1.1 200 Things are fine in server land (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1100>
+
+<!-- Request number 2: Digest auth, USER2 -->
+<data200>
+HTTP/1.1 401 Need Digest auth (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="2"
+
+This is not the real page!
+</data200>
+
+<data1200>
+HTTP/1.1 200 Things are fine in server land (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1200>
+
+<!-- Requests number 3: Digest auth, user1 -->
+<data300>
+HTTP/1.1 401 Need Digest auth (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="3"
+
+This is not the real page!
+</data300>
+<data1300>
+HTTP/1.1 200 Things are fine in server land (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1300>
+
+<!-- Requests number 4: Digest auth, user1 -->
+<!-- This 401 response should not be sent, as the request should have Digest Auth header -->
+<data310>
+HTTP/1.1 401 Need Digest auth (3-1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="3-1"
+
+This is not the real page!
+</data310>
+<data1310>
+HTTP/1.1 200 Things are fine in server land (3-1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1310>
+
+<!-- Requests number 5: Digest auth, USER2 -->
+<data400>
+HTTP/1.1 401 Need Digest auth (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="4"
+
+This is not the real page!
+</data400>
+<data1400>
+HTTP/1.1 200 Things are fine in server land (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1400>
+
+<!-- Requests number 6: Digest auth, USER2 -->
+<!-- This 401 response should not be sent, as the request should have Digest Auth header -->
+<data410>
+HTTP/1.1 401 Need Digest auth (4-1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="4-1"
+
+This is not the real page!
+</data410>
+<data1410>
+HTTP/1.1 200 Things are fine in server land (4-1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1410>
+<datacheck>
+HTTP/1.1 401 Need Digest auth (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="1"
+
+HTTP/1.1 200 Things are fine in server land (1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Digest auth (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="2"
+
+HTTP/1.1 200 Things are fine in server land (2)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Digest auth (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="3"
+
+HTTP/1.1 200 Things are fine in server land (3)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (3-1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Digest auth (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="4"
+
+HTTP/1.1 200 Things are fine in server land (4)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (4-1)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+crypto
+!SSPI
+</features>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP Digest auth repeat with varying user
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER digest user1-USER2
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="user1", realm="testrealm", nonce="1", uri="/%TESTNUMBER0100", response="0c8f36f4bd48c781db5c288e9ad8dfc5"
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="USER2", realm="testrealm", nonce="2", uri="/%TESTNUMBER0200", response="cb0da6b1ee670d466ce0495c63891de8"
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="user1", realm="testrealm", nonce="3", uri="/%TESTNUMBER0300", response="c2cbe700066069a6e458eeb071dedd37"
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="user1", realm="testrealm", nonce="3", uri="/%TESTNUMBER0310", response="7615ad0b247d78c3321afed7106619f3"
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="USER2", realm="testrealm", nonce="4", uri="/%TESTNUMBER0400", response="26201b4f814b8cda1e16a67bc575f68b"
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="USER2", realm="testrealm", nonce="4", uri="/%TESTNUMBER0410", response="e88f00b291dd8d2bc846347301ee8c86"
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2091
+++ b/tests/data/test2091
@@ -1,0 +1,232 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Basic auth
+HTTP Digest auth
+</keywords>
+</info>
+# Server-side
+<reply>
+
+<!-- Request number 1: Basic auth -->
+<data100>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data100>
+
+<!-- Request number 2: Digest auth -->
+<data200>
+HTTP/1.1 401 Need Basic or Digest auth (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="200"
+
+This is not the real page!
+</data200>
+
+<data1200>
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1200>
+
+<!-- Requests number 3: Basic auth -->
+<data300>
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data300>
+
+<!-- Requests number 4: Basic auth -->
+<data310>
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data310>
+
+<!-- Requests number 5: Digest auth -->
+<data400>
+HTTP/1.1 401 Need Basic or Digest auth (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="400"
+
+This is not the real page!
+</data400>
+<data1400>
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1400>
+
+<!-- Requests number 6: Digest auth -->
+<!-- This 401 response should not be sent, as the request should have Digest Auth header -->
+<data410>
+HTTP/1.1 401 Need Basic or Digest auth (#410)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="410"
+
+This is not the real page!
+</data410>
+<data1410>
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1410>
+<datacheck>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Basic or Digest auth (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="200"
+
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Basic or Digest auth (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="400"
+
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+crypto
+!SSPI
+</features>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP Basic then Digest auth repeat
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER basic-digest
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="200", uri="/%TESTNUMBER0200", response="8e52efe415591db19333761d3c54e121"
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="400", uri="/%TESTNUMBER0400", response="9eeca93aecc7f1a072673bff9581399c"
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="400", uri="/%TESTNUMBER0410", response="b80fc90f5f467a8751cf81a23034ccba"
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2092
+++ b/tests/data/test2092
@@ -1,0 +1,232 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Basic auth
+HTTP Digest auth
+</keywords>
+</info>
+# Server-side
+<reply>
+
+<!-- Request number 1: Basic auth, user1 -->
+<data100>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data100>
+
+<!-- Request number 2: Digest auth, USER2 -->
+<data200>
+HTTP/1.1 401 Need Basic or Digest auth (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="200"
+WWW-Authenticate: Basic realm="testrealm"
+
+This is not the real page!
+</data200>
+
+<data1200>
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1200>
+
+<!-- Requests number 3: Basic auth, user1 -->
+<data300>
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data300>
+
+<!-- Requests number 4: Basic auth, user1 -->
+<data310>
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data310>
+
+<!-- Requests number 5: Digest auth, USER2 -->
+<data400>
+HTTP/1.1 401 Need Basic or Digest auth (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="400"
+WWW-Authenticate: Basic realm="testrealm"
+
+This is not the real page!
+</data400>
+<data1400>
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1400>
+
+<!-- Requests number 6: Digest auth, USER2 -->
+<!-- This 401 response should not be sent, as the request should have Digest Auth header -->
+<data410>
+HTTP/1.1 401 Need Basic or Digest auth (#410)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="410"
+WWW-Authenticate: Basic realm="testrealm"
+
+This is not the real page!
+</data410>
+<data1410>
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1410>
+<datacheck>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Basic or Digest auth (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="200"
+WWW-Authenticate: Basic realm="testrealm"
+
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need Basic or Digest auth (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="400"
+WWW-Authenticate: Basic realm="testrealm"
+
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: libmicrohttpd
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+crypto
+!SSPI
+</features>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP Basic then Digest auth repeat with different users
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER basic-digest user1-USER2
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="USER2", realm="testrealm", nonce="200", uri="/%TESTNUMBER0200", response="f1f79a8a7547be0e18d4cd00aaa8aab5"
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjE6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="USER2", realm="testrealm", nonce="400", uri="/%TESTNUMBER0400", response="1dfe33cca40460e6caf9dd0490b90fcc"
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="USER2", realm="testrealm", nonce="400", uri="/%TESTNUMBER0410", response="1beeac3a332171aa5c1b0ef3814d34ab"
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2093
+++ b/tests/data/test2093
@@ -1,0 +1,272 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Digest auth
+HTTP NTLM auth
+</keywords>
+</info>
+# Server-side
+<reply>
+<servercmd>
+connection-number
+</servercmd>
+
+<!-- Request number 1: NTLM auth -->
+<!-- This 401 response should not be sent, as the request should have NTLM Auth header -->
+<data100>
+HTTP/1.1 401 Need NTLM or Digest auth (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: NTLM
+WWW-Authenticate: Digest realm="testrealm", nonce="100"
+
+This is not the real page!
+</data100>
+<data1101>
+HTTP/1.1 401 NTLM intermediate (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 33
+WWW-Authenticate: NTLM TlRMTVNTUAACAAAACAAIADAAAACGgAEAq6U1NAWaJCIAAAAAAAAAAAAAAAA4AAAATlRMTUF1dGg=
+
+This is still not the real page!
+</data1101>
+<data1102>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1102>
+
+
+<!-- Request number 2: Digest auth -->
+<data200>
+HTTP/1.1 401 Need NTLM or Digest auth (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: NTLM
+WWW-Authenticate: Digest realm="testrealm", nonce="200"
+
+This is not the real page!
+</data200>
+
+<data1200>
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1200>
+
+<!-- Requests number 3: NTLM auth -->
+<!-- The same (already authorised) connection must be reused, no authentication headers -->
+<data300>
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data300>
+
+<!-- Requests number 4: NTLM auth -->
+<!-- The same (already authorised) connection must be reused, no authentication headers -->
+<data310>
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data310>
+
+<!-- Requests number 5: Digest auth -->
+<data400>
+HTTP/1.1 401 Need NTLM or Digest auth (#400)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="400"
+WWW-Authenticate: NTLM
+
+This is not the real page!
+</data400>
+<data1400>
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1400>
+
+<!-- Requests number 6: Digest auth -->
+<!-- This 401 response should not be sent, as the request should have Digest Auth header -->
+<data410>
+HTTP/1.1 401 Need NTLM or Digest auth (#410)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="410"
+WWW-Authenticate: NTLM
+
+This is not the real page!
+</data410>
+<data1410>
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1410>
+<datacheck>
+HTTP/1.1 401 NTLM intermediate (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 33
+WWW-Authenticate: NTLM TlRMTVNTUAACAAAACAAIADAAAACGgAEAq6U1NAWaJCIAAAAAAAAAAAAAAAA4AAAATlRMTUF1dGg=
+
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need NTLM or Digest auth (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: NTLM
+WWW-Authenticate: Digest realm="testrealm", nonce="200"
+
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 401 Need NTLM or Digest auth (#400)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 27
+WWW-Authenticate: Digest realm="testrealm", nonce="400"
+WWW-Authenticate: NTLM
+
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+crypto
+NTLM
+!SSPI
+</features>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP NTLM then Digest auth repeat with the same credentials
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER NTLM-digest
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+[CONNECTION #1]
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: NTLM TlRMTVNTUAABAAAABoIIAAAAAAAAAAAAAAAAAAAAAAA=
+Accept: */*
+
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: NTLM TlRMTVNTUAADAAAAGAAYAEAAAAAYABgAWAAAAAAAAABwAAAACAAIAHAAAAALAAsAeAAAAAAAAAAAAAAAhoABAI+/Fp9IERAQ74OsdNPbBpg7o8CVwLSO4DtFyIcZHUMKVktWIu92s2892OVpd2JzqnRlc3R1c2VyV09SS1NUQVRJT04=
+Accept: */*
+
+[CONNECTION #2]
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="200", uri="/%TESTNUMBER0200", response="7ad54e8c38e0c8027b4b2177b6052987"
+Accept: */*
+
+[CONNECTION #1]
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+[CONNECTION #2]
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="400", uri="/%TESTNUMBER0400", response="7e3297c9ee208df1cb5e39abb80d4be9"
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="400", uri="/%TESTNUMBER0410", response="471c93e9189c9b41f680a413f292ea64"
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2094
+++ b/tests/data/test2094
@@ -1,0 +1,253 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Basic auth
+HTTP Digest auth
+HTTP NTLM auth
+</keywords>
+</info>
+# Server-side
+<reply>
+<servercmd>
+connection-number
+</servercmd>
+
+<!-- Request number 1: Basic auth -->
+<data100>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#100)
+</data100>
+
+<!-- Request number 2: NTLM auth -->
+<!-- This 401 response should not be sent, as the request should have NTLM Auth header -->
+<data200>
+HTTP/1.1 401 Need Basic or NTLM or Digest auth (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 34
+WWW-Authenticate: NTLM
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm"
+
+This is not the real page! (#200)
+</data200>
+<data1201>
+HTTP/1.1 401 NTLM intermediate (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 40
+WWW-Authenticate: NTLM TlRMTVNTUAACAAAACAAIADAAAACGgAEAq6U1NAWaJCIAAAAAAAAAAAAAAAA4AAAATlRMTUF1dGg=
+
+This is still not the real page! (#200)
+</data1201>
+<data1202>
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#200)
+</data1202>
+
+
+<!-- Requests number 3: Digest auth -->
+<data300>
+HTTP/1.1 401 Need NTLM or Digest or Basic auth (#300)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 34
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="300"
+WWW-Authenticate: NTLM
+
+This is not the real page! (#300)
+</data300>
+<data1300>
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#300)
+</data1300>
+
+<!-- Requests number 4: Digest auth -->
+<!-- This 401 response should not be sent, as the request should have Digest Auth header -->
+<data310>
+HTTP/1.1 401 Need NTLM or Digest or Basic auth (#310)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 34
+WWW-Authenticate: Digest realm="testrealm", nonce="310"
+WWW-Authenticate: NTLM
+
+This is not the real page! (#310)
+</data310>
+<data1310>
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#310)
+</data1310>
+
+<!-- Requests number 5: NTLM auth -->
+<!-- The same (already authorised) connection must be reused, no authentication headers -->
+<data400>
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#400)
+</data400>
+
+<!-- Requests number 6: NTLM auth -->
+<!-- The same (already authorised) connection must be reused, no authentication headers -->
+<data410>
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#410)
+</data410>
+<datacheck>
+HTTP/1.1 200 Things are fine in server land (#100)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#100)
+HTTP/1.1 401 NTLM intermediate (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 40
+WWW-Authenticate: NTLM TlRMTVNTUAACAAAACAAIADAAAACGgAEAq6U1NAWaJCIAAAAAAAAAAAAAAAA4AAAATlRMTUF1dGg=
+
+HTTP/1.1 200 Things are fine in server land (#200)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#200)
+HTTP/1.1 401 Need NTLM or Digest or Basic auth (#300)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 34
+WWW-Authenticate: Basic realm="testrealm"
+WWW-Authenticate: Digest realm="testrealm", nonce="300"
+WWW-Authenticate: NTLM
+
+HTTP/1.1 200 Things are fine in server land (#300)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#300)
+HTTP/1.1 200 Things are fine in server land (#310)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#310)
+HTTP/1.1 200 Things are fine in server land (#400)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#400)
+HTTP/1.1 200 Things are fine in server land (#410)
+Server: Microsoft-IIS/10.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 39
+
+Finally, this is the real page! (#410)
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+crypto
+NTLM
+!SSPI
+</features>
+<server>
+http
+</server>
+<tool>
+libauthrepeat
+</tool>
+
+<name>
+HTTP Basic-NTLM-Digest-NTLM auth repeat with the same credentials
+</name>
+<setenv>
+# we force our own host name, in order to make the test machine independent
+CURL_GETHOSTNAME=curlhost
+# we try to use the LD_PRELOAD hack, if not a debug build
+LD_PRELOAD=%PWD/libtest/.libs/libhostname.so
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER basic-NTLM-digest-NTLM
+</command>
+<precheck>
+chkhostname curlhost
+</precheck>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+[CONNECTION #1]
+GET /%TESTNUMBER0100 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: NTLM TlRMTVNTUAABAAAABoIIAAAAAAAAAAAAAAAAAAAAAAA=
+Accept: */*
+
+GET /%TESTNUMBER0200 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: NTLM TlRMTVNTUAADAAAAGAAYAEAAAAAYABgAWAAAAAAAAABwAAAACAAIAHAAAAALAAsAeAAAAAAAAAAAAAAAhoABAI+/Fp9IERAQ74OsdNPbBpg7o8CVwLSO4DtFyIcZHUMKVktWIu92s2892OVpd2JzqnRlc3R1c2VyV09SS1NUQVRJT04=
+Accept: */*
+
+[CONNECTION #2]
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0300 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="300", uri="/%TESTNUMBER0300", response="24a72f3362d3d5c496becb223587f285"
+Accept: */*
+
+GET /%TESTNUMBER0310 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="300", uri="/%TESTNUMBER0310", response="4d1658648f76bae952d200df283f3d79"
+Accept: */*
+
+[CONNECTION #1]
+GET /%TESTNUMBER0400 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0410 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/.gitignore
+++ b/tests/libtest/.gitignore
@@ -8,5 +8,6 @@ lib[123][0-9][0-9][0-9]
 lib[56][0-9][0-9]
 lib1521.c
 libauthretry
+libauthrepeat
 libntlmconnect
 libprereq

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -37,7 +37,7 @@ MULTIBYTE = ../../lib/curl_multibyte.c ../../lib/curl_multibyte.h
 SUPPORTFILES = ../../lib/timediff.c ../../lib/timediff.h first.c test.h
 
 # These are all libcurl test programs
-noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
+noinst_PROGRAMS = chkhostname libauthretry libauthrepeat libntlmconnect  \
  chkdecimalpoint libprereq                                               \
  lib500 lib501 lib502 lib503 lib504 lib505 lib506 lib507 lib508 lib509   \
  lib510 lib511 lib512 lib513 lib514 lib515 lib516 lib517 lib518 lib519   \
@@ -84,6 +84,9 @@ libntlmconnect_CPPFLAGS = $(AM_CPPFLAGS)
 
 libauthretry_SOURCES = libauthretry.c $(SUPPORTFILES)
 libauthretry_CPPFLAGS = $(AM_CPPFLAGS)
+
+libauthrepeat_SOURCES = libauthrepeat.c $(SUPPORTFILES)
+libauthrepeat_CPPFLAGS = $(AM_CPPFLAGS)
 
 libprereq_SOURCES = libprereq.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 libprereq_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -80,6 +80,7 @@ void wait_ms(int ms)
 
 char *libtest_arg2 = NULL;
 char *libtest_arg3 = NULL;
+char *libtest_arg4 = NULL;
 int test_argc;
 char **test_argv;
 
@@ -172,6 +173,9 @@ int main(int argc, char **argv)
 
   if(argc>3)
     libtest_arg3 = argv[3];
+
+  if(argc > 4)
+    libtest_arg4 = argv[4];
 
   URL = argv[1]; /* provide this to the rest */
 

--- a/tests/libtest/libauthrepeat.c
+++ b/tests/libtest/libauthrepeat.c
@@ -1,0 +1,254 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* argv1 = URL
+ * argv2 = auth types in form auth1[-auth2[-auth3[-user4]]]
+ * argv3 = auth users in form [user1[-user2[-user3[-user4]]]]
+ * argv4 = auth passwords in form [pwd1[-pwd2[-pwd3[-pwd4]]]]
+ */
+/*
+   This tool issue requests with specified auth types and user names in order:
+   * one request with auth1 and user1:pwd1
+   * one request with auth2 and user2:pwd2
+   * two requests with auth3 and user3:pwd3
+   * two requests with auth4 and user4:pwd4
+
+   Auth types 2, 3, and 4 are optional, if missing then first values
+   will be repeated. The same applies for user names and passwords.
+   If no username is specified then default value 'testuser' is used.
+   If no password is specified then default value 'testpass' is used.
+ */
+
+#include "test.h"
+#include "memdebug.h"
+
+static const char *auth_scheme_name(long auth_scheme)
+{
+  switch(auth_scheme) {
+  case CURLAUTH_NONE:
+    return "none";
+  case CURLAUTH_BASIC:
+    return "Basic";
+  case CURLAUTH_DIGEST:
+    return "Digest";
+  case CURLAUTH_NTLM:
+    return "NTLM";
+  default:
+    break;
+  }
+  return "UNKNOWN";
+}
+
+static CURLcode send_request(CURL *curl, const char *url, int seq,
+                             long auth_scheme, const char *user,
+                             const char *pwd)
+{
+  CURLcode res;
+  size_t len = strlen(url) + 4 + 1;
+  char *full_url = malloc(len);
+  if(!full_url) {
+    fprintf(stderr, "Not enough memory for full url\n");
+    return CURLE_OUT_OF_MEMORY;
+  }
+
+  msnprintf(full_url, len, "%s%04d", url, seq);
+  fprintf(stderr, "Sending new request %d to %s with credential %s:%s "
+          "(auth %s)\n", seq, full_url, user, pwd,
+          auth_scheme_name(auth_scheme));
+  test_setopt(curl, CURLOPT_URL, full_url);
+  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  test_setopt(curl, CURLOPT_HEADER, 1L);
+  test_setopt(curl, CURLOPT_HTTPGET, 1L);
+  test_setopt(curl, CURLOPT_USERNAME, user);
+  test_setopt(curl, CURLOPT_PASSWORD, pwd);
+  test_setopt(curl, CURLOPT_HTTPAUTH, auth_scheme);
+  test_setopt(curl, CURLOPT_FAILONERROR, 1L);
+
+  res = curl_easy_perform(curl);
+
+test_cleanup:
+  free(full_url);
+  return res;
+}
+
+#ifndef HAVE_STRDUP
+static char *local_strdup(const char *str)
+{
+  char *ptr;
+  size_t len = strlen(str);
+  ptr = malloc(len + 1);
+  if(!ptr)
+    return ptr;
+  memcpy(ptr, str, len + 1);
+  return ptr;
+}
+
+#ifdef strdup
+#undef strdup
+#endif
+#define strdup local_strdup
+#endif
+
+static int parse_auth_types(const char *arg, long auth_types[4])
+{
+  char *arg_copy;
+  const char *token;
+  char *sep;
+  unsigned int i;
+  unsigned int j;
+
+  if(!arg) {
+    fprintf(stderr, "no auth scheme on commandline\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+  arg_copy = strdup(arg);
+  if(!arg_copy) {
+    fprintf(stderr, "out of memory error\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  i = 0;
+  token = arg_copy;
+  while(!0) {
+    if(i >= 4) {
+      fprintf(stderr, "too many auth schemes on commandline\n");
+      free(arg_copy);
+      return TEST_ERR_MAJOR_BAD;
+    }
+    sep = strchr(token, '-');
+    if(sep)
+      *sep = 0;
+    if(curl_strequal(token, "none"))
+      auth_types[i++] = CURLAUTH_NONE;
+    else if(curl_strequal(token, "basic"))
+      auth_types[i++] = CURLAUTH_BASIC;
+    else if(curl_strequal(token, "digest"))
+      auth_types[i++] = CURLAUTH_DIGEST;
+    else if(curl_strequal(token, "ntlm"))
+      auth_types[i++] = CURLAUTH_NTLM;
+    else {
+      fprintf(stderr, "unknown auth scheme on commandline\n");
+      free(arg_copy);
+      return TEST_ERR_MAJOR_BAD;
+    }
+    if(!sep)
+      break;
+    token = sep + 1;
+  }
+  free(arg_copy);
+  for(j = i; j < 4; j++) {
+    auth_types[j] = auth_types[j % i];
+  }
+  return 0;
+}
+
+
+static int parse_cred_strings(const char *arg, char creds[4][32],
+                              const char *def_str)
+{
+  unsigned int i;
+  unsigned int j;
+
+  i = 0;
+  if(!arg)
+    strcpy(creds[i++], def_str);
+  else {
+    const char *sep;
+    const char *token;
+    size_t len;
+
+    token = arg;
+    while(!0) {
+      if(i >= 4) {
+        fprintf(stderr, "too many usernames or passwords on commandline\n");
+        return TEST_ERR_MAJOR_BAD;
+      }
+      sep = strchr(token, '-');
+      if(sep)
+        len = (size_t) (sep - token);
+      else
+        len = strlen(token);
+      if(len > 31) {
+        fprintf(stderr, "too long username or password\n");
+        return TEST_ERR_MAJOR_BAD;
+      }
+      memcpy(creds[i], token, len);
+      creds[i][len] = 0;
+      i++;
+      if(!sep)
+        break;
+      token = sep + 1;
+    }
+  }
+
+  for(j = i; j < 4; j++) {
+    strcpy(creds[j], creds[j % i]);
+  }
+  return 0;
+}
+
+int test(char *url)
+{
+  CURLcode res;
+  CURL *curl = NULL;
+  long auth_types[4];
+  char usernames[4][32];
+  char passwords[4][32];
+  int i;
+
+  if(parse_auth_types(libtest_arg2, auth_types) ||
+     parse_cred_strings(libtest_arg3, usernames, "testuser") ||
+     parse_cred_strings(libtest_arg4, passwords, "testpass"))
+    return TEST_ERR_MAJOR_BAD;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  for(i = 0; i < 4; i++) {
+    res = send_request(curl, url, 100 * (i + 1), auth_types[i],
+                       usernames[i], passwords[i]);
+    if(res != CURLE_OK)
+      break;
+    if(i >= 2) {
+      /* Send the same request twice */
+      res = send_request(curl, url, 100 * (i + 1) + 10, auth_types[i],
+                         usernames[i], passwords[i]);
+      if(res != CURLE_OK)
+        break;
+    }
+  }
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return (int)res;
+}

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -52,6 +52,7 @@
 
 extern char *libtest_arg2; /* set by first.c to the argv[2] or NULL */
 extern char *libtest_arg3; /* set by first.c to the argv[3] or NULL */
+extern char *libtest_arg4; /* set by first.c to the argv[4] or NULL */
 
 /* argc and argv as passed in to the main() function */
 extern int test_argc;


### PR DESCRIPTION
This PR should fix situation not tested by testsuite: changed password or (and) username for easy handle which has been authorized before.
This is applicable only when `libcurl` is used directly, `curl` binary resets easy handle after each request.

If new username/password (or authorisation type) is used then for the next transfer authorisation status must be reset otherwise new username/password will not be used.
As for digest authorisation servers may associate unique nonce values with clients (for session types protocols servers *must* remember nonce-client association together with first `cnonce` (or `H(A1)`) value as the same value is used for the rest of the session), so if `nonce` value was used to send the response it is better to get a fresh `nonce` to avoid any problems with authentication.

As centralized reset of digest data is implemented, a workaround in SSPI code to detect new username/password is removed.

To reduce the number of requests, added tracking whether server 'nonce' has been used at least one time. For example if Digest header was decoded when doing NTLM or Basic authorisation, but `nonce` hasn't been used, the code will use already received `nonce`.

This PR also resets `state.authhost.avail` and `state.authhost.avail` as otherwise digest headers are rejected as duplication by https://github.com/curl/curl/blob/e6f8445edef8e7996d1cfb141d6df184efef972c/lib/http.c#L1031-L1032

Small notification is printed as debug string, when authorisation status and/or digest are reset so user may understand better the ongoing processes.

With accurate tracking of used `nonce` number of required requests are even lower than needed before this patch. Removed not needed now comment about duplicated 401 responses from tests 2027 and 2030.

Added new type of tests with seven additional tests. Added report for connection number in tests to deal with NTLM which requires new/existing connection switching when one of the connection is authorised by  NTLM.