### PR TITLE
CI/azure: align torture shallowness with GHA

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,7 +77,7 @@ stages:
           name: torture
           install: libnghttp2-dev
           configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl
-          tests: -n -t --shallow=40 !FTP
+          tests: -n -t --shallow=25 !FTP
     steps:
     - script: sudo apt-get update && sudo apt-get install -y stunnel4 python3-impacket libzstd-dev libbrotli-dev $(install)
       displayName: 'apt install'


### PR DESCRIPTION
There 25 is used with FTP tests skipped, and 20 for FTP tests.
This should make torture tests stay within the 60min timeout.