### PR TITLE
HTTP-COOKIES.md: mention that http://localhost is a secure context

### DIFF
--- a/docs/HTTP-COOKIES.md
+++ b/docs/HTTP-COOKIES.md
@@ -29,6 +29,11 @@
   RFC6265. Cookie prefixes and secure cookie modification protection has been
   implemented by curl.
 
+  curl considers `http://localhost` to be a *secure context*, meaning that it
+  will allow and use cookies marked with the `secure` keyword even when done
+  over plain HTTP for this host. curl does this to match how popular browsers
+  work with secure cookies.
+
 ## Cookies saved to disk
 
   Netscape once created a file format for storing cookies on disk so that they


### PR DESCRIPTION
Reported-by: Trail of Bits