### PR TITLE
Enabling Digest with OpenSSL (USE_OPENSSL) to work along with Windows SSPI (USE_WINDOWS_SSPI)

### DIFF
--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -81,7 +81,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   bool have_chlg;
 
   /* Point to the address of the pointer that holds the string to send to the
-     server, which is for a plain host or for a HTTP proxy */
+     server, which is for a plain host or for an HTTP proxy */
   char **allocuserpwd;
 
   /* Point to the name and password for this */
@@ -120,7 +120,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   if(!passwdp)
     passwdp = "";
 
-#if defined(USE_WINDOWS_SSPI) && defined(USE_SCHANNEL)
+#if defined(USE_WINDOWS_SSPI)
   have_chlg = digest->input_token ? TRUE : FALSE;
 #else
   have_chlg = digest->nonce ? TRUE : FALSE;

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -120,7 +120,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   if(!passwdp)
     passwdp = "";
 
-#if defined(USE_WINDOWS_SSPI)
+#if defined(USE_WINDOWS_SSPI) && defined(USE_SCHANNEL)
   have_chlg = digest->input_token ? TRUE : FALSE;
 #else
   have_chlg = digest->nonce ? TRUE : FALSE;

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -81,7 +81,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   bool have_chlg;
 
   /* Point to the address of the pointer that holds the string to send to the
-     server, which is for a plain host or for an HTTP proxy */
+     server, which is for a plain host or for a HTTP proxy */
   char **allocuserpwd;
 
   /* Point to the name and password for this */
@@ -120,7 +120,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   if(!passwdp)
     passwdp = "";
 
