### PR TITLE
curl-openssl.m4: do not add $prefix/include/openssl to CPPFLAGS

### DIFF
--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -102,7 +102,6 @@ if test "x$OPT_OPENSSL" != xno; then
       SSL_LDFLAGS="-L$LIB_OPENSSL"
       SSL_CPPFLAGS="-I$PREFIX_OPENSSL/include"
     fi
-    SSL_CPPFLAGS="$SSL_CPPFLAGS -I$PREFIX_OPENSSL/include/openssl"
     ;;
   esac
 
@@ -150,7 +149,7 @@ if test "x$OPT_OPENSSL" != xno; then
      fi
      if test "$PKGCONFIG" = "no" -a -n "$PREFIX_OPENSSL" ; then
        # only set this if pkg-config wasn't used
-       CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include/openssl -I$PREFIX_OPENSSL/include"
+       CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_OPENSSL/include"
      fi
      # Linking previously failed, try extra paths from --with-openssl or
      # pkg-config.  Use a different function name to avoid reusing the earlier

--- a/scripts/zuul/script.sh
+++ b/scripts/zuul/script.sh
@@ -53,15 +53,9 @@ if [ "$T" = "debug" ]; then
   fi
 fi
 
-if [ "$T" = "debug-bearssl" ]; then
-  ./configure --enable-debug --enable-werror $C
-  make
-  make "TFLAGS=-n !313" test-nonflaky
-fi
-
 if [ "$T" = "novalgrind" ]; then
   ./configure --enable-werror $C
-  make
+  make V=1
   make examples
   make TFLAGS=-n test-nonflaky
 fi


### PR DESCRIPTION
As openssl include files are all using `openssl/*.h`, we just risk that openssl files will "shadow" include files without path.

Fixes #9989 