### PR TITLE
ALPN handling improvements (v1)

### DIFF
--- a/docs/examples/http3.c
+++ b/docs/examples/http3.c
@@ -40,7 +40,8 @@ int main(void)
     /* Forcing HTTP/3 will make the connection fail if the server is not
        accessible over QUIC + HTTP/3 on the given host and port.
        Consider using CURLOPT_ALTSVC instead! */
-    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long)CURL_HTTP_VERSION_3);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION,
+                     (long)CURL_HTTP_VERSION_3ONLY);
 
     /* Perform the request, res will get the return code */
     res = curl_easy_perform(curl);

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1130,8 +1130,8 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   DEBUGASSERT(data->conn == cf->conn);
   nwritten = Curl_send_plain(data, cf->sockindex, buf, len, err);
-  DEBUGF(LOG_CF(data, cf, "send(len=%zu) -> %d, err=%d",
-                len, (int)nwritten, *err));
+  DEBUGF(LOG_CF(data, cf, "send(len=%zu) -> %zd, err=%d",
+                len, nwritten, *err));
   return nwritten;
 }
 
@@ -1142,8 +1142,8 @@ static ssize_t cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   DEBUGASSERT(data->conn == cf->conn);
   nread = Curl_recv_plain(data, cf->sockindex, buf, len, err);
