### PR TITLE
tool_paramhelp: str2udouble 'max' changed to double

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -808,7 +808,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case 'c': /* connect-timeout */
         err = str2udouble(&config->connecttimeout, nextarg,
-                          LONG_MAX/1000);
+                          (double)LONG_MAX/1000);
         if(err)
           return err;
         break;
@@ -1374,7 +1374,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           return err;
         break;
       case 'R': /* --expect100-timeout */
-        err = str2udouble(&config->expect100timeout, nextarg, LONG_MAX/1000);
+        err = str2udouble(&config->expect100timeout, nextarg,
+                          (double)LONG_MAX/1000);
         if(err)
           return err;
         break;
@@ -2067,7 +2068,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case 'm':
       /* specified max time */
-      err = str2udouble(&config->timeout, nextarg, LONG_MAX/1000);
+      err = str2udouble(&config->timeout, nextarg, (double)LONG_MAX/1000);
       if(err)
         return err;
       break;

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -218,7 +218,7 @@ ParameterError str2unummax(long *val, const char *str, long max)
  * data.
  */
 
-static ParameterError str2double(double *val, const char *str, long max)
+static ParameterError str2double(double *val, const char *str, double max)
 {
   if(str) {
     char *endptr;
@@ -251,7 +251,7 @@ static ParameterError str2double(double *val, const char *str, long max)
  * data.
  */
 
-ParameterError str2udouble(double *valp, const char *str, long max)
+ParameterError str2udouble(double *valp, const char *str, double max)
 {
   double value;
   ParameterError result = str2double(&value, str, max);

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -36,7 +36,7 @@ ParameterError str2num(long *val, const char *str);
 ParameterError str2unum(long *val, const char *str);
 ParameterError oct2nummax(long *val, const char *str, long max);
 ParameterError str2unummax(long *val, const char *str, long max);
-ParameterError str2udouble(double *val, const char *str, long max);
+ParameterError str2udouble(double *val, const char *str, double max);
 
 ParameterError proto2num(struct OperationConfig *config,
                          const char * const *val, char **obuf,


### PR DESCRIPTION
It is Hacktoberfest. I found myself here. Nitpicking in this glorious repository.

My LSP told me:

"Implicit conversion from 'long' to 'double' may lose precision"

I therefore thought that I perhaps could make a little PR.

Actually, with this PR; one may now be able to wait even longer for a connection to fail!
And that might also be a good thing. 
