### PR TITLE
Makefile.m32: delete legacy component bits [ci skip]

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -172,9 +172,9 @@ adjust as necessary. It is also possible to override these paths with
 environment variables, for example:
 
 ```cmd
-set ZLIB_PATH=c:\zlib-1.2.8
-set OPENSSL_PATH=c:\openssl-1.0.2c
-set LIBSSH2_PATH=c:\libssh2-1.6.0
+set ZLIB_PATH=c:\zlib-1.2.12
+set OPENSSL_PATH=c:\openssl-3.0.5
+set LIBSSH2_PATH=c:\libssh2-1.10.0
 ```
 
 It is also possible to build with other LDAP installations than MS LDAP;
@@ -182,14 +182,15 @@ currently it is possible to build with native Win32 OpenLDAP, or with the
 *Novell CLDAP* SDK. If you want to use these you need to set these vars:
 
 ```cmd
-set LDAP_SDK=c:\openldap
-set USE_LDAP_OPENLDAP=1
+set CURL_CFLAG_EXTRAS=-Ic:/openldap/include -DCURL_HAS_OPENLDAP_LDAPSDK
+set CURL_LDFLAG_EXTRAS=-Lc:/openldap/lib -lldap -llber
 ```
 
 or for using the Novell SDK:
 
 ```cmd
-set USE_LDAP_NOVELL=1
+set CURL_CFLAG_EXTRAS=-Ic:/openldapsdk/inc -DCURL_HAS_NOVELL_LDAPSDK
+set CURL_LDFLAG_EXTRAS=-Lc:/openldapsdk/lib/mscvc -lldapsdk -lldapssl -lldapx
 ```
 
 If you want to enable LDAPS support then set LDAPS=1.

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -325,7 +325,10 @@ endif
 ifdef LDAPS
   CFLAGS += -DHAVE_LDAP_SSL
 endif
-curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt -lwldap32
+ifeq ($(findstring -lldap,$(LDFLAGS)),)
+  curl_LDADD += -lwldap32
+endif
+curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt
 
 # Makefile.inc provides the check_PROGRAMS define
 include Makefile.inc

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -61,10 +61,6 @@ endif
 ifndef LIBIDN2_PATH
 LIBIDN2_PATH = $(PROOT)/../libidn2
 endif
-# https://www.novell.com/developer/ndk/ldap_libraries_for_c.html
-ifndef LDAP_SDK
-LDAP_SDK = $(PROOT)/../openldapsdk
-endif
 ifndef NGHTTP2_PATH
 NGHTTP2_PATH = $(PROOT)/../nghttp2
 endif
@@ -269,30 +265,11 @@ ifdef NGHTTP3
 endif
 ifdef SSL
   ifndef OPENSSL_INCLUDE
-    ifeq "$(wildcard $(OPENSSL_PATH)/outinc)" "$(OPENSSL_PATH)/outinc"
-      # OpenSSL 1.0.2 and earlier
-      OPENSSL_INCLUDE = $(OPENSSL_PATH)/outinc
-    endif
-    ifeq "$(wildcard $(OPENSSL_PATH)/include)" "$(OPENSSL_PATH)/include"
-      OPENSSL_INCLUDE = $(OPENSSL_PATH)/include
-    endif
-  endif
-  ifneq "$(wildcard $(OPENSSL_INCLUDE)/openssl/opensslv.h)" "$(OPENSSL_INCLUDE)/openssl/opensslv.h"
-    $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
+    OPENSSL_INCLUDE = $(OPENSSL_PATH)/include
   endif
   ifndef OPENSSL_LIBPATH
     OPENSSL_LIBS = -lssl -lcrypto
-    ifeq "$(wildcard $(OPENSSL_PATH)/out)" "$(OPENSSL_PATH)/out"
-      # OpenSSL 1.0.2 and earlier
-      OPENSSL_LIBPATH = $(OPENSSL_PATH)/out
-      OPENSSL_LIBS = -lssl32 -leay32
-      ifndef DYN
-        OPENSSL_LIBS += -lgdi32
-      endif
-    endif
-    ifeq "$(wildcard $(OPENSSL_PATH)/lib)" "$(OPENSSL_PATH)/lib"
-      OPENSSL_LIBPATH = $(OPENSSL_PATH)/lib
-    endif
+    OPENSSL_LIBPATH = $(OPENSSL_PATH)/lib
   endif
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
   CFLAGS += -DUSE_OPENSSL
