### PR TITLE
improve/freebsd-ci: Bootstrapping the pip installer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,8 +42,10 @@ freebsd_task:
 
   pkginstall_script:
     - pkg update -f
-    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel py39-pip
+    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel
     - pkg delete -y curl
+    - python -m ensurepip --default-pip
+    - python -m pip install --upgrade pip
     - pip install "cryptography<3.2"
     - pip install "pyOpenSSL<20.0"
     - pip install "impacket"


### PR DESCRIPTION
This PR improves the maintenance of freebsd-ci.
use regular python shipped on ci.
Install pip w/ python -m ensurepip --default-pip
The idea is to reduce the maintenance effort and keep the CI stable as long as possible. ;)
Reduce pkgs count to 29 ~ 30
@bagder @jay @danielgustafsson