### PR TITLE
getparameter: return PARAM_MANUAL_REQUESTED for -M even when disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,9 +47,7 @@ if(USE_MANUAL)
 else()
   add_custom_command(
     OUTPUT tool_hugehelp.c
-    COMMAND ${CMAKE_COMMAND} -E echo "/* built-in manual is disabled, blank function */" > tool_hugehelp.c
-    COMMAND ${CMAKE_COMMAND} -E echo "#include \"tool_hugehelp.h\"" >> tool_hugehelp.c
-    COMMAND ${CMAKE_COMMAND} -E echo "void hugehelp(void) {}" >> tool_hugehelp.c
+    COMMAND ${CMAKE_COMMAND} -E echo "#include \"tool_hugehelp.h\"" > tool_hugehelp.c
     DEPENDS
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
     VERBATIM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,9 +127,7 @@ endif
 else # USE_MANUAL
 # built-in manual has been disabled, make a blank file
 $(HUGE):
-	$(HUGECMD)(echo "/* built-in manual is disabled, blank function */" > $(HUGE); \
-	echo '#include "tool_hugehelp.h"' >> $(HUGE); \
-	echo "void hugehelp(void) {}" >>$(HUGE) )
+	echo '#include "tool_hugehelp.h"' >> $(HUGE)
 endif
 
 # ignore tool_hugehelp.c since it is generated source code and it plays

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -227,10 +227,6 @@ foot();
 
 sub foot {
   print <<FOOT
-#else /* !USE_MANUAL */
-/* built-in manual is disabled, blank function */
-#include "tool_hugehelp.h"
-void hugehelp(void) {}
 #endif /* USE_MANUAL */
 FOOT
   ;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2045,13 +2045,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case 'M': /* M for manual, huge help */
       if(toggle) { /* --no-manual shows no manual... */
-#ifdef USE_MANUAL
-        return PARAM_MANUAL_REQUESTED;
-#else
+#ifndef USE_MANUAL
         warnf(global,
               "built-in manual was disabled at build-time!\n");
-        return PARAM_OPTION_UNKNOWN;
 #endif
+        return PARAM_MANUAL_REQUESTED;
       }
       break;
     case 'n':

--- a/src/tool_hugehelp.h
+++ b/src/tool_hugehelp.h
@@ -29,7 +29,7 @@
 void hugehelp(void);
 #else
 /* do nothing if not there */
-#define hugehelp(x)
+#define hugehelp()
 #endif
 
 #endif /* HEADER_CURL_TOOL_HUGEHELP_H */

--- a/src/tool_hugehelp.h
+++ b/src/tool_hugehelp.h
@@ -25,6 +25,11 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
+#ifdef USE_MANUAL
 void hugehelp(void);
+#else
+/* do nothing if not there */
+#define hugehelp(x)
+#endif
 
 #endif /* HEADER_CURL_TOOL_HUGEHELP_H */


### PR DESCRIPTION
... to improve the output in this situation. Now it doesn't say "option unknown" anymore.