### PR TITLE
urldata: make 'use_port' an usigned short

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PORT.3
+++ b/docs/libcurl/opts/CURLOPT_PORT.3
@@ -42,8 +42,9 @@ protocol.
 Usually, you just let the URL decide which port to use but this allows the
 application to override that.
 
-While this option accepts a 'long', a port number is usually a 16 bit number
-and therefore using a port number over 65535 will cause a runtime error.
+While this option accepts a 'long', a port number is an unsigned 16 bit number
+and therefore using a port number lower than zero or over 65535 will cause a
+\fBCURLE_BAD_FUNCTION_ARGUMENT\fP error.
 .SH DEFAULT
 By default this is 0 which makes it not used. This also makes port number zero
 impossible to set with this API.

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1431,12 +1431,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
   case CURLOPT_PORT:
     /*
-     * The port number to use when getting the URL
+     * The port number to use when getting the URL. 0 disables it.
      */
     arg = va_arg(param, long);
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.use_port = arg;
+    data->set.use_port = (unsigned short)arg;
     break;
   case CURLOPT_TIMEOUT:
     /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -2128,7 +2128,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     unsigned long port = strtoul(data->state.up.port, NULL, 10);
     conn->port = conn->remote_port =
       (data->set.use_port && data->state.allow_port) ?
-      (int)data->set.use_port : curlx_ultous(port);
+      data->set.use_port : curlx_ultous(port);
   }
 
   (void)curl_url_get(uh, CURLUPART_QUERY, &data->state.up.query, 0);
@@ -2964,7 +2964,7 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
     /* if set, we use this instead of the port possibly given in the URL */
     char portbuf[16];
     CURLUcode uc;
-    conn->remote_port = (unsigned short)data->set.use_port;
+    conn->remote_port = data->set.use_port;
     msnprintf(portbuf, sizeof(portbuf), "%d", conn->remote_port);
     uc = curl_url_set(data->state.uh, CURLUPART_PORT, portbuf, 0);
     if(uc)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1649,7 +1649,7 @@ struct UserDefined {
   void *out;         /* CURLOPT_WRITEDATA */
   void *in_set;      /* CURLOPT_READDATA */
   void *writeheader; /* write the header to this if non-NULL */
-  long use_port;     /* which port to use (when not using default) */
+  unsigned short use_port; /* which port to use (when not using default) */
   unsigned long httpauth;  /* kind of HTTP authentication to use (bitmask) */
   unsigned long proxyauth; /* kind of proxy authentication to use (bitmask) */
 #ifndef CURL_DISABLE_PROXY


### PR DESCRIPTION
... instead of a long. It is already enforced to not attempt to set any
value outside of 16 bits unsigned.