### PR TITLE
tool_libinfo: silence "different 'const' qualifiers" in qsort()

### DIFF
--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -187,9 +187,10 @@ CURLcode get_libcurl_info(void)
     if(result)
       return result;
 
-    /* Sort the protocols to be sure the primary ones are always accessible and
-     * to retain their list order for testing purposes. */
-    qsort(built_in_protos, proto_last, sizeof(built_in_protos[0]), protocmp);
+    /* Sort the protocols to be sure the primary ones are always accessible
+     * and to retain their list order for testing purposes. */
+    qsort((char *)built_in_protos, proto_last,
+          sizeof(built_in_protos[0]), protocmp);
 
     /* Identify protocols we are interested in. */
     for(p = possibly_built_in; p->proto_name; p++)


### PR DESCRIPTION
MSVC 15.0.30729.1 warned about it

Follow-up to dd2a024323dcc