### PR TITLE
curl_endian: remove Curl_write64_le from header

### DIFF
--- a/lib/curl_endian.h
+++ b/lib/curl_endian.h
@@ -33,13 +33,4 @@ unsigned int Curl_read32_le(const unsigned char *buf);
 /* Converts a 16-bit integer from big endian */
 unsigned short Curl_read16_be(const unsigned char *buf);
 
-#if (SIZEOF_CURL_OFF_T > 4)
-/* Converts a 64-bit integer to little endian */
-#if defined(HAVE_LONGLONG)
-void Curl_write64_le(const long long value, unsigned char *buffer);
-#else
-void Curl_write64_le(const __int64 value, unsigned char *buffer);
-#endif
-#endif
-
 #endif /* HEADER_CURL_ENDIAN_H */


### PR DESCRIPTION
The actual function was already removed in 4331c6dc.

See #7280