### PR TITLE
fopen: tempname is already NULL

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -106,7 +106,6 @@ fail:
 
   free(tempstore);
 
-  *tempname = NULL;
   return result;
 }
 


### PR DESCRIPTION
[CWE-1164] V1048: The '* tempname' variable was assigned the same value.
https://pvs-studio.com/en/docs/warnings/v1048/