### PR TITLE
Makefile.m32: support more options [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -186,7 +186,7 @@ ifneq ($(findstring -ssh2,$(CFG)),)
   _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
   _LIBS += -lssh2
 else ifneq ($(findstring -libssh,$(CFG)),)
-  # You really should avoid libssh on Windows in production, due to its
+  # Avoid using libssh on Windows in production, due to its
   # by-default-world-writable configuration vulnerability (as of 0.10.4)
   LIBSSH_PATH ?= $(PROOT)/../libssh
   CPPFLAGS += -DUSE_LIBSSH

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -294,9 +294,9 @@ ifeq ($(findstring -lldap,$(LIBS)),)
 endif
 _LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
-# Each SSL lib appends '1'. If '11' can be found, it means we have
-# multiple SSL libs, telling us to enable MultiSSL.
-ifneq ($(findstring 11,$(SSLLIBS)),)
+# Each additional SSL lib appends ' 1'. Finding '1 1' means we have multiple
+# SSL libs.
+ifneq ($(findstring 1 1,$(SSLLIBS)),)
   CPPFLAGS += -DCURL_WITH_MULTI_SSL
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -130,6 +130,29 @@ ifneq ($(findstring -rtmp,$(CFG)),)
   ZLIB := 1
 endif
 
+ifneq ($(findstring -ssh2,$(CFG)),)
+  LIBSSH2_PATH ?= $(PROOT)/../libssh2
+  CPPFLAGS += -DUSE_LIBSSH2
+  CPPFLAGS += -I"$(LIBSSH2_PATH)/include"
+  _LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
+  _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
+  _LIBS += -lssh2
+else ifneq ($(findstring -libssh,$(CFG)),)
+  # Avoid using libssh on Windows in production, due to its
+  # by-default-world-writable configuration vulnerability (as of 0.10.4)
+  LIBSSH_PATH ?= $(PROOT)/../libssh
+  CPPFLAGS += -DUSE_LIBSSH
+  CPPFLAGS += -I"$(LIBSSH_PATH)/include"
+  _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
+  _LIBS += -lssh
+else ifneq ($(findstring -wolfssh,$(CFG)),)
+  WOLFSSH_PATH ?= $(PROOT)/../wolfssh
+  CPPFLAGS += -DUSE_WOLFSSH
+  CPPFLAGS += -I"$(WOLFSSH_PATH)/include"
+  _LDFLAGS += -L"$(WOLFSSH_PATH)/lib"
+  _LIBS += -lwolfssh
+endif
+
 ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_PATH ?= $(PROOT)/../openssl
   CPPFLAGS += -DUSE_OPENSSL
@@ -176,30 +199,6 @@ endif
 ifneq ($(findstring -schannel,$(CFG)),)
   CPPFLAGS += -DUSE_SCHANNEL
   SSLLIBS += 1
-endif
-
-ifneq ($(findstring -ssh2,$(CFG)),)
-  LIBSSH2_PATH ?= $(PROOT)/../libssh2
-  CPPFLAGS += -DUSE_LIBSSH2
-  CPPFLAGS += -I"$(LIBSSH2_PATH)/include"
-  _LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
-  _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
-  _LIBS += -lssh2
-else ifneq ($(findstring -libssh,$(CFG)),)
-  # Avoid using libssh on Windows in production, due to its
-  # by-default-world-writable configuration vulnerability (as of 0.10.4)
-  LIBSSH_PATH ?= $(PROOT)/../libssh
-  CPPFLAGS += -DUSE_LIBSSH
-  CPPFLAGS += -I"$(LIBSSH_PATH)/include"
-  _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
-  # Workaround when used with libressl 'duplicate symbol: explicit_bzero'
-  _LIBS := -lssh $(_LIBS)
-else ifeq ($(OPENSSL)$(findstring -wolfssh,$(CFG)),wolfssl-wolfssh)
-  WOLFSSH_PATH ?= $(PROOT)/../wolfssh
-  CPPFLAGS += -DUSE_WOLFSSH
-  CPPFLAGS += -I"$(WOLFSSH_PATH)/include"
-  _LDFLAGS += -L"$(WOLFSSH_PATH)/lib"
-  _LIBS += -lwolfssh
 endif
 
 ifneq ($(findstring -nghttp2,$(CFG)),)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -114,13 +114,13 @@ _LIBS :=
 ifneq ($(findstring -sync,$(CFG)),)
   CPPFLAGS += -DUSE_SYNC_DNS
 else
-  ifneq ($(findstring -ares,$(CFG)),)
-    LIBCARES_PATH ?= $(PROOT)/../c-ares
-    CPPFLAGS += -DUSE_ARES
-    CPPFLAGS += -I"$(LIBCARES_PATH)/include"
-    _LDFLAGS += -L"$(LIBCARES_PATH)/lib"
-    _LIBS += -lcares
-  endif
+ifneq ($(findstring -ares,$(CFG)),)
+  LIBCARES_PATH ?= $(PROOT)/../c-ares
+  CPPFLAGS += -DUSE_ARES
+  CPPFLAGS += -I"$(LIBCARES_PATH)/include"
+  _LDFLAGS += -L"$(LIBCARES_PATH)/lib"
+  _LIBS += -lcares
+endif
 endif
 ifneq ($(findstring -rtmp,$(CFG)),)
   LIBRTMP_PATH ?= $(PROOT)/../librtmp
@@ -146,20 +146,20 @@ ifneq ($(findstring -nghttp2,$(CFG)),)
   _LIBS += -lnghttp2
 endif
 ifneq ($(findstring -nghttp3,$(CFG)),)
-  ifneq ($(findstring -ngtcp2,$(CFG)),)
-    NGHTTP3_PATH ?= $(PROOT)/../nghttp3
-    CPPFLAGS += -DUSE_NGHTTP3
-    CPPFLAGS += -I"$(NGHTTP3_PATH)/include"
-    _LDFLAGS += -L"$(NGHTTP3_PATH)/lib"
-    _LIBS += -lnghttp3
+ifneq ($(findstring -ngtcp2,$(CFG)),)
+  NGHTTP3_PATH ?= $(PROOT)/../nghttp3
+  CPPFLAGS += -DUSE_NGHTTP3
+  CPPFLAGS += -I"$(NGHTTP3_PATH)/include"
+  _LDFLAGS += -L"$(NGHTTP3_PATH)/lib"
+  _LIBS += -lnghttp3
 
-    NGTCP2_PATH ?= $(PROOT)/../ngtcp2
-    CPPFLAGS += -DUSE_NGTCP2
-    CPPFLAGS += -I"$(NGTCP2_PATH)/include"
-    _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-    NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_openssl
-    _LIBS += $(NGTCP2_LIBS)
-  endif
+  NGTCP2_PATH ?= $(PROOT)/../ngtcp2
+  CPPFLAGS += -DUSE_NGTCP2
+  CPPFLAGS += -I"$(NGTCP2_PATH)/include"
+  _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
+  NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_openssl
+  _LIBS += $(NGTCP2_LIBS)
+endif
 endif
 ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_PATH ?= $(PROOT)/../openssl

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -144,9 +144,9 @@ ifneq ($(findstring -ssl,$(CFG)),)
   _LIBS += $(OPENSSL_LIBS)
 
   ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/aead.h),)
