### PR TITLE
websockets: sync prototypes in docs with implementation [ci skip]

### DIFF
--- a/docs/libcurl/curl_ws_recv.3
+++ b/docs/libcurl/curl_ws_recv.3
@@ -30,7 +30,7 @@ curl_ws_recv - receive websocket data
 #include <curl/easy.h>
 
 CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
-                      size_t *nread, unsigned int *recvflags);
+                      size_t *recv, unsigned int *recvflags);
 .fi
 .SH DESCRIPTION
 This function call is EXPERIMENTAL.

--- a/docs/libcurl/curl_ws_send.3
+++ b/docs/libcurl/curl_ws_send.3
@@ -29,8 +29,8 @@ curl_ws_send - receive websocket data
 .nf
 #include <curl/easy.h>
 
-CURLcode curl_ws_send(CURL *curl, char *buffer, size_t buflen, size_t *sent,
-                      unsigned int sendflags);
+CURLcode curl_ws_send(CURL *curl, const void *buffer, size_t buflen,
+                      size_t *sent, unsigned int sendflags);
 .fi
 .SH DESCRIPTION
 This function call is EXPERIMENTAL.


### PR DESCRIPTION
Docs for the new send/recv functions synced with the committed versions of these.

Closes #xxxx
