### PR TITLE
pretransfer: fail on Windows if WRITEDATA set without WRITEFUNCTION

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1203,6 +1203,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * Custom pointer to pass the header write callback function
      */
     data->set.writeheader = (void *)va_arg(param, void *);
+    data->set.is_writeheader_from_user = true;
     break;
   case CURLOPT_ERRORBUFFER:
     /*
@@ -1217,6 +1218,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * used as argument to the write callback.
      */
     data->set.out = va_arg(param, void *);
+    data->set.is_out_from_user = true;
     break;
 
   case CURLOPT_DIRLISTONLY:
@@ -1349,6 +1351,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * used as argument to the read callback.
      */
     data->set.in_set = va_arg(param, void *);
+    data->set.is_in_set_from_user = true;
     break;
   case CURLOPT_INFILESIZE:
     /*
@@ -1661,15 +1664,23 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * Set header write callback
      */
     data->set.fwrite_header = va_arg(param, curl_write_callback);
+    if(!data->set.fwrite_header)
+      data->set.is_fwrite_header_from_user = false;
+    else
+      data->set.is_fwrite_header_from_user = true;
     break;
   case CURLOPT_WRITEFUNCTION:
     /*
      * Set data write callback
      */
     data->set.fwrite_func = va_arg(param, curl_write_callback);
-    if(!data->set.fwrite_func)
+    if(!data->set.fwrite_func) {
+      data->set.is_fwrite_func_from_user = false;
       /* When set to NULL, reset to our internal default function */
       data->set.fwrite_func = (curl_write_callback)fwrite;
+    }
+    else
+      data->set.is_fwrite_func_from_user = true;
     break;
   case CURLOPT_READFUNCTION:
     /*
@@ -1677,12 +1688,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      */
     data->set.fread_func_set = va_arg(param, curl_read_callback);
     if(!data->set.fread_func_set) {
-      data->set.is_fread_set = 0;
+      data->set.is_fread_set_from_user = false;
       /* When set to NULL, reset to our internal default function */
       data->set.fread_func_set = (curl_read_callback)fread;
     }
     else
-      data->set.is_fread_set = 1;
+      data->set.is_fread_set_from_user = true;
     break;
   case CURLOPT_SEEKFUNCTION:
     /*

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1700,6 +1700,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * Seek callback. Might be NULL.
      */
     data->set.seek_func = va_arg(param, curl_seek_callback);
+    if(!data->set.seek_func)
+      data->set.is_seek_func_from_user = false;
+    else
+      data->set.is_seek_func_from_user = true;
     break;
   case CURLOPT_SEEKDATA:
     /*
@@ -1712,6 +1716,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * I/O control callback. Might be NULL.
      */
     data->set.ioctl_func = va_arg(param, curl_ioctl_callback);
+    if(!data->set.ioctl_func)
+      data->set.is_ioctl_func_from_user = false;
+    else
+      data->set.is_ioctl_func_from_user = true;
     break;
   case CURLOPT_IOCTLDATA:
     /*

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -45,6 +45,9 @@ static HMODULE s_hIpHlpApiDll = NULL;
 /* Pointer to the if_nametoindex function */
 IF_NAMETOINDEX_FN Curl_if_nametoindex = NULL;
 
+/* Pointer to the GetModuleHandleExA function */
+GETMODULEHANDLEEXA_FN Curl_GetModuleHandleExA = NULL;
+
 /* Curl_win32_init() performs win32 global initialization */
 CURLcode Curl_win32_init(long flags)
 {
@@ -92,6 +95,10 @@ CURLcode Curl_win32_init(long flags)
       return result;
   }
 #endif
