### PR TITLE
openssl: silence compiler warning when not using IPv6

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2037,6 +2037,11 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
   const char * const dispname = SSL_HOST_DISPNAME();
   size_t hostlen = strlen(hostname);
 
+#ifndef ENABLE_IPV6
+  /* Silence compiler warnings for unused params */
+  (void) conn;
+#endif
+
 #ifdef ENABLE_IPV6
   if(conn->bits.ipv6_ip &&
      Curl_inet_pton(AF_INET6, hostname, &addr)) {


### PR DESCRIPTION
In non-IPv6 builds the conn parameter is unused, and compilers which run with "-Werror=unused-parameter" (or similar) warnings turned on fails to build. Below is an excerpt from a [CI job](https://dev.azure.com/daniel0244/curl/_build/results?buildId=12812&view=logs&jobId=8165c288-ede3-54c0-ec36-33b42243957c&j=8165c288-ede3-54c0-ec36-33b42243957c&t=820f14c3-d30d-5339-1895-1d0a242aa820):
```
vtls/openssl.c: In function ‘Curl_ossl_verifyhost’:
vtls/openssl.c:2016:75: error: unused parameter ‘conn’ [-Werror=unused-parameter]
 2016 | CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
      |                                                       ~~~~~~~~~~~~~~~~~~~~^~~~
```