### PR TITLE
doh: use https protocol by default

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -243,6 +243,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
        the gcc typecheck helpers */
     struct dynbuf *resp = &p->serverdoh;
     ERROR_CHECK_SETOPT(CURLOPT_URL, url);
+    ERROR_CHECK_SETOPT(CURLOPT_DEFAULT_PROTOCOL, "https");
     ERROR_CHECK_SETOPT(CURLOPT_WRITEFUNCTION, doh_write_cb);
     ERROR_CHECK_SETOPT(CURLOPT_WRITEDATA, resp);
     ERROR_CHECK_SETOPT(CURLOPT_POSTFIELDS, p->dohbuffer);


### PR DESCRIPTION
The only allowed protocol is https, so it makes sense to use that
by default if not passed explicitly by the user.

Fixes #9163
Closes #xxxx