### PR TITLE
fix [Known Bugs]1.11 CURLOPT_SEEKFUNCTION not called with CURLFORM_STREAM

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -716,7 +716,7 @@ int curl_formget(struct curl_httppost *form, void *arg,
   curl_mimepart toppart;
 
   Curl_mime_initpart(&toppart, NULL); /* default form is empty */
-  result = Curl_getformdata(NULL, &toppart, form, NULL);
+  result = Curl_getformdata(NULL, &toppart, form, NULL, NULL);
   if(!result)
     result = Curl_mime_prepare_headers(&toppart, "multipart/form-data",
                                        NULL, MIMESTRATEGY_FORM);
@@ -802,7 +802,8 @@ static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
 CURLcode Curl_getformdata(struct Curl_easy *data,
                           curl_mimepart *finalform,
                           struct curl_httppost *post,
-                          curl_read_callback fread_func)
+                          curl_read_callback fread_func,
+                          curl_seek_callback seek_func)
 {
   CURLcode result = CURLE_OK;
   curl_mime *form = NULL;
@@ -892,7 +893,7 @@ CURLcode Curl_getformdata(struct Curl_easy *data,
           if(!clen)
             clen = -1;
           result = curl_mime_data_cb(part, clen,
-                                     fread_func, NULL, NULL, post->userp);
+                                     fread_func, seek_func, NULL, post->userp);
         }
         else {
           size_t uclen;

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -52,7 +52,8 @@ struct FormInfo {
 CURLcode Curl_getformdata(struct Curl_easy *data,
                           curl_mimepart *,
                           struct curl_httppost *post,
-                          curl_read_callback fread_func);
+                          curl_read_callback fread_func,
+                          curl_seek_callback seek_func);
 #else
 /* disabled */
 #define Curl_getformdata(a,b,c,d) CURLE_NOT_BUILT_IN

--- a/lib/http.c
+++ b/lib/http.c
@@ -2305,7 +2305,8 @@ CURLcode Curl_http_body(struct Curl_easy *data, struct connectdata *conn,
     /* Convert the form structure into a mime structure. */
     Curl_mime_cleanpart(&http->form);
     result = Curl_getformdata(data, &http->form, data->set.httppost,
-                              data->state.fread_func);
+                              data->state.fread_func,
+                              data->state.seek_func);
     if(result)
       return result;
     http->sendit = &http->form;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1375,6 +1375,7 @@ void Curl_init_CONNECT(struct Curl_easy *data)
 {
   data->state.fread_func = data->set.fread_func_set;
   data->state.in = data->set.in_set;
+  data->state.seek_func = data->set.seek_func;
 }
 
 /*

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1423,6 +1423,7 @@ struct UrlState {
 
   curl_read_callback fread_func; /* read callback/function */
   void *in;                      /* CURLOPT_READDATA */
+  curl_seek_callback seek_func;
 #ifdef USE_HTTP2
   struct Curl_easy *stream_depends_on;
   int stream_weight;


### PR DESCRIPTION
When using libcurl to POST form data using a FILE* with the CURLFORM_STREAM option of curl_formadd(). I notice that if the connection drops at just the right time, the POST is reattempted without the data from the file. It seems like the file stream position is not getting reset to the beginning of the file. I found the CURLOPT_SEEKFUNCTION option and set that with a function that performs an fseek() on the FILE*. However, setting that did not seem to fix the issue or even get called.

I have fixed this know issue locally, please help to review it, thanks

Fixes https://github.com/curl/curl/issues/9120