### PR TITLE
In SFTP, do not add '/' if homedir ends with one

### DIFF
--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -71,10 +71,14 @@ CURLcode Curl_getworkingpath(struct Curl_easy *data,
       /* It is referenced to the home directory, so strip the
          leading '/' */
       memcpy(real_path, homedir, homelen);
-      real_path[homelen] = '/';
-      real_path[homelen + 1] = '\0';
+      /* Only add a trailing '/' if homedir does not end with one */
+      if(homelen == 0 || real_path[homelen - 1] != '/') {
+        real_path[homelen] = '/';
+        homelen++;
+        real_path[homelen] = '\0';
+      }
       if(working_path_len > 3) {
-        memcpy(real_path + homelen + 1, working_path + 3,
+        memcpy(real_path + homelen, working_path + 3,
                1 + working_path_len -3);
       }
     }


### PR DESCRIPTION
When using SFTP and a path relative to the user home, do not add a trailing '/' to the user home dir if it already ends with one.

Background:

We have an SFTP server which serves files out of a virtual directory structure. Because of this, the "HOME" directory for all users is "/" by configuration (we do not have user home directories in the virtual filesystem).

When using curl to upload files with a command such as this:
`curl -T file_to_upload.txt sftp://hostname/~/folder/`

curl first resolves the home directory to "/" and then uploads the file with this filename: `//folder/file_to_upload.txt`

In our case, this caused the path to be misinterpreted as a network path which ultimately caused the upload to fail. We will implement a fix in the SFTP server for this.

The fix here is simply such that curl uploads the file with this filename instead in this situation:
`/folder/file_to_upload.txt`

which is the intended path I believe.