### PR TITLE
cmake: define BUILDING_LIBCURL in CMakeLists, not config.h

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@
 ###########################################################################
 set(LIB_NAME libcurl)
 set(LIBCURL_OUTPUT_NAME libcurl CACHE STRING "Basename of the curl library")
+add_definitions(-DBUILDING_LIBCURL)
 
 if(BUILD_SHARED_LIBS)
   set(CURL_STATICLIB NO)

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -23,9 +23,6 @@
  ***************************************************************************/
 /* lib/curl_config.h.in.  Generated somehow by cmake.  */
 
-/* when building libcurl itself */
-#cmakedefine BUILDING_LIBCURL 1
-
 /* Location of default ca bundle */
 #cmakedefine CURL_CA_BUNDLE "${CURL_CA_BUNDLE}"
 


### PR DESCRIPTION
Since the config file might also get included by the tool code at times. This syncs with how other builds do it.