### PR TITLE
h2h3: Fix bug overriding the 'TE: Trailers' header

### DIFF
--- a/lib/h2h3.c
+++ b/lib/h2h3.c
@@ -258,9 +258,6 @@ CURLcode Curl_pseudo_headers(struct Curl_easy *data,
       nva[i].valuelen = (end - hdbuf);
     }
 
-    nva[i].value = hdbuf;
-    nva[i].valuelen = (end - hdbuf);
-
     ++i;
   }
 


### PR DESCRIPTION
A 'TE: Trailers' header is explicitly replaced by 'te: trailers'
(lowercase) in Curl_pseudo_headers() when building the list of HTTP/2
or HTTP/3 headers. However, this is then replaced again by the original
value due to a bug, resulting in the uppercased version being sent. Some
HTTP/2 servers reject the whole HTTP/2 stream when this is the case.

Fixes #9171 