### PR TITLE
http, vauth: always provide Curl_allow_auth_to_host() functionality

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -721,21 +721,6 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data)
   return result;
 }
 
-/*
- * Curl_allow_auth_to_host() tells if authentication, cookies or other
- * "sensitive data" can (still) be sent to this host.
- */
-bool Curl_allow_auth_to_host(struct Curl_easy *data)
-{
-  struct connectdata *conn = data->conn;
-  return (!data->state.this_is_a_follow ||
-          data->set.allow_auth_to_other_hosts ||
-          (data->state.first_host &&
-           strcasecompare(data->state.first_host, conn->host.name) &&
-           (data->state.first_remote_port == conn->remote_port) &&
-           (data->state.first_remote_protocol == conn->handler->protocol)));
-}
-
 #ifndef CURL_DISABLE_HTTP_AUTH
 /*
  * Output the correct authentication header depending on the auth type
@@ -934,7 +919,7 @@ Curl_http_output_auth(struct Curl_easy *data,
 
   /* To prevent the user+password to get sent to other than the original host
      due to a location-follow */
-  if(Curl_allow_auth_to_host(data)
+  if(Curl_auth_allowed_to_host(data)
 #ifndef CURL_DISABLE_NETRC
      || conn->bits.netrc
 #endif
@@ -1988,7 +1973,7 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
                    checkprefix("Cookie:", compare)) &&
                   /* be careful of sending this potentially sensitive header to
                      other hosts */
-                  !Curl_allow_auth_to_host(data))
+                  !Curl_auth_allowed_to_host(data))
             ;
           else {
 #ifdef USE_HYPER

--- a/lib/http.h
+++ b/lib/http.h
@@ -392,10 +392,4 @@ Curl_http_output_auth(struct Curl_easy *data,
                       bool proxytunnel); /* TRUE if this is the request setting
                                             up the proxy tunnel */
 
-/*
- * Curl_allow_auth_to_host() tells if authentication, cookies or other
- * "sensitive data" can (still) be sent to this host.
- */
-bool Curl_allow_auth_to_host(struct Curl_easy *data);
-
 #endif /* HEADER_CURL_HTTP_H */

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -27,6 +27,8 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
+#include "urldata.h"
+#include "strcase.h"
 #include "curl_multibyte.h"
 #include "curl_printf.h"
 
@@ -143,4 +145,19 @@ bool Curl_auth_user_contains_domain(const char *user)
 #endif
 
   return valid;
+}
+
+/*
+ * Curl_auth_ollowed_to_host() tells if authentication, cookies or other
+ * "sensitive data" can (still) be sent to this host.
+ */
+bool Curl_auth_allowed_to_host(struct Curl_easy *data)
+{
+  struct connectdata *conn = data->conn;
+  return (!data->state.this_is_a_follow ||
+          data->set.allow_auth_to_other_hosts ||
+          (data->state.first_host &&
+           strcasecompare(data->state.first_host, conn->host.name) &&
+           (data->state.first_remote_port == conn->remote_port) &&
+           (data->state.first_remote_protocol == conn->handler->protocol)));
 }

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -54,6 +54,12 @@ struct gsasldata;
 #define GSS_ERROR(status) ((status) & 0x80000000)
 #endif
 
+/*
+ * Curl_auth_allowed_to_host() tells if authentication, cookies or other
+ * "sensitive data" can (still) be sent to this host.
+ */
+bool Curl_auth_allowed_to_host(struct Curl_easy *data);
+
 /* This is used to build a SPN string */
 #if !defined(USE_WINDOWS_SSPI)
 char *Curl_auth_build_spn(const char *service, const char *host,

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -45,6 +45,7 @@
 #include "inet_pton.h"
 #include "gtls.h"
 #include "vtls.h"
+#include "vauth/vauth.h"
 #include "parsedate.h"
 #include "connect.h" /* for the connect timeout */
 #include "select.h"
@@ -448,7 +449,7 @@ gtls_connect_step1(struct Curl_easy *data,
 
 #ifdef USE_GNUTLS_SRP
   if((SSL_SET_OPTION(primary.authtype) == CURL_TLSAUTH_SRP) &&
-     Curl_allow_auth_to_host(data)) {
+     Curl_auth_allowed_to_host(data)) {
     infof(data, "Using TLS-SRP username: %s",
           SSL_SET_OPTION(primary.username));
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -55,6 +55,7 @@
 #include "slist.h"
 #include "select.h"
 #include "vtls.h"
+#include "vauth/vauth.h"
 #include "keylog.h"
 #include "strcase.h"
 #include "hostcheck.h"
@@ -2833,7 +2834,7 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
 
 #ifdef USE_OPENSSL_SRP
   if((ssl_authtype == CURL_TLSAUTH_SRP) &&
-     Curl_allow_auth_to_host(data)) {
+     Curl_auth_allowed_to_host(data)) {
     char * const ssl_username = SSL_SET_OPTION(primary.username);
     char * const ssl_password = SSL_SET_OPTION(primary.password);
     infof(data, "Using TLS-SRP username: %s", ssl_username);


### PR DESCRIPTION
This function is currently located in the lib/http.c module and is therefore disabled by the `CURL_DISABLE_HTTP` conditional token.

As it may be called by TLS backends, disabling HTTP results in an undefined reference error at link time.

Move this function to vauth/vauth.c to always provide it and rename it as `Curl_auth_allowed_to_host`() to respect the vauth module naming convention.