### PR TITLE
connect: remove the wrong error message on connect failures

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1047,7 +1047,6 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
      (conn->tempsock[1] == CURL_SOCKET_BAD)) {
     /* no more addresses to try */
     const char *hostname;
-    char buffer[STRERROR_LEN];
     CURLcode failreason = result;
 
     /* if the first address family runs out of addresses to try before the
@@ -1074,11 +1073,7 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
           "%" CURL_FORMAT_TIMEDIFF_T " ms: %s",
           hostname, conn->port,
           Curl_timediff(now, data->progress.t_startsingle),
-#ifdef ENABLE_QUIC
-          (conn->transport == TRNSPRT_QUIC) ?
-          curl_easy_strerror(result) :
-#endif
-          Curl_strerror(error, buffer, sizeof(buffer)));
+          curl_easy_strerror(result));
 
     Curl_quic_disconnect(data, conn, 0);
     Curl_quic_disconnect(data, conn, 1);


### PR DESCRIPTION
The "Failed to connect to" message after a connection failure would include the strerror message based on the presumed previous socket error, but in times it seems that error number is not set when reaching this code and therefore it would include the wrong error message.

The strerror message is now removed from here and the curl_easy_strerror error is used instead.

Reported-by: Edoardo Lolletti
Fixes #9549