### PR TITLE
cmake: fix enabling websocket support

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -801,3 +801,6 @@ ${SIZEOF_TIME_T_CODE}
 
 /* to make the compiler know the prototypes of Windows IDN APIs */
 #cmakedefine WANT_IDN_PROTOTYPES 1
+
+/* Define to 1 to enable websocket support. */
+#cmakedefine USE_WEBSOCKETS 1


### PR DESCRIPTION
Follow-up from 664249d095275ec532f55dd1752d80c8c1093a77

Closes #9660
