### PR TITLE
curl_url_get.3: remove spurious backtick

### DIFF
--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -58,7 +58,7 @@ default port for the scheme.
 .IP CURLU_URLDECODE
 Asks \fIcurl_url_get(3)\fP to URL decode the contents before returning it. It
 will not attempt to decode the scheme, the port number or the full URL.
-´
+
 The query component will also get plus-to-space conversion as a bonus when
 this bit is set.
 


### PR DESCRIPTION
Put there by mistake.

Follow-up from 9a8564a92