### PR TITLE
Correctly define curl_off_t on NonStop ia64 and x86 for 32-bit builds.

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -172,6 +172,17 @@
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
+#elif defined(__TANDEM)
+# if ! defined(__LP64)
+   /* Required for 32-bit NonStop builds only. */
+#  define CURL_TYPEOF_CURL_OFF_T     long long
+#  define CURL_FORMAT_CURL_OFF_T     "lld"
+#  define CURL_FORMAT_CURL_OFF_TU    "llu"
+#  define CURL_SUFFIX_CURL_OFF_T     LL
+#  define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  define CURL_TYPEOF_CURL_SOCKLEN_T int
+# endif
+
 #elif defined(_WIN32_WCE)
 #  define CURL_TYPEOF_CURL_OFF_T     __int64
 #  define CURL_FORMAT_CURL_OFF_T     "I64d"


### PR DESCRIPTION
This change is not required for 64-bit builds on NonStop where curl_off_t would be 64-bit automatically.

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>