### PR TITLE
strcase: add and use Curl_timestrcmp

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -198,9 +198,9 @@ static int parsenetrc(const char *host,
           /* we are now parsing sub-keywords concerning "our" host */
           if(state_login) {
             if(specific_login) {
-              state_our_login = !strcmp(login, tok);
+              state_our_login = !Curl_timestrcmp(login, tok);
             }
-            else if(!login || strcmp(login, tok)) {
+            else if(!login || Curl_timestrcmp(login, tok)) {
               if(login_alloc) {
                 free(login);
                 login_alloc = FALSE;
@@ -216,7 +216,7 @@ static int parsenetrc(const char *host,
           }
           else if(state_password) {
             if((state_our_login || !specific_login)
-                && (!password || strcmp(password, tok))) {
+               && (!password || Curl_timestrcmp(password, tok))) {
               if(password_alloc) {
                 free(password);
                 password_alloc = FALSE;

--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -177,6 +177,28 @@ bool Curl_safecmp(char *a, char *b)
   return !a && !b;
 }
 
+/*
+ * Curl_timestrcmp() returns 0 if the two strings are identical. The time this
+ * function spends is a function of the shortest string, not of the contents.
+ */
+int Curl_timestrcmp(const char *a, const char *b)
+{
+  int match = 0;
+  int i = 0;
+
+  if(a && b) {
+    while(1) {
+      match |= a[i]^b[i];
+      if(!a[i] || !b[i])
+        break;
+      i++;
+    }
+  }
+  else
+    return !a && !b;
+  return match;
+}
+
 /* --- public functions --- */
 
 int curl_strequal(const char *first, const char *second)

--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -195,7 +195,7 @@ int Curl_timestrcmp(const char *a, const char *b)
     }
   }
   else
-    return !a && !b;
+    return a || b;
   return match;
 }
 

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -53,5 +53,6 @@ void Curl_strntoupper(char *dest, const char *src, size_t n);
 void Curl_strntolower(char *dest, const char *src, size_t n);
 
 bool Curl_safecmp(char *a, char *b);
+int Curl_timestrcmp(const char *first, const char *second);
 
 #endif /* HEADER_CURL_STRCASE_H */

--- a/lib/url.c
+++ b/lib/url.c
@@ -957,21 +957,11 @@ socks_proxy_info_matches(const struct proxy_info *data,
   /* the user information is case-sensitive
      or at least it is not defined as case-insensitive
      see https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1 */
-  if(!data->user != !needle->user)
-    return FALSE;
+
   /* curl_strequal does a case insensitive comparison,
      so do not use it here! */
-  if(data->user &&
-     needle->user &&
-     Curl_timestrcmp(data->user, needle->user) != 0)
-    return FALSE;
-  if(!data->passwd != !needle->passwd)
-    return FALSE;
-  /* curl_strequal does a case insensitive comparison,
-     so do not use it here! */
-  if(data->passwd &&
-     needle->passwd &&
-     Curl_timestrcmp(data->passwd, needle->passwd) != 0)
+  if(Curl_timestrcmp(data->user, needle->user) ||
+     Curl_timestrcmp(data->passwd, needle->passwd))
     return FALSE;
   return TRUE;
 }
@@ -1375,8 +1365,8 @@ ConnectionExists(struct Curl_easy *data,
            so verify that we're using the same name and password as well */
         if(Curl_timestrcmp(needle->user, check->user) ||
            Curl_timestrcmp(needle->passwd, check->passwd) ||
-           !Curl_safecmp(needle->sasl_authzid, check->sasl_authzid) ||
-           !Curl_safecmp(needle->oauth_bearer, check->oauth_bearer)) {
+           Curl_timestrcmp(needle->sasl_authzid, check->sasl_authzid) ||
+           Curl_timestrcmp(needle->oauth_bearer, check->oauth_bearer)) {
           /* one of them was different */
           continue;
         }

--- a/lib/url.c
+++ b/lib/url.c
@@ -963,7 +963,7 @@ socks_proxy_info_matches(const struct proxy_info *data,
      so do not use it here! */
   if(data->user &&
      needle->user &&
-     strcmp(data->user, needle->user) != 0)
+     Curl_timestrcmp(data->user, needle->user) != 0)
     return FALSE;
   if(!data->passwd != !needle->passwd)
     return FALSE;
@@ -971,7 +971,7 @@ socks_proxy_info_matches(const struct proxy_info *data,
      so do not use it here! */
   if(data->passwd &&
      needle->passwd &&
-     strcmp(data->passwd, needle->passwd) != 0)
+     Curl_timestrcmp(data->passwd, needle->passwd) != 0)
     return FALSE;
   return TRUE;
 }
@@ -1373,8 +1373,8 @@ ConnectionExists(struct Curl_easy *data,
       if(!(needle->handler->flags & PROTOPT_CREDSPERREQUEST)) {
         /* This protocol requires credentials per connection,
            so verify that we're using the same name and password as well */
-        if(strcmp(needle->user, check->user) ||
-           strcmp(needle->passwd, check->passwd) ||
+        if(Curl_timestrcmp(needle->user, check->user) ||
+           Curl_timestrcmp(needle->passwd, check->passwd) ||
            !Curl_safecmp(needle->sasl_authzid, check->sasl_authzid) ||
            !Curl_safecmp(needle->oauth_bearer, check->oauth_bearer)) {
           /* one of them was different */
@@ -1452,8 +1452,8 @@ ConnectionExists(struct Curl_easy *data,
            possible. (Especially we must not reuse the same connection if
            partway through a handshake!) */
         if(wantNTLMhttp) {
-          if(strcmp(needle->user, check->user) ||
-             strcmp(needle->passwd, check->passwd)) {
+          if(Curl_timestrcmp(needle->user, check->user) ||
+             Curl_timestrcmp(needle->passwd, check->passwd)) {
 
             /* we prefer a credential match, but this is at least a connection
                that can be reused and "upgraded" to NTLM */
@@ -1475,8 +1475,10 @@ ConnectionExists(struct Curl_easy *data,
           if(!check->http_proxy.user || !check->http_proxy.passwd)
             continue;
 
-          if(strcmp(needle->http_proxy.user, check->http_proxy.user) ||
-             strcmp(needle->http_proxy.passwd, check->http_proxy.passwd))
+          if(Curl_timestrcmp(needle->http_proxy.user,
+                             check->http_proxy.user) ||
+             Curl_timestrcmp(needle->http_proxy.passwd,
+                             check->http_proxy.passwd))
             continue;
         }
         else if(check->proxy_ntlm_state != NTLMSTATE_NONE) {

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -431,8 +431,8 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
      has changed then delete that context. */
   if((userp && !digest->user) || (!userp && digest->user) ||
      (passwdp && !digest->passwd) || (!passwdp && digest->passwd) ||
-     (userp && digest->user && strcmp(userp, digest->user)) ||
-     (passwdp && digest->passwd && strcmp(passwdp, digest->passwd))) {
+     (userp && digest->user && Curl_timestrcmp(userp, digest->user)) ||
+     (passwdp && digest->passwd && Curl_timestrcmp(passwdp, digest->passwd))) {
     if(digest->http_context) {
       s_pSecFn->DeleteSecurityContext(digest->http_context);
       Curl_safefree(digest->http_context);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -146,8 +146,8 @@ Curl_ssl_config_matches(struct ssl_primary_config *data,
      Curl_safecmp(data->issuercert, needle->issuercert) &&
      Curl_safecmp(data->clientcert, needle->clientcert) &&
 #ifdef USE_TLS_SRP
-     Curl_safecmp(data->username, needle->username) &&
-     Curl_safecmp(data->password, needle->password) &&
+     !Curl_timestrcmp(data->username, needle->username) &&
+     !Curl_timestrcmp(data->password, needle->password) &&
      (data->authtype == needle->authtype) &&
 #endif
      Curl_safe_strcasecompare(data->cipher_list, needle->cipher_list) &&


### PR DESCRIPTION
This is a strcmp() alternative function for comparing "secrets", designed to take the same time no matter the content to not leak match/non-match info to observers based on how fast it is.

The time this function takes is only a function of the shortest input string.

Reported-by: Trail of Bits