### PR TITLE
[Windows] Missing 'sleep()' for MSVC

### DIFF
--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -37,10 +37,6 @@
 
 #define DNS_TIMEOUT 1
 
-#if defined(WIN32) || defined(_WIN32)
-#define sleep(sec) Sleep ((sec)*1000)
-#endif
-
 static int debug_callback(CURL *curl, curl_infotype info, char *msg,
                           size_t len, void *ptr)
 {

--- a/tests/libtest/lib1542.c
+++ b/tests/libtest/lib1542.c
@@ -36,10 +36,6 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-#if defined(WIN32) || defined(_WIN32)
-#define sleep(sec) Sleep ((sec)*1000)
-#endif
-
 int test(char *URL)
 {
   CURL *easy = NULL;

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -42,6 +42,10 @@
 
 #include "curl_printf.h"
 
+#ifdef WIN32
+#define sleep(sec) Sleep ((sec)*1000)
+#endif
+
 #define test_setopt(A,B,C)                                      \
   if((res = curl_easy_setopt((A), (B), (C))) != CURLE_OK)       \
     goto test_cleanup


### PR DESCRIPTION
Done similar to how `lib1515.c` and `lib1542.c` does it for Windows.
Although MinGW do have `sleep()`, this patch should not hurt.
But perhaps add this to `test.h` instead?