### PR TITLE
altsvc: fix rejection of negative port numbers

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -519,10 +519,11 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
         if(*p == ':') {
           unsigned long port = 0;
           p++;
-          if(ISDIGIT(*p)) {
+          if(ISDIGIT(*p))
             /* a port number */
             port = strtoul(p, &end_ptr, 10);
-          }
+          else
+            end_ptr = (char *)p; /* not left uninitialized */
           if(!port || port > USHRT_MAX || end_ptr == p || *end_ptr != '\"') {
             infof(data, "Unknown alt-svc port number, ignoring.");
             valid = FALSE;

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -517,15 +517,20 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
           dsthost = srchost;
         }
         if(*p == ':') {
-          /* a port number */
-          unsigned long port = strtoul(++p, &end_ptr, 10);
-          if(port > USHRT_MAX || end_ptr == p || *end_ptr != '\"') {
+          unsigned long port = 0;
+          p++;
+          if(ISDIGIT(*p)) {
+            /* a port number */
+            port = strtoul(p, &end_ptr, 10);
+          }
+          if(!port || port > USHRT_MAX || end_ptr == p || *end_ptr != '\"') {
             infof(data, "Unknown alt-svc port number, ignoring.");
             valid = FALSE;
           }
-          else
+          else {
             dstport = curlx_ultous(port);
-          p = end_ptr;
+            p = end_ptr;
+          }
         }
         if(*p++ != '\"')
           break;

--- a/tests/data/test356
+++ b/tests/data/test356
@@ -17,6 +17,7 @@ Connection: close
 Content-Type: text/html
 Funny-head: yesyes
 Alt-Svc: h1="nowhere.foo:-1"
+Alt-Svc: h1="nowhere.foo:-18446744073709551614"
 Alt-Svc: h1="nowhere.foo:81", un-kno22!wn=":82"
 Alt-Svc: h1="nowhere.foo:70000"
 


### PR DESCRIPTION
strtoul() accepts a leading minus so better make sure there is none

Extended test 356 somewhat to use a huge negative 64 bit number that otherwise becomes a low positive number.