### PR TITLE
AmiSSL v5 support and AmigaOS 4.x configure + resolver

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -813,6 +813,7 @@ dnl return value in RECV_TYPE_RETV.
 
 AC_DEFUN([CURL_CHECK_FUNC_RECV], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
+  AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   AC_CHECK_HEADERS(sys/types.h sys/socket.h)
   #
   AC_MSG_CHECKING([for recv])
@@ -828,10 +829,7 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #include <winsock2.h>
 #endif
 #else
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#endif
+$curl_includes_bsdsocket
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -873,10 +871,7 @@ struct Library *SocketBase = NULL;
 #endif
 #define RECVCALLCONV PASCAL
 #else
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#endif
+                      $curl_includes_bsdsocket
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -948,6 +943,7 @@ dnl type qualifier of second argument in SEND_QUAL_ARG2.
 
 AC_DEFUN([CURL_CHECK_FUNC_SEND], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINSOCK2])dnl
+  AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   AC_CHECK_HEADERS(sys/types.h sys/socket.h)
   #
   AC_MSG_CHECKING([for send])
@@ -963,10 +959,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #include <winsock2.h>
 #endif
 #else
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#endif
+$curl_includes_bsdsocket
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1008,10 +1001,7 @@ struct Library *SocketBase = NULL;
 #endif
 #define SENDCALLCONV PASCAL
 #else
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#endif
+$curl_includes_bsdsocket
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1121,10 +1111,6 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
 #include <winsock2.h>
 #endif
 #else
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
@@ -1544,6 +1530,7 @@ dnl in SELECT_QUAL_ARG5.
 
 AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
   AC_REQUIRE([CURL_CHECK_STRUCT_TIMEVAL])dnl
+  AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   AC_CHECK_HEADERS(sys/select.h sys/socket.h)
   #
   AC_MSG_CHECKING([for select])
@@ -1575,11 +1562,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
-#endif
+$curl_includes_bsdsocket
 #endif
     ]],[[
       select(0, 0, 0, 0, 0);
@@ -1630,11 +1613,7 @@ struct Library *SocketBase = NULL;
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
-#ifdef HAVE_PROTO_BSDSOCKET_H
-#include <proto/bsdsocket.h>
-struct Library *SocketBase = NULL;
-#define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
-#endif
+$curl_includes_bsdsocket
 #define SELECTCALLCONV
 #endif
 #ifndef HAVE_STRUCT_TIMEVAL

--- a/configure.ac
+++ b/configure.ac
@@ -1151,8 +1151,13 @@ then
   AC_MSG_CHECKING([for gethostbyname for AmigaOS bsdsocket.library])
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
+  #define __USE_INLINE__
   #include <proto/bsdsocket.h>
+  #ifdef __amigaos4__
+  struct SocketIFace *ISocket = NULL;
+  #else
   struct Library *SocketBase = NULL;
+  #endif
     ]],[[
       gethostbyname("www.dummysite.com");
     ]])
@@ -1942,7 +1947,7 @@ if test "x$curl_cv_native_windows" = "xyes" &&
   LIBS="-lbcrypt $LIBS"
 fi
 
-case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$AMISSL_ENABLED$RUSTLS_ENABLED"
+case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$RUSTLS_ENABLED"
 in
 x)
   AC_MSG_WARN([SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.])
@@ -3617,6 +3622,9 @@ if test "$want_pthreads" != "no"; then
       dnl if it wasn't found without lib, search for it in pthread lib
       if test "$USE_THREADS_POSIX" != "1"
       then
+        # assign PTHREAD for pkg-config use
+        PTHREAD=" -pthread"
+
         case $host in
         *-ibm-aix*)
            dnl Check if compiler is xlC
@@ -3627,12 +3635,14 @@ if test "$want_pthreads" != "no"; then
              CFLAGS="$CFLAGS -qthreaded"
            fi
            ;;
+        powerpc-*amigaos*)
+           dnl No -pthread option, but link with -lpthread
+           PTHREAD=" -lpthread"
+           ;;
         *)
            CFLAGS="$CFLAGS -pthread"
            ;;
         esac
-        # assign PTHREAD for pkg-config use
-        PTHREAD=" -pthread"
         AC_CHECK_LIB(pthread, pthread_create,
                      [USE_THREADS_POSIX=1],
                      [ CFLAGS="$save_CFLAGS"])

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -24,22 +24,193 @@
 
 #include "curl_setup.h"
 
