### PR TITLE
Makefile.m32: add `CURL_RC` and `CURL_STRIP` variables [ci skip]

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -113,11 +113,14 @@ endif
 ifeq ($(CURL_AR),)
 CURL_AR := $(CROSSPREFIX)ar
 endif
+ifeq ($(CURL_RC),)
+CURL_RC := $(CROSSPREFIX)windres
+endif
 
 CC = $(CURL_CC)
 CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE)
-RC = $(CROSSPREFIX)windres
+RC = $(CURL_RC)
 RCFLAGS = --include-dir=$(PROOT)/include -O coff $(CURL_RCFLAG_EXTRAS)
 
 # Set environment var ARCH to your architecture to override autodetection.

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -108,15 +108,21 @@ endif
 ifeq ($(CURL_RANLIB),)
 CURL_RANLIB := $(CROSSPREFIX)ranlib
 endif
+ifeq ($(CURL_RC),)
+CURL_RC := $(CROSSPREFIX)windres
+endif
+ifeq ($(CURL_STRIP),)
+CURL_STRIP := $(CROSSPREFIX)strip
+endif
 
 CC = $(CURL_CC)
 CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_DLL)
 AR = $(CURL_AR)
 RANLIB = $(CURL_RANLIB)
-RC = $(CROSSPREFIX)windres
+RC = $(CURL_RC)
 RCFLAGS = --include-dir=$(PROOT)/include -O coff $(CURL_RCFLAG_EXTRAS)
-STRIP   = $(CROSSPREFIX)strip -g
+STRIP   = $(CURL_STRIP) -g
 
 # Set environment var ARCH to your architecture to override autodetection.
 ifndef ARCH

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -113,14 +113,20 @@ endif
 ifeq ($(CURL_AR),)
 CURL_AR := $(CROSSPREFIX)ar
 endif
+ifeq ($(CURL_RC),)
+CURL_RC := $(CROSSPREFIX)windres
+endif
+ifeq ($(CURL_STRIP),)
+CURL_STRIP := $(CROSSPREFIX)strip
+endif
 
 CC = $(CURL_CC)
 CFLAGS = -O3 $(CURL_CFLAG_EXTRAS) -W -Wall
 LDFLAGS = $(CURL_LDFLAG_EXTRAS) $(CURL_LDFLAG_EXTRAS_EXE)
 AR = $(CURL_AR)
-RC = $(CROSSPREFIX)windres
+RC = $(CURL_RC)
 RCFLAGS = --include-dir=$(PROOT)/include -O coff -DCURL_EMBED_MANIFEST $(CURL_RCFLAG_EXTRAS)
-STRIP   = $(CROSSPREFIX)strip -g
+STRIP   = $(CURL_STRIP) -g
 
 # We may need these someday
 # PERL = perl


### PR DESCRIPTION
They allow to override the hardcoded values for the `windres` and `strip`
tools, complementing the existing set of `CURL_{CC,AR,RANLIB}` variables.

`CURL_RC` comes handy when using LLVM tools with `CROSSPREFIX=llvm-` and
`CURL_CC=clang` set on current latest debian:unstable or earlier, where
`llvm-windres` is missing, and a `CURL_RC=<triplet>-windres` fixes it.
Hopefully this will be fixed in the llvm package. FWIW `llvm-windres`
does exist in Homebrew llvm, MSYS2 llvm and llvm-mingw.