### PR TITLE
Implement `curl_easy_init_ex` that returns an error code.

### DIFF
--- a/docs/libcurl/curl_easy_init.3
+++ b/docs/libcurl/curl_easy_init.3
@@ -58,8 +58,16 @@ if(curl) {
 .SH AVAILABILITY
 Always
 .SH RETURN VALUE
-If this function returns NULL, something went wrong and you cannot use the
-other curl functions.
+Returns a valid non-null handle on success.
+
+On failure, returns NULL. If \fIcurl_global_init(3)\fP was called prior to
+\fIcurl_easy_init(3)\fP, then it means the process has ran out of memory. If
+\fIcurl_global_init(3)\fP was not called beforehand, it could also be due to a
+global initialization failure.
+
+In order to better isolate failure cases, the user is strongly advised to
+manually call \fIcurl_global_init(3)\fP instead of relying on libcurl doing it
+implicitly.
 .SH "SEE ALSO"
 .BR curl_easy_cleanup "(3), " curl_global_init "(3), " curl_easy_reset "(3), "
 .BR curl_easy_perform "(3) "


### PR DESCRIPTION
In a production grade software project it is often useful to check, log
and/or collect error codes for better error handling, diagnostics and
bug fixing.

The majority of libcurl functions provide error codes as part of their
interface. `curl_easy_init` is one of the most important functions of
the library, yet it lacks proper means of retrieving an error code when
it fails, making the bug fixing process more involved on certain
situations.

Looking closer at the implementation of `curl_easy_init`, it's apparent
that the error codes are readily available. All that's missing is an
interface to extract them to the call site.

This commit aims to provide an alternative interface capable of
surfacing the error code, while otherwise being identical in behavior to
`curl_easy_init`. By not directly modifying `curl_easy_init`'s
interface, the library remains backwards compatible.

`curl_easy_init_ex`'s implementation is almost identical to
`curl_easy_init`, with slight changes to accomodate for the new
interface.

Having an identical interface to `Curl_open`, it allows `curl_easy_init`
to be implemented as a thin wrapper on top of it, adding virtually zero
overhead (likely zero through trivial compiler optimizations). This has
two main benefits:
- avoid code duplication;
- leverage the vast existing test suite already in place for
  `curl_easy_init` without requiring immediate effort towards quality
  assurance.

Documentation for `curl_easy_init` has also been updated to accommodate
the new interface.