### PR TITLE
urlapi: fix parsing URL without slash with CURLU_URLENCODE

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -119,8 +119,10 @@ static const char *find_host_sep(const char *url)
  * Decide in an encoding-independent manner whether a character in a URL must
  * be escaped. This is used in urlencode_str().
  */
-#define urlchar_needs_escaping(c)               \
-  !(ISCNTRL(c) || ISSPACE(c) || ISGRAPH(c))
+static bool urlchar_needs_escaping(int c)
+{
+  return !(ISCNTRL(c) || ISSPACE(c) || ISGRAPH(c));
+}
 
 /* urlencode_str() writes data into an output dynbuf and URL-encodes the
  * spaces in the source URL accordingly.

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -849,6 +849,14 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
 }
 
 static const struct redircase set_url_list[] = {
+  {"http://local.test?redirect=http://local.test:80?-321",
+   "http://local.test:80?-123",
+   "http://local.test:80/?-123",
+   0, CURLU_URLENCODE|CURLU_ALLOW_SPACE, CURLUE_OK},
+  {"http://local.test?redirect=http://local.test:80?-321",
+   "http://local.test:80?-123",
+   "http://local.test:80/?-123",
+   0, 0, CURLUE_OK},
   {"http://example.org/static/favicon/wikipedia.ico",
    "//fake.example.com/licenses/by-sa/3.0/",
    "http://fake.example.com/licenses/by-sa/3.0/",

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -138,6 +138,12 @@ struct clearurlcase {
 };
 
 static const struct testcase get_parts_list[] ={
+  {"https://user@example.net?he l lo",
+   "https | user | [12] | [13] | example.net | [15] | / | he+l+lo | [17]",
+   CURLU_ALLOW_SPACE, CURLU_URLENCODE, CURLUE_OK},
+  {"https://user@example.net?he l lo",
+   "https | user | [12] | [13] | example.net | [15] | / | he l lo | [17]",
+   CURLU_ALLOW_SPACE, 0, CURLUE_OK},
   {"https://exam{}[]ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam{ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam}ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
@@ -849,6 +855,10 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
 }
 
 static const struct redircase set_url_list[] = {
+  {"http://example.com/please/../gimme/%TESTNUMBER?foobar#hello",
+   "http://example.net/there/it/is/../../tes t case=/%TESTNUMBER0002? yes no",
+   "http://example.net/there/tes%20t%20case=/%TESTNUMBER0002?+yes+no",
+   0, CURLU_URLENCODE|CURLU_ALLOW_SPACE, CURLUE_OK},
   {"http://local.test?redirect=http://local.test:80?-321",
    "http://local.test:80?-123",
    "http://local.test:80/?-123",


### PR DESCRIPTION
When CURLU_URLENCODE is set, the parser would mistreat the path component if the URL was specified without a slash like in http://local.test:80?-123

Extended test 1560 to reproduce and verify the fix.

Reported-by: Trail of Bits