### PR TITLE
man pages: call the custom user pointer 'clientp' consistently

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_PUSHDATA.3
+++ b/docs/libcurl/opts/CURLMOPT_PUSHDATA.3
@@ -46,10 +46,10 @@ int push_callback(CURL *parent,
                   CURL *easy,
                   size_t num_headers,
                   struct curl_pushheaders *headers,
-                  void *userp)
+                  void *clientp)
 {
   char *headp;
-  int *transfers = (int *)userp;
+  int *transfers = (int *)clientp;
   FILE *out;
   headp = curl_pushheader_byname(headers, ":path");
   if(headp && !strncmp(headp, "/push-", 6)) {

--- a/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.3
@@ -36,7 +36,7 @@ int curl_push_callback(CURL *parent,
                        CURL *easy,
                        size_t num_headers,
                        struct curl_pushheaders *headers,
-                       void *userp);
+                       void *clientp);
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PUSHFUNCTION,
                             curl_push_callback func);
@@ -63,7 +63,7 @@ functions described below. This only accesses and provides the PUSH_PROMISE
 headers, the normal response headers will be provided in the header callback
 as usual.
 
-\fIuserp\fP is the pointer set with \fICURLMOPT_PUSHDATA(3)\fP
+\fIclientp\fP is the pointer set with \fICURLMOPT_PUSHDATA(3)\fP
 
 If the callback returns CURL_PUSH_OK, the 'easy' handle will be added to the
 multi handle, the callback must not do that by itself.
@@ -104,10 +104,10 @@ int push_callback(CURL *parent,
                   CURL *easy,
                   size_t num_headers,
                   struct curl_pushheaders *headers,
-                  void *userp)
+                  void *clientp)
 {
   char *headp;
-  int *transfers = (int *)userp;
+  int *transfers = (int *)clientp;
   FILE *out;
   headp = curl_pushheader_byname(headers, ":path");
   if(headp && !strncmp(headp, "/push-", 6)) {

--- a/docs/libcurl/opts/CURLMOPT_SOCKETDATA.3
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETDATA.3
@@ -35,7 +35,7 @@ A data \fIpointer\fP to pass to the socket callback set with the
 \fICURLMOPT_SOCKETFUNCTION(3)\fP option.
 
 This pointer will not be touched by libcurl but will only be passed in to the
-socket callbacks's \fBuserp\fP argument.
+socket callbacks's \fBclientp\fP argument.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
@@ -32,7 +32,7 @@ CURLMOPT_SOCKETFUNCTION \- callback informed about what to wait for
 int socket_callback(CURL *easy,      /* easy handle */
                     curl_socket_t s, /* socket */
                     int what,        /* describes the socket */
-                    void *userp,     /* private callback pointer */
+                    void *clientp,     /* private callback pointer */
                     void *socketp);  /* private socket pointer */
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_SOCKETFUNCTION, socket_callback);
@@ -63,7 +63,7 @@ The socket callback should return 0 on success, and -1 on error. If this
 callback returns error, \fBall\fP transfers currently in progress in this
 multi handle will be aborted and fail.
 
-\fBuserp\fP is set with \fICURLMOPT_SOCKETDATA(3)\fP.
+\fBclientp\fP is set with \fICURLMOPT_SOCKETDATA(3)\fP.
 
 \fBsocketp\fP is set with \fIcurl_multi_assign(3)\fP or will be NULL.
 

--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.3
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.3
@@ -35,7 +35,7 @@ A data \fBpointer\fP to pass to the timer callback set with the
 \fICURLMOPT_TIMERFUNCTION(3)\fP option.
 
 This pointer will not be touched by libcurl but will only be passed in to the
-timer callbacks's \fBuserp\fP argument.
+timer callbacks's \fBclientp\fP argument.
 .SH DEFAULT
 NULL
 .SH PROTOCOLS
@@ -53,9 +53,9 @@ static gboolean timeout_cb(gpointer user_data)
   return G_SOURCE_REMOVE;
 }
 