-#if defined(USE_WINDOWS_SSPI)
+#if defined(USE_WINDOWS_SSPI) && defined(USE_SCHANNEL)
   have_chlg = digest->input_token ? TRUE : FALSE;
 #else
   have_chlg = digest->nonce ? TRUE : FALSE;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -340,7 +340,7 @@ struct Curl_ssl_session {
 
 /* Struct used for Digest challenge-response authentication */
 struct digestdata {
-#if defined(USE_WINDOWS_SSPI)
+#if defined(USE_WINDOWS_SSPI) && defined(USE_SCHANNEL)
   BYTE *input_token;
   size_t input_token_len;
   CtxtHandle *http_context;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -113,6 +113,24 @@ typedef unsigned int curl_prot_t;
    input easier and better. */
 #define CURL_MAX_INPUT_LENGTH 8000000
 
+/* Macros intended for DEBUGF logging, use like:
+ * DEBUGF(infof(data, CFMSG(cf, "this filter %s rocks"), "very much"));
+ * and it will output:
+ * [CONN-1-0][CF-SSL] this filter very much rocks
+ * on connection #1 with sockindex 0 for filter of type "SSL". */
+#define DMSG(d,msg)  \
+  "[CONN-%ld] "msg, (d)->conn->connection_id
+#define DMSGI(d,i,msg)  \
+  "[CONN-%ld-%d] "msg, (d)->conn->connection_id, (i)
+#define CMSG(c,msg)  \
+  "[CONN-%ld] "msg, (conn)->connection_id
+#define CMSGI(c,i,msg)  \
+  "[CONN-%ld-%d] "msg, (conn)->connection_id, (i)
+#define CFMSG(cf,msg)  \
+  "[CONN-%ld-%d][CF-%s] "msg, (cf)->conn->connection_id, \
+  (cf)->sockindex, (cf)->cft->name
+
+
 #include "cookie.h"
 #include "psl.h"
 #include "formdata.h"
@@ -249,22 +267,9 @@ typedef enum {
 /* SSL backend-specific data; declared differently by each SSL backend */
 struct ssl_backend_data;
 
-/* struct for data related to each SSL connection */
-struct ssl_connect_data {
-  ssl_connection_state state;
-  ssl_connect_state connecting_state;
-#if defined(USE_SSL)
-  struct ssl_backend_data *backend;
-#endif
-  /* Use ssl encrypted communications TRUE/FALSE. The library is not
-     necessarily using ssl at the moment but at least asked to or means to use
-     it. See 'state' for the exact current state of the connection. */
-  BIT(use);
-};
-
 struct ssl_primary_config {
   long version;          /* what version the client wants to use */
-  long version_max;      /* max supported version the client wants to use*/
+  long version_max;      /* max supported version the client wants to use */
   char *CApath;          /* certificate dir (doesn't work on windows) */
   char *CAfile;          /* certificate to verify peer against */
   char *issuercert;      /* optional issuer certificate filename */
@@ -301,7 +306,7 @@ struct ssl_config_data {
   char *key_passwd; /* plain text private key password */
   BIT(certinfo);     /* gather lots of certificate info */
   BIT(falsestart);
-  BIT(enable_beast); /* allow this flaw for interoperability's sake*/
+  BIT(enable_beast); /* allow this flaw for interoperability's sake */
   BIT(no_revoke);    /* disable SSL certificate revocation checks */
   BIT(no_partialchain); /* don't accept partial certificate chains */
   BIT(revoke_best_effort); /* ignore SSL revocation offline/missing revocation
@@ -313,6 +318,7 @@ struct ssl_config_data {
 
 struct ssl_general_config {
   size_t max_ssl_sessions; /* SSL session id cache size */
+  int ca_cache_timeout;  /* Certificate store cache timeout (seconds) */
 };
 
 /* information stored about one single SSL session */
@@ -334,7 +340,7 @@ struct Curl_ssl_session {
 
 /* Struct used for Digest challenge-response authentication */
 struct digestdata {
-#if defined(USE_WINDOWS_SSPI) && defined(USE_SCHANNEL)
+#if defined(USE_WINDOWS_SSPI)
   BYTE *input_token;
   size_t input_token_len;
   CtxtHandle *http_context;
@@ -476,12 +482,8 @@ struct negotiatedata {
  * Boolean values that concerns this connection.
  */
 struct ConnectBits {
-  bool tcpconnect[2]; /* the TCP layer (or similar) is connected, this is set
-                         the first time on the first connect function call */
 #ifndef CURL_DISABLE_PROXY
-  bool proxy_ssl_connected[2]; /* TRUE when SSL initialization for HTTPS proxy
-                                  is complete */
-  BIT(httpproxy);  /* if set, this transfer is done through a http proxy */
+  BIT(httpproxy);  /* if set, this transfer is done through an HTTP proxy */
   BIT(socksproxy); /* if set, this transfer is done through a socks proxy */
   BIT(proxy_user_passwd); /* user+password for the proxy? */
   BIT(tunnel_proxy);  /* if CONNECT is used to "tunnel" through the proxy.
@@ -514,10 +516,6 @@ struct ConnectBits {
                          that we are creating a request with an auth header,
                          but it is not the final request in the auth
                          negotiation. */
-  BIT(rewindaftersend);/* TRUE when the sending couldn't be stopped even
-                          though it will be discarded. When the whole send
-                          operation is done, we must call the data rewind
-                          callback. */
 #ifndef CURL_DISABLE_FTP
   BIT(ftp_use_epsv);  /* As set with CURLOPT_FTP_USE_EPSV, but if we find out
                          EPSV doesn't work we disable it for the forthcoming
@@ -724,6 +722,7 @@ struct SingleRequest {
   BIT(forbidchunk);  /* used only to explicitly forbid chunk-upload for
                         specific upload buffers. See readmoredata() in http.c
                         for details. */
+  BIT(no_body);      /* the response has no body */
 };
 
 /*
@@ -865,7 +864,7 @@ struct postponed_data {
 
 struct proxy_info {
   struct hostname host;
-  long port;
+  int port;
   unsigned char proxytype; /* curl_proxytype: what kind of proxy that is in
                               use */
   char *user;    /* proxy user name string, allocated */
@@ -873,38 +872,6 @@ struct proxy_info {
 };
 
 struct ldapconninfo;
-struct http_connect_state;
-
-/* for the (SOCKS) connect state machine */
-enum connect_t {
-  CONNECT_INIT,
-  CONNECT_SOCKS_INIT, /* 1 */
-  CONNECT_SOCKS_SEND, /* 2 waiting to send more first data */
-  CONNECT_SOCKS_READ_INIT, /* 3 set up read */
-  CONNECT_SOCKS_READ, /* 4 read server response */
-  CONNECT_GSSAPI_INIT, /* 5 */
-  CONNECT_AUTH_INIT, /* 6 setup outgoing auth buffer */
-  CONNECT_AUTH_SEND, /* 7 send auth */
-  CONNECT_AUTH_READ, /* 8 read auth response */
-  CONNECT_REQ_INIT,  /* 9 init SOCKS "request" */
-  CONNECT_RESOLVING, /* 10 */
-  CONNECT_RESOLVED,  /* 11 */
-  CONNECT_RESOLVE_REMOTE, /* 12 */
-  CONNECT_REQ_SEND,  /* 13 */
-  CONNECT_REQ_SENDING, /* 14 */
-  CONNECT_REQ_READ,  /* 15 */
-  CONNECT_REQ_READ_MORE, /* 16 */
-  CONNECT_DONE /* 17 connected fine to the remote or the SOCKS proxy */
-};
-
-#define SOCKS_STATE(x) (((x) >= CONNECT_SOCKS_INIT) &&  \
-                        ((x) < CONNECT_DONE))
-
-struct connstate {
-  enum connect_t state;
-  ssize_t outstanding;  /* send this many bytes more */
-  unsigned char *outp; /* send from this pointer */
-};
 
 #define TRNSPRT_TCP 3
 #define TRNSPRT_UDP 4
@@ -916,12 +883,11 @@ struct connstate {
  * unique for an entire connection.
  */
 struct connectdata {
-  struct connstate cnnct;
   struct Curl_llist_element bundle_node; /* conncache */
 
   /* chunk is for HTTP chunked encoding, but is in the general connectdata
-     struct only because we can do just about any protocol through a HTTP proxy
-     and a HTTP proxy may in fact respond using chunked encoding */
+     struct only because we can do just about any protocol through an HTTP
+     proxy and an HTTP proxy may in fact respond using chunked encoding */
   struct Curl_chunker chunk;
 
   curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
@@ -985,17 +951,11 @@ struct connectdata {
   int tempfamily[2]; /* family used for the temp sockets */
   Curl_recv *recv[2];
   Curl_send *send[2];
+  struct Curl_cfilter *cfilter[2]; /* connection filters */
 
 #ifdef USE_RECV_BEFORE_SEND_WORKAROUND
   struct postponed_data postponed[2]; /* two buffers for two sockets */
 #endif /* USE_RECV_BEFORE_SEND_WORKAROUND */
-  struct ssl_connect_data ssl[2]; /* this is for ssl-stuff */
-#ifndef CURL_DISABLE_PROXY
-  struct ssl_connect_data proxy_ssl[2]; /* this is for proxy ssl-stuff */
-#endif
-#ifdef USE_SSL
-  void *ssl_extra; /* separately allocated backend-specific data */
-#endif
   struct ssl_primary_config ssl_config;
 #ifndef CURL_DISABLE_PROXY
   struct ssl_primary_config proxy_ssl_config;
@@ -1112,7 +1072,6 @@ struct connectdata {
 #endif
   } proto;
 
-  struct http_connect_state *connect_state; /* for HTTP CONNECT */
   struct connectbundle *bundle; /* The bundle we are member of */
 #ifdef USE_UNIX_SOCKETS
   char *unix_domain_socket;
@@ -1520,6 +1479,9 @@ struct UrlState {
   BIT(url_alloc);   /* URL string is malloc()'ed */
   BIT(referer_alloc); /* referer string is malloc()ed */
   BIT(wildcard_resolve); /* Set to true if any resolve change is a wildcard */
+  BIT(rewindbeforesend);/* TRUE when the sending couldn't be stopped even
+                           though it will be discarded. We must call the data
+                           rewind callback before trying to send again. */
 };
 
 /*
@@ -1531,7 +1493,7 @@ struct UrlState {
  * Character pointer fields point to dynamic storage, unless otherwise stated.
  */
 
-struct Curl_multi;    /* declared and used only in multi.c */
+struct Curl_multi;    /* declared in multihandle.c */
 
 /*
  * This enumeration MUST not use conditional directives (#ifdefs), new
@@ -1655,12 +1617,12 @@ struct UserDefined {
   FILE *err;         /* the stderr user data goes here */
   void *debugdata;   /* the data that will be passed to fdebug */
   char *errorbuffer; /* (Static) store failure messages in here */
-  long proxyport; /* If non-zero, use this port number by default. If the
-                     proxy string features a ":[port]" that one will override
-                     this. */
   void *out;         /* CURLOPT_WRITEDATA */
   void *in_set;      /* CURLOPT_READDATA */
   void *writeheader; /* write the header to this if non-NULL */
+  unsigned short proxyport; /* If non-zero, use this port number by
+                               default. If the proxy string features a
+                               ":[port]" that one will override this. */
   unsigned short use_port; /* which port to use (when not using default) */
   unsigned long httpauth;  /* kind of HTTP authentication to use (bitmask) */
   unsigned long proxyauth; /* kind of proxy authentication to use (bitmask) */
@@ -1859,8 +1821,12 @@ struct UserDefined {
 /* Here follows boolean settings that define how to behave during
    this session. They are STATIC, set by libcurl users or at least initially
    and they don't change during operations. */
+  BIT(quick_exit);       /* set 1L when it is okay to leak things (like
+                            threads), as we're about to exit() anyway and
+                            don't want lengthy cleanups to delay termination,
+                            e.g. after a DNS timeout */
   BIT(get_filetime);     /* get the time and get of the remote file */
-  BIT(tunnel_thru_httpproxy); /* use CONNECT through a HTTP proxy */
+  BIT(tunnel_thru_httpproxy); /* use CONNECT through an HTTP proxy */
   BIT(prefer_ascii);     /* ASCII rather than binary */
   BIT(remote_append);    /* append, not overwrite, on upload */
   BIT(list_only);        /* list directory */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -58,7 +58,7 @@
 #define ALGO_SHA512_256 4
 #define ALGO_SHA512_256SESS (ALGO_SHA512_256 | SESSION_ALGO)
 
-#if !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_WINDOWS_SSPI) || defined(USE_OPENSSL)
 #define DIGEST_QOP_VALUE_AUTH             (1 << 0)
 #define DIGEST_QOP_VALUE_AUTH_INT         (1 << 1)
 #define DIGEST_QOP_VALUE_AUTH_CONF        (1 << 2)
@@ -66,7 +66,7 @@
 #define DIGEST_QOP_VALUE_STRING_AUTH      "auth"
 #define DIGEST_QOP_VALUE_STRING_AUTH_INT  "auth-int"
 #define DIGEST_QOP_VALUE_STRING_AUTH_CONF "auth-conf"
-#endif
+#endif /* !USE_WINDOWS_SSPI || USE_OPENSSL */
 
 bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
                                const char **endptr)
@@ -141,7 +141,7 @@ bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
   return TRUE;
 }
 
-#if !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_WINDOWS_SSPI) || defined(USE_OPENSSL)
 /* Convert md5 chunk to RFC2617 (section 3.1.3) -suitable ascii string */
 static void auth_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
                                      unsigned char *dest) /* 33 bytes */
@@ -989,6 +989,6 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   digest->stale = FALSE; /* default means normal, not stale */
   digest->userhash = FALSE;
 }
-#endif  /* !USE_WINDOWS_SSPI */
+#endif  /* !USE_WINDOWS_SSPI  || USE_OPENSSL */
 
 #endif  /* CURL_DISABLE_CRYPTO_AUTH */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -993,6 +993,6 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   digest->stale = FALSE; /* default means normal, not stale */
   digest->userhash = FALSE;
 }
-#endif  /* !USE_WINDOWS_SSPI  || !USE_SCHANNEL */
+#endif  /* !USE_WINDOWS_SSPI || !USE_SCHANNEL */
 
 #endif  /* CURL_DISABLE_CRYPTO_AUTH */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -58,7 +58,7 @@
 #define ALGO_SHA512_256 4
 #define ALGO_SHA512_256SESS (ALGO_SHA512_256 | SESSION_ALGO)
 
-#if !defined(USE_WINDOWS_SSPI) || defined(USE_OPENSSL)
+#if !defined(USE_WINDOWS_SSPI)
 #define DIGEST_QOP_VALUE_AUTH             (1 << 0)
 #define DIGEST_QOP_VALUE_AUTH_INT         (1 << 1)
 #define DIGEST_QOP_VALUE_AUTH_CONF        (1 << 2)
@@ -66,7 +66,7 @@
 #define DIGEST_QOP_VALUE_STRING_AUTH      "auth"
 #define DIGEST_QOP_VALUE_STRING_AUTH_INT  "auth-int"
 #define DIGEST_QOP_VALUE_STRING_AUTH_CONF "auth-conf"
-#endif /* !USE_WINDOWS_SSPI || USE_OPENSSL */
+#endif
 
 bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
                                const char **endptr)
@@ -141,8 +141,8 @@ bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
   return TRUE;
 }
 
-#if !defined(USE_WINDOWS_SSPI) || defined(USE_OPENSSL)
-/* Convert md5 chunk to RFC2617 (section 3.1.3) -suitable ascii string*/
+#if !defined(USE_WINDOWS_SSPI)
+/* Convert md5 chunk to RFC2617 (section 3.1.3) -suitable ascii string */
 static void auth_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
                                      unsigned char *dest) /* 33 bytes */
 {
@@ -151,7 +151,7 @@ static void auth_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
     msnprintf((char *) &dest[i * 2], 3, "%02x", source[i]);
 }
 
-/* Convert sha256 chunk to RFC7616 -suitable ascii string*/
+/* Convert sha256 chunk to RFC7616 -suitable ascii string */
 static void auth_digest_sha256_to_ascii(unsigned char *source, /* 32 bytes */
                                      unsigned char *dest) /* 65 bytes */
 {
@@ -186,7 +186,7 @@ static char *auth_digest_string_quoted(const char *source)
       }
       *d++ = *s++;
     }
-    *d = 0;
+    *d = '\0';
   }
 
   return dest;
