### PR TITLE
docs: make sure libcurl opts examples pass in long arguments

### DIFF
--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
@@ -52,7 +52,8 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);
 
   /* If-Modified-Since the above time stamp */
-  curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
+  curl_easy_setopt(curl, CURLOPT_TIMECONDITION,
+                   (long)CURL_TIMECOND_IFMODSINCE);
 
   /* Perform the request */
   res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.3
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.3
@@ -75,7 +75,7 @@ HTTPS
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1);
+  curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, (long)CURLALTSVC_H1);
   curl_easy_setopt(curl, CURLOPT_ALTSVC, "altsvc-cache.txt");
   curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.3
@@ -54,7 +54,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/file.txt");
   curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_TRY);
   /* funny server, ask for SSL before TLS */
-  curl_easy_setopt(curl, CURLOPT_FTPSSLAUTH, CURLFTPAUTH_SSL);
+  curl_easy_setopt(curl, CURLOPT_FTPSSLAUTH, (long)CURLFTPAUTH_SSL);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.3
@@ -66,7 +66,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/non-existing/new.txt");
   curl_easy_setopt(curl, CURLOPT_FTP_CREATE_MISSING_DIRS,
-                         CURLFTP_CREATE_DIR_RETRY);
+                   (long)CURLFTP_CREATE_DIR_RETRY);
 
   ret = curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.3
@@ -60,7 +60,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/1/2/3/4/new.txt");
   curl_easy_setopt(curl, CURLOPT_FTP_FILEMETHOD,
-                         CURLFTPMETHOD_SINGLECWD);
+                   (long)CURLFTPMETHOD_SINGLECWD);
 
   ret = curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.3
@@ -55,7 +55,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/file.txt");
   curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_CONTROL);
   /* go back to clear-text FTP after authenticating */
-  curl_easy_setopt(curl, CURLOPT_FTP_SSL_CCC, CURLFTPSSL_CCC_ACTIVE);
+  curl_easy_setopt(curl, CURLOPT_FTP_SSL_CCC, (long)CURLFTPSSL_CCC_ACTIVE);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.3
+++ b/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.3
@@ -51,7 +51,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
   /* delegate if okayed by policy */
   curl_easy_setopt(curl, CURLOPT_GSSAPI_DELEGATION,
-                         CURLGSSAPI_DELEGATION_POLICY_FLAG);
+                   (long)CURLGSSAPI_DELEGATION_POLICY_FLAG);
   ret = curl_easy_perform(curl);
 }
 .fi

--- a/docs/libcurl/opts/CURLOPT_HSTS_CTRL.3
+++ b/docs/libcurl/opts/CURLOPT_HSTS_CTRL.3
@@ -57,7 +57,7 @@ HTTPS and HTTP
 .nf
 CURL *curl = curl_easy_init();
 if(curl) {
-  curl_easy_setopt(curl, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
+  curl_easy_setopt(curl, CURLOPT_HSTS_CTRL, (long)CURLHSTS_ENABLE);
   curl_easy_perform(curl);
 }
 .fi

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.3
@@ -114,7 +114,7 @@ if(curl) {
   CURLcode ret;
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
   /* allow whatever auth the server speaks */
-  curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
   curl_easy_setopt(curl, CURLOPT_USERPWD, "james:bond");
   ret = curl_easy_perform(curl);
 }

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
@@ -85,7 +85,8 @@ CURL *curl = curl_easy_init();
 if(curl) {
   CURLcode ret;
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-  curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
+  curl_easy_setopt(curl, CURLOPT_HTTP_VERSION,
+                   (long)CURL_HTTP_VERSION_2TLS);
   ret = curl_easy_perform(curl);
   if(ret == CURLE_HTTP_RETURNED_ERROR) {
     /* an HTTP response error problem */

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.3
@@ -52,7 +52,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_PROXY, "socks5://user:pass@myproxy.com");
 
   /* enable username/password authentication only */
-  curl_easy_setopt(curl, CURLOPT_SOCKS5_AUTH, CURLAUTH_BASIC);
+  curl_easy_setopt(curl, CURLOPT_SOCKS5_AUTH, (long)CURLAUTH_BASIC);
 
   /* Perform the request */
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -99,7 +99,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
   /* ask libcurl to use TLS version 1.0 or later */
-  curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+  curl_easy_setopt(curl, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1);
 
   /* Perform the request */
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -82,7 +82,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
   /* weaken TLS only for use with silly servers */
-  curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_ALLOW_BEAST |
+  curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_ALLOW_BEAST |
                    CURLSSLOPT_NO_REVOKE);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
@@ -55,7 +55,8 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);
 
   /* If-Modified-Since the above time stamp */
-  curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
+  curl_easy_setopt(curl, CURLOPT_TIMECONDITION,
+                   (long)CURL_TIMECOND_IFMODSINCE);
 
   /* Perform the request */
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.3
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.3
@@ -59,7 +59,7 @@ if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/dir/file.ext");
 
   /* require use of SSL for this, or fail */
-  curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL);
+  curl_easy_setopt(curl, CURLOPT_USE_SSL, (long)CURLUSESSL_ALL);
 
   /* Perform the request */
   curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.3
@@ -56,7 +56,7 @@ CURL *curl = curl_easy_init();
 if(curl) {
   curl_easy_setopt(curl, CURLOPT_URL, "ws://example.com/");
   /* tell curl we deal with all the WebSocket magic ourselves */
-  curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, CURLWS_RAW_MODE);
+  curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, (long)CURLWS_RAW_MODE);
   ret = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 }


### PR DESCRIPTION
Reported-by: Sergey
Fixes #9779