### PR TITLE
asyn-thread: make getaddrinfo_complete return CURLcode

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -269,18 +269,18 @@ int init_thread_sync_data(struct thread_data *td,
   return 0;
 }
 
-static int getaddrinfo_complete(struct Curl_easy *data)
+static CURLcode getaddrinfo_complete(struct Curl_easy *data)
 {
   struct thread_sync_data *tsd = conn_thread_sync_data(data);
-  int rc;
+  CURLcode result;
 
-  rc = Curl_addrinfo_callback(data, tsd->sock_error, tsd->res);
+  result = Curl_addrinfo_callback(data, tsd->sock_error, tsd->res);
   /* The tsd->res structure has been copied to async.dns and perhaps the DNS
      cache.  Set our copy to NULL so destroy_thread_sync_data doesn't free it.
   */
   tsd->res = NULL;
 
-  return rc;
+  return result;
 }
 
 


### PR DESCRIPTION
... as the only caller that cares about what it returns assumes that
anyway. This caused icc to warn:

asyn-thread.c(505): error #188: enumerated type mixed with another type
        result = getaddrinfo_complete(data);

Repoorted-by: Matthew Thompson
Bug: https://github.com/curl/curl/issues/9081#issuecomment-1182143076