@@ -490,7 +490,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 /*
  * Curl_auth_decode_digest_http_message()
  *
- * This is used to decode a HTTP DIGEST challenge message into the separate
+ * This is used to decode an HTTP DIGEST challenge message into the separate
  * attributes.
  *
  * Parameters:
@@ -650,7 +650,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 /*
  * auth_create_digest_http_message()
  *
- * This is used to generate a HTTP DIGEST response message ready for sending
+ * This is used to generate an HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:
@@ -926,7 +926,7 @@ static CURLcode auth_create_digest_http_message(
 /*
  * Curl_auth_create_digest_http_message()
  *
- * This is used to generate a HTTP DIGEST response message ready for sending
+ * This is used to generate an HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:
@@ -989,6 +989,6 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   digest->stale = FALSE; /* default means normal, not stale */
   digest->userhash = FALSE;
 }
-#endif  /* !USE_WINDOWS_SSPI  || USE_OPENSSL */
+#endif  /* !USE_WINDOWS_SSPI */
 
 #endif  /* CURL_DISABLE_CRYPTO_AUTH */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -58,7 +58,7 @@
 #define ALGO_SHA512_256 4
 #define ALGO_SHA512_256SESS (ALGO_SHA512_256 | SESSION_ALGO)
 
-#if !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_WINDOWS_SSPI) || defined(USE_OPENSSL)
 #define DIGEST_QOP_VALUE_AUTH             (1 << 0)
 #define DIGEST_QOP_VALUE_AUTH_INT         (1 << 1)
 #define DIGEST_QOP_VALUE_AUTH_CONF        (1 << 2)
