### PR TITLE
curl.h: Include <sys/select.h> on SunOS

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -75,7 +75,8 @@
     defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
     defined(__CYGWIN__) || defined(AMIGA) || defined(__NuttX__) || \
    (defined(__FreeBSD_version) && (__FreeBSD_version < 800000)) || \
-   (defined(__MidnightBSD_version) && (__MidnightBSD_version < 100000))
+   (defined(__MidnightBSD_version) && (__MidnightBSD_version < 100000)) || \
+    defined(__sun__)
 #include <sys/select.h>
 #endif
 


### PR DESCRIPTION
It is needed for fd_set to be visible to downstream consumers that
use <curl/multi.h>. Header is known to exist at least as far back
as Solaris 2.6.