### PR TITLE
Fixed typo in curl_ws_send documentation

### DIFF
--- a/docs/libcurl/curl_ws_send.3
+++ b/docs/libcurl/curl_ws_send.3
@@ -67,9 +67,9 @@ set.
 .IP CURLWS_CLOSE
 Close this transfer.
 .IP CURLWS_PING
-This as a ping.
+This is a ping.
 .IP CURLWS_PONG
-This as a pong.
+This is a pong.
 .IP CURLWS_OFFSET
 The provided data is only a partial fragment and there will be more in a
 following call to \fIcurl_ws_send()\fP. When sending only a piece of the


### PR DESCRIPTION
as vs. is