-    SSLNAME := boringssl
+    OPENSSL := boringssl
   else
-    SSLNAME := openssl
+    OPENSSL := openssl
   endif
 
   ifneq ($(findstring -srp,$(CFG)),)
@@ -181,7 +181,7 @@ endif
 
 ifneq ($(findstring -nghttp3,$(CFG)),)
 ifneq ($(findstring -ngtcp2,$(CFG)),)
-ifneq ($(SSLNAME),)
+ifneq ($(OPENSSL),)
   NGHTTP3_PATH ?= $(PROOT)/../nghttp3
   CPPFLAGS += -DUSE_NGHTTP3
   CPPFLAGS += -I"$(NGHTTP3_PATH)/include"
@@ -192,7 +192,7 @@ ifneq ($(SSLNAME),)
   CPPFLAGS += -DUSE_NGTCP2
   CPPFLAGS += -I"$(NGTCP2_PATH)/include"
   _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-  NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_$(SSLNAME)
+  NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_$(OPENSSL)
   _LIBS += $(NGTCP2_LIBS)
 endif
 endif

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -132,6 +132,30 @@ ifneq ($(findstring -rtmp,$(CFG)),)
   ZLIB := 1
 endif
 
+ifneq ($(findstring -ssl,$(CFG)),)
+  OPENSSL_PATH ?= $(PROOT)/../openssl
+  CPPFLAGS += -DUSE_OPENSSL
+  CPPFLAGS += -DCURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG
+  OPENSSL_INCLUDE ?= $(OPENSSL_PATH)/include
+  OPENSSL_LIBPATH ?= $(OPENSSL_PATH)/lib
+  CPPFLAGS += -I"$(OPENSSL_INCLUDE)"
+  _LDFLAGS += -L"$(OPENSSL_LIBPATH)"
+  OPENSSL_LIBS ?= -lssl -lcrypto
+  _LIBS += $(OPENSSL_LIBS)
+
+  ifneq ($(findstring -srp,$(CFG)),)
+    ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h),)
+      # OpenSSL 1.0.1 and later.
+      CPPFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
+    endif
+  endif
+  SSLLIBS += 1
+endif
+ifneq ($(findstring -schannel,$(CFG)),)
+  CPPFLAGS += -DUSE_SCHANNEL
+  SSLLIBS += 1
+endif
+
 ifneq ($(findstring -ssh2,$(CFG)),)
   LIBSSH2_PATH ?= $(PROOT)/../libssh2
   CPPFLAGS += -DUSE_LIBSSH2
