### PR TITLE
smb: replace CURL_WIN32 with WIN32

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -34,7 +34,7 @@
 #include <process.h>
 #ifdef CURL_WINDOWS_APP
 #define getpid GetCurrentProcessId
-#elif defined(CURL_WIN32)
+#elif defined(WIN32)
 #define getpid _getpid
 #endif
 #endif


### PR DESCRIPTION
PR #9255 aimed to fix a Cygwin/MSYS issue. It used the `CURL_WIN32` macro, but that one is not defined here, while compiling curl itself. This patch changes this to `WIN32`, assuming this was the original intent.

Regression from 1c52e8a3795ccdf8ec9c308f4f8f19cf10ea1f1a.

Ref: #8220

Closes #9701

/cc @orgads, @MarcelRaad