### PR TITLE
Partially revert "somewhat protect Mac OS X users from using Mac OS 9 config file"

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -92,7 +92,7 @@
 #  endif
 #endif
 
-#if defined(macintosh) && defined(__MRC__)
+#ifdef macintosh
 #  include "config-mac.h"
 #endif
 

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -47,7 +47,7 @@
  * Platform specific stuff.
  */
 
-#if defined(macintosh) && defined(__MRC__)
+#ifdef macintosh
 #  define main(x,y) curl_main(x,y)
 #endif
 


### PR DESCRIPTION
This reverts part of commit 62519bfe059251af2914199f284c736553ff0489.

Do things that are specific to classic Mac OS (i.e. include config-mac.h in curl_setup.h and rename `main` to `curl_main` in tool_setup.h) when only `macintosh` is defined. Remove the additional condition that `__MRC__` should be defined since that would only be true with the MPW MrC compiler which prevents the use of other reasonable compilers like the MPW SC compiler and especially the Metrowerks CodeWarrior compilers. `macintosh` is only defined by classic Mac OS compilers so this change should not affect users of Mac OS X / OS X / macOS / any other OS.

-----

The first line of the commit message is markedly longer than 50 characters. I wasn't sure if there was a recommended way to truncate it when reverting a commit like this, or if I should use a more descriptive first line that doesn't mention the reversion.