-#ifdef __AMIGA__
-#  include "amigaos.h"
-#  if defined(HAVE_PROTO_BSDSOCKET_H) && !defined(USE_AMISSL)
+#if defined(__AMIGA__)
+
+#include "hostip.h"
+#include "amigaos.h"
+
+#if defined(HAVE_PROTO_BSDSOCKET_H)
+#  if defined(__amigaos4__)
+#    include <bsdsocket/socketbasetags.h>
+#  elif !defined(USE_AMISSL)
 #    include <amitcp/socketbasetags.h>
 #  endif
-#  ifdef __libnix__
-#    include <stabs.h>
-#  endif
+#endif
+
+#if defined(__libnix__)
+#  include <stabs.h>
 #endif
 
 /* The last #include files should be: */
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#ifdef __AMIGA__
-#if defined(HAVE_PROTO_BSDSOCKET_H) && !defined(USE_AMISSL)
+#if defined(HAVE_PROTO_BSDSOCKET_H)
+
+#if defined(__amigaos4__)
+/*
+ * AmigaOS 4.x specific code
+ */
+
+/*
+ * hostip4.c - Curl_ipv4_resolve_r() replacement code
+ *
+ * Logic that needs to be considered are the following build cases:
+ * - newlib networking
+ * - clib2 networking
+ * - direct bsdsocket.library networking (usually AmiSSL builds)
+ * Each with the threaded resolver enabled or not.
+ *
+ * With the threaded resolver enabled, try to use gethostbyname_r() where
+ * available, otherwise (re)open bsdsocket.library and fallback to
+ * gethostbyname().
+ */
+
+#include <proto/bsdsocket.h>
+
+static struct SocketIFace *__CurlISocket = NULL;
+static uint32 SocketFeatures = 0;
+
+#define HAVE_BSDSOCKET_GETHOSTBYNAME_R 0x01
+#define HAVE_BSDSOCKET_GETADDRINFO     0x02
+
+CURLcode Curl_amiga_init(void)
+{
+  struct SocketIFace *ISocket;
+  struct Library *base = OpenLibrary("bsdsocket.library", 4);
+
+  if(base) {
+    ISocket = (struct SocketIFace *)GetInterface(base, "main", 1, NULL);
+    if(ISocket) {
+      ULONG enabled = 0;
+
+      SocketBaseTags(SBTM_SETVAL(SBTC_CAN_SHARE_LIBRARY_BASES), TRUE,
+                     SBTM_GETREF(SBTC_HAVE_GETHOSTADDR_R_API), (ULONG)&enabled,
+                     TAG_DONE);
+
+      if(enabled) {
+        SocketFeatures |= HAVE_BSDSOCKET_GETHOSTBYNAME_R;
+      }
+
+      __CurlISocket = ISocket;
+
+      atexit(Curl_amiga_cleanup);
+
+      return CURLE_OK;
+    }
+    CloseLibrary(base);
+  }
+
+  return CURLE_FAILED_INIT;
+}
+
+void Curl_amiga_cleanup(void)
+{
+  if(__CurlISocket) {
+    struct Library *base = __CurlISocket->Data.LibBase;
+    DropInterface((struct Interface *)__CurlISocket);
+    CloseLibrary(base);
+    __CurlISocket = NULL;
+  }
+}
+
+#if defined(CURLRES_AMIGA)
+/*
+ * Because we need to handle the different cases in hostip4.c at run-time,
+ * not at compile-time, based on what was detected in Curl_amiga_init(),
+ * we replace it completely with our own as to not complicate the baseline code
+ */
+
+struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
+                                          int port)
+{
+  struct Curl_addrinfo *ai = NULL;
+  struct hostent *h;
+  struct SocketIFace *ISocket = __CurlISocket;
+
+  if(SocketFeatures & HAVE_BSDSOCKET_GETHOSTBYNAME_R) {
+    LONG h_errnop = 0;
+    struct hostent *buf;
+
+    /* Don't use malloc/calloc/free as they are not necessarily threadsafe */
+    buf = AllocVecTags(CURL_HOSTENT_SIZE,
+                       AVT_Type, MEMF_SHARED,
+                       AVT_Lock, FALSE,
+                       AVT_ClearWithValue, 0,
+                       TAG_DONE);
+    if(buf) {
+      h = gethostbyname_r((STRPTR)hostname, buf,
+                          (char *)buf + sizeof(struct hostent),
+                          CURL_HOSTENT_SIZE - sizeof(struct hostent),
+                          &h_errnop);
+      if(h) {
+        ai = Curl_he2ai(h, port);
+      }
+      FreeVec(buf);
+    }
+  }
+  else {
+    #if defined(CURLRES_THREADED)
+    /* gethostbyname() is not thread safe, so we need to reopen bsdsocket
+     * on the thread's context
+     */
+    struct Library *base = OpenLibrary("bsdsocket.library", 4);
+    if(base) {
+      ISocket = (struct SocketIFace *)GetInterface(base, "main", 1, NULL);
+      if(ISocket) {
+        h = gethostbyname((STRPTR)hostname);
+        if(h) {
+          ai = Curl_he2ai(h, port);
+        }
+        DropInterface((struct Interface *)ISocket);
+      }
+      CloseLibrary(base);
+    }
+    #else
+    /* not using threaded resolver - safe to use this as-is */
+    h = gethostbyname(hostname);
+    if(h) {
+      ai = Curl_he2ai(h, port);
+    }
+    #endif
+  }
+
+  return ai;
+}
+#endif /* defined(CURLRES_AMIGA) */
+
+#if defined(USE_AMISSL)
+int Curl_amiga_select(int nfds, fd_set *readfds, fd_set *writefds,
+                      fd_set *errorfds, struct timeval *timeout)
+{
+  int r = WaitSelect(nfds, readfds, writefds, errorfds, timeout, 0);
+  /* Ensure Ctrl-C signal is actioned */
+  if((r == -1) && (SOCKERRNO == EINTR))
+    raise(SIGINT);
+  return r;
+}
+#endif
+
+#if defined(HAVE_GETADDRINFO_RUNTIME_COND)
+bool Curl_getaddrinfo_is_available(bool in_thread)
+{
+  /* Curl_getaddrinfo_ex() uses malloc() which may not be threadsafe  */
+  #if defined(__NEWLIB__)
+  if(SocketFeatures & HAVE_BSDSOCKET_GETADDRINFO)
+    return TRUE;
+  #else
+  if((SocketFeatures & HAVE_BSDSOCKET_GETADDRINFO) && !in_thread)
+    return TRUE;
+  #endif
+  return FALSE
+}
+#endif /* HAVE_GETADDRINFO_RUNTIME_COND */
+
+#elif !defined(USE_AMISSL) /* defined(__amigaos4__) */
+/*
+ * Amiga OS3 specific code
+ */
+
 struct Library *SocketBase = NULL;
 extern int errno, h_errno;
 
