### PR TITLE
strtoofft: optimization with macro ISSPACEBASE

### DIFF
--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -41,7 +41,7 @@
 #define ISUPPER(x)  (((x) >= 'A') && ((x) <= 'Z'))
 #define ISLOWER(x)  (((x) >= 'a') && ((x) <= 'z'))
 #define ISDIGIT(x)  (((x) >= '0') && ((x) <= '9'))
-#define ISBLANK(x)  (((x) == ' ') || ((x) == '\t'))
-#define ISSPACE(x)  (ISBLANK(x) || (((x) >= 0xa) && ((x) <= 0x0d)))
+#define ISSPACEBASE(x)  (((x) >= 0xa) && ((x) <= 0x0d))
+#define ISSPACE(x)  (ISBLANK(x) || ISSPACEBASE(x))
 
 #endif /* HEADER_CURL_CTYPE_H */

--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -41,7 +41,7 @@
 #define ISUPPER(x)  (((x) >= 'A') && ((x) <= 'Z'))
 #define ISLOWER(x)  (((x) >= 'a') && ((x) <= 'z'))
 #define ISDIGIT(x)  (((x) >= '0') && ((x) <= '9'))
-#define ISSPACEBASE(x)  (((x) >= 0xa) && ((x) <= 0x0d))
-#define ISSPACE(x)  (ISBLANK(x) || ISSPACEBASE(x))
+#define ISXDIGIT(x)  (((x) >= 0xa) && ((x) <= 0x0d))
+#define ISSPACE(x)  (ISBLANK(x) || ISXDIGIT(x))
 
 #endif /* HEADER_CURL_CTYPE_H */

--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -41,7 +41,7 @@
 #define ISUPPER(x)  (((x) >= 'A') && ((x) <= 'Z'))
 #define ISLOWER(x)  (((x) >= 'a') && ((x) <= 'z'))
 #define ISDIGIT(x)  (((x) >= '0') && ((x) <= '9'))
-#define ISXDIGIT(x)  (((x) >= 0xa) && ((x) <= 0x0d))
-#define ISSPACE(x)  (ISBLANK(x) || ISXDIGIT(x))
+#define ISSPACEBASE(x)  (((x) >= 0xa) && ((x) <= 0x0d))
+#define ISSPACE(x)  (ISBLANK(x) || ISSPACEBASE(x))
 
 #endif /* HEADER_CURL_CTYPE_H */

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -225,7 +225,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
 
   while(*str && ISBLANK(*str))
     str++;
-  if(('-' == *str) || (ISSPACE(*str))) {
+  if(('-' == *str) || (ISSPACEBASE(*str))) {
     if(endp)
       *endp = (char *)str; /* didn't actually move */
     return CURL_OFFT_INVAL; /* nothing parsed */

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -225,7 +225,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
 
   while(*str && ISBLANK(*str))
     str++;
-  if(('-' == *str) || (ISXDIGIT(*str))) {
+  if(('-' == *str) || (ISSPACEBASE(*str))) {
     if(endp)
       *endp = (char *)str; /* didn't actually move */
     return CURL_OFFT_INVAL; /* nothing parsed */

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -225,7 +225,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
 
   while(*str && ISBLANK(*str))
     str++;
-  if(('-' == *str) || (ISSPACEBASE(*str))) {
+  if(('-' == *str) || (ISXDIGIT(*str))) {
     if(endp)
       *endp = (char *)str; /* didn't actually move */
     return CURL_OFFT_INVAL; /* nothing parsed */


### PR DESCRIPTION
[CWE-570] V560: A part of conditional expression is always false: ((* str) == ' ').
[CWE-570] V560: A part of conditional expression is always false: ((* str) == '\t').

https://pvs-studio.com/en/docs/warnings/v560/