### PR TITLE
gen.pl: encode leading single and double quotes automatically

### DIFF
--- a/docs/cmdline-opts/capath.d
+++ b/docs/cmdline-opts/capath.d
@@ -11,7 +11,7 @@ Added: 7.9.8
 ---
 Tells curl to use the specified certificate directory to verify the
 peer. Multiple paths can be provided by separating them with ":" (e.g.
-\&"path1:path2:path3"). The certificates must be in PEM format, and if curl is
+"path1:path2:path3"). The certificates must be in PEM format, and if curl is
 built against OpenSSL, the directory must have been processed using the
 c_rehash utility supplied with OpenSSL. Using --capath can allow
 OpenSSL-powered curl to make SSL-connections much more efficiently than using

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -14,7 +14,7 @@ Tells curl to use the specified client certificate file when getting a file
 with HTTPS, FTPS or another SSL-based protocol. The certificate must be in
 PKCS#12 format if using Secure Transport, or PEM format if using any other
 engine. If the optional password is not specified, it will be queried for on
-the terminal. Note that this option assumes a \&"certificate" file that is the
+the terminal. Note that this option assumes a "certificate" file that is the
 private key and the client certificate concatenated! See --cert and --key to
 specify them independently.
 

--- a/docs/cmdline-opts/data.d
+++ b/docs/cmdline-opts/data.d
@@ -25,12 +25,12 @@ the @ character. To post data purely binary, you should instead use the
 
 If any of these options is used more than once on the same command line, the
 data pieces specified will be merged with a separating &-symbol. Thus, using
-\&'-d name=daniel -d skill=lousy' would generate a post chunk that looks like
-\&'name=daniel&skill=lousy'.
+'-d name=daniel -d skill=lousy' would generate a post chunk that looks like
+'name=daniel&skill=lousy'.
 
 If you start the data with the letter @, the rest should be a file name to
 read the data from, or - if you want curl to read the data from stdin. Posting
-data from a file named \&'foobar' would thus be done with --data @foobar. When
+data from a file named 'foobar' would thus be done with --data @foobar. When
 --data is told to read from a file like that, carriage returns and newlines
 will be stripped out. If you do not want the @ character to have a special
 interpretation use --data-raw instead.

--- a/docs/cmdline-opts/form-string.d
+++ b/docs/cmdline-opts/form-string.d
@@ -10,7 +10,7 @@ Example: --form-string "data" $URL
 Added: 7.13.2
 ---
 Similar to --form except that the value string for the named parameter is used
-literally. Leading \&'@' and \&'<' characters, and the \&';type=' string in
+literally. Leading '@' and '<' characters, and the ';type=' string in
 the value have no special meaning. Use this in preference to --form if
 there's any possibility that the string value may accidentally trigger the
-\&'@' or \&'<' features of --form.
+'@' or '<' features of --form.

--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -34,7 +34,7 @@ be effectively read at transmission time; since the full size is unknown
 before the transfer starts, such data is sent as chunks by HTTP and rejected
 by IMAP.
 
-Example: send an image to an HTTP server, where \&'profile' is the name of the
+Example: send an image to an HTTP server, where 'profile' is the name of the
 form-field to which the file portrait.jpg will be the input:
 
  curl -F profile=@portrait.jpg https://example.com/upload.cgi

--- a/docs/cmdline-opts/ftp-method.d
+++ b/docs/cmdline-opts/ftp-method.d
@@ -23,6 +23,6 @@ curl does no CWD at all. curl will do SIZE, RETR, STOR etc and give a full
 path to the server for all these commands. This is the fastest behavior.
 .IP singlecwd
 curl does one CWD with the full target directory and then operates on the file
-\&"normally" (like in the multicwd case). This is somewhat more standards
+"normally" (like in the multicwd case). This is somewhat more standards
 compliant than 'nocwd' but without the full penalty of 'multicwd'.
 .RE

--- a/docs/cmdline-opts/ftp-port.d
+++ b/docs/cmdline-opts/ftp-port.d
@@ -33,7 +33,7 @@ If this option is used several times, the last one will be used. Disable the
 use of PORT with --ftp-pasv. Disable the attempt to use the EPRT command
 instead of PORT by using --disable-eprt. EPRT is really PORT++.
 
