### PR TITLE
hyper: customize test1274 to how hyper unfolds headers

### DIFF
--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -72,7 +72,6 @@
 # 1021 re-added here due to flakiness
 1021
 1117
-1274
 1417
 1533
 1540

--- a/tests/data/test1274
+++ b/tests/data/test1274
@@ -13,14 +13,22 @@ header line folding
 <data>
 HTTP/1.1 200 OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
+%if hyper
+Server: test-server/ fake folded
+%else
 Server: test-server/
  fake
  folded
+%endif
 Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
 ETag: "21025-dc7-39462498"
 Content-Length: 6
+%if hyper
+Connection: close
+%else
 Connection:                                              
    close
+%endif
 
 -foo-
 </data>


### PR DESCRIPTION
I tried following the way I see some other test data files do this, but after I made the changes locally and re-run `./runtests.pl 1274`, it still sees the old output. Perhaps there's a step in `make test` that I'm skipping locally?