### PR TITLE
sendf: fix build for Linux TCP fastopen

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -363,7 +363,8 @@ ssize_t Curl_send_plain(struct Curl_easy *data, int num,
 #if defined(MSG_FASTOPEN) && !defined(TCP_FASTOPEN_CONNECT) /* Linux */
   if(conn->bits.tcp_fastopen) {
     bytes_written = sendto(sockfd, mem, len, MSG_FASTOPEN,
-                           conn->remote_addr.addr, conn->remote_addr.addrlen);
+                           &conn->remote_addr->sa_addr,
+                           conn->remote_addr->addrlen);
     conn->bits.tcp_fastopen = FALSE;
   }
   else

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -188,6 +188,7 @@ typedef CURLcode (*Curl_datastream)(struct Curl_easy *data,
 #include "wildcard.h"
 #include "multihandle.h"
 #include "c-hyper.h"
+#include "cf-socket.h"
 
 #ifdef HAVE_GSSAPI
 # ifdef HAVE_GSSGNU


### PR DESCRIPTION
sendf: fix build for Linux TCP fastopen

- Fix the remote addr struct dereference.

- Include cf-socket.h in urldata.h.

Follow-up to 6a8d7ef9 which changed conn->ipaddr (Curl_addrinfo* ) member to conn->remote_addr (Curl_sockaddr_ex *) several days ago.

Reported-by: Stephan Guilloux

Fixes https://github.com/curl/curl/issues/10249
Closes #xxxx
