### PR TITLE
Add link for building libcurl with Bazel

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,6 +21,10 @@ The curl port in vcpkg is kept up to date by Microsoft team members and
 community contributors. If the version is out of date, please [create an issue
 or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+## Building libcurl using Bazel
+
+Please refer to [hedronvision/bazel-make-cc-https-easy](https://github.com/hedronvision/bazel-make-cc-https-easy).
+
 ## Building from git
 
 If you get your code off a git repository instead of a release tarball, see


### PR DESCRIPTION
Hi again, @bagder!

Following #9732 and seeing people struggling to use libcurl from Bazel, I released our files for easily and correctly doing so. They work across a few platforms in this initial release (Android + all the Apple platforms). More to come.

I'm hoping you might be willing to link to the new project from your docs to help Bazelers find it, since I think it'd solve an acute pain point for them. (Bazel's CMake/autotools wrappers aren't up to the task, sadly.)

On me to keep it in sync with your build. We're actively using it, so I'd better! And if you aren't satisfied long term, obviously feel free to revert out this link. Heard you loud and clear on not wanting to support more build systems yourself. But we needed this one and I figured it'd be good to share it with the world.

Thanks for all you do,
Chris

P.S. Fun fact I just discovered reading the docs: Curl and I share a birthday!