### PR TITLE
lib3028: check CURLOPT_CERTINFO certificate chain contains leaf first.

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -248,4 +248,4 @@ test2300 test2301 test2302 test2303 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
-test3024 test3025 test3026 test3027
+test3024 test3025 test3026 test3027 test3028

--- a/tests/data/test3028
+++ b/tests/data/test3028
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+
+MooMoo
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+SSL
+</features>
+<server>
+https
+</server>
+ <name>
+Verify certificate chain order with simple HTTPS GET
+ </name>
+<tool>
+lib%TESTNUMBER
+</tool>
+ <command option="no-include">
+https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -66,7 +66,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1933 lib1934 lib1935 lib1936 lib1937 lib1938 lib1939 lib1940 \
  lib1945 lib1946 lib1947 lib1948 lib1955 \
  lib2301 lib2302 \
- lib3010 lib3025 lib3026 lib3027
+ lib3010 lib3025 lib3026 lib3027 lib3028
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
  ../../lib/dynbuf.c ../../lib/strdup.c
@@ -782,3 +782,7 @@ lib3026_CPPFLAGS = $(AM_CPPFLAGS)
 lib3027_SOURCES = lib3027.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib3027_LDADD = $(TESTUTIL_LIBS)
 lib3027_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib3028_SOURCES = lib3028.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib3028_LDADD = $(TESTUTIL_LIBS)
+lib3028_CPPFLAGS = $(AM_CPPFLAGS)

--- a/tests/libtest/lib3028.c
+++ b/tests/libtest/lib3028.c
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "memdebug.h"
+
+/*
+ * Verify correct order of certificates in the chain by comparing the
+ * subject and issuer attributes of each certificate.
+ */
+static bool is_chain_in_order(struct curl_certinfo *cert_info)
+{
+  char *last_issuer = NULL;
+  int cert;
+
+  /* Chains with only a single certificate are always in order */
+  if(cert_info->num_of_certs <= 1)
+    return 1;
+
+  /* Enumerate each certificate in the chain */
+  for(cert = 0; cert < cert_info->num_of_certs; cert++) {
+    struct curl_slist *slist = cert_info->certinfo[cert];
+    char *issuer = NULL;
+    char *subject = NULL;
+
+    /* Find the certificate issuer and subject by enumerating each field */
+    for(; slist && (!issuer || !subject); slist = slist->next) {
+      const char issuer_prefix[] = "Issuer:";
+      const char subject_prefix[] = "Subject:";
+
+      if(!strncmp(slist->data, issuer_prefix, sizeof(issuer_prefix)-1)) {
+        issuer = slist->data + sizeof(issuer_prefix)-1;
+      }
+      if(!strncmp(slist->data, subject_prefix, sizeof(subject_prefix)-1)) {
+        subject = slist->data + sizeof(subject_prefix)-1;
+      }
+    }
+
+    if(subject && issuer) {
+      printf("cert %d\n", cert);
+      printf("  subject: %s\n", subject);
+      printf("  issuer: %s\n", issuer);
+
+      if(last_issuer) {
+        /* If the last certificate's issuer matches the current certificate's
+         * subject, then the chain is in order */
+        if(strcmp(last_issuer, subject) != 0) {
+          printf("cert %d issuer does not match cert %d subject\n",
+                 cert - 1, cert);
+          printf("certificate chain is not in order\n");
+          return false;
+        }
+      }
+    }
+
+    last_issuer = issuer;
+  }
+
+  printf("certificate chain is in order\n");
+  return true;
+}
+
+static size_t wrfu(void *ptr,  size_t  size,  size_t  nmemb,  void *stream)
+{
+  (void)stream;
+  (void)ptr;
+  return size * nmemb;
+}
+
+int test(char *URL)
+{
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  /* Set the HTTPS url to retrieve. */
+  test_setopt(curl, CURLOPT_URL, URL);
+
+  /* Capture certificate information */
+  test_setopt(curl, CURLOPT_CERTINFO, 1L);
+
+  /* Ignore output */
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, wrfu);
+
+  /* Perform the request, res will get the return code */
+  res = curl_easy_perform(curl);
+  if(!res) {
+    struct curl_certinfo *cert_info = NULL;
+    /* Get the certificate information */
+    res = curl_easy_getinfo(curl, CURLINFO_CERTINFO, &cert_info);
+    if(!res) {
+      /* Check to see if the certificate chain is ordered correctly */
+      if(!is_chain_in_order(cert_info))
+        res = TEST_ERR_FAILURE;
+    }
+  }
+
+test_cleanup:
+
+  /* always cleanup */
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return res;
+}


### PR DESCRIPTION
This lib test checks that the certificate chain returned from `curl_easy_getinfo(curl, CURLINFO_CERTINFO, &cert_info)` is in the correct order: leaf first, root last. 

This was inspired by the fact that on recent versions of Windows 11 22H2, the certificates returned from SChannel are in reverse order.  See #9706.

I have named it `lib3028` but I can rename to whatever you want, because I didn't see anywhere what each range of tests targeted.