### PR TITLE
GHA: build tests in a separate step from the running of them

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,7 +166,10 @@ jobs:
     - run: make V=1 examples
       name: 'make examples'
 
+    - run: make V=1 -C tests
+      name: 'make tests'
+
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -110,8 +110,11 @@ jobs:
     - run: make V=1 examples
       name: 'make examples'
 
+    - run: make V=1 -C tests
+      name: 'make tests'
+
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }} ~1452"
 

--- a/.github/workflows/msh3.yml
+++ b/.github/workflows/msh3.yml
@@ -64,10 +64,10 @@ jobs:
     - run: make V=1
       name: 'make'
 
-    - run: make V=1 examples
-      name: 'make examples'
+    - run: make V=1 -C tests
+      name: 'make tests'
 
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -85,7 +85,10 @@ jobs:
     - run: make V=1 examples
       name: 'make examples'
 
+    - run: make V=1 -C tests
+      name: 'make tests'
+
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/ngtcp2-wolfssl.yml
+++ b/.github/workflows/ngtcp2-wolfssl.yml
@@ -77,7 +77,10 @@ jobs:
     - run: make V=1 examples
       name: 'make examples'
 
+    - run: make V=1 -C tests
+      name: 'make tests'
+
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -74,7 +74,10 @@ jobs:
     - run: make V=1 examples
       name: 'make examples'
 
+    - run: make V=1 -C tests
+      name: 'make tests'
+
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -54,7 +54,10 @@ jobs:
     - run: make V=1
       name: 'make'
 
-    - run: make V=1 test-torture
-      name: 'test'
+    - run: make V=1 -C tests
+      name: 'make tests'
+
+    - run: make V=1 test-ci
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -57,7 +57,7 @@ jobs:
     - run: make V=1 -C tests
       name: 'make tests'
 
-    - run: make V=1 test-ci
+    - run: make V=1 test-torture
       name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -66,7 +66,10 @@ jobs:
     - run: make V=1 examples
       name: 'make examples'
 
+    - run: make V=1 -C tests
+      name: 'make tests'
+
     - run: make V=1 test-ci
-      name: 'test'
+      name: 'run tests'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"


### PR DESCRIPTION
... to make the output smaller for when you want to look at test failures.