### PR TITLE
connect: change verbose IPv6 address:port to [address]:port

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1222,7 +1222,11 @@ static CURLcode singleipconnect(struct Curl_easy *data,
     Curl_closesocket(data, conn, sockfd);
     return CURLE_OK;
   }
-  infof(data, "  Trying %s:%d...", ipaddress, port);
+  infof(data, "  Trying %s%s%s:%d...",
+        (addr.family == AF_INET6 ? "[" : ""),
+        ipaddress,
+        (addr.family == AF_INET6 ? "]" : ""),
+        port);
 
 #ifdef ENABLE_IPV6
   is_tcp = (addr.family == AF_INET || addr.family == AF_INET6) &&


### PR DESCRIPTION
- Use brackets for the IPv6 address shown in verbose message when the format is address:port so that it is less confusing.

Before: Trying 2606:4700:4700::1111:443...
After: Trying [2606:4700:4700::1111]:443...

Bug: https://curl.se/mail/archive-2022-02/0041.html
Reported-by: David Hu

Closes #xxxx
