### PR TITLE
windows: add .rc support to autotools builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,8 @@ CURL_CHECK_OPTION_ECH
 
 XC_CHECK_PATH_SEPARATOR
 
+LT_LANG([Windows Resource])
+
 #
 # save the configure arguments
 #
@@ -568,6 +570,7 @@ CURL_DARWIN_CFLAGS
 CURL_DARWIN_SYSTEMCONFIGURATION
 CURL_SUPPORTS_BUILTIN_AVAILABLE
 
+AM_CONDITIONAL([OS_WINDOWS], [test "$curl_cv_native_windows" = "yes"])
 
 dnl ************************************************************
 dnl switch off particular protocols

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -75,6 +75,12 @@ AM_CPPFLAGS += -DBUILDING_LIBCURL
 AM_LDFLAGS =
 AM_CFLAGS =
 
+# Makefile.inc provides the CSOURCES and HHEADERS defines
+include Makefile.inc
+
+libcurl_la_SOURCES = $(CSOURCES) $(HHEADERS)
+libcurlu_la_SOURCES = $(CSOURCES) $(HHEADERS)
+
 libcurl_la_CPPFLAGS_EXTRA =
 libcurl_la_LDFLAGS_EXTRA =
 libcurl_la_CFLAGS_EXTRA =
@@ -102,6 +108,11 @@ endif
 
 if USE_CPPFLAG_CURL_STATICLIB
 libcurl_la_CPPFLAGS_EXTRA += -DCURL_STATICLIB
+else
+if OS_WINDOWS
+libcurl_la_SOURCES += $(LIB_RCFILES)
+$(LIB_RCFILES): $(top_srcdir)/include/curl/curlver.h
+endif
 endif
 
 if DOING_CURL_SYMBOL_HIDING
@@ -116,12 +127,6 @@ libcurl_la_CFLAGS = $(AM_CFLAGS) $(libcurl_la_CFLAGS_EXTRA)
 libcurlu_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurlu_la_LDFLAGS = $(AM_LDFLAGS) -static $(LIBCURL_LIBS)
 libcurlu_la_CFLAGS = $(AM_CFLAGS)
-
-# Makefile.inc provides the CSOURCES and HHEADERS defines
-include Makefile.inc
-
-libcurl_la_SOURCES = $(CSOURCES) $(HHEADERS)
-libcurlu_la_SOURCES = $(CSOURCES) $(HHEADERS)
 
 CHECKSRC = $(CS_$(V))
 CS_0 = @echo "  RUN     " $@;
@@ -148,3 +153,9 @@ tidy:
 
 optiontable:
 	perl optiontable.pl < $(top_srcdir)/include/curl/curl.h > easyoptions.c
+
+if OS_WINDOWS
+# Warning is "normal": libtool:   error: ignoring unknown tag RC
+.rc.lo:
+	$(LIBTOOL) --tag=RC --mode=compile $(RC) -I$(top_srcdir)/include $(RCFLAGS) -i $< -o $@
+endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,7 +79,7 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) \
                           -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LINKFLAGS)
-libcurltool_la_SOURCES = $(curl_SOURCES)
+libcurltool_la_SOURCES = $(CURL_FILES)
 endif
 
 CLEANFILES = tool_hugehelp.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -55,6 +55,10 @@ include Makefile.inc
 
 # CURL_FILES comes from Makefile.inc
 curl_SOURCES = $(CURL_FILES)
+if OS_WINDOWS
+curl_SOURCES += $(CURL_RCFILES)
+$(CURL_RCFILES): tool_version.h
+endif
 
 # This might hold -Werror
 CFLAGS += @CURL_CFLAG_EXTRAS@
@@ -151,3 +155,9 @@ tidy:
 
 listhelp:
 	(cd $(top_srcdir)/docs/cmdline-opts && ./gen.pl listhelp *.d) > tool_listhelp.c
+
+if OS_WINDOWS
+# Warning is "normal": libtool:   error: ignoring unknown tag RC
+.rc.o:
+	$(LIBTOOL) --tag=RC --mode=compile $(RC) -I$(top_srcdir)/include -DCURL_EMBED_MANIFEST $(RCFLAGS) -i $< -o $@
+endif


### PR DESCRIPTION
After this update autotools builds will compile and link `.rc` resources
to Windows executables. Bringing this feature on par with CMake
and Makefile.m32 builds. And also making it unnecessary to improvise
these steps manually, while monkey patching build files, e.g. [0].

You can customize the resource compiler via the `RC` envvar, and its
options via `RCFLAGS`.

This harmless warning may appear throughout the build, even though the
autotools manual documents [1] `RC` as a valid tag:
`libtool:   error: ignoring unknown tag RC`

[0] https://github.com/curl/curl-for-win/blob/535f19060d4b708f72e75dd849409ce50baa1b84/curl-autotools.sh#L376-L382
[1] https://www.gnu.org/software/libtool/manual/html_node/Tags.html

Closes #9521
