### PR TITLE
unit2600: make sure CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS gets a long

### DIFF
--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -270,7 +270,8 @@ static void test_connect(struct test_case *tc)
   list = curl_slist_append(NULL, tc->resolve_info);
   fail_unless(list, "error allocating resolve list entry");
   curl_easy_setopt(easy, CURLOPT_RESOLVE, list);
-  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, tc->connect_timeout_ms);
+  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS,
+                   (long)tc->connect_timeout_ms);
   curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
                    (long)tc->he_timeout_ms);
 

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -271,7 +271,8 @@ static void test_connect(struct test_case *tc)
   fail_unless(list, "error allocating resolve list entry");
   curl_easy_setopt(easy, CURLOPT_RESOLVE, list);
   curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, tc->connect_timeout_ms);
-  curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS, tc->he_timeout_ms);
+  curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
+                   (long)tc->he_timeout_ms);
 
   curl_easy_setopt(easy, CURLOPT_URL, tc->url);
   memset(&tr, 0, sizeof(tr));


### PR DESCRIPTION
Follow-up to 671158242db3203

Reported-by: Marcel Raad
Fixes #10410