### PR TITLE
schannel: when importing PFX, disable key persistence

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -186,6 +186,10 @@
 #define ALG_CLASS_DHASH ALG_CLASS_HASH
 #endif
 
+#ifndef PKCS12_NO_PERSIST_KEY
+#define PKCS12_NO_PERSIST_KEY 0x00008000
+#endif
+
 static Curl_recv schannel_recv;
 static Curl_send schannel_send;
 
@@ -676,7 +680,13 @@ schannel_acquire_credential_handle(struct Curl_easy *data,
         else
           pszPassword[0] = 0;
 
-        cert_store = PFXImportCertStore(&datablob, pszPassword, 0);
+        if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
+                                        VERSION_GREATER_THAN_EQUAL))
+          cert_store = PFXImportCertStore(&datablob, pszPassword,
+                                          PKCS12_NO_PERSIST_KEY);
+        else
+          cert_store = PFXImportCertStore(&datablob, pszPassword, 0);
+
         free(pszPassword);
       }
       if(!blob)

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -155,6 +155,7 @@ struct Curl_schannel_cred {
   CredHandle cred_handle;
   TimeStamp time_stamp;
   TCHAR *sni_hostname;
+  HCERTSTORE client_cert_store;
   int refcount;
 };
 


### PR DESCRIPTION
By default, the PFXImportCertStore API persists the key in the user's
key store (as though the certificate was being imported for permanent,
ongoing use.)

The documentation specifies that keys that are not to be persisted
should be imported with the flag `PKCS12_NO_PERSIST_KEY`.
NOTE: this flag is only supported on versions of Windows newer than XP
and Server 2003.

When you import a P12 into memory alone, you must keep the handle to the
certificate store alive until you're done with the credential; minor
changes were made to the schannel credential context to support closing
the client certificate store handle at the end of an SSL session.

Supersedes #9363
Closes #9300