### PR TITLE
openssl: fix BoringSSL symbol conflicts with LDAP and Schannel

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -45,6 +45,13 @@
 # else
 #  include <winber.h>
 # endif
+  /* Undefine wincrypt conflicting symbols for BoringSSL. */
+# undef X509_NAME
+# undef X509_EXTENSIONS
+# undef PKCS7_ISSUER_AND_SERIAL
+# undef PKCS7_SIGNER_INFO
+# undef OCSP_REQUEST
+# undef OCSP_RESPONSE
 #else
 # define LDAP_DEPRECATED 1      /* Be sure ldap_init() is defined. */
 # ifdef HAVE_LBER_H

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -37,6 +37,18 @@
  * OpenLDAP library versions, USE_OPENLDAP shall not be defined.
  */
 
+/* Wincrypt must be included before anything that could include OpenSSL. */
+#if defined(WIN32)
+#include <wincrypt.h>
+/* Undefine wincrypt conflicting symbols for BoringSSL. */
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef PKCS7_SIGNER_INFO
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif
+
 #ifdef USE_WIN32_LDAP           /* Use Windows LDAP implementation. */
 # include <winldap.h>
 # ifndef LDAP_VENDOR_NAME
@@ -45,13 +57,6 @@
 # else
 #  include <winber.h>
 # endif
-  /* Undefine wincrypt conflicting symbols for BoringSSL. */
-# undef X509_NAME
-# undef X509_EXTENSIONS
-# undef PKCS7_ISSUER_AND_SERIAL
-# undef PKCS7_SIGNER_INFO
-# undef OCSP_REQUEST
-# undef OCSP_RESPONSE
 #else
 # define LDAP_DEPRECATED 1      /* Be sure ldap_init() is defined. */
 # ifdef HAVE_LBER_H

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -38,7 +38,7 @@
  */
 
 /* Wincrypt must be included before anything that could include OpenSSL. */
-#if defined(WIN32)
+#if defined(USE_WIN32_CRYPTO)
 #include <wincrypt.h>
 /* Undefine wincrypt conflicting symbols for BoringSSL. */
 #undef X509_NAME

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -29,6 +29,14 @@
 #ifdef USE_SCHANNEL
 
 #include <schnlsp.h>
+/* Undefine wincrypt conflicting symbols for BoringSSL. */
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef PKCS7_SIGNER_INFO
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+
 #include <schannel.h>
 #include "curl_sspi.h"
 

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -28,7 +28,9 @@
 
 #ifdef USE_SCHANNEL
 
-#include <schnlsp.h>
+/* Wincrypt must be included before anything that could include OpenSSL. */
+#if defined(WIN32)
+#include <wincrypt.h>
 /* Undefine wincrypt conflicting symbols for BoringSSL. */
 #undef X509_NAME
 #undef X509_EXTENSIONS
@@ -36,7 +38,9 @@
 #undef PKCS7_SIGNER_INFO
 #undef OCSP_REQUEST
 #undef OCSP_RESPONSE
+#endif
 
+#include <schnlsp.h>
 #include <schannel.h>
 #include "curl_sspi.h"
 

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -29,7 +29,7 @@
 #ifdef USE_SCHANNEL
 
 /* Wincrypt must be included before anything that could include OpenSSL. */
-#if defined(WIN32)
+#if defined(USE_WIN32_CRYPTO)
 #include <wincrypt.h>
 /* Undefine wincrypt conflicting symbols for BoringSSL. */
 #undef X509_NAME


### PR DESCRIPTION
Same issue as here [1], but this time when building curl with BoringSSL
for Windows with LDAP(S) or Schannel support enabled.

Apply the same fix [2] for these source files as well.

This can also be fixed by moving `#include "urldata.h"` _before_
including `winldap.h` and `schnlsp.h` respectively. This seems like
a cleaner fix, though I'm not sure why it works and if it has any
downside. (see [below](https://github.com/curl/curl/pull/9110#issuecomment-1175624864))

[1] https://github.com/curl/curl/issues/5669
[2] https://github.com/curl/curl/commit/fbe07c6829ba8c5793c84c2856526e19e9029ab9