### PR TITLE
curl.h: include <sys/select.h> on SerenityOS

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -92,7 +92,7 @@
     defined(__CYGWIN__) || defined(AMIGA) || defined(__NuttX__) || \
    (defined(__FreeBSD_version) && (__FreeBSD_version < 800000)) || \
    (defined(__MidnightBSD_version) && (__MidnightBSD_version < 100000)) || \
-    defined(__sun__)
+    defined(__sun__) || defined(__serenity__)
 #include <sys/select.h>
 #endif
 


### PR DESCRIPTION
This is a patch that's needed for the curl port on SerenityOS we would like to upstream.