### PR TITLE
urlapi.c: nitpick grammar in function comment

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -116,7 +116,7 @@ static const char *find_host_sep(const char *url)
 }
 
 /*
- * Decide in an encoding-independent manner whether a character in an
+ * Decide in an encoding-independent manner whether a character in a
  * URL must be escaped. The same criterion must be used in strlen_url()
  * and strcpy_url().
  */


### PR DESCRIPTION
because the 'u' in URL is actually a consonant *sound* it is only correct to write "a URL"

sorry this is a bit nitpicky :P

https://english.stackexchange.com/questions/152/when-should-i-use-a-vs-an 
https://www.techtarget.com/whatis/feature/Which-is-correct-a-URL-or-an-URL