### PR TITLE
Fix for HTTP/3: Windows build sends lots of empty UDP datagrams

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1166,6 +1166,8 @@ static DWORD multi_getsocktype(struct Curl_multi *multi, curl_socket_t s)
   int res;
 
   struct Curl_sh_entry *entry = sh_getentry(&multi->sockhash, s);
+  if(!entry)
+    entry = sh_addentry(&multi->sockhash, s);
   fprintf(stderr, "entry=%d\n", entry);
   if(!entry)
     return SOCK_STREAM;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2919,6 +2919,16 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
         entry->writers++;
     }
     else if(!sincebefore) {
+#ifdef USE_WINSOCK
+      /* refresh socketype */
+      DWORD st = 0;
+      int sl = sizeof(st);
+      if(getsockopt(s, SOL_SOCKET, SO_TYPE, (char *)&st, &sl) != SOCKET_ERROR)
+        entry->socketype = st;
+      else
+        entry->socketype = 0;
+#endif
+
       /* a new user */
       entry->users++;
       if(action & CURL_POLL_IN)


### PR DESCRIPTION
Attempt to #9086 by: fix sending empty UDP packets to reset FD_WRITE

On Windows the internal state of FD_WRITE as returned from
WSAEnumNetworkEvents is only reset after successful send().
Since multi_wait can be called multiple times without such
a send() happening in between calls, we need to call send()
ourselves to make sure we still get a fresh FD_WRITE signal.

For TCP connections an empty send() does not actually send
something on the wire, but for UDP an empty message packet
is actually send on the wire, leading to hundreds of such.

This commit makes the send()-workaround apply only to TCP.