### PR TITLE
CI: event-based: often get cancled due timeout encrease it to 2h

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
   autotools:
     name: ${{ matrix.build.name }}
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Example:
https://github.com/curl/curl/actions/runs/3730372864/jobs/6327357216#step:20:249