### PR TITLE
Update msh3 to v0.5 Release

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -168,7 +168,7 @@ jobs:
 
     - if: ${{ contains(matrix.build.install_steps, 'msh3') }}
       run: |
-        git clone --depth=1 --recursive https://github.com/nibanks/msh3
+        git clone -b v0.5.0 --depth=1 --recursive https://github.com/nibanks/msh3
         cd msh3 && mkdir build && cd build
         cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/msh3 ..
         cmake --build .

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -15,7 +15,7 @@ QUIC libraries we are experimenting with:
 
 [quiche](https://github.com/cloudflare/quiche)
 
-[msquic](https://github.com/microsoft/msquic) & [msh3](https://github.com/nibanks/msh3)
+[msh3](https://github.com/nibanks/msh3) (with [msquic](https://github.com/microsoft/msquic))
 
 ## Experimental
 
@@ -181,7 +181,7 @@ Build curl:
 
 Build msh3:
 
-     % git clone -b v0.4.0 --depth 1 --recursive https://github.com/nibanks/msh3
+     % git clone -b v0.5.0 --depth 1 --recursive https://github.com/nibanks/msh3
      % cd msh3 && mkdir build && cd build
      % cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
      % cmake --build .
@@ -202,7 +202,7 @@ Run from `/usr/local/bin/curl`.
 
 Build msh3:
 
-     % git clone -b v0.4.0 --depth 1 --recursive https://github.com/nibanks/msh3
+     % git clone -b v0.5.0 --depth 1 --recursive https://github.com/nibanks/msh3
      % cd msh3 && mkdir build && cd build
      % cmake -G 'Visual Studio 17 2022' -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
      % cmake --build . --config Release

--- a/lib/vquic/msh3.c
+++ b/lib/vquic/msh3.c
@@ -406,7 +406,8 @@ static ssize_t msh3_stream_send(struct Curl_easy *data,
     }
     H3BUGF(infof(data, "starting request with %zu headers", hreq->entries));
     stream->req = MsH3RequestOpen(qs->conn, &msh3_request_if, stream,
-                                 (MSH3_HEADER*)hreq->header, hreq->entries);
+                                 (MSH3_HEADER*)hreq->header, hreq->entries,
+                                 MSH3_REQUEST_FLAG_FIN);
     Curl_pseudo_free(hreq);
     if(!stream->req) {
       failf(data, "request open failed");

--- a/lib/vquic/msh3.c
+++ b/lib/vquic/msh3.c
@@ -68,6 +68,8 @@ static void MSH3_CALL msh3_data_received(MSH3_REQUEST *Request,
 static void MSH3_CALL msh3_complete(MSH3_REQUEST *Request, void *IfContext,
                                     bool Aborted, uint64_t AbortError);
 static void MSH3_CALL msh3_shutdown(MSH3_REQUEST *Request, void *IfContext);
+static void MSH3_CALL msh3_send_complete(MSH3_REQUEST* Request, void* IfContext,
+                                         void* SendContext);
 
 static const struct Curl_handler msh3_curl_handler_http3 = {
   "HTTPS",                              /* scheme */
@@ -96,7 +98,8 @@ static const MSH3_REQUEST_IF msh3_request_if = {
   msh3_header_received,
   msh3_data_received,
   msh3_complete,
-  msh3_shutdown
+  msh3_shutdown,
+  msh3_send_complete
 };
 
 void Curl_quic_ver(char *p, size_t len)
@@ -379,6 +382,15 @@ static void MSH3_CALL msh3_shutdown(MSH3_REQUEST *Request, void *IfContext)
   struct HTTP *stream = IfContext;
   (void)Request;
   (void)stream;
+}
+
+static void MSH3_CALL msh3_send_complete(MSH3_REQUEST* Request, void* IfContext,
+                                         void* SendContext)
+{
+  struct HTTP *stream = IfContext;
+  (void)Request;
+  (void)stream;
+  (void)SendContext;
 }
 
 static ssize_t msh3_stream_send(struct Curl_easy *data,

--- a/lib/vquic/msh3.c
+++ b/lib/vquic/msh3.c
@@ -68,8 +68,8 @@ static void MSH3_CALL msh3_data_received(MSH3_REQUEST *Request,
 static void MSH3_CALL msh3_complete(MSH3_REQUEST *Request, void *IfContext,
                                     bool Aborted, uint64_t AbortError);
 static void MSH3_CALL msh3_shutdown(MSH3_REQUEST *Request, void *IfContext);
-static void MSH3_CALL msh3_send_complete(MSH3_REQUEST* Request, void* IfContext,
-                                         void* SendContext);
+static void MSH3_CALL msh3_send_complete(MSH3_REQUEST *Request,
+                                         void *IfContext, void *SendContext);
 
 static const struct Curl_handler msh3_curl_handler_http3 = {
   "HTTPS",                              /* scheme */
@@ -384,8 +384,8 @@ static void MSH3_CALL msh3_shutdown(MSH3_REQUEST *Request, void *IfContext)
   (void)stream;
 }
 
-static void MSH3_CALL msh3_send_complete(MSH3_REQUEST* Request, void* IfContext,
-                                         void* SendContext)
+static void MSH3_CALL msh3_send_complete(MSH3_REQUEST *Request,
+                                         void *IfContext, void *SendContext)
 {
   struct HTTP *stream = IfContext;
   (void)Request;


### PR DESCRIPTION
FYI, a follow up PR will leverage the new features in msh3 v0.5 to send request payload.