### PR TITLE
tool_getparam: fix cleanarg for wide characters in Windows

### DIFF
--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -456,10 +456,16 @@ typedef unsigned int bit;
 
 #ifdef __VMS
 #define argv_item_t  __char_ptr32
+#define argv_strlen_func  strlen
+#define argv_fill_char  ' '
 #elif defined(_UNICODE)
-#define argv_item_t wchar_t *
+#define argv_item_t  wchar_t *
+#define argv_strlen_func  wcslen
+#define argv_fill_char  L' '
 #else
 #define argv_item_t  char *
+#define argv_strlen_func  strlen
+#define argv_fill_char  ' '
 #endif
 
 

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -54,7 +54,8 @@ typedef enum {
 struct GlobalConfig;
 struct OperationConfig;
 
-ParameterError getparameter(const char *flag, char *nextarg, char *clearthis,
+ParameterError getparameter(const char *flag, char *nextarg,
+                            argv_item_t clearthis,
                             bool *usedarg,
                             struct GlobalConfig *global,
                             struct OperationConfig *operation);


### PR DESCRIPTION
Follow-up to bf7e887 which fixed cleaning sensitive arguments from the
command line in Windows. That fix (if it works) only works for Windows
multibyte builds (char) and not Windows Unicode builds (wchar_t).

Ref: https://github.com/curl/curl/issues/9128

Closes #xxxx

---

This doesn't work the way I expect. HAVE_WRITABLE_ARGV isn't defined in my Visual Studio Unicode build. If I override that and the sensitive arguments are cleaned, in Process Explorer I can see the command line doesn't change. Is this supposed to work at all on Windows? @MarcelRaad