@@ -66,7 +66,7 @@
 #define DIGEST_QOP_VALUE_STRING_AUTH      "auth"
 #define DIGEST_QOP_VALUE_STRING_AUTH_INT  "auth-int"
 #define DIGEST_QOP_VALUE_STRING_AUTH_CONF "auth-conf"
-#endif
+#endif /* !USE_WINDOWS_SSPI || USE_OPENSSL */
 
 bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
                                const char **endptr)
@@ -141,8 +141,8 @@ bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
   return TRUE;
 }
 
-#if !defined(USE_WINDOWS_SSPI)
-/* Convert md5 chunk to RFC2617 (section 3.1.3) -suitable ascii string */
+#if !defined(USE_WINDOWS_SSPI) || defined(USE_OPENSSL)
+/* Convert md5 chunk to RFC2617 (section 3.1.3) -suitable ascii string*/
 static void auth_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
                                      unsigned char *dest) /* 33 bytes */
 {
@@ -151,7 +151,7 @@ static void auth_digest_md5_to_ascii(unsigned char *source, /* 16 bytes */
     msnprintf((char *) &dest[i * 2], 3, "%02x", source[i]);
 }
 
-/* Convert sha256 chunk to RFC7616 -suitable ascii string */
+/* Convert sha256 chunk to RFC7616 -suitable ascii string*/
 static void auth_digest_sha256_to_ascii(unsigned char *source, /* 32 bytes */
                                      unsigned char *dest) /* 65 bytes */
 {
@@ -186,7 +186,7 @@ static char *auth_digest_string_quoted(const char *source)
       }
       *d++ = *s++;
     }
