### PR TITLE
Correct missing uppercases in Markdown files

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -245,7 +245,7 @@
  tracker.
 
  The `TODO` document is full of ideas and suggestions of what we can add or
- fix one day. you are always encouraged and free to grab one of those items and
+ fix one day. You are always encouraged and free to grab one of those items and
  take up a discussion with the curl development team on how that could be
  implemented or provided in the project so that you can work on ticking it odd
  that document.

--- a/docs/SSLCERTS.md
+++ b/docs/SSLCERTS.md
@@ -22,7 +22,7 @@ It is about trust
 
 This system is about trust. In your local CA certificate store you have certs
 from *trusted* Certificate Authorities that you then can use to verify that the
-server certificates you see are valid. they are signed by one of the CAs you
+server certificates you see are valid. They are signed by one of the CAs you
 trust.
 
 Which CAs do you trust? You can decide to trust the same set of companies your

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -1,7 +1,7 @@
 Version Numbers and Releases
 ============================
 
- Curl is not only curl. Curl is also libcurl. they are actually individually
+ Curl is not only curl. Curl is also libcurl. They are actually individually
  versioned, but they usually follow each other closely.
 
  The version numbering is always built up using the same system:


### PR DESCRIPTION
To detect these typos I used:

```
grep -rn '\. [a-z]' . | \
uniq | \
grep -v '\. lib' | \
grep -v '[0-9]\. [a-z]' | \
grep -v '\.\. [a-z]' | \
grep -v '\. curl' | \
grep -v 'e.g. [a-z]' | \
grep -v 'eg. [a-z]' | \
grep -v '\etc. [a-z]' | \
grep -v 'i.e\. [a-z]' | \
grep --color=always '\. [a-z]' | \
grep '\.md'
```