### PR TITLE
Remove the trace message "Mark bundle... multiuse"

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -4290,7 +4290,6 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
           }
           if(conn->httpversion < 20) {
             conn->bundle->multiuse = BUNDLE_NO_MULTIUSE;
-            infof(data, "Mark bundle as not supporting multiuse");
           }
         }
         else if(!nc) {


### PR DESCRIPTION
The message "Mark bundle as not supporting multiuse" was added at commit 29364d93 when an http/2-related bug was fixed, and it appears to be a leftover trace message.

This message should be removed because:
 * it conveys no information to the user
 * it is enabled in the default build (--enable-verbose)
 * it reads like a warning/unexpected condition
 * it is equivalent to "Detected http proto < 2", which is not a useful message.
 * it is a time-wasting red-herring for anyone who encounters it for the first time while investigating some other, real problem.

This commit removes the trace message "Mark bundle as not supporting multiuse"