### PR TITLE
curl.h: reword comment to not use deprecated option

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1140,7 +1140,7 @@ typedef enum {
   /* Time-out the read operation after this amount of seconds */
   CURLOPT(CURLOPT_TIMEOUT, CURLOPTTYPE_LONG, 13),
 
-  /* If the CURLOPT_INFILE is used, this can be used to inform libcurl about
+  /* If CURLOPT_READDATA is used, this can be used to inform libcurl about
    * how large the file being sent really is. That allows better error
    * checking and better verifies that the upload was successful. -1 means
    * unknown size.


### PR DESCRIPTION
CURLOPT_INFILE was replaced by CURLOPT_READDATA in 7.9.7, reword the comment mentioning it to make grepping easier and also improve the documentation.