### PR TITLE
Makefile.m32: deduplicate build rules

### DIFF
--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -159,6 +159,8 @@ include Makefile.inc
 TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime.c))
 RESOURCE := $(PROOT)/src/curl.res
 
+TOCLEAN := $(TARGETS:.exe=.o)
+
 ### Rules
 
 CC ?= $(CROSSPREFIX)gcc
@@ -182,7 +184,7 @@ all: $(TARGETS)
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@
 
 clean:
-	@$(call DEL, $(TARGETS:.exe=.o))
+	@$(call DEL, $(TOCLEAN))
 
 distclean vclean: clean
 	@$(call DEL, $(TARGETS))

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -32,31 +32,8 @@
 
 PROOT := ../..
 
-CPPFLAGS += -I. -I$(PROOT)/include
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
-
-ifneq ($(ARCH),custom)
-  # Set environment var ARCH to your architecture to override autodetection.
-  ifndef ARCH
-    ifneq ($(findstring x86_64,$(shell $(CC) -dumpmachine)),)
-      ARCH := w64
-    else
-      ARCH := w32
-    endif
-  endif
-  ifeq ($(ARCH),w64)
-    CFLAGS  += -m64
-    LDFLAGS += -m64
-    RCFLAGS += --target=pe-x86-64
-  else
-    CFLAGS  += -m32
-    LDFLAGS += -m32
-    RCFLAGS += --target=pe-i386
-  endif
-endif
-
-### Optional features
 
 ifneq ($(findstring -dyn,$(CFG)),)
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl$(CURL_DLL_SUFFIX).dll
@@ -66,89 +43,6 @@ else
   CPPFLAGS += -DCURL_STATICLIB
   LDFLAGS += -static
 endif
-
-ifneq ($(findstring -unicode,$(CFG)),)
-  CPPFLAGS += -DUNICODE -D_UNICODE
-  LDFLAGS += -municode
-endif
-ifneq ($(findstring -sync,$(CFG)),)
-else
-  ifneq ($(findstring -ares,$(CFG)),)
-    LIBCARES_PATH ?= $(PROOT)/../c-ares
-    LDFLAGS += -L"$(LIBCARES_PATH)/lib"
-    LIBS += -lcares
-  endif
-endif
-ifneq ($(findstring -rtmp,$(CFG)),)
-  LIBRTMP_PATH ?= $(PROOT)/../librtmp
-  LDFLAGS += -L"$(LIBRTMP_PATH)/librtmp"
-  LIBS += -lrtmp -lwinmm
-  ZLIB := 1
-endif
-ifneq ($(findstring -ssh2,$(CFG)),)
-  LIBSSH2_PATH ?= $(PROOT)/../libssh2
-  LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
-  LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
-  LIBS += -lssh2
-endif
-ifneq ($(findstring -nghttp2,$(CFG)),)
-  NGHTTP2_PATH ?= $(PROOT)/../nghttp2
-  LDFLAGS += -L"$(NGHTTP2_PATH)/lib"
-  LIBS += -lnghttp2
-endif
-ifneq ($(findstring -nghttp3,$(CFG)),)
-  ifneq ($(findstring -ngtcp2,$(CFG)),)
-    NGHTTP3_PATH ?= $(PROOT)/../nghttp3
-    LDFLAGS += -L"$(NGHTTP3_PATH)/lib"
-    LIBS += -lnghttp3
-    NGTCP2_PATH ?= $(PROOT)/../ngtcp2
-    LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-    NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_openssl
-    LIBS += $(NGTCP2_LIBS)
-  endif
-endif
-ifneq ($(findstring -ssl,$(CFG)),)
-  OPENSSL_PATH ?= $(PROOT)/../openssl
-  OPENSSL_LIBPATH ?= $(OPENSSL_PATH)/lib
-  LDFLAGS += -L"$(OPENSSL_LIBPATH)"
-  OPENSSL_LIBS ?= -lssl -lcrypto
-  LIBS += $(OPENSSL_LIBS)
-endif
-ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
-  ZLIB_PATH ?= $(PROOT)/../zlib
-  LDFLAGS += -L"$(ZLIB_PATH)"
-  LIBS += -lz
-endif
-ifneq ($(findstring -zstd,$(CFG)),)
-  ZSTD_PATH ?= $(PROOT)/../zstd
-  LDFLAGS += -L"$(ZSTD_PATH)/lib"
-  ZSTD_LIBS ?= -lzstd
-  LIBS += $(ZSTD_LIBS)
-endif
-ifneq ($(findstring -brotli,$(CFG)),)
-  BROTLI_PATH ?= $(PROOT)/../brotli
-  LDFLAGS += -L"$(BROTLI_PATH)/lib"
-  BROTLI_LIBS ?= -lbrotlidec -lbrotlicommon
-  LIBS += $(BROTLI_LIBS)
-endif
-ifneq ($(findstring -gsasl,$(CFG)),)
-  LIBGSASL_PATH ?= $(PROOT)/../gsasl
-  LDFLAGS += -L"$(LIBGSASL_PATH)/lib"
-  LIBS += -lgsasl
-endif
-ifneq ($(findstring -idn2,$(CFG)),)
-  LIBIDN2_PATH ?= $(PROOT)/../libidn2
-  LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
-  LIBS += -lidn2
-else
-ifneq ($(findstring -winidn,$(CFG)),)
-  LIBS += -lnormaliz
-endif
-endif
-ifeq ($(findstring -lldap,$(LIBS)),)
-  LIBS += -lwldap32
-endif
-LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
 ### Sources and targets
 
