### PR TITLE
log2changes.pl: wrap long lines at 80 columns

### DIFF
--- a/scripts/log2changes.pl
+++ b/scripts/log2changes.pl
@@ -43,6 +43,9 @@ sub printmsg {
         print $p.substr($msg, 0, 77, "")."\n";
         $p="  ";
     }
+    if($msg eq "") {
+        $p = "";
+    }
     print "$p$msg\n";
 }
 

--- a/scripts/log2changes.pl
+++ b/scripts/log2changes.pl
@@ -37,6 +37,15 @@ sub nicedate {
     return $date;
 }
 
+sub printmsg {
+    my ($p, $msg)=@_;
+    while(length($msg) > 77) {
+        print $p.substr($msg, 0, 77, "")."\n";
+        $p="  ";
+    }
+    print "$p$msg\n";
+}
+
 print
 '                                  _   _ ____  _
                               ___| | | |  _ \| |
@@ -47,7 +56,6 @@ print
                                   Changelog
 ';
 
-my $line;
 my $tag;
 while(<STDIN>) {
     my $l = $_;
@@ -61,44 +69,32 @@ while(<STDIN>) {
         }
     }
     elsif($l =~ /^Author: *(.*) +</) {
-        $a = $1;
-    }
-    elsif($l =~ /^Commit: *(.*) +</) {
         $c = $1;
     }
     elsif($l =~ /^CommitDate: (.*)/) {
         $date = nicedate($1);
     }
     elsif($l =~ /^(    )(.*)/) {
-        my $extra;
+        my $pref = "  ";
         if ($tag) {
             # Version entries have a special format
             print "\nVersion " . $tag." ($date)\n";
             $oldc = "";
             $tag = "";
         }
-        if($a ne $c) {
-            $extra=sprintf("\n- [%s brought this change]\n\n  ", $a);
-        }
-        else {
-            $extra="\n- ";
-        }
         if($co ne $oldco) {
             if($c ne $oldc) {
-                print "\n$c ($date)$extra";
+                print "\n$c ($date)\n\n";
             }
             else {
-                print "$extra";
+                print "\n";
             }
-            $line =0;
+            $pref = "- ";
         }
 
         $oldco = $co;
         $oldc = $c;
         $olddate = $date;
-        if($line++ && $2 ne "") {
-            print "  ";
-        }
-        print $2."\n";
+        printmsg($pref, $2);
     }
 }


### PR DESCRIPTION
Also, only use author names in the output.

Fixes #9896
Reported-by: John Sherrill