### PR TITLE
Remove him/her from documentation

### DIFF
--- a/docs/MAIL-ETIQUETTE
+++ b/docs/MAIL-ETIQUETTE
@@ -277,7 +277,7 @@ MAIL ETIQUETTE
   one of the hints was what solved your problems. The guys who write answers
   feel good to know that they provided a good answer and that you fixed the
   problem. Far too often, the person who asked the question is never heard from
-  again, and we never get to know if he/she is gone because the problem was
+  again, and we never get to know if they are gone because the problem was
   solved or perhaps because the problem was unsolvable.
 
   Getting the solution posted also helps other users that experience the same

--- a/docs/MAIL-ETIQUETTE
+++ b/docs/MAIL-ETIQUETTE
@@ -105,7 +105,7 @@ MAIL ETIQUETTE
   messages"
 
   No matter what, we NEVER EVER respond to trolls or spammers on the list. If
-  you believe the list admin should do something in particular, contact him/her
+  you believe the list admin should do something in particular, contact them
   off-list. The subject will be taken care of as much as possible to prevent
   repeated offenses, but responding on the list to such messages never leads to
   anything good and only puts the light even more on the offender: which was

--- a/docs/SECURITY-PROCESS.md
+++ b/docs/SECURITY-PROCESS.md
@@ -40,7 +40,7 @@ announcement.
 
 - If the report is rejected, the team writes to the reporter to explain why.
 
-- If the report is accepted, the team writes to the reporter to let him/her
+- If the report is accepted, the team writes to the reporter to let them
   know it is accepted and that they are working on a fix.
 
 - The security team discusses the problem, works out a fix, considers the

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1127,7 +1127,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
           /*
            * If the user has also selected --anyauth or --proxy-anyauth
-           * we should warn him/her.
+           * we should warn them.
            */
           if(config->proxyanyauth || (authbits>1)) {
             warnf(global,


### PR DESCRIPTION
I noticed some places in the documentation still using `him/her` in contrast to most of the documentation which is using `them`. 
