### PR TITLE
CMake: remove APPEND in export(TARGETS)

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -140,6 +140,6 @@ install(TARGETS ${LIB_NAME}
 )
 
 export(TARGETS ${LIB_NAME}
-       APPEND FILE ${PROJECT_BINARY_DIR}/libcurl-target.cmake
+       FILE ${PROJECT_BINARY_DIR}/libcurl-target.cmake
        NAMESPACE ${PROJECT_NAME}::
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,6 @@ target_link_libraries(${EXE_NAME} libcurl ${CURL_LIBS})
 
 install(TARGETS ${EXE_NAME} EXPORT ${TARGETS_EXPORT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 export(TARGETS ${EXE_NAME}
-       APPEND FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
+       FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
        NAMESPACE ${PROJECT_NAME}::
 )


### PR DESCRIPTION
When running cmake several times, new content was appended to already
existing generated files, which is not appropriate