@@ -160,30 +54,11 @@ RESOURCE := $(PROOT)/src/curl.res
 
 TOCLEAN := $(TARGETS:.exe=.o)
 
-### Rules
-
-CC ?= $(CROSSPREFIX)gcc
-RC ?= $(CROSSPREFIX)windres
-
-ifneq ($(findstring /sh,$(SHELL)),)
-DEL = rm -f $1
-else
-DEL = -del 2>NUL /q /f $(subst /,\,$1)
-endif
-
-all: $(TARGETS)
+### Local rules
 
 %.exe: %.o $(RESOURCE) $(curl_DEPENDENCIES)
-	$(CC) $(LDFLAGS) -o $@ $< $(RESOURCE) $(LIBS)
+	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $< $(RESOURCE) $(LIBS)
 
-%.o: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+### Global script
 
-%.res: %.rc
-	$(RC) -O coff $(RCFLAGS) -i $< -o $@
-
-clean:
-	@$(call DEL, $(TOCLEAN))
-
-distclean vclean: clean
-	@$(call DEL, $(TARGETS) $(TOVCLEAN))
+include $(PROOT)/lib/Makefile.m32

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -30,7 +30,6 @@ LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
 
 ifneq ($(findstring -dyn,$(CFG)),)
-  curl_DEPENDENCIES := $(PROOT)/lib/libcurl$(CURL_DLL_SUFFIX).dll
   curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
 else
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -22,7 +22,7 @@
 #
 #***************************************************************************
 
-# See usage in lib/Makefile.m32
+# Before use, make sure to build curl via Makefile.m32.
 
 PROOT := ../..
 

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -38,7 +38,6 @@ else
   LDFLAGS += -static
 endif
 
-# For externalsocket.c
 LIBS += -lws2_32
 
 ### Sources and targets

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -45,7 +45,6 @@ include Makefile.inc
 
 TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime.c))
 RESOURCE := $(PROOT)/src/curl.res
-
 TOCLEAN := $(TARGETS:.exe=.o)
 
 ### Local rules

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -29,12 +29,12 @@ PROOT := ../..
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
 
-ifneq ($(findstring -dyn,$(CFG)),)
-  curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
-else
+ifneq ($(findstring -static,$(CFG)),)
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
   CPPFLAGS += -DCURL_STATICLIB
   LDFLAGS += -static
+else
+  curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
 endif
 
 ### Sources and targets

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -187,4 +187,4 @@ clean:
 	@$(call DEL, $(TOCLEAN))
 
 distclean vclean: clean
-	@$(call DEL, $(TARGETS))
+	@$(call DEL, $(TARGETS) $(TOVCLEAN))

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -22,13 +22,7 @@
 #
 #***************************************************************************
 
-# Makefile for building curl examples with MinGW and optional features.
-#
-# Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
-# Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
-#
-# Set component roots via envvar <feature>_PATH. CPPFLAGS, LDFLAGS, LIBS,
-# CFLAGS, RCFLAGS (and more) are also available for customization.
+# See usage in lib/Makefile.m32
 
 PROOT := ../..
 

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -159,8 +159,6 @@ include Makefile.inc
 TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime.c))
 RESOURCE := $(PROOT)/src/curl.res
 
-.PRECIOUS: %.o
-
 ### Rules
 
 CC ?= $(CROSSPREFIX)gcc

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -33,7 +33,6 @@
 PROOT := ../..
 
 CPPFLAGS += -I. -I$(PROOT)/include
-RCFLAGS  += -I$(PROOT)/include -DCURL_EMBED_MANIFEST
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
 

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -38,12 +38,15 @@ else
   LDFLAGS += -static
 endif
 
+# For externalsocket.c
+LIBS += -lws2_32
+
 ### Sources and targets
 
 # Provides check_PROGRAMS
 include Makefile.inc
 
-TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime.c))
+TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime))
 RESOURCE := $(PROOT)/src/curl.res
 TOCLEAN := $(TARGETS:.exe=.o)
 

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -22,7 +22,7 @@
 #
 #***************************************************************************
 
-# Before use, make sure to build curl via Makefile.m32.
+# Build libcurl via lib/Makefile.m32 first.
 
 PROOT := ../..
 
@@ -47,13 +47,12 @@ LIBS += -lws2_32
 include Makefile.inc
 
 TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime))
-RESOURCE := $(PROOT)/src/curl.res
 TOCLEAN := $(TARGETS:.exe=.o)
 
 ### Local rules
 
-%.exe: %.o $(RESOURCE) $(curl_DEPENDENCIES)
-	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $< $(RESOURCE) $(LIBS)
+%.exe: %.o $(curl_DEPENDENCIES)
+	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $< $(LIBS)
 
 ### Global script
 

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -156,9 +156,7 @@ LIBS += -lws2_32 -lcrypt32 -lbcrypt
 # Provides check_PROGRAMS
 include Makefile.inc
 
-TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS)))
-TARGETS += synctime.exe
-
+TARGETS := $(patsubst %,%.exe,$(strip $(check_PROGRAMS) synctime.c))
 RESOURCE := $(PROOT)/src/curl.res
 
 .PRECIOUS: %.o
@@ -186,7 +184,7 @@ all: $(TARGETS)
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@
 
 clean:
-	@$(call DEL, $(TARGETS:.exe=.o) $(RESOURCE))
+	@$(call DEL, $(TARGETS:.exe=.o))
 
 distclean vclean: clean
 	@$(call DEL, $(TARGETS))

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -29,13 +29,13 @@ PROOT := ../..
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
 
-ifneq ($(findstring -static,$(CFG)),)
+ifeq ($(findstring -static,$(CFG)),)
+  curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
+  DYN := 1
+else
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
   CPPFLAGS += -DCURL_STATICLIB
   LDFLAGS += -static
-else
-  curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
-  DYN := 1
 endif
 
 ### Sources and targets

--- a/docs/examples/Makefile.m32
+++ b/docs/examples/Makefile.m32
@@ -35,6 +35,7 @@ ifneq ($(findstring -static,$(CFG)),)
   LDFLAGS += -static
 else
   curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
+  DYN := 1
 endif
 
 ### Sources and targets

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -201,8 +201,8 @@ libcurl_a_LIBRARY := libcurl.a
 
 libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
 libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
-
-RESOURCE := $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
+libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
+libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
 
 ### Rules
 
@@ -222,8 +222,8 @@ $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 	@$(call DEL, $@)
 	$(AR) rcs $@ $(libcurl_a_OBJECTS)
 
-$(libcurl_dll_LIBRARY): $(libcurl_a_OBJECTS) $(RESOURCE)
-	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_a_OBJECTS) $(RESOURCE) $(LIBS) \
+$(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
+	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
 	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
 
 %.o: %.c
@@ -233,7 +233,7 @@ $(libcurl_dll_LIBRARY): $(libcurl_a_OBJECTS) $(RESOURCE)
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@
 
 clean:
-	@$(call DEL, $(libcurl_a_OBJECTS) $(RESOURCE))
+	@$(call DEL, $(libcurl_dll_OBJECTS))
 
 distclean vclean: clean
 	@$(call DEL, $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY) $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY))

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -199,12 +199,12 @@ libcurl_dll_LIBRARY := libcurl$(CURL_DLL_SUFFIX).dll
 libcurl_dll_a_LIBRARY := libcurl.dll.a
 libcurl_a_LIBRARY := libcurl.a
 
+TARGETS := $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
+
 libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
 libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
 libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
-
-TARGETS := $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
 
 ### Rules
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -192,7 +192,7 @@ LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
 ### Sources and targets
 
-# Provides CSOURCES and HHEADERS
+# Provides CSOURCES, HHEADERS, LIB_RCFILES
 include Makefile.inc
 
 libcurl_dll_LIBRARY := libcurl$(CURL_DLL_SUFFIX).dll

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -199,7 +199,7 @@ libcurl_dll_LIBRARY := libcurl$(CURL_DLL_SUFFIX).dll
 libcurl_dll_a_LIBRARY := libcurl.dll.a
 libcurl_a_LIBRARY := libcurl.a
 
-libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(strip $(CSOURCES)))
+libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
 libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 
 RESOURCE := libcurl.res
@@ -227,7 +227,7 @@ $(libcurl_dll_LIBRARY): $(libcurl_a_OBJECTS) $(RESOURCE)
 	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
 
 %.res: %.rc
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -30,10 +30,17 @@
 # Set component roots via envvar <feature>_PATH. CPPFLAGS, LDFLAGS, LIBS,
 # CFLAGS, RCFLAGS (and more) are also available for customization.
 
+ifndef PROOT
+local := 1
 PROOT := ..
+endif
 
-CPPFLAGS += -I. -I$(PROOT)/include -DBUILDING_LIBCURL
+CPPFLAGS += -I. -I$(PROOT)/include
 RCFLAGS  += -I$(PROOT)/include
+
+ifdef local
+CPPFLAGS += -DBUILDING_LIBCURL
+endif
 
 ifneq ($(ARCH),custom)
   # Set environment var ARCH to your architecture to override autodetection.
@@ -59,6 +66,7 @@ endif
 
 ifneq ($(findstring -unicode,$(CFG)),)
   CPPFLAGS += -DUNICODE -D_UNICODE
+  CURL_LDFLAGS_BIN += -municode
 endif
 ifneq ($(findstring -sync,$(CFG)),)
   CPPFLAGS += -DUSE_SYNC_DNS
@@ -135,6 +143,7 @@ ifneq ($(findstring -schannel,$(CFG)),)
 endif
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
   ZLIB_PATH ?= $(PROOT)/../zlib
+  # These CPPFLAGS are the only ones necessary when compiling the curl tool.
   CPPFLAGS += -DHAVE_LIBZ -DHAVE_ZLIB_H
   CPPFLAGS += -I"$(ZLIB_PATH)"
   LDFLAGS += -L"$(ZLIB_PATH)"
