### PR TITLE
misc: ISSPACE() => ISBLANK()

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -1044,7 +1044,7 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
     size_t namelen;
 
     /* Parse a single encoding name. */
-    while(ISSPACE(*enclist) || *enclist == ',')
+    while(ISBLANK(*enclist) || *enclist == ',')
       enclist++;
 
     name = enclist;

--- a/lib/curl_range.c
+++ b/lib/curl_range.c
@@ -47,7 +47,7 @@ CURLcode Curl_range(struct Curl_easy *data)
     from_t = curlx_strtoofft(data->state.range, &ptr, 0, &from);
     if(from_t == CURL_OFFT_FLOW)
       return CURLE_RANGE_ERROR;
-    while(*ptr && (ISSPACE(*ptr) || (*ptr == '-')))
+    while(*ptr && (ISBLANK(*ptr) || (*ptr == '-')))
       ptr++;
     to_t = curlx_strtoofft(ptr, &ptr2, 0, &to);
     if(to_t == CURL_OFFT_FLOW)

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -422,7 +422,7 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
               char *endptr = finfo->b_data + 6;
               /* here we can deal with directory size, pass the leading
                  whitespace and then the digits */
-              while(ISSPACE(*endptr))
+              while(ISBLANK(*endptr))
                 endptr++;
               while(ISDIGIT(*endptr))
                 endptr++;
