### PR TITLE
transfer: break the read loop when RECV is cleared

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -776,8 +776,8 @@ static CURLcode readwrite_data(struct Curl_easy *data,
       k->keepon &= ~KEEP_RECV;
     }
 
-    if(k->keepon & KEEP_RECV_PAUSE) {
-      /* this is a paused transfer */
+    if((k->keepon & KEEP_RECV_PAUSE) || !(k->keepon & KEEP_RECV)) {
+      /* this is a paused or stopped transfer */
       break;
     }
 


### PR DESCRIPTION
When the RECV bit is cleared because the response reading for this transfer is complete, the read loop should be stopped. data_pending() can otherwise still return TRUE and another read would be attempted.

Reported-by: Hide Ishikawa
Fixes #10172
Closes #