### PR TITLE
curl-compilers.m4: for gcc + want warnings, set gnu89 standard

### DIFF
--- a/lib/vquic/msh3.c
+++ b/lib/vquic/msh3.c
@@ -381,9 +381,6 @@ static void MSH3_CALL msh3_shutdown(MSH3_REQUEST *Request, void *IfContext)
   (void)stream;
 }
 
-static_assert(sizeof(MSH3_HEADER) == sizeof(struct h2h3pseudo),
-              "Sizes must match for cast below to work");
-
 static ssize_t msh3_stream_send(struct Curl_easy *data,
                                 int sockindex,
                                 const void *mem,
@@ -396,6 +393,9 @@ static ssize_t msh3_stream_send(struct Curl_easy *data,
   struct h2h3req *hreq;
 
   (void)sockindex;
+  /* Sizes must match for cast below to work" */
+  DEBUGASSERT(sizeof(MSH3_HEADER) == sizeof(struct h2h3pseudo));
+
   H3BUGF(infof(data, "msh3_stream_send %zu", len));
 
   if(!stream->req) {

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -76,9 +76,9 @@ struct cafile_parser {
 #define CAFILE_SOURCE_PATH 1
 #define CAFILE_SOURCE_BLOB 2
 struct cafile_source {
-  const int type;
-  const char * const data;
-  const size_t len;
+  int type;
+  const char *data;
+  size_t len;
 };
 
 static void append_dn(void *ctx, const void *buf, size_t len)
@@ -618,11 +618,11 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
   }
 
   if(ca_info_blob) {
-    struct cafile_source source = {
-      CAFILE_SOURCE_BLOB,
-      ca_info_blob->data,
-      ca_info_blob->len,
-    };
+    struct cafile_source source;
+    source.type = CAFILE_SOURCE_BLOB;
+    source.data = ca_info_blob->data;
+    source.len = ca_info_blob->len;
+
     ret = load_cafile(&source, &backend->anchors, &backend->anchors_len);
     if(ret != CURLE_OK) {
       if(verifypeer) {
@@ -635,11 +635,11 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
   }
 
   if(ssl_cafile) {
-    struct cafile_source source = {
-      CAFILE_SOURCE_PATH,
-      ssl_cafile,
-      0,
-    };
+    struct cafile_source source;
+    source.type = CAFILE_SOURCE_PATH;
+    source.data = ssl_cafile;
+    source.len = 0;
+
     ret = load_cafile(&source, &backend->anchors, &backend->anchors_len);
     if(ret != CURLE_OK) {
       if(verifypeer) {

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -860,6 +860,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
       GNU_C)
         #
         if test "$want_warnings" = "yes"; then
+          tmp_CFLAGS="$tmp_CFLAGS -std=gnu89"
           #
           dnl Do not enable -pedantic when cross-compiling with a gcc older
           dnl than 3.0, to avoid warnings from third party system headers.


### PR DESCRIPTION
To better verify that the code is C89