### PR TITLE
test1560: use a UTF8-using locale when run

### DIFF
--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -12,6 +12,9 @@ URLAPI
 <server>
 none
 </server>
+<setenv>
+LANG=en_US.UTF-8
+</setenv>
 <features>
 file
 https


### PR DESCRIPTION
There are odd cases that don't use UTF8 and then the IDN handling goes wrong.

Reported-by: Marcel Raad
Fixes #10193