### PR TITLE
mprintf: use snprintf if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1079,6 +1079,7 @@ check_symbol_exists(getrlimit      "${CURL_INCLUDES}" HAVE_GETRLIMIT)
 check_symbol_exists(setlocale      "${CURL_INCLUDES}" HAVE_SETLOCALE)
 check_symbol_exists(setmode        "${CURL_INCLUDES}" HAVE_SETMODE)
 check_symbol_exists(setrlimit      "${CURL_INCLUDES}" HAVE_SETRLIMIT)
+check_symbol_exists(snprintf       "${CURL_INCLUDES}" HAVE_SNPRINTF)
 check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
 check_symbol_exists(inet_pton      "${CURL_INCLUDES}" HAVE_INET_PTON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1079,7 +1079,11 @@ check_symbol_exists(getrlimit      "${CURL_INCLUDES}" HAVE_GETRLIMIT)
 check_symbol_exists(setlocale      "${CURL_INCLUDES}" HAVE_SETLOCALE)
 check_symbol_exists(setmode        "${CURL_INCLUDES}" HAVE_SETMODE)
 check_symbol_exists(setrlimit      "${CURL_INCLUDES}" HAVE_SETRLIMIT)
-check_symbol_exists(snprintf       "${CURL_INCLUDES}" HAVE_SNPRINTF)
+
+if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1900))
+  # earlier MSVC compilers had faulty snprintf implementations
+  check_symbol_exists(snprintf       "${CURL_INCLUDES}" HAVE_SNPRINTF)
+endif()
 check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
 check_symbol_exists(inet_pton      "${CURL_INCLUDES}" HAVE_INET_PTON)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3535,6 +3535,7 @@ AC_CHECK_FUNCS([fnmatch \
   setlocale \
   setmode \
   setrlimit \
+  snprintf \
   utime \
   utimes
 ],[

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -254,6 +254,11 @@
 /* Define to the function return type for send. */
 #define SEND_TYPE_RETV int
 
+/* Define to 1 if you have the snprintf function. */
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#define HAVE_SNPRINTF 1
+#endif
+
 /* ---------------------------------------------------------------- */
 /*                       TYPEDEF REPLACEMENTS                       */
 /* ---------------------------------------------------------------- */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -964,7 +964,11 @@ static int dprintf_formatf(
 #endif
         /* NOTE NOTE NOTE!! Not all sprintf implementations return number of
            output characters */
+#ifdef HAVE_SNPRINTF
+        (snprintf)(work, sizeof(work), formatbuf, p->data.dnum);
+#else
         (sprintf)(work, formatbuf, p->data.dnum);
+#endif
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
This is the single place in libcurl code where it uses the "native" s(n)printf() function. Used for writing floats. The use has been reviewed and vetted and uses a HUGE target buffer, but switching to snprintf() still makes this safer and removes build-time warnings.

Reported-by: Philip Heiduck