### PR TITLE
TODO: Reduce CA certificate bundle reparsing

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -120,6 +120,7 @@
  13.9 TLS record padding
  13.10 Support Authority Information Access certificate extension (AIA)
  13.11 Support intermediate & root pinning for PINNEDPUBLICKEY
+ 13.12 Reduce CA certificate bundle reparsing
  13.13 Make sure we forbid TLS 1.3 post-handshake authentication
  13.14 Support the clienthello extension
 
@@ -843,6 +844,15 @@
 
  Adding this feature would make curls pinning 100% compatible to HPKP and
  allow more flexible pinning.
+
+13.12 Reduce CA certificate bundle reparsing
+
+ When using the OpenSSL backend, curl will load and reparse the CA bundle at
+ the creation of the "SSL context" when it sets up a connection to do a TLS
+ handshake. A more effective way would be to somehow cache the CA bundle to
+ avoid it having to be repeatedly reloaded and reparsed.
+
+ See https://github.com/curl/curl/issues/9379
 
 13.13 Make sure we forbid TLS 1.3 post-handshake authentication
 


### PR DESCRIPTION
By adding some sort of cache.

Reported-by: Michael Drake
Closes #9379

Add this issue to the `TODO` document because it would be a good idea but nobody is working at it for the moment.