### PR TITLE
CI: report AppVeyor build status for each job

### DIFF
--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -1,0 +1,39 @@
+# Copyright (C) 2000 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: AppVeyor Status Report
+
+on:
+  status
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.sha }}-${{ github.event.target_url }}
+  cancel-in-progress: true
+
+permissions:
+  statuses: write
+
+jobs:
+  split:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.sender.login == 'appveyor[bot]' }}
+    steps:
+      - name: Create individual AppVeyor build statuses
+        if: ${{ github.event.sha && github.event.target_url }}
+        env:
+          APPVEYOR_COMMIT_SHA: ${{ github.event.sha }}
+          APPVEYOR_TARGET_URL: ${{ github.event.target_url }}
+          APPVEYOR_REPOSITORY: ${{ github.event.repository.full_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo ${APPVEYOR_TARGET_URL} | sed 's/\/project\//\/api\/projects\//' | xargs -t -n1 curl -s | \
+            jq -c '.build.jobs[] | {target_url: (($target_url | sub("s\\/\\d+"; "/job/")) + .jobId),
+                                    context: (.name | sub("^(Environment: )?"; "AppVeyor / ")),
+                                    state: (.status | sub("queued"; "pending")
+                                                    | sub("running"; "pending")
+                                                    | sub("failed"; "failure")
+                                                    | sub("cancelled"; "error")),
+                                    description: .status}' \
+                --arg target_url ${APPVEYOR_TARGET_URL} | parallel --pipe -j 1 -N 1 \
+              gh api --silent --input - repos/${APPVEYOR_REPOSITORY}/statuses/${APPVEYOR_COMMIT_SHA}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ version: 7.50.0.{build}
 environment:
     matrix:
       # generated CMake-based Visual Studio Release builds
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "CMake, VS2008, Release x86, Schannel"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 9 2008"
         PRJ_CFG: Release
@@ -38,7 +39,8 @@ environment:
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "CMake, VS2022, Release x64, OpenSSL, WebSockets"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
@@ -51,7 +53,8 @@ environment:
         SHARED: ON
         DISABLED_TESTS: ""
         WEBSOCKETS: ON
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "CMake, VS2022, Release arm64, Schannel, Static"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A ARM64"
@@ -64,7 +67,8 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: ""
       # generated CMake-based Visual Studio Debug builds
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "CMake, VS2010, Debug x64, no SSL, Static"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 10 2010 Win64"
         PRJ_CFG: Debug
@@ -76,7 +80,8 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501 ~1056"
         ADD_PATH: "C:\\msys64\\usr\\bin"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "CMake, VS2022, Debug x64, Schannel, Static, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
@@ -89,7 +94,8 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501 ~1056"
         ADD_PATH: "C:\\msys64\\usr\\bin"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "CMake, VS2022, Debug x64, no SSL, Static"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
@@ -102,7 +108,8 @@ environment:
         SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501 ~1056"
         ADD_PATH: "C:\\msys64\\usr\\bin"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "CMake, VS2022, Debug x64, no SSL, Static, HTTP only"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
@@ -116,7 +123,8 @@ environment:
         DISABLED_TESTS: "!1139 !1501 ~1056"
         ADD_PATH: "C:\\msys64\\usr\\bin"
       # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "CMake, mingw-w64, Debug x64, Schannel, Static, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
@@ -130,7 +138,8 @@ environment:
         ADD_PATH: "C:\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "CMake, mingw-w64, Debug x64, Schannel, Static, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
@@ -144,7 +153,8 @@ environment:
         ADD_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "CMake, mingw-w64, Debug x86, Schannel, Static"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
@@ -158,7 +168,8 @@ environment:
         ADD_PATH: "C:\\mingw-w64\\i686-6.3.0-posix-dwarf-rt_v5-rev1\\mingw32\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "CMake, mingw, Debug x86, no SSL, Static"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
@@ -173,81 +184,94 @@ environment:
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
       # winbuild-based builds
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "winbuild, VS2015, Debug"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: winbuild_vs2015
         DEBUG: yes
         PATHPART: debug
         TESTING: OFF
         ENABLE_UNICODE: no
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "winbuild, VS2015, Release"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: winbuild_vs2015
         DEBUG: no
         PATHPART: release
         TESTING: OFF
         ENABLE_UNICODE: no
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "winbuild, VS2017, Debug"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: winbuild_vs2017
         DEBUG: yes
         PATHPART: debug
         TESTING: OFF
         ENABLE_UNICODE: no
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "winbuild, VS2017, Release"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: winbuild_vs2017
         DEBUG: no
         PATHPART: release
         TESTING: OFF
         ENABLE_UNICODE: no
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "winbuild, VS2015, Debug, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: winbuild_vs2015
         DEBUG: yes
         PATHPART: debug
         TESTING: OFF
         ENABLE_UNICODE: yes
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      - job_name: "winbuild, VS2015, Release, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: winbuild_vs2015
         DEBUG: no
         PATHPART: release
         TESTING: OFF
         ENABLE_UNICODE: yes
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "winbuild, VS2017, Debug, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: winbuild_vs2017
         DEBUG: yes
         PATHPART: debug
         TESTING: OFF
         ENABLE_UNICODE: yes
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "winbuild, VS2017, Release, Unicode"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: winbuild_vs2017
         DEBUG: no
         PATHPART: release
         TESTING: OFF
         ENABLE_UNICODE: yes
       # generated VisualStudioSolution-based builds
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "VisualStudioSolution, VS2017, Debug"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: VisualStudioSolution
         PRJ_CFG: "DLL Debug - DLL Windows SSPI - DLL WinIDN"
         TESTING: OFF
         VC_VERSION: VC14.10
       # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "autotools, msys2, Debug, no Proxy, no SSL"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 ~1056 !1233"
         ADD_PATH: "C:\\msys64\\usr\\bin"
         CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy --without-ssl --enable-websockets"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "autotools, msys2, Debug, no SSL"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
         ADD_PATH: "C:\\msys64\\usr\\bin"
         CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets"
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      - job_name: "autotools, msys2, Release, no SSL"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "!19 !504 !704 !705 ~1056 !1233"
         ADD_PATH: "C:\\msys64\\usr\\bin"
         CONFIG_ARGS: "--enable-warnings --enable-werror --without-ssl --enable-websockets"
       # autotools-based Cygwin build
-      - APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      - job_name: "autotools, cygwin, Debug, no SSL"
+        APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: autotools
         TESTING: ON
         DISABLED_TESTS: "~1056"


### PR DESCRIPTION
Also give each job on AppVeyor CI a human-readable name.

This aims to make job and therefore build failures more visible.

--
Example status split can be seen in: https://github.com/mback2k/curl/commit/a537d729222d02f49192b510c52181638b26b81a
![image](https://user-images.githubusercontent.com/231943/196667036-1cfbdadf-0455-47de-a1a3-ea3607e4f70e.png)

New job names can be seen here: https://ci.appveyor.com/project/mback2k/curl/builds/45109026
![image](https://user-images.githubusercontent.com/231943/196667208-3f800752-2d4f-47c5-bcb4-e5e6a2c49e62.png)
