### PR TITLE
setopt: use the handler table for protocol name to number conversions

### DIFF
--- a/docs/cmdline-opts/proto.d
+++ b/docs/cmdline-opts/proto.d
@@ -39,9 +39,9 @@ only enables http and https
 also only enables http and https
 .RE
 .IP
-Unknown protocols produce a warning. This allows scripts to safely rely on
-being able to disable potentially dangerous protocols, without relying upon
-support for that protocol being built into curl to avoid an error.
+Unknown and disabled protocols produce a warning. This allows scripts to
+safely rely on being able to disable potentially dangerous protocols, without
+relying upon support for that protocol being built into curl to avoid an error.
 
 This option can be used multiple times, in which case the effect is the same
 as concatenating the protocols into one instance of the option.

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.3
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.3
@@ -45,8 +45,8 @@ set, it returns error.
 These are the available protocols:
 
 DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS,
-POP3, POP3S, RTMP, RTMPE, RTMPS, RTMPT, RTMPTE, RTMPTS, RTSP, SCP, SFTP, SMB,
-SMBS, SMTP, SMTPS, TELNET, TFTP
+MQTT, POP3, POP3S, RTMP, RTMPE, RTMPS, RTMPT, RTMPTE, RTMPTS, RTSP, SCP, SFTP,
+SMB, SMBS, SMTP, SMTPS, TELNET, TFTP, WS, WSS
 
 You can set "ALL" as a short-cut to enable all protocols. Note that by setting
 all, you may enable protocols that were not supported the day you write this
