### PR TITLE
ngtcp2: fix the build without 'sendmsg'

### DIFF
--- a/lib/vquic/ngtcp2.c
+++ b/lib/vquic/ngtcp2.c
@@ -1707,7 +1707,6 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
   }
 #else
   ssize_t sent;
-  (void)qs;
   (void)gsolen;
 
   *psent = 0;


### PR DESCRIPTION
Follow-up from 71b7e0161032