### PR TITLE
tool_operate: reduce errorbuffer allocs

### DIFF
--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -52,7 +52,6 @@ struct per_transfer {
   struct HdrCbData hdrcbdata;
   long num_headers;
   bool was_last_header_empty;
-  char errorbuffer[CURL_ERROR_SIZE];
 
   bool added; /* set TRUE when added to the multi handle */
   time_t startat; /* when doing parallel transfers, this is a retry transfer
@@ -72,6 +71,8 @@ struct per_transfer {
 
   /* NULL or malloced */
   char *uploadfile;
+  char *errorbuffer; /* alloced and assigned while this is used for a
+                        transfer */
 };
 
 CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[]);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -195,8 +195,8 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
     switch(wovar->id) {
     case VAR_ERRORMSG:
       if(per_result) {
-        strinfo = per->errorbuffer[0] ? per->errorbuffer :
-                  curl_easy_strerror(per_result);
+        strinfo = (per->errorbuffer && per->errorbuffer[0]) ?
+          per->errorbuffer : curl_easy_strerror(per_result);
         valid = true;
       }
       break;


### PR DESCRIPTION
- parallel transfers: only alloc and keep errorbuffers in memory for actual "live" transfers and not for the ones in the pending queue

- serial transfers: reuse the same fixed buffer for all transfers, not allocated at all.