### PR TITLE
CURLOPT_AUTOREFERER: default to origin-only

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -77,6 +77,7 @@
  5.5 auth= in URLs
  5.6 alt-svc should fallback if alt-svc does not work
  5.7 Require HTTP version X or higher
+ 5.8 Referrer-Policy
 
  6. TELNET
  6.1 ditch stdin
@@ -630,6 +631,13 @@
  consider adding a way to require a minimum version.
 
  See https://github.com/curl/curl/issues/7980
+
+5.8 Referrer-Policy
+
+ The response header Referrer-Policy tells the client what details to include
+ when creating referer headers when redirects are followed on this site.
+
+ See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
 
 6. TELNET
 

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
@@ -32,9 +32,15 @@ CURLOPT_AUTOREFERER \- automatically update the referer header
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_AUTOREFERER, long autorefer);
 .fi
 .SH DESCRIPTION
-Pass a parameter set to 1 to enable this. When enabled, libcurl will
-automatically set the Referer: header field in HTTP requests to the full URL
-where it follows a Location: redirect.
+Pass a long parameter set to 1 to enable automatic referer headers. When
+enabled, libcurl will automatically set the Referer: header field in HTTP
+requests to the full URL where it follows a Location: redirect.
+
+Starting in curl 7.87.0: setting the value to 1 will make libcurl use
+\fIorigin-only mode\fP, where it only sets the "origin" in the header. That
+means scheme, host name and port number. Set the value to 2 to make libcurl
+also inclued the path and query parts in the \fBReferer:\fP header. Before
+7.87.0, libcurl would also act as if 2 was set.
 .SH DEFAULT
 0, disabled
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
@@ -39,7 +39,7 @@ requests to the full URL where it follows a Location: redirect.
 Starting in curl 7.87.0: setting the value to 1 will make libcurl use
 \fIorigin-only mode\fP, where it only sets the "origin" in the header. That
 means scheme, host name and port number. Set the value to 2 to make libcurl
-also inclued the path and query parts in the \fBReferer:\fP header. Before
+also include the path and query parts in the \fBReferer:\fP header. Before
 7.87.0, libcurl would also act as if 2 was set.
 .SH DEFAULT
 0, disabled

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -562,9 +562,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 #ifndef CURL_DISABLE_HTTP
   case CURLOPT_AUTOREFERER:
     /*
-     * Switch on automatic referer that gets set if curl follows locations.
+     * Automatic referer when curl follows HTTP redirects.
      */
-    data->set.http_auto_referer = (0 != va_arg(param, long)) ? TRUE : FALSE;
+    arg = va_arg(param, long);
+    if((arg < REFERER_NONE) || (arg > REFERER_FULL))
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    data->set.auto_referer = (unsigned char)arg;
     break;
 
   case CURLOPT_ACCEPT_ENCODING:

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1596,7 +1596,7 @@ CURLcode Curl_follow(struct Curl_easy *data,
 
       data->state.followlocation++; /* count location-followers */
 
-      if(data->set.http_auto_referer) {
+      if(data->set.auto_referer) {
         CURLU *u;
         char *referer = NULL;
 
@@ -1622,7 +1622,13 @@ CURLcode Curl_follow(struct Curl_easy *data,
         if(!uc)
           uc = curl_url_set(u, CURLUPART_PASSWORD, NULL, 0);
         if(!uc)
-          uc = curl_url_get(u, CURLUPART_URL, &referer, 0);
+          uc = curl_url_set(u, CURLUPART_PATH, NULL, 0);
+        if(data->set.auto_referer != REFERER_FULL) {
+          if(!uc)
+            uc = curl_url_set(u, CURLUPART_QUERY, NULL, 0);
+          if(!uc)
+            uc = curl_url_get(u, CURLUPART_URL, &referer, 0);
+        }
 
         curl_url_cleanup(u);
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1646,6 +1646,10 @@ enum dupblob {
   BLOB_LAST
 };
 
+#define REFERER_NONE   0 /* no automatic referer */
+#define REFERER_ORIGIN 1 /* only send the scheme, host + port */
+#define REFERER_FULL   2 /* also include path and query */
+
 /* callback that gets called when this easy handle is completed within a multi
    handle.  Only used for internally created transfers, like for example
    DoH. */
@@ -1847,6 +1851,7 @@ struct UserDefined {
 #endif
   unsigned char connect_only; /* make connection/request, then let
                                  application use the socket */
+  unsigned char auto_referer; /* set HTTP referer when following location */
   BIT(is_fread_set); /* has read callback been set to non-NULL? */
 #ifndef CURL_DISABLE_TFTP
   BIT(tftp_no_options); /* do not send TFTP options requests */
@@ -1881,8 +1886,6 @@ struct UserDefined {
   BIT(allow_auth_to_other_hosts);
   BIT(include_header); /* include received protocol headers in data output */
   BIT(http_set_referer); /* is a custom referer used */
-  BIT(http_auto_referer); /* set "correct" referer when following
-                             location: */
   BIT(opt_no_body);    /* as set with CURLOPT_NOBODY */
   BIT(upload);         /* upload request */
   BIT(verbose);        /* output verbosity */

--- a/tests/data/test1067
+++ b/tests/data/test1067
@@ -70,11 +70,11 @@ GET /want/data/%TESTNUMBER0002.txt?coolsite=yes HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Referer: http://%HOSTIP:%HTTPPORT/want/%TESTNUMBER
+Referer: http://%HOSTIP:%HTTPPORT/
 
 </protocol>
 <stderr nonewline="yes">
-|http://%HOSTIP:%HTTPPORT/want/%TESTNUMBER|
+|http://%HOSTIP:%HTTPPORT/|
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test2081
+++ b/tests/data/test2081
@@ -54,7 +54,7 @@ Host: %HOSTIP:%HTTPPORT
 Authorization: Basic dXNlcjpwYXNz
 User-Agent: curl/%VERSION
 Accept: */*
-Referer: http://%HOSTIP:%HTTPPORT/we/want/our/%TESTNUMBER
+Referer: http://%HOSTIP:%HTTPPORT/
 
 </protocol>
 <stdout>
@@ -67,7 +67,7 @@ HTTP/1.1 200 This is another weirdo text message swsclose
 Connection: close
 
 Thanks for following.
-http://%HOSTIP:%HTTPPORT/we/want/our/%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/
 </stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
Automatic referers now default to only setting the "origin" (scheme + host + port). For privacy, especially when redirecting to non-secure schemes.

CURLOPT_AUTOREFERER now accepts the value '2' to force it to also include path and query in referer header fields.

A future improvement might be to support the Referrer-Policy header and rather act according to the server's will.

- [x] use origin-only by default
- [ ] add test case for referer-full
- [ ] provide command line option for referer-full