@@ -164,30 +188,6 @@ ifneq ($(findstring -ngtcp2,$(CFG)),)
   NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_openssl
   _LIBS += $(NGTCP2_LIBS)
 endif
-endif
-
-ifneq ($(findstring -ssl,$(CFG)),)
-  OPENSSL_PATH ?= $(PROOT)/../openssl
-  CPPFLAGS += -DUSE_OPENSSL
-  CPPFLAGS += -DCURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG
-  OPENSSL_INCLUDE ?= $(OPENSSL_PATH)/include
-  OPENSSL_LIBPATH ?= $(OPENSSL_PATH)/lib
-  CPPFLAGS += -I"$(OPENSSL_INCLUDE)"
-  _LDFLAGS += -L"$(OPENSSL_LIBPATH)"
-  OPENSSL_LIBS ?= -lssl -lcrypto
-  _LIBS += $(OPENSSL_LIBS)
-
-  ifneq ($(findstring -srp,$(CFG)),)
-    ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h),)
-      # OpenSSL 1.0.1 and later.
-      CPPFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
-    endif
-  endif
-  SSLLIBS += 1
-endif
-ifneq ($(findstring -schannel,$(CFG)),)
-  CPPFLAGS += -DUSE_SCHANNEL
-  SSLLIBS += 1
 endif
 
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -144,6 +144,7 @@ ifneq ($(findstring -ssl,$(CFG)),)
   ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/aead.h),)
     OPENSSL := boringssl
   else
+    # including libressl
     OPENSSL := openssl
   endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -178,13 +178,11 @@ ifneq ($(findstring -ssl,$(CFG)),)
       CPPFLAGS += -DHAVE_OPENSSL_SRP -DUSE_TLS_SRP
     endif
   endif
