### PR TITLE
tool_getparam: pass in the snprintf("%.*s") string length as 'int'

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -637,7 +637,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
         return PARAM_NO_MEM;
       }
       if(nlen > 0) { /* only append '=' if we have a name */
-        msnprintf(n, outlen, "%.*s=%s", nlen, nextarg, enc);
+        msnprintf(n, outlen, "%.*s=%s", (int)nlen, nextarg, enc);
         size = outlen-1;
       }
       else {


### PR DESCRIPTION
Reported by Coverity CID 1515928