### PR TITLE
schannel: ban server ALPN selection during recv renegotiation

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1314,6 +1314,7 @@ schannel_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   backend->recv_unrecoverable_err = CURLE_OK;
   backend->recv_sspi_close_notify = false;
   backend->recv_connection_closed = false;
+  backend->recv_renegotiating = false;
   backend->encdata_is_incomplete = false;
 
   /* continue to second handshake step */
@@ -1711,8 +1712,14 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
       return CURLE_SSL_CONNECT_ERROR;
     }
 
-    if(alpn_result.ProtoNegoStatus ==
-       SecApplicationProtocolNegotiationStatus_Success) {
+    if(backend->recv_renegotiating &&
+       (alpn_result.ProtoNegoStatus !=
+        SecApplicationProtocolNegotiationStatus_None)) {
+      failf(data, "schannel: the server selected an ALPN protocol too late");
+      return CURLE_SSL_CONNECT_ERROR;
+    }
+    else if(alpn_result.ProtoNegoStatus ==
+            SecApplicationProtocolNegotiationStatus_Success) {
 
       infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR,
             alpn_result.ProtocolIdSize, alpn_result.ProtocolId);
@@ -1732,8 +1739,11 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
     }
     else
       infof(data, VTLS_INFOF_NO_ALPN);
-    Curl_multiuse_state(data, conn->alpn == CURL_HTTP_VERSION_2 ?
-                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+
+    if(!backend->recv_renegotiating) {
+      Curl_multiuse_state(data, conn->alpn == CURL_HTTP_VERSION_2 ?
+                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+    }
   }
 #endif
 
@@ -2293,7 +2303,9 @@ schannel_recv(struct Curl_easy *data, int sockindex,
         infof(data, "schannel: renegotiating SSL/TLS connection");
         connssl->state = ssl_connection_negotiating;
         connssl->connecting_state = ssl_connect_2_writing;
+        backend->recv_renegotiating = true;
         *err = schannel_connect_common(data, conn, sockindex, FALSE, &done);
+        backend->recv_renegotiating = false;
         if(*err) {
           infof(data, "schannel: renegotiation failed");
           goto cleanup;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1714,7 +1714,7 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
 
     if(alpn_result.ProtoNegoStatus ==
        SecApplicationProtocolNegotiationStatus_Success) {
-      unsigned char alpn;
+      unsigned char alpn = 0;
 
       if(!backend->recv_renegotiating) {
         infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR,

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -179,6 +179,7 @@ struct ssl_backend_data {
   CURLcode recv_unrecoverable_err; /* schannel_recv had an unrecoverable err */
   bool recv_sspi_close_notify; /* true if connection closed by close_notify */
   bool recv_connection_closed; /* true if connection closed, regardless how */
+  bool recv_renegotiating;     /* true if recv is doing renegotiation */
   bool use_alpn; /* true if ALPN is used for this connection */
 #ifdef HAS_MANUAL_VERIFY_API
   bool use_manual_cred_validation; /* true if manual cred validation is used */


### PR DESCRIPTION
By the time schannel_recv is renegotiating the connection, libcurl has already decided on a protocol and it is too late for the server to select a protocol via ALPN.

Ref: https://github.com/curl/curl/issues/9451

Closes #xxxx

---

I'm not entirely sure if this is correct, I don't really understand the way ALPN is expected to work on renegotiation. For example, if the connection is immediately renegotiated before any application data is received, then maybe it would work to change protocols based on server ALPN selection?