-  SSL := 1
+  SSLLIBS += 1
 endif
 ifneq ($(findstring -schannel,$(CFG)),)
   CPPFLAGS += -DUSE_SCHANNEL
-  ifdef SSL
-    CPPFLAGS += -DCURL_WITH_MULTI_SSL
-  endif
+  SSLLIBS += 1
 endif
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
   ZLIB_PATH ?= $(PROOT)/../zlib
@@ -243,6 +241,12 @@ ifeq ($(findstring -lldap,$(LIBS)),)
   _LIBS += -lwldap32
 endif
 _LIBS += -lws2_32 -lcrypt32 -lbcrypt
+
+# Each SSL lib appends '1'. If '11' can be found, it means we have
+# multiple SSL libs, telling us to enable MultiSSL.
+ifneq ($(findstring 11,$(SSLLIBS)),)
+  CPPFLAGS += -DCURL_WITH_MULTI_SSL
+endif
 
 ifndef DYN
   LDFLAGS += $(_LDFLAGS)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -122,6 +122,7 @@ ifneq ($(findstring -ares,$(CFG)),)
   _LIBS += -lcares
 endif
 endif
+
 ifneq ($(findstring -rtmp,$(CFG)),)
   LIBRTMP_PATH ?= $(PROOT)/../librtmp
   CPPFLAGS += -DUSE_LIBRTMP
@@ -130,6 +131,7 @@ ifneq ($(findstring -rtmp,$(CFG)),)
   _LIBS += -lrtmp -lwinmm
   ZLIB := 1
 endif
+
 ifneq ($(findstring -ssh2,$(CFG)),)
   LIBSSH2_PATH ?= $(PROOT)/../libssh2
   CPPFLAGS += -DUSE_LIBSSH2
@@ -138,6 +140,7 @@ ifneq ($(findstring -ssh2,$(CFG)),)
   _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
   _LIBS += -lssh2
 endif
+
 ifneq ($(findstring -nghttp2,$(CFG)),)
   NGHTTP2_PATH ?= $(PROOT)/../nghttp2
   CPPFLAGS += -DUSE_NGHTTP2
@@ -145,6 +148,7 @@ ifneq ($(findstring -nghttp2,$(CFG)),)
   _LDFLAGS += -L"$(NGHTTP2_PATH)/lib"
   _LIBS += -lnghttp2
 endif
+
 ifneq ($(findstring -nghttp3,$(CFG)),)
 ifneq ($(findstring -ngtcp2,$(CFG)),)
   NGHTTP3_PATH ?= $(PROOT)/../nghttp3
@@ -161,6 +165,7 @@ ifneq ($(findstring -ngtcp2,$(CFG)),)
   _LIBS += $(NGTCP2_LIBS)
 endif
 endif
+
 ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_PATH ?= $(PROOT)/../openssl
   CPPFLAGS += -DUSE_OPENSSL
@@ -184,6 +189,7 @@ ifneq ($(findstring -schannel,$(CFG)),)
   CPPFLAGS += -DUSE_SCHANNEL
   SSLLIBS += 1
 endif
+
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
   ZLIB_PATH ?= $(PROOT)/../zlib
   # These CPPFLAGS are also required when compiling the curl tool via 'src'.
@@ -215,6 +221,7 @@ ifneq ($(findstring -gsasl,$(CFG)),)
   _LDFLAGS += -L"$(LIBGSASL_PATH)/lib"
   _LIBS += -lgsasl
 endif
+
 ifneq ($(findstring -idn2,$(CFG)),)
   LIBIDN2_PATH ?= $(PROOT)/../libidn2
   CPPFLAGS += -DUSE_LIBIDN2
@@ -228,6 +235,7 @@ ifneq ($(findstring -winidn,$(CFG)),)
   _LIBS += -lnormaliz
 endif
 endif
