### PR TITLE
base64: encode without snprintf: a 29x speedup

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -205,7 +205,7 @@ static CURLcode base64_encode(const char *table64,
   }
   if(insize) {
     /* this is only one or two bytes now */
-    for(i = inputparts = 0; i < 2; i++) {
+    for(i = inputparts = 0; i < 3; i++) {
       if(insize) {
         inputparts++;
         ibuf[i] = *in;

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -37,8 +37,7 @@
 #include "warnless.h"
 #include "curl_base64.h"
 
-/* The last 3 #include files should be in this order */
-#include "curl_printf.h"
+/* The last 2 #include files should be in this order */
 #include "curl_memory.h"
 #include "memdebug.h"
 

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -173,7 +173,7 @@ static CURLcode base64_encode(const char *table64,
                               char **outptr, size_t *outlen)
 {
   unsigned char ibuf[3];
-  unsigned char obuf[4];
+  unsigned char o;
   int i;
   int inputparts;
   char *output;
@@ -208,11 +208,10 @@ static CURLcode base64_encode(const char *table64,
         ibuf[i] = 0;
     }
 
-    obuf[0] = ibuf[0] >> 2;
-    obuf[1] = (((ibuf[0] & 0x03) << 4) | ((ibuf[1] & 0xF0) >> 4));
-
-    *output++ = table64[obuf[0]];
-    *output++ = table64[obuf[1]];
+    o = ibuf[0] >> 2;
+    *output++ = table64[o];
+    o = (((ibuf[0] & 0x03) << 4) | ((ibuf[1] & 0xF0) >> 4));
+    *output++ = table64[o];
 
     switch(inputparts) {
     case 1: /* only one byte read */
@@ -223,17 +222,17 @@ static CURLcode base64_encode(const char *table64,
       break;
 
     case 2: /* two bytes read */
-      obuf[2] = (((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6));
-      *output++ = table64[obuf[2]];
+      o = (((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6));
+      *output++ = table64[o];
       if(*padstr)
         *output++ = *padstr;
       break;
 
     default:
-      obuf[2] = (((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6));
-      obuf[3] = ibuf[2] & 0x3F;
-      *output++ = table64[obuf[2]];
-      *output++ = table64[obuf[3]];
+      o = (((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6));
+      *output++ = table64[o];
+      o = ibuf[2] & 0x3F;
+      *output++ = table64[o];
       break;
     }
   }

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -173,7 +173,6 @@ static CURLcode base64_encode(const char *table64,
                               char **outptr, size_t *outlen)
 {
   unsigned char ibuf[3];
-  unsigned char o;
   int i;
   int inputparts;
   char *output;
@@ -208,10 +207,8 @@ static CURLcode base64_encode(const char *table64,
         ibuf[i] = 0;
     }
 
-    o = ibuf[0] >> 2;
-    *output++ = table64[o];
-    o = (((ibuf[0] & 0x03) << 4) | ((ibuf[1] & 0xF0) >> 4));
-    *output++ = table64[o];
+    *output++ = table64[ ibuf[0] >> 2 ];
+    *output++ = table64[ ((ibuf[0] & 0x03) << 4) | ((ibuf[1] & 0xF0) >> 4) ];
 
     switch(inputparts) {
     case 1: /* only one byte read */
@@ -222,17 +219,14 @@ static CURLcode base64_encode(const char *table64,
       break;
 
     case 2: /* two bytes read */
-      o = (((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6));
-      *output++ = table64[o];
+      *output++ = table64[ ((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6) ];
       if(*padstr)
         *output++ = *padstr;
       break;
 
     default:
-      o = (((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6));
-      *output++ = table64[o];
-      o = ibuf[2] & 0x3F;
-      *output++ = table64[o];
+      *output++ = table64[ ((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6) ];
+      *output++ = table64[ ibuf[2] & 0x3F ];
       break;
     }
   }

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -172,9 +172,6 @@ static CURLcode base64_encode(const char *table64,
                               const char *inputbuff, size_t insize,
                               char **outptr, size_t *outlen)
 {
-  unsigned char ibuf[3];
-  int i;
-  int inputparts;
   char *output;
   char *base64data;
   const unsigned char *in = (unsigned char *)inputbuff;
@@ -205,28 +202,18 @@ static CURLcode base64_encode(const char *table64,
   }
   if(insize) {
     /* this is only one or two bytes now */
-    for(i = inputparts = 0; i < 3; i++) {
-      if(insize) {
-        inputparts++;
-        ibuf[i] = *in;
-        in++;
-        insize--;
-      }
-      else
-        ibuf[i] = 0;
-    }
-
-    *output++ = table64[ ibuf[0] >> 2 ];
-    *output++ = table64[ ((ibuf[0] & 0x03) << 4) | ((ibuf[1] & 0xF0) >> 4) ];
-
-    if(inputparts == 1) {
+    *output++ = table64[ in[0] >> 2 ];
+    if(insize == 1) {
+      *output++ = table64[ ((in[0] & 0x03) << 4) ];
       if(*padstr) {
         *output++ = *padstr;
         *output++ = *padstr;
       }
     }
     else {
-      *output++ = table64[ ((ibuf[1] & 0x0F) << 2) | ((ibuf[2] & 0xC0) >> 6) ];
+      /* insize == 2 */
+      *output++ = table64[ ((in[0] & 0x03) << 4) | ((in[1] & 0xF0) >> 4) ];
+      *output++ = table64[ ((in[1] & 0x0F) << 2) ];
       if(*padstr)
         *output++ = *padstr;
     }


### PR DESCRIPTION
For speed

# Test setup

https://gist.github.com/bagder/baee5725e09a5977ef5b0471e2b3334f

## Measurements

Best out  three runs on my machine.

Old code: 5m55.291
New code: 12.254 seconds

A 28.99 times speedup.

