### PR TITLE
lib: parse numbers with fixed known base 10

### DIFF
--- a/lib/curl_range.c
+++ b/lib/curl_range.c
@@ -44,12 +44,12 @@ CURLcode Curl_range(struct Curl_easy *data)
   if(data->state.use_range && data->state.range) {
     CURLofft from_t;
     CURLofft to_t;
-    from_t = curlx_strtoofft(data->state.range, &ptr, 0, &from);
+    from_t = curlx_strtoofft(data->state.range, &ptr, 10, &from);
     if(from_t == CURL_OFFT_FLOW)
       return CURLE_RANGE_ERROR;
     while(*ptr && (ISBLANK(*ptr) || (*ptr == '-')))
       ptr++;
-    to_t = curlx_strtoofft(ptr, &ptr2, 0, &to);
+    to_t = curlx_strtoofft(ptr, &ptr2, 10, &to);
     if(to_t == CURL_OFFT_FLOW)
       return CURLE_RANGE_ERROR;
     if((to_t == CURL_OFFT_INVAL) && !from_t) {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2299,7 +2299,7 @@ static CURLcode ftp_state_size_resp(struct Curl_easy *data,
     else
       fdigit = start;
     /* ignores parsing errors, which will make the size remain unknown */
-    (void)curlx_strtoofft(fdigit, NULL, 0, &filesize);
+    (void)curlx_strtoofft(fdigit, NULL, 10, &filesize);
 
   }
   else if(ftpcode == 550) { /* "No such file or directory" */
@@ -2484,7 +2484,7 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
         if(bytes) {
           ++bytes;
           /* get the number! */
-          (void)curlx_strtoofft(bytes, NULL, 0, &size);
+          (void)curlx_strtoofft(bytes, NULL, 10, &size);
         }
       }
     }

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -221,6 +221,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
   curl_off_t number;
   errno = 0;
   *num = 0; /* clear by default */
+  DEBUGASSERT(base); /* starting now, avoid base zero */
 
   while(*str && ISBLANK(*str))
     str++;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1663,13 +1663,13 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
           CURLofft to_t;
           CURLofft from_t;
 
-          from_t = curlx_strtoofft(data->state.range, &ptr, 0, &from);
+          from_t = curlx_strtoofft(data->state.range, &ptr, 10, &from);
           if(from_t == CURL_OFFT_FLOW) {
             return CURLE_RANGE_ERROR;
           }
           while(*ptr && (ISBLANK(*ptr) || (*ptr == '-')))
             ptr++;
-          to_t = curlx_strtoofft(ptr, &ptr2, 0, &to);
+          to_t = curlx_strtoofft(ptr, &ptr2, 10, &to);
           if(to_t == CURL_OFFT_FLOW) {
             return CURLE_RANGE_ERROR;
           }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2503,12 +2503,12 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
           CURLofft to_t;
           CURLofft from_t;
 
-          from_t = curlx_strtoofft(data->state.range, &ptr, 0, &from);
+          from_t = curlx_strtoofft(data->state.range, &ptr, 10, &from);
           if(from_t == CURL_OFFT_FLOW)
             return CURLE_RANGE_ERROR;
           while(*ptr && (ISBLANK(*ptr) || (*ptr == '-')))
             ptr++;
-          to_t = curlx_strtoofft(ptr, &ptr2, 0, &to);
+          to_t = curlx_strtoofft(ptr, &ptr2, 10, &to);
           if(to_t == CURL_OFFT_FLOW)
             return CURLE_RANGE_ERROR;
           if((to_t == CURL_OFFT_INVAL) /* no "to" value given */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -502,7 +502,7 @@ static ParameterError GetSizeParameter(struct GlobalConfig *global,
   char *unit;
   curl_off_t value;
 
-  if(curlx_strtoofft(arg, &unit, 0, &value)) {
+  if(curlx_strtoofft(arg, &unit, 10, &value)) {
     warnf(global, "invalid number specified for %s\n", which);
     return PARAM_BAD_USE;
   }

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -473,7 +473,7 @@ ParameterError str2offset(curl_off_t *val, const char *str)
 
 #if(SIZEOF_CURL_OFF_T > SIZEOF_LONG)
   {
-    CURLofft offt = curlx_strtoofft(str, &endptr, 0, val);
+    CURLofft offt = curlx_strtoofft(str, &endptr, 10, val);
     if(CURL_OFFT_FLOW == offt)
       return PARAM_NUMBER_TOO_LARGE;
     else if(CURL_OFFT_INVAL == offt)


### PR DESCRIPTION
... instead of using 0 argument that allows decimal, hex or octal when the number is documented and assumed to use base 10.