### PR TITLE
fix Cygwin/MSYS compilation

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -34,7 +34,7 @@
 #include <process.h>
 #ifdef CURL_WINDOWS_APP
 #define getpid GetCurrentProcessId
-#elif !defined(MSDOS)
+#elif defined(CURL_WIN32)
 #define getpid _getpid
 #endif
 #endif


### PR DESCRIPTION
_getpid is Windows API. On Cygwin variants it should remain getpid.

Fixes #8220.