### PR TITLE
spellcheck.words: remove 'github' as an accepted word

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -246,7 +246,6 @@ getpwuid
 ggcov
 Ghedini
 Gisle
-github
 Glesys
 globbing
 gmail

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -131,7 +131,7 @@ Build nghttp3
      % make
      % make install
 
-Build ngtcp2 (once https://github.com/ngtcp2/ngtcp2/pull/505 is merged)
+Build ngtcp2
 
      % cd ..
      % git clone https://github.com/ngtcp2/ngtcp2

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,4 +21,4 @@ See: https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-02
  See Daniel's post on [Support of Encrypted
  SNI](https://curl.se/mail/lib-2019-03/0000.html) on the mailing list.
 
- Initial work exists in https://github.com/curl/curl/pull/4011
+ Initial work exists in [PR 4011](https://github.com/curl/curl/pull/4011)

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -7,8 +7,8 @@ SPDX-License-Identifier: curl
 Fuzz tests
 ==========
 
-The fuzzing tests for curl have been moved to a separate repository:
+The fuzzing tests for curl have been moved to [a separate
+repository](https://github.com/curl/curl-fuzzer).
 
-https://github.com/curl/curl-fuzzer
-
-More information on how to get started with curl fuzz testing can be found there.
+More information on how to get started with curl fuzz testing can be found
+there.


### PR DESCRIPTION
Prefer the properly cased version: GitHub