### PR TITLE
tool: determine the correct fopen option for -D 

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -969,7 +969,21 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           /* open file for output: */
           if(strcmp(config->headerfile, "-")) {
             FILE *newfile;
-            newfile = fopen(config->headerfile, per->prev == NULL?"wb":"ab");
+
+            /*
+             * this checks if the previous transfer had the same
+             * OperationConfig, which would mean, that the an output file has
+             * already been created and data can be appened to it, instead
+             * of overwriting it.
+             * TODO: Consider placing the file handle inside the
+             * OperationConfig, so that it does not need to be opened/closed
+             * for every transfer.
+             */
+            if(per->prev && per->prev->config == config)
+              newfile = fopen(config->headerfile, "ab+");
+            else
+              newfile = fopen(config->headerfile, "wb+");
+
             if(!newfile) {
               warnf(global, "Failed to open %s\n", config->headerfile);
               result = CURLE_WRITE_ERROR;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -248,7 +248,7 @@ test2500 \
 test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
-test3024 test3025 test3026 test3027 test3028 \
+test3024 test3025 test3026 test3027 test3028 test3029 test3030 \
 \
 test3100 test3101 \
 test3200

--- a/tests/data/test3029
+++ b/tests/data/test3029
@@ -1,0 +1,39 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+</keywords>
+</info>
+
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+
+-foo-
+</data>
+</reply>
+
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with multiple -D
+</name>
+<command>
+-D log/heads%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER --next -D log/heads%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+<file name="log/heads%TESTNUMBER">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+
+</file>
+</verify>
+
+</testcase>

--- a/tests/data/test3030
+++ b/tests/data/test3030
@@ -1,0 +1,43 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+</keywords>
+</info>
+
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+
+-foo-
+</data>
+</reply>
+
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with multiple transfers in one -D
+</name>
+<command>
+-D log/heads%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+<file name="log/heads%TESTNUMBER">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+
+</file>
+</verify>
+
+</testcase>


### PR DESCRIPTION
This commit fixes a bug in the dump-header feature regarding the
determination of the second fopen(3) option.

See https://github.com/curl/curl/issues/4753
See https://github.com/curl/curl/pull/4762
Fixes https://github.com/curl/curl/issues/10074
Closes https://github.com/curl/curl/pull/10079