### PR TITLE
curl.h: name all public function parameters

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2772,8 +2772,8 @@ CURL_EXTERN CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
  * Appends a string to a linked list. If no list exists, it will be created
  * first. Returns the new list, after appending.
  */
-CURL_EXTERN struct curl_slist *curl_slist_append(struct curl_slist *,
-                                                 const char *);
+CURL_EXTERN struct curl_slist *curl_slist_append(struct curl_slist *list,
+                                                 const char *data);
 
 /*
  * NAME curl_slist_free_all()
@@ -2782,7 +2782,7 @@ CURL_EXTERN struct curl_slist *curl_slist_append(struct curl_slist *,
  *
  * free a previously built curl_slist.
  */
-CURL_EXTERN void curl_slist_free_all(struct curl_slist *);
+CURL_EXTERN void curl_slist_free_all(struct curl_slist *list);
 
 /*
  * NAME curl_getdate()
@@ -2995,8 +2995,9 @@ typedef enum {
 } CURLSHoption;
 
 CURL_EXTERN CURLSH *curl_share_init(void);
-CURL_EXTERN CURLSHcode curl_share_setopt(CURLSH *, CURLSHoption option, ...);
-CURL_EXTERN CURLSHcode curl_share_cleanup(CURLSH *);
+CURL_EXTERN CURLSHcode curl_share_setopt(CURLSH *share, CURLSHoption option,
+                                         ...);
+CURL_EXTERN CURLSHcode curl_share_cleanup(CURLSH *share);
 
 /****************************************************************************
  * Structures for querying information about the curl library at runtime.


### PR DESCRIPTION
Most public function parameters already have names; this adds those that were missing.

-----

I took the parameter names from where the functions were defined in the C sources. In some cases this does not match the documentation. For example, in lib/slist.c (and, with this PR, in curl.h) the second parameter of `curl_slist_append` is called `data` while [in the documentation](https://curl.se/libcurl/c/curl_slist_append.html) it's called `string`.

-----

My motivation for making these changes arose when I wrote a script to parse the curl headers in part to get the public function parameter names and I noticed a few functions didn't have them. Do you have any objections to adding these?