### PR TITLE
Makefile.m32: fix regression with tool_hugehelp [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -169,7 +169,7 @@ ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_LIBS ?= -lssl -lcrypto
   LIBS += $(OPENSSL_LIBS)
   ifneq ($(findstring -srp,$(CFG)),)
-    ifeq "$(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h)" "$(OPENSSL_INCLUDE)/openssl/srp.h"
+    ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h),)
       # OpenSSL 1.0.1 and later, except BoringSSL
       CPPFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
     endif
@@ -249,9 +249,11 @@ RC ?= $(CROSSPREFIX)windres
 AR ?= $(CROSSPREFIX)ar
 
 ifneq ($(findstring /sh,$(SHELL)),)
-DEL = rm -f $1
+DEL  = rm -f $1
+COPY = -cp -afv $1 $2
 else
-DEL = -del 2>NUL /q /f $(subst /,\,$1)
+DEL  = -del 2>NUL /q /f $(subst /,\,$1)
+COPY = -copy 2>NUL /y $(subst /,\,$1) $(subst /,\,$2)
 endif
 
 all: $(TARGETS)

--- a/src/Makefile.m32
+++ b/src/Makefile.m32
@@ -54,11 +54,18 @@ curl_OBJECTS += $(patsubst %.rc,%.res,$(strip $(CURL_RCFILES)))
 vpath %.c $(PROOT)/lib
 
 TOCLEAN := $(curl_OBJECTS)
+ifneq ($(wildcard tool_hugehelp.c.cvs),)
+TOCLEAN += tool_hugehelp.c
+endif
 
 ### Local rules
 
 $(TARGETS): $(curl_OBJECTS) $(curl_DEPENDENCIES)
 	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $(curl_OBJECTS) $(LIBS)
+
+tool_hugehelp.c:
+	@echo Creating $@
+	@$(call COPY, $@.cvs, $@)
 
 ### Global script
 


### PR DESCRIPTION
In a recent commit I mistakenly deleted this logic, after seeing a reference to a filename ending with `.cvs` and thinking it must have been long gone. Turns out this is an existing file. Restore the rule and the necessary `COPY` definitions with it.

The restored logic is required for a successful build on a bare source tree (as opposed to a source release tarball).

Also shorten an existing condition similar to the one added in this patch.

Regression since 07a0047882dd3f1fbf73486c5dd9c15370877ad6

Closes #xxxx