### PR TITLE
cmake: set TESTCASES as sources

### DIFF
--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -27,4 +27,4 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 # Prints all available test cases. Do not quote TESTCASES, it must be displayed
 # as a space-separated string rather than comma-separated (a list in CMake).
-add_custom_target(show COMMAND echo ${TESTCASES})
+add_custom_target(show COMMAND echo ${TESTCASES} SOURCES ${TESTCASES})


### PR DESCRIPTION
This includes them in the project tree for IDEs.