### PR TITLE
CURLOPT_CONNECT_ONLY.3: for ws(s) as well

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
@@ -42,7 +42,7 @@ useful when used with the \fICURLINFO_ACTIVESOCKET(3)\fP option to
 the application can obtain the most recently used socket for special data
 transfers.
 
-Since 7.85.0, this option can be set to '2' and if HTTP or WebSockets are
+Since 7.86.0, this option can be set to '2' and if HTTP or WebSockets are
 used, libcurl will do the request and read all response headers before handing
 over control to the application.
 
@@ -57,7 +57,7 @@ application wants to use it. Once it has been removed with
 .SH DEFAULT
 0
 .SH PROTOCOLS
-HTTP, SMTP, POP3 and IMAP
+HTTP, SMTP, POP3 and IMAP. For WS and WSS starting in 7.86.0.
 .SH EXAMPLE
 .nf
 CURL *curl = curl_easy_init();


### PR DESCRIPTION
and correct the version number for when that support comes. Even if it is still experimental for websockets.