### PR TITLE
Removing attached easy handles from OpenSSL SSL instances. Refs #10150.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4218,6 +4218,13 @@ if test "x$want_ech" != "xno"; then
 fi
 
 dnl *************************************************************
+dnl check whether OpenSSL (lookalikes) have SSL_set0_wbio
+dnl
+if test "x$OPENSSL_ENABLED" = "x1"; then
+  AC_CHECK_FUNCS([SSL_set0_wbio])
+fi
+
+dnl *************************************************************
 dnl WebSockets
 dnl
 AC_MSG_CHECKING([whether to support WebSockets])


### PR DESCRIPTION
- keeping the "current" easy handle registered at SSL* is no longer necessary, since the "calling" data object is already stored in the cfilter's context (and used by other SSL backends from there).
- The "detach" of an easy handle that goes out of scope is then avoided.
- This could be the cause of the crash reported in #10150.