### PR TITLE
Connection filter types have flags indicating what they do.

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -374,6 +374,21 @@ bool Curl_cfilter_is_connected(struct Curl_easy *data,
   return cf && cf->connected;
 }
 
+bool Curl_conn_is_ip_connected(struct Curl_easy *data, int sockindex)
+{
+  struct Curl_cfilter *cf;
+
+  cf = data->conn->cfilter[sockindex];
+  while(cf) {
+    if(cf->connected)
+      return TRUE;
+    if(cf->cft->flags & CF_TYPE_IP_CONNECT)
+      return FALSE;
+    cf = cf->next;
+  }
+  return FALSE;
+}
+
 bool Curl_cfilter_data_pending(const struct Curl_easy *data,
                                struct connectdata *conn, int sockindex)
 {

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -83,9 +83,13 @@ typedef void     Curl_cf_detach_data(struct Curl_cfilter *cf,
  */
 void Curl_cfilter_detach(struct connectdata *conn, struct Curl_easy *data);
 
+#define CF_TYPE_IP_CONNECT  (1 << 0)
+#define CF_TYPE_SSL         (1 << 1)
+
 /* A connection filter type, e.g. specific implementation. */
 struct Curl_cftype {
   const char *name;                      /* name of the filter type */
+  long flags;                            /* flags of filter type */
   Curl_cf_destroy *destroy;              /* destroy resources held */
   Curl_cf_attach_data *attach_data;      /* data is being handled here */
   Curl_cf_detach_data *detach_data;      /* data is no longer handled here */
@@ -164,6 +168,12 @@ CURLcode Curl_cfilter_connect(struct Curl_easy *data,
                               bool blocking, bool *done);
 bool Curl_cfilter_is_connected(struct Curl_easy *data,
                                struct connectdata *conn, int sockindex);
+/**
+ * Determine if we have reached the remote host on IP level, e.g.
+ * have a TCP connection. This turns TRUE before a possible SSL
+ * handshake has been started/done.
+ */
+bool Curl_conn_is_ip_connected(struct Curl_easy *data, int sockindex);
 
 void Curl_cfilter_close(struct Curl_easy *data,
                         struct connectdata *conn, int index);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1822,6 +1822,7 @@ static void socket_cf_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 
 static const struct Curl_cftype cft_socket = {
   "SOCKET",
+  CF_TYPE_IP_CONNECT,
   socket_cf_destroy,
   Curl_cf_def_attach_data,
   Curl_cf_def_detach_data,
@@ -1892,6 +1893,7 @@ static CURLcode socket_accept_cf_setup(struct Curl_cfilter *cf,
 
 static const struct Curl_cftype cft_socket_accept = {
   "SOCKET-ACCEPT",
+  CF_TYPE_IP_CONNECT,
   socket_cf_destroy,
   Curl_cf_def_attach_data,
   Curl_cf_def_detach_data,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -1162,6 +1162,7 @@ static void http_proxy_cf_close(struct Curl_cfilter *cf,
 
 static const struct Curl_cftype cft_http_proxy = {
   "HTTP-PROXY",
+  CF_TYPE_IP_CONNECT,
   http_proxy_cf_destroy,
   Curl_cf_def_attach_data,
   http_proxy_cf_detach_data,
@@ -1246,6 +1247,7 @@ static CURLcode haproxy_cf_connect(struct Curl_cfilter *cf,
 
 static const struct Curl_cftype cft_haproxy = {
   "HAPROXY",
+  0,
   Curl_cf_def_destroy,
   Curl_cf_def_attach_data,
   Curl_cf_def_detach_data,

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1214,6 +1214,7 @@ static void socks_proxy_cf_detach_data(struct Curl_cfilter *cf,
 
 static const struct Curl_cftype cft_socks_proxy = {
   "SOCKS-PROXYY",
+  CF_TYPE_IP_CONNECT,
   socks_proxy_cf_destroy,
   Curl_cf_def_attach_data,
   socks_proxy_cf_detach_data,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1655,6 +1655,7 @@ static void ssl_cf_def_detach_data(struct Curl_cfilter *cf,
 
 static const struct Curl_cftype cft_ssl = {
   "SSL",
+  CF_TYPE_SSL,
   ssl_cf_destroy,
   ssl_cf_def_attach_data,
   ssl_cf_def_detach_data,
@@ -1670,6 +1671,7 @@ static const struct Curl_cftype cft_ssl = {
 #ifndef CURL_DISABLE_PROXY
 static const struct Curl_cftype cft_ssl_proxy = {
   "SSL-PROXY",
+  CF_TYPE_SSL,
   ssl_cf_destroy,
   ssl_cf_def_attach_data,
   ssl_cf_def_detach_data,


### PR DESCRIPTION
- Adding Curl_conn_is_ip_connected() to check if network connectivity has been reached
- having ftp wait for network connectivity before proceeding with transfers.

This fixes test failures 1631 and 1632 with hyper, happening because hyper is slow.