### PR TITLE
ctype: remove all use of <ctype.h>, use our own versions

### DIFF
--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -33,7 +33,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-#include <ctype.h>
 #include <time.h>
 
 #ifdef HAVE_ERRNO_H
@@ -228,9 +227,6 @@ struct timeval {
 #else
 #  define sfcntl  fcntl
 #endif
-
-#define TOLOWER(x)  (tolower((int)  ((unsigned char)x)))
-
 
 /*
  * 'bool' stuff compatible with HP-UX headers.

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -181,7 +181,7 @@ create_hostcache_id(const char *name, int port, char *ptr, size_t buflen)
     len = buflen - 7;
   /* store and lower case the name */
   while(len--)
-    *ptr++ = (char)TOLOWER(*name++);
+    *ptr++ = Curl_raw_tolower(*name++);
   msnprintf(ptr, 7, ":%u", port);
 }
 

--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -28,8 +28,6 @@
 
 #include "strcase.h"
 
-static char raw_tolower(char in);
-
 /* Mapping table to go from lowercase to uppercase for plain ASCII.*/
 static const unsigned char touppermap[256] = {
 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
@@ -79,7 +77,7 @@ char Curl_raw_toupper(char in)
 
 /* Portable, consistent tolower. Do not use tolower() because its behavior is
    altered by the current locale. */
-static char raw_tolower(char in)
+char Curl_raw_tolower(char in)
 {
   return tolowermap[(unsigned char) in];
 }
@@ -165,7 +163,7 @@ void Curl_strntolower(char *dest, const char *src, size_t n)
     return;
 
   do {
-    *dest++ = raw_tolower(*src);
+    *dest++ = Curl_raw_tolower(*src);
   } while(*src++ && --n);
 }
 

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -43,6 +43,7 @@ int Curl_safe_strcasecompare(const char *first, const char *second);
 int Curl_strncasecompare(const char *first, const char *second, size_t max);
 
 char Curl_raw_toupper(char in);
+char Curl_raw_tolower(char in);
 
 /* checkprefix() is a shorter version of the above, used when the first
    argument is the string literal */

--- a/lib/url.c
+++ b/lib/url.c
@@ -2376,7 +2376,7 @@ static char *detect_proxy(struct Curl_easy *data,
 
   /* Now, build <protocol>_proxy and check for such a one to use */
   while(*protop)
-    *envp++ = (char)tolower((int)*protop++);
+    *envp++ = Curl_raw_tolower(*protop++);
 
   /* append _proxy */
   strcpy(envp, "_proxy");

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -260,7 +260,7 @@ bool Curl_is_absolute_url(const char *url, char *buf, size_t buflen)
     if(buf) {
       buf[i] = 0;
       while(i--) {
-        buf[i] = (char)TOLOWER(url[i]);
+        buf[i] = Curl_raw_tolower(url[i]);
       }
     }
     return TRUE;
@@ -1664,8 +1664,8 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
         /* make sure percent encoded are lower case */
         if((*p == '%') && ISXDIGIT(p[1]) && ISXDIGIT(p[2]) &&
            (ISUPPER(p[1]) || ISUPPER(p[2]))) {
-          p[1] = (char)TOLOWER(p[1]);
-          p[2] = (char)TOLOWER(p[2]);
+          p[1] = Curl_raw_tolower(p[1]);
+          p[2] = Curl_raw_tolower(p[2]);
           p += 3;
         }
         else

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -45,6 +45,7 @@
 #include <curl/curl.h>
 #include "urldata.h"
 #include "strcase.h"
+#include "curl_ctype.h"
 #include "hostcheck.h"
 #include "vtls/vtls.h"
 #include "sendf.h"
@@ -716,7 +717,7 @@ static ssize_t encodeDN(char *buf, size_t buflen, struct Curl_asn1Element *dn)
       /* Encode delimiter.
          If attribute has a short uppercase name, delimiter is ", ". */
       if(l) {
-        for(p3 = str; isupper(*p3); p3++)
+        for(p3 = str; ISUPPER(*p3); p3++)
           ;
         for(p3 = (*p3 || p3 - str > 2)? "/": ", "; *p3; p3++) {
           if(l < buflen)

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -281,7 +281,7 @@ static char *c_escape(const char *str, curl_off_t len)
       strcpy(e, "\\?");
       e += 2;
     }
-    else if(!isprint(c)) {
+    else if(!ISPRINT(c)) {
       msnprintf(e, 5, "\\x%02x", (unsigned)c);
       e += 4;
     }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -88,6 +88,8 @@
 #include <pwd.h>
 #endif
 
+#include <ctype.h>
+
 #define ENABLE_CURLX_PRINTF
 /* make the curlx header define all printf() functions to use the curlx_*
    versions instead */


### PR DESCRIPTION
Except in the test servers.