### PR TITLE
CI: Add a workflow to automatically label pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,181 @@
+# Copyright (C) Daniel Fandrich, <dan@coneharvesters.com>, et al.
+#
+# SPDX-License-Identifier: curl
+
+# The workflow configures the .github/workflows/label.yml action
+# to add labels to pull requests. This is not (yet?) a replacement for human
+# triaging, but is intended to add labels to the easy cases. If the matching
+# language becomes more powerful, more cases should be able to be handled.
+#
+# The biggest low-hanging problem is this:
+# It looks like there's no way of specifying that a label be added if *all* the
+# files match *any* one of a number of globs. This feature request is tracked
+# in https://github.com/actions/labeler/issues/423
+
+authentication:
+- all: ['docs/mk-ca-bundle.1']
+- all: ['lib/*gssapi*']
+- all: ['lib/*krb5*']
+- all: ['lib/*ntlm*']
+- all: ['lib/curl_sasl.*']
+- all: ['lib/http_aws*']
+- all: ['lib/http_digest.*']
+- all: ['lib/http_negotiate.*']
+- all: ['lib/vauth/**']
+
+build:
+- all: ['**/CMakeLists.txt']
+- all: ['**/Makefile.am']
+- all: ['**/*.inc']
+- all: ['**/*.m4']
+- all: ['**/*.mk']
+- all: ['configure.ac']
+- all: ['m4/**']
+- all: ['packages/**']
+- all: ['plan9/**']
+- all: ['projects/**']
+- all: ['winbuild/**']
+
+CI:
+- all: ['.azure-pipelines.yml']
+- all: ['.circleci/**']
+- all: ['.cirrus.yml']
+- all: ['.github/**']
+- all: ['appveyor.yml']
+- all: ['zuul.d/**']
+
+cmake:
+- all: ['**/CMakeLists.txt']
+
+cmdline tool:
+- all: ['src/**']
+
+connecting & proxies:
+- all: ['lib/http_proxy.*']
+- all: ['lib/noproxy.*']
+- all: ['lib/socks.*']
+
+cookies:
+- all: ['lib/cookie.*']
+- all: ['lib/psl.*']
+
+cryptography:
+- all: ['docs/CIPHERS.md']
+- all: ['lib/*sha256*']
+- all: ['lib/curl_hmac.*']
+- all: ['lib/curl_md?.*']
+- all: ['lib/md?.*']
+
+DICT:
+- all: ['lib/dict.*']
+
+documentation:
+- all: ['**/*.md']
+- all: ['**/*.txt', '!**/CMakeLists.txt']
+- all: ['**/*.1']
+- all: ['**/*.3']
+- all: ['docs/**', '!docs/examples/**']
+- all: ['RELEASE-NOTES']
+
+FTP:
+- all: ['lib/curl_range.*']
+- all: ['lib/ftp*']
+
+GOPHER:
+- all: ['lib/gopher*']
+
+HTTP:
+- all: ['docs/HSTS.md']
+- all: ['docs/HTTP-COOKIES.md']
+- all: ['lib/h2h3.*']
+- all: ['lib/http*']
+
+HTTP/2:
+- all: ['docs/HTTP2.md']
+- all: ['lib/http2*']
+
+HTTP/3:
+- all: ['docs/HTTP3.md']
+- all: ['lib/vquic/**']
+
+Hyper:
+- all: ['lib/c-hyper.*']
+
+IMAP:
+- all: ['lib/imap*']
+
+LDAP:
+- all: ['lib/*ldap*']
+
+libcurl API:
+- all: ['docs/libcurl/ABI.md']
+- all: ['include/curl/**']
+
+MIME:
+- all: ['docs/libcurl/curl_mime_*']
+- all: ['lib/mime*']
+
+MQTT:
+- all: ['docs/MQTT.md']
+- all: ['lib/mqtt*']
+
+name lookup:
+- all: ['lib/asyn*']
+- all: ['lib/curl_gethostname.*']
+- all: ['lib/doh*']
+- all: ['lib/host*']
+- all: ['lib/idn*']
+- all: ['lib/socketpair*']
+
+POP3:
+- all: ['lib/pop3.*']
+
+RTMP:
+- all: ['lib/curl_rtmp.*']
+
+RTSP:
+- all: ['lib/rtsp.*']
+
+SCP/SFTP:
+- all: ['lib/vssh/**']
+
+script:
+- all: ['scripts/**']
+- all: ['**/*.pl']
+- all: ['**/*.sh']
+
+SMB:
+- all: ['lib/smb.*']
+
+SMTP:
+- all: ['lib/smtp.*']
+
+tests:
+- all: ['tests/**']
+
+TFTP:
+- all: ['lib/tftp.*']
+
+TLS:
+- all: ['docs/HYPER.md']
+- all: ['docs/SSL*']
+- all: ['lib/vtls/**']
+
+URL:
+- all: ['docs/libcurl/curl_url*']
+- all: ['lib/urlapi*']
+- all: ['lib/url.*']
+
+WebSocket:
+- all: ['docs/WEBSOCKET.md*']
+- all: ['lib/ws.*']
+- all: ['docs/WebSockets.md']
+- all: ['docs/libcurl/opts/CURLOPT_WS_OPTIONS.3']
+- all: ['docs/libcurl/curl_ws_*']
+
+Windows:
+- all: ['projects/Windows/**']
+- all: ['lib/*win32*']
+- all: ['lib/curl_multibyte.*']
+- all: ['lib/rename.*']
+- all: ['winbuild/**']

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,26 @@
+# Copyright (C) Daniel Fandrich, <dan@coneharvesters.com>, et al.
+#
+# SPDX-License-Identifier: curl
+
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The labeler language is quite restrictive right now so labels are added
quite conservatively, meaning that many PRs won't get labels when it's
"obvious" they should. It will still save some manual work on those
that it can label.

If this labeler were already running, it would have labeled this PR with "CI".