### PR TITLE
config-mac: fix typo: size_T -> size_t

### DIFF
--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -91,7 +91,7 @@
 #define SEND_TYPE_ARG1 int
 #define SEND_QUAL_ARG2 const
 #define SEND_TYPE_ARG2 void *
-#define SEND_TYPE_ARG3 size_T
+#define SEND_TYPE_ARG3 size_t
 #define SEND_TYPE_ARG4 int
 #define SEND_TYPE_RETV ssize_t
 


### PR DESCRIPTION
Both MPW and CodeWarrior compilers complained about this.