### PR TITLE
maketgz: set the right version in lib/libcurl.plist

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -64,6 +64,7 @@ numeric=`perl -e 'printf("%02x%02x%02x\n", '"$major, $minor, $patch);"`
 HEADER=include/curl/curlver.h
 CHEADER=src/tool_version.h
 PLIST=lib/libcurl.plist
+PLISTO=$PLIST
 
 if test -z "$only"; then
   ext=".dist"
@@ -93,6 +94,9 @@ rm -f "$HEADER.bak"
 # Replace version number in header file:
 sed -i.bak 's/#define CURL_VERSION .*/#define CURL_VERSION "'$curlversion'"/g' $CHEADER
 rm -f "$CHEADER.bak"
+
+# Replace version number in plist file:
+sed "s/@CURL_PLIST_VERSION@/$curlversion/g" < $PLISTO.in >$PLIST
 
 if test -n "$only"; then
   # done!


### PR DESCRIPTION
Follow-up to e498a9b1fe5964a18eb2a3a99dc52

Make sure the tarball gets a version of the libcurl.plist file that is updated with the new version string.

Reported-by: jvreelanda on github
Fixes #9866