+
 ifneq ($(findstring -sspi,$(CFG)),)
   CPPFLAGS += -DUSE_WINDOWS_SSPI
 endif
@@ -237,6 +245,7 @@ endif
 ifneq ($(findstring -ldaps,$(CFG)),)
   CPPFLAGS += -DHAVE_LDAP_SSL
 endif
+
 ifeq ($(findstring -lldap,$(LIBS)),)
   _LIBS += -lwldap32
 endif

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -157,6 +157,14 @@ ifneq ($(findstring -ssl,$(CFG)),)
   endif
   SSLLIBS += 1
 endif
+ifneq ($(findstring -mbedtls,$(CFG)),)
+  MBEDTLS_PATH ?= $(PROOT)/../zlib
+  CPPFLAGS += -DUSE_MBEDTLS
+  CPPFLAGS += -I"$(MBEDTLS_PATH)/include"
+  _LDFLAGS += -L"$(MBEDTLS_PATH)/lib"
+  _LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
+  SSLLIBS += 1
+endif
 ifneq ($(findstring -schannel,$(CFG)),)
   CPPFLAGS += -DUSE_SCHANNEL
   SSLLIBS += 1

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -192,7 +192,8 @@ else ifneq ($(findstring -libssh,$(CFG)),)
   CPPFLAGS += -DUSE_LIBSSH
   CPPFLAGS += -I"$(LIBSSH_PATH)/include"
   _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
-  _LIBS += -lssh
+  # Workaround when used with libressl 'duplicate symbol: explicit_bzero'
+  _LIBS := -lssh $(_LIBS)
 else ifeq ($(OPENSSL)$(findstring -wolfssh,$(CFG)),wolfssl-wolfssh)
   WOLFSSH_PATH ?= $(PROOT)/../wolfssh
   CPPFLAGS += -DUSE_WOLFSSH

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -138,8 +138,6 @@ ifneq ($(findstring -ssh2,$(CFG)),)
   _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
   _LIBS += -lssh2
 else ifneq ($(findstring -libssh,$(CFG)),)
-  # Avoid using libssh on Windows in production, due to its
-  # by-default-world-writable configuration vulnerability (as of 0.10.4)
   LIBSSH_PATH ?= $(PROOT)/../libssh
   CPPFLAGS += -DUSE_LIBSSH
   CPPFLAGS += -I"$(LIBSSH_PATH)/include"

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -28,9 +28,9 @@
 # Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 #
 # Set component roots via envvar <feature>_PATH. Also available for
-# customization: CPPFLAGS, LDFLAGS, LIBS, CFLAGS, RCFLAGS, ARCH[=custom],
-# CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX, and more for individual
-# components.
+# customization: CC, RC, AR, CROSSPREFIX, CPPFLAGS, LDFLAGS, LIBS, CFLAGS,
+# RCFLAGS, ARCH[=custom], CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX,
+# and more for individual components (see below).
 
 # This script is reused by 'src' and 'docs/examples' Makefile.m32 scripts.
 # Skip lib-specific parts when called through them.

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -177,6 +177,16 @@ ifneq ($(findstring -ssh2,$(CFG)),)
   _LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
   _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
   _LIBS += -lssh2
+else
+ifneq ($(findstring -libssh,$(CFG)),)
+  # You really should avoid libssh on Windows in production, due to its
+  # by-default-world-writable configuration vulnerability (as of 0.10.4)
+  LIBSSH_PATH ?= $(PROOT)/../libssh
+  CPPFLAGS += -DUSE_LIBSSH
+  CPPFLAGS += -I"$(LIBSSH_PATH)/include"
+  _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
+  _LIBS += -lssh
+endif
 endif
 
 ifneq ($(findstring -nghttp2,$(CFG)),)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -208,8 +208,7 @@ ifneq ($(findstring -nghttp2,$(CFG)),)
   _LIBS += -lnghttp2
 endif
 
