### PR TITLE
test1275: verify upercase after period in markdown

### DIFF
--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -299,8 +299,7 @@ want the matching `MAILINDEX` numbers returned then you could search via URL:
 
     imap://user:password@mail.example.com/INBOX?TEXT%20%22foo%20bar%22
 
-.. but if you wanted matching `UID` numbers you would have to use a custom
-request:
+If you want matching `UID` numbers you have to use a custom request:
 
     imap://user:password@mail.example.com/INBOX -X "UID SEARCH TEXT \"foo bar\""
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -161,7 +161,7 @@ test1240 test1241 test1242 test1243 test1244 test1245 test1246 test1247 \
 test1248 test1249 test1250 test1251 test1252 test1253 test1254 test1255 \
 test1256 test1257 test1258 test1259 test1260 test1261 test1262 test1263 \
 test1264 test1265 test1266 test1267 test1268 test1269 test1270 test1271 \
-test1272 test1273 test1274 \
+test1272 test1273 test1274 test1275 \
 \
 test1280 test1281 test1282 test1283 test1284 test1285 test1286 test1287 \
 test1288 test1289 test1290 test1291 test1292 test1293 test1294 test1295 \

--- a/tests/data/test1275
+++ b/tests/data/test1275
@@ -1,0 +1,33 @@
+<testcase>
+<info>
+<keywords>
+source analysis
+symbols-in-versions
+documentation
+--manual
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+
+<name>
+Verify capital letters after period in markdown files
+</name>
+
+<command type="perl">
+%SRCDIR/markdown-uppercase.pl %SRCDIR/..
+</command>
+</client>
+
+<verify>
+<stderr>
+ok
+</stderr>
+</verify>
+
+</testcase>

--- a/tests/markdown-uppercase.pl
+++ b/tests/markdown-uppercase.pl
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2016 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+my $root=$ARGV[0] || "..";
+
+my @m = `git ls-files -- $root`;
+
+my $errors;
+
+sub checkfile {
+    my ($f) = @_;
+    chomp $f;
+    if($f !~ /\.md\z/) {
+        return;
+    }
+    print "scan $f\n";
+    open(F, "<$f");
+    my $l = 1;
+    while(<F>) {
+        my $line = $_;
+        if($line =~ /^(.*)\. +([a-z]+)/) {
+            my ($prefix, $word) = ($1, $2);
+
+            if(($prefix =~ /\.\.\z/) ||
+               ($prefix =~ /[0-9]\z/) ||
+               ($prefix =~ /e.g\z/) ||
+               ($prefix =~ /i.e\z/) ||
+               ($prefix =~ /etc\z/) ||
+               ($word eq "curl") ||
+               ($word eq "libcurl")
+                ) {
+            }
+            else {
+                my $c = length($prefix) + 2;
+                print STDERR "$f:$l:$c:error: lowercase after period\n";
+                print STDERR $line;
+                print STDERR ' ' x $c;
+                print STDERR "^\n";
+                $errors++;
+            }
+        }
+        $l++;
+    }
+    close(F);
+}
+
+
+for my $f (@m) {
+    checkfile($f);
+}
+
+if($errors) {
+    exit 1;
+}
+print STDERR "ok\n";


### PR DESCRIPTION
Script based on the #9474 pull-request logic, but implemented in perl.

Updated docs/URL-SYNTAX.md accordingly.

Suggested-by: Dan Fandrich