### PR TITLE
test972: verify the output without using external tool

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
       matrix:
         default:
           name: default
-          install: jsonlint
+          install:
           configure: --enable-debug --with-openssl
         disable_ipv6:
           name: w/o IPv6

--- a/tests/data/test972
+++ b/tests/data/test972
@@ -45,7 +45,7 @@ CURL_VERSION=curl-unit-test-fake-version
 Verify JSON output
 </name>
 <command option="no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -s --write-out '%{json}' -o log/out972
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -s --write-out '%{json}\n' -o log/out972
 </command>
 </client>
 
@@ -59,7 +59,7 @@ User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>
-<stdout mode="text" nonewline="yes">
+<stdout mode="text">
 {"content_type":"text/html","errormsg":null,"exitcode":0,"filename_effective":"log/out972","ftp_entry_path":null,"http_code":200,"http_connect":0,"http_version":"1.1","local_ip":"%HOSTIP","local_port":13,"method":"GET","num_connects":1,"num_headers":9,"num_redirects":0,"proxy_ssl_verify_result":0,"redirect_url":null,"referer":null,"remote_ip":"%HOSTIP","remote_port":%HTTPPORT,"response_code":200,"scheme":"HTTP","size_download":445,"size_header":4019,"size_request":4019,"size_upload":0,"speed_download":13,"speed_upload":13,"ssl_verify_result":0,"time_appconnect":0.000013,"time_connect":0.000013,"time_namelookup":0.000013,"time_pretransfer":0.000013,"time_redirect":0.000013,"time_starttransfer":0.000013,"time_total":0.000013,"url":"http://%HOSTIP:%HTTPPORT/%TESTNUMBER","url_effective":"http://%HOSTIP:%HTTPPORT/%TESTNUMBER","urlnum":0,"curl_version":"curl-unit-test-fake-version"}
 </stdout>
 </verify>

--- a/tests/data/test972
+++ b/tests/data/test972
@@ -28,9 +28,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 #
 # Client-side
 <client>
-<precheck>
-/usr/bin/which jsonlint-php >log/%TESTNUMBER-check
-</precheck>
+
 <server>
 http
 </server>
@@ -47,7 +45,7 @@ CURL_VERSION=curl-unit-test-fake-version
 Verify JSON output
 </name>
 <command option="no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -s --write-out '%{json}' -o log/out972 | jsonlint-php -q
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -s --write-out '%{json}' -o log/out972
 </command>
 </client>
 
@@ -61,5 +59,8 @@ User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>
+<stdout mode="text" nonewline="yes">
+{"content_type":"text/html","errormsg":null,"exitcode":0,"filename_effective":"log/out972","ftp_entry_path":null,"http_code":200,"http_connect":0,"http_version":"1.1","local_ip":"%HOSTIP","local_port":13,"method":"GET","num_connects":1,"num_headers":9,"num_redirects":0,"proxy_ssl_verify_result":0,"redirect_url":null,"referer":null,"remote_ip":"%HOSTIP","remote_port":%HTTPPORT,"response_code":200,"scheme":"HTTP","size_download":445,"size_header":4019,"size_request":4019,"size_upload":0,"speed_download":13,"speed_upload":13,"ssl_verify_result":0,"time_appconnect":0.000013,"time_connect":0.000013,"time_namelookup":0.000013,"time_pretransfer":0.000013,"time_redirect":0.000013,"time_starttransfer":0.000013,"time_total":0.000013,"url":"http://%HOSTIP:%HTTPPORT/%TESTNUMBER","url_effective":"http://%HOSTIP:%HTTPPORT/%TESTNUMBER","urlnum":0,"curl_version":"curl-unit-test-fake-version"}
+</stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
It seems too restrictive to assume and use an external tool to verify the JSON. This now verifies the outut byte per byte. We could consider building a local "JSON verifyer" in a future.

Reported-by: Marcel Raad
Fixes #9563