### PR TITLE
Makefile.m32: allow -nghttp3/-ngtcp2 without -ssl [ci skip]

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -275,21 +275,23 @@ ifdef SSH2
     endif
   endif
 endif
-ifdef SSL
-  ifdef NGHTTP3
-    CFLAGS += -DUSE_NGHTTP3
-    curl_LDADD += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
-    ifdef NGTCP2
-      CFLAGS += -DUSE_NGTCP2
-      curl_LDADD += -L"$(NGTCP2_PATH)/lib"
-      ifdef NGTCP2_LIBS
-        curl_LDADD += $(NGTCP2_LIBS)
-      else
-        curl_LDADD += -lngtcp2 -lngtcp2_crypto_openssl
+ifdef NGHTTP3
+  CFLAGS += -DUSE_NGHTTP3
+  curl_LDADD += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
+  ifdef NGTCP2
+    CFLAGS += -DUSE_NGTCP2
+    curl_LDADD += -L"$(NGTCP2_PATH)/lib"
+    ifdef NGTCP2_LIBS
+      curl_LDADD += $(NGTCP2_LIBS)
+    else
+      curl_LDADD += -lngtcp2
+      ifdef SSL
+        curl_LDADD += -lngtcp2_crypto_openssl
       endif
     endif
   endif
-
+endif
+ifdef SSL
   ifndef OPENSSL_INCLUDE
     ifeq "$(wildcard $(OPENSSL_PATH)/outinc)" "$(OPENSSL_PATH)/outinc"
       OPENSSL_INCLUDE = $(OPENSSL_PATH)/outinc

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -291,23 +291,25 @@ ifdef SSH2
     endif
   endif
 endif
-ifdef SSL
-  ifdef NGHTTP3
-    INCLUDES += -I"$(NGHTTP3_PATH)/include"
-    CFLAGS += -DUSE_NGHTTP3
-    DLL_LIBS += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
-    ifdef NGTCP2
-      INCLUDES += -I"$(NGTCP2_PATH)/include"
-      CFLAGS += -DUSE_NGTCP2
-      DLL_LIBS += -L"$(NGTCP2_PATH)/lib"
-      ifdef NGTCP2_LIBS
-        DLL_LIBS += $(NGTCP2_LIBS)
-      else
-        DLL_LIBS += -lngtcp2 -lngtcp2_crypto_openssl
+ifdef NGHTTP3
+  INCLUDES += -I"$(NGHTTP3_PATH)/include"
+  CFLAGS += -DUSE_NGHTTP3
+  DLL_LIBS += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
+  ifdef NGTCP2
+    INCLUDES += -I"$(NGTCP2_PATH)/include"
+    CFLAGS += -DUSE_NGTCP2
+    DLL_LIBS += -L"$(NGTCP2_PATH)/lib"
+    ifdef NGTCP2_LIBS
+      DLL_LIBS += $(NGTCP2_LIBS)
+    else
+      DLL_LIBS += -lngtcp2
+      ifdef SSL
+        DLL_LIBS += -lngtcp2_crypto_openssl
       endif
     endif
   endif
-
+endif
+ifdef SSL
   ifndef OPENSSL_INCLUDE
     ifeq "$(wildcard $(OPENSSL_PATH)/outinc)" "$(OPENSSL_PATH)/outinc"
       OPENSSL_INCLUDE = $(OPENSSL_PATH)/outinc

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -303,21 +303,23 @@ ifdef SSH2
     endif
   endif
 endif
-ifdef SSL
-  ifdef NGHTTP3
-    CFLAGS += -DUSE_NGHTTP3
-    curl_LDADD += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
-    ifdef NGTCP2
-      CFLAGS += -DUSE_NGTCP2
-      curl_LDADD += -L"$(NGTCP2_PATH)/lib"
-      ifdef NGTCP2_LIBS
-        curl_LDADD += $(NGTCP2_LIBS)
-      else
-        curl_LDADD += -lngtcp2 -lngtcp2_crypto_openssl
+ifdef NGHTTP3
+  CFLAGS += -DUSE_NGHTTP3
+  curl_LDADD += -L"$(NGHTTP3_PATH)/lib" -lnghttp3
+  ifdef NGTCP2
+    CFLAGS += -DUSE_NGTCP2
+    curl_LDADD += -L"$(NGTCP2_PATH)/lib"
+    ifdef NGTCP2_LIBS
+      curl_LDADD += $(NGTCP2_LIBS)
+    else
+      curl_LDADD += -lngtcp2
+      ifdef SSL
+        curl_LDADD += -lngtcp2_crypto_openssl
       endif
     endif
   endif
-
+endif
+ifdef SSL
   ifndef OPENSSL_INCLUDE
     ifeq "$(wildcard $(OPENSSL_PATH)/outinc)" "$(OPENSSL_PATH)/outinc"
       OPENSSL_INCLUDE = $(OPENSSL_PATH)/outinc


### PR DESCRIPTION
Before this patch `-nghttp3`/`-ngtcp2` had an effect only when `-ssl` was
also enabled. `-ssl` meaning OpenSSL (and its forks). After
8a13be227eede2601c2b3b1c63e08b3dc9b35dd5 nghttp3/ngtcp2 can also be used
together with wolfSSL. This patch adds the ability to enable
`-nghttp3`/`-ngtcp2` independently from `-ssl` (OpenSSL), allowing to use
it with wolfSSL or other, future TLS backends.

Before this patch, it was fine to enable `-nghttp3`/`-ngtcp2`
unconditionally. After this patch, this is no longer the case, and now
it's the user's responsibility to enable `-nghttp3`/`-ngtcp2` only
together with a compatible TLS backend.

When using a TLS backend other than OpenSSL, the TLS-specific ngtcp2
library must be configured manually, e.g.:
  `export CURL_LDFLAG_EXTRAS=-lngtcp2_crypto_wolfssl`