@@ -192,6 +201,7 @@ LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
 ### Sources and targets
 
+ifdef local
 # Provides CSOURCES, HHEADERS, LIB_RCFILES
 include Makefile.inc
 
@@ -209,8 +219,9 @@ vpath %.c vauth vquic vssh vtls
 
 TOCLEAN := $(libcurl_dll_OBJECTS)
 TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)
+endif
 
-### Rules
+### Global rules
 
 CC ?= $(CROSSPREFIX)gcc
 RC ?= $(CROSSPREFIX)windres
@@ -224,6 +235,9 @@ endif
 
 all: $(TARGETS)
 
+ifdef local
+### Local rules
+
 $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 	@$(call DEL, $@)
 	$(AR) rcs $@ $(libcurl_a_OBJECTS)
@@ -231,6 +245,7 @@ $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 $(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
 	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
 	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
+endif
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -28,7 +28,7 @@
 # Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 #
 # Set component roots via envvar <feature>_PATH. Also available for
-# customization: CPPFLAGS, LDFLAGS, LIBS, CFLAGS, RCFLAGS, ARCH,
+# customization: CPPFLAGS, LDFLAGS, LIBS, CFLAGS, RCFLAGS, ARCH[=custom],
 # CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX, and more for individual
 # components.
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -61,6 +61,9 @@ TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)
 
 ### Local rules
 
+# Keep this at the top to act as the default target.
+all: $(TARGETS)
+
 $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 	@$(call DEL, $@)
 	$(AR) rcs $@ $(libcurl_a_OBJECTS)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -202,7 +202,7 @@ libcurl_a_LIBRARY := libcurl.a
 libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
 libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 
-RESOURCE := libcurl.res
+RESOURCE := $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
 
 ### Rules
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -71,7 +71,6 @@ $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 $(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
 	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
 	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
-
 endif
 
 CPPFLAGS += -I. -I$(PROOT)/include

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -207,6 +207,7 @@ libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
 libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
 
 TOCLEAN := $(libcurl_dll_OBJECTS)
+TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)
 
 ### Rules
 
@@ -240,4 +241,4 @@ clean:
 	@$(call DEL, $(TOCLEAN))
 
 distclean vclean: clean
-	@$(call DEL, $(TARGETS) $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY))
+	@$(call DEL, $(TARGETS) $(TOVCLEAN))

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -35,16 +35,44 @@
 # This script is reused by 'src' and 'docs/examples' Makefile.m32 scripts.
 # Skip lib-specific parts when called through them.
 ifndef PROOT
-local := 1
 PROOT := ..
+
+CPPFLAGS += -DBUILDING_LIBCURL
+
+### Sources and targets
+
+# Provides CSOURCES, HHEADERS, LIB_RCFILES
+include Makefile.inc
+
+libcurl_dll_LIBRARY := libcurl$(CURL_DLL_SUFFIX).dll
+libcurl_dll_a_LIBRARY := libcurl.dll.a
+libcurl_a_LIBRARY := libcurl.a
+
+TARGETS := $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
+
+libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
+libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
+libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
+libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES)))
+vpath %.c vauth vquic vssh vtls
+
+TOCLEAN := $(libcurl_dll_OBJECTS)
+TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)
+
+### Local rules
+
+$(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
+	@$(call DEL, $@)
+	$(AR) rcs $@ $(libcurl_a_OBJECTS)
+
+$(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
+	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
+	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
+
 endif
 
 CPPFLAGS += -I. -I$(PROOT)/include
 RCFLAGS  += -I$(PROOT)/include
-
-ifdef local
-CPPFLAGS += -DBUILDING_LIBCURL
-endif
 
 ifneq ($(ARCH),custom)
   # Set environment var ARCH to your architecture to override autodetection.
@@ -68,8 +96,8 @@ endif
 
 ### Optional features
 
-# Most CPPFLAGS are only necessary in 'local' mode. We include them always for
-# simplicity and for being in sync with other build systems.
+# Most CPPFLAGS are only necessary when building libcurl via 'lib'. We include
+# them always for simplicity and for being in sync with other build systems.
 
 ifneq ($(findstring -unicode,$(CFG)),)
   CPPFLAGS += -DUNICODE -D_UNICODE
@@ -205,40 +233,6 @@ ifeq ($(findstring -lldap,$(LIBS)),)
   LIBS += -lwldap32
 endif
 LIBS += -lws2_32 -lcrypt32 -lbcrypt
-
-ifdef local
-
-### Sources and targets
-
-# Provides CSOURCES, HHEADERS, LIB_RCFILES
-include Makefile.inc
-
-libcurl_dll_LIBRARY := libcurl$(CURL_DLL_SUFFIX).dll
-libcurl_dll_a_LIBRARY := libcurl.dll.a
-libcurl_a_LIBRARY := libcurl.a
-
-TARGETS := $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
-
-libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
-libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
-libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
-libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES)))
-vpath %.c vauth vquic vssh vtls
-
-TOCLEAN := $(libcurl_dll_OBJECTS)
-TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)
-
-### Local rules (libcurl)
-
-$(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
-	@$(call DEL, $@)
-	$(AR) rcs $@ $(libcurl_a_OBJECTS)
-
-$(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
-	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
-	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
-
-endif
 
 ### Global rules
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -204,7 +204,8 @@ TARGETS := $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
 libcurl_a_OBJECTS := $(patsubst %.c,%.o,$(notdir $(strip $(CSOURCES))))
 libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
-libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
+libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES)))
+vpath %.c vauth vquic vssh vtls
 
 TOCLEAN := $(libcurl_dll_OBJECTS)
 TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -206,6 +206,8 @@ libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
 libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
 
