### PR TITLE
tool_getparam: fix cleanarg() for unicode builds

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -541,24 +541,26 @@ static ParameterError GetSizeParameter(struct GlobalConfig *global,
   return PARAM_OK;
 }
 
-static void cleanarg(char *str)
-{
 #ifdef HAVE_WRITABLE_ARGV
+static void cleanarg(argv_item_t str)
+{
   /* now that GetStr has copied the contents of nextarg, wipe the next
    * argument out so that the username:password isn't displayed in the
    * system process list */
   if(str) {
-    size_t len = strlen(str);
+    size_t len = strlen((char *)str);
     memset(str, ' ', len);
   }
-#else
-  (void)str;
-#endif
 }
+#else
+#define cleanarg(x)
+#endif
 
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
-                            char *clearthis,
+#ifdef HAVE_WRITABLE_ARGV
+                            argv_item_t clearthis,
+#endif
                             bool *usedarg,    /* set to TRUE if the arg
                                                  has been used */
                             struct GlobalConfig *global,
@@ -2440,7 +2442,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
         stillflags = FALSE;
       else {
         char *nextarg = NULL;
-        char *clear = NULL;
+        argv_item_t clear = NULL;
         if(i < (argc - 1)) {
           nextarg = curlx_convert_tchar_to_UTF8(argv[i + 1]);
           if(!nextarg) {

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -548,7 +548,7 @@ static void cleanarg(argv_item_t str)
    * argument out so that the username:password isn't displayed in the
    * system process list */
   if(str) {
-    size_t len = strlen((char *)str);
+    size_t len = strlen(str);
     memset(str, ' ', len);
   }
 }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -558,9 +558,7 @@ static void cleanarg(argv_item_t str)
 
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
-#ifdef HAVE_WRITABLE_ARGV
                             argv_item_t clearthis,
-#endif
                             bool *usedarg,    /* set to TRUE if the arg
                                                  has been used */
                             struct GlobalConfig *global,
@@ -578,7 +576,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   ParameterError err;
   bool toggle = TRUE; /* how to switch boolean options, on or off. Controlled
                          by using --OPTION or --no-OPTION */
-
+  (void)clearthis; /* for !HAVE_WRITABLE_ARGV builds */
   *usedarg = FALSE; /* default is that we don't use the arg */
 
   if(('-' != flag[0]) || ('-' == flag[1])) {

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -55,9 +55,7 @@ struct GlobalConfig;
 struct OperationConfig;
 
 ParameterError getparameter(const char *flag, char *nextarg,
-#ifdef HAVE_WRITABLE_ARGV
                             argv_item_t clearthis,
-#endif
                             bool *usedarg,
                             struct GlobalConfig *global,
                             struct OperationConfig *operation);

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -54,7 +54,10 @@ typedef enum {
 struct GlobalConfig;
 struct OperationConfig;
 
-ParameterError getparameter(const char *flag, char *nextarg, char *clearthis,
+ParameterError getparameter(const char *flag, char *nextarg,
+#ifdef HAVE_WRITABLE_ARGV
+                            argv_item_t clearthis,
+#endif
                             bool *usedarg,
                             struct GlobalConfig *global,
                             struct OperationConfig *operation);


### PR DESCRIPTION
Use the correct type, and make cleanarg an empty macro if the cleaning
ability is absent.

Fixes #9195