### PR TITLE
url: really use the user provided in the url when netrc entry exists

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3039,29 +3039,25 @@ static CURLcode override_login(struct Curl_easy *data,
       conn->user = strdup(*userp);
       if(!conn->user)
         return CURLE_OUT_OF_MEMORY;
-      /* don't update the user name below */
-      userp = NULL;
     }
   }
 #endif
 
   /* for updated strings, we update them in the URL */
-  if(userp) {
-    if(*userp) {
-      CURLcode result = Curl_setstropt(&data->state.aptr.user, *userp);
-      if(result)
-        return result;
-    }
-    if(data->state.aptr.user) {
-      uc = curl_url_set(data->state.uh, CURLUPART_USER, data->state.aptr.user,
-                        CURLU_URLENCODE);
-      if(uc)
-        return Curl_uc_to_curlcode(uc);
-      if(!*userp) {
-        *userp = strdup(data->state.aptr.user);
-        if(!*userp)
-          return CURLE_OUT_OF_MEMORY;
-      }
+  if(*userp) {
+    CURLcode result = Curl_setstropt(&data->state.aptr.user, *userp);
+    if(result)
+      return result;
+  }
+  if(data->state.aptr.user) {
+    uc = curl_url_set(data->state.uh, CURLUPART_USER, data->state.aptr.user,
+                      CURLU_URLENCODE);
+    if(uc)
+      return Curl_uc_to_curlcode(uc);
+    if(!*userp) {
+      *userp = strdup(data->state.aptr.user);
+      if(!*userp)
+        return CURLE_OUT_OF_MEMORY;
     }
   }
   if(*passwdp) {


### PR DESCRIPTION
If the user is specified as part of the URL, and the same user exists
in .netrc, Authorization header was not sent at all.

The user and password fields were assigned in conn->user and password
but the user was not assigned to data->state.aptr, which is the field
that is used in output_auth_headers and friends.

Fix by assigning the user also to aptr.

Amends commit d1237ac906ae7e3cd7a22c3a2d3a135a97edfbf5.

- Fixes #9243