### PR TITLE
Use SecPKCS12Import on temporary keychain if p12 certificate not found

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3056,10 +3056,10 @@ static CURLcode collect_server_cert(struct Curl_cfilter *cf,
 static CURLcode sectransp_connect_step3(struct Curl_cfilter *cf,
                                         struct Curl_easy *data)
 {
+  struct ssl_connect_data *connssl = cf->ctx;
 #if CURL_BUILD_MAC_10_7
   DeleteTemporaryKeychain();
 #endif
-  struct ssl_connect_data *connssl = cf->ctx;
 
   /* There is no step 3!
    * Well, okay, let's collect server certificates, and if verbose mode is on,

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1199,6 +1199,7 @@ static CFTypeRef ExtractIdentityFromArray(CFArrayRef pArray)
                                               kSecImportItemIdentity);
     }
   }
+  return NULL;
 }
 #endif /* CURL_BUILD_MAC_10_7 */
 


### PR DESCRIPTION
Using Secure Transport, if we are using a path to a p12 certificate which itself or private key is not in the keychain, it will fail with errSecItemNotFound. With this change, we are trying a last-resort solution of creating a temporary keychain, importing the p12 certificate via SecPKCS12Import and successively delete the temporary keychain.

This is to fix #10038.

Please note that with my current build (latest changes at time of writing, commit 3f06b423c4986a5e6c8ce44559d6859991b1e06e), I always seem to be getting "curl: (35) Internal SSL engine error encountered during the SSL handshake" with or without this change. However, to make sure it works, I instead used the latest released version at time of writing (7.86.0) and I can confirm it works OK on my end.

The downsides of this change is that the APIs to create and delete a keychain (SecKeychainCreate and SecKeychainDelete) have been deprecated at macOS 10.10.

The upside is that you won't need to add a p12 cert or its private key to the default keychain if using Secure Transport.

If the deprecated APIs will ever be removed, a more robust solution I can think of would be to use SecPKCS12Import and try removing the certificate that was just added with SecItemDelete, but would need to find a way to target that specific certificate in order to avoid deleting other certificates/private keys.

Let me know if you'd like anything changed in the PR!