### PR TITLE
Forced IPv4 resolve mode to use only A queries.

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -781,7 +781,8 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
 #ifdef CURLRES_IPV6
       if(Curl_ipv6works(data))
         /* The stack seems to be IPv6-enabled */
-        pf = PF_UNSPEC;
+        if(data->conn->ip_version != CURL_IPRESOLVE_V4)
+          pf = PF_UNSPEC;
 #endif /* CURLRES_IPV6 */
       hints.ai_family = pf;
       hints.ai_socktype = (data->conn->transport == TRNSPRT_TCP)?
@@ -794,7 +795,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
 #else
 
 #ifdef HAVE_CARES_IPV6
-    if(Curl_ipv6works(data)) {
+    if(Curl_ipv6works(data) && data->conn->ip_version != CURL_IPRESOLVE_V4) {
       /* The stack seems to be IPv6-enabled */
       res->num_pending = 2;
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -707,7 +707,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   *waitp = 0; /* default to synchronous response */
 
 #ifdef CURLRES_IPV6
-  if(Curl_ipv6works(data))
+  if(Curl_ipv6works(data) && data->conn->ip_version != CURL_IPRESOLVE_V4)
     /* The stack seems to be IPv6-enabled */
     pf = PF_UNSPEC;
 #endif /* CURLRES_IPV6 */

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -396,7 +396,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
     goto error;
   dohp->pending++;
 
-  if(Curl_ipv6works(data)) {
+  if(Curl_ipv6works(data) && conn->ip_version != CURL_IPRESOLVE_V4) {
     /* create IPv6 DoH request */
     result = dohprobe(data, &dohp->probe[DOH_PROBE_SLOT_IPADDR_V6],
                       DNS_TYPE_AAAA, hostname, data->set.str[STRING_DOH],

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -297,6 +297,29 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
     }
   }
 
+  /* See if the returned entry matches the required resolve mode */
+  if(dns && data->conn->ip_version != CURL_IPRESOLVE_WHATEVER) {
+    int pf = PF_INET;
+    bool found = false;
+    struct Curl_addrinfo *addr = dns->addr;
+
+    if(data->conn->ip_version == CURL_IPRESOLVE_V6)
+      pf = PF_INET6;
+
+    while(addr) {
+      if(addr->ai_family == pf) {
+        found = true;
+        break;
+      }
+      addr = addr->ai_next;
+    }
+
+    if(!found) {
+      infof(data, "Hostname in DNS cache doesn't have needed family, zapped");
+      dns = NULL; /* the memory deallocation is being handled by the hash */
+      Curl_hash_delete(data->dns.hostcache, entry_id, entry_len + 1);
+    }
+  }
   return dns;
 }
 

--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -117,7 +117,7 @@ struct Curl_addrinfo *Curl_getaddrinfo(struct Curl_easy *data,
 
   *waitp = 0; /* synchronous response only */
 
-  if(Curl_ipv6works(data))
+  if(Curl_ipv6works(data) && data->conn->ip_version != CURL_IPRESOLVE_V4)
     /* The stack seems to be IPv6-enabled */
     pf = PF_UNSPEC;
 


### PR DESCRIPTION
These changes force using IPv4 name resolution queries for the "IP4 only" resolve mode in IPv6-enabled dual-stack libcurl.
They protect "IPv4 only" transfers from undesired bad IPv6-related side effects and make IPv4 transfers in dual-stack libcurl behave the same way as in IPv4 single-stack libcurl.

The e-mail thread describing the problem and some ideas to solve it can be found at:
https://curl.se/mail/lib-2022-05/0004.html