### PR TITLE
Improvements to SSL connection checks

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1437,7 +1437,7 @@ bool Curl_connalive(struct Curl_easy *data, struct connectdata *conn)
 {
   (void)data;
   /* First determine if ssl */
-  if(Curl_ssl_use(conn, FIRSTSOCKET)) {
+  if(Curl_conn_is_ssl(data, FIRSTSOCKET)) {
     /* use the SSL context */
     if(!Curl_ssl_check_cxn(data, conn))
       return false;   /* FIN received */
@@ -1695,7 +1695,7 @@ static CURLcode socket_cf_connect(struct Curl_cfilter *cf,
       result = is_connected(data, conn, sockindex, done);
       if(!result && *done) {
         Curl_pgrsTime(data, TIMER_CONNECT);    /* we're connected already */
-        if(Curl_ssl_use(conn, FIRSTSOCKET) ||
+        if(Curl_conn_is_ssl(data, FIRSTSOCKET) ||
            (conn->handler->protocol & PROTO_FAMILY_SSH))
           Curl_pgrsTime(data, TIMER_APPCONNECT); /* we're connected already */
         post_connect(data, conn, sockindex);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1694,6 +1694,7 @@ static CURLcode socket_cf_connect(struct Curl_cfilter *cf,
     case SCFST_WAITING:
       result = is_connected(data, conn, sockindex, done);
       if(!result && *done) {
+        /* TODO: there's got to be a better way to do this */
         Curl_pgrsTime(data, TIMER_CONNECT);    /* we're connected already */
         if(Curl_conn_is_ssl(data, FIRSTSOCKET) ||
            (conn->handler->protocol & PROTO_FAMILY_SSH))

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -952,7 +952,7 @@ static CURLcode imap_state_capability_resp(struct Curl_easy *data,
       line += wordlen;
     }
   }
-  else if(data->set.use_ssl && !Curl_ssl_use(conn, FIRSTSOCKET)) {
+  else if(data->set.use_ssl && !Curl_conn_is_ssl(data, FIRSTSOCKET)) {
     /* PREAUTH is not compatible with STARTTLS. */
     if(imapcode == IMAP_RESP_OK && imapc->tls_supported && !imapc->preauth) {
       /* Switch to TLS connection now */

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -769,7 +769,7 @@ static CURLcode pop3_state_capa_resp(struct Curl_easy *data, int pop3code,
     if(pop3code != '+')
       pop3c->authtypes |= POP3_TYPE_CLEARTEXT;
 
-    if(!data->set.use_ssl || Curl_ssl_use(conn, FIRSTSOCKET))
+    if(!data->set.use_ssl || Curl_conn_is_ssl(data, FIRSTSOCKET))
       result = pop3_perform_authentication(data, conn);
     else if(pop3code == '+' && pop3c->tls_supported)
       /* Switch to TLS connection now */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -889,7 +889,8 @@ static CURLcode smtp_state_ehlo_resp(struct Curl_easy *data,
   (void)instate; /* no use for this yet */
 
   if(smtpcode/100 != 2 && smtpcode != 1) {
-    if(data->set.use_ssl <= CURLUSESSL_TRY || Curl_ssl_use(conn, FIRSTSOCKET))
+    if(data->set.use_ssl <= CURLUSESSL_TRY
+       || Curl_conn_is_ssl(data, FIRSTSOCKET))
       result = smtp_perform_helo(data, conn);
     else {
       failf(data, "Remote access denied: %d", smtpcode);
@@ -954,7 +955,7 @@ static CURLcode smtp_state_ehlo_resp(struct Curl_easy *data,
     }
 
     if(smtpcode != 1) {
-      if(data->set.use_ssl && !Curl_ssl_use(conn, FIRSTSOCKET)) {
+      if(data->set.use_ssl && !Curl_conn_is_ssl(data, FIRSTSOCKET)) {
         /* We don't have a SSL/TLS connection yet, but SSL is requested */
         if(smtpc->tls_supported)
           /* Switch to TLS connection now */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1725,11 +1725,6 @@ void *Curl_ssl_get_internals(struct Curl_easy *data, int sockindex,
   return result;
 }
 
-bool Curl_ssl_use(struct connectdata *conn, int sockindex)
-{
-  return Curl_ssl_cf_get_ssl(conn->cfilter[sockindex]) != NULL;
-}
-
 CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
                                  int sockindex)
 {
@@ -1818,11 +1813,9 @@ Curl_ssl_get_primary_config(struct Curl_easy *data,
 
 struct Curl_cfilter *Curl_ssl_cf_get_ssl(struct Curl_cfilter *cf)
 {
-  struct Curl_cfilter *cfn;
-
-  for(cfn = cf->next; cfn; cfn = cfn->next) {
-    if(cfn->cft == &cft_ssl || cfn->cft == &cft_ssl_proxy)
-      return cfn;
+  for(; cf; cf = cf->next) {
+    if(cf->cft == &cft_ssl || cf->cft == &cft_ssl_proxy)
+      return cf;
   }
   return NULL;
 }

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -208,8 +208,6 @@ bool Curl_ssl_supports(struct Curl_easy *data, int ssl_option);
 void *Curl_ssl_get_internals(struct Curl_easy *data, int sockindex,
                              CURLINFO info, int n);
 
-bool Curl_ssl_use(struct connectdata *conn, int sockindex);
-
 #else /* if not USE_SSL */
 
 /* When SSL support is not present, just define away these function calls */
@@ -228,7 +226,6 @@ bool Curl_ssl_use(struct connectdata *conn, int sockindex);
 #define Curl_ssl_false_start(a) FALSE
 #define Curl_ssl_get_internals(a,b,c,d) NULL
 #define Curl_ssl_supports(a,b) FALSE
-#define Curl_ssl_use(a,b) FALSE
 #define Curl_ssl_cfilter_add(a,b,c) CURLE_NOT_BUILT_IN
 #define Curl_ssl_cfilter_proxy_add(a,b,c) CURLE_NOT_BUILT_IN
 #define Curl_ssl_get_config(a,b) NULL


### PR DESCRIPTION
- fixes `Curl_ssl_cf_get_ssl()` to detect also the first filter instance as ssl (refs #10053)
- replaces `Curl_ssl_use()` with the correct `Curl_conn_is_ssl()`