### PR TITLE
docs: spelling nits

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -426,7 +426,7 @@ Micrium
 MicroBlaze
 MicroOS
 mingw
-MingW
+MinGW
 MINIX
 misconfigured
 Mishyn

--- a/docs/FAQ
+++ b/docs/FAQ
@@ -1209,7 +1209,7 @@ FAQ
 
        Target:          static lib.   import lib for libcurl*.dll.
        -----------------------------------------------------------
-       MingW:           libcurl.a     libcurldll.a
+       MinGW:           libcurl.a     libcurldll.a
        MSVC (release):  libcurl.lib   libcurl_imp.lib
        MSVC (debug):    libcurld.lib  libcurld_imp.lib
        Borland:         libcurl.lib   libcurl_imp.lib

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -149,9 +149,9 @@ multi-threaded dynamic C runtime.
 
  If you get linkage errors read section 5.7 of the FAQ document.
 
-## MingW32
+## MinGW32
 
-Make sure that MingW32's bin directory is in the search path, for example:
+Make sure that MinGW32's bin directory is in the search path, for example:
 
 ```cmd
 set PATH=c:\mingw32\bin;%PATH%

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -24,14 +24,14 @@
 
 ###########################################################################
 #
-## Makefile for building curl examples with MingW (GCC-3.2 or later)
+## Makefile for building curl examples with MinGW (GCC-3.2 or later)
 ## and optionally OpenSSL (1.0.2a), libssh2 (1.5), zlib (1.2.8), librtmp (2.4),
 ## brotli (1.0.1), zstd (1.4.5)
 ##
 ## Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
 ## Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 ##
-## Hint: you can also set environment vars to control the build, f.e.:
+## Hint: you can also set environment vars to control the build, e.g.:
 ## set ZLIB_PATH=c:/zlib-1.2.8
 ## set ZLIB=1
 #

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -24,14 +24,14 @@
 
 ###########################################################################
 #
-## Makefile for building libcurl.a with MingW (GCC-3.2 or later or LLVM/Clang)
+## Makefile for building libcurl.a with MinGW (GCC-3.2 or later or LLVM/Clang)
 ## and optionally OpenSSL (1.0.2a), libssh2 (1.5), zlib (1.2.8), librtmp (2.4),
 ## brotli (1.0.1), zstd (1.4.5)
 ##
 ## Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
 ## Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 ##
-## Hint: you can also set environment vars to control the build, f.e.:
+## Hint: you can also set environment vars to control the build, e.g.:
 ## set ZLIB_PATH=c:/zlib-1.2.8
 ## set ZLIB=1
 #

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -742,12 +742,12 @@
 #define SHUT_RDWR 0x02
 #endif
 
-/* Define S_ISREG if not defined by system headers, f.e. MSVC */
+/* Define S_ISREG if not defined by system headers, e.g. MSVC */
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
 
-/* Define S_ISDIR if not defined by system headers, f.e. MSVC */
+/* Define S_ISDIR if not defined by system headers, e.g. MSVC */
 #if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -580,7 +580,7 @@ struct Curl_async {
   struct Curl_dns_entry *dns;
   struct thread_data *tdata;
   void *resolver; /* resolver state, if it is used in the URL state -
-                     ares_channel f.e. */
+                     ares_channel e.g. */
   int port;
   int status; /* if done is TRUE, this is the status from the callback */
   BIT(done);  /* set TRUE when the lookup is complete */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -108,7 +108,7 @@
 #define BCRYPT_SHA384_ALGORITHM L"SHA384"
 #endif
 
-/* Workaround broken compilers like MingW.
+/* Workaround broken compilers like MinGW.
    Return the number of elements in a statically sized array.
 */
 #ifndef ARRAYSIZE

--- a/packages/DOS/README
+++ b/packages/DOS/README
@@ -1,4 +1,4 @@
-Gisle Vanem made curl build fine on DOS (and MingW) with djgpp, OpenSSL and his
+Gisle Vanem made curl build fine on DOS (and MinGW) with djgpp, OpenSSL and his
 Watt-32 stack.
 
 'make -f Makefile.dist djgpp' in the root curl dir should build it fine.
@@ -11,7 +11,7 @@ Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
 Note 2: Compile Watt-32 (and OpenSSL) with the same version of djgpp.
         Otherwise things go wrong because things like FS-extensions and
         errnos have been changed between releases.
-        
+
 Note 3: Several 'USE_x' variables in 'common.dj' are on the 'USE_x ?= 0'
         form (conditional variable assignment). So one can build like this:
           c:\curl\lib> make -f makefile.dj USE_OPENSSL=1 USE_ZLIB=1 clean all

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -24,14 +24,14 @@
 
 ###########################################################################
 #
-## Makefile for building curl.exe with MingW (GCC-3.2 or later or LLVM/Clang)
+## Makefile for building curl.exe with MinGW (GCC-3.2 or later or LLVM/Clang)
 ## and optionally OpenSSL (1.0.2a), libssh2 (1.5), zlib (1.2.8), librtmp (2.4),
 ## brotli (1.0.1), zstd (1.4.5)
 ##
 ## Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
 ## Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 ##
-## Hint: you can also set environment vars to control the build, f.e.:
+## Hint: you can also set environment vars to control the build, e.g.:
 ## set ZLIB_PATH=c:/zlib-1.2.8
 ## set ZLIB=1
 #

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -273,11 +273,11 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
     /* VMS Note:
      *
      * Reading binary from files can be a problem...  Only FIXED, VAR
-     * etc WITHOUT implied CC will work Others need a \n appended to a
-     * line
+     * etc WITHOUT implied CC will work. Others need a \n appended to
+     * a line
      *
-     * - Stat gives a size but this is UNRELIABLE in VMS As a f.e. a
-     * fixed file with implied CC needs to have a byte added for every
+     * - Stat gives a size but this is UNRELIABLE in VMS. E.g.
+     * a fixed file with implied CC needs to have a byte added for every
      * record processed, this can be derived from Filesize & recordsize
      * for VARiable record files the records need to be counted!  for
      * every record add 1 for linefeed and subtract 2 for the record


### PR DESCRIPTION
- MingW -> MinGW (Minimalist GNU for Windows)
- f.e. -> e.g.
- some whitespace and punctuation.

Closes #xxxx