### PR TITLE
packaging: remove traces of deleted files

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -53,10 +53,6 @@ Files: mlc_config.json
 Copyright: 2022 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-Files: packages/DOS/README
-Copyright: 2003 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
-License: curl
-
 Files: packages/OS400/README.OS400
 Copyright: 2007 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -24,8 +24,6 @@
 SUBDIRS = vms
 
 EXTRA_DIST = README \
-  DOS/README \
-  DOS/common.dj \
   OS400/README.OS400 \
   OS400/ccsidcurl.c \
   OS400/ccsidcurl.h \


### PR DESCRIPTION
Commit a8861b6cc removed packages/DOS but left a few traces of it which broke the [distcheck CI](https://dev.azure.com/daniel0244/curl/_build/results?buildId=12812&view=logs&jobId=d48ac40c-533b-5630-0f21-eb2b0e2d0e12&j=d48ac40c-533b-5630-0f21-eb2b0e2d0e12&t=b38823a1-2aca-5288-27d5-801c93ba59ed). Remove all traces.