### PR TITLE
openssl: add ability identify BoringSSL via `CURL_BORINGSSL_VERSION`

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4454,7 +4454,13 @@ static size_t ossl_version(char *buffer, size_t size)
                    (LIBRESSL_VERSION_NUMBER>>12)&0xff);
 #endif
 #elif defined(OPENSSL_IS_BORINGSSL)
+#ifdef CURL_BORINGSSL_VERSION
+  return msnprintf(buffer, size, "%s/%s",
+                   OSSL_PACKAGE,
+                   CURL_BORINGSSL_VERSION);
+#else
   return msnprintf(buffer, size, OSSL_PACKAGE);
+#endif
 #elif defined(HAVE_OPENSSL_VERSION) && defined(OPENSSL_VERSION_STRING)
   return msnprintf(buffer, size, "%s/%s",
                    OSSL_PACKAGE, OpenSSL_version(OPENSSL_VERSION_STRING));


### PR DESCRIPTION
BoringSSL doesn't keep a version number, and doesn't self-identify itself
via any other revision number via its own headers. BoringSSL revision can
be identified by its commit hash. This hash is usually known by the
builder. This patch adds a way to pass this hash to libcurl, so that it
can display in the curl version string:

For example:

`CFLAGS=-DCURL_BORINGSSL_VERSION="c239ffd0"`

```
curl 7.84.0 (x86_64-w64-mingw32) libcurl/7.84.0 BoringSSL/c239ffd0 (Schannel) zlib/1.2.12 brotli/1.0.9 libidn2/2.3.2 libssh2/1.10.0 nghttp2/1.48.0 ngtcp2/0.6.0 nghttp3/0.5.0 libgsasl/1.100
Release-Date: 2022-06-27
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli gsasl HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL SSPI threadsafe UnixSockets
```

The setting is optional, and if not passed, BoringSSL will appear without
a version number, just like before this patch.