+
+  Curl_GetModuleHandleExA =
+    CURLX_FUNCTION_CAST(GETMODULEHANDLEEXA_FN,
+      GetProcAddress(GetModuleHandleA("kernel32"), "GetModuleHandleExA"));
 
   s_hIpHlpApiDll = Curl_load_library(TEXT("iphlpapi.dll"));
   if(s_hIpHlpApiDll) {

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -40,6 +40,21 @@ typedef unsigned int(WINAPI *IF_NAMETOINDEX_FN)(const char *);
 /* This is used instead of if_nametoindex if available on Windows */
 extern IF_NAMETOINDEX_FN Curl_if_nametoindex;
 
+#ifndef GET_MODULE_HANDLE_EX_FLAG_PIN
+#define GET_MODULE_HANDLE_EX_FLAG_PIN                  0x00000001
+#endif
+#ifndef GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT
+#define GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT   0x00000002
+#endif
+#ifndef GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+#define GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS         0x00000004
+#endif
+
+typedef BOOL(WINAPI *GETMODULEHANDLEEXA_FN)(DWORD, LPCSTR, HMODULE *);
+
+/* This is used instead of GetModuleHandleExA if available on Windows */
+extern GETMODULEHANDLEEXA_FN Curl_GetModuleHandleExA;
+
 /* This is used to dynamically load DLLs */
 HMODULE Curl_load_library(LPCTSTR filename);
 

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1319,7 +1319,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
   /* If stdin_handle is a pipe, use PeekNamedPipe() method to check it,
      else use the old WaitForMultipleObjects() way */
   if(GetFileType(stdin_handle) == FILE_TYPE_PIPE ||
-     data->set.is_fread_set) {
+     data->set.is_fread_set_from_user) {
     /* Don't wait for stdin_handle, just wait for event_handle */
     obj_count = 1;
     /* Check stdin_handle per 100 milliseconds */
@@ -1340,7 +1340,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case WAIT_TIMEOUT:
     {
       for(;;) {
-        if(data->set.is_fread_set) {
+        if(data->set.is_fread_set_from_user) {
           size_t n;
           /* read from user-supplied method */
           n = data->state.fread_func(buf, 1, buf_size, data->state.in);
@@ -1475,7 +1475,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
   pfd[0].fd = sockfd;
   pfd[0].events = POLLIN;
 
-  if(data->set.is_fread_set) {
+  if(data->set.is_fread_set_from_user) {
     poll_cnt = 1;
     interval_ms = 100; /* poll user-supplied read function */
   }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1314,6 +1314,20 @@ static CURLcode check_for_option_conflicts(struct Curl_easy *data)
 #endif
 
     if(dll) {
+      if(data->set.is_ioctl_func_from_user &&
+         (!data->set.is_in_set_from_user ||
+          !data->set.is_fread_set_from_user)) {
+        failf(data, "Windows DLL users must set CURLOPT_READDATA and "
+                    "CURLOPT_READFUNCTION if CURLOPT_IOCTLFUNCTION is set.");
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+      }
+      if(data->set.is_seek_func_from_user &&
+         (!data->set.is_in_set_from_user ||
+          !data->set.is_fread_set_from_user)) {
+        failf(data, "Windows DLL users must set CURLOPT_READDATA and "
+                    "CURLOPT_READFUNCTION if CURLOPT_SEEKFUNCTION is set.");
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+      }
       if(data->set.is_in_set_from_user &&
          !data->set.is_fread_set_from_user) {
         failf(data, "Windows DLL users must set CURLOPT_READFUNCTION if "

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1293,15 +1293,25 @@ static CURLcode check_for_option_conflicts(struct Curl_easy *data)
   if(Curl_GetModuleHandleExA) {
     HMODULE module;
 
+/* disable warning for function pointer to data pointer */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#elif defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable:4054) /* function pointer to data pointer */
+#pragma warning(disable:4054)
+#endif
     bool dll = /* true if our code is running from a DLL */
       Curl_GetModuleHandleExA(
         (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT),
         ((LPCSTR)(void *)check_for_option_conflicts), &module) &&
       module != GetModuleHandleA(NULL);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
 #pragma warning(pop)
+#endif
 
     if(dll) {
       if(data->set.is_in_set_from_user &&

--- a/lib/url.c
+++ b/lib/url.c
@@ -511,7 +511,6 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   /* use fread as default function to read input */
   set->fread_func_set = (curl_read_callback)fread;
-  set->is_fread_set = 0;
 
   set->seek_func = ZERO_NULL;
   set->seek_client = ZERO_NULL;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1805,7 +1805,18 @@ struct UserDefined {
 #endif
   unsigned char connect_only; /* make connection/request, then let
                                  application use the socket */
-  BIT(is_fread_set); /* has read callback been set to non-NULL? */
+  /* has READFUNCTION been set to non-NULL by user? */
+  BIT(is_fread_set_from_user);
+  /* has WRITEFUNCTION been set to non-NULL by user? */
+  BIT(is_fwrite_func_from_user);
+  /* has HEADERFUNCTION been set to non-NULL by user? */
+  BIT(is_fwrite_header_from_user);
+  /* has READDATA been set by user? */
+  BIT(is_in_set_from_user);
+  /* has WRITEDATA been set by user? */
+  BIT(is_out_from_user);
+  /* has HEADERDATA been set by user? */
+  BIT(is_writeheader_from_user);
 #ifndef CURL_DISABLE_TFTP
   BIT(tftp_no_options); /* do not send TFTP options requests */
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1805,6 +1805,10 @@ struct UserDefined {
 #endif
   unsigned char connect_only; /* make connection/request, then let
                                  application use the socket */
+  /* has SEEKFUNCTION been set to non-NULL by user? */
+  BIT(is_seek_func_from_user);
+  /* has IOCTLFUNCTION been set to non-NULL by user? */
+  BIT(is_ioctl_func_from_user);
   /* has READFUNCTION been set to non-NULL by user? */
   BIT(is_fread_set_from_user);
   /* has WRITEFUNCTION been set to non-NULL by user? */


### PR DESCRIPTION
.. and also do the same for set HEADERDATA without a set HEADERFUNCTION or WRITEFUNCTION; and READDATA without a set READFUNCTION.

Prior to this change if libcurl was running from a DLL and the user set the DATA option without also setting an applicable FUNCTION option then libcurl could crash writing to a FILE stream that was created by a different C runtime. This is because in Windows each DLL that is part of a program may or may not have its own C runtime.

We already warn about this in the WRITEDATA doc but apparently that is not enough.

Reported-by: Daniel Gibson

Fixes https://github.com/curl/curl/issues/10231
Closes #xxxx