### PR TITLE
appveyor: pass target windows version to MSVS 2022 + cmake + msys build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -159,6 +159,7 @@ environment:
         BUILD_OPT: -k
       - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
+        CMAKE_OPTS: -DCURL_TARGET_WINDOWS_VERSION=0x0501
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
         OPENSSL: OFF
@@ -274,6 +275,7 @@ build_script:
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=""
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=""
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
+        %CMAKE_OPTS%
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT%
       ) else (


### PR DESCRIPTION
Fixes #9214

Suggested-by: Marcel Raad