### PR TITLE
CURLOPT_DEBUGFUNCTION.3: do not assume nul-termination in example

### DIFF
--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
@@ -125,7 +125,8 @@ int my_trace(CURL *handle, curl_infotype type,
 
   switch (type) {
   case CURLINFO_TEXT:
-    fprintf(stderr, "== Info: %s", data);
+    fputs("== Info: ", stderr);
+    fwrite(data, size, 1, stderr);
   default: /* in case a new one is introduced to shock us */
     return 0;
 


### PR DESCRIPTION
Reported-by: Oskar Sigvardsson

Bug: https://curl.se/mail/lib-2022-11/0016.html