### PR TITLE
urlapi: skip path checks if path is just "/"

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1200,9 +1200,10 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     path = u->path = Curl_dyn_ptr(&enc);
   }
 
-  if(!pathlen) {
-    /* there is no path left, unset */
+  if(pathlen <= 1) {
+    /* there is no path left or just the slash, unset */
     path = NULL;
+    pathlen = 0;
   }
   else {
     if(!u->path) {


### PR DESCRIPTION
As a miniscule optimization, treat a path of the length 1 as the same as non-existing, as it can only be a single leading slash, and that's what we do for no paths as well.