@@ -76,7 +76,9 @@ if(curl) {
 .SH AVAILABILITY
 Added in 7.85.0
 .SH RETURN VALUE
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+Returns CURLE_UNKNOWN_OPTION if the option is not implemented,
+CURLE_UNSUPPORTED_PROTOCOL if a listed protocol is not supported or disabled,
+CURLE_BAD_FUNCTION_ARGUMENT if no protocol is listed else CURLE_OK.
 .SH "SEE ALSO"
 .BR CURLOPT_REDIR_PROTOCOLS_STR "(3), " CURLOPT_URL "(3), "
 .BR curl_version_info "(3), " CURLINFO_SCHEME "(3), "

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.3
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.3
@@ -51,8 +51,8 @@ and since 7.40.0 SMB and SMBS are also disabled.
 These are the available protocols:
 
 DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS,
-POP3, POP3S, RTMP, RTMPE, RTMPS, RTMPT, RTMPTE, RTMPTS, RTSP, SCP, SFTP, SMB,
-SMBS, SMTP, SMTPS, TELNET, TFTP
+MQTT, POP3, POP3S, RTMP, RTMPE, RTMPS, RTMPT, RTMPTE, RTMPTS, RTSP, SCP, SFTP,
+SMB, SMBS, SMTP, SMTPS, TELNET, TFTP, WS, WSS
 
 You can set "ALL" as a short-cut to enable all protocols. Note that by setting
 all, you may enable protocols that were not supported the day you write this
@@ -84,6 +84,8 @@ if(curl) {
 .SH AVAILABILITY
 Added in 7.85.0.
 .SH RETURN VALUE
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+Returns CURLE_UNKNOWN_OPTION if the option is not implemented,
+CURLE_UNSUPPORTED_PROTOCOL if a listed protocol is not supported or disabled,
+CURLE_BAD_FUNCTION_ARGUMENT if no protocol is listed else CURLE_OK.
 .SH "SEE ALSO"
 .BR CURLOPT_PROTOCOLS_STR "(3), "

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1697,7 +1697,7 @@ CURLcode Curl_follow(struct Curl_easy *data,
           return Curl_uc_to_curlcode(uc);
         }
 
-        p = Curl_builtin_scheme(scheme);
+        p = Curl_builtin_scheme(scheme, CURL_ZERO_TERMINATED);
         if(p && (p->protocol != data->info.conn_protocol)) {
           infof(data, "Clear auth, redirects scheme from %s to %s",
                 data->info.conn_scheme, scheme);

--- a/lib/url.h
+++ b/lib/url.h
@@ -46,7 +46,8 @@ CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userptr, char **passwdptr,
                                   char **optionsptr);
 
-const struct Curl_handler *Curl_builtin_scheme(const char *scheme);
+const struct Curl_handler *Curl_builtin_scheme(const char *scheme,
+                                               size_t schemelen);
 
 bool Curl_is_ASCII_name(const char *hostname);
 CURLcode Curl_idnconvert_hostname(struct Curl_easy *data,

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -423,7 +423,7 @@ static CURLUcode parse_hostname_login(struct Curl_URL *u,
 
   /* if this is a known scheme, get some details */
   if(u->scheme)
-    h = Curl_builtin_scheme(u->scheme);
+    h = Curl_builtin_scheme(u->scheme, CURL_ZERO_TERMINATED);
 
   /* We could use the login information in the URL so extract it. Only parse
      options if the handler says we should. Note that 'h' might be NULL! */
@@ -1066,7 +1066,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
       }
 
       schemep = schemebuf;
-      if(!Curl_builtin_scheme(schemep) &&
+      if(!Curl_builtin_scheme(schemep, CURL_ZERO_TERMINATED) &&
          !(flags & CURLU_NON_SUPPORT_SCHEME)) {
         result = CURLUE_UNSUPPORTED_SCHEME;
         goto fail;
@@ -1402,7 +1402,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
       /* there's no stored port number, but asked to deliver
          a default one for the scheme */
       const struct Curl_handler *h =
-        Curl_builtin_scheme(u->scheme);
+        Curl_builtin_scheme(u->scheme, CURL_ZERO_TERMINATED);
       if(h) {
         msnprintf(portbuf, sizeof(portbuf), "%u", h->defport);
         ptr = portbuf;
@@ -1412,7 +1412,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
       /* there is a stored port number, but ask to inhibit if
          it matches the default one for the scheme */
       const struct Curl_handler *h =
-        Curl_builtin_scheme(u->scheme);
+        Curl_builtin_scheme(u->scheme, CURL_ZERO_TERMINATED);
       if(h && (h->defport == u->portnum) &&
          (flags & CURLU_NO_DEFAULT_PORT))
         ptr = NULL;
@@ -1458,7 +1458,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
       else
         return CURLUE_NO_SCHEME;
 
-      h = Curl_builtin_scheme(scheme);
+      h = Curl_builtin_scheme(scheme, CURL_ZERO_TERMINATED);
       if(!port && (flags & CURLU_DEFAULT_PORT)) {
         /* there's no stored port number, but asked to deliver
            a default one for the scheme */
@@ -1664,7 +1664,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
       return CURLUE_BAD_SCHEME;
     if(!(flags & CURLU_NON_SUPPORT_SCHEME) &&
        /* verify that it is a fine scheme */
-       !Curl_builtin_scheme(part))
+       !Curl_builtin_scheme(part, CURL_ZERO_TERMINATED))
       return CURLUE_UNSUPPORTED_SCHEME;
     storep = &u->scheme;
     urlencode = FALSE; /* never */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1206,15 +1206,14 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case 'D': /* --proto */
         config->proto_present = TRUE;
-        err = proto2num(config, (unsigned int)CURLPROTO_ALL,
-                        &config->proto_str, nextarg);
+        err = proto2num(config, PROTO_ALL, &config->proto_str, nextarg);
         if(err)
           return err;
         break;
       case 'E': /* --proto-redir */
         config->proto_redir_present = TRUE;
-        if(proto2num(config, CURLPROTO_HTTP|CURLPROTO_HTTPS|
-                     CURLPROTO_FTP|CURLPROTO_FTPS,
+        if(proto2num(config, PROTO_BIT(proto_http) | PROTO_BIT(proto_https) |
+                     PROTO_BIT(proto_ftp) | PROTO_BIT(proto_ftps),
                      &config->proto_redir_str, nextarg))
           return PARAM_BAD_USE;
         break;

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -221,7 +221,10 @@ void tool_version_info(void)
   if(curlinfo->protocols) {
     printf("Protocols: ");
     for(proto = curlinfo->protocols; *proto; ++proto) {
-      printf("%s ", *proto);
+      /* Special case: do not list rtmp?* protocols.
+         They may only appear together with "rtmp" */
+      if(!curl_strnequal(*proto, "rtmp", 4) || !proto[0][4])
+        printf("%s ", *proto);
     }
     puts(""); /* newline */
   }

--- a/src/tool_libinfo.h
+++ b/src/tool_libinfo.h
@@ -27,10 +27,38 @@
 
 /* global variable declarations, for libcurl run-time info */
 
+typedef unsigned int proto_t;   /* A protocol number.*/
+
+#define PROTO_NONE ((proto_t) -1)
+
+/* Protocol numbers set type. This should have enough bits for all
+ * enabled protocols.
+ */
+typedef unsigned int proto_set_t;
+
+#define PROTO_MAX       ((proto_t) (8 * sizeof(proto_set_t)))
+
+#define PROTO_BIT(p)    ((p) < PROTO_MAX? (proto_set_t) 1 << (p):       \
+                                          (proto_set_t) 0)
+
+#define PROTO_ALL       (PROTO_BIT(proto_last) - (proto_set_t) 1)
+
+
 extern curl_version_info_data *curlinfo;
-extern long built_in_protos;
+extern proto_t proto_last;
+
+extern proto_t proto_ftp;
+extern proto_t proto_ftps;
+extern proto_t proto_http;
+extern proto_t proto_https;
+extern proto_t proto_file;
+extern proto_t proto_rtsp;
+extern proto_t proto_scp;
+extern proto_t proto_sftp;
+extern proto_t proto_tftp;
 
 CURLcode get_libcurl_info(void);
-long scheme2protocol(const char *scheme);
+proto_t scheme2protocol(const char *scheme);
+const char *protocol2scheme(proto_t proto);
 
 #endif /* HEADER_CURL_TOOL_LIBINFO_H */

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -24,6 +24,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
+#include "tool_libinfo.h"
 
 struct getout *new_getout(struct OperationConfig *config);
 
@@ -38,7 +39,7 @@ ParameterError str2unummax(long *val, const char *str, long max);
 ParameterError str2udouble(double *val, const char *str, long max);
 
 ParameterError proto2num(struct OperationConfig *config,
-                         unsigned int val, char **obuf,
+                         proto_set_t val, char **obuf,
                          const char *str);
 
 ParameterError check_protocol(const char *str);

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -145,35 +145,6 @@ const struct NameValue setopt_nv_CURL_NETRC[] = {
   NVEND,
 };
 
-/* These mappings essentially triplicated - see
- * tool_libinfo.c and tool_paramhlp.c */
-const struct NameValue setopt_nv_CURLPROTO[] = {
-  NV(CURLPROTO_ALL),            /* combination */
-  NV(CURLPROTO_DICT),
-  NV(CURLPROTO_FILE),
-  NV(CURLPROTO_FTP),
-  NV(CURLPROTO_FTPS),
-  NV(CURLPROTO_GOPHER),
-  NV(CURLPROTO_HTTP),
-  NV(CURLPROTO_HTTPS),
-  NV(CURLPROTO_IMAP),
-  NV(CURLPROTO_IMAPS),
-  NV(CURLPROTO_LDAP),
-  NV(CURLPROTO_LDAPS),
-  NV(CURLPROTO_POP3),
-  NV(CURLPROTO_POP3S),
-  NV(CURLPROTO_RTSP),
-  NV(CURLPROTO_SCP),
-  NV(CURLPROTO_SFTP),
-  NV(CURLPROTO_SMB),
-  NV(CURLPROTO_SMBS),
-  NV(CURLPROTO_SMTP),
-  NV(CURLPROTO_SMTPS),
-  NV(CURLPROTO_TELNET),
-  NV(CURLPROTO_TFTP),
-  NVEND,
-};
-
 /* These options have non-zero default values. */
 static const struct NameValue setopt_nv_CURLNONZERODEFAULTS[] = {
   NV1(CURLOPT_SSL_VERIFYPEER, 1),

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -57,7 +57,6 @@ extern const struct NameValue setopt_nv_CURLFTPSSL_CCC[];
 extern const struct NameValue setopt_nv_CURLUSESSL[];
 extern const struct NameValueUnsigned setopt_nv_CURLSSLOPT[];
 extern const struct NameValue setopt_nv_CURL_NETRC[];
-extern const struct NameValue setopt_nv_CURLPROTO[];
 extern const struct NameValueUnsigned setopt_nv_CURLAUTH[];
 extern const struct NameValueUnsigned setopt_nv_CURLHSTS[];
 
@@ -73,8 +72,6 @@ extern const struct NameValueUnsigned setopt_nv_CURLHSTS[];
 #define setopt_nv_CURLOPT_SSL_OPTIONS setopt_nv_CURLSSLOPT
 #define setopt_nv_CURLOPT_PROXY_SSL_OPTIONS setopt_nv_CURLSSLOPT
 #define setopt_nv_CURLOPT_NETRC setopt_nv_CURL_NETRC
-#define setopt_nv_CURLOPT_PROTOCOLS setopt_nv_CURLPROTO
-#define setopt_nv_CURLOPT_REDIR_PROTOCOLS setopt_nv_CURLPROTO
 #define setopt_nv_CURLOPT_PROXYTYPE setopt_nv_CURLPROXY
 #define setopt_nv_CURLOPT_PROXYAUTH setopt_nv_CURLAUTH
 #define setopt_nv_CURLOPT_SOCKS5_AUTH setopt_nv_CURLAUTH

--- a/tests/data/test1401
+++ b/tests/data/test1401
@@ -31,6 +31,11 @@ http
  <name>
 --libcurl for GET with various options
  </name>
+<features>
+http
+ftp
+file
+</features>
 <setenv>
 SSL_CERT_FILE=
 </setenv>

--- a/tests/libtest/lib1597.c
+++ b/tests/libtest/lib1597.c
@@ -30,7 +30,7 @@
 
 struct pair {
   const char *in;
-  CURLcode exp;
+  CURLcode *exp;
 };
 
 int test(char *URL)
@@ -38,27 +38,34 @@ int test(char *URL)
   CURL *curl = NULL;
   int res = 0;
   CURLcode result = CURLE_OK;
+  CURLcode ok = CURLE_OK;
+  CURLcode bad = CURLE_BAD_FUNCTION_ARGUMENT;
+  CURLcode unsup = CURLE_UNSUPPORTED_PROTOCOL;
+  CURLcode httpcode = CURLE_UNSUPPORTED_PROTOCOL;
+  CURLcode httpscode = CURLE_UNSUPPORTED_PROTOCOL;
+  curl_version_info_data *curlinfo;
+  const char *const *proto;
+  char protolist[1024];
+  int n;
   int i;
 
   struct pair prots[] = {
-    {"goobar", CURLE_BAD_FUNCTION_ARGUMENT},
-    {"http ", CURLE_BAD_FUNCTION_ARGUMENT},
-    {" http", CURLE_BAD_FUNCTION_ARGUMENT},
-    {"http", CURLE_OK},
-    {"http,", CURLE_OK},
-    {"https,", CURLE_OK},
-    {"https,http", CURLE_OK},
-    {"http,http", CURLE_OK},
-    {"HTTP,HTTP", CURLE_OK},
-    {",HTTP,HTTP", CURLE_OK},
-    {"http,http,ft", CURLE_BAD_FUNCTION_ARGUMENT},
-    {"", CURLE_BAD_FUNCTION_ARGUMENT},
-    {",,", CURLE_BAD_FUNCTION_ARGUMENT},
-    {"DICT,FILE,FTP,FTPS,GOPHER,GOPHERS,HTTP,HTTPS,IMAP,IMAPS,LDAP,LDAPS,"
-     "POP3,POP3S,RTMP,RTMPE,RTMPS,RTMPT,RTMPTE,RTMPTS,RTSP,SCP,SFTP,SMB,"
-     "SMBS,SMTP,SMTPS,TELNET,TFTP", CURLE_OK},
-    {"all", CURLE_OK},
-    {NULL, CURLE_OK},
+    {"goobar", &unsup},
+    {"http ", &unsup},
+    {" http", &unsup},
+    {"http", &httpcode},
+    {"http,", &httpcode},
+    {"https,", &httpscode},
+    {"https,http", &httpscode},
+    {"http,http", &httpcode},
+    {"HTTP,HTTP", &httpcode},
+    {",HTTP,HTTP", &httpcode},
+    {"http,http,ft", &unsup},
+    {"", &bad},
+    {",,", &bad},
+    {protolist, &ok},
+    {"all", &ok},
+    {NULL, NULL},
   };
   (void)URL;
 
@@ -66,9 +73,32 @@ int test(char *URL)
 
   easy_init(curl);
 
+  /* Get enabled protocols.*/
+  curlinfo = curl_version_info(CURLVERSION_NOW);
+  if(!curlinfo) {
+    fputs("curl_version_info failed\n", stderr);
+    res = (int) TEST_ERR_FAILURE;
+    goto test_cleanup;
+  }
+
+  n = 0;
+  for(proto = curlinfo->protocols; *proto; proto++) {
+    if((size_t) n >= sizeof(protolist)) {
+      puts("protolist buffer too small\n");
+      res = (int) TEST_ERR_FAILURE;
+      goto test_cleanup;
+    }
+    n += msnprintf(protolist + n, sizeof(protolist) - n, ",%s", *proto);
+    if(curl_strequal(*proto, "http"))
+      httpcode = CURLE_OK;
+    if(curl_strequal(*proto, "https"))
+      httpscode = CURLE_OK;
+  }
+
+  /* Run the tests. */
   for(i = 0; prots[i].in; i++) {
     result = curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, prots[i].in);
-    if(result != prots[i].exp) {
+    if(result != *prots[i].exp) {
       printf("unexpectedly '%s' returned %u\n",
              prots[i].in, result);
       break;

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -79,6 +79,7 @@ int test(char *URL)
       case CURLE_BAD_FUNCTION_ARGUMENT: /* the most normal */
       case CURLE_UNKNOWN_OPTION: /* left out from the build */
       case CURLE_NOT_BUILT_IN: /* not supported */
+      case CURLE_UNSUPPORTED_PROTOCOL: /* detected by protocol2num() */
         break;
       default:
         /* all other return codes are unexpected */


### PR DESCRIPTION
This also returns error `CURLE_UNSUPPORTED_PROTOCOL` rather than `CURLE_BAD_FUNCTION_ARGUMENT` when a listed protocol name is not found.

A new `schemelen` parameter is added to `Curl_builtin_scheme()` to support this extended use.

Note that disabled protocols are not recognized anymore.

Test programs 1597 and 1911 adapted accordingly.