### PR TITLE
http: mark it 'this_is_a_follow' in the Location: logic

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1607,10 +1607,8 @@ CURLcode Curl_follow(struct Curl_easy *data,
                              to URL */
     }
     else {
-      /* mark the next request as a followed location: */
-      data->state.this_is_a_follow = TRUE;
-
-      data->state.followlocation++; /* count location-followers */
+      data->state.followlocation++; /* count redirect-followings, including
+                                       auth reloads */
 
       if(data->set.http_auto_referer) {
         CURLU *u;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -249,4 +249,4 @@ test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
 test3024 test3025 test3026 test3027 test3028 \
 \
-test3100
+test3100 test3101

--- a/tests/data/test3101
+++ b/tests/data/test3101
@@ -1,0 +1,88 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP Basic auth
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 401 Authorization Required swsbounce
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Blackmagic realm="gimme all yer s3cr3ts"
+WWW-Authenticate: Basic realm="gimme all yer s3cr3ts"
+Content-Length: 26
+Content-Type: text/html; charset=iso-8859-1
+
+This is not the real page
+</data>
+
+# This is supposed to be returned when the server gets a
+# Authorization: Digest line passed-in from the client
+<data1>
+HTTP/1.1 200 OK
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 23
+Connection: close
+
+This IS the real page!
+</data1>
+
+<datacheck>
+HTTP/1.1 401 Authorization Required swsbounce
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+WWW-Authenticate: Blackmagic realm="gimme all yer s3cr3ts"
+WWW-Authenticate: Basic realm="gimme all yer s3cr3ts"
+Content-Length: 26
+Content-Type: text/html; charset=iso-8859-1
+
+HTTP/1.1 200 OK
+Server: Apache/1.3.27 (Darwin) PHP/4.1.2
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 23
+Connection: close
+
+This IS the real page!
+</datacheck>
+</reply>
+
+# Client-Side
+<client>
+# require https because the code sets that as an acceptable redirect proto
+<features>
+https
+</features>
+<server>
+http
+</server>
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<name>
+HTTP auth without redirection protocols
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjpwYXNzd29yZA==
+Accept: */*
+
+</protocol>
+</verify>
+
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -68,7 +68,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1945 lib1946 lib1947 lib1948 lib1955 \
  lib2301 lib2302 \
  lib3010 lib3025 lib3026 lib3027 \
- lib3100
+ lib3100 lib3101
 
 chkdecimalpoint_SOURCES = chkdecimalpoint.c ../../lib/mprintf.c \
  ../../lib/dynbuf.c ../../lib/strdup.c
@@ -791,4 +791,7 @@ lib3027_CPPFLAGS = $(AM_CPPFLAGS)
 
 lib3100_SOURCES = lib3100.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib3100_LDADD = $(TESTUTIL_LIBS)
-lib3100_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib3101_SOURCES = lib3101.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib3101_LDADD = $(TESTUTIL_LIBS)
+

--- a/tests/libtest/lib3101.c
+++ b/tests/libtest/lib3101.c
@@ -1,0 +1,64 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+#include "memdebug.h"
+
+int test(char *URL)
+{
+  int res;
+  CURL *curl;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  test_setopt(curl, CURLOPT_URL, URL);
+  test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  test_setopt(curl, CURLOPT_USERNAME, "user");
+  test_setopt(curl, CURLOPT_PASSWORD, "password");
+  test_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+
+  res = curl_easy_perform(curl);
+  if(res != (int)CURLE_OK) {
+    res = TEST_ERR_MAJOR_BAD;
+    goto test_cleanup;
+  }
+
+test_cleanup:
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return res;
+}


### PR DESCRIPTION
To make regular auth "reloads" to not count as redirects.

Verified by test 3101

Fixes #9885
Closes #9887