### PR TITLE
Classic Mac OS: fix socklen_t, curl_off_t, long long

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -170,7 +170,7 @@
 #  define CURL_FORMAT_CURL_OFF_TU    "llu"
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
-#  define CURL_TYPEOF_CURL_SOCKLEN_T int
+#  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
 
 #elif defined(__TANDEM)
 # if ! defined(__LP64)

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -165,11 +165,20 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
 
 #elif defined(macintosh)
-#  define CURL_TYPEOF_CURL_OFF_T     long long
-#  define CURL_FORMAT_CURL_OFF_T     "lld"
-#  define CURL_FORMAT_CURL_OFF_TU    "llu"
-#  define CURL_SUFFIX_CURL_OFF_T     LL
-#  define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  include <ConditionalMacros.h>
+#  if TYPE_LONGLONG
+#    define CURL_TYPEOF_CURL_OFF_T     long long
+#    define CURL_FORMAT_CURL_OFF_T     "lld"
+#    define CURL_FORMAT_CURL_OFF_TU    "llu"
+#    define CURL_SUFFIX_CURL_OFF_T     LL
+#    define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  else
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
 
 #elif defined(__TANDEM)

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -164,7 +164,7 @@
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
 
-#elif defined(__MWERKS__)
+#elif defined(macintosh)
 #  define CURL_TYPEOF_CURL_OFF_T     long long
 #  define CURL_FORMAT_CURL_OFF_T     "lld"
 #  define CURL_FORMAT_CURL_OFF_TU    "llu"

--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -34,6 +34,11 @@
 #define OS "mac"
 #endif
 
+#include <ConditionalMacros.h>
+#if TYPE_LONGLONG
+#define HAVE_LONGLONG           1
+#endif
+
 /* Define if you want the built-in manual */
 #define USE_MANUAL              1
 

--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -83,6 +83,11 @@
 
 #define SIZEOF_INT              4
 #define SIZEOF_SIZE_T           4
+#ifdef HAVE_LONGLONG
+#define SIZEOF_CURL_OFF_T       8
+#else
+#define SIZEOF_CURL_OFF_T       4
+#endif
 
 #define HAVE_RECV 1
 #define RECV_TYPE_ARG1 int

--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -82,6 +82,7 @@
 #define HAVE_IOCTL_FIONBIO      1
 
 #define SIZEOF_INT              4
+#define SIZEOF_LONG             4
 #define SIZEOF_SIZE_T           4
 #ifdef HAVE_LONGLONG
 #define SIZEOF_CURL_OFF_T       8


### PR DESCRIPTION
Change `CURL_TYPEOF_CURL_SOCKLEN_T` from `int` to `unsigned int` when `__MWERKS__` is defined (i.e. Metrowerks compilers i.e. CodeWarrior).

This fixes a build failure when compiling for classic Mac OS with GUSI with CodeWarrior compilers.

-----

The error was:

```sh
#----------------------------------------------------------
### MWC68K Compiler Error:
#	if(getsockname(sockfd, (struct sockaddr *) &add, &size) < 0) {
#	                                                      ^
# cannot convert
# 'int *' to
# 'unsigned int *'
#----------------------------------------------------------
File "connect.c"; Line 462
#----------------------------------------------------------
### MWC68K Compiler Error:
#	if(0 != getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (void *)&err, &errSize))
#	                                                                       ^
# cannot convert
# 'int *' to
# 'unsigned int *'
#----------------------------------------------------------
File "connect.c"; Line 535
#----------------------------------------------------------
```

-----

It's unclear to me what system was envisioned when the `__MWERKS__` block was originally added in 2008 in 3ac692991912e596959aaedb49ff2798537e7af5. Metrowerks CodeWarrior was originally a classic Mac OS compiler in the 90s but, later, versions for BeOS, Windows, and Mac OS X existed, and it could cross-compile code for other systems as well. The Metrowerks company no longer exists today but CodeWarrior still does and is now used for embedded systems. I'm not certain that all of the systems CodeWarrior supports or supported will have the same values for the constants being defined here.

For example, POSIX says `socklen_t` should be unsigned.

* GUSI for classic Mac OS started using `socklen_t` in version 2. It is unsigned in the earliest version still posted on the site (2.1.3 from 2000) and in the last version (2.2.3 from 2002).
* Mac OS X first used `socklen_t` in version 10.3 (2003) and it was signed. By Mac OS X 10.4 (2005) it was unsigned.
* BeOS (1995-2001) apparently used a signed `socklen_t` at least for a time according to a quick Internet search. Don't know what Haiku (the reimplementation of BeOS) does.
* No idea what Windows or embedded systems do.

I'm not sure how these potential differences should be handled here.