### PR TITLE
[MSDOS] name-clash in url.c

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -519,9 +519,6 @@
 #    ifdef byte
 #      undef byte
 #    endif
-#    ifdef resolve_ip
-#      undef resolve_ip
-#    endif
 
 #  endif /* MSDOS */
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -519,6 +519,9 @@
 #    ifdef byte
 #      undef byte
 #    endif
+#    ifdef resolve_ip
+#      undef resolve_ip
+#    endif
 
 #  endif /* MSDOS */
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3503,9 +3503,9 @@ static CURLcode resolve_proxy(struct Curl_easy *data,
 }
 #endif
 
-static CURLcode resolve_ip(struct Curl_easy *data,
-                           struct connectdata *conn,
-                           bool *async)
+static CURLcode resolve_host(struct Curl_easy *data,
+                             struct connectdata *conn,
+                             bool *async)
 {
   struct Curl_dns_entry *hostaddr = NULL;
   struct hostname *connhost;
@@ -3571,7 +3571,7 @@ static CURLcode resolve_fresh(struct Curl_easy *data,
     return resolve_proxy(data, conn, async);
 #endif
 
-  return resolve_ip(data, conn, async);
+  return resolve_host(data, conn, async);
 }
 
 /*************************************************************


### PR DESCRIPTION
In commit https://github.com/curl/curl/commit/764c958c52edb427f39530f53623e85d34409904, the new function `resolve_ip()`
clashes with an [internal function](https://github.com/gvanem/Watt-32/blob/master/inc/tcp.h#L376) in Watt-32. Hence undefine it in libcurl.