### PR TITLE
cookie: reject cookie names or content with TAB characters

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -538,7 +538,7 @@ Curl_cookie_add(struct Curl_easy *data,
     do {
       /* we have a <what>=<this> pair or a stand-alone word here */
       name[0] = what[0] = 0; /* init the buffers */
-      if(1 <= sscanf(ptr, "%" MAX_NAME_TXT "[^;\r\n=] =%"
+      if(1 <= sscanf(ptr, "%" MAX_NAME_TXT "[^;\t\r\n=] =%"
                      MAX_NAME_TXT "[^;\r\n]",
                      name, what)) {
         /*
@@ -591,6 +591,13 @@ Curl_cookie_add(struct Curl_easy *data,
         whatptr = what;
         while(*whatptr && ISBLANK(*whatptr))
           whatptr++;
+
+        /* Reject cookies with a TAB inside the content */
+        if(strchr(whatptr, '\t')) {
+          freecookie(co);
+          infof(data, "cookie contains TAB, dropping");
+          return NULL;
+        }
 
         /*
          * Check if we have a reserved prefix set before anything else, as we

--- a/tests/data/test1105
+++ b/tests/data/test1105
@@ -19,6 +19,9 @@ Funny-head: yesyes swsclose
 Set-Cookie: foobar=name;
 Set-Cookie: mismatch=this; domain=127.0.0.1; path="/silly/";
 Set-Cookie: partmatch=present; domain=.0.0.1; path=/;
+Set-Cookie: foo	bar=barfoo
+Set-Cookie: bar	foo=
+Set-Cookie: bar=foo	bar
 
 </data>
 </reply>

--- a/tests/data/test8
+++ b/tests/data/test8
@@ -54,7 +54,7 @@ Set-Cookie: cookie5=%hex[%05-junk]hex%
 Set-Cookie: cookie6=%hex[%06-junk]hex%
 Set-Cookie: cookie7=%hex[%07-junk]hex%
 Set-Cookie: cookie8=%hex[%08-junk]hex%
-Set-Cookie: cookie9=%hex[junk-%09-]hex%
+Set-Cookie: cookie9=%hex[junk--%09]hex%
 Set-Cookie: cookie11=%hex[%0b-junk]hex%
 Set-Cookie: cookie12=%hex[%0c-junk]hex%
 Set-Cookie: cookie14=%hex[%0e-junk]hex%
@@ -90,7 +90,7 @@ GET /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Cookie: name with space=is weird but; trailingspace=removed; cookie=perhaps; cookie=yes; foobar=name; blexp=yesyes; cookie9=junk-	-
+Cookie: name with space=is weird but; trailingspace=removed; cookie=perhaps; cookie=yes; foobar=name; blexp=yesyes; cookie9=junk--
 
 </protocol>
 </verify>


### PR DESCRIPTION
TABs in name and content seem allowed by RFC 6265: "the algorithm strips leading and trailing whitespace from the cookie name and value (but maintains internal whitespace)"
    
Cookies with TABs in the names are rejected by Firefox and Chrome.
    
TABs in content are stripped out by Firefox, while Chrome discards the whole cookie.
    
TABs in cookies also cause issues in saved netscape cookie files.
