### PR TITLE
windows: autotools .rc warnings fixup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,8 +55,6 @@ CURL_CHECK_OPTION_ECH
 
 XC_CHECK_PATH_SEPARATOR
 
-LT_LANG([Windows Resource])
-
 #
 # save the configure arguments
 #
@@ -350,6 +348,8 @@ dnl check for how to do large files
 AC_SYS_LARGEFILE
 
 XC_LIBTOOL
+
+LT_LANG([Windows Resource])
 
 #
 # Automake conditionals based on libtool related checks


### PR DESCRIPTION
Move `LT_LANG([Windows Resource])` after `XC_LIBTOOL`, fixing:

- Warnings when running `autoreconf -fi`.

- Warning when compiling .rc files:
  ```
  libtool: compile: unable to infer tagged configuration
  libtool:   error: specify a tag with '--tag'
  ```

Follow up to 6de7322c03d5b4d91576a7d9fc893e03cc9d1057
Ref: https://github.com/curl/curl/pull/9521#issuecomment-1256291156

Suggested-by: Patrick Monnerat
Closes #9582