### PR TITLE
Remove/Replace Curl_addrinfo references at connectdata and filters

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -369,10 +369,14 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
 
   cf = data->conn->cfilter[sockindex];
   DEBUGASSERT(cf);
+  if(!cf)
+    return CURLE_FAILED_INIT;
+
   *done = cf->connected;
   if(!*done) {
-    result = cf->cft->connect (cf, data, blocking, done);
+    result = cf->cft->connect(cf, data, blocking, done);
     if(!result && *done) {
+      Curl_conn_ev_update_info(data, data->conn);
       data->conn->keepalive = Curl_now();
     }
   }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1010,9 +1010,9 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
 
     if(*addr != '\0') {
       /* attempt to get the address of the given interface name */
-      switch(Curl_if2ip(conn->ip_addr->ai_family,
+      switch(Curl_if2ip(conn->remote_addr->family,
 #ifdef ENABLE_IPV6
-                        Curl_ipv6_scope(conn->ip_addr->ai_addr),
+                        Curl_ipv6_scope(&conn->remote_addr->sa_addr),
                         conn->scope_id,
 #endif
                         addr, hbuf, sizeof(hbuf))) {

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -46,6 +46,7 @@
 #endif
 
 #include "urldata.h"
+#include "cf-socket.h"
 #include "curl_base64.h"
 #include "ftp.h"
 #include "curl_gssapi.h"
@@ -207,8 +208,8 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
   gss_ctx_id_t *context = app_data;
   struct gss_channel_bindings_struct chan;
   size_t base64_sz = 0;
-  struct sockaddr_in **remote_addr =
-    (struct sockaddr_in **)&conn->ip_addr->ai_addr;
+  struct sockaddr_in *remote_addr =
+    (struct sockaddr_in *)&conn->remote_addr->sa_addr;
   char *stringp;
 
   if(getsockname(conn->sock[FIRSTSOCKET],
@@ -220,7 +221,7 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
   chan.initiator_address.value = &conn->local_addr.sin_addr.s_addr;
   chan.acceptor_addrtype = GSS_C_AF_INET;
   chan.acceptor_address.length = l - 4;
-  chan.acceptor_address.value = &(*remote_addr)->sin_addr.s_addr;
+  chan.acceptor_address.value = &remote_addr->sin_addr.s_addr;
   chan.application_data.length = 0;
   chan.application_data.value = NULL;
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -363,7 +363,7 @@ ssize_t Curl_send_plain(struct Curl_easy *data, int num,
 #if defined(MSG_FASTOPEN) && !defined(TCP_FASTOPEN_CONNECT) /* Linux */
   if(conn->bits.tcp_fastopen) {
     bytes_written = sendto(sockfd, mem, len, MSG_FASTOPEN,
-                           conn->ip_addr->ai_addr, conn->ip_addr->ai_addrlen);
+                           conn->remote_addr.addr, conn->remote_addr.addrlen);
     conn->bits.tcp_fastopen = FALSE;
   }
   else

--- a/lib/url.c
+++ b/lib/url.c
@@ -3381,9 +3381,6 @@ static void reuse_conn(struct Curl_easy *data,
   existing->hostname_resolve = temp->hostname_resolve;
   temp->hostname_resolve = NULL;
 
-  /* persist existing connection info in data */
-  Curl_conn_ev_update_info(data, existing);
-
   conn_reset_all_postponed_data(temp); /* free buffers */
 
   /* re-use init */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -907,10 +907,9 @@ struct connectdata {
      there is no name resolve done. */
   struct Curl_dns_entry *dns_entry;
 
-  /* 'ip_addr' is the particular IP we connected to. It points to a struct
-     within the DNS cache, so this pointer is only valid as long as the DNS
-     cache entry remains locked. It gets unlocked in multi_done() */
-  const struct Curl_addrinfo *ip_addr;
+  /* 'remote_addr' is the particular IP we connected to. it is owned, set
+   * and NULLed by the connected socket filter (if there is one). */
+  const struct Curl_sockaddr_ex *remote_addr;
 
   struct hostname host;
   char *hostname_resolve; /* host name to resolve to address, allocated */


### PR DESCRIPTION
Keep sockaddr local in the socket filters.

- copy `struct Curl_addrinfo` on filter setup into context
- replace `struct Curl_addrinfo *` with `struct Curl_sockaddr_ex *` in connectdata that is set and NULLed by the socket filter
- this means we have no reference to the resolver info in connectdata or its filters

- trigger the CF_CTRL_CONN_INFO_UPDATE event when the complete filter chain reaches connected status
- update easy handle connection information on CF_CTRL_DATA_SETUP event.