### PR TITLE
Build with rustls on macOS

### DIFF
--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -38,6 +38,14 @@ if test "x$OPT_RUSTLS" != xno; then
       OPT_RUSTLS=""
     fi
 
+    case $host_os in
+      darwin*)
+        LDFLAGS="$LDFLAGS -framework Security"
+        ;;
+      *)
+        ;;
+    esac
+
     if test -z "$OPT_RUSTLS" ; then
       dnl check for lib first without setting any new path
 


### PR DESCRIPTION
On macOS, linking rustls also needs the Security framework.