### PR TITLE
CI: move distcheck job from Azure Pipelines to GitHub Actions

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -116,59 +116,6 @@ stages:
         AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
         TFLAGS: "-ac /usr/bin/curl -r $(tests)"
 
-- stage: distcheck
-  dependsOn: []
-  jobs:
-  - job: ubuntu
-    timeoutInMinutes: 30
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-    - script: autoreconf -fi && ./configure --without-ssl
-      displayName: 'configure'
-
-    - script: make && ./maketgz 99.98.97
-      displayName: 'make tarball'
-
-    - script: |
-        tar xf curl-99.98.97.tar.gz
-        cd curl-99.98.97
-        ./configure --prefix=$HOME/temp --without-ssl
-        make
-        make TFLAGS=1 test
-        make install
-        # basic check of the installed files
-        cd ..
-        bash scripts/installcheck.sh $HOME/temp
-        rm -rf curl-99.98.97
-
-      displayName: 'verify in-tree configure build'
-
-    - script: |
-        # verify out-of-tree build
-        tar xf curl-99.98.97.tar.gz
-        touch curl-99.98.97/docs/{cmdline-opts,libcurl}/Makefile.inc
-        mkdir build
-        cd build
-        ../curl-99.98.97/configure --without-ssl
-        make
-        make TFLAGS='-p 1 1139' test
-        # verify cmake build
-        cd ..
-        rm -rf curl-99.98.97
-
-      displayName: 'verify out-of-tree configure build'
-
-    - script: |
-        tar xf curl-99.98.97.tar.gz
-        cd curl-99.98.97
-        mkdir build
-        cd build
-        cmake ..
-        make
-
-      displayName: 'verify out-of-tree cmake build'
-
 - stage: scanbuild
   dependsOn: []
   jobs:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -1,0 +1,101 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: dist
+
+on:
+  push:
+    branches:
+    - master
+    - '*/ci'
+  pull_request:
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  maketgz-and-verify-in-tree:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+
+    - run: sudo apt-get purge -y curl libcurl4 libcurl4-doc
+      name: 'remove preinstalled curl libcurl4{-doc}'
+
+    - run: autoreconf -fi
+      name: 'autoreconf'
+
+    - run: ./configure --without-ssl
+      name: 'configure'
+
+    - run: make V=1 && make V=1 clean
+      name: 'make and clean'
+
+    - run: ./maketgz 99.98.97
+      name: 'maketgz'
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: 'release-tgz'
+        path: 'curl-99.98.97.tar.gz'
+
+    - run: |
+        echo "::stop-commands::$(uuidgen)"
+        tar xvf curl-99.98.97.tar.gz
+        pushd curl-99.98.97
+        ./configure --prefix=$HOME/temp --without-ssl
+        make
+        make TFLAGS=1 test
+        make install
+        popd
+        # basic check of the installed files
+        bash scripts/installcheck.sh $HOME/temp
+        rm -rf curl-99.98.97
+      name: 'verify in-tree configure build including install'
+
+  verify-out-of-tree-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: maketgz-and-verify-in-tree
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: 'release-tgz'
+
+    - run: |
+        echo "::stop-commands::$(uuidgen)"
+        tar xvf curl-99.98.97.tar.gz
+        touch curl-99.98.97/docs/{cmdline-opts,libcurl}/Makefile.inc
+        mkdir build
+        pushd build
+        ../curl-99.98.97/configure --without-ssl
+        make
+        make TFLAGS='-p 1 1139' test
+        popd
+        rm -rf build
+        rm -rf curl-99.98.97
+      name: 'verify out-of-tree configure build including docs'
+
+  verify-out-of-tree-cmake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: maketgz-and-verify-in-tree
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: 'release-tgz'
+
+    - run: |
+        echo "::stop-commands::$(uuidgen)"
+        tar xvf curl-99.98.97.tar.gz
+        pushd curl-99.98.97
+        mkdir build
+        pushd build
+        cmake ..
+        make
+      name: 'verify out-of-tree cmake build'


### PR DESCRIPTION
This is in preparation of adding trigger excludes to Azure Pipelines.