### PR TITLE
http: Send PROXY exactly once

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1572,14 +1572,14 @@ CURLcode Curl_http_connect(struct Curl_easy *data, bool *done)
     /* nothing else to do except wait right now - we're not done here. */
     return CURLE_OK;
 
-  if(data->set.haproxyprotocol && !data->state.is_proxy_hdr_sent) {
+  if(data->set.haproxyprotocol && !data->state.is_haproxy_hdr_sent) {
     /* add HAProxy PROXY protocol header */
     result = add_haproxy_protocol_header(data);
     if(result)
       return result;
 
     /* do not send the header again after successful try */
-    data->state.is_proxy_hdr_sent = TRUE;
+    data->state.is_haproxy_hdr_sent = TRUE;
   }
 #endif
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1577,6 +1577,9 @@ CURLcode Curl_http_connect(struct Curl_easy *data, bool *done)
     result = add_haproxy_protocol_header(data);
     if(result)
       return result;
+
+    /* do not send the header again after successful try */
+    data->set.haproxyprotocol = FALSE;
   }
 #endif
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1572,14 +1572,14 @@ CURLcode Curl_http_connect(struct Curl_easy *data, bool *done)
     /* nothing else to do except wait right now - we're not done here. */
     return CURLE_OK;
 
-  if(data->set.haproxyprotocol) {
+  if(data->set.haproxyprotocol && !data->state.is_proxy_hdr_sent) {
     /* add HAProxy PROXY protocol header */
     result = add_haproxy_protocol_header(data);
     if(result)
       return result;
 
     /* do not send the header again after successful try */
-    data->set.haproxyprotocol = FALSE;
+    data->state.is_proxy_hdr_sent = TRUE;
   }
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1463,7 +1463,7 @@ struct UrlState {
 #endif
 #ifndef CURL_DISABLE_PROXY
   /* to keep track whether we already sent PROXY header or not */
-  BIT(is_proxy_hdr_sent);
+  BIT(is_haproxy_hdr_sent);
 #endif
 #ifdef USE_HYPER
   bool hconnect;  /* set if a CONNECT request */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1461,6 +1461,10 @@ struct UrlState {
   trailers_state trailers_state; /* whether we are sending trailers
                                     and what stage are we at */
 #endif
+#ifndef CURL_DISABLE_PROXY
+  /* to keep track whether we already sent PROXY header or not */
+  BIT(is_proxy_hdr_sent);
+#endif
 #ifdef USE_HYPER
   bool hconnect;  /* set if a CONNECT request */
   CURLcode hresult; /* used to pass return codes back from hyper callbacks */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -247,6 +247,6 @@ test2300 test2301 test2302 test2303 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
-test3024 test3025 test3026 test3027 \
+test3024 test3025 test3026 test3027 test3028 \
 \
 test3100

--- a/tests/data/test3028
+++ b/tests/data/test3028
@@ -1,0 +1,74 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP CONNECT
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<connect>
+HTTP/1.1 200 Mighty fine indeed
+
+</connect>
+
+<data nocheck="yes">
+HTTP/1.1 404 Not Found
+Server: nginx/1.23.2
+Date: Wed, 09 Nov 2022 09:44:58 GMT
+Content-Type: text/plain; charset=utf-8
+Content-Length: 4
+Connection: keep-alive
+X-Content-Type-Options: nosniff
+
+haha
+</data>
+
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+http-proxy
+</server>
+<name>
+HTTP GET when PROXY Protocol enabled behind a proxy
+</name>
+<command>
+--haproxy-protocol http://%HOSTIP:%HTTPPORT/page --proxytunnel -x %HOSTIP:%PROXYPORT
+</command>
+<features>
+proxy
+</features>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<strippart>
+s/^PROXY TCP4 %CLIENTIP %HOSTIP (\d*) %PROXYPORT/proxy-line/
+s/\r/\\r/
+</strippart>
+
+<proxy>
+CONNECT %HOSTIP:%HTTPPORT HTTP/1.1\r
+Host: %HOSTIP:%HTTPPORT\r
+User-Agent: curl/%VERSION\r
+Proxy-Connection: Keep-Alive\r
+\r
+</proxy>
+
+<protocol>
+proxy-line\r
+GET /page HTTP/1.1\r
+Host: %HOSTIP:%HTTPPORT\r
+User-Agent: curl/%VERSION\r
+Accept: */*\r
+\r
+</protocol>
+
+</verify>
+</testcase>

--- a/tests/data/test3028
+++ b/tests/data/test3028
@@ -50,24 +50,23 @@ proxy
 <verify>
 <strippart>
 s/^PROXY TCP4 %CLIENTIP %HOSTIP (\d*) %PROXYPORT/proxy-line/
-s/\r/\\r/
 </strippart>
 
 <proxy>
-CONNECT %HOSTIP:%HTTPPORT HTTP/1.1\r
-Host: %HOSTIP:%HTTPPORT\r
-User-Agent: curl/%VERSION\r
-Proxy-Connection: Keep-Alive\r
-\r
+CONNECT %HOSTIP:%HTTPPORT HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
 </proxy>
 
 <protocol>
-proxy-line\r
-GET /page HTTP/1.1\r
-Host: %HOSTIP:%HTTPPORT\r
-User-Agent: curl/%VERSION\r
-Accept: */*\r
-\r
+proxy-line
+GET /page HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
 </protocol>
 
 </verify>


### PR DESCRIPTION
Fixes #9442

The root cause of the issue is that for `HTTP`, `HTTPS`, `WS`, and `WSS` we will call `Curl_http_connect` (which will call 
`add_haproxy_protocol_header` -- function that adds `PROXY` header) during `MSTATE_TUNNELING` and `MSTATE_PROTOCONNECT`.

Curl already has internal state that keeps track whether `CONNECT` (when calling `Curl_http_connect`) is already 
successful or not that prevents `CONNECT` getting sent twice, but not for `PROXY`.

This PR will keep track whether `PROXY` is already sent successfully or not to avoid sending it twice to the destination
server.