-    *d = '\0';
+    *d = 0;
   }
 
   return dest;
@@ -490,7 +490,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 /*
  * Curl_auth_decode_digest_http_message()
  *
- * This is used to decode an HTTP DIGEST challenge message into the separate
+ * This is used to decode a HTTP DIGEST challenge message into the separate
  * attributes.
  *
  * Parameters:
@@ -650,7 +650,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 /*
  * auth_create_digest_http_message()
  *
- * This is used to generate an HTTP DIGEST response message ready for sending
+ * This is used to generate a HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:
@@ -926,7 +926,7 @@ static CURLcode auth_create_digest_http_message(
 /*
  * Curl_auth_create_digest_http_message()
  *
- * This is used to generate an HTTP DIGEST response message ready for sending
+ * This is used to generate a HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:
@@ -989,6 +989,6 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   digest->stale = FALSE; /* default means normal, not stale */
   digest->userhash = FALSE;
 }
-#endif  /* !USE_WINDOWS_SSPI */
+#endif  /* !USE_WINDOWS_SSPI  || USE_OPENSSL */
 
 #endif  /* CURL_DISABLE_CRYPTO_AUTH */

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -27,7 +27,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH) && !defined(USE_OPENSSL)
 
 #include <curl/curl.h>
 
@@ -307,7 +307,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
 /*
  * Curl_auth_decode_digest_http_message()
  *
- * This is used to decode an HTTP DIGEST challenge message into the separate
+ * This is used to decode a HTTP DIGEST challenge message into the separate
  * attributes.
  *
  * Parameters:
@@ -371,7 +371,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 /*
  * Curl_auth_create_digest_http_message()
  *
- * This is used to generate an HTTP DIGEST response message ready for sending
+ * This is used to generate a HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -667,4 +667,4 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   Curl_safefree(digest->passwd);
 }
 
-#endif /* USE_WINDOWS_SSPI && !CURL_DISABLE_CRYPTO_AUTH */
+#endif /* USE_WINDOWS_SSPI && !CURL_DISABLE_CRYPTO_AUTH && USE_SCHANNEL */

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -27,7 +27,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH) && !defined(USE_OPENSSL)
+#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH) && defined(USE_SCHANNEL)
 
 #include <curl/curl.h>
 
