### PR TITLE
getinfo: add CURLINFO_ADDED_TIME_T

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2909,6 +2909,7 @@ typedef enum {
   CURLINFO_REFERER          = CURLINFO_STRING + 60,
   CURLINFO_CAINFO           = CURLINFO_STRING + 61,
   CURLINFO_CAPATH           = CURLINFO_STRING + 62,
+  CURLINFO_ADDED_TIME_T     = CURLINFO_OFF_T + 63, /* debug only for now */
   CURLINFO_LASTONE          = 62
 } CURLINFO;
 

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -391,7 +391,12 @@ static CURLcode getinfo_offt(struct Curl_easy *data, CURLINFO info,
     *param_offt = (data->progress.flags & PGRS_UL_SIZE_KNOWN)?
       data->progress.size_ul:-1;
     break;
-   case CURLINFO_TOTAL_TIME_T:
+#ifdef CURLDEBUG
+  case CURLINFO_ADDED_TIME_T:
+    *param_offt = data->progress.t_added;
+    break;
+#endif
+  case CURLINFO_TOTAL_TIME_T:
     *param_offt = data->progress.timespent;
     break;
   case CURLINFO_NAMELOOKUP_TIME_T:

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -149,6 +149,9 @@ struct Curl_multi {
   struct curltime timer_lastcall; /* the fixed time for the timeout for the
                                     previous callback */
   unsigned int max_concurrent_streams;
+#ifdef CURLDEBUG
+  struct curltime t_created;
+#endif
 
 #ifdef USE_WINSOCK
   WSAEVENT wsa_event; /* winsock event used for waits */

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -181,6 +181,14 @@ struct curltime Curl_pgrsTime(struct Curl_easy *data, timerid timer)
   case TIMER_NONE:
     /* mistake filter */
     break;
+#ifdef CURLDEBUG
+  case TIMER_ADDED: {
+    /* relative time from the creation of the multi handle */
+    struct Curl_multi *m = data->multi_easy ? data->multi_easy : data->multi;
+    data->progress.t_added = Curl_timediff_us(now, m->t_created);
+    break;
+  }
+#endif
   case TIMER_STARTOP:
     /* This is set at the start of a transfer */
     data->progress.t_startop = now;

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -39,6 +39,9 @@ typedef enum {
   TIMER_POSTRANSFER,
   TIMER_STARTACCEPT,
   TIMER_REDIRECT,
+#ifdef CURLDEBUG
+  TIMER_ADDED,
+#endif
   TIMER_LAST /* must be last */
 } timerid;
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1278,14 +1278,6 @@ int Curl_single_getsock(struct Curl_easy *data,
   return bitmap;
 }
 
-/* Curl_init_CONNECT() gets called each time the handle switches to CONNECT
-   which means this gets called once for each subsequent redirect etc */
-void Curl_init_CONNECT(struct Curl_easy *data)
-{
-  data->state.fread_func = data->set.fread_func_set;
-  data->state.in = data->set.in_set;
-}
-
 /*
  * Curl_pretransfer() is called immediately before a transfer starts, and only
  * once for one transfer no matter if it has redirects or do multi-pass

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -29,8 +29,6 @@ char *Curl_checkheaders(const struct Curl_easy *data,
                         const char *thisheader,
                         const size_t thislen);
 
-void Curl_init_CONNECT(struct Curl_easy *data);
-
 CURLcode Curl_pretransfer(struct Curl_easy *data);
 CURLcode Curl_posttransfer(struct Curl_easy *data);
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1164,6 +1164,9 @@ struct Progress {
   timediff_t t_pretransfer;
   timediff_t t_starttransfer;
   timediff_t t_redirect;
+#ifdef CURLDEBUG
+  timediff_t t_added;
+#endif
 
   struct curltime start;
   struct curltime t_startsingle;

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -111,6 +111,7 @@ static const struct writeoutvar variables[] = {
    writeLong},
   {"stderr", VAR_STDERR, CURLINFO_NONE, NULL},
   {"stdout", VAR_STDOUT, CURLINFO_NONE, NULL},
+  {"time_added", VAR_ADDED_TIME, CURLINFO_ADDED_TIME_T, writeTime},
   {"time_appconnect", VAR_APPCONNECT_TIME, CURLINFO_APPCONNECT_TIME_T,
    writeTime},
   {"time_connect", VAR_CONNECT_TIME, CURLINFO_CONNECT_TIME_T, writeTime},

--- a/src/tool_writeout.h
+++ b/src/tool_writeout.h
@@ -28,6 +28,7 @@
 
 typedef enum {
   VAR_NONE,       /* must be the first */
+  VAR_ADDED_TIME,
   VAR_APPCONNECT_TIME,
   VAR_CERT,
   VAR_CONNECT_TIME,


### PR DESCRIPTION
initial take for debug and discussion purposes

This timer is a relative time from when multi handle is created until the MSTATE_DO state executes. Exposed for the tool as `%{time_added}`.

Debug-only for now.

@icing here's a first take for what we discussed. Good enough? Needs tweaking?