### PR TITLE
Add additional condition for including stdint.h in lib/http.h

### DIFF
--- a/lib/http.h
+++ b/lib/http.h
@@ -42,7 +42,7 @@ typedef enum {
 
 #ifndef CURL_DISABLE_HTTP
 
-#if defined(_WIN32) && defined(ENABLE_QUIC)
+#if defined(_WIN32) && (defined(ENABLE_QUIC) || defined(USE_NGHTTP2))
 #include <stdint.h>
 #endif
 


### PR DESCRIPTION
stdint.h was only included in http.h when ENABLE_QUIC was defined, but symbols from stdint.h are also used when USE_NGHTTP2 is defined. This causes build errors when USE_NGHTTP2 is defined but ENABLE_QUIC is not.

I don't know if such a configuration *should* be possible, but I had a friend encounter it while building media-autobuild_suite.

Fixes m-ab-s/media-autobuild_suite#2353