### PR TITLE
Document --cert escape handling

### DIFF
--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -32,11 +32,6 @@ loaded.
 If you provide a path relative to the current directory, you must prefix the
 path with "./" in order to avoid confusion with an NSS database nickname.
 
-If the NSS nickname or certificate filename contains the character ":", it
-must be prefixed by "\\" so that it is not recognized as the password
-delimiter. Similarly, if the nickname or filename contains "\\", it must be
-escaped as "\\\\" so that it is not recognized as an escape character.
-
 If curl is built against OpenSSL library, and the engine pkcs11 is available,
 then a PKCS#11 URI (RFC 7512) can be used to specify a certificate located in
 a PKCS#11 device. A string beginning with "pkcs11:" will be interpreted as a

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -14,9 +14,14 @@ Tells curl to use the specified client certificate file when getting a file
 with HTTPS, FTPS or another SSL-based protocol. The certificate must be in
 PKCS#12 format if using Secure Transport, or PEM format if using any other
 engine. If the optional password is not specified, it will be queried for on
-the terminal if required. Note that this option assumes a \&"certificate"
-file that is the private key and the client certificate concatenated! See
---cert and --key to specify them independently.
+the terminal. Note that this option assumes a \&"certificate" file that is the
+private key and the client certificate concatenated! See --cert and --key to
+specify them independently.
+
+In the <certificate> portion of the argument, you must escape the character ":"
+as "\\:" so that it is not recognized as the password delimiter. Similarly, you
+must escape the character "\\" as "\\\\" so that it is not recognized as an
+escape character.
 
 If curl is built against the NSS SSL library then this option can tell
 curl the nickname of the certificate to use within the NSS database defined
@@ -24,9 +29,8 @@ by the environment variable SSL_DIR (or by default /etc/pki/nssdb). If the
 NSS PEM PKCS#11 module (libnsspem.so) is available then PEM files may be
 loaded.
 
-If you intend to use a certificate file and provide a path relative to the
-current directory, you must prefix the path with "./" in order to avoid
-confusion with an NSS database nickname.
+If you provide a path relative to the current directory, you must prefix the
+path with "./" in order to avoid confusion with an NSS database nickname.
 
 If the NSS nickname or certificate filename contains the character ":", it
 must be prefixed by "\\" so that it is not recognized as the password

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -14,19 +14,24 @@ Tells curl to use the specified client certificate file when getting a file
 with HTTPS, FTPS or another SSL-based protocol. The certificate must be in
 PKCS#12 format if using Secure Transport, or PEM format if using any other
 engine. If the optional password is not specified, it will be queried for on
-the terminal. Note that this option assumes a \&"certificate" file that is the
-private key and the client certificate concatenated! See --cert and --key to
-specify them independently.
+the terminal if required. Note that this option assumes a \&"certificate"
+file that is the private key and the client certificate concatenated! See
+--cert and --key to specify them independently.
 
 If curl is built against the NSS SSL library then this option can tell
 curl the nickname of the certificate to use within the NSS database defined
 by the environment variable SSL_DIR (or by default /etc/pki/nssdb). If the
 NSS PEM PKCS#11 module (libnsspem.so) is available then PEM files may be
-loaded. If you want to use a file from the current directory, please precede
-it with "./" prefix, in order to avoid confusion with a nickname. If the
-nickname contains ":", it needs to be preceded by "\\" so that it is not
-recognized as password delimiter. If the nickname contains "\\", it needs to
-be escaped as "\\\\" so that it is not recognized as an escape character.
+loaded.
+
+If you intend to use a certificate file and provide a path relative to the
+current directory, you must prefix the path with "./" in order to avoid
+confusion with an NSS database nickname.
+
+If the NSS nickname or certificate filename contains the character ":", it
+must be prefixed by "\\" so that it is not recognized as the password
+delimiter. Similarly, if the nickname or filename contains "\\", it must be
+escaped as "\\\\" so that it is not recognized as an escape character.
 
 If curl is built against OpenSSL library, and the engine pkcs11 is available,
 then a PKCS#11 URI (RFC 7512) can be used to specify a certificate located in

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -793,9 +793,10 @@ int cert_stuff(struct Curl_easy *data,
         SSL_CTX_use_certificate_chain_file(ctx, cert_file);
       if(cert_use_result != 1) {
         failf(data,
-              "could not load PEM client certificate, " OSSL_PACKAGE
+              "could not load PEM client certificate from %s, " OSSL_PACKAGE
               " error %s, "
               "(no key found, wrong pass phrase, or wrong file format?)",
+              (cert_blob ? "CURLOPT_SSLCERT_BLOB" : cert_file),
               ossl_strerror(ERR_get_error(), error_buffer,
                             sizeof(error_buffer)) );
         return 0;
@@ -813,9 +814,10 @@ int cert_stuff(struct Curl_easy *data,
         SSL_CTX_use_certificate_file(ctx, cert_file, file_type);
       if(cert_use_result != 1) {
         failf(data,
-              "could not load ASN1 client certificate, " OSSL_PACKAGE
+              "could not load ASN1 client certificate from %s, " OSSL_PACKAGE
               " error %s, "
               "(no key found, wrong pass phrase, or wrong file format?)",
+              (cert_blob ? "CURLOPT_SSLCERT_BLOB" : cert_file),
               ossl_strerror(ERR_get_error(), error_buffer,
                             sizeof(error_buffer)) );
         return 0;


### PR DESCRIPTION
See: https://github.com/curl/curl/issues/9346

Includes two commits:

1) Clarify in the documentation for `--cert` that escape sequences for `:` and `/` apply to file paths as well as NSS nicknames

2) In lib/vtls/openssl.c, prints the file path (if available) of the certificate that was used if an error occurs when loading it.