### PR TITLE
Makefile.m32: drop CROSSPREFIX and manual CC/AR defaults [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -28,8 +28,8 @@
 # Example: mingw32-make -f Makefile.m32 CFG=-zlib-ssl-sspi-winidn
 #
 # Set component roots via envvar <feature>_PATH. Also available for
-# customization: CC, RC, AR, CROSSPREFIX, CPPFLAGS, LDFLAGS, LIBS, CFLAGS,
-# RCFLAGS, ARCH[=custom], CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX,
+# customization: CC, RC, AR, CPPFLAGS, LDFLAGS, LIBS, CFLAGS, RCFLAGS,
+# ARCH[=custom], CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX,
 # and more for individual components (see below).
 
 # This script is reused by 'src' and 'docs/examples' Makefile.m32 scripts.
@@ -77,7 +77,7 @@ CPPFLAGS += -I. -I$(PROOT)/include
 RCFLAGS  += -I$(PROOT)/include
 
 ifneq ($(ARCH),custom)
-  # Set environment var ARCH to your architecture to override autodetection.
+  # Set environment var ARCH to your architecture to override auto-detection.
   ifndef ARCH
     ifneq ($(findstring x86_64,$(shell $(CC) -dumpmachine)),)
       ARCH := w64
@@ -302,9 +302,7 @@ endif
 
 ### Global rules
 
-CC ?= $(CROSSPREFIX)gcc
-RC ?= $(CROSSPREFIX)windres
-AR ?= $(CROSSPREFIX)ar
+RC ?= windres
 
 ifneq ($(findstring /sh,$(SHELL)),)
 DEL  = rm -f $1


### PR DESCRIPTION
This patch aimed to fix a regression [0], where `CC` initialization moved beyond its first use. But, on closer inspection it turned out that the `CC` initialization does not work as expected due to GNU Make filling it with `cc` by default. So unless implicit values were explicitly disabled via a GNU Make option, the default value of `$CROSSPREFIX` + `gcc` was never used. At the same time the implicit value `cc` maps to `gcc` in (most/all?) MinGW envs.

`AR` has the same issue, with a default value of `ar`.

We could reintroduce a separate variable to fix this without ill effects, but for simplicity and flexibility, it seems better to drop support for `CROSSPREFIX`, along with our own `CC`/`AR` init logic, and require the caller to initialize `CC`, `AR` and `RC` to the full (prefixed if necessary) names of these tools, as desired.

We keep `RC ?= windres` because `RC` is empty by default.

Also fix grammar in a comment.

[0] 10fbd8b4e3f83b967fd9ad9a41ab484c0e7e7ca3