### PR TITLE
CI/GHA: cancel outdated CI runs on new PR changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,8 +5,6 @@
 name: CodeQL
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -16,6 +14,9 @@ on:
     - master
   schedule:
     - cron: '0 0 * * 4'
+
+concurrency:
+  group: ${{ github.workflow }}
 
 permissions:
   security-events: write

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,8 +5,6 @@
 name: Fuzzer
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,10 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   fuzzing:

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -5,10 +5,14 @@
 name: Hacktoberfest
 
 on:
-  # run for all pushes to master branch
+  # this must not ever run on any other branch than master
   push:
     branches:
     - master
+
+concurrency:
+  # this should not run in parallel, so just run one at a time
+  group: ${{ github.workflow }}
 
 permissions:
   # requires issues AND pull-requests write permissions to edit labels on PRs!

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -5,8 +5,6 @@
 name: Markdown links
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,10 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   # Docs: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,8 +5,6 @@
 name: Linux
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,10 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,8 +5,6 @@
 name: macOS
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,10 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/msh3.yml
+++ b/.github/workflows/msh3.yml
@@ -5,8 +5,6 @@
 name: Linux
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,11 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  # Hardcoded workflow filename as workflow name above is just Linux again
+  group: msh3-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -5,8 +5,6 @@
 name: ngtcp2
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,11 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  # Hardcoded workflow filename as workflow name above is just Linux again
+  group: ngtcp2-gnutls-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/ngtcp2-wolfssl.yml
+++ b/.github/workflows/ngtcp2-wolfssl.yml
@@ -5,8 +5,6 @@
 name: ngtcp2
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,11 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  # Hardcoded workflow filename as workflow name above is just Linux again
+  group: ngtcp2-wolfssl-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -5,8 +5,6 @@
 name: Linux
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,11 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  # Hardcoded workflow filename as workflow name above is just Linux again
+  group: openssl3-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,8 +6,6 @@
 name: REUSE compliance
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -15,6 +13,10 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -5,8 +5,6 @@
 name: Linux
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,11 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  # Hardcoded workflow filename as workflow name above is just Linux again
+  group: torture-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -5,8 +5,6 @@
 name: Linux
 
 on:
-  # Trigger the workflow on push or pull requests, but only for the
-  # master branch
   push:
     branches:
     - master
@@ -14,6 +12,11 @@ on:
   pull_request:
     branches:
     - master
+
+concurrency:
+  # Hardcoded workflow filename as workflow name above is just Linux again
+  group: wolfssl-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   autotools:


### PR DESCRIPTION
Avoid letting outdated CI runs continue if a PR receives new changes. Outside a PR we let them continue running
by tying the concurrency to the commit hash instead.

Also only let one CodeQL or Hacktoberfest job run at a time.

Other CI platforms we use have this build in, but GitHub unfortunately neither by default nor with a simple option.

This saves CI resources and therefore a little energy.