### PR TITLE
smb: tidy-up getpid on Windows

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -30,7 +30,7 @@
 
 #define BUILDING_CURL_SMB_C
 
-#if defined(WIN32)
+#ifdef WIN32
 #define getpid GetCurrentProcessId
 #elif defined(HAVE_PROCESS_H)
 #include <process.h>

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -32,8 +32,6 @@
 
 #ifdef WIN32
 #define getpid GetCurrentProcessId
-#elif defined(HAVE_PROCESS_H)
-#include <process.h>
 #endif
 
 #include "smb.h"

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -30,13 +30,10 @@
 
 #define BUILDING_CURL_SMB_C
 
-#ifdef HAVE_PROCESS_H
-#include <process.h>
-#ifdef CURL_WINDOWS_APP
+#if defined(WIN32)
 #define getpid GetCurrentProcessId
-#elif defined(CURL_WIN32)
-#define getpid _getpid
-#endif
+#elif defined(HAVE_PROCESS_H)
+#include <process.h>
 #endif
 
 #include "smb.h"

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -32,6 +32,8 @@
 
 #ifdef WIN32
 #define getpid GetCurrentProcessId
+#elif defined(HAVE_PROCESS_H)
+#include <process.h>
 #endif
 
 #include "smb.h"


### PR DESCRIPTION
Always use the `GetCurrentProcessId()` on Windows.

It was always used for UWP apps, leaving other Windows builds with `getpid()` or `_getpid()` dependening on build configuration.

Ref: https://github.com/curl/curl/pull/9701#issuecomment-1274928405
