### PR TITLE
amiga: do not hardcode openssl/zlib into the os configuration [ci skip]

### DIFF
--- a/lib/config-amigaos.h
+++ b/lib/config-amigaos.h
@@ -36,7 +36,6 @@
 #define HAVE_INTTYPES_H 1
 #define HAVE_IOCTLSOCKET_CAMEL 1
 #define HAVE_IOCTLSOCKET_CAMEL_FIONBIO 1
-#define HAVE_LIBZ 1
 #define HAVE_LONGLONG 1
 #define HAVE_NETDB_H 1
 #define HAVE_NETINET_IN_H 1
@@ -73,7 +72,6 @@
 #define SIZEOF_SIZE_T 4
 
 #define USE_MANUAL 1
-#define USE_OPENSSL 1
 #define CURL_DISABLE_LDAP 1
 
 #define OS "AmigaOS"

--- a/lib/makefile.amiga
+++ b/lib/makefile.amiga
@@ -31,7 +31,7 @@ ATCPSDKI= /GG/netinclude
 
 
 CC = m68k-amigaos-gcc
-CFLAGS = -I$(ATCPSDKI) -m68020-60 -O2 -msoft-float -noixemul -g -I. -I../include -W -Wall
+CFLAGS = -I$(ATCPSDKI) -m68020-60 -O2 -msoft-float -noixemul -g -I. -I../include -W -Wall -DUSE_OPENSSL -DHAVE_LIBZ
 
 include Makefile.inc
 OBJS = $(CSOURCES:.c=.o)

--- a/src/makefile.amiga
+++ b/src/makefile.amiga
@@ -31,7 +31,7 @@ ATCPSDKI= /GG/netinclude
 
 
 CC = m68k-amigaos-gcc
-CFLAGS  = -I$(ATCPSDKI) -m68020-60 -O2 -msoft-float -noixemul -g -I. -I../include -W -Wall
+CFLAGS  = -I$(ATCPSDKI) -m68020-60 -O2 -msoft-float -noixemul -g -I. -I../include -W -Wall -DUSE_OPENSSL -DHAVE_LIBZ
 LIBS    = ../lib/libcurl.a -lssl -lcrypto -lz
 MANPAGE = ../docs/curl.1
 README  = ../docs/MANUAL


### PR DESCRIPTION
Enable them in `lib/makefile.amiga` and `src/makefile.amiga` instead.

This allows builds without openssl and/or zlib. E.g. with the https://github.com/bebbo/amiga-gcc cross-compiler.

Closes #xxxx