### PR TITLE
Fix pointer mismatchings and other warnings

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -398,18 +398,23 @@ static CURLcode bindlocal(struct Curl_easy *data,
 #ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
         char *scope_ptr = strchr(myhost, '%');
         if(scope_ptr)
-          *(scope_ptr++) = 0;
+          *(scope_ptr++) = '\0';
 #endif
         if(Curl_inet_pton(AF_INET6, myhost, &si6->sin6_addr) > 0) {
           si6->sin6_family = AF_INET6;
           si6->sin6_port = htons(port);
 #ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
-          if(scope_ptr)
+          if(scope_ptr) {
             /* The "myhost" string either comes from Curl_if2ip or from
                Curl_printable_address. The latter returns only numeric scope
                IDs and the former returns none at all.  So the scope ID, if
                present, is known to be numeric */
-            si6->sin6_scope_id = atoi(scope_ptr);
+            unsigned long scope_id = strtoul(scope_ptr, NULL, 10);
+            if(scope_id > UINT_MAX)
+              return CURLE_UNSUPPORTED_PROTOCOL;
+
+            si6->sin6_scope_id = (unsigned int)scope_id;
+          }
 #endif
         }
         sizeof_sa = sizeof(struct sockaddr_in6);
@@ -866,7 +871,7 @@ CURLcode Curl_is_connected(struct Curl_easy *data,
   int error = 0;
   struct curltime now;
   int rc = 0;
-  unsigned int i;
+  int i;
 
   DEBUGASSERT(sockindex >= FIRSTSOCKET && sockindex <= SECONDARYSOCKET);
 
@@ -1207,7 +1212,7 @@ static CURLcode singleipconnect(struct Curl_easy *data,
     return result;
 
   /* store remote address and port used in this connection attempt */
-  if(!Curl_addr2string((struct sockaddr*)&addr.sa_addr, addr.addrlen,
+  if(!Curl_addr2string(&addr.sa_addr, addr.addrlen,
                        ipaddress, &port)) {
     /* malformed address or bug in inet_ntop, try next address */
     failf(data, "sa_addr inet_ntop() failed with errno %d: %s",
@@ -1262,7 +1267,7 @@ static CURLcode singleipconnect(struct Curl_easy *data,
 #endif
     ) {
     result = bindlocal(data, sockfd, addr.family,
-                       Curl_ipv6_scope((struct sockaddr*)&addr.sa_addr));
+                       Curl_ipv6_scope(&addr.sa_addr));
     if(result) {
       Curl_closesocket(data, conn, sockfd); /* close socket and bail out */
       if(result == CURLE_UNSUPPORTED_PROTOCOL) {
@@ -1709,7 +1714,7 @@ void Curl_conncontrol(struct connectdata *conn,
      (conn->handler->flags & PROTOPT_STREAM))
     ;
   else if((bit)closeit != conn->bits.close) {
-    conn->bits.close = closeit; /* the only place in the source code that
+    conn->bits.close = (bit)closeit; /* the only place in the source code that
                                    should assign this bit */
   }
 }

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -300,12 +300,11 @@ static char *sanitize_cookie_path(const char *cookie_path)
   /* some stupid site sends path attribute with '"'. */
   len = strlen(new_path);
   if(new_path[0] == '\"') {
-    memmove((void *)new_path, (const void *)(new_path + 1), len);
+    memmove(new_path, new_path + 1, len);
     len--;
   }
   if(len && (new_path[len - 1] == '\"')) {
-    new_path[len - 1] = 0x0;
-    len--;
+    new_path[--len] = 0x0;
   }
 
   /* RFC6265 5.2.4 The Path Attribute */

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -268,7 +268,7 @@ Curl_he2ai(const struct hostent *he, int port)
   struct sockaddr_in6 *addr6;
 #endif
   CURLcode result = CURLE_OK;
-  int i;
+  size_t i;
   char *curr;
 
   if(!he)
@@ -422,8 +422,8 @@ Curl_ip2addr(int af, const void *inaddr, const char *hostname, int port)
   h = &buf->hostentry;
   h->h_name = hoststr;
   h->h_aliases = NULL;
-  h->h_addrtype = (short)af;
-  h->h_length = (short)addrsize;
+  h->h_addrtype = af;
+  h->h_length = (int)addrsize;
   h->h_addr_list = &buf->h_addr_list[0];
   h->h_addr_list[0] = addrentry;
   h->h_addr_list[1] = NULL; /* terminate list of entries */

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -71,18 +71,19 @@ typedef enum {
 #define SETCHARSET_OK     1
 #define SETCHARSET_FAIL   0
 
-static int parsekeyword(unsigned char **pattern, unsigned char *charset)
+static int parsekeyword(char **pattern, char *charset)
 {
   parsekey_state state = CURLFNM_PKW_INIT;
 #define KEYLEN 10
   char keyword[KEYLEN] = { 0 };
-  int found = FALSE;
-  int i;
-  unsigned char *p = *pattern;
+  bool found = FALSE;
+  unsigned int i;
+  char *p = *pattern;
+  char c;
   for(i = 0; !found; i++) {
-    char c = *p++;
     if(i >= KEYLEN)
       return SETCHARSET_FAIL;
+    c = *p++;
     switch(state) {
     case CURLFNM_PKW_INIT:
       if(ISLOWER(c))
@@ -128,7 +129,7 @@ static int parsekeyword(unsigned char **pattern, unsigned char *charset)
 }
 
 /* Return the character class. */
-static char_class charclass(unsigned char c)
+static char_class charclass(char c)
 {
   if(ISUPPER(c))
     return CCLASS_UPPER;
@@ -140,33 +141,33 @@ static char_class charclass(unsigned char c)
 }
 
 /* Include a character or a range in set. */
-static void setcharorrange(unsigned char **pp, unsigned char *charset)
+static void setcharorrange(char **pp, char *charset)
 {
-  unsigned char *p = (*pp)++;
-  unsigned char c = *p++;
+  char *p = (*pp)++;
+  char c = *p++;
 
-  charset[c] = 1;
+  charset[(unsigned int)c] = 1;
   if(ISALNUM(c) && *p++ == '-') {
     char_class cc = charclass(c);
-    unsigned char endrange = *p++;
+    char endrange = *p++;
 
     if(endrange == '\\')
       endrange = *p++;
     if(endrange >= c && charclass(endrange) == cc) {
       while(c++ != endrange)
         if(charclass(c) == cc)  /* Chars in class may be not consecutive. */
-          charset[c] = 1;
+          charset[(unsigned int)c] = 1;
       *pp = p;
     }
   }
 }
 
 /* returns 1 (true) if pattern is OK, 0 if is bad ("p" is pattern pointer) */
-static int setcharset(unsigned char **p, unsigned char *charset)
+static int setcharset(char **p, char *charset)
 {
   setcharset_state state = CURLFNM_SCHS_DEFAULT;
   bool something_found = FALSE;
-  unsigned char c;
+  char c;
 
   memset(charset, 0, CURLFNM_CHSET_SIZE);
   for(;;) {
@@ -181,16 +182,16 @@ static int setcharset(unsigned char **p, unsigned char *charset)
           return SETCHARSET_OK;
         something_found = TRUE;
         state = CURLFNM_SCHS_RIGHTBR;
-        charset[c] = 1;
+        charset[(unsigned int)c] = 1;
         (*p)++;
       }
       else if(c == '[') {
-        unsigned char *pp = *p + 1;
+        char *pp = *p + 1;
 
         if(*pp++ == ':' && parsekeyword(&pp, charset))
           *p = pp;
         else {
-          charset[c] = 1;
+          charset[(unsigned int)c] = 1;
           (*p)++;
         }
         something_found = TRUE;
@@ -198,14 +199,14 @@ static int setcharset(unsigned char **p, unsigned char *charset)
       else if(c == '^' || c == '!') {
         if(!something_found) {
           if(charset[CURLFNM_NEGATE]) {
-            charset[c] = 1;
+            charset[(unsigned int)c] = 1;
             something_found = TRUE;
           }
           else
             charset[CURLFNM_NEGATE] = 1; /* negate charset */
         }
         else
-          charset[c] = 1;
+          charset[(unsigned int)c] = 1;
         (*p)++;
       }
       else if(c == '\\') {
@@ -224,14 +225,14 @@ static int setcharset(unsigned char **p, unsigned char *charset)
     case CURLFNM_SCHS_RIGHTBR:
       if(c == '[') {
         state = CURLFNM_SCHS_RIGHTBRLEFTBR;
-        charset[c] = 1;
+        charset[(unsigned int)c] = 1;
         (*p)++;
       }
       else if(c == ']') {
         return SETCHARSET_OK;
       }
       else if(ISPRINT(c)) {
-        charset[c] = 1;
+        charset[(unsigned int)c] = 1;
         (*p)++;
         state = CURLFNM_SCHS_DEFAULT;
       }
@@ -245,7 +246,7 @@ static int setcharset(unsigned char **p, unsigned char *charset)
       if(c == ']')
         return SETCHARSET_OK;
       state  = CURLFNM_SCHS_DEFAULT;
-      charset[c] = 1;
+      charset[(unsigned int)c] = 1;
       (*p)++;
       break;
     }
@@ -254,15 +255,15 @@ fail:
   return SETCHARSET_FAIL;
 }
 
-static int loop(const unsigned char *pattern, const unsigned char *string,
-                int maxstars)
+static int loop(const char *pattern, const char *string,
+                unsigned int maxstars)
 {
-  unsigned char *p = (unsigned char *)pattern;
-  unsigned char *s = (unsigned char *)string;
-  unsigned char charset[CURLFNM_CHSET_SIZE] = { 0 };
+  char *p = (char *)pattern;
+  char *s = (char *)string;
+  char charset[CURLFNM_CHSET_SIZE] = { 0 };
 
   for(;;) {
-    unsigned char *pp;
+    char *pp;
 
     switch(*p) {
     case '*':
@@ -359,7 +360,7 @@ int Curl_fnmatch(void *ptr, const char *pattern, const char *string)
   if(!pattern || !string) {
     return CURL_FNMATCH_FAIL;
   }
-  return loop((unsigned char *)pattern, (unsigned char *)string, 2);
+  return loop(pattern, string, 2);
 }
 #else
 #include <fnmatch.h>
@@ -368,14 +369,13 @@ int Curl_fnmatch(void *ptr, const char *pattern, const char *string)
  */
 int Curl_fnmatch(void *ptr, const char *pattern, const char *string)
 {
-  int rc;
   (void)ptr; /* the argument is specified by the curl_fnmatch_callback
                 prototype, but not used by Curl_fnmatch() */
   if(!pattern || !string) {
     return CURL_FNMATCH_FAIL;
   }
-  rc = fnmatch(pattern, string, 0);
-  switch(rc) {
+
+  switch(fnmatch(pattern, string, 0)) {
   case 0:
     return CURL_FNMATCH_MATCH;
   case FNM_NOMATCH:

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -441,12 +441,12 @@ static DOHcode skipqname(const unsigned char *doh, size_t dohlen,
   return DOH_OK;
 }
 
-static unsigned short get16bit(const unsigned char *doh, int index)
+static unsigned short get16bit(const unsigned char *doh, unsigned int index)
 {
   return (unsigned short)((doh[index] << 8) | doh[index + 1]);
 }
 
-static unsigned int get32bit(const unsigned char *doh, int index)
+static unsigned int get32bit(const unsigned char *doh, unsigned int index)
 {
    /* make clang and gcc optimize this to bswap by incrementing
       the pointer first. */
@@ -455,10 +455,12 @@ static unsigned int get32bit(const unsigned char *doh, int index)
    /* avoid undefined behavior by casting to unsigned before shifting
       24 bits, possibly into the sign bit. codegen is same, but
       ub sanitizer won't be upset */
-  return ( (unsigned)doh[0] << 24) | (doh[1] << 16) |(doh[2] << 8) | doh[3];
+  return ((unsigned int)doh[0] << 24) | (doh[1] << 16) |(doh[2] << 8) | doh[3];
 }
 
-static DOHcode store_a(const unsigned char *doh, int index, struct dohentry *d)
+static DOHcode store_a(const unsigned char *doh,
+                       unsigned int index,
+                       struct dohentry *d)
 {
   /* silently ignore addresses over the limit */
   if(d->numaddr < DOH_MAX_ADDR) {
@@ -471,7 +473,7 @@ static DOHcode store_a(const unsigned char *doh, int index, struct dohentry *d)
 }
 
 static DOHcode store_aaaa(const unsigned char *doh,
-                          int index,
+                          unsigned int index,
                           struct dohentry *d)
 {
   /* silently ignore addresses over the limit */
@@ -502,13 +504,13 @@ static DOHcode store_cname(const unsigned char *doh,
       return DOH_DNS_OUT_OF_RANGE;
     length = doh[index];
     if((length & 0xc0) == 0xc0) {
-      int newpos;
+      unsigned int newpos;
       /* name pointer, get the new offset (14 bits) */
       if((index + 1) >= dohlen)
         return DOH_DNS_OUT_OF_RANGE;
 
       /* move to the new index */
-      newpos = (length & 0x3f) << 8 | doh[index + 1];
+      newpos = (unsigned int) ((length & 0x3f) << 8 | doh[index + 1]);
       index = newpos;
       continue;
     }

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -96,8 +96,9 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   if(!length)
     return strdup("");
 
-  while(length--) {
-    unsigned char in = *string; /* we need to treat the characters unsigned */
+  for(; length; length--) {
+    /* we need to treat the characters unsigned */
+    unsigned char in = (unsigned char)*string;
 
     if(Curl_isunreserved(in)) {
       /* append this */
@@ -136,7 +137,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
                         enum urlreject ctrl)
 {
   size_t alloc;
-  char *ns;
+  unsigned char *ns;
   size_t strindex = 0;
   unsigned long hex;
 
@@ -150,7 +151,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
     return CURLE_OUT_OF_MEMORY;
 
   while(--alloc > 0) {
-    unsigned char in = *string;
+    char in = *string;
     if(('%' == in) && (alloc > 2) &&
        ISXDIGIT(string[1]) && ISXDIGIT(string[2])) {
       /* this is two hexadecimal digits following a '%' */
@@ -184,7 +185,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
     *olen = strindex;
 
   /* store output string */
-  *ostring = ns;
+  *ostring = (char *)ns;
 
   return CURLE_OK;
 }
@@ -202,7 +203,7 @@ char *curl_easy_unescape(struct Curl_easy *data, const char *string,
   char *str = NULL;
   (void)data;
   if(length >= 0) {
-    size_t inputlen = length;
+    size_t inputlen = (size_t) length;
     size_t outputlen;
     CURLcode res = Curl_urldecode(string, inputlen, &str, &outputlen,
                                   REJECT_NADA);

--- a/lib/file.c
+++ b/lib/file.c
@@ -329,7 +329,7 @@ static CURLcode file_upload(struct Curl_easy *data)
 
   while(!result) {
     size_t nread;
-    size_t nwrite;
+    ssize_t nwrite;
     size_t readcount;
     result = Curl_fillreadbuffer(data, data->set.buffer_size, &readcount);
     if(result)
@@ -358,7 +358,7 @@ static CURLcode file_upload(struct Curl_easy *data)
 
     /* write the data to the target */
     nwrite = write(fd, buf2, nread);
-    if(nwrite != nread) {
+    if((size_t)nwrite != nread) {
       result = CURLE_SEND_ERROR;
       break;
     }
@@ -556,7 +556,7 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
     if(size_known)
       expected_size -= nread;
 
-    result = Curl_client_write(data, CLIENTWRITE_BODY, buf, nread);
+    result = Curl_client_write(data, CLIENTWRITE_BODY, buf, (size_t) nread);
     if(result)
       return result;
 

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -135,15 +135,13 @@ static struct FormInfo *AddFormInfo(char *value,
 {
   struct FormInfo *form_info;
   form_info = calloc(1, sizeof(struct FormInfo));
-  if(form_info) {
-    if(value)
-      form_info->value = value;
-    if(contenttype)
-      form_info->contenttype = contenttype;
-    form_info->flags = HTTPPOST_FILENAME;
-  }
-  else
+  if(!form_info)
     return NULL;
+  if(value)
+    form_info->value = value;
+  if(contenttype)
+    form_info->contenttype = contenttype;
+  form_info->flags = HTTPPOST_FILENAME;
 
   if(parent_form_info) {
     /* now, point our 'more' to the original 'more' */
@@ -890,7 +888,7 @@ CURLcode Curl_getformdata(struct Curl_easy *data,
                                   post->bufferlength? post->bufferlength: -1);
         else if(post->flags & HTTPPOST_CALLBACK) {
           /* the contents should be read with the callback and the size is set
-             with the contentslength */
+             with the content's length */
           if(!clen)
             clen = -1;
           result = curl_mime_data_cb(part, clen,

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1174,7 +1174,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
   /* get the name again after the bind() so that we can extract the
      port number it uses now */
   sslen = sizeof(ss);
-  if(getsockname(portsock, (struct sockaddr *)sa, &sslen)) {
+  if(getsockname(portsock, sa, &sslen)) {
     failf(data, "getsockname() failed: %s",
           Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     Curl_closesocket(data, conn, portsock);
@@ -1950,7 +1950,7 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
      */
     const char * const host_name = conn->bits.socksproxy ?
       conn->socks_proxy.host.name : conn->http_proxy.host.name;
-    rc = Curl_resolv(data, host_name, (int)conn->port, FALSE, &addr);
+    rc = Curl_resolv(data, host_name, conn->port, FALSE, &addr);
     if(rc == CURLRESOLV_PENDING)
       /* BLOCKING, ignores the return code but 'addr' will be NULL in
          case of failure */
@@ -4167,7 +4167,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
         /* get path before last slash, except for / */
         size_t dirlen = slashPos - rawPath;
         if(dirlen == 0)
-            dirlen++;
+            dirlen = 1;
 
         ftpc->dirs = calloc(1, sizeof(ftpc->dirs[0]));
         if(!ftpc->dirs) {
@@ -4194,7 +4194,8 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
       /* current position: begin of next path component */
       const char *curPos = rawPath;
 
-      int dirAlloc = 0; /* number of entries allocated for the 'dirs' array */
+       /* number of entries allocated for the 'dirs' array */
+      size_t dirAlloc = 0;
       const char *str = rawPath;
       for(; *str != 0; ++str)
         if (*str == '/')
@@ -4230,7 +4231,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           curPos = slashPos + 1;
         }
       }
-      DEBUGASSERT(ftpc->dirdepth <= dirAlloc);
+      DEBUGASSERT((long long)ftpc->dirdepth <= (long long)dirAlloc);
       fileName = curPos; /* the rest is the file name (or empty) */
     }
     break;

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -205,9 +205,9 @@ CURLcode Curl_ftp_parselist_geterror(struct ftp_parselist_data *pl_data)
 
 #define FTP_LP_MALFORMATED_PERM 0x01000000
 
-static int ftp_pl_get_permission(const char *str)
+static unsigned int ftp_pl_get_permission(const char *str)
 {
-  int permissions = 0;
+  unsigned int permissions = 0;
   /* USER */
   if(str[0] == 'r')
     permissions |= 1 << 8;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -180,7 +180,7 @@ create_hostcache_id(const char *name, int port, char *ptr, size_t buflen)
   if(len > (buflen - 7))
     len = buflen - 7;
   /* store and lower case the name */
-  while(len--)
+  for(; len; len--)
     *ptr++ = Curl_raw_tolower(*name++);
   msnprintf(ptr, 7, ":%u", port);
 }

--- a/lib/http.c
+++ b/lib/http.c
@@ -648,9 +648,9 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data)
   unsigned long authmask = ~0ul;
 
   if(!data->set.str[STRING_BEARER])
-    authmask &= (unsigned long)~CURLAUTH_BEARER;
+    authmask = (unsigned long)~CURLAUTH_BEARER;
 
-  if(100 <= data->req.httpcode && 199 >= data->req.httpcode)
+  if(100 <= data->req.httpcode && data->req.httpcode <= 199)
     /* this is a transient response code, ignore */
     return CURLE_OK;
 
@@ -3751,7 +3751,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
     result = Curl_altsvc_parse(data, data->asi,
                                headp + strlen("Alt-Svc:"),
                                id, conn->host.name,
-                               curlx_uitous(conn->remote_port));
+                               curlx_uitous((unsigned int)conn->remote_port));
     if(result)
       return result;
   }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -367,17 +367,21 @@ static CURLcode imap_get_message(struct Curl_easy *data, struct bufref *out)
   if(len > 2) {
     /* Find the start of the message */
     len -= 2;
-    for(message += 2; *message == ' ' || *message == '\t'; message++, len--)
-      ;
+    for(message += 2; *message == ' ' || *message == '\t'; message++)
+      len--;
 
     /* Find the end of the message */
-    while(len--)
+    while(len) {
+      --len;
       if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
-         message[len] != '\t')
+          message[len] != '\t') {
+        ++len;
         break;
+      }
+    }
 
     /* Terminate the message */
-    message[++len] = '\0';
+    message[len] = '\0';
     Curl_bufref_set(out, message, len, NULL);
   }
   else

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -565,7 +565,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
         goto quit;
       }
 
-      result = Curl_client_write(data, CLIENTWRITE_BODY, (char *) name,
+      result = Curl_client_write(data, CLIENTWRITE_BODY, name,
                                  name_len);
       if(result) {
         FREE_ON_WINLDAP(name);
@@ -623,7 +623,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
           }
 
           result = Curl_client_write(data, CLIENTWRITE_BODY,
-                                     (char *) attr, attr_len);
+                                     attr, attr_len);
           if(result) {
             ldap_value_free_len(vals);
             FREE_ON_WINLDAP(attr);
@@ -648,7 +648,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
           dlsize += attr_len + 3;
 
           if((attr_len > 7) &&
-             (strcmp(";binary", (char *) attr + (attr_len - 7)) == 0)) {
+             (strcmp(";binary", attr + (attr_len - 7)) == 0)) {
             /* Binary attribute, encode to base64. */
             result = Curl_base64_encode(vals[i]->bv_val, vals[i]->bv_len,
                                         &val_b64, &val_b64_sz);

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1636,7 +1636,7 @@ static size_t slist_size(struct curl_slist *s,
 static curl_off_t multipart_size(curl_mime *mime)
 {
   curl_off_t size;
-  size_t boundarysize;
+  curl_off_t boundarysize;
   curl_mimepart *part;
 
   if(!mime)

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -114,7 +114,7 @@ static CURLcode mqtt_setup_conn(struct Curl_easy *data,
 }
 
 static CURLcode mqtt_send(struct Curl_easy *data,
-                          char *buf, size_t len)
+                          unsigned char *buf, size_t len)
 {
   CURLcode result = CURLE_OK;
   struct connectdata *conn = data->conn;
@@ -123,7 +123,7 @@ static CURLcode mqtt_send(struct Curl_easy *data,
   ssize_t n;
   result = Curl_write(data, sockfd, buf, len, &n);
   if(!result)
-    Curl_debug(data, CURLINFO_HEADER_OUT, buf, (size_t)n);
+    Curl_debug(data, CURLINFO_HEADER_OUT, (char *)buf, (size_t)n);
   if(len != (size_t)n) {
     size_t nsend = len - n;
     char *sendleftovers = Curl_memdup(&buf[n], nsend);
@@ -151,10 +151,10 @@ static int mqtt_getsock(struct Curl_easy *data,
   return GETSOCK_READSOCK(FIRSTSOCKET);
 }
 
-static int mqtt_encode_len(char *buf, size_t len)
+static size_t mqtt_encode_len(unsigned char *buf, size_t len)
 {
   unsigned char encoded;
-  int i;
+  size_t i;
 
   for(i = 0; (len > 0) && (i<4); i++) {
     encoded = len % 0x80;
@@ -169,7 +169,8 @@ static int mqtt_encode_len(char *buf, size_t len)
 
 /* add the passwd to the CONNECT packet */
 static int add_passwd(const char *passwd, const size_t plen,
-                       char *pkt, const size_t start, int remain_pos)
+                      unsigned char *pkt, const size_t start,
+                      size_t remain_pos)
 {
   /* magic number that need to be set properly */
   const size_t conn_flags_pos = remain_pos + 8;
@@ -180,15 +181,16 @@ static int add_passwd(const char *passwd, const size_t plen,
   pkt[conn_flags_pos] |= 0x40;
 
   /* length of password provided */
-  pkt[start] = (char)((plen >> 8) & 0xFF);
-  pkt[start + 1] = (char)(plen & 0xFF);
+  pkt[start] = ((plen >> 8) & 0xFF);
+  pkt[start + 1] = (plen & 0xFF);
   memcpy(&pkt[start + 2], passwd, plen);
   return 0;
 }
 
 /* add user to the CONNECT packet */
 static int add_user(const char *username, const size_t ulen,
-                    unsigned char *pkt, const size_t start, int remain_pos)
+                    unsigned char *pkt, const size_t start,
+                    size_t remain_pos)
 {
   /* magic number that need to be set properly */
   const size_t conn_flags_pos = remain_pos + 8;
@@ -206,7 +208,7 @@ static int add_user(const char *username, const size_t ulen,
 
 /* add client ID to the CONNECT packet */
 static int add_client_id(const char *client_id, const size_t client_id_len,
-                         char *pkt, const size_t start)
+                         unsigned char *pkt, const size_t start)
 {
   if(client_id_len != MQTT_CLIENTID_LEN)
     return 1;
@@ -217,7 +219,8 @@ static int add_client_id(const char *client_id, const size_t client_id_len,
 }
 
 /* Set initial values of CONNECT packet */
-static int init_connpack(char *packet, char *remain, int remain_pos)
+static size_t init_connpack(unsigned char *packet, char *remain,
+                            size_t remain_pos)
 {
   /* Fixed header starts */
   /* packet type */
@@ -249,10 +252,10 @@ static int init_connpack(char *packet, char *remain, int remain_pos)
 static CURLcode mqtt_connect(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OK;
-  int pos = 0;
+  size_t pos = 0;
   int rc = 0;
   /*remain length*/
-  int remain_pos = 0;
+  size_t remain_pos = 0;
   char remain[4] = {0};
   size_t packetlen = 0;
   size_t payloadlen = 0;
@@ -260,7 +263,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   size_t start_pwd = 0;
   char client_id[MQTT_CLIENTID_LEN + 1] = "curl";
   const size_t clen = strlen("curl");
-  char *packet = NULL;
+  unsigned char *packet = NULL;
 
   /* extracting username from request */
   const char *username = data->state.aptr.user ?
@@ -280,7 +283,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
     payloadlen += 2;
 
   /* getting how much occupy the remain length */
-  remain_pos = mqtt_encode_len(remain, payloadlen + 10);
+  remain_pos = mqtt_encode_len((unsigned char *)remain, payloadlen + 10);
 
   /* 10 length of variable header and 1 the first byte of the fixed header */
   packetlen = payloadlen + 10 + remain_pos + 1;
@@ -315,8 +318,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   if(ulen) {
     start_pwd += 2;
 
-    rc = add_user(username, ulen,
-                  (unsigned char *)packet, start_user, remain_pos);
+    rc = add_user(username, ulen, packet, start_user, remain_pos);
     if(rc) {
       failf(data, "Username is too large: [%lu]", ulen);
       result = CURLE_WEIRD_SERVER_REPLY;
@@ -349,7 +351,7 @@ static CURLcode mqtt_disconnect(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OK;
   struct MQTT *mq = data->req.p.mqtt;
-  result = mqtt_send(data, (char *)"\xe0\x00", 2);
+  result = mqtt_send(data, (unsigned char *)"\xe0\x00", 2);
   Curl_safefree(mq->sendleftovers);
   return result;
 }
@@ -410,7 +412,7 @@ static CURLcode mqtt_subscribe(struct Curl_easy *data)
   size_t topiclen;
   unsigned char *packet = NULL;
   size_t packetlen;
-  char encodedsize[4];
+  unsigned char encodedsize[4];
   size_t n;
   struct connectdata *conn = data->conn;
 
@@ -422,7 +424,7 @@ static CURLcode mqtt_subscribe(struct Curl_easy *data)
 
   packetlen = topiclen + 5; /* packetid + topic (has a two byte length field)
                                + 2 bytes topic length + QoS byte */
-  n = mqtt_encode_len((char *)encodedsize, packetlen);
+  n = mqtt_encode_len(encodedsize, packetlen);
   packetlen += n + 1; /* add one for the control packet type byte */
 
   packet = malloc(packetlen);
@@ -440,7 +442,7 @@ static CURLcode mqtt_subscribe(struct Curl_easy *data)
   memcpy(&packet[5 + n], topic, topiclen);
   packet[5 + n + topiclen] = 0; /* QoS zero */
 
-  result = mqtt_send(data, (char *)packet, packetlen);
+  result = mqtt_send(data, packet, packetlen);
 
 fail:
   free(topic);
@@ -493,7 +495,7 @@ static CURLcode mqtt_publish(struct Curl_easy *data)
   size_t i = 0;
   size_t remaininglength;
   size_t encodelen;
-  char encodedbytes[4];
+  unsigned char encodedbytes[4];
   curl_off_t postfieldsize = data->set.postfieldsize;
 
   if(!payload)
@@ -527,7 +529,7 @@ static CURLcode mqtt_publish(struct Curl_easy *data)
   i += topiclen;
   memcpy(&pkt[i], payload, payloadlen);
   i += payloadlen;
-  result = mqtt_send(data, (char *)pkt, i);
+  result = mqtt_send(data, pkt, i);
 
 fail:
   free(pkt);
@@ -731,7 +733,7 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
   if(mq->nsend) {
     /* send the remainder of an outgoing packet */
     char *ptr = mq->sendleftovers;
-    result = mqtt_send(data, mq->sendleftovers, mq->nsend);
+    result = mqtt_send(data, (unsigned char *)mq->sendleftovers, mq->nsend);
     free(ptr);
     if(result)
       return result;

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -79,15 +79,15 @@ UNITTEST bool Curl_cidr6_match(const char *ipv6,
                                unsigned int bits)
 {
 #ifdef ENABLE_IPV6
-  int bytes;
-  int rest;
+  size_t bytes;
+  unsigned int rest;
   unsigned char address[16];
   unsigned char check[16];
 
   if(!bits)
     bits = 128;
 
-  bytes = bits/8;
+  bytes = bits >> 3;
   rest = bits & 0x07;
   if(1 != Curl_inet_pton(AF_INET6, ipv6, address))
     return FALSE;
@@ -222,7 +222,12 @@ bool Curl_check_noproxy(const char *name, const char *no_proxy)
           slash = strchr(check, '/');
           /* if the slash is part of this token, use it */
           if(slash) {
-            bits = atoi(slash + 1);
+            unsigned long longbits = strtoul(slash + 1, NULL, 10);
+            if(longbits > UINT_MAX)
+              /* this cannot match */
+              break;
+
+            bits = (unsigned int)longbits;
             *slash = 0; /* null terminate there */
           }
           if(type == TYPE_IPV6)

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -264,17 +264,21 @@ static CURLcode pop3_get_message(struct Curl_easy *data, struct bufref *out)
   if(len > 2) {
     /* Find the start of the message */
     len -= 2;
-    for(message += 2; *message == ' ' || *message == '\t'; message++, len--)
-      ;
+    for(message += 2; *message == ' ' || *message == '\t'; message++)
+      len--;
 
     /* Find the end of the message */
-    while(len--)
+    while(len) {
+      --len;
       if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
-         message[len] != '\t')
+          message[len] != '\t') {
+        ++len;
         break;
+      }
+    }
 
     /* Terminate the message */
-    message[++len] = '\0';
+    message[len] = '\0';
     Curl_bufref_set(out, message, len, NULL);
   }
   else

--- a/lib/select.c
+++ b/lib/select.c
@@ -187,7 +187,7 @@ int Curl_socket_check(curl_socket_t readfd0, /* two sockets to read from */
                       timediff_t timeout_ms) /* milliseconds to wait */
 {
   struct pollfd pfd[3];
-  int num;
+  unsigned int num;
   int r;
 
   if((readfd0 == CURL_SOCKET_BAD) && (readfd1 == CURL_SOCKET_BAD) &&

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2205,7 +2205,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     else if(arg < READBUFFER_MIN)
       arg = READBUFFER_MIN;
 
-    data->set.buffer_size = (int)arg;
+    data->set.buffer_size = (unsigned int)arg;
     break;
 
   case CURLOPT_UPLOAD_BUFFERSIZE:

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -360,7 +360,7 @@ static void smb_format_message(struct Curl_easy *data, struct smb_header *h,
   struct connectdata *conn = data->conn;
   struct smb_conn *smbc = &conn->proto.smbc;
   struct smb_request *req = data->req.p.smb;
-  unsigned int pid;
+  pid_t pid;
 
   memset(h, 0, sizeof(*h));
   h->nbt_length = htons((unsigned short) (sizeof(*h) - sizeof(unsigned int) +

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -262,17 +262,21 @@ static CURLcode smtp_get_message(struct Curl_easy *data, struct bufref *out)
   if(len > 4) {
     /* Find the start of the message */
     len -= 4;
-    for(message += 4; *message == ' ' || *message == '\t'; message++, len--)
-      ;
+    for(message += 4; *message == ' ' || *message == '\t'; message++)
+      len--;
 
     /* Find the end of the message */
-    while(len--)
+    while(len) {
+      --len;
       if(message[len] != '\r' && message[len] != '\n' && message[len] != ' ' &&
-         message[len] != '\t')
+          message[len] != '\t') {
+        ++len;
         break;
+      }
+    }
 
     /* Terminate the message */
-    message[++len] = '\0';
+    message[len] = '\0';
     Curl_bufref_set(out, message, len, NULL);
   }
   else

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -513,7 +513,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
   struct connectdata *conn = data->conn;
   unsigned char *socksreq = (unsigned char *)data->state.buffer;
   char dest[256] = "unknown";  /* printable hostname:port */
-  int idx;
+  ssize_t idx;
   ssize_t actualread;
   ssize_t written;
   CURLcode result;
@@ -566,7 +566,8 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
     /* write the number of authentication methods */
     socksreq[1] = (unsigned char) (idx - 2);
 
-    result = Curl_write_plain(data, sockfd, (char *)socksreq, idx, &written);
+    result = Curl_write_plain(data, sockfd, (char *)socksreq,
+                              (size_t)idx, &written);
     if(result && (CURLE_AGAIN != result)) {
       failf(data, "Unable to send initial SOCKS5 request.");
       return CURLPX_SEND_CONNECT;
@@ -712,7 +713,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
   }
     /* FALLTHROUGH */
   case CONNECT_AUTH_SEND:
-    result = Curl_write_plain(data, sockfd, (char *)sx->outp,
+    result = Curl_write_plain(data, sockfd, sx->outp,
                               sx->outstanding, &written);
     if(result && (CURLE_AGAIN != result)) {
       failf(data, "Failed to send SOCKS5 sub-negotiation request.");
@@ -829,7 +830,7 @@ CURLproxycode Curl_SOCKS5(const char *proxy_user,
     }
 #ifdef ENABLE_IPV6
     else if(hp->ai_family == AF_INET6) {
-      int i;
+      unsigned int i;
       struct sockaddr_in6 *saddr_in6;
       socksreq[len++] = 4; /* ATYP: IPv6 = 4 */
 

--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -184,7 +184,7 @@ bool Curl_safecmp(char *a, char *b)
 int Curl_timestrcmp(const char *a, const char *b)
 {
   int match = 0;
-  int i = 0;
+  size_t i = 0;
 
   if(a && b) {
     while(1) {

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1039,7 +1039,7 @@ CURLcode telrcv(struct Curl_easy *data,
 
 #define bufferflush() startskipping()
 
-  while(count--) {
+  for(; count > 0; count--) {
     c = inbuf[in];
 
     switch(tn->telrcv_state) {
@@ -1200,11 +1200,11 @@ static CURLcode send_telnet_data(struct Curl_easy *data,
 
     j = 0;
     for(i = 0; i < nread; i++) {
-      outbuf[j++] = buffer[i];
+      outbuf[j++] = (unsigned char)buffer[i];
       if((unsigned char)buffer[i] == CURL_IAC)
         outbuf[j++] = CURL_IAC;
     }
-    outbuf[j] = '\0';
+    outbuf[j] = 0;
   }
 
   total_written = 0;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -522,7 +522,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
   ssize_t nread; /* number of bytes read */
   size_t excess = 0; /* excess bytes read */
   bool readmore = FALSE; /* used by RTP to signal for more data */
-  int maxloops = 100;
+  unsigned int maxloops = 101;
   char *buf = data->state.buffer;
   DEBUGASSERT(buf);
 
@@ -857,9 +857,9 @@ static CURLcode readwrite_data(struct Curl_easy *data,
       break;
     }
 
-  } while(data_pending(data) && maxloops--);
+  } while(--maxloops && data_pending(data));
 
-  if(maxloops <= 0) {
+  if(maxloops == 0) {
     /* we mark it as read-again-please */
     conn->cselect_bits = CURL_CSELECT_IN;
     *comeback = TRUE;
@@ -946,7 +946,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
        k->upload_present < curl_upload_refill_watermark(data) &&
        !k->upload_chunky &&/*(variable sized chunked header; append not safe)*/
        !k->upload_done &&  /*!(k->upload_done once k->upload_present sent)*/
-       !(k->writebytecount + k->upload_present - k->pendingheader ==
+       (k->writebytecount + k->upload_present - k->pendingheader !=
          data->state.infilesize)) {
       offset = k->upload_present;
     }

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -71,11 +71,11 @@
 bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
                                const char **endptr)
 {
-  int c;
+  unsigned int c;
   bool starts_with_quote = FALSE;
   bool escape = FALSE;
 
-  for(c = DIGEST_MAX_VALUE_LENGTH - 1; (*str && (*str != '=') && c--);)
+  for(c = DIGEST_MAX_VALUE_LENGTH - 1; (*str && (*str != '=') && c); c--)
     *value++ = *str++;
   *value = 0;
 
@@ -89,7 +89,8 @@ bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
     starts_with_quote = TRUE;
   }
 
-  for(c = DIGEST_MAX_CONTENT_LENGTH - 1; *str && c--; str++) {
+  for(c = DIGEST_MAX_CONTENT_LENGTH - 1; *str && c; str++) {
+    c--;
     if(!escape) {
       switch(*str) {
       case '\\':
@@ -186,7 +187,7 @@ static char *auth_digest_string_quoted(const char *source)
       }
       *d++ = *s++;
     }
-    *d = 0;
+    *d = '\0';
   }
 
   return dest;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3208,7 +3208,7 @@ static int sectransp_shutdown(struct Curl_easy *data,
   int what;
   int rc;
   char buf[120];
-  int loop = 10; /* avoid getting stuck */
+  unsigned int loop; /* avoid getting stuck */
 
   DEBUGASSERT(backend);
 
@@ -3226,7 +3226,7 @@ static int sectransp_shutdown(struct Curl_easy *data,
 
   what = SOCKET_READABLE(conn->sock[sockindex], SSL_SHUTDOWN_TIMEOUT);
 
-  while(loop--) {
+  for(loop = 10; loop; loop--) {
     if(what < 0) {
       /* anything that gets here is fatally bad */
       failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -394,10 +394,10 @@ curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid)
 {
   curl_version_info_data *p;
   char *cp;
-  int n;
-  int nproto;
+  size_t n;
+  size_t nproto;
   curl_version_info_data *id;
-  int i;
+  size_t i;
   const char **cpp;
   static const size_t charfields[] = {
     offsetof(curl_version_info_data, version),
@@ -472,7 +472,7 @@ curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid)
   memcpy((char *) id, (char *) p, sizeof(*p));
 
   if(id->protocols) {
-    int i = nproto * sizeof(id->protocols[0]);
+    i = nproto * sizeof(id->protocols[0]);
 
     id->protocols = (const char * const *) cp;
     memcpy(cp, (char *) p->protocols, i);
@@ -487,7 +487,7 @@ curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid)
 
   for(i = 0; i < sizeof(charfields) / sizeof(charfields[0]); i++) {
     cpp = (const char **) ((char *) p + charfields[i]);
-    if (*cpp && convert_version_info_string(cpp, &cp, &n, ccsid))
+    if(*cpp && convert_version_info_string(cpp, &cp, &n, ccsid))
       return (curl_version_info_data *) NULL;
   }
 
@@ -498,7 +498,7 @@ curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid)
 const char *
 curl_easy_strerror_ccsid(CURLcode error, unsigned int ccsid)
 {
-  int i;
+  size_t i;
   const char *s;
   char *buf;
 
@@ -523,7 +523,7 @@ curl_easy_strerror_ccsid(CURLcode error, unsigned int ccsid)
 const char *
 curl_share_strerror_ccsid(CURLSHcode error, unsigned int ccsid)
 {
-  int i;
+  size_t i;
   const char *s;
   char *buf;
 
@@ -548,7 +548,7 @@ curl_share_strerror_ccsid(CURLSHcode error, unsigned int ccsid)
 const char *
 curl_multi_strerror_ccsid(CURLMcode error, unsigned int ccsid)
 {
-  int i;
+  size_t i;
   const char *s;
   char *buf;
 
@@ -709,7 +709,7 @@ Curl_is_formadd_string(CURLformoption option)
 static void
 Curl_formadd_release_local(struct curl_forms *forms, int nargs, int skip)
 {
-  while(nargs--)
+  while(nargs-- > 0)
     if(nargs != skip)
       if(Curl_is_formadd_string(forms[nargs].option))
         if(forms[nargs].value)

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -745,7 +745,7 @@ OM_uint32
 Curl_gss_import_name_a(OM_uint32 *minor_status, gss_buffer_t in_name,
                        gss_OID in_name_type, gss_name_t *out_name)
 {
-  int rc;
+  OM_uint32 rc;
   unsigned int i;
   gss_buffer_desc in;
 
@@ -859,7 +859,7 @@ Curl_gss_delete_sec_context_a(OM_uint32 *minor_status,
                               gss_ctx_id_t *context_handle,
                               gss_buffer_t output_token)
 {
-  int rc;
+  OM_uint32 rc;
 
   rc = gss_delete_sec_context(minor_status, context_handle, output_token);
 
@@ -886,7 +886,7 @@ Curl_gss_delete_sec_context_a(OM_uint32 *minor_status,
 void *
 Curl_ldap_init_a(char *host, int port)
 {
-  unsigned int i;
+  size_t i;
   char *ehost;
   void *result;
 

--- a/packages/vms/curl_crtl_init.c
+++ b/packages/vms/curl_crtl_init.c
@@ -130,7 +130,7 @@ static int sys_trnlnm
 
     status = SYS$TRNLNM(&attr, &table_dsc, &name_dsc, 0, itlst);
 
-    if ($VMS_STATUS_SUCCESS(status)) {
+    if($VMS_STATUS_SUCCESS(status)) {
 
          /* Null terminate and return the string */
         /*--------------------------------------*/
@@ -192,7 +192,7 @@ static void set_feature_default(const char *name, int value)
 
     index = decc$feature_get_index(name);
 
-    if (index > 0)
+    if(index > 0)
         decc$feature_set_value (index, 0, value);
 }
 #endif
@@ -205,7 +205,7 @@ static void set_features(void)
 
     status = sys_trnlnm("GNV$UNIX_SHELL",
                         unix_shell_name, sizeof unix_shell_name -1);
-    if (!$VMS_STATUS_SUCCESS(status)) {
+    if(!$VMS_STATUS_SUCCESS(status)) {
         use_unix_settings = 0;
     }
 
@@ -249,7 +249,7 @@ static void set_features(void)
     /* Fix mv aa.bb aa  */
     set_feature_default ("DECC$RENAME_NO_INHERIT", ENABLE);
 
-    if (use_unix_settings) {
+    if(use_unix_settings) {
 
         /* POSIX requires that open files be able to be removed */
         set_feature_default ("DECC$ALLOW_REMOVE_OPEN_FILES", ENABLE);

--- a/packages/vms/report_openssl_version.c
+++ b/packages/vms/report_openssl_version.c
@@ -49,7 +49,7 @@ void * libptr;
 const char * (*ssl_version)(int t);
 const char * version;
 
-   if (argc < 1) {
+   if(argc < 1) {
        puts("report_openssl_version filename");
        exit(1);
    }
@@ -57,16 +57,16 @@ const char * version;
    libptr = dlopen(argv[1], 0);
 
    ssl_version = (const char * (*)(int))dlsym(libptr, "SSLeay_version");
-   if ((void *)ssl_version == NULL) {
+   if(ssl_version == NULL) {
       ssl_version = (const char * (*)(int))dlsym(libptr, "ssleay_version");
-      if ((void *)ssl_version == NULL) {
+      if(ssl_version == NULL) {
          ssl_version = (const char * (*)(int))dlsym(libptr, "SSLEAY_VERSION");
       }
    }
 
    dlclose(libptr);
 
-   if ((void *)ssl_version == NULL) {
+   if(ssl_version == NULL) {
       puts("Unable to lookup version of OpenSSL");
       exit(1);
    }
@@ -76,7 +76,7 @@ const char * version;
    puts(version);
 
    /* Was a symbol argument given? */
-   if (argc > 1) {
+   if(argc > 1) {
       int status;
       struct dsc$descriptor_s symbol_dsc;
       struct dsc$descriptor_s value_dsc;
@@ -93,7 +93,7 @@ const char * version;
       value_dsc.dsc$b_class = DSC$K_CLASS_S;
 
       status = LIB$SET_SYMBOL(&symbol_dsc, &value_dsc, &table_type);
-      if (!$VMS_STATUS_SUCCESS(status)) {
+      if(!$VMS_STATUS_SUCCESS(status)) {
          exit(status);
       }
    }

--- a/tests/libtest/lib1542.c
+++ b/tests/libtest/lib1542.c
@@ -76,13 +76,11 @@ int test(char *URL)
   easy_setopt(easy, CURLOPT_MAXLIFETIME_CONN, 1L);
 
   res = curl_easy_perform(easy);
-  if(res)
-    goto test_cleanup;
 
 test_cleanup:
 
   curl_easy_cleanup(easy);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1568.c
+++ b/tests/libtest/lib1568.c
@@ -40,7 +40,7 @@ int test(char *URL)
   curl_easy_setopt(hnd, CURLOPT_USERAGENT, "lib1568");
   curl_easy_setopt(hnd, CURLOPT_HTTPAUTH, (long)CURLAUTH_DIGEST);
   curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
-  curl_easy_setopt(hnd, CURLOPT_PORT, (long)atoi(libtest_arg2));
+  curl_easy_setopt(hnd, CURLOPT_PORT, strtol(libtest_arg2, NULL, 10));
 
   ret = curl_easy_perform(hnd);
 

--- a/tests/server/disabled.c
+++ b/tests/server/disabled.c
@@ -84,7 +84,7 @@ static const char *disabled[]={
 
 int main(void)
 {
-  int i;
+  size_t i;
   for(i = 0; disabled[i]; i++)
     printf("%s\n", disabled[i]);
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -352,7 +352,7 @@ static void lograw(unsigned char *buffer, ssize_t len)
   unsigned char *ptr = buffer;
   char *optr = data;
   ssize_t width = 0;
-  int left = sizeof(data);
+  size_t left = sizeof(data);
 
   for(i = 0; i<len; i++) {
     switch(ptr[i]) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -251,10 +251,10 @@ static void loghex(unsigned char *buffer, ssize_t len)
   unsigned char *ptr = buffer;
   char *optr = data;
   ssize_t width = 0;
-  int left = sizeof(data);
+  ssize_t left = sizeof(data);
 
   for(i = 0; i<len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
+    msnprintf(optr, (size_t)left, "%02x", ptr[i]);
     width += 2;
     optr += 2;
     left -= 2;

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -367,7 +367,7 @@ static int readit(struct testcase *test, struct tftphdr **dpp,
 static void read_ahead(struct testcase *test,
                        int convert /* if true, convert to ascii */)
 {
-  int i;
+  unsigned int i;
   char *p;
   int c;
   struct bf *b;


### PR DESCRIPTION
Many of these castings are unneeded if we change the variables to work better with each other.

Note that none of the public facing functions had their signature changed.