### PR TITLE
cmdline/docs: add a required 'multi' keyword for each option

### DIFF
--- a/docs/cmdline-opts/MANPAGE.md
+++ b/docs/cmdline-opts/MANPAGE.md
@@ -23,20 +23,22 @@ Each file has a set of meta-data and a body of text.
 
 ### Meta-data
 
-    Short: (single letter, without dash)
-    Long: (long form name, without dashes)
-    Arg: (the argument the option takes)
-    Magic: (description of "magic" options)
-    Tags: (space separated list)
-    Protocols: (space separated list for which protocols this option works)
     Added: (version number in which this was added)
+    Arg: (the argument the option takes)
+    c: (copyright line)
+    Example: (example command line, without "curl" and can use `$URL`)
+    Experimental: yes (if so)
+    Help: (short text for the --help output for this option)
+    Long: (long form name, without dashes)
+    Magic: (description of "magic" options)
+    Multi: single/append/boolean/mutex (if used more than once)
     Mutexed: (space separated list of options this overrides, no dashes)
+    Protocols: (space separated list for which protocols this option works)
     Requires: (space separated list of features this requires, no dashes)
     See-also: (space separated list of related options, no dashes)
-    Help: (short text for the --help output for this option)
-    Example: (example command line, without "curl" and can use `$URL`)
-    c: (copyright line)
+    Short: (single letter, without dash)
     SPDX-License-Identifier: curl
+    Tags: (space separated list)
     --- (end of meta-data)
 
 ### Body

--- a/docs/cmdline-opts/abstract-unix-socket.d
+++ b/docs/cmdline-opts/abstract-unix-socket.d
@@ -8,6 +8,7 @@ Protocols: HTTP
 Category: connection
 See-also: unix-socket
 Example: --abstract-unix-socket socketpath $URL
+Multi: single
 ---
 Connect through an abstract Unix domain socket, instead of using the network.
 Note: netstat shows the path of an abstract socket prefixed with '@', however

--- a/docs/cmdline-opts/alt-svc.d
+++ b/docs/cmdline-opts/alt-svc.d
@@ -8,6 +8,7 @@ Added: 7.64.1
 Category: http
 See-also: resolve connect-to
 Example: --alt-svc svc.txt $URL
+Multi: append
 ---
 This option enables the alt-svc parser in curl. If the file name points to an
 existing alt-svc cache file, that will be used. After a completed transfer,

--- a/docs/cmdline-opts/anyauth.d
+++ b/docs/cmdline-opts/anyauth.d
@@ -7,6 +7,7 @@ See-also: proxy-anyauth basic digest
 Category: http proxy auth
 Example: --anyauth --user me:pwd $URL
 Added: 7.10.6
+Multi: mutex
 ---
 Tells curl to figure out authentication method by itself, and use the most
 secure one the remote site claims to support. This is done by first doing a

--- a/docs/cmdline-opts/append.d
+++ b/docs/cmdline-opts/append.d
@@ -8,6 +8,7 @@ Category: ftp sftp
 See-also: range continue-at
 Example: --upload-file local --append ftp://example.com/
 Added: 4.8
+Multi: boolean
 ---
 When used in an upload, this makes curl append to the target file instead of
 overwriting it. If the remote file does not exist, it will be created. Note

--- a/docs/cmdline-opts/aws-sigv4.d
+++ b/docs/cmdline-opts/aws-sigv4.d
@@ -7,6 +7,7 @@ Category: auth http
 Added: 7.75.0
 See-also: basic user
 Example: --aws-sigv4 "aws:amz:east-2:es" --user "key:secret" $URL
+Multi: single
 ---
 Use AWS V4 signature authentication in the transfer.
 

--- a/docs/cmdline-opts/basic.d
+++ b/docs/cmdline-opts/basic.d
@@ -7,6 +7,7 @@ Protocols: HTTP
 Category: auth
 Example: -u name:password --basic $URL
 Added: 7.10.6
+Multi: mutex
 ---
 Tells curl to use HTTP Basic authentication with the remote host. This is the
 default and this option is usually pointless, unless you use it to override a

--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -8,6 +8,7 @@ Category: tls
 See-also: capath insecure
 Example: --cacert CA-file.txt $URL
 Added: 7.5
+Multi: single
 ---
 Tells curl to use the specified certificate file to verify the peer. The file
 may contain multiple CA certificates. The certificate(s) must be in PEM
@@ -35,5 +36,3 @@ preferred method of verifying the peer's certificate chain.
 with libcurl 7.60 or later. This option is supported for backward
 compatibility with other SSL engines; instead it is recommended to use
 Windows' store of root certificates (the default for Schannel).
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/capath.d
+++ b/docs/cmdline-opts/capath.d
@@ -8,6 +8,7 @@ Category: tls
 See-also: cacert insecure
 Example: --capath /local/directory $URL
 Added: 7.9.8