-ifneq ($(findstring -nghttp3,$(CFG)),)
-ifneq ($(findstring -ngtcp2,$(CFG)),)
+ifeq ($(findstring -nghttp3,$(CFG))$(findstring -ngtcp2,$(CFG)),-nghttp3-ngtcp2)
 ifneq ($(OPENSSL),)
   NGHTTP3_PATH ?= $(PROOT)/../nghttp3
   CPPFLAGS += -DUSE_NGHTTP3
@@ -223,7 +222,6 @@ ifneq ($(OPENSSL),)
   _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
   NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_$(OPENSSL)
   _LIBS += $(NGTCP2_LIBS)
-endif
 endif
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -156,6 +156,17 @@ ifneq ($(findstring -ssl,$(CFG)),)
     endif
   endif
   SSLLIBS += 1
+else
+ifneq ($(findstring -wolfssl,$(CFG)),)
+  WOLFSSL_PATH ?= $(PROOT)/../zlib
+  CPPFLAGS += -DUSE_WOLFSSL
+  CPPFLAGS += -DSIZEOF_LONG_LONG=8
+  CPPFLAGS += -I"$(WOLFSSL_PATH)/include"
+  _LDFLAGS += -L"$(WOLFSSL_PATH)/lib"
+  _LIBS += -lwolfssl
+  OPENSSL := wolfssl
+  SSLLIBS += 1
+endif
 endif
 ifneq ($(findstring -mbedtls,$(CFG)),)
   MBEDTLS_PATH ?= $(PROOT)/../zlib
@@ -186,6 +197,14 @@ ifneq ($(findstring -libssh,$(CFG)),)
   CPPFLAGS += -I"$(LIBSSH_PATH)/include"
   _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
   _LIBS += -lssh
+else
+ifeq ($(OPENSSL)$(findstring -wolfssh,$(CFG)),wolfssl-wolfssh)
+  WOLFSSH_PATH ?= $(PROOT)/../wolfssh
+  CPPFLAGS += -DUSE_WOLFSSH
+  CPPFLAGS += -I"$(WOLFSSH_PATH)/include"
+  _LDFLAGS += -L"$(WOLFSSH_PATH)/lib"
+  _LIBS += -lwolfssh
+endif
 endif
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -293,8 +293,6 @@ ifeq ($(findstring -lldap,$(LIBS)),)
 endif
 _LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
-# Each additional SSL lib appends ' 1'.
-# Strip spaces and look for '11' to detect multiple SSL libs.
 ifneq ($(findstring 11,$(subst $() ,,$(SSLLIBS))),)
   CPPFLAGS += -DCURL_WITH_MULTI_SSL
 endif

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -264,6 +264,14 @@ ifneq ($(findstring -idn2,$(CFG)),)
   CPPFLAGS += -I"$(LIBIDN2_PATH)/include"
   _LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
   _LIBS += -lidn2
+
+ifneq ($(findstring -psl,$(CFG)),)
+  LIBPSL_PATH ?= $(PROOT)/../libpsl
+  CPPFLAGS += -DUSE_LIBPSL
+  CPPFLAGS += -I"$(LIBPSL_PATH)/include"
+  _LDFLAGS += -L"$(LIBPSL_PATH)/lib"
+  _LIBS += -lpsl
+endif
 else ifneq ($(findstring -winidn,$(CFG)),)
   CPPFLAGS += -DUSE_WIN32_IDN
   CPPFLAGS += -DWANT_IDN_PROTOTYPES

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -294,9 +294,9 @@ ifeq ($(findstring -lldap,$(LIBS)),)
 endif
 _LIBS += -lws2_32 -lcrypt32 -lbcrypt
 
