### PR TITLE
mprintf: reject two kinds of precision for the same argument

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -318,6 +318,11 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
             flags |= FLAGS_PREC;
             precision = strtol(fmt, &fmt, 10);
           }
+          if((flags & (FLAGS_PREC | FLAGS_PRECPARAM)) ==
+             (FLAGS_PREC | FLAGS_PRECPARAM))
+            /* it is not permitted to use both kinds of precision for the same
+               argument */
+            return 1;
           break;
         case 'h':
           flags |= FLAGS_SHORT;

--- a/tests/unit/unit1398.c
+++ b/tests/unit/unit1398.c
@@ -89,4 +89,8 @@ rc = curl_msnprintf(output, 16, "%8d%8d", 1234, 5678);
 fail_unless(rc == 15, "return code should be 15");
 fail_unless(!strcmp(output, "    1234    567"), "wrong output");
 
+/* double precision */
+rc = curl_msnprintf(output, 24, "%.*1$.99d", 3, 5678);
+fail_unless(rc == 0, "return code should be 0");
+
 UNITTEST_STOP


### PR DESCRIPTION
An input like "%.*1$.9999d" would first use the precision taken as an argument *and* then the precision specified in the string, which is confusing and wrong. pass1 will now instead return error on this double use.

Adjusted unit test 1398 to verify

Reported-by: Peter Goodman