### PR TITLE
sigv4: set the max string lengths with strlen(), not sizeof()

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -122,12 +122,10 @@ static void trim_headers(struct curl_slist *head)
 #define MAX_SIGV4_LEN 64
 #define MAX_SIGV4_LEN_TXT "64"
 
-/* strlen("X--Date") == 7 */
-#define DATE_HDR_KEY_LEN (MAX_SIGV4_LEN + 7)
+#define DATE_HDR_KEY_LEN (MAX_SIGV4_LEN + sizeof("X--Date"))
 
 #define MAX_HOST_LEN 255
-/* FQDN + strlen(host:) */
-#define FULL_HOST_LEN (MAX_HOST_LEN + 5)
+#define FULL_HOST_LEN (MAX_HOST_LEN + sizeof("host:") - 1)
 
 /* string been x-PROVIDER-date:TIMESTAMP, I need +1 for ':' */
 #define DATE_FULL_HDR_LEN (DATE_HDR_KEY_LEN + TIMESTAMP_SIZE + 1)
@@ -141,7 +139,7 @@ static CURLcode make_headers(struct Curl_easy *data,
                              struct dynbuf *canonical_headers,
                              struct dynbuf *signed_headers)
 {
-  char date_hdr_key[DATE_HDR_KEY_LEN + 1];
+  char date_hdr_key[DATE_HDR_KEY_LEN];
   char date_full_hdr[DATE_FULL_HDR_LEN + 1];
   struct curl_slist *head = NULL;
   struct curl_slist *tmp_head = NULL;

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -140,7 +140,7 @@ static CURLcode make_headers(struct Curl_easy *data,
                              struct dynbuf *signed_headers)
 {
   char date_hdr_key[DATE_HDR_KEY_LEN];
-  char date_full_hdr[DATE_FULL_HDR_LEN + 1];
+  char date_full_hdr[DATE_FULL_HDR_LEN];
   struct curl_slist *head = NULL;
   struct curl_slist *tmp_head = NULL;
   CURLcode ret = CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
... as otherwise we are off-by-one. Also, change some msnprintf() calls to use sizeof(target buffer) instead of a define to make sure the right target size is used.

Second take at fixing OSS-fuzz issue 52349