@@ -49,7 +220,7 @@ void __request(const char *msg);
 # define __request(msg)       Printf(msg "\n\a")
 #endif
 
-void Curl_amiga_cleanup()
+void Curl_amiga_cleanup(void)
 {
   if(SocketBase) {
     CloseLibrary(SocketBase);
@@ -57,68 +228,36 @@ void Curl_amiga_cleanup()
   }
 }
 
-bool Curl_amiga_init()
+CURLcode Curl_amiga_init(void)
 {
   if(!SocketBase)
     SocketBase = OpenLibrary("bsdsocket.library", 4);
 
   if(!SocketBase) {
     __request("No TCP/IP Stack running!");
-    return FALSE;
+    return CURLE_FAILED_INIT;
   }
 
   if(SocketBaseTags(SBTM_SETVAL(SBTC_ERRNOPTR(sizeof(errno))), (ULONG) &errno,
                     SBTM_SETVAL(SBTC_LOGTAGPTR), (ULONG) "curl",
                     TAG_DONE)) {
     __request("SocketBaseTags ERROR");
-    return FALSE;
+    return CURLE_FAILED_INIT;
   }
 
 #ifndef __libnix__
   atexit(Curl_amiga_cleanup);
 #endif
 
-  return TRUE;
+  return CURLE_OK;
 }
 
 #ifdef __libnix__
 ADD2EXIT(Curl_amiga_cleanup, -50);
 #endif
 
-#endif /* HAVE_PROTO_BSDSOCKET_H */
+#endif /* !defined(USE_AMISSL) */
 
-#ifdef USE_AMISSL
-void Curl_amiga_X509_free(X509 *a)
-{
-  X509_free(a);
-}
+#endif /* defined(PROTO_BSDSOCKET_H) */
 
-/* AmiSSL replaces many functions with macros. Curl requires pointer
- * to some of these functions. Thus, we have to encapsulate these macros.
- */
-
-#include "warnless.h"
-
-int (SHA256_Init)(SHA256_CTX *c)
-{
-  return SHA256_Init(c);
-};
-
-int (SHA256_Update)(SHA256_CTX *c, const void *data, size_t len)
-{
-  return SHA256_Update(c, data, curlx_uztoui(len));
-};
-
-int (SHA256_Final)(unsigned char *md, SHA256_CTX *c)
-{
-  return SHA256_Final(md, c);
-};
-
-void (X509_INFO_free)(X509_INFO *a)
-{
-  X509_INFO_free(a);
-};
-
-#endif /* USE_AMISSL */
-#endif /* __AMIGA__ */
-
+#endif /* defined(__AMIGA__) */

