### PR TITLE
cookies: optimize control character check

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -458,11 +458,10 @@ static int invalid_octets(const char *p)
     "\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14"
     "\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f"
   };
-  size_t vlen, len;
+  size_t len;
   /* scan for all the octets that are *not* in cookie-octet */
   len = strcspn(p, badoctets);
-  vlen = strlen(p);
-  return (len != vlen);
+  return (p[len] != '\0');
 }
 
 /*


### PR DESCRIPTION
When checking for invalid octets the `strcspn()` call will return the position of the first found invalid char or the first `NULL` byte. This means that we can check the indicated position in the search- string saving a `strlen()` call.