### PR TITLE
curl: don't ignore query part when using --remote-name

### DIFF
--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -161,6 +161,9 @@ CURLcode get_url_file_name(char **filename, const char *url)
 
   if(!curl_url_set(uh, CURLUPART_URL, url, CURLU_GUESS_SCHEME) &&
      !curl_url_get(uh, CURLUPART_PATH, &path, 0)) {
+    char *query = NULL;
+    curl_url_get(uh, CURLUPART_QUERY, &query, 0);
+
     curl_url_cleanup(uh);
 
     pc = strrchr(path, '/');
@@ -175,7 +178,12 @@ CURLcode get_url_file_name(char **filename, const char *url)
       /* no slash => empty string */
       pc = "";
 
-    *filename = strdup(pc);
+    if(query) {
+      *filename = aprintf("%s?%s", pc, query);
+      curl_free(query);
+    }
+    else
+      *filename = strdup(pc);
     curl_free(path);
     if(!*filename)
       return CURLE_OUT_OF_MEMORY;

--- a/tests/data/test1210
+++ b/tests/data/test1210
@@ -53,7 +53,11 @@ User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>
-<file name="log/%TESTNUMBER">
+%if win32
+<file name="log/%TESTNUMBER_junk">
+%else
+<file name="log/%TESTNUMBER?junk">
+%endif
 12345
 </file>
 


### PR DESCRIPTION
PR #9684 changed the behaviour of --remote-name to ignore the possible query part of the URL when generating the output file name. This breaks existing code that use curl and expect the old behaviour. This update restores the original behaviour whilst still using the URL parser.

Fixes #9826