### PR TITLE
openssl: return -1 on errors

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -713,13 +713,8 @@ static int bio_cf_out_write(BIO *bio, const char *buf, int blen)
   BIO_clear_retry_flags(bio);
   connssl->backend->io_result = result;
   if(nwritten < 0) {
-    if(CURLE_AGAIN == result) {
+    if(CURLE_AGAIN == result)
       BIO_set_retry_write(bio);
-      nwritten = 0;
-    }
-    else {
-      nwritten = -1;
-    }
   }
   return (int)nwritten;
 }
@@ -743,13 +738,8 @@ static int bio_cf_in_read(BIO *bio, char *buf, int blen)
   BIO_clear_retry_flags(bio);
   connssl->backend->io_result = result;
   if(nread < 0) {
-    if(CURLE_AGAIN == result) {
+    if(CURLE_AGAIN == result)
       BIO_set_retry_read(bio);
-      nread = 0;
-    }
-    else {
-      nread = -1;
-    }
   }
   return (int)nread;
 }


### PR DESCRIPTION
BIO_read and BIO_write return negative numbers on error, including retryable ones. This seems to have been a regression from 55807e6. Both branches should be returning -1.

The APIs are patterned after POSIX read and write which, similarly, return -1 on errors, not zero, with EAGAIN treated as an error.

Reverts commit 5c27f6c452f02507b3bb9506e1079ea2f3943e4e and solves it differently.

Bug: https://github.com/curl/curl/issues/10013#issuecomment-1335308146
Reported-by: David Benjamin @davidben 

/cc @icing 