### PR TITLE
curl: use dot as decimal separator independent of locale

### DIFF
--- a/docs/cmdline-opts/connect-timeout.d
+++ b/docs/cmdline-opts/connect-timeout.d
@@ -14,3 +14,6 @@ Maximum time in seconds that you allow curl's connection to take.  This only
 limits the connection phase, so if curl connects within the given period it
 will continue - if not it will exit.  Since version 7.32.0, this option
 accepts decimal values.
+
+The decimal value needs to provided using a dot (.) as decimal separator - not
+the local version even if it might be using another separator.

--- a/docs/cmdline-opts/expect100-timeout.d
+++ b/docs/cmdline-opts/expect100-timeout.d
@@ -14,3 +14,6 @@ Maximum time in seconds that you allow curl to wait for a 100-continue
 response when curl emits an Expects: 100-continue header in its request. By
 default curl will wait one second. This option accepts decimal values! When
 curl stops waiting, it will continue as if the response has been received.
+
+The decimal value needs to provided using a dot (.) as decimal separator - not
+the local version even if it might be using another separator.

--- a/docs/cmdline-opts/max-time.d
+++ b/docs/cmdline-opts/max-time.d
@@ -20,3 +20,6 @@ timeout increases in decimal precision.
 If you enable retrying the transfer (--retry) then the maximum time counter is
 reset each time the transfer is retried. You can use --retry-max-time to limit
 the retry time.
+
+The decimal value needs to provided using a dot (.) as decimal separator - not
+the local version even if it might be using another separator.

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2638,9 +2638,9 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
   CURLcode result = CURLE_OK;
   char *first_arg = argc > 1 ? curlx_convert_tchar_to_UTF8(argv[1]) : NULL;
 
-  /* Setup proper locale from environment */
 #ifdef HAVE_SETLOCALE
-  setlocale(LC_ALL, "");
+  /* Override locales for uniform and consistent behavior */
+  setlocale(LC_ALL, "C");
 #endif
 
   /* Parse .curlrc if necessary */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2639,8 +2639,9 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
   char *first_arg = argc > 1 ? curlx_convert_tchar_to_UTF8(argv[1]) : NULL;
 
 #ifdef HAVE_SETLOCALE
-  /* Override locales for uniform and consistent behavior */
-  setlocale(LC_ALL, "C");
+  /* Override locale for number parsing (only) */
+  setlocale(LC_ALL, "");
+  setlocale(LC_NUMERIC, "C");
 #endif
 
   /* Parse .curlrc if necessary */


### PR DESCRIPTION
Independently of what the locale says

Reported-by: Daniel Faust
Ref: #9969