### PR TITLE
ci: bump to gcc-11 for macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -129,8 +129,8 @@ jobs:
         - CC: clang
           CXX: clang++
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-deprecated-declarations"
-        - CC: gcc-9
-          CXX: g++-9
+        - CC: gcc-11
+          CXX: g++-11
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"
         build:
         - name: OpenSSL


### PR DESCRIPTION
Ref: https://github.blog/changelog/2022-10-03-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-12/
Ref: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

Closes #xxxx