--- a/lib/amigaos.h
+++ b/lib/amigaos.h
@@ -25,22 +25,18 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(__AMIGA__) && defined(HAVE_BSDSOCKET_H) && !defined(USE_AMISSL)
+#if defined(__AMIGA__) && defined(HAVE_PROTO_BSDSOCKET_H) && \
+  (!defined(USE_AMISSL) || defined(__amigaos4__))
 
-bool Curl_amiga_init();
-void Curl_amiga_cleanup();
+CURLcode Curl_amiga_init(void);
+void Curl_amiga_cleanup(void);
 
 #else
 
-#define Curl_amiga_init() 1
+#define Curl_amiga_init() CURLE_OK
 #define Curl_amiga_cleanup() Curl_nop_stmt
 
 #endif
-
-#ifdef USE_AMISSL
-#include <openssl/x509v3.h>
-void Curl_amiga_X509_free(X509 *a);
-#endif /* USE_AMISSL */
 
 #endif /* HEADER_CURL_AMIGAOS_H */
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -273,15 +273,45 @@
 #  include <extra/strdup.h>
 #endif
 
-#ifdef __AMIGA__
+#if defined(__AMIGA__)
+#  if defined(__amigaos4__)
+#    define __USE_INLINE__
+     /* use our own resolver which uses runtime feature detection */
+#    define CURLRES_AMIGA
+     /* getaddrinfo() currently crashes bsdsocket.library, so disable */
+#    undef HAVE_GETADDRINFO
+#    if defined(HAVE_GETADDRINFO)
+#      define HAVE_GETADDRINFO_RUNTIME_COND
+#    endif
+#    if !(defined(__NEWLIB__) || \
+          (defined(__CLIB2__) && defined(__THREAD_SAFE)))
+       /* disable threaded resolver with clib2 - requires newlib or clib-ts */
+#      undef USE_THREADS_POSIX
+#    endif
+#  endif
 #  include <exec/types.h>
 #  include <exec/execbase.h>
 #  include <proto/exec.h>
 #  include <proto/dos.h>
 #  include <unistd.h>
-#  ifdef HAVE_PROTO_BSDSOCKET_H
-#    include <proto/bsdsocket.h> /* ensure bsdsocket.library use */
-#    define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
+#  if defined(HAVE_PROTO_BSDSOCKET_H) && \
+    (!defined(__amigaos4__) || defined(USE_AMISSL))
+     /* use bsdsocket.library directly, instead of libc networking functions */
+#    include <proto/bsdsocket.h>
+#    if defined(__amigaos4__)
+       int Curl_amiga_select(int nfds, fd_set *readfds, fd_set *writefds,
+                             fd_set *errorfds, struct timeval *timeout);
+#      define select(a,b,c,d,e) Curl_amiga_select(a,b,c,d,e)
+#    else
+#      define select(a,b,c,d,e) WaitSelect(a,b,c,d,e,0)
+#    endif
+     /* must not use libc's fcntl() on bsdsocket.library sockfds! */
+#    undef HAVE_FCNTL
+#    undef HAVE_FCNTL_O_NONBLOCK
+#  else
+     /* use libc networking and hence close() and fnctl() */
+#    undef HAVE_CLOSESOCKET_CAMEL
+#    undef HAVE_IOCTLSOCKET_CAMEL
 #  endif
 /*
  * In clib2 arpa/inet.h warns that some prototypes may clash

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -177,7 +177,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 #endif
 
 #ifdef __AMIGA__
-  if(!Curl_amiga_init()) {
+  if(Curl_amiga_init()) {
     DEBUGF(fprintf(stderr, "Error: Curl_amiga_init failed\n"));
     goto fail;
   }

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -112,7 +112,8 @@ struct Curl_addrinfo *Curl_getaddrinfo(struct Curl_easy *data,
 #endif /* CURLRES_SYNCH */
 #endif /* CURLRES_IPV4 */
 