-# Each additional SSL lib appends ' 1'. Finding '1 1' means we have multiple
-# SSL libs.
-ifneq ($(findstring 1 1,$(SSLLIBS)),)
+# Each additional SSL lib appends ' 1'.
+# Strip spaces and look for '11' to detect multiple SSL libs.
+ifneq ($(findstring 11,$(subst $() ,,$(SSLLIBS))),)
   CPPFLAGS += -DCURL_WITH_MULTI_SSL
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -210,7 +210,6 @@ ifneq ($(findstring -nghttp2,$(CFG)),)
 endif
 
 ifeq ($(findstring -nghttp3,$(CFG))$(findstring -ngtcp2,$(CFG)),-nghttp3-ngtcp2)
-ifneq ($(OPENSSL),)
   NGHTTP3_PATH ?= $(PROOT)/../nghttp3
   CPPFLAGS += -DUSE_NGHTTP3
   CPPFLAGS += -I"$(NGHTTP3_PATH)/include"
@@ -221,9 +220,10 @@ ifneq ($(OPENSSL),)
   CPPFLAGS += -DUSE_NGTCP2
   CPPFLAGS += -I"$(NGTCP2_PATH)/include"
   _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-  NGTCP2_LIBS ?= -lngtcp2_crypto_$(OPENSSL)
+  ifneq ($(OPENSSL),)
+    NGTCP2_LIBS ?= -lngtcp2_crypto_$(OPENSSL)
+  endif
   _LIBS += -lngtcp2 $(NGTCP2_LIBS)
-endif
 endif
 
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -220,8 +220,8 @@ ifneq ($(OPENSSL),)
   CPPFLAGS += -DUSE_NGTCP2
   CPPFLAGS += -I"$(NGTCP2_PATH)/include"
   _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-  NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_$(OPENSSL)
-  _LIBS += $(NGTCP2_LIBS)
+  NGTCP2_LIBS ?= -lngtcp2_crypto_$(OPENSSL)
+  _LIBS += -lngtcp2 $(NGTCP2_LIBS)
 endif
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -143,6 +143,12 @@ ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_LIBS ?= -lssl -lcrypto
   _LIBS += $(OPENSSL_LIBS)
 
+  ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/aead.h),)
+    SSLNAME := boringssl
+  else
+    SSLNAME := openssl
+  endif
+
   ifneq ($(findstring -srp,$(CFG)),)
     ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h),)
       # OpenSSL 1.0.1 and later.
@@ -175,6 +181,7 @@ endif
 
 ifneq ($(findstring -nghttp3,$(CFG)),)
 ifneq ($(findstring -ngtcp2,$(CFG)),)
+ifneq ($(SSLNAME),)
   NGHTTP3_PATH ?= $(PROOT)/../nghttp3
   CPPFLAGS += -DUSE_NGHTTP3
   CPPFLAGS += -I"$(NGHTTP3_PATH)/include"
@@ -185,8 +192,9 @@ ifneq ($(findstring -ngtcp2,$(CFG)),)
   CPPFLAGS += -DUSE_NGTCP2
   CPPFLAGS += -I"$(NGTCP2_PATH)/include"
   _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-  NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_openssl
+  NGTCP2_LIBS ?= -lngtcp2 -lngtcp2_crypto_$(SSLNAME)
   _LIBS += $(NGTCP2_LIBS)
+endif
 endif
 endif
 

--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -113,14 +113,12 @@ _LIBS :=
 
 ifneq ($(findstring -sync,$(CFG)),)
   CPPFLAGS += -DUSE_SYNC_DNS
-else
-ifneq ($(findstring -ares,$(CFG)),)
+else ifneq ($(findstring -ares,$(CFG)),)
   LIBCARES_PATH ?= $(PROOT)/../c-ares
   CPPFLAGS += -DUSE_ARES
   CPPFLAGS += -I"$(LIBCARES_PATH)/include"
   _LDFLAGS += -L"$(LIBCARES_PATH)/lib"
   _LIBS += -lcares
-endif
 endif
 
 ifneq ($(findstring -rtmp,$(CFG)),)
