### PR TITLE
connect: remove include of <sys/filio.h> on NetWare

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -48,9 +48,6 @@
 #include <arpa/inet.h>
 #endif
 
-#if (defined(HAVE_IOCTL_FIONBIO) && defined(NETWARE))
-#include <sys/filio.h>
-#endif
 #ifdef NETWARE
 #undef in_addr_t
 #define in_addr_t unsigned long


### PR DESCRIPTION
The code that used to use `FIONBIO` from <sys/filio.h> was moved to nonblock.c in d709cb2a and bdbfe1f8.

At least it looks that way to me. I don't have a NetWare system to test on.