### PR TITLE
file: implement support for directory listing 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3324,6 +3324,7 @@ AC_CHECK_HEADERS(
         termios.h \
         termio.h \
         fcntl.h \
+        dirent.h \
         io.h \
         pwd.h \
         utime.h \
@@ -3554,6 +3555,7 @@ AC_CHECK_FUNCS([fnmatch \
   gettimeofday \
   if_nametoindex \
   mach_absolute_time \
+  opendir \
   pipe \
   sched_yield \
   sendmsg \

--- a/lib/file.c
+++ b/lib/file.c
@@ -391,126 +391,92 @@ static CURLcode file_upload(struct Curl_easy *data)
   return result;
 }
 
-/*
- * file_do() is the protocol-specific function for the do-phase, separated
- * from the connect-phase above. Other protocols merely setup the transfer in
- * the do-phase, to have it done in the main transfer loop but since some
- * platforms we support don't allow select()ing etc on file handles (as
- * opposed to sockets) we instead perform the whole do-operation in this
- * function.
- */
-static CURLcode file_do(struct Curl_easy *data, bool *done)
+/* Fetch a file, which is in this case anything but a directory */
+static CURLcode fetch_file(struct Curl_easy *data, struct_stat *statbuf)
 {
-  /* This implementation ignores the host name in conformance with
-     RFC 1738. Only local files (reachable via the standard file system)
-     are supported. This means that files on remotely mounted directories
-     (via NFS, Samba, NT sharing) can be accessed through a file:// URL
-  */
+  struct FILEPROTO *file = data->req.p.file;
+  int fd = file->fd;
   CURLcode result = CURLE_OK;
-  struct_stat statbuf; /* struct_stat instead of struct stat just to allow the
-                          Windows version to have a different struct without
-                          having to redefine the simple word 'stat' */
-  curl_off_t expected_size = -1;
+  curl_off_t expected_size = -1, bytecount = 0;
   bool size_known;
-  bool fstated = FALSE;
-  char *buf = data->state.buffer;
-  curl_off_t bytecount = 0;
-  int fd;
-  struct FILEPROTO *file;
 
-  *done = TRUE; /* unconditionally */
+  if(statbuf) {
+    expected_size = statbuf->st_size;
+    data->info.filetime = statbuf->st_mtime;
 
-  Curl_pgrsStartNow(data);
-
-  if(data->set.upload)
-    return file_upload(data);
-
-  file = data->req.p.file;
-
-  /* get the fd from the connection phase */
-  fd = file->fd;
-
-  /* VMS: This only works reliable for STREAMLF files */
-  if(-1 != fstat(fd, &statbuf)) {
-    if(!S_ISDIR(statbuf.st_mode))
-      expected_size = statbuf.st_size;
-    /* and store the modification time */
-    data->info.filetime = statbuf.st_mtime;
-    fstated = TRUE;
-  }
-
-  if(fstated && !data->state.range && data->set.timecondition) {
-    if(!Curl_meets_timecondition(data, data->info.filetime)) {
-      *done = TRUE;
+    if(!data->state.range && data->set.timecondition &&
+       !Curl_meets_timecondition(data, data->info.filetime))
       return CURLE_OK;
-    }
-  }
 
-  if(fstated) {
-    time_t filetime;
-    struct tm buffer;
-    const struct tm *tm = &buffer;
-    char header[80];
-    int headerlen;
-    char accept_ranges[24]= { "Accept-ranges: bytes\r\n" };
-    if(expected_size >= 0) {
+    /* TODO: Consider moving this into one or several separate functions */
+    {
+      struct tm buffer;
+      const struct tm *tm = &buffer;
+      char header[80];
+      int headerlen;
+
+      DEBUGASSERT(expected_size >= 0);
+
+      /* Content-Length */
       headerlen = msnprintf(header, sizeof(header),
-                "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n",
-                expected_size);
+                            "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n",
+                            expected_size);
       result = Curl_client_write(data, CLIENTWRITE_HEADER, header, headerlen);
       if(result)
         return result;
 
-      result = Curl_client_write(data, CLIENTWRITE_HEADER,
-                                 accept_ranges, strlen(accept_ranges));
-      if(result != CURLE_OK)
+      /* Accept-Ranges */
+      strcpy(header, "Accept-ranges: bytes\r\n");
+      result = Curl_client_write(data, CLIENTWRITE_HEADER, header,
+                                 strlen(header));
+      if(result)
+        return result;
+
+      /* Last-Modified */
+      /* Convert the filetime (epoch) to a string */
+      result = Curl_gmtime((time_t)statbuf->st_mtime, &buffer);
+      if(result)
+        return result;
+
+      headerlen = msnprintf(header, sizeof(header),
+                    "Last-Modified: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n%s",
+                    Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
+                    tm->tm_mday,
+                    Curl_month[tm->tm_mon],
+                    tm->tm_year + 1900,
+                    tm->tm_hour,
+                    tm->tm_min,
+                    tm->tm_sec,
+                    data->req.no_body ? "": "\r\n");
+      result = Curl_client_write(data, CLIENTWRITE_HEADER, header, headerlen);
+      if(result)
         return result;
     }
 
-    filetime = (time_t)statbuf.st_mtime;
-    result = Curl_gmtime(filetime, &buffer);
-    if(result)
-      return result;
-
-    /* format: "Tue, 15 Nov 1994 12:45:26 GMT" */
-    headerlen = msnprintf(header, sizeof(header),
-              "Last-Modified: %s, %02d %s %4d %02d:%02d:%02d GMT\r\n%s",
-              Curl_wkday[tm->tm_wday?tm->tm_wday-1:6],
-              tm->tm_mday,
-              Curl_month[tm->tm_mon],
-              tm->tm_year + 1900,
-              tm->tm_hour,
-              tm->tm_min,
-              tm->tm_sec,
-              data->req.no_body ? "": "\r\n");
-    result = Curl_client_write(data, CLIENTWRITE_HEADER, header, headerlen);
-    if(result)
-      return result;
-    /* set the file size to make it available post transfer */
+    /* Set the file size to make it available post transfer */
     Curl_pgrsSetDownloadSize(data, expected_size);
     if(data->req.no_body)
       return result;
   }
 
-  /* Check whether file range has been specified */
+  /* Check whether a file range has been specified */
   result = Curl_range(data);
   if(result)
     return result;
 
-  /* Adjust the start offset in case we want to get the N last bytes
-   * of the stream if the filesize could be determined */
+  /* Adjust the start offset in case we want to get the N last bytes of the
+     stream if the filesize could be determined */
   if(data->state.resume_from < 0) {
-    if(!fstated) {
+    if(!statbuf) {
       failf(data, "Can't get the size of file.");
       return CURLE_READ_ERROR;
     }
-    data->state.resume_from += (curl_off_t)statbuf.st_size;
+    data->state.resume_from += (curl_off_t)statbuf->st_size;
   }
-
-  if(data->state.resume_from > 0) {
-    /* We check explicitly if we have a start offset, because
-     * expected_size may be -1 if we don't know how large the file is,
-     * in which case we should not adjust it. */
+  else if(data->state.resume_from > 0) {
+    /* We check explicitly if we have a start offset, because expected_size
+       may be -1 if we don't know how large the file is, in which case we
+       should not adjust it. */
     if(data->state.resume_from <= expected_size)
       expected_size -= data->state.resume_from;
     else {
@@ -519,55 +485,48 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
     }
   }
 
-  /* A high water mark has been specified so we obey... */
+  /* A high water mark has been specified so we obey ... */
   if(data->req.maxdownload > 0)
     expected_size = data->req.maxdownload;
 
-  if(!fstated || (expected_size <= 0))
-    size_known = FALSE;
-  else
-    size_known = TRUE;
+  size_known = (!statbuf || expected_size <= 0) ? FALSE : TRUE;
 
-  /* The following is a shortcut implementation of file reading
-     this is both more efficient than the former call to download() and
-     it avoids problems with select() and recv() on file descriptors
-     in Winsock */
+  /* The following is a shortcut implementation of file reading this is both
+     more efficient than the former call to download() and it avoid problems
+     with select() and recv() on file descriptors in Winsock. */
   if(size_known)
     Curl_pgrsSetDownloadSize(data, expected_size);
 
-  if(data->state.resume_from) {
-    if(data->state.resume_from !=
-       lseek(fd, data->state.resume_from, SEEK_SET))
-      return CURLE_BAD_DOWNLOAD_RESUME;
-  }
+  if(data->state.resume_from &&
+     data->state.resume_from != lseek(fd, data->state.resume_from, SEEK_SET))
+    return CURLE_BAD_DOWNLOAD_RESUME;
 
   Curl_pgrsTime(data, TIMER_STARTTRANSFER);
 
   while(!result) {
     ssize_t nread;
-    /* Don't fill a whole buffer if we want less than all data */
     size_t bytestoread;
 
-    if(size_known) {
+    if(size_known)
       bytestoread = (expected_size < data->set.buffer_size) ?
         curlx_sotouz(expected_size) : (size_t)data->set.buffer_size;
-    }
     else
-      bytestoread = data->set.buffer_size-1;
+      bytestoread = data->set.buffer_size - 1;
 
-    nread = read(fd, buf, bytestoread);
+    nread = read(fd, data->state.buffer, bytestoread);
 
     if(nread > 0)
-      buf[nread] = 0;
+      data->state.buffer[nread] = 0;
 
-    if(nread <= 0 || (size_known && (expected_size == 0)))
+    if(nread <= 0 || (size_known && expected_size == 0))
       break;
 
     bytecount += nread;
     if(size_known)
       expected_size -= nread;
 
-    result = Curl_client_write(data, CLIENTWRITE_BODY, buf, nread);
+    result = Curl_client_write(data, CLIENTWRITE_BODY, data->state.buffer,
+                               nread);
     if(result)
       return result;
 
@@ -582,6 +541,42 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
     result = CURLE_ABORTED_BY_CALLBACK;
 
   return result;
+}
+
+/*
+ * file_do() is the protocol-specific function for the do-phase, separated
+ * from the connect-phase above. Other protocols merely setup the transfer in
+ * the do-phase, to have it done in the main transfer loop but since some
+ * platforms we support don't allow select()ing etc on file handles (as
+ * opposed to sockets) we instead perform the whole do-operation in this
+ * function.
+ */
+static CURLcode file_do(struct Curl_easy *data, bool *done)
+{
+  *done = TRUE; /* unconditionally */
+  Curl_pgrsStartNow(data);
+
+  /* Choose the mode of operation. */
+  if(data->set.upload)
+    return file_upload(data);
+  else {
+    /* Download a file */
+    struct_stat statbuf; /* struct_stat instead of struct stat just to allow
+                            Windows version to have a different struct without
+                            having to redefine the simple word "stat" */
+    struct FILEPROTO *file = data->req.p.file;
+
+    if(fstat(file->fd, &statbuf) == -1) {
+      /* fstat(2) failed, meaning we cannot do much more but assume it is an
+         ordinary file on the file system */
+      return fetch_file(data, NULL);
+    }
+
+    if(S_ISDIR(statbuf.st_mode))
+      return CURLE_OK;
+    else
+      return fetch_file(data, &statbuf);
+  }
 }
 
 #endif

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -24,4 +24,5 @@ runtests.pdf
 testcurl.html
 testcurl.pdf
 *.port
+static/
 config

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -248,7 +248,8 @@ test2500 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
-test3024 test3025 test3026 test3027 test3028 test3029 test3030 \
+test3024 test3025 test3026 test3027 test3028 test3029 test3030 test3031 \
+test3032 \
 \
 test3100 test3101 \
 test3200

--- a/tests/data/test3031
+++ b/tests/data/test3031
@@ -1,0 +1,37 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<client>
+<server>
+none
+</server>
+<features>
+file
+!win32
+</features>
+<name>
+Directory listing through a file:// transfer
+</name>
+<command>
+-I file://%FILE_PWD/static/
+</command>
+</client>
+
+<verify>
+<stripfile>
+s/^-.+	\d+	+/----------	0	/
+s/^d.+	\d+	+/d---------	0	/
+</stripfile>
+<stdout>
+Last-Modified: Fri, 20 Mar 1998 09:00:00 GMT
+
+----------	0	1998-03-20T09:00:00Z	dummy
+----------	0	2001-11-29T09:00:00Z	dummy2
+d---------	0	1998-03-20T09:00:00Z	subdir
+</stdout>
+</verify>
+</testcase>

--- a/tests/data/test3032
+++ b/tests/data/test3032
@@ -1,0 +1,33 @@
+<testcase>
+<info>
+<keywords>
+FILE
+</keywords>
+</info>
+
+<client>
+<server>
+none
+</server>
+<features>
+file
+!win32
+</features>
+<name>
+List a directory as a file through a file:// transfer
+</name>
+<command>
+-I file://%FILE_PWD/static
+</command>
+</client>
+
+<verify>
+<stripfile>
+s/^Content-Length:.*\n//
+</stripfile>
+<stdout>
+Accept-ranges: bytes
+Last-Modified: Fri, 20 Mar 1998 09:00:00 GMT
+</stdout>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -184,6 +184,7 @@ my $ACURL=$VCURL;  # what curl binary to use to talk to APIs (relevant for CI)
                    # ACURL is handy to set to the system one for reliability
 my $DBGCURL=$CURL; #"../src/.libs/curl";  # alternative for debugging
 my $LOGDIR="log";
+my $STATICDIR="static";
 my $TESTDIR="$srcdir/data";
 my $LIBDIR="./libtest";
 my $UNITDIR="./unit";
@@ -6088,6 +6089,31 @@ $SOCKSUNIXPATH    = $pwd."/socks$$.sock"; # HTTP server Unix domain socket path,
 
 cleardir($LOGDIR);
 mkdir($LOGDIR, 0777);
+
+#######################################################################
+# clear and create the static directory directory:
+#
+
+cleardir($STATICDIR);
+mkdir($STATICDIR, 0777);
+mkdir($STATICDIR . '/subdir', 0777);
+
+{
+  my $fh;
+  open $fh, '>>', "$STATICDIR/dummy" or die "cannot create static directory: $!";
+  close $fh;
+  open $fh, '>>', "$STATICDIR/dummy2" or die "cannot create static directory: $!";
+  close $fh;
+}
+utime(time(), 890384400, $STATICDIR);           # 1998-03-20 (curl day)
+utime(time(), 890384400, "$STATICDIR/subdir");
+utime(time(), 890384400, "$STATICDIR/dummy");
+utime(time(), 1007024400, "$STATICDIR/dummy2"); # 2001-11-29 (RIP George Harrison)
+
+chmod 0755, "$STATICDIR/subdir";
+chmod 0644, "$STATICDIR/dummy";
+chmod 0644, "$STATICDIR/dummy2";
+
 
 #######################################################################
 # initialize some variables


### PR DESCRIPTION
~Based on #9745~

This commit implements support to the file:// protocol for directory
listings, similar to FTP.

Directory entries are printed as follows:
`MODE    SIZE    MTIME    NAME`

An example directory listing:
```sh
[engler@lennon curl]$ src/curl file:///home/engler
drwxr-xr-x	0	Oct 12 14:09	Desktop
drwxr-xr-x	362	Oct 14 08:31	Downloads
drwxr-xr-x	0	Oct 12 14:09	Templates
drwxr-xr-x	0	Oct 12 14:09	Public
drwxr-xr-x	0	Oct 12 14:09	Documents
drwxr-xr-x	0	Oct 12 14:09	Music
drwxr-xr-x	108	Oct 14 08:34	Pictures
drwxr-xr-x	0	Oct 12 14:09	Videos
drwxr-xr-x	96	Oct 15 17:58	projects
-rw-r--r--	2278067	Oct 13 18:51	wallpaper.jpg
drwxr-xr-x	12	Oct 14 11:21	go
```