### PR TITLE
configure: the ngtcp2 option should default to 'no'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2718,7 +2718,7 @@ dnl **********************************************************************
 dnl Check for ngtcp2 (QUIC)
 dnl **********************************************************************
 
-OPT_TCP2="yes"
+OPT_TCP2="no"
 
 if test "x$disable_http" = "xyes"; then
   # without HTTP, ngtcp2 is no use


### PR DESCRIPTION
While still experimental.

Bug: https://curl.se/mail/lib-2022-10/0007.html
Reported-by: Daniel Hallberg