### PR TITLE
tool_operate.c: fix several problems about the usage of curl_easy_init()

### DIFF
--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -560,7 +560,7 @@ CURLcode Curl_getinfo(struct Curl_easy *data, CURLINFO info, ...)
   CURLcode result = CURLE_UNKNOWN_OPTION;
 
   if(!data)
-    return result;
+    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   va_start(arg, info);
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2392,11 +2392,6 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
     CURL *curltls = curl_easy_init();
     struct curl_tlssessioninfo *tls_backend_info = NULL;
 
-    if(!curltls) {
-      errorf(global, "out of memory\n");
-      return CURLE_OUT_OF_MEMORY;
-    }
-
     /* With the addition of CAINFO support for Schannel, this search could find
      * a certificate bundle that was previously ignored. To maintain backward
      * compatibility, only perform this search if not using Schannel.


### PR DESCRIPTION
On the one hand, curl_easy_init() returns NULL if some errors happen.
So it is better to check the return of it to propagate the proper status.
Without the check, if curl_easy_init() fails, transfer_per_config() will
return CURLE_UNKNOWN_OPTION since curl_easy_getinfo() returns that status
when the first argument is NULL.

On the other hand, we should call curl_easy_cleanup() to prevent potential
memory leaks on other error handling paths.