### PR TITLE
CI: fixup: pip install --use-pep517 ...

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,9 +46,9 @@ freebsd_task:
     - pkg delete -y curl
     - python -m ensurepip --default-pip
     - python -m pip install --upgrade pip
-    - pip install "cryptography<3.2"
-    - pip install "pyOpenSSL<20.0"
-    - pip install "impacket"
+    - pip install --use-pep517 "cryptography<3.2"
+    - pip install --use-pep517 "pyOpenSSL<20.0"
+    - pip install --use-pep517 "impacket"
   configure_script:
     - autoreconf -fi
     # Building with the address sanitizer is causing unexplainable test issues due to timeouts


### PR DESCRIPTION
e.g. "DEPRECATION: pycryptodomex is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559"