### PR TITLE
docs/INSTALL.md: list OSes and CPUs quoted

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -591,8 +591,8 @@ and runs on, that is not listed, please let us know!
     Wii system software, Windows, Windows CE, Xbox System, Xenix, Zephyr,
     z/OS, z/TPF, z/VM, z/VSE
 
-## 25 CPU Architectures
+## 26 CPU Architectures
 
-    Alpha, ARC, ARM, AVR32, Elbrus, ETRAX, HP-PA, Itanium, LoongArch, m68k,
-    m88k, MicroBlaze, MIPS, Nios, OpenRISC, POWER, PowerPC, RISC-V, s390, SH4,
-    SPARC, Tilera, VAX, x86, Xtensa
+    Alpha, ARC, ARM, AVR32, CompactRISC, Elbrus, ETRAX, HP-PA, Itanium,
+    LoongArch, m68k, m88k, MicroBlaze, MIPS, Nios, OpenRISC, POWER, PowerPC,
+    RISC-V, s390, SH4, SPARC, Tilera, VAX, x86, Xtensa

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -578,20 +578,21 @@ and runs on, that is not listed, please let us know!
 
 ## 92 Operating Systems
 
-AIX, AmigaOS, Android, Aros, BeOS, Blackberry 10, Blackberry Tablet OS, Cell
-OS, Chrome OS, Cisco IOS, Cygwin, DG/UX, Dragonfly BSD, DR DOS, eCOS, FreeBSD,
-FreeDOS, FreeRTOS, Fuchsia, Garmin OS, Genode, Haiku, HardenedBSD, HP-UX,
-Hurd, Illumos, Integrity, iOS, ipadOS, IRIX, Linux, Lua RTOS, Mac OS 9, macOS,
-Mbed, Micrium, MINIX, MorphOS, MPE/iX, MS-DOS, NCR MP-RAS, NetBSD, Netware,
-Nintendo Switch, NonStop OS, NuttX, Omni OS, OpenBSD, OpenStep, Orbis OS,
-OS/2, OS/400, OS21, Plan 9, PlayStation Portable, QNX, Qubes OS, ReactOS,
-Redox, RICS OS, RTEMS, Sailfish OS, SCO Unix, Serenity, SINIX-Z, Solaris,
-SunOS, Syllable OS, Symbian, Tizen, TPF, Tru64, tvOS, ucLinux, Ultrix, UNICOS,
-UnixWare, VMS, vxWorks, watchOS, WebOS, Wii system software, Windows, Windows
-CE, Xbox System, Xenix, Zephyr, z/OS, z/TPF, z/VM, z/VSE
+    AIX, AmigaOS, Android, Aros, BeOS, Blackberry 10, Blackberry Tablet OS,
+    Cell OS, Chrome OS, Cisco IOS, Cygwin, DG/UX, Dragonfly BSD, DR DOS, eCOS,
+    FreeBSD, FreeDOS, FreeRTOS, Fuchsia, Garmin OS, Genode, Haiku, HardenedBSD,
+    HP-UX, Hurd, Illumos, Integrity, iOS, ipadOS, IRIX, Linux, Lua RTOS,
+    Mac OS 9, macOS, Mbed, Micrium, MINIX, MorphOS, MPE/iX, MS-DOS, NCR MP-RAS,
+    NetBSD, Netware, Nintendo Switch, NonStop OS, NuttX, Omni OS, OpenBSD,
+    OpenStep, Orbis OS, OS/2, OS/400, OS21, Plan 9, PlayStation Portable, QNX,
+    Qubes OS, ReactOS, Redox, RICS OS, RTEMS, Sailfish OS, SCO Unix, Serenity,
+    SINIX-Z, Solaris, SunOS, Syllable OS, Symbian, Tizen, TPF, Tru64, tvOS,
+    ucLinux, Ultrix, UNICOS, UnixWare, VMS, vxWorks, watchOS, WebOS,
+    Wii system software, Windows, Windows CE, Xbox System, Xenix, Zephyr,
+    z/OS, z/TPF, z/VM, z/VSE
 
 ## 25 CPU Architectures
 
-Alpha, ARC, ARM, AVR32, Elbrus, ETRAX, HP-PA, Itanium, LoongArch, m68k, m88k,
-MicroBlaze, MIPS, Nios, OpenRISC, POWER, PowerPC, RISC-V, s390, SH4, SPARC,
-Tilera, VAX, x86, Xtensa
+    Alpha, ARC, ARM, AVR32, Elbrus, ETRAX, HP-PA, Itanium, LoongArch, m68k,
+    m88k, MicroBlaze, MIPS, Nios, OpenRISC, POWER, PowerPC, RISC-V, s390, SH4,
+    SPARC, Tilera, VAX, x86, Xtensa


### PR DESCRIPTION
to make them skip spellcheck

Follow-up to 4506cbf7f24a2a