### PR TITLE
tool_getparam: fix compiler warning when !HAVE_WRITABLE_ARGV

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -691,6 +691,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                          by using --OPTION or --no-OPTION */
 #ifdef HAVE_WRITABLE_ARGV
   argv_item_t clearthis = NULL;
+#else
+  (void)cleararg;
 #endif
 
   static const char *redir_protos[] = {

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -689,12 +689,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   ParameterError err;
   bool toggle = TRUE; /* how to switch boolean options, on or off. Controlled
                          by using --OPTION or --no-OPTION */
-#ifdef HAVE_WRITABLE_ARGV
-  argv_item_t clearthis = NULL;
-#else
-  (void)cleararg;
-#endif
-
   static const char *redir_protos[] = {
     "http",
     "https",
@@ -702,6 +696,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     "ftps",
     NULL
   };
+#ifdef HAVE_WRITABLE_ARGV
+  argv_item_t clearthis = NULL;
+#else
+  (void)cleararg;
+#endif
 
   *usedarg = FALSE; /* default is that we don't use the arg */
 


### PR DESCRIPTION
Follow-up to 2ed0e1f70ee176edf3d2