### PR TITLE
tiny tweak on tests/ftpserver.pl data timeout

### DIFF
--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -2577,7 +2577,7 @@ sub PASV_ftp {
         local $SIG{ALRM} = sub { die "alarm\n" };
 
         # assume swift operations unless explicitly slow
-        alarm ($datadelay?20:10);
+        alarm ($datadelay?20:2);
 
         # Wait for 'CNCT'
         my $input;


### PR DESCRIPTION
Lower the normal DATA connect timeout in the server to speed up torture tests.

- tests/ftpserver.pl blocks when expecting a DATA connection from the client.
- the previous 10 seconds were encountered repeatedly in torture tests and let to long waits.
- 2 seconds should still be sufficient for current hw, but CI will show.