### PR TITLE
noproxy: guard against empty hostnames in noproxy check

### DIFF
--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -121,6 +121,13 @@ enum nametype {
 ****************************************************************/
 bool Curl_check_noproxy(const char *name, const char *no_proxy)
 {
+  /*
+   * If we don't have a hostname at all, like for example with a FILE
+   * transfer, we have nothing to interrogate the noproxy list with.
+   */
+  if(!name || name[0] == '\0')
+    return FALSE;
+
   /* no_proxy=domain1.dom,host.domain2.dom
    *   (a comma-separated list of hosts which should
    *   not be proxied, or an asterisk to override


### PR DESCRIPTION
When checking for a noproxy setting we need to ensure that we get a hostname passed in. If there is no hostname then there cannot be a matching noproxy rule for it by definition.

A larger, independent of this patch, body of work is to ensure that we don't check for proxy information at all on protocols where it doesn't make sense.