-You can also append \&":[start]-[end]\&" to the right of the address, to tell
+You can also append ":[start]-[end]\&" to the right of the address, to tell
 curl what TCP port range to use. That means you specify a port range, from a
 lower to a higher number. A single number works as well, but do note that it
 increases the risk of failure since the port may not be available.

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -113,7 +113,9 @@ sub printdesc {
         $d =~ s/( |\\fI|^)--/$1\\-\\-/g;
         $d =~ s/([ -]|\\fI|^)-/$1\\-/g;
         # handle single quotes first on the line
-        $d =~ s/(\s*)\'/$1\\(aq/;
+        $d =~ s/^(\s*)\'/$1\\(aq/;
+        # handle double quotes first on the line
+        $d =~ s/^(\s*)\"/$1\\(dq/;
         print $d;
     }
     if($exam) {

--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -19,9 +19,9 @@ externally set header will be used instead of the internal one. This allows
 you to make even trickier stuff than curl would normally do. You should not
 replace internally set headers without knowing perfectly well what you are
 doing. Remove an internal header by giving a replacement without content on
-the right side of the colon, as in: -H \&"Host:". If you send the custom
+the right side of the colon, as in: -H "Host:". If you send the custom
 header with no-value then its header must be terminated with a semicolon, such
-as \-H \&"X-Custom-Header;" to send "X-Custom-Header:".
+as \-H "X-Custom-Header;" to send "X-Custom-Header:".
 
 curl will make sure that each header you add/replace is sent with the proper
 end-of-line marker, you should thus **not** add that as a part of the header

--- a/docs/cmdline-opts/insecure.d
+++ b/docs/cmdline-opts/insecure.d
@@ -22,6 +22,6 @@ See this online resource for further details:
 
 For SFTP and SCP, this option makes curl skip the *known_hosts* verification.
 *known_hosts* is a file normally stored in the user's home directory in the
-\&.ssh subdirectory, which contains host names and their public keys.
+".ssh" subdirectory, which contains host names and their public keys.
 
 **WARNING**: using this option makes the transfer insecure.

--- a/docs/cmdline-opts/json.d
+++ b/docs/cmdline-opts/json.d
@@ -25,7 +25,7 @@ the syntax is correct.
 
 If you start the data with the letter @, the rest should be a file name to
 read the data from, or a single dash (-) if you want curl to read the data
-from stdin. Posting data from a file named \&'foobar' would thus be done with
+from stdin. Posting data from a file named 'foobar' would thus be done with
 --json @foobar and to instead read the data from stdin, use --json @-.
 
 If this option is used more than once on the same command line, the additional

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -11,7 +11,7 @@ See-also: key-type cert
 ---
 Private key file name. Allows you to provide your private key in this separate
 file. For SSH, if not specified, curl tries the following candidates in order:
-\&'~/.ssh/id_rsa', '~/.ssh/id_dsa', './id_rsa', './id_dsa'.
+'~/.ssh/id_rsa', '~/.ssh/id_dsa', './id_rsa', './id_dsa'.
 
 If curl is built against OpenSSL library, and the engine pkcs11 is available,
 then a PKCS#11 URI (RFC 7512) can be used to specify a private key located in a

--- a/docs/cmdline-opts/netrc.d
+++ b/docs/cmdline-opts/netrc.d
@@ -17,7 +17,7 @@ neither world- nor group-readable). The environment variable "HOME" is used
 to find the home directory.
 
 A quick and simple example of how to setup a *.netrc* to allow curl to FTP to
-the machine host.domain.com with user name \&'myself' and password \&'secret'
+the machine host.domain.com with user name 'myself' and password 'secret'
 could look similar to:
 
  machine host.domain.com

--- a/docs/cmdline-opts/noproxy.d
+++ b/docs/cmdline-opts/noproxy.d
@@ -17,4 +17,4 @@ not www.notlocal.com.
 
 Since 7.53.0, This option overrides the environment variables that disable the
 proxy ('no_proxy' and 'NO_PROXY'). If there's an environment variable
-disabling a proxy, you can set the noproxy list to \&"" to override it.
+disabling a proxy, you can set the noproxy list to "" to override it.

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -22,7 +22,7 @@ SMTP, LDAP, etc.
 Sets the proxy server to use if no protocol-specific proxy is set.
 .IP "NO_PROXY <comma-separated list of hosts/domains>"
 list of host names that should not go through any proxy. If set to an asterisk
-\&'*' only, it matches all hosts. Each name in this list is matched as either
+'*' only, it matches all hosts. Each name in this list is matched as either
 a domain name which contains the hostname, or the hostname itself.
 
 This environment variable disables use of the proxy even when specified with

--- a/docs/cmdline-opts/proto.d
+++ b/docs/cmdline-opts/proto.d
@@ -10,7 +10,7 @@ Example: --proto =http,https,sftp $URL
 ---
 Tells curl to limit what protocols it may use for transfers. Protocols are
 evaluated left to right, are comma separated, and are each a protocol name or
-\&'all', optionally prefixed by zero or more modifiers. Available modifiers are:
+'all', optionally prefixed by zero or more modifiers. Available modifiers are:
 .RS
 .TP 3
 .B +

--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -30,7 +30,7 @@ If the port number is not specified in the proxy string, it is assumed to be
 
 This option overrides existing environment variables that set the proxy to
 use. If there's an environment variable setting a proxy, you can set proxy to
-\&"" to override it.
+"" to override it.
 
 All operations that are performed over an HTTP proxy will transparently be
 converted to HTTP. It means that certain protocol specific operations might

--- a/docs/cmdline-opts/range.d
+++ b/docs/cmdline-opts/range.d
@@ -38,7 +38,7 @@ response, which will be returned as-is by curl! Parsing or otherwise
 transforming this response is the responsibility of the caller.
 
 Only digit characters (0-9) are valid in the 'start' and 'stop' fields of the
-\&'start-stop' range syntax. If a non-digit character is given in the range,
+'start-stop' range syntax. If a non-digit character is given in the range,
 the server's response will be unspecified, depending on the server's
 configuration.
 

--- a/docs/cmdline-opts/referer.d
+++ b/docs/cmdline-opts/referer.d
@@ -15,7 +15,7 @@ Added: 4.0
 Sends the "Referrer Page" information to the HTTP server. This can also be set
 with the --header flag of course. When used with --location you can append
 ";auto" to the --referer URL to make curl automatically set the previous URL
-when it follows a Location: header. The \&";auto" string can be used alone,
+when it follows a Location: header. The ";auto" string can be used alone,
 even if you do not set an initial --referer.
 
 If this option is used several times, the last one will be used.


### PR DESCRIPTION
This removes the need for having the escape letters in the files themselves.