### PR TITLE
write-out.d: clarify Windows % symbol escaping

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -31,8 +31,10 @@ trailing colon). The header contents are exactly as sent over the network,
 with leading and trailing whitespace trimmed. Added in curl 7.84.0.
 
 .B NOTE:
-The %-symbol is a special symbol in the win32-environment, where all
-occurrences of % must be doubled when using this option.
+In Windows the %-symbol is a special symbol used to expand environment
+variables. In batch files all occurrences of % must be doubled when using this
+option to properly escape. If this option is used at the command prompt then
+the % cannot be escaped and unintended expansion is possible.
 
 The variables available are:
 .RS


### PR DESCRIPTION
- Clarify that in Windows batch files the % must be escaped as %%, and at the command prompt it cannot be escaped which could lead to incorrect expansion.

Prior to this change the doc implied % must be escaped as %% in win32 always.

---

Examples:

If curl --write-out "%{http_code}" is executed in a batch file: {http_code}

If curl --write-out "%%{http_code}" is executed in a batch file: %{http_code}

If curl --write-out "%{http_code}" is executed from the command prompt: %{http_code}

If curl --write-out "%%{http_code}" is executed from the command prompt: %%{http_code}

At the command prompt something like "%{speed_download}%{http_code}" would first be parsed by the command interpreter as %{speed_download}% and would be expanded as environment variable {speed_download} if it existed, though that's highly unlikely since Windows environment names don't use braces.

---

Reported-by: Muhammad Hussein Ammari

Fixes https://github.com/curl/curl/issues/10323
Closes #xxxx