### PR TITLE
header: define public API functions as extern c

### DIFF
--- a/include/curl/header.h
+++ b/include/curl/header.h
@@ -24,6 +24,10 @@
  *
  ***************************************************************************/
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 struct curl_header {
   char *name;    /* this might not use the same case */
   char *value;
@@ -62,5 +66,9 @@ CURL_EXTERN struct curl_header *curl_easy_nextheader(CURL *easy,
                                                      unsigned int origin,
                                                      int request,
                                                      struct curl_header *prev);
+
+#ifdef __cplusplus
+} /* end of extern "C" */
+#endif
 
 #endif /* CURLINC_HEADER_H */


### PR DESCRIPTION
Prior to this change linker errors would occur if curl_easy_header or curl_easy_nextheader was called from a C++ unit.

Bug: https://github.com/curl/curl/issues/9424#issuecomment-1238818007
Reported-by: Andrew Lambert

Closes #xxxx