### PR TITLE
Fix HAProxy protocol information to be send before TLS handhshake.

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -319,7 +319,14 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
         if(result)
           goto out;
       }
+    }
 #endif /* !CURL_DISABLE_HTTP */
+
+    /* HAProxy protocol comes *before* SSL, see #10165 */
+    if(data->set.haproxyprotocol) {
+      result = Curl_conn_haproxy_add(data, conn, sockindex);
+      if(result)
+        goto out;
     }
 #endif /* !CURL_DISABLE_PROXY */
 
@@ -334,14 +341,6 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
 #else
     (void)ssl_mode;
 #endif /* USE_SSL */
-
-#if !defined(CURL_DISABLE_PROXY) && !defined(CURL_DISABLE_HTTP)
-    if(data->set.haproxyprotocol) {
-      result = Curl_conn_haproxy_add(data, conn, sockindex);
-      if(result)
-        goto out;
-    }
-#endif /* !CURL_DISABLE_PROXY && !CURL_DISABLE_HTTP */
 
   }
   DEBUGASSERT(conn->cfilter[sockindex]);

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -1195,6 +1195,9 @@ CURLcode Curl_conn_http_proxy_add(struct Curl_easy *data,
   return result;
 }
 
+#endif /* !CURL_DISABLE_PROXY &6 ! CURL_DISABLE_HTTP */
+
+#if !defined(CURL_DISABLE_PROXY)
 
 static CURLcode send_haproxy_header(struct Curl_cfilter*cf,
                                     struct Curl_easy *data)
@@ -1280,4 +1283,4 @@ CURLcode Curl_conn_haproxy_add(struct Curl_easy *data,
   return result;
 }
 
-#endif /* !CURL_DISABLE_PROXY &6 ! CURL_DISABLE_HTTP */
+#endif /* !CURL_DISABLE_PROXY */

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -27,19 +27,21 @@
 #include "curl_setup.h"
 #include "urldata.h"
 
-#if !defined(CURL_DISABLE_PROXY) && !defined(CURL_DISABLE_HTTP)
+#if !defined(CURL_DISABLE_PROXY)
 
+#if !defined(CURL_DISABLE_HTTP)
 /* Default proxy timeout in milliseconds */
 #define PROXY_TIMEOUT (3600*1000)
 
 CURLcode Curl_conn_http_proxy_add(struct Curl_easy *data,
                                   struct connectdata *conn,
                                   int sockindex);
+#endif /* !CURL_DISABLE_HTTP */
 
 CURLcode Curl_conn_haproxy_add(struct Curl_easy *data,
                                struct connectdata *conn,
                                int sockindex);
 
-#endif /* !CURL_DISABLE_PROXY && !CURL_DISABLE_HTTP */
+#endif /* !CURL_DISABLE_PROXY */
 
 #endif /* HEADER_CURL_HTTP_PROXY_H */


### PR DESCRIPTION
- refs #10165
- reverse order of haproxy and final ssl cfilter
- make haproxy avaiable on PROXY builds, independent of HTTP support as it can be used with any protocol.