### PR TITLE
formdata: typecast the va_arg return value

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -254,7 +254,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
       /* This is not array-state, get next option. This gets an 'int' with
          va_arg() because CURLformoption might be a smaller type than int and
          might cause compiler warnings and wrong behavior. */
-      option = va_arg(params, int);
+      option = (CURLformoption)va_arg(params, int);
       if(CURLFORM_END == option)
         break;
     }


### PR DESCRIPTION
To avoid "enumerated type mixed with another type" warnings

Follow-up from 0f52dd5fd5aa3592691a