### PR TITLE
url: a zero-length userinfo part in the URL is still a (blank) user

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2912,15 +2912,15 @@ CURLcode Curl_parse_login_details(const char *login, const size_t len,
           (psep && psep > osep ? (size_t)(psep - osep) :
                                  (size_t)(login + len - osep)) - 1 : 0);
 
-  /* Allocate the user portion buffer */
-  if(userp && ulen) {
+  /* Allocate the user portion buffer, which can be zero length */
+  if(userp) {
     ubuf = malloc(ulen + 1);
     if(!ubuf)
       result = CURLE_OUT_OF_MEMORY;
   }
 
   /* Allocate the password portion buffer */
-  if(!result && passwdp && plen) {
+  if(!result && passwdp && psep) {
     pbuf = malloc(plen + 1);
     if(!pbuf) {
       free(ubuf);

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -138,6 +138,14 @@ struct clearurlcase {
 };
 
 static const struct testcase get_parts_list[] ={
+  /* blank user is blank */
+  {"https://:password@example.net",
+   "https |  | password | [13] | example.net | [15] | / | [16] | [17]",
+   0, 0, CURLUE_OK},
+  /* blank user + blank password */
+  {"https://:@example.net",
+   "https |  |  | [13] | example.net | [15] | / | [16] | [17]",
+   0, 0, CURLUE_OK},
 #ifdef USE_WEBSOCKETS
   {"ws://example.com/color/?green",
    "ws | [11] | [12] | [13] | example.com | [15] | /color/ | green |"
@@ -528,7 +536,7 @@ static const struct urltestcase get_url_list[] = {
    "",
    CURLU_DISALLOW_USER, 0, CURLUE_USER_NOT_ALLOWED},
   {"http:/@example.com:123",
-   "http://example.com:123/",
+   "http://@example.com:123/",
    0, 0, CURLUE_OK},
   {"http:/:password@example.com",
    "http://:password@example.com/",
@@ -1253,7 +1261,7 @@ static int get_nothing(void)
       fprintf(stderr, "unexpected return code line %u\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_ZONEID, &p, 0);
-    if(rc != CURLUE_OK)
+    if(rc != CURLUE_NO_ZONEID)
       fprintf(stderr, "unexpected return code %u on line %u\n", (int)rc,
               __LINE__);
 

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -146,6 +146,10 @@ static const struct testcase get_parts_list[] ={
   {"https://:@example.net",
    "https |  |  | [13] | example.net | [15] | / | [16] | [17]",
    0, 0, CURLUE_OK},
+  /* user-only (no password) */
+  {"https://user@example.net",
+   "https | user | [12] | [13] | example.net | [15] | / | [16] | [17]",
+   0, 0, CURLUE_OK},
 #ifdef USE_WEBSOCKETS
   {"ws://example.com/color/?green",
    "ws | [11] | [12] | [13] | example.com | [15] | /color/ | green |"


### PR DESCRIPTION
Adjusted test 1560 to verify

Reported-by: Jay Satiro

Fixes #9088