### PR TITLE
fixup: replace py38-pip with py39-pip resolve curl #9201

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,7 +42,7 @@ freebsd_task:
 
   pkginstall_script:
     - pkg update -f
-    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel py38-pip
+    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel py39-pip
     - pkg delete -y curl
     - pip install "cryptography<3.2"
     - pip install "pyOpenSSL<20.0"


### PR DESCRIPTION
fixes: pkg: No packages available to install matching 'py38-pip' have been found in the repositories
Discovered-by: Jay Satiro
Follow up to https://github.com/curl/curl/pull/8783
Closes https://github.com/curl/curl/issues/9201