### PR TITLE
cfilters:Curl_conn_get_select_socks: use the first non-connected filter

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -437,6 +437,10 @@ int Curl_conn_get_select_socks(struct Curl_easy *data, int sockindex,
   DEBUGASSERT(data);
   DEBUGASSERT(data->conn);
   cf = data->conn->cfilter[sockindex];
+
+  /* if the next one is not yet connected, that's the one we want */
+  while(cf && cf->next && !cf->next->connected)
+    cf = cf->next;
   if(cf) {
     return cf->cft->get_select_socks(cf, data, socks);
   }


### PR DESCRIPTION
When there are filters addded for both socket and SSL, the code previously checked the SSL sockets during connect when it *should* first check the socket layer until that has connected.

Fixes #10157

This might also fix #10146.