### PR TITLE
schannel: Don't reset recv/send function pointers on renegotiation

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1935,8 +1935,7 @@ schannel_connect_common(struct Curl_easy *data, struct connectdata *conn,
 
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
-    if(!connssl->backend->recv_renegotiating)
-    {
+    if(!connssl->backend->recv_renegotiating) {
       /* On renegotiation, we don't want to reset the existing recv/send
        * function pointers. They will have been set after the initial TLS
        * handshake was completed. If they were subsequently modified, as

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1935,8 +1935,16 @@ schannel_connect_common(struct Curl_easy *data, struct connectdata *conn,
 
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
-    conn->recv[sockindex] = schannel_recv;
-    conn->send[sockindex] = schannel_send;
+    if(!connssl->backend->recv_renegotiating)
+    {
+      /* On renegotiation, we don't want to reset the existing recv/send
+       * function pointers. They will have been set after the initial TLS
+       * handshake was completed. If they were subsequently modified, as
+       * is the case with HTTP/2, we don't want to override that change.
+       */
+      conn->recv[sockindex] = schannel_recv;
+      conn->send[sockindex] = schannel_send;
+    }
 
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
     /* When SSPI is used in combination with Schannel


### PR DESCRIPTION
Fixes #9451 

These function pointers will have been set when the initial TLS handshake was completed. If they are unchanged, there is no need to set them again. If they have been changed, as is the case with HTTP/2, we don't want to override that change. That would result in the http2_recv/send functions being completely bypassed.

It should be investigated whether the same change should be made to the other TLS backends. They don't seem to have the same amount of renegotiation logic that SChannel does. It appears that OpenSSL/BoringSSL may outright forbid TLS renegotiation.