### PR TITLE
Use platform socklen_t in os400 Curl_getnameinfo_a

### DIFF
--- a/lib/setup-os400.h
+++ b/lib/setup-os400.h
@@ -49,11 +49,11 @@ extern int Curl_getaddrinfo_a(const char *nodename,
                               struct addrinfo **res);
 #define getaddrinfo             Curl_getaddrinfo_a
 
-
+/* Note socklen_t must be used as this is declared before curl_socklen_t */
 extern int Curl_getnameinfo_a(const struct sockaddr *sa,
-                              curl_socklen_t salen,
-                              char *nodename, curl_socklen_t nodenamelen,
-                              char *servname, curl_socklen_t servnamelen,
+                              socklen_t salen,
+                              char *nodename, socklen_t nodenamelen,
+                              char *servname, socklen_t servnamelen,
                               int flags);
 #define getnameinfo             Curl_getnameinfo_a
 

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -255,9 +255,9 @@ set_thread_string(localkey_t key, const char *s)
 
 
 int
-Curl_getnameinfo_a(const struct sockaddr *sa, curl_socklen_t salen,
-                   char *nodename, curl_socklen_t nodenamelen,
-                   char *servname, curl_socklen_t servnamelen,
+Curl_getnameinfo_a(const struct sockaddr *sa, socklen_t salen,
+                   char *nodename, socklen_t nodenamelen,
+                   char *servname, socklen_t servnamelen,
                    int flags)
 {
   char *enodename = NULL;


### PR DESCRIPTION
Curl_getnameinfo_a() is prototyped before including curl.h as an ASCII'fied wrapper for the platform getnameinfo(), which itself is prototyped with socklen_t arguments, so the wrapper prototype should use the platform socklen_t and not curl_socklen_t.

This should resolve https://github.com/curl/curl/issues/9811