### PR TITLE
docs: Remove Duplicate Word

### DIFF
--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -62,7 +62,7 @@ Could not resolve host. The given remote host was not resolved.
 .IP "CURLE_COULDNT_CONNECT (7)"
 Failed to connect() to host or proxy.
 .IP "CURLE_WEIRD_SERVER_REPLY (8)"
-The server sent data libcurl could not parse. This error code was known as as
+The server sent data libcurl could not parse. This error code was known as
 \fICURLE_FTP_WEIRD_SERVER_REPLY\fP before 7.51.0.
 .IP "CURLE_REMOTE_ACCESS_DENIED (9)"
 We were denied access to the resource given in the URL. For FTP, this occurs


### PR DESCRIPTION
Removes a repeated word in the `CURLE_REMOTE_ACCESS_DENIED` error's documentation.