### PR TITLE
openldap: fix missing sasl symbols at build in specific configs

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -36,7 +36,8 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3)
+  !defined(CURL_DISABLE_POP3) || \
+  (!defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP))
 
 #include <curl/curl.h>
 #include "urldata.h"

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -28,7 +28,8 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) ||       \
-  !defined(CURL_DISABLE_POP3)
+  !defined(CURL_DISABLE_POP3) || \
+  (!defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP))
 
 #include <curl/curl.h>
 #include "urldata.h"

--- a/lib/vauth/oauth2.c
+++ b/lib/vauth/oauth2.c
@@ -27,7 +27,8 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3)
+  !defined(CURL_DISABLE_POP3) || \
+  (!defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP))
 
 #include <curl/curl.h>
 #include "urldata.h"


### PR DESCRIPTION
If curl is built with openldap support (`USE_OPENLDAP=1`) but does not have also some other protocol (IMAP/SMTP/POP3) enabled that brings in `Curl_sasl_*` functions, then the build will fail with undefined references to various symbols:

```
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_decode_mech' 
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_parse_url_auth_option' 
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_cleanup' 
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_can_authenticate' 
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_continue' 
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_start' 
ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_sasl_init'
```

This was tracked down to these functions bein used in `openldap.c` but defined in `curl_sasl.c` and then forward in two `vauth/` files to have a guard against a set of #define configurations that was now extended to cover also this case.

Example configuration targeted that could reproduce the problem:
```
curl 7.87.1-DEV () libcurl/7.87.1-DEV .... OpenLDAP/2.6.3
Protocols: file ftp ftps http https ldap ldaps
```