### PR TITLE
lib: remove bad set.opt_no_body assignments

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -471,13 +471,13 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
               tm->tm_hour,
               tm->tm_min,
               tm->tm_sec,
-              data->set.opt_no_body ? "": "\r\n");
+              data->req.no_body ? "": "\r\n");
     result = Curl_client_write(data, CLIENTWRITE_HEADER, header, headerlen);
     if(result)
       return result;
     /* set the file size to make it available post transfer */
     Curl_pgrsSetDownloadSize(data, expected_size);
-    if(data->set.opt_no_body)
+    if(data->req.no_body)
       return result;
   }
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1524,7 +1524,7 @@ static CURLcode ftp_state_type(struct Curl_easy *data)
   /* If we have selected NOBODY and HEADER, it means that we only want file
      information. Which in FTP can't be much more than the file size and
      date. */
-  if(data->set.opt_no_body && ftpc->file &&
+  if(data->req.no_body && ftpc->file &&
      ftp_need_type(conn, data->state.prefer_ascii)) {
     /* The SIZE command is _not_ RFC 959 specified, and therefore many servers
        may not support it! It is however the only way we have to get a file's
@@ -2093,7 +2093,7 @@ static CURLcode ftp_state_mdtm_resp(struct Curl_easy *data,
       /* If we asked for a time of the file and we actually got one as well,
          we "emulate" an HTTP-style header in our output. */
 
-      if(data->set.opt_no_body &&
+      if(data->req.no_body &&
          ftpc->file &&
          data->set.get_filetime &&
          (data->info.filetime >= 0) ) {
@@ -3742,7 +3742,7 @@ CURLcode ftp_perform(struct Curl_easy *data,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->set.opt_no_body) {
+  if(data->req.no_body) {
     /* requested no body means no transfer... */
     struct FTP *ftp = data->req.p.ftp;
     ftp->transfer = PPTRANSFER_INFO;

--- a/lib/http.c
+++ b/lib/http.c
@@ -2108,7 +2108,7 @@ void Curl_http_method(struct Curl_easy *data, struct connectdata *conn,
   if(data->set.str[STRING_CUSTOMREQUEST])
     request = data->set.str[STRING_CUSTOMREQUEST];
   else {
-    if(data->set.opt_no_body)
+    if(data->req.no_body)
       request = "HEAD";
     else {
       DEBUGASSERT((httpreq >= HTTPREQ_GET) && (httpreq <= HTTPREQ_HEAD));
@@ -4262,7 +4262,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
          * If we requested a "no body", this is a good time to get
          * out and return home.
          */
-        if(data->set.opt_no_body)
+        if(data->req.no_body)
           *stop_reading = TRUE;
 #ifndef CURL_DISABLE_RTSP
         else if((conn->handler->protocol & CURLPROTO_RTSP) &&

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1560,7 +1560,7 @@ static CURLcode imap_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->set.opt_no_body) {
+  if(data->req.no_body) {
     /* Requested no body means no transfer */
     imap->transfer = PPTRANSFER_INFO;
   }

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -948,7 +948,7 @@ static CURLcode pop3_state_command_resp(struct Curl_easy *data,
          content so send it as such. Note that there may even be additional
          "headers" after the body */
 
-      if(!data->set.opt_no_body) {
+      if(!data->req.no_body) {
         result = Curl_pop3_write(data, pp->cache, pp->cache_size);
         if(result)
           return result;
@@ -1197,7 +1197,7 @@ static CURLcode pop3_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->set.opt_no_body) {
+  if(data->req.no_body) {
     /* Requested no body means no transfer */
     pop3->transfer = PPTRANSFER_INFO;
   }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -283,7 +283,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
    * Since all RTSP requests are included here, there is no need to
    * support custom requests like HTTP.
    **/
-  data->set.opt_no_body = TRUE; /* most requests don't contain a body */
+  data->req.no_body = TRUE; /* most requests don't contain a body */
   switch(rtspreq) {
   default:
     failf(data, "Got invalid RTSP request");
@@ -293,7 +293,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     break;
   case RTSPREQ_DESCRIBE:
     p_request = "DESCRIBE";
-    data->set.opt_no_body = FALSE;
+    data->req.no_body = FALSE;
     break;
   case RTSPREQ_ANNOUNCE:
     p_request = "ANNOUNCE";
@@ -313,7 +313,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   case RTSPREQ_GET_PARAMETER:
     /* GET_PARAMETER's no_body status is determined later */
     p_request = "GET_PARAMETER";
-    data->set.opt_no_body = FALSE;
+    data->req.no_body = FALSE;
     break;
   case RTSPREQ_SET_PARAMETER:
     p_request = "SET_PARAMETER";
@@ -324,7 +324,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   case RTSPREQ_RECEIVE:
     p_request = "";
     /* Treat interleaved RTP as body */
-    data->set.opt_no_body = FALSE;
+    data->req.no_body = FALSE;
     break;
   case RTSPREQ_LAST:
     failf(data, "Got invalid RTSP request: RTSPREQ_LAST");
@@ -573,7 +573,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     else if(rtspreq == RTSPREQ_GET_PARAMETER) {
       /* Check for an empty GET_PARAMETER (heartbeat) request */
       data->state.httpreq = HTTPREQ_HEAD;
-      data->set.opt_no_body = TRUE;
+      data->req.no_body = TRUE;
     }
   }
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1043,7 +1043,7 @@ static CURLcode smtp_state_command_resp(struct Curl_easy *data, int smtpcode,
   }
   else {
     /* Temporarily add the LF character back and send as body to the client */
-    if(!data->set.opt_no_body) {
+    if(!data->req.no_body) {
       line[len] = '\n';
       result = Curl_client_write(data, CLIENTWRITE_BODY, line, len + 1);
       line[len] = '\0';
@@ -1484,7 +1484,7 @@ static CURLcode smtp_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->set.opt_no_body) {
+  if(data->req.no_body) {
     /* Requested no body means no transfer */
     smtp->transfer = PPTRANSFER_INFO;
   }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -665,7 +665,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
        is non-headers. */
     if(!k->header && (nread > 0 || is_empty_data)) {
 
-      if(data->set.opt_no_body) {
+      if(data->req.no_body) {
         /* data arrives although we want none, bail out */
         streamclose(conn, "ignoring body");
         *done = TRUE;
@@ -1300,7 +1300,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
      * returning.
      */
 
-    if(!(data->set.opt_no_body) && (k->size != -1) &&
+    if(!(data->req.no_body) && (k->size != -1) &&
        (k->bytecount != k->size) &&
 #ifdef CURL_DO_LINEEND_CONV
        /* Most FTP servers don't adjust their file SIZE response for CRLFs,
@@ -1314,7 +1314,7 @@ CURLcode Curl_readwrite(struct connectdata *conn,
             " bytes remaining to read", k->size - k->bytecount);
       return CURLE_PARTIAL_FILE;
     }
-    if(!(data->set.opt_no_body) && k->chunk &&
+    if(!(data->req.no_body) && k->chunk &&
        (conn->chunk.state != CHUNK_STOP)) {
       /*
        * In chunked mode, return an error if the connection is closed prior to
@@ -1823,7 +1823,7 @@ CURLcode Curl_follow(struct Curl_easy *data,
       data->state.httpreq = HTTPREQ_GET;
       data->set.upload = false;
       infof(data, "Switch to %s",
-            data->set.opt_no_body?"HEAD":"GET");
+            data->req.no_body?"HEAD":"GET");
     }
     break;
   case 304: /* Not Modified */
@@ -1865,7 +1865,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
 
   if((data->req.bytecount + data->req.headerbytecount == 0) &&
      conn->bits.reuse &&
-     (!data->set.opt_no_body || (conn->handler->protocol & PROTO_FAMILY_HTTP))
+     (!data->req.no_body || (conn->handler->protocol & PROTO_FAMILY_HTTP))
 #ifndef CURL_DISABLE_RTSP
      && (data->set.rtspreq != RTSPREQ_RECEIVE)
 #endif
@@ -1979,7 +1979,7 @@ Curl_setup_transfer(
       Curl_pgrsSetDownloadSize(data, size);
   }
   /* we want header and/or body, if neither then don't do this! */
-  if(k->getheader || !data->set.opt_no_body) {
+  if(k->getheader || !data->req.no_body) {
 
     if(sockindex != -1)
       k->keepon |= KEEP_RECV;
@@ -2015,6 +2015,6 @@ Curl_setup_transfer(
         k->keepon |= KEEP_SEND;
       }
     } /* if(writesockindex != -1) */
-  } /* if(k->getheader || !data->set.opt_no_body) */
+  } /* if(k->getheader || !data->req.no_body) */
 
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -4135,6 +4135,7 @@ CURLcode Curl_connect(struct Curl_easy *data,
   Curl_free_request_state(data);
   memset(&data->req, 0, sizeof(struct SingleRequest));
   data->req.size = data->req.maxdownload = -1;
+  data->req.no_body = data->set.opt_no_body;
 
   /* call the stuff that needs to be called */
   result = create_conn(data, &conn, asyncp);
@@ -4196,7 +4197,7 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
   data->state.done = FALSE; /* *_done() is not called yet */
   data->state.expect100header = FALSE;
 
-  if(data->set.opt_no_body)
+  if(data->req.no_body)
     /* in HTTP lingo, no body means using the HEAD request... */
     data->state.httpreq = HTTPREQ_HEAD;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -725,6 +725,7 @@ struct SingleRequest {
   BIT(forbidchunk);  /* used only to explicitly forbid chunk-upload for
                         specific upload buffers. See readmoredata() in http.c
                         for details. */
+  BIT(no_body);      /* the response has no body */
 };
 
 /*

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1415,7 +1415,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 
     case SSH_SFTP_READDIR_INIT:
       Curl_pgrsSetDownloadSize(data, -1);
-      if(data->set.opt_no_body) {
+      if(data->req.no_body) {
         state(data, SSH_STOP);
         break;
       }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2250,7 +2250,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
 
     case SSH_SFTP_READDIR_INIT:
       Curl_pgrsSetDownloadSize(data, -1);
-      if(data->set.opt_no_body) {
+      if(data->req.no_body) {
         state(data, SSH_STOP);
         break;
       }

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -836,7 +836,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
 
     case SSH_SFTP_READDIR_INIT:
       Curl_pgrsSetDownloadSize(data, -1);
-      if(data->set.opt_no_body) {
+      if(data->req.no_body) {
         state(data, SSH_STOP);
         break;
       }


### PR DESCRIPTION
This struct field MUST remain what the application set it to, so that handle reuse and handle duplication work.

Instead, the request state bit 'no_body' is introduced for code flows that need to change this in run-time.