### PR TITLE
digest: fix memory leak, fix not quoted 'opaque'

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -880,8 +880,9 @@ static CURLcode auth_create_digest_http_message(
       free(response);
       return CURLE_OUT_OF_MEMORY;
     }
-    tmp = aprintf("%s, opaque=\"%s\"", response, digest->opaque);
+    tmp = aprintf("%s, opaque=\"%s\"", response, opaque_quoted);
     free(response);
+    free(opaque_quoted);
     if(!tmp)
       return CURLE_OUT_OF_MEMORY;
 


### PR DESCRIPTION
Fix leak regression introduced by 3a6fe0c7671f8053f338fd9649a8f7f074b0e5cf