### PR TITLE
Add details to error: "unable to set client certificate"

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -872,8 +872,9 @@ int cert_stuff(struct Curl_easy *data,
           }
 
           if(SSL_CTX_use_certificate(ctx, params.cert) != 1) {
-            failf(data, "unable to set client certificate");
-            X509_free(params.cert);
+            failf(data, "unable to set client certificate [%s]",
+                  ossl_strerror(ERR_get_error(), error_buffer,
+                                sizeof(error_buffer)));
             return 0;
           }
           X509_free(params.cert); /* we don't need the handle any more... */


### PR DESCRIPTION
error "unable to set client certificate" is, imho, too generic.
I would add the message from openssl.
In my case:
from: "curl: (58) unable to set client certificate"
to: curl: (58) unable to set client certificate [error:0A00018F:SSL routines::ee key too small]