### PR TITLE
vtls: use a thread lock for multissl init

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -326,7 +326,7 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
 
   global_init_lock();
 
-  rc = Curl_init_sslset_nolock(id, name, avail);
+  rc = Curl_init_sslset(id, name, avail);
 
   global_init_unlock();
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -125,8 +125,8 @@ struct curl_slist *Curl_none_engines_list(struct Curl_easy *data);
 bool Curl_none_false_start(void);
 bool Curl_ssl_tls13_ciphersuites(void);
 
-CURLsslset Curl_init_sslset_nolock(curl_sslbackend id, const char *name,
-                                   const curl_ssl_backend ***avail);
+CURLsslset Curl_init_sslset(curl_sslbackend id, const char *name,
+                            const curl_ssl_backend ***avail);
 
 #include "openssl.h"        /* OpenSSL versions */
 #include "gtls.h"           /* GnuTLS versions */


### PR DESCRIPTION
.. because multissl_setup() and multissl_version() can be called by functions that do not hold the global init lock.

Ref: https://curl.se/mail/lib-2022-09/0104.html

Closes #xxxx

---

This PR is to further discussion on the mailing list about why multissl_setup and multissl_version would need to be protected by a lock. But why would they not be called during libcurl initialization? Yet there's a bunch of functions calling multissl_setup without a lock, why? IMO it seems like compensating for user error not initializing. I think we probably don't need this PR but just in case I'm wrong here's how it can be done.