### PR TITLE
docs: add dns category to --resolve

### DIFF
--- a/docs/cmdline-opts/resolve.d
+++ b/docs/cmdline-opts/resolve.d
@@ -4,7 +4,7 @@ Long: resolve
 Arg: <[+]host:port:addr[,addr]...>
 Help: Resolve the host+port to this address
 Added: 7.21.3
-Category: connection
+Category: connection dns
 Example: --resolve example.com:443:127.0.0.1 $URL
 See-also: connect-to alt-svc
 ---

--- a/src/tool_listhelp.c
+++ b/src/tool_listhelp.c
@@ -593,7 +593,7 @@ const struct helptxt helptext[] = {
    CURLHELP_HTTP},
   {"    --resolve <[+]host:port:addr[,addr]...>",
    "Resolve the host+port to this address",
-   CURLHELP_CONNECTION},
+   CURLHELP_CONNECTION | CURLHELP_DNS},
   {"    --retry <num>",
    "Retry request if transient problems occur",
    CURLHELP_CURL},


### PR DESCRIPTION
This commit adds the dns category to the --resolve command line option,
because it can be interpreted as both: a low-level connection option and
an option related to the resolving of a hostname.

It is also not common for dns options to belong to the connection
category and vice versa.  --ipv4 and --ipv6 are both good examples.