### PR TITLE
curl-wolfssl.m4: add options header

### DIFF
--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -95,6 +95,7 @@ if test "x$OPT_WOLFSSL" != xno; then
    They are set up properly later if it is detected.  */
 #undef SIZEOF_LONG
 #undef SIZEOF_LONG_LONG
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 	]],[[
 	  return wolfSSL_Init();


### PR DESCRIPTION
Needed for certain configurations of wolfSSL. Otherwise, missing header error may occur.

Tested with OpenWrt.