### PR TITLE
cmdline-opts/gen.pl: improve performance

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -103,10 +103,10 @@ sub printdesc {
             print ".fi\n"; # fill-in
         }
         # skip lines starting with space (examples)
-        if($d =~ /^[^ ]/) {
+        if($d =~ /^[^ ]/ && $d =~ /--/) {
             for my $k (keys %optlong) {
                 my $l = manpageify($k);
-                $d =~ s/--$k([^a-z0-9_-])(\W)/$l$1$2/;
+                $d =~ s/--\Q$k\E([^a-z0-9_-])([^a-zA-Z0-9_])/$l$1$2/;
             }
         }
         # quote "bare" minuses in the output


### PR DESCRIPTION
On some systems, the gen.pl script takes nearly two minutes for the
generation of the main-page, which is a completely unacceptable time.

The commit author thinks, that the terrible performance comes from some
low-level locale checks regarding the use of "\W" in a regular
expression.

This commit replaces the "\W" with [^a-zA-Z0-9_], which is, according to
regex101.com, functionally equivalent to the previous operation, except
that it is obviously limited to ASCII, which is fine, as the curl
project is English-only anyway.

See #8299
Fixes #9230
Closes #XXXX

<hr>

cc @bagder

Does this still fixes the issue you've encountered six months ago? I wasn't exactly sure what your patch was meant to fix.