### PR TITLE
curl-compilers.m4: use -O2 as default optimize for clang

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -107,7 +107,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
     compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
     flags_dbg_yes="-g"
     flags_opt_all="-O -O0 -O1 -O2 -Os -O3 -O4"
-    flags_opt_yes="-Os"
+    flags_opt_yes="-O2"
     flags_opt_off="-O0"
   else
     AC_MSG_RESULT([no])


### PR DESCRIPTION
Not -Os