### PR TITLE
base64: better alloc size

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -192,7 +192,7 @@ static CURLcode base64_encode(const char *table64,
     return CURLE_OUT_OF_MEMORY;
 #endif
 
-  base64data = output = malloc(insize * 4 / 3 + 4);
+  base64data = output = malloc((insize + 2) / 3 * 4 + 1);
   if(!output)
     return CURLE_OUT_OF_MEMORY;
 


### PR DESCRIPTION
The previous algorithm allocated more bytes than necessary.

Suggested-by: xtonik on github
Fixes #10024