### PR TITLE
cookies: fp is always not NULL

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1299,7 +1299,7 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
      */
     remove_expired(c);
 
-    if(fromfile && fp)
+    if(fromfile)
       fclose(fp);
   }
 


### PR DESCRIPTION
```c
if (fp) {
...
    if(fromfile && fp) // At this line fp is always not null
...
}
```