### PR TITLE
scripts: use `grep -E` instead of `egrep`

### DIFF
--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -36,15 +36,15 @@ jobs:
       - name: Search relevant commit message lines starting with Closes/Merges
         run: |
           git log --format=email ${{ github.event.before }}..${{ github.event.after }} | \
-            egrep -i "^Close[sd]? " | sort | uniq | tee log
+            grep -Ei "^Close[sd]? " | sort | uniq | tee log
         if: steps.check.outputs.label == 'hacktoberfest'
 
       - name: Search for Number-based PR references
         run: |
-          egrep -o "#([0-9]+)" log | cut -d# -f2 | sort | uniq | xargs -t -n1 -I{} \
+          grep -Eo "#([0-9]+)" log | cut -d# -f2 | sort | uniq | xargs -t -n1 -I{} \
             gh pr view {} --json number,createdAt \
               --jq '{number, opened: .createdAt} | [.number, .opened] | join(":")' | tee /dev/stderr | \
-            egrep -o '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
+            grep -Eo '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
               gh pr edit {} --add-label 'hacktoberfest-accepted'
         if: steps.check.outputs.label == 'hacktoberfest'
         env:
@@ -52,10 +52,10 @@ jobs:
 
       - name: Search for URL-based PR references
         run: |
-          egrep -o "github.com/(.+)/(.+)/pull/([0-9]+)" log | sort | uniq | xargs -t -n1 -I{} \
+          grep -Eo "github.com/(.+)/(.+)/pull/([0-9]+)" log | sort | uniq | xargs -t -n1 -I{} \
             gh pr view "https://{}" --json number,createdAt \
               --jq '{number, opened: .createdAt} | [.number, .opened] | join(":")' | tee /dev/stderr | \
-            egrep -o '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
+            grep -Eo '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
               gh pr edit {} --add-label 'hacktoberfest-accepted'
         if: steps.check.outputs.label == 'hacktoberfest'
         env:

--- a/MacOSX-Framework
+++ b/MacOSX-Framework
@@ -83,12 +83,12 @@ if test $PPC64_NEEDED -gt 0
 then
   SDK64=10.5
   ARCHES64='-arch x86_64 -arch ppc64'
-  SDK64=`ls  $SDK_PATH|grep 10.5|head -1`
+  SDK64=`ls  $SDK_PATH | grep "10\.5" | head -1`
 else
  ARCHES64='-arch x86_64'
  #We "know" that 10.4 and earlier do not support 64bit
- OLD_SDK64=`ls  $SDK_PATH|egrep -v "10.[0-4]"|head -1`
- NEW_SDK64=`ls -r $SDK_PATH|egrep -v "10.[0-4][^0-9]" | head -1`
+ OLD_SDK64=`ls  $SDK_PATH | grep -v "10\.[0-4]" | head -1`
+ NEW_SDK64=`ls -r $SDK_PATH | grep -v "10\.[0-4][^0-9]" | head -1`
  if test $USE_OLD -gt 0
   then
    SDK64=$OLD_SDK64

--- a/scripts/contributors.sh
+++ b/scripts/contributors.sh
@@ -63,7 +63,7 @@ fi
    git -C ../curl-www log --pretty=full --use-mailmap $start..HEAD
   fi
  ) | \
-egrep -ai '(^Author|^Commit|by):' | \
+grep -Eai '(^Author|^Commit|by):' | \
 cut -d: -f2- | \
 cut '-d(' -f1 | \
 cut '-d<' -f1 | \

--- a/scripts/contrithanks.sh
+++ b/scripts/contrithanks.sh
@@ -55,7 +55,7 @@ cat ./docs/THANKS
   fi
  ) | \
 
-egrep -ai '(^Author|^Commit|by):' | \
+grep -Eai '(^Author|^Commit|by):' | \
 cut -d: -f2- | \
 cut '-d(' -f1 | \
 cut '-d<' -f1 | \


### PR DESCRIPTION
latest GNU grep emits a deprecation message when `egrep` is invoked. All platforms that can be expected to run the three changed scripts already have `grep -E` as a replacement.