### PR TITLE
configure: fail if '--without-ssl' has been set together with an explicit parameter for an ssl lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1957,7 +1957,7 @@ if test "x$curl_cv_native_windows" = "xyes" &&
   LIBS="-lbcrypt $LIBS"
 fi
 
-case "x$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$RUSTLS_ENABLED$SSL_DISABLED"
+case "x$SSL_DISABLED$OPENSSL_ENABLED$GNUTLS_ENABLED$NSS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$SECURETRANSPORT_ENABLED$BEARSSL_ENABLED$RUSTLS_ENABLED"
 in
 x)
   AC_MSG_ERROR([TLS not detected, you will not be able to use HTTPS, FTPS, NTLM and more.
@@ -1971,6 +1971,11 @@ x1)
   ;;
 xD)
   # explicitly built without TLS
+  ;;
+xD*)
+  AC_MSG_ERROR([--without-ssl has been set together with an explicit option to use an ssl library
+(e.g. --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-nss, --with-schannel, --with-secure-transport, --with-amissl, --with-bearssl, --with-rustls).
+Since these are conflicting parameters, verify which is the desired one and drop the other.])
   ;;
 *)
   # more than one SSL backend is enabled


### PR DESCRIPTION
As part of packaging 7.85.0 on Debian, I noticed a build issue due to our packaging using the wrong configure flags, it would set both `--without-ssl` and `--with-nss` or `--with-gnutls`, this would result in the build being marked as a MultiSSL one.

I have addressed the issue by removing the wrong parameter (`--without-ssl`), which I believe was added with the intention of behaving like `--without-openssl` (though this parameter is not available), but it looks like it's a good idea to make the configure script stricter to avoid this from happening altogether, so I figure you might be interested in this change.

Commit description below:
 A side effect of a previous change to configure (576e507c78bdd2ec88da442a5354f9dd661b9a8a)
 exposed a non-critical issue that can happen if configure is called
 with both '--without-ssl' and some parameter setting the use of a
 ssl library (e.g. --with-gnutls). The configure script would end
 up assuming this is a MultiSSL build, due to the way the case
 statement is written.

 I have changed the order of the variables in the string concatenation
 for the case statement and also tweaked the options so that
 --without-ssl never turns the build into a MultiSSL one and
 also clearly stating that there are conflicting parameters
 if the user sets it like described above.