### PR TITLE
tls: fixes for wolfssl + openssl combo builds

### DIFF
--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -183,13 +183,6 @@ ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_LIBS ?= -lssl -lcrypto
   _LIBS += $(OPENSSL_LIBS)
 
-  ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/aead.h),)
-    OPENSSL := boringssl
-  else
-    # including libressl
-    OPENSSL := openssl
-  endif
-
   ifneq ($(findstring -srp,$(CFG)),)
     ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h),)
       # OpenSSL 1.0.1 and later.
@@ -197,14 +190,14 @@ ifneq ($(findstring -ssl,$(CFG)),)
     endif
   endif
   SSLLIBS += 1
-else ifneq ($(findstring -wolfssl,$(CFG)),)
+endif
+ifneq ($(findstring -wolfssl,$(CFG)),)
   WOLFSSL_PATH ?= $(PROOT)/../wolfssl
   CPPFLAGS += -DUSE_WOLFSSL
   CPPFLAGS += -DSIZEOF_LONG_LONG=8
   CPPFLAGS += -I"$(WOLFSSL_PATH)/include"
   _LDFLAGS += -L"$(WOLFSSL_PATH)/lib"
   _LIBS += -lwolfssl
-  OPENSSL := wolfssl
   SSLLIBS += 1
 endif
 ifneq ($(findstring -mbedtls,$(CFG)),)
@@ -239,9 +232,20 @@ ifeq ($(findstring -nghttp3,$(CFG))$(findstring -ngtcp2,$(CFG)),-nghttp3-ngtcp2)
   CPPFLAGS += -DUSE_NGTCP2
   CPPFLAGS += -I"$(NGTCP2_PATH)/include"
   _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
-  ifneq ($(OPENSSL),)
-    NGTCP2_LIBS ?= -lngtcp2_crypto_$(OPENSSL)
+
+  NGTCP2_LIBS ?=
+  ifeq ($(NGTCP2_LIBS),)
+    ifneq ($(findstring -ssl,$(CFG)),)
+      ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/aead.h),)
+        NGTCP2_LIBS := -lngtcp2_crypto_boringssl
+      else  # including libressl
+        NGTCP2_LIBS := -lngtcp2_crypto_openssl
+      endif
+    else ifneq ($(findstring -wolfssl,$(CFG)),)
+      NGTCP2_LIBS := -lngtcp2_crypto_wolfssl
+    endif
   endif
+
   _LIBS += -lngtcp2 $(NGTCP2_LIBS)
 endif
 

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -36,12 +36,13 @@
 /* Please keep the SSL backend-specific #if branches in this order:
 
    1. USE_OPENSSL
-   2. USE_GNUTLS
-   3. USE_NSS
-   4. USE_MBEDTLS
-   5. USE_SECTRANSP
-   6. USE_OS400CRYPTO
-   7. USE_WIN32_CRYPTO
+   2. USE_WOLFSSL
+   3. USE_GNUTLS
+   4. USE_NSS
+   5. USE_MBEDTLS
+   6. USE_SECTRANSP
+   7. USE_OS400CRYPTO
+   8. USE_WIN32_CRYPTO
 
    This ensures that:
    - the same SSL branch gets activated throughout this source

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -37,11 +37,11 @@
 #define NTLM_NEEDS_NSS_INIT
 #endif
 
-#ifdef USE_WOLFSSL
+#if defined(USE_OPENSSL)
+#  include <openssl/ssl.h>
+#elif defined(USE_WOLFSSL)
 #  include <wolfssl/options.h>
 #  include <wolfssl/openssl/ssl.h>
-#elif defined(USE_OPENSSL)
-#  include <openssl/ssl.h>
 #endif
 
 /* Helpers to generate function byte arguments in little endian order */


### PR DESCRIPTION
1. Add `USE_WOLFSSL` to the TLS backend priority list in `lib/curl_ntlm_core.c`.

2. Fix `lib/curl_ntlm_core.h` to respect TLS backend priority, bringing this in sync with the above list and `lib/curl_ntlm_core.c` itself.

   Reported-by: Mark Roszko
   Ref: https://github.com/curl/curl/issues/10321

3. Allow enabling both wolfSSL and OpenSSL at the same time in `lib/Makefile.mk`. Update the logic to select the crypto-specific lib for `ngtcp2`, where only one TLS backend is supported at the same time.

Closes #10322