### PR TITLE
Use NMake batch-rules for compilation

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -621,20 +621,20 @@ $(CURL_DIROBJ):
 
 .SUFFIXES: .c .obj .res
 
-{$(LIBCURL_SRC_DIR)\}.c{$(LIB_DIROBJ)\}.obj:
-	$(CURL_CC) $(CFLAGS) /Fo"$@"  $<
+{$(LIBCURL_SRC_DIR)\}.c{$(LIB_DIROBJ)\}.obj::
+	$(CURL_CC) $(CFLAGS) /Fo"$(LIB_DIROBJ)\\"  $<
 
-{$(LIBCURL_SRC_DIR)\vauth\}.c{$(LIB_DIROBJ)\vauth\}.obj:
-	$(CURL_CC) $(CFLAGS) /Fo"$@"  $<
+{$(LIBCURL_SRC_DIR)\vauth\}.c{$(LIB_DIROBJ)\vauth\}.obj::
+	$(CURL_CC) $(CFLAGS) /Fo"$(LIB_DIROBJ)\vauth\\"  $<
 
-{$(LIBCURL_SRC_DIR)\vtls\}.c{$(LIB_DIROBJ)\vtls\}.obj:
-	$(CURL_CC) $(CFLAGS) /Fo"$@"  $<
+{$(LIBCURL_SRC_DIR)\vtls\}.c{$(LIB_DIROBJ)\vtls\}.obj::
+	$(CURL_CC) $(CFLAGS) /Fo"$(LIB_DIROBJ)\vtls\\"  $<
 
-{$(LIBCURL_SRC_DIR)\vssh\}.c{$(LIB_DIROBJ)\vssh\}.obj:
-	$(CURL_CC) $(CFLAGS) /Fo"$@"  $<
+{$(LIBCURL_SRC_DIR)\vssh\}.c{$(LIB_DIROBJ)\vssh\}.obj::
+	$(CURL_CC) $(CFLAGS) /Fo"$(LIB_DIROBJ)\vssh\\"  $<
 
-{$(LIBCURL_SRC_DIR)\vquic\}.c{$(LIB_DIROBJ)\vquic\}.obj:
-	$(CURL_CC) $(CFLAGS) /Fo"$@"  $<
+{$(LIBCURL_SRC_DIR)\vquic\}.c{$(LIB_DIROBJ)\vquic\}.obj::
+	$(CURL_CC) $(CFLAGS) /Fo"$(LIB_DIROBJ)\vquic\\"  $<
 
 $(LIB_DIROBJ)\libcurl.res: $(LIBCURL_SRC_DIR)\libcurl.rc
 	$(RC) $(RC_FLAGS)
@@ -670,8 +670,8 @@ $(PROGRAM_NAME): $(CURL_DIROBJ) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
 	$(CURL_LINK) $(CURL_LFLAGS) $(CURL_LIBCURL_LIBNAME) $(WIN_LIBS) $(CURL_FROM_LIBCURL) $(EXE_OBJS)
 	$(MANIFESTTOOL)
 
-{$(CURL_SRC_DIR)\}.c{$(CURL_DIROBJ)\}.obj:
-	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@"  $<
+{$(CURL_SRC_DIR)\}.c{$(CURL_DIROBJ)\}.obj::
+	$(CURL_CC) $(CURL_CFLAGS) /Fo"$(CURL_DIROBJ)\\"  $<
 
 $(CURL_DIROBJ)\tool_hugehelp.obj: $(CURL_SRC_DIR)\tool_hugehelp.c
 	$(CURL_CC) $(CURL_CFLAGS) /Zm200 /Fo"$@" $(CURL_SRC_DIR)\tool_hugehelp.c


### PR DESCRIPTION
Currently NMake based build invokes cl.exe for every file. This pull request enable NMake batch-mode rules for cl.exe. In this case cl.exe invoked for multiple .c files.

This is significantly improves compilation time. For example in my environment: 40 s → 20 s.