+TOCLEAN := $(libcurl_dll_OBJECTS)
+
 ### Rules
 
 CC ?= $(CROSSPREFIX)gcc
@@ -235,7 +237,7 @@ $(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@
 
 clean:
-	@$(call DEL, $(libcurl_dll_OBJECTS))
+	@$(call DEL, $(TOCLEAN))
 
 distclean vclean: clean
 	@$(call DEL, $(TARGETS) $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY))

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -100,9 +100,10 @@ endif
 
 # Most CPPFLAGS are only necessary when building libcurl via 'lib'. We include
 # them always for simplicity and for being in sync with other build systems.
+# See comment below about the exception.
 
-# TODO: LDFLAGS and LIBS below are not required when building 'src' or
-#       'docs/examples' in DYN mode.
+# LDFLAGS and LIBS below are not required when building 'src' and
+# 'docs/examples' in DYN mode.
 
 ifneq ($(findstring -unicode,$(CFG)),)
   CPPFLAGS += -DUNICODE -D_UNICODE

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -22,14 +22,18 @@
 #
 #***************************************************************************
 
-# Makefile for building libcurl with MinGW and optional features.
+# Makefile for building curl parts with MinGW and optional features.
 #
 # Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
 # Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 #
-# Set component roots via envvar <feature>_PATH. CPPFLAGS, LDFLAGS, LIBS,
-# CFLAGS, RCFLAGS (and more) are also available for customization.
+# Set component roots via envvar <feature>_PATH. Also available for
+# customization: CPPFLAGS, LDFLAGS, LIBS, CFLAGS, RCFLAGS, ARCH,
+# CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX, and more for individual
+# components.
 
+# This script is reused by 'src' and 'docs/examples' Makefile.m32 scripts.
+# Skip lib-specific parts when called through them.
 ifndef PROOT
 local := 1
 PROOT := ..
@@ -63,6 +67,9 @@ ifneq ($(ARCH),custom)
 endif
 
 ### Optional features
+
+# Most CPPFLAGS are only necessary in 'local' mode. We include them always for
+# simplicity and for being in sync with other build systems.
 
 ifneq ($(findstring -unicode,$(CFG)),)
   CPPFLAGS += -DUNICODE -D_UNICODE
@@ -143,7 +150,7 @@ ifneq ($(findstring -schannel,$(CFG)),)
 endif
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
   ZLIB_PATH ?= $(PROOT)/../zlib
-  # These CPPFLAGS are the only ones necessary when compiling the curl tool.
+  # These CPPFLAGS are also required when compiling the curl tool via 'src'.
   CPPFLAGS += -DHAVE_LIBZ -DHAVE_ZLIB_H
   CPPFLAGS += -I"$(ZLIB_PATH)"
   LDFLAGS += -L"$(ZLIB_PATH)"
@@ -199,9 +206,10 @@ ifeq ($(findstring -lldap,$(LIBS)),)
 endif
 LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
+ifdef local
+
 ### Sources and targets
 
-ifdef local
 # Provides CSOURCES, HHEADERS, LIB_RCFILES
 include Makefile.inc
 
@@ -219,6 +227,17 @@ vpath %.c vauth vquic vssh vtls
 
 TOCLEAN := $(libcurl_dll_OBJECTS)
 TOVCLEAN := $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY)
