### PR TITLE
Nested cfilter calls, handling of current data

### DIFF
--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -465,16 +465,16 @@ struct cf_call_data {
  * #define CF_CTX_CALL_DATA(cf)   -> struct cf_call_data instance
 */
 
-#define CF_DATA_SAVE(cf, data) \
-  struct cf_call_data cf_cd_save = CF_CTX_CALL_DATA(cf); \
-  DEBUGASSERT(cf_cd_save.data == NULL || cf_cd_save.depth > 0); \
+#define CF_DATA_SAVE(save, cf, data) \
+  (save) = CF_CTX_CALL_DATA(cf); \
+  DEBUGASSERT((save).data == NULL || (save).depth > 0); \
   CF_CTX_CALL_DATA(cf).data = (struct Curl_easy *)data; \
   CF_CTX_CALL_DATA(cf).depth++
 
-#define CF_DATA_RESTORE(cf) \
-  DEBUGASSERT(CF_CTX_CALL_DATA(cf).depth == cf_cd_save.depth + 1); \
-  DEBUGASSERT(cf_cd_save.data == NULL || cf_cd_save.depth > 0); \
-  CF_CTX_CALL_DATA(cf) = cf_cd_save
+#define CF_DATA_RESTORE(cf, save) \
+  DEBUGASSERT(CF_CTX_CALL_DATA(cf).depth == (save).depth + 1); \
+  DEBUGASSERT((save).data == NULL || (save).depth > 0); \
+  CF_CTX_CALL_DATA(cf) = (save)
 
 #define CF_DATA_CURRENT(cf) \
   ((cf)? (CF_CTX_CALL_DATA(cf).data) : NULL)

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -84,7 +84,7 @@ static ssize_t gtls_push(void *s, const void *buf, size_t blen)
 {
   struct Curl_cfilter *cf = s;
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result;
 
@@ -102,7 +102,7 @@ static ssize_t gtls_pull(void *s, void *buf, size_t blen)
 {
   struct Curl_cfilter *cf = s;
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result;
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -160,7 +160,7 @@ static int bio_cf_write(void *bio, const unsigned char *buf, size_t blen)
 {
   struct Curl_cfilter *cf = bio;
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result;
 
@@ -178,7 +178,7 @@ static int bio_cf_read(void *bio, unsigned char *buf, size_t blen)
 {
   struct Curl_cfilter *cf = bio;
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result;
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -159,7 +159,6 @@ static void mbed_debug(void *context, int level, const char *f_name,
 static int bio_cf_write(void *bio, const unsigned char *buf, size_t blen)
 {
   struct Curl_cfilter *cf = bio;
-  struct ssl_connect_data *connssl = cf->ctx;
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result;
@@ -177,7 +176,6 @@ static int bio_cf_write(void *bio, const unsigned char *buf, size_t blen)
 static int bio_cf_read(void *bio, unsigned char *buf, size_t blen)
 {
   struct Curl_cfilter *cf = bio;
-  struct ssl_connect_data *connssl = cf->ctx;
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -702,7 +702,7 @@ static int bio_cf_out_write(BIO *bio, const char *buf, int blen)
 {
   struct Curl_cfilter *cf = BIO_get_data(bio);
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result = CURLE_SEND_ERROR;
 
@@ -723,7 +723,7 @@ static int bio_cf_in_read(BIO *bio, char *buf, int blen)
 {
   struct Curl_cfilter *cf = BIO_get_data(bio);
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result = CURLE_RECV_ERROR;
 
@@ -2650,7 +2650,7 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
   connssl = cf->ctx;
   DEBUGASSERT(connssl);
   DEBUGASSERT(connssl->backend);
-  data = connssl->call_data;
+  data = CF_DATA_CURRENT(cf);
 
   if(!conn || !data || !data->set.fdebug
      || (direction != 0 && direction != 1))
@@ -2951,7 +2951,7 @@ static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
     return 0;
   cf = (struct Curl_cfilter*) SSL_get_ex_data(ssl, cf_idx);
   connssl = cf? cf->ctx : NULL;
-  data = connssl? connssl->call_data : NULL;
+  data = connssl? CF_DATA_CURRENT(cf) : NULL;
   /* The sockindex has been stored as a pointer to an array element */
   if(!cf || !data)
     return 0;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2639,7 +2639,6 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
   const char *verstr = "???";
   struct connectdata *conn = userp;
   int cf_idx = ossl_get_ssl_cf_index();
-  struct ssl_connect_data *connssl;
   struct Curl_easy *data = NULL;
   struct Curl_cfilter *cf;
   char unknown[32];
@@ -2647,9 +2646,6 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
   DEBUGASSERT(cf_idx >= 0);
   cf = (struct Curl_cfilter*) SSL_get_ex_data(ssl, cf_idx);
   DEBUGASSERT(cf);
-  connssl = cf->ctx;
-  DEBUGASSERT(connssl);
-  DEBUGASSERT(connssl->backend);
   data = CF_DATA_CURRENT(cf);
 
   if(!conn || !data || !data->set.fdebug

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -832,7 +832,7 @@ static OSStatus bio_cf_in_read(SSLConnectionRef connection,
   struct Curl_cfilter *cf = (struct Curl_cfilter *)connection;
   struct ssl_connect_data *connssl = cf->ctx;
   struct ssl_backend_data *backend = connssl->backend;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result;
   OSStatus rtn = noErr;
@@ -868,7 +868,7 @@ static OSStatus bio_cf_out_write(SSLConnectionRef connection,
   struct Curl_cfilter *cf = (struct Curl_cfilter *)connection;
   struct ssl_connect_data *connssl = cf->ctx;
   struct ssl_backend_data *backend = connssl->backend;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result;
   OSStatus rtn = noErr;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -315,13 +315,6 @@ static void cf_ctx_free(struct ssl_connect_data *ctx)
   }
 }
 
-static void cf_ctx_set_data(struct Curl_cfilter *cf,
-                            struct Curl_easy *data)
-{
-  if(cf->ctx)
-    ((struct ssl_connect_data *)cf->ctx)->call_data = data;
-}
-
 static CURLcode ssl_connect(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
@@ -1482,8 +1475,9 @@ static CURLcode reinit_hostname(struct Curl_cfilter *cf)
 
 static void ssl_cf_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
-  cf_ctx_set_data(cf, data);
+  CF_DATA_SAVE(cf, data);
   cf_close(cf, data);
+  CF_DATA_RESTORE(cf);
   cf_ctx_free(cf->ctx);
   cf->ctx = NULL;
 }
@@ -1491,10 +1485,10 @@ static void ssl_cf_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 static void ssl_cf_close(struct Curl_cfilter *cf,
                          struct Curl_easy *data)
 {
-  cf_ctx_set_data(cf, data);
+  CF_DATA_SAVE(cf, data);
   cf_close(cf, data);
   cf->next->cft->close(cf->next, data);
-  cf_ctx_set_data(cf, NULL);
+  CF_DATA_RESTORE(cf);
 }
 
 static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
@@ -1503,13 +1497,14 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
 {
   struct ssl_connect_data *connssl = cf->ctx;
   CURLcode result;
+  CF_DATA_SAVE(cf, data);
 
   if(cf->connected) {
     *done = TRUE;
+    CF_DATA_RESTORE(cf);
     return CURLE_OK;
   }
 
-  cf_ctx_set_data(cf, data);
   (void)connssl;
   DEBUGASSERT(data->conn);
   DEBUGASSERT(data->conn == cf->conn);
@@ -1540,7 +1535,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
     DEBUGASSERT(connssl->state == ssl_connection_complete);
   }
 out:
-  cf_ctx_set_data(cf, NULL);
+  CF_DATA_RESTORE(cf);
   return result;
 }
 
@@ -1548,13 +1543,13 @@ static bool ssl_cf_data_pending(struct Curl_cfilter *cf,
                                 const struct Curl_easy *data)
 {
   bool result;
+  CF_DATA_SAVE(cf, data);
 
-  cf_ctx_set_data(cf, (struct Curl_easy *)data);
   if(cf->ctx && Curl_ssl->data_pending(cf, data))
     result = TRUE;
   else
     result = cf->next->cft->has_data_pending(cf->next, data);
-  cf_ctx_set_data(cf, NULL);
+  CF_DATA_RESTORE(cf);
   return result;
 }
 
@@ -1563,11 +1558,11 @@ static ssize_t ssl_cf_send(struct Curl_cfilter *cf,
                            CURLcode *err)
 {
   ssize_t nwritten;
+  CF_DATA_SAVE(cf, data);
 
   *err = CURLE_OK;
-  cf_ctx_set_data(cf, data);
   nwritten = Curl_ssl->send_plain(cf, data, buf, len, err);
-  cf_ctx_set_data(cf, NULL);
+  CF_DATA_RESTORE(cf);
   return nwritten;
 }
 
@@ -1575,12 +1570,12 @@ static ssize_t ssl_cf_recv(struct Curl_cfilter *cf,
                            struct Curl_easy *data, char *buf, size_t len,
                            CURLcode *err)
 {
+  CF_DATA_SAVE(cf, data);
   ssize_t nread;
 
   *err = CURLE_OK;
-  cf_ctx_set_data(cf, data);
   nread = Curl_ssl->recv_plain(cf, data, buf, len, err);
-  cf_ctx_set_data(cf, NULL);
+  CF_DATA_RESTORE(cf);
   return nread;
 }
 
@@ -1588,11 +1583,11 @@ static int ssl_cf_get_select_socks(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
                                    curl_socket_t *socks)
 {
+  CF_DATA_SAVE(cf, data);
   int result;
 
-  cf_ctx_set_data(cf, data);
   result = Curl_ssl->get_select_socks(cf, data, socks);
-  cf_ctx_set_data(cf, NULL);
+  CF_DATA_RESTORE(cf);
   return result;
 }
 
@@ -1600,31 +1595,32 @@ static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf,
                              struct Curl_easy *data,
                              int event, int arg1, void *arg2)
 {
+  CF_DATA_SAVE(cf, data);
+
   (void)arg1;
   (void)arg2;
   switch(event) {
   case CF_CTRL_DATA_ATTACH:
     if(Curl_ssl->attach_data) {
-      cf_ctx_set_data(cf, data);
       Curl_ssl->attach_data(cf, data);
-      cf_ctx_set_data(cf, NULL);
     }
     break;
   case CF_CTRL_DATA_DETACH:
     if(Curl_ssl->detach_data) {
-      cf_ctx_set_data(cf, data);
       Curl_ssl->detach_data(cf, data);
-      cf_ctx_set_data(cf, NULL);
     }
     break;
   default:
     break;
   }
+  CF_DATA_RESTORE(cf);
   return CURLE_OK;
 }
 
 static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
+  CF_DATA_SAVE(cf, data);
+  bool result;
   /*
    * This function tries to determine connection status.
    *
@@ -1633,7 +1629,9 @@ static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data)
    *     0 means the connection has been closed
    *    -1 means the connection status is unknown
    */
-  return Curl_ssl->check_cxn(cf, data) != 0;
+  result = Curl_ssl->check_cxn(cf, data) != 0;
+  CF_DATA_RESTORE(cf);
+  return result;
 }
 
 struct Curl_cftype Curl_cft_ssl = {
@@ -1786,9 +1784,9 @@ void *Curl_ssl_get_internals(struct Curl_easy *data, int sockindex,
     /* get first filter in chain, if any is present */
     cf = Curl_ssl_cf_get_ssl(data->conn->cfilter[sockindex]);
     if(cf) {
-      cf_ctx_set_data(cf, data);
+      CF_DATA_SAVE(cf, data);
       result = Curl_ssl->get_internals(cf->ctx, info);
-      cf_ctx_set_data(cf, NULL);
+      CF_DATA_RESTORE(cf);
     }
   }
   return result;

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -37,12 +37,12 @@ struct ssl_connect_data {
   char *dispname;                   /* display version of hostname */
   int port;                         /* remote port at origin */
   struct ssl_backend_data *backend; /* vtls backend specific props */
-  struct Curl_easy *call_data;      /* data handle used in current call,
-                                     * same as parameter passed, but available
-                                     * here for backend internal callbacks
-                                     * that need it. NULLed after at the
-                                     * end of each vtls filter invcocation. */
+  struct cf_call_data call_data;    /* data handle used in current call */
 };
+
+
+#define CF_CTX_CALL_DATA(cf)  \
+  ((struct ssl_connect_data *)(cf)->ctx)->call_data
 
 
 /* Definitions for SSL Implementations */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -299,7 +299,6 @@ static long bio_cf_ctrl(WOLFSSL_BIO *bio, int cmd, long num, void *ptr)
 static int bio_cf_out_write(WOLFSSL_BIO *bio, const char *buf, int blen)
 {
   struct Curl_cfilter *cf = wolfSSL_BIO_get_data(bio);
-  struct ssl_connect_data *connssl = cf->ctx;
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result = CURLE_OK;
@@ -315,7 +314,6 @@ static int bio_cf_out_write(WOLFSSL_BIO *bio, const char *buf, int blen)
 static int bio_cf_in_read(WOLFSSL_BIO *bio, char *buf, int blen)
 {
   struct Curl_cfilter *cf = wolfSSL_BIO_get_data(bio);
-  struct ssl_connect_data *connssl = cf->ctx;
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result = CURLE_OK;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -300,7 +300,7 @@ static int bio_cf_out_write(WOLFSSL_BIO *bio, const char *buf, int blen)
 {
   struct Curl_cfilter *cf = wolfSSL_BIO_get_data(bio);
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
   CURLcode result = CURLE_OK;
 
@@ -316,7 +316,7 @@ static int bio_cf_in_read(WOLFSSL_BIO *bio, char *buf, int blen)
 {
   struct Curl_cfilter *cf = wolfSSL_BIO_get_data(bio);
   struct ssl_connect_data *connssl = cf->ctx;
-  struct Curl_easy *data = connssl->call_data;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
   CURLcode result = CURLE_OK;
 


### PR DESCRIPTION
Manage handling of current easy handle in nested cfilter calls.

- refs #10336 where the previous implementation cleared `data` so the outer invocation lost its data.