### PR TITLE
curl.h: allow up to 10M buffer size

### DIFF
--- a/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
@@ -41,11 +41,13 @@ This is just treated as a request, not an order. You cannot be guaranteed to
 actually get the given size.
 
 This buffer size is by default \fICURL_MAX_WRITE_SIZE\fP (16kB). The maximum
-buffer size allowed to be set is \fICURL_MAX_READ_SIZE\fP (512kB). The minimum
+buffer size allowed to be set is \fICURL_MAX_READ_SIZE\fP (10MB). The minimum
 buffer size allowed to be set is 1024.
 
 DO NOT set this option on a handle that is currently used for an active
 transfer as that may lead to unintended consequences.
+
+The maximum size was 512kB until 7.88.0.
 .SH DEFAULT
 CURL_MAX_WRITE_SIZE (16kB)
 .SH PROTOCOLS

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -248,7 +248,7 @@ typedef int (*curl_xferinfo_callback)(void *clientp,
 
 #ifndef CURL_MAX_READ_SIZE
   /* The maximum receive buffer size configurable via CURLOPT_BUFFERSIZE. */
-#define CURL_MAX_READ_SIZE 524288
+#define CURL_MAX_READ_SIZE (10*1024*1024)
 #endif
 
 #ifndef CURL_MAX_WRITE_SIZE


### PR DESCRIPTION
Bump the limit from 512K. There might be reasons for applications using h3 to set larger buffers and there is no strong reason for curl to have a very small maximum.

Ref: https://curl.se/mail/lib-2023-01/0026.html