### PR TITLE
file: add handling of native AmigaOS paths

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -71,6 +71,8 @@
 
 #if defined(WIN32) || defined(MSDOS) || defined(__EMX__)
 #define DOS_FILESYSTEM 1
+#elif defined(__amigaos4__)
+#define AMIGA_FILESYSTEM 1
 #endif
 
 #ifdef OPEN_NEEDS_ARG3
@@ -196,8 +198,33 @@ static CURLcode file_connect(struct Curl_easy *data, bool *done)
     return CURLE_URL_MALFORMAT;
   }
 
+  #if defined(AMIGA_FILESYSTEM)
+  /*
+   * A leading slash in an AmigaDOS path denotes the parent
+   * directory, and hence we block this as it is relative.
+   * Absolute paths start with 'volumename:', so we check for
+   * this first. Failing that, we treat the path as a real unix
+   * path, but only if the application was compiled with -lunix.
+   */
+  fd = -1;
+  file->path = real_path;
+
+  if(real_path[0] == '/') {
+    extern int __unix_path_semantics;
+    if(strchr(real_path, ':')) {
+      /* Amiga absolute path */
+      fd = open_readonly(real_path + 1, O_RDONLY);
+      file->path++;
+    }
+    else if(__unix_path_semantics) {
+      /* -lunix fallback */
+      fd = open_readonly(real_path, O_RDONLY);
+    }
+  }
+  #else
   fd = open_readonly(real_path, O_RDONLY);
   file->path = real_path;
+  #endif
 #endif
   file->freepath = real_path; /* free this when done */
 


### PR DESCRIPTION
On AmigaOS 4.x, handle native absolute paths, whilst blocking relative
paths. Also allow unix style paths if feature enabled at link time.

Inspiration-from: Michael Trebilcock