-#if defined(CURLRES_IPV4) && !defined(CURLRES_ARES)
+#if defined(CURLRES_IPV4) && \
+   !defined(CURLRES_ARES) && !defined(CURLRES_AMIGA)
 
 /*
  * Curl_ipv4_resolve_r() - ipv4 threadsafe resolver function.
@@ -297,4 +298,5 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
 
   return ai;
 }
-#endif /* defined(CURLRES_IPV4) && !defined(CURLRES_ARES) */
+#endif /* defined(CURLRES_IPV4) && !defined(CURLRES_ARES) &&
+                                   !defined(CURLRES_AMIGA) */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -32,7 +32,8 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3) && \
+   !defined(USE_AMISSL)
 /* OpenSSL 3.0.0 marks the MD4 functions as deprecated */
 #define OPENSSL_NO_MD4
 #endif

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -41,7 +41,7 @@
 #endif
 #endif /* USE_MBEDTLS */
 
-#if defined(USE_OPENSSL) && !defined(USE_AMISSL)
+#if defined(USE_OPENSSL)
   #include <openssl/opensslconf.h>
   #if !defined(OPENSSL_NO_MD5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     #define USE_OPENSSL_MD5

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -78,10 +78,6 @@
 #include <openssl/buffer.h>
 #include <openssl/pkcs12.h>
 
-#ifdef USE_AMISSL
-#include "amigaos.h"
-#endif
-
 #if (OPENSSL_VERSION_NUMBER >= 0x0090808fL) && !defined(OPENSSL_NO_OCSP)
 #include <openssl/ocsp.h>
 #endif
@@ -996,11 +992,7 @@ int cert_stuff(struct Curl_easy *data,
   fail:
       EVP_PKEY_free(pri);
       X509_free(x509);
-#ifdef USE_AMISSL
-      sk_X509_pop_free(ca, Curl_amiga_X509_free);
-#else
       sk_X509_pop_free(ca, X509_free);
-#endif
       if(!cert_done)
         return 0; /* failure! */
       break;

--- a/m4/curl-amissl.m4
+++ b/m4/curl-amissl.m4
@@ -23,21 +23,46 @@
 #***************************************************************************
 
 AC_DEFUN([CURL_WITH_AMISSL], [
-AC_MSG_CHECKING([whether to enable Amiga native SSL/TLS (AmiSSL)])
+AC_MSG_CHECKING([whether to enable Amiga native SSL/TLS (AmiSSL v5)])
 if test "$HAVE_PROTO_BSDSOCKET_H" = "1"; then
   if test "x$OPT_AMISSL" != xno; then
     ssl_msg=
-    if test "x$OPT_AMISSL" != "xno"; then
-      AC_MSG_RESULT(yes)
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+        #include <libraries/amisslmaster.h>
+        #include <openssl/opensslv.h>
+      ]],[[
+        #if defined(AMISSL_CURRENT_VERSION) && (AMISSL_CURRENT_VERSION >= AMISSL_V303) && \
+            defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3) && \
+            defined(PROTO_AMISSL_H)
+        return 0;
+        #else
+        #error not AmiSSL v5 / OpenSSL 3
+        #endif
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
       ssl_msg="AmiSSL"
       test amissl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
       AMISSL_ENABLED=1
-      LIBS="-lamisslauto $LIBS"
+      OPENSSL_ENABLED=1
+      # Use AmiSSL's built-in ca bundle
+      check_for_ca_bundle=1
+      with_ca_fallback=yes
+      LIBS="-lamisslstubs -lamisslauto $LIBS"
       AC_DEFINE(USE_AMISSL, 1, [if AmiSSL is in use])
       AC_DEFINE(USE_OPENSSL, 1, [if OpenSSL is in use])
-    else
-      AC_MSG_RESULT(no)
-    fi
+      AC_DEFINE_UNQUOTED(HAVE_OPENSSL3, 1, [Define to 1 if using OpenSSL 3 or later.])
+      AC_CHECK_HEADERS(openssl/x509.h openssl/rsa.h openssl/crypto.h \
+                       openssl/pem.h openssl/ssl.h openssl/err.h)
+      dnl OpenSSLv3 marks the DES functions deprecated but we have no
+      dnl replacements (yet) so tell the compiler to not warn for them
+      dnl
+      dnl Ask OpenSSL to suppress the warnings.
+      CPPFLAGS="$CPPFLAGS -DOPENSSL_SUPPRESS_DEPRECATED"
+    ],[
+      AC_MSG_RESULT([no])
+    ])
     test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
   else
     AC_MSG_RESULT(no)


### PR DESCRIPTION
These commits bump the minimum AmiSSL requirement to 5.1 (OpenSSL 3.0), which also allows some of the old workarounds like function stubs to be removed from all the sources (as libamisslstubs.a now covers those from the AmiSSL SDK). The configure script now works better for AmigaOS 4.x and has AmiSSL v5 detection. Finally, the threaded resolver has been fixed to work properly on AmigaOS 4.x, as it was not actually thread safe before.