### PR TITLE
Makefile.mk: improve a GNU Make hack [ci skip]

### DIFF
--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -324,7 +324,7 @@ ifdef WIN32
   _LIBS += -lws2_32 -lcrypt32 -lbcrypt
 endif
 
-ifneq ($(findstring 11,$(subst $() ,,$(SSLLIBS))),)
+ifneq ($(findstring 11,$(subst $(subst ,, ),,$(SSLLIBS))),)
   CPPFLAGS += -DCURL_WITH_MULTI_SSL
 endif
 


### PR DESCRIPTION
Replace the hack of using `$() ` to represent a single space. The new method avoids the `--warn-undefined-variables` debug warning.

Closes #xxxxx