### PR TITLE
schannel: don't reverse cert chain for CURLOPT_CERTINFO on Win 11 22H2+.

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1665,7 +1665,12 @@ add_cert_to_certinfo(const CERT_CONTEXT *ccert_context, void *raw_arg)
   if(valid_cert_encoding(ccert_context)) {
     const char *beg = (const char *) ccert_context->pbCertEncoded;
     const char *end = beg + ccert_context->cbCertEncoded;
-    int insert_index = (args->certs_count - 1) - args->idx;
+    int insert_index = args->idx;
+    /* Windows prior to 11 22H2 returned certificates in reverse order. */
+    if(curlx_verify_windows_version(10, 0, 22621, PLATFORM_WINNT,
+                                    VERSION_LESS_THAN)) {
+      insert_index += args->certs_count - 1;
+    }
     args->result = Curl_extract_certinfo(args->data, insert_index,
                                          beg, end);
     args->idx++;


### PR DESCRIPTION
On newer versions of Windows 11 (22H2 or higher) `QueryContextAttributes` and `CertEnumCertificatesInStore` return the certificate chain in the expected order, leaf first so there is no need to reverse the insertion order of the certificates when adding to the chain. See #9706.

Co-authored-by: Sergey Markelov