### PR TITLE
Add 'since version' to %{header_json} documentation

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -65,7 +65,7 @@ server. (Added in 7.15.4)
 .B header_json
 A JSON object with all HTTP response headers from the recent transfer. Values
 are provided as arrays, since in the case of multiple headers there can be
-multiple values.
+multiple values. (Added in 7.83.0)
 
 The header names provided in lowercase, listed in order of appearance over the
 wire. Except for duplicated headers. They are grouped on the first occurrence


### PR DESCRIPTION
The documentation of `%{header_json}` missed to mention since which version this variable for `--write-out` is present.

Based on commit https://github.com/curl/curl/commit/4133a69f2daa476bb6d902687f1dd6660ea9c3c5 we can determine from the tags were this commit is present that the first version to include it was `7.83.0`.
This could be also checked with: `git tag --contains 4133a69f2daa476bb6d902687f1dd6660ea9c3c5`