### PR TITLE
wolfSSL: Fix session management bug.

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -811,8 +811,10 @@ wolfssl_connect_step3(struct Curl_easy *data, struct connectdata *conn,
 
   if(SSL_SET_OPTION(primary.sessionid)) {
     bool incache;
+    bool added = FALSE;
     void *old_ssl_sessionid = NULL;
-    SSL_SESSION *our_ssl_sessionid = SSL_get_session(backend->handle);
+    /* SSL_get1_session allocates memory that has to be freed. */
+    SSL_SESSION *our_ssl_sessionid = SSL_get1_session(backend->handle);
     bool isproxy = SSL_IS_PROXY() ? TRUE : FALSE;
 
     if(our_ssl_sessionid) {
@@ -832,11 +834,20 @@ wolfssl_connect_step3(struct Curl_easy *data, struct connectdata *conn,
                                        0, sockindex, NULL);
         if(result) {
           Curl_ssl_sessionid_unlock(data);
+          SSL_SESSION_free(our_ssl_sessionid);
           failf(data, "failed to store ssl session");
           return result;
         }
+        else {
+          added = TRUE;
+        }
       }
       Curl_ssl_sessionid_unlock(data);
+
+      if(!added) {
+        /* If the session info wasn't added to the cache, free our copy. */
+        SSL_SESSION_free(our_ssl_sessionid);
+      }
     }
   }
 
@@ -956,8 +967,7 @@ static ssize_t wolfssl_recv(struct Curl_easy *data,
 
 static void wolfssl_session_free(void *ptr)
 {
-  (void)ptr;
-  /* wolfSSL reuses sessions on own, no free */
+  SSL_SESSION_free(ptr);
 }
 
 


### PR DESCRIPTION
Prior to this commit, non-persistent pointers were being used to store sessions. When a WOLFSSL object was then freed, that freed the session it owned, and thus invalidated the pointer held in curl's cache. This commit makes it so we get a persistent (deep copied) session pointer that we then add to the cache. Accordingly, wolfssl_session_free, which was previously a no-op, now needs to actually call SSL_SESSION_free.

This bug was discovered by a wolfSSL customer.