### PR TITLE
CURLOPT_PROXY_SSLCERT_BLOB.3: this is for HTTPS proxies

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
@@ -48,7 +48,7 @@ expects a file name as input.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS
-All TLS based protocols: HTTPS, FTPS, IMAPS, POP3S, SMTPS etc.
+Used with HTTPS proxy
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();


### PR DESCRIPTION
The 'protocols' listed were previously wrong.

Reported-by: ProceduralMan on github
Fixes #9434