### PR TITLE
tool_operate: Check USE_MANUAL before call hugehelp

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2679,8 +2679,10 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
       if(res == PARAM_HELP_REQUESTED)
         tool_help(global->help_category);
       /* Check if we were asked for the manual */
+#ifdef USE_MANUAL
       else if(res == PARAM_MANUAL_REQUESTED)
         hugehelp();
+#endif
       /* Check if we were asked for the version information */
       else if(res == PARAM_VERSION_INFO_REQUESTED)
         tool_version_info();


### PR DESCRIPTION
since PARAM_MANUAL_REQUESTED isn't returned when USE_MANUAL isn't defined
