### PR TITLE
CURLOPT_SSL_CTX_FUNCTION for ngtcp2

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -354,6 +354,19 @@ static SSL_CTX *quic_ssl_ctx(struct Curl_cfilter *cf, struct Curl_easy *data)
     }
 #endif
   }
+
+  /* give application a chance to interfere with SSL set up. */
+  if(data->set.ssl.fsslctx) {
+    CURLcode result;
+    Curl_set_in_callback(data, true);
+    result = (*data->set.ssl.fsslctx)(data, ssl_ctx,
+                                      data->set.ssl.fsslctxp);
+    Curl_set_in_callback(data, false);
+    if(result) {
+      failf(data, "error signaled by ssl ctx callback");
+      return NULL;
+    }
+  }
   return ssl_ctx;
 }
 
@@ -527,6 +540,18 @@ static WOLFSSL_CTX *quic_ssl_ctx(struct Curl_cfilter *cf,
     wolfSSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);
   }
 
+  /* give application a chance to interfere with SSL set up. */
+  if(data->set.ssl.fsslctx) {
+    CURLcode result;
+    Curl_set_in_callback(data, true);
+    result = (*data->set.ssl.fsslctx)(data, ssl_ctx,
+                                      data->set.ssl.fsslctxp);
+    Curl_set_in_callback(data, false);
+    if(result) {
+      failf(data, "error signaled by ssl ctx callback");
+      return NULL;
+    }
+  }
   return ssl_ctx;
 }
 

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -56,5 +56,14 @@ CURLcode Curl_ossl_set_client_cert(struct Curl_easy *data,
 
 CURLcode Curl_ossl_certchain(struct Curl_easy *data, SSL *ssl);
 
+/**
+ * Setup the OpenSSL X509_STORE in `ssl_ctx` for the cfilter `cf` and
+ * easy handle `data`. Will allow reuse of a shared cache if suitable
+ * and configured.
+ */
+CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   SSL_CTX *ssl_ctx);
+
 #endif /* USE_OPENSSL */
 #endif /* HEADER_CURL_SSLUSE_H */


### PR DESCRIPTION
Adding CURLOPT_SSL_CTX_FUNCTION support for openssl+wolfssl in ngtcp2 quic. Refs #10222.