### PR TITLE
Check for HAVE_STDATOMIC_H in easy_lock

### DIFF
--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -47,7 +47,7 @@ typedef PVOID SRWLOCK, *PSRWLOCK;
 #define curl_simple_lock_lock(m) AcquireSRWLockExclusive(m)
 #define curl_simple_lock_unlock(m) ReleaseSRWLockExclusive(m)
 
-#elif defined (HAVE_ATOMIC)
+#elif defined(HAVE_ATOMIC) && defined(HAVE_STDATOMIC_H)
 #include <stdatomic.h>
 #if defined(HAVE_SCHED_YIELD)
 #include <sched.h>


### PR DESCRIPTION
The check for `HAVE_STDATOMIC_H` looks to see if the `stdatomic.h` header is present.