### PR TITLE
windows: fail early with a missing windres in autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -570,7 +570,13 @@ CURL_DARWIN_CFLAGS
 CURL_DARWIN_SYSTEMCONFIGURATION
 CURL_SUPPORTS_BUILTIN_AVAILABLE
 
-AM_CONDITIONAL([OS_WINDOWS], [test "$curl_cv_native_windows" = "yes"])
+AM_CONDITIONAL([HAVE_WINDRES],
+  [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])
+
+if test "$curl_cv_native_windows" = "yes"; then
+  AM_COND_IF([HAVE_WINDRES],,
+    [AC_MSG_ERROR([windres not found in PATH. Windows builds require windres. Cannot continue.])])
+fi
 
 dnl ************************************************************
 dnl switch off particular protocols

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -109,7 +109,7 @@ endif
 if USE_CPPFLAG_CURL_STATICLIB
 libcurl_la_CPPFLAGS_EXTRA += -DCURL_STATICLIB
 else
-if OS_WINDOWS
+if HAVE_WINDRES
 libcurl_la_SOURCES += $(LIB_RCFILES)
 $(LIB_RCFILES): $(top_srcdir)/include/curl/curlver.h
 endif
@@ -154,7 +154,7 @@ tidy:
 optiontable:
 	perl optiontable.pl < $(top_srcdir)/include/curl/curl.h > easyoptions.c
 
-if OS_WINDOWS
+if HAVE_WINDRES
 .rc.lo:
 	$(LIBTOOL) --tag=RC --mode=compile $(RC) -I$(top_srcdir)/include $(RCFLAGS) -i $< -o $@
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -55,7 +55,7 @@ include Makefile.inc
 
 # CURL_FILES comes from Makefile.inc
 curl_SOURCES = $(CURL_FILES)
-if OS_WINDOWS
+if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)
 $(CURL_RCFILES): tool_version.h
 endif
@@ -156,7 +156,7 @@ tidy:
 listhelp:
 	(cd $(top_srcdir)/docs/cmdline-opts && ./gen.pl listhelp *.d) > tool_listhelp.c
 
-if OS_WINDOWS
+if HAVE_WINDRES
 .rc.o:
 	$(RC) -I$(top_srcdir)/include -DCURL_EMBED_MANIFEST $(RCFLAGS) -i $< -o $@
 endif


### PR DESCRIPTION
`windres` is not always auto-detected by autotools when building for Windows. When this happened, the build failed with a confusing error due to the empty `RC` command:

```
/bin/bash ../libtool --tag=RC --mode=compile  -I../include -DCURL_EMBED_MANIFEST  -i curl.rc -o curl.o
[...]
Usage: /sandbox/curl/libtool [OPTION]... [MODE-ARG]...
Try 'libtool --help' for more information.
libtool:   error: unrecognised option: '-I../include'
```

Improve this by verifying if `RC` is set, and fail with a clear error otherwise.

Follow-up to 6de7322c03d5b4d91576a7d9fc893e03cc9d1057

Ref: https://curl.se/mail/lib-2022-10/0049.html
Reported-by: Thomas Glanzmann
Closes #9781
