### PR TITLE
include/curl/curl.h: bump the deprecated requirements to gcc 5.3

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -35,7 +35,7 @@
 
 /* Compile-time deprecation macros. */
 #if defined(__GNUC__) && defined(__GNUC_MINOR__) && \
-    ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)) && \
+    ((__GNUC__ > 5) || (__GNUC__ == 5 && __GNUC_MINOR__ >= 3)) && \
     !defined(__INTEL_COMPILER) && \
     !defined(CURL_DISABLE_DEPRECATION) && !defined(BUILDING_LIBCURL)
 #define CURL_DEPRECATED(version, message) \


### PR DESCRIPTION
Reported-by: Stephan Guilloux
Fixes #9917