### PR TITLE
docs: explain the noproxy CIDR notation support

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -92,6 +92,7 @@ chmod
 chown
 ChromeOS
 CI's
+CIDR
 CIFS
 CLA
 CLAs

--- a/docs/cmdline-opts/noproxy.d
+++ b/docs/cmdline-opts/noproxy.d
@@ -19,3 +19,8 @@ not www.notlocal.com.
 Since 7.53.0, This option overrides the environment variables that disable the
 proxy ('no_proxy' and 'NO_PROXY'). If there's an environment variable
 disabling a proxy, you can set the noproxy list to "" to override it.
+
+Since 7.86.0, IP addresses specified to this option can be provided using CIDR
+notation: an appended slash and number specifies the number of "network bits"
+out of the address to use in the comparison. For example "192.168.0.0/16"
+would match all addresses starting with "192.168".

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -37,9 +37,10 @@ accesses the target URL through the proxy.
 The list of host names can also be include numerical IP addresses, and IPv6
 versions should then be given without enclosing brackets.
 
-IPv6 numerical addresses are compared as strings, so they will only match if
-the representations are the same: "::1" is the same as "::0:1" but they do not
-match.
+Since 7.86.0, IP addresses can be specified using CIDR notation: an appended
+slash and number specifies the number of "network bits" out of the address to
+use in the comparison. For example "192.168.0.0/16" would match all addresses
+starting with "192.168".
 .IP "APPDATA <dir>"
 On Windows, this variable is used when trying to find the home directory. If
 the primary home variable are all unset.

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -53,6 +53,11 @@ brackets:
 
  "example.com,::1,localhost"
 
+Since 7.86.0, IP addresses specified to this option can be provided using CIDR
+notation: an appended slash and number specifies the number of "network bits"
+out of the address to use in the comparison. For example "192.168.0.0/16"
+would match all addresses starting with "192.168".
+
 The application does not have to keep the string around after setting this
 option.
 .SH "Environment variables"


### PR DESCRIPTION
Follow-up to 1e9a538e05c0107c