### PR TITLE
http: fix fail code returned if 3xx or 4xx on range request

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2911,6 +2911,11 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
      (data->state.httpreq == HTTPREQ_GET) &&
      !k->ignorebody) {
 
+    if(!(200 <= data->info.httpcode && data->info.httpcode < 300)) {
+      /* We wanted to resume a download, but the server doesn't respond with a
+       * successful code, we don't know if the server supports byte ranges */
+      return CURLE_OK;
+    }
     if(k->size == data->state.resume_from) {
       /* The resume point is at the end of file, consider this fine even if it
          doesn't allow resume from here. */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -251,7 +251,7 @@ test2500 test2501 test2502 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
-test3024 test3025 test3026 test3027 test3028 test3029 test3030 \
+test3024 test3025 test3026 test3027 test3028 test3029 test3030 test3031 \
 \
 test3100 test3101 \
 test3200

--- a/tests/data/test3031
+++ b/tests/data/test3031
@@ -5,14 +5,15 @@ HTTP
 HTTP GET
 Resume
 Largefile
-FAILURE
+Not found
+SUCCESS
 </keywords>
 </info>
 #
 # Server-side
 <reply>
 <data>
-HTTP/1.1 200 OK
+HTTP/1.1 404 Nah
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Connection: close
 Content-Length: 13
@@ -22,12 +23,13 @@ Funny-head: yesyes
 </data>
 
 <datacheck>
-HTTP/1.1 200 OK
+HTTP/1.1 404 Nah
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Connection: close
 Content-Length: 13
 Funny-head: yesyes
 
+012345678912
 </datacheck>
 </reply>
 
@@ -41,7 +43,7 @@ large_file
 http
 </server>
  <name>
-HTTP GET with large-file resume point and failed resume
+HTTP GET with large-file resume point and not found is not a failure
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -C 9999999999
@@ -51,9 +53,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -C 9999999999
 #
 # Verify data after the test has been "shot"
 <verify>
-# 33 is CURLE_RANGE_ERROR
 <errorcode>
-33
+0
 </errorcode>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1


### PR DESCRIPTION
Data range can be requested and 401 Unauthorized can be responded with a body
unrelated to the requested content, and without Content-Range header, with
unrelated Content-Length value. `curl_easy_perform()` fails with the error
`CURLE_RANGE_ERROR`. It should not fail.