### PR TITLE
curl_setup: include system.h instead of curl.h

### DIFF
--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -31,6 +31,7 @@
  * be shared.
  */
 
+#include <curl/curl.h>
 #include "timeval.h"
 
 struct connectdata;

--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -26,6 +26,8 @@
 
 #ifndef CURL_DISABLE_CRYPTO_AUTH
 
+#include <curl/curl.h>
+
 #define HMAC_MD5_LENGTH 16
 
 typedef CURLcode (* HMAC_hinit_func)(void *context);

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -244,7 +244,7 @@
 #  include "setup-win32.h"
 #endif
 
-#include <curl/curl.h>
+#include <curl/system.h>
 
 /*
  * Use getaddrinfo to resolve the IPv4 address literal. If the current network

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -158,8 +158,6 @@
 /*  please, do it beyond the point further indicated in this file.  */
 /* ================================================================ */
 
-#include <curl/curl.h>
-
 /*
  * Disable other protocols when http is the only one desired.
  */
@@ -219,7 +217,7 @@
 
 /* ================================================================ */
 /* No system header file shall be included in this file before this */
-/* point. The only allowed ones are those included from curl/system.h */
+/* point.                                                           */
 /* ================================================================ */
 
 /*
@@ -245,6 +243,8 @@
 #ifdef HAVE_WINDOWS_H
 #  include "setup-win32.h"
 #endif
+
+#include <curl/curl.h>
 
 /*
  * Use getaddrinfo to resolve the IPv4 address literal. If the current network

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -26,6 +26,7 @@
  ***************************************************************************/
 
 #ifndef CURL_DISABLE_CRYPTO_AUTH
+#include <curl/curl.h>
 #include "curl_hmac.h"
 
 extern const struct HMAC_params Curl_HMAC_SHA256[1];

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -24,6 +24,8 @@
  *
  ***************************************************************************/
 
+#include <curl/curl.h>
+
 #ifndef BUILDING_LIBCURL
 /* this renames the functions so that the tool code can use the same code
    without getting symbol collisions */

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -30,6 +30,8 @@
  * as well as the library. Do not mix with library internals!
  */
 
+#include <curl/curl.h>
+
 #if defined(__GNUC__) && __GNUC__ >= 3
 #  define ALLOC_FUNC __attribute__((malloc))
 #  define ALLOC_SIZE(s) __attribute__((alloc_size(s)))

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -26,6 +26,8 @@
 
 #include "curl_setup.h"
 #ifndef HAVE_SOCKETPAIR
+#include <curl/curl.h>
+
 int Curl_socketpair(int domain, int type, int protocol,
                     curl_socket_t socks[2]);
 #else

--- a/lib/timediff.c
+++ b/lib/timediff.c
@@ -24,6 +24,8 @@
 
 #include "timediff.h"
 
+#include <limits.h>
+
 /*
  * Converts number of milliseconds into a timeval structure.
  *

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -24,6 +24,7 @@
 #include "curl_setup.h"
 
 #include "keylog.h"
+#include <curl/curl.h>
 
 /* The last #include files should be: */
 #include "curl_memory.h"

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -39,6 +39,8 @@
 
 #include "warnless.h"
 
+#include <limits.h>
+
 #define CURL_MASK_UCHAR   ((unsigned char)~0)
 #define CURL_MASK_SCHAR   (CURL_MASK_UCHAR >> 1)
 

--- a/lib/wildcard.h
+++ b/lib/wildcard.h
@@ -27,6 +27,7 @@
 #include "curl_setup.h"
 
 #ifndef CURL_DISABLE_FTP
+#include <curl/curl.h>
 #include "llist.h"
 
 /* list of wildcard process states */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -83,6 +83,8 @@ void restore_signal_handlers(bool keep_sigalrm);
 
 #ifdef USE_UNIX_SOCKETS
 
+#include <curl/curl.h> /* for curl_socket_t */
+
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h> /* for sockaddr_un */
 #endif /* HAVE_SYS_UN_H */


### PR DESCRIPTION
... and after the platform setup headers instead of before them.

This makes the definitions set in the platform setup headers apply to the platform includes in system.h.