@@ -894,7 +894,7 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
         parser->item_length++;
         switch(parser->state.NT.sub.time) {
         case PL_WINNT_TIME_PRESPACE:
-          if(!ISSPACE(c)) {
+          if(!ISBLANK(c)) {
             parser->state.NT.sub.time = PL_WINNT_TIME_TIME;
           }
           break;

--- a/lib/h2h3.c
+++ b/lib/h2h3.c
@@ -191,7 +191,7 @@ CURLcode Curl_pseudo_headers(struct Curl_easy *data,
   vptr = Curl_checkheaders(data, STRCONST(H2H3_PSEUDO_SCHEME));
   if(vptr) {
     vptr += sizeof(H2H3_PSEUDO_SCHEME);
-    while(*vptr && ISSPACE(*vptr))
+    while(*vptr && ISBLANK(*vptr))
       vptr++;
     nva[2].value = vptr;
     infof(data, "set pseudo header %s to %s", H2H3_PSEUDO_SCHEME, vptr);

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -213,7 +213,7 @@ static CURLcode namevalue(char *header, size_t hlen, unsigned int type,
   *value = header;
 
   /* skip all trailing space letters */
-  while((end > header) && ISBLANK(*end))
+  while((end > header) && ISSPACE(*end))
     *end-- = 0; /* nul terminate */
   return CURLE_OK;
 }
@@ -233,7 +233,7 @@ static CURLcode unfold_value(struct Curl_easy *data, const char *value,
   oalloc = olen + offset + 1;
 
   /* skip all trailing space letters */
-  while(vlen && ISBLANK(value[vlen - 1]))
+  while(vlen && ISSPACE(value[vlen - 1]))
     vlen--;
 
   /* save only one leading space */

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -207,13 +207,13 @@ static CURLcode namevalue(char *header, size_t hlen, unsigned int type,
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
   /* skip all leading space letters */
-  while(*header && ISSPACE(*header))
+  while(*header && ISBLANK(*header))
     header++;
 
   *value = header;
 
   /* skip all trailing space letters */
-  while((end > header) && ISSPACE(*end))
+  while((end > header) && ISBLANK(*end))
     *end-- = 0; /* nul terminate */
   return CURLE_OK;
 }
@@ -233,11 +233,11 @@ static CURLcode unfold_value(struct Curl_easy *data, const char *value,
   oalloc = olen + offset + 1;
 
   /* skip all trailing space letters */
-  while(vlen && ISSPACE(value[vlen - 1]))
+  while(vlen && ISBLANK(value[vlen - 1]))
     vlen--;
 
   /* save only one leading space */
-  while((vlen > 1) && ISSPACE(value[0]) && ISSPACE(value[1])) {
+  while((vlen > 1) && ISBLANK(value[0]) && ISBLANK(value[1])) {
     vlen--;
     value++;
   }

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -156,7 +156,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
     return CURLE_OK;
 
   do {
-    while(*p && ISSPACE(*p))
+    while(*p && ISBLANK(*p))
       p++;
     if(Curl_strncasecompare("max-age=", p, 8)) {
       bool quoted = FALSE;
@@ -167,7 +167,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
         return CURLE_BAD_FUNCTION_ARGUMENT;
 
       p += 8;
-      while(*p && ISSPACE(*p))
+      while(*p && ISBLANK(*p))
         p++;
       if(*p == '\"') {
         p++;
@@ -200,7 +200,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
         p++;
     }
 
-    while(*p && ISSPACE(*p))
+    while(*p && ISBLANK(*p))
       p++;
     if(*p == ';')
       p++;

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -58,11 +58,11 @@ CURLcode Curl_input_digest(struct Curl_easy *data,
     digest = &data->state.digest;
   }
 
-  if(!checkprefix("Digest", header) || !ISSPACE(header[6]))
+  if(!checkprefix("Digest", header) || !ISBLANK(header[6]))
     return CURLE_BAD_CONTENT_ENCODING;
 
   header += strlen("Digest");
-  while(*header && ISSPACE(*header))
+  while(*header && ISBLANK(*header))
     header++;
 
   return Curl_auth_decode_digest_http_message(header, digest);

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -84,7 +84,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 
   /* Obtain the input token, if any */
   header += strlen("Negotiate");
-  while(*header && ISSPACE(*header))
+  while(*header && ISBLANK(*header))
     header++;
 
   len = strlen(header);

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -96,7 +96,7 @@ static int parsenetrc(const char *host,
       }
       tok = netrcbuffer;
       while(tok) {
-        while(ISSPACE(*tok))
+        while(ISBLANK(*tok))
           tok++;
         /* tok is first non-space letter */
         if(!*tok || (*tok == '#'))

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1068,8 +1068,8 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
 
         if(!binary) {
           /* check for leading or trailing whitespace */
-          if(ISSPACE(bvals[i].bv_val[0]) ||
-             ISSPACE(bvals[i].bv_val[bvals[i].bv_len - 1]))
+          if(ISBLANK(bvals[i].bv_val[0]) ||
+             ISBLANK(bvals[i].bv_val[bvals[i].bv_len - 1]))
             binval = 1;
           else {
             /* check for unprintable characters */

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -794,7 +794,7 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
 
     /* Find the first non-space letter */
     start = header + 8;
-    while(*start && ISSPACE(*start))
+    while(*start && ISBLANK(*start))
       start++;
 
     if(!*start) {

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -87,7 +87,7 @@ static curl_off_t strtooff(const char *nptr, char **endptr, int base)
 
   /* Skip leading whitespace. */
   end = (char *)nptr;
-  while(ISSPACE(end[0])) {
+  while(ISBLANK(end[0])) {
     end++;
   }
 
@@ -222,7 +222,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
   errno = 0;
   *num = 0; /* clear by default */
 
-  while(*str && ISSPACE(*str))
+  while(*str && ISBLANK(*str))
     str++;
   if('-' == *str) {
     if(endp)

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -521,7 +521,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
     char content[DIGEST_MAX_CONTENT_LENGTH];
 
     /* Pass all additional spaces here */
-    while(*chlg && ISSPACE(*chlg))
+    while(*chlg && ISBLANK(*chlg))
       chlg++;
 
     /* Extract a value=content pair */
@@ -561,7 +561,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
         token = strtok_r(tmp, ",", &tok_buf);
         while(token) {
           /* Pass additional spaces here */
-          while(*token && ISSPACE(*token))
+          while(*token && ISBLANK(*token))
             token++;
           if(strcasecompare(token, DIGEST_QOP_VALUE_STRING_AUTH)) {
             foundAuth = TRUE;
@@ -622,7 +622,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
       break; /* We're done here */
 
     /* Pass all additional spaces here */
-    while(*chlg && ISSPACE(*chlg))
+    while(*chlg && ISBLANK(*chlg))
       chlg++;
 
     /* Allow the list to be comma-separated */

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -259,7 +259,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
       char content[DIGEST_MAX_CONTENT_LENGTH];
 
       /* Pass all additional spaces here */
-      while(*chlg && ISSPACE(*chlg))
+      while(*chlg && ISBLANK(*chlg))
         chlg++;
 
       /* Extract a value=content pair */
@@ -292,7 +292,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
         break; /* We're done here */
 
       /* Pass all additional spaces here */
-      while(*chlg && ISSPACE(*chlg))
+      while(*chlg && ISBLANK(*chlg))
         chlg++;
 
       /* Allow the list to be comma-separated */
@@ -333,7 +333,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
       char value[DIGEST_MAX_VALUE_LENGTH];
       char content[DIGEST_MAX_CONTENT_LENGTH];
 
-      while(*p && ISSPACE(*p))
+      while(*p && ISBLANK(*p))
         p++;
 
       if(!Curl_auth_digest_get_pair(p, value, content, &p))
@@ -345,7 +345,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
         break;
       }
 
-      while(*p && ISSPACE(*p))
+      while(*p && ISBLANK(*p))
         p++;
 
       if(',' == *p)

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1667,7 +1667,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
           if(from_t == CURL_OFFT_FLOW) {
             return CURLE_RANGE_ERROR;
           }
-          while(*ptr && (ISSPACE(*ptr) || (*ptr == '-')))
+          while(*ptr && (ISBLANK(*ptr) || (*ptr == '-')))
             ptr++;
           to_t = curlx_strtoofft(ptr, &ptr2, 0, &to);
           if(to_t == CURL_OFFT_FLOW) {

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2506,7 +2506,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
           from_t = curlx_strtoofft(data->state.range, &ptr, 0, &from);
           if(from_t == CURL_OFFT_FLOW)
             return CURLE_RANGE_ERROR;
-          while(*ptr && (ISSPACE(*ptr) || (*ptr == '-')))
+          while(*ptr && (ISBLANK(*ptr) || (*ptr == '-')))
             ptr++;
           to_t = curlx_strtoofft(ptr, &ptr2, 0, &to);
           if(to_t == CURL_OFFT_FLOW)

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -336,7 +336,7 @@ static SECStatus set_ciphers(struct Curl_easy *data, PRFileDesc *model,
     char name[MAX_CIPHER_LENGTH + 1];
     size_t len;
     bool found = FALSE;
-    while((*cipher) && (ISSPACE(*cipher)))
+    while((*cipher) && (ISBLANK(*cipher)))
       ++cipher;
 
     end = strpbrk(cipher, ":, ");

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4366,7 +4366,7 @@ static size_t ossl_version(char *buffer, size_t size)
   }
   count = msnprintf(buffer, size, "%s/%s", OSSL_PACKAGE, ver);
   for(p = buffer; *p; ++p) {
-    if(ISSPACE(*p))
+    if(ISBLANK(*p))
       *p = '_';
   }
   return count;

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -116,7 +116,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       const char *etag_h = &str[5];
       const char *eot = end - 1;
       if(*eot == '\n') {
-        while(ISSPACE(*etag_h) && (etag_h < eot))
+        while(ISBLANK(*etag_h) && (etag_h < eot))
           etag_h++;
         while(ISSPACE(*eot))
           eot--;

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -59,7 +59,7 @@ static void voutf(struct GlobalConfig *config,
       if(len > width) {
         size_t cut = width-1;
 
-        while(!ISSPACE(ptr[cut]) && cut) {
+        while(!ISBLANK(ptr[cut]) && cut) {
           cut--;
         }
         if(0 == cut)


### PR DESCRIPTION
Instances of ISSPACE() use that should rather use ISBLANK(). I think somewhat carelessly used because it sounds as if it checks for space or whitespace, but also includes %0a to %0d.

For parsing purposes, we should only accept what we must and not be overly liberal. It leads to surprises and surprises lead to bad things.