### PR TITLE
cmake: move libcurl to src directory on Windows

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -111,6 +111,10 @@ endif()
 set_target_properties(${LIB_NAME} PROPERTIES PREFIX "")
 set_target_properties(${LIB_NAME} PROPERTIES IMPORT_PREFIX "")
 
+if(WIN32 OR CYGWIN)
+  set_target_properties(${LIB_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "../src")
+endif()
+
 if(CURL_HAS_LTO)
   set_target_properties(${LIB_NAME} PROPERTIES
     INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE


### PR DESCRIPTION
It has to be in the same directory for the executable to use it.