### PR TITLE
File renames in vquic implementations, fix for quiche build.

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -79,15 +79,15 @@ LIB_VTLS_HFILES =           \
   vtls/x509asn1.h
 
 LIB_VQUIC_CFILES = \
-  vquic/msh3.c   \
-  vquic/ngtcp2.c   \
-  vquic/quiche.c   \
+  vquic/curl_msh3.c   \
+  vquic/curl_ngtcp2.c   \
+  vquic/curl_quiche.c   \
   vquic/vquic.c
 
 LIB_VQUIC_HFILES = \
-  vquic/msh3.h   \
-  vquic/ngtcp2.h   \
-  vquic/quiche.h   \
+  vquic/curl_msh3.h   \
+  vquic/curl_ngtcp2.h   \
+  vquic/curl_quiche.h   \
   vquic/vquic.h    \
   vquic/vquic_int.h
 

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -33,7 +33,7 @@
 #include "cfilters.h"
 #include "connect.h"
 #include "h2h3.h"
-#include "msh3.h"
+#include "curl_msh3.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/vquic/curl_msh3.h
+++ b/lib/vquic/curl_msh3.h
@@ -1,5 +1,5 @@
-#ifndef HEADER_CURL_VQUIC_NGTCP2_H
-#define HEADER_CURL_VQUIC_NGTCP2_H
+#ifndef HEADER_CURL_VQUIC_CURL_MSH3_H
+#define HEADER_CURL_VQUIC_CURL_MSH3_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -26,36 +26,21 @@
 
 #include "curl_setup.h"
 
-#ifdef USE_NGTCP2
+#ifdef USE_MSH3
 
-#ifdef HAVE_NETINET_UDP_H
-#include <netinet/udp.h>
-#endif
+#include <msh3.h>
 
-#include <ngtcp2/ngtcp2_crypto.h>
-#include <nghttp3/nghttp3.h>
-#ifdef USE_OPENSSL
-#include <openssl/ssl.h>
-#elif defined(USE_WOLFSSL)
-#include <wolfssl/options.h>
-#include <wolfssl/ssl.h>
-#include <wolfssl/quic.h>
-#endif
+void Curl_msh3_ver(char *p, size_t len);
 
-struct Curl_cfilter;
-
-#include "urldata.h"
-
-void Curl_ngtcp2_ver(char *p, size_t len);
-
-CURLcode Curl_cf_ngtcp2_create(struct Curl_cfilter **pcf,
+CURLcode Curl_cf_msh3_create(struct Curl_cfilter **pcf,
                              struct Curl_easy *data,
                              struct connectdata *conn,
                              const struct Curl_addrinfo *ai);
 
-bool Curl_conn_is_ngtcp2(const struct Curl_easy *data,
-                         const struct connectdata *conn,
-                         int sockindex);
-#endif
+bool Curl_conn_is_msh3(const struct Curl_easy *data,
+                       const struct connectdata *conn,
+                       int sockindex);
 
-#endif /* HEADER_CURL_VQUIC_NGTCP2_H */
+#endif /* USE_MSQUIC */
+
+#endif /* HEADER_CURL_VQUIC_CURL_MSH3_H */

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -48,7 +48,6 @@
 #include "sendf.h"
 #include "strdup.h"
 #include "rand.h"
-#include "ngtcp2.h"
 #include "multiif.h"
 #include "strcase.h"
 #include "cfilters.h"
@@ -60,6 +59,7 @@
 #include "h2h3.h"
 #include "vtls/keylog.h"
 #include "vtls/vtls.h"
+#include "curl_ngtcp2.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/vquic/curl_ngtcp2.h
+++ b/lib/vquic/curl_ngtcp2.h
@@ -1,5 +1,5 @@
-#ifndef HEADER_CURL_VQUIC_MSH3_H
-#define HEADER_CURL_VQUIC_MSH3_H
+#ifndef HEADER_CURL_VQUIC_CURL_NGTCP2_H
+#define HEADER_CURL_VQUIC_CURL_NGTCP2_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -26,21 +26,36 @@
 
 #include "curl_setup.h"
 
-#ifdef USE_MSH3
+#ifdef USE_NGTCP2
 
-#include <msh3.h>
+#ifdef HAVE_NETINET_UDP_H
+#include <netinet/udp.h>
+#endif
 
-void Curl_msh3_ver(char *p, size_t len);
+#include <ngtcp2/ngtcp2_crypto.h>
+#include <nghttp3/nghttp3.h>
+#ifdef USE_OPENSSL
+#include <openssl/ssl.h>
+#elif defined(USE_WOLFSSL)
+#include <wolfssl/options.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/quic.h>
+#endif
 
-CURLcode Curl_cf_msh3_create(struct Curl_cfilter **pcf,
+struct Curl_cfilter;
+
+#include "urldata.h"
+
+void Curl_ngtcp2_ver(char *p, size_t len);
+
+CURLcode Curl_cf_ngtcp2_create(struct Curl_cfilter **pcf,
                              struct Curl_easy *data,
                              struct connectdata *conn,
                              const struct Curl_addrinfo *ai);
 
-bool Curl_conn_is_msh3(const struct Curl_easy *data,
-                       const struct connectdata *conn,
-                       int sockindex);
+bool Curl_conn_is_ngtcp2(const struct Curl_easy *data,
+                         const struct connectdata *conn,
+                         int sockindex);
+#endif
 
-#endif /* USE_MSQUIC */
-
-#endif /* HEADER_CURL_VQUIC_MSH3_H */
+#endif /* HEADER_CURL_VQUIC_CURL_NGTCP2_H */

--- a/lib/vquic/curl_quiche.h
+++ b/lib/vquic/curl_quiche.h
@@ -1,5 +1,5 @@
-#ifndef HEADER_CURL_VQUIC_QUICHE_H
-#define HEADER_CURL_VQUIC_QUICHE_H
+#ifndef HEADER_CURL_VQUIC_CURL_QUICHE_H
+#define HEADER_CURL_VQUIC_CURL_QUICHE_H
 /***************************************************************************
  *                                  _   _ ____  _
  *  Project                     ___| | | |  _ \| |
@@ -47,4 +47,4 @@ bool Curl_conn_is_quiche(const struct Curl_easy *data,
 
 #endif
 
-#endif /* HEADER_CURL_VQUIC_QUICHE_H */
+#endif /* HEADER_CURL_VQUIC_CURL_QUICHE_H */

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -32,9 +32,9 @@
 #include "urldata.h"
 #include "dynbuf.h"
 #include "curl_printf.h"
-#include "msh3.h"
-#include "ngtcp2.h"
-#include "quiche.h"
+#include "curl_msh3.h"
+#include "curl_ngtcp2.h"
+#include "curl_quiche.h"
 #include "vquic.h"
 
 #ifdef O_BINARY


### PR DESCRIPTION
- quiche in debug mode did not build, fixed.
- moved all vquic implementation files to prefix curl_* to avoid the potential mixups between provided .h files and our own.
- quich passes test 2500 and 2502. 2501, the POST, fail with the body being rejected. Quich bug?