### PR TITLE
contributors.sh: actually use $CURLWWW instead of just setting it.

### DIFF
--- a/scripts/contributors.sh
+++ b/scripts/contributors.sh
@@ -60,7 +60,7 @@ fi
   git log --pretty=full --use-mailmap $start..HEAD
   if [ -d "$CURLWWW" ]
   then
-   git -C ../curl-www log --pretty=full --use-mailmap $start..HEAD
+   git -C "$CURLWWW" log --pretty=full --use-mailmap $start..HEAD
   fi
  ) | \
 grep -Eai '(^Author|^Commit|by):' | \


### PR DESCRIPTION
The script was all set up for flexibility where curl-www is in the filesystem, but then hard-coded ../curl-www anyway...