### PR TITLE
fix ssh_hostkeyfunc bug missing return status

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -791,10 +791,14 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data)
         Curl_set_in_callback(data, false);
         if(rc!= CURLKHMATCH_OK) {
           state(data, SSH_SESSION_FREE);
+          sshc->actualcode = CURLE_PEER_FAILED_VERIFICATION;
+          return sshc->actualcode;
         }
       }
       else {
         state(data, SSH_SESSION_FREE);
+        sshc->actualcode = CURLE_PEER_FAILED_VERIFICATION;
+        return sshc->actualcode;
       }
       return CURLE_OK;
     }


### PR DESCRIPTION
return CURLE_PEER_FAILED_VERIFICATION if verification with the callback return a result different than CURLKHMATCH_OK

In my previous commit this was missing. I've tested it on the version curl 7.86 and it worked.