### PR TITLE
runtests: --no-debuginfod now disables DEBUGINFOD_URLS

### DIFF
--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -95,6 +95,9 @@ using curl's regression test suite.
 Lists all test case names.
 .IP "-n"
 Disable the check for and use of valgrind.
+.IP "--no-debuginfod"
+Delete the DEBUGINFOD_URLS variable if that is defined. Makes valgrind, gdb
+etc not able to use this functionality.
 .IP "-o <variablename=value>"
 Overwrite the specified internal \fBvariable\fP with \fBvalue\fP.
 Useful to change variables that didn't get a dedicated flag to change them.

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -347,6 +347,7 @@ my $short;
 my $automakestyle;
 my $verbose;
 my $debugprotocol;
+my $no_debuginfod;
 my $anyway;
 my $gdbthis;      # run test case with gdb debugger
 my $gdbxwin;      # use windowed gdb when using gdb
@@ -435,7 +436,6 @@ foreach $protocol (('ftp', 'http', 'ftps', 'https', 'no', 'all')) {
 
 delete $ENV{'SSL_CERT_DIR'} if($ENV{'SSL_CERT_DIR'});
 delete $ENV{'SSL_CERT_PATH'} if($ENV{'SSL_CERT_PATH'});
-delete $ENV{'DEBUGINFOD_URLS'} if($ENV{'DEBUGINFOD_URLS'});
 delete $ENV{'CURL_CA_BUNDLE'} if($ENV{'CURL_CA_BUNDLE'});
 
 #######################################################################
@@ -5661,6 +5661,10 @@ while(@ARGV) {
         # no valgrind
         undef $valgrind;
     }
+    elsif($ARGV[0] eq "--no-debuginfod") {
+        # disable the valgrind debuginfod functionality
+        $no_debuginfod = 1;
+    }
     elsif ($ARGV[0] eq "-R") {
         # execute in scrambled order
         $scrambleorder=1;
@@ -5840,6 +5844,8 @@ EOHELP
     }
     shift @ARGV;
 }
+
+delete $ENV{'DEBUGINFOD_URLS'} if($ENV{'DEBUGINFOD_URLS'} && $no_debuginfod);
 
 if(!$randseed) {
     my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =


### PR DESCRIPTION
If this option is not used, valgrind may use this environment variable (if set) to do HTTP API request calls to get information.