### PR TITLE
tool_operate: fix `CURLOPT_SOCKS5_GSSAPI_NEC` type

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1939,8 +1939,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         /* new in curl 7.19.4 */
         if(config->socks5_gssapi_nec)
-          my_setopt_str(curl, CURLOPT_SOCKS5_GSSAPI_NEC,
-                        config->socks5_gssapi_nec);
+          my_setopt_str(curl, CURLOPT_SOCKS5_GSSAPI_NEC, 1L);
 
         /* new in curl 7.55.0 */
         if(config->socks5_auth)


### PR DESCRIPTION
`CURLOPT_SOCKS5_GSSAPI_NEC` is a long, while `socks5_gssapi_nec` was made a bool in commit 4ac64eadf60.