### PR TITLE
Disable use of FLOSS for 64-bit NonStop builds.

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -322,8 +322,10 @@
 #include <assert.h>
 #endif
 
-#ifdef __TANDEM /* for nsr-tandem-nsk systems */
-#include <floss.h>
+#ifdef __TANDEM /* for ns*-tandem-nsk systems */
+# if ! defined __LP64
+#  include <floss.h> /* FLOSS is only used for 32-bit builds. */
+# endif
 #endif
 
 #ifndef STDC_HEADERS /* no standard C headers! */


### PR DESCRIPTION
Older 32-bit builds currently need FLOSS. This dependency may be removed in future OS releases.

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>