-static int timerfunc(CURLM *multi, long timeout_ms, void *userp)
+static int timerfunc(CURLM *multi, long timeout_ms, void *clientp)
 {
-  guint *id = userp;
+  guint *id = clientp;
 
   if(id)
     g_source_remove(*id);

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.3
@@ -31,7 +31,7 @@ CURLMOPT_TIMERFUNCTION \- callback to receive timeout values
 
 int timer_callback(CURLM *multi,    /* multi handle */
                    long timeout_ms, /* timeout in number of ms */
-                   void *userp);    /* private callback pointer */
+                   void *clientp);    /* private callback pointer */
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_TIMERFUNCTION, timer_callback);
 .SH DESCRIPTION
@@ -52,7 +52,7 @@ the timer. All other values are valid expire times in number of milliseconds.
 The \fBtimer_callback\fP will only be called when the timeout expire time is
 changed.
 
-The \fBuserp\fP pointer is set with \fICURLMOPT_TIMERDATA(3)\fP.
+The \fBclientp\fP pointer is set with \fICURLMOPT_TIMERDATA(3)\fP.
 
 The timer callback should return 0 on success, and -1 on error. If this
 callback returns error, \fBall\fP transfers currently in progress in this
@@ -82,9 +82,9 @@ static gboolean timeout_cb(gpointer user_data)
   return G_SOURCE_REMOVE;
 }
 
-static int timerfunc(CURLM *multi, long timeout_ms, void *userp)
+static int timerfunc(CURLM *multi, long timeout_ms, void *clientp)
 {
-  guint *id = userp;
+  guint *id = clientp;
 
   if(id)
     g_source_remove(*id);

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
@@ -44,7 +44,7 @@ int debug_callback(CURL *handle,
                    curl_infotype type,
                    char *data,
                    size_t size,
-                   void *userptr);
+                   void *clientp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DEBUGFUNCTION,
                           debug_callback);
@@ -59,7 +59,7 @@ return 0. The \fIdata\fP pointed to by the char * passed to this function WILL
 NOT be null-terminated, but will be exactly of the \fIsize\fP as told by the
 \fIsize\fP argument.
 
-The \fIuserptr\fP argument is the pointer set with \fICURLOPT_DEBUGDATA(3)\fP.
+The \fIclientp\fP argument is the pointer set with \fICURLOPT_DEBUGDATA(3)\fP.
 
 Available \fBcurl_infotype\fP values:
 .IP CURLINFO_TEXT
