### PR TITLE
manpages: Fix spelling of "allows to" -> "allows one to"

### DIFF
--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.3
@@ -47,7 +47,7 @@ carriage return and line feed to %22, %0D and %0A respectively.
 Before version 7.81.0, percent-encoding was never applied.
 
 HTTP browsers used to do backslash-escaping in the past but have over time
-transitioned to use percent-encoding. This option allows to address
+transitioned to use percent-encoding. This option allows one to address
 server-side applications that have not yet have been converted.
 
 As an example, consider field or file name \fIstrange\\name"kind\fP.

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -88,7 +88,7 @@ Keep output and log files in log/ after a test run, even if no error was
 detected. Useful for debugging.
 .IP "-L <file>"
 Load and execute the specified file which should contain perl code.
-This option allows to change \fIruntests.pl\fP behaviour by overwriting
+This option allows one to change \fIruntests.pl\fP behaviour by overwriting
 functions and variables and is useful when testing external proxies
 using curl's regression test suite.
 .IP "-l"
@@ -101,7 +101,7 @@ Useful to change variables that didn't get a dedicated flag to change them.
 Check the source to see which variables are available.
 .IP "-P <proxy>"
 Use the specified HTTP proxy when executing tests, even if the tests
-themselves don't specify a proxy. This option allows to test external
+themselves don't specify a proxy. This option allows one to test external
 proxies using curl's regression test suite.
 .IP "-p"
 Prints out all files in "log/" to stdout when a test case fails. Very


### PR DESCRIPTION
 References:
 https://salsa.debian.org/lintian/lintian/-/blob/master/tags/t/typo-in-manual-page.tag
 https://english.stackexchange.com/questions/60271/grammatical-complements-for-allow/60285#60285