### PR TITLE
ws: fix an infof() call to use %uz for size_t output

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -293,7 +293,7 @@ static CURLcode ws_decode(struct Curl_easy *data,
   *olen = payloadssize;
   wsp->usedbuf = total; /* number of bytes "used" from the buffer */
   *endp = &p[total];
-  infof(data, "WS: received %u bytes payload", payloadssize);
+  infof(data, "WS: received %uz bytes payload", payloadssize);
   return CURLE_OK;
 }
 


### PR DESCRIPTION
Detected by Coverity, CID 1514665.