### PR TITLE
documenting stronger guarantees for `curl_easy_init` failures

### DIFF
--- a/docs/libcurl/curl_easy_init.3
+++ b/docs/libcurl/curl_easy_init.3
@@ -58,8 +58,12 @@ if(curl) {
 .SH AVAILABILITY
 Always
 .SH RETURN VALUE
-If this function returns NULL, something went wrong and you cannot use the
-other curl functions.
+It returns a pointer to a CURL easy handle on success.
+
+On failure, it returns NULL. If \fIcurl_global_init(3)\fP was called prior to
+\fIcurl_easy_init(3)\fP, then it means the process has ran out of memory.
+Future revisions may add other failure modes. If \fIcurl_global_init(3)\fP was
+not called beforehand, it could also be due to a global initialization failure.
 .SH "SEE ALSO"
 .BR curl_easy_cleanup "(3), " curl_global_init "(3), " curl_easy_reset "(3), "
 .BR curl_easy_perform "(3) "


### PR DESCRIPTION
In a production grade software project it is often useful to check, log
and/or collect error codes for better error handling, diagnostics and
bug fixing.

The majority of libcurl functions provide error codes as part of their
interface. `curl_easy_init` is one of the most important functions of
the library, yet it lacks proper means of retrieving an error code when
it fails, making the bug fixing process more involved on certain
situations.

The failures modes for `curl_easy_init` are well understood so after some
discussion in #9338, the community decided towards not adding a new interface
for surfacing the error codes of a failed easy handle creation.

This proposal is a follow up that aims to document and strengthen the API
contract by making the documentation clearer on the topic.