### PR TITLE
docs/INSTALL: document how to use multiple TLS backends

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -143,7 +143,7 @@ These options are provided to select the TLS backend to use.
 
 You can build curl with *multiple* TLS backends at your choice, but some TLS
 backends cannot be combined: if you build with an OpenSSL fork (or wolfSSL),
-you cannot add another OpenSSL for (or wolfSSL) simply because they have
+you cannot add another OpenSSL fork (or wolfSSL) simply because they have
 conflicting identical symbol names.
 
 When you build with multipl TLS backends, you can select the active one at

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,7 +146,7 @@ backends cannot be combined: if you build with an OpenSSL fork (or wolfSSL),
 you cannot add another OpenSSL fork (or wolfSSL) simply because they have
 conflicting identical symbol names.
 
-When you build with multipl TLS backends, you can select the active one at
+When you build with multiple TLS backends, you can select the active one at
 run-time when curl starts up.
 
 # Windows

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -135,11 +135,19 @@ These options are provided to select the TLS backend to use.
  - GnuTLS: `--with-gnutls`.
  - mbedTLS: `--with-mbedtls`
  - NSS: `--with-nss`
- - OpenSSL: `--with-openssl` (also for BoringSSL and libressl)
+ - OpenSSL: `--with-openssl` (also for BoringSSL, libressl and quictls)
  - rustls: `--with-rustls`
  - Schannel: `--with-schannel`
  - Secure Transport: `--with-secure-transport`
  - wolfSSL: `--with-wolfssl`
+
+You can build curl with *multiple* TLS backends at your choice, but some TLS
+backends cannot be combined: if you build with an OpenSSL fork (or wolfSSL),
+you cannot add another OpenSSL for (or wolfSSL) simply because they have
+conflicting identical symbol names.
+
+When you build with multipl TLS backends, you can select the active one at
+run-time when curl starts up.
 
 # Windows
 


### PR DESCRIPTION
And document how OpenSSL forks and wolfSSL cannot be used at the same time.

Reported-by: Mark Roszko
Fixes #10321