### PR TITLE
strdup: name it Curl_strdup

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -113,7 +113,7 @@ static curl_simple_lock s_lock = CURL_SIMPLE_LOCK_INIT;
 #if defined(_WIN32_WCE)
 #define system_strdup _strdup
 #elif !defined(HAVE_STRDUP)
-#define system_strdup curlx_strdup
+#define system_strdup Curl_strdup
 #else
 #define system_strdup strdup
 #endif

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -37,7 +37,7 @@
 #include "memdebug.h"
 
 #ifndef HAVE_STRDUP
-char *curlx_strdup(const char *str)
+char *Curl_strdup(const char *str)
 {
   size_t len;
   char *newstr;

--- a/lib/strdup.h
+++ b/lib/strdup.h
@@ -26,7 +26,7 @@
 #include "curl_setup.h"
 
 #ifndef HAVE_STRDUP
-extern char *curlx_strdup(const char *str);
+char *Curl_strdup(const char *str);
 #endif
 #ifdef WIN32
 wchar_t* Curl_wcsdup(const wchar_t* src);


### PR DESCRIPTION
It does not belong in the curlx_ name space as it is never used externally.