@@ -348,20 +325,7 @@ endif
 ifdef LDAPS
   CFLAGS += -DHAVE_LDAP_SSL
 endif
-ifdef USE_LDAP_NOVELL
-  CFLAGS += -DCURL_HAS_NOVELL_LDAPSDK
-  curl_LDADD += -L"$(LDAP_SDK)/lib/mscvc" -lldapsdk -lldapssl -lldapx
-endif
-ifdef USE_LDAP_OPENLDAP
-  CFLAGS += -DCURL_HAS_OPENLDAP_LDAPSDK
-  curl_LDADD += -L"$(LDAP_SDK)/lib" -lldap -llber
-endif
-ifndef USE_LDAP_NOVELL
-ifndef USE_LDAP_OPENLDAP
-  curl_LDADD += -lwldap32
-endif
-endif
-curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt
+curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt -lwldap32
 
 # Makefile.inc provides the check_PROGRAMS define
 include Makefile.inc

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -351,7 +351,10 @@ endif
 ifdef LDAPS
   CFLAGS += -DHAVE_LDAP_SSL
 endif
-curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt -lwldap32
+ifeq ($(findstring -lldap,$(LDFLAGS)),)
+  curl_LDADD += -lwldap32
+endif
+curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt
 
 # Makefile.inc provides the CSOURCES and HHEADERS defines
 include Makefile.inc

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -61,10 +61,6 @@ endif
 ifndef LIBIDN2_PATH
 LIBIDN2_PATH = $(PROOT)/../libidn2
 endif
-# https://www.novell.com/developer/ndk/ldap_libraries_for_c.html
-ifndef LDAP_SDK
-LDAP_SDK = $(PROOT)/../openldapsdk
-endif
 ifndef NGHTTP2_PATH
 NGHTTP2_PATH = $(PROOT)/../nghttp2
 endif
@@ -283,39 +279,17 @@ ifdef NGHTTP3
 endif
 ifdef SSL
   ifndef OPENSSL_INCLUDE
-    ifeq "$(wildcard $(OPENSSL_PATH)/outinc)" "$(OPENSSL_PATH)/outinc"
-      # OpenSSL 1.0.2 and earlier
-      OPENSSL_INCLUDE = $(OPENSSL_PATH)/outinc
-    endif
-    ifeq "$(wildcard $(OPENSSL_PATH)/include)" "$(OPENSSL_PATH)/include"
-      OPENSSL_INCLUDE = $(OPENSSL_PATH)/include
-    endif
-  endif
-  ifneq "$(wildcard $(OPENSSL_INCLUDE)/openssl/opensslv.h)" "$(OPENSSL_INCLUDE)/openssl/opensslv.h"
-    $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
+    OPENSSL_INCLUDE = $(OPENSSL_PATH)/include
   endif
   ifndef OPENSSL_LIBPATH
     OPENSSL_LIBS = -lssl -lcrypto
-    ifeq "$(wildcard $(OPENSSL_PATH)/out)" "$(OPENSSL_PATH)/out"
-      # OpenSSL 1.0.2 and earlier
-      OPENSSL_LIBPATH = $(OPENSSL_PATH)/out
-      OPENSSL_LIBS = -lssl32 -leay32
-      ifndef DYN
-        OPENSSL_LIBS += -lgdi32
-      endif
-    endif
-    ifeq "$(wildcard $(OPENSSL_PATH)/lib)" "$(OPENSSL_PATH)/lib"
-      OPENSSL_LIBPATH = $(OPENSSL_PATH)/lib
-    endif
+    OPENSSL_LIBPATH = $(OPENSSL_PATH)/lib
   endif
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
   CFLAGS += -DUSE_OPENSSL
   curl_LDADD += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
   ifdef SRP
