### PR TITLE
vtls: fix failf() format argument type for %.*s handling

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -2022,7 +2022,7 @@ CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
 #endif
     else {
       cf->conn->alpn = CURL_HTTP_VERSION_NONE;
-      failf(data, "unsupported ALPN protocol: '%.*s'", proto_len, proto);
+      failf(data, "unsupported ALPN protocol: '%.*s'", (int)proto_len, proto);
       /* TODO: do we want to fail this? Previous code just ignored it and
        * some vtls backends even ignore the return code of this function. */
       /* return CURLE_NOT_BUILT_IN; */


### PR DESCRIPTION
Reported by Coverity