### PR TITLE
tool_operate: prevent over-queuing in parallel mode

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -205,6 +205,7 @@ static curl_off_t VmsSpecialSize(const char *name,
 
 struct per_transfer *transfers; /* first node */
 static struct per_transfer *transfersl; /* last node */
+static long all_pers;
 
 /* add_per_transfer creates a new 'per_transfer' node in the linked
    list of transfers */
@@ -227,6 +228,8 @@ static CURLcode add_per_transfer(struct per_transfer **per)
   }
   *per = p;
   all_xfers++; /* count total number of transfers added */
+  all_pers++;
+
   return CURLE_OK;
 }
 
@@ -254,6 +257,7 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
     transfersl = p;
 
   free(per);
+  all_pers--;
 
   return n;
 }
@@ -2194,9 +2198,11 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
   bool sleeping = FALSE;
   *addedp = FALSE;
   *morep = FALSE;
-  result = create_transfer(global, share, addedp);
-  if(result)
-    return result;
+  if(all_pers < (global->parallel_max*2)) {
+    result = create_transfer(global, share, addedp);
+    if(result)
+      return result;
+  }
   for(per = transfers; per && (all_added < global->parallel_max);
       per = per->next) {
     bool getadded = FALSE;

--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -161,8 +161,8 @@ static bool indexwrapped;
 static struct speedcount speedstore[SPEEDCNT];
 
 /*
-  |DL% UL%  Dled  Uled  Xfers  Live   Qd Total     Current  Left    Speed
-  |  6 --   9.9G     0     2     2     0  0:00:40  0:00:02  0:00:37 4087M
+  |DL% UL%  Dled  Uled  Xfers  Live Total     Current  Left    Speed
+  |  6 --   9.9G     0     2     2   0:00:40  0:00:02  0:00:37 4087M
 */
 bool progress_meter(struct GlobalConfig *global,
                     struct timeval *start,
@@ -181,7 +181,7 @@ bool progress_meter(struct GlobalConfig *global,
 
   if(!header) {
     header = TRUE;
-    fputs("DL% UL%  Dled  Uled  Xfers  Live   Qd "
+    fputs("DL% UL%  Dled  Uled  Xfers  Live "
           "Total     Current  Left    Speed\n",
           global->errors);
   }
@@ -199,7 +199,6 @@ bool progress_meter(struct GlobalConfig *global,
     bool dlknown = TRUE;
     bool ulknown = TRUE;
     curl_off_t all_running = 0; /* in progress */
-    curl_off_t all_queued = 0;  /* pending */
     curl_off_t speed = 0;
     unsigned int i;
     stamp = now;
@@ -225,9 +224,7 @@ bool progress_meter(struct GlobalConfig *global,
         all_ultotal += per->ultotal;
         per->ultotal_added = TRUE;
       }
-      if(!per->added)
-        all_queued++;
-      else
+      if(per->added)
         all_running++;
     }
     if(dlknown && all_dltotal)
@@ -296,8 +293,7 @@ bool progress_meter(struct GlobalConfig *global,
             "%s " /* Uled */
             "%5" CURL_FORMAT_CURL_OFF_T " " /* Xfers */
             "%5" CURL_FORMAT_CURL_OFF_T " " /* Live */
-            "%5" CURL_FORMAT_CURL_OFF_T " " /* Queued */
-            "%s "  /* Total time */
+            " %s "  /* Total time */
             "%s "  /* Current time */
             "%s "  /* Time left */
             "%s "  /* Speed */
@@ -309,7 +305,6 @@ bool progress_meter(struct GlobalConfig *global,
             max5data(all_ulnow, buffer[1]),
             all_xfers,
             all_running,
-            all_queued,
             time_total,
             time_spent,
             time_left,


### PR DESCRIPTION
When doing a huge amount of parallel transfers, we must not add them to the per_transfer list frivolously since they all use memory after all. This was previous done without really considering millions or billions of transfers. Massive parallelism would use a lot of memory for no good purpose.

The queue is now limited to twice the parallelism number.

This makes the 'Qd' value in the parallel progress meter mostly useless for users, but works for now for us as a debug display.

Reported-by: justchen1369 on github
Fixes #8933