### PR TITLE
docs: update sourceforge project links [ci skip]

### DIFF
--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -20,7 +20,7 @@ C++: [curlpp](https://github.com/jpbarrette/curlpp/) Written by Jean-Philippe Ba
 [curlcpp](https://github.com/JosephP91/curlcpp) by Giuseppe Persico and [C++
 Requests](https://github.com/libcpr/cpr) by Huu Nguyen
 
-[Ch](https://chcurl.sourceforge.io/) Written by Stephen Nestinger and Jonathan Rogado
+[Ch](https://chcurl.sourceforge.net/) Written by Stephen Nestinger and Jonathan Rogado
 
 Cocoa: [BBHTTP](https://github.com/biasedbit/BBHTTP) written by Bruno de Carvalho
 [curlhandle](https://github.com/karelia/curlhandle) Written by Dan Wood
@@ -31,7 +31,7 @@ Clojure: [clj-curl](https://github.com/lsevero/clj-curl) by Lucas Severo
 
 [Delphi](https://github.com/Mercury13/curl4delphi) Written by Mikhail Merkuryev
 
-[Dylan](https://dylanlibs.sourceforge.io/) Written by Chris Double
+[Dylan](https://dylanlibs.sourceforge.net/) Written by Chris Double
 
 [Eiffel](https://iron.eiffel.com/repository/20.11/package/ABEF6975-37AC-45FD-9C67-52D10BA0669B) Written by Eiffel Software
 
@@ -41,7 +41,7 @@ Clojure: [clj-curl](https://github.com/lsevero/clj-curl) by Lucas Severo
 
 [Ferite](https://web.archive.org/web/20150102192018/ferite.org/) Written by Paul Querna
 
-[Gambas](https://gambas.sourceforge.io/)
+[Gambas](https://gambas.sourceforge.net/)
 
 [glib/GTK+](https://web.archive.org/web/20100526203452/atterer.net/glibcurl) Written by Richard Atterer
 
@@ -94,13 +94,13 @@ Bailiff and Bálint Szilakszi,
 
 [Python](http://pycurl.io/) PycURL by Kjetil Jacobsen
 
-[Q](https://q-lang.sourceforge.io/) The libcurl module is part of the default install
+[Q](https://q-lang.sourceforge.net/) The libcurl module is part of the default install
 
 [R](https://cran.r-project.org/package=curl)
 
-[Rexx](https://rexxcurl.sourceforge.io/) Written Mark Hessling
+[Rexx](https://rexxcurl.sourceforge.net/) Written Mark Hessling
 
-[Ring](https://ring-lang.sourceforge.io/doc1.3/libcurl.html) RingLibCurl by Mahmoud Fayed
+[Ring](https://ring-lang.sourceforge.net/doc1.3/libcurl.html) RingLibCurl by Mahmoud Fayed
 
 RPG, support for ILE/RPG on OS/400 is included in source distribution
 
@@ -127,7 +127,7 @@ Ruby: [curb](https://github.com/taf2/curb) written by Ross Bamford,
 
 [Visual Foxpro](https://web.archive.org/web/20130730181523/www.ctl32.com.ar/libcurl.asp) by Carlos Alloatti
 
-[wxWidgets](https://wxcode.sourceforge.io/components/wxcurl/) Written by Casey O'Donnell
+[wxWidgets](https://wxcode.sourceforge.net/components/wxcurl/) Written by Casey O'Donnell
 
 [XBLite](https://web.archive.org/web/20060426150418/perso.wanadoo.fr/xblite/libraries.html) Written by David Szafranski
 

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -100,7 +100,7 @@ Bailiff and Bálint Szilakszi,
 
 [Rexx](https://rexxcurl.sourceforge.net/) Written Mark Hessling
 
-[Ring](https://ring-lang.sourceforge.net/doc1.3/libcurl.html) RingLibCurl by Mahmoud Fayed
+[Ring](https://ring-lang.sourceforge.io/doc1.3/libcurl.html) RingLibCurl by Mahmoud Fayed
 
 RPG, support for ILE/RPG on OS/400 is included in source distribution
 

--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -41,7 +41,7 @@
  *
  * The function is a port of the Java based oddParity() function over at:
  *
- * https://davenport.sourceforge.io/ntlm.html
+ * https://davenport.sourceforge.net/ntlm.html
  *
  * Parameters:
  *

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -29,7 +29,7 @@
 /*
  * NTLM details:
  *
- * https://davenport.sourceforge.io/ntlm.html
+ * https://davenport.sourceforge.net/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -30,7 +30,7 @@
 /*
  * NTLM details:
  *
- * https://davenport.sourceforge.io/ntlm.html
+ * https://davenport.sourceforge.net/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -29,7 +29,7 @@
 /*
  * NTLM details:
  *
- * https://davenport.sourceforge.io/ntlm.html
+ * https://davenport.sourceforge.net/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -29,7 +29,7 @@
 /*
  * NTLM details:
  *
- * https://davenport.sourceforge.io/ntlm.html
+ * https://davenport.sourceforge.net/ntlm.html
  * https://www.innovation.ch/java/ntlm.html
  */
 
@@ -600,7 +600,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
     /* A safer but less compatible alternative is:
      *   Curl_ntlm_core_lm_resp(ntbuffer, &ntlm->nonce[0], lmresp);
-     * See https://davenport.sourceforge.io/ntlm.html#ntlmVersion2 */
+     * See https://davenport.sourceforge.net/ntlm.html#ntlmVersion2 */
   }
 
   if(unicode) {

--- a/lib/vauth/ntlm.h
+++ b/lib/vauth/ntlm.h
@@ -34,7 +34,7 @@
 /* Stuff only required for curl_ntlm_msgs.c */
 #ifdef BUILDING_CURL_NTLM_MSGS_C
 
-/* Flag bits definitions based on https://davenport.sourceforge.io/ntlm.html */
+/* Flag bits definitions based on https://davenport.sourceforge.net/ntlm.html */
 
 #define NTLMFLAG_NEGOTIATE_UNICODE               (1<<0)
 /* Indicates that Unicode strings are supported for use in security buffer


### PR DESCRIPTION
PROJECT.sourceforge.net addresses support HTTPS now, seemingly by default. [^1]

Until recently [^3][^4], equivalent .io addresses were offering HTTPS, with a redirect to the HTTP .net site for projects that did not opt-in to HTTPS and staying on .io for those that did. PROJECT.sourceforge.net did not offer HTTPS at all.

Now, .io addresses became a project-selectable option [^2], so _some_ of them perm-redirect to the .net URL, but with _HTTP_, even though all those got HTTPS enabled. Then HTTP gets perm-redirected back to HTTPS in a next step. Possible deployment glitch? Other project stay on the .io address. Needs to be detected on a per-project basis.

FWIW, both .io and .net are served through Cloudflare.

The step back from .io to .net for user content is a little bit puzzling, as well as the insecure redirect between them and the ambiguity in deciding which flavor is the canonical one (= without a redirect).

This patch converts all .io addresses (back) to .net, so now they are all accessible via HTTPS, without a redirect.

[^1]: https://sourceforge.net/p/forge/documentation/Project%20Web%20Services/#changes-as-of-september-2022
[^2]: https://sourceforge.net/p/forge/documentation/Project%20Web%20Services/diff?v1=57&v2=56
[^3]: https://sourceforge.net/p/forge/documentation/Convert%20your%20website%20to%20HTTPS/
[^4]: https://sourceforge.net/blog/introducing-https-for-project-websites/
