### PR TITLE
CURLOPT_WILDCARDMATCH.3: Fix backslash escaping under single quotes

### DIFF
--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
@@ -72,7 +72,7 @@ right bracket and matches exactly one character. Some examples follow:
 \fB[][-!^]\fP - special case \- matches only '\-', ']', '[', '!' or '^'. These
 characters have no special purpose.
 
-\fB[\\[\\]\\\\]\fP - escape syntax. Matches '[', ']' or '\\'.
+\fB[\\[\\]\\\\]\fP - escape syntax. Matches '[', ']' or '\e'.
 
 Using the rules above, a file name pattern can be constructed:
 


### PR DESCRIPTION
 Lintian (on Debian) has been complaining about this for a while but
 I didn't bother initially as the groff parser that we use is not
 affected by this.

 But I have now noticed that the online manpage is affected by it:
 https://curl.se/libcurl/c/CURLOPT_WILDCARDMATCH.html

 (I'm using double quotes for quoting-only down below)

 The section that should be parsed as `"'\'"` ends up being parsed as
 `"'´"`.

 This is due to roffit not parsing `"'\\'"` correctly, which is fine
 as the "correct" way of writing `"'\'"` is `"'\e'"` instead.

 Note that this fix is not enough to fix the online manpage at
 curl's website, as roffit seems to parse it wrongly either way.

 My intent is to at least fix the manpage so that roffit can
 be changed to parse `"'\e'"` correctly (although I suggest making
 roffit parse both ways correctly, since that's what groff does).

 More details at:
 https://bugs.debian.org/966803
 https://salsa.debian.org/lintian/lintian/-/blob/930b18e4b28b7540253f458ef42a884cca7965c3/tags/a/acute-accent-in-manual-page.tag