### PR TITLE
cf-socket: Fix build when not HAVE_GETPEERNAME

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1174,8 +1174,6 @@ static void conn_set_primary_ip(struct Curl_cfilter *cf,
 #else
   cf->conn->primary_ip[0] = 0;
   (void)data;
-  (void)conn;
-  (void)sockfd;
 #endif
 }
 


### PR DESCRIPTION
Remove remaining references to `conn` and `sockfd`, which were removed from the function signature when `conninfo_remote` was renamed to `conn_set_primary_ip` in 6a8d7ef.

See #10213

Fixes this build failure when building for Classic Mac OS (using a new Makefile I haven't contributed yet):

```
### MWC68K Compiler Error:
#	(void)conn;
#	      ^^^^
# undefined identifier 'conn'
#----------------------------------------------------------
File "cf-socket.c"; Line 1177
#----------------------------------------------------------
### MWC68K Compiler Error:
#	(void)sockfd;
#	      ^^^^^^
# undefined identifier 'sockfd'
#----------------------------------------------------------
File "cf-socket.c"; Line 1178
#----------------------------------------------------------
```