### PR TITLE
Check whether atomics can link rather than just compile.

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -5905,11 +5905,12 @@ dnl
 AC_DEFUN([CURL_ATOMIC],[
   AC_CHECK_HEADERS(stdatomic.h, [
     AC_MSG_CHECKING([if _Atomic is available])
-    AC_COMPILE_IFELSE([
+    AC_LINK_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_unistd
       ]],[[
         _Atomic int i = 0;
+        i = 4;  // Force an atomic-write operation.
       ]])
     ],[
       AC_MSG_RESULT([yes])


### PR DESCRIPTION
Some build toolchains support C11 atomics (i.e., `_Atomic` types), but will not link the associated atomics runtime unless a flag is passed. In such an environment, linking an application with `libcurl.a` can fail due to undefined symbols for atomic load/store functions.

I encountered this behavior when upgrading `curl` to 7.84.0 and attempting to build with Solaris Studio 12.6. Solaris provides the flag `-xatomic=[gcc | studio]`, allowing users to link to one of two atomics runtime implementations. However, if the user does not provide this flag, then neither runtime is linked. This led to builds failing in CI, because:
1. The test-program from `m4/curl-functions.m4` compiled.
2. The `HAVE_ATOMICS` macro was given a definition.
3. Curl's thread-safe global initialization was enabled.
4. Linker errors for undefined atomic load/store functions.

My suggested fix is to:
1. Modify the program that tests for `_Atomic` support to assign to the variable after initializing it. For toolchains that implement atomic loads/stores by linking external libraries, this ensures that such a function will be required.
2. Check that the program can not only be compiled, but also linked.