### PR TITLE
vtls: fix typo in vtls_int.h

### DIFF
--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -38,7 +38,7 @@ struct ssl_connect_data {
   int port;                         /* remote port at origin */
   struct ssl_backend_data *backend; /* vtls backend specific props */
   struct Curl_easy *call_data;      /* data handle used in current call,
-                                     * same as paramter passed, but available
+                                     * same as parameter passed, but available
                                      * here for backend internal callbacks
                                      * that need it. NULLed after at the
                                      * end of each vtls filter invcocation. */


### PR DESCRIPTION
paramter -> parameter