### PR TITLE
lib and tool: install large bit mask type when more than 32 protocols

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -577,11 +577,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   set->new_file_perms = 0644;    /* Default permissions */
   set->new_directory_perms = 0755; /* Default permissions */
-
-  /* for the *protocols fields we don't use the CURLPROTO_ALL convenience
-     define since we internally only use the lower 16 bits for the passed
-     in bitmask to not conflict with the private bits */
-  set->allowed_protocols = (unsigned int)CURLPROTO_ALL;
+  set->allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
   set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP |
                          CURLPROTO_FTPS;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -60,13 +60,18 @@
  * protocol fields in the protocol handler.
  */
 #define CURLPROTO_WS     (1<<30)
-#define CURLPROTO_WSS    (1LL<<31)
-
-/* This type should be bumped to a curl_off_t once we need bit 32 or higher */
-typedef unsigned int curl_prot_t;
+#define CURLPROTO_WSS    ((curl_prot_t)1<<31)
 #else
 #define CURLPROTO_WS 0
 #define CURLPROTO_WSS 0
+#endif
+
+/* This should be undefined once we need bit 32 or higher */
+#define PROTO_TYPE_SMALL
+
+#ifndef PROTO_TYPE_SMALL
+typedef curl_off_t curl_prot_t;
+#else
 typedef unsigned int curl_prot_t;
 #endif
 


### PR DESCRIPTION
In the library, complete support for more than 32 protocols:
- Describe a conditional sequence to define a new protocol bit mask.
- Introduce a conditional curl_prot_t definition based on high protocols availability.
- Fix a cast in a curl_prot_t assignment.
- Remove an outdated comment.

Large prototype bit mask type is also introduced in the cli tool. As there is no way to determine whether the library supports high protocols at compile time, this is unconditional.

Follow-up to cd5ca80.