### PR TITLE
test1275: remove the check of stderr

### DIFF
--- a/tests/data/test1275
+++ b/tests/data/test1275
@@ -21,10 +21,4 @@ Verify capital letters after period in markdown files
 </command>
 </client>
 
-<verify>
-<stderr>
-ok
-</stderr>
-</verify>
-
 </testcase>

--- a/tests/markdown-uppercase.pl
+++ b/tests/markdown-uppercase.pl
@@ -88,4 +88,4 @@ for my $f (@m) {
 if($errors) {
     exit 1;
 }
-print STDERR "ok\n";
+print "ok\n";


### PR DESCRIPTION
To avoid the mysterious test failures on Windows, instead rely on the error code returned on failure.

Fixes #9716