### PR TITLE
lib: use size_t or int etc instead of longs

### DIFF
--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -334,7 +334,7 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
   struct ftp_parselist_data *parser = ftpwc->parser;
   struct fileinfo *infop;
   struct curl_fileinfo *finfo;
-  unsigned long i = 0;
+  size_t i = 0;
   CURLcode result;
   size_t retsize = bufflen;
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1166,7 +1166,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
 
   case CURLOPT_SOCKS5_AUTH:
-    data->set.socks5auth = va_arg(param, unsigned long);
+    data->set.socks5auth = (unsigned char)va_arg(param, unsigned long);
     if(data->set.socks5auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
       result = CURLE_NOT_BUILT_IN;
     break;

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -526,10 +526,11 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
     (conn->socks_proxy.proxytype == CURLPROXY_SOCKS5) ? TRUE : FALSE;
   const size_t hostname_len = strlen(sx->hostname);
   ssize_t len = 0;
-  const unsigned long auth = data->set.socks5auth;
+  const unsigned char auth = data->set.socks5auth;
   bool allow_gssapi = FALSE;
   struct Curl_dns_entry *dns = NULL;
 
+  DEBUGASSERT(auth & (CURLAUTH_BASIC | CURLAUTH_GSSAPI));
   switch(sx->state) {
   case CONNECT_SOCKS_INIT:
     if(conn->bits.httpproxy)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1627,7 +1627,7 @@ struct UserDefined {
   unsigned long httpauth;  /* kind of HTTP authentication to use (bitmask) */
   unsigned long proxyauth; /* kind of proxy authentication to use (bitmask) */
 #ifndef CURL_DISABLE_PROXY
-  unsigned long socks5auth;/* kind of SOCKS5 authentication to use (bitmask) */
+  unsigned char socks5auth;/* kind of SOCKS5 authentication to use (bitmask) */
 #endif
   long maxredirs;    /* maximum no. of http(s) redirects to follow, set to -1
                         for infinity */

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -182,7 +182,7 @@ static const char *getASN1Element(struct Curl_asn1Element *elem,
                                   const char *beg, const char *end)
 {
   unsigned char b;
-  unsigned long len;
+  size_t len;
   struct Curl_asn1Element lelem;
 
   /* Get a single ASN.1 element into `elem', parse ASN.1 string at `beg'
@@ -307,7 +307,7 @@ static const char *bit2str(const char *beg, const char *end)
  */
 static const char *int2str(const char *beg, const char *end)
 {
-  unsigned long val = 0;
+  unsigned int val = 0;
   size_t n = end - beg;
 
   if(!n)
@@ -323,7 +323,7 @@ static const char *int2str(const char *beg, const char *end)
   do
     val = (val << 8) | *(const unsigned char *) beg++;
   while(beg < end);
-  return curl_maprintf("%s%lx", val >= 10? "0x": "", val);
+  return curl_maprintf("%s%x", val >= 10? "0x": "", val);
 }
 
 /*
@@ -953,8 +953,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
      * ECC public key is all the data, a value of type BIT STRING mapped to
      * OCTET STRING and should not be parsed as an ASN.1 value.
      */
-    const unsigned long len =
-      (unsigned long)((pubkey->end - pubkey->beg - 2) * 4);
+    const size_t len = ((pubkey->end - pubkey->beg - 2) * 4);
     if(!certnum)
       infof(data, "   ECC Public Key (%lu bits)", len);
     if(data->set.ssl.certinfo) {
@@ -972,7 +971,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
 
   if(strcasecompare(algo, "rsaEncryption")) {
     const char *q;
-    unsigned long len;
+    size_t len;
 
     p = getASN1Element(&elem, pk.beg, pk.end);
     if(!p)
@@ -981,7 +980,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
     /* Compute key length. */
     for(q = elem.beg; !*q && q < elem.end; q++)
       ;
-    len = (unsigned long)((elem.end - q) * 8);
+    len = ((elem.end - q) * 8);
     if(len) {
       unsigned int i;
       for(i = *(unsigned char *) q; !(i & 0x80); i <<= 1)
@@ -1073,7 +1072,7 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data,
   size_t cl1;
   char *cp2;
   CURLcode result = CURLE_OK;
-  unsigned long version;
+  unsigned int version;
   size_t i;
   size_t j;
 
@@ -1360,8 +1359,8 @@ CURLcode Curl_verifyhost(struct Curl_cfilter *cf,
           break;
 
         case 7: /* IP address. */
-          matched = (size_t) (name.end - name.beg) == addrlen &&
-                    !memcmp(&addr, name.beg, addrlen);
+          matched = (name.end - name.beg) == addrlen &&
+            !memcmp(&addr, name.beg, addrlen);
           break;
         }
       }


### PR DESCRIPTION
Since long is not using a consistent data size in curl builds.