### PR TITLE
build: restore old msdos, amigaos makefiles

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -161,6 +161,7 @@ distro
 distro's
 distros
 DJGPP
+djgpp
 dlist
 DLL
 dll

--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -160,8 +160,6 @@ dir
 distro
 distro's
 distros
-DJGPP
-djgpp
 dlist
 DLL
 dll
@@ -228,7 +226,6 @@ FreeDOS
 FreeRTOS
 freshmeat
 Frexx
-FS
 fseek
 FTPing
 fuzzer

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -53,6 +53,10 @@ Files: mlc_config.json
 Copyright: 2022 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
+Files: packages/DOS/README
+Copyright: 2003 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
+License: curl
+
 Files: packages/OS400/README.OS400
 Copyright: 2007 - 2022 Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -72,8 +72,8 @@ cygwin-ssl:
 	make
 
 amiga:
-	$(MAKE) -C lib -f Makefile.mk CROSSPREFIX=m68k-amigaos-
-	$(MAKE) -C src -f Makefile.mk CROSSPREFIX=m68k-amigaos-
+	$(MAKE) -C lib -f makefile.amiga
+	$(MAKE) -C src -f makefile.amiga
 
 unix: all
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -59,9 +59,9 @@ vc-x64:
 	cd winbuild
 	nmake /f Makefile.vc MACHINE=x64
 
-djgpp%:
-	$(MAKE) -C lib -f Makefile.mk CFG=$@ CROSSPREFIX=i586-pc-msdosdjgpp-
-	$(MAKE) -C src -f Makefile.mk CFG=$@ CROSSPREFIX=i586-pc-msdosdjgpp-
+djgpp:
+	$(MAKE) -C lib -f Makefile.mk CROSSPREFIX=i586-pc-msdosdjgpp-
+	$(MAKE) -C src -f Makefile.mk CROSSPREFIX=i586-pc-msdosdjgpp-
 
 cygwin:
 	./configure
@@ -71,9 +71,9 @@ cygwin-ssl:
 	./configure --with-openssl
 	make
 
-amiga%:
-	$(MAKE) -C lib -f Makefile.mk CFG=$@ CROSSPREFIX=m68k-amigaos-
-	$(MAKE) -C src -f Makefile.mk CFG=$@ CROSSPREFIX=m68k-amigaos-
+amiga:
+	$(MAKE) -C lib -f Makefile.mk CROSSPREFIX=m68k-amigaos-
+	$(MAKE) -C src -f Makefile.mk CROSSPREFIX=m68k-amigaos-
 
 unix: all
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -60,8 +60,8 @@ vc-x64:
 	nmake /f Makefile.vc MACHINE=x64
 
 djgpp:
-	$(MAKE) -C lib -f Makefile.mk CROSSPREFIX=i586-pc-msdosdjgpp-
-	$(MAKE) -C src -f Makefile.mk CROSSPREFIX=i586-pc-msdosdjgpp-
+	$(MAKE) -C lib -f makefile.dj
+	$(MAKE) -C src -f makefile.dj
 
 cygwin:
 	./configure

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -225,7 +225,7 @@ Run `make`
 Requires DJGPP in the search path and pointing to the Watt-32 stack via
 `WATT_PATH=c:/djgpp/net/watt`.
 
-Run `make -f Makefile.dist djgpp` in the root curl dir.
+Run 'make -f Makefile.dist djgpp' in the root curl dir.
 
 For build configuration options, please see the MinGW32 section.
 
@@ -240,7 +240,7 @@ Notes:
 
 ## AmigaOS
 
-Run `make -f Makefile.dist amiga` in the root curl dir.
+Run 'make -f Makefile.dist amiga' in the root curl dir.
 
 For build configuration options, please see the MinGW32 section.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -222,21 +222,19 @@ Run `make`
 
 ## MS-DOS
 
-Requires DJGPP in the search path and pointing to the Watt-32 stack via
-`WATT_PATH=c:/djgpp/net/watt`.
+Requires djgpp in the search path and pointing to Gisle Vanem's Watt-32 stack
+via `WATT_PATH=c:/djgpp/net/watt`.
 
 Run 'make -f Makefile.dist djgpp' in the root curl dir.
 
 For build configuration options, please see the MinGW32 section.
 
-Notes:
+Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
+        done properly. Use djgpp 2.03 until they fix it.
 
