### PR TITLE
urlapi: fix PVS warning V560

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1102,10 +1102,10 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     hostp = p; /* host name starts here */
 
     /* find the end of the host name + port number */
-    while(p && *p && !HOSTNAME_END(*p))
+    while(*p && !HOSTNAME_END(*p))
       p++;
 
-    len = p ? p - hostp : 0;
+    len = p - hostp;
     if(len) {
       if(Curl_dyn_addn(&host, hostp, len)) {
         result = CURLUE_OUT_OF_MEMORY;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1102,10 +1102,10 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     hostp = p; /* host name starts here */
 
     /* find the end of the host name + port number */
-    while(*p && !HOSTNAME_END(*p))
+    while(p && *p && !HOSTNAME_END(*p))
       p++;
 
-    len = p - hostp;
+    len = p ? p - hostp : 0;
     if(len) {
       if(Curl_dyn_addn(&host, hostp, len)) {
         result = CURLUE_OUT_OF_MEMORY;
@@ -1153,7 +1153,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     size_t qlen = strlen(query) - fraglen; /* includes '?' */
     pathlen = strlen(path) - qlen - fraglen;
     if(qlen > 1) {
-      if(qlen && (flags & CURLU_URLENCODE)) {
+      if(flags & CURLU_URLENCODE) {
         struct dynbuf enc;
         Curl_dyn_init(&enc, CURL_MAX_INPUT_LENGTH);
         /* skip the leading question mark */


### PR DESCRIPTION
[CWE-571] V560: A part of conditional expression is always true: qlen.
https://pvs-studio.com/en/docs/warnings/v560/