### PR TITLE
Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -964,7 +964,7 @@ static int dprintf_formatf(
 #endif
         /* NOTE NOTE NOTE!! Not all sprintf implementations return number of
            output characters */
-        (sprintf)(work, formatbuf, p->data.dnum);
+        (snprintf)(work, formatbuf, p->data.dnum);
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
ensure compatibility with macOS 13