### PR TITLE
runtests: only do CRLF for hyper if it is HTTP

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3728,7 +3728,8 @@ sub prepro {
             # The processor does CRLF replacements in the <data*> sections if
             # necessary since those parts might be read by separate servers.
             if($s =~ /^ *<data(.*)\>/) {
-                if($1 =~ /crlf="yes"/ || $has_hyper) {
+                if($1 =~ /crlf="yes"/ ||
+                   ($has_hyper && ($keywords{"HTTP"} || $keywords{"HTTPS"}))) {
                     $data_crlf = 1;
                 }
             }


### PR DESCRIPTION
To make them work again in Hyper builds