### PR TITLE
github-actions: clarify workflows permissions, set least possible privilege

### DIFF
--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -11,13 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.sha }}-${{ github.event.target_url }}
   cancel-in-progress: true
 
-permissions:
-  statuses: write
+permissions: {}
 
 jobs:
   split:
     runs-on: ubuntu-latest
     if: ${{ github.event.sender.login == 'appveyor[bot]' }}
+    permissions:
+      statuses: write
     steps:
       - name: Create individual AppVeyor build statuses
         if: ${{ github.event.sha && github.event.target_url }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,12 +18,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}
 
-permissions:
-  security-events: write
+permissions: {}
 
 jobs:
   codeql:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,11 +13,11 @@ on:
     branches:
     - master
 
-permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   fuzzing:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,6 +13,8 @@ on:
     branches:
     - master
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -14,16 +14,17 @@ concurrency:
   # this should not run in parallel, so just run one at a time
   group: ${{ github.workflow }}
 
-permissions:
-  # requires issues AND pull-requests write permissions to edit labels on PRs!
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # add hacktoberfest-accepted label to PRs opened starting from September 30th
   # till November 1st which are closed via commit reference from master branch.
   merged:
     runs-on: ubuntu-latest
+    permissions:
+      # requires issues AND pull-requests write permissions to edit labels on PRs!
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -23,6 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   # Docs: https://github.com/marketplace/actions/markdown-link-check
   check:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ngtcp2-gnutls-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}

--- a/.github/workflows/ngtcp2-wolfssl.yml
+++ b/.github/workflows/ngtcp2-wolfssl.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ngtcp2-wolfssl-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}

--- a/.github/workflows/proselint.yml
+++ b/.github/workflows/proselint.yml
@@ -23,6 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -21,10 +21,11 @@ on:
     - '**.1'
     - '.github/**'
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -18,6 +18,8 @@ concurrency:
   group: torture-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -18,6 +18,8 @@ concurrency:
   group: wolfssl-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}


### PR DESCRIPTION
Set top-level permissions to None on all workflows and then set per-job permissions, giving only the necessary ones. This avoids that new jobs inherit unwanted privileges.

Previously most of the workflows did not have written permissions, so their permissions were depending on the permission set as default on the Github repo settings

Discussion: https://curl.se/mail/lib-2022-11/0028.html