- - DJGPP 2.04 beta has a `sscanf()` bug so the URL parsing is not done
-   properly. Use DJGPP 2.03 until they fix it.
-
- - Compile Watt-32 (and OpenSSL) with the same version of DJGPP. Otherwise
-   things go wrong because things like FS-extensions and `errno` values have
-   been changed between releases.
+Note 2: Compile Watt-32 (and OpenSSL) with the same version of djgpp.
+        Otherwise things go wrong because things like FS-extensions and
+        errnos have been changed between releases.
 
 ## AmigaOS
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -220,28 +220,6 @@ executable in `/bin/` or you will see the configure fail toward the end.
 
 Run `make`
 
-## MS-DOS
-
-Requires djgpp in the search path and pointing to Gisle Vanem's Watt-32 stack
-via `WATT_PATH=c:/djgpp/net/watt`.
-
-Run 'make -f Makefile.dist djgpp' in the root curl dir.
-
-For build configuration options, please see the MinGW32 section.
-
-Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
-        done properly. Use djgpp 2.03 until they fix it.
-
-Note 2: Compile Watt-32 (and OpenSSL) with the same version of djgpp.
-        Otherwise things go wrong because things like FS-extensions and
-        errnos have been changed between releases.
-
-## AmigaOS
-
-Run 'make -f Makefile.dist amiga' in the root curl dir.
-
-For build configuration options, please see the MinGW32 section.
-
 ## Disabling Specific Protocols in Windows builds
 
 The configure utility, unfortunately, is not available for the Windows

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -25,7 +25,7 @@
 AUTOMAKE_OPTIONS = foreign nostdinc
 
 EXTRA_DIST = README.md Makefile.example Makefile.inc Makefile.mk \
-  $(COMPLICATED_EXAMPLES) .checksrc
+  makefile.dj $(COMPLICATED_EXAMPLES) .checksrc
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library

--- a/docs/examples/makefile.dj
+++ b/docs/examples/makefile.dj
@@ -1,0 +1,57 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+TOPDIR = ../..
+
+include $(TOPDIR)/packages/DOS/common.dj
+
+CFLAGS += -DFALSE=0 -DTRUE=1
+
+LIBS = $(TOPDIR)/lib/libcurl.a
+
+ifeq ($(USE_SSL),1)
+  LIBS += $(OPENSSL_ROOT)/lib/libssl.a $(OPENSSL_ROOT)/lib/libcrypt.a
+endif
+
+ifeq ($(USE_IDNA),1)
+  LIBS += $(LIBIDN_ROOT)/lib/dj_obj/libidn.a -liconv
+endif
+
+LIBS += $(WATT32_ROOT)/lib/libwatt.a $(ZLIB_ROOT)/libz.a
+
+include Makefile.inc
+
+PROGRAMS = $(patsubst %,%.exe,$(check_PROGRAMS))
+
+all: $(PROGRAMS)
+	@echo Welcome to libcurl example program
+
+%.exe: %.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	@echo
+
+clean vclean realclean:
+	- rm -f $(PROGRAMS) depend.dj
+
+-include depend.dj

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -27,7 +27,7 @@ CMAKE_DIST = CMakeLists.txt curl_config.h.cmake
 
 EXTRA_DIST = Makefile.mk config-win32.h config-win32ce.h config-plan9.h    \
  config-riscos.h config-mac.h curl_config.h.in config-dos.h                \
- libcurl.plist libcurl.rc config-amigaos.h config-win32ce.h                \
+ libcurl.plist libcurl.rc config-amigaos.h makefile.amiga config-win32ce.h \
  config-os400.h setup-os400.h $(CMAKE_DIST) setup-win32.h .checksrc
 
 lib_LTLIBRARIES = libcurl.la

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -26,7 +26,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 CMAKE_DIST = CMakeLists.txt curl_config.h.cmake
 
 EXTRA_DIST = Makefile.mk config-win32.h config-win32ce.h config-plan9.h    \
- config-riscos.h config-mac.h curl_config.h.in config-dos.h                \
+ config-riscos.h config-mac.h curl_config.h.in makefile.dj config-dos.h    \
  libcurl.plist libcurl.rc config-amigaos.h makefile.amiga config-win32ce.h \
  config-os400.h setup-os400.h $(CMAKE_DIST) setup-win32.h .checksrc
 

--- a/lib/config-dos.h
+++ b/lib/config-dos.h
@@ -41,8 +41,6 @@
 
 #define PACKAGE  "curl"
 
