### PR TITLE
CURLOPT_HEADERDATA.3: warn DLL users must set write function

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.3
@@ -40,6 +40,10 @@ If \fICURLOPT_WRITEFUNCTION(3)\fP or \fICURLOPT_HEADERFUNCTION(3)\fP is used,
 
 If neither of those options are set, \fIpointer\fP must be a valid FILE * and
 it will be used by a plain fwrite() to write headers to.
+
+If you are using libcurl as a win32 DLL, you \fBMUST\fP use a
+\fICURLOPT_WRITEFUNCTION(3)\fP or \fICURLOPT_HEADERFUNCTION(3)\fP if you set
+this option or you will experience crashes.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS


### PR DESCRIPTION
- Warn that in Windows if libcurl is running from a DLL and if CURLOPT_HEADERDATA is set then CURLOPT_WRITEFUNCTION or CURLOPT_HEADERFUNCTION must be set as well, otherwise the user may experience crashes.

We already have a similar warning in CURLOPT_WRITEDATA. Basically, in Windows libcurl could crash writing a FILE pointer that was created by a different C runtime. In Windows each DLL that is part of a program may or may not have its own C runtime.

Ref: https://github.com/curl/curl/issues/10231

Closes #xxxx