### PR TITLE
url: reject URLs with hostnames longer than 65535 bytes

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2025,6 +2025,10 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     if(!strcasecompare("file", data->state.up.scheme))
       return CURLE_OUT_OF_MEMORY;
   }
+  else if(strlen(data->state.up.hostname) > 0xffff) {
+    failf(data, "Too long host name");
+    return CURLE_URL_MALFORMAT;
+  }
 
 #ifndef CURL_DISABLE_HSTS
   if(data->hsts && strcasecompare("http", data->state.up.scheme)) {

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -66,9 +66,8 @@ test361 test362 test363 test364 test365 test366 test367 test368 test369 \
 test370 test371 test372 test373 test374 test375 test376 test378 test379 \
 test380 test381 test383 test384 test385 test386 test387 test388 test389 \
 test390 test391 test392 test393 test394 test395 test396 test397 test398 \
-\
-test400 test401 test402 test403 test404 test405 test406 test407 test408 \
-test409 test410 test411 test412 test413 test414 \
+test399 test400 test401 test402 test403 test404 test405 test406 test407 \
+test408 test409 test410 test411 test412 test413 test414 \
 \
 test430 test431 test432 test433 test434 test435 test436 \
 \

--- a/tests/data/test399
+++ b/tests/data/test399
@@ -1,0 +1,29 @@
+<testcase>
+<info>
+<keywords>
+URL
+</keywords>
+</info>
+
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+65536 bytes long host name in URL
+ </name>
+ <command>
+http://%repeat[65536 x a]%/399
+</command>
+</client>
+
+<verify>
+# 3 == CURLE_URL_MALFORMAT
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
It *probably* causes other problems too since DNS can't resolve such
long names, but the SNI field in TLS is limited to 16 bits length.