### PR TITLE
rewind BEFORE request instead of AFTER previous

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -576,7 +576,7 @@ static CURLcode http_perhapsrewind(struct Curl_easy *data,
     }
   }
 
-  conn->bits.rewindaftersend = FALSE; /* default */
+  data->state.rewindbeforesend = FALSE; /* default */
 
   if((expectsend == -1) || (expectsend > bytessent)) {
 #if defined(USE_NTLM)
@@ -593,8 +593,8 @@ static CURLcode http_perhapsrewind(struct Curl_easy *data,
 
         /* rewind data when completely done sending! */
         if(!conn->bits.authneg && (conn->writesockfd != CURL_SOCKET_BAD)) {
-          conn->bits.rewindaftersend = TRUE;
-          infof(data, "Rewind stream after send");
+          data->state.rewindbeforesend = TRUE;
+          infof(data, "Rewind stream before next send");
         }
 
         return CURLE_OK;
@@ -621,8 +621,8 @@ static CURLcode http_perhapsrewind(struct Curl_easy *data,
 
         /* rewind data when completely done sending! */
         if(!conn->bits.authneg && (conn->writesockfd != CURL_SOCKET_BAD)) {
-          conn->bits.rewindaftersend = TRUE;
-          infof(data, "Rewind stream after send");
+          data->state.rewindbeforesend = TRUE;
+          infof(data, "Rewind stream before next send");
         }
 
         return CURLE_OK;
@@ -646,9 +646,11 @@ static CURLcode http_perhapsrewind(struct Curl_easy *data,
        closure so we can safely do the rewind right now */
   }
 
-  if(bytessent)
-    /* we rewind now at once since if we already sent something */
-    return Curl_readrewind(data);
+  if(bytessent) {
+    /* mark for rewind since if we already sent something */
+    data->state.rewindbeforesend = TRUE;
+    infof(data, "Please rewind output before next send");
+  }
 
   return CURLE_OK;
 }
@@ -705,7 +707,7 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data)
   if(pickhost || pickproxy) {
     if((data->state.httpreq != HTTPREQ_GET) &&
        (data->state.httpreq != HTTPREQ_HEAD) &&
-       !conn->bits.rewindaftersend) {
+       !data->state.rewindbeforesend) {
       result = http_perhapsrewind(data, conn);
       if(result)
         return result;
@@ -4096,7 +4098,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
 
       if(k->httpcode >= 300) {
         if((!conn->bits.authneg) && !conn->bits.close &&
-           !conn->bits.rewindaftersend) {
+           !data->state.rewindbeforesend) {
           /*
            * General treatment of errors when about to send data. Including :
            * "417 Expectation Failed", while waiting for 100-continue.
@@ -4106,7 +4108,7 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
            * something else should've considered the big picture and we
            * avoid this check.
            *
-           * rewindaftersend indicates that something has told libcurl to
+           * rewindbeforesend indicates that something has told libcurl to
            * continue sending even if it gets discarded
            */
 
@@ -4155,9 +4157,9 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
           }
         }
 
-        if(conn->bits.rewindaftersend) {
-          /* We rewind after a complete send, so thus we continue
-             sending now */
+        if(data->state.rewindbeforesend &&
+           (conn->writesockfd != CURL_SOCKET_BAD)) {
+          /* We rewind before next send, continue sending now */
           infof(data, "Keep sending data to get tossed away");
           k->keepon |= KEEP_SEND;
         }

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -73,7 +73,7 @@ bool Curl_h2_http_1_1_error(struct Curl_easy *data);
 #define Curl_http2_init_state(x)
 #define Curl_http2_init_userset(x)
 #define Curl_http2_done(x,y)
-#define Curl_http2_done_sending(x,y)
+#define Curl_http2_done_sending(x,y) (void)y
 #define Curl_http2_add_child(x, y, z)
 #define Curl_http2_remove_child(x, y)
 #define Curl_http2_cleanup_dependencies(x)

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -204,9 +204,6 @@ static void tunnel_go_state(struct Curl_cfilter *cf,
 
   case TUNNEL_ESTABLISHED:
     infof(data, "CONNECT phase completed");
-    if(cf->conn)
-      /* make sure this isn't set for the document request  */
-      cf->conn->bits.rewindaftersend = FALSE;
     data->state.authproxy.done = TRUE;
     data->state.authproxy.multipass = FALSE;
     /* FALLTHROUGH */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1730,6 +1730,90 @@ static CURLcode protocol_connect(struct Curl_easy *data,
 }
 
 /*
+ * readrewind() rewinds the read stream. This is typically used for HTTP
+ * POST/PUT with multi-pass authentication when a sending was denied and a
+ * resend is necessary.
+ */
+static CURLcode readrewind(struct Curl_easy *data)
+{
+  struct connectdata *conn = data->conn;
+  curl_mimepart *mimepart = &data->set.mimepost;
+  DEBUGASSERT(conn);
+
+  data->state.rewindbeforesend = FALSE; /* we rewind now */
+
+  /* explicitly switch off sending data on this connection now since we are
+     about to restart a new transfer and thus we want to avoid inadvertently
+     sending more data on the existing connection until the next transfer
+     starts */
+  data->req.keepon &= ~KEEP_SEND;
+
+  /* We have sent away data. If not using CURLOPT_POSTFIELDS or
+     CURLOPT_HTTPPOST, call app to rewind
+  */
+  if(conn->handler->protocol & PROTO_FAMILY_HTTP) {
+    struct HTTP *http = data->req.p.http;
+
+    if(http->sendit)
+      mimepart = http->sendit;
+  }
+  if(data->set.postfields ||
+     (data->state.httpreq == HTTPREQ_GET) ||
+     (data->state.httpreq == HTTPREQ_HEAD))
+    ; /* no need to rewind */
+  else if(data->state.httpreq == HTTPREQ_POST_MIME ||
+          data->state.httpreq == HTTPREQ_POST_FORM) {
+    CURLcode result = Curl_mime_rewind(mimepart);
+    if(result) {
+      failf(data, "Cannot rewind mime/post data");
+      return result;
+    }
+  }
+  else {
+    if(data->set.seek_func) {
+      int err;
+
+      Curl_set_in_callback(data, true);
+      err = (data->set.seek_func)(data->set.seek_client, 0, SEEK_SET);
+      Curl_set_in_callback(data, false);
+      if(err) {
+        failf(data, "seek callback returned error %d", (int)err);
+        return CURLE_SEND_FAIL_REWIND;
+      }
+    }
+    else if(data->set.ioctl_func) {
+      curlioerr err;
+
+      Curl_set_in_callback(data, true);
+      err = (data->set.ioctl_func)(data, CURLIOCMD_RESTARTREAD,
+                                   data->set.ioctl_client);
+      Curl_set_in_callback(data, false);
+      infof(data, "the ioctl callback returned %d", (int)err);
+
+      if(err) {
+        failf(data, "ioctl callback returned error %d", (int)err);
+        return CURLE_SEND_FAIL_REWIND;
+      }
+    }
+    else {
+      /* If no CURLOPT_READFUNCTION is used, we know that we operate on a
+         given FILE * stream and we can actually attempt to rewind that
+         ourselves with fseek() */
+      if(data->state.fread_func == (curl_read_callback)fread) {
+        if(-1 != fseek(data->state.in, 0, SEEK_SET))
+          /* successful rewind */
+          return CURLE_OK;
+      }
+
+      /* no callback set or failure above, makes us fail at once */
+      failf(data, "necessary data rewind wasn't possible");
+      return CURLE_SEND_FAIL_REWIND;
+    }
+  }
+  return CURLE_OK;
+}
+
+/*
  * Curl_preconnect() is called immediately before a connect starts. When a
  * redirect is followed, this is then called multiple times during a single
  * transfer.
@@ -1741,6 +1825,7 @@ CURLcode Curl_preconnect(struct Curl_easy *data)
     if(!data->state.buffer)
       return CURLE_OUT_OF_MEMORY;
   }
+
   return CURLE_OK;
 }
 
@@ -1997,7 +2082,10 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       break;
 
     case MSTATE_PROTOCONNECT:
-      if(data->conn->bits.reuse) {
+      if(data->state.rewindbeforesend)
+        result = readrewind(data);
+
+      if(!result && data->conn->bits.reuse) {
         /* ftp seems to hang when protoconnect on reused connection
          * since we handle PROTOCONNECT in general inside the filers, it
          * seems wrong to restart this on a reused connection. */
@@ -2005,7 +2093,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         rc = CURLM_CALL_MULTI_PERFORM;
         break;
       }
-      result = protocol_connect(data, &protocol_connected);
+      if(!result)
+        result = protocol_connect(data, &protocol_connected);
       if(!result && !protocol_connected)
         /* switch to waiting state */
         multistate(data, MSTATE_PROTOCONNECTING);

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -50,7 +50,6 @@ CURLcode Curl_readwrite(struct connectdata *conn,
                         bool *comeback);
 int Curl_single_getsock(struct Curl_easy *data,
                         struct connectdata *conn, curl_socket_t *socks);
-CURLcode Curl_readrewind(struct Curl_easy *data);
 CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
                              size_t *nreadp);
 CURLcode Curl_retry_request(struct Curl_easy *data, char **url);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -516,10 +516,6 @@ struct ConnectBits {
                          that we are creating a request with an auth header,
                          but it is not the final request in the auth
                          negotiation. */
-  BIT(rewindaftersend);/* TRUE when the sending couldn't be stopped even
-                          though it will be discarded. When the whole send
-                          operation is done, we must call the data rewind
-                          callback. */
 #ifndef CURL_DISABLE_FTP
   BIT(ftp_use_epsv);  /* As set with CURLOPT_FTP_USE_EPSV, but if we find out
                          EPSV doesn't work we disable it for the forthcoming
@@ -1483,6 +1479,9 @@ struct UrlState {
   BIT(url_alloc);   /* URL string is malloc()'ed */
   BIT(referer_alloc); /* referer string is malloc()ed */
   BIT(wildcard_resolve); /* Set to true if any resolve change is a wildcard */
+  BIT(rewindbeforesend);/* TRUE when the sending couldn't be stopped even
+                           though it will be discarded. We must call the data
+                           rewind callback before trying to send again. */
 };
 
 /*

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -208,7 +208,7 @@ test1620 test1621 \
 test1630 test1631 test1632 test1633 test1634 test1635 \
 \
 test1650 test1651 test1652 test1653 test1654 test1655 \
-test1660 test1661 \
+test1660 test1661 test1662 \
 \
 test1670 test1671 \
 \

--- a/tests/data/test1662
+++ b/tests/data/test1662
@@ -1,0 +1,67 @@
+<testcase><testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 301 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Location: %TESTNUMBER0002
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+<data2 nocheck="yes">
+HTTP/1.1 200 OK
+Content-Length: 6
+Connection: close
+Funny-head: nono
+
+-bar-
+</data2>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+Mime
+debug
+</features>
+<server>
+http
+</server>
+<name>
+HTTP formpost from callback and a redirect and switch to GET
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+
+# This does not verify the protocol because the sending of data might be
+# aborted early making it hard to check properly.
+<stdout>
+-bar-
+</stdout>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -62,6 +62,9 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
  lib1550 lib1551 lib1552 lib1553 lib1554 lib1555 lib1556 lib1557 \
  lib1558 lib1559 lib1560 lib1564 lib1565 lib1567 lib1568 lib1569 \
  lib1591 lib1592 lib1593 lib1594 lib1596 lib1597 \
+ \
+ lib1662 \
+ \
          lib1905 lib1906 lib1907 lib1908 lib1910 lib1911 lib1912 lib1913 \
          lib1915 lib1916 lib1917 lib1918 lib1919 \
  lib1933 lib1934 lib1935 lib1936 lib1937 lib1938 lib1939 lib1940 \
@@ -666,6 +669,9 @@ lib1596_CPPFLAGS = $(AM_CPPFLAGS) -DLIB1596
 
 lib1597_SOURCES = lib1597.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1597_LDADD = $(TESTUTIL_LIBS)
+
+lib1662_SOURCES = lib1662.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
+lib1662_LDADD = $(TESTUTIL_LIBS)
 
 lib1905_SOURCES = lib1905.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1905_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1662.c
+++ b/tests/libtest/lib1662.c
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+
+static char data[]="mooaaa";
+
+struct WriteThis {
+  size_t sizeleft;
+};
+
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
+{
+  struct WriteThis *pooh = (struct WriteThis *)userp;
+  size_t len = strlen(data);
+
+  if(size*nmemb < len)
+    return 0;
+
+  if(pooh->sizeleft) {
+    memcpy(ptr, data, strlen(data));
+    pooh->sizeleft = 0;
+    return len;
+  }
+
+  return 0;                         /* no more data left to deliver */
+}
+
+
+int test(char *URL)
+{
+  CURLcode res = CURLE_OK;
+  CURL *hnd;
+  curl_mime *mime1;
+  curl_mimepart *part1;
+  struct WriteThis pooh = { 1 };
+
+  mime1 = NULL;
+
+  global_init(CURL_GLOBAL_ALL);
+
+  hnd = curl_easy_init();
+  if(hnd) {
+    curl_easy_setopt(hnd, CURLOPT_BUFFERSIZE, 102400L);
+    curl_easy_setopt(hnd, CURLOPT_URL, URL);
+    curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 1L);
+    mime1 = curl_mime_init(hnd);
+    if(mime1) {
+      part1 = curl_mime_addpart(mime1);
+      curl_mime_data_cb(part1, -1, read_callback, NULL, NULL, &pooh);
+      curl_mime_filename(part1, "poetry.txt");
+      curl_mime_name(part1, "content");
+      curl_easy_setopt(hnd, CURLOPT_MIMEPOST, mime1);
+      curl_easy_setopt(hnd, CURLOPT_USERAGENT, "curl/2000");
+      curl_easy_setopt(hnd, CURLOPT_FOLLOWLOCATION, 1L);
+      curl_easy_setopt(hnd, CURLOPT_MAXREDIRS, 50L);
+      curl_easy_setopt(hnd, CURLOPT_HTTP_VERSION,
+                       (long)CURL_HTTP_VERSION_2TLS);
+      curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
+      curl_easy_setopt(hnd, CURLOPT_FTP_SKIP_PASV_IP, 1L);
+      curl_easy_setopt(hnd, CURLOPT_TCP_KEEPALIVE, 1L);
+      res = curl_easy_perform(hnd);
+    }
+  }
+
+  curl_easy_cleanup(hnd);
+  curl_mime_free(mime1);
+  curl_global_cleanup();
+  return (int)res;
+}
+


### PR DESCRIPTION
This makes a big difference for cases when the rewind is not actually necessary to perform (for example HTTP response code 301 converts to GET) and therefore the rewind can be avoided. In particular for situations when that rewind *fails*.
