### PR TITLE
CURLSHOPT_UNLOCKFUNC.3: the callback as no 'access' argument

### DIFF
--- a/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
@@ -45,8 +45,6 @@ is released.
 The \fIdata\fP argument tells what kind of data libcurl wants to unlock. Make
 sure that the callback uses a different lock for each kind of data.
 
-\fIaccess\fP defines what access type libcurl wants, shared or single.
-
 \fIuserptr\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
 This pointer is not used by libcurl itself.
 .SH PROTOCOLS


### PR DESCRIPTION
Probably a copy and paste error from the lock function man page.

Reported-by: Robby Simpson
Fixes #9612