### PR TITLE
urlapi: avoid Curl_dyn_addf() for hex outputs

### DIFF
--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -27,7 +27,7 @@
 #define ISLOWHEXALHA(x) (((x) >= 'a') && ((x) <= 'f'))
 #define ISUPHEXALHA(x) (((x) >= 'A') && ((x) <= 'F'))
 
-#define ISLOWCNTRL(x) ((x) >= 0 && ((x) <= 0x1f))
+#define ISLOWCNTRL(x) ((unsigned char)(x) <= 0x1f)
 #define IS7F(x) ((x) == 0x7f)
 
 #define ISLOWPRINT(x) (((x) >= 9) && ((x) <= 0x0d))


### PR DESCRIPTION
inspired by the recent fixes to escape.c, we really should avoid calling Curl_dyn_addf() in loops, perhaps in particular when adding something so simple such as `%HH` codes - for performance reasons. This change thus makes the same thing for the URL parser's two URL-encoding loops.