### PR TITLE
Fix warning: 'CURLformoption' is promoted to 'int' when passed through '...'

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -252,7 +252,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     }
     else {
       /* This is not array-state, get next option */
-      option = va_arg(params, CURLformoption);
+      option = va_arg(params, int);
       if(CURLFORM_END == option)
         break;
     }


### PR DESCRIPTION
```
curl/lib/formdata.c: In function 'FormAdd':
curl/lib/formdata.c:249:31: warning: 'CURLformoption' is promoted to 'int' when passed through '...'
  249 |       option = va_arg(params, CURLformoption);
      |                               ^
curl/lib/formdata.c:249:31: note: (so you should pass 'int' not 'CURLformoption' to 'va_arg')
curl/lib/formdata.c:249:31: note: if this code is reached, the program will abort
```
