### PR TITLE
noproxy: silence unused variable warnings with no ipv6

### DIFF
--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -94,6 +94,9 @@ UNITTEST bool Curl_cidr6_match(const char *ipv6,
 
   return TRUE;
 #else
+  (void)ipv6;
+  (void)network;
+  (void)bits;
   return FALSE;
 #endif
 }
@@ -213,4 +216,3 @@ bool Curl_check_noproxy(const char *name, const char *no_proxy)
 }
 
 #endif /* CURL_DISABLE_PROXY */
-


### PR DESCRIPTION
Follow-up to 36474f1050c7f4117e3c8de6cc9217cfebfc717d

Closes #xxxx