### PR TITLE
gen.pl: Generate the option man page text multithreaded

### DIFF
--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -38,6 +38,12 @@ jobs:
         sudo python3 -m pip install impacket
       name: 'install prereqs and impacket'
 
+    # for a faster gen.pl
+    - uses: perl-actions/install-with-cpm@v1.3
+      with:
+        install: |
+          Proc::ParallelLoop
+
     - run: |
         git clone --depth=1 https://github.com/openssl/openssl
         cd openssl


### PR DESCRIPTION
Doing it in parallel reduces the time take by 60% on an octacore system.
The number of threads is hard-coded to 8 which is a reasonable
compromise between memory and speed on current systems. Ideally, this
could be tuned to the number of CPU cores available.