@@ -156,8 +154,7 @@ ifneq ($(findstring -ssl,$(CFG)),)
     endif
   endif
   SSLLIBS += 1
-else
-ifneq ($(findstring -wolfssl,$(CFG)),)
+else ifneq ($(findstring -wolfssl,$(CFG)),)
   WOLFSSL_PATH ?= $(PROOT)/../zlib
   CPPFLAGS += -DUSE_WOLFSSL
   CPPFLAGS += -DSIZEOF_LONG_LONG=8
@@ -166,7 +163,6 @@ ifneq ($(findstring -wolfssl,$(CFG)),)
   _LIBS += -lwolfssl
   OPENSSL := wolfssl
   SSLLIBS += 1
-endif
 endif
 ifneq ($(findstring -mbedtls,$(CFG)),)
   MBEDTLS_PATH ?= $(PROOT)/../zlib
@@ -188,8 +184,7 @@ ifneq ($(findstring -ssh2,$(CFG)),)
   _LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
   _LDFLAGS += -L"$(LIBSSH2_PATH)/win32"
   _LIBS += -lssh2
-else
-ifneq ($(findstring -libssh,$(CFG)),)
+else ifneq ($(findstring -libssh,$(CFG)),)
   # You really should avoid libssh on Windows in production, due to its
   # by-default-world-writable configuration vulnerability (as of 0.10.4)
   LIBSSH_PATH ?= $(PROOT)/../libssh
@@ -197,15 +192,12 @@ ifneq ($(findstring -libssh,$(CFG)),)
   CPPFLAGS += -I"$(LIBSSH_PATH)/include"
   _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
   _LIBS += -lssh
-else
-ifeq ($(OPENSSL)$(findstring -wolfssh,$(CFG)),wolfssl-wolfssh)
+else ifeq ($(OPENSSL)$(findstring -wolfssh,$(CFG)),wolfssl-wolfssh)
   WOLFSSH_PATH ?= $(PROOT)/../wolfssh
   CPPFLAGS += -DUSE_WOLFSSH
   CPPFLAGS += -I"$(WOLFSSH_PATH)/include"
   _LDFLAGS += -L"$(WOLFSSH_PATH)/lib"
   _LIBS += -lwolfssh
-endif
-endif
 endif
 
 ifneq ($(findstring -nghttp2,$(CFG)),)
@@ -273,12 +265,10 @@ ifneq ($(findstring -idn2,$(CFG)),)
   CPPFLAGS += -I"$(LIBIDN2_PATH)/include"
   _LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
   _LIBS += -lidn2
-else
-ifneq ($(findstring -winidn,$(CFG)),)
+else ifneq ($(findstring -winidn,$(CFG)),)
   CPPFLAGS += -DUSE_WIN32_IDN
   CPPFLAGS += -DWANT_IDN_PROTOTYPES
   _LIBS += -lnormaliz
-endif
 endif
 
 ifneq ($(findstring -sspi,$(CFG)),)


### PR DESCRIPTION
- Add support for these options:
  `-wolfssl`, `-wolfssh`, `-mbedtls`, `-libssh`, `-psl`
  Caveats:
  - `-wolfssh` requires `-wolfssl`.
  - `-wolfssl` cannot be used with OpenSSL backends in parallel.
  - `-libssh` has build issues with BoringSSL and LibreSSL, and also
     what looks like a world-writable-config vulnerability on Windows.
     Consider it experimental.
  - `-psl` requires `-idn2` and extra libs passed via
    `LIBS=-liconv -lunistring`.
- Detect BoringSSL/wolfSSL and set ngtcp2 crypto lib accordingly.
- Generalize MultiSSL detection.
- Use else-if syntax. Requires GNU Make 3.81 (2006-04-01).
- Document more customization options.

This brings over some configuration logic from `curl-for-win`.

Closes #9680

Cleaner patch w/o whitespace changes: https://github.com/curl/curl/pull/9680/files?w=1
