### PR TITLE
Disable log printf format checks on MINGW builds.

### DIFF
--- a/lib/curl_log.h
+++ b/lib/curl_log.h
@@ -82,7 +82,8 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
 
 void Curl_log_cf_debug(struct Curl_easy *data, struct Curl_cfilter *cf,
 #if defined(__GNUC__) && !defined(printf) && \
-    defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+    defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+    !defined(__MINGW32__) && !defined(__MINGW64__)
                        const char *fmt, ...)
                        __attribute__((format(printf, 3, 4)));
 #else


### PR DESCRIPTION
The MINGW compiler reports C99 and yet refuses to recognize %z formats. Disable printf log checks for these builds.