### PR TITLE
misc: fix typos in comments which repeat a word

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -356,7 +356,7 @@ struct eyeballer {
   int ai_family;                     /* matching address family only */
   cf_ip_connect_create *cf_create;   /* for creating cf */
   struct Curl_cfilter *cf;           /* current sub-cfilter connecting */
-  struct eyeballer *primary;         /* eyeballer this one is is backup for */
+  struct eyeballer *primary;         /* eyeballer this one is backup for */
   timediff_t delay_ms;               /* delay until start */
   timediff_t timeoutms;              /* timeout for all tries */
   expire_id timeout_id;              /* ID for Curl_expire() */

--- a/lib/url.c
+++ b/lib/url.c
@@ -2318,7 +2318,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
       result = CURLE_OUT_OF_MEMORY;
       goto error;
     }
-    /* path will be "/", if no path was was found */
+    /* path will be "/", if no path was found */
     if(strcmp("/", path)) {
       is_unix_proxy = TRUE;
       free(host);


### PR DESCRIPTION
Remove erroneously duplicated words in code comments of files `lib.connect.c` and `lib/url.c`.