### PR TITLE
setup-win32: no longer define UNICODE/_UNICODE implicitly

### DIFF
--- a/lib/setup-win32.h
+++ b/lib/setup-win32.h
@@ -37,10 +37,10 @@
 
 #ifdef HAVE_WINDOWS_H
 #  if defined(UNICODE) && !defined(_UNICODE)
-#    define _UNICODE
+#    error "UNICODE is defined but _UNICODE is not defined"
 #  endif
 #  if defined(_UNICODE) && !defined(UNICODE)
-#    define UNICODE
+#    error "_UNICODE is defined but UNICODE is not defined"
 #  endif
 #  include <winerror.h>
 #  include <windows.h>


### PR DESCRIPTION
- If UNICODE or _UNICODE is defined but the other isn't then error
  instead of implicitly defining it.

As Marcel pointed out it is too late at this point to make such a define
because Windows headers may already be included, so likely it never
worked. We never noticed because build systems that can make Windows
Unicode builds always define both. If one is defined but not the other
then something went wrong during the build configuration.

Bug: https://github.com/curl/curl/pull/9375#discussion_r956545272
Reported-by: Marcel Raad

Closes #xxxx