### PR TITLE
KNOWN_BUGS: remove "Multi perform hangs waiting for threaded resolver"

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -104,7 +104,6 @@ problems may have been fixed or changed somewhat since this was written.
  11.9 DoH does not inherit all transfer options
  11.10 Blocking socket operations in non-blocking API
  11.11 A shared connection cache is not thread-safe
- 11.14 Multi perform hangs waiting for threaded resolver
  11.15 CURLOPT_OPENSOCKETPAIRFUNCTION is missing
  11.16 libcurl uses renames instead of locking for atomic operations
 
@@ -763,15 +762,6 @@ problems may have been fixed or changed somewhat since this was written.
  still not thread-safe when used shared.
 
  See https://github.com/curl/curl/issues/4915 and lib1541.c
-
-11.14 Multi perform hangs waiting for threaded resolver
-
- If a threaded resolver takes a long time to complete, libcurl can be blocked
- waiting for it for a longer time than expected - and longer than the set
- timeouts.
-
- See https://github.com/curl/curl/issues/2975 and
- https://github.com/curl/curl/issues/4852
 
 11.15 CURLOPT_OPENSOCKETPAIRFUNCTION is missing
 


### PR DESCRIPTION
We now offer a way to avoid that hang, using CURLOPT_QUICK_EXIT.

Follow-up to 49798cac832ab1 fixed via #9147