### PR TITLE
ftp: use a correct expire ID for timer expiry

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -518,7 +518,8 @@ static CURLcode AllowServerConnect(struct Curl_easy *data, bool *connected)
     /* Add timeout to multi handle and break out of the loop */
     if(*connected == FALSE) {
       Curl_expire(data, data->set.accepttimeout > 0 ?
-                  data->set.accepttimeout: DEFAULT_ACCEPT_TIMEOUT, 0);
+                  data->set.accepttimeout: DEFAULT_ACCEPT_TIMEOUT,
+                  EXPIRE_FTP_ACCEPT);
     }
   }
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1283,6 +1283,7 @@ typedef enum {
   EXPIRE_TIMEOUT,
   EXPIRE_TOOFAST,
   EXPIRE_QUIC,
+  EXPIRE_FTP_ACCEPT,
   EXPIRE_LAST /* not an actual timer, used as a marker only */
 } expire_id;
 


### PR DESCRIPTION
This was an accurate error pointed out by the icc warning: enumerated
type mixed with another type

Ref: #9179