### PR TITLE
Minor fixes found using experimental web sockets without CONNECT_ONLY

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -735,9 +735,10 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
     static const char s_infotype[CURLINFO_END][3] = {
       "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
     if(data->set.fdebug) {
+      bool inCallback = Curl_is_in_callback(data);
       Curl_set_in_callback(data, true);
       (void)(*data->set.fdebug)(data, type, ptr, size, data->set.debugdata);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, inCallback);
     }
     else {
       switch(type) {


### PR DESCRIPTION
- Fixed an issue where `is_in_callback` was getting cleared when using web sockets with debug logging enabled
- Ensure the handle is `is_in_callback` when calling out to `fwrite_func`
- Don't send along a masking key for 0-length frames (empty ping)
- Change the `write` vs. `send_data` decision to whether or not the handle is in `CONNECT_ONLY` mode.
- Account for `buflen` not including the header length in `curl_ws_send`