+
+### Local rules (libcurl)
+
+$(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
+	@$(call DEL, $@)
+	$(AR) rcs $@ $(libcurl_a_OBJECTS)
+
+$(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
+	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
+	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
+
 endif
 
 ### Global rules
@@ -234,18 +253,6 @@ DEL = -del 2>NUL /q /f $(subst /,\,$1)
 endif
 
 all: $(TARGETS)
-
-ifdef local
-### Local rules
-
-$(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
-	@$(call DEL, $@)
-	$(AR) rcs $@ $(libcurl_a_OBJECTS)
-
-$(libcurl_dll_LIBRARY): $(libcurl_dll_OBJECTS)
-	$(CC) $(LDFLAGS) -shared $(CURL_LDFLAGS_LIB) -o $@ $(libcurl_dll_OBJECTS) $(LIBS) \
-	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY)
-endif
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -101,6 +101,9 @@ endif
 # Most CPPFLAGS are only necessary when building libcurl via 'lib'. We include
 # them always for simplicity and for being in sync with other build systems.
 
+# TODO: LDFLAGS and LIBS below are not required when building 'src' or
+#       'docs/examples' in DYN mode.
+
 ifneq ($(findstring -unicode,$(CFG)),)
   CPPFLAGS += -DUNICODE -D_UNICODE
   CURL_LDFLAGS_BIN += -municode
@@ -231,10 +234,12 @@ endif
 ifneq ($(findstring -ldaps,$(CFG)),)
   CPPFLAGS += -DHAVE_LDAP_SSL
 endif
-ifeq ($(findstring -lldap,$(LIBS)),)
-  LIBS += -lwldap32
+ifndef DYN
+  ifeq ($(findstring -lldap,$(LIBS)),)
+    LIBS += -lwldap32
+  endif
+  LIBS += -lws2_32 -lcrypt32 -lbcrypt
 endif
-LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
 ### Global rules
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -204,6 +204,8 @@ libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 libcurl_dll_OBJECTS := $(libcurl_a_OBJECTS)
 libcurl_dll_OBJECTS += $(patsubst %.rc,%.res,$(strip $(LIB_RCFILES))))
 
+TARGETS := $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
+
 ### Rules
 
 CC ?= $(CROSSPREFIX)gcc
@@ -216,7 +218,7 @@ else
 DEL = -del 2>NUL /q /f $(subst /,\,$1)
 endif
 
-all: $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY)
+all: $(TARGETS)
 
 $(libcurl_a_LIBRARY): $(libcurl_a_OBJECTS) $(libcurl_a_DEPENDENCIES)
 	@$(call DEL, $@)
@@ -236,4 +238,4 @@ clean:
 	@$(call DEL, $(libcurl_dll_OBJECTS))
 
 distclean vclean: clean
-	@$(call DEL, $(libcurl_a_LIBRARY) $(libcurl_dll_LIBRARY) $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY))
+	@$(call DEL, $(TARGETS) $(libcurl_dll_LIBRARY:.dll=.def) $(libcurl_dll_a_LIBRARY))

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -159,6 +159,7 @@ LIBS += -lws2_32 -lcrypt32 -lbcrypt
 include Makefile.inc
 
 TARGETS := curl.exe
+
 curl_OBJECTS := $(patsubst %.c,%.o,$(strip $(CURL_CFILES)))
 curl_OBJECTS += $(patsubst %.c,%.o,$(notdir $(strip $(CURLX_CFILES))))
 curl_OBJECTS += $(patsubst %.rc,%.res,$(strip $(CURL_RCFILES)))

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -32,32 +32,13 @@
 
 PROOT := ..
 
-CPPFLAGS += -I. -I$(PROOT)/include -I$(PROOT)/lib
-RCFLAGS  += -I$(PROOT)/include -DCURL_EMBED_MANIFEST
+# Provides CURL_CFILES, CURLX_CFILES, CURL_RCFILES
+include Makefile.inc
+
+CPPFLAGS += -I$(PROOT)/lib
+RCFLAGS  += -DCURL_EMBED_MANIFEST
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
-
-ifneq ($(ARCH),custom)
-  # Set environment var ARCH to your architecture to override autodetection.
-  ifndef ARCH
-    ifneq ($(findstring x86_64,$(shell $(CC) -dumpmachine)),)
-      ARCH := w64
-    else
-      ARCH := w32
-    endif
-  endif
-  ifeq ($(ARCH),w64)
-    CFLAGS  += -m64
-    LDFLAGS += -m64
-    RCFLAGS += --target=pe-x86-64
-  else
-    CFLAGS  += -m32
-    LDFLAGS += -m32
-    RCFLAGS += --target=pe-i386
-  endif
-endif
-
-### Optional features
 
 ifneq ($(findstring -dyn,$(CFG)),)
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl$(CURL_DLL_SUFFIX).dll
@@ -68,95 +49,7 @@ else
   LDFLAGS += -static
 endif
 
