### PR TITLE
tool_operate: make --doh-url "" switch it off

### DIFF
--- a/docs/cmdline-opts/doh-url.d
+++ b/docs/cmdline-opts/doh-url.d
@@ -16,4 +16,7 @@ name lookups take place over SSL. However, the certificate verification
 settings are not inherited and can be controlled separately via
 --doh-insecure and --doh-cert-status.
 
+This option is unset if an empty string "" is used as the URL. (Added in
+7.85.0)
+
 If this option is used several times, the last one will be used.

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -701,6 +701,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case 'C': /* doh-url */
         GetStr(&config->doh_url, nextarg);
+        if(config->doh_url && !config->doh_url[0])
+          /* if given a blank string, we make it NULL again */
+          Curl_safefree(config->doh_url);
         break;
       case 'd': /* ciphers */
         GetStr(&config->cipher_list, nextarg);


### PR DESCRIPTION
A possible future addition could be to parse the URL first too to verify
that it is valid before trying to use it.