### PR TITLE
ldap: adapt to conn->port now being an 'int'

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -356,7 +356,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 #ifdef HAVE_LDAP_SSL
 #ifdef USE_WIN32_LDAP
     /* Win32 LDAP SDK doesn't support insecure mode without CA! */
-    server = ldap_sslinit(host, (int)conn->port, 1);
+    server = ldap_sslinit(host, conn->port, 1);
     ldap_set_option(server, LDAP_OPT_SSL, LDAP_OPT_ON);
 #else
     int ldap_option;
@@ -402,9 +402,9 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       result = CURLE_SSL_CERTPROBLEM;
       goto quit;
     }
-    server = ldapssl_init(host, (int)conn->port, 1);
+    server = ldapssl_init(host, conn->port, 1);
     if(!server) {
-      failf(data, "LDAP local: Cannot connect to %s:%ld",
+      failf(data, "LDAP local: Cannot connect to %s:%u",
             conn->host.dispname, conn->port);
       result = CURLE_COULDNT_CONNECT;
       goto quit;
@@ -443,9 +443,9 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       result = CURLE_SSL_CERTPROBLEM;
       goto quit;
     }
-    server = ldap_init(host, (int)conn->port);
+    server = ldap_init(host, conn->port);
     if(!server) {
-      failf(data, "LDAP local: Cannot connect to %s:%ld",
+      failf(data, "LDAP local: Cannot connect to %s:%u",
             conn->host.dispname, conn->port);
       result = CURLE_COULDNT_CONNECT;
       goto quit;
@@ -484,9 +484,9 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     goto quit;
   }
   else {
-    server = ldap_init(host, (int)conn->port);
+    server = ldap_init(host, conn->port);
     if(!server) {
-      failf(data, "LDAP local: Cannot connect to %s:%ld",
+      failf(data, "LDAP local: Cannot connect to %s:%u",
             conn->host.dispname, conn->port);
       result = CURLE_COULDNT_CONNECT;
       goto quit;


### PR DESCRIPTION
Remove typecasts. Fix printf() formats.

Follow-up from 764c6bd3bf.
Pointed out by Coverity CID 1507858.