### PR TITLE
Revert "x509asn1: avoid freeing unallocated pointers"

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1348,15 +1348,14 @@ CURLcode Curl_verifyhost(struct Curl_cfilter *cf,
           break;
         switch(name.tag) {
         case 2: /* DNS name. */
-          matched = 0;
           len = utf8asn1str(&dnsname, CURL_ASN1_IA5_STRING,
                             name.beg, name.end);
-          if(len > 0) {
-            if(size_t)len == strlen(dnsname)
-              matched = Curl_cert_hostcheck(dnsname, (size_t)len,
-                                            connssl->hostname, hostlen);
-            free(dnsname);
-          }
+          if(len > 0 && (size_t)len == strlen(dnsname))
+            matched = Curl_cert_hostcheck(dnsname, (size_t)len,
+                                          connssl->hostname, hostlen);
+          else
+            matched = 0;
+          free(dnsname);
           break;
 
         case 7: /* IP address. */
@@ -1406,8 +1405,10 @@ CURLcode Curl_verifyhost(struct Curl_cfilter *cf,
     failf(data, "SSL: unable to obtain common name from peer certificate");
   else {
     len = utf8asn1str(&dnsname, elem.tag, elem.beg, elem.end);
-    if(len < 0)
+    if(len < 0) {
+      free(dnsname);
       return CURLE_OUT_OF_MEMORY;
+    }
     if(strlen(dnsname) != (size_t) len)         /* Nul byte in string ? */
       failf(data, "SSL: illegal cert name field");
     else if(Curl_cert_hostcheck((const char *) dnsname,


### PR DESCRIPTION
This reverts commit 6b19247e794cfdf4ec63c5880d8f4f5485f653ab.

Fixes #10163