### PR TITLE
README.md: add GHA status badges for Linux and macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ SPDX-License-Identifier: curl
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/l1vv31029huhf4g4?svg=true)](https://ci.appveyor.com/project/curlorg/curl)
 [![Azure DevOps Build Status](https://dev.azure.com/daniel0244/curl/_apis/build/status/curl.curl?branchName=master)](https://dev.azure.com/daniel0244/curl/_build/latest?definitionId=1&branchName=master)
 [![Cirrus Build Status](https://api.cirrus-ci.com/github/curl/curl.svg?branch=master)](https://cirrus-ci.com/github/curl/curl)
+[![GitHub Actions Linux Build Status](https://github.com/curl/curl/actions/workflows/linux.yml/badge.svg)](https://github.com/curl/curl/actions/workflows/linux.yml)
+[![GitHub Actions macOS Build Status](https://github.com/curl/curl/actions/workflows/macos.yml/badge.svg)](https://github.com/curl/curl/actions/workflows/macos.yml)
 [![Backers on Open Collective](https://opencollective.com/curl/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/curl/sponsors/badge.svg)](#sponsors)
 [![Language Grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/curl/curl.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/curl/curl/context:cpp)


### PR DESCRIPTION
This makes sense now that Linux builds are being consolidated.

[skip ci]