### PR TITLE
docs/cmdline-opts: fix example and categories for --form-escape

### DIFF
--- a/docs/cmdline-opts/form-escape.d
+++ b/docs/cmdline-opts/form-escape.d
@@ -5,8 +5,8 @@ Help: Escape multipart form field/file names using backslash
 Protocols: HTTP
 See-also: form
 Added: 7.81.0
-Category: http post
-Example: --form-escape --form 'field\\name=curl' 'file=@load"this' $URL
+Category: http upload
+Example: --form-escape -F 'field\\name=curl' -F 'file=@load"this' $URL
 ---
 Tells curl to pass on names of multipart form fields and files using
 backslash-escaping instead of percent-encoding.

--- a/src/tool_listhelp.c
+++ b/src/tool_listhelp.c
@@ -197,7 +197,7 @@ const struct helptxt helptext[] = {
    CURLHELP_HTTP | CURLHELP_UPLOAD},
   {"    --form-escape",
    "Escape multipart form field/file names using backslash",
-   CURLHELP_HTTP | CURLHELP_POST},
+   CURLHELP_HTTP | CURLHELP_UPLOAD},
   {"    --form-string <name=string>",
    "Specify multipart MIME data",
    CURLHELP_HTTP | CURLHELP_UPLOAD},


### PR DESCRIPTION
The example was missing a "--form" argument
I also replaced "--form" with "-F" to shorten the line a bit since it
was already very long.

And I also moved --form-escape from the "post" category to the "upload"
category (this is what I originally wanted to fix, before also noticing
the mistake in the example).