### PR TITLE
url: move back the IDN conversion of proxy names

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2059,18 +2059,6 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     if(result)
       return result;
   }
-#ifndef CURL_DISABLE_PROXY
-  if(conn->bits.httpproxy) {
-    result = Curl_idnconvert_hostname(data, &conn->http_proxy.host);
-    if(result)
-      return result;
-  }
-  if(conn->bits.socksproxy) {
-    result = Curl_idnconvert_hostname(data, &conn->socks_proxy.host);
-    if(result)
-      return result;
-  }
-#endif
 
 #ifndef CURL_DISABLE_HSTS
   /* HSTS upgrade */
@@ -3730,6 +3718,21 @@ static CURLcode create_conn(struct Curl_easy *data,
   if(result)
     goto out;
 
+  /*************************************************************
+   * IDN-convert the proxy hostnames
+   *************************************************************/
+#ifndef CURL_DISABLE_PROXY
+  if(conn->bits.httpproxy) {
+    result = Curl_idnconvert_hostname(data, &conn->http_proxy.host);
+    if(result)
+      return result;
+  }
+  if(conn->bits.socksproxy) {
+    result = Curl_idnconvert_hostname(data, &conn->socks_proxy.host);
+    if(result)
+      return result;
+  }
+#endif
 
   /*************************************************************
    * Check whether the host and the "connect to host" are equal.


### PR DESCRIPTION
Regression: in commit 53bcf55 we moved the IDN conversion calls to happen before the HSTS checks. But the HSTS checks are only done on the server host name, not the proxy names. By moving the proxy name IDN conversions, we accidentally broke the verbose output showing the proxy name.

This change moves back the IDN conversions for the proxy names to the place in the code path they were before 53bcf55.

Reported-by: Andy Stamp
Fixes #9937