### PR TITLE
config-mac: define HAVE_SYS_IOCTL_H

### DIFF
--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -53,6 +53,7 @@
 #define HAVE_UTIME_H            1
 #define HAVE_SYS_TIME_H         1
 #define HAVE_SYS_UTIME_H        1
+#define HAVE_SYS_IOCTL_H        1
 
 #define TIME_WITH_SYS_TIME      1
 


### PR DESCRIPTION
~~Define `HAVE_SYS_FILIO_H` in config-mac.h and include <sys/filio.h> in nonblock.c when `HAVE_SYS_FILIO_H` is defined.~~

Define `HAVE_SYS_IOCTL_H` in config-mac.h. This is needed to compile nonblock.c on classic Mac OS with GUSI because nonblock.c uses `FIONBIO` which is defined in <sys/filio.h> which is included by <sys/ioctl.h>.
