### PR TITLE
autotools: allow --enable-symbol-hiding with windows

### DIFF
--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -458,8 +458,7 @@ AC_DEFUN([CURL_CONFIGURE_SYMBOL_HIDING], [
   AC_MSG_CHECKING([whether hiding of library internal symbols will actually happen])
   CFLAG_CURL_SYMBOL_HIDING=""
   doing_symbol_hiding="no"
-  if test x"$curl_cv_native_windows" != "xyes" &&
-    test "$want_symbol_hiding" = "yes" &&
+  if test "$want_symbol_hiding" = "yes" &&
     test "$supports_symbol_hiding" = "yes"; then
     doing_symbol_hiding="yes"
     CFLAG_CURL_SYMBOL_HIDING="$symbol_hiding_CFLAGS"


### PR DESCRIPTION
This local autotools logic was put in place in 9e24b9c7afbcb81120af4cf3f6cdee49a06d8224 (in 2012) which disabled it for Windows unconditionally. Testing reveals that it actually works with tested toolchains (mingw-w64 and CI ones), so let's allow this build feature on that platform. Bringing this in sync with CMake, which already supported this.

Closes #9586
