### PR TITLE
tool: adjust handling of non-existent url scheme

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1249,14 +1249,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(result)
           break;
 
-        /* here */
         use_proto = url_proto(per->this_url);
-#if 0
-        if(!use_proto) {
-          warnf(global, "URL is '%s' but no support for the scheme\n",
-                per->this_url);
-        }
-#endif
 
         if(!config->tcp_nodelay)
           my_setopt(curl, CURLOPT_TCP_NODELAY, 0L);

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -271,6 +271,8 @@ static size_t protoset_index(const char * const *protoset, const char *proto)
 {
   const char * const *p = protoset;
 
+  DEBUGASSERT(proto == proto_token(proto));     /* Ensure it is tokenized. */
+
   for(; *p; p++)
     if(proto == *p)
       break;


### PR DESCRIPTION
The test for a non-existent protocol scheme in an URL is currently always false and the warning message can never occur. Fortunately this has no impact as this test is now unconditionally excluded.
This commit fixes it however, in case this warning is reenabled.

A debug assertion is also added to verify protocols included/excluded in a set are always tokenized.

Follow-up to commit 677266c.