### PR TITLE
configure: deprecate builds with small curl_off_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3388,6 +3388,18 @@ AC_CHECK_TYPE(long long,
 )
 
 
+if test ${ac_cv_sizeof_curl_off_t} -lt 8; then
+  AC_ARG_WITH(n64-deprecated,dnl
+AS_HELP_STRING([--with-n64-deprecated],[confirm you realize support for systems without 64 bit data types is going away]),
+  if test X"$withval" != Xno; then
+    OPT_N64_AWARE=$withval
+  fi
+)
+  if test -z "$OPT_N64_AWARE"; then
+    AC_MSG_ERROR([support for systems without 64 bit curl_off_t is deprecated, use --with-n64-deprecated until then])
+  fi
+fi
+
 # check for ssize_t
 AC_CHECK_TYPE(ssize_t, ,
    AC_DEFINE(ssize_t, int, [the signed version of size_t]))

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -23,6 +23,10 @@ compilers since the 1990s.
 
 Starting in 8.0.0 (March 2023), the plan is to drop support.
 
+Starting in 7.86.0, building curl with configure requires the additional flag
+`--with-n64-deprecated` if the `curl_off_t` type on your system is smaller
+than 8 bytes, in an attempt to highlight these plans to affected users.
+
 ## NSS
 
 We remove support for building curl with the NSS TLS library in August 2023.


### PR DESCRIPTION
If curl_off_t turns out to be smaller than 8 bytes, --with-n64-deprecated needs to be used to allow the build to continue. This is to highlight the fact that support for such builds is going away next year.