### PR TITLE
escape: hex decode with a lookup-table

### DIFF
--- a/lib/escape.c
+++ b/lib/escape.c
@@ -177,8 +177,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
 
     if(((ctrl == REJECT_CTRL) && (in < 0x20)) ||
        ((ctrl == REJECT_ZERO) && (in == 0))) {
-      free(ns);
-      *ostring = NULL;
+      Curl_safefree(*ostring);
       return CURLE_URL_MALFORMAT;
     }
 

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -115,6 +115,16 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   return Curl_dyn_ptr(&d);
 }
 
+static const unsigned char hextable[] = {
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0,       /* 0x30 - 0x3f */
+  0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x40 - 0x4f */
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,       /* 0x50 - 0x5f */
+  0, 10, 11, 12, 13, 14, 15                             /* 0x60 - 0x66 */
+};
+
+/* the input is a single hex digit */
+#define onehex2dec(x) hextable[x - '0']
+
 /*
  * Curl_urldecode() URL decodes the given string.
  *
@@ -137,54 +147,48 @@ CURLcode Curl_urldecode(const char *string, size_t length,
 {
   size_t alloc;
   char *ns;
-  size_t strindex = 0;
-  unsigned long hex;
 
   DEBUGASSERT(string);
   DEBUGASSERT(ctrl >= REJECT_NADA); /* crash on TRUE/FALSE */
 
-  alloc = (length?length:strlen(string)) + 1;
-  ns = malloc(alloc);
+  alloc = (length?length:strlen(string));
+  ns = malloc(alloc + 1);
 
   if(!ns)
     return CURLE_OUT_OF_MEMORY;
 
-  while(--alloc > 0) {
+  /* store output string */
+  *ostring = ns;
+
+  while(alloc) {
     unsigned char in = *string;
     if(('%' == in) && (alloc > 2) &&
        ISXDIGIT(string[1]) && ISXDIGIT(string[2])) {
       /* this is two hexadecimal digits following a '%' */
-      char hexstr[3];
-      char *ptr;
-      hexstr[0] = string[1];
-      hexstr[1] = string[2];
-      hexstr[2] = 0;
+      in = (unsigned char)(onehex2dec(string[1]) << 4) | onehex2dec(string[2]);
 
-      hex = strtoul(hexstr, &ptr, 16);
-
-      in = curlx_ultouc(hex); /* this long is never bigger than 255 anyway */
-
-      string += 2;
-      alloc -= 2;
+      string += 3;
+      alloc -= 3;
+    }
+    else {
+      string++;
+      alloc--;
     }
 
     if(((ctrl == REJECT_CTRL) && (in < 0x20)) ||
        ((ctrl == REJECT_ZERO) && (in == 0))) {
       free(ns);
+      *ostring = NULL;
       return CURLE_URL_MALFORMAT;
     }
 
-    ns[strindex++] = in;
-    string++;
+    *ns++ = in;
   }
-  ns[strindex] = 0; /* terminate it */
+  *ns = 0; /* terminate it */
 
   if(olen)
     /* store output size */
-    *olen = strindex;
-
-  /* store output string */
-  *ostring = ns;
+    *olen = ns - *ostring;
 
   return CURLE_OK;
 }


### PR DESCRIPTION
# Faster URL decodes in curl

I wrote [a test program](https://gist.github.com/bagder/d984079fca82524ed64e69dcaa429644) that uses a 1MB buffer in which byte sequences are stored from 0 to 255 over and over.

Then `curl_easy_escape()` is called, to generate a URL encoded version of that input.

`curl_easy_unescape()` is then called repeatedly to decode that huge string and I measure the time needed for it to complete 10000 iterations.

On my dev host, the new code runs 2.8 times faster.
