### PR TITLE
Makefile.m32: stop trying to build libcares.a [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -459,6 +459,3 @@ clean:
 
 distclean vclean: clean
 	@$(call DEL, $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY) $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY))
-
-$(LIBCARES_PATH)/libcares.a:
-	$(MAKE) -C $(LIBCARES_PATH) -f Makefile.m32


### PR DESCRIPTION
Before this patch, `lib/Makefile.m32` had a rule to build `libcares.a` in
`-cares`-enabled builds, via c-ares's own `Makefile.m32`. Committed in
2007 [1]. The commit message doesn't specifically address this particular
change. No other curl dependency has such special treatment. It probably
helped building a curl + c-ares combo in a single go, back when there
were less optional curl dependencies? I can only guess.

This feature creates problems when building c-ares first, using CMake
and pointing `LIBCARES_PATH` to its install prefix, where `Makefile.m32`
is missing in such case. A sub-build for c-ares is undesired also when
c-ares had already been build via its own `Makefile.m32`.

So, to avoid the sub-build, this patch deletes its Makefile rule. After
this patch `libcares.a` needs to be manually built before using it in
`Makefile.m32`. Aligning it with the rest of dependencies.

[1] 46c92c0b806da041d7a5c6fb64dbcdc474d99b31