### PR TITLE
Update Docs to msh3 v0.4.0

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -140,7 +140,7 @@ Build curl:
 
 Build msh3:
 
-     % git clone --depth 1 --recursive https://github.com/nibanks/msh3
+     % git clone -b v0.4.0 --depth 1 --recursive https://github.com/nibanks/msh3
      % cd msh3 && mkdir build && cd build
      % cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
      % cmake --build .
@@ -161,7 +161,7 @@ Run from `/usr/local/bin/curl`.
 
 Build msh3:
 
-     % git clone --depth 1 --recursive https://github.com/nibanks/msh3
+     % git clone -b v0.4.0 --depth 1 --recursive https://github.com/nibanks/msh3
      % cd msh3 && mkdir build && cd build
      % cmake -G 'Visual Studio 17 2022' -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
      % cmake --build . --config Release


### PR DESCRIPTION
Updates msh3 usage to [latest release](https://github.com/nibanks/msh3/releases/tag/v0.4.0), which includes:

- Uses latest release of msquic ([v2.1](https://github.com/microsoft/msquic/releases/tag/v2.1.0)).
- A few fixes, including a partial one for #8915.

FYI, it'd be great to hook up some curl automation to verify things, but I'm not sure how to do that.

Also, I'm not sure it's worth mentioning here, but by moving to libmsquic.2.1.0, we have [official, signed packages published](https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/libm/libmsquic/) that could be referenced instead of building it yourself.