### PR TITLE
setopt: make protocol2num use a curl_off_t for the protocol bit

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -153,7 +153,7 @@ static CURLcode protocol2num(char *str, curl_off_t *val)
   bool found_comma = FALSE;
   static struct scheme {
     const char *name;
-    long bit;
+    curl_off_t bit;
   } const protos[] = {
     { "dict", CURLPROTO_DICT },
     { "file", CURLPROTO_FILE },


### PR DESCRIPTION
... since WSS does not fit within 32 bit.

Bug: https://github.com/curl/curl/pull/9467#issuecomment-1243014887