### PR TITLE
feat.h: defines what features to enable

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -267,6 +267,7 @@ LIB_HFILES =         \
   easyif.h           \
   easyoptions.h      \
   escape.h           \
+  feat.h             \
   file.h             \
   fileinfo.h         \
   fopen.h            \

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -27,7 +27,7 @@
  */
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_ALTSVC)
+#ifdef FEAT_ALTSVC
 #include <curl/curl.h>
 #include "urldata.h"
 #include "altsvc.h"
@@ -463,7 +463,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
   unsigned short dstport = srcport; /* the same by default */
   CURLcode result = getalnum(&p, alpnbuf, sizeof(alpnbuf));
   size_t entries = 0;
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
   (void)data;
 #endif
   if(result) {
@@ -653,4 +653,4 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
   return FALSE;
 }
 
-#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_ALTSVC */
+#endif /* FEAT_ALTSVC */

--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_ALTSVC)
+#ifdef FEAT_ALTSVC
 #include <curl/curl.h>
 #include "llist.h"
 
@@ -77,5 +77,5 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
 /* disabled */
 #define Curl_altsvc_save(a,b,c)
 #define Curl_altsvc_cleanup(x)
-#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_ALTSVC */
+#endif /* FEAT_ALTSVC */
 #endif /* HEADER_CURL_ALTSVC_H */

--- a/lib/arpa_telnet.h
+++ b/lib/arpa_telnet.h
@@ -23,7 +23,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#ifndef CURL_DISABLE_TELNET
+#ifdef FEAT_TELNET
 /*
  * Telnet option defines. Add more here if in need.
  */
@@ -39,7 +39,7 @@
 #define CURL_NEW_ENV_VAR   0
 #define CURL_NEW_ENV_VALUE 1
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 /*
  * The telnet options represented as strings
  */
@@ -80,7 +80,7 @@ static const char * const telnetoptions[]=
 #define CURL_DONT 254 /* DON'T use this option! */
 #define CURL_IAC  255 /* Interpret As Command */
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 /*
  * Then those numbers represented as strings:
  */
@@ -105,6 +105,6 @@ static const char * const telnetcmds[]=
                        ((unsigned int)(x) <= CURL_TELCMD_MAXIMUM) )
 #define CURL_TELCMD(x)    telnetcmds[(x)-CURL_TELCMD_MINIMUM]
 
-#endif /* CURL_DISABLE_TELNET */
+#endif /* FEAT_TELNET */
 
 #endif /* HEADER_CURL_ARPA_TELNET_H */

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -26,12 +26,9 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP_AUTH) || defined(USE_SSH) || \
-  !defined(CURL_DISABLE_LDAP) || \
-  !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3) || \
-  !defined(CURL_DISABLE_IMAP) || \
-  !defined(CURL_DISABLE_DOH) || defined(USE_SSL)
+#if defined(FEAT_HTTP_AUTH) || defined(USE_SSH) || defined(FEAT_LDAP) || \
+  defined(FEAT_SMTP) || defined(FEAT_POP3) || defined(FEAT_IMAP) ||     \
+  defined(FEAT_DOH) || defined(USE_SSL)
 
 #include "urldata.h" /* for the Curl_easy definition */
 #include "warnless.h"

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_HYPER)
+#if defined(FEAT_HTTP) && defined(USE_HYPER)
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -1076,7 +1076,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
       goto error;
   }
 
-#ifndef CURL_DISABLE_ALTSVC
+#ifdef FEAT_ALTSVC
   if(conn->bits.altused && !Curl_checkheaders(data, STRCONST("Alt-Used"))) {
     char *altused = aprintf("Alt-Used: %s:%d\r\n",
                             conn->conn_to_host.name, conn->conn_to_port);
@@ -1091,7 +1091,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   }
 #endif
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->bits.httpproxy && !conn->bits.tunnel_proxy &&
      !Curl_checkheaders(data, STRCONST("Proxy-Connection")) &&
      !Curl_checkProxyheaders(data, conn, STRCONST("Proxy-Connection"))) {
@@ -1226,4 +1226,4 @@ void Curl_hyper_done(struct Curl_easy *data)
   }
 }
 
-#endif /* !defined(CURL_DISABLE_HTTP) && defined(USE_HYPER) */
+#endif /* defined(FEAT_HTTP) && defined(USE_HYPER) */

--- a/lib/c-hyper.h
+++ b/lib/c-hyper.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_HYPER)
+#if defined(FEAT_HTTP) && defined(USE_HYPER)
 
 #include <hyper.h>
 
@@ -56,5 +56,5 @@ void Curl_hyper_done(struct Curl_easy *);
 #else
 #define Curl_hyper_done(x)
 
