### PR TITLE
Set ARES_AI_NUMERICSERV hint flags when calling ares_getaddrinfo

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -786,6 +786,10 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
       hints.ai_family = pf;
       hints.ai_socktype = (data->conn->transport == TRNSPRT_TCP)?
         SOCK_STREAM : SOCK_DGRAM;
+      /* Since the service is a numerical one, set the hint flags
+       * accordingly to save a call to getservbyname in inside C-Ares
+       */
+      hints.ai_flags = ARES_AI_NUMERICSERV;
       msnprintf(service, sizeof(service), "%d", port);
       res->num_pending = 1;
       ares_getaddrinfo((ares_channel)data->state.async.resolver, hostname,


### PR DESCRIPTION
The hint flag is ARES_AI_NUMERICSERV, and it will save a call to getservbyname or getservbyname_r to set it.

This is where the hint flag is used in the C-Ares library -> https://github.com/c-ares/c-ares/blob/main/src/lib/ares_getaddrinfo.c#L645

For context we are trying to make a static binary that can run on any linux box, however that fails as not setting the hint triggers a getservbyname_r calls, which in turn loads the nss libraries which might not be on a different linux box (possible if that box runs alpine).

```
[pid 42269] openat(AT_FDCWD, "/etc/services", O_RDONLY|O_CLOEXEC) = 76
 > /lib/x86_64-linux-gnu/libc-2.27.so(__open_nocancel+0x41) [0x10fd61]
 > /lib/x86_64-linux-gnu/libc-2.27.so(_IO_file_fopen+0x79d) [0x8cbed]
 > /lib/x86_64-linux-gnu/libc-2.27.so(fopen+0x7a) [0x7ee5a]
 > /lib/x86_64-linux-gnu/libnss_files-2.27.so(_nss_files_getservbyname_r+0x39) [0x31a9]
 > /path/to/our/app(__getservbyname_r+0x153) [0x175a4f3]
```