### PR TITLE
httpput-postfields.c: shorten string for C89 compliance

### DIFF
--- a/docs/examples/httpput-postfields.c
+++ b/docs/examples/httpput-postfields.c
@@ -37,8 +37,10 @@ static const char olivertwist[]=
   "small: to wit, a workhouse; and in this workhouse was born; on a day and "
   "date which I need not trouble myself to repeat, inasmuch as it can be of "
   "no possible consequence to the reader, in this stage of the business at "
-  "all events; the item of mortality whose name is prefixed to the head of "
-  "this chapter.";
+  "all events; the item of mortality whose name is prefixed";
+
+/* ... to the head of this chapter. String cut off to stick within the C90
+   509 byte limit. */
 
 /*
  * This example shows a HTTP PUT operation that sends a fixed buffer with


### PR DESCRIPTION
~~~
httpput-postfields.c:41:3: error: string length ‘522’ is greater than the length ‘509’ ISO C90 compilers are required to support [-Woverlength-strings]
   41 |   "this chapter.";
      |   ^~~~~~~~~~~~~~~