### PR TITLE
curl/websockets.h: remove leftover bad typedef

### DIFF
--- a/include/curl/websockets.h
+++ b/include/curl/websockets.h
@@ -58,10 +58,6 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *curl, const void *buffer,
                                   size_t buflen, size_t *sent,
                                   unsigned int sendflags);
 
-typedef ssize_t (*curl_ws_write_callback)(void *userdata, char *data,
-                                          size_t len,
-                                          unsigned int flags);
-
 /* bits for the CURLOPT_WS_OPTIONS bitmask: */
 #define CURLWS_RAW_MODE (1<<0)
 


### PR DESCRIPTION
Just a leftover trace of a development thing that did not stay like that.

Reported-by: Marc Hörsken
Fixes #9465