### PR TITLE
socketpair: allow localhost MITM sniffers

### DIFF
--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -119,7 +119,7 @@ int Curl_socketpair(int domain, int type, int protocol,
     swrite(socks[0], &now, sizeof(now));
     /* verify that we read the correct data */
     if((sizeof(now) != sread(socks[1], &check, sizeof(check)) ||
-        (now != check)))
+        memcmp(&now, &check, sizeof(check))))
       goto error;
   }
 

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -65,7 +65,7 @@ int Curl_socketpair(int domain, int type, int protocol,
   union {
     struct sockaddr_in inaddr;
     struct sockaddr addr;
-  } a, a2;
+  } a;
   curl_socket_t listener;
   curl_socklen_t addrlen = sizeof(a.inaddr);
   int reuse = 1;


### PR DESCRIPTION
Windows allow programs to MITM connections to localhost. The previous check here would detect that and error out. This new method writes data to verify the pipe thus allowing MITM.

Reported-by: SerusDev on github
Fixes #10144