### PR TITLE
docs/cmdline: mark fail and fail-with-body as mutually exclusive

### DIFF
--- a/docs/cmdline-opts/fail-with-body.d
+++ b/docs/cmdline-opts/fail-with-body.d
@@ -6,6 +6,7 @@ Help: Fail on HTTP errors but save the body
 Category: http output
 Added: 7.76.0
 See-also: fail
+Mutexed: fail
 Example: --fail-with-body $URL
 ---
 Return an error on server errors where the HTTP response code is 400 or

--- a/docs/cmdline-opts/fail.d
+++ b/docs/cmdline-opts/fail.d
@@ -7,6 +7,7 @@ Help: Fail fast with no output on HTTP errors
 See-also: fail-with-body
 Category: important http
 Example: --fail $URL
+Mutexed: fail-with-body
 Added: 4.0
 ---
 Fail fast with no output at all on server errors. This is useful to enable


### PR DESCRIPTION
Reported-by: Andreas Sommer
Fixes #9221