### PR TITLE
urldata: make 'negnpn' use less storage

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1119,7 +1119,8 @@ struct connectdata {
   int localportrange;
   int cselect_bits; /* bitmask of socket events */
   int waitfor;      /* current READ/WRITE bits to wait for */
-  int negnpn; /* APLN or NPN TLS negotiated protocol, CURL_HTTP_VERSION* */
+  unsigned char negnpn; /* APLN or NPN TLS negotiated protocol,
+                           a CURL_HTTP_VERSION* value */
 
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   int socks5_gssapi_enctype;


### PR DESCRIPTION
The connectdata struct field 'negnpn' never holds a value larger than
30, so an unsigned char saves 3 bytes struct space.