### PR TITLE
schannel: verify hostname independent of verify cert

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -21,7 +21,6 @@ problems may have been fixed or changed somewhat since this was written.
  2.4 Secure Transport will not import PKCS#12 client certificates without a password
  2.5 Client cert handling with Issuer DN differs between backends
  2.7 Client cert (MTLS) issues with Schannel
- 2.8 Schannel disable CURLOPT_SSL_VERIFYPEER and verify hostname
  2.11 Schannel TLS 1.2 handshake bug in old Windows versions
  2.12 FTPS with Schannel times out file list operation
  2.13 CURLOPT_CERTINFO results in CURLE_OUT_OF_MEMORY with Schannel
@@ -162,12 +161,6 @@ problems may have been fixed or changed somewhat since this was written.
 2.7 Client cert (MTLS) issues with Schannel
 
  See https://github.com/curl/curl/issues/3145
-
-2.8 Schannel disable CURLOPT_SSL_VERIFYPEER and verify hostname
-
- This seems to be a limitation in the underlying Schannel API.
-
- https://github.com/curl/curl/issues/3284
 
 2.11 Schannel TLS 1.2 handshake bug in old Windows versions
 

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -76,6 +76,9 @@
 
 extern const struct Curl_ssl Curl_ssl_schannel;
 
+CURLcode Curl_verify_host(struct Curl_cfilter *cf,
+                          struct Curl_easy *data);
+
 CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
                                  struct Curl_easy *data);
 

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -43,6 +43,58 @@
 #define HAS_CLIENT_CERT_PATH
 #endif
 
+#ifndef CRYPT_DECODE_NOCOPY_FLAG
+#define CRYPT_DECODE_NOCOPY_FLAG 0x1
+#endif
+
+#ifndef CRYPT_DECODE_ALLOC_FLAG
+#define CRYPT_DECODE_ALLOC_FLAG 0x8000
+#endif
+
+#ifndef CERT_ALT_NAME_DNS_NAME
+#define CERT_ALT_NAME_DNS_NAME 3
+#endif
+
+#ifndef CERT_ALT_NAME_IP_ADDRESS
+#define CERT_ALT_NAME_IP_ADDRESS 8
+#endif
+
+
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
+/* Original mingw is missing CERT structs or they're disabled.
+   Refer to w32api-5.0.2-mingw32-dev\include\wincrypt.h. */
+
+/* !checksrc! disable TYPEDEFSTRUCT 4 */
+typedef struct _CERT_OTHER_NAME {
+  LPSTR pszObjId;
+  CRYPT_OBJID_BLOB Value;
+} CERT_OTHER_NAME, *PCERT_OTHER_NAME;
+
+typedef struct _CERT_ALT_NAME_ENTRY {
+  DWORD dwAltNameChoice;
+  union {
+    PCERT_OTHER_NAME pOtherName;
+    LPWSTR pwszRfc822Name;
+    LPWSTR pwszDNSName;
+    CERT_NAME_BLOB DirectoryName;
+    LPWSTR pwszURL;
+    CRYPT_DATA_BLOB IPAddress;
+    LPSTR pszRegisteredID;
+  };
+} CERT_ALT_NAME_ENTRY, *PCERT_ALT_NAME_ENTRY;
+
+typedef struct _CERT_ALT_NAME_INFO {
+  DWORD cAltEntry;
+  PCERT_ALT_NAME_ENTRY rgAltEntry;
+} CERT_ALT_NAME_INFO, *PCERT_ALT_NAME_INFO;
+
+typedef struct _CRYPT_DECODE_PARA {
+  DWORD cbSize;
+  PFN_CRYPT_ALLOC pfnAlloc;
+  PFN_CRYPT_FREE pfnFree;
+} CRYPT_DECODE_PARA, *PCRYPT_DECODE_PARA;
+#endif
+
 #ifndef SCH_CREDENTIALS_VERSION
 
 #define SCH_CREDENTIALS_VERSION  0x00000005


### PR DESCRIPTION
Prior to this change when CURLOPT_SSL_VERIFYPEER (verifypeer) was off and CURLOPT_SSL_VERIFYHOST (verifyhost) was on we did not verify the hostname in schannel code.

This fixes KNOWN_BUG 2.8 "Schannel disable CURLOPT_SSL_VERIFYPEER and verify hostname". We discussed a fix several years ago in #3285 but it went stale.

Assisted-by: Daniel Stenberg

Bug: https://curl.haxx.se/mail/lib-2018-10/0113.html
Reported-by: Martin Galvan

Ref: https://github.com/curl/curl/blob/curl-7_86_0/docs/KNOWN_BUGS#L304-L308
Ref: https://github.com/curl/curl/pull/3285

Fixes https://github.com/curl/curl/issues/3284
Closes #xxxx

---

This PR looks like a lot of change but it's really not. Most of the change is I moved two functions out of the HAS_MANUAL_VERIFY_API guard and then made one of them public (Curl_verify_host) so that hostnames could be verified independently of the server certificate.