### PR TITLE
lib517: fix C89 constant signedness

### DIFF
--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -126,7 +126,7 @@ static const struct dcheck dates[] = {
   {"Thu, 31-Dec-1969 23:59:58 GMT", -2 },
   {"Thu, 31-Dec-1969 23:59:59 GMT", 0 }, /* avoids -1 ! */
 #if SIZEOF_TIME_T > 4
-  {"Sun, 06 Nov 2044 08:49:37 GMT", 2362034977 },
+  {"Sun, 06 Nov 2044 08:49:37 GMT", (time_t) CURL_OFF_TU_C(2362034977) },
   {"Sun, 06 Nov 3144 08:49:37 GMT", 37074617377 },
 #ifndef HAVE_TIME_T_UNSIGNED
 #if 0


### PR DESCRIPTION
In C89, positive integer literals that overflow an int but not an unsigned int may be understood as a negative int.

```
lib517.c:129:3: warning: this decimal constant is unsigned only in ISO C90
   {"Sun, 06 Nov 2044 08:49:37 GMT", 2362034977 },
   ^
```