-#endif /* !defined(CURL_DISABLE_HTTP) && defined(USE_HYPER) */
+#endif /* defined(FEAT_HTTP) && defined(USE_HYPER) */
 #endif /* HEADER_CURL_HYPER_H */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -139,7 +139,7 @@ static void hashkey(struct connectdata *conn, char *buf, size_t len)
   const char *hostname;
   long port = conn->remote_port;
   DEBUGASSERT(len >= HASHKEY_SIZE);
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->bits.httpproxy && !conn->bits.tunnel_proxy) {
     hostname = conn->http_proxy.host.name;
     port = conn->port;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -790,7 +790,7 @@ static CURLcode connect_SOCKS(struct Curl_easy *data, int sockindex,
                               bool *done)
 {
   CURLcode result = CURLE_OK;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   CURLproxycode pxresult = CURLPX_OK;
   struct connectdata *conn = data->conn;
   if(conn->bits.socksproxy) {
@@ -835,7 +835,7 @@ static CURLcode connect_SOCKS(struct Curl_easy *data, int sockindex,
 #else
     (void)data;
     (void)sockindex;
-#endif /* CURL_DISABLE_PROXY */
+#endif /* FEAT_PROXY */
     *done = TRUE; /* no SOCKS proxy, so consider us connected */
 
   return result;
@@ -995,7 +995,7 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
       SET_SOCKERRNO(error);
       if(conn->tempaddr[i]) {
         CURLcode status;
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
         char ipaddress[MAX_IPADR_LEN];
         char buffer[STRERROR_LEN];
         Curl_printable_address(conn->tempaddr[i], ipaddress,
@@ -1057,7 +1057,7 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
 
     result = failreason;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     if(conn->bits.socksproxy)
       hostname = conn->socks_proxy.host.name;
     else if(conn->bits.httpproxy)
@@ -1094,10 +1094,10 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
 
 static void tcpnodelay(struct Curl_easy *data, curl_socket_t sockfd)
 {
-#if defined(TCP_NODELAY)
+#ifdef TCP_NODELAY
   curl_socklen_t onoff = (curl_socklen_t) 1;
   int level = IPPROTO_TCP;
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
   char buffer[STRERROR_LEN];
 #else
   (void) data;
@@ -1124,7 +1124,7 @@ static void nosigpipe(struct Curl_easy *data,
   int onoff = 1;
   if(setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, (void *)&onoff,
                 sizeof(onoff)) < 0) {
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
     char buffer[STRERROR_LEN];
     infof(data, "Could not set SO_NOSIGPIPE: %s",
           Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
@@ -1691,7 +1691,7 @@ CURLcode Curl_socket(struct Curl_easy *data,
  */
 void Curl_conncontrol(struct connectdata *conn,
                       int ctrl /* see defines in header */
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
                       , const char *reason
 #endif
   )
@@ -1701,7 +1701,7 @@ void Curl_conncontrol(struct connectdata *conn,
      associated with a transfer. */
   bool closeit;
   DEBUGASSERT(conn);
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   (void)reason; /* useful for debugging */
 #endif
   closeit = (ctrl == CONNCTRL_CONNECTION) ||

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -138,16 +138,16 @@ CURLcode Curl_socket(struct Curl_easy *data,
 
 void Curl_conncontrol(struct connectdata *conn,
                       int closeit
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
                       , const char *reason
 #endif
   );
 
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
 #define streamclose(x,y) Curl_conncontrol(x, CONNCTRL_STREAM, y)
 #define connclose(x,y) Curl_conncontrol(x, CONNCTRL_CONNECTION, y)
 #define connkeep(x,y) Curl_conncontrol(x, CONNCTRL_KEEP, y)
-#else /* if !DEBUGBUILD || CURL_DISABLE_VERBOSE_STRINGS */
+#else /* if !DEBUGBUILD || !FEAT_VERBOSE_STRINGS */
 #define streamclose(x,y) Curl_conncontrol(x, CONNCTRL_STREAM)
 #define connclose(x,y) Curl_conncontrol(x, CONNCTRL_CONNECTION)
 #define connkeep(x,y) Curl_conncontrol(x, CONNCTRL_KEEP)

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -50,7 +50,7 @@
 
 #define CONTENT_ENCODING_DEFAULT  "identity"
 
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
 
 #define DSIZ CURL_MAX_WRITE_SIZE /* buffer size for decompressed data */
 
@@ -1128,4 +1128,4 @@ char *Curl_all_content_encodings(void)
   return strdup(CONTENT_ENCODING_DEFAULT);  /* Satisfy caller. */
 }
 
-#endif /* CURL_DISABLE_HTTP */
+#endif /* !FEAT_HTTP */

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -85,7 +85,7 @@ Example set of cookies:
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
 
 #include "urldata.h"
 #include "cookie.h"
@@ -502,7 +502,7 @@ Curl_cookie_add(struct Curl_easy *data,
   bool badcookie = FALSE; /* cookies are good by default. mmmmm yummy */
   size_t myhash;
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
   (void)data;
 #endif
 
@@ -1820,4 +1820,4 @@ void Curl_flush_cookies(struct Curl_easy *data, bool cleanup)
   Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
 }
 
-#endif /* CURL_DISABLE_HTTP || CURL_DISABLE_COOKIES */
+#endif /* FEAT_HTTP || FEAT_COOKIES */

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -122,7 +122,7 @@ void Curl_cookie_freelist(struct Cookie *cookies);
 void Curl_cookie_clearall(struct CookieInfo *cookies);
 void Curl_cookie_clearsess(struct CookieInfo *cookies);
 
-#if defined(CURL_DISABLE_HTTP) || defined(CURL_DISABLE_COOKIES)
+#if !defined(FEAT_HTTP) || !defined(FEAT_COOKIES)
 #define Curl_cookie_list(x) NULL
 #define Curl_cookie_loadfiles(x) Curl_nop_stmt
 #define Curl_cookie_init(x,y,z,w) NULL

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 #include <curl/curl.h>
 
 #include "curl_fnmatch.h"

--- a/lib/curl_get_line.c
+++ b/lib/curl_get_line.c
@@ -24,8 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC) ||  \
-  !defined(CURL_DISABLE_HSTS)
+#if defined(FEAT_COOKIES) || defined(FEAT_ALTSVC) || defined(FEAT_HSTS)
 
 #include "curl_get_line.h"
 #include "curl_memory.h"

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -137,7 +137,7 @@ void Curl_gss_log_error(struct Curl_easy *data, const char *prefix,
   display_gss_error(minor, GSS_C_MECH_CODE, buf, len);
 
   infof(data, "%s%s", prefix, buf);
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
   (void)data;
   (void)prefix;
 #endif

--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -24,7 +24,7 @@
  *
  ***************************************************************************/
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 
 #include <curl/curl.h>
 

--- a/lib/curl_ldap.h
+++ b/lib/curl_ldap.h
@@ -23,10 +23,10 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#ifndef CURL_DISABLE_LDAP
+#ifdef FEAT_LDAP
 extern const struct Curl_handler Curl_handler_ldap;
 
-#if !defined(CURL_DISABLE_LDAPS) && \
+#if defined(FEAT_LDAPS) && \
     ((defined(USE_OPENLDAP) && defined(USE_SSL)) || \
      (!defined(USE_OPENLDAP) && defined(HAVE_LDAP_SSL)))
 extern const struct Curl_handler Curl_handler_ldaps;

--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -26,13 +26,13 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 
 #define MD4_DIGEST_LENGTH 16
 
 void Curl_md4it(unsigned char *output, const unsigned char *input,
                 const size_t len);
 
-#endif /* !defined(CURL_DISABLE_CRYPTO_AUTH) */
+#endif /* FEAT_CRYPTO_AUTH */
 
 #endif /* HEADER_CURL_MD4_H */

--- a/lib/curl_md5.h
+++ b/lib/curl_md5.h
@@ -24,7 +24,7 @@
  *
  ***************************************************************************/
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 #include "curl_hmac.h"
 
 #define MD5_DIGEST_LEN  16

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -24,8 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM) && \
-    defined(NTLM_WB_ENABLED)
+#if defined(FEAT_HTTP) && defined(USE_NTLM) && defined(NTLM_WB_ENABLED)
 
 /*
  * NTLM details:
@@ -129,7 +128,7 @@ static CURLcode ntlm_wb_init(struct Curl_easy *data, struct ntlmdata *ntlm,
 #endif
   char buffer[STRERROR_LEN];
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) data;
 #endif
 
@@ -399,7 +398,7 @@ CURLcode Curl_output_ntlm_wb(struct Curl_easy *data, struct connectdata *conn,
   DEBUGASSERT(data);
 
   if(proxy) {
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     allocuserpwd = &data->state.aptr.proxyuserpwd;
     userp = conn->http_proxy.user;
     ntlm = &conn->proxyntlm;
@@ -497,4 +496,4 @@ void Curl_http_auth_cleanup_ntlm_wb(struct connectdata *conn)
   ntlm_wb_cleanup(&conn->proxyntlm);
 }
 
-#endif /* !CURL_DISABLE_HTTP && USE_NTLM && NTLM_WB_ENABLED */
+#endif /* FEAT_HTTP && USE_NTLM && NTLM_WB_ENABLED */

--- a/lib/curl_ntlm_wb.h
+++ b/lib/curl_ntlm_wb.h
@@ -26,8 +26,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM) && \
-    defined(NTLM_WB_ENABLED)
+#if defined(FEAT_HTTP) && defined(USE_NTLM) && defined(NTLM_WB_ENABLED)
 
 /* this is for ntlm header input */
 CURLcode Curl_input_ntlm_wb(struct Curl_easy *data,
@@ -40,6 +39,6 @@ CURLcode Curl_output_ntlm_wb(struct Curl_easy *data, struct connectdata *conn,
 
 void Curl_http_auth_cleanup_ntlm_wb(struct connectdata *conn);
 
-#endif /* !CURL_DISABLE_HTTP && USE_NTLM && NTLM_WB_ENABLED */
+#endif /* FEAT_HTTP && USE_NTLM && NTLM_WB_ENABLED */
 
 #endif /* HEADER_CURL_NTLM_WB_H */

--- a/lib/curl_range.c
+++ b/lib/curl_range.c
@@ -28,8 +28,7 @@
 #include "sendf.h"
 #include "strtoofft.h"
 
-/* Only include this function if one or more of FTP, FILE are enabled. */
-#if !defined(CURL_DISABLE_FTP) || !defined(CURL_DISABLE_FILE)
+#if defined(FEAT_FTP) || defined(FEAT_FILE)
 
  /*
   Check if this is a range download, and if so, set the internal variables

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -35,8 +35,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3)
+#if defined(FEAT_IMAP) || defined(FEAT_SMTP) || defined(FEAT_POP3)
 
 #include <curl/curl.h>
 #include "urldata.h"
@@ -226,7 +225,7 @@ void Curl_sasl_init(struct SASL *sasl, struct Curl_easy *data,
 static void state(struct SASL *sasl, struct Curl_easy *data,
                   saslstate newstate)
 {
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[]={
     "STOP",
@@ -417,7 +416,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
     }
     else
 #endif
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
     if((enabledmechs & SASL_MECH_DIGEST_MD5) &&
        Curl_auth_is_digest_supported()) {
       mech = SASL_MECH_STRING_DIGEST_MD5;
@@ -527,8 +526,7 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
   struct bufref resp;
   const char * const hostname = SSL_HOST_NAME();
   const long int port = SSL_HOST_PORT();
-#if !defined(CURL_DISABLE_CRYPTO_AUTH) || defined(USE_KERBEROS5) ||     \
-  defined(USE_NTLM)
+#if defined(FEAT_CRYPTO_AUTH) || defined(USE_KERBEROS5) || defined(USE_NTLM)
   const char *service = data->set.str[STRING_SERVICE_NAME] ?
     data->set.str[STRING_SERVICE_NAME] :
     sasl->params->service;
@@ -573,7 +571,7 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
   case SASL_EXTERNAL:
     result = Curl_auth_create_external_message(conn->user, &resp);
     break;
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 #ifdef USE_GSASL
   case SASL_GSASL:
     result = get_server_message(sasl, data, &serverdata);

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,6 +28,8 @@
 #define CURL_NO_OLDIES
 #endif
 
+#include "feat.h"
+
 /* define mingw version macros, eg __MINGW{32,64}_{MINOR,MAJOR}_VERSION */
 #ifdef __MINGW32__
 #include <_mingw.h>
@@ -157,63 +159,6 @@
 /*  If you need to include a system header file for your platform,  */
 /*  please, do it beyond the point further indicated in this file.  */
 /* ================================================================ */
-
-/*
- * Disable other protocols when http is the only one desired.
- */
-
-#ifdef HTTP_ONLY
-#  ifndef CURL_DISABLE_DICT
-#    define CURL_DISABLE_DICT
-#  endif
-#  ifndef CURL_DISABLE_FILE
-#    define CURL_DISABLE_FILE
-#  endif
-#  ifndef CURL_DISABLE_FTP
-#    define CURL_DISABLE_FTP
-#  endif
-#  ifndef CURL_DISABLE_GOPHER
-#    define CURL_DISABLE_GOPHER
-#  endif
-#  ifndef CURL_DISABLE_IMAP
-#    define CURL_DISABLE_IMAP
-#  endif
-#  ifndef CURL_DISABLE_LDAP
-#    define CURL_DISABLE_LDAP
-#  endif
-#  ifndef CURL_DISABLE_LDAPS
-#    define CURL_DISABLE_LDAPS
-#  endif
-#  ifndef CURL_DISABLE_MQTT
-#    define CURL_DISABLE_MQTT
-#  endif
-#  ifndef CURL_DISABLE_POP3
-#    define CURL_DISABLE_POP3
-#  endif
-#  ifndef CURL_DISABLE_RTSP
-#    define CURL_DISABLE_RTSP
-#  endif
-#  ifndef CURL_DISABLE_SMB
-#    define CURL_DISABLE_SMB
-#  endif
-#  ifndef CURL_DISABLE_SMTP
-#    define CURL_DISABLE_SMTP
-#  endif
-#  ifndef CURL_DISABLE_TELNET
-#    define CURL_DISABLE_TELNET
-#  endif
-#  ifndef CURL_DISABLE_TFTP
-#    define CURL_DISABLE_TFTP
-#  endif
-#endif
-
-/*
- * When http is disabled rtsp is not supported.
- */
-
-#if defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_RTSP)
-#  define CURL_DISABLE_RTSP
-#endif
 
 /* ================================================================ */
 /* No system header file shall be included in this file before this */
@@ -625,7 +570,7 @@
 #      error MSVC 6.0 requires "February 2003 Platform SDK" a.k.a. \
              "Windows Server 2003 PSDK"
 #    else
-#      define CURL_DISABLE_LDAP 1
+#      undef FEAT_LDAP
 #    endif
 #  endif
 #endif
@@ -650,23 +595,23 @@
 #endif
 
 /* Single point where USE_SPNEGO definition might be defined */
-#if !defined(CURL_DISABLE_CRYPTO_AUTH) && \
-    (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))
+#if defined(FEAT_CRYPTO_AUTH) &&                        \
+  (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))
 #define USE_SPNEGO
 #endif
 
 /* Single point where USE_KERBEROS5 definition might be defined */
-#if !defined(CURL_DISABLE_CRYPTO_AUTH) && \
-    (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))
+#if defined(FEAT_CRYPTO_AUTH) && \
+  (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))
 #define USE_KERBEROS5
 #endif
 
 /* Single point where USE_NTLM definition might be defined */
-#if !defined(CURL_DISABLE_CRYPTO_AUTH) && !defined(CURL_DISABLE_NTLM)
-#  if defined(USE_OPENSSL) || defined(USE_MBEDTLS) ||                       \
-      defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_SECTRANSP) ||  \
-      defined(USE_OS400CRYPTO) || defined(USE_WIN32_CRYPTO) ||              \
-      (defined(USE_WOLFSSL) && defined(HAVE_WOLFSSL_DES_ECB_ENCRYPT))
+#if defined(FEAT_CRYPTO_AUTH) && defined(FEAT_NTLM)
+#  if defined(USE_OPENSSL) || defined(USE_MBEDTLS) ||                   \
+  defined(USE_GNUTLS) || defined(USE_NSS) || defined(USE_SECTRANSP) ||  \
+  defined(USE_OS400CRYPTO) || defined(USE_WIN32_CRYPTO) ||              \
+  (defined(USE_WOLFSSL) && defined(HAVE_WOLFSSL_DES_ECB_ENCRYPT))
 #    define USE_CURL_NTLM_CORE
 #  endif
 #  if defined(USE_CURL_NTLM_CORE) || defined(USE_WINDOWS_SSPI)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,8 +28,6 @@
 #define CURL_NO_OLDIES
 #endif
 
-#include "feat.h"
-
 /* define mingw version macros, eg __MINGW{32,64}_{MINOR,MAJOR}_VERSION */
 #ifdef __MINGW32__
 #include <_mingw.h>
@@ -115,6 +113,8 @@
 #endif
 
 #endif /* HAVE_CONFIG_H */
+
+#include "feat.h"
 
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -25,7 +25,7 @@
  *
  ***************************************************************************/
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 #include <curl/curl.h>
 #include "curl_hmac.h"
 

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_DICT
+#ifdef FEAT_DICT
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -319,4 +319,4 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
 
   return CURLE_OK;
 }
-#endif /*CURL_DISABLE_DICT*/
+#endif /* FEAT_DICT */

--- a/lib/dict.h
+++ b/lib/dict.h
@@ -24,7 +24,7 @@
  *
  ***************************************************************************/
 
-#ifndef CURL_DISABLE_DICT
+#ifdef FEAT_DICT
 extern const struct Curl_handler Curl_handler_dict;
 #endif
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
 
 #include "urldata.h"
 #include "curl_addrinfo.h"
@@ -45,7 +45,7 @@
 
 #define DNS_CLASS_IN 0x01
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static const char * const errors[]={
   "",
   "Bad label",
@@ -727,7 +727,7 @@ UNITTEST DOHcode doh_decode(const unsigned char *doh,
   return DOH_OK; /* ok */
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static void showdoh(struct Curl_easy *data,
                     const struct dohentry *d)
 {
@@ -873,7 +873,7 @@ doh2ai(const struct dohentry *de, const char *hostname, int port)
   return firstai;
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static const char *type2name(DNStype dnstype)
 {
   return (dnstype == DNS_TYPE_A)?"A":"AAAA";
@@ -979,4 +979,4 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_DOH */
+#endif /* FEAT_DOH */

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -27,7 +27,7 @@
 #include "urldata.h"
 #include "curl_addrinfo.h"
 
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
 
 typedef enum {
   DOH_OK,

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -454,7 +454,7 @@ static int events_socket(struct Curl_easy *easy,      /* easy handle */
   struct socketmonitor *m;
   struct socketmonitor *prev = NULL;
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) easy;
 #endif
   (void)socketp;
@@ -902,7 +902,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   outcurl->progress.flags    = data->progress.flags;
   outcurl->progress.callback = data->progress.callback;
 
-#ifndef CURL_DISABLE_COOKIES
+#ifdef FEAT_COOKIES
   if(data->cookies) {
     /* If cookies are enabled in the parent handle, we enable them
        in the clone as well! */
@@ -944,7 +944,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
       goto fail;
   }
 
-#ifndef CURL_DISABLE_ALTSVC
+#ifdef FEAT_ALTSVC
   if(data->asi) {
     outcurl->asi = Curl_altsvc_init();
     if(!outcurl->asi)
@@ -953,7 +953,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
       (void)Curl_altsvc_load(outcurl->asi, outcurl->set.str[STRING_ALTSVC]);
   }
 #endif
-#ifndef CURL_DISABLE_HSTS
+#ifdef FEAT_HSTS
   if(data->hsts) {
     outcurl->hsts = Curl_hsts_init();
     if(!outcurl->hsts)
@@ -1003,7 +1003,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   fail:
 
   if(outcurl) {
-#ifndef CURL_DISABLE_COOKIES
+#ifdef FEAT_COOKIES
     curl_slist_free_all(outcurl->state.cookielist);
     outcurl->state.cookielist = NULL;
 #endif
@@ -1047,7 +1047,7 @@ void curl_easy_reset(struct Curl_easy *data)
   memset(&data->state.authhost, 0, sizeof(struct auth));
   memset(&data->state.authproxy, 0, sizeof(struct auth));
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(FEAT_HTTP) && defined(FEAT_CRYPTO_AUTH)
   Curl_http_auth_cleanup_digest(data);
 #endif
 }

--- a/lib/easygetopt.c
+++ b/lib/easygetopt.c
@@ -26,7 +26,7 @@
 #include "strcase.h"
 #include "easyoptions.h"
 
-#ifndef CURL_DISABLE_GETOPTIONS
+#ifdef FEAT_GETOPTIONS
 
 /* Lookups easy options at runtime */
 static struct curl_easyoption *lookup(const char *name, CURLoption id)

--- a/lib/feat.h
+++ b/lib/feat.h
@@ -69,9 +69,9 @@
 #endif
 #ifndef CURL_DISABLE_LDAP
 #define FEAT_LDAP /* protocol */
-#endif
 #ifndef CURL_DISABLE_LDAPS
 #define FEAT_LDAPS /* protocol */
+#endif
 #endif
 #ifndef CURL_DISABLE_LIBCURL_OPTION
 #define FEAT_LIBCURL_OPTION

--- a/lib/feat.h
+++ b/lib/feat.h
@@ -1,0 +1,161 @@
+#ifndef HEADER_CURL_FEAT_H
+#define HEADER_CURL_FEAT_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#ifndef CURL_DISABLE_ALTSVC
+#ifndef CURL_DISABLE_HTTP
+#define FEAT_ALTSVC
+#endif
+#endif
+#ifndef CURL_DISABLE_COOKIES
+#define FEAT_COOKIES
+#endif
+#ifndef CURL_DISABLE_CRYPTO_AUTH
+#define FEAT_CRYPTO_AUTH
+#endif
+#ifndef CURL_DISABLE_DICT
+#define FEAT_DICT /* protocol */
+#endif
+#ifndef CURL_DISABLE_DOH
+#define FEAT_DOH
+#endif
+#ifndef CURL_DISABLE_FILE
+#define FEAT_FILE /* protocol */
+#endif
+#ifndef CURL_DISABLE_FTP
+#define FEAT_FTP /* protocol */
+#endif
+#ifndef CURL_DISABLE_GETOPTIONS
+#define FEAT_GETOPTIONS
+#endif
+#ifndef CURL_DISABLE_GOPHER
+#define FEAT_GOPHER /* protocol */
+#endif
+#ifndef CURL_DISABLE_HEADERS_API
+#define FEAT_HEADERS_API
+#endif
+#ifndef CURL_DISABLE_HSTS
+#define FEAT_HSTS
+#endif
+#ifndef CURL_DISABLE_HTTP
+#define FEAT_HTTP /* protocol */
+#endif
+#ifndef CURL_DISABLE_HTTP_AUTH
+#define FEAT_HTTP_AUTH
+#endif
+#ifndef CURL_DISABLE_IMAP
+#define FEAT_IMAP /* protocol */
+#endif
+#ifndef CURL_DISABLE_LDAP
+#define FEAT_LDAP /* protocol */
+#endif
+#ifndef CURL_DISABLE_LDAPS
+#define FEAT_LDAPS /* protocol */
+#endif
+#ifndef CURL_DISABLE_LIBCURL_OPTION
+#define FEAT_LIBCURL_OPTION
+#endif
+#ifndef CURL_DISABLE_MIME
+#define FEAT_MIME
+#endif
+#ifndef CURL_DISABLE_MQTT
+#define FEAT_MQTT /* protocol */
+#endif
+#ifndef CURL_DISABLE_NETRC
+#define FEAT_NETRC
+#endif
+#ifndef CURL_DISABLE_NTLM
+#define FEAT_NTLM
+#endif
+#ifndef CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG
+#define FEAT_OPENSSL_AUTO_LOAD_CONFIG
+#endif
+#ifndef CURL_DISABLE_PARSEDATE
+#define FEAT_PARSEDATE
+#endif
+#ifndef CURL_DISABLE_POP3
+#define FEAT_POP3 /* protocol */
+#endif
+#ifndef CURL_DISABLE_PROGRESS_METER
+#define FEAT_PROGRESS_METER
+#endif
+#ifndef CURL_DISABLE_PROXY
+#define FEAT_PROXY
+#endif
+#ifndef CURL_DISABLE_RTSP
+#define FEAT_RTSP /* protocol */
+#endif
+#ifndef CURL_DISABLE_SHUFFLE_DNS
+#define FEAT_SHUFFLE_DNS
+#endif
+#ifndef CURL_DISABLE_SMB
+#define FEAT_SMB /* protocol */
+#endif
+#ifndef CURL_DISABLE_SMTP
+#define FEAT_SMTP /* protocol */
+#endif
+#ifndef CURL_DISABLE_SOCKETPAIR
+#define FEAT_SOCKETPAIR
+#endif
+#ifndef CURL_DISABLE_TELNET
+#define FEAT_TELNET /* protocol */
+#endif
+#ifndef CURL_DISABLE_TFTP
+#define FEAT_TFTP /* protocol */
+#endif
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#define FEAT_VERBOSE_STRINGS
+#endif
+
+#ifdef USE_WEBSOCKETS
+#define FEAT_WS
+#endif
+
+/* Disable all other protocols when http is the only one desired. */
+#ifdef HTTP_ONLY
+  #undef FEAT_DICT
+  #undef FEAT_FILE
+  #undef FEAT_FTP
+  #undef FEAT_GOPHER
+  #undef FEAT_IMAP
+  #undef FEAT_LDAP
+  #undef FEAT_LDAPS
+  #undef FEAT_MQTT
+  #undef FEAT_POP3
+  #undef FEAT_RTSP
+  #undef FEAT_SMB
+  #undef FEAT_SMTP
+  #undef FEAT_TELNET
+  #undef FEAT_TFTP
+  #undef FEAT_WS
+#endif
+
+/* When HTTP is disabled, RTSP is not supported. */
+
+#ifndef FEAT_HTTP
+#undef FEAT_RTSP
+#endif
+
+
+#endif /* HEADER_CURL_FEAT_H */

--- a/lib/file.c
+++ b/lib/file.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_FILE
+#ifdef FEAT_FILE
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>

--- a/lib/file.h
+++ b/lib/file.h
@@ -35,7 +35,7 @@ struct FILEPROTO {
   int fd;     /* open file descriptor to read from! */
 };
 
-#ifndef CURL_DISABLE_FILE
+#ifdef FEAT_FILE
 extern const struct Curl_handler Curl_handler_file;
 #endif
 

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 #include "strdup.h"
 #include "fileinfo.h"
 #include "curl_memory.h"

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -24,8 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC) ||  \
-  !defined(CURL_DISABLE_HSTS)
+#if defined(FEAT_COOKIES) || defined(FEAT_ALTSVC) || defined(FEAT_HSTS)
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -27,7 +27,7 @@
 #include <curl/curl.h>
 
 #include "formdata.h"
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_MIME)
+#if defined(FEAT_HTTP) && defined(FEAT_MIME)
 
 #if defined(HAVE_LIBGEN_H) && defined(HAVE_BASENAME)
 #include <libgen.h>

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_MIME
+#ifdef FEAT_MIME
 
 /* used by FormAdd for temporary storage */
 struct FormInfo {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -91,7 +91,7 @@
 #define INET_ADDRSTRLEN 16
 #endif
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
 #define ftp_pasv_verbose(a,b,c,d)  Curl_nop_stmt
 #endif
 
@@ -113,7 +113,7 @@ static CURLcode ftp_sendquote(struct Curl_easy *data,
 static CURLcode ftp_quit(struct Curl_easy *data, struct connectdata *conn);
 static CURLcode ftp_parse_url_path(struct Curl_easy *data);
 static CURLcode ftp_regular_transfer(struct Curl_easy *data, bool *done);
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static void ftp_pasv_verbose(struct Curl_easy *data,
                              struct Curl_addrinfo *ai,
                              char *newhost, /* ascii version */
@@ -224,7 +224,7 @@ static void close_secondarysocket(struct Curl_easy *data,
     conn->sock[SECONDARYSOCKET] = CURL_SOCKET_BAD;
   }
   conn->bits.tcpconnect[SECONDARYSOCKET] = FALSE;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   conn->bits.proxy_ssl_connected[SECONDARYSOCKET] = FALSE;
 #endif
 }
@@ -712,7 +712,7 @@ CURLcode Curl_GetFTPResponse(struct Curl_easy *data,
   return result;
 }
 
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
 static const char * const ftp_state_names[]={
   "STOP",
@@ -765,8 +765,7 @@ static void _state(struct Curl_easy *data,
   struct ftp_conn *ftpc = &conn->proto.ftpc;
 
 #if defined(DEBUGBUILD)
-
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) lineno;
 #else
   if(ftpc->state != newstate)
@@ -1794,7 +1793,7 @@ static CURLcode ftp_epsv_disable(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
 
   if(conn->bits.ipv6
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
      && !(conn->bits.tunnel_proxy || conn->bits.socksproxy)
 #endif
     ) {
@@ -1824,7 +1823,7 @@ static char *control_address(struct connectdata *conn)
      If a proxy tunnel is used, returns the original host name instead, because
      the effective control connection address is the proxy address,
      not the ftp host. */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->bits.tunnel_proxy || conn->bits.socksproxy)
     return conn->host.name;
 #endif
@@ -1944,7 +1943,7 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
     return CURLE_FTP_WEIRD_PASV_REPLY;
   }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->bits.proxy) {
     /*
      * This connection uses a proxy and we need to connect to the proxy again
@@ -3536,7 +3535,7 @@ static CURLcode ftp_nb_type(struct Curl_easy *data,
  * possibly new IP address.
  *
  */
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static void
 ftp_pasv_verbose(struct Curl_easy *data,
                  struct Curl_addrinfo *ai,
@@ -3599,7 +3598,7 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
     }
   }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   result = Curl_proxy_connect(data, SECONDARYSOCKET);
   if(result)
     return result;
@@ -4420,4 +4419,4 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_FTP */
+#endif /* FEAT_FTP */

--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -28,7 +28,7 @@
 
 #include "pingpong.h"
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 extern const struct Curl_handler Curl_handler_ftp;
 
 #ifdef USE_SSL
@@ -37,7 +37,7 @@ extern const struct Curl_handler Curl_handler_ftps;
 
 CURLcode Curl_GetFTPResponse(struct Curl_easy *data, ssize_t *nread,
                              int *ftpcode);
-#endif /* CURL_DISABLE_FTP */
+#endif /* FEAT_FTP */
 
 /****************************************************************************
  * FTP unique setup

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -39,7 +39,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 
 #include <curl/curl.h>
 
@@ -1017,4 +1017,4 @@ fail:
   return retsize;
 }
 
-#endif /* CURL_DISABLE_FTP */
+#endif /* FEAT_FTP */

--- a/lib/ftplistparser.h
+++ b/lib/ftplistparser.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 
 /* WRITEFUNCTION callback for parsing LIST responses */
 size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
@@ -39,5 +39,5 @@ struct ftp_parselist_data *Curl_ftp_parselist_data_alloc(void);
 
 void Curl_ftp_parselist_data_free(struct ftp_parselist_data **pl_data);
 
-#endif /* CURL_DISABLE_FTP */
+#endif /* FEAT_FTP */
 #endif /* HEADER_CURL_FTPLISTPARSER_H */

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -103,7 +103,7 @@ static CURLcode getinfo_char(struct Curl_easy *data, CURLINFO info,
     if(!m) {
       if(data->set.opt_no_body)
         m = "HEAD";
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
       else {
         switch(data->state.httpreq) {
         case HTTPREQ_POST:
@@ -249,7 +249,7 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
   case CURLINFO_SSL_VERIFYRESULT:
     *param_longp = data->set.ssl.certverifyresult;
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLINFO_PROXY_SSL_VERIFYRESULT:
     *param_longp = data->set.proxy_ssl.certverifyresult;
     break;
@@ -301,7 +301,7 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
       /* return if the condition prevented the document to get transferred */
       *param_longp = data->info.timecond ? 1L : 0L;
     break;
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
   case CURLINFO_RTSP_CLIENT_CSEQ:
     *param_longp = data->state.rtsp_next_client_CSeq;
     break;

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_GOPHER
+#ifdef FEAT_GOPHER
 
 #include "urldata.h"
 #include <curl/curl.h>
@@ -236,4 +236,4 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
   Curl_setup_transfer(data, FIRSTSOCKET, -1, FALSE, -1);
   return CURLE_OK;
 }
-#endif /*CURL_DISABLE_GOPHER*/
+#endif /* FEAT_GOPHER */

--- a/lib/gopher.h
+++ b/lib/gopher.h
@@ -24,7 +24,7 @@
  *
  ***************************************************************************/
 
-#ifndef CURL_DISABLE_GOPHER
+#ifdef FEAT_GOPHER
 extern const struct Curl_handler Curl_handler_gopher;
 #ifdef USE_SSL
 extern const struct Curl_handler Curl_handler_gophers;

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -34,7 +34,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_HEADERS_API)
+#if defined(FEAT_HTTP) && defined(FEAT_HEADERS_API)
 
 /* Generate the curl_header struct for the user. This function MUST assign all
    struct fields in the output struct. */

--- a/lib/headers.h
+++ b/lib/headers.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_HEADERS_API)
+#if defined(FEAT_HTTP) && defined(FEAT_HEADERS_API)
 
 struct Curl_header_store {
   struct Curl_llist_element node;

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 
 #include <curl/curl.h>
 
@@ -169,4 +169,4 @@ CURLcode Curl_hmacit(const struct HMAC_params *hashparams,
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_CRYPTO_AUTH */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -358,7 +358,7 @@ Curl_fetch_addr(struct Curl_easy *data,
   return dns;
 }
 
-#ifndef CURL_DISABLE_SHUFFLE_DNS
+#ifdef FEAT_SHUFFLE_DNS
 UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
                                     struct Curl_addrinfo **addr);
 /*
@@ -447,7 +447,7 @@ Curl_cache_addr(struct Curl_easy *data,
   struct Curl_dns_entry *dns;
   struct Curl_dns_entry *dns2;
 
-#ifndef CURL_DISABLE_SHUFFLE_DNS
+#ifdef FEAT_SHUFFLE_DNS
   /* shuffle addresses if requested */
   if(data->set.dns_shuffle_addresses) {
     CURLcode result = Curl_shuffle_addr(data, &addr);
@@ -649,7 +649,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
   enum resolve_t rc = CURLRESOLV_ERROR; /* default to failure */
   struct connectdata *conn = data->conn;
   *entry = NULL;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   conn->bits.doh = FALSE; /* default is not */
 #else
   (void)allowDOH;
@@ -674,15 +674,11 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
 
     struct Curl_addrinfo *addr = NULL;
     int respwait = 0;
-#if !defined(CURL_DISABLE_DOH) || !defined(USE_RESOLVE_ON_IPS)
+#if defined(FEAT_DOH) || !defined(USE_RESOLVE_ON_IPS)
     struct in_addr in;
-#endif
-#ifndef CURL_DISABLE_DOH
-#ifndef USE_RESOLVE_ON_IPS
     const
 #endif
       bool ipnum = FALSE;
-#endif
 
     /* notify the resolver start callback */
     if(data->set.resolver_start) {
@@ -734,7 +730,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
 #endif /* ENABLE_IPV6 */
 
 #else /* if USE_RESOLVE_ON_IPS */
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
     /* First check if this is an IPv4 address string */
     if(Curl_inet_pton(AF_INET, hostname, &in) > 0)
       /* This is a dotted IP address 123.123.123.123-style */
@@ -748,7 +744,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
         ipnum = TRUE;
     }
 #endif /* ENABLE_IPV6 */
-#endif /* CURL_DISABLE_DOH */
+#endif /* FEAT_DOH */
 
 #endif /* !USE_RESOLVE_ON_IPS */
 
@@ -759,7 +755,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
       if(strcasecompare(hostname, "localhost") ||
          tailmatch(hostname, ".localhost"))
         addr = get_localhost(port, hostname);
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
       else if(allowDOH && data->set.doh && !ipnum)
         addr = Curl_doh(data, hostname, port, &respwait);
 #endif
@@ -1098,7 +1094,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
       struct Curl_addrinfo *head = NULL, *tail = NULL;
       size_t entry_len;
       char address[64];
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
       char *addresses = NULL;
 #endif
       char *addr_begin;
@@ -1130,7 +1126,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
         goto err;
 
       port = (int)tmp_port;
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
       addresses = end_ptr + 1;
 #endif
 
@@ -1260,11 +1256,11 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
 CURLcode Curl_resolv_check(struct Curl_easy *data,
                            struct Curl_dns_entry **dns)
 {
-#if defined(CURL_DISABLE_DOH) && !defined(CURLRES_ASYNCH)
+#if !defined(FEAT_DOH) && !defined(CURLRES_ASYNCH)
   (void)data;
   (void)dns;
 #endif
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   if(data->conn->bits.doh)
     return Curl_doh_is_resolved(data, dns);
 #endif
@@ -1275,7 +1271,7 @@ int Curl_resolv_getsock(struct Curl_easy *data,
                         curl_socket_t *socks)
 {
 #ifdef CURLRES_ASYNCH
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   if(data->conn->bits.doh)
     /* nothing to wait for during DoH resolve, those handles have their own
        sockets */
@@ -1327,7 +1323,7 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
   const char *host_or_proxy;
   CURLcode result;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct connectdata *conn = data->conn;
   if(conn->bits.httpproxy) {
     host_or_proxy = "proxy";

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -97,7 +97,7 @@ struct Curl_addrinfo *Curl_getaddrinfo(struct Curl_easy *data,
 {
   struct Curl_addrinfo *ai = NULL;
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
   (void)data;
 #endif
 

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -27,7 +27,7 @@
  */
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_HSTS)
+#if defined(FEAT_HTTP) && defined(FEAT_HSTS)
 #include <curl/curl.h>
 #include "urldata.h"
 #include "llist.h"
@@ -552,4 +552,4 @@ CURLcode Curl_hsts_loadcb(struct Curl_easy *data, struct hsts *h)
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_HTTP || CURL_DISABLE_HSTS */
+#endif /* FEAT_HTTP && FEAT_HSTS */

--- a/lib/hsts.h
+++ b/lib/hsts.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_HSTS)
+#if defined(FEAT_HTTP) && defined(FEAT_HSTS)
 #include <curl/curl.h>
 #include "llist.h"
 
@@ -63,5 +63,5 @@ CURLcode Curl_hsts_loadcb(struct Curl_easy *data,
 #define Curl_hsts_cleanup(x)
 #define Curl_hsts_loadcb(x,y) CURLE_OK
 #define Curl_hsts_save(x,y,z)
-#endif /* CURL_DISABLE_HTTP || CURL_DISABLE_HSTS */
+#endif /* FEAT_HTTP && FEAT_HSTS */
 #endif /* HEADER_CURL_HSTS_H */

--- a/lib/http.h
+++ b/lib/http.h
@@ -35,7 +35,7 @@ typedef enum {
   HTTPREQ_HEAD
 } Curl_HttpReq;
 
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
 
 #ifdef USE_NGHTTP2
 #include <nghttp2/nghttp2.h>
@@ -116,7 +116,7 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
                             struct dynbuf *r, Curl_HttpReq httpreq);
 bool Curl_use_http_1_1plus(const struct Curl_easy *data,
                            const struct connectdata *conn);
-#ifndef CURL_DISABLE_COOKIES
+#ifdef FEAT_COOKIES
 CURLcode Curl_http_cookies(struct Curl_easy *data,
                            struct connectdata *conn,
                            struct dynbuf *r);
@@ -173,7 +173,7 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data);
 #define EXPECT_100_THRESHOLD (1024*1024)
 #endif
 
-#endif /* CURL_DISABLE_HTTP */
+#endif /* FEAT_HTTP */
 
 #ifdef USE_NGHTTP3
 struct h3out; /* see ngtcp2 */
@@ -243,7 +243,7 @@ struct HTTP {
   struct websockets ws;
 #endif
 
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
   struct dynbuf send_buffer; /* used if the request couldn't be sent in one
                                 chunk, points to an allocated send_buffer
                                 struct */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -53,7 +53,7 @@
 #error too old nghttp2 version, upgrade!
 #endif
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
 #define nghttp2_session_callbacks_set_error_callback(x,y)
 #endif
 
@@ -1193,7 +1193,7 @@ static ssize_t data_source_read_callback(nghttp2_session *session,
   return nread;
 }
 
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
 static int error_callback(nghttp2_session *session,
                           const char *msg,
                           size_t len,

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(FEAT_HTTP) && defined(FEAT_CRYPTO_AUTH)
 
 #include "urldata.h"
 #include "strcase.h"
@@ -402,4 +402,4 @@ fail:
   return ret;
 }
 
-#endif /* !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH) */
+#endif /* FEAT_HTTP) && FEAT_CRYPTO_AUTH */

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
 
 #include "urldata.h" /* it includes http_chunks.h */
 #include "sendf.h"   /* for the client write stuff */
@@ -316,4 +316,4 @@ const char *Curl_chunked_strerror(CHUNKcode code)
   }
 }
 
-#endif /* CURL_DISABLE_HTTP */
+#endif /* FEAT_HTTP */

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(FEAT_HTTP) && defined(FEAT_CRYPTO_AUTH)
 
 #include "urldata.h"
 #include "strcase.h"
@@ -93,14 +93,14 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   struct auth *authp;
 
   if(proxy) {
-#ifdef CURL_DISABLE_PROXY
-    return CURLE_NOT_BUILT_IN;
-#else
+#ifdef FEAT_PROXY
     digest = &data->state.proxydigest;
     allocuserpwd = &data->state.aptr.proxyuserpwd;
     userp = data->state.aptr.proxyuser;
     passwdp = data->state.aptr.proxypasswd;
     authp = &data->state.authproxy;
+#else
+    return CURLE_NOT_BUILT_IN;
 #endif
   }
   else {

--- a/lib/http_digest.h
+++ b/lib/http_digest.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(FEAT_HTTP) && defined(FEAT_CRYPTO_AUTH)
 
 /* this is for digest header input */
 CURLcode Curl_input_digest(struct Curl_easy *data,
@@ -39,6 +39,6 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
 
 void Curl_http_auth_cleanup_digest(struct Curl_easy *data);
 
-#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_HTTP && FEAT_CRYPTO_AUTH */
 
 #endif /* HEADER_CURL_HTTP_DIGEST_H */

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
+#if defined(FEAT_HTTP) && defined(USE_SPNEGO)
 
 #include "urldata.h"
 #include "sendf.h"
@@ -53,7 +53,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
   curlnegotiate state;
 
   if(proxy) {
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     userp = conn->http_proxy.user;
     passwdp = conn->http_proxy.passwd;
     service = data->set.str[STRING_PROXY_SERVICE_NAME] ?
@@ -221,4 +221,4 @@ void Curl_http_auth_cleanup_negotiate(struct connectdata *conn)
   Curl_auth_cleanup_spnego(&conn->proxyneg);
 }
 
-#endif /* !CURL_DISABLE_HTTP && USE_SPNEGO */
+#endif /* FEAT_HTTP && USE_SPNEGO */

--- a/lib/http_negotiate.h
+++ b/lib/http_negotiate.h
@@ -24,7 +24,7 @@
  *
  ***************************************************************************/
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
+#if defined(FEAT_HTTP) && defined(USE_SPNEGO)
 
 /* this is for Negotiate header input */
 CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
@@ -36,7 +36,7 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
 
 void Curl_http_auth_cleanup_negotiate(struct connectdata *conn);
 
-#else /* !CURL_DISABLE_HTTP && USE_SPNEGO */
+#else /* FEAT_HTTP && USE_SPNEGO */
 #define Curl_http_auth_cleanup_negotiate(x)
 #endif
 

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM)
+#if defined(FEAT_HTTP) && defined(USE_NTLM)
 
 /*
  * NTLM details:
@@ -153,7 +153,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   DEBUGASSERT(data);
 
   if(proxy) {
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     allocuserpwd = &data->state.aptr.proxyuserpwd;
     userp = data->state.aptr.proxyuser;
     passwdp = data->state.aptr.proxypasswd;
@@ -272,4 +272,4 @@ void Curl_http_auth_cleanup_ntlm(struct connectdata *conn)
 #endif
 }
 
-#endif /* !CURL_DISABLE_HTTP && USE_NTLM */
+#endif /* FEAT_HTTP && USE_NTLM */

--- a/lib/http_ntlm.h
+++ b/lib/http_ntlm.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM)
+#if defined(FEAT_HTTP) && defined(USE_NTLM)
 
 /* this is for ntlm header input */
 CURLcode Curl_input_ntlm(struct Curl_easy *data, bool proxy,
@@ -37,7 +37,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy);
 
 void Curl_http_auth_cleanup_ntlm(struct connectdata *conn);
 
-#else /* !CURL_DISABLE_HTTP && USE_NTLM */
+#else /* FEAT_HTTP && USE_NTLM */
 #define Curl_http_auth_cleanup_ntlm(x)
 #endif
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -26,7 +26,7 @@
 
 #include "http_proxy.h"
 
-#if !defined(CURL_DISABLE_PROXY) && !defined(CURL_DISABLE_HTTP)
+#if defined(FEAT_PROXY) && defined(FEAT_HTTP)
 
 #include <curl/curl.h>
 #ifdef USE_HYPER
@@ -89,7 +89,7 @@ CURLcode Curl_proxy_connect(struct Curl_easy *data, int sockindex)
   }
 
   if(conn->bits.tunnel_proxy && conn->bits.httpproxy) {
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     /* for [protocol] tunneled through HTTP proxy */
     const char *hostname;
     int remote_port;
@@ -1076,4 +1076,4 @@ void Curl_connect_free(struct Curl_easy *data)
   (void)data;
 }
 
-#endif /* CURL_DISABLE_PROXY */
+#endif /* FEAT_PROXY */

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -27,7 +27,7 @@
 #include "curl_setup.h"
 #include "urldata.h"
 
-#if !defined(CURL_DISABLE_PROXY) && !defined(CURL_DISABLE_HTTP)
+#if defined(FEAT_PROXY) && defined(FEAT_HTTP)
 /* ftp can use this as well */
 CURLcode Curl_proxyCONNECT(struct Curl_easy *data,
                            int tunnelsocket,

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -37,7 +37,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_IMAP
+#ifdef FEAT_IMAP
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -397,7 +397,7 @@ static CURLcode imap_get_message(struct Curl_easy *data, struct bufref *out)
 static void state(struct Curl_easy *data, imapstate newstate)
 {
   struct imap_conn *imapc = &data->conn->proto.imapc;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[]={
     "STOP",
@@ -2128,4 +2128,4 @@ static CURLcode imap_parse_custom_request(struct Curl_easy *data)
   return result;
 }
 
-#endif /* CURL_DISABLE_IMAP */
+#endif /* FEAT_IMAP */

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -36,7 +36,7 @@
 
 #include "curl_setup.h"
 
-#if defined(HAVE_GSSAPI) && !defined(CURL_DISABLE_FTP)
+#if defined(HAVE_GSSAPI) && defined(FEAT_FTP)
 
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
@@ -896,4 +896,4 @@ Curl_sec_end(struct connectdata *conn)
   conn->mech = NULL;
 }
 
-#endif /* HAVE_GSSAPI && !CURL_DISABLE_FTP */
+#endif /* HAVE_GSSAPI && FEAT_FTP */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_LDAP) && !defined(USE_OPENLDAP)
+#if defined(FEAT_LDAP) && !defined(USE_OPENLDAP)
 
 /*
  * Notice that USE_OPENLDAP is only a source code selection switch. When
@@ -223,7 +223,7 @@ static int ldap_win_bind_auth(LDAP *server, const char *user,
   }
   else
 #endif
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
   if(authflags & CURLAUTH_DIGEST) {
     method = LDAP_AUTH_DIGEST;
   }
@@ -1102,4 +1102,4 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp)
   free(ludp);
 }
 #endif  /* !HAVE_LDAP_URL_PARSE */
-#endif  /* !CURL_DISABLE_LDAP && !USE_OPENLDAP */
+#endif  /* FEAT_LDAP && !USE_OPENLDAP */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 
 #include "curl_md4.h"
 #include "warnless.h"
@@ -517,4 +517,4 @@ void Curl_md4it(unsigned char *output, const unsigned char *input,
   MD4_Final(output, &ctx);
 }
 
-#endif /* CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_CRYPTO_AUTH */

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 
 #include <curl/curl.h>
 
@@ -666,4 +666,4 @@ CURLcode Curl_MD5_final(struct MD5_context *context, unsigned char *result)
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_CRYPTO_AUTH */

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -31,9 +31,9 @@
 #include "urldata.h"
 #include "sendf.h"
 
-#if !defined(CURL_DISABLE_MIME) && (!defined(CURL_DISABLE_HTTP) ||      \
-                                    !defined(CURL_DISABLE_SMTP) ||      \
-                                    !defined(CURL_DISABLE_IMAP))
+#if defined(FEAT_MIME) && (defined(FEAT_HTTP) ||      \
+                           defined(FEAT_SMTP) ||      \
+                           defined(FEAT_IMAP))
 
 #if defined(HAVE_LIBGEN_H) && defined(HAVE_BASENAME)
 #include <libgen.h>
@@ -1925,8 +1925,7 @@ void Curl_mime_unpause(curl_mimepart *part)
 }
 
 
-#else /* !CURL_DISABLE_MIME && (!CURL_DISABLE_HTTP ||
-                                !CURL_DISABLE_SMTP || !CURL_DISABLE_IMAP) */
+#else /* FEAT_MIME && (FEAT_HTTP || FEAT_SMTP || FEAT_IMAP) */
 
 /* Mime not compiled in: define stubs for externally-referenced functions. */
 curl_mime *curl_mime_init(CURL *easy)

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -134,9 +134,9 @@ struct curl_mimepart {
 
 CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...);
 
-#if !defined(CURL_DISABLE_MIME) && (!defined(CURL_DISABLE_HTTP) ||      \
-                                    !defined(CURL_DISABLE_SMTP) ||      \
-                                    !defined(CURL_DISABLE_IMAP))
+#if defined(FEAT_MIME) && (defined(FEAT_HTTP) ||               \
+                           defined(FEAT_SMTP) ||               \
+                           defined(FEAT_IMAP))
 
 /* Prototypes. */
 void Curl_mime_initpart(struct curl_mimepart *part, struct Curl_easy *easy);

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -25,7 +25,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_MQTT
+#ifdef FEAT_MQTT
 
 #include "urldata.h"
 #include <curl/curl.h>
@@ -812,4 +812,4 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
   return result;
 }
 
-#endif /* CURL_DISABLE_MQTT */
+#endif /* FEAT_MQTT */

--- a/lib/mqtt.h
+++ b/lib/mqtt.h
@@ -24,7 +24,7 @@
  *
  ***************************************************************************/
 
-#ifndef CURL_DISABLE_MQTT
+#ifdef FEAT_MQTT
 extern const struct Curl_handler Curl_handler_mqtt;
 #endif
 

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -72,7 +72,7 @@ typedef enum {
 
 #define CURLPIPE_ANY (CURLPIPE_MULTIPLEX)
 
-#if !defined(CURL_DISABLE_SOCKETPAIR)
+#ifdef FEAT_SOCKETPAIR
 #define ENABLE_WAKEUP
 #endif
 

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
-#ifndef CURL_DISABLE_NETRC
+#ifdef FEAT_NETRC
 
 #ifdef HAVE_PWD_H
 #include <pwd.h>

--- a/lib/netrc.h
+++ b/lib/netrc.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
-#ifndef CURL_DISABLE_NETRC
+#ifdef FEAT_NETRC
 
 /* returns -1 on failure, 0 if the host is found, 1 is the host isn't found */
 int Curl_parsenetrc(const char *host,

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -25,7 +25,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP)
+#if defined(FEAT_LDAP) && defined(USE_OPENLDAP)
 
 /*
  * Notice that USE_OPENLDAP is only a source code selection switch. When
@@ -206,7 +206,7 @@ static void state(struct Curl_easy *data, ldapstate newstate)
 {
   struct ldapconninfo *ldapc = data->conn->proto.ldapc;
 
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[] = {
     "STOP",
@@ -1208,4 +1208,4 @@ static Sockbuf_IO ldapsb_tls =
 };
 #endif /* USE_SSL */
 
-#endif /* !CURL_DISABLE_LDAP && USE_OPENLDAP */
+#endif /* FEAT_LDAP && USE_OPENLDAP */

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -102,8 +102,7 @@ static int parsedate(const char *date, time_t *output);
 #define PARSEDATE_LATER  1
 #define PARSEDATE_SOONER 2
 
-#if !defined(CURL_DISABLE_PARSEDATE) || !defined(CURL_DISABLE_FTP) || \
-  !defined(CURL_DISABLE_FILE)
+#if defined(FEAT_PARSEDATE) || defined(FEAT_FTP) || defined(FEAT_FILE)
 /* These names are also used by FTP and FILE code */
 const char * const Curl_wkday[] =
 {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
@@ -112,7 +111,7 @@ const char * const Curl_month[]=
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 #endif
 
-#ifndef CURL_DISABLE_PARSEDATE
+#ifdef FEAT_PARSEDATE
 static const char * const weekday[] =
 { "Monday", "Tuesday", "Wednesday", "Thursday",
   "Friday", "Saturday", "Sunday" };

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -26,8 +26,8 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_FTP) || \
-  !defined(CURL_DISABLE_POP3) || !defined(CURL_DISABLE_SMTP)
+#if defined(FEAT_IMAP) || defined(FEAT_FTP) || defined(FEAT_POP3) ||    \
+  defined(FEAT_SMTP)
 #define USE_PINGPONG
 #endif
 

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -39,7 +39,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_POP3
+#ifdef FEAT_POP3
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -293,7 +293,7 @@ static CURLcode pop3_get_message(struct Curl_easy *data, struct bufref *out)
 static void state(struct Curl_easy *data, pop3state newstate)
 {
   struct pop3_conn *pop3c = &data->conn->proto.pop3c;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[] = {
     "STOP",
@@ -418,7 +418,7 @@ static CURLcode pop3_perform_user(struct Curl_easy *data,
   return result;
 }
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 /***********************************************************************
  *
  * pop3_perform_apop()
@@ -562,7 +562,7 @@ static CURLcode pop3_perform_authentication(struct Curl_easy *data,
   }
 
   if(!result && progress == SASL_IDLE) {
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
     if(pop3c->authtypes & pop3c->preftype & POP3_TYPE_APOP)
       /* Perform APOP authentication */
       result = pop3_perform_apop(data, conn);
@@ -830,7 +830,7 @@ static CURLcode pop3_state_auth_resp(struct Curl_easy *data,
       state(data, POP3_STOP);  /* Authenticated */
       break;
     case SASL_IDLE:            /* No mechanism left after cancellation */
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
       if(pop3c->authtypes & pop3c->preftype & POP3_TYPE_APOP)
         /* Perform APOP authentication */
         result = pop3_perform_apop(data, conn);
@@ -851,7 +851,7 @@ static CURLcode pop3_state_auth_resp(struct Curl_easy *data,
   return result;
 }
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 /* For APOP responses */
 static CURLcode pop3_state_apop_resp(struct Curl_easy *data, int pop3code,
                                      pop3state instate)
@@ -1014,7 +1014,7 @@ static CURLcode pop3_statemachine(struct Curl_easy *data,
       result = pop3_state_auth_resp(data, pop3code, pop3c->state);
       break;
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
     case POP3_APOP:
       result = pop3_state_apop_resp(data, pop3code, pop3c->state);
       break;
@@ -1583,4 +1583,4 @@ CURLcode Curl_pop3_write(struct Curl_easy *data, char *str, size_t nread)
   return result;
 }
 
-#endif /* CURL_DISABLE_POP3 */
+#endif /* FEAT_POP3 */

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -34,7 +34,7 @@
 /* check rate limits within this many recent milliseconds, at minimum. */
 #define MIN_RATE_LIMIT_PERIOD 3000
 
-#ifndef CURL_DISABLE_PROGRESS_METER
+#ifdef FEAT_PROGRESS_METER
 /* Provide a string that is 2 + 1 + 2 + 1 + 2 = 8 letters long (plus the zero
    byte) */
 static void time2str(char *r, curl_off_t seconds)
@@ -459,7 +459,7 @@ static bool progress_calc(struct Curl_easy *data, struct curltime now)
   return timetoshow;
 }
 
-#ifndef CURL_DISABLE_PROGRESS_METER
+#ifdef FEAT_PROGRESS_METER
 static void progress_meter(struct Curl_easy *data)
 {
   char max5[6][10];

--- a/lib/rename.c
+++ b/lib/rename.c
@@ -26,8 +26,7 @@
 
 #include "curl_setup.h"
 
-#if (!defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_COOKIES)) || \
-  !defined(CURL_DISABLE_ALTSVC)
+#if defined(FEAT_HTTP) && (defined(FEAT_COOKIES) || defined(FEAT_ALTSVC))
 
 #include "curl_multibyte.h"
 #include "timeval.h"

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_RTSP) && !defined(USE_HYPER)
+#if defined(FEAT_RTSP) && !defined(USE_HYPER)
 
 #include "urldata.h"
 #include <curl/curl.h>
@@ -839,4 +839,4 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_RTSP or using Hyper */
+#endif /* FEAT_RTSP and !Hyper */

--- a/lib/rtsp.h
+++ b/lib/rtsp.h
@@ -24,10 +24,10 @@
  *
  ***************************************************************************/
 #ifdef USE_HYPER
-#define CURL_DISABLE_RTSP 1
+#undef FEAT_RTSP
 #endif
 
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
 
 extern const struct Curl_handler Curl_handler_rtsp;
 
@@ -37,7 +37,7 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header);
 /* disabled */
 #define Curl_rtsp_parseheader(x,y) CURLE_NOT_BUILT_IN
 
-#endif /* CURL_DISABLE_RTSP */
+#endif /* FEAT_RTSP */
 
 /*
  * RTSP Connection data

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -55,7 +55,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#if defined(CURL_DO_LINEEND_CONV) && !defined(CURL_DISABLE_FTP)
+#if defined(CURL_DO_LINEEND_CONV) && defined(FEAT_FTP)
 /*
  * convert_lineends() changes CRLF (\r\n) end-of-line markers to a single LF
  * (\n), with special processing for CRLF sequences that are split between two
@@ -135,7 +135,7 @@ static size_t convert_lineends(struct Curl_easy *data,
   }
   return size;
 }
-#endif /* CURL_DO_LINEEND_CONV && !CURL_DISABLE_FTP */
+#endif /* CURL_DO_LINEEND_CONV && FEAT_FTP */
 
 #ifdef USE_RECV_BEFORE_SEND_WORKAROUND
 bool Curl_recv_has_postponed_data(struct connectdata *conn, int sockindex)
@@ -598,7 +598,7 @@ static CURLcode chop_write(struct Curl_easy *data,
     len -= chunklen;
   }
 
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
   /* HTTP header, but not status-line */
   if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
      (type & CLIENTWRITE_HEADER) && !(type & CLIENTWRITE_STATUS) ) {
@@ -652,7 +652,7 @@ CURLcode Curl_client_write(struct Curl_easy *data,
                            char *ptr,
                            size_t len)
 {
-#if !defined(CURL_DISABLE_FTP) && defined(CURL_DO_LINEEND_CONV)
+#if defined(FEAT_FTP) && defined(CURL_DO_LINEEND_CONV)
   /* FTP data may need conversion. */
   if((type & CLIENTWRITE_BODY) &&
      (data->conn->handler->protocol & PROTO_FAMILY_FTP) &&

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -29,7 +29,7 @@
 void Curl_infof(struct Curl_easy *, const char *fmt, ...);
 void Curl_failf(struct Curl_easy *, const char *fmt, ...);
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
 
 #if defined(HAVE_VARIADIC_MACROS_C99)
 #define infof(...)  Curl_nop_stmt
@@ -39,11 +39,11 @@ void Curl_failf(struct Curl_easy *, const char *fmt, ...);
 #error "missing VARIADIC macro define, fix and rebuild!"
 #endif
 
-#else /* CURL_DISABLE_VERBOSE_STRINGS */
+#else /* !FEAT__VERBOSE_STRINGS */
 
 #define infof Curl_infof
 
-#endif /* CURL_DISABLE_VERBOSE_STRINGS */
+#endif /* FEAT_VERBOSE_STRINGS */
 
 #define failf Curl_failf
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -212,7 +212,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST],
                             va_arg(param, char *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSL_CIPHER_LIST:
     /* set a list of cipher we want to use in the SSL connection for proxy */
     result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST_PROXY],
@@ -228,7 +228,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     else
       return CURLE_NOT_BUILT_IN;
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_TLS13_CIPHERS:
     if(Curl_ssl_tls13_ciphersuites()) {
       /* set preferred list of TLS 1.3 cipher suites for proxy */
@@ -295,7 +295,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * Do not include the body part in the output data stream.
      */
     data->set.opt_no_body = (0 != va_arg(param, long)) ? TRUE : FALSE;
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
     if(data->set.opt_no_body)
       /* in HTTP lingo, no body means using the HEAD request... */
       data->set.method = HTTPREQ_HEAD;
@@ -353,7 +353,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     else
       return CURLE_BAD_FUNCTION_ARGUMENT;
     break;
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
   case CURLOPT_TFTP_NO_OPTIONS:
     /*
      * Option that prevents libcurl from sending TFTP option requests to the
@@ -371,7 +371,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.tftp_blksize = arg;
     break;
 #endif
-#ifndef CURL_DISABLE_NETRC
+#ifdef FEAT_NETRC
   case CURLOPT_NETRC:
     /*
      * Parse the $HOME/.netrc file
@@ -425,7 +425,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
 
   case CURLOPT_SSLVERSION:
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSLVERSION:
 #endif
     /*
@@ -436,7 +436,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     {
       long version, version_max;
       struct ssl_primary_config *primary = &data->set.ssl.primary;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
       if(option != CURLOPT_SSLVERSION)
         primary = &data->set.proxy_ssl.primary;
 #endif
@@ -463,7 +463,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
 
     /* MQTT "borrows" some of the HTTP options */
-#if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_MQTT)
+#if defined(FEAT_HTTP) || defined(FEAT_MQTT)
   case CURLOPT_COPYPOSTFIELDS:
     /*
      * A string with POST data. Makes curl HTTP POST. Even if it is NULL.
@@ -559,7 +559,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.postfieldsize = bigsize;
     break;
 #endif
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
   case CURLOPT_AUTOREFERER:
     /*
      * Switch on automatic referer that gets set if curl follows locations.
@@ -654,7 +654,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.upload = FALSE;
     break;
 
-#ifndef CURL_DISABLE_MIME
+#ifdef FEAT_MIME
   case CURLOPT_HTTPPOST:
     /*
      * Set to make us do HTTP POST
@@ -700,7 +700,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
                             va_arg(param, char *));
     break;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXYHEADER:
     /*
      * Set a list with proxy headers to use (or replace internals with)
@@ -730,7 +730,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.http200aliases = va_arg(param, struct curl_slist *);
     break;
 
-#if !defined(CURL_DISABLE_COOKIES)
+#ifdef FEAT_COOKIES
   case CURLOPT_COOKIE:
     /*
      * Cookie string to send to the remote server in the request.
@@ -874,7 +874,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     }
 
     break;
-#endif /* !CURL_DISABLE_COOKIES */
+#endif /* FEAT_COOKIES */
 
   case CURLOPT_HTTPGET:
     /*
@@ -935,11 +935,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.http09_allowed = arg ? TRUE : FALSE;
 #endif
     break;
-#endif   /* CURL_DISABLE_HTTP */
+#endif   /* FEAT_HTTP */
 
-#if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_SMTP) ||       \
-    !defined(CURL_DISABLE_IMAP)
-# if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_MIME)
+#if defined(FEAT_HTTP) || defined(FEAT_SMTP) || defined(FEAT_IMAP)
+# if defined(FEAT_HTTP) || defined(FEAT_MIME)
   case CURLOPT_HTTPHEADER:
     /*
      * Set a list with HTTP headers to use (or replace internals with)
@@ -948,7 +947,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
 # endif
 
-# ifndef CURL_DISABLE_MIME
+#ifdef FEAT_MIME
   case CURLOPT_MIMEPOST:
     /*
      * Set to make us do MIME POST
@@ -1032,7 +1031,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
        and this just changes the actual request keyword */
     break;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_HTTPPROXYTUNNEL:
     /*
      * Tunnel operations through the proxy instead of normal proxy use
@@ -1161,7 +1160,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     if(data->set.socks5auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
       result = CURLE_NOT_BUILT_IN;
     break;
-#endif   /* CURL_DISABLE_PROXY */
+#endif   /* FEAT_PROXY */
 
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   case CURLOPT_SOCKS5_GSSAPI_NEC:
@@ -1171,7 +1170,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.socks5_gssapi_nec = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
 #endif
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_SOCKS5_GSSAPI_SERVICE:
   case CURLOPT_PROXY_SERVICE_NAME:
     /*
@@ -1226,7 +1225,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.remote_append = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   case CURLOPT_FTP_FILEMETHOD:
     /*
      * How do access files over FTP.
@@ -1445,7 +1444,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.connecttimeout = (unsigned int)uarg;
     break;
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   case CURLOPT_ACCEPTTIMEOUT_MS:
     /*
      * The maximum time for curl to wait for FTP server connect
@@ -1562,7 +1561,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.progress_client = va_arg(param, void *);
     break;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXYUSERPWD:
     /*
      * user:password needed to use the proxy
@@ -1710,7 +1709,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setblobopt(&data->set.blobs[BLOB_CERT],
                              va_arg(param, struct curl_blob *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSLCERT:
     /*
      * String that holds file name of the SSL certificate to use for proxy
@@ -1733,7 +1732,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setstropt(&data->set.str[STRING_CERT_TYPE],
                             va_arg(param, char *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSLCERTTYPE:
     /*
      * String that holds file type of the SSL certificate to use for proxy
@@ -1756,7 +1755,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setblobopt(&data->set.blobs[BLOB_KEY],
                              va_arg(param, struct curl_blob *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSLKEY:
     /*
      * String that holds file name of the SSL key to use for proxy
@@ -1779,7 +1778,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setstropt(&data->set.str[STRING_KEY_TYPE],
                             va_arg(param, char *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSLKEYTYPE:
     /*
      * String that holds file type of the SSL key to use for proxy
@@ -1795,7 +1794,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setstropt(&data->set.str[STRING_KEY_PASSWD],
                             va_arg(param, char *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_KEYPASSWD:
     /*
      * String that holds the SSL private key password for proxy.
@@ -1830,7 +1829,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      */
     data->set.crlf = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_HAPROXYPROTOCOL:
     /*
      * Set to send the HAProxy Proxy Protocol header
@@ -1886,7 +1885,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         data->set.ssl.primary.verifypeer;
     }
     break;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   case CURLOPT_DOH_SSL_VERIFYPEER:
     /*
      * Enable peer SSL verifying for DoH.
@@ -1895,7 +1894,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       TRUE : FALSE;
     break;
 #endif
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSL_VERIFYPEER:
     /*
      * Enable peer SSL verifying for proxy.
@@ -1927,7 +1926,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         data->set.ssl.primary.verifyhost;
     }
     break;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   case CURLOPT_DOH_SSL_VERIFYHOST:
     /*
      * Enable verification of the host name in the peer certificate for DoH
@@ -1938,7 +1937,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.doh_verifyhost = (bool)((arg & 3) ? TRUE : FALSE);
     break;
 #endif
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSL_VERIFYHOST:
     /*
      * Enable verification of the host name in the peer certificate for proxy
@@ -1973,7 +1972,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         data->set.ssl.primary.verifystatus;
     }
     break;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   case CURLOPT_DOH_SSL_VERIFYSTATUS:
     /*
      * Enable certificate status verifying for DoH.
@@ -2041,7 +2040,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 #endif
       result = CURLE_NOT_BUILT_IN;
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_PINNEDPUBLICKEY:
     /*
      * Set pinned public key for SSL connection.
@@ -2077,7 +2076,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       return CURLE_NOT_BUILT_IN;
 
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_CAINFO:
     /*
      * Set CA info SSL connection for proxy. Specify file name of the
@@ -2114,7 +2113,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 #endif
       result = CURLE_NOT_BUILT_IN;
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_CAPATH:
     /*
      * Set CA path info for SSL connection proxy. Specify directory name of the
@@ -2138,7 +2137,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setstropt(&data->set.str[STRING_SSL_CRLFILE],
                             va_arg(param, char *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_CRLFILE:
     /*
      * Set CRL file info for SSL connection for proxy. Specify file name of the
@@ -2163,7 +2162,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setblobopt(&data->set.blobs[BLOB_SSL_ISSUERCERT],
                              va_arg(param, struct curl_blob *));
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_ISSUERCERT:
     /*
      * Set Issuer certificate file
@@ -2180,7 +2179,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
                              va_arg(param, struct curl_blob *));
     break;
 #endif
-#ifndef CURL_DISABLE_TELNET
+#ifdef FEAT_TELNET
   case CURLOPT_TELNETOPTIONS:
     /*
      * Set a linked list of telnet options
@@ -2246,7 +2245,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         data->dns.hostcachetype = HCACHE_NONE;
       }
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
       if(data->share->cookies == data->cookies)
         data->cookies = NULL;
 #endif
@@ -2279,14 +2278,14 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
         data->dns.hostcache = &data->share->hostcache;
         data->dns.hostcachetype = HCACHE_SHARED;
       }
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
       if(data->share->cookies) {
         /* use shared cookie list, first free own one if any */
         Curl_cookie_cleanup(data->cookies);
         /* enable cookies since we now use a share that uses cookies! */
         data->cookies = data->share->cookies;
       }
-#endif   /* CURL_DISABLE_HTTP */
+#endif   /* FEAT_HTTP && FEAT_COOKIES */
       if(data->share->sslsession) {
         data->set.general_ssl.max_ssl_sessions = data->share->max_ssl_sessions;
         data->state.session = data->share->sslsession;
@@ -2344,7 +2343,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
        which sets its own CURLOPT_SSL_OPTIONS based on these settings. */
     break;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_SSL_OPTIONS:
     arg = va_arg(param, long);
     data->set.proxy_ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
@@ -2471,7 +2470,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
   case CURLOPT_SSL_SESSIONID_CACHE:
     data->set.ssl.primary.sessionid = (0 != va_arg(param, long)) ?
       TRUE : FALSE;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     data->set.proxy_ssl.primary.sessionid = data->set.ssl.primary.sessionid;
 #endif
     break;
@@ -2571,7 +2570,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.http_ce_skip = (0 == va_arg(param, long)) ? TRUE : FALSE;
     break;
 
-#if !defined(CURL_DISABLE_FTP) || defined(USE_SSH)
+#if defined(FEAT_FTP) || defined(USE_SSH)
   case CURLOPT_NEW_FILE_PERMS:
     /*
      * Uses these permissions instead of 0644
@@ -2649,7 +2648,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     result = Curl_setstropt(&data->set.str[STRING_DEFAULT_PROTOCOL],
                             va_arg(param, char *));
     break;
-#ifndef CURL_DISABLE_SMTP
+#ifdef FEAT_SMTP
   case CURLOPT_MAIL_FROM:
     /* Set the SMTP mail originator */
     result = Curl_setstropt(&data->set.str[STRING_MAIL_FROM],
@@ -2682,7 +2681,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /* Enable/disable SASL initial response */
     data->set.sasl_ir = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
   case CURLOPT_RTSP_REQUEST:
   {
     /*
@@ -2792,7 +2791,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.fwrite_rtp = va_arg(param, curl_write_callback);
     break;
 #endif
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   case CURLOPT_WILDCARDMATCH:
     data->set.wildcard_enabled = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
@@ -2820,7 +2819,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
        !data->set.ssl.primary.authtype)
       data->set.ssl.primary.authtype = CURL_TLSAUTH_SRP; /* default to SRP */
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_TLSAUTH_USERNAME:
     result = Curl_setstropt(&data->set.str[STRING_TLSAUTH_USERNAME_PROXY],
                             va_arg(param, char *));
@@ -2837,7 +2836,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
        !data->set.ssl.primary.authtype)
       data->set.ssl.primary.authtype = CURL_TLSAUTH_SRP; /* default */
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_TLSAUTH_PASSWORD:
     result = Curl_setstropt(&data->set.str[STRING_TLSAUTH_PASSWORD_PROXY],
                             va_arg(param, char *));
@@ -2854,7 +2853,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     else
       data->set.ssl.primary.authtype = CURL_TLSAUTH_NONE;
     break;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   case CURLOPT_PROXY_TLSAUTH_TYPE:
     argptr = va_arg(param, char *);
     if(!argptr ||
@@ -2983,7 +2982,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       uarg = UINT_MAX;
     data->set.happy_eyeballs_timeout = (unsigned int)uarg;
     break;
-#ifndef CURL_DISABLE_SHUFFLE_DNS
+#ifdef FEAT_SHUFFLE_DNS
   case CURLOPT_DNS_SHUFFLE_ADDRESSES:
     data->set.dns_shuffle_addresses = (0 != va_arg(param, long)) ? TRUE:FALSE;
     break;
@@ -2992,7 +2991,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.disallow_username_in_url =
       (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   case CURLOPT_DOH_URL:
     result = Curl_setstropt(&data->set.str[STRING_DOH],
                             va_arg(param, char *));
@@ -3018,16 +3017,16 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.maxlifetime_conn = arg;
     break;
   case CURLOPT_TRAILERFUNCTION:
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
     data->set.trailer_callback = va_arg(param, curl_trailer_callback);
 #endif
     break;
   case CURLOPT_TRAILERDATA:
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
     data->set.trailer_data = va_arg(param, void *);
 #endif
     break;
-#ifndef CURL_DISABLE_HSTS
+#ifdef FEAT_HSTS
   case CURLOPT_HSTSREADFUNCTION:
     data->set.hsts_read = va_arg(param, curl_hstsread_callback);
     break;
@@ -3066,7 +3065,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       Curl_hsts_cleanup(&data->hsts);
     break;
 #endif
-#ifndef CURL_DISABLE_ALTSVC
+#ifdef FEAT_ALTSVC
   case CURLOPT_ALTSVC:
     if(!data->asi) {
       data->asi = Curl_altsvc_init();

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -25,7 +25,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
 
 #include "warnless.h"
 #include "curl_sha256.h"
@@ -546,4 +546,4 @@ const struct HMAC_params Curl_HMAC_SHA256[] = {
 };
 
 
-#endif /* CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_CRYPTO_AUTH */

--- a/lib/share.c
+++ b/lib/share.c
@@ -78,13 +78,13 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       break;
 
     case CURL_LOCK_DATA_COOKIE:
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
       if(!share->cookies) {
         share->cookies = Curl_cookie_init(NULL, NULL, NULL, TRUE);
         if(!share->cookies)
           res = CURLSHE_NOMEM;
       }
-#else   /* CURL_DISABLE_HTTP */
+#else   /* FEAT_HTTP && FEAT_COOKIES */
       res = CURLSHE_NOT_BUILT_IN;
 #endif
       break;
@@ -131,12 +131,12 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       break;
 
     case CURL_LOCK_DATA_COOKIE:
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
       if(share->cookies) {
         Curl_cookie_cleanup(share->cookies);
         share->cookies = NULL;
       }
-#else   /* CURL_DISABLE_HTTP */
+#else   /* FEAT_HTTP && FEAT_COOKIES */
       res = CURLSHE_NOT_BUILT_IN;
 #endif
       break;
@@ -203,7 +203,7 @@ curl_share_cleanup(struct Curl_share *share)
   Curl_conncache_destroy(&share->conn_cache);
   Curl_hash_destroy(&share->hostcache);
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
   Curl_cookie_cleanup(share->cookies);
 #endif
 

--- a/lib/share.h
+++ b/lib/share.h
@@ -53,7 +53,7 @@ struct Curl_share {
   void *clientdata;
   struct conncache conn_cache;
   struct Curl_hash hostcache;
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
+#if defined(FEAT_HTTP) && defined(FEAT_COOKIES)
   struct CookieInfo *cookies;
 #endif
 #ifdef USE_LIBPSL

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -25,7 +25,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE) &&  \
+#if defined(FEAT_SMB) && defined(USE_CURL_NTLM_CORE) &&  \
   (SIZEOF_CURL_OFF_T > 4)
 
 #define BUILDING_CURL_SMB_C
@@ -194,7 +194,7 @@ struct smb_request {
 static void conn_state(struct Curl_easy *data, enum smb_conn_state newstate)
 {
   struct smb_conn *smbc = &data->conn->proto.smbc;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* For debug purposes */
   static const char * const names[] = {
     "SMB_NOT_CONNECTED",
@@ -217,7 +217,7 @@ static void request_state(struct Curl_easy *data,
                           enum smb_req_state newstate)
 {
   struct smb_request *req = data->req.p.smb;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* For debug purposes */
   static const char * const names[] = {
     "SMB_REQUESTING",
@@ -1023,5 +1023,4 @@ static CURLcode smb_parse_url_path(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_SMB && USE_CURL_NTLM_CORE &&
-          SIZEOF_CURL_OFF_T > 4 */
+#endif /* FEAT_SMB && USE_CURL_NTLM_CORE && SIZEOF_CURL_OFF_T > 4 */

--- a/lib/smb.h
+++ b/lib/smb.h
@@ -245,13 +245,11 @@ struct smb_tree_disconnect {
 
 #endif /* BUILDING_CURL_SMB_C */
 
-#if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE) && \
-    (SIZEOF_CURL_OFF_T > 4)
+#if defined(FEAT_SMB) && defined(USE_CURL_NTLM_CORE) && (SIZEOF_CURL_OFF_T > 4)
 
 extern const struct Curl_handler Curl_handler_smb;
 extern const struct Curl_handler Curl_handler_smbs;
 
-#endif /* CURL_DISABLE_SMB && USE_CURL_NTLM_CORE &&
-          SIZEOF_CURL_OFF_T > 4 */
+#endif /* FEAT_SMB && USE_CURL_NTLM_CORE && SIZEOF_CURL_OFF_T > 4 */
 
 #endif /* HEADER_CURL_SMB_H */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -41,7 +41,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_SMTP
+#ifdef FEAT_SMTP
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -291,7 +291,7 @@ static CURLcode smtp_get_message(struct Curl_easy *data, struct bufref *out)
 static void state(struct Curl_easy *data, smtpstate newstate)
 {
   struct smtp_conn *smtpc = &data->conn->proto.smtpc;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[] = {
     "STOP",
@@ -1924,4 +1924,4 @@ CURLcode Curl_smtp_escape_eob(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#endif /* CURL_DISABLE_SMTP */
+#endif /* FEAT_SMTP */

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -25,7 +25,7 @@
 #include "curl_setup.h"
 #include "socketpair.h"
 
-#if !defined(HAVE_SOCKETPAIR) && !defined(CURL_DISABLE_SOCKETPAIR)
+#if !defined(HAVE_SOCKETPAIR) && defined(FEAT_SOCKETPAIR)
 #ifdef WIN32
 /*
  * This is a socketpair() implementation for Windows.

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_PROXY)
+#ifdef FEAT_PROXY
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -102,7 +102,7 @@ int Curl_blockread_all(struct Curl_easy *data,   /* transfer */
 }
 #endif
 
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
 #define DEBUG_AND_VERBOSE
 #define sxstate(x,y) socksstate(x,y, __LINE__)
 #else
@@ -1055,4 +1055,4 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
   return CURLPX_OK; /* Proxy was successful! */
 }
 
-#endif /* CURL_DISABLE_PROXY */
+#endif /* FEAT_PROXY */

--- a/lib/socks.h
+++ b/lib/socks.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifdef CURL_DISABLE_PROXY
+#ifndef FEAT_PROXY
 #define Curl_SOCKS4(a,b,c,d,e) CURLE_NOT_BUILT_IN
 #define Curl_SOCKS5(a,b,c,d,e,f) CURLE_NOT_BUILT_IN
 #define Curl_SOCKS_getsock(x,y,z) 0
@@ -77,6 +77,6 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
                                       struct Curl_easy *data);
 #endif
 
-#endif /* CURL_DISABLE_PROXY */
+#endif /* FEAT_PROXY */
 
 #endif  /* HEADER_CURL_SOCKS_H */

--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -25,7 +25,7 @@
 
 #include "curl_setup.h"
 
-#if defined(HAVE_GSSAPI) && !defined(CURL_DISABLE_PROXY)
+#if defined(HAVE_GSSAPI) && defined(FEAT_PROXY)
 
 #include "curl_gssapi.h"
 #include "urldata.h"
@@ -531,4 +531,4 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
   return CURLE_OK;
 }
 
-#endif /* HAVE_GSSAPI && !CURL_DISABLE_PROXY */
+#endif /* HAVE_GSSAPI && FEAT_PROXY */

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -25,7 +25,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_PROXY)
+#if defined(USE_WINDOWS_SSPI) && defined(FEAT_PROXY)
 
 #include "urldata.h"
 #include "sendf.h"

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -55,7 +55,7 @@
 const char *
 curl_easy_strerror(CURLcode error)
 {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   switch(error) {
   case CURLE_OK:
     return "No error";
@@ -362,7 +362,7 @@ curl_easy_strerror(CURLcode error)
 const char *
 curl_multi_strerror(CURLMcode error)
 {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   switch(error) {
   case CURLM_CALL_MULTI_PERFORM:
     return "Please call curl_multi_perform() soon";
@@ -422,7 +422,7 @@ curl_multi_strerror(CURLMcode error)
 const char *
 curl_share_strerror(CURLSHcode error)
 {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   switch(error) {
   case CURLSHE_OK:
     return "No error";
@@ -458,7 +458,7 @@ curl_share_strerror(CURLSHcode error)
 const char *
 curl_url_strerror(CURLUcode error)
 {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   switch(error) {
   case CURLUE_OK:
     return "No error";
@@ -571,7 +571,7 @@ curl_url_strerror(CURLUcode error)
 static const char *
 get_winsock_error (int err, char *buf, size_t len)
 {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   const char *p;
 #endif
 
@@ -580,7 +580,7 @@ get_winsock_error (int err, char *buf, size_t len)
 
   *buf = '\0';
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
   (void)err;
   return NULL;
 #else
@@ -933,7 +933,7 @@ const char *Curl_winapi_strerror(DWORD err, char *buf, size_t buflen)
 
   *buf = '\0';
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   if(!get_winapi_error(err, buf, buflen)) {
     msnprintf(buf, buflen, "Unknown error %u (0x%08X)", err, err);
   }
@@ -975,7 +975,7 @@ const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
 
   *buf = '\0';
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 
   switch(err) {
     case SEC_E_OK:

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_TELNET
+#ifdef FEAT_TELNET
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -85,7 +85,7 @@
 #define  CURL_SB_PEEK(x) ((*x->subpointer)&0xff)
 #define  CURL_SB_EOF(x) (x->subpointer >= x->subend) */
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
+#ifndef FEAT_VERBOSE_STRINGS
 #define printoption(a,b,c,d)  Curl_nop_stmt
 #endif
 
@@ -94,7 +94,7 @@ CURLcode telrcv(struct Curl_easy *data,
                 const unsigned char *inbuf, /* Data received from socket */
                 ssize_t count);             /* Number of bytes received */
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static void printoption(struct Curl_easy *data,
                         const char *direction,
                         int cmd, int option);
@@ -263,7 +263,7 @@ static void negotiate(struct Curl_easy *data)
   }
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static void printoption(struct Curl_easy *data,
                         const char *direction, int cmd, int option)
 {

--- a/lib/telnet.h
+++ b/lib/telnet.h
@@ -23,7 +23,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#ifndef CURL_DISABLE_TELNET
+#ifdef FEAT_TELNET
 extern const struct Curl_handler Curl_handler_telnet;
 #endif
 

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
 
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -396,7 +396,7 @@ static CURLcode tftp_connect_for_tx(struct tftp_state_data *state,
                                     tftp_event_t event)
 {
   CURLcode result;
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   struct Curl_easy *data = state->data;
 
   infof(data, "%s", "Connected for transmit");
@@ -412,7 +412,7 @@ static CURLcode tftp_connect_for_rx(struct tftp_state_data *state,
                                     tftp_event_t event)
 {
   CURLcode result;
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   struct Curl_easy *data = state->data;
 
   infof(data, "%s", "Connected for receive");

--- a/lib/tftp.h
+++ b/lib/tftp.h
@@ -23,7 +23,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
 extern const struct Curl_handler Curl_handler_tftp;
 #endif
 

--- a/lib/url.h
+++ b/lib/url.h
@@ -58,15 +58,13 @@ void Curl_free_idnconverted_hostname(struct hostname *host);
 #define CURL_DEFAULT_HTTPS_PROXY_PORT 443 /* default https proxy port unless
                                              specified */
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
-#define Curl_verboseconnect(x,y)  Curl_nop_stmt
-#else
+#ifdef FEAT_VERBOSE_STRINGS
 void Curl_verboseconnect(struct Curl_easy *data, struct connectdata *conn);
+#else
+#define Curl_verboseconnect(x,y)  Curl_nop_stmt
 #endif
 
-#ifdef CURL_DISABLE_PROXY
-#define CONNECT_PROXY_SSL() FALSE
-#else
+#ifdef FEAT_PROXY
 
 #define CONNECT_PROXY_SSL()\
   (conn->http_proxy.proxytype == CURLPROXY_HTTPS &&\
@@ -79,6 +77,8 @@ void Curl_verboseconnect(struct Curl_easy *data, struct connectdata *conn);
 #define CONNECT_SECONDARYSOCKET_PROXY_SSL()\
   (conn->http_proxy.proxytype == CURLPROXY_HTTPS &&\
   !conn->bits.proxy_ssl_connected[SECONDARYSOCKET])
-#endif /* !CURL_DISABLE_PROXY */
+#else
+#define CONNECT_PROXY_SSL() FALSE
+#endif /* !FEAT_PROXY */
 
 #endif /* HEADER_CURL_URL_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -466,10 +466,10 @@ struct negotiatedata {
 };
 #endif
 
-#ifdef CURL_DISABLE_PROXY
-#define CONN_IS_PROXIED(x) 0
-#else
+#ifdef FEAT_PROXY
 #define CONN_IS_PROXIED(x) x->bits.proxy
+#else
+#define CONN_IS_PROXIED(x) 0
 #endif
 
 /*
@@ -478,7 +478,7 @@ struct negotiatedata {
 struct ConnectBits {
   bool tcpconnect[2]; /* the TCP layer (or similar) is connected, this is set
                          the first time on the first connect function call */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   bool proxy_ssl_connected[2]; /* TRUE when SSL initialization for HTTPS proxy
                                   is complete */
   BIT(httpproxy);  /* if set, this transfer is done through a http proxy */
@@ -518,7 +518,7 @@ struct ConnectBits {
                           though it will be discarded. When the whole send
                           operation is done, we must call the data rewind
                           callback. */
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   BIT(ftp_use_epsv);  /* As set with CURLOPT_FTP_USE_EPSV, but if we find out
                          EPSV doesn't work we disable it for the forthcoming
                          requests */
@@ -528,7 +528,7 @@ struct ConnectBits {
   BIT(ftp_use_data_ssl); /* Enabled SSL for the data connection */
   BIT(ftp_use_control_ssl); /* Enabled SSL for the control connection */
 #endif
-#ifndef CURL_DISABLE_NETRC
+#ifdef FEAT_NETRC
   BIT(netrc);         /* name+password provided by netrc */
 #endif
   BIT(bound); /* set true if bind() has already been done on this socket/
@@ -536,7 +536,7 @@ struct ConnectBits {
   BIT(multiplex); /* connection is multiplexed */
   BIT(tcp_fastopen); /* use TCP Fast Open */
   BIT(tls_enable_alpn); /* TLS ALPN extension? */
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   BIT(doh);
 #endif
 #ifdef USE_UNIX_SOCKETS
@@ -573,7 +573,7 @@ struct hostname {
 #define KEEP_RECVBITS (KEEP_RECV | KEEP_RECV_HOLD | KEEP_RECV_PAUSE)
 #define KEEP_SENDBITS (KEEP_SEND | KEEP_SEND_HOLD | KEEP_SEND_PAUSE)
 
-#if defined(CURLRES_ASYNCH) || !defined(CURL_DISABLE_DOH)
+#if defined(CURLRES_ASYNCH) || defined(FEAT_DOH)
 #define USE_CURL_ASYNC
 struct Curl_async {
   char *hostname;
@@ -705,7 +705,7 @@ struct SingleRequest {
     struct SSHPROTO *ssh;
     struct TELNET *telnet;
   } p;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   struct dohdata *doh; /* DoH specific data for this request */
 #endif
   unsigned char setcookies;
@@ -959,7 +959,7 @@ struct connectdata {
   char *secondaryhostname; /* secondary socket host name (ftp) */
   struct hostname conn_to_host; /* the host to connect to. valid only if
                                    bits.conn_to_host is set */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct proxy_info socks_proxy;
   struct proxy_info http_proxy;
 #endif
@@ -990,14 +990,14 @@ struct connectdata {
   struct postponed_data postponed[2]; /* two buffers for two sockets */
 #endif /* USE_RECV_BEFORE_SEND_WORKAROUND */
   struct ssl_connect_data ssl[2]; /* this is for ssl-stuff */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_connect_data proxy_ssl[2]; /* this is for proxy ssl-stuff */
 #endif
 #ifdef USE_SSL
   void *ssl_extra; /* separately allocated backend-specific data */
 #endif
   struct ssl_primary_config ssl_config;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_primary_config proxy_ssl_config;
 #endif
   struct ConnectBits bits;    /* various state-flags for this connection */
@@ -1078,36 +1078,36 @@ struct connectdata {
   struct dynbuf trailer;
 
   union {
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
     struct ftp_conn ftpc;
 #endif
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
     struct http_conn httpc;
 #endif
 #ifdef USE_SSH
     struct ssh_conn sshc;
 #endif
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
     struct tftp_state_data *tftpc;
 #endif
-#ifndef CURL_DISABLE_IMAP
+#ifdef FEAT_IMAP
     struct imap_conn imapc;
 #endif
-#ifndef CURL_DISABLE_POP3
+#ifdef FEAT_POP3
     struct pop3_conn pop3c;
 #endif
-#ifndef CURL_DISABLE_SMTP
+#ifdef FEAT_SMTP
     struct smtp_conn smtpc;
 #endif
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
     struct rtsp_conn rtspc;
 #endif
-#ifndef CURL_DISABLE_SMB
+#ifdef FEAT_SMB
     struct smb_conn smbc;
 #endif
     void *rtmp;
     struct ldapconninfo *ldapc;
-#ifndef CURL_DISABLE_MQTT
+#ifdef FEAT_MQTT
     struct mqtt_conn mqtt;
 #endif
   } proto;
@@ -1379,7 +1379,7 @@ struct UrlState {
   /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
   void (*prev_signal)(int sig);
 #endif
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef FEAT_CRYPTO_AUTH
   struct digestdata digest;      /* state data for host Digest auth */
   struct digestdata proxydigest; /* state data for proxy Digest auth */
 #endif
@@ -1417,7 +1417,7 @@ struct UrlState {
                   this syntax. */
   curl_off_t resume_from; /* continue [ftp] transfer from here */
 
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
   /* This RTSP state information survives requests and connections */
   long rtsp_next_client_CSeq; /* the session's next client CSeq */
   long rtsp_next_server_CSeq; /* the session's next server CSeq */
@@ -1444,13 +1444,13 @@ struct UrlState {
                             is this */
   char *url;        /* work URL, copied from UserDefined */
   char *referer;    /* referer string */
-#ifndef CURL_DISABLE_COOKIES
+#ifdef FEAT_COOKIES
   struct curl_slist *cookielist; /* list of cookie files set by
                                     curl_easy_setopt(COOKIEFILE) calls */
 #endif
   struct curl_slist *resolve; /* set to point to the set.resolve list when
                                  this should be dealt with in pretransfer */
-#ifndef CURL_DISABLE_HTTP
+#ifdef FEAT_HTTP
   size_t trailers_bytes_sent;
   struct dynbuf trailers_buf; /* a buffer containing the compiled trailing
                                  headers */
@@ -1664,7 +1664,7 @@ struct UserDefined {
   unsigned short use_port; /* which port to use (when not using default) */
   unsigned long httpauth;  /* kind of HTTP authentication to use (bitmask) */
   unsigned long proxyauth; /* kind of proxy authentication to use (bitmask) */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   unsigned long socks5auth;/* kind of SOCKS5 authentication to use (bitmask) */
 #endif
   long maxredirs;    /* maximum no. of http(s) redirects to follow, set to -1
@@ -1699,7 +1699,7 @@ struct UserDefined {
   void *prereq_userp; /* pre-initial request user data */
 
   void *seek_client;    /* pointer to pass to the seek callback */
-#ifndef CURL_DISABLE_HSTS
+#ifdef FEAT_HSTS
   curl_hstsread_callback hsts_read;
   void *hsts_read_userp;
   curl_hstswrite_callback hsts_write;
@@ -1715,7 +1715,7 @@ struct UserDefined {
                            is to be reused */
   long maxlifetime_conn; /* in seconds, max time since creation to allow a
                             connection that is to be reused */
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
   long tftp_blksize;    /* in bytes, 0 means use default */
 #endif
   curl_off_t filesize;  /* size of file to upload, -1 means unknown */
@@ -1737,7 +1737,7 @@ struct UserDefined {
                                           the transfer on source host */
   struct curl_slist *source_postquote; /* in 3rd party transfer mode - after
                                           the transfer on source host */
-#ifndef CURL_DISABLE_TELNET
+#ifdef FEAT_TELNET
   struct curl_slist *telnet_options; /* linked list of telnet options */
 #endif
   struct curl_slist *resolve;     /* list of names to add/remove from
@@ -1751,7 +1751,7 @@ struct UserDefined {
   unsigned char httpwant; /* when non-zero, a specific HTTP version requested
                              to be used in the library's request(s) */
   struct ssl_config_data ssl;  /* user defined SSL stuff */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_config_data proxy_ssl;  /* user defined SSL stuff for proxy */
 #endif
   struct ssl_general_config general_ssl; /* general user defined SSL stuff */
@@ -1764,7 +1764,7 @@ struct UserDefined {
   unsigned char ipver; /* the CURL_IPRESOLVE_* defines in the public header
                           file 0 - whatever, 1 - v2, 2 - v6 */
   curl_off_t max_filesize; /* Maximum file size to download */
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   unsigned char ftp_filemethod; /* how to get to a file: curl_ftpfile  */
   unsigned char ftpsslauth; /* what AUTH XXX to try: curl_ftpauth */
   unsigned char ftp_ccc;   /* FTP CCC options: curl_ftpccc */
@@ -1782,7 +1782,7 @@ struct UserDefined {
 
   curl_sshkeycallback ssh_keyfunc; /* key matching callback */
   void *ssh_keyfunc_userp;         /* custom pointer to callback */
-#ifndef CURL_DISABLE_NETRC
+#ifdef FEAT_NETRC
   unsigned char use_netrc;        /* enum CURL_NETRC_OPTION values  */
 #endif
   curl_usessl use_ssl;   /* if AUTH TLS is to be attempted etc, for FTP or
@@ -1799,12 +1799,12 @@ struct UserDefined {
   curl_prot_t redir_protocols;
   unsigned int mime_options;      /* Mime option flags. */
 
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
   void *rtp_out;     /* write RTP to this if non-NULL */
   /* Common RTSP header options */
   Curl_RtspReq rtspreq; /* RTSP request type */
 #endif
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   curl_chunk_bgn_callback chunk_bgn; /* called before part of transfer
                                         starts */
   curl_chunk_end_callback chunk_end; /* called after part transferring
@@ -1832,7 +1832,7 @@ struct UserDefined {
   void *resolver_start_client; /* pointer to pass to resolver start callback */
   long upkeep_interval_ms;      /* Time between calls for connection upkeep. */
   multidone_func fmultidone;
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   struct Curl_easy *dohfor; /* this is a DoH request for that transfer */
 #endif
   CURLU *uh; /* URL handle for the current parsed URL */
@@ -1840,7 +1840,7 @@ struct UserDefined {
   curl_trailer_callback trailer_callback; /* trailing data callback */
   char keep_post;     /* keep POSTs as POSTs after a 30x request; each
                          bit represents a request, from 301 to 303 */
-#ifndef CURL_DISABLE_SMTP
+#ifdef FEAT_SMTP
   struct curl_slist *mail_rcpt; /* linked list of mail recipients */
   BIT(mail_rcpt_allowfails); /* allow RCPT TO command to fail for some
                                 recipients */
@@ -1848,7 +1848,7 @@ struct UserDefined {
   unsigned char connect_only; /* make connection/request, then let
                                  application use the socket */
   BIT(is_fread_set); /* has read callback been set to non-NULL? */
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
   BIT(tftp_no_options); /* do not send TFTP options requests */
 #endif
   BIT(sep_headers);     /* handle host and proxy headers separately */
@@ -1864,7 +1864,7 @@ struct UserDefined {
   BIT(prefer_ascii);     /* ASCII rather than binary */
   BIT(remote_append);    /* append, not overwrite, on upload */
   BIT(list_only);        /* list directory */
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   BIT(ftp_use_port);     /* use the FTP PORT command */
   BIT(ftp_use_epsv);     /* if EPSV is to be attempted or not */
   BIT(ftp_use_eprt);     /* if EPRT is to be attempted or not */
@@ -1916,7 +1916,7 @@ struct UserDefined {
                            header */
   BIT(abstract_unix_socket);
   BIT(disallow_username_in_url); /* disallow username in url */
-#ifndef CURL_DISABLE_DOH
+#ifdef FEAT_DOH
   BIT(doh); /* DNS-over-HTTPS enabled */
   BIT(doh_verifypeer);     /* DoH certificate peer verification */
   BIT(doh_verifyhost);     /* DoH certificate hostname verification */
@@ -1987,22 +1987,22 @@ struct Curl_easy {
 #endif
   struct SingleRequest req;    /* Request-specific data */
   struct UserDefined set;      /* values set by the libcurl user */
-#ifndef CURL_DISABLE_COOKIES
+#ifdef FEAT_COOKIES
   struct CookieInfo *cookies;  /* the cookies, read from files and servers.
                                   NOTE that the 'cookie' field in the
                                   UserDefined struct defines if the "engine"
                                   is to be used or not. */
 #endif
-#ifndef CURL_DISABLE_HSTS
+#ifdef FEAT_HSTS
   struct hsts *hsts;
 #endif
-#ifndef CURL_DISABLE_ALTSVC
+#ifdef FEAT_ALTSVC
   struct altsvcinfo *asi;      /* the alt-svc cache */
 #endif
   struct Progress progress;    /* for all the progress meter data */
   struct UrlState state;       /* struct for fields used for state info and
                                   other dynamic purposes */
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   struct WildcardData wildcard; /* wildcard download state info */
 #endif
   struct PureInfo info;        /* stats, reports and info data */

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -27,8 +27,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) ||       \
-  !defined(CURL_DISABLE_POP3)
+#if defined(FEAT_IMAP) || defined(FEAT_SMTP) || defined(FEAT_POP3)
 
 #include <curl/curl.h>
 #include "urldata.h"

--- a/lib/vauth/cram.c
+++ b/lib/vauth/cram.c
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 
 #include <curl/curl.h>
 #include "urldata.h"
@@ -94,4 +94,4 @@ CURLcode Curl_auth_create_cram_md5_message(const struct bufref *chlg,
   return CURLE_OK;
 }
 
-#endif /* !CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_CRYPTO_AUTH */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -27,7 +27,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 
 #include <curl/curl.h>
 
@@ -991,4 +991,4 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
 }
 #endif  /* !USE_WINDOWS_SSPI */
 
-#endif  /* CURL_DISABLE_CRYPTO_AUTH */
+#endif  /* FEAT_CRYPTO_AUTH */

--- a/lib/vauth/digest.h
+++ b/lib/vauth/digest.h
@@ -26,7 +26,7 @@
 
 #include <curl/curl.h>
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 
 #define DIGEST_MAX_VALUE_LENGTH           256
 #define DIGEST_MAX_CONTENT_LENGTH         1024

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -27,7 +27,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(USE_WINDOWS_SSPI) && defined(FEAT_CRYPTO_AUTH)
 
 #include <curl/curl.h>
 
@@ -199,7 +199,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
      status == SEC_I_COMPLETE_AND_CONTINUE)
     s_pSecFn->CompleteAuthToken(&credentials, &resp_desc);
   else if(status != SEC_E_OK && status != SEC_I_CONTINUE_NEEDED) {
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
     char buffer[STRERROR_LEN];
 #endif
 
@@ -589,7 +589,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
        status == SEC_I_COMPLETE_AND_CONTINUE)
       s_pSecFn->CompleteAuthToken(&credentials, &resp_desc);
     else if(status != SEC_E_OK && status != SEC_I_CONTINUE_NEEDED) {
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifdef FEAT_VERBOSE_STRINGS
       char buffer[STRERROR_LEN];
 #endif
 
@@ -665,4 +665,4 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   Curl_safefree(digest->passwd);
 }
 
-#endif /* USE_WINDOWS_SSPI && !CURL_DISABLE_CRYPTO_AUTH */
+#endif /* USE_WINDOWS_SSPI && FEAT_CRYPTO_AUTH */

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -271,7 +271,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   SecPkgContext_Sizes sizes;
   SECURITY_STATUS status;
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) data;
 #endif
 

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -175,7 +175,7 @@ static CURLcode ntlm_decode_type2_target(struct Curl_easy *data,
   const unsigned char *type2 = Curl_bufref_ptr(type2ref);
   size_t type2len = Curl_bufref_len(type2ref);
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) data;
 #endif
 
@@ -281,7 +281,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   result = Curl_nss_force_init(data);
   if(result)
     return result;
-#elif defined(CURL_DISABLE_VERBOSE_STRINGS)
+#elif !defined(FEAT_VERBOSE_STRINGS)
   (void)data;
 #endif
 

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -202,7 +202,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
                                              const struct bufref *type2,
                                              struct ntlmdata *ntlm)
 {
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) data;
 #endif
 
@@ -255,7 +255,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   unsigned long attrs;
   TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) data;
 #endif
   (void) passwdp;

--- a/lib/vauth/oauth2.c
+++ b/lib/vauth/oauth2.c
@@ -26,8 +26,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3)
+#if defined(FEAT_IMAP) || defined(FEAT_SMTP) || defined(FEAT_POP3)
 
 #include <curl/curl.h>
 #include "urldata.h"

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -107,7 +107,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   unsigned long attrs;
   TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
-#if defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef FEAT_VERBOSE_STRINGS
   (void) data;
 #endif
 

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -30,7 +30,7 @@
 
 struct Curl_easy;
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 struct digestdata;
 #endif
 
@@ -86,7 +86,7 @@ CURLcode Curl_auth_create_login_message(const char *value,
 CURLcode Curl_auth_create_external_message(const char *user,
                                            struct bufref *out);
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#ifdef FEAT_CRYPTO_AUTH
 /* This is used to generate a CRAM-MD5 response message */
 CURLcode Curl_auth_create_cram_md5_message(const struct bufref *chlg,
                                            const char *userp,
@@ -119,7 +119,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 
 /* This is used to clean up the digest specific data */
 void Curl_auth_digest_cleanup(struct digestdata *digest);
-#endif /* !CURL_DISABLE_CRYPTO_AUTH */
+#endif /* FEAT_CRYPTO_AUTH */
 
 #ifdef USE_GSASL
 /* This is used to evaluate if MECH is supported by gsasl */

--- a/lib/version.c
+++ b/lib/version.c
@@ -289,52 +289,52 @@ char *curl_version(void)
  */
 
 static const char * const protocols[] = {
-#ifndef CURL_DISABLE_DICT
+#ifdef FEAT_DICT
   "dict",
 #endif
-#ifndef CURL_DISABLE_FILE
+#ifdef FEAT_FILE
   "file",
 #endif
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   "ftp",
-#endif
-#if defined(USE_SSL) && !defined(CURL_DISABLE_FTP)
+#ifdef USE_SSL
   "ftps",
 #endif
-#ifndef CURL_DISABLE_GOPHER
-  "gopher",
 #endif
-#if defined(USE_SSL) && !defined(CURL_DISABLE_GOPHER)
+#ifdef FEAT_GOPHER
+  "gopher",
+#ifdef USE_SSL
   "gophers",
 #endif
-#ifndef CURL_DISABLE_HTTP
-  "http",
 #endif
-#if defined(USE_SSL) && !defined(CURL_DISABLE_HTTP)
+#ifdef FEAT_HTTP
+  "http",
+#ifdef USE_SSL
   "https",
 #endif
-#ifndef CURL_DISABLE_IMAP
-  "imap",
 #endif
-#if defined(USE_SSL) && !defined(CURL_DISABLE_IMAP)
+#ifdef FEAT_IMAP
+  "imap",
+#ifdef USE_SSL
   "imaps",
 #endif
-#ifndef CURL_DISABLE_LDAP
+#endif
+#ifdef FEAT_LDAP
   "ldap",
-#if !defined(CURL_DISABLE_LDAPS) && \
-    ((defined(USE_OPENLDAP) && defined(USE_SSL)) || \
-     (!defined(USE_OPENLDAP) && defined(HAVE_LDAP_SSL)))
+#if defined(FEAT_LDAPS) &&                          \
+  ((defined(USE_OPENLDAP) && defined(USE_SSL)) ||               \
+   (!defined(USE_OPENLDAP) && defined(HAVE_LDAP_SSL)))
   "ldaps",
 #endif
 #endif
-#ifndef CURL_DISABLE_MQTT
+#ifdef FEAT_MQTT
   "mqtt",
 #endif
-#ifndef CURL_DISABLE_POP3
+#ifdef FEAT_POP3
   "pop3",
-#endif
-#if defined(USE_SSL) && !defined(CURL_DISABLE_POP3)
+#ifdef USE_SSL
   "pop3s",
+#endif
 #endif
 #ifdef USE_LIBRTMP
   "rtmp",
@@ -344,7 +344,7 @@ static const char * const protocols[] = {
   "rtmpte",
   "rtmpts",
 #endif
-#ifndef CURL_DISABLE_RTSP
+#ifdef FEAT_RTSP
   "rtsp",
 #endif
 #if defined(USE_SSH) && !defined(USE_WOLFSSH)
@@ -353,30 +353,30 @@ static const char * const protocols[] = {
 #ifdef USE_SSH
   "sftp",
 #endif
-#if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE) && \
+#if defined(FEAT_SMB) && defined(USE_CURL_NTLM_CORE) && \
    (SIZEOF_CURL_OFF_T > 4)
   "smb",
 #  ifdef USE_SSL
   "smbs",
 #  endif
 #endif
-#ifndef CURL_DISABLE_SMTP
+#ifdef FEAT_SMTP
   "smtp",
-#endif
-#if defined(USE_SSL) && !defined(CURL_DISABLE_SMTP)
+#ifdef USE_SSL
   "smtps",
 #endif
-#ifndef CURL_DISABLE_TELNET
+#endif
+#ifdef FEAT_TELNET
   "telnet",
 #endif
-#ifndef CURL_DISABLE_TFTP
+#ifdef FEAT_TFTP
   "tftp",
 #endif
-#ifdef USE_WEBSOCKETS
+#ifdef FEAT_WS
   "ws",
-#endif
-#if defined(USE_SSL) && defined(USE_WEBSOCKETS)
+#ifdef USE_SSL
   "wss",
+#endif
 #endif
 
   NULL
@@ -397,7 +397,7 @@ static curl_version_info_data version_info = {
 #ifdef USE_NTLM
   | CURL_VERSION_NTLM
 #endif
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_NTLM) && \
+#if defined(FEAT_HTTP) && defined(USE_NTLM) && \
   defined(NTLM_WB_ENABLED)
   | CURL_VERSION_NTLM_WB
 #endif
@@ -456,10 +456,10 @@ static curl_version_info_data version_info = {
 #if defined(HAVE_ZSTD)
   | CURL_VERSION_ZSTD
 #endif
-#ifndef CURL_DISABLE_ALTSVC
+#ifdef FEAT_ALTSVC
   | CURL_VERSION_ALTSVC
 #endif
-#ifndef CURL_DISABLE_HSTS
+#ifdef FEAT_HSTS
   | CURL_VERSION_HSTS
 #endif
 #if defined(USE_GSASL)
@@ -521,7 +521,7 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
 #ifdef USE_SSL
   Curl_ssl_version(ssl_buffer, sizeof(ssl_buffer));
   version_info.ssl_version = ssl_buffer;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(Curl_ssl->supports & SSLSUPP_HTTPS_PROXY)
     version_info.features |= CURL_VERSION_HTTPS_PROXY;
   else

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -252,7 +252,7 @@ static void mystate(struct Curl_easy *data, sshstate nowstate
 {
   struct connectdata *conn = data->conn;
   struct ssh_conn *sshc = &conn->proto.sshc;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char *const names[] = {
     "SSH_STOP",

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -315,7 +315,7 @@ static void state(struct Curl_easy *data, sshstate nowstate)
 {
   struct connectdata *conn = data->conn;
   struct ssh_conn *sshc = &conn->proto.sshc;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[] = {
     "SSH_STOP",
@@ -3172,7 +3172,7 @@ static CURLcode ssh_setup_connection(struct Curl_easy *data,
 static Curl_recv scp_recv, sftp_recv;
 static Curl_send scp_send, sftp_send;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
 static ssize_t ssh_tls_recv(libssh2_socket_t sock, void *buffer,
                             size_t length, int flags, void **abstract)
 {
@@ -3266,7 +3266,7 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
     return CURLE_FAILED_INIT;
   }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->http_proxy.proxytype == CURLPROXY_HTTPS) {
     /*
      * This crazy union dance is here to avoid assigning a void pointer a
@@ -3311,7 +3311,7 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
     sshc->tls_send = conn->send[FIRSTSOCKET];
   }
 
-#endif /* CURL_DISABLE_PROXY */
+#endif /* FEAT_PROXY */
   if(conn->handler->protocol & CURLPROTO_SCP) {
     conn->recv[FIRSTSOCKET] = scp_recv;
     conn->send[FIRSTSOCKET] = scp_send;

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -185,7 +185,7 @@ struct ssh_conn {
   LIBSSH2_SFTP *sftp_session;   /* SFTP handle */
   LIBSSH2_SFTP_HANDLE *sftp_handle;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   /* for HTTPS proxy storage */
   Curl_recv *tls_recv;
   Curl_send *tls_send;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -138,7 +138,7 @@ static void state(struct Curl_easy *data, sshstate nowstate)
 {
   struct connectdata *conn = data->conn;
   struct ssh_conn *sshc = &conn->proto.sshc;
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   /* for debug purposes */
   static const char * const names[] = {
     "SSH_STOP",

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -695,7 +695,7 @@ static CURLcode bearssl_connect_step1(struct Curl_easy *data,
 
 #ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
       && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
       ) {

--- a/lib/vtls/gskit.c
+++ b/lib/vtls/gskit.c
@@ -105,7 +105,7 @@
 struct ssl_backend_data {
   gsk_handle handle;
   int iocport;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   int localfd;
   int remotefd;
 #endif
@@ -512,7 +512,7 @@ static void close_async_handshake(struct ssl_connect_data *connssl)
 static int pipe_ssloverssl(struct connectdata *conn, int sockindex,
                            int directions)
 {
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
   struct ssl_connect_data *connproxyssl = &conn->proxy_ssl[sockindex];
   struct pollfd fds[2];
@@ -597,7 +597,7 @@ static void close_one(struct ssl_connect_data *connssl, struct Curl_easy *data,
     while(pipe_ssloverssl(conn, sockindex, SOS_WRITE) > 0)
       ;
     BACKEND->handle = (gsk_handle) NULL;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     if(BACKEND->localfd >= 0) {
       close(BACKEND->localfd);
       BACKEND->localfd = -1;
@@ -717,7 +717,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
   const char *sni;
   unsigned int protoflags = 0;
   Qso_OverlappedIO_t commarea;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   int sockpair[2];
   static const int sobufsize = CURL_MAX_WRITE_SIZE;
 #endif
@@ -727,7 +727,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
 
   BACKEND->handle = (gsk_handle) NULL;
   BACKEND->iocport = -1;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   BACKEND->localfd = -1;
   BACKEND->remotefd = -1;
 #endif
@@ -769,7 +769,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
   if(result)
     return result;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   /* Establish a pipelining socket pair for SSL over SSL. */
   if(conn->proxy_ssl[sockindex].use) {
     if(Curl_socketpair(0, 0, 0, sockpair))
@@ -845,7 +845,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
   if(!result)
     result = set_numeric(data, BACKEND->handle, GSK_OS400_READ_TIMEOUT, 1);
   if(!result)
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     result = set_numeric(data, BACKEND->handle, GSK_FD, BACKEND->localfd >= 0?
                          BACKEND->localfd: conn->sock[sockindex]);
 #else
@@ -920,7 +920,7 @@ static CURLcode gskit_connect_step1(struct Curl_easy *data,
     else if(errno != ENOBUFS)
       result = gskit_status(data, GSK_ERROR_IO,
                             "QsoCreateIOCompletionPort()", 0);
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     else if(conn->proxy_ssl[sockindex].use) {
       /* Cannot pipeline while handshaking synchronously. */
       result = CURLE_SSL_CONNECT_ERROR;
@@ -1189,7 +1189,7 @@ static void gskit_close(struct Curl_easy *data, struct connectdata *conn,
                         int sockindex)
 {
   close_one(&conn->ssl[sockindex], data, conn, sockindex);
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   close_one(&conn->proxy_ssl[sockindex], data, conn, sockindex);
 #endif
 }
@@ -1209,7 +1209,7 @@ static int gskit_shutdown(struct Curl_easy *data,
   if(!BACKEND->handle)
     return 0;
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   if(data->set.ftp_ccc != CURLFTPSSL_CCC_ACTIVE)
     return 0;
 #endif

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -144,7 +144,7 @@ static void gtls_cleanup(void)
   }
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 static void showtime(struct Curl_easy *data,
                      const char *text,
                      time_t stamp)
@@ -637,7 +637,7 @@ gtls_connect_step1(struct Curl_easy *data,
 
 #ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
        && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
        ) {
@@ -716,7 +716,7 @@ gtls_connect_step1(struct Curl_easy *data,
     }
   }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->proxy_ssl[sockindex].use) {
     struct ssl_backend_data *proxy_backend;
     proxy_backend = conn->proxy_ssl[sockindex].backend;
@@ -851,7 +851,7 @@ Curl_gtls_verifyserver(struct Curl_easy *data,
   int rc;
   gnutls_datum_t proto;
   CURLcode result = CURLE_OK;
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   unsigned int algo;
   unsigned int bits;
   gnutls_protocol_t version = gnutls_protocol_get_version(session);
@@ -1227,7 +1227,7 @@ Curl_gtls_verifyserver(struct Curl_easy *data,
 
   */
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   /* public key algorithm's parameters */
   algo = gnutls_x509_crt_get_pk_algorithm(x509_cert, &bits);
   infof(data, "  certificate public key: %s",
@@ -1427,7 +1427,7 @@ static bool gtls_data_pending(const struct connectdata *conn,
      0 != gnutls_record_check_pending(backend->session))
     res = TRUE;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   connssl = &conn->proxy_ssl[connindex];
   backend = connssl->backend;
   DEBUGASSERT(backend);
@@ -1495,7 +1495,7 @@ static void gtls_close(struct Curl_easy *data, struct connectdata *conn,
 {
   (void) data;
   close_one(&conn->ssl[sockindex]);
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   close_one(&conn->proxy_ssl[sockindex]);
 #endif
 }
@@ -1513,7 +1513,7 @@ static int gtls_shutdown(struct Curl_easy *data, struct connectdata *conn,
 
   DEBUGASSERT(backend);
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   /* This has only been tested on the proftpd server, and the mod_tls code
      sends a close notify alert without waiting for a close notify alert in
      response. Thus we wait for a close notify alert from the server, but

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -283,7 +283,7 @@ mbed_connect_step1(struct Curl_easy *data, struct connectdata *conn,
   const struct curl_blob *ssl_cert_blob = SSL_SET_OPTION(primary.cert_blob);
   const char * const ssl_crlfile = SSL_SET_OPTION(primary.CRLfile);
   const char * const hostname = SSL_HOST_NAME();
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   const long int port = SSL_HOST_PORT();
 #endif
   int ret = -1;

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -1616,19 +1616,19 @@ static void nss_close(struct Curl_easy *data, struct connectdata *conn,
                       int sockindex)
 {
   struct ssl_connect_data *connssl = &conn->ssl[sockindex];
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_connect_data *connssl_proxy = &conn->proxy_ssl[sockindex];
 #endif
   struct ssl_backend_data *backend = connssl->backend;
   (void)data;
 
   DEBUGASSERT(backend);
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   DEBUGASSERT(connssl_proxy->backend != NULL);
 #endif
 
   if(backend->handle
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
     || connssl_proxy->backend->handle
 #endif
     ) {
@@ -1638,7 +1638,7 @@ static void nss_close(struct Curl_easy *data, struct connectdata *conn,
     conn->sock[sockindex] = CURL_SOCKET_BAD;
   }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(backend->handle)
     /* nss_close(connssl) will transitively close also
        connssl_proxy->backend->handle if both are used. Clear it to avoid
@@ -2075,7 +2075,7 @@ static CURLcode nss_setup_connect(struct Curl_easy *data,
     goto error;
   }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->proxy_ssl[sockindex].use) {
     struct ssl_backend_data *proxy_backend;
     proxy_backend = conn->proxy_ssl[sockindex].backend;
@@ -2161,7 +2161,7 @@ static CURLcode nss_setup_connect(struct Curl_easy *data,
 
 #ifdef USE_HTTP2
     if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
        && (!SSL_IS_PROXY() || !conn->bits.tunnel_proxy)
 #endif
       ) {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1667,7 +1667,7 @@ schannel_connect_step3(struct Curl_easy *data, struct connectdata *conn,
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CERT_CONTEXT *ccert_context = NULL;
   bool isproxy = SSL_IS_PROXY();
-#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(DEBUGBUILD) && defined(FEAT_VERBOSE_STRINGS)
   const char * const hostname = SSL_HOST_NAME();
 #endif
 #ifdef HAS_ALPN
@@ -2340,7 +2340,7 @@ schannel_recv(struct Curl_easy *data, int sockindex,
       goto cleanup;
     }
     else {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
       char buffer[STRERROR_LEN];
 #endif
       *err = CURLE_RECV_ERROR;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -937,7 +937,7 @@ static OSStatus SocketWrite(SSLConnectionRef connection,
   return ortn;
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
 CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
 {
   /* The first ciphers in the ciphertable are continuous. Here we do small
@@ -956,7 +956,7 @@ CF_INLINE const char *TLSCipherNameForNumber(SSLCipherSuite cipher)
   }
   return ciphertable[SSL_NULL_WITH_NULL_NULL].name;
 }
-#endif /* !CURL_DISABLE_VERBOSE_STRINGS */
+#endif /* FEAT_VERBOSE_STRINGS */
 
 #if CURL_BUILD_MAC
 CF_INLINE void GetDarwinVersionNumber(int *major, int *minor)
@@ -1848,7 +1848,7 @@ static CURLcode sectransp_connect_step1(struct Curl_easy *data,
 
 #ifdef USE_HTTP2
       if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
          && (!isproxy || !conn->bits.tunnel_proxy)
 #endif
         ) {
@@ -2899,7 +2899,7 @@ collect_server_cert_single(struct Curl_easy *data,
                            CFIndex idx)
 {
   CURLcode result = CURLE_OK;
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   if(data->set.verbose) {
     char *certp;
     result = CopyCertSubject(data, server_cert, &certp);
@@ -2920,7 +2920,7 @@ collect_server_cert(struct Curl_easy *data,
                     struct connectdata *conn,
                     int sockindex)
 {
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
+#ifdef FEAT_VERBOSE_STRINGS
   const bool show_verbose_server_cert = data->set.verbose;
 #else
   const bool show_verbose_server_cert = false;
@@ -3216,7 +3216,7 @@ static int sectransp_shutdown(struct Curl_easy *data,
   if(!backend->ssl_ctx)
     return 0;
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
   if(data->set.ftp_ccc != CURLFTPSSL_CCC_ACTIVE)
     return 0;
 #endif

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -291,7 +291,7 @@ static bool ssl_prefs_check(struct Curl_easy *data)
   return TRUE;
 }
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
 static CURLcode
 ssl_connect_init_proxy(struct connectdata *conn, int sockindex)
 {
@@ -325,7 +325,7 @@ Curl_ssl_connect(struct Curl_easy *data, struct connectdata *conn,
 {
   CURLcode result;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->bits.proxy_ssl_connected[sockindex]) {
     result = ssl_connect_init_proxy(conn, sockindex);
     if(result)
@@ -356,7 +356,7 @@ Curl_ssl_connect_nonblocking(struct Curl_easy *data, struct connectdata *conn,
 {
   CURLcode result;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   if(conn->bits.proxy_ssl_connected[sockindex]) {
     result = ssl_connect_init_proxy(conn, sockindex);
     if(result)
@@ -410,7 +410,7 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
   long *general_age;
   bool no_match = TRUE;
 
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_primary_config * const ssl_config = isProxy ?
     &conn->proxy_ssl_config :
     &conn->ssl_config;
@@ -426,7 +426,7 @@ bool Curl_ssl_getsessionid(struct Curl_easy *data,
   (void)sockindex;
   *ssl_sessionid = NULL;
 
-#ifdef CURL_DISABLE_PROXY
+#ifndef FEAT_PROXY
   if(isProxy)
     return TRUE;
 #endif
@@ -536,7 +536,7 @@ CURLcode Curl_ssl_addsessionid(struct Curl_easy *data,
   char *clone_conn_to_host;
   int conn_to_port;
   long *general_age;
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
   struct ssl_primary_config * const ssl_config = isProxy ?
     &conn->proxy_ssl_config :
     &conn->ssl_config;

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -155,7 +155,7 @@ CURLsslset Curl_init_sslset_nolock(curl_sslbackend id, const char *name,
 
 /* set of helper macros for the backends to access the correct fields. For the
    proxy or for the remote host - to properly support HTTPS proxy */
-#ifndef CURL_DISABLE_PROXY
+#ifdef FEAT_PROXY
 #define SSL_IS_PROXY()                                                  \
   (CURLPROXY_HTTPS == conn->http_proxy.proxytype &&                     \
    ssl_connection_complete !=                                           \

--- a/lib/wildcard.c
+++ b/lib/wildcard.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 
 #include "wildcard.h"
 #include "llist.h"

--- a/lib/wildcard.h
+++ b/lib/wildcard.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_FTP
+#ifdef FEAT_FTP
 #include <curl/curl.h>
 #include "llist.h"
 


### PR DESCRIPTION
All C files now check for the *presence* of features with `FEAT` instead of the former often used `CURL_DISABLE` that checked for disabled features. This simplifies #ifs and #ifdefs in numerous places.

`CURL_DISABLE` defines can still be set by config-*.h files or by configure/cmake.

feat.h defines what fatures to build, respecting the will of any `CURL_DISABLE` defines set.

**DRAFT** to get a sense for how it works and feels.