### PR TITLE
CI: macOS fixup nghttp2 install

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,6 +87,8 @@ jobs:
           configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl
           macosx-version-min: 10.15
     steps:
+    - run: brew uninstall azure-cli pipx python@3.10 python@3.11
+      name: 'uninstall Python'
     - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 
@@ -149,6 +151,8 @@ jobs:
           install: nghttp2 openssl libssh2
           generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON
     steps:
+    - run: brew uninstall azure-cli pipx python@3.10 python@3.11
+      name: 'uninstall Python'
     - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,8 +87,9 @@ jobs:
           configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl
           macosx-version-min: 10.15
     steps:
+    # We need to uninstall Python 3.10 and 3.11 otherwise nghttp2 fail to install
     - run: brew uninstall azure-cli pipx python@3.10 python@3.11
-      name: 'uninstall Python'
+      name: 'uninstall unused dependencies'
     - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 
@@ -151,8 +152,9 @@ jobs:
           install: nghttp2 openssl libssh2
           generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON
     steps:
+    # We need to uninstall Python 3.10 and 3.11 otherwise nghttp2 fail to install
     - run: brew uninstall azure-cli pipx python@3.10 python@3.11
-      name: 'uninstall Python'
+      name: 'uninstall unused dependencies'
     - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 


### PR DESCRIPTION
branch rename of https://github.com/curl/curl/pull/10287
CI issue: https://github.com/curl/curl/actions/runs/3904373833/jobs/6670071643#step:3:590
Goal fixup macOS github CIs to install nghttp2
Solved by uninstall both Python3 versions 3.11 and 3.10
3.9 is used to install pip pkgs.