### PR TITLE
http: use the IDN decoded name in HSTS checks

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3646,7 +3646,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
 #endif
             )) {
     CURLcode check =
-      Curl_hsts_parse(data->hsts, data->state.up.hostname,
+      Curl_hsts_parse(data->hsts, conn->host.name,
                       headp + strlen("Strict-Transport-Security:"));
     if(check)
       infof(data, "Illegal STS header skipped");


### PR DESCRIPTION
Otherwise it stores the info HSTS into the persistent cache for the IDN name which will not match when the HSTS status is later checked for using the decoded name.

Reported-by: Hiroki Kurosawa