### PR TITLE
lib: set more flags in config-win32.h

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -79,7 +79,7 @@
 
 /* Define to 1 if you have the <stdbool.h> header file. */
 #if (defined(_MSC_VER) && (_MSC_VER >= 1800)) || \
-    (defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR))
+    defined(__MINGW64_VERSION_MAJOR)
 #define HAVE_STDBOOL_H 1
 #endif
 
@@ -146,7 +146,7 @@
 #define HAVE_STRING_H 1
 
 /* Define to 1 if you have the <libgen.h> header file. */
-#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#if defined(__MINGW64_VERSION_MAJOR)
 #define HAVE_LIBGEN_H 1
 #endif
 
@@ -162,7 +162,7 @@
 
 /* Define to 1 if bool is an available type. */
 #if (defined(_MSC_VER) && (_MSC_VER >= 1800)) || \
-    (defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR))
+    defined(__MINGW64_VERSION_MAJOR)
 #define HAVE_BOOL_T 1
 #endif
 
@@ -174,7 +174,7 @@
 #define HAVE_CLOSESOCKET 1
 
 /* Define if you have the ftruncate function. */
-#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#if defined(__MINGW64_VERSION_MAJOR)
 #define HAVE_FTRUNCATE 1
 #endif
 
@@ -282,12 +282,12 @@
 #endif
 
 /* Define to 1 if you have the `basename' function. */
-#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#if defined(__MINGW64_VERSION_MAJOR)
 #define HAVE_BASENAME 1
 #endif
 
 /* Define to 1 if you have the strtok_r function. */
-#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#if defined(__MINGW64_VERSION_MAJOR)
 #define HAVE_STRTOK_R 1
 #endif
 
@@ -577,7 +577,7 @@ Vista
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 #if defined(USE_WIN32_LARGE_FILES)
-#  if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#  if defined(__MINGW64_VERSION_MAJOR)
 #    ifndef _FILE_OFFSET_BITS
 #    define _FILE_OFFSET_BITS 64
 #    endif

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -78,7 +78,8 @@
 /* #define HAVE_SSL_H 1 */
 
 /* Define to 1 if you have the <stdbool.h> header file. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1800)) || \
+    (defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR))
 #define HAVE_STDBOOL_H 1
 #endif
 
@@ -138,6 +139,17 @@
 #define HAVE_WS2TCPIP_H 1
 #endif
 
+/* Define to 1 if you have the <setjmp.h> header file. */
+#define HAVE_SETJMP_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <libgen.h> header file. */
+#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#define HAVE_LIBGEN_H 1
+#endif
+
 /* ---------------------------------------------------------------- */
 /*                        OTHER HEADER INFO                         */
 /* ---------------------------------------------------------------- */
@@ -149,7 +161,8 @@
 /* #define TIME_WITH_SYS_TIME 1 */
 
 /* Define to 1 if bool is an available type. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#if (defined(_MSC_VER) && (_MSC_VER >= 1800)) || \
+    (defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR))
 #define HAVE_BOOL_T 1
 #endif
 
@@ -161,7 +174,9 @@
 #define HAVE_CLOSESOCKET 1
 
 /* Define if you have the ftruncate function. */
-/* #define HAVE_FTRUNCATE 1 */
+#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#define HAVE_FTRUNCATE 1
+#endif
 
 /* Define to 1 if you have the `getpeername' function. */
 #define HAVE_GETPEERNAME 1
@@ -259,6 +274,26 @@
 #define HAVE_SNPRINTF 1
 #endif
 
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600  /* Vista */
+/* Define to 1 if you have a IPv6 capable working inet_ntop function. */
+#define HAVE_INET_NTOP 1
+/* Define to 1 if you have a IPv6 capable working inet_pton function. */
+#define HAVE_INET_PTON 1
+#endif
+
+/* Define to 1 if you have the `basename' function. */
+#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#define HAVE_BASENAME 1
+#endif
+
+/* Define to 1 if you have the strtok_r function. */
+#if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#define HAVE_STRTOK_R 1
+#endif
+
+/* Define to 1 if you have the signal function. */
+#define HAVE_SIGNAL 1
+
 /* ---------------------------------------------------------------- */
 /*                       TYPEDEF REPLACEMENTS                       */
 /* ---------------------------------------------------------------- */
@@ -300,6 +335,11 @@
 
 /* Define to the size of `curl_off_t', as computed by sizeof. */
 #define SIZEOF_CURL_OFF_T 8
+
+/* Define to the size of `off_t', as computed by sizeof. */
+#ifndef SIZEOF_OFF_T
+#define SIZEOF_OFF_T 8
+#endif
 
 /* ---------------------------------------------------------------- */
 /*               BSD-style lwIP TCP/IP stack SPECIFIC               */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -575,6 +575,15 @@ Vista
 #  define USE_WIN32_SMALL_FILES
 #endif
 
+/* Number of bits in a file offset, on hosts where this is settable. */
+#if defined(USE_WIN32_LARGE_FILES)
+#  if defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)
+#    ifndef _FILE_OFFSET_BITS
+#    define _FILE_OFFSET_BITS 64
+#    endif
+#  endif
+#endif
+
 /* ---------------------------------------------------------------- */
 /*                       DNS RESOLVER SPECIALTY                     */
 /* ---------------------------------------------------------------- */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -576,11 +576,9 @@ Vista
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
-#if defined(USE_WIN32_LARGE_FILES)
-#  if defined(__MINGW64_VERSION_MAJOR)
-#    ifndef _FILE_OFFSET_BITS
-#    define _FILE_OFFSET_BITS 64
-#    endif
+#if defined(USE_WIN32_LARGE_FILES) && defined(__MINGW64_VERSION_MAJOR)
+#  ifndef _FILE_OFFSET_BITS
+#  define _FILE_OFFSET_BITS 64
 #  endif
 #endif
 


### PR DESCRIPTION
The goal is to add any flag that affect the created binary, to get in sync with the ones built with CMake and autotools.

I took these flags from curl-for-win [0], where they've been tested with mingw-w64 and proven to work well.

This patch brings them to curl as follows:

- Enable unconditionally those force-enabled via `CMake/WindowsCache.cmake`:

  - `HAVE_SETJMP_H`
  - `HAVE_STRING_H`
  - `HAVE_SIGNAL` (CMake equivalent is `HAVE_SIGNAL_FUNC`)

- Expand existing guards with mingw-w64:

  - `HAVE_STDBOOL_H`
  - `HAVE_BOOL_T`

- Enable Win32 API functions for Windows Vista and later:

  - `HAVE_INET_NTOP`
  - `HAVE_INET_PTON`

- Set sizes, if not already set:
    
  - `SIZEOF_OFF_T = 8`
  - `_FILE_OFFSET_BITS = 64` when `USE_WIN32_LARGE_FILES` is set,
    and using mingw-w64.

- Add the remaining for mingw-w64 only. Feel free to expand as desired:

  - `HAVE_LIBGEN_H`
  - `HAVE_FTRUNCATE`
  - `HAVE_BASENAME`
  - `HAVE_STRTOK_R`

Future TODOs:

- `HAVE_SIGNAL` has a different meaning in CMake. It's enabled when both the `signal()` function and the `SIGALRM` macro are found. In autotools and this header, it means the function only. For the function alone, CMake uses `HAVE_SIGNAL_FUNC`.

[0] https://github.com/curl/curl-for-win/blob/c9b9a5f273c94c73d2b565ee892c4dff0ca97a8c/curl-m32.sh#L53-L58

Closes #xxxx