### PR TITLE
noproxy: fix builds without AF_INET6

### DIFF
--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -70,6 +70,7 @@ UNITTEST bool Curl_cidr6_match(const char *ipv6,
                                const char *network,
                                unsigned int bits)
 {
+#ifdef ENABLE_IPV6
   int bytes;
   int rest;
   unsigned char address[16];
@@ -92,6 +93,9 @@ UNITTEST bool Curl_cidr6_match(const char *ipv6,
     return FALSE;
 
   return TRUE;
+#else
+  return FALSE;
+#endif
 }
 
 enum nametype {


### PR DESCRIPTION
Regression from 1e9a538e05c0107c54ef81d9de7cd0b27cd13309

Closes #xxxx

---

This fixes the build error, but it's not necessarily the best fallback.
