### PR TITLE
tests/Makefile: remove run time stats from ci-test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -75,7 +75,7 @@ TEST_E = -a -e
 TEST_NF = -a -p !flaky
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm
+TEST_CI = $(TEST_NF) -rm
 endif
 
 # make sure that PERL is pointing to an executable


### PR DESCRIPTION
The ci-test is the normal makefile target invoked in CI jobs. This has been using the -r option to runtests.pl since a long time, but I find that it mostly just adds many lines to the test output report without anyone caring much about those stats.

Remove it.