-  DEBUGF(LOG_CF(data, cf, "recv(len=%zu) -> %d, err=%d", len, (int)nread,
-                *err));
+  DEBUGF(LOG_CF(data, cf, "recv(len=%zu) -> %zd, err=%d",
+                len, nread, *err));
   return nread;
 }
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1064,6 +1064,7 @@ struct cf_setup_ctx {
   cf_setup_state state;
   const struct Curl_dns_entry *remotehost;
   int ssl_mode;
+  int transport;
 };
 
 static CURLcode cf_setup_connect(struct Curl_cfilter *cf,
@@ -1087,8 +1088,7 @@ connect_sub_chain:
   }
 
   if(ctx->state < CF_SETUP_CNNCT_EYEBALLS) {
-    result = cf_he_insert_after(cf, data, ctx->remotehost,
-                                cf->conn->transport);
+    result = cf_he_insert_after(cf, data, ctx->remotehost, ctx->transport);
     if(result)
       return result;
     ctx->state = CF_SETUP_CNNCT_EYEBALLS;
@@ -1236,6 +1236,7 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
     ctx->state = CF_SETUP_INIT;
     ctx->remotehost = remotehost;
     ctx->ssl_mode = ssl_mode;
+    ctx->transport = conn->transport;
 
     result = Curl_cf_create(&cf, &Curl_cft_setup, ctx);
     if(result)

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -53,8 +53,11 @@ extern struct Curl_cftype Curl_cft_http3;
 
 #else /* ENABLE_QUIC */
 
-#define Curl_conn_is_http3(a,b,c)  FALSE
+#define Curl_conn_is_http3(a,b,c)   FALSE
 
 #endif /* !ENABLE_QUIC */
+
+CURLcode Curl_conn_may_http3(struct Curl_easy *data,
+                             const struct connectdata *conn);
 
 #endif /* HEADER_CURL_VQUIC_QUIC_H */

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -58,7 +58,7 @@ struct ssl_backend_data {
   unsigned char buf[BR_SSL_BUFSIZE_BIDI];
   br_x509_trust_anchor *anchors;
   size_t anchors_len;
-  const char *protocols[2];
+  const char *protocols[ALPN_ENTRIES_MAX];
   /* SSL client context is active */
   bool active;
   /* size of pending write, yet to be flushed */
@@ -691,35 +691,17 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
     Curl_ssl_sessionid_unlock(data);
   }
 
-  if(cf->conn->bits.tls_enable_alpn) {
-    int cur = 0;
+  if(connssl->alpn) {
+    struct alpn_proto_buf proto;
+    size_t i;
 
-    /* NOTE: when adding more protocols here, increase the size of the
-     * protocols array in `struct ssl_backend_data`.
-     */
-
-    if(data->state.httpwant == CURL_HTTP_VERSION_1_0) {
-      backend->protocols[cur++] = ALPN_HTTP_1_0;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_0);
+    for(i = 0; i < connssl->alpn->count; ++i) {
+      backend->protocols[i] = connssl->alpn->entries[i];
     }
-    else {
-#ifdef USE_HTTP2
-      if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
-         && (!Curl_ssl_cf_is_proxy(cf) || !cf->conn->bits.tunnel_proxy)
-#endif
-        ) {
-        backend->protocols[cur++] = ALPN_H2;
-        infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_H2);
-      }
-#endif
-
-      backend->protocols[cur++] = ALPN_HTTP_1_1;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_1);
-    }
-
-    br_ssl_engine_set_protocol_names(&backend->ctx.eng,
-                                     backend->protocols, cur);
+    br_ssl_engine_set_protocol_names(&backend->ctx.eng, backend->protocols,
+                                     connssl->alpn->count);
+    Curl_alpn_to_proto_str(&proto, connssl->alpn);
+    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
 
   if((1 == Curl_inet_pton(AF_INET, hostname, &addr))
@@ -868,26 +850,11 @@ static CURLcode bearssl_connect_step3(struct Curl_cfilter *cf,
   DEBUGASSERT(backend);
 
   if(cf->conn->bits.tls_enable_alpn) {
-    const char *protocol;
+    const char *proto;
 
-    protocol = br_ssl_engine_get_selected_protocol(&backend->ctx.eng);
-    if(protocol) {
-      infof(data, VTLS_INFOF_ALPN_ACCEPTED_1STR, protocol);
-
-#ifdef USE_HTTP2
-      if(!strcmp(protocol, ALPN_H2))
-        cf->conn->alpn = CURL_HTTP_VERSION_2;
-      else
-#endif
-      if(!strcmp(protocol, ALPN_HTTP_1_1))
-        cf->conn->alpn = CURL_HTTP_VERSION_1_1;
-      else
-        infof(data, "ALPN, unrecognized protocol %s", protocol);
-      Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
-    }
-    else
-      infof(data, VTLS_INFOF_NO_ALPN);
+    proto = br_ssl_engine_get_selected_protocol(&backend->ctx.eng);
+    Curl_alpn_set_negotiated(cf, data, (const unsigned char *)proto,
+                             proto? strlen(proto) : 0);
   }
 
   if(ssl_config->primary.sessionid) {

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -698,37 +698,22 @@ gtls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   if(result)
     return result;
 
-  if(cf->conn->bits.tls_enable_alpn) {
-    int cur = 0;
-    gnutls_datum_t protocols[2];
+  if(connssl->alpn) {
+    struct alpn_proto_buf proto;
+    gnutls_datum_t alpn[ALPN_ENTRIES_MAX];
+    size_t i;
 
-    if(data->state.httpwant == CURL_HTTP_VERSION_1_0) {
-      protocols[cur].data = (unsigned char *)ALPN_HTTP_1_0;
-      protocols[cur++].size = ALPN_HTTP_1_0_LENGTH;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_0);
+    for(i = 0; i < connssl->alpn->count; ++i) {
+      alpn[i].data = (unsigned char *)connssl->alpn->entries[i];
+      alpn[i].size = (unsigned)strlen(connssl->alpn->entries[i]);
     }
-    else {
-#ifdef USE_HTTP2
-      if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
-         && (!Curl_ssl_cf_is_proxy(cf) || !cf->conn->bits.tunnel_proxy)
-#endif
-        ) {
-        protocols[cur].data = (unsigned char *)ALPN_H2;
-        protocols[cur++].size = ALPN_H2_LENGTH;
-        infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_H2);
-      }
-#endif
-
-      protocols[cur].data = (unsigned char *)ALPN_HTTP_1_1;
-      protocols[cur++].size = ALPN_HTTP_1_1_LENGTH;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_1);
-    }
-
-    if(gnutls_alpn_set_protocols(backend->gtls.session, protocols, cur, 0)) {
+    if(gnutls_alpn_set_protocols(backend->gtls.session, alpn,
+                                 (unsigned)connssl->alpn->count, 0)) {
       failf(data, "failed setting ALPN");
       return CURLE_SSL_CONNECT_ERROR;
     }
+    Curl_alpn_to_proto_str(&proto, connssl->alpn);
+    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
 
   /* This might be a reconnect, so we check for a session ID in the cache
@@ -1272,28 +1257,10 @@ static CURLcode gtls_verifyserver(struct Curl_cfilter *cf,
     int rc;
 
     rc = gnutls_alpn_get_selected_protocol(session, &proto);
-    if(rc == 0) {
-      infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR, proto.size,
-            proto.data);
-
-#ifdef USE_HTTP2
-      if(proto.size == ALPN_H2_LENGTH &&
-         !memcmp(ALPN_H2, proto.data,
-                 ALPN_H2_LENGTH)) {
-        cf->conn->alpn = CURL_HTTP_VERSION_2;
-      }
-      else
-#endif
-      if(proto.size == ALPN_HTTP_1_1_LENGTH &&
-         !memcmp(ALPN_HTTP_1_1, proto.data, ALPN_HTTP_1_1_LENGTH)) {
-        cf->conn->alpn = CURL_HTTP_VERSION_1_1;
-      }
-    }
+    if(rc == 0)
+      Curl_alpn_set_negotiated(cf, data, proto.data, proto.size);
     else
-      infof(data, VTLS_INFOF_NO_ALPN);
-
-    Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+      Curl_alpn_set_negotiated(cf, data, NULL, 0);
   }
 
   if(ssl_config->primary.sessionid) {

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -648,19 +648,13 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 
 #ifdef HAS_ALPN
-  if(cf->conn->bits.tls_enable_alpn) {
-    const char **p = &backend->protocols[0];
-    if(data->state.httpwant == CURL_HTTP_VERSION_1_0) {
-      *p++ = ALPN_HTTP_1_0;
+  if(connssl->alpn) {
+    struct alpn_proto_buf proto;
+    size_t i;
+
+    for(i = 0; i < connssl->alpn->count; ++i) {
+      backend->protocols[i] = connssl->alpn->entries[i];
     }
-    else {
-#ifdef USE_HTTP2
-      if(data->state.httpwant >= CURL_HTTP_VERSION_2)
-        *p++ = ALPN_H2;
-#endif
-      *p++ = ALPN_HTTP_1_1;
-    }
-    *p = NULL;
     /* this function doesn't clone the protocols array, which is why we need
        to keep it around */
     if(mbedtls_ssl_conf_alpn_protocols(&backend->config,
@@ -668,8 +662,8 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       failf(data, "Failed setting ALPN protocols");
       return CURLE_SSL_CONNECT_ERROR;
     }
-    for(p = &backend->protocols[0]; *p; ++p)
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, *p);
+    Curl_alpn_to_proto_str(&proto, connssl->alpn);
+    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
 #endif
 
@@ -849,28 +843,11 @@ mbed_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 
 #ifdef HAS_ALPN
-  if(cf->conn->bits.tls_enable_alpn) {
-    const char *next_protocol = mbedtls_ssl_get_alpn_protocol(&backend->ssl);
+  if(connssl->alpn) {
+    const char *proto = mbedtls_ssl_get_alpn_protocol(&backend->ssl);
 
-    if(next_protocol) {
-      infof(data, VTLS_INFOF_ALPN_ACCEPTED_1STR, next_protocol);
-#ifdef USE_HTTP2
-      if(!strncmp(next_protocol, ALPN_H2, ALPN_H2_LENGTH) &&
-         !next_protocol[ALPN_H2_LENGTH]) {
-        cf->conn->alpn = CURL_HTTP_VERSION_2;
-      }
-      else
-#endif
-        if(!strncmp(next_protocol, ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH) &&
-           !next_protocol[ALPN_HTTP_1_1_LENGTH]) {
-          cf->conn->alpn = CURL_HTTP_VERSION_1_1;
-        }
-    }
-    else {
-      infof(data, VTLS_INFOF_NO_ALPN);
-    }
-    Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+    Curl_alpn_set_negotiated(cf, data, (const unsigned char *)proto,
+                             proto? strlen(proto) : 0);
   }
 #endif
 

--- a/lib/vtls/nss.c
+++ b/lib/vtls/nss.c
@@ -873,11 +873,11 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
 #endif
     case SSL_NEXT_PROTO_NO_SUPPORT:
     case SSL_NEXT_PROTO_NO_OVERLAP:
-      infof(data, VTLS_INFOF_NO_ALPN);
+      Curl_alpn_set_negotiated(cf, data, NULL, 0);
       return;
 #ifdef SSL_ENABLE_ALPN
     case SSL_NEXT_PROTO_SELECTED:
-      infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR, buflen, buf);
+      Curl_alpn_set_negotiated(cf, data, buf, buflen);
       break;
 #endif
     default:
@@ -885,29 +885,6 @@ static void HandshakeCallback(PRFileDesc *sock, void *arg)
       break;
     }
 
-#ifdef USE_HTTP2
-    if(buflen == ALPN_H2_LENGTH &&
-       !memcmp(ALPN_H2, buf, ALPN_H2_LENGTH)) {
-      cf->conn->alpn = CURL_HTTP_VERSION_2;
-    }
-    else
-#endif
-    if(buflen == ALPN_HTTP_1_1_LENGTH &&
-       !memcmp(ALPN_HTTP_1_1, buf, ALPN_HTTP_1_1_LENGTH)) {
-      cf->conn->alpn = CURL_HTTP_VERSION_1_1;
-    }
-    else if(buflen == ALPN_HTTP_1_0_LENGTH &&
-            !memcmp(ALPN_HTTP_1_0, buf, ALPN_HTTP_1_0_LENGTH)) {
-      cf->conn->alpn = CURL_HTTP_VERSION_1_0;
-    }
-
-    /* This callback might get called when PR_Recv() is used within
-     * close_one() during a connection shutdown. At that point there might not
-     * be any "bundle" associated with the connection anymore.
-     */
-    if(conn->bundle)
-      Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   }
 }
 
