### PR TITLE
curl/get_url_file_name: use libcurl URL parser

### DIFF
--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -150,7 +150,7 @@ CURLcode get_url_file_name(char **filename, const char *url)
     curl_url_cleanup(uh);
 
     pc = strrchr(path, '/');
-    pc2 = strrchr(pc?pc+1:path, '\\');
+    pc2 = strrchr(pc ? pc + 1 : path, '\\');
     if(pc2)
       pc = pc2;
 

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -149,9 +149,9 @@ CURLcode get_url_file_name(char **filename, const char *url)
      !curl_url_get(uh, CURLUPART_PATH, &path, 0)) {
     curl_url_cleanup(uh);
 
-    pc2 = strrchr(path, '\\');
     pc = strrchr(path, '/');
-    if(pc2 && (!pc || pc < pc2))
+    pc2 = strrchr(pc?pc+1:path, '\\');
+    if(pc2)
       pc = pc2;
 
     if(pc)

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -137,61 +137,65 @@ char *add_file_name_to_url(char *url, const char *filename)
 CURLcode get_url_file_name(char **filename, const char *url)
 {
   const char *pc, *pc2;
+  CURLU *uh = curl_url();
+  char *path = NULL;
+
+  if(!uh)
+    return CURLE_OUT_OF_MEMORY;
 
   *filename = NULL;
 
-  /* Find and get the remote file name */
-  pc = strstr(url, "://");
-  if(pc)
-    pc += 3;
-  else
-    pc = url;
+  if(!curl_url_set(uh, CURLUPART_URL, url, CURLU_GUESS_SCHEME) &&
+     !curl_url_get(uh, CURLUPART_PATH, &path, 0)) {
+    curl_url_cleanup(uh);
 
-  pc2 = strrchr(pc, '\\');
-  pc = strrchr(pc, '/');
-  if(pc2 && (!pc || pc < pc2))
-    pc = pc2;
+    pc2 = strrchr(path, '\\');
+    pc = strrchr(path, '/');
+    if(pc2 && (!pc || pc < pc2))
+      pc = pc2;
 
-  if(pc)
-    /* duplicate the string beyond the slash */
-    pc++;
-  else
-    /* no slash => empty string */
-    pc = "";
+    if(pc)
+      /* duplicate the string beyond the slash */
+      pc++;
+    else
+      /* no slash => empty string */
+      pc = "";
 
-  *filename = strdup(pc);
-  if(!*filename)
-    return CURLE_OUT_OF_MEMORY;
+    *filename = strdup(pc);
+    curl_free(path);
+    if(!*filename)
+      return CURLE_OUT_OF_MEMORY;
 
 #if defined(MSDOS) || defined(WIN32)
-  {
-    char *sanitized;
-    SANITIZEcode sc = sanitize_file_name(&sanitized, *filename, 0);
-    Curl_safefree(*filename);
-    if(sc)
-      return CURLE_URL_MALFORMAT;
-    *filename = sanitized;
-  }
+    {
+      char *sanitized;
+      SANITIZEcode sc = sanitize_file_name(&sanitized, *filename, 0);
+      Curl_safefree(*filename);
+      if(sc)
+        return CURLE_URL_MALFORMAT;
+      *filename = sanitized;
+    }
 #endif /* MSDOS || WIN32 */
 
-  /* in case we built debug enabled, we allow an environment variable
-   * named CURL_TESTDIR to prefix the given file name to put it into a
-   * specific directory
-   */
+    /* in case we built debug enabled, we allow an environment variable
+     * named CURL_TESTDIR to prefix the given file name to put it into a
+     * specific directory
+     */
 #ifdef DEBUGBUILD
-  {
-    char *tdir = curlx_getenv("CURL_TESTDIR");
-    if(tdir) {
-      char buffer[512]; /* suitably large */
-      msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, *filename);
-      Curl_safefree(*filename);
-      *filename = strdup(buffer); /* clone the buffer */
-      curl_free(tdir);
-      if(!*filename)
-        return CURLE_OUT_OF_MEMORY;
+    {
+      char *tdir = curlx_getenv("CURL_TESTDIR");
+      if(tdir) {
+        char *alt = aprintf("%s/%s", tdir, *filename);
+        Curl_safefree(*filename);
+        *filename = alt;
+        curl_free(tdir);
+        if(!*filename)
+          return CURLE_OUT_OF_MEMORY;
+      }
     }
-  }
 #endif
-
-  return CURLE_OK;
+    return CURLE_OK;
+  }
+  curl_url_cleanup(uh);
+  return CURLE_URL_MALFORMAT;
 }

--- a/tests/data/test1210
+++ b/tests/data/test1210
@@ -39,7 +39,7 @@ HTTP GET with -J without Content-Disposition
 CURL_TESTDIR=%PWD/log
 </setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER?junk -J -O
 </command>
 </client>
 
@@ -47,7 +47,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O
 # Verify data after the test has been "shot"
 <verify>
 <protocol>
-GET /%TESTNUMBER HTTP/1.1
+GET /%TESTNUMBER?junk HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*


### PR DESCRIPTION
To avoid URL tricks, use the URL parser for this.

This update changes curl's behavior slightly in that it will ignore the possible query part from the URL and only use the file name from the actual path from the URL. I consider it a bugfix.

"curl -O localhost/name?giveme-giveme" will now save the output in the local file named 'name'