### PR TITLE
runtests: increase valgrind max thread count limit

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -727,6 +727,7 @@ sub torture {
                 $valgrindcmd .= "--suppressions=$srcdir/valgrind.supp ";
                 # $valgrindcmd .= "--gen-suppressions=all ";
                 $valgrindcmd .= "--num-callers=16 ";
+                $valgrindcmd .= "--max-threads=1030 ";
                 $valgrindcmd .= "${valgrind_logfile}=$LOGDIR/valgrind$testnum";
                 $cmd = "$valgrindcmd $testcmd";
             }
@@ -4197,6 +4198,7 @@ sub singletest {
             $valgrindcmd .= "--suppressions=$srcdir/valgrind.supp ";
            # $valgrindcmd .= "--gen-suppressions=all ";
             $valgrindcmd .= "--num-callers=16 ";
+            $valgrindcmd .= "--max-threads=1030 ";
             $valgrindcmd .= "${valgrind_logfile}=$LOGDIR/valgrind$testnum";
             $CMDLINE = "$valgrindcmd $CMDLINE";
         }


### PR DESCRIPTION
By default, valgrind limits the number of threads in the target program
to 500 while test 3026 creates at least 1000.

Increase the valgrind limit to avoid a systematic test 3026 failure.