### PR TITLE
config-win32: fix SIZEOF_OFF_T for MSVC and old MinGW

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -332,8 +332,8 @@
 #define SIZEOF_CURL_OFF_T 8
 
 /* Define to the size of `off_t', as computed by sizeof. */
-#ifndef SIZEOF_OFF_T
-#define SIZEOF_OFF_T 8
+#if defined(__MINGW32__)
+#  define SIZEOF_OFF_T 8
 #endif
 
 /* ---------------------------------------------------------------- */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -333,7 +333,7 @@
 
 /* Define to the size of `off_t', as computed by sizeof. */
 #if defined(__MINGW32__)
-#  define SIZEOF_OFF_T 8
+#define SIZEOF_OFF_T 8
 #endif
 
 /* ---------------------------------------------------------------- */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -331,11 +331,6 @@
 /* Define to the size of `curl_off_t', as computed by sizeof. */
 #define SIZEOF_CURL_OFF_T 8
 
-/* Define to the size of `off_t', as computed by sizeof. */
-#if defined(__MINGW32__)
-#define SIZEOF_OFF_T 8
-#endif
-
 /* ---------------------------------------------------------------- */
 /*               BSD-style lwIP TCP/IP stack SPECIFIC               */
 /* ---------------------------------------------------------------- */
@@ -575,6 +570,14 @@ Vista
 #  ifndef _FILE_OFFSET_BITS
 #  define _FILE_OFFSET_BITS 64
 #  endif
+#endif
+
+/* Define to the size of `off_t', as computed by sizeof. */
+#if defined(__MINGW64_VERSION_MAJOR) && \
+  defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+#  define SIZEOF_OFF_T 8
+#else
+#  define SIZEOF_OFF_T 4
 #endif
 
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
The previously set default value of 8 (64-bit) is only correct for mingw-w64 and only when `_FILE_OFFSET_BITS` is set to 64 (the default when building curl). For MSVC, old MinGW and other Windows compilers, the correct value is 4 (32-bit). Adjust condition accordingly. Also drop the manual override option.

Regression in 7.86.0 (from 68fa9bf3f5d7b4fcbb57619f70cb4aabb79a51f6)

Bug: https://github.com/curl/curl/pull/9712#issuecomment-1307330551
Reported-by: Peter Piekarski
Closes #xxxx