+Multi: single
 ---
 Tells curl to use the specified certificate directory to verify the
 peer. Multiple paths can be provided by separating them with ":" (e.g.
@@ -17,5 +18,4 @@ c_rehash utility supplied with OpenSSL. Using --capath can allow
 OpenSSL-powered curl to make SSL-connections much more efficiently than using
 --cacert if the --cacert file contains many CA certificates.
 
-If this option is set, the default capath value will be ignored, and if it is
-used several times, the last one will be used.
+If this option is set, the default capath value will be ignored.

--- a/docs/cmdline-opts/cert-status.d
+++ b/docs/cmdline-opts/cert-status.d
@@ -7,12 +7,13 @@ Help: Verify the status of the server cert via OCSP-staple
 Category: tls
 See-also: pinnedpubkey
 Example: --cert-status $URL
+Multi: boolean
 ---
 Tells curl to verify the status of the server certificate by using the
 Certificate Status Request (aka. OCSP stapling) TLS extension.
 
 If this option is enabled and the server sends an invalid (e.g. expired)
-response, if the response suggests that the server certificate has been revoked,
-or no response at all is received, the verification fails.
+response, if the response suggests that the server certificate has been
+revoked, or no response at all is received, the verification fails.
 
 This is currently only implemented in the OpenSSL, GnuTLS and NSS backends.

--- a/docs/cmdline-opts/cert-type.d
+++ b/docs/cmdline-opts/cert-type.d
@@ -8,6 +8,7 @@ See-also: cert key key-type
 Category: tls
 Example: --cert-type PEM --cert file $URL
 Added: 7.9.3
+Multi: single
 ---
 Tells curl what type the provided client certificate is using. PEM, DER, ENG
 and P12 are recognized types.
@@ -15,5 +16,3 @@ and P12 are recognized types.
 The default type depends on the TLS backend and is usually PEM, however for
 Secure Transport and Schannel it is P12. If --cert is a pkcs11: URI then ENG is
 the default type.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/cert.d
+++ b/docs/cmdline-opts/cert.d
@@ -9,6 +9,7 @@ See-also: cert-type key key-type
 Category: tls
 Example: --cert certfile --key keyfile $URL
 Added: 5.0
+Multi: single
 ---
 Tells curl to use the specified client certificate file when getting a file
 with HTTPS, FTPS or another SSL-based protocol. The certificate must be in
@@ -55,5 +56,3 @@ usually a SHA-1 hex string which you can see in certificate details. Following
 store locations are supported: CurrentUser, LocalMachine, CurrentService,
 Services, CurrentUserGroupPolicy, LocalMachineGroupPolicy,
 LocalMachineEnterprise.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/ciphers.d
+++ b/docs/cmdline-opts/ciphers.d
@@ -8,10 +8,9 @@ Category: tls
 See-also: tlsv1.3
 Example: --ciphers ECDHE-ECDSA-AES256-CCM8 $URL
 Added: 7.9
+Multi: single
 ---
 Specifies which ciphers to use in the connection. The list of ciphers must
 specify valid ciphers. Read up on SSL cipher list details on this URL:
 
  https://curl.se/docs/ssl-ciphers.html
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/compressed-ssh.d
+++ b/docs/cmdline-opts/compressed-ssh.d
@@ -7,6 +7,7 @@ Added: 7.56.0
 Category: scp ssh
 See-also: compressed
 Example: --compressed-ssh sftp://example.com/
+Multi: boolean
 ---
 Enables built-in SSH compression.
 This is a request, not an order; the server may or may not do it.

--- a/docs/cmdline-opts/compressed.d
+++ b/docs/cmdline-opts/compressed.d
@@ -7,6 +7,7 @@ Category: http
 Example: --compressed $URL
 See-also: compressed-ssh
 Added: 7.10
+Multi: boolean
 ---
 Request a compressed response using one of the algorithms curl supports, and
 automatically decompress the content. Headers are not modified.

--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -8,6 +8,7 @@ Category: curl
 Example: --config file.txt $URL
 Added: 4.10
 See-also: disable
+Multi: append
 ---
 Specify a text file to read curl arguments from. The command line arguments
 found in the text file will be used as if they were provided on the command
@@ -73,5 +74,3 @@ checks for one in the same dir the curl executable is placed.
 
 On Windows two filenames are checked per location: .curlrc and _curlrc,
 preferring the former. Older versions on Windows checked for _curlrc only.
-
-This option can be used multiple times to load multiple config files.

--- a/docs/cmdline-opts/connect-timeout.d
+++ b/docs/cmdline-opts/connect-timeout.d
@@ -8,10 +8,9 @@ Category: connection
 Example: --connect-timeout 20 $URL
 Example: --connect-timeout 3.14 $URL
 Added: 7.7
+Multi: single
 ---
 Maximum time in seconds that you allow curl's connection to take.  This only
 limits the connection phase, so if curl connects within the given period it
 will continue - if not it will exit.  Since version 7.32.0, this option
 accepts decimal values.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/connect-to.d
+++ b/docs/cmdline-opts/connect-to.d
@@ -7,6 +7,7 @@ Added: 7.49.0
 See-also: resolve header
 Category: connection
 Example: --connect-to example.com:443:example.net:8443 $URL
+Multi: append
 ---
 
 For a request to the given HOST1:PORT1 pair, connect to HOST2:PORT2 instead.
@@ -21,5 +22,3 @@ request's original host/port".
 A "host" specified to this option is compared as a string, so it needs to
 match the name used in request URL. It can be either numerical such as
 "127.0.0.1" or the full host name such as "example.org".
-
-This option can be used many times to add many connect rules.

--- a/docs/cmdline-opts/continue-at.d
+++ b/docs/cmdline-opts/continue-at.d
@@ -9,6 +9,7 @@ Category: connection
 Example: -C - $URL
 Example: -C 400 $URL
 Added: 4.8
+Multi: single
 ---
 Continue/Resume a previous file transfer at the given offset. The given offset
 is the exact number of bytes that will be skipped, counting from the beginning
@@ -17,5 +18,3 @@ uploads, the FTP server command SIZE will not be used by curl.
 
 Use "-C -" to tell curl to automatically find out where/how to resume the
 transfer. It then uses the given output/input files to figure that out.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/cookie-jar.d
+++ b/docs/cmdline-opts/cookie-jar.d
@@ -10,6 +10,7 @@ Example: -c store-here.txt $URL
 Example: -c store-here.txt -b read-these $URL
 Added: 7.9
 See-also: cookie
+Multi: single
 ---
 Specify to which file you want curl to write all cookies after a completed
 operation. Curl writes all cookies from its in-memory cookie storage to the
@@ -26,6 +27,3 @@ If the cookie jar cannot be created or written to, the whole curl operation
 will not fail or even report an error clearly. Using --verbose will get a
 warning displayed, but that is the only visible feedback you get about this
 possibly lethal situation.
-
-If this option is used several times, the last specified file name will be
-used.

--- a/docs/cmdline-opts/cookie.d
+++ b/docs/cmdline-opts/cookie.d
@@ -10,6 +10,7 @@ Example: -b cookiefile $URL
 Example: -b cookiefile -c cookiefile $URL
 See-also: cookie-jar junk-session-cookies
 Added: 4.9
+Multi: append
 ---
 Pass the data to the HTTP server in the Cookie header. It is supposedly the
 data previously received from the server in a "Set-Cookie:" line. The data
@@ -35,8 +36,6 @@ If you use the Set-Cookie file format and do not specify a domain then the
 cookie is not sent since the domain will never match. To address this, set a
 domain in Set-Cookie line (doing that will include sub-domains) or preferably:
 use the Netscape format.
-
-This option can be used multiple times.
 
 Users often want to both read cookies from a file and write updated cookies
 back to a file, so using both --cookie and --cookie-jar in the same command

--- a/docs/cmdline-opts/create-dirs.d
+++ b/docs/cmdline-opts/create-dirs.d
@@ -6,6 +6,7 @@ Category: curl
 Example: --create-dirs --output local/dir/file $URL
 Added: 7.10.3
 See-also: ftp-create-dirs output-dir
+Multi: boolean
 ---
 When used in conjunction with the --output option, curl will create the
 necessary local directory hierarchy as needed. This option creates the

--- a/docs/cmdline-opts/create-file-mode.d
+++ b/docs/cmdline-opts/create-file-mode.d
@@ -8,11 +8,10 @@ Category: sftp scp file upload
 See-also: ftp-create-dirs
 Added: 7.75.0
 Example: --create-file-mode 0777 -T localfile sftp://example.com/new
+Multi: single
 ---
 When curl is used to create files remotely using one of the supported
 protocols, this option allows the user to set which 'mode' to set on the file
 at creation time, instead of the default 0644.
 
 This option takes an octal number as argument.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/crlf.d
+++ b/docs/cmdline-opts/crlf.d
@@ -7,6 +7,7 @@ Category: ftp smtp
 Example: --crlf -T file ftp://example.com/
 Added: 5.7
 See-also: use-ascii
+Multi: boolean
 ---
 Convert LF to CRLF in upload. Useful for MVS (OS/390).
 

--- a/docs/cmdline-opts/crlfile.d
+++ b/docs/cmdline-opts/crlfile.d
@@ -8,8 +8,7 @@ Added: 7.19.7
 Category: tls
 Example: --crlfile rejects.txt $URL
 See-also: cacert capath
+Multi: single
 ---
 Provide a file using PEM format with a Certificate Revocation List that may
 specify peer certificates that are to be considered revoked.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/curves.d
+++ b/docs/cmdline-opts/curves.d
@@ -8,6 +8,7 @@ Added: 7.73.0
 Category: tls
 Example: --curves X25519 $URL
 See-also: ciphers
+Multi: single
 ---
 Tells curl to request specific curves to use during SSL session establishment
 according to RFC 8422, 5.1.  Multiple algorithms can be provided by separating

--- a/docs/cmdline-opts/data-ascii.d
+++ b/docs/cmdline-opts/data-ascii.d
@@ -8,5 +8,6 @@ Category: http post upload
 Example: --data-ascii @file $URL
 Added: 7.2
 See-also: data-binary data-raw data-urlencode
+Multi: append
 ---
 This is just an alias for --data.

--- a/docs/cmdline-opts/data-binary.d
+++ b/docs/cmdline-opts/data-binary.d
@@ -8,6 +8,7 @@ Category: http post upload
 Example: --data-binary @filename $URL
 Added: 7.2
 See-also: data-ascii
+Multi: append
 ---
 This posts data exactly as specified with no extra processing whatsoever.
 

--- a/docs/cmdline-opts/data-raw.d
+++ b/docs/cmdline-opts/data-raw.d
@@ -9,6 +9,7 @@ See-also: data
 Category: http post upload
 Example: --data-raw "hello" $URL
 Example: --data-raw "@at@at@" $URL
+Multi: append
 ---
 This posts data similarly to --data but without the special
 interpretation of the @ character.

--- a/docs/cmdline-opts/data-urlencode.d
+++ b/docs/cmdline-opts/data-urlencode.d
@@ -11,6 +11,7 @@ Example: --data-urlencode name=val $URL
 Example: --data-urlencode =encodethis $URL
 Example: --data-urlencode name@file $URL
 Example: --data-urlencode @fileonly $URL
+Multi: append
 ---
 This posts data, similar to the other --data options with the exception
 that this performs URL-encoding.

--- a/docs/cmdline-opts/data.d
+++ b/docs/cmdline-opts/data.d
@@ -12,6 +12,7 @@ Example: -d "name=curl" $URL
 Example: -d "name=curl" -d "tool=cmdline" $URL
 Example: -d @filename $URL
 Added: 4.0
+Multi: append
 ---
 Sends the specified data in a POST request to the HTTP server, in the same way
 that a browser does when a user has filled in an HTML form and presses the

--- a/docs/cmdline-opts/delegation.d
+++ b/docs/cmdline-opts/delegation.d
@@ -8,6 +8,7 @@ Category: auth
 Example: --delegation "none" $URL
 Added: 7.22.0
 See-also: insecure ssl
+Multi: single
 ---
 Set LEVEL to tell the server what it is allowed to delegate when it
 comes to user credentials.
@@ -20,5 +21,3 @@ service ticket, which is a matter of realm policy.
 .IP "always"
 Unconditionally allow the server to delegate.
 .RE
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/digest.d
+++ b/docs/cmdline-opts/digest.d
@@ -8,9 +8,8 @@ See-also: user proxy-digest anyauth
 Category: proxy auth http
 Example: -u name:password --digest $URL
 Added: 7.10.6
+Multi: boolean
 ---
 Enables HTTP Digest authentication. This is an authentication scheme that
 prevents the password from being sent over the wire in clear text. Use this in
 combination with the normal --user option to set user name and password.
-
-If this option is used several times, only the first one is used.

--- a/docs/cmdline-opts/disable-eprt.d
+++ b/docs/cmdline-opts/disable-eprt.d
@@ -7,6 +7,7 @@ Category: ftp
 Example: --disable-eprt ftp://example.com/
 Added: 7.10.5
 See-also: disable-epsv ftp-port
+Multi: boolean
 ---
 Tell curl to disable the use of the EPRT and LPRT commands when doing active
 FTP transfers. Curl will normally always first attempt to use EPRT, then LPRT

--- a/docs/cmdline-opts/disable-epsv.d
+++ b/docs/cmdline-opts/disable-epsv.d
@@ -7,6 +7,7 @@ Category: ftp
 Example: --disable-epsv ftp://example.com/
 Added: 7.9.2
 See-also: disable-eprt ftp-port
+Multi: boolean
 ---
 Tell curl to disable the use of the EPSV command when doing passive FTP
 transfers. Curl will normally always first attempt to use EPSV before

--- a/docs/cmdline-opts/disable.d
+++ b/docs/cmdline-opts/disable.d
@@ -7,6 +7,7 @@ Category: curl
 Example: -q $URL
 Added: 5.0
 See-also: config
+Multi: boolean
 ---
 If used as the first parameter on the command line, the *curlrc* config
 file will not be read and used. See the --config for details on the default

--- a/docs/cmdline-opts/disallow-username-in-url.d
+++ b/docs/cmdline-opts/disallow-username-in-url.d
@@ -7,6 +7,7 @@ Added: 7.61.0
 See-also: proto
 Category: curl http
 Example: --disallow-username-in-url $URL
+Multi: boolean
 ---
 This tells curl to exit if passed a URL containing a username. This is probably
 most useful when the URL is being provided at runtime or similar.

--- a/docs/cmdline-opts/dns-interface.d
+++ b/docs/cmdline-opts/dns-interface.d
@@ -9,6 +9,7 @@ Added: 7.33.0
 Requires: c-ares
 Category: dns
 Example: --dns-interface eth0 $URL
+Multi: single
 ---
 Tell curl to send outgoing DNS requests through <interface>. This option is a
 counterpart to --interface (which does not affect DNS). The supplied string

--- a/docs/cmdline-opts/dns-ipv4-addr.d
+++ b/docs/cmdline-opts/dns-ipv4-addr.d
@@ -9,9 +9,8 @@ Added: 7.33.0
 Requires: c-ares
 Category: dns
 Example: --dns-ipv4-addr 10.1.2.3 $URL
+Multi: single
 ---
 Tell curl to bind to <ip-address> when making IPv4 DNS requests, so that
 the DNS requests originate from this address. The argument should be a
 single IPv4 address.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/dns-ipv6-addr.d
+++ b/docs/cmdline-opts/dns-ipv6-addr.d
@@ -9,9 +9,8 @@ Added: 7.33.0
 Requires: c-ares
 Category: dns
 Example: --dns-ipv6-addr 2a04:4e42::561 $URL
+Multi: single
 ---
 Tell curl to bind to <ip-address> when making IPv6 DNS requests, so that
 the DNS requests originate from this address. The argument should be a
 single IPv6 address.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/dns-servers.d
+++ b/docs/cmdline-opts/dns-servers.d
@@ -8,10 +8,9 @@ Added: 7.33.0
 Category: dns
 Example: --dns-servers 192.168.0.1,192.168.0.2 $URL
 See-also: dns-interface dns-ipv4-addr
+Multi: single
 ---
 Set the list of DNS servers to be used instead of the system default.
 The list of IP addresses should be separated with commas. Port numbers
 may also optionally be given as *:<port-number>* after each IP
 address.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/doh-cert-status.d
+++ b/docs/cmdline-opts/doh-cert-status.d
@@ -6,5 +6,6 @@ Added: 7.76.0
 Category: dns tls
 Example: --doh-cert-status --doh-url https://doh.example $URL
 See-also: doh-insecure
+Multi: boolean
 ---
 Same as --cert-status but used for DoH (DNS-over-HTTPS).

--- a/docs/cmdline-opts/doh-insecure.d
+++ b/docs/cmdline-opts/doh-insecure.d
@@ -6,5 +6,6 @@ Added: 7.76.0
 Category: dns tls
 Example: --doh-insecure --doh-url https://doh.example $URL
 See-also: doh-url
+Multi: boolean
 ---
 Same as --insecure but used for DoH (DNS-over-HTTPS).

--- a/docs/cmdline-opts/doh-url.d
+++ b/docs/cmdline-opts/doh-url.d
@@ -7,6 +7,7 @@ Added: 7.62.0
 Category: dns
 Example: --doh-url https://doh.example $URL
 See-also: doh-insecure
+Multi: single
 ---
 Specifies which DNS-over-HTTPS (DoH) server to use to resolve hostnames,
 instead of using the default name resolver mechanism. The URL must be HTTPS.
@@ -18,5 +19,3 @@ settings are not inherited and can be controlled separately via
 
 This option is unset if an empty string "" is used as the URL. (Added in
 7.85.0)
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/dump-header.d
+++ b/docs/cmdline-opts/dump-header.d
@@ -9,11 +9,10 @@ See-also: output
 Category: http ftp
 Example: --dump-header store.txt $URL
 Added: 5.7
+Multi: single
 ---
 Write the received protocol headers to the specified file. If no headers are
 received, the use of this option will create an empty file.
 
 When used in FTP, the FTP server response lines are considered being "headers"
 and thus are saved there.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/egd-file.d
+++ b/docs/cmdline-opts/egd-file.d
@@ -8,6 +8,7 @@ See-also: random-file
 Category: tls
 Example: --egd-file /random/here $URL
 Added: 7.7
+Multi: single
 ---
 Deprecated option. This option is ignored by curl since 7.84.0. Prior to that
 it only had an effect on curl if built to use old versions of OpenSSL.

--- a/docs/cmdline-opts/engine.d
+++ b/docs/cmdline-opts/engine.d
@@ -8,6 +8,7 @@ Category: tls
 Example: --engine flavor $URL
 Added: 7.9.3
 See-also: ciphers curves
+Multi: single
 ---
 Select the OpenSSL crypto engine to use for cipher operations. Use --engine
 list to print a list of build-time supported engines. Note that not all (and

--- a/docs/cmdline-opts/etag-compare.d
+++ b/docs/cmdline-opts/etag-compare.d
@@ -8,6 +8,7 @@ Added: 7.68.0
 Category: http
 Example: --etag-compare etag.txt $URL
 See-also: etag-save time-cond
+Multi: single
 ---
 This option makes a conditional HTTP request for the specific ETag read
 from the given file by sending a custom If-None-Match header using the

--- a/docs/cmdline-opts/etag-save.d
+++ b/docs/cmdline-opts/etag-save.d
@@ -8,6 +8,7 @@ Added: 7.68.0
 Category: http
 Example: --etag-save storetag.txt $URL
 See-also: etag-compare
+Multi: single
 ---
 This option saves an HTTP ETag to the specified file. An ETag is a
 caching related header, usually returned in a response.

--- a/docs/cmdline-opts/expect100-timeout.d
+++ b/docs/cmdline-opts/expect100-timeout.d
@@ -8,6 +8,7 @@ Added: 7.47.0
 See-also: connect-timeout
 Category: http
 Example: --expect100-timeout 2.5 -T file $URL
+Multi: single
 ---
 Maximum time in seconds that you allow curl to wait for a 100-continue
 response when curl emits an Expects: 100-continue header in its request. By

--- a/docs/cmdline-opts/fail-early.d
+++ b/docs/cmdline-opts/fail-early.d
@@ -6,6 +6,7 @@ Added: 7.52.0
 Category: curl
 Example: --fail-early $URL https://two.example
 See-also: fail fail-with-body
+Multi: boolean
 ---
 Fail and exit on the first detected transfer error.
 

--- a/docs/cmdline-opts/fail-with-body.d
+++ b/docs/cmdline-opts/fail-with-body.d
@@ -8,6 +8,7 @@ Added: 7.76.0
 See-also: fail
 Mutexed: fail
 Example: --fail-with-body $URL
+Multi: boolean
 ---
 Return an error on server errors where the HTTP response code is 400 or
 greater). In normal cases when an HTTP server fails to deliver a document, it

--- a/docs/cmdline-opts/fail.d
+++ b/docs/cmdline-opts/fail.d
@@ -9,6 +9,7 @@ Category: important http
 Example: --fail $URL
 Mutexed: fail-with-body
 Added: 4.0
+Multi: boolean
 ---
 Fail fast with no output at all on server errors. This is useful to enable
 scripts and users to better deal with failed attempts. In normal cases when an

--- a/docs/cmdline-opts/false-start.d
+++ b/docs/cmdline-opts/false-start.d
@@ -7,6 +7,7 @@ Added: 7.42.0
 Category: tls
 Example: --false-start $URL
 See-also: tcp-fastopen
+Multi: boolean
 ---
 Tells curl to use false start during the TLS handshake. False start is a mode
 where a TLS client will start sending application data before verifying the

--- a/docs/cmdline-opts/form-escape.d
+++ b/docs/cmdline-opts/form-escape.d
@@ -7,6 +7,7 @@ See-also: form
 Added: 7.81.0
 Category: http upload
 Example: --form-escape -F 'field\\name=curl' -F 'file=@load"this' $URL
+Multi: single
 ---
 Tells curl to pass on names of multipart form fields and files using
 backslash-escaping instead of percent-encoding.

--- a/docs/cmdline-opts/form-string.d
+++ b/docs/cmdline-opts/form-string.d
@@ -8,6 +8,7 @@ See-also: form
 Category: http upload
 Example: --form-string "data" $URL
 Added: 7.13.2
+Multi: append
 ---
 Similar to --form except that the value string for the named parameter is used
 literally. Leading '@' and '<' characters, and the ';type=' string in

--- a/docs/cmdline-opts/form.d
+++ b/docs/cmdline-opts/form.d
@@ -10,6 +10,7 @@ Category: http upload
 Example: --form "name=curl" --form "file=@loadthis" $URL
 Added: 5.0
 See-also: data form-string form-escape
+Multi: append
 ---
 For HTTP protocol family, this lets curl emulate a filled-in form in which a
 user has pressed the submit button. This causes curl to POST data using the
@@ -132,5 +133,3 @@ base64 attached file:
       -F '=@localfile;encoder=base64' ... smtp://example.com
 
 See further examples and details in the MANUAL.
-
-This option can be used multiple times.

--- a/docs/cmdline-opts/ftp-account.d
+++ b/docs/cmdline-opts/ftp-account.d
@@ -8,8 +8,7 @@ Added: 7.13.0
 Category: ftp auth
 Example: --ftp-account "mr.robot" ftp://example.com/
 See-also: user
+Multi: single
 ---
 When an FTP server asks for "account data" after user name and password has
 been provided, this data is sent off using the ACCT command.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/ftp-alternative-to-user.d
+++ b/docs/cmdline-opts/ftp-alternative-to-user.d
@@ -8,6 +8,7 @@ Added: 7.15.5
 Category: ftp
 Example: --ftp-alternative-to-user "U53r" ftp://example.com
 See-also: ftp-account user
+Multi: single
 ---
 If authenticating with the USER and PASS commands fails, send this command.
 When connecting to Tumbleweed's Secure Transport server over FTPS using a

--- a/docs/cmdline-opts/ftp-create-dirs.d
+++ b/docs/cmdline-opts/ftp-create-dirs.d
@@ -7,6 +7,7 @@ See-also: create-dirs
 Category: ftp sftp curl
 Example: --ftp-create-dirs -T file ftp://example.com/remote/path/file
 Added: 7.10.7
+Multi: boolean
 ---
 When an FTP or SFTP URL/operation uses a path that does not currently exist on
 the server, the standard behavior of curl is to fail. Using this option, curl

--- a/docs/cmdline-opts/ftp-method.d
+++ b/docs/cmdline-opts/ftp-method.d
@@ -10,6 +10,7 @@ Example: --ftp-method multicwd ftp://example.com/dir1/dir2/file
 Example: --ftp-method nocwd ftp://example.com/dir1/dir2/file
 Example: --ftp-method singlecwd ftp://example.com/dir1/dir2/file
 See-also: list-only
+Multi: single
 ---
 Control what method curl should use to reach a file on an FTP(S)
 server. The method argument should be one of the following alternatives:

--- a/docs/cmdline-opts/ftp-pasv.d
+++ b/docs/cmdline-opts/ftp-pasv.d
@@ -7,14 +7,14 @@ Added: 7.11.0
 See-also: disable-epsv
 Category: ftp
 Example: --ftp-pasv ftp://example.com/
+Multi: boolean
 ---
 Use passive mode for the data connection. Passive is the internal default
 behavior, but using this option can be used to override a previous --ftp-port
 option.
 
-If this option is used several times, only the first one is used. Undoing an
-enforced passive really is not doable but you must then instead enforce the
-correct --ftp-port again.
+Reversing an enforced passive really is not doable but you must then instead
+enforce the correct --ftp-port again.
 
 Passive mode means that curl will try the EPSV command first and then PASV,
 unless --disable-epsv is used.

--- a/docs/cmdline-opts/ftp-port.d
+++ b/docs/cmdline-opts/ftp-port.d
@@ -11,6 +11,7 @@ Example: -P - ftp:/example.com
 Example: -P eth0 ftp:/example.com
 Example: -P 192.168.0.2 ftp:/example.com
 Added: 4.0
+Multi: single
 ---
 Reverses the default initiator/listener roles when connecting with FTP. This
 option makes curl use active mode. curl then tells the server to connect back
@@ -29,9 +30,8 @@ make curl pick the same IP address that is already used for the control
 connection
 .RE
 
-If this option is used several times, the last one will be used. Disable the
-use of PORT with --ftp-pasv. Disable the attempt to use the EPRT command
-instead of PORT by using --disable-eprt. EPRT is really PORT++.
+Disable the use of PORT with --ftp-pasv. Disable the attempt to use the EPRT
+command instead of PORT by using --disable-eprt. EPRT is really PORT++.
 
 You can also append ":[start]-[end]\&" to the right of the address, to tell
 curl what TCP port range to use. That means you specify a port range, from a

--- a/docs/cmdline-opts/ftp-pret.d
+++ b/docs/cmdline-opts/ftp-pret.d
@@ -7,6 +7,7 @@ Added: 7.20.0
 Category: ftp
 Example: --ftp-pret ftp://example.com/
 See-also: ftp-port ftp-pasv
+Multi: boolean
 ---
 Tell curl to send a PRET command before PASV (and EPSV). Certain FTP servers,
 mainly drftpd, require this non-standard command for directory listings as

--- a/docs/cmdline-opts/ftp-skip-pasv-ip.d
+++ b/docs/cmdline-opts/ftp-skip-pasv-ip.d
@@ -7,6 +7,7 @@ Added: 7.14.2
 See-also: ftp-pasv
 Category: ftp
 Example: --ftp-skip-pasv-ip ftp://example.com/
+Multi: boolean
 ---
 Tell curl to not use the IP address the server suggests in its response
 to curl's PASV command when curl connects the data connection. Instead curl

--- a/docs/cmdline-opts/ftp-ssl-ccc-mode.d
+++ b/docs/cmdline-opts/ftp-ssl-ccc-mode.d
@@ -8,6 +8,7 @@ Added: 7.16.2
 See-also: ftp-ssl-ccc
 Category: ftp tls
 Example: --ftp-ssl-ccc-mode active --ftp-ssl-ccc ftps://example.com/
+Multi: boolean
 ---
 Sets the CCC mode. The passive mode will not initiate the shutdown, but
 instead wait for the server to do it, and will not reply to the shutdown from

--- a/docs/cmdline-opts/ftp-ssl-ccc.d
+++ b/docs/cmdline-opts/ftp-ssl-ccc.d
@@ -7,6 +7,7 @@ See-also: ssl ftp-ssl-ccc-mode
 Added: 7.16.1
 Category: ftp tls
 Example: --ftp-ssl-ccc ftps://example.com/
+Multi: boolean
 ---
 Use CCC (Clear Command Channel) Shuts down the SSL/TLS layer after
 authenticating. The rest of the control channel communication will be

--- a/docs/cmdline-opts/ftp-ssl-control.d
+++ b/docs/cmdline-opts/ftp-ssl-control.d
@@ -7,6 +7,7 @@ Added: 7.16.0
 Category: ftp tls
 Example: --ftp-ssl-control ftp://example.com
 See-also: ssl
+Multi: boolean
 ---
 Require SSL/TLS for the FTP login, clear for transfer.  Allows secure
 authentication, but non-encrypted data transfers for efficiency.  Fails the

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -204,6 +204,8 @@ sub single {
     my @examples; # there can be more than one
     my $magic; # cmdline special option
     my $line;
+    my $multi;
+    my $experimental;
     while(<F>) {
         $line++;
         if(/^Short: *(.)/i) {
@@ -242,6 +244,12 @@ sub single {
         elsif(/^Example: *(.*)/i) {
             push @examples, $1;
         }
+        elsif(/^Multi: *(.*)/i) {
+            $multi=$1;
+        }
+        elsif(/^Experimental: yes/i) {
+            $experimental=1;
+        }
         elsif(/^C: (.*)/i) {
             $copyright=$1;
         }
@@ -254,6 +262,10 @@ sub single {
         elsif(/^---/) {
             if(!$long) {
                 print STDERR "ERROR: no 'Long:' in $f\n";
+                return 1;
+            }
+            if($multi !~ /(single|append|boolean|mutex)/) {
+                print STDERR "ERROR: bad 'Multi:' in $f\n";
                 return 1;
             }
             if(!$category) {
@@ -326,8 +338,34 @@ sub single {
         print ".SH DESCRIPTION\n";
     }
 
+    if($experimental) {
+        print "**WARNING**: this option is experimental. Do not use in production.\n\n";
+    }
+
     printdesc(@desc);
     undef @desc;
+
+    if($multi eq "single") {
+        print "\nIf --$long is provided several times, the last set ".
+            "value will be used.\n";
+    }
+    elsif($multi eq "append") {
+        print "\n--$long can be used several times in a command line\n";
+    }
+    elsif($multi eq "boolean") {
+        my $rev = "no-$long";
+        # for options that start with "no-" the reverse is then without
+        # the no- prefix
+        if($long =~ /^no-/) {
+            $rev = $long;
+            $rev =~ s/^no-//;
+        }
+        print "\nProviding --$long multiple times has no extra effect.\n".
+            "Disable it again with --$rev.\n";
+    }
+    elsif($multi eq "mutex") {
+        print "\nProviding --$long multiple times has no extra effect.\n";
+    }
 
     my @foot;
     if($seealso) {

--- a/docs/cmdline-opts/get.d
+++ b/docs/cmdline-opts/get.d
@@ -9,6 +9,7 @@ Example: --get -d "tool=curl" -d "age=old" $URL
 Example: --get -I -d "tool=curl" $URL
 Added: 7.8.1
 See-also: data request
+Multi: boolean
 ---
 When used, this option will make all data specified with --data, --data-binary
 or --data-urlencode to be used in an HTTP GET request instead of the POST
@@ -17,7 +18,3 @@ with a '?' separator.
 
 If used in combination with --head, the POST data will instead be appended to
 the URL with a HEAD request.
-
-If this option is used several times, only the first one is used. This is
-because undoing a GET does not make sense, but you should then instead enforce
-the alternative method you prefer.

--- a/docs/cmdline-opts/globoff.d
+++ b/docs/cmdline-opts/globoff.d
@@ -7,6 +7,7 @@ Category: curl
 Example: -g "https://example.com/{[]}}}}"
 Added: 7.6
 See-also: config disable
+Multi: boolean
 ---
 This option switches off the "URL globbing parser". When you set this option,
 you can specify URLs that contain the letters {}[] without having curl itself

--- a/docs/cmdline-opts/happy-eyeballs-timeout-ms.d
+++ b/docs/cmdline-opts/happy-eyeballs-timeout-ms.d
@@ -7,6 +7,7 @@ Added: 7.59.0
 Category: connection
 Example: --happy-eyeballs-timeout-ms 500 $URL
 See-also: max-time connect-timeout
+Multi: single
 ---
 Happy Eyeballs is an algorithm that attempts to connect to both IPv4 and IPv6
 addresses for dual-stack hosts, giving IPv6 a head-start of the specified
@@ -18,5 +19,3 @@ The range of suggested useful values is limited. Happy Eyeballs RFC 6555 says
 "It is RECOMMENDED that connection attempts be paced 150-250 ms apart to
 balance human factors against network load." libcurl currently defaults to
 200 ms. Firefox and Chrome currently default to 300 ms.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/haproxy-protocol.d
+++ b/docs/cmdline-opts/haproxy-protocol.d
@@ -7,6 +7,7 @@ Added: 7.60.0
 Category: http proxy
 Example: --haproxy-protocol $URL
 See-also: proxy
+Multi: boolean
 ---
 Send a HAProxy PROXY protocol v1 header at the beginning of the
 connection. This is used by some load balancers and reverse proxies to

--- a/docs/cmdline-opts/head.d
+++ b/docs/cmdline-opts/head.d
@@ -8,6 +8,7 @@ Category: http ftp file
 Example: -I $URL
 Added: 4.0
 See-also: get verbose trace-ascii
+Multi: boolean
 ---
 Fetch the headers only! HTTP-servers feature the command HEAD which this uses
 to get nothing but the header of a document. When used on an FTP or FILE file,

--- a/docs/cmdline-opts/header.d
+++ b/docs/cmdline-opts/header.d
@@ -11,6 +11,7 @@ Example: -H "X-First-Name: Joe" $URL
 Example: -H "User-Agent: yes-please/2000" $URL
 Example: -H "Host:" $URL
 Added: 5.0
+Multi: append
 ---
 Extra header to include in information sent. When used within an HTTP request,
 it is added to the regular request headers.
@@ -53,5 +54,3 @@ with a request body, will make curl send the data using chunked encoding.
 lead to the header being sent to other hosts than the original host, so
 sensitive headers should be used with caution combined with following
 redirects.
-
-This option can be used multiple times to add/replace/remove multiple headers.

--- a/docs/cmdline-opts/help.d
+++ b/docs/cmdline-opts/help.d
@@ -8,6 +8,7 @@ Category: important curl
 Example: --help all
 Added: 4.0
 See-also: verbose
+Multi: boolean
 ---
 Usage help. This lists all commands of the <category>.
 If no arg was provided, curl will display the most important

--- a/docs/cmdline-opts/hostpubmd5.d
+++ b/docs/cmdline-opts/hostpubmd5.d
@@ -8,6 +8,7 @@ Added: 7.17.1
 Category: sftp scp
 Example: --hostpubmd5 e5c1c49020640a5ab0f2034854c321a8 sftp://example.com/
 See-also: hostpubsha256
+Multi: single
 ---
 Pass a string containing 32 hexadecimal digits. The string should
 be the 128 bit MD5 checksum of the remote host's public key, curl will refuse

--- a/docs/cmdline-opts/hostpubsha256.d
+++ b/docs/cmdline-opts/hostpubsha256.d
@@ -8,6 +8,7 @@ Added: 7.80.0
 Category: sftp scp
 Example: --hostpubsha256 NDVkMTQxMGQ1ODdmMjQ3MjczYjAyOTY5MmRkMjVmNDQ= sftp://example.com/
 See-also: hostpubmd5
+Multi: single
 ---
 Pass a string containing a Base64-encoded SHA256 hash of the remote
 host's public key. Curl will refuse the connection with the host

--- a/docs/cmdline-opts/hsts.d
+++ b/docs/cmdline-opts/hsts.d
@@ -8,6 +8,7 @@ Added: 7.74.0
 Category: http
 Example: --hsts cache.txt $URL
 See-also: proto
+Multi: append
 ---
 This option enables HSTS for the transfer. If the file name points to an
 existing HSTS cache file, that will be used. After a completed transfer, the

--- a/docs/cmdline-opts/http0.9.d
+++ b/docs/cmdline-opts/http0.9.d
@@ -8,6 +8,7 @@ Category: http
 Example: --http0.9 $URL
 Added: 7.64.0
 See-also: http1.1 http2 http3
+Multi: boolean
 ---
 Tells curl to be fine with HTTP version 0.9 response.
 

--- a/docs/cmdline-opts/http1.0.d
+++ b/docs/cmdline-opts/http1.0.d
@@ -10,6 +10,7 @@ Help: Use HTTP 1.0
 Category: http
 Example: --http1.0 $URL
 See-also: http0.9 http1.1
+Multi: mutex
 ---
 Tells curl to use HTTP version 1.0 instead of using its internally preferred
 HTTP version.

--- a/docs/cmdline-opts/http1.1.d
+++ b/docs/cmdline-opts/http1.1.d
@@ -9,5 +9,6 @@ Help: Use HTTP 1.1
 Category: http
 Example: --http1.1 $URL
 See-also: http1.0 http0.9
+Multi: mutex
 ---
 Tells curl to use HTTP version 1.1.

--- a/docs/cmdline-opts/http2-prior-knowledge.d
+++ b/docs/cmdline-opts/http2-prior-knowledge.d
@@ -10,6 +10,7 @@ Help: Use HTTP 2 without HTTP/1.1 Upgrade
 Category: http
 Example: --http2-prior-knowledge $URL
 See-also: http2 http3
+Multi: boolean
 ---
 Tells curl to issue its non-TLS HTTP requests using HTTP/2 without HTTP/1.1
 Upgrade. It requires prior knowledge that the server supports HTTP/2 straight

--- a/docs/cmdline-opts/http2.d
+++ b/docs/cmdline-opts/http2.d
@@ -11,6 +11,7 @@ Help: Use HTTP 2
 See-also: http1.1 http3
 Category: http
 Example: --http2 $URL
+Multi: mutex
 ---
 Tells curl to use HTTP version 2.
 

--- a/docs/cmdline-opts/http3.d
+++ b/docs/cmdline-opts/http3.d
@@ -10,9 +10,9 @@ Help: Use HTTP v3
 See-also: http1.1 http2
 Category: http
 Example: --http3 $URL
+Multi: mutex
+Experimental: yes
 ---
-**WARNING**: this option is experimental. Do not use in production.
-
 Tells curl to use HTTP version 3 directly to the host and port number used in
 the URL. A normal HTTP/3 transaction will be done to a host and then get
 redirected via Alt-Svc, but this option allows a user to circumvent that when

--- a/docs/cmdline-opts/ignore-content-length.d
+++ b/docs/cmdline-opts/ignore-content-length.d
@@ -7,6 +7,7 @@ Category: http ftp
 Example: --ignore-content-length $URL
 Added: 7.14.1
 See-also: ftp-skip-pasv-ip
+Multi: boolean
 ---
 For HTTP, Ignore the Content-Length header. This is particularly useful for
 servers running Apache 1.x, which will report incorrect Content-Length for

--- a/docs/cmdline-opts/include.d
+++ b/docs/cmdline-opts/include.d
@@ -7,6 +7,7 @@ See-also: verbose
 Category: important verbose
 Example: -i $URL
 Added: 4.8
+Multi: boolean
 ---
 Include the HTTP response headers in the output. The HTTP response headers can
 include things like server name, cookies, date of the document, HTTP version

--- a/docs/cmdline-opts/insecure.d
+++ b/docs/cmdline-opts/insecure.d
@@ -8,6 +8,7 @@ See-also: proxy-insecure cacert capath
 Category: tls sftp scp
 Example: --insecure $URL
 Added: 7.10
+Multi: boolean
 ---
 By default, every secure connection curl makes is verified to be secure before
 the transfer takes place. This option makes curl skip the verification step

--- a/docs/cmdline-opts/interface.d
+++ b/docs/cmdline-opts/interface.d
@@ -7,13 +7,12 @@ See-also: dns-interface
 Category: connection
 Example: --interface eth0 $URL
 Added: 7.3
+Multi: single
 ---
 Perform an operation using a specified interface. You can enter interface
 name, IP address or host name. An example could look like:
 
  curl --interface eth0:1 https://www.example.com/
-
-If this option is used several times, the last one will be used.
 
 On Linux it can be used to specify a VRF, but the binary needs to either
 have CAP_NET_RAW or to be run as root. More information about Linux VRF:

--- a/docs/cmdline-opts/ipv4.d
+++ b/docs/cmdline-opts/ipv4.d
@@ -11,6 +11,7 @@ See-also: http1.1 http2
 Help: Resolve names to IPv4 addresses
 Category: connection dns
 Example: --ipv4 $URL
+Multi: boolean
 ---
 This option tells curl to use IPv4 addresses only, and not for example try
 IPv6.

--- a/docs/cmdline-opts/ipv6.d
+++ b/docs/cmdline-opts/ipv6.d
@@ -11,6 +11,7 @@ See-also: http1.1 http2
 Help: Resolve names to IPv6 addresses
 Category: connection dns
 Example: --ipv6 $URL
+Multi: boolean
 ---
 This option tells curl to use IPv6 addresses only, and not for example try
 IPv4.

--- a/docs/cmdline-opts/json.d
+++ b/docs/cmdline-opts/json.d
@@ -12,6 +12,7 @@ Example: --json '{ "drink":' --json ' "coffe" }' $URL
 Example: --json @prepared $URL
 Example: --json @- $URL < json.txt
 Added: 7.82.0
+Multi: append
 ---
 Sends the specified JSON data in a POST request to the HTTP server. --json
 works as a shortcut for passing on these three options:

--- a/docs/cmdline-opts/junk-session-cookies.d
+++ b/docs/cmdline-opts/junk-session-cookies.d
@@ -8,6 +8,7 @@ See-also: cookie cookie-jar
 Category: http
 Example: --junk-session-cookies -b cookies.txt $URL
 Added: 7.9.7
+Multi: boolean
 ---
 When curl is told to read cookies from a given file, this option will make it
 discard all "session cookies". This will basically have the same effect as if

--- a/docs/cmdline-opts/keepalive-time.d
+++ b/docs/cmdline-opts/keepalive-time.d
@@ -7,6 +7,7 @@ Added: 7.18.0
 Category: connection
 Example: --keepalive-time 20 $URL
 See-also: no-keepalive max-time
+Multi: single
 ---
 This option sets the time a connection needs to remain idle before sending
 keepalive probes and the time between individual keepalive probes. It is
@@ -17,5 +18,4 @@ connections. The number of missed keepalive probes before declaring the
 connection down is OS dependent and is commonly 9 or 10. This option has no
 effect if --no-keepalive is used.
 
-If this option is used several times, the last one will be used. If
-unspecified, the option defaults to 60 seconds.
+If unspecified, the option defaults to 60 seconds.

--- a/docs/cmdline-opts/key-type.d
+++ b/docs/cmdline-opts/key-type.d
@@ -8,8 +8,7 @@ Category: tls
 Example: --key-type DER --key here $URL
 Added: 7.9.3
 See-also: key
+Multi: single
 ---
 Private key file type. Specify which type your --key provided private key
 is. DER, PEM, and ENG are supported. If not specified, PEM is assumed.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/key.d
+++ b/docs/cmdline-opts/key.d
@@ -8,6 +8,7 @@ Category: tls ssh
 Example: --cert certificate --key here $URL
 Added: 7.9.3
 See-also: key-type cert
+Multi: single
 ---
 Private key file name. Allows you to provide your private key in this separate
 file. For SSH, if not specified, curl tries the following candidates in order:
@@ -24,5 +25,3 @@ If curl is built against Secure Transport or Schannel then this option is
 ignored for TLS protocols (HTTPS, etc). Those backends expect the private key
 to be already present in the keychain or PKCS#12 file containing the
 certificate.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/krb.d
+++ b/docs/cmdline-opts/krb.d
@@ -9,9 +9,8 @@ Category: ftp
 Example: --krb clear ftp://example.com/
 Added: 7.3
 See-also: delegation ssl
+Multi: single
 ---
 Enable Kerberos authentication and use. The level must be entered and should
 be one of 'clear', 'safe', 'confidential', or 'private'. Should you use a
 level that is not one of these, 'private' will instead be used.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/libcurl.d
+++ b/docs/cmdline-opts/libcurl.d
@@ -7,6 +7,7 @@ Added: 7.16.1
 Category: curl
 Example: --libcurl client.c $URL
 See-also: verbose
+Multi: single
 ---
 Append this option to any ordinary curl command line, and you will get
 libcurl-using C source code written to the file that does the equivalent
@@ -14,6 +15,3 @@ of what your command-line operation does!
 
 This option is global and does not need to be specified for each use of
 --next.
-
-If this option is used several times, the last given file name will be
-used.

--- a/docs/cmdline-opts/limit-rate.d
+++ b/docs/cmdline-opts/limit-rate.d
@@ -9,6 +9,7 @@ Example: --limit-rate 1000 $URL
 Example: --limit-rate 10M $URL
 Added: 7.10
 See-also: speed-limit speed-time
+Multi: single
 ---
 Specify the maximum transfer rate you want curl to use - for both downloads
 and uploads. This feature is useful if you have a limited pipe and you would like
@@ -26,5 +27,3 @@ the set threshold over a period of multiple seconds.
 If you also use the --speed-limit option, that option will take precedence and
 might cripple the rate-limiting slightly, to help keeping the speed-limit
 logic working.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/list-only.d
+++ b/docs/cmdline-opts/list-only.d
@@ -8,6 +8,7 @@ Added: 4.0
 Category: ftp pop3
 Example: --list-only ftp://example.com/dir/
 See-also: quote request
+Multi: boolean
 ---
 (FTP)
 When listing an FTP directory, this switch forces a name-only view. This is

--- a/docs/cmdline-opts/local-port.d
+++ b/docs/cmdline-opts/local-port.d
@@ -7,6 +7,7 @@ Added: 7.15.2
 Category: connection
 Example: --local-port 1000-3000 $URL
 See-also: globoff
+Multi: single
 ---
 Set a preferred single number or range (FROM-TO) of local port numbers to use
 for the connection(s).  Note that port numbers by nature are a scarce resource

--- a/docs/cmdline-opts/location-trusted.d
+++ b/docs/cmdline-opts/location-trusted.d
@@ -7,6 +7,7 @@ See-also: user
 Category: http auth
 Example: --location-trusted -u user:password $URL
 Added: 7.10.4
+Multi: boolean
 ---
 Like --location, but will allow sending the name + password to all hosts that
 the site may redirect to. This may or may not introduce a security breach if

--- a/docs/cmdline-opts/location.d
+++ b/docs/cmdline-opts/location.d
@@ -8,6 +8,7 @@ Category: http
 Example: -L $URL
 Added: 4.9
 See-also: resolve alt-svc
+Multi: boolean
 ---
 If the server reports that the requested page has moved to a different
 location (indicated with a Location: header and a 3XX response code), this

--- a/docs/cmdline-opts/login-options.d
+++ b/docs/cmdline-opts/login-options.d
@@ -8,6 +8,7 @@ Added: 7.34.0
 Category: imap pop3 smtp auth
 Example: --login-options 'AUTH=*' imap://example.com
 See-also: user
+Multi: single
 ---
 Specify the login options to use during server authentication.
 
@@ -15,5 +16,3 @@ You can use login options to specify protocol specific options that may be
 used during authentication. At present only IMAP, POP3 and SMTP support
 login options. For more information about login options please see RFC
 2384, RFC 5092 and IETF draft draft-earhart-url-smtp-00.txt
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/mail-auth.d
+++ b/docs/cmdline-opts/mail-auth.d
@@ -8,6 +8,7 @@ Added: 7.25.0
 See-also: mail-rcpt mail-from
 Category: smtp
 Example: --mail-auth user@example.come -T mail smtp://example.com/
+Multi: single
 ---
 Specify a single address. This will be used to specify the authentication
 address (identity) of a submitted message that is being relayed to another

--- a/docs/cmdline-opts/mail-from.d
+++ b/docs/cmdline-opts/mail-from.d
@@ -8,5 +8,6 @@ Added: 7.20.0
 See-also: mail-rcpt mail-auth
 Category: smtp
 Example: --mail-from user@example.com -T mail smtp://example.com/
+Multi: single
 ---
 Specify a single address that the given mail should get sent from.

--- a/docs/cmdline-opts/mail-rcpt-allowfails.d
+++ b/docs/cmdline-opts/mail-rcpt-allowfails.d
@@ -7,6 +7,7 @@ Added: 7.69.0
 Category: smtp
 Example: --mail-rcpt-allowfails --mail-rcpt dest@example.com smtp://example.com
 See-also: mail-rcpt
+Multi: boolean
 ---
 When sending data to multiple recipients, by default curl will abort SMTP
 conversation if at least one of the recipients causes RCPT TO command to

--- a/docs/cmdline-opts/mail-rcpt.d
+++ b/docs/cmdline-opts/mail-rcpt.d
@@ -8,6 +8,7 @@ Added: 7.20.0
 Category: smtp
 Example: --mail-rcpt user@example.net smtp://example.com
 See-also: mail-rcpt-allowfails
+Multi: append
 ---
 Specify a single email address, user name or mailing list name. Repeat this
 option several times to send to multiple recipients.

--- a/docs/cmdline-opts/manual.d
+++ b/docs/cmdline-opts/manual.d
@@ -7,5 +7,6 @@ Category: curl
 Example: --manual
 Added: 5.2
 See-also: verbose libcurl trace
+Multi: boolean
 ---
 Manual. Display the huge help text.

--- a/docs/cmdline-opts/max-filesize.d
+++ b/docs/cmdline-opts/max-filesize.d
@@ -8,6 +8,7 @@ See-also: limit-rate
 Category: connection
 Example: --max-filesize 100K $URL
 Added: 7.10.8
+Multi: single
 ---
 Specify the maximum size (in bytes) of a file to download. If the file
 requested is larger than this value, the transfer will not start and curl will

--- a/docs/cmdline-opts/max-redirs.d
+++ b/docs/cmdline-opts/max-redirs.d
@@ -8,9 +8,8 @@ Category: http
 Example: --max-redirs 3 --location $URL
 Added: 7.5
 See-also: location
+Multi: single
 ---
 Set maximum number of redirections to follow. When --location is used, to
 prevent curl from following too many redirects, by default, the limit is
 set to 50 redirects. Set this option to -1 to make it unlimited.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/max-time.d
+++ b/docs/cmdline-opts/max-time.d
@@ -9,6 +9,7 @@ Category: connection
 Example: --max-time 10 $URL
 Example: --max-time 2.92 $URL
 Added: 4.0
+Multi: single
 ---
 Maximum time in seconds that you allow each transfer to take.  This is
 useful for preventing your batch jobs from hanging for hours due to slow
@@ -19,5 +20,3 @@ timeout increases in decimal precision.
 If you enable retrying the transfer (--retry) then the maximum time counter is
 reset each time the transfer is retried. You can use --retry-max-time to limit
 the retry time.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/metalink.d
+++ b/docs/cmdline-opts/metalink.d
@@ -6,6 +6,7 @@ Added: 7.27.0
 Category: misc
 Example: --metalink file $URL
 See-also: parallel
+Multi: single
 ---
 This option was previously used to specify a metalink resource. Metalink
 support has been disabled in curl since 7.78.0 for security reasons.

--- a/docs/cmdline-opts/negotiate.d
+++ b/docs/cmdline-opts/negotiate.d
@@ -7,6 +7,7 @@ See-also: basic ntlm anyauth proxy-negotiate
 Category: auth http
 Example: --negotiate -u : $URL
 Added: 7.10.6
+Multi: mutex
 ---
 Enables Negotiate (SPNEGO) authentication.
 

--- a/docs/cmdline-opts/netrc-file.d
+++ b/docs/cmdline-opts/netrc-file.d
@@ -8,10 +8,10 @@ Mutexed: netrc
 Category: curl
 Example: --netrc-file netrc $URL
 See-also: netrc user config
+Multi: single
 ---
 This option is similar to --netrc, except that you provide the path (absolute
 or relative) to the netrc file that curl should use. You can only specify one
-netrc file per invocation. If several --netrc-file options are provided,
-the last one will be used.
+netrc file per invocation.
 
 It will abide by --netrc-optional if specified.

--- a/docs/cmdline-opts/netrc-optional.d
+++ b/docs/cmdline-opts/netrc-optional.d
@@ -7,6 +7,7 @@ See-also: netrc-file
 Category: curl
 Example: --netrc-optional $URL
 Added: 7.9.8
+Multi: boolean
 ---
 Similar to --netrc, but this option makes the .netrc usage **optional**
 and not mandatory as the --netrc option does.

--- a/docs/cmdline-opts/netrc.d
+++ b/docs/cmdline-opts/netrc.d
@@ -7,6 +7,7 @@ Category: curl
 Example: --netrc $URL
 Added: 4.6
 See-also: netrc-file config user
+Multi: boolean
 ---
 Makes curl scan the *.netrc* (*_netrc* on Windows) file in the user's home
 directory for login name and password. This is typically used for FTP on

--- a/docs/cmdline-opts/next.d
+++ b/docs/cmdline-opts/next.d
@@ -11,6 +11,7 @@ Category: curl
 Example: $URL --next -d postthis www2.example.com
 Example: -I $URL --next https://example.net/
 See-also: parallel config
+Multi: append
 ---
 Tells curl to use a separate operation for the following URL and associated
 options. This allows you to send several URL requests, each with their own

--- a/docs/cmdline-opts/no-alpn.d
+++ b/docs/cmdline-opts/no-alpn.d
@@ -9,6 +9,7 @@ Requires: TLS
 Help: Disable the ALPN TLS extension
 Category: tls http
 Example: --no-alpn $URL
+Multi: boolean
 ---
 Disable the ALPN TLS extension. ALPN is enabled by default if libcurl was built
 with an SSL library that supports ALPN. ALPN is used by a libcurl that supports

--- a/docs/cmdline-opts/no-buffer.d
+++ b/docs/cmdline-opts/no-buffer.d
@@ -7,11 +7,9 @@ Category: curl
 Example: --no-buffer $URL
 Added: 6.5
 See-also: progress-bar
+Multi: boolean
 ---
 Disables the buffering of the output stream. In normal work situations, curl
 will use a standard buffered output stream that will have the effect that it
 will output the data in chunks, not necessarily exactly when the data arrives.
 Using this option will disable that buffering.
-
-Note that this is the negated option name documented. You can thus use
---buffer to enforce the buffering.

--- a/docs/cmdline-opts/no-clobber.d
+++ b/docs/cmdline-opts/no-clobber.d
@@ -6,6 +6,7 @@ Category: curl output
 Added: 7.83.0
 See-also: output remote-name
 Example: --no-clobber --output local/dir/file $URL
+Multi: boolean
 ---
 When used in conjunction with the --output, --remote-header-name,
 --remote-name, or --remote-name-all options, curl avoids overwriting files

--- a/docs/cmdline-opts/no-keepalive.d
+++ b/docs/cmdline-opts/no-keepalive.d
@@ -6,6 +6,7 @@ Category: connection
 Example: --no-keepalive $URL
 Added: 7.18.0
 See-also: keepalive-time
+Multi: boolean
 ---
 Disables the use of keepalive messages on the TCP connection. curl otherwise
 enables them by default.

--- a/docs/cmdline-opts/no-npn.d
+++ b/docs/cmdline-opts/no-npn.d
@@ -10,6 +10,7 @@ Requires: TLS
 Help: Disable the NPN TLS extension
 Category: tls http
 Example: --no-npn $URL
+Multi: boolean
 ---
 In curl 7.86.0 and later, curl never uses NPN.
 

--- a/docs/cmdline-opts/no-progress-meter.d
+++ b/docs/cmdline-opts/no-progress-meter.d
@@ -6,6 +6,7 @@ See-also: verbose silent
 Added: 7.67.0
 Category: verbose
 Example: --no-progress-meter -o store $URL
+Multi: boolean
 ---
 Option to switch off the progress meter output without muting or otherwise
 affecting warning and informational messages like --silent does.

--- a/docs/cmdline-opts/no-sessionid.d
+++ b/docs/cmdline-opts/no-sessionid.d
@@ -7,6 +7,7 @@ Added: 7.16.0
 Category: tls
 Example: --no-sessionid $URL
 See-also: insecure
+Multi: boolean
 ---
 Disable curl's use of SSL session-ID caching. By default all transfers are
 done using the cache. Note that while nothing should ever get hurt by

--- a/docs/cmdline-opts/noproxy.d
+++ b/docs/cmdline-opts/noproxy.d
@@ -7,6 +7,7 @@ Added: 7.19.4
 Category: proxy
 Example: --noproxy "www.example" $URL
 See-also: proxy
+Multi: single
 ---
 Comma-separated list of hosts for which not to use a proxy, if one is
 specified. The only wildcard is a single * character, which matches all hosts,

--- a/docs/cmdline-opts/ntlm-wb.d
+++ b/docs/cmdline-opts/ntlm-wb.d
@@ -7,6 +7,7 @@ See-also: ntlm proxy-ntlm
 Category: auth http
 Example: --ntlm-wb -u user:password $URL
 Added: 7.22.0
+Multi: mutex
 ---
 Enables NTLM much in the style --ntlm does, but hand over the authentication
 to the separate binary ntlmauth application that is executed when needed.

--- a/docs/cmdline-opts/ntlm.d
+++ b/docs/cmdline-opts/ntlm.d
@@ -9,6 +9,7 @@ Requires: TLS
 Category: auth http
 Example: --ntlm -u user:password $URL
 Added: 7.10.6
+Multi: mutex
 ---
 Enables NTLM authentication. The NTLM authentication method was designed by
 Microsoft and is used by IIS web servers. It is a proprietary protocol,

--- a/docs/cmdline-opts/oauth2-bearer.d
+++ b/docs/cmdline-opts/oauth2-bearer.d
@@ -8,11 +8,10 @@ Category: auth
 Example: --oauth2-bearer "mF_9.B5f-4.1JqM" $URL
 Added: 7.33.0
 See-also: basic ntlm digest
+Multi: single
 ---
 Specify the Bearer Token for OAUTH 2.0 server authentication. The Bearer Token
 is used in conjunction with the user name which can be specified as part of
 the --url or --user options.
 
 The Bearer Token and user name are formatted according to RFC 6750.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/output-dir.d
+++ b/docs/cmdline-opts/output-dir.d
@@ -7,8 +7,8 @@ Added: 7.73.0
 See-also: remote-name remote-header-name
 Category: curl
 Example: --output-dir "tmp" -O $URL
+Multi: single
 ---
-
 This option specifies the directory in which files should be stored, when
 --remote-name or --output are used.
 
@@ -17,6 +17,3 @@ command line, up until the first --next.
 
 If the specified target directory does not exist, the operation will fail
 unless --create-dirs is also used.
-
-If this option is used multiple times, the last specified directory will be
-used.

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -11,6 +11,7 @@ Example: "http://{one,two}.example.com" -o "file_#1.txt"
 Example: "http://{site,host}.host[1-5].com" -o "#1_#2"
 Example: -o file $URL -o file2 https://example.net
 Added: 4.0
+Multi: append
 ---
 Write output to <file> instead of stdout. If you are using {} or [] to fetch
 multiple documents, you should quote the URL and you can use '#' followed by a

--- a/docs/cmdline-opts/parallel-immediate.d
+++ b/docs/cmdline-opts/parallel-immediate.d
@@ -6,6 +6,7 @@ Added: 7.68.0
 See-also: parallel parallel-max
 Category: connection curl
 Example: --parallel-immediate -Z $URL -o file1 $URL -o file2
+Multi: boolean
 ---
 When doing parallel transfers, this option will instruct curl that it should
 rather prefer opening up more connections in parallel at once rather than

--- a/docs/cmdline-opts/parallel-max.d
+++ b/docs/cmdline-opts/parallel-max.d
@@ -7,6 +7,7 @@ Added: 7.66.0
 See-also: parallel
 Category: connection curl
 Example: --parallel-max 100 -Z $URL ftp://example.com/
+Multi: single
 ---
 When asked to do parallel transfers, using --parallel, this option controls
 the maximum amount of transfers to do simultaneously.

--- a/docs/cmdline-opts/parallel.d
+++ b/docs/cmdline-opts/parallel.d
@@ -7,6 +7,7 @@ Added: 7.66.0
 Category: connection curl
 Example: --parallel $URL -o file1 $URL -o file2
 See-also: next verbose
+Multi: boolean
 ---
 Makes curl perform its transfers in parallel as compared to the regular serial
 manner.

--- a/docs/cmdline-opts/pass.d
+++ b/docs/cmdline-opts/pass.d
@@ -8,7 +8,6 @@ Category: ssh tls auth
 Example: --pass secret --key file $URL
 Added: 7.9.3
 See-also: key user
+Multi: single
 ---
 Passphrase for the private key.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/path-as-is.d
+++ b/docs/cmdline-opts/path-as-is.d
@@ -6,6 +6,7 @@ Added: 7.42.0
 Category: curl
 Example: --path-as-is https://example.com/../../etc/passwd
 See-also: request-target
+Multi: boolean
 ---
 Tell curl to not handle sequences of /../ or /./ in the given URL
 path. Normally curl will squash or merge them according to standards but with

--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -9,6 +9,7 @@ Example: --pinnedpubkey keyfile $URL
 Example: --pinnedpubkey 'sha256//ce118b51897f4452dc' $URL
 Added: 7.39.0
 See-also: hostpubsha256
+Multi: single
 ---
 Tells curl to use the specified public key file (or hashes) to verify the
 peer. This can be a path to a file which contains a single public key in PEM
@@ -35,5 +36,3 @@ sha256 support:
 7.47.0: mbedtls
 
 Other SSL backends not supported.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/post301.d
+++ b/docs/cmdline-opts/post301.d
@@ -7,6 +7,7 @@ See-also: post302 post303 location
 Added: 7.17.1
 Category: http post
 Example: --post301 --location -d "data" $URL
+Multi: boolean
 ---
 Tells curl to respect RFC 7231/6.4.2 and not convert POST requests into GET
 requests when following a 301 redirection. The non-RFC behavior is ubiquitous

--- a/docs/cmdline-opts/post302.d
+++ b/docs/cmdline-opts/post302.d
@@ -7,6 +7,7 @@ See-also: post301 post303 location
 Added: 7.19.1
 Category: http post
 Example: --post302 --location -d "data" $URL
+Multi: boolean
 ---
 Tells curl to respect RFC 7231/6.4.3 and not convert POST requests into GET
 requests when following a 302 redirection. The non-RFC behavior is ubiquitous

--- a/docs/cmdline-opts/post303.d
+++ b/docs/cmdline-opts/post303.d
@@ -7,6 +7,7 @@ See-also: post302 post301 location
 Added: 7.26.0
 Category: http post
 Example: --post303 --location -d "data" $URL
+Multi: boolean
 ---
 Tells curl to violate RFC 7231/6.4.4 and not convert POST requests into GET
 requests when following 303 redirections. A server may require a POST to

--- a/docs/cmdline-opts/preproxy.d
+++ b/docs/cmdline-opts/preproxy.d
@@ -7,6 +7,7 @@ Added: 7.52.0
 Category: proxy
 Example: --preproxy socks5://proxy.example -x http://http.example $URL
 See-also: proxy socks5
+Multi: single
 ---
 Use the specified SOCKS proxy before connecting to an HTTP or HTTPS --proxy. In
 such a case curl first connects to the SOCKS proxy and then connects (through
@@ -23,5 +24,3 @@ If the port number is not specified in the proxy string, it is assumed to be
 User and password that might be provided in the proxy string are URL decoded
 by curl. This allows you to pass in special characters such as @ by using %40
 or pass in a colon with %3a.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/progress-bar.d
+++ b/docs/cmdline-opts/progress-bar.d
@@ -7,6 +7,7 @@ Category: verbose
 Example: -# -O $URL
 Added: 5.10
 See-also: styled-output
+Multi: boolean
 ---
 Make curl display transfer progress as a simple progress bar instead of the
 standard, more informational, meter.

--- a/docs/cmdline-opts/proto-default.d
+++ b/docs/cmdline-opts/proto-default.d
@@ -7,6 +7,7 @@ Added: 7.45.0
 Category: connection curl
 Example: --proto-default https ftp.example.com
 See-also: proto proto-redir
+Multi: single
 ---
 Tells curl to use *protocol* for any URL missing a scheme name.
 

--- a/docs/cmdline-opts/proto-redir.d
+++ b/docs/cmdline-opts/proto-redir.d
@@ -7,6 +7,7 @@ Added: 7.20.2
 Category: connection curl
 Example: --proto-redir =http,https $URL
 See-also: proto
+Multi: single
 ---
 Tells curl to limit what protocols it may use on redirect. Protocols denied by
 --proto are not overridden by this option. See --proto for how protocols are

--- a/docs/cmdline-opts/proto.d
+++ b/docs/cmdline-opts/proto.d
@@ -7,6 +7,7 @@ See-also: proto-redir proto-default
 Added: 7.20.2
 Category: connection curl
 Example: --proto =http,https,sftp $URL
+Multi: single
 ---
 Tells curl to limit what protocols it may use for transfers. Protocols are
 evaluated left to right, are comma separated, and are each a protocol name or

--- a/docs/cmdline-opts/proxy-anyauth.d
+++ b/docs/cmdline-opts/proxy-anyauth.d
@@ -6,6 +6,7 @@ Added: 7.13.2
 See-also: proxy proxy-basic proxy-digest
 Category: proxy auth
 Example: --proxy-anyauth --proxy-user user:passwd -x proxy $URL
+Multi: mutex
 ---
 Tells curl to pick a suitable authentication method when communicating with
 the given HTTP proxy. This might cause an extra request/response round-trip.

--- a/docs/cmdline-opts/proxy-basic.d
+++ b/docs/cmdline-opts/proxy-basic.d
@@ -6,6 +6,7 @@ See-also: proxy proxy-anyauth proxy-digest
 Category: proxy auth
 Example: --proxy-basic --proxy-user user:passwd -x proxy $URL
 Added: 7.12.0
+Multi: mutex
 ---
 Tells curl to use HTTP Basic authentication when communicating with the given
 proxy. Use --basic for enabling HTTP Basic with a remote host. Basic is the

--- a/docs/cmdline-opts/proxy-cacert.d
+++ b/docs/cmdline-opts/proxy-cacert.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 See-also: proxy-capath cacert capath proxy
 Category: proxy tls
 Example: --proxy-cacert CA-file.txt -x https://proxy $URL
+Multi: single
 ---
 Same as --cacert but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-capath.d
+++ b/docs/cmdline-opts/proxy-capath.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 See-also: proxy-cacert proxy capath
 Category: proxy tls
 Example: --proxy-capath /local/directory -x https://proxy $URL
+Multi: single
 ---
 Same as --capath but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-cert-type.d
+++ b/docs/cmdline-opts/proxy-cert-type.d
@@ -7,5 +7,6 @@ Help: Client certificate type for HTTPS proxy
 Category: proxy tls
 Example: --proxy-cert-type PEM --proxy-cert file -x https://proxy $URL
 See-also: proxy-cert
+Multi: single
 ---
 Same as --cert-type but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-cert.d
+++ b/docs/cmdline-opts/proxy-cert.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls
 Example: --proxy-cert file -x https://proxy $URL
 See-also: proxy-cert-type
+Multi: single
 ---
 Same as --cert but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-ciphers.d
+++ b/docs/cmdline-opts/proxy-ciphers.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls
 Example: --proxy-ciphers ECDHE-ECDSA-AES256-CCM8 -x https://proxy $URL
 See-also: ciphers curves proxy
+Multi: single
 ---
 Same as --ciphers but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-crlfile.d
+++ b/docs/cmdline-opts/proxy-crlfile.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls
 Example: --proxy-crlfile rejects.txt -x https://proxy $URL
 See-also: crlfile proxy
+Multi: single
 ---
 Same as --crlfile but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-digest.d
+++ b/docs/cmdline-opts/proxy-digest.d
@@ -6,6 +6,7 @@ See-also: proxy proxy-anyauth proxy-basic
 Category: proxy tls
 Example: --proxy-digest --proxy-user user:passwd -x proxy $URL
 Added: 7.12.0
+Multi: mutex
 ---
 Tells curl to use HTTP Digest authentication when communicating with the given
 proxy. Use --digest for enabling HTTP Digest with a remote host.

--- a/docs/cmdline-opts/proxy-header.d
+++ b/docs/cmdline-opts/proxy-header.d
@@ -10,6 +10,7 @@ Example: --proxy-header "X-First-Name: Joe" -x http://proxy $URL
 Example: --proxy-header "User-Agent: surprise" -x http://proxy $URL
 Example: --proxy-header "Host:" -x http://proxy $URL
 See-also: proxy
+Multi: append
 ---
 Extra header to include in the request when sending HTTP to a proxy. You may
 specify any number of extra headers. This is the equivalent option to --header

--- a/docs/cmdline-opts/proxy-insecure.d
+++ b/docs/cmdline-opts/proxy-insecure.d
@@ -6,5 +6,6 @@ Added: 7.52.0
 Category: proxy tls
 Example: --proxy-insecure -x https://proxy $URL
 See-also: proxy insecure
+Multi: boolean
 ---
 Same as --insecure but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-key-type.d
+++ b/docs/cmdline-opts/proxy-key-type.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls
 Example: --proxy-key-type DER --proxy-key here -x https://proxy $URL
 See-also: proxy-key proxy
+Multi: single
 ---
 Same as --key-type but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-key.d
+++ b/docs/cmdline-opts/proxy-key.d
@@ -7,5 +7,6 @@ Category: proxy tls
 Example: --proxy-key here -x https://proxy $URL
 Added: 7.52.0
 See-also: proxy-key-type proxy
+Multi: single
 ---
 Same as --key but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-negotiate.d
+++ b/docs/cmdline-opts/proxy-negotiate.d
@@ -6,6 +6,7 @@ Added: 7.17.1
 See-also: proxy-anyauth proxy-basic
 Category: proxy auth
 Example: --proxy-negotiate --proxy-user user:passwd -x proxy $URL
+Multi: mutex
 ---
 Tells curl to use HTTP Negotiate (SPNEGO) authentication when communicating
 with the given proxy. Use --negotiate for enabling HTTP Negotiate (SPNEGO)

--- a/docs/cmdline-opts/proxy-ntlm.d
+++ b/docs/cmdline-opts/proxy-ntlm.d
@@ -6,6 +6,7 @@ See-also: proxy-negotiate proxy-anyauth
 Category: proxy auth
 Example: --proxy-ntlm --proxy-user user:passwd -x http://proxy $URL
 Added: 7.10.7
+Multi: mutex
 ---
 Tells curl to use HTTP NTLM authentication when communicating with the given
 proxy. Use --ntlm for enabling NTLM with a remote host.

--- a/docs/cmdline-opts/proxy-pass.d
+++ b/docs/cmdline-opts/proxy-pass.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-pass secret --proxy-key here -x https://proxy $URL
 See-also: proxy proxy-key
+Multi: single
 ---
 Same as --pass but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-pinnedpubkey.d
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.d
@@ -9,6 +9,7 @@ Example: --proxy-pinnedpubkey keyfile $URL
 Example: --proxy-pinnedpubkey 'sha256//ce118b51897f4452dc' $URL
 Added: 7.59.0
 See-also: pinnedpubkey proxy
+Multi: single
 ---
 Tells curl to use the specified public key file (or hashes) to verify the
 proxy. This can be a path to a file which contains a single public key in PEM
@@ -19,5 +20,3 @@ When negotiating a TLS or SSL connection, the server sends a certificate
 indicating its identity. A public key is extracted from this certificate and
 if it does not exactly match the public key provided to this option, curl will
 abort the connection before sending or receiving any data.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/proxy-service-name.d
+++ b/docs/cmdline-opts/proxy-service-name.d
@@ -7,5 +7,6 @@ Added: 7.43.0
 Category: proxy tls
 Example: --proxy-service-name "shrubbery" -x proxy $URL
 See-also: service-name proxy
+Multi: single
 ---
 This option allows you to change the service name for proxy negotiation.

--- a/docs/cmdline-opts/proxy-ssl-allow-beast.d
+++ b/docs/cmdline-opts/proxy-ssl-allow-beast.d
@@ -6,5 +6,6 @@ Added: 7.52.0
 Category: proxy tls
 Example: --proxy-ssl-allow-beast -x https://proxy $URL
 See-also: ssl-allow-beast proxy
+Multi: boolean
 ---
 Same as --ssl-allow-beast but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-ssl-auto-client-cert.d
+++ b/docs/cmdline-opts/proxy-ssl-auto-client-cert.d
@@ -6,5 +6,6 @@ Added: 7.77.0
 Category: proxy tls
 Example: --proxy-ssl-auto-client-cert -x https://proxy $URL
 See-also: ssl-auto-client-cert proxy
+Multi: boolean
 ---
 Same as --ssl-auto-client-cert but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tls13-ciphers.d
+++ b/docs/cmdline-opts/proxy-tls13-ciphers.d
@@ -8,6 +8,7 @@ Category: proxy tls
 Example: --proxy-tls13-ciphers TLS_AES_128_GCM_SHA256 -x proxy $URL
 Added: 7.61.0
 See-also: tls13-ciphers curves
+Multi: single
 ---
 Specifies which cipher suites to use in the connection to your HTTPS proxy
 when it negotiates TLS 1.3. The list of ciphers suites must specify valid
@@ -18,5 +19,3 @@ ciphers. Read up on TLS 1.3 cipher suite details on this URL:
 This option is currently used only when curl is built to use OpenSSL 1.1.1 or
 later. If you are using a different SSL backend you can try setting TLS 1.3
 cipher suites by using the --proxy-ciphers option.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/proxy-tlsauthtype.d
+++ b/docs/cmdline-opts/proxy-tlsauthtype.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlsauthtype SRP -x https://proxy $URL
 See-also: proxy proxy-tlsuser
+Multi: single
 ---
 Same as --tlsauthtype but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tlspassword.d
+++ b/docs/cmdline-opts/proxy-tlspassword.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlspassword passwd -x https://proxy $URL
 See-also: proxy proxy-tlsuser
+Multi: single
 ---
 Same as --tlspassword but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tlsuser.d
+++ b/docs/cmdline-opts/proxy-tlsuser.d
@@ -7,5 +7,6 @@ Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlsuser smith -x https://proxy $URL
 See-also: proxy proxy-tlspassword
+Multi: single
 ---
 Same as --tlsuser but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-tlsv1.d
+++ b/docs/cmdline-opts/proxy-tlsv1.d
@@ -6,5 +6,6 @@ Added: 7.52.0
 Category: proxy tls auth
 Example: --proxy-tlsv1 -x https://proxy $URL
 See-also: proxy
+Multi: mutex
 ---
 Same as --tlsv1 but used in HTTPS proxy context.

--- a/docs/cmdline-opts/proxy-user.d
+++ b/docs/cmdline-opts/proxy-user.d
@@ -8,6 +8,7 @@ Category: proxy auth
 Example: --proxy-user name:pwd -x proxy $URL
 Added: 4.0
 See-also: proxy-pass
+Multi: single
 ---
 Specify the user name and password to use for proxy authentication.
 
@@ -20,5 +21,3 @@ process listings. This is not enough to protect credentials from possibly
 getting seen by other users on the same system as they will still be visible
 for a moment before cleared. Such sensitive data should be retrieved from a
 file instead or similar and never used in clear text in a command line.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/proxy.d
+++ b/docs/cmdline-opts/proxy.d
@@ -8,6 +8,7 @@ Category: proxy
 Example: --proxy http://proxy.example $URL
 Added: 4.0
 See-also: socks5 proxy-basic
+Multi: single
 ---
 Use the specified proxy.
 
@@ -44,5 +45,3 @@ or pass in a colon with %3a.
 The proxy host can be specified the same way as the proxy environment
 variables, including the protocol prefix (http://) and the embedded user +
 password.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/proxy1.0.d
+++ b/docs/cmdline-opts/proxy1.0.d
@@ -7,6 +7,7 @@ Category: proxy
 Example: --proxy1.0 -x http://proxy $URL
 Added: 7.19.4
 See-also: proxy socks5 preproxy
+Multi: mutex
 ---
 Use the specified HTTP 1.0 proxy. If the port number is not specified, it is
 assumed at port 1080.

--- a/docs/cmdline-opts/proxytunnel.d
+++ b/docs/cmdline-opts/proxytunnel.d
@@ -7,6 +7,7 @@ See-also: proxy
 Category: proxy
 Example: --proxytunnel -x http://proxy $URL
 Added: 7.3
+Multi: boolean
 ---
 When an HTTP proxy is used --proxy, this option will make curl tunnel through
 the proxy. The tunnel approach is made with the HTTP proxy CONNECT request and

--- a/docs/cmdline-opts/pubkey.d
+++ b/docs/cmdline-opts/pubkey.d
@@ -8,11 +8,10 @@ Category: sftp scp auth
 Example: --pubkey file.pub sftp://example.com/
 Added: 7.16.2
 See-also: pass
+Multi: single
 ---
 Public key file name. Allows you to provide your public key in this separate
 file.
-
-If this option is used several times, the last one will be used.
 
 (As of 7.39.0, curl attempts to automatically extract the public key from the
 private key file, so passing this option is generally not required. Note that

--- a/docs/cmdline-opts/quote.d
+++ b/docs/cmdline-opts/quote.d
@@ -9,6 +9,7 @@ Category: ftp sftp
 Example: --quote "DELE file" ftp://example.com/foo
 Added: 5.3
 See-also: request
+Multi: append
 ---
 Send an arbitrary command to the remote FTP or SFTP server. Quote commands are
 sent BEFORE the transfer takes place (just after the initial PWD command in an

--- a/docs/cmdline-opts/random-file.d
+++ b/docs/cmdline-opts/random-file.d
@@ -7,6 +7,7 @@ Category: misc
 Example: --random-file rubbish $URL
 Added: 7.7
 See-also: egd-file
+Multi: single
 ---
 Deprecated option. This option is ignored by curl since 7.84.0. Prior to that
 it only had an effect on curl if built to use old versions of OpenSSL.

--- a/docs/cmdline-opts/range.d
+++ b/docs/cmdline-opts/range.d
@@ -9,6 +9,7 @@ Category: http ftp sftp file
 Example: --range 22-44 $URL
 Added: 4.0
 See-also: continue-at append
+Multi: single
 ---
 Retrieve a byte range (i.e. a partial document) from an HTTP/1.1, FTP or SFTP
 server or a local FILE. Ranges can be specified in a number of ways.
@@ -49,5 +50,3 @@ whole document.
 FTP and SFTP range downloads only support the simple 'start-stop' syntax
 (optionally with one of the numbers omitted). FTP use depends on the extended
 FTP command SIZE.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/rate.d
+++ b/docs/cmdline-opts/rate.d
@@ -9,6 +9,7 @@ Example: --rate 3/h $URL
 Example: --rate 14/m $URL
 Added: 7.84.0
 See-also: limit-rate retry-delay
+Multi: single
 ---
 Specify the maximum transfer frequency you allow curl to use - in number of
 transfer starts per time unit (sometimes called request rate). Without this
@@ -31,5 +32,3 @@ more than 1000 per second, it will instead run unrestricted.
 
 When retrying transfers, enabled with --retry, the separate retry delay logic
 is used and not this setting.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/raw.d
+++ b/docs/cmdline-opts/raw.d
@@ -7,6 +7,7 @@ Protocols: HTTP
 Category: http
 Example: --raw $URL
 See-also: tr-encoding
+Multi: boolean
 ---
 When used, it disables all internal HTTP decoding of content or transfer
 encodings and instead makes them passed on unaltered, raw.

--- a/docs/cmdline-opts/referer.d
+++ b/docs/cmdline-opts/referer.d
@@ -11,11 +11,10 @@ Example: --referer "https://fake.example" $URL
 Example: --referer "https://fake.example;auto" -L $URL
 Example: --referer ";auto" -L $URL
 Added: 4.0
+Multi: single
 ---
 Sends the "Referrer Page" information to the HTTP server. This can also be set
 with the --header flag of course. When used with --location you can append
 ";auto" to the --referer URL to make curl automatically set the previous URL
 when it follows a Location: header. The ";auto" string can be used alone,
 even if you do not set an initial --referer.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/remote-header-name.d
+++ b/docs/cmdline-opts/remote-header-name.d
@@ -8,6 +8,7 @@ Category: output
 Example: -OJ https://example.com/file
 Added: 7.20.0
 See-also: remote-name
+Multi: boolean
 ---
 This option tells the --remote-name option to use the server-specified
 Content-Disposition filename instead of extracting a filename from the URL. If

--- a/docs/cmdline-opts/remote-name-all.d
+++ b/docs/cmdline-opts/remote-name-all.d
@@ -6,6 +6,7 @@ Added: 7.19.0
 Category: output
 Example: --remote-name-all ftp://example.com/file1 ftp://example.com/file2
 See-also: remote-name
+Multi: boolean
 ---
 This option changes the default action for all given URLs to be dealt with as
 if --remote-name were used for each one. So if you want to disable that for a

--- a/docs/cmdline-opts/remote-name.d
+++ b/docs/cmdline-opts/remote-name.d
@@ -7,6 +7,7 @@ Category: important output
 Example: -O https://example.com/filename
 Added: 4.0
 See-also: remote-name-all output-dir remote-header-name
+Multi: append
 ---
 Write output to a local file named like the remote file we get. (Only the file
 part of the remote file is used, the path is cut off.)

--- a/docs/cmdline-opts/remote-time.d
+++ b/docs/cmdline-opts/remote-time.d
@@ -7,6 +7,7 @@ Category: output
 Example: --remote-time -o foo $URL
 Added: 7.9
 See-also: remote-name time-cond
+Multi: boolean
 ---
 When used, this will make curl attempt to figure out the timestamp of the
 remote file, and if that is available make the local file get that same

--- a/docs/cmdline-opts/remove-on-error.d
+++ b/docs/cmdline-opts/remove-on-error.d
@@ -6,6 +6,7 @@ See-also: fail
 Category: curl
 Example: --remove-on-error -o output $URL
 Added: 7.83.0
+Multi: boolean
 ---
 When curl returns an error when told to save output in a local file, this
 option removes that saved file before exiting. This prevents curl from

--- a/docs/cmdline-opts/request-target.d
+++ b/docs/cmdline-opts/request-target.d
@@ -8,6 +8,7 @@ Added: 7.55.0
 Category: http
 Example: --request-target "*" -X OPTIONS $URL
 See-also: request
+Multi: single
 ---
 Tells curl to use an alternative "target" (path) instead of using the path as
 provided in the URL. Particularly useful when wanting to issue HTTP requests

--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -9,6 +9,7 @@ Example: -X "DELETE" $URL
 Example: -X NLST ftp://example.com/
 Added: 6.0
 See-also: request-target
+Multi: single
 ---
 (HTTP) Specifies a custom request method to use when communicating with the
 HTTP server. The specified request method will be used instead of the method
@@ -42,5 +43,3 @@ Specifies a custom IMAP command to use instead of LIST. (Added in 7.30.0)
 
 (SMTP)
 Specifies a custom SMTP command to use instead of HELP or VRFY. (Added in 7.34.0)
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/resolve.d
+++ b/docs/cmdline-opts/resolve.d
@@ -7,6 +7,7 @@ Added: 7.21.3
 Category: connection dns
 Example: --resolve example.com:443:127.0.0.1 $URL
 See-also: connect-to alt-svc
+Multi: append
 ---
 Provide a custom address for a specific host and port pair. Using this, you
 can make the curl requests(s) use a specified address and prevent the

--- a/docs/cmdline-opts/retry-all-errors.d
+++ b/docs/cmdline-opts/retry-all-errors.d
@@ -6,6 +6,7 @@ Added: 7.71.0
 Category: curl
 Example: --retry 5 --retry-all-errors $URL
 See-also: retry
+Multi: boolean
 ---
 Retry on any error. This option is used together with --retry.
 

--- a/docs/cmdline-opts/retry-connrefused.d
+++ b/docs/cmdline-opts/retry-connrefused.d
@@ -6,6 +6,7 @@ Added: 7.52.0
 Category: curl
 Example: --retry-connrefused --retry $URL
 See-also: retry retry-all-errors
+Multi: boolean
 ---
 In addition to the other conditions, consider ECONNREFUSED as a transient
 error too for --retry. This option is used together with --retry.

--- a/docs/cmdline-opts/retry-delay.d
+++ b/docs/cmdline-opts/retry-delay.d
@@ -7,10 +7,9 @@ Added: 7.12.3
 Category: curl
 Example: --retry-delay 5 --retry $URL
 See-also: retry
+Multi: single
 ---
 Make curl sleep this amount of time before each retry when a transfer has
 failed with a transient error (it changes the default backoff time algorithm
 between retries). This option is only interesting if --retry is also
 used. Setting this delay to zero will make curl use the default backoff time.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/retry-max-time.d
+++ b/docs/cmdline-opts/retry-max-time.d
@@ -7,6 +7,7 @@ Added: 7.12.3
 Category: curl
 Example: --retry-max-time 30 --retry 10 $URL
 See-also: retry
+Multi: single
 ---
 The retry timer is reset before the first transfer attempt. Retries will be
 done as usual (see --retry) as long as the timer has not reached this given
@@ -14,5 +15,3 @@ limit. Notice that if the timer has not reached the limit, the request will be
 made and while performing, it may take longer than this given time period. To
 limit a single request's maximum time, use --max-time. Set this option to
 zero to not timeout retries.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/retry.d
+++ b/docs/cmdline-opts/retry.d
@@ -7,6 +7,7 @@ Help: Retry request if transient problems occur
 Category: curl
 Example: --retry 7 $URL
 See-also: retry-max-time
+Multi: single
 ---
 If a transient error is returned when curl tries to perform a transfer, it
 will retry this number of times before giving up. Setting the number to 0
@@ -22,5 +23,3 @@ using --retry-delay you disable this exponential backoff algorithm. See also
 
 Since curl 7.66.0, curl will comply with the Retry-After: response header if
 one was present to know when to issue the next retry.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/sasl-authzid.d
+++ b/docs/cmdline-opts/sasl-authzid.d
@@ -7,6 +7,7 @@ Added: 7.66.0
 Category: auth
 Example: --sasl-authzid zid imap://example.com/
 See-also: login-options
+Multi: single
 ---
 Use this authorization identity (authzid), during SASL PLAIN authentication,
 in addition to the authentication identity (authcid) as specified by --user.

--- a/docs/cmdline-opts/sasl-ir.d
+++ b/docs/cmdline-opts/sasl-ir.d
@@ -6,5 +6,6 @@ Added: 7.31.0
 Category: auth
 Example: --sasl-ir imap://example.com/
 See-also: sasl-authzid
+Multi: boolean
 ---
 Enable initial response in SASL authentication.

--- a/docs/cmdline-opts/service-name.d
+++ b/docs/cmdline-opts/service-name.d
@@ -7,6 +7,7 @@ Added: 7.43.0
 Category: misc
 Example: --service-name sockd/server $URL
 See-also: negotiate proxy-service-name
+Multi: single
 ---
 This option allows you to change the service name for SPNEGO.
 

--- a/docs/cmdline-opts/show-error.d
+++ b/docs/cmdline-opts/show-error.d
@@ -7,6 +7,7 @@ See-also: no-progress-meter
 Category: curl
 Example: --show-error --silent $URL
 Added: 5.9
+Multi: boolean
 ---
 When used with --silent, it makes curl show an error message if it fails.
 

--- a/docs/cmdline-opts/silent.d
+++ b/docs/cmdline-opts/silent.d
@@ -7,6 +7,7 @@ See-also: verbose stderr no-progress-meter
 Category: important verbose
 Example: -s $URL
 Added: 4.0
+Multi: boolean
 ---
 Silent or quiet mode. Do not show progress meter or error messages. Makes Curl
 mute. It will still output the data you ask for, potentially even to the

--- a/docs/cmdline-opts/socks4.d
+++ b/docs/cmdline-opts/socks4.d
@@ -7,6 +7,7 @@ Added: 7.15.2
 Category: proxy
 Example: --socks4 hostname:4096 $URL
 See-also: socks4a socks5 socks5-hostname
+Multi: single
 ---
 Use the specified SOCKS4 proxy. If the port number is not specified, it is
 assumed at port 1080. Using this socket type make curl resolve the host name
@@ -24,5 +25,3 @@ using a socks4:// protocol prefix. (Added in 7.21.7)
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to
 the SOCKS proxy and then connects (through SOCKS) to the HTTP or HTTPS proxy.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/socks4a.d
+++ b/docs/cmdline-opts/socks4a.d
@@ -7,6 +7,7 @@ Added: 7.18.0
 Category: proxy
 Example: --socks4a hostname:4096 $URL
 See-also: socks4 socks5 socks5-hostname
+Multi: single
 ---
 Use the specified SOCKS4a proxy. If the port number is not specified, it is
 assumed at port 1080. This asks the proxy to resolve the host name.
@@ -23,5 +24,3 @@ using a socks4a:// protocol prefix. (Added in 7.21.7)
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to
 the SOCKS proxy and then connects (through SOCKS) to the HTTP or HTTPS proxy.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/socks5-basic.d
+++ b/docs/cmdline-opts/socks5-basic.d
@@ -6,6 +6,7 @@ Added: 7.55.0
 Category: proxy auth
 Example: --socks5-basic --socks5 hostname:4096 $URL
 See-also: socks5
+Multi: mutex
 ---
 Tells curl to use username/password authentication when connecting to a SOCKS5
 proxy.  The username/password authentication is enabled by default.  Use

--- a/docs/cmdline-opts/socks5-gssapi-nec.d
+++ b/docs/cmdline-opts/socks5-gssapi-nec.d
@@ -6,6 +6,7 @@ Added: 7.19.4
 Category: proxy auth
 Example: --socks5-gssapi-nec --socks5 hostname:4096 $URL
 See-also: socks5
+Multi: boolean
 ---
 As part of the GSS-API negotiation a protection mode is negotiated. RFC 1961
 says in section 4.3/4.4 it should be protected, but the NEC reference

--- a/docs/cmdline-opts/socks5-gssapi-service.d
+++ b/docs/cmdline-opts/socks5-gssapi-service.d
@@ -7,6 +7,7 @@ Added: 7.19.4
 Category: proxy auth
 Example: --socks5-gssapi-service sockd --socks5 hostname:4096 $URL
 See-also: socks5
+Multi: single
 ---
 The default service name for a socks server is rcmd/server-fqdn. This option
 allows you to change it.

--- a/docs/cmdline-opts/socks5-gssapi.d
+++ b/docs/cmdline-opts/socks5-gssapi.d
@@ -6,6 +6,7 @@ Added: 7.55.0
 Category: proxy auth
 Example: --socks5-gssapi --socks5 hostname:4096 $URL
 See-also: socks5
+Multi: boolean
 ---
 Tells curl to use GSS-API authentication when connecting to a SOCKS5 proxy.
 The GSS-API authentication is enabled by default (if curl is compiled with

--- a/docs/cmdline-opts/socks5-hostname.d
+++ b/docs/cmdline-opts/socks5-hostname.d
@@ -7,6 +7,7 @@ Added: 7.18.0
 Category: proxy
 Example: --socks5-hostname proxy.example:7000 $URL
 See-also: socks5 socks4a
+Multi: single
 ---
 Use the specified SOCKS5 proxy (and let the proxy resolve the host name). If
 the port number is not specified, it is assumed at port 1080.
@@ -23,5 +24,3 @@ This option is superfluous since you can specify a socks5 hostname proxy with
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to
 the SOCKS proxy and then connects (through SOCKS) to the HTTP or HTTPS proxy.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/socks5.d
+++ b/docs/cmdline-opts/socks5.d
@@ -7,6 +7,7 @@ Added: 7.18.0
 Category: proxy
 Example: --socks5 proxy.example:7000 $URL
 See-also: socks5-hostname socks4a
+Multi: single
 ---
 Use the specified SOCKS5 proxy - but resolve the host name locally. If the
 port number is not specified, it is assumed at port 1080.
@@ -23,7 +24,5 @@ using a socks5:// protocol prefix. (Added in 7.21.7)
 Since 7.52.0, --preproxy can be used to specify a SOCKS proxy at the same time
 --proxy is used with an HTTP/HTTPS proxy. In such a case curl first connects to
 the SOCKS proxy and then connects (through SOCKS) to the HTTP or HTTPS proxy.
-
-If this option is used several times, the last one will be used.
 
 This option (as well as --socks4) does not work with IPV6, FTPS or LDAP.

--- a/docs/cmdline-opts/speed-limit.d
+++ b/docs/cmdline-opts/speed-limit.d
@@ -8,9 +8,8 @@ Category: connection
 Example: --speed-limit 300 --speed-time 10 $URL
 Added: 4.7
 See-also: speed-time limit-rate max-time
+Multi: single
 ---
 If a transfer is slower than this given speed (in bytes per second) for
 speed-time seconds it gets aborted. speed-time is set with --speed-time and is
 30 if not set.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/speed-time.d
+++ b/docs/cmdline-opts/speed-time.d
@@ -8,6 +8,7 @@ Category: connection
 Example: --speed-limit 300 --speed-time 10 $URL
 Added: 4.7
 See-also: speed-limit limit-rate
+Multi: single
 ---
 If a transfer runs slower than speed-limit bytes per second during a speed-time
 period, the transfer is aborted. If speed-time is used, the default
@@ -15,5 +16,3 @@ speed-limit will be 1 unless set with --speed-limit.
 
 This option controls transfers (in both directions) but will not affect slow
 connects etc. If this is a concern for you, try the --connect-timeout option.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/ssl-allow-beast.d
+++ b/docs/cmdline-opts/ssl-allow-beast.d
@@ -6,6 +6,7 @@ Added: 7.25.0
 Category: tls
 Example: --ssl-allow-beast $URL
 See-also: proxy-ssl-allow-beast insecure
+Multi: boolean
 ---
 This option tells curl to not work around a security flaw in the SSL3 and
 TLS1.0 protocols known as BEAST.  If this option is not used, the SSL layer

--- a/docs/cmdline-opts/ssl-auto-client-cert.d
+++ b/docs/cmdline-opts/ssl-auto-client-cert.d
@@ -6,6 +6,7 @@ Added: 7.77.0
 See-also: proxy-ssl-auto-client-cert
 Category: tls
 Example: --ssl-auto-client-cert $URL
+Multi: boolean
 ---
 Tell libcurl to automatically locate and use a client certificate for
 authentication, when requested by the server. This option is only supported

--- a/docs/cmdline-opts/ssl-no-revoke.d
+++ b/docs/cmdline-opts/ssl-no-revoke.d
@@ -6,6 +6,7 @@ Added: 7.44.0
 Category: tls
 Example: --ssl-no-revoke $URL
 See-also: crlfile
+Multi: boolean
 ---
 (Schannel) This option tells curl to disable certificate revocation checks.
 WARNING: this option loosens the SSL security, and by using this flag you ask

--- a/docs/cmdline-opts/ssl-reqd.d
+++ b/docs/cmdline-opts/ssl-reqd.d
@@ -7,6 +7,7 @@ Added: 7.20.0
 Category: tls
 Example: --ssl-reqd ftp://example.com
 See-also: ssl insecure
+Multi: boolean
 ---
 Require SSL/TLS for the connection. Terminates the connection if the server
 does not support SSL/TLS.

--- a/docs/cmdline-opts/ssl-revoke-best-effort.d
+++ b/docs/cmdline-opts/ssl-revoke-best-effort.d
@@ -6,6 +6,7 @@ Added: 7.70.0
 Category: tls
 Example: --ssl-revoke-best-effort $URL
 See-also: crlfile insecure
+Multi: boolean
 ---
 (Schannel) This option tells curl to ignore certificate revocation checks when
 they failed due to missing/offline distribution points for the revocation check

--- a/docs/cmdline-opts/ssl.d
+++ b/docs/cmdline-opts/ssl.d
@@ -7,6 +7,7 @@ Added: 7.20.0
 Category: tls
 Example: --ssl pop3://example.com/
 See-also: ssl-reqd insecure ciphers
+Multi: boolean
 ---
 Warning: this is considered an insecure option. Consider using --ssl-reqd
 instead to be sure curl upgrades to a secure connection.

--- a/docs/cmdline-opts/sslv2.d
+++ b/docs/cmdline-opts/sslv2.d
@@ -11,6 +11,7 @@ See-also: http1.1 http2
 Help: Use SSLv2
 Category: tls
 Example: --sslv2 $URL
+Multi: mutex
 ---
 This option previously asked curl to use SSLv2, but starting in curl 7.77.0
 this instruction is ignored. SSLv2 is widely considered insecure (see RFC

--- a/docs/cmdline-opts/sslv3.d
+++ b/docs/cmdline-opts/sslv3.d
@@ -11,6 +11,7 @@ See-also: http1.1 http2
 Help: Use SSLv3
 Category: tls
 Example: --sslv3 $URL
+Multi: mutex
 ---
 This option previously asked curl to use SSLv3, but starting in curl 7.77.0
 this instruction is ignored. SSLv3 is widely considered insecure (see RFC

--- a/docs/cmdline-opts/stderr.d
+++ b/docs/cmdline-opts/stderr.d
@@ -7,11 +7,10 @@ See-also: verbose silent
 Category: verbose
 Example: --stderr output.txt $URL
 Added: 6.2
+Multi: single
 ---
 Redirect all writes to stderr to the specified file instead. If the file name
 is a plain '-', it is instead written to stdout.
 
 This option is global and does not need to be specified for each use of
 --next.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/styled-output.d
+++ b/docs/cmdline-opts/styled-output.d
@@ -6,6 +6,7 @@ Added: 7.61.0
 Category: verbose
 Example: --styled-output -I $URL
 See-also: head verbose
+Multi: boolean
 ---
 Enables the automatic use of bold font styles when writing HTTP headers to the
 terminal. Use --no-styled-output to switch them off.

--- a/docs/cmdline-opts/suppress-connect-headers.d
+++ b/docs/cmdline-opts/suppress-connect-headers.d
@@ -6,6 +6,7 @@ See-also: dump-header include proxytunnel
 Category: proxy
 Example: --suppress-connect-headers --include -x proxy $URL
 Added: 7.54.0
+Multi: boolean
 ---
 When --proxytunnel is used and a CONNECT request is made do not output proxy
 CONNECT response headers. This option is meant to be used with --dump-header or

--- a/docs/cmdline-opts/tcp-fastopen.d
+++ b/docs/cmdline-opts/tcp-fastopen.d
@@ -6,5 +6,6 @@ Help: Use TCP Fast Open
 Category: connection
 Example: --tcp-fastopen $URL
 See-also: false-start
+Multi: boolean
 ---
 Enable use of TCP Fast Open (RFC7413).

--- a/docs/cmdline-opts/tcp-nodelay.d
+++ b/docs/cmdline-opts/tcp-nodelay.d
@@ -6,6 +6,7 @@ Added: 7.11.2
 Category: connection
 Example: --tcp-nodelay $URL
 See-also: no-buffer
+Multi: boolean
 ---
 Turn on the TCP_NODELAY option. See the *curl_easy_setopt(3)* man page for
 details about this option.

--- a/docs/cmdline-opts/telnet-option.d
+++ b/docs/cmdline-opts/telnet-option.d
@@ -8,6 +8,7 @@ Category: telnet
 Example: -t TTYPE=vt100 telnet://example.com/
 Added: 7.7
 See-also: config
+Multi: append
 ---
 Pass options to the telnet protocol. Supported options are:
 

--- a/docs/cmdline-opts/tftp-blksize.d
+++ b/docs/cmdline-opts/tftp-blksize.d
@@ -8,9 +8,8 @@ Added: 7.20.0
 Category: tftp
 Example: --tftp-blksize 1024 tftp://example.com/file
 See-also: tftp-no-options
+Multi: single
 ---
 Set TFTP BLKSIZE option (must be >512). This is the block size that curl will
 try to use when transferring data to or from a TFTP server. By default 512
 bytes will be used.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/tftp-no-options.d
+++ b/docs/cmdline-opts/tftp-no-options.d
@@ -7,6 +7,7 @@ Added: 7.48.0
 Category: tftp
 Example: --tftp-no-options tftp://192.168.0.1/
 See-also: tftp-blksize
+Multi: boolean
 ---
 Tells curl not to send TFTP options requests.
 

--- a/docs/cmdline-opts/time-cond.d
+++ b/docs/cmdline-opts/time-cond.d
@@ -11,6 +11,7 @@ Example: -z "-Wed 01 Sep 2021 12:18:00" $URL
 Example: -z file $URL
 Added: 5.8
 See-also: etag-compare remote-time
+Multi: single
 ---
 Request a file that has been modified later than the given time and date, or
 one that has been modified before that time. The <date expression> can be all
@@ -21,5 +22,3 @@ instead. See the *curl_getdate(3)* man pages for date expression details.
 Start the date expression with a dash (-) to make it request for a document
 that is older than the given date/time, default is a document that is newer
 than the specified date/time.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/tls-max.d
+++ b/docs/cmdline-opts/tls-max.d
@@ -11,6 +11,7 @@ Help: Set maximum allowed TLS version
 Category: tls
 Example: --tls-max 1.2 $URL
 Example: --tls-max 1.3 --tlsv1.2 $URL
+Multi: single
 ---
 VERSION defines maximum supported TLS version. The minimum acceptable version
 is set by tlsv1.0, tlsv1.1, tlsv1.2 or tlsv1.3.

--- a/docs/cmdline-opts/tls13-ciphers.d
+++ b/docs/cmdline-opts/tls13-ciphers.d
@@ -8,6 +8,7 @@ Category: tls
 Example: --tls13-ciphers TLS_AES_128_GCM_SHA256 $URL
 Added: 7.61.0
 See-also: ciphers curves
+Multi: single
 ---
 Specifies which cipher suites to use in the connection if it negotiates TLS
 1.3. The list of ciphers suites must specify valid ciphers. Read up on TLS 1.3
@@ -18,5 +19,3 @@ cipher suite details on this URL:
 This option is currently used only when curl is built to use OpenSSL 1.1.1 or
 later. If you are using a different SSL backend you can try setting TLS 1.3
 cipher suites by using the --ciphers option.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/tlsauthtype.d
+++ b/docs/cmdline-opts/tlsauthtype.d
@@ -7,6 +7,7 @@ Added: 7.21.4
 Category: tls auth
 Example: --tlsauthtype SRP $URL
 See-also: tlsuser
+Multi: single
 ---
 Set TLS authentication type. Currently, the only supported option is "SRP",
 for TLS-SRP (RFC 5054). If --tlsuser and --tlspassword are specified but

--- a/docs/cmdline-opts/tlspassword.d
+++ b/docs/cmdline-opts/tlspassword.d
@@ -7,6 +7,7 @@ Added: 7.21.4
 Category: tls auth
 Example: --tlspassword pwd --tlsuser user $URL
 See-also: tlsuser
+Multi: single
 ---
 Set password for use with the TLS authentication method specified with
 --tlsauthtype. Requires that --tlsuser also be set.

--- a/docs/cmdline-opts/tlsuser.d
+++ b/docs/cmdline-opts/tlsuser.d
@@ -7,6 +7,7 @@ Added: 7.21.4
 Category: tls auth
 Example: --tlspassword pwd --tlsuser user $URL
 See-also: tlspassword
+Multi: single
 ---
 Set username for use with the TLS authentication method specified with
 --tlsauthtype. Requires that --tlspassword also is set.

--- a/docs/cmdline-opts/tlsv1.0.d
+++ b/docs/cmdline-opts/tlsv1.0.d
@@ -7,6 +7,7 @@ Added: 7.34.0
 Category: tls
 Example: --tlsv1.0 $URL
 See-also: tlsv1.3
+Multi: mutex
 ---
 Forces curl to use TLS version 1.0 or later when connecting to a remote TLS server.
 

--- a/docs/cmdline-opts/tlsv1.1.d
+++ b/docs/cmdline-opts/tlsv1.1.d
@@ -7,6 +7,7 @@ Added: 7.34.0
 Category: tls
 Example: --tlsv1.1 $URL
 See-also: tlsv1.3 tls-max
+Multi: mutex
 ---
 Forces curl to use TLS version 1.1 or later when connecting to a remote TLS server.
 

--- a/docs/cmdline-opts/tlsv1.2.d
+++ b/docs/cmdline-opts/tlsv1.2.d
@@ -7,6 +7,7 @@ Added: 7.34.0
 Category: tls
 Example: --tlsv1.2 $URL
 See-also: tlsv1.3 tls-max
+Multi: mutex
 ---
 Forces curl to use TLS version 1.2 or later when connecting to a remote TLS server.
 

--- a/docs/cmdline-opts/tlsv1.3.d
+++ b/docs/cmdline-opts/tlsv1.3.d
@@ -7,6 +7,7 @@ Added: 7.52.0
 Category: tls
 Example: --tlsv1.3 $URL
 See-also: tlsv1.2 tls-max
+Multi: mutex
 ---
 Forces curl to use TLS version 1.3 or later when connecting to a remote TLS
 server.

--- a/docs/cmdline-opts/tlsv1.d
+++ b/docs/cmdline-opts/tlsv1.d
@@ -11,6 +11,7 @@ See-also: http1.1 http2
 Help: Use TLSv1.0 or greater
 Category: tls
 Example: --tlsv1 $URL
+Multi: mutex
 ---
 Tells curl to use at least TLS version 1.x when negotiating with a remote TLS
 server. That means TLS version 1.0 or higher

--- a/docs/cmdline-opts/tr-encoding.d
+++ b/docs/cmdline-opts/tr-encoding.d
@@ -7,6 +7,7 @@ Protocols: HTTP
 Category: http
 Example: --tr-encoding $URL
 See-also: compressed
+Multi: boolean
 ---
 Request a compressed Transfer-Encoding response using one of the algorithms
 curl supports, and uncompress the data while receiving it.

--- a/docs/cmdline-opts/trace-ascii.d
+++ b/docs/cmdline-opts/trace-ascii.d
@@ -8,6 +8,7 @@ Category: verbose
 Example: --trace-ascii log.txt $URL
 Added: 7.9.7
 See-also: verbose trace
+Multi: single
 ---
 Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have
@@ -19,5 +20,3 @@ for untrained humans.
 
 This option is global and does not need to be specified for each use of
 --next.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/trace-time.d
+++ b/docs/cmdline-opts/trace-time.d
@@ -6,6 +6,7 @@ Added: 7.14.0
 Category: verbose
 Example: --trace-time --trace-ascii output $URL
 See-also: trace verbose
+Multi: boolean
 ---
 Prepends a time stamp to each trace or verbose line that curl displays.
 

--- a/docs/cmdline-opts/trace.d
+++ b/docs/cmdline-opts/trace.d
@@ -8,6 +8,7 @@ Category: verbose
 Example: --trace log.txt $URL
 Added: 7.9.7
 See-also: trace-ascii trace-time
+Multi: single
 ---
 Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have
@@ -16,5 +17,3 @@ stderr.
 
 This option is global and does not need to be specified for each use of
 --next.
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/unix-socket.d
+++ b/docs/cmdline-opts/unix-socket.d
@@ -8,5 +8,6 @@ Protocols: HTTP
 Category: connection
 See-also: abstract-unix-socket
 Example: --unix-socket socket-path $URL
+Multi: single
 ---
 Connect through this Unix domain socket, instead of using the network.

--- a/docs/cmdline-opts/upload-file.d
+++ b/docs/cmdline-opts/upload-file.d
@@ -10,6 +10,7 @@ Example: -T "img[1-1000].png" ftp://ftp.example.com/
 Example: --upload-file "{file1,file2}" $URL
 Added: 4.0
 See-also: get head
+Multi: append
 ---
 This transfers the specified local file to the remote URL. If there is no file
 part in the specified URL, curl will append the local file name. NOTE that you

--- a/docs/cmdline-opts/url.d
+++ b/docs/cmdline-opts/url.d
@@ -7,6 +7,7 @@ Category: curl
 Example: --url $URL
 Added: 7.5
 See-also: next config
+Multi: append
 ---
 Specify a URL to fetch. This option is mostly handy when you want to specify
 URL(s) in a config file.
@@ -17,8 +18,8 @@ name matches DICT, FTP, IMAP, LDAP, POP3 or SMTP then that protocol will be
 used, otherwise HTTP will be used. Since 7.45.0 guessing can be disabled by
 setting a default protocol, see --proto-default for details.
 
-This option may be used any number of times. To control where this URL is
-written, use the --output or the --remote-name options.
+To control where this URL is written, use the --output or the --remote-name
+options.
 
 **WARNING**: On Windows, particular file:// accesses can be converted to
 network accesses by the operating system. Beware!

--- a/docs/cmdline-opts/use-ascii.d
+++ b/docs/cmdline-opts/use-ascii.d
@@ -8,6 +8,7 @@ Category: misc
 Example: -B ftp://example.com/README
 Added: 5.0
 See-also: crlf data-ascii
+Multi: boolean
 ---
 Enable ASCII transfer. For FTP, this can also be enforced by using a URL that
 ends with ";type=A". This option causes data sent to stdout to be in text mode

--- a/docs/cmdline-opts/user-agent.d
+++ b/docs/cmdline-opts/user-agent.d
@@ -9,6 +9,7 @@ Category: important http
 Example: -A "Agent 007" $URL
 Added: 4.5.1
 See-also: header proxy-header
+Multi: single
 ---
 Specify the User-Agent string to send to the HTTP server. To encode blanks in
 the string, surround the string with single quote marks. This header can also
@@ -17,5 +18,3 @@ be set with the --header or the --proxy-header options.
 If you give an empty argument to --user-agent (""), it will remove the header
 completely from the request. If you prefer a blank header, you can set it to a
 single space (" ").
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/user.d
+++ b/docs/cmdline-opts/user.d
@@ -8,6 +8,7 @@ Category: important auth
 Example: -u user:secret $URL
 Added: 4.0
 See-also: netrc config
+Multi: single
 ---
 Specify the user name and password to use for server authentication. Overrides
 --netrc and --netrc-optional.
@@ -41,5 +42,3 @@ If you use a Windows SSPI-enabled curl binary and perform Kerberos V5,
 Negotiate, NTLM or Digest authentication then you can tell curl to select
 the user name and password from your environment by specifying a single colon
 with this option: "-u :".
-
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/verbose.d
+++ b/docs/cmdline-opts/verbose.d
@@ -8,6 +8,7 @@ See-also: include
 Category: important verbose
 Example: --verbose $URL
 Added: 4.0
+Multi: boolean
 ---
 Makes curl verbose during the operation. Useful for debugging and seeing
 what's going on "under the hood". A line starting with '>' means "header data"

--- a/docs/cmdline-opts/version.d
+++ b/docs/cmdline-opts/version.d
@@ -7,6 +7,7 @@ Category: important curl
 Example: --version
 Added: 4.0
 See-also: help manual
+Multi: boolean
 ---
 Displays information about curl and the libcurl version it uses.
 

--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -8,6 +8,7 @@ Category: verbose
 Example: -w '%{http_code}\\n' $URL
 Added: 6.5
 See-also: verbose head
+Multi: single
 ---
 Make curl display information on stdout after a completed transfer. The format
 is a string that may contain plain text mixed with any number of
@@ -206,4 +207,3 @@ The URL that was fetched last. This is most meaningful if you have told curl
 to follow location: headers.
 .RE
 .IP
-If this option is used several times, the last one will be used.

--- a/docs/cmdline-opts/xattr.d
+++ b/docs/cmdline-opts/xattr.d
@@ -6,6 +6,7 @@ Category: misc
 Example: --xattr -o storage $URL
 Added: 7.21.3
 See-also: remote-time write-out verbose
+Multi: boolean
 ---
 When saving output to a file, this option tells curl to store certain file
 metadata in extended file attributes. Currently, the URL is stored in the


### PR DESCRIPTION
The keyword specifies how option works when specified multiple times:

 - single: the last provided value replaces the earlier ones
 - append: it supports being provided multiple times
 - boolean: on/off values
 - mutex: flag-like option that disable anoter flag

The 'gen.pl' script then outputs the proper and unified language for each option's multi-use behavior in the generated man page.

The multi: header is requires in each .d file and will cause build error if missing or set to an unknown value.