### PR TITLE
urlapi: reject more bad characters from the host name field

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -637,7 +637,7 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
   }
   else {
     /* letters from the second string are not ok */
-    len = strcspn(hostname, " \r\n\t/:#?!@");
+    len = strcspn(hostname, " \r\n\t/:#?!@{}[]\\$\'\"^`*<>=;");
     if(hlen != len)
       /* hostname with bad content */
       return CURLUE_BAD_HOSTNAME;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -637,7 +637,7 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
   }
   else {
     /* letters from the second string are not ok */
-    len = strcspn(hostname, " \r\n\t/:#?!@{}[]\\$\'\"^`*<>=;");
+    len = strcspn(hostname, " \r\n\t/:#?!@{}[]\\$\'\"^`*<>=;,");
     if(hlen != len)
       /* hostname with bad content */
       return CURLUE_BAD_HOSTNAME;

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -138,6 +138,25 @@ struct clearurlcase {
 };
 
 static const struct testcase get_parts_list[] ={
+  {"https://exam{}[]ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam{ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam}ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam]ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam\\ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam$ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam'ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam\"ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam^ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam`ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam*ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam<ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam>ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam=ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://exam;ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://example.net/}",
+   "https | [11] | [12] | [13] | example.net | [15] | /} | [16] | [17]",
+   0, 0, CURLUE_OK},
+
   /* blank user is blank */
   {"https://:password@example.net",
    "https |  | password | [13] | example.net | [15] | / | [16] | [17]",

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -153,6 +153,7 @@ static const struct testcase get_parts_list[] ={
   {"https://exam>ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam=ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam;ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
+  {"https://example,net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://example.net/}",
    "https | [11] | [12] | [13] | example.net | [15] | /} | [16] | [17]",
    0, 0, CURLUE_OK},


### PR DESCRIPTION
Extended test 1560 to verify

Report from the ongoing source code audit by Trail of Bits.