### PR TITLE
socks: fix infof() flag for outputing a char

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -546,7 +546,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
 
     if(auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
       infof(data,
-            "warning: unsupported value passed to CURLOPT_SOCKS5_AUTH: %lu",
+            "warning: unsupported value passed to CURLOPT_SOCKS5_AUTH: %u",
             auth);
     if(!(auth & CURLAUTH_BASIC))
       /* disable username/password auth */


### PR DESCRIPTION
It used to be a 'long', %lu is no longer correct.

Follow-up to 57d2d9b6bed33d
Detected by Coverity CID 1517663