### PR TITLE
autotools: use AC_SEARCH_LIBS instead of AC_CHECK_LIB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1054,7 +1054,7 @@ dnl gethostbyname without lib or in the nsl lib?
 AC_CHECK_FUNC(gethostbyname,
               [HAVE_GETHOSTBYNAME="1"
               ],
-              [ AC_CHECK_LIB(nsl, gethostbyname,
+              [ AC_SEARCH_LIBS([gethostbyname], [nsl],
                              [HAVE_GETHOSTBYNAME="1"
                              LIBS="-lnsl $LIBS"
                              ])


### PR DESCRIPTION
Maybe this would help with https://github.com/curl/curl/issues/10127 ?

https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Libraries.html#index-AC_005fCHECK_005fLIB-1

>AC_CHECK_LIB requires some care in usage, and should be avoided in some
common cases. Many standard functions like gethostbyname appear in the standard C library on some hosts, and in special libraries like nsl on other hosts. On some hosts the special libraries contain variant implementations that you may not want to use. These days it is normally better to use AC_SEARCH_LIBS([gethostbyname], [nsl]) instead of AC_CHECK_LIB([nsl], [gethostbyname]).