### PR TITLE
tool_paramhelp: asserts verify maximum sizes for string loading

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -68,6 +68,7 @@ struct getout *new_getout(struct OperationConfig *config)
 ParameterError file2string(char **bufp, FILE *file)
 {
   struct curlx_dynbuf dyn;
+  DEBUGASSERT(MAX_FILE2STRING < INT_MAX); /* needs to fit in an int later */
   curlx_dyn_init(&dyn, MAX_FILE2STRING);
   if(file) {
     char buffer[256];
@@ -94,6 +95,8 @@ ParameterError file2memory(char **bufp, size_t *size, FILE *file)
   if(file) {
     size_t nread;
     struct curlx_dynbuf dyn;
+    /* The size needs to fit in an int later */
+    DEBUGASSERT(MAX_FILE2MEMORY < INT_MAX);
     curlx_dyn_init(&dyn, MAX_FILE2MEMORY);
     do {
       char buffer[4096];


### PR DESCRIPTION
The two defines MAX_FILE2MEMORY and MAX_FILE2STRING define the largest strings accepted when loading files into memory, but as the size is later used as input to functions that take the size as 'int' as argument, the sizes must not be larger than INT_MAX.

These two new assert()s make the code error out if someone would bump the sizes without this consideration.

Reported-by Trail of Bits