-ifneq ($(findstring -unicode,$(CFG)),)
-  CPPFLAGS += -DUNICODE -D_UNICODE
-  LDFLAGS += -municode
-endif
-ifneq ($(findstring -sync,$(CFG)),)
-else
-  ifneq ($(findstring -ares,$(CFG)),)
-    LIBCARES_PATH ?= $(PROOT)/../c-ares
-    LDFLAGS += -L"$(LIBCARES_PATH)/lib"
-    LIBS += -lcares
-  endif
-endif
-ifneq ($(findstring -rtmp,$(CFG)),)
-  LIBRTMP_PATH ?= $(PROOT)/../librtmp
-  LDFLAGS += -L"$(LIBRTMP_PATH)/librtmp"
-  LIBS += -lrtmp -lwinmm
-  ZLIB := 1
-endif
-ifneq ($(findstring -ssh2,$(CFG)),)
-  LIBSSH2_PATH ?= $(PROOT)/../libssh2
-  LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
-  LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
-  LIBS += -lssh2
-endif
-ifneq ($(findstring -nghttp2,$(CFG)),)
-  NGHTTP2_PATH ?= $(PROOT)/../nghttp2
-  LDFLAGS += -L"$(NGHTTP2_PATH)/lib"
-  LIBS += -lnghttp2
-endif
-ifneq ($(findstring -nghttp3,$(CFG)),)
-  ifneq ($(findstring -ngtcp2,$(CFG)),)
-    NGHTTP3_PATH ?= $(PROOT)/../nghttp3
-    LDFLAGS += -L"$(NGHTTP3_PATH)/lib"
-    LIBS += -lnghttp3
-    NGTCP2_PATH ?= $(PROOT)/../ngtcp2
-    LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-    NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_openssl
-    LIBS += $(NGTCP2_LIBS)
-  endif
-endif
-ifneq ($(findstring -ssl,$(CFG)),)
-  OPENSSL_PATH ?= $(PROOT)/../openssl
-  OPENSSL_LIBPATH ?= $(OPENSSL_PATH)/lib
-  LDFLAGS += -L"$(OPENSSL_LIBPATH)"
-  OPENSSL_LIBS ?= -lssl -lcrypto
-  LIBS += $(OPENSSL_LIBS)
-endif
-ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
-  ZLIB_PATH ?= $(PROOT)/../zlib
-  CPPFLAGS += -DHAVE_LIBZ -DHAVE_ZLIB_H
-  CPPFLAGS += -I"$(ZLIB_PATH)"
-  LDFLAGS += -L"$(ZLIB_PATH)"
-  LIBS += -lz
-endif
-ifneq ($(findstring -zstd,$(CFG)),)
-  ZSTD_PATH ?= $(PROOT)/../zstd
-  LDFLAGS += -L"$(ZSTD_PATH)/lib"
-  ZSTD_LIBS ?= -lzstd
-  LIBS += $(ZSTD_LIBS)
-endif
-ifneq ($(findstring -brotli,$(CFG)),)
-  BROTLI_PATH ?= $(PROOT)/../brotli
-  LDFLAGS += -L"$(BROTLI_PATH)/lib"
-  BROTLI_LIBS ?= -lbrotlidec -lbrotlicommon
-  LIBS += $(BROTLI_LIBS)
-endif
-ifneq ($(findstring -gsasl,$(CFG)),)
-  LIBGSASL_PATH ?= $(PROOT)/../gsasl
-  LDFLAGS += -L"$(LIBGSASL_PATH)/lib"
-  LIBS += -lgsasl
-endif
-ifneq ($(findstring -idn2,$(CFG)),)
-  LIBIDN2_PATH ?= $(PROOT)/../libidn2
-  LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
-  LIBS += -lidn2
-else
-ifneq ($(findstring -winidn,$(CFG)),)
-  LIBS += -lnormaliz
-endif
-endif
-ifeq ($(findstring -lldap,$(LIBS)),)
-  LIBS += -lwldap32
-endif
-LIBS += -lws2_32 -lcrypt32 -lbcrypt
-
 ### Sources and targets
-
-# Provides CURL_CFILES, CURLX_CFILES, CURL_RCFILES
-include Makefile.inc
 
 TARGETS := curl.exe
 
@@ -167,30 +60,11 @@ vpath %.c $(PROOT)/lib
 
 TOCLEAN := $(curl_OBJECTS)
 
-### Rules
-
-CC ?= $(CROSSPREFIX)gcc
-RC ?= $(CROSSPREFIX)windres
-
-ifneq ($(findstring /sh,$(SHELL)),)
-DEL = rm -f $1
-else
-DEL = -del 2>NUL /q /f $(subst /,\,$1)
-endif
-
-all: $(TARGETS)
+### Local rules
 
 $(TARGETS): $(curl_OBJECTS) $(curl_DEPENDENCIES)
 	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $(curl_OBJECTS) $(LIBS)
 
-%.o: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+### Global script
 
-%.res: %.rc
-	$(RC) -O coff $(RCFLAGS) -i $< -o $@
-
-clean:
-	@$(call DEL, $(TOCLEAN))
-
-distclean vclean: clean
-	@$(call DEL, $(TARGETS) $(TOVCLEAN))
+include $(PROOT)/lib/Makefile.m32

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -26,11 +26,8 @@
 
 PROOT := ..
 
-# Provides CURL_CFILES, CURLX_CFILES, CURL_RCFILES
-include Makefile.inc
-
-CPPFLAGS += -I$(PROOT)/lib
 RCFLAGS  += -DCURL_EMBED_MANIFEST
+CPPFLAGS += -I$(PROOT)/lib
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     += -lcurl
 
@@ -44,6 +41,9 @@ else
 endif
 
 ### Sources and targets
+
+# Provides CURL_CFILES, CURLX_CFILES, CURL_RCFILES
+include Makefile.inc
 
 TARGETS := curl.exe
 

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -34,6 +34,7 @@ LIBS     += -lcurl
 ifneq ($(findstring -dyn,$(CFG)),)
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl$(CURL_DLL_SUFFIX).dll
   curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
+  DYN := 1
 else
   curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
   CPPFLAGS += -DCURL_STATICLIB

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -22,13 +22,7 @@
 #
 #***************************************************************************
 
-# Makefile for building curl with MinGW and optional features.
-#
-# Usage:   mingw32-make -f Makefile.m32 CFG=-feature1[-feature2][-feature3][...]
-# Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
-#
-# Set component roots via envvar <feature>_PATH. CPPFLAGS, LDFLAGS, LIBS,
-# CFLAGS, RCFLAGS (and more) are also available for customization.
+# See usage in lib/Makefile.m32
 
 PROOT := ..
 

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -155,7 +155,7 @@ LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
 ### Sources and targets
 
