### PR TITLE
digest: pass over leading spaces in qop values

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -560,6 +560,9 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 
         token = strtok_r(tmp, ",", &tok_buf);
         while(token) {
+          /* Pass additional spaces here */
+          while(*token && ISSPACE(*token))
+            token++;
           if(strcasecompare(token, DIGEST_QOP_VALUE_STRING_AUTH)) {
             foundAuth = TRUE;
           }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -64,7 +64,7 @@ test343 test344 test345 test346 test347 test348 test349 test350 test351 \
 test352 test353 test354 test355 test356 test357 test358 test359 test360 \
 test361 test362 test363 test364 test365 test366 test367 test368 test369 \
 test370 test371 test372 test373 test374 test375 test376 test378 test379 \
-test380 test381 test383 test384 test385 test386 test387 \
+test380 test381 test383 test384 test385 test386 test387 test388 \
 \
 test390 test391 test392 test393 test394 test395 test396 test397 test398 \
 \

--- a/tests/data/test388
+++ b/tests/data/test388
@@ -1,0 +1,156 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP Digest auth
+</keywords>
+</info>
+
+# Server-side
+<reply>
+# First reply back and ask for Digest auth
+<data1>
+HTTP/1.1 401 Authorization Required swsclose
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604145"
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 26
+
+This is not the real page
+</data1>
+
+# second reply back
+<data2>
+HTTP/1.1 401 Authorization Required swsclose
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604145"
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 26
+
+This is not the real page
+</data2>
+
+# This is supposed to be returned when the server gets a
+# Authorization: Digest line passed-in from the client
+<data1001>
+HTTP/1.1 200 OK
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 23
+
+This IS the real page!
+</data1001>
+
+#
+# This is the second request, and this sends back a response saying that
+# the request contained stale data. We want an update. Set swsbounce to
+# bounce on to data1003 on the second request.
+<data1002>
+HTTP/1.1 401 Authorization re-negotiation please swsbounce
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Digest realm="testrealm", algorithm=MD5, nonce="999999", stale=true, qop="crazy, auth"
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 26
+
+This is not the real page
+</data1002>
+
+# The second request to the 1002 section will bounce this one back instead
+# thanks to the swsbounce keyword up there
+<data1003>
+HTTP/1.1 200 OK
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 30
+
+This IS the second real page!
+</data1003>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+!SSPI
+crypto
+</features>
+ <name>
+HTTP with Digest and multiple qop values with leading space
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 -u testuser:testpass --digest http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^Authorization.*cnonce
+</strip>
+<protocol>
+GET /%TESTNUMBER0001 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0001 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="1053604145", uri="/%TESTNUMBER0001", response="ea598bbfdb5c54b7352c977e3885e44d"
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="1053604145", uri="/%TESTNUMBER0002", response="921a8e6db782d6359db1f40d9ed7e6a6"
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="testuser", realm="testrealm", nonce="999999", uri="/%TESTNUMBER0002", cnonce="MTA4MzIy", nc="00000001", qop="auth", response="25291c357671604a16c0242f56721c07", algorithm=MD5
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<stdout>
+HTTP/1.1 401 Authorization Required swsclose
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604145"
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 26
+
+HTTP/1.1 200 OK
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 23
+
+This IS the real page!
+HTTP/1.1 401 Authorization Required swsclose
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Digest realm="testrealm", nonce="1053604145"
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 26
+
+HTTP/1.1 401 Authorization re-negotiation please swsbounce
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Digest realm="testrealm", algorithm=MD5, nonce="999999", stale=true, qop="crazy, auth"
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 26
+
+HTTP/1.1 200 OK
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 30
+
+This IS the second real page!
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
When parsing the "qop=" parameter of the digest authentication, and the
value is provided within quotes, the list of values can have leading
white space which the parser previously did not handle correctly.

Add test case 388 to verify.

Reported-by: vlubart on github
Fixes #9264
Closes #