### PR TITLE
urlapi: remove pathlen assignment

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1203,7 +1203,6 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   if(pathlen <= 1) {
     /* there is no path left or just the slash, unset */
     path = NULL;
-    pathlen = 0;
   }
   else {
     if(!u->path) {


### PR DESCRIPTION
"Value stored to 'pathlen' is never read"

Follow-up to 804d5293f89

Reported-by: Kvarec Lezki