### PR TITLE
cookie: open cookie jar as a binary file

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1264,7 +1264,7 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
     fp = NULL;
   }
   else {
-    fp = fopen(file, FOPEN_READTEXT);
+    fp = fopen(file, "rb");
     if(!fp)
       infof(data, "WARNING: failed to open cookie file \"%s\"", file);
   }


### PR DESCRIPTION
On Windows there is a difference and for text files, ^Z means end of file which is not desirable.

Ref: #9973