### PR TITLE
url: only acknowledge fresh_reuse for non-followed transfers

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3907,7 +3907,7 @@ static CURLcode create_conn(struct Curl_easy *data,
      we only acknowledge this option if this is not a re-used connection
      already (which happens due to follow-location or during an HTTP
      authentication phase). CONNECT_ONLY transfers also refuse reuse. */
-  if((data->set.reuse_fresh && !data->state.this_is_a_follow) ||
+  if((data->set.reuse_fresh && !data->state.followlocation) ||
      data->set.connect_only)
     reuse = FALSE;
   else


### PR DESCRIPTION
... to make sure NTLM auth sticks to the connection it needs, as verified by 2032.

Follow-up to fa0b9227616e

Assisted-by: Stefan Eissing