### PR TITLE
header.d: add category smtp and imap

### DIFF
--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -5,7 +5,7 @@ Short: H
 Arg: <header/@file>
 Help: Pass custom header(s) to server
 Protocols: HTTP IMAP SMTP
-Category: http
+Category: http imap smtp
 See-also: user-agent referer
 Example: -H "X-First-Name: Joe" $URL
 Example: -H "User-Agent: yes-please/2000" $URL


### PR DESCRIPTION
They were previously (erroneously) added manually to tool_listhelp.c which would make them get removed again when the file is updated next time, unless added correctly here in header.d

Follow-up to 2437fac01