### PR TITLE
headers: reset the requests counter at transfer start

### DIFF
--- a/lib/headers.c
+++ b/lib/headers.c
@@ -335,6 +335,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
 static void headers_init(struct Curl_easy *data)
 {
   Curl_llist_init(&data->state.httphdrs, NULL);
+  data->state.requests = 0;
 }
 
 /*

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -335,7 +335,6 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
 static void headers_init(struct Curl_easy *data)
 {
   Curl_llist_init(&data->state.httphdrs, NULL);
-  data->state.requests = 0;
 }
 
 /*

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1439,6 +1439,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
   if(result)
     return result;
 
+  data->state.requests = 0;
   data->state.followlocation = 0; /* reset the location-follow counter */
   data->state.this_is_a_follow = FALSE; /* reset this */
   data->state.errorbuf = FALSE; /* no error has occurred */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -224,7 +224,7 @@ test1908 test1909 test1910 test1911 test1912 test1913 test1914 test1915 \
 test1916 test1917 test1918 test1919 \
 \
 test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
-test1941 test1942 test1943 test1944 test1945 test1946 \
+test1941 test1942 test1943 test1944 test1945 test1946 test1947 \
 \
 test2000 test2001 test2002 test2003 test2004 \
 \

--- a/tests/data/test1947
+++ b/tests/data/test1947
@@ -1,0 +1,71 @@
+<testcase>
+<info>
+<keywords>
+curl_easy_nextheader
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 302 OK
+Date: Thu, 01 Nov 2001 14:49:00 GMT
+Server:       test with trailing space     
+Content-Type: text/html
+Content-Length: 0
+Set-Cookie: onecookie=data;
+Set-Cookie: secondcookie=2data;
+Set-Cookie: cookie3=data3;
+Location: /%TESTNUMBER0002
+
+</data>
+<data2 nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: the other one
+Content-Type: text/html
+Content-Length: 0
+Set-Cookie: 1cookie=data1;
+Set-Cookie: 2cookie=data2;
+
+</data2>
+
+<data3 nocheck="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: the other one
+Content-Type: text/html
+Content-Length: 0
+
+</data3>
+</reply>
+
+# Client-side
+<client>
+<features>
+headers-api
+</features>
+<server>
+http
+</server>
+
+<name>
+curl_easy_nextheader on second request after first did redirects
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0003
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<stdout>
+count = 2
+count = 1
+</stdout>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -64,7 +64,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
          lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
          lib1915 lib1916 lib1917 lib1918 lib1919 \
  lib1933 lib1934 lib1935 lib1936 lib1937 lib1938 lib1939 lib1940 \
- lib1945 lib1946 \
+ lib1945 lib1946 lib1947 \
  lib3010 lib3025 lib3026 lib3027
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
@@ -747,6 +747,10 @@ lib1945_CPPFLAGS = $(AM_CPPFLAGS)
 lib1946_SOURCES = lib1940.c $(SUPPORTFILES)
 lib1946_LDADD = $(TESTUTIL_LIBS)
 lib1946_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1946
+
+lib1947_SOURCES = lib1947.c $(SUPPORTFILES)
+lib1947_LDADD = $(TESTUTIL_LIBS)
+lib1947_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib3010_SOURCES = lib3010.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib3010_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1947.c
+++ b/tests/libtest/lib1947.c
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "test.h"
+
+#include "memdebug.h"
+
+static size_t writecb(char *data, size_t n, size_t l, void *userp)
+{
+  /* ignore the data */
+  (void)data;
+  (void)userp;
+  return n*l;
+}
+int test(char *URL)
+{
+  CURL *curl;
+  CURLcode res;
+
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+
+  curl = curl_easy_init();
+  if(curl) {
+    struct curl_header *h;
+    int count = 0;
+    int origins;
+
+    /* perform a request that involves redirection */
+    curl_easy_setopt(curl, CURLOPT_URL, URL);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    res = curl_easy_perform(curl);
+    if(res)
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+
+    /* count the number of requests by reading the first header of each
+       request. */
+    origins = (CURLH_HEADER|CURLH_TRAILER|CURLH_CONNECT|
+               CURLH_1XX|CURLH_PSEUDO);
+    do {
+      h = curl_easy_nextheader(curl, origins, count, NULL);
+      if(h)
+        count++;
+    } while(h);
+    printf("count = %u\n", count);
+
+    /* perform another request - without redirect */
+    curl_easy_setopt(curl, CURLOPT_URL, libtest_arg2);
+    res = curl_easy_perform(curl);
+    if(res)
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+
+    /* count the number of requests again. */
+    count = 0;
+    do {
+      h = curl_easy_nextheader(curl, origins, count, NULL);
+      if(h)
+        count++;
+    } while(h);
+    printf("count = %u\n", count);
+    curl_easy_cleanup(curl);
+  }
+
+  curl_global_cleanup();
+  return 0;
+}


### PR DESCRIPTION
If not, reusing an easy handle to do a subsequent transfer would continue the counter from the previous invoke, which then would make use of the header API difficult/impossible as the request counter mismatched.

Add libtest 1947 to verify.

Reported-by: Andrew Lambert
Fixes #9424