### PR TITLE
setopt: make protocols2num() work with websockets

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -185,6 +185,10 @@ static CURLcode protocol2num(char *str, curl_off_t *val)
     { "smtps", CURLPROTO_SMTPS },
     { "telnet", CURLPROTO_TELNET },
     { "tftp", CURLPROTO_TFTP },
+#ifdef USE_WEBSOCKETS
+    { "ws", CURLPROTO_WS },
+    { "wss", CURLPROTO_WSS },
+#endif
     { NULL, 0 }
   };
 


### PR DESCRIPTION
So that CURLOPT_PROTOCOLS_STR and CURLOPT_REDIR_PROTOCOLS_STR can specify those as well.

Reported-by: Patrick Monnerat
Bug: https://curl.se/mail/lib-2022-09/0016.html