### PR TITLE
H3 special setup of connection filters

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -247,6 +247,7 @@ static CURLcode h3_setup_conn(struct Curl_easy *data,
 
 #else /* ENABLE_QUIC */
   (void)conn;
+  (void)data;
   DEBUGF(infof(data, "QUIC is not supported in this build"));
   return CURLE_NOT_BUILT_IN;
 #endif /* !ENABLE_QUIC */

--- a/lib/http.c
+++ b/lib/http.c
@@ -246,6 +246,7 @@ static CURLcode h3_setup_conn(struct Curl_easy *data,
   return Curl_cfilter_socket_set(data, conn, FIRSTSOCKET);
 
 #else /* ENABLE_QUIC */
+  (void)conn;
   DEBUGF(infof(data, "QUIC is not supported in this build"));
   return CURLE_NOT_BUILT_IN;
 #endif /* !ENABLE_QUIC */

--- a/lib/http.c
+++ b/lib/http.c
@@ -224,7 +224,7 @@ static CURLcode h3_setup_conn(struct Curl_easy *data,
 #ifdef ENABLE_QUIC
   /* We want HTTP/3 directly, setup the filter chain ourself,
    * overriding the default behaviour. */
-  DEBUGASSERT(conn->transport = TRNSPRT_QUIC);
+  DEBUGASSERT(conn->transport == TRNSPRT_QUIC);
 
   if(!(conn->handler->flags & PROTOPT_SSL)) {
     failf(data, "HTTP/3 requested for non-HTTPS URL");


### PR DESCRIPTION
Restore HTTP/3 to working condition after connection filter introduction.

HTTP/3 needs a special filter chain, since it does the TLS handling itself. This PR adds special setup handling in the HTTP protocol handler that takes are of it.

When a handler, in its setup method, installs filters, the default behaviour for managing the filter chain is overridden.