-# Provides CURL_CFILES and CURLX_CFILES
+# Provides CURL_CFILES, CURLX_CFILES, CURL_RCFILES
 include Makefile.inc
 
 TARGETS := curl.exe

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -161,9 +161,8 @@ include Makefile.inc
 TARGETS := curl.exe
 curl_OBJECTS := $(patsubst %.c,%.o,$(strip $(CURL_CFILES)))
 curl_OBJECTS += $(patsubst %.c,%.o,$(notdir $(strip $(CURLX_CFILES))))
+curl_OBJECTS += $(patsubst %.rc,%.res,$(strip $(CURL_RCFILES)))
 vpath %.c $(PROOT)/lib
-
-RESOURCE := $(patsubst %.rc,%.res,$(strip $(CURL_RCFILES)))
 
 ### Rules
 
@@ -178,8 +177,8 @@ endif
 
 all: $(TARGETS)
 
-$(TARGETS): $(curl_OBJECTS) $(RESOURCE) $(curl_DEPENDENCIES)
-	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $(curl_OBJECTS) $(RESOURCE) $(LIBS)
+$(TARGETS): $(curl_OBJECTS) $(curl_DEPENDENCIES)
+	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $(curl_OBJECTS) $(LIBS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
@@ -188,7 +187,7 @@ $(TARGETS): $(curl_OBJECTS) $(RESOURCE) $(curl_DEPENDENCIES)
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@
 
 clean:
-	@$(call DEL, $(curl_OBJECTS) $(RESOURCE))
+	@$(call DEL, $(curl_OBJECTS))
 
 distclean vclean: clean
 	@$(call DEL, $(TARGETS))

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -193,4 +193,4 @@ clean:
 	@$(call DEL, $(TOCLEAN))
 
 distclean vclean: clean
-	@$(call DEL, $(TARGETS))
+	@$(call DEL, $(TARGETS) $(TOVCLEAN))

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -165,6 +165,8 @@ curl_OBJECTS += $(patsubst %.c,%.o,$(notdir $(strip $(CURLX_CFILES))))
 curl_OBJECTS += $(patsubst %.rc,%.res,$(strip $(CURL_RCFILES)))
 vpath %.c $(PROOT)/lib
 
+TOCLEAN := $(curl_OBJECTS)
+
 ### Rules
 
 CC ?= $(CROSSPREFIX)gcc
@@ -188,7 +190,7 @@ $(TARGETS): $(curl_OBJECTS) $(curl_DEPENDENCIES)
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@
 
 clean:
-	@$(call DEL, $(curl_OBJECTS))
+	@$(call DEL, $(TOCLEAN))
 
 distclean vclean: clean
 	@$(call DEL, $(TARGETS))

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -163,7 +163,7 @@ curl_OBJECTS := $(patsubst %.c,%.o,$(strip $(CURL_CFILES)))
 curl_OBJECTS += $(patsubst %.c,%.o,$(notdir $(strip $(CURLX_CFILES))))
 vpath %.c $(PROOT)/lib
 
-RESOURCE := curl.res
+RESOURCE := $(patsubst %.rc,%.res,$(strip $(CURL_RCFILES)))
 
 ### Rules
 


### PR DESCRIPTION
After this patch, we reduce the three copies of most `Makefile.m32` logic
to one. This now resides in `lib/Makefile.m32`. It makes future updates
easier, the code shorter, with a small amount of added complexity.

`Makefile.m32` reduction:

|                   |  bytes | LOC total |  blank |  comment |  code |
|-------------------|-------:|----------:|-------:|---------:|------:|
| 7.85.0            |  34772 |      1337 |     79 |      192 |  1066 |
| before this patch |  17601 |       625 |     62 |      106 |   457 |
| after this patch  |  11680 |       392 |     52 |      104 |   236 |

Details:

- Change rules to create objects for the `v*` subdirs in the `lib` dir.
  This allows to use a shared compile rule and assumes that filenames
  are not (and will not be) colliding across these directories.
  `Makefile.m32` now also stores a list of these subdirs. They are
  changing rarely though.

- Sync as much as possible between the three `Makefile.m32` scripts'
  rules and their source/target sections.

- After this patch `CPPFLAGS` are all applied to the `src` sources once
  again. This matches the behaviour of cmake/autotools. Only zlib ones
  are actually required there.

- Use `.rc` names from `Makefile.inc` instead of keeping a duplicate.

- Change examples to link `libcurl.dll` by default. This makes building
  trivial, even as a cross-build:
    `CC=x86_64-w64-mingw32-gcc make -f Makefile.m32`
  To run them, you need to move/copy or add-to-path `libcurl.dll`.
  You can select static mode via `CFG=-static`.

- List more of the `Makefile.m32` config variables.

- Drop `.rc` support from examples. It made it more fragile without much
  benefit.

- Include a necessary system lib for the `externalsocket.c` example.

- Exclude unnecessary systems libs when building in `-dyn` mode.

Closes #9642
