### PR TITLE
examples/10-at-a-time: fix possible skipped final transfers

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -34,6 +34,14 @@
 #endif
 #include <curl/curl.h>
 
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
 static const char *urls[] = {
   "https://www.microsoft.com",
   "https://opensource.org",


### PR DESCRIPTION
Prior to this change if curl_multi_perform returned 0 running handles and then all remaining transfers were added, then the perform loop would end immediately without performing those transfers.

Reported-by: Mikhail Kuznetsov

Fixes https://github.com/curl/curl/issues/9953
Closes #xxxx