-    ifeq "$(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h)" "$(OPENSSL_INCLUDE)/openssl/srp.h"
-      # OpenSSL 1.0.1 and later
-      CFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
-    endif
+    CFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
   endif
 endif
 ifdef SCHANNEL
@@ -374,22 +348,7 @@ endif
 ifdef LDAPS
   CFLAGS += -DHAVE_LDAP_SSL
 endif
-ifdef USE_LDAP_NOVELL
-  INCLUDES += -I"$(LDAP_SDK)/inc"
-  CFLAGS += -DCURL_HAS_NOVELL_LDAPSDK
-  curl_LDADD += -L"$(LDAP_SDK)/lib/mscvc" -lldapsdk -lldapssl -lldapx
-endif
-ifdef USE_LDAP_OPENLDAP
-  INCLUDES += -I"$(LDAP_SDK)/include"
-  CFLAGS += -DCURL_HAS_OPENLDAP_LDAPSDK
-  curl_LDADD += -L"$(LDAP_SDK)/lib" -lldap -llber
-endif
-ifndef USE_LDAP_NOVELL
-ifndef USE_LDAP_OPENLDAP
-  curl_LDADD += -lwldap32
-endif
-endif
-curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt
+curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt -lwldap32
 
 # Makefile.inc provides the CSOURCES and HHEADERS defines
 include Makefile.inc

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -290,6 +290,7 @@ ifdef SSL
   curl_LDADD += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
   ifdef SRP
     ifeq "$(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h)" "$(OPENSSL_INCLUDE)/openssl/srp.h"
+      # OpenSSL 1.0.1 and later, except BoringSSL
       CFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
     endif
   endif

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -289,7 +289,9 @@ ifdef SSL
   CFLAGS += -DUSE_OPENSSL
   curl_LDADD += -L"$(OPENSSL_LIBPATH)" $(OPENSSL_LIBS)
   ifdef SRP
-    CFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
+    ifeq "$(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h)" "$(OPENSSL_INCLUDE)/openssl/srp.h"
+      CFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
+    endif
   endif
 endif
 ifdef SCHANNEL

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -330,7 +330,10 @@ endif
 ifdef LDAPS
   CFLAGS += -DHAVE_LDAP_SSL
 endif
-curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt -lwldap32
+ifeq ($(findstring -lldap,$(LDFLAGS)),)
+  curl_LDADD += -lwldap32
+endif
+curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt
 
 # Makefile.inc provides the CURL_CFILES and CURLX_CFILES defines
 include Makefile.inc

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -61,10 +61,6 @@ endif
 ifndef LIBIDN2_PATH
 LIBIDN2_PATH = $(PROOT)/../libidn2
 endif
-# https://www.novell.com/developer/ndk/ldap_libraries_for_c.html
-ifndef LDAP_SDK
-LDAP_SDK = $(PROOT)/../openldapsdk
-endif
 ifndef NGHTTP2_PATH
 NGHTTP2_PATH = $(PROOT)/../nghttp2
 endif
@@ -274,30 +270,11 @@ ifdef NGHTTP3
 endif
 ifdef SSL
   ifndef OPENSSL_INCLUDE
-    ifeq "$(wildcard $(OPENSSL_PATH)/outinc)" "$(OPENSSL_PATH)/outinc"
-      # OpenSSL 1.0.2 and earlier
-      OPENSSL_INCLUDE = $(OPENSSL_PATH)/outinc
-    endif
-    ifeq "$(wildcard $(OPENSSL_PATH)/include)" "$(OPENSSL_PATH)/include"
-      OPENSSL_INCLUDE = $(OPENSSL_PATH)/include
-    endif
-  endif
-  ifneq "$(wildcard $(OPENSSL_INCLUDE)/openssl/opensslv.h)" "$(OPENSSL_INCLUDE)/openssl/opensslv.h"
-    $(error Invalid path to OpenSSL package: $(OPENSSL_PATH))
+    OPENSSL_INCLUDE = $(OPENSSL_PATH)/include
   endif
   ifndef OPENSSL_LIBPATH
     OPENSSL_LIBS = -lssl -lcrypto
