### PR TITLE
docs: explain curl_easy_escape/unescape curl handle is ignored

### DIFF
--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -41,6 +41,10 @@ If \fIlength\fP is set to 0 (zero), \fIcurl_easy_escape(3)\fP uses strlen() on
 the input \fIstring\fP to find out the size. This function does not accept
 input strings longer than \fBCURL_MAX_INPUT_LENGTH\fP (8 MB).
 
+Since 7.82.0, the \fBcurl\fP parameter is ignored. Prior to that there was
+per-handle character conversion support for some very old operating systems
+such as TPF, but it was otherwise ignored.
+
 You must \fIcurl_free(3)\fP the returned string when you are done with it.
 .SH ENCODING
 libcurl is typically not aware of, nor does it care about, character

--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -48,6 +48,10 @@ pointer to an \fIint\fP type, it can only return a value up to INT_MAX so no
 longer string can be unescaped if the string length is returned in this
 parameter.
 
+Since 7.82.0, the \fBcurl\fP parameter is ignored. Prior to that there was
+per-handle character conversion support for some very old operating systems
+such as TPF, but it was otherwise ignored.
+
 You must \fIcurl_free(3)\fP the returned string when you are done with it.
 .SH EXAMPLE
 .nf

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -77,6 +77,9 @@ char *curl_unescape(const char *string, int length)
   return curl_easy_unescape(NULL, string, length, NULL);
 }
 
+/* Escapes for URL the given unescaped string of given length.
+ * 'data' is ignored since 7.82.0.
+ */
 char *curl_easy_escape(struct Curl_easy *data, const char *string,
                        int inlength)
 {
@@ -191,6 +194,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
  * pointer to a malloced string with length given in *olen.
  * If length == 0, the length is assumed to be strlen(string).
  * If olen == NULL, no output length is stored.
+ * 'data' is ignored since 7.82.0.
  */
 char *curl_easy_unescape(struct Curl_easy *data, const char *string,
                          int length, int *olen)


### PR DESCRIPTION
26101421 (precedes 7.82.0) removed character conversion support used by
very old legacy operating systems and since then the curl handle passed
to curl_easy_escape/unescape is always ignored.

Bug: https://github.com/curl/curl/discussions/9115
Reported-by: Ted Lyngmo

Closes #xxxx
