### PR TITLE
trace: 0x7F character is non-printable

### DIFF
--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -232,7 +232,7 @@ static void dump(const char *timebuf, const char *text,
         break;
       }
       (void)infotype;
-      fprintf(stream, "%c", ((ptr[i + c] >= 0x20) && (ptr[i + c] < 0x80)) ?
+      fprintf(stream, "%c", ((ptr[i + c] >= 0x20) && (ptr[i + c] < 0x7F)) ?
               ptr[i + c] : UNPRINTABLE_CHAR);
       /* check again for 0D0A, to avoid an extra \n if it's at width */
       if((tracetype == TRACE_ASCII) &&


### PR DESCRIPTION
`0x7F` is `DEL`, a non-printable symbol, so print it as `UNPRINTABLE_CHAR`.

Reported-by: MasterInQuestion on github
Fixes #9162
Closes #xxxx