### PR TITLE
unit2600: avoid error: ‘TEST_CASES’ defined but not used

### DIFF
--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -354,6 +354,7 @@ UNITTEST_START
   }
 #else
   (void)TEST_CASES;
+  (void)test_connect;
 #endif
 
 UNITTEST_STOP

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -352,7 +352,8 @@ UNITTEST_START
   for(i = 0; i < sizeof(TEST_CASES)/sizeof(TEST_CASES[0]); ++i) {
     test_connect(&TEST_CASES[i]);
   }
-
+#else
+  (void)TEST_CASES;
 #endif
 
 UNITTEST_STOP


### PR DESCRIPTION
Follow-up to d55de24dce9d51