### PR TITLE
curl_easy_pause.3: unpausing is as fast as possible

### DIFF
--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -48,8 +48,8 @@ progress callback (\fICURLOPT_PROGRESSFUNCTION(3)\fP).
 When this function is called to unpause receiving, the write callback might
 get called before this function returns to deliver cached content. When
 libcurl delivers such cached data to the write callback, it will be delivered
-as fast as possible, which may overstep the boundary set in \fI
-CURLOPT_MAX_RECV_SPEED_LARGE(3)\fP etc.
+as fast as possible, which may overstep the boundary set in
+\fICURLOPT_MAX_RECV_SPEED_LARGE(3)\fP etc.
 
 The \fBhandle\fP argument identifies the transfer you want to pause or
 unpause.

--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -45,8 +45,11 @@ While it may feel tempting, take care and notice that you cannot call this
 function from another thread. To unpause, you may for example call it from the
 progress callback (\fICURLOPT_PROGRESSFUNCTION(3)\fP).
 
-When this function is called to unpause receiving, the chance is high that you
-will get your write callback called before this function returns.
+When this function is called to unpause receiving, the write callback might
+get called before this function returns to deliver cached content. When
+libcurl delivers such cached data to the write callback, it will be delivered
+as fast as possible, which may overstep the boundary set in \fI
+CURLOPT_MAX_RECV_SPEED_LARGE(3)\fP etc.
 
 The \fBhandle\fP argument identifies the transfer you want to pause or
 unpause.


### PR DESCRIPTION
Reported-by: ssdbest on github
Fixes #9410