### PR TITLE
Documentation of cfilter debug logging options.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -158,7 +158,35 @@ SPDX-License-Identifier: curl
 
   All logs are generated in the log/ subdirectory (it is emptied first in the
   runtests.pl script). They remain in there after a test run.
+  
+### Log Verbosity
 
+  A curl build with `--enable-debug` offers more verbose output in the logs.
+  This applies not only for test cases, but also when running it standalone
+  with `curl -v`. A curl built with debug is ***not suitable for production***, 
+  but it greatly helps to track down problems.
+  
+  Sometimes, one needs very detailed logging of operations, but does not want
+  to drown in output. The newly introduced *connection filters* allows one to
+  dynamically increase log verbosity for a particular *filter type*. Example:
+  
+    CURL_DEBUG=ssl curl -v https://curl.se
+
+  will make the `ssl` connection filter log more details. One may do that for
+  every filter type and also use a combination of names, separated by `,` or 
+  space.
+  
+    CURL_DEBUG=ssl,http/2 curl -v https://curl.se
+
+   The order of filter type names is not relevant. Names used here are
+   case insensitive. Note that these names are implementation internals and
+   subject to change.
+   
+   Some, likely stable names are `tcp`, `ssl`, `http/2`. For a current list,
+   one may search the sources for `struct Curl_cftype` definitions and find
+   the names there. Also, some filters are only available with certain build
+   options, of course.
+   
 ### Test input files
 
   All test cases are put in the `data/` subdirectory. Each test is stored in

--- a/tests/README.md
+++ b/tests/README.md
@@ -163,10 +163,11 @@ SPDX-License-Identifier: curl
 
   A curl build with `--enable-debug` offers more verbose output in the logs.
   This applies not only for test cases, but also when running it standalone
-  with `curl -v`. A curl built with debug is ***not suitable for production***, 
-  but it greatly helps to track down problems.
+  with `curl -v`. While a curl debug built is
+  ***not suitable for production***, it is often helpful in tracking down
+  problems.
   
-  Sometimes, one needs very detailed logging of operations, but does not want
+  Sometimes, one needs detailed logging of operations, but does not want
   to drown in output. The newly introduced *connection filters* allows one to
   dynamically increase log verbosity for a particular *filter type*. Example:
   


### PR DESCRIPTION
List in ` tests/README.md` how the new dynamic logging can be used.