@@ -2167,34 +2144,17 @@ static CURLcode nss_setup_connect(struct Curl_cfilter *cf,
 #endif
 
 #if defined(SSL_ENABLE_ALPN)
-  if(cf->conn->bits.tls_enable_alpn) {
-    int cur = 0;
-    unsigned char protocols[128];
+  if(connssl->alpn) {
+    struct alpn_proto_buf proto;
 
-    if(data->state.httpwant == CURL_HTTP_VERSION_1_0) {
-      protocols[cur++] = ALPN_HTTP_1_0_LENGTH;
-      memcpy(&protocols[cur], ALPN_HTTP_1_0, ALPN_HTTP_1_0_LENGTH);
-      cur += ALPN_HTTP_1_0_LENGTH;
-    }
-    else {
-#ifdef USE_HTTP2
-      if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
-         && (!Curl_ssl_cf_is_proxy(cf) || !cf->conn->bits.tunnel_proxy)
-#endif
-        ) {
-        protocols[cur++] = ALPN_H2_LENGTH;
-        memcpy(&protocols[cur], ALPN_H2, ALPN_H2_LENGTH);
-        cur += ALPN_H2_LENGTH;
-      }
-#endif
-      protocols[cur++] = ALPN_HTTP_1_1_LENGTH;
-      memcpy(&protocols[cur], ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH);
-      cur += ALPN_HTTP_1_1_LENGTH;
-    }
-
-    if(SSL_SetNextProtoNego(backend->handle, protocols, cur) != SECSuccess)
+    result = Curl_alpn_to_proto_buf(&proto, connssl->alpn);
+    if(result || SSL_SetNextProtoNego(backend->handle, proto.data, proto.len)
+                   != SECSuccess) {
+      failf(data, "Error setting ALPN");
       goto error;
+    }
+    Curl_alpn_to_proto_str(&proto, connssl->alpn);
+    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
 #endif
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3633,43 +3633,17 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
   SSL_CTX_set_options(backend->ctx, ctx_options);
 
 #ifdef HAS_ALPN
-  if(cf->conn->bits.tls_enable_alpn) {
-    int cur = 0;
-    unsigned char protocols[128];
+  if(connssl->alpn) {
+    struct alpn_proto_buf proto;
 
-    if(data->state.httpwant == CURL_HTTP_VERSION_1_0) {
-      protocols[cur++] = ALPN_HTTP_1_0_LENGTH;
-      memcpy(&protocols[cur], ALPN_HTTP_1_0, ALPN_HTTP_1_0_LENGTH);
-      cur += ALPN_HTTP_1_0_LENGTH;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_0);
-    }
-    else {
-#ifdef USE_HTTP2
-      if(data->state.httpwant >= CURL_HTTP_VERSION_2
-#ifndef CURL_DISABLE_PROXY
-         && (!Curl_ssl_cf_is_proxy(cf) || !cf->conn->bits.tunnel_proxy)
-#endif
-        ) {
-        protocols[cur++] = ALPN_H2_LENGTH;
-
-        memcpy(&protocols[cur], ALPN_H2, ALPN_H2_LENGTH);
-        cur += ALPN_H2_LENGTH;
-        infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_H2);
-      }
-#endif
-
-      protocols[cur++] = ALPN_HTTP_1_1_LENGTH;
-      memcpy(&protocols[cur], ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH);
-      cur += ALPN_HTTP_1_1_LENGTH;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_1);
-    }
-    /* expects length prefixed preference ordered list of protocols in wire
-     * format
-     */
-    if(SSL_CTX_set_alpn_protos(backend->ctx, protocols, cur)) {
+    result = Curl_alpn_to_proto_buf(&proto, connssl->alpn);
+    if(result ||
+       SSL_CTX_set_alpn_protos(backend->ctx, proto.data, proto.len)) {
       failf(data, "Error setting ALPN");
       return CURLE_SSL_CONNECT_ERROR;
     }
+    Curl_alpn_to_proto_str(&proto, connssl->alpn);
+    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
 #endif
 
@@ -4020,26 +3994,8 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
       const unsigned char *neg_protocol;
       unsigned int len;
       SSL_get0_alpn_selected(backend->handle, &neg_protocol, &len);
-      if(len) {
-        infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR, len, neg_protocol);
 
-#ifdef USE_HTTP2
-        if(len == ALPN_H2_LENGTH &&
-           !memcmp(ALPN_H2, neg_protocol, len)) {
-          cf->conn->alpn = CURL_HTTP_VERSION_2;
-        }
-        else
-#endif
-        if(len == ALPN_HTTP_1_1_LENGTH &&
-           !memcmp(ALPN_HTTP_1_1, neg_protocol, ALPN_HTTP_1_1_LENGTH)) {
-          cf->conn->alpn = CURL_HTTP_VERSION_1_1;
-        }
-      }
-      else
-        infof(data, VTLS_INFOF_NO_ALPN);
-
-      Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+      return Curl_alpn_set_negotiated(cf, data, neg_protocol, len);
     }
 #endif
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1105,7 +1105,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
 #ifdef HAS_ALPN
   /* ALPN is only supported on Windows 8.1 / Server 2012 R2 and above.
      Also it doesn't seem to be supported for Wine, see curl bug #983. */
