### PR TITLE
cmdline-opts/gen.pl: improve speed

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -106,7 +106,7 @@ sub printdesc {
         if($d =~ /^[^ ]/) {
             for my $k (keys %optlong) {
                 my $l = manpageify($k);
-                $d =~ s/--$k([^a-z0-9_-])(\W)/$l$1$2/;
+                $d =~ s/--\Q$k\E([^a-z0-9_-])\b/$l$1/;
             }
         }
         # quote "bare" minuses in the output


### PR DESCRIPTION
The character capure and the (`\W`) capture substituted with themselves is unnecessary. I replaced them with a lookahead assertion and a `\b` assertion.

I also quoted the injection of $k in the regex since the unquoted injection was not intended and could potentially cause problems.

This improved the speed of

 ./gen.pl mainpage *.d > /dev/null

from 12.3 seconds to 0.6 seconds on my PC!

Reported-by: Emil Engler <me@emilengler.com>
Fixes https://github.com/curl/curl/issues/9230
Closes https://github.com/curl/curl/pull/9231