### PR TITLE
zuul: remove the clang-tidy job

### DIFF
--- a/scripts/zuul/script.sh
+++ b/scripts/zuul/script.sh
@@ -83,12 +83,6 @@ if [ "$T" = "normal" ]; then
   fi
 fi
 
-if [ "$T" = "tidy" ]; then
-  ./configure --enable-warnings --enable-werror $C
-  make
-  make tidy
-fi
-
 if [ "$T" = "cmake" ]; then
   mkdir -p build
   cd ./build

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -202,24 +202,6 @@
         T: fuzzer
 
 - job:
-    name: curl-tidy
-    parent: curl-base
-    vars:
-      curl_apt_packages:
-        - clang
-        - clang-tidy
-        - clang-9
-        - clang-tidy-9
-        - libpsl-dev
-        - libbrotli-dev
-        - libzstd-dev
-      curl_env:
-        CC: clang-9
-        CXX: clang++-9
-        T: tidy
-        C: --with-openssl
-
-- job:
     name: curl-debug-clang-with-openssl-dl-ubsan
     parent: curl-base
     vars:
@@ -258,6 +240,5 @@
       - curl-cmake-boringssl-quiche
       - curl-cmake-ngtcp2
       - curl-fuzzer
-      - curl-tidy
       - curl-debug-clang-with-openssl-dl-ubsan
 ...


### PR DESCRIPTION
Turns out we don't see the warnings, but the warnings right now are plain ridiculous and unhelpful so we can just as well just kill this job.