### PR TITLE
ci: Reuse fuzzing snippet from curl-fuzzer project

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,25 +18,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fuzzing:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Build Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'curl'
-        dry-run: false
-
-    - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'curl'
-        fuzz-seconds: 2400
-        dry-run: false
-
-    - name: Upload Crash
-      uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: artifacts
-        path: ./out/artifacts
+  Fuzzing:
+    uses: curl/curl-fuzzer/.github/workflows/ci.yml@master


### PR DESCRIPTION
For discussion - our current practice would have this pointing at the default branch of `curl/curl-fuzzer` so it's kept up to date (as curl-fuzzer doesn't do releases). Github's docs say this is a potential security issue but I think in practice we'll be fine.