### PR TITLE
doh: Optimization for disabled ENABLE_IPV6

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -396,6 +396,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
     goto error;
   dohp->pending++;
 
+#ifdef ENABLE_IPV6
   if((conn->ip_version != CURL_IPRESOLVE_V4) && Curl_ipv6works(data)) {
     /* create IPv6 DoH request */
     result = dohprobe(data, &dohp->probe[DOH_PROBE_SLOT_IPADDR_V6],
@@ -405,6 +406,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
       goto error;
     dohp->pending++;
   }
+#endif
   return NULL;
 
   error:


### PR DESCRIPTION
For disabled IPv6 a condition (conn->ip_version != CURL_IPRESOLVE_V4) is always false.
https://pvs-studio.com/en/docs/warnings/v560/