### PR TITLE
connect: Fix build when not ENABLE_IPV6

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -395,7 +395,10 @@ static CURLcode eyeballer_new(struct eyeballer **pballer,
     return CURLE_OUT_OF_MEMORY;
 
   baller->name = ((ai_family == AF_INET)? "ipv4" : (
-                  (ai_family == AF_INET6)? "ipv6" : "ip"));
+#ifdef ENABLE_IPV6
+                  (ai_family == AF_INET6)? "ipv6" :
+#endif
+                  "ip"));
   baller->cf_create = cf_create;
   baller->addr = addr;
   baller->ai_family = ai_family;


### PR DESCRIPTION
Check for `ENABLE_IPV6` before accessing `AF_INET6`. Fixes build failure introduced in 1c5d8ac.

See #10248

Fixes this error when building for Classic Mac OS:

```
### MWC68K Compiler Error:
#	(ai_family == AF_INET6)? "ipv6" : "ip"));
#	              ^^^^^^^^
# undefined identifier 'AF_INET6'
#----------------------------------------------------------
File "connect.c"; Line 398
#----------------------------------------------------------
# errors caused tool to abort
```
