### PR TITLE
docs: add missing parameters for retry flag

### DIFF
--- a/docs/cmdline-opts/retry-connrefused.d
+++ b/docs/cmdline-opts/retry-connrefused.d
@@ -4,7 +4,7 @@ Long: retry-connrefused
 Help: Retry on connection refused (use with --retry)
 Added: 7.52.0
 Category: curl
-Example: --retry-connrefused --retry $URL
+Example: --retry-connrefused --retry 7 $URL
 See-also: retry retry-all-errors
 Multi: boolean
 ---

--- a/docs/cmdline-opts/retry-delay.d
+++ b/docs/cmdline-opts/retry-delay.d
@@ -5,7 +5,7 @@ Arg: <seconds>
 Help: Wait time between retries
 Added: 7.12.3
 Category: curl
-Example: --retry-delay 5 --retry $URL
+Example: --retry-delay 5 --retry 7 $URL
 See-also: retry
 Multi: single
 ---


### PR DESCRIPTION
Option `--retry` expects a proper numerical parameter but there's no one in some examples.