@@ -120,11 +120,11 @@ void dump(const char *text,
 static
 int my_trace(CURL *handle, curl_infotype type,
              char *data, size_t size,
-             void *userp)
+             void *clientp)
 {
   const char *text;
   (void)handle; /* prevent compiler warning */
-  (void)userp;
+  (void)clientp;
 
   switch (type) {
   case CURLINFO_TEXT:

--- a/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.3
@@ -36,7 +36,7 @@ struct curl_hstsentry {
   char expire[18]; /* YYYYMMDD HH:MM:SS [null-terminated] */
 };
 
-CURLSTScode hstsread(CURL *easy, struct curl_hstsentry *sts, void *userp);
+CURLSTScode hstsread(CURL *easy, struct curl_hstsentry *sts, void *clientp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTSREADFUNCTION, hstsread);
 .fi
@@ -46,8 +46,8 @@ Pass a pointer to your callback function, as the prototype shows above.
 This callback function gets called by libcurl repeatedly when it populates the
 in-memory HSTS cache.
 
-Set the \fIuserp\fP argument with the \fICURLOPT_HSTSREADDATA(3)\fP option or
-it will be NULL.
+Set the \fIclientp\fP argument with the \fICURLOPT_HSTSREADDATA(3)\fP option
+or it will be NULL.
 
 When this callback is invoked, the \fIsts\fP pointer points to a populated
 struct: Copy the host name to \fIname\fP (no longer than \fInamelen\fP

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
@@ -42,7 +42,7 @@ struct curl_index {
 };
 
 CURLSTScode hstswrite(CURL *easy, struct curl_hstsentry *sts,
-                      struct curl_index *count, void *userp);
+                      struct curl_index *count, void *clientp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTSWRITEFUNCTION, hstswrite);
 .fi
@@ -53,8 +53,8 @@ This callback function gets called by libcurl repeatedly to allow the
 application to store the in-memory HSTS cache when libcurl is about to discard
 it.
 
-Set the \fIuserp\fP argument with the \fICURLOPT_HSTSWRITEDATA(3)\fP option or
-it will be NULL.
+Set the \fIclientp\fP argument with the \fICURLOPT_HSTSWRITEDATA(3)\fP option
+or it will be NULL.
 
 When the callback is invoked, the \fIsts\fP pointer points to a populated
 struct: Read the host name to 'name' (it is \fInamelen\fP bytes long and null

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
@@ -51,7 +51,7 @@ All
                                  double ultotal,
                                  double ulnow)
  {
-   struct memory *progress = (struct progress *)userp;
+   struct memory *progress = (struct progress *)clientp;
 
    /* use the values */
 

--- a/docs/libcurl/opts/CURLOPT_SEEKDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SEEKDATA.3
@@ -41,9 +41,9 @@ If you do not set this, NULL is passed to the callback.
 HTTP, FTP, SFTP
 .SH EXAMPLE
 .nf
-static int seek_cb(void *userp, curl_off_t offset, int origin)
+static int seek_cb(void *clientp, curl_off_t offset, int origin)
 {
-  struct data *d = (struct data *)userp;
+  struct data *d = (struct data *)clientp;
   lseek(d->our_fd, offset, origin);
   return CURL_SEEKFUNC_OK;
 }

--- a/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.3
@@ -35,7 +35,7 @@ CURLOPT_SEEKFUNCTION \- user callback for seeking in input stream
 #define CURL_SEEKFUNC_CANTSEEK 2 /* tell libcurl seeking cannot be done, so
                                     libcurl might try other means instead */
 
-int seek_callback(void *userp, curl_off_t offset, int origin);
+int seek_callback(void *clientp, curl_off_t offset, int origin);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SEEKFUNCTION, seek_callback);
 .SH DESCRIPTION
@@ -53,7 +53,7 @@ connection. The function shall work like fseek(3) or lseek(3) and it gets
 SEEK_SET, SEEK_CUR or SEEK_END as argument for \fIorigin\fP, although libcurl
 currently only passes SEEK_SET.
 
-\fIuserp\fP is the pointer you set with \fICURLOPT_SEEKDATA(3)\fP.
+\fIclientp\fP is the pointer you set with \fICURLOPT_SEEKDATA(3)\fP.
 
 The callback function must return \fICURL_SEEKFUNC_OK\fP on success,
 \fICURL_SEEKFUNC_FAIL\fP to cause the upload operation to fail or
@@ -70,9 +70,9 @@ By default, this is NULL and unused.
 HTTP, FTP, SFTP
 .SH EXAMPLE
 .nf
-static int seek_cb(void *userp, curl_off_t offset, int origin)
+static int seek_cb(void *clientp, curl_off_t offset, int origin)
 {
-  struct data *d = (struct data *)userp;
+  struct data *d = (struct data *)clientp;
   lseek(our_fd, offset, origin);
   return CURL_SEEKFUNC_OK;
 }

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -29,7 +29,7 @@ CURLOPT_SSL_CTX_FUNCTION \- SSL context callback for OpenSSL, wolfSSL or mbedTLS
 .nf
 #include <curl/curl.h>
 
-CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr);
+CURLcode ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *clientp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_FUNCTION,
                           ssl_ctx_callback);
@@ -49,7 +49,7 @@ library's \fISSL_CTX\fP for OpenSSL or wolfSSL, a pointer to
 \fImbedtls_ssl_config\fP for mbedTLS or a pointer to
 \fIbr_ssl_client_context\fP for BearSSL. If an error is returned from the
 callback no attempt to establish a connection is made and the perform
