### PR TITLE
netrc: Use the password from lines without login

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -73,8 +73,8 @@ static int parsenetrc(const char *host,
 
   char state_login = 0;      /* Found a login keyword */
   char state_password = 0;   /* Found a password keyword */
-  int state_our_login = FALSE;  /* With specific_login, found *our* login
-                                   name */
+  int state_our_login = TRUE;  /* With specific_login, found *our* login
+                                  name (or login-less line) */
 
   DEBUGASSERT(netrcfile);
 


### PR DESCRIPTION
If netrc entry has password with empty login, use it for any username.

Example:
.netrc:
machine example.com password 123456

curl -vn http://user@example.com/

Fix it by initializing state_our_login to TRUE, and reset it only when
finding an entry with the same host and different login.