### PR TITLE
CURLOPT_DNS_INTERFACE.3: mention it works for almost all protocols

### DIFF
--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
@@ -42,6 +42,7 @@ option.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS
+All protocols except file:// - protocols that resolve host names.
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();


### PR DESCRIPTION
Except file.

Reported-by: ProceduralMan on github
Fixes #9427