### PR TITLE
memory debug tracking annotates whether the returns pointer does not …

### DIFF
--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -129,7 +129,8 @@ static bool countcheck(const char *func, int line, const char *source)
   return FALSE; /* allow this */
 }
 
-void *curl_dbg_malloc(size_t wantedsize, int line, const char *source)
+ALLOC_FUNC void *curl_dbg_malloc(size_t wantedsize,
+                       int line, const char *source)
 {
   struct memdebug *mem;
   size_t size;
@@ -155,7 +156,7 @@ void *curl_dbg_malloc(size_t wantedsize, int line, const char *source)
   return (mem ? mem->mem : NULL);
 }
 
-void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
+ALLOC_FUNC void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
                       int line, const char *source)
 {
   struct memdebug *mem;
@@ -183,7 +184,8 @@ void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
   return (mem ? mem->mem : NULL);
 }
 
-char *curl_dbg_strdup(const char *str, int line, const char *source)
+ALLOC_FUNC char *curl_dbg_strdup(const char *str,
+                    int line, const char *source)
 {
   char *mem;
   size_t len;
@@ -207,7 +209,8 @@ char *curl_dbg_strdup(const char *str, int line, const char *source)
 }
 
 #if defined(WIN32) && defined(UNICODE)
-wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source)
+ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
+                    int line, const char *source)
 {
   wchar_t *mem;
   size_t wsiz, bsiz;
@@ -410,7 +413,7 @@ int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
   return res;
 }
 
-FILE *curl_dbg_fopen(const char *file, const char *mode,
+ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
                     int line, const char *source)
 {
   FILE *res = fopen(file, mode);
@@ -422,7 +425,7 @@ FILE *curl_dbg_fopen(const char *file, const char *mode,
   return res;
 }
 
-FILE *curl_dbg_fdopen(int filedes, const char *mode,
+ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
                       int line, const char *source)
 {
   FILE *res = fdopen(filedes, mode);

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -30,21 +30,37 @@
  * as well as the library. Do not mix with library internals!
  */
 
+#if defined(__GNUC__) && __GNUC__ >= 3
+#  define ALLOC_FUNC __attribute__((malloc))
+#  define ALLOC_SIZE(s) __attribute__((alloc_size(s)))
+#  define ALLOC_SIZE2(n, s) __attribute__((alloc_size(n, s)))
+#elif defined(_MSC_VER)
+#  define ALLOC_FUNC __declspec(restrict)
+#  define ALLOC_SIZE(s)
+#  define ALLOC_SIZE2(n, s)
+#else
+#  define ALLOC_FUNC
+#  define ALLOC_SIZE(s)
+#  define ALLOC_SIZE2(n, s)
+#endif
+
 #define CURL_MT_LOGFNAME_BUFSIZE 512
 
 extern FILE *curl_dbg_logfile;
 
 /* memory functions */
-CURL_EXTERN void *curl_dbg_malloc(size_t size, int line, const char *source);
-CURL_EXTERN void *curl_dbg_calloc(size_t elements, size_t size, int line,
-                                  const char *source);
-CURL_EXTERN void *curl_dbg_realloc(void *ptr, size_t size, int line,
-                                   const char *source);
+CURL_EXTERN ALLOC_FUNC ALLOC_SIZE(1) void *curl_dbg_malloc(size_t size,
+                                   int line, const char *source);
+CURL_EXTERN ALLOC_FUNC ALLOC_SIZE2(1, 2) void *curl_dbg_calloc(size_t elements,
+                                   size_t size, int line, const char *source);
+CURL_EXTERN ALLOC_SIZE(2) void *curl_dbg_realloc(void *ptr, size_t size,
+                                   int line, const char *source);
 CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
-CURL_EXTERN char *curl_dbg_strdup(const char *str, int line, const char *src);
+CURL_EXTERN ALLOC_FUNC char *curl_dbg_strdup(const char *str, int line,
+                                   const char *src);
 #if defined(WIN32) && defined(UNICODE)
-CURL_EXTERN wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line,
-                                     const char *source);
+CURL_EXTERN ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
+                                   int line, const char *source);
 #endif
 
 CURL_EXTERN void curl_dbg_memdebug(const char *logname);
@@ -79,9 +95,9 @@ CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
                                          const char *source);
 
 /* FILE functions */
-CURL_EXTERN FILE *curl_dbg_fopen(const char *file, const char *mode, int line,
-                                 const char *source);
-CURL_EXTERN FILE *curl_dbg_fdopen(int filedes, const char *mode,
+CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
+                                  int line, const char *source);
+CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
                                   int line, const char *source);
 
 CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);


### PR DESCRIPTION
…`alias`,

 hints where the size required is, for Windows to be better debuggued
via Visual Studio.