### PR TITLE
tidy-up: delete HAVE_STRUCT_POLLFD

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -511,11 +511,6 @@ Vista
 /* Define if struct sockaddr_in6 has the sin6_scope_id member. */
 #define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID 1
 
-#if defined(HAVE_WINSOCK2_H) && defined(_WIN32_WINNT) && \
-    (_WIN32_WINNT >= 0x0600)
-#define HAVE_STRUCT_POLLFD 1
-#endif
-
 /* ---------------------------------------------------------------- */
 /*                        LARGE FILE SUPPORT                        */
 /* ---------------------------------------------------------------- */

--- a/lib/select.h
+++ b/lib/select.h
@@ -36,8 +36,7 @@
  * Definition of pollfd struct and constants for platforms lacking them.
  */
 
-#if !defined(HAVE_STRUCT_POLLFD) && \
-    !defined(HAVE_SYS_POLL_H) && \
+#if !defined(HAVE_SYS_POLL_H) && \
     !defined(HAVE_POLL_H) && \
     !defined(POLLIN)
 


### PR DESCRIPTION
It was only defined in `lib/config-win32.h`, when building for Vista.

It was only used in `select.h`, in a condition that also included a check for `POLLIN` which is a superior choice for this detection and which was already used by cmake and autotools builds.

Delete both instances of this macro.

Closes #xxxx