### PR TITLE
easy: fix the altsvc init for curl_easy_duphandle

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -944,7 +944,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
       goto fail;
   }
 
-#ifdef USE_ALTSVC
+#ifndef CURL_DISABLE_ALTSVC
   if(data->asi) {
     outcurl->asi = Curl_altsvc_init();
     if(!outcurl->asi)


### PR DESCRIPTION
It was using the old #ifdef which nothing sets anymore