### PR TITLE
hostip: guard PF_INET6 use

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -303,8 +303,10 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
     bool found = false;
     struct Curl_addrinfo *addr = dns->addr;
 
+#ifdef PF_INET6
     if(data->conn->ip_version == CURL_IPRESOLVE_V6)
       pf = PF_INET6;
+#endif
 
     while(addr) {
       if(addr->ai_family == pf) {


### PR DESCRIPTION
Some platforms (e.g. Amiga OS) do not have `PF_INET6`. Adjust the code for these.

```
hostip.c: In function 'fetch_addr':
hostip.c:308:12: error: 'PF_INET6' undeclared (first use in this function)
       pf = PF_INET6;
            ^~~~~~~~
```

Regression from 1902e8fc511078fb5e26fc2b907b4cce77e1240d

Closes #xxxx