### PR TITLE
Fix build on NonStop requiring htonl that is defined in arpa/inet.h.

### DIFF
--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -34,6 +34,10 @@
 #include <netinet/in.h>
 #endif
 
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h> /* for htonl() */
+#endif
+
 /*
  * Curl_cidr4_match() returns TRUE if the given IPv4 address is within the
  * specified CIDR address range.


### PR DESCRIPTION
The location of htonl() is not in the typical place on NonStop.

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>