### PR TITLE
curl_ws_send.3: call the argument 'fragsize'

### DIFF
--- a/docs/libcurl/curl_ws_send.3
+++ b/docs/libcurl/curl_ws_send.3
@@ -30,7 +30,7 @@ curl_ws_send - send WebSocket data
 #include <curl/easy.h>
 
 CURLcode curl_ws_send(CURL *curl, const void *buffer, size_t buflen,
-                      size_t *sent, curl_off_t framesize,
+                      size_t *sent, curl_off_t fragsize,
                       unsigned int flags);
 .fi
 .SH DESCRIPTION
@@ -43,11 +43,11 @@ number of payload bytes in that memory area.
 \fIsent\fP is returned as the number of payload bytes actually sent.
 
 To send a (huge) fragment using multiple calls with partial content per
-invoke, set the \fICURLWS_OFFSET\fP bit and the \fIframesize\fP argument as
-the total expected size for the first part, then set the \fICURLWS_OFFSET\fP
-with a zero \fItotalsize\fP for the following parts.
+invoke, set the \fICURLWS_OFFSET\fP bit and the \fIfragsize\fP argument as the
+total expected size for the first part, then set the \fICURLWS_OFFSET\fP with
+a zero \fIfragsize\fP for the following parts.
 
-If not sending a partial fragment or if this is raw mode, \fIframsize\fP
+If not sending a partial fragment or if this is raw mode, \fIfragsize\fP
 should be set to zero.
 
 If \fBCURLWS_RAW_MODE\fP is enabled in \fICURLOPT_WS_OPTIONS(3)\fP, the
@@ -73,8 +73,8 @@ This as a pong.
 .IP CURLWS_OFFSET
 The provided data is only a partial fragment and there will be more in a
 following call to \fIcurl_ws_send()\fP. When sending only a piece of the
-fragment like this, the \fIframesize\fP must be provided with the total
-expected frame size in the first call and it needs to be zero in subsequent
+fragment like this, the \fIfragsize\fP must be provided with the total
+expected fragment size in the first call and it needs to be zero in subsequent
 calls.
 .SH EXAMPLE
 .nf


### PR DESCRIPTION
Since WebSocket works with "fragments" not "frames"