### PR TITLE
ldap: delete stray CURL_HAS_MOZILLA_LDAP reference

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -565,7 +565,7 @@ Vista
 /*                           LDAP SUPPORT                           */
 /* ---------------------------------------------------------------- */
 
-#if defined(CURL_HAS_NOVELL_LDAPSDK) || defined(CURL_HAS_MOZILLA_LDAPSDK)
+#if defined(CURL_HAS_NOVELL_LDAPSDK)
 #undef USE_WIN32_LDAP
 #define HAVE_LDAP_SSL_H 1
 #define HAVE_LDAP_URL_PARSE 1


### PR DESCRIPTION
Added in 68b215157fdf69612edebdb220b3804822277822, while adding openldap support. This is also the single mention of this constant in the source tree and also in that commit. Based on these, it seems like an accident.

Delete this reference.

Closes #xxxx