### PR TITLE
curl-config: quote directories with potential space

### DIFF
--- a/curl-config.in
+++ b/curl-config.in
@@ -23,7 +23,7 @@
 #
 ###########################################################################
 
-prefix=@prefix@
+prefix="@prefix@"
 exec_prefix=@exec_prefix@
 includedir=@includedir@
 cppflag_curl_staticlib=@CPPFLAG_CURL_STATICLIB@
@@ -174,7 +174,7 @@ while test $# -gt 0; do
 
     --static-libs)
         if test "X@ENABLE_STATIC@" != "Xno" ; then
-          echo @libdir@/libcurl.@libext@ @LDFLAGS@ @LIBCURL_LIBS@
+          echo "@libdir@/libcurl.@libext@" @LDFLAGS@ @LIBCURL_LIBS@
         else
           echo "curl was built with static libraries disabled" >&2
           exit 1


### PR DESCRIPTION
On Windows (at least with CMake), the default prefix is
`C:/Program Files (x86)/CURL`.