### PR TITLE
content_encoding: handle alignment explicitly

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -219,6 +219,7 @@ LIB_CFILES =         \
   wildcard.c
 
 LIB_HFILES =         \
+  align.h            \
   altsvc.h           \
   amigaos.h          \
   arpa_telnet.h      \

--- a/lib/align.h
+++ b/lib/align.h
@@ -1,0 +1,68 @@
+#ifndef HEADER_CURL_ALIGN_H
+#define HEADER_CURL_ALIGN_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+/* Universal type alignment macros. */
+
+#include "curl_setup.h"
+#include <stddef.h>
+
+/* Alignment for type.*/
+#define ALIGN(type)     offsetof(struct { char c; type t; }, t)
+
+/* Union of all scalar types for universal alignment computation. */
+union all_scalar_types {
+  char          c;
+  short         s;
+  int           i;
+  long          l;
+#ifdef HAVE_LONGLONG
+  long long     ll;
+#endif
+  float         f;
+  double        d;
+#ifdef HAVE_LONGDOUBLE
+  long double   ld;
+#endif
+  void *        p;
+  void         (*pf)(void); /* May have a different alignment than void *. */
+};
+
+/* Universal alignment constant. */
+#define UALIGN  ALIGN(union all_scalar_types)
+
+/* Align a size downwards.*/
+#define DNALIGNSIZE(s, a)   ((s) - ((s) % (a)))
+
+/* Align a size upwards.*/
+#define UPALIGNSIZE(s, a)   DNALIGNSIZE((s) + (a) - 1, (a))
+
+/* Align a pointer downwards.*/
+#define DNALIGNPTR(p, a)    ((void *) ((char *) (p) - ((size_t) (p) % (a))))
+
+/* Align a pointer upwards.*/
+#define UPALIGNPTR(p, a)    DNALIGNPTR((char *) (p) + (a) - 1, (a))
+
+#endif /* HEADER_CURL_ALIGN_H */

--- a/lib/content_encoding.h
+++ b/lib/content_encoding.h
@@ -28,7 +28,7 @@
 struct contenc_writer {
   const struct content_encoding *handler;  /* Encoding handler. */
   struct contenc_writer *downstream;  /* Downstream writer. */
-  void *params;  /* Encoding-specific storage (variable length). */
+  /* Encoding-specific storage (variable length) follows. */
 };
 
 /* Content encoding writer. */


### PR DESCRIPTION
The variable-sized encoding-specific storage of a struct contenc_writer currently relies on void * alignment that may be insufficient with regards to the specific storage fields, although having not caused any problems yet.

In addition, gcc 11.3 issues a warning on access to fields of partially allocated structures that can occur when the specific storage size is 0:

```
  content_encoding.c: In function ‘Curl_build_unencoding_stack’:
  content_encoding.c:980:21: warning: array subscript ‘struct contenc_writer[0]’ is partly outside array bounds of ‘unsigned char[16]’ [-Warray-bounds]
    980 |     writer->handler = handler;
        |     ~~~~~~~~~~~~~~~~^~~~~~~~~
  In file included from content_encoding.c:49:
  memdebug.h:115:29: note: referencing an object of size 16 allocated by ‘curl_dbg_calloc’
    115 | #define calloc(nbelem,size) curl_dbg_calloc(nbelem, size, __LINE__, __FILE__)
        |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  content_encoding.c:977:60: note: in expansion of macro ‘calloc’
    977 |   struct contenc_writer *writer = (struct contenc_writer *)calloc(1, sz);
```

To resolve both problems, this commit:
- adds an align.h header file to define alignment macros,
- removes the "params" field of structure contenc_writer.
- computes the allocation size and effective offset of specific storage from the struct contenc_writer address in an alignment-aware way. This makes sure the structure is fully allocated and specific storage properly aligned (warning disappears).

New align.h file is generic and may be re-used in another module if ever needed.