### PR TITLE
CODEOWNERS: remove the peeps mentioned as CI owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,3 @@
 # Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # SPDX-License-Identifier: curl
-
-# Code owners for CI configuration
-## GitHub Actions
-.github/workflows/ @cmeister2 @mback2k
-## AppVeyor
-appveyor.yml @MarcelRaad @mback2k
-tests/appveyor.pm @mback2k
-## Azure Pipelines
-.azure-pipelines.yml @cmeister2 @mback2k
-tests/azure.pm @mback2k


### PR DESCRIPTION
These owners do not have the bandwidth/energy to do the reviews which makes PRs stall and this ownership claim flawed.

Follow-up to c04c78ac87c4d46737934345a