@@ -137,7 +137,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   /* Generate our SPN */
-  spn = Curl_auth_build_spn(service, data->conn->host.name, NULL);
+  spn = Curl_auth_build_spn_WIN(service, data->conn->host.name, NULL);
   if(!spn) {
     free(output_token);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -27,7 +27,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH) && !defined(USE_OPENSSL)
+#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH)
 
 #include <curl/curl.h>
 
@@ -307,7 +307,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
 /*
  * Curl_auth_decode_digest_http_message()
  *
- * This is used to decode a HTTP DIGEST challenge message into the separate
+ * This is used to decode an HTTP DIGEST challenge message into the separate
  * attributes.
  *
  * Parameters:
@@ -371,7 +371,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 /*
  * Curl_auth_create_digest_http_message()
  *
- * This is used to generate a HTTP DIGEST response message ready for sending
+ * This is used to generate an HTTP DIGEST response message ready for sending
  * to the recipient.
  *
  * Parameters:

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -27,7 +27,9 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH) && defined(USE_SCHANNEL)
+#if defined(USE_WINDOWS_SSPI) \
+    && !defined(CURL_DISABLE_CRYPTO_AUTH)\
+     && defined(USE_SCHANNEL)
 
 #include <curl/curl.h>
 

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -27,7 +27,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(USE_WINDOWS_SSPI) && !defined(CURL_DISABLE_CRYPTO_AUTH) && !defined(USE_OPENSSL)
 
 #include <curl/curl.h>
 

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -111,7 +111,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
 
   if(!krb5->spn) {
     /* Generate our SPN */
-    krb5->spn = Curl_auth_build_spn(service, host, NULL);
+    krb5->spn = Curl_auth_build_spn_WIN(service, host, NULL);
     if(!krb5->spn)
       return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -153,7 +153,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   if(!ntlm->context)
     return CURLE_OUT_OF_MEMORY;
 
