### PR TITLE
os400 fixes to make-lib.sh and initscript.sh

### DIFF
--- a/packages/OS400/initscript.sh
+++ b/packages/OS400/initscript.sh
@@ -234,7 +234,7 @@ make_module()
         CMD="${CMD} OPTIMIZE(${OPTIMIZE})"
         CMD="${CMD} DBGVIEW(${DEBUG})"
 
-        DEFINES="${3} BUILDING_LIBCURL"
+        DEFINES="${3} BUILDING_LIBCURL 'qadrt_use_inline'"
 
         if [ "${WITH_ZLIB}" != "0" ]
         then    DEFINES="${DEFINES} HAVE_LIBZ"


### PR DESCRIPTION
Adjust how exports list is generated from header files to account for declarations across multiple lines and CURL_DEPRECATED(...) tags.

Update initscript.sh

Specify qadrt_use_inline to prevent unistd.h in ASCII runtime defining close(a) -> close_a(a)

This addresses [issue 10266](https://github.com/curl/curl/issues/10266).