### PR TITLE
CURLOPT_COOKIELIST.3: fix formatting mistake

### DIFF
--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.3
@@ -116,7 +116,7 @@ online here: https://curl.se/docs/http-cookies.html
 
 \fBFLUSH\fP was added in 7.17.1
 
-\fFRELOAD\fP was added in 7.39.0
+\fBRELOAD\fP was added in 7.39.0
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/tests/manpage-syntax.pl
+++ b/tests/manpage-syntax.pl
@@ -163,6 +163,14 @@ sub scanmanpage {
                 $errors++;
             }
         }
+        if($_ =~ /(.*)\\f([^BIP])/) {
+            my ($pre, $format) = ($1, $2);
+            if($pre !~ /\\\z/) {
+                # only if there wasn't another backslash before the \f
+                print STDERR "$file:$line suspicios \\f format!\n";
+                $errors++;
+            }
+        }
         if($optpage && $SH && ($SH !~ /^(SYNOPSIS|EXAMPLE|NAME|SEE ALSO)/i) &&
            ($_ =~ /(.*)(CURL(OPT_|MOPT_|INFO_)[A-Z0-9_]*)/)) {
             # an option with its own man page, check that it is tagged


### PR DESCRIPTION
Also, updated manpage-syntax.pl to make it detect this error in test 1173.

Reported-by: ProceduralMan on github
Fixes #9639