### PR TITLE
Call OPENSSL_cleanup() in ossl_cleanup() to fix memory leaks

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1613,6 +1613,7 @@ static void ossl_cleanup(void)
     !defined(LIBRESSL_VERSION_NUMBER)
   /* OpenSSL 1.1 deprecates all these cleanup functions and
      turns them into no-ops in OpenSSL 1.0 compatibility mode */
+  OPENSSL_cleanup();
 #else
   /* Free ciphers and digests lists */
   EVP_cleanup();


### PR DESCRIPTION
Fixes #9955