### PR TITLE
mprintf: fix *dyn_vprintf() when out-of-memory

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1068,13 +1068,12 @@ extern int Curl_dyn_vprintf(struct dynbuf *dyn,
 /* appends the formatted string, returns 0 on success, 1 on error */
 int Curl_dyn_vprintf(struct dynbuf *dyn, const char *format, va_list ap_save)
 {
-  int retcode;
   struct asprintf info;
   info.b = dyn;
   info.fail = 0;
 
-  retcode = dprintf_formatf(&info, alloc_addbyter, format, ap_save);
-  if(!retcode && info.fail) {
+  (void)dprintf_formatf(&info, alloc_addbyter, format, ap_save);
+  if(info.fail) {
     Curl_dyn_free(info.b);
     return 1;
   }


### PR DESCRIPTION
Follow-up to 0e48ac1f99a. Torture-testing 1455 would lead to a memory
leak otherwise.