### PR TITLE
Makefile.m32: reintroduce CROSSPREFIX and -W -Wall [ci skip]

### DIFF
--- a/lib/Makefile.m32
+++ b/lib/Makefile.m32
@@ -29,7 +29,7 @@
 #
 # Set component roots via envvar <feature>_PATH. Also available for
 # customization: CC, RC, AR, CPPFLAGS, LDFLAGS, LIBS, CFLAGS, RCFLAGS,
-# ARCH[=custom], CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX,
+# ARCH[=custom], CROSSPREFIX, CURL_LDFLAGS_BIN, CURL_LDFLAGS_LIB, CURL_DLL_SUFFIX,
 # and more for individual components (see below).
 
 # This script is reused by 'src' and 'docs/examples' Makefile.m32 scripts.
@@ -75,6 +75,10 @@ endif
 
 CPPFLAGS += -I. -I$(PROOT)/include
 RCFLAGS  += -I$(PROOT)/include
+
+CC := $(CROSSPREFIX)$(CC)
+AR := $(CROSSPREFIX)$(AR)
+RC ?= $(CROSSPREFIX)windres
 
 ifneq ($(ARCH),custom)
   # Set environment var ARCH to your architecture to override auto-detection.
@@ -302,8 +306,6 @@ endif
 
 ### Global rules
 
-RC ?= windres
-
 ifneq ($(findstring /sh,$(SHELL)),)
 DEL  = rm -f $1
 COPY = -cp -afv $1 $2
@@ -315,7 +317,7 @@ endif
 all: $(TARGETS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+	$(CC) -W -Wall $(CFLAGS) $(CPPFLAGS) -c $<
 
 %.res: %.rc
 	$(RC) -O coff $(RCFLAGS) -i $< -o $@


### PR DESCRIPTION
- Reintroduce `CROSSPREFIX`:

  If set, we add it to the `CC` and `AR` values, and to the _default_ value of `RC`, which is `windres`. This allows to control each of these individidually, while also allowing to simplify configuration via `CROSSPREFIX`.

  This variable worked differently earlier. Hopefully this new solution hits a better compromise in usefulness/complexity/flexibility.

  Follow-up to: aa970c4c08775afcd0c2853be89b0a6f02582d50

- Enable warnings again:

  This time with an option to override it via `CFLAGS`. Warnings are also enabled by default in CMake, `makefile.dj` and `makefile.amiga` builds (not in autotools though).

  Follow-up to 10fbd8b4e3f83b967fd9ad9a41ab484c0e7e7ca3

Closes #xxxx