### PR TITLE
Makefile.m32: add `NGTCP2_LIBS` option [ci skip]

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -278,7 +278,12 @@ ifdef SSL
     curl_LDADD += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
     ifdef NGTCP2
       CFLAGS += -DUSE_NGTCP2
-      curl_LDADD += -L"$(NGTCP2_PATH)/lib" -lngtcp2 -lngtcp2_crypto_openssl
+      curl_LDADD += -L"$(NGTCP2_PATH)/lib"
+      ifdef NGTCP2_LIBS
+        curl_LDADD += $(NGTCP2_LIBS)
+      else
+        curl_LDADD += -lngtcp2 -lngtcp2_crypto_openssl
+      endif
     endif
   endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -293,7 +293,12 @@ ifdef SSL
     ifdef NGTCP2
       INCLUDES += -I"$(NGTCP2_PATH)/include"
       CFLAGS += -DUSE_NGTCP2
-      DLL_LIBS += -L"$(NGTCP2_PATH)/lib" -lngtcp2 -lngtcp2_crypto_openssl
+      DLL_LIBS += -L"$(NGTCP2_PATH)/lib"
+      ifdef NGTCP2_LIBS
+        DLL_LIBS += $(NGTCP2_LIBS)
+      else
+        DLL_LIBS += -lngtcp2 -lngtcp2_crypto_openssl
+      endif
     endif
   endif
 

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -303,7 +303,12 @@ ifdef SSL
     curl_LDADD += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
     ifdef NGTCP2
       CFLAGS += -DUSE_NGTCP2
-      curl_LDADD += -L"$(NGTCP2_PATH)/lib" -lngtcp2 -lngtcp2_crypto_openssl
+      curl_LDADD += -L"$(NGTCP2_PATH)/lib"
+      ifdef NGTCP2_LIBS
+        curl_LDADD += $(NGTCP2_LIBS)
+      else
+        curl_LDADD += -lngtcp2 -lngtcp2_crypto_openssl
+      endif
     endif
   endif
 


### PR DESCRIPTION
Makefile.m32's ngtcp2 has its two libs hardwired for OpenSSL.
Add `NGTCP2_LIBS` envvar to override them with a custom list,
making it possible to use BoringSSL, or any other backend.