### PR TITLE
mprintf: make dprintf_formatf never return negative

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -245,7 +245,7 @@ void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
   DEBUGASSERT(!strchr(fmt, '\n'));
   if(data && data->set.verbose) {
     va_list ap;
-    size_t len;
+    int len;
     char buffer[MAXINFO + 2];
     va_start(ap, fmt);
     len = mvsnprintf(buffer, MAXINFO, fmt, ap);
@@ -265,7 +265,7 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
   DEBUGASSERT(!strchr(fmt, '\n'));
   if(data->set.verbose || data->set.errorbuffer) {
     va_list ap;
-    size_t len;
+    int len;
     char error[CURL_ERROR_SIZE + 2];
     va_start(ap, fmt);
     len = mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1532,8 +1532,8 @@ static int test_weird_arguments(void)
                       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, /* 10 11 */
                       0, 1, 2, 3, 4, 5, 6, 7, 8);   /* 9 */
 
-  if(rc != -1) {
-    printf("curl_mprintf() returned %d and not -1!\n", rc);
+  if(rc) {
+    printf("curl_mprintf() returned %d and not 0\n", rc);
     errors++;
   }
 


### PR DESCRIPTION
This function no longer returns a negative value if the formatting
string is bad since the return value would sometimes be propagated as a
return code from the mprintf* functions and they are documented to
return the length of the output. Which cannot be negative.

Fixes #9149
Reported-by: yiyuaner on github