### PR TITLE
lib670: make test.h the first include

### DIFF
--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -22,13 +22,13 @@
  *
  ***************************************************************************/
 
-#include <time.h>
-
 #if !defined(LIB670) && !defined(LIB671)
 #define CURL_DISABLE_DEPRECATION  /* Using and testing the form api */
 #endif
 
 #include "test.h"
+
+#include <time.h>
 
 #include "memdebug.h"
 


### PR DESCRIPTION
As in all other lib tests. This avoids a macro redefinition warning for `_FILE_OFFSET_BITS` visible in the autobuilds.