### PR TITLE
tests: skip mime/form tests when mime is not built-in

### DIFF
--- a/tests/data/test1053
+++ b/tests/data/test1053
@@ -51,6 +51,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1133
+++ b/tests/data/test1133
@@ -19,6 +19,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1158
+++ b/tests/data/test1158
@@ -19,6 +19,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1186
+++ b/tests/data/test1186
@@ -19,6 +19,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1187
+++ b/tests/data/test1187
@@ -14,6 +14,9 @@ MULTIPART
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 smtp
 </server>

--- a/tests/data/test1189
+++ b/tests/data/test1189
@@ -19,6 +19,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1293
+++ b/tests/data/test1293
@@ -29,6 +29,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1308
+++ b/tests/data/test1308
@@ -16,6 +16,7 @@ none
 <features>
 unittest
 http
+Mime
 </features>
  <name>
 formpost unit tests

--- a/tests/data/test1315
+++ b/tests/data/test1315
@@ -22,6 +22,9 @@ Connection: close
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -23,6 +23,9 @@ Connection: close
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1553
+++ b/tests/data/test1553
@@ -28,6 +28,9 @@ body
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 imap
 </server>

--- a/tests/data/test158
+++ b/tests/data/test158
@@ -17,6 +17,9 @@ Silly-header: yeeeees
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test163
+++ b/tests/data/test163
@@ -20,6 +20,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test166
+++ b/tests/data/test166
@@ -20,6 +20,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test170
+++ b/tests/data/test170
@@ -18,6 +18,7 @@ HTTP proxy NTLM auth
 http
 </server>
 <features>
+Mime
 NTLM
 SSL
 !SSPI

--- a/tests/data/test173
+++ b/tests/data/test173
@@ -21,6 +21,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test186
+++ b/tests/data/test186
@@ -21,6 +21,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test2073
+++ b/tests/data/test2073
@@ -27,6 +27,9 @@ contents2
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test21
+++ b/tests/data/test21
@@ -13,6 +13,9 @@ multiple HTTP requests
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test258
+++ b/tests/data/test258
@@ -56,6 +56,7 @@ ok
 http
 </server>
 <features>
+Mime
 !SSPI
 crypto
 proxy

--- a/tests/data/test259
+++ b/tests/data/test259
@@ -52,6 +52,7 @@ ok
 http
 </server>
 <features>
+Mime
 !SSPI
 crypto
 proxy

--- a/tests/data/test277
+++ b/tests/data/test277
@@ -20,6 +20,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test304
+++ b/tests/data/test304
@@ -21,6 +21,7 @@ blablabla
 # Client-side
 <client>
 <features>
+Mime
 SSL
 </features>
 <server>

--- a/tests/data/test39
+++ b/tests/data/test39
@@ -19,6 +19,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test41
+++ b/tests/data/test41
@@ -12,6 +12,9 @@ FAILURE
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test44
+++ b/tests/data/test44
@@ -20,6 +20,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test516
+++ b/tests/data/test516
@@ -21,6 +21,9 @@ OK
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test554
+++ b/tests/data/test554
@@ -38,6 +38,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test584
+++ b/tests/data/test584
@@ -36,6 +36,9 @@ OK
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test587
+++ b/tests/data/test587
@@ -16,6 +16,9 @@ flaky
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test589
+++ b/tests/data/test589
@@ -22,6 +22,9 @@ OK
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test643
+++ b/tests/data/test643
@@ -39,6 +39,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test645
+++ b/tests/data/test645
@@ -39,6 +39,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test646
+++ b/tests/data/test646
@@ -14,6 +14,9 @@ MULTIPART
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 smtp
 </server>

--- a/tests/data/test647
+++ b/tests/data/test647
@@ -15,6 +15,9 @@ MULTIPART
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 imap
 </server>

--- a/tests/data/test648
+++ b/tests/data/test648
@@ -14,6 +14,9 @@ MULTIPART
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 smtp
 </server>

--- a/tests/data/test649
+++ b/tests/data/test649
@@ -14,6 +14,9 @@ MULTIPART
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 smtp
 </server>

--- a/tests/data/test650
+++ b/tests/data/test650
@@ -23,6 +23,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test651
+++ b/tests/data/test651
@@ -23,6 +23,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test652
+++ b/tests/data/test652
@@ -14,6 +14,9 @@ MIME
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 smtp
 </server>

--- a/tests/data/test653
+++ b/tests/data/test653
@@ -39,6 +39,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test654
+++ b/tests/data/test654
@@ -39,6 +39,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test666
+++ b/tests/data/test666
@@ -32,6 +32,9 @@ OK
 #
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test667
+++ b/tests/data/test667
@@ -32,6 +32,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test668
+++ b/tests/data/test668
@@ -32,6 +32,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test669
+++ b/tests/data/test669
@@ -21,6 +21,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test670
+++ b/tests/data/test670
@@ -32,6 +32,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test671
+++ b/tests/data/test671
@@ -32,6 +32,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test672
+++ b/tests/data/test672
@@ -32,6 +32,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test673
+++ b/tests/data/test673
@@ -32,6 +32,9 @@ hello
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test71
+++ b/tests/data/test71
@@ -21,6 +21,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>

--- a/tests/data/test9
+++ b/tests/data/test9
@@ -20,6 +20,9 @@ blablabla
 
 # Client-side
 <client>
+<features>
+Mime
+</features>
 <server>
 http
 </server>


### PR DESCRIPTION
`configure --disable-mime; make; make check` currently reports several tests failing. Condition their execution on mime support presence.