### PR TITLE
imap: Provide method to disable SASL if it is advertised

### DIFF
--- a/docs/cmdline-opts/login-options.d
+++ b/docs/cmdline-opts/login-options.d
@@ -16,3 +16,9 @@ You can use login options to specify protocol specific options that may be
 used during authentication. At present only IMAP, POP3 and SMTP support
 login options. For more information about login options please see RFC
 2384, RFC 5092 and IETF draft draft-earhart-url-smtp-00.txt
+
+Since 8.2.0, IMAP supports the login option "AUTH=+LOGIN". With this option,
+curl uses the plain (not SASL) LOGIN IMAP command even if the server advertises
+SASL authentication. Care should be taken in using this option, as it will send
+out your password in plain text. This will not work if the IMAP server disables
+the plain LOGIN (e.g. to prevent password snooping).

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
@@ -43,6 +43,12 @@ options, such as the preferred authentication mechanism via "AUTH=NTLM" or
 "AUTH=*", and should be used in conjunction with the \fICURLOPT_USERNAME(3)\fP
 option.
 
+Since 8.2.0, IMAP supports the login option "AUTH=+LOGIN". With this option,
+curl uses the plain (not SASL) LOGIN IMAP command even if the server advertises
+SASL authentication. Care should be taken in using this option, as it will send
+out your password in plain text. This will not work if the IMAP server disables
+the plain LOGIN (e.g. to prevent password snooping).
+
 The application does not have to keep the string around after setting this
 option.
 .SH DEFAULT

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -102,6 +102,7 @@ test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \
 test718 test719 test720 test721 \
 \
+test799 \
 test800 test801 test802 test803 test804 test805 test806 test807 test808 \
 test809 test810 test811 test812 test813 test814 test815 test816 test817 \
 test818 test819 test820 test821 test822 test823 test824 test825 test826 \

--- a/tests/data/test799
+++ b/tests/data/test799
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+SASL AUTH +LOGIN
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<servercmd>
+AUTH PLAIN
+REPLY LOGIN A002 OK LOGIN completed
+</servercmd>
+<data>
+From: me@somewhere
+To: fake@nowhere
+
+body
+
+--
+  yours sincerely
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+imap
+</server>
+ <name>
+IMAP with --login-options 'AUTH=+LOGIN'
+ </name>
+ <command>
+'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=1' -u user:secret --login-options AUTH=+LOGIN
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+A001 CAPABILITY
+A002 LOGIN user secret
+A003 SELECT %TESTNUMBER
+A004 FETCH 1 BODY[]
+A005 LOGOUT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Hello!

There is no method to be able to use plain LOGIN (Plain LOGIN vs. SASL LOGIN) if an IMAP server advertises SASL capabilities. However, this may be desirable for e.g. a misconfigured server.

Per: https://www.ietf.org/rfc/rfc5092.html#section-3.2

";AUTH=<enc-auth-type>" looks to be the correct way to specify what authenication method to use, regardless of SASL or not.

Since https://www.rfc-editor.org/rfc/rfc3501.html#section-6.1.1 provides no way to have no SASL mechanisms, "XNONE" looks to be the best RFC compliant way of doing it.

While this does provide a method for cleartext password being sent, a user must expliciticly call `AUTH=XNONE` to excerise this.

I should note I originally thought of adding this in `Curl_sasl_parse_url_auth_option()` to add a more general way of disabling SASL authentication (it did not break any scripts), but I wasn't sure which would be more appropriate.