### PR TITLE
runtests: fix uninitialized value on ignored tests

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -6286,7 +6286,7 @@ if($total) {
     logmsg sprintf("TESTDONE: $ok tests out of $total reported OK: %d%%\n",
                    $ok/$total*100);
 
-    if($ok != $total) {
+    if($failed && $ok != $total) {
         logmsg "\nTESTFAIL: These test cases failed: $failed\n\n";
     }
 }


### PR DESCRIPTION
- Don't show TESTFAIL message (ie tests failed which aren't ignored) if only ignored tests failed.

Before:
IGNORED: failed tests: 571 612 1056
TESTDONE: 1214 tests out of 1217 reported OK: 99%
Use of uninitialized value $failed in concatenation (.) or string at ./runtests.pl line 6290.
TESTFAIL: These test cases failed:

After:
IGNORED: failed tests: 571 612 1056
TESTDONE: 1214 tests out of 1217 reported OK: 99%

Closes #xxxx