### PR TITLE
setopt: move the SHA256 opt within #ifdef libssh2

### DIFF
--- a/docs/cmdline-opts/hostpubsha256.d
+++ b/docs/cmdline-opts/hostpubsha256.d
@@ -13,3 +13,6 @@ Multi: single
 Pass a string containing a Base64-encoded SHA256 hash of the remote
 host's public key. Curl will refuse the connection with the host
 unless the hashes match.
+
+This feature requires libcurl to be built with libssh2 and does not work with
+other SSH backends.

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2531,6 +2531,14 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
                             va_arg(param, char *));
     break;
 
+  case CURLOPT_SSH_KNOWNHOSTS:
+    /*
+     * Store the file name to read known hosts from.
+     */
+    result = Curl_setstropt(&data->set.str[STRING_SSH_KNOWNHOSTS],
+                            va_arg(param, char *));
+    break;
+#ifdef USE_LIBSSH2
   case CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256:
     /*
      * Option to allow for the SHA256 of the host public key to be checked
@@ -2540,14 +2548,6 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
                             va_arg(param, char *));
     break;
 
-  case CURLOPT_SSH_KNOWNHOSTS:
-    /*
-     * Store the file name to read known hosts from.
-     */
-    result = Curl_setstropt(&data->set.str[STRING_SSH_KNOWNHOSTS],
-                            va_arg(param, char *));
-    break;
-#ifdef USE_LIBSSH2
   case CURLOPT_SSH_HOSTKEYFUNCTION:
     /* the callback to check the hostkey without the knownhost file */
     data->set.ssh_hostkeyfunc = va_arg(param, curl_sshhostkeycallback);


### PR DESCRIPTION
Because only the libssh2 backend supports it and thus this should return error if this option is used with
other backends.

Reported-by: Harry Sintonen