### PR TITLE
runtest.pl: add expected fourth return value

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1542,7 +1542,7 @@ sub runhttp2server {
 
     # don't retry if the server doesn't work
     if ($doesntrun{$pidfile}) {
-        return (0, 0, 0);
+        return (0, 0, 0, 0);
     }
 
     my $pid = processexists($pidfile);


### PR DESCRIPTION
Fixes warning in autobild log: "Use of uninitialized value $HTTP2TLSPORT in substitution iterator at /tests/runtests.pl line 3516"