-  backend->use_alpn = cf->conn->bits.tls_enable_alpn &&
+  backend->use_alpn = connssl->alpn &&
     !GetProcAddress(GetModuleHandle(TEXT("ntdll")),
                     "wine_get_version") &&
     curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
@@ -1196,6 +1196,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     int list_start_index = 0;
     unsigned int *extension_len = NULL;
     unsigned short* list_len = NULL;
+    struct alpn_proto_buf proto;
 
     /* The first four bytes will be an unsigned int indicating number
        of bytes of data in the rest of the buffer. */
@@ -1215,33 +1216,22 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
 
     list_start_index = cur;
 
-    if(data->state.httpwant == CURL_HTTP_VERSION_1_0) {
-      alpn_buffer[cur++] = ALPN_HTTP_1_0_LENGTH;
-      memcpy(&alpn_buffer[cur], ALPN_HTTP_1_0, ALPN_HTTP_1_0_LENGTH);
-      cur += ALPN_HTTP_1_0_LENGTH;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_0);
+    result = Curl_alpn_to_proto_buf(&proto, connssl->alpn);
+    if(result) {
+      failf(data, "Error setting ALPN");
+      return CURLE_SSL_CONNECT_ERROR;
     }
-    else {
-#ifdef USE_HTTP2
-      if(data->state.httpwant >= CURL_HTTP_VERSION_2) {
-        alpn_buffer[cur++] = ALPN_H2_LENGTH;
-        memcpy(&alpn_buffer[cur], ALPN_H2, ALPN_H2_LENGTH);
-        cur += ALPN_H2_LENGTH;
-        infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_H2);
-      }
-#endif
-
-      alpn_buffer[cur++] = ALPN_HTTP_1_1_LENGTH;
-      memcpy(&alpn_buffer[cur], ALPN_HTTP_1_1, ALPN_HTTP_1_1_LENGTH);
-      cur += ALPN_HTTP_1_1_LENGTH;
-      infof(data, VTLS_INFOF_ALPN_OFFER_1STR, ALPN_HTTP_1_1);
-    }
+    memcpy(&alpn_buffer[cur], proto.data, proto.len);
+    cur += proto.len;
 
     *list_len = curlx_uitous(cur - list_start_index);
     *extension_len = *list_len + sizeof(unsigned int) + sizeof(unsigned short);
 
     InitSecBuffer(&inbuf, SECBUFFER_APPLICATION_PROTOCOLS, alpn_buffer, cur);
     InitSecBufferDesc(&inbuf_desc, &inbuf, 1);
