### PR TITLE
urlapi: remove two variable assigns

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1160,8 +1160,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
         }
-        qlen = Curl_dyn_len(&enc);
-        query = u->query = Curl_dyn_ptr(&enc);
+        u->query = Curl_dyn_ptr(&enc);
       }
       else {
         u->query = Curl_memdup(query + 1, qlen);


### PR DESCRIPTION
To please scan-build:

urlapi.c:1163:9: warning: Value stored to 'qlen' is never read
        qlen = Curl_dyn_len(&enc);
        ^      ~~~~~~~~~~~~~~~~~~
urlapi.c:1164:9: warning: Value stored to 'query' is never read
        query = u->query = Curl_dyn_ptr(&enc);
        ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Follow-up to 7d6cf06f571d57