### PR TITLE
config-mac: remove HAVE_SYS_SELECT_H

### DIFF
--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -40,7 +40,6 @@
 #define HAVE_ERRNO_H            1
 #define HAVE_NETINET_IN_H       1
 #define HAVE_SYS_SOCKET_H       1
-#define HAVE_SYS_SELECT_H       1
 #define HAVE_NETDB_H            1
 #define HAVE_ARPA_INET_H        1
 #define HAVE_UNISTD_H           1


### PR DESCRIPTION
When compiling for classic Mac OS with GUSI, there is no sys/select.h. GUSI provides the `select` function prototype in sys/time.h.