### PR TITLE
setopt: optimization for WIN32

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -199,8 +199,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     arg = va_arg(param, long);
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
+#if SIZEOF_LONG > 4
     else if(arg > INT_MAX)
       arg = INT_MAX;
+#endif
 
     data->set.dns_cache_timeout = (int)arg;
     break;
@@ -208,8 +210,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     arg = va_arg(param, long);
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
+#if SIZEOF_LONG > 4
     else if(arg > INT_MAX)
       arg = INT_MAX;
+#endif
 
     data->set.general_ssl.ca_cache_timeout = (int)arg;
     break;
@@ -1452,8 +1456,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_TIMEOUT_MS:
     uarg = va_arg(param, unsigned long);
-    if(uarg >= UINT_MAX)
+#if SIZEOF_LONG > 4
+    if(uarg > UINT_MAX)
       uarg = UINT_MAX;
+#endif
     data->set.timeout = (unsigned int)uarg;
     break;
 
@@ -1470,8 +1476,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_CONNECTTIMEOUT_MS:
     uarg = va_arg(param, unsigned long);
-    if(uarg >= UINT_MAX)
+#if SIZEOF_LONG > 4
+    if(uarg > UINT_MAX)
       uarg = UINT_MAX;
+#endif
     data->set.connecttimeout = (unsigned int)uarg;
     break;
 
@@ -1481,8 +1489,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * The maximum time for curl to wait for FTP server connect
      */
     uarg = va_arg(param, unsigned long);
+#if SIZEOF_LONG > 4
     if(uarg >= UINT_MAX)
       uarg = UINT_MAX;
+#endif
     data->set.accepttimeout = (unsigned int)uarg;
     break;
 #endif
@@ -2910,16 +2920,20 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     arg = va_arg(param, long);
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
+#if SIZEOF_LONG > 4
     else if(arg > INT_MAX)
       arg = INT_MAX;
+#endif
     data->set.tcp_keepidle = (int)arg;
     break;
   case CURLOPT_TCP_KEEPINTVL:
     arg = va_arg(param, long);
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
+#if SIZEOF_LONG > 4
     else if(arg > INT_MAX)
       arg = INT_MAX;
+#endif
     data->set.tcp_keepintvl = (int)arg;
     break;
   case CURLOPT_TCP_FASTOPEN:
@@ -2981,8 +2995,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     break;
   case CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS:
     uarg = va_arg(param, unsigned long);
-    if(uarg >= UINT_MAX)
+#if SIZEOF_LONG > 4
+    if(uarg > UINT_MAX)
       uarg = UINT_MAX;
+#endif
     data->set.happy_eyeballs_timeout = (unsigned int)uarg;
     break;
 #ifndef CURL_DISABLE_SHUFFLE_DNS

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1490,7 +1490,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      */
     uarg = va_arg(param, unsigned long);
 #if SIZEOF_LONG > 4
-    if(uarg >= UINT_MAX)
+    if(uarg > UINT_MAX)
       uarg = UINT_MAX;
 #endif
     data->set.accepttimeout = (unsigned int)uarg;


### PR DESCRIPTION
[CWE-570] V547: Expression 'arg > 2147483647' is always false.
https://pvs-studio.com/en/docs/warnings/v547/

[CWE-1164] V1048: The 'uarg' variable was assigned the same value.
https://pvs-studio.com/en/docs/warnings/v1048/