### PR TITLE
tool_operate: more transfer cleanup after parallel transfer fail

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -350,6 +350,26 @@ static void AmigaSetComment(struct per_transfer *per,
 /* When doing serial transfers, we use a single fixed error area */
 static char global_errorbuffer[CURL_ERROR_SIZE];
 
+static void single_transfer_cleanup(struct OperationConfig *config)
+{
+  if(config) {
+    struct State *state = &config->state;
+    if(state->urls) {
+      /* Free list of remaining URLs */
+      glob_cleanup(state->urls);
+      state->urls = NULL;
+    }
+    Curl_safefree(state->outfiles);
+    Curl_safefree(state->httpgetfields);
+    Curl_safefree(state->uploadfile);
+    if(state->inglob) {
+      /* Free list of globbed upload files */
+      glob_cleanup(state->inglob);
+      state->inglob = NULL;
+    }
+  }
+}
+
 /*
  * Call this after a transfer has completed.
  */
@@ -429,6 +449,8 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         fprintf(global->errors, "curl: (%d) Failed writing body\n", result);
     }
   }
+  if(result)
+    single_transfer_cleanup(config);
 
   /* if retry-max-time is non-zero, make sure we haven't exceeded the
      time */
@@ -664,26 +686,6 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     free(per->errorbuffer);
 
   return result;
-}
-
-static void single_transfer_cleanup(struct OperationConfig *config)
-{
-  if(config) {
-    struct State *state = &config->state;
-    if(state->urls) {
-      /* Free list of remaining URLs */
-      glob_cleanup(state->urls);
-      state->urls = NULL;
-    }
-    Curl_safefree(state->outfiles);
-    Curl_safefree(state->httpgetfields);
-    Curl_safefree(state->uploadfile);
-    if(state->inglob) {
-      /* Free list of globbed upload files */
-      glob_cleanup(state->inglob);
-      state->inglob = NULL;
-    }
-  }
 }
 
 /*

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -350,7 +350,7 @@ static void AmigaSetComment(struct per_transfer *per,
 /* When doing serial transfers, we use a single fixed error area */
 static char global_errorbuffer[CURL_ERROR_SIZE];
 
-static void single_transfer_cleanup(struct OperationConfig *config)
+void single_transfer_cleanup(struct OperationConfig *config)
 {
   if(config) {
     struct State *state = &config->state;
@@ -449,8 +449,6 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         fprintf(global->errors, "curl: (%d) Failed writing body\n", result);
     }
   }
-  if(result)
-    single_transfer_cleanup(config);
 
   /* if retry-max-time is non-zero, make sure we haven't exceeded the
      time */

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -76,6 +76,7 @@ struct per_transfer {
 };
 
 CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[]);
+void single_transfer_cleanup(struct OperationConfig *config);
 
 extern struct per_transfer *transfers; /* first node */
 

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -22,6 +22,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
+#include "tool_operate.h"
 
 #include "strcase.h"
 
@@ -51,6 +52,7 @@ void clean_getout(struct OperationConfig *config)
     }
     config->url_list = NULL;
   }
+  single_transfer_cleanup(config);
 }
 
 bool output_expected(const char *url, const char *uploadfile)

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test430 test431 test432 test433 test434 test435 test436 \
 \
 test440 test441 test442 test443 test444 \
 \
-test490 test491 test492 test493 test494 test495 \
+test490 test491 test492 test493 test494 test495 test496 \
 \
 test500 test501 test502 test503 test504 test505 test506 test507 test508 \
 test509 test510 test511 test512 test513 test514 test515 test516 test517 \

--- a/tests/data/test496
+++ b/tests/data/test496
@@ -1,0 +1,36 @@
+<testcase>
+<info>
+<keywords>
+curl tool
+cmdline
+parallel
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+parallel upload missing file
+</name>
+ <command>
+0 -Z -Tz
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+26
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
In some circumstances when doing parallel transfers, the single_transfer_cleanup() would not be called and then 'inglob' could leak.

Test 496 verifies

Reported-by: Trail of Bits