### PR TITLE
cmake: set SOVERSION also for macOS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -108,6 +108,7 @@ set_target_properties(${LIB_NAME} PROPERTIES
 
 if(CMAKE_SYSTEM_NAME STREQUAL "AIX" OR
   CMAKE_SYSTEM_NAME STREQUAL "Linux" OR
+  CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
   CMAKE_SYSTEM_NAME STREQUAL "GNU/kFreeBSD" OR
 
   # FreeBSD comes with the a.out and elf flavours


### PR DESCRIPTION
 https://github.com/curl/curl/pull/10023 added support for SOVERSION in CMake, which is great. But Mac is missing in the listed platforms. It works fine on Mac and it matches the Autotools output, which also sets the soversion.

The installed libs I get after adding Darwin to the list:
```
libcurl.4.8.0.dylib
libcurl.4.dylib -> libcurl.4.8.0.dylib
libcurl.dylib -> libcurl.4.dylib
```

I think this is correct.