### PR TITLE
noproxy: include netinet/in.h for htonl()

### DIFF
--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -30,6 +30,10 @@
 #include "strcase.h"
 #include "noproxy.h"
 
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+
 /*
  * Curl_cidr4_match() returns TRUE if the given IPv4 address is within the
  * specified CIDR address range.


### PR DESCRIPTION
Solve the Amiga build warning by including `netinet/in.h`.

`krb5.c` and `socketpair.c` are using `htonl()` too. This header is already included in those sources.

Closes #9787
