### PR TITLE
configure: if asked to use TLS, fail if no TLS lib was detected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1969,6 +1969,9 @@ x1)
   SSL_ENABLED="1"
   AC_MSG_NOTICE([built with one SSL backend])
   ;;
+xD)
+  # explicitly built without TLS
+  ;;
 *)
   # more than one SSL backend is enabled
   AC_SUBST(SSL_ENABLED)

--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,8 @@ AS_HELP_STRING([--without-ssl], [build without any TLS library]),[
   OPT_OPENSSL=$withval
   if test X"$withval" != Xno; then
     TLSCHOICE="${TLSCHOICE:+$TLSCHOICE, }OpenSSL"
+  else
+    SSL_DISABLED="D"
   fi
 ])
 
@@ -1955,11 +1957,11 @@ if test "x$curl_cv_native_windows" = "xyes" &&
   LIBS="-lbcrypt $LIBS"
 fi
 
-case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$RUSTLS_ENABLED"
+case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$RUSTLS_ENABLED$SSL_DISABLED"
 in
 x)
-  AC_MSG_WARN([SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.])
-  AC_MSG_WARN([Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-nss, --with-schannel, --with-secure-transport, --with-amissl, --with-bearssl or --with-rustls to address this.])
+  AC_MSG_ERROR([TLS not detected, you will not be able to use HTTPS, FTPS, NTLM and more.
+Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-nss, --with-schannel, --with-secure-transport, --with-amissl, --with-bearssl or --with-rustls to address this.])
   ;;
 x1)
   # one SSL backend is enabled


### PR DESCRIPTION
Previously the configure script would just warn about this fact and continue with TLS disabled build which is not always helpful. TLS should be explicitly disabled if that is what the user wants.