### PR TITLE
system.h: assume OS400 is always built with ILEC compiler

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -227,16 +227,14 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T unsigned int
 
 #elif defined(__OS400__)
-#  if defined(__ILEC400__)
-#    define CURL_TYPEOF_CURL_OFF_T     long long
-#    define CURL_FORMAT_CURL_OFF_T     "lld"
-#    define CURL_FORMAT_CURL_OFF_TU    "llu"
-#    define CURL_SUFFIX_CURL_OFF_T     LL
-#    define CURL_SUFFIX_CURL_OFF_TU    ULL
-#    define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
-#    define CURL_PULL_SYS_TYPES_H      1
-#    define CURL_PULL_SYS_SOCKET_H     1
-#  endif
+#  define CURL_TYPEOF_CURL_OFF_T     long long
+#  define CURL_FORMAT_CURL_OFF_T     "lld"
+#  define CURL_FORMAT_CURL_OFF_TU    "llu"
+#  define CURL_SUFFIX_CURL_OFF_T     LL
+#  define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
+#  define CURL_PULL_SYS_TYPES_H      1
+#  define CURL_PULL_SYS_SOCKET_H     1
 
 #elif defined(__MVS__)
 #  if defined(__IBMC__) || defined(__IBMCPP__)


### PR DESCRIPTION
Prior to this change the OS400 types were only defined when `__ILEC400__`. That symbol is only defined by IBM's C compiler and not their C++ compiler, which led to missing types when users would compile a C++ application.

Assisted-by: Jon Rumsey
Reported-by: John Sherrill

Fixes https://github.com/curl/curl/issues/10305
Closes #xxxx

---

Can we be sure that these types are the only types used and that compiler is the only compiler used on OS400?

/cc @jonrumsey @johnsherrill 
