### PR TITLE
Various typo and grammar fixes in non-code files

### DIFF
--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -148,7 +148,7 @@ changes.
 
 ### About pull requests
 
-With github it is easy to send a [pull
+With GitHub it is easy to send a [pull
 request](https://github.com/curl/curl/pulls) to the curl project to have
 changes merged.
 

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -10,7 +10,7 @@ Experimental support in curl means:
    "carved in stone".
 2. You must enable the feature when invoking configure as otherwise curl will
    not be built with the feature present.
-3. We strongly advice against using this feature in production.
+3. We strongly advise against using this feature in production.
 4. **We reserve the right to change behavior** of the feature without sticking
    to our API/ABI rules as we do for regular features, as long as it is marked
    experimental.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -158,7 +158,7 @@ When you are merging patches/pull requests...
 - squash patch sets into a few logical commits even if the PR did not, if
   necessary
 - avoid the "merge" button on GitHub, do it "manually" instead to get full
-  control and full audit trail (github leaves out you as "Committer:")
+  control and full audit trail (GitHub leaves out you as "Committer:")
 - remember to credit the reporter and the helpers.
 
 ## Who are maintainers?

--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -9,7 +9,7 @@ Hyper support in curl is considered **EXPERIMENTAL** until further notice. It
 needs to be explicitly enabled at build-time.
 
 Further development and tweaking of the Hyper backend support in curl will
-happen in in the master branch using pull-requests, just like ordinary
+happen in the master branch using pull-requests, just like ordinary
 changes.
 
 ## Hyper version

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -164,7 +164,7 @@ problems may have been fixed or changed somewhat since this was written.
  18. HTTP/3
  18.1 If the HTTP/3 server closes connection during upload curl hangs
  18.2 Transfer closed with n bytes remaining to read
- 18.4 timeout when reusing a http3 connection
+ 18.4 timeout when reusing an http3 connection
  18.9 connection migration does not work
 
 ==============================================================================
@@ -1159,7 +1159,7 @@ problems may have been fixed or changed somewhat since this was written.
 
  https://github.com/curl/curl/issues/8523
 
-18.4 timeout when reusing a http3 connection
+18.4 timeout when reusing an http3 connection
 
  HTTP/3 with quiche seems to not work and always timeout a subsequent transfer
  that reuses an already established connection

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -649,7 +649,7 @@ which of them to use. Default address can also be used:
     curl -P - ftp.download.com
 
 Download with `PORT` but use the IP address of our `le0` interface (this does
-not work on windows):
+not work on Windows):
 
     curl -P le0 ftp.download.com
 
@@ -829,7 +829,7 @@ The usage of the `-x`/`--proxy` flag overrides the environment variables.
 Unix introduced the `.netrc` concept a long time ago. It is a way for a user
 to specify name and password for commonly visited FTP sites in a file so that
 you do not have to type them in each time you visit those sites. You realize
-this is a big security risk if someone else gets hold of your passwords, so
+this is a big security risk if someone else gets hold of your passwords,
 therefore most Unix programs will not read this file unless it is only readable
 by yourself (curl does not care though).
 

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -1,6 +1,6 @@
 # Rustls
 
-[Rustls is a TLS backend written in Rust.](https://docs.rs/rustls/). Curl can
+[Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
 version of curl depends on version v0.8.2 of rustls-ffi.

--- a/docs/SSL-PROBLEMS.md
+++ b/docs/SSL-PROBLEMS.md
@@ -66,7 +66,7 @@
 
   Schannel in Windows XP is not able to connect to servers that no longer
   support the legacy handshakes and algorithms used by those versions, so we
-  advice against building curl to use Schannel on really old Windows versions.
+  advise against building curl to use Schannel on really old Windows versions.
 
   Reference: [Prohibiting RC4 Cipher
   Suites](https://datatracker.ietf.org/doc/html/draft-popov-tls-prohibiting-rc4-01)

--- a/docs/WEBSOCKET.md
+++ b/docs/WEBSOCKET.md
@@ -17,7 +17,7 @@ WebSocket with libcurl can be done two ways.
    of it).
 
 2. Set `CURLOPT_CONNECT_ONLY` to 2L (new for WebSocket), which makes libcurl
-   do a HTTP GET + `Upgrade:` request plus response in the
+   do an HTTP GET + `Upgrade:` request plus response in the
    `curl_easy_perform()` call before it returns and then you can use
    `curl_ws_recv()` and `curl_ws_send()` to receive and send WebSocket frames
    from and to the server.

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -44,7 +44,7 @@
 #endif
 
 /*
- * This example shows a HTTP PUT operation with authentication using "any"
+ * This example shows an HTTP PUT operation with authentication using "any"
  * type. It PUTs a file given as a command line argument to the URL also given
  * on the command line.
  *

--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -22,7 +22,7 @@
  *
  ***************************************************************************/
 /* <DESC>
- * CA cert in memory with OpenSSL to get a HTTPS page.
+ * CA cert in memory with OpenSSL to get an HTTPS page.
  * </DESC>
  */
 

--- a/docs/examples/http-post.c
+++ b/docs/examples/http-post.c
@@ -40,7 +40,7 @@ int main(void)
   curl = curl_easy_init();
   if(curl) {
     /* First set the URL that is about to receive our POST. This URL can
-       just as well be a https:// URL if that is what should receive the
+       just as well be an https:// URL if that is what should receive the
        data. */
     curl_easy_setopt(curl, CURLOPT_URL, "http://postit.example.com/moo.cgi");
     /* Now specify the POST data */

--- a/docs/examples/httpput-postfields.c
+++ b/docs/examples/httpput-postfields.c
@@ -43,7 +43,7 @@ static const char olivertwist[]=
    509 byte limit. */
 
 /*
- * This example shows a HTTP PUT operation that sends a fixed buffer with
+ * This example shows an HTTP PUT operation that sends a fixed buffer with
  * CURLOPT_POSTFIELDS to the URL given as an argument.
  */
 

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -31,7 +31,7 @@
 #include <curl/curl.h>
 
 /*
- * This example shows a HTTP PUT operation. PUTs a file given as a command
+ * This example shows an HTTP PUT operation. PUTs a file given as a command
  * line argument to the URL also given on the command line.
  *
  * This example also uses its own read callback.

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -38,7 +38,7 @@
 #include <curl/curl.h>
 
 /*
- * Download a HTTP file and upload an FTP file simultaneously.
+ * Download an HTTP file and upload an FTP file simultaneously.
  */
 
 #define HANDLECOUNT 2   /* Number of simultaneous transfers */

--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -126,7 +126,7 @@ int my_trace(CURL *handle, curl_infotype type,
 }
 
 /*
- * Simply download a HTTP file.
+ * Simply download an HTTP file.
  */
 int main(void)
 {

--- a/docs/examples/multi-legacy.c
+++ b/docs/examples/multi-legacy.c
@@ -38,7 +38,7 @@
 #include <curl/curl.h>
 
 /*
- * Download a HTTP file and upload an FTP file simultaneously.
+ * Download an HTTP file and upload an FTP file simultaneously.
  */
 
 #define HANDLECOUNT 2   /* Number of simultaneous transfers */

--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -37,7 +37,7 @@
 #include <curl/curl.h>
 
 /*
- * Simply download a HTTP file.
+ * Simply download an HTTP file.
  */
 int main(void)
 {

--- a/docs/examples/post-callback.c
+++ b/docs/examples/post-callback.c
@@ -101,7 +101,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
     /*
-      If you use POST to a HTTP 1.1 server, you can send data without knowing
+      If you use POST to an HTTP 1.1 server, you can send data without knowing
       the size before starting the POST if you use chunked encoding. You
       enable this by adding a header like "Transfer-Encoding: chunked" with
       CURLOPT_HTTPHEADER. With HTTP 1.0 or without chunked transfer, you must

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -22,7 +22,7 @@
  *
  ***************************************************************************/
 /* <DESC>
- * Make a HTTP POST with data from memory and receive response in memory.
+ * Make an HTTP POST with data from memory and receive response in memory.
  * </DESC>
  */
 #include <stdio.h>

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1286,7 +1286,7 @@ typedef enum {
   /* size of the POST input data, if strlen() is not good to use */
   CURLOPT(CURLOPT_POSTFIELDSIZE, CURLOPTTYPE_LONG, 60),
 
-  /* tunnel non-http operations through a HTTP proxy */
+  /* tunnel non-http operations through an HTTP proxy */
   CURLOPT(CURLOPT_HTTPPROXYTUNNEL, CURLOPTTYPE_LONG, 61),
 
   /* Set the interface string to use as outgoing network interface */
@@ -1864,7 +1864,7 @@ typedef enum {
   /* Enable/disable TLS ALPN extension (http2 over ssl might fail without) */
   CURLOPT(CURLOPT_SSL_ENABLE_ALPN, CURLOPTTYPE_LONG, 226),
 
-  /* Time to wait for a response to a HTTP request containing an
+  /* Time to wait for a response to an HTTP request containing an
    * Expect: 100-continue header before sending the data anyway. */
   CURLOPT(CURLOPT_EXPECT_100_TIMEOUT_MS, CURLOPTTYPE_LONG, 227),
 

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -245,7 +245,7 @@ static int hyper_body_chunk(void *userdata, const hyper_buf *chunk)
 }
 
 /*
- * Hyper does not consider the status line, the first line in a HTTP/1
+ * Hyper does not consider the status line, the first line in an HTTP/1
  * response, to be a header. The libcurl API does. This function sends the
  * status line in the header callback. */
 static CURLcode status_line(struct Curl_easy *data,
@@ -740,7 +740,7 @@ static int uploadstreamed(void *userdata, hyper_context *ctx,
 }
 
 /*
- * bodysend() sets up headers in the outgoing request for a HTTP transfer that
+ * bodysend() sets up headers in the outgoing request for an HTTP transfer that
  * sends a body
  */
 
@@ -845,7 +845,7 @@ static void http1xx_cb(void *arg, struct hyper_response *resp)
 }
 
 /*
- * Curl_http() gets called from the generic multi_do() function when a HTTP
+ * Curl_http() gets called from the generic multi_do() function when an HTTP
  * request is to be performed. This creates and sends a properly constructed
  * HTTP request.
  */

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -515,7 +515,7 @@ Curl_cookie_add(struct Curl_easy *data,
     return NULL; /* bail out if we're this low on memory */
 
   if(httpheader) {
-    /* This line was read off a HTTP-header */
+    /* This line was read off an HTTP-header */
     char name[MAX_NAME];
     char what[MAX_NAME];
     const char *ptr;
@@ -864,7 +864,7 @@ Curl_cookie_add(struct Curl_easy *data,
   }
   else {
     /*
-     * This line is NOT a HTTP header style line, we do offer support for
+     * This line is NOT an HTTP header style line, we do offer support for
      * reading the odd netscape cookies-file format here
      */
     char *ptr;

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -385,7 +385,7 @@ CURLcode Curl_output_ntlm_wb(struct Curl_easy *data, struct connectdata *conn,
                              bool proxy)
 {
   /* point to the address of the pointer that holds the string to send to the
-     server, which is for a plain host or for a HTTP proxy */
+     server, which is for a plain host or for an HTTP proxy */
   char **allocuserpwd;
   /* point to the name and password for this */
   const char *userp;

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -59,7 +59,7 @@
  *
  * AddHttpPost()
  *
- * Adds a HttpPost structure to the list, if parent_post is given becomes
+ * Adds an HttpPost structure to the list, if parent_post is given becomes
  * a subpost of parent_post instead of a direct list element.
  *
  * Returns newly allocated HttpPost on success and NULL if malloc failed.
@@ -199,7 +199,7 @@ static struct FormInfo *AddFormInfo(char *value,
  * CURL_FORMADD_MEMORY         if the allocation of a FormInfo struct failed
  * CURL_FORMADD_UNKNOWN_OPTION if an unknown option was used
  * CURL_FORMADD_INCOMPLETE     if the some FormInfo is not complete (or error)
- * CURL_FORMADD_MEMORY         if a HttpPost struct cannot be allocated
+ * CURL_FORMADD_MEMORY         if an HttpPost struct cannot be allocated
  * CURL_FORMADD_MEMORY         if some allocation for string copying failed.
  * CURL_FORMADD_ILLEGAL_ARRAY  if an illegal option is used in an array
  *

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2092,7 +2092,7 @@ static CURLcode ftp_state_mdtm_resp(struct Curl_easy *data,
 
 #ifdef CURL_FTP_HTTPSTYLE_HEAD
       /* If we asked for a time of the file and we actually got one as well,
-         we "emulate" a HTTP-style header in our output. */
+         we "emulate" an HTTP-style header in our output. */
 
       if(data->set.opt_no_body &&
          ftpc->file &&

--- a/lib/h2h3.c
+++ b/lib/h2h3.c
@@ -36,7 +36,7 @@
 
 /*
  * Curl_pseudo_headers() creates the array with pseudo headers to be
- * used in a HTTP/2 or HTTP/3 request.
+ * used in an HTTP/2 or HTTP/3 request.
  */
 
 #if defined(USE_NGHTTP2) || defined(ENABLE_QUIC)

--- a/lib/h2h3.h
+++ b/lib/h2h3.h
@@ -45,7 +45,7 @@ struct h2h3req {
 
 /*
  * Curl_pseudo_headers() creates the array with pseudo headers to be
- * used in a HTTP/2 or HTTP/3 request. Returns an allocated struct.
+ * used in an HTTP/2 or HTTP/3 request. Returns an allocated struct.
  * Free it with Curl_pseudo_free().
  */
 CURLcode Curl_pseudo_headers(struct Curl_easy *data,

--- a/lib/http.c
+++ b/lib/http.c
@@ -1241,7 +1241,7 @@ static size_t readmoredata(char *buffer,
     /* nothing to return */
     return 0;
 
-  /* make sure that a HTTP request is never sent away chunked! */
+  /* make sure that an HTTP request is never sent away chunked! */
   data->req.forbidchunk = (http->sending == HTTPSEND_REQUEST)?TRUE:FALSE;
 
   if(data->set.max_send_speed &&
@@ -3027,14 +3027,14 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
   if(data->set.timecondition && !data->state.range) {
     /* A time condition has been set AND no ranges have been requested. This
        seems to be what chapter 13.3.4 of RFC 2616 defines to be the correct
-       action for a HTTP/1.1 client */
+       action for an HTTP/1.1 client */
 
     if(!Curl_meets_timecondition(data, k->timeofdoc)) {
       *done = TRUE;
-      /* We're simulating a http 304 from server so we return
+      /* We're simulating an HTTP 304 from server so we return
          what should have been returned from the server */
       data->info.httpcode = 304;
-      infof(data, "Simulate a HTTP 304 response");
+      infof(data, "Simulate an HTTP 304 response");
       /* we abort the transfer before it is completed == we ruin the
          re-use ability. Close the connection */
       streamclose(conn, "Simulated 304 handling");
@@ -3080,7 +3080,7 @@ CURLcode Curl_transferencode(struct Curl_easy *data)
 
 #ifndef USE_HYPER
 /*
- * Curl_http() gets called from the generic multi_do() function when a HTTP
+ * Curl_http() gets called from the generic multi_do() function when an HTTP
  * request is to be performed. This creates and sends a properly constructed
  * HTTP request.
  */
@@ -3140,7 +3140,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
       }
     }
     else {
-      /* prepare for a http2 request */
+      /* prepare for an http2 request */
       result = Curl_http2_setup(data, conn);
       if(result)
         return result;
@@ -3497,7 +3497,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
                              STRCONST("Proxy-Connection:"),
                              STRCONST("keep-alive"))) {
     /*
-     * When a HTTP/1.0 reply comes when using a proxy, the
+     * When an HTTP/1.0 reply comes when using a proxy, the
      * 'Proxy-Connection: keep-alive' line tells us the
      * connection will be kept alive for our pleasure.
      * Default action for 1.0 is to close.
@@ -3511,7 +3511,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
                              STRCONST("Proxy-Connection:"),
                              STRCONST("close"))) {
     /*
-     * We get a HTTP/1.1 response from a proxy and it says it'll
+     * We get an HTTP/1.1 response from a proxy and it says it'll
      * close down after this transfer.
      */
     connclose(conn, "Proxy-Connection: asked to close after done");
@@ -3523,7 +3523,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
                              STRCONST("Connection:"),
                              STRCONST("keep-alive"))) {
     /*
-     * A HTTP/1.0 reply with the 'Connection: keep-alive' line
+     * An HTTP/1.0 reply with the 'Connection: keep-alive' line
      * tells us the connection will be kept alive for our
      * pleasure.  Default action for 1.0 is to close.
      *
@@ -4012,7 +4012,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
         switch(k->httpcode) {
         case 100:
           /*
-           * We have made a HTTP PUT or POST and this is 1.1-lingo
+           * We have made an HTTP PUT or POST and this is 1.1-lingo
            * that tells us that the server is OK with this and ready
            * to receive the data.
            * However, we'll get more headers now so we must get

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -109,7 +109,7 @@ static int http2_getsock(struct Curl_easy *data,
   sock[0] = conn->sock[FIRSTSOCKET];
 
   if(!(k->keepon & KEEP_RECV_PAUSE))
-    /* Unless paused - in a HTTP/2 connection we can basically always get a
+    /* Unless paused - in an HTTP/2 connection we can basically always get a
        frame so we should always be ready for one */
     bitmap |= GETSOCK_READSOCK(FIRSTSOCKET);
 
@@ -1120,7 +1120,7 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
 
   /* nghttp2 guarantees that namelen > 0, and :status was already
      received, and this is not pseudo-header field . */
-  /* convert to a HTTP1-style header */
+  /* convert to an HTTP1-style header */
   result = Curl_dyn_addn(&stream->header_recvbuf, name, namelen);
   if(result)
     return NGHTTP2_ERR_CALLBACK_FAILURE;
@@ -1351,7 +1351,7 @@ static CURLcode http2_init(struct Curl_easy *data, struct connectdata *conn)
 }
 
 /*
- * Append headers to ask for a HTTP1.1 to HTTP2 upgrade.
+ * Append headers to ask for an HTTP1.1 to HTTP2 upgrade.
  */
 CURLcode Curl_http2_request_upgrade(struct dynbuf *req,
                                     struct Curl_easy *data)
@@ -2307,7 +2307,7 @@ void Curl_http2_cleanup_dependencies(struct Curl_easy *data)
     Curl_http2_remove_child(data->set.stream_depends_on, data);
 }
 
-/* Only call this function for a transfer that already got a HTTP/2
+/* Only call this function for a transfer that already got an HTTP/2
    CURLE_HTTP2_STREAM error! */
 bool Curl_h2_http_1_1_error(struct Curl_easy *data)
 {

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -81,7 +81,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   bool have_chlg;
 
   /* Point to the address of the pointer that holds the string to send to the
-     server, which is for a plain host or for a HTTP proxy */
+     server, which is for a plain host or for an HTTP proxy */
   char **allocuserpwd;
 
   /* Point to the name and password for this */

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -134,7 +134,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   struct bufref ntlmmsg;
 
   /* point to the address of the pointer that holds the string to send to the
-     server, which is for a plain host or for a HTTP proxy */
+     server, which is for a plain host or for an HTTP proxy */
   char **allocuserpwd;
 
   /* point to the username, password, service and host */

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -1043,7 +1043,7 @@ void Curl_connect_free(struct Curl_easy *data)
 }
 
 /*
- * Curl_proxyCONNECT() requires that we're connected to a HTTP proxy. This
+ * Curl_proxyCONNECT() requires that we're connected to an HTTP proxy. This
  * function will issue the necessary commands to get a seamless tunnel through
  * this proxy. After that, the socket can be used just as a normal socket.
  */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -598,7 +598,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_FOLLOWLOCATION:
     /*
-     * Follow Location: header hints on a HTTP-server.
+     * Follow Location: header hints on an HTTP-server.
      */
     data->set.http_follow_location = (0 != va_arg(param, long)) ? TRUE : FALSE;
     break;
@@ -914,7 +914,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_EXPECT_100_TIMEOUT_MS:
     /*
-     * Time to wait for a response to a HTTP request containing an
+     * Time to wait for a response to an HTTP request containing an
      * Expect: 100-continue header before sending the data anyway.
      */
     arg = va_arg(param, long);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1511,7 +1511,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 
   /*
    * Set user-agent. Used for HTTP, but since we can attempt to tunnel
-   * basically anything through a http proxy we can't limit this based on
+   * basically anything through an HTTP proxy we can't limit this based on
    * protocol.
    */
   if(data->set.str[STRING_USERAGENT]) {
@@ -1743,7 +1743,7 @@ CURLcode Curl_follow(struct Curl_easy *data,
    * differently based on exactly what return code there was.
    *
    * News from 7.10.6: we can also get here on a 401 or 407, in case we act on
-   * a HTTP (proxy-) authentication scheme other than Basic.
+   * an HTTP (proxy-) authentication scheme other than Basic.
    */
   switch(data->info.httpcode) {
     /* 401 - Act on a WWW-Authenticate, we keep on moving and do the

--- a/lib/url.c
+++ b/lib/url.c
@@ -914,7 +914,7 @@ static int IsMultiplexingPossible(const struct Curl_easy *handle,
 {
   int avail = 0;
 
-  /* If a HTTP protocol and multiplexing is enabled */
+  /* If an HTTP protocol and multiplexing is enabled */
   if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
      (!conn->bits.protoconnstart || !conn->bits.close)) {
 
@@ -1197,7 +1197,7 @@ ConnectionExists(struct Curl_easy *data,
       size_t multiplexed = 0;
 
       /*
-       * Note that if we use a HTTP proxy in normal mode (no tunneling), we
+       * Note that if we use an HTTP proxy in normal mode (no tunneling), we
        * check connections to that proxy and not to the actual remote server.
        */
       check = curr->ptr;
@@ -1381,9 +1381,9 @@ ConnectionExists(struct Curl_easy *data,
          || !needle->bits.httpproxy || needle->bits.tunnel_proxy
 #endif
         ) {
-        /* The requested connection does not use a HTTP proxy or it uses SSL or
-           it is a non-SSL protocol tunneled or it is a non-SSL protocol which
-           is allowed to be upgraded via TLS */
+        /* The requested connection does not use an HTTP proxy or it uses SSL
+           or it is a non-SSL protocol tunneled or it is a non-SSL protocol
+           which is allowed to be upgraded via TLS */
 
         if((strcasecompare(needle->handler->scheme, check->handler->scheme) ||
             (get_protocol_family(check->handler) ==
@@ -2704,7 +2704,7 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
 
     if(conn->http_proxy.host.rawalloc) {
 #ifdef CURL_DISABLE_HTTP
-      /* asking for a HTTP proxy is a bit funny when HTTP is disabled... */
+      /* asking for an HTTP proxy is a bit funny when HTTP is disabled... */
       result = CURLE_UNSUPPORTED_PROTOCOL;
       goto out;
 #else
@@ -2721,7 +2721,7 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
 #endif
     }
     else {
-      conn->bits.httpproxy = FALSE; /* not a HTTP proxy */
+      conn->bits.httpproxy = FALSE; /* not an HTTP proxy */
       conn->bits.tunnel_proxy = FALSE; /* no tunneling if not HTTP */
     }
 
@@ -3907,7 +3907,7 @@ static CURLcode create_conn(struct Curl_easy *data,
 
   /* reuse_fresh is TRUE if we are told to use a new connection by force, but
      we only acknowledge this option if this is not a re-used connection
-     already (which happens due to follow-location or during a HTTP
+     already (which happens due to follow-location or during an HTTP
      authentication phase). CONNECT_ONLY transfers also refuse reuse. */
   if((data->set.reuse_fresh && !data->state.this_is_a_follow) ||
      data->set.connect_only)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -481,7 +481,7 @@ struct ConnectBits {
 #ifndef CURL_DISABLE_PROXY
   bool proxy_ssl_connected[2]; /* TRUE when SSL initialization for HTTPS proxy
                                   is complete */
-  BIT(httpproxy);  /* if set, this transfer is done through a http proxy */
+  BIT(httpproxy);  /* if set, this transfer is done through an HTTP proxy */
   BIT(socksproxy); /* if set, this transfer is done through a socks proxy */
   BIT(proxy_user_passwd); /* user+password for the proxy? */
   BIT(tunnel_proxy);  /* if CONNECT is used to "tunnel" through the proxy.
@@ -920,8 +920,8 @@ struct connectdata {
   struct Curl_llist_element bundle_node; /* conncache */
 
   /* chunk is for HTTP chunked encoding, but is in the general connectdata
-     struct only because we can do just about any protocol through a HTTP proxy
-     and a HTTP proxy may in fact respond using chunked encoding */
+     struct only because we can do just about any protocol through an HTTP
+     proxy and an HTTP proxy may in fact respond using chunked encoding */
   struct Curl_chunker chunk;
 
   curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
@@ -1860,7 +1860,7 @@ struct UserDefined {
    this session. They are STATIC, set by libcurl users or at least initially
    and they don't change during operations. */
   BIT(get_filetime);     /* get the time and get of the remote file */
-  BIT(tunnel_thru_httpproxy); /* use CONNECT through a HTTP proxy */
+  BIT(tunnel_thru_httpproxy); /* use CONNECT through an HTTP proxy */
   BIT(prefer_ascii);     /* ASCII rather than binary */
   BIT(remote_append);    /* append, not overwrite, on upload */
   BIT(list_only);        /* list directory */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -490,7 +490,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 /*
  * Curl_auth_decode_digest_http_message()
  *
- * This is used to decode a HTTP DIGEST challenge message into the separate
+ * This is used to decode an HTTP DIGEST challenge message into the separate
  * attributes.
  *
  * Parameters:
@@ -650,7 +650,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 /*
  * auth_create_digest_http_message()
  *
- * This is used to generate a HTTP DIGEST response message ready for sending
+ * This is used to generate an HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:
@@ -926,7 +926,7 @@ static CURLcode auth_create_digest_http_message(
 /*
  * Curl_auth_create_digest_http_message()
  *
- * This is used to generate a HTTP DIGEST response message ready for sending
+ * This is used to generate an HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -307,7 +307,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
 /*
  * Curl_auth_decode_digest_http_message()
  *
- * This is used to decode a HTTP DIGEST challenge message into the separate
+ * This is used to decode an HTTP DIGEST challenge message into the separate
  * attributes.
  *
  * Parameters:
@@ -371,7 +371,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 /*
  * Curl_auth_create_digest_http_message()
  *
- * This is used to generate a HTTP DIGEST response message ready for sending
+ * This is used to generate an HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -104,11 +104,11 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                                              const char *service,
                                              struct bufref *out);
 
-/* This is used to decode a HTTP DIGEST challenge message */
+/* This is used to decode an HTTP DIGEST challenge message */
 CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
                                               struct digestdata *digest);
 
-/* This is used to generate a HTTP DIGEST response message */
+/* This is used to generate an HTTP DIGEST response message */
 CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                               const char *userp,
                                               const char *passwdp,

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -894,7 +894,7 @@ static int ng_getsock(struct Curl_easy *data, struct connectdata *conn,
 
   socks[0] = conn->sock[FIRSTSOCKET];
 
-  /* in a HTTP/2 connection we can basically always get a frame so we should
+  /* in an HTTP/2 connection we can basically always get a frame so we should
      always be ready for one */
   bitmap |= GETSOCK_READSOCK(FIRSTSOCKET);
 
@@ -1170,7 +1170,7 @@ static int cb_h3_recv_header(nghttp3_conn *conn, int64_t stream_id,
     }
   }
   else {
-    /* store as a HTTP1-style header */
+    /* store as an HTTP1-style header */
     result = write_data(stream, h3name.base, h3name.len);
     if(result) {
       return -1;

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -80,7 +80,7 @@ static int quiche_getsock(struct Curl_easy *data,
 
   socks[0] = conn->sock[FIRSTSOCKET];
 
-  /* in a HTTP/2 connection we can basically always get a frame so we should
+  /* in an HTTP/2 connection we can basically always get a frame so we should
      always be ready for one */
   bitmap |= GETSOCK_READSOCK(FIRSTSOCKET);
 

--- a/packages/vms/curl_gnv_build_steps.txt
+++ b/packages/vms/curl_gnv_build_steps.txt
@@ -251,7 +251,7 @@ branding the PCSI kit based on who is making the kit.
       step of backing up the source files will probably hang or fail.
 
       You need to copy the source files to VMS mounted disks and create
-      logical names SRC_ROOT1 and VMS_ROOT1 to work around this to to
+      logical names SRC_ROOT1 and VMS_ROOT1 to work around this to
       reference local disks.  Make sure src_root1:[000000] and
       vms_root1:[000000] exist and can be written to.
 

--- a/packages/vms/curl_release_note_start.txt
+++ b/packages/vms/curl_release_note_start.txt
@@ -58,12 +58,12 @@ For the HP SSL work around to work for GNV do the following:
  dcl @gnv\$gnu:[vms_bin]curl.com $*
  ^Z
 
-Similar work arounds will be needed for any program linked with GNV$LIBCURL
+Similar workarounds will be needed for any program linked with GNV$LIBCURL
 until the HP OpenSSL is upgraded to the current 1.4 version or later.
 
 If you are installing a "daily" build instead of a release build of Curl, some
 things have been changed so that it can be installed at the same time as
-a production build with out conflicts.
+a production build without conflicts.
 
    The CURL_DAILY_STARTUP.COM will be supplied instead of CURL_STARTUP.COM.
    This file is actually not used with the daily package and is provided as

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -730,7 +730,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
   if(config->postfields) {
     if(config->use_httpget) {
       if(!httpgetfields) {
-        /* Use the postfields data for a http get */
+        /* Use the postfields data for an HTTP get */
         httpgetfields = state->httpgetfields = strdup(config->postfields);
         Curl_safefree(config->postfields);
         if(!httpgetfields) {

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -350,7 +350,7 @@ static bool peek_ipv6(const char *str, size_t *skip)
   memcpy(hostname, str, hlen);
   hostname[hlen] = 0;
 
-  /* ask to "guess scheme" as then it works without a https:// prefix */
+  /* ask to "guess scheme" as then it works without an https:// prefix */
   rc = curl_url_set(u, CURLUPART_URL, hostname, CURLU_GUESS_SCHEME);
 
   curl_url_cleanup(u);

--- a/tests/CI.md
+++ b/tests/CI.md
@@ -54,9 +54,9 @@ below.
 Here are the different CI environments that are currently in use, and how they
 are configured:
 
-### Github Actions
+### GitHub Actions
 
-Github Actions runs the following tests:
+GitHub Actions runs the following tests:
 
 - Mac OS tests with a variety of different compilation options
 - Fuzz tests ([see tests/fuzz/README for
@@ -101,7 +101,7 @@ BoringSSL, etc).
 - Curl compiled with different C compilers.
 
 As of November 2021, the tests run (sometimes) but do not run consistently and
-do not report results to the Github checks runner - you need to manually check
+do not report results to the GitHub checks runner - you need to manually check
 for failures. See [#7522](https://github.com/curl/curl/issues/7522) for more
 information.
 

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -23,7 +23,7 @@ with a `testcase` tag, which encompasses the remainder of the file.
 # Preprocessing
 
 When a test is to be executed, the source file is first preprocessed and
-variables are substituted by the their respective contents and the output
+variables are substituted by their respective contents and the output
 version of the test file is stored as `log/testNUM`. That version is what will
 be read and used by the test servers.
 
@@ -70,7 +70,7 @@ string may contain `%HH` hexadecimal codes:
 
     %repeat[<number> x <string>]%
 
-For example, to insert the word hello a 100 times:
+For example, to insert the word hello 100 times:
 
     %repeat[100 x hello]%
 
@@ -114,7 +114,7 @@ Available substitute variables include:
 - `%CLIENT6IP` - IPv6 address of the client running curl
 - `%CLIENTIP` - IPv4 address of the client running curl
 - `%CURL` - Path to the curl executable
-- `%FILE_PWD` - Current directory, on windows prefixed with a slash
+- `%FILE_PWD` - Current directory, on Windows prefixed with a slash
 - `%FTP6PORT` - IPv6 port number of the FTP server
 - `%FTPPORT` - Port number of the FTP server
 - `%FTPSPORT` - Port number of the FTPS server
@@ -203,7 +203,7 @@ arrived safely. Set `nocheck="yes"` to prevent the test script from verifying
 the arrival of this data.
 
 If the data contains `swsclose` anywhere within the start and end tag, and
-this is a HTTP test, then the connection will be closed by the server after
+this is an HTTP test, then the connection will be closed by the server after
 this response is sent. If not, the connection will be kept persistent.
 
 If the data contains `swsbounce` anywhere within the start and end tag, the
@@ -237,10 +237,10 @@ Send back this contents instead of the <data> one. The `NUM` is set by:
  - The test number in the request line is >10000 and this is the remainder
    of [test case number]%10000.
  - The request was HTTP and included digest details, which adds 1000 to `NUM`
- - If a HTTP request is NTLM type-1, it adds 1001 to `NUM`
- - If a HTTP request is NTLM type-3, it adds 1002 to `NUM`
- - If a HTTP request is Basic and `NUM` is already >=1000, it adds 1 to `NUM`
- - If a HTTP request is Negotiate, `NUM` gets incremented by one for each
+ - If an HTTP request is NTLM type-1, it adds 1001 to `NUM`
+ - If an HTTP request is NTLM type-3, it adds 1002 to `NUM`
+ - If an HTTP request is Basic and `NUM` is already >=1000, it adds 1 to `NUM`
+ - If an HTTP request is Negotiate, `NUM` gets incremented by one for each
    request with Negotiate authorization header on the same test case.
 
 Dynamically changing `NUM` in this way allows the test harness to be used to
@@ -570,7 +570,7 @@ comparisons are made.
 
 ### `<proxy [nonewline="yes"]>`
 
-The protocol dump curl should transmit to a HTTP proxy (when the http-proxy
+The protocol dump curl should transmit to an HTTP proxy (when the http-proxy
 server is used), if `nonewline` is set, we will cut off the trailing newline
 of this given data before comparing with the one actually sent by the client
 The `<strip>` and `<strippart>` rules are applied before comparisons are made.

--- a/tests/data/test1215
+++ b/tests/data/test1215
@@ -1,6 +1,6 @@
 <testcase>
 <info>
-# This test is a copy of test 67, modified to use a HTTP proxy.
+# This test is a copy of test 67, modified to use an HTTP proxy.
 <keywords>
 HTTP
 HTTP GET

--- a/tests/data/test1232
+++ b/tests/data/test1232
@@ -1,6 +1,6 @@
 <testcase>
 <info>
-# This test is a copy of test 1231, modified to use a HTTP proxy.
+# This test is a copy of test 1231, modified to use an HTTP proxy.
 <keywords>
 HTTP
 HTTP GET

--- a/tests/data/test516
+++ b/tests/data/test516
@@ -33,7 +33,7 @@ lib%TESTNUMBER
 </tool>
 
  <name>
-make a HTTPPOST set to NULL
+make an HTTPPOST set to NULL
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER

--- a/tests/data/test589
+++ b/tests/data/test589
@@ -34,7 +34,7 @@ lib%TESTNUMBER
 </tool>
 
  <name>
-make a HTTP MIME POST set to NULL
+make an HTTP MIME POST set to NULL
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER

--- a/tests/libtest/lib556.c
+++ b/tests/libtest/lib556.c
@@ -61,7 +61,7 @@ int test(char *URL)
   res = curl_easy_perform(curl);
 
   if(!res) {
-    /* we are connected, now get a HTTP document the raw way */
+    /* we are connected, now get an HTTP document the raw way */
     const char *request =
       "GET /556 HTTP/1.1\r\n"
       "Host: ninja\r\n\r\n";

--- a/tests/libtest/lib560.c
+++ b/tests/libtest/lib560.c
@@ -30,7 +30,7 @@
 #define TEST_HANG_TIMEOUT 60 * 1000
 
 /*
- * Simply download a HTTPS file!
+ * Simply download an HTTPS file!
  *
  * This test was added after the HTTPS-using-multi-interface with OpenSSL
  * regression of 7.19.1 to hopefully prevent this embarrassing mistake from

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -450,10 +450,10 @@ static int ProcessRequest(struct httprequest *req)
 
   /* **** Persistence ****
    *
-   * If the request is a HTTP/1.0 one, we close the connection unconditionally
+   * If the request is an HTTP/1.0 one, we close the connection unconditionally
    * when we're done.
    *
-   * If the request is a HTTP/1.1 one, we MUST check for a "Connection:"
+   * If the request is an HTTP/1.1 one, we MUST check for a "Connection:"
    * header that might say "close". If it does, we close a connection when
    * this request is processed. Otherwise, we keep the connection alive for X
    * seconds.

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -602,10 +602,10 @@ static int ProcessRequest(struct httprequest *req)
 
   /* **** Persistence ****
    *
-   * If the request is a HTTP/1.0 one, we close the connection unconditionally
+   * If the request is an HTTP/1.0 one, we close the connection unconditionally
    * when we're done.
    *
-   * If the request is a HTTP/1.1 one, we MUST check for a "Connection:"
+   * If the request is an HTTP/1.1 one, we MUST check for a "Connection:"
    * header that might say "close". If it does, we close a connection when
    * this request is processed. Otherwise, we keep the connection alive for X
    * seconds.

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -24,7 +24,7 @@
 
 # The results of each of these jobs can be found at 
 # https://curl.zuul.vexxhost.dev/builds. As of November 2021 they are not being
-# propagated to the Github "checks" UI, you need to check for them manually.
+# propagated to the GitHub "checks" UI, you need to check for them manually.
 
 ---
 - job:


### PR DESCRIPTION
- Replace `Github` with `GitHub`.
- Replace `windows` with `Windows`
- Replace `advice` with `advise` where a verb is used.
- A few fixes on removing repeated words.
- Replace `a HTTP` with `an HTTP`