### PR TITLE
Support for Request Payload with msh3

### DIFF
--- a/lib/h2h3.c
+++ b/lib/h2h3.c
@@ -118,6 +118,7 @@ static header_instruction inspect_header(const char *name, size_t namelen,
 CURLcode Curl_pseudo_headers(struct Curl_easy *data,
                              const char *mem, /* the request */
                              const size_t len /* size of request */,
+                             size_t* hdrlen /* opt size of headers read */,
                              struct h2h3req **hp)
 {
   struct connectdata *conn = data->conn;
@@ -289,6 +290,12 @@ CURLcode Curl_pseudo_headers(struct Curl_easy *data,
             "headers exceeds %d bytes and that could cause the "
             "stream to be rejected.", MAX_ACC);
     }
+  }
+
+  if(hdrlen) {
+    /* Skip trailing CRLF */
+    end += 4;
+    *hdrlen = end - mem;
   }
 
   hreq->entries = nheader;

--- a/lib/h2h3.h
+++ b/lib/h2h3.h
@@ -51,6 +51,7 @@ struct h2h3req {
 CURLcode Curl_pseudo_headers(struct Curl_easy *data,
                              const char *request,
                              const size_t len,
+                             size_t* hdrlen /* optional */,
                              struct h2h3req **hp);
 
 /*

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1942,7 +1942,7 @@ static ssize_t http2_send(struct Curl_easy *data, int sockindex,
     return len;
   }
 
-  result = Curl_pseudo_headers(data, mem, len, &hreq);
+  result = Curl_pseudo_headers(data, mem, len, NULL, &hreq);
   if(result) {
     *err = result;
     return -1;

--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1526,7 +1526,7 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
   stream->h3req = TRUE; /* senf off! */
   Curl_dyn_init(&stream->overflow, CURL_MAX_READ_SIZE);
 
-  result = Curl_pseudo_headers(data, mem, len, &hreq);
+  result = Curl_pseudo_headers(data, mem, len, NULL, &hreq);
   if(result)
     goto fail;
   nheader = hreq->entries;

--- a/lib/vquic/quiche.c
+++ b/lib/vquic/quiche.c
@@ -765,7 +765,7 @@ static CURLcode http_request(struct Curl_easy *data, const void *mem,
 
   stream->h3req = TRUE; /* senf off! */
 
-  result = Curl_pseudo_headers(data, mem, len, &hreq);
+  result = Curl_pseudo_headers(data, mem, len, NULL, &hreq);
   if(result)
     goto fail;
   nheader = hreq->entries;


### PR DESCRIPTION
This updates the msh3 HTTP/3 code to support sending request data. A few option issues that can probably be handled in future PRs:

* How do we make sure curl doesn't free the send data before the send is complete?
* How do we know when to FIN the request?
  * Currently, we only will support a single send call from curl and FIN after that.