-#define USE_MANUAL 1
-
 #define HAVE_ARPA_INET_H       1
 #define HAVE_ASSERT_H          1
 #define HAVE_ERRNO_H           1

--- a/lib/makefile.amiga
+++ b/lib/makefile.amiga
@@ -1,0 +1,45 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+# libcurl Makefile for AmigaOS ...
+#
+
+# Download: https://aminet.net/comm/tcp/AmiTCP-SDK-4.3.lha
+# change the follow to where you have the AmiTCP SDK v4.3 includes:
+
+ATCPSDKI= /GG/netinclude
+
+
+CC = m68k-amigaos-gcc
+CFLAGS = -I$(ATCPSDKI) -m68020-60 -O2 -msoft-float -noixemul -g -I. -I../include -W -Wall -DUSE_OPENSSL -DHAVE_LIBZ
+
+include Makefile.inc
+OBJS = $(CSOURCES:.c=.o)
+
+all: $(OBJS)
+	ar cru libcurl.a $(OBJS)
+	ranlib libcurl.a
+
+install:
+	$(INSTALL) -c ./libcurl.a /lib/libcurl.a

--- a/lib/makefile.dj
+++ b/lib/makefile.dj
@@ -1,0 +1,73 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2003 - 2022, Gisle Vanem <gvanem@yahoo.no>.
+# Copyright (C) 2003 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+#***************************************************************************
+
+#
+#  Adapted for djgpp2 / Watt-32 / DOS
+#
+
+DEPEND_PREREQ = curl_config.h
+VPATH  = vtls vauth vquic vssh
+TOPDIR = ..
+
+include ../packages/DOS/common.dj
+include Makefile.inc
+
+CFLAGS += -DBUILDING_LIBCURL
+
+SOURCES = $(sort $(CSOURCES))
+OBJECTS = $(addprefix $(OBJ_DIR)/, $(notdir $(SOURCES:.c=.o)))
+
+CURL_LIB = libcurl.a
+
+all: $(OBJ_DIR) curl_config.h $(CURL_LIB)
+
+$(CURL_LIB): $(OBJECTS)
+	ar rs $@ $?
+
+curl_config.h: config-dos.h
+	$(COPY) $^ $@
+
+# clean generated files
+#
+genclean:
+	- $(DELETE) curl_config.h
+
+# clean object files and subdir
+#
+objclean: genclean
+	- $(DELETE) $(OBJ_DIR)$(DS)*.o
+	- $(RMDIR) $(OBJ_DIR)
+
+# clean without removing built library
+#
+clean: objclean
+	- $(DELETE) depend.dj
+
+# clean everything
+#
+realclean vclean: clean
+	- $(DELETE) $(CURL_LIB)
+
+-include depend.dj

--- a/packages/DOS/README
+++ b/packages/DOS/README
@@ -1,0 +1,17 @@
+Gisle Vanem made curl build fine on DOS (and MinGW) with djgpp, OpenSSL and his
+Watt-32 stack.
+
+'make -f Makefile.dist djgpp' in the root curl dir should build it fine.
+Or enter 'lib' and do a 'make -f Makefile.dj clean all' to first delete
+'lib/curl_config.h' which is possibly from a previous incompatible Windows-build.
+
+Note 1: djgpp 2.04 beta has a sscanf() bug so the URL parsing isn't
+        done properly. Use djgpp 2.03 until they fix it.
+
+Note 2: Compile Watt-32 (and OpenSSL) with the same version of djgpp.
+        Otherwise things go wrong because things like FS-extensions and
+        errnos have been changed between releases.
+
+Note 3: Several 'USE_x' variables in 'common.dj' are on the 'USE_x ?= 0'
+        form (conditional variable assignment). So one can build like this:
+          c:\curl\lib> make -f makefile.dj USE_OPENSSL=1 USE_ZLIB=1 clean all