-operation will return the callback's error code. Set the \fIuserptr\fP
+operation will return the callback's error code. Set the \fIclientp\fP
 argument with the \fICURLOPT_SSL_CTX_DATA(3)\fP option.
 
 This function will get called on all new connections made to a server, during

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -85,10 +85,10 @@ struct memory {
   size_t size;
 };
 
-static size_t cb(void *data, size_t size, size_t nmemb, void *userp)
+static size_t cb(void *data, size_t size, size_t nmemb, void *clientp)
 {
   size_t realsize = size * nmemb;
-  struct memory *mem = (struct memory *)userp;
+  struct memory *mem = (struct memory *)clientp;
 
   char *ptr = realloc(mem->response, mem->size + realsize + 1);
   if(ptr == NULL)

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
@@ -53,7 +53,7 @@ All
                                  curl_off_t ultotal,
                                  curl_off_t ulnow)
  {
-   struct memory *progress = (struct progress *)userp;
+   struct memory *progress = (struct progress *)clientp;
 
    /* use the values */
 

--- a/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
@@ -29,7 +29,7 @@ CURLSHOPT_LOCKFUNC - mutex lock callback
 #include <curl/curl.h>
 
 void lockcb(CURL *handle, curl_lock_data data, curl_lock_access access,
-            void *userptr);
+            void *clientp);
 
 CURLSHcode curl_share_setopt(CURLSH *share, CURLSHOPT_LOCKFUNC, lockcb);
 .fi
@@ -49,7 +49,7 @@ sure that the callback uses a different lock for each kind of data.
 
 \fIaccess\fP defines what access type libcurl wants, shared or single.
 
-\fIuserptr\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
+\fIclientp\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
 This pointer is not used by libcurl itself.
 .SH PROTOCOLS
 All

--- a/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
@@ -28,7 +28,7 @@ CURLSHOPT_UNLOCKFUNC - mutex unlock callback
 .nf
 #include <curl/curl.h>
 
-void unlockcb(CURL *handle, curl_lock_data data, void *userptr);
+void unlockcb(CURL *handle, curl_lock_data data, void *clientp);
 
 CURLSHcode curl_share_setopt(CURLSH *share, CURLSHOPT_UNLOCKFUNC, unlockcb);
 .fi
@@ -45,7 +45,7 @@ is released.
 The \fIdata\fP argument tells what kind of data libcurl wants to unlock. Make
 sure that the callback uses a different lock for each kind of data.
 
-\fIuserptr\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
+\fIclientp\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
 This pointer is not used by libcurl itself.
 .SH PROTOCOLS
 All

--- a/docs/libcurl/opts/CURLSHOPT_USERDATA.3
+++ b/docs/libcurl/opts/CURLSHOPT_USERDATA.3
@@ -28,12 +28,12 @@ CURLSHOPT_USERDATA - pointer passed to the lock and unlock mutex callbacks
 .nf
 #include <curl/curl.h>
 
-CURLSHcode curl_share_setopt(CURLSH *share, CURLSHOPT_USERDATA, void *ptr);
+CURLSHcode curl_share_setopt(CURLSH *share, CURLSHOPT_USERDATA, void *clientp);
 .fi
 .SH DESCRIPTION
-The \fIptr\fP parameter is held verbatim by libcurl and is passed on as the
-\fIuserptr\fP argument to the callbacks set with \fICURLSHOPT_LOCKFUNC(3)\fP
-and \fICURLSHOPT_UNLOCKFUNC(3)\fP.
+The \fIclientp\fP parameter is held verbatim by libcurl and is passed on as
+the \fIclientp\fP argument to the callbacks set with
+\fICURLSHOPT_LOCKFUNC(3)\fP and \fICURLSHOPT_UNLOCKFUNC(3)\fP.
 .SH PROTOCOLS
 All
 .SH EXAMPLE


### PR DESCRIPTION
The variable had a few different names. Now try to use 'clientp' consistently for all man pages using a custom pointer set by the application.

Reported-by: Gerrit Renker

Fixes #10434