### PR TITLE
tool: reintroduce set file comment code for AmigaOS

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -327,6 +327,22 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
   return result;
 }
 
+#ifdef __AMIGA__
+static void AmigaSetComment(struct per_transfer *per,
+                            CURLcode result)
+{
+  struct OutStruct *outs = &per->outs;
+  if(!result && outs->s_isreg && outs->filename) {
+    /* Set the url (up to 80 chars) as comment for the file */
+    if(strlen(per->this_url) > 78)
+      per->this_url[79] = '\0';
+    SetComment(outs->filename, per->this_url);
+  }
+}
+#else
+#define AmigaSetComment(x,y) Curl_nop_stmt
+#endif
+
 /*
  * Call this after a transfer has completed.
  */
@@ -603,14 +619,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     }
   }
 
-#ifdef __AMIGA__
-  if(!result && outs->s_isreg && outs->filename) {
-    /* Set the url (up to 80 chars) as comment for the file */
-    if(strlen(per->this_url) > 78)
-      per->this_url[79] = '\0';
-    SetComment(outs->filename, per->this_url);
-  }
-#endif
+  AmigaSetComment(per, result);
 
   /* File time can only be set _after_ the file has been closed */
   if(!result && config->remote_time && outs->s_isreg && outs->filename) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -603,6 +603,15 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     }
   }
 
+#ifdef __AMIGA__
+  if(!result && outs->s_isreg && outs->filename) {
+    /* Set the url (up to 80 chars) as comment for the file */
+    if(strlen(per->this_url) > 78)
+      per->this_url[79] = '\0';
+    SetComment(outs->filename, per->this_url);
+  }
+#endif
+
   /* File time can only be set _after_ the file has been closed */
   if(!result && config->remote_time && outs->s_isreg && outs->filename) {
     /* Ask libcurl if we got a remote file time */


### PR DESCRIPTION
Amiga specific code which put the URL in the file comment was perhaps
accidentally removed in b88940850002a3f1c25bc6488b95ad30eb80d696 having
originally been added in 5c215bdbdfde8b2350cdcbac82aae0c914da5314.
Reworked to fit the code changes and added it back in.

Reported-by: Michael Trebilcock
Originally-added-by: Chris Young