-  ntlm->spn = Curl_auth_build_spn(service, host, NULL);
+  ntlm->spn = Curl_auth_build_spn_WIN(service, host, NULL);
   if(!ntlm->spn)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -121,7 +121,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   if(!nego->spn) {
     /* Generate our SPN */
-    nego->spn = Curl_auth_build_spn(service, host, NULL);
+    nego->spn = Curl_auth_build_spn_WIN(service, host, NULL);
     if(!nego->spn)
       return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -54,7 +54,6 @@
  * Returns a pointer to the newly allocated SPN.
  */
 
-#if !defined(USE_SCHANNEL)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm)
 {
@@ -71,9 +70,6 @@ char *Curl_auth_build_spn(const char *service, const char *host,
   /* Return our newly allocated SPN */
   return spn;
 }
-#endif/* !USE_SCHANNEL */
-
-#if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
 TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
                            const char *realm)
 {
@@ -91,12 +87,7 @@ TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
      formulate the SPN instead. */
 
   /* Generate our UTF8 based SPN */
-  if (host && realm)
-    utf8_spn = aprintf("%s/%s@%s", service, host, realm);
-  else if (host)
-    utf8_spn = aprintf("%s/%s", service, host);
-  else if (realm)
-    utf8_spn = aprintf("%s@%s", service, realm);
+  utf8_spn = Curl_auth_build_spn(service, host, realm);
   if(!utf8_spn)
     return NULL;
 
@@ -111,7 +102,6 @@ TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
   curlx_unicodefree(tchar_spn);
   return dupe_tchar_spn;
 }
-#endif /* USE_WINDOWS_SSPI || USE_SCHANNEL */
 
 /*
  * Curl_auth_user_contains_domain()

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -53,6 +53,25 @@
  *
  * Returns a pointer to the newly allocated SPN.
  */
+
+#if defined(USE_OPENSSL)
+char *Curl_auth_build_spn_openssl(const char *service, const char *host,
+                          const char *realm)
+{
+  char *spn = NULL;
+
+  /* Generate our SPN */
+  if(host && realm)
+    spn = aprintf("%s/%s@%s", service, host, realm);
+  else if(host)
+    spn = aprintf("%s/%s", service, host);
+  else if(realm)
+    spn = aprintf("%s@%s", service, realm);
+
+  /* Return our newly allocated SPN */
+  return spn;
+}
+#endif
 #if !defined(USE_WINDOWS_SSPI)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm)

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -54,6 +54,7 @@
  * Returns a pointer to the newly allocated SPN.
  */
 
+#if !defined(USE_SCHANNEL)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm)
 {
@@ -70,6 +71,9 @@ char *Curl_auth_build_spn(const char *service, const char *host,
   /* Return our newly allocated SPN */
   return spn;
 }
+#endif/* !USE_SCHANNEL */
+
+#if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
 TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
                            const char *realm)
 {
@@ -87,7 +91,9 @@ TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
      formulate the SPN instead. */
 
   /* Generate our UTF8 based SPN */
-  utf8_spn = Curl_auth_build_spn(service, host, realm);
+  if (host)
+      utf8_spn = aprintf("%s/%s", service, host);
+
   if(!utf8_spn)
     return NULL;
 
@@ -102,6 +108,7 @@ TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
   curlx_unicodefree(tchar_spn);
   return dupe_tchar_spn;
 }
+#endif /* USE_WINDOWS_SSPI || USE_SCHANNEL */
 
 /*
  * Curl_auth_user_contains_domain()

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -91,7 +91,12 @@ TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
      formulate the SPN instead. */
 
   /* Generate our UTF8 based SPN */
-  utf8_spn = aprintf("%s/%s", service, host);
+  if (host && realm)
+    utf8_spn = aprintf("%s/%s@%s", service, host, realm);
+  else if (host)
+    utf8_spn = aprintf("%s/%s", service, host);
+  else if (realm)
+    utf8_spn = aprintf("%s@%s", service, realm);
   if(!utf8_spn)
     return NULL;
 

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -53,25 +53,6 @@
  *
  * Returns a pointer to the newly allocated SPN.
  */
-
-#if defined(USE_OPENSSL)
-char *Curl_auth_build_spn_openssl(const char *service, const char *host,
-                          const char *realm)
-{
-  char *spn = NULL;
-
-  /* Generate our SPN */
-  if(host && realm)
-    spn = aprintf("%s/%s@%s", service, host, realm);
-  else if(host)
-    spn = aprintf("%s/%s", service, host);
-  else if(realm)
-    spn = aprintf("%s@%s", service, realm);
-
-  /* Return our newly allocated SPN */
-  return spn;
-}
-#endif
 #if !defined(USE_WINDOWS_SSPI)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm)

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -91,9 +91,7 @@ TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
      formulate the SPN instead. */
 
   /* Generate our UTF8 based SPN */
-  if (host)
-      utf8_spn = aprintf("%s/%s", service, host);
-
+  utf8_spn = aprintf("%s/%s", service, host);
   if(!utf8_spn)
     return NULL;
 

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -54,25 +54,7 @@
  * Returns a pointer to the newly allocated SPN.
  */
 
-#if defined(USE_OPENSSL)
-char *Curl_auth_build_spn_openssl(const char *service, const char *host,
-                          const char *realm)
-{
-  char *spn = NULL;
-
-  /* Generate our SPN */
-  if(host && realm)
-    spn = aprintf("%s/%s@%s", service, host, realm);
-  else if(host)
-    spn = aprintf("%s/%s", service, host);
-  else if(realm)
-    spn = aprintf("%s@%s", service, realm);
-
-  /* Return our newly allocated SPN */
-  return spn;
-}
-#endif
-#if !defined(USE_WINDOWS_SSPI)
+#if !defined(USE_SCHANNEL)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm)
 {
@@ -89,8 +71,10 @@ char *Curl_auth_build_spn(const char *service, const char *host,
   /* Return our newly allocated SPN */
   return spn;
 }
-#else
-TCHAR *Curl_auth_build_spn(const char *service, const char *host,
+#endif/* !USE_SCHANNEL */
+
+#if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
+TCHAR *Curl_auth_build_spn_WIN(const char *service, const char *host,
                            const char *realm)
 {
   char *utf8_spn = NULL;
@@ -122,7 +106,7 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
   curlx_unicodefree(tchar_spn);
   return dupe_tchar_spn;
 }
-#endif /* USE_WINDOWS_SSPI */
+#endif /* USE_WINDOWS_SSPI || USE_SCHANNEL */
 
 /*
  * Curl_auth_user_contains_domain()

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -61,6 +61,11 @@ struct gsasldata;
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
+#if defined(USE_OPENSSL)
+char* Curl_auth_build_spn_openssl(const char* service, const char* host,
+    const char* realm);
+#endif
+
 #if !defined(USE_WINDOWS_SSPI)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm);
@@ -104,11 +109,11 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                                              const char *service,
                                              struct bufref *out);
 
-/* This is used to decode an HTTP DIGEST challenge message */
+/* This is used to decode a HTTP DIGEST challenge message */
 CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
                                               struct digestdata *digest);
 
-/* This is used to generate an HTTP DIGEST response message */
+/* This is used to generate a HTTP DIGEST response message */
 CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                               const char *userp,
                                               const char *passwdp,

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -61,16 +61,13 @@ struct gsasldata;
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
-#if defined(USE_OPENSSL)
-char* Curl_auth_build_spn_openssl(const char* service, const char* host,
+#if !defined(USE_SCHANNEL)
+char* Curl_auth_build_spn(const char* service, const char* host,
     const char* realm);
 #endif
 
-#if !defined(USE_WINDOWS_SSPI)
-char *Curl_auth_build_spn(const char *service, const char *host,
-                          const char *realm);
-#else
-TCHAR *Curl_auth_build_spn(const char *service, const char *host,
+#if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
+TCHAR* Curl_auth_build_spn_WIN(const char* service, const char* host,
                            const char *realm);
 #endif
 

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -61,12 +61,17 @@ struct gsasldata;
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
+#if !defined(USE_SCHANNEL)
 char *Curl_auth_build_spn(const char *service,
                             const char *host,
                             const char *realm);
+#endif
+
+#if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
 TCHAR *Curl_auth_build_spn_WIN(const char *service,
                                 const char *host,
                                 const char *realm);
+#endif
 
 /* This is used to test if the user contains a Windows domain name */
 bool Curl_auth_user_contains_domain(const char *user);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -62,12 +62,12 @@ bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
 #if !defined(USE_SCHANNEL)
-char* Curl_auth_build_spn(const char* service, const char* host,
-    const char* realm);
+char* Curl_auth_build_spn(const char *service, const char *host,
+    const char *realm);
 #endif
 
 #if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
-TCHAR* Curl_auth_build_spn_WIN(const char* service, const char* host,
+TCHAR* Curl_auth_build_spn_WIN(const char *service, const char *host,
                            const char *realm);
 #endif
 

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -62,13 +62,15 @@ bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
 #if !defined(USE_SCHANNEL)
-char* Curl_auth_build_spn(const char *service, const char *host,
-    const char *realm);
+char* Curl_auth_build_spn(const char *service,
+                            const char *host,
+                            const char *realm);
 #endif
 
 #if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
-TCHAR* Curl_auth_build_spn_WIN(const char *service, const char *host,
-                           const char *realm);
+TCHAR* Curl_auth_build_spn_WIN(const char *service,
+                                const char *host,
+                                const char *realm);
 #endif
 
 /* This is used to test if the user contains a Windows domain name */

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -61,11 +61,6 @@ struct gsasldata;
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
-#if defined(USE_OPENSSL)
-char* Curl_auth_build_spn_openssl(const char* service, const char* host,
-    const char* realm);
-#endif
-
 #if !defined(USE_WINDOWS_SSPI)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm);
@@ -109,11 +104,11 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                                              const char *service,
                                              struct bufref *out);
 
-/* This is used to decode a HTTP DIGEST challenge message */
+/* This is used to decode an HTTP DIGEST challenge message */
 CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
                                               struct digestdata *digest);
 
-/* This is used to generate a HTTP DIGEST response message */
+/* This is used to generate an HTTP DIGEST response message */
 CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                               const char *userp,
                                               const char *passwdp,

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -61,17 +61,12 @@ struct gsasldata;
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
-#if !defined(USE_SCHANNEL)
 char *Curl_auth_build_spn(const char *service,
                             const char *host,
                             const char *realm);
-#endif
-
-#if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
 TCHAR *Curl_auth_build_spn_WIN(const char *service,
                                 const char *host,
                                 const char *realm);
-#endif
 
 /* This is used to test if the user contains a Windows domain name */
 bool Curl_auth_user_contains_domain(const char *user);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -61,6 +61,11 @@ struct gsasldata;
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
+#if defined(USE_OPENSSL)
+char* Curl_auth_build_spn_openssl(const char* service, const char* host,
+    const char* realm);
+#endif
+
 #if !defined(USE_WINDOWS_SSPI)
 char *Curl_auth_build_spn(const char *service, const char *host,
                           const char *realm);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -62,13 +62,13 @@ bool Curl_auth_allowed_to_host(struct Curl_easy *data);
 
 /* This is used to build a SPN string */
 #if !defined(USE_SCHANNEL)
-char* Curl_auth_build_spn(const char *service,
+char *Curl_auth_build_spn(const char *service,
                             const char *host,
                             const char *realm);
 #endif
 
 #if defined(USE_WINDOWS_SSPI) || defined(USE_SCHANNEL)
-TCHAR* Curl_auth_build_spn_WIN(const char *service,
+TCHAR *Curl_auth_build_spn_WIN(const char *service,
                                 const char *host,
                                 const char *realm);
 #endif


### PR DESCRIPTION
Hi Bagder,
I found that if I enable Kerberos authentication along with Windows SSPI (USE_WINDOWS_SSPI), it disables some APIs required for Openssl based Curl build (USE_OPENSSL). Instead it takes SSL from S-Channel on Windows.

I have made changes and tested on my local network with both Digest and Kerberos Authentications.

Please take the necessary changes and make necessary changes on top of this to be in line with your coding guidelines.

I have tested with Curl 7.86 and my local changes.

Sincerely,
Ganesh Kamath