### PR TITLE
easy: fix the #include order

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -82,11 +82,12 @@
 #include "altsvc.h"
 #include "hsts.h"
 
+#include "easy_lock.h"
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
 #include "memdebug.h"
-#include "easy_lock.h"
 
 /* true globals -- for curl_global_init() and curl_global_cleanup() */
 static unsigned int  initialized;


### PR DESCRIPTION
The mentioned "last 3 includes" order should be respected. easy_lock.h should be included before those three.

Reported-by: Yuriy Chernyshov
Fixes #9560