### PR TITLE
OtherTests.cmake: check for cross-compile, not for toolchain

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -85,51 +85,51 @@ endif()
 
 unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
 
-if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+if(NOT CMAKE_CROSSCOMPILING)
   if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "iOS")
-  # only try this on non-apple platforms
+    # only try this on non-apple platforms
 
-  # if not cross-compilation...
-  include(CheckCSourceRuns)
-  set(CMAKE_REQUIRED_FLAGS "")
-  if(HAVE_SYS_POLL_H)
-    set(CMAKE_REQUIRED_FLAGS "-DHAVE_SYS_POLL_H")
-  elseif(HAVE_POLL_H)
-    set(CMAKE_REQUIRED_FLAGS "-DHAVE_POLL_H")
-  endif()
-  check_c_source_runs("
-    #include <stdlib.h>
-    #include <sys/time.h>
+    # if not cross-compilation...
+    include(CheckCSourceRuns)
+    set(CMAKE_REQUIRED_FLAGS "")
+    if(HAVE_SYS_POLL_H)
+      set(CMAKE_REQUIRED_FLAGS "-DHAVE_SYS_POLL_H")
+    elseif(HAVE_POLL_H)
+      set(CMAKE_REQUIRED_FLAGS "-DHAVE_POLL_H")
+    endif()
+    check_c_source_runs("
+      #include <stdlib.h>
+      #include <sys/time.h>
 
-    #ifdef HAVE_SYS_POLL_H
-    #  include <sys/poll.h>
-    #elif  HAVE_POLL_H
-    #  include <poll.h>
-    #endif
+      #ifdef HAVE_SYS_POLL_H
+      #  include <sys/poll.h>
+      #elif  HAVE_POLL_H
+      #  include <poll.h>
+      #endif
 
-    int main(void)
-    {
-        if(0 != poll(0, 0, 10)) {
-          return 1; /* fail */
-        }
-        else {
-          /* detect the 10.12 poll() breakage */
-          struct timeval before, after;
-          int rc;
-          size_t us;
-
-          gettimeofday(&before, NULL);
-          rc = poll(NULL, 0, 500);
-          gettimeofday(&after, NULL);
-
-          us = (after.tv_sec - before.tv_sec) * 1000000 +
-            (after.tv_usec - before.tv_usec);
-
-          if(us < 400000) {
-            return 1;
+      int main(void)
+      {
+          if(0 != poll(0, 0, 10)) {
+            return 1; /* fail */
           }
-        }
-        return 0;
+          else {
+            /* detect the 10.12 poll() breakage */
+            struct timeval before, after;
+            int rc;
+            size_t us;
+
+            gettimeofday(&before, NULL);
+            rc = poll(NULL, 0, 500);
+            gettimeofday(&after, NULL);
+
+            us = (after.tv_sec - before.tv_sec) * 1000000 +
+              (after.tv_usec - before.tv_usec);
+
+            if(us < 400000) {
+              return 1;
+            }
+          }
+          return 0;
     }" HAVE_POLL_FINE)
   endif()
 endif()


### PR DESCRIPTION
Build systems like vcpkg alway sets `CMAKE_TOOLCHAIN_FILE` so it should not be used as a sign that this is a cross-compile.

Also indented the function correctly.

Reported-by: Philip Chan
Fixes #9921