### PR TITLE
tool_operate: provide better errmsg for -G with bad URL

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1195,16 +1195,24 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           if(uh) {
             char *updated;
             if(curl_url_set(uh, CURLUPART_URL, per->this_url,
-                            CURLU_GUESS_SCHEME) ||
-               curl_url_set(uh, CURLUPART_QUERY, q, CURLU_APPENDQUERY) ||
-               curl_url_get(uh, CURLUPART_URL, &updated, CURLU_GUESS_SCHEME)) {
-              curl_url_cleanup(uh);
-              result = CURLE_OUT_OF_MEMORY;
-              break;
+                            CURLU_GUESS_SCHEME)) {
+              result = CURLE_FAILED_INIT;
+              errorf(global, "(%d) Could not parse the URL, "
+                     "failed to set query\n", result);
+              config->synthetic_error = TRUE;
             }
-            Curl_safefree(per->this_url); /* free previous URL */
-            per->this_url = updated; /* use our new URL instead! */
+            else if(curl_url_set(uh, CURLUPART_QUERY, q, CURLU_APPENDQUERY) ||
+                    curl_url_get(uh, CURLUPART_URL, &updated,
+                                 CURLU_GUESS_SCHEME)) {
+              result = CURLE_OUT_OF_MEMORY;
+            }
+            else {
+              Curl_safefree(per->this_url); /* free previous URL */
+              per->this_url = updated; /* use our new URL instead! */
+            }
             curl_url_cleanup(uh);
+            if(result)
+              break;
           }
         }
 


### PR DESCRIPTION
If the URL that -G would try to add a query to could not be parsed, it would display

 curl: (27) Out of memory

It now instead shows:

 curl: (2) Could not parse the URL, failed to set query

Reported-by: Alex Xu
Fixes #9889