-    ifeq "$(wildcard $(OPENSSL_PATH)/out)" "$(OPENSSL_PATH)/out"
-      # OpenSSL 1.0.2 and earlier
-      OPENSSL_LIBPATH = $(OPENSSL_PATH)/out
-      OPENSSL_LIBS = -lssl32 -leay32
-      ifndef DYN
-        OPENSSL_LIBS += -lgdi32
-      endif
-    endif
-    ifeq "$(wildcard $(OPENSSL_PATH)/lib)" "$(OPENSSL_PATH)/lib"
-      OPENSSL_LIBPATH = $(OPENSSL_PATH)/lib
-    endif
+    OPENSSL_LIBPATH = $(OPENSSL_PATH)/lib
   endif
   INCLUDES += -I"$(OPENSSL_INCLUDE)"
   CFLAGS += -DUSE_OPENSSL
@@ -353,20 +330,7 @@ endif
 ifdef LDAPS
   CFLAGS += -DHAVE_LDAP_SSL
 endif
-ifdef USE_LDAP_NOVELL
-  CFLAGS += -DCURL_HAS_NOVELL_LDAPSDK
-  curl_LDADD += -L"$(LDAP_SDK)/lib/mscvc" -lldapsdk -lldapssl -lldapx
-endif
-ifdef USE_LDAP_OPENLDAP
-  CFLAGS += -DCURL_HAS_OPENLDAP_LDAPSDK
-  curl_LDADD += -L"$(LDAP_SDK)/lib" -lldap -llber
-endif
-ifndef USE_LDAP_NOVELL
-ifndef USE_LDAP_OPENLDAP
-  curl_LDADD += -lwldap32
-endif
-endif
-curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt
+curl_LDADD += -lws2_32 -lcrypt32 -lbcrypt -lwldap32
 
 # Makefile.inc provides the CURL_CFILES and CURLX_CFILES defines
 include Makefile.inc


### PR DESCRIPTION
- Drop auto-detection of OpenSSL 1.0.2 and earlier. Now defaulting to OpenSSL 1.1.0 and later, LibreSSL and BoringSSL.

- Drop `Invalid path to OpenSSL package` detection. OpenSSL has been using a standard file layout since 1.1.0, so this seems unnecessary now.

- Drop special logic to enable Novell LDAP SDK support.

- Drop special logic to enable OpenLDAP LDAP SDK support. This seems to be distinct from native OpenLDAP, with support implemented inside `lib/ldap.c` (vs. `lib/openldap.c`) back when the latter did not exist yet in curl.

- Add `-lwldap32` only if there is no other LDAP library (either native OpenLDAP, or SDKs above) present.

- Update `doc/INSTALL.md` accordingly.

After this patch, it's necessary to make configration changes when using OpenSSL 1.0.2 or earlier, or the two LDAP SDKs.

OpenSSL 1.0.2 and earlier:
```
export OPENSSL_INCLUDE = <path-to-openssl>/outinc
export OPENSSL_LIBPATH = <path-to-openssl>/out
export OPENSSL_LIBS = -lssl32 -leay32 -lgdi32
```

Novell LDAP SDK, previously enabled via `USE_LDAP_NOVELL=1`:
```
export CURL_CFLAG_EXTRAS = -I<path-to-sdk>/inc -DCURL_HAS_NOVELL_LDAPSDK
export CURL_LDFLAG_EXTRAS = -L<path-to-sdk>/lib/mscvc -lldapsdk -lldapssl -lldapx
```

OpenLDAP LDAP SDK, previously enabled via `USE_LDAP_OPENLDAP=1`:
```
export CURL_CFLAG_EXTRAS = -I<path-to-sdk>/include -DCURL_HAS_OPENLDAP_LDAPSDK
export CURL_LDFLAG_EXTRAS = -L<path-to-sdk>/lib -lldap -llber
```

I haven't tested these scenarios, and in general we recommend using a recent OpenSSL release. Also, WinLDAP (the Windows default) and OpenLDAP (via `-DUSE_OPENLDAP`) are the LDAP options actively worked on in curl.

Closes #9631
