### PR TITLE
strtoofft: after space, there cannot be a control code

### DIFF
--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -224,7 +224,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
 
   while(*str && ISBLANK(*str))
     str++;
-  if('-' == *str) {
+  if(('-' == *str) || (ISSPACE(*str))) {
     if(endp)
       *endp = (char *)str; /* didn't actually move */
     return CURL_OFFT_INVAL; /* nothing parsed */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -67,7 +67,7 @@ test370 test371 test372 test373 test374 test375 test376 test378 test379 \
 test380 test381 test383 test384 test385 test386 test387 test388 test389 \
 test390 test391 test392 test393 test394 test395 test396 test397 test398 \
 test399 test400 test401 test402 test403 test404 test405 test406 test407 \
-test408 test409 test410 test411 test412 test413 test414 \
+test408 test409 test410 test411 test412 test413 test414 test415 \
 \
 test430 test431 test432 test433 test434 test435 test436 \
 \

--- a/tests/data/test415
+++ b/tests/data/test415
@@ -1,0 +1,65 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK swsclose
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: -6
+Content-Type: text/html
+Funny-head: yesyes
+
+moooooooooooo
+</data>
+<datacheck>
+%if hyper
+%else
+HTTP/1.1 200 OK swsclose
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+%endif
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP response with control code then negative Content-Length
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+
+# Hyper curl returns unsupported protocol
+# bullt-in curl returns weird_server_reply
+<errorcode>
+%if hyper
+1
+%else
+8
+%endif
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
With the change from ISSPACE() to ISBLANK() this function no longer deals with (ignores) control codes the same way, which could lead to this function returning unexpected values like in the case of "Content-Length: \r-12354".

Follow-up to 6f9fb7ec2d7cb389a0da5

Detected by OSS-fuzz
Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51140
Assisted-by: Max Dymond