### PR TITLE
Update Android Instructions for newer NDKs

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -328,7 +328,7 @@ In all above, the built libraries and executables can be found in the
 
 # Android
 
-When building curl for Android it's recommended to use a Linux environment
+When building curl for Android it's recommended to use a Linux/macOS environment
 since using curl's `configure` script is the easiest way to build curl
 for Android. Before you can build curl for Android, you need to install the
 Android NDK first. This can be done using the SDK Manager that is part of
@@ -338,16 +338,16 @@ launching `configure`. On macOS, those variables could look like this to compile
 for `aarch64` and API level 29:
 
 ```bash
-export NDK=~/Library/Android/sdk/ndk/20.1.5948944
-export HOST_TAG=darwin-x86_64
-export TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/$HOST_TAG
-export AR=$TOOLCHAIN/bin/aarch64-linux-android-ar
-export AS=$TOOLCHAIN/bin/aarch64-linux-android-as
-export CC=$TOOLCHAIN/bin/aarch64-linux-android29-clang
-export CXX=$TOOLCHAIN/bin/aarch64-linux-android29-clang++
-export LD=$TOOLCHAIN/bin/aarch64-linux-android-ld
-export RANLIB=$TOOLCHAIN/bin/aarch64-linux-android-ranlib
-export STRIP=$TOOLCHAIN/bin/aarch64-linux-android-strip
+export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/25.1.8937393 # Point into your NDK.
+export HOST_TAG=darwin-x86_64 # Same tag for Apple Silicon. Other OS values here: https://developer.android.com/ndk/guides/other_build_systems#overview
+export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$HOST_TAG
+export AR=$TOOLCHAIN/bin/llvm-ar
+export AS=$TOOLCHAIN/bin/llvm-as
+export CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang
+export CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++
+export LD=$TOOLCHAIN/bin/ld
+export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
+export STRIP=$TOOLCHAIN/bin/llvm-strip
 ```
 
 When building on Linux or targeting other API levels or architectures, you need
@@ -363,11 +363,10 @@ OpenSSL, follow the OpenSSL build instructions and then install `libssl.a` and
 `$TOOLCHAIN/sysroot/usr/include`. Now you can build curl for Android using
 OpenSSL like this:
 
-    ./configure --host aarch64-linux-android --with-pic --disable-shared --with-openssl="$TOOLCHAIN/sysroot/usr"
-
-Note, however, that you must target at least Android M (API level 23) or `configure`
-will not be able to detect OpenSSL since `stderr` (and the like) were not defined
-before Android M.
+```bash
+LIBS="-lssl -lcrypto -lc++" # For OpenSSL/BoringSSL. In general, you'll need to the SSL/TLS layer's transtive dependencies if you're linking statically.
+./configure --host aarch64-linux-android --with-pic --disable-shared --with-openssl="$TOOLCHAIN/sysroot/usr"
+```
 
 # IBM i
 


### PR DESCRIPTION
Hi, @bagder!

First and foremost, thank you so much for such a wonderful tool and library--and for sharing it with the world.

I was building things across platforms, reading your good docs. Along the way, I noticed that some of the Android instructions seemed to have gotten out of date with the switch to LLVM toolchains in newer NDK versions. So, I figured I'd try to leave things even better than I found them, especially since the triggered error messages are different enough from their root causes. Here's my shot at that for your consideration.

Cheers!
Chris

P.S. To explain some of the changes:
- ANDROID_NDK_HOME is the Google-standard variable for pointing into the NDK, so I thought I should change us over to that, since some people will already have it set and know about it from elsewhere.
- The other variables are just the result of changed paths in the NDK with the switch to llvm tools. The old paths are no longer valid, which can cause issues that look like missing SSL libraries.
- I think the LIBS/static linking issue probably predated all this. LMK if you have a cleaner way to express that--I'm certainly no auto tools expert, unfortunately. The error otherwise misleadingly manifests itself as the script thinking libcrypto is missing SSL_connect. And BoringSSL needs libc++, so I included it, thinking it was better to be safe than sorry.

P.P.S. What originally brought me to the doc was to create a cross-platforms set of build scripts for libcurl for Bazel, which is an increasingly popular build system from Google. Lots of folks have been spinning up Bazel BUILD files for libcurl online, mostly copying tensorflow's (fairly buggy) ones. Since those all looked problematic, I figured I'd take a shot at writing an improved set. If you'd be open to accepting my good set of Bazel BUILD files, please let me know! The advantage would be stupid easy (incremental) builds across platforms, and making libcurl easily usable by Bazel users.

P.P.P.S :) Just to confirm a hypothesis: It's the need to support older compilers that prevents all the HAVE_[whatever]_H macros from being converted to __has_include's, right? 