--- a/packages/DOS/common.dj
+++ b/packages/DOS/common.dj
@@ -1,0 +1,223 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+# Common defines for curl (djgpp/Watt-32)
+#
+# Assumes you've unpacked curl with long-file names
+# I.e use "set LFN=y" before untaring on Win9x/XP.
+# Requires sed, rm and the usual stuff.
+#
+# Define TOPDIR before including this file.
+
+MAKEFILE = Makefile.dj
+OBJ_DIR = djgpp
+
+#
+# Find out if using a Unix-like shell or a DOS command interpreter
+#
+ifneq ($(findstring COMMAND.COM,$(SHELL)),COMMAND.COM)
+  ifneq ($(findstring CMD.EXE,$(SHELL)),CMD.EXE)
+    ifneq ($(findstring 4DOS.COM,$(SHELL)),4DOS.COM)
+      IS_UNIX_SHELL = 1
+    endif
+  endif
+endif
+
+#
+# Define shell dependent commands and vars
+#
+ifeq ($(IS_UNIX_SHELL),1)
+  COPY   = cp -f
+  DELETE = rm -f
+  MKDIR  = mkdir
+  RMDIR  = rm -f -r
+  DS     = /
+else
+  COPY   = copy
+  DELETE = del
+  MKDIR  = mkdir
+  RMDIR  = rmdir
+  DS     = \$(NOTHING)
+endif
+
+ifeq ($(OS),Windows_NT)
+  #
+  # Windows hosted djgpp cross compiler. Get it from:
+  #   https://github.com/andrewwutw/build-djgpp/releases
+  #
+  DJ_PREFIX ?= c:/some-path/djgpp/bin/i586-pc-msdosdjgpp-
+  CC = $(DJ_PREFIX)gcc
+
+else
+  #
+  # The normal djgpp 'gcc' for MSDOS.
+  #
+  CC = gcc
+endif
+
+#
+# OpenSSL is available from www.openssl.org and builds okay
+# with djgpp/Watt-32. Set to 0 if you don't need https URLs
+# (reduces curl.exe with approx 700 kB)
+#
+USE_OPENSSL ?= 0
+
+#
+# Use zlib for contents encoding. Needed for 'USE_OPENSSL=1' too.
+#
+USE_ZLIB ?= 0
+
+#
+# Use libidn for international domain names
+#
+USE_IDNA ?= 0
+
+#
+# Use Watt-32 IPv6 stack (only IPv6 name resolution working at the moment)
+#
+USE_IPV6 ?= 0
+
+#
+# Use C-Ares resolver library
+#
+USE_ARES ?= 0
+
+#
+# Enable debug code in libcurl/curl
+#
+USE_DEBUG ?= 0
+
+#
+# Enable memory tracking code in libcurl/curl
+#
+USE_CURLDEBUG ?= 0
+
+#
+# Generate a .map file in 'link_EXE' macro
+#
+MAKE_MAP_FILE ?= 0
+
+default: all
+
+#
+# Root directory for Waterloo tcp/ip etc. Change to suite.
+# WATT_ROOT should be set during Watt-32 install.
+#
+WATT32_ROOT   = $(realpath $(WATT_ROOT))
+OPENSSL_ROOT ?= $(TOPDIR)/../crypto/OpenSSL
+ZLIB_ROOT    ?= e:/djgpp/contrib/zlib
+LIBIDN_ROOT  ?= $(TOPDIR)/../IDN/libidn
+ARES_ROOT    ?= $(TOPDIR)/../DNS/c-ares
+
+CFLAGS = -g -O2 -I. -I$(TOPDIR)/include -I$(TOPDIR)/lib \
+         -I$(WATT32_ROOT)/inc -Wall -DHAVE_CONFIG_H
+
+ifeq ($(USE_OPENSSL),1)
+  CFLAGS += -DUSE_OPENSSL -I$(OPENSSL_ROOT)/include
+
+  #
+  # Squelch the warnings on deprecated functions.
+  #
+  CFLAGS += -DOPENSSL_SUPPRESS_DEPRECATED
+
+  #
+  # Use some of these too?
+  #
+  # CFLAGS += -DUSE_TLS_SRP=1                    \
+  #           -DHAVE_ENGINE_LOAD_BUILTIN_ENGINES \
+  #           -DHAVE_SSLV2_CLIENT_METHOD         \
+  #           -DOPENSSL_NO_DEPRECATED
+
+  #
+  # 'libcomm.a' is normally 'libcommon.a'. But to keep it 8+3 clean, it's
+  # shortened to 'libcomm.a'. The official OpenSSL build was recently changed
+  # and this "Common" library was added for several of the Crypto Providers.
+  #
+  OPENSSL_LIBS = $(OPENSSL_ROOT)/lib/libssl.a   \
+                 $(OPENSSL_ROOT)/lib/libcrypt.a \
+                 $(OPENSSL_ROOT)/lib/libcomm.a
+endif
+
+ifeq ($(USE_ZLIB),1)
+  CFLAGS += -DHAVE_LIBZ -I$(ZLIB_ROOT)
+endif
+
+ifeq ($(USE_IPV6),1)
+  CFLAGS += -DENABLE_IPV6
+endif
+
+ifeq ($(USE_ARES),1)
+  CFLAGS += -DUSE_ARES -I$(ARES_ROOT)/include
+endif
+
+ifeq ($(USE_IDNA),1)
+  CFLAGS += -DHAVE_LIBIDN -I$(LIBIDN_ROOT)/lib
+endif
+
+ifeq ($(USE_DEBUG),1)
+  CFLAGS += -DDEBUG=1 -DDEBUGBUILD
+endif
+
+ifeq ($(USE_CURLDEBUG),1)
+  CFLAGS += -DCURLDEBUG
+endif
+
+$(OBJ_DIR):
+	$(MKDIR) $(OBJ_DIR)
+
+$(OBJ_DIR)/%.o: %.c
+	$(CC) $(CFLAGS) -o $@ -c $<
+	@echo
+
+#
+# Link-EXE macro:
+#   $(1): the .exe
+#   $(2): the .o-files and libraries
+#
+ifeq ($(MAKE_MAP_FILE),1)
+  define link_EXE
+    $(CC) -o $(1) $(LDFLAGS) -Wl,--print-map,--sort-common $(2) > $(1:.exe=.map)
+  endef
+else
+  define link_EXE
+    $(CC) $(LDFLAGS) -o $(1) $(2)
+  endef
+endif
+
+$(TOPDIR)/docs/curl.1: $(wildcard $(TOPDIR)/docs/cmdline-opts/*.d)
+	cd $(TOPDIR)/docs/cmdline-opts; \
+	perl gen.pl mainpage > ../$(TOPDIR)/docs/curl.1
+
+DEP_REPLACE = sed -e 's@\(.*\)\.o: @\n$$(OBJ_DIR)\/\1.o: @' \
+                  -e 's@$(ARES_ROOT)@$$(ARES_ROOT)@g'       \
+                  -e 's@$(OPENSSL_ROOT)@$$(OPENSSL_ROOT)@g' \
+                  -e 's@$(WATT32_ROOT)@$$(WATT32_ROOT)@g'   \
+                  -e 's@$(ZLIB_ROOT)@$$(ZLIB_ROOT)@g'
+
+#
+# One may have to do 'make -f Makefile.dj clean' first in case
+# a foreign 'curl_config.h' is making trouble.
+#
+depend: $(DEPEND_PREREQ) $(MAKEFILE)
+	$(CC) -MM $(CFLAGS) $(CSOURCES) | $(DEP_REPLACE) > depend.dj

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -24,6 +24,8 @@
 SUBDIRS = vms
 
 EXTRA_DIST = README \
+  DOS/README \
+  DOS/common.dj \
   OS400/README.OS400 \
   OS400/ccsidcurl.c \
   OS400/ccsidcurl.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,7 +88,7 @@ CLEANFILES = tool_hugehelp.c
 NROFF=env LC_ALL=C @NROFF@ @MANOPT@ # figured out by the configure script
 
 EXTRA_DIST = mkhelp.pl \
- Makefile.mk curl.rc Makefile.inc CMakeLists.txt
+ Makefile.mk makefile.amiga curl.rc Makefile.inc CMakeLists.txt
 
 # Use absolute directory to disable VPATH
 MANPAGE=$(abs_top_builddir)/docs/curl.1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,7 +87,7 @@ CLEANFILES = tool_hugehelp.c
 # embedded text.
 NROFF=env LC_ALL=C @NROFF@ @MANOPT@ # figured out by the configure script
 
-EXTRA_DIST = mkhelp.pl \
+EXTRA_DIST = mkhelp.pl makefile.dj \
  Makefile.mk makefile.amiga curl.rc Makefile.inc CMakeLists.txt
 
 # Use absolute directory to disable VPATH

--- a/src/makefile.amiga
+++ b/src/makefile.amiga
@@ -1,0 +1,52 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 1998 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+# curl Makefile for AmigaOS ...
+#
+
+# change the follow to where you have the AmiTCP SDK v4.3 includes:
+
+ATCPSDKI= /GG/netinclude
+
+
+CC = m68k-amigaos-gcc
+CFLAGS  = -I$(ATCPSDKI) -m68020-60 -O2 -msoft-float -noixemul -g -I. -I../include -W -Wall -DUSE_OPENSSL -DHAVE_LIBZ
+LIBS    = ../lib/libcurl.a -lssl -lcrypto -lz
+MANPAGE = ../docs/curl.1
+README  = ../docs/MANUAL
+MKHELP  = ../src/mkhelp.pl
+
+include Makefile.inc
+
+OBJS = $(CURL_CFILES:.c=.o) $(CURLX_CFILES:.c=.o)
+
+all: tool_hugehelp.c $(OBJS)
+	$(CC) $(CFLAGS) -o curl $(OBJS) $(LIBS) -Wl,-Map,curl.map,--cref
+
+tool_hugehelp.c: $(README) $(MANPAGE)  mkhelp.pl
+	rm -f tool_hugehelp.c
+	/bin/nroff -man $(MANPAGE) | /bin/perl $(MKHELP) -c $(README) > tool_hugehelp.c
+
+install:
+	$(INSTALL) -c curl /c/curl

--- a/src/makefile.dj
+++ b/src/makefile.dj
@@ -1,0 +1,101 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2003 - 2022, Gisle Vanem <gvanem@yahoo.no>.
+# Copyright (C) 2003 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+#***************************************************************************
+
+#
+#  Adapted for djgpp2 / Watt-32 / DOS
+#
+
+DEPEND_PREREQ = # tool_hugehelp.c
+
+TOPDIR = ..
+
+vpath %.c ../lib
+
+include ../packages/DOS/common.dj
+include Makefile.inc
+
+CSOURCES = $(CURL_CFILES) $(CURLX_CFILES)
+
+ifeq ($(USE_OPENSSL),1)
+  EX_LIBS += $(OPENSSL_LIBS)
+endif
+
+ifeq ($(USE_ARES),1)
+  EX_LIBS += $(ARES_ROOT)/libcares.a
+endif
+
+ifeq ($(USE_ZLIB),1)
+  EX_LIBS += $(ZLIB_ROOT)/libz.a
+  CFLAGS  += -DUSE_MANUAL
+endif
+
+ifeq ($(USE_IDNA),1)
+  EX_LIBS += $(LIBIDN_ROOT)/lib/dj_obj/libidn.a -liconv
+endif
+
+EX_LIBS += $(WATT32_ROOT)/lib/libwatt.a
+
+PROGRAM = curl.exe
+OBJECTS = $(addprefix $(OBJ_DIR)/, $(notdir $(CSOURCES:.c=.o)))
+
+all: $(OBJ_DIR) $(PROGRAM)
+	@echo Welcome to curl
+
+$(PROGRAM): $(OBJECTS) ../lib/libcurl.a
+	$(CC) -o $@ $^ $(LDFLAGS) $(EX_LIBS)
+
+#
+# groff 1.18+ requires "-P -c"
+# If 'USE_ZLIB = 1', create a compressed help-file.
+#
+ifeq ($(USE_ZLIB),1)
+  COMPRESS_OPT = -c
+endif
+
+tool_hugehelp.c: ../docs/curl.1 mkhelp.pl Makefile.dj
+	groff -Tascii -man $< | perl -w mkhelp.pl $(COMPRESS_OPT) $< > $@
+
+# clean generated files
+#
+genclean:
+	- $(DELETE) tool_hugehelp.c
+
+# clean object files and subdir
+#
+objclean: genclean
+	- $(DELETE) $(OBJ_DIR)$(DS)*.o
+	- $(RMDIR) $(OBJ_DIR)
+
+# clean without removing built program
+#
+clean: objclean
+	- $(DELETE) depend.dj
+
+# clean everything
+#
+realclean vclean: clean
+	- $(DELETE) $(PROGRAM)
+
+-include depend.dj


### PR DESCRIPTION
- Restore original legacy Makefiles for MS-DOS and AmigaOS. Some envs do not recognize double-quoted command-line arguments.
- Status of MS-DOS/AmigaOS platform support inside `Makefile.mk` changes to experimental.

Regression from a8861b6ccdd7ca35b6115588a578e36d765c9e38 (Partial revert)

Reported-by: Gisle Vanem
Fixes https://github.com/curl/curl/pull/9764#issuecomment-1328216388
Closes #xxxx

---

The extra clutter in `Makefile.mk` that belong to these two platorms is quite tiny: 23 lines. Extra 30 lines for `WIN32`-specific stuff, which can be removed if we support Windows-only here.

[ Not saying that these couldn't be made work with `Makefile.mk`, but I don't have the capacity to test/support the needs of these platforms. Also, supporting them seems to be difficult without hurting legibility of mingw32-specific logic. ]
