### PR TITLE
libssh: ignore deprecation warnings

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -96,6 +96,13 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+/* in 0.10.0 or later, ignore deprecated warnings */
+#if defined(__GNUC__) &&                        \
+  (LIBSSH_VERSION_MINOR >= 10) ||               \
+  (LIBSSH_VERSION_MAJOR > 0)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /* A recent macro provided by libssh. Or make our own. */
 #ifndef SSH_STRING_FREE_CHAR
 #define SSH_STRING_FREE_CHAR(x)                 \


### PR DESCRIPTION
libssh 0.10.0 marks all SCP functions as "deprecated" which causes compiler warnings and errors in our CI jobs and elsewhere. Ignore deprecation warnings if 0.10.0 or later is found in the build.

If they actually remove the functions at a later point, then someone can deal with that pain and functionality break then.

Fixes #9382