### PR TITLE
macos.yml: revert to Xcode 14.0.1 to avoid cmake/gcc-11 build errors

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,9 @@ concurrency:
 
 permissions: {}
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}


### PR DESCRIPTION
Possible fix for: https://github.com/curl/curl/issues/10356