### PR TITLE
Fix build with `--disable-cookies`

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -431,7 +431,9 @@ CURLcode Curl_close(struct Curl_easy **datap)
   Curl_dyn_free(&data->state.headerb);
   Curl_safefree(data->state.ulbuf);
   Curl_flush_cookies(data, TRUE);
+#ifndef CURL_DISABLE_COOKIES
   curl_slist_free_all(data->set.cookielist); /* clean up list */
+#endif
   Curl_altsvc_save(data, data->asi, data->set.str[STRING_ALTSVC]);
   Curl_altsvc_cleanup(&data->asi);
   Curl_hsts_save(data, data->hsts, data->set.str[STRING_HSTS]);


### PR DESCRIPTION
Struct `UserDefined` has no member `cookielist` if `CURL_DISABLE_COOKIES` is defined.