### PR TITLE
tool_paramhlp: free the proto strings on exit

### DIFF
--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -90,6 +90,8 @@ static void free_config_fields(struct OperationConfig *config)
 
   Curl_safefree(config->netrc_file);
   Curl_safefree(config->output_dir);
+  Curl_safefree(config->proto_str);
+  Curl_safefree(config->proto_redir_str);
 
   urlnode = config->url_list;
   while(urlnode) {

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -433,6 +433,7 @@ ParameterError proto2num(struct OperationConfig *config,
     result = curlx_dyn_addf(&obuf, "%s,", protoset[proto]);
   free((char *) protoset);
   curlx_dyn_setlen(&obuf, curlx_dyn_len(&obuf) - 1);
+  free(*ostr);
   *ostr = curlx_dyn_ptr(&obuf);
 
   return *ostr ? PARAM_OK : PARAM_NO_MEM;


### PR DESCRIPTION
And also make sure that repeated use of the options free the previous string before it stores a new.