+
+    Curl_alpn_to_proto_str(&proto, connssl->alpn);
+    infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
   else {
     InitSecBuffer(&inbuf, SECBUFFER_EMPTY, NULL, 0);
@@ -1735,40 +1725,23 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
 
     if(alpn_result.ProtoNegoStatus ==
        SecApplicationProtocolNegotiationStatus_Success) {
-      unsigned char alpn = 0;
+      unsigned char prev_alpn = cf->conn->alpn;
 
-      infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR,
-            alpn_result.ProtocolIdSize, alpn_result.ProtocolId);
-
-#ifdef USE_HTTP2
-      if(alpn_result.ProtocolIdSize == ALPN_H2_LENGTH &&
-         !memcmp(ALPN_H2, alpn_result.ProtocolId, ALPN_H2_LENGTH)) {
-        alpn = CURL_HTTP_VERSION_2;
-      }
-      else
-#endif
-        if(alpn_result.ProtocolIdSize == ALPN_HTTP_1_1_LENGTH &&
-           !memcmp(ALPN_HTTP_1_1, alpn_result.ProtocolId,
-                   ALPN_HTTP_1_1_LENGTH)) {
-          alpn = CURL_HTTP_VERSION_1_1;
-        }
+      Curl_alpn_set_negotiated(cf, data, alpn_result.ProtocolId,
+                               alpn_result.ProtocolIdSize);
       if(backend->recv_renegotiating) {
-        if(alpn != cf->conn->alpn) {
+        if(prev_alpn != cf->conn->alpn &&
+           prev_alpn != CURL_HTTP_VERSION_NONE) {
+          /* Renegotiation selected a different protocol now, we cannot
+           * deal with this */
           failf(data, "schannel: server selected an ALPN protocol too late");
           return CURLE_SSL_CONNECT_ERROR;
         }
       }
-      else
-        cf->conn->alpn = alpn;
     }
     else {
       if(!backend->recv_renegotiating)
-        infof(data, VTLS_INFOF_NO_ALPN);
-    }
-
-    if(!backend->recv_renegotiating) {
-      Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                          BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+        Curl_alpn_set_negotiated(cf, data, NULL, 0);
     }
   }
 #endif

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1636,7 +1636,6 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   const bool verifypeer = conn_config->verifypeer;
   char * const ssl_cert = ssl_config->primary.clientcert;
   const struct curl_blob *ssl_cert_blob = ssl_config->primary.cert_blob;
-  bool isproxy = Curl_ssl_cf_is_proxy(cf);
 #ifdef ENABLE_IPV6
   struct in6_addr addr;
 #else

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1875,9 +1875,11 @@ static const struct alpn_spec ALPN_SPEC_H10 = {
 static const struct alpn_spec ALPN_SPEC_H11 = {
   { ALPN_HTTP_1_1 }, 1
 };
+#ifdef USE_HTTP2
 static const struct alpn_spec ALPN_SPEC_H2_H11 = {
   { ALPN_H2, ALPN_HTTP_1_1 }, 2
 };
+#endif
 
 const struct alpn_spec *
 Curl_alpn_get_spec(struct Curl_easy *data, struct connectdata *conn)

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -290,7 +290,8 @@ static bool ssl_prefs_check(struct Curl_easy *data)
   return TRUE;
 }
 
-static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data)
+static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data,
+                                           const struct alpn_spec *alpn)
 {
   struct ssl_connect_data *ctx;
 
@@ -299,6 +300,7 @@ static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data)
   if(!ctx)
     return NULL;
 
+  ctx->alpn = alpn;
   ctx->backend = calloc(1, Curl_ssl->sizeof_ssl_backend_data);
   if(!ctx->backend) {
     free(ctx);
@@ -1649,14 +1651,16 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
 };
 
 static CURLcode cf_ssl_create(struct Curl_cfilter **pcf,
-                              struct Curl_easy *data)
+                              struct Curl_easy *data,
+                              struct connectdata *conn)
 {
   struct Curl_cfilter *cf = NULL;
   struct ssl_connect_data *ctx;
   CURLcode result;
 
   DEBUGASSERT(data->conn);
-  ctx = cf_ctx_new(data);
+
+  ctx = cf_ctx_new(data, Curl_alpn_get_spec(data, conn));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -1678,7 +1682,7 @@ CURLcode Curl_ssl_cfilter_add(struct Curl_easy *data,
   struct Curl_cfilter *cf;
   CURLcode result;
 
-  result = cf_ssl_create(&cf, data);
+  result = cf_ssl_create(&cf, data, conn);
   if(!result)
     Curl_conn_cf_add(data, conn, sockindex, cf);
   return result;
@@ -1690,7 +1694,7 @@ CURLcode Curl_cf_ssl_insert_after(struct Curl_cfilter *cf_at,
   struct Curl_cfilter *cf;
   CURLcode result;
 
-  result = cf_ssl_create(&cf, data);
+  result = cf_ssl_create(&cf, data, cf_at->conn);
   if(!result)
     Curl_conn_cf_insert_after(cf_at, cf);
   return result;
@@ -1698,18 +1702,18 @@ CURLcode Curl_cf_ssl_insert_after(struct Curl_cfilter *cf_at,
 
 #ifndef CURL_DISABLE_PROXY
 static CURLcode cf_ssl_proxy_create(struct Curl_cfilter **pcf,
-                                    struct Curl_easy *data)
+                                    struct Curl_easy *data,
+                                    struct connectdata *conn)
 {
   struct Curl_cfilter *cf = NULL;
   struct ssl_connect_data *ctx;
   CURLcode result;
 
-  ctx = cf_ctx_new(data);
+  ctx = cf_ctx_new(data, Curl_alpn_get_proxy_spec(data, conn));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
-
   result = Curl_cf_create(&cf, &Curl_cft_ssl_proxy, ctx);
 
 out:
@@ -1726,7 +1730,7 @@ CURLcode Curl_ssl_cfilter_proxy_add(struct Curl_easy *data,
   struct Curl_cfilter *cf;
   CURLcode result;
 
-  result = cf_ssl_proxy_create(&cf, data);
+  result = cf_ssl_proxy_create(&cf, data, conn);
   if(!result)
     Curl_conn_cf_add(data, conn, sockindex, cf);
   return result;
@@ -1738,7 +1742,7 @@ CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,
   struct Curl_cfilter *cf;
   CURLcode result;
 
-  result = cf_ssl_proxy_create(&cf, data);
+  result = cf_ssl_proxy_create(&cf, data, cf_at->conn);
   if(!result)
     Curl_conn_cf_insert_after(cf_at, cf);
   return result;
@@ -1863,6 +1867,136 @@ struct Curl_cfilter *Curl_ssl_cf_get_ssl(struct Curl_cfilter *cf)
       return cf;
   }
   return NULL;
+}
+
+static const struct alpn_spec ALPN_SPEC_H10 = {
+  { ALPN_HTTP_1_0 }, 1
+};
+static const struct alpn_spec ALPN_SPEC_H11 = {
+  { ALPN_HTTP_1_1 }, 1
+};
+static const struct alpn_spec ALPN_SPEC_H2_H11 = {
+  { ALPN_H2, ALPN_HTTP_1_1 }, 2
+};
+
+const struct alpn_spec *
+Curl_alpn_get_spec(struct Curl_easy *data, struct connectdata *conn)
+{
+  if(!conn->bits.tls_enable_alpn)
+    return NULL;
+  if(data->state.httpwant == CURL_HTTP_VERSION_1_0)
+    return &ALPN_SPEC_H10;
+#ifdef USE_HTTP2
+  if(data->state.httpwant >= CURL_HTTP_VERSION_2)
+    return &ALPN_SPEC_H2_H11;
+#endif
+  return &ALPN_SPEC_H11;
+}
+
+const struct alpn_spec *
+Curl_alpn_get_proxy_spec(struct Curl_easy *data, struct connectdata *conn)
+{
+  if(!conn->bits.tls_enable_alpn)
+    return NULL;
+  if(data->state.httpwant == CURL_HTTP_VERSION_1_0)
+    return &ALPN_SPEC_H10;
+  return &ALPN_SPEC_H11;
+}
+
+CURLcode Curl_alpn_to_proto_buf(struct alpn_proto_buf *buf,
+                                const struct alpn_spec *spec)
+{
+  size_t i, len;
+  int off = 0;
+  unsigned char blen;
+
+  memset(buf, 0, sizeof(*buf));
+  for(i = 0; spec && i < spec->count; ++i) {
+    len = strlen(spec->entries[i]);
+    if(len > 255)
+      return CURLE_FAILED_INIT;
+    blen = (unsigned  char)len;
+    if(off + blen + 1 >= (int)sizeof(buf->data))
+      return CURLE_FAILED_INIT;
+    buf->data[off++] = blen;
+    memcpy(buf->data + off, spec->entries[i], blen);
+    off += blen;
+  }
+  buf->len = off;
+  return CURLE_OK;
+}
+
+CURLcode Curl_alpn_to_proto_str(struct alpn_proto_buf *buf,
+                                const struct alpn_spec *spec)
+{
+  size_t i, len;
+  size_t off = 0;
+
+  memset(buf, 0, sizeof(*buf));
+  for(i = 0; spec && i < spec->count; ++i) {
+    len = strlen(spec->entries[i]);
+    if(len > 255)
+      return CURLE_FAILED_INIT;
+    if(off + len + 2 >= (int)sizeof(buf->data))
+      return CURLE_FAILED_INIT;
+    if(off)
+      buf->data[off++] = ',';
+    memcpy(buf->data + off, spec->entries[i], len);
+    off += len;
+  }
+  buf->data[off] = '\0';
+  buf->len = (int)off;
+  return CURLE_OK;
+}
+
+CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
+                                  struct Curl_easy *data,
+                                  const unsigned char *proto,
+                                  size_t proto_len)
+{
+  int can_multi = 0;
+
+  if(proto && proto_len) {
+    if(proto_len == ALPN_HTTP_1_1_LENGTH &&
+            !memcmp(ALPN_HTTP_1_1, proto, ALPN_HTTP_1_1_LENGTH)) {
+      cf->conn->alpn = CURL_HTTP_VERSION_1_1;
+    }
+    else if(proto_len == ALPN_HTTP_1_0_LENGTH &&
+            !memcmp(ALPN_HTTP_1_0, proto, ALPN_HTTP_1_0_LENGTH)) {
+      cf->conn->alpn = CURL_HTTP_VERSION_1_0;
+    }
+#ifdef USE_HTTP2
+    else if(proto_len == ALPN_H2_LENGTH &&
+            !memcmp(ALPN_H2, proto, ALPN_H2_LENGTH)) {
+      cf->conn->alpn = CURL_HTTP_VERSION_2;
+      can_multi = 1;
+    }
+#endif
+#ifdef USE_HTTP3
+    else if(proto_len == ALPN_H3_LENGTH &&
+       !memcmp(ALPN_H3, proto, ALPN_H3_LENGTH)) {
+      cf->conn->alpn = CURL_HTTP_VERSION_3;
+      can_multi = 1;
+    }
+#endif
+    else {
+      cf->conn->alpn = CURL_HTTP_VERSION_NONE;
+      failf(data, "unsupported ALPN protocol: '%.*s'", proto_len, proto);
+      /* TODO: do we want to fail this? Previous code just ignored it and
+       * some vtls backends even ignore the return code of this function. */
+      /* return CURLE_NOT_BUILT_IN; */
+      goto out;
+    }
+    infof(data, VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR, proto_len, proto);
+  }
+  else {
+    cf->conn->alpn = CURL_HTTP_VERSION_NONE;
+    infof(data, VTLS_INFOF_NO_ALPN);
+  }
+
+out:
+  Curl_multiuse_state(data, can_multi? BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
+  return CURLE_OK;
 }
 
 #endif /* USE_SSL */

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -27,7 +27,6 @@
 
 struct connectdata;
 struct ssl_config_data;
-struct ssl_connect_data;
 struct ssl_primary_config;
 struct Curl_ssl_session;
 
@@ -73,6 +72,49 @@ CURLsslset Curl_init_sslset_nolock(curl_sslbackend id, const char *name,
 #define ALPN_HTTP_1_0 "http/1.0"
 #define ALPN_H2_LENGTH 2
 #define ALPN_H2 "h2"
+#define ALPN_H3_LENGTH 2
+#define ALPN_H3 "h3"
+
+/* conservative sizes on the ALPN entries and count we are handling,
+ * we can increase these if we ever feel the need or have to accomodate
+ * ALPN strings from the "outside". */
+#define ALPN_NAME_MAX     10
+#define ALPN_ENTRIES_MAX  3
+#define ALPN_PROTO_BUF_MAX   (ALPN_ENTRIES_MAX * (ALPN_NAME_MAX + 1))
+
+struct alpn_spec {
+  const char entries[ALPN_ENTRIES_MAX][ALPN_NAME_MAX];
+  size_t count; /* number of entries */
+};
+
+struct alpn_proto_buf {
+  unsigned char data[ALPN_PROTO_BUF_MAX];
+  int len;
+};
+
+CURLcode Curl_alpn_to_proto_buf(struct alpn_proto_buf *buf,
+                                const struct alpn_spec *spec);
+CURLcode Curl_alpn_to_proto_str(struct alpn_proto_buf *buf,
+                                const struct alpn_spec *spec);
+
+CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
+                                  struct Curl_easy *data,
+                                  const unsigned char *proto,
+                                  size_t proto_len);
+
+/**
+ * Get the ALPN specification to use for talking to remote host.
+ * May return NULL if ALPN is disabled on the connection.
+ */
+const struct alpn_spec *
+Curl_alpn_get_spec(struct Curl_easy *data, struct connectdata *conn);
+
+/**
+ * Get the ALPN specification to use for talking to the proxy.
+ * May return NULL if ALPN is disabled on the connection.
+ */
+const struct alpn_spec *
+Curl_alpn_get_proxy_spec(struct Curl_easy *data, struct connectdata *conn);
 
 
 char *Curl_ssl_snihost(struct Curl_easy *data, const char *host, size_t *olen);

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -36,6 +36,7 @@ struct ssl_connect_data {
   const char *hostname;             /* hostnaem for verification */
   const char *dispname;             /* display version of hostname */
   int port;                         /* remote port at origin */
+  const struct alpn_spec *alpn;     /* ALPN to use or NULL for none */
   struct ssl_backend_data *backend; /* vtls backend specific props */
   struct Curl_easy *call_data;      /* data handle used in current call,
                                      * same as parameter passed, but available

--- a/tests/libtest/lib2502.c
+++ b/tests/libtest/lib2502.c
@@ -74,7 +74,7 @@ int test(char *URL)
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go http2 */
-    easy_setopt(curl[i], CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
+    easy_setopt(curl[i], CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3ONLY);
     easy_setopt(curl[i], CURLOPT_CONNECTTIMEOUT_MS, (long)5000);
     easy_setopt(curl[i], CURLOPT_CAINFO, "./certs/EdelCurlRoot-ca.cacert");
     /* wait for first connection establised to see if we can share it */

--- a/tests/tests-httpd/config.ini.in
+++ b/tests/tests-httpd/config.ini.in
@@ -33,7 +33,7 @@ apachectl = @APACHECTL@
 [test]
 http_port = 5001
 https_port = 5002
-h3_port = 5003
+h3_port = 5002
 
 [nghttpx]
 nghttpx = @HTTPD_NGHTTPX@

--- a/tests/tests-httpd/conftest.py
+++ b/tests/tests-httpd/conftest.py
@@ -70,7 +70,7 @@ def httpd(env) -> Httpd:
 
 
 @pytest.fixture(scope='package')
-def nghttpx(env) -> Optional[Nghttpx]:
+def nghttpx(env, httpd) -> Optional[Nghttpx]:
     if env.have_h3_server():
         nghttpx = Nghttpx(env=env)
         nghttpx.clear_logs()

--- a/tests/tests-httpd/test_01_basic.py
+++ b/tests/tests-httpd/test_01_basic.py
@@ -38,6 +38,11 @@ log = logging.getLogger(__name__)
                     reason=f"missing: {Env.incomplete_reason()}")
 class TestBasic:
 
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+
     # simple http: GET
     def test_01_01_http_get(self, env: Env, httpd):
         curl = CurlClient(env=env)

--- a/tests/tests-httpd/test_02_download.py
+++ b/tests/tests-httpd/test_02_download.py
@@ -39,6 +39,11 @@ log = logging.getLogger(__name__)
                     reason=f"missing: {Env.incomplete_reason()}")
 class TestDownload:
 
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+
     # download 1 file
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_01_download_1(self, env: Env, httpd, nghttpx, repeat, proto):

--- a/tests/tests-httpd/test_03_goaway.py
+++ b/tests/tests-httpd/test_03_goaway.py
@@ -42,6 +42,11 @@ log = logging.getLogger(__name__)
                     reason=f"missing: {Env.incomplete_reason()}")
 class TestGoAway:
 
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+
     # download files sequentially with delay, reload server for GOAWAY
     def test_03_01_h2_goaway(self, env: Env, httpd, nghttpx, repeat):
         proto = 'h2'

--- a/tests/tests-httpd/test_04_stuttered.py
+++ b/tests/tests-httpd/test_04_stuttered.py
@@ -38,6 +38,11 @@ log = logging.getLogger(__name__)
                     reason=f"missing: {Env.incomplete_reason()}")
 class TestStuttered:
 
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+
     # download 1 file, check that delayed response works in general
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_04_01_download_1(self, env: Env, httpd, nghttpx, repeat,

--- a/tests/tests-httpd/test_05_errors.py
+++ b/tests/tests-httpd/test_05_errors.py
@@ -39,6 +39,11 @@ log = logging.getLogger(__name__)
                     reason=f"missing: {Env.incomplete_reason()}")
 class TestErrors:
 
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+
     # download 1 file, check that we get CURLE_PARTIAL_FILE
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, repeat,

--- a/tests/tests-httpd/test_06_eyeballs.py
+++ b/tests/tests-httpd/test_06_eyeballs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2008 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+import json
+import logging
+from typing import Optional, Tuple, List, Dict
+import pytest
+
+from testenv import Env, CurlClient, ExecResult
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(condition=Env.setup_incomplete(),
+                    reason=f"missing: {Env.incomplete_reason()}")
+@pytest.mark.skipif(condition=not Env.have_h3_server(),
+                    reason=f"missing HTTP/3 server")
+@pytest.mark.skipif(condition=not Env.have_h3_curl(),
+                    reason=f"curl built without HTTP/3")
+class TestEyeballs:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+
+    # download using only HTTP/3 on working server
+    def test_06_01_h3_only(self, env: Env, httpd, nghttpx, repeat):
+        curl = CurlClient(env=env)
+        urln = f'https://{env.authority_for(env.domain1, "h3")}/data.json'
+        r = curl.http_download(urls=[urln], extra_args=['--http3-only'])
+        assert r.exit_code == 0, f'{r}'
+        r.check_responses(count=1, exp_status=200)
+        assert r.responses[0]['protocol'] == 'HTTP/3'
+
+    # download using only HTTP/3 on missing server
+    def test_06_02_h3_only(self, env: Env, httpd, nghttpx, repeat):
+        nghttpx.stop_if_running()
+        curl = CurlClient(env=env)
+        urln = f'https://{env.authority_for(env.domain1, "h3")}/data.json'
+        r = curl.http_download(urls=[urln], extra_args=['--http3-only'])
+        assert r.exit_code == 7, f'{r}'  # could not connect
+
+    # download using HTTP/3 on missing server with fallback on h2
+    @pytest.mark.skip(f'TODO: implement h3 fallback')
+    def test_06_03_h3_fallback_h2(self, env: Env, httpd, nghttpx, repeat):
+        nghttpx.stop_if_running()
+        curl = CurlClient(env=env)
+        urln = f'https://{env.authority_for(env.domain1, "h3")}/data.json'
+        r = curl.http_download(urls=[urln], extra_args=['--http3'])
+        assert r.exit_code == 0, f'{r}'
+        r.check_responses(count=1, exp_status=200)
+        assert r.responses[0]['protocol'] == 'HTTP/2'
+
+    # download using HTTP/3 on missing server with fallback on http/1.1
+    @pytest.mark.skip(f'TODO: implement h3 fallback')
+    def test_06_04_h3_fallback_h1(self, env: Env, httpd, nghttpx, repeat):
+        nghttpx.stop_if_running()
+        curl = CurlClient(env=env)
+        urln = f'https://{env.authority_for(env.domain2, "h3")}/data.json'
+        r = curl.http_download(urls=[urln], extra_args=['--http3'])
+        assert r.exit_code == 0, f'{r}'
+        r.check_responses(count=1, exp_status=200)
+        assert r.responses[0]['protocol'] == 'HTTP/1.1'


### PR DESCRIPTION
Working http3 selection meanings into the code.

Centralising ALPN handling for vtls backends.

    - ALPN selection for SSL/SSL-PROXY filters in one vtls set of functions, replaces
      copy of logic in all tls backends.
    - standardized the infof logging of offered ALPNs
    - ALPN negotiated: have common function for all backends that sets alpn proprty
      and connection related things based on the negotiated protocol (or lack thereof).

tests-https:

    - Adding test cases for h3 eyeballing: --http3 and --http3-only
        - --http3 skipped for now as implementation missing
        - adding stop/start checks for nghttpx
        - adding nghttpx start fixtures to test that need it, as
          we have now tests that stop it
    - Make HTTPS and QUIC port the same in tests/tests-httpd