### PR TITLE
test3026: try to reduce runtime within legacy mingw build environments

### DIFF
--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -62,10 +62,8 @@ int test(char *URL)
      libcurl calls LoadLibrary/FreeLibrary it only increases/decreases the
      library's refcount rather than actually loading/unloading the library,
      which would affect the test runtime. */
-#ifdef WIN32
   (void)win32_load_system_library(TEXT("secur32.dll"));
   (void)win32_load_system_library(TEXT("iphlpapi.dll"));
-#endif
 
   for(i = 0; i < tid_count; i++) {
     HANDLE th;

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -57,6 +57,16 @@ int test(char *URL)
     return -1;
   }
 
+  /* On Windows libcurl global init/cleanup calls LoadLibrary/FreeLibrary for
+     secur32.dll and iphlpapi.dll. Here we load them beforehand so that when
+     libcurl calls LoadLibrary/FreeLibrary it only increases/decreases the
+     library's refcount rather than actually loading/unloading the library,
+     which would affect the test runtime. */
+#ifdef WIN32
+  (void)win32_load_system_library(TEXT("secur32.dll"));
+  (void)win32_load_system_library(TEXT("iphlpapi.dll"));
+#endif
+
   for(i = 0; i < tid_count; i++) {
     HANDLE th;
     results[i] = CURL_LAST; /* initialize with invalid value */

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -131,7 +131,7 @@ double tutil_tvdiff_secs(struct timeval newer, struct timeval older)
 }
 
 #ifdef WIN32
-HMODULE win32_load_system_library(TCHAR *filename)
+HMODULE win32_load_system_library(const TCHAR *filename)
 {
   size_t filenamelen = _tcslen(filename);
   size_t systemdirlen = GetSystemDirectory(NULL, 0);

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -117,7 +117,6 @@ long tutil_tvdiff(struct timeval newer, struct timeval older)
     (long)(newer.tv_usec-older.tv_usec)/1000;
 }
 
-
 /*
  * Same as tutil_tvdiff but with full usec resolution.
  *
@@ -130,3 +129,34 @@ double tutil_tvdiff_secs(struct timeval newer, struct timeval older)
       (double)(newer.tv_usec-older.tv_usec)/1000000.0;
   return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
+
+#ifdef WIN32
+HMODULE win32_load_system_library(TCHAR *filename)
+{
+  size_t filenamelen = _tcslen(filename);
+  size_t systemdirlen = GetSystemDirectory(NULL, 0);
+  size_t written;
+  TCHAR *path;
+
+  if(!filenamelen || filenamelen > 32768 ||
+     !systemdirlen || systemdirlen > 32768)
+    return NULL;
+
+  /* systemdirlen includes null character */
+  path = malloc(sizeof(TCHAR) * (systemdirlen + 1 + filenamelen));
+  if(!path)
+    return NULL;
+
+  /* if written >= systemdirlen then nothing was written */
+  written = GetSystemDirectory(path, (unsigned int)systemdirlen);
+  if(!written || written >= systemdirlen)
+    return NULL;
+
+  if(path[written - 1] != _T('\\'))
+    path[written++] = _T('\\');
+
+  _tcscpy(path + written, filename);
+
+  return LoadLibrary(path);
+}
+#endif

--- a/tests/libtest/testutil.h
+++ b/tests/libtest/testutil.h
@@ -43,7 +43,7 @@ long tutil_tvdiff(struct timeval t1, struct timeval t2);
 double tutil_tvdiff_secs(struct timeval t1, struct timeval t2);
 
 #ifdef WIN32
-HMODULE win32_load_system_library(TCHAR *filename);
+HMODULE win32_load_system_library(const TCHAR *filename);
 #endif
 
 #endif  /* HEADER_CURL_LIBTEST_TESTUTIL_H */

--- a/tests/libtest/testutil.h
+++ b/tests/libtest/testutil.h
@@ -42,5 +42,8 @@ long tutil_tvdiff(struct timeval t1, struct timeval t2);
  */
 double tutil_tvdiff_secs(struct timeval t1, struct timeval t2);
 
+#ifdef WIN32
+HMODULE win32_load_system_library(TCHAR *filename);
+#endif
 
 #endif  /* HEADER_CURL_LIBTEST_TESTUTIL_H */


### PR DESCRIPTION
Right now the test seems to take between 15 and 20 minutes
on our Windows CI environments. _Which is quite extreme for
just 100 threads, but anyway 42 looks like a better number._