### PR TITLE
altsvc: use 'h3' for h3

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -52,15 +52,7 @@
 #define MAX_ALTSVC_ALPNLENSTR "10"
 #define MAX_ALTSVC_ALPNLEN 10
 
-#if defined(USE_QUICHE) && !defined(UNITTESTS)
-#define H3VERSION "h3-29"
-#elif defined(USE_NGTCP2) && !defined(UNITTESTS)
-#define H3VERSION "h3-29"
-#elif defined(USE_MSH3) && !defined(UNITTESTS)
-#define H3VERSION "h3-29"
-#else
 #define H3VERSION "h3"
-#endif
 
 static enum alpnid alpn2alpnid(char *name)
 {


### PR DESCRIPTION
Since the official and real version has been out for a while now and servers are deployed out there using it, there is no point in sticking to h3-29.

Reported-by: ウさん
Fixes #9515