### PR TITLE
Do not offer http/1.1 when --http2-prior-knowledge is given

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3507,10 +3507,12 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
     }
 #endif
 
-    protocols[cur++] = ALPN_HTTP_1_1_LENGTH;
-    memcpy(&protocols[cur], ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH);
-    cur += ALPN_HTTP_1_1_LENGTH;
-    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_1);
+    if(data->state.httpwant != CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE) {
+      protocols[cur++] = ALPN_HTTP_1_1_LENGTH;
+      memcpy(&protocols[cur], ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH);
+      cur += ALPN_HTTP_1_1_LENGTH;
+      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_1);
+    }
 
     /* expects length prefixed preference ordered list of protocols in wire
      * format


### PR DESCRIPTION
Fixes https://github.com/curl/curl/issues/9963

Temporary note: at the moment this PR only fixes this for the openssl backend. Since it would be a simple copy/past of the solution to other backend, i'd like to be sure that this solution would be accepted first before committing to changing the rest of the backends.

Also feel free to push into this branch if it's faster for you this way. I might not have time / forget to follow up on this PR.