### PR TITLE
tool_operate: fix msnprintfing the error message

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2325,8 +2325,9 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
           curl_multi_remove_handle(multi, easy);
 
           if(ended->abort && tres == CURLE_ABORTED_BY_CALLBACK) {
-            msnprintf(ended->errorbuffer, sizeof(ended->errorbuffer),
-              "Transfer aborted due to critical error in another transfer");
+            msnprintf(ended->errorbuffer, CURL_ERROR_SIZE,
+                      "Transfer aborted due to critical error "
+                      "in another transfer");
           }
           tres = post_per_transfer(global, ended, tres, &retry, &delay);
           progress_finalize(ended); /* before it goes away */


### PR DESCRIPTION
Follow-up to 7be53774c41c59b47075fba

Coverity CID 1513717 pointed out that we cannot use sizeof() on the error buffer anymore.