### PR TITLE
netrc: replace fgets with Curl_get_line

### DIFF
--- a/lib/curl_get_line.c
+++ b/lib/curl_get_line.c
@@ -25,7 +25,7 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC) ||  \
-  !defined(CURL_DISABLE_HSTS)
+  !defined(CURL_DISABLE_HSTS) || !defined(CURL_DISABLE_NETRC)
 
 #include "curl_get_line.h"
 #include "curl_memory.h"
@@ -33,8 +33,8 @@
 #include "memdebug.h"
 
 /*
- * get_line() makes sure to only return complete whole lines that fit in 'len'
- * bytes and end with a newline.
+ * Curl_get_line() makes sure to only return complete whole lines that fit in
+ * 'len' bytes and end with a newline.
  */
 char *Curl_get_line(char *buf, int len, FILE *input)
 {

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -33,6 +33,7 @@
 #include "netrc.h"
 #include "strtok.h"
 #include "strcase.h"
+#include "curl_get_line.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -82,7 +83,7 @@ static int parsenetrc(const char *host,
     char netrcbuffer[4096];
     int  netrcbuffsize = (int)sizeof(netrcbuffer);
 
-    while(!done && fgets(netrcbuffer, netrcbuffsize, file)) {
+    while(!done && Curl_get_line(netrcbuffer, netrcbuffsize, file)) {
       char *tok;
       char *tok_end;
       bool quoted;
@@ -241,7 +242,7 @@ static int parsenetrc(const char *host,
         } /* switch (state) */
         tok = ++tok_end;
       }
-    } /* while fgets() */
+    } /* while Curl_get_line() */
 
     out:
     if(!retcode) {


### PR DESCRIPTION
Make the parser only accept complete lines and avoid problems with overly long lines.

Reported-by: Hiroki Kurosawa