### PR TITLE
Remove mentions of deprecated '--without-openssl' config parameter

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -106,7 +106,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure --without-openssl --with-gnutls=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
+     % ./configure --with-gnutls=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
      % make install
 
@@ -147,7 +147,7 @@ Build curl
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure --without-openssl --with-wolfssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
+     % ./configure --with-wolfssl=<somewhere1> --with-nghttp3=<somewhere2> --with-ngtcp2=<somewhere3>
      % make
      % make install
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -267,8 +267,7 @@ Windows you should choose another SSL backend such as OpenSSL.
 
 On modern Apple operating systems, curl can be built to use Apple's SSL/TLS
 implementation, Secure Transport, instead of OpenSSL. To build with Secure
-Transport for SSL/TLS, use the configure option `--with-secure-transport`. (It
-is not necessary to use the option `--without-openssl`.)
+Transport for SSL/TLS, use the configure option `--with-secure-transport`.
 
 When Secure Transport is in use, the curl options `--cacert` and `--capath`
 and their libcurl equivalents, will be ignored, because Secure Transport uses


### PR DESCRIPTION
I noticed this when working on a similar PR:
https://github.com/curl/curl/pull/9414