### PR TITLE
ftp: ignore a 550 response to MDTM

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2131,9 +2131,11 @@ static CURLcode ftp_state_mdtm_resp(struct Curl_easy *data,
   default:
     infof(data, "unsupported MDTM reply format");
     break;
-  case 550: /* "No such file or directory" */
-    failf(data, "Given file does not exist");
-    result = CURLE_REMOTE_FILE_NOT_FOUND;
+  case 550: /* 550 is used for several different problems, e.g.
+               "No such file or directory" or "Permission denied".
+               It does not mean that the file does not exist at all. */
+    infof(data, "MDTM failed: file does not exist or permission problem,"
+          " continuing");
     break;
   }
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -245,4 +245,4 @@ test2200 test2201 test2202 test2203 test2204 test2205 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
-test3024 test3025 test3026
+test3024 test3025 test3026 test3027

--- a/tests/data/test3027
+++ b/tests/data/test3027
@@ -2,16 +2,21 @@
 <info>
 <keywords>
 FTP
+CURLOPT_FILETIME
+MDTM fail
 </keywords>
 </info>
 
-#
 # Server-side
 <reply>
 <servercmd>
-REPLY MDTM 550 bluah you f00l!
-REPLY SIZE 550 bluah you f00l!
+REPLY MDTM 550 Permission denied
 </servercmd>
+<data>
+data blobb
+</data>
+
+# data is sent to stdout
 </reply>
 
 # Client-side
@@ -19,33 +24,31 @@ REPLY SIZE 550 bluah you f00l!
 <server>
 ftp
 </server>
-# tool is what to use instead of 'curl'
-<tool>
-lib%TESTNUMBER
-</tool>
-
  <name>
-FTP with FILETIME and NOBODY but missing file
+Get a file via FTP but 550 after MDTM command
  </name>
- <command>
+<tool>
+lib3027
+</tool>
+<command option="no-include">
 ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
 </command>
+<stdout>
+data blobb
+</stdout>
 </client>
 
-#
 # Verify data after the test has been "shot"
 <verify>
-# CURLE_REMOTE_FILE_NOT_FOUND
-<errorcode>
-78
-</errorcode>
 <protocol>
 USER anonymous
 PASS ftp@example.com
 PWD
 MDTM %TESTNUMBER
+EPSV
 TYPE I
 SIZE %TESTNUMBER
+RETR %TESTNUMBER
 QUIT
 </protocol>
 </verify>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -65,7 +65,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
          lib1915 lib1916 lib1917 lib1918 lib1919 \
  lib1933 lib1934 lib1935 lib1936 lib1937 lib1938 lib1939 lib1940 \
  lib1945 lib1946 \
- lib3010 lib3025 lib3026
+ lib3010 lib3025 lib3026 lib3027
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
  ../../lib/curl_ctype.c  ../../lib/dynbuf.c ../../lib/strdup.c
@@ -759,3 +759,7 @@ lib3025_CPPFLAGS = $(AM_CPPFLAGS)
 lib3026_SOURCES = lib3026.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib3026_LDADD = $(TESTUTIL_LIBS)
 lib3026_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib3027_SOURCES = lib3027.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib3027_LDADD = $(TESTUTIL_LIBS)
+lib3027_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/libtest/lib3027.c
+++ b/tests/libtest/lib3027.c
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 2020 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+  CURLcode ret = CURLE_OK;
+  CURL *hnd;
+  start_test_timing();
+
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  hnd = curl_easy_init();
+  if(hnd) {
+    curl_easy_setopt(hnd, CURLOPT_URL, URL);
+    curl_easy_setopt(hnd, CURLOPT_FILETIME, 1L);
+    ret = curl_easy_perform(hnd);
+    if(CURLE_OK == ret) {
+      long filetime;
+      ret = curl_easy_getinfo(hnd, CURLINFO_FILETIME, &filetime);
+      /* MTDM fails with 550, so filetime should be -1 */
+      if((CURLE_OK == ret) && (filetime != -1)) {
+        /* we just need to return something which is not CURLE_OK */
+        ret = CURLE_UNSUPPORTED_PROTOCOL;
+      }
+    }
+    curl_easy_cleanup(hnd);
+  }
+  curl_global_cleanup();
+  return (int)ret;
+}


### PR DESCRIPTION
The 550 is overused as a return code for multiple error case, e.g.
file not found and/or insufficient permissions to access the file.

So we cannot fail hard in this case.

Adjust test 511 since we now fail later.
Add new test 3027 which check that when MDTM failed, but the file could
actually be retrieved, that in this case no filetime is provided.

Reported-by: Michael Heimpold
Fixes #9357