### PR TITLE
libssh: if sftp_init fails, don't get the sftp error code

### DIFF
--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -122,7 +122,8 @@ CURLcode Curl_get_pathname(const char **cpp, char **path, char *homedir)
   bool relativePath = false;
   static const char WHITESPACE[] = " \t\r\n";
 
-  if(!*cp) {
+  DEBUGASSERT(homedir);
+  if(!*cp || !homedir) {
     *cpp = NULL;
     *path = NULL;
     return CURLE_QUOTE_ERROR;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -963,10 +963,9 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 
       rc = sftp_init(sshc->sftp_session);
       if(rc != SSH_OK) {
-        rc = sftp_get_error(sshc->sftp_session);
         failf(data, "Failure initializing sftp session: %s",
               ssh_get_error(sshc->ssh_session));
-        MOVE_TO_ERROR_STATE(sftp_error_to_CURLE(rc));
+        MOVE_TO_ERROR_STATE(sftp_error_to_CURLE(SSH_FX_FAILURE));
         break;
       }
       state(data, SSH_SFTP_REALPATH);


### PR DESCRIPTION
This flow extracted the wrong code (sftp code instead of ssh code), and the code is sometimes (erroneously) returned as zero anyway, so skip getting it and set a generic error.

Reported-by: David McLaughlin
Fixes #9737