### PR TITLE
tests/certs/scripts: insert standard curl source headers

### DIFF
--- a/tests/certs/scripts/genroot.sh
+++ b/tests/certs/scripts/genroot.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
-
-# (c) CopyRight 2000 - 2020, EdelWeb for EdelKey and OpenEvidence
-# Author: Peter Sylvester
-
-# "libre" for integration with curl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2000 - 2022, EdelWeb for EdelKey and OpenEvidence
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
 
 OPENSSL=openssl
 if [ -f /usr/local/ssl/bin/openssl ] ; then

--- a/tests/certs/scripts/genserv.sh
+++ b/tests/certs/scripts/genserv.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
-
-# (c) CopyRight 2000 - 2020, EdelWeb for EdelKey and OpenEvidence
-# Author: Peter Sylvester
-
-# "libre" for integration with curl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2000 - 2022, EdelWeb for EdelKey and OpenEvidence
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
 
 OPENSSL=openssl
 if [ -f /usr/local/ssl/bin/openssl ] ; then


### PR DESCRIPTION
... including the SPDX-License-Identifier.

These omissions were not detected by the RUEUSE CI job nor the copyright.pl scanners because we have a general wildcard in .reuse/dep5 for "tests/certs/*".

Reported-by: Samuel Henrique
Fixes #9417