### PR TITLE
test399: switch it to use a config file instead

### DIFF
--- a/tests/data/test399
+++ b/tests/data/test399
@@ -12,11 +12,14 @@ URL
 <server>
 http
 </server>
- <name>
+<name>
 65536 bytes long host name in URL
- </name>
- <command>
-http://%repeat[65536 x a]%/399
+</name>
+<file name="log/input%TESTNUM">
+url = http://%repeat[65536 x a]%/399
+</file>
+<command>
+-K log/input%TESTNUM
 </command>
 </client>
 


### PR DESCRIPTION
... as using a 65535 bytes host name in a URL does not fit on the
command line on some systems - like Windows.

Reported-by: Marcel Raad
Fixes #9321