### PR TITLE
nghttp2, better handling of cf_h2_send() return value.

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2039,7 +2039,7 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
 
 #ifdef DEBUG_HTTP2
-    if(!len) {
+    if(!nwritten) {
       infof(data, "http2_send: easy %p (stream %u) win %u/%u",
             data, stream->stream_id,
             nghttp2_session_get_remote_window_size(ctx->h2),
@@ -2048,12 +2048,14 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
         );
 
     }
-    infof(data, "http2_send returns %zu for stream %u", len,
+    infof(data, "http2_send returns %zd for stream %u", nwritten,
           stream->stream_id);
 #endif
+    /* handled writing BODY for open stream. */
     goto out;
   }
-
+  /* Stream has not been opened yet. `buf` is expected to contain
+   * request headers. */
   /* TODO: this assumes that the `buf` and `len` we are called with
    * is *all* HEADERs and no body. We have no way to determine here
    * if that is indeed the case. */
@@ -2123,7 +2125,7 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   infof(data, "Using Stream ID: %u (easy handle %p)",
         stream_id, (void *)data);
   stream->stream_id = stream_id;
-  /* See comment above. We assume that the whole buf was consumed by
+  /* See TODO above. We assume that the whole buf was consumed by
    * generating the request headers. */
   nwritten = len;
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1977,6 +1977,7 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   CURLcode result;
   struct h2h3req *hreq;
   struct cf_call_data save;
+  ssize_t nwritten;
 
   CF_DATA_SAVE(save, cf, data);
   DEBUGF(LOG_CF(data, cf, "send len=%zu", len));
@@ -1985,11 +1986,11 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(stream->close_handled) {
       infof(data, "stream %u closed", stream->stream_id);
       *err = CURLE_HTTP2_STREAM;
-      len = -1;
+      nwritten = -1;
       goto out;
     }
     else if(stream->closed) {
-      len = http2_handle_stream_close(cf, data, stream, err);
+      nwritten = http2_handle_stream_close(cf, data, stream, err);
       goto out;
     }
     /* If stream_id != -1, we have dispatched request HEADERS, and now
@@ -1999,26 +2000,33 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     rv = nghttp2_session_resume_data(ctx->h2, stream->stream_id);
     if(nghttp2_is_fatal(rv)) {
       *err = CURLE_SEND_ERROR;
-      len = -1;
+      nwritten = -1;
       goto out;
     }
     result = h2_session_send(cf, data);
     if(result) {
       *err = result;
-      len = -1;
+      nwritten = -1;
       goto out;
     }
-    len -= stream->upload_len;
 
-    /* Nullify here because we call nghttp2_session_send() and they
-       might refer to the old buffer. */
+    /* The callback for stream input updates `upload_len` with what it
+     * has provided to nghttp2. If it has *not* been called, `upload_len`
+     * is unchanged and we should report a block on send. */
+    if(stream->upload_len == len) {
+      *err = CURLE_AGAIN;
+      nwritten = -1;
+      goto out;
+    }
+
+    nwritten = len - stream->upload_len;
     stream->upload_mem = NULL;
     stream->upload_len = 0;
 
     if(should_close_session(ctx)) {
       DEBUGF(LOG_CF(data, cf, "send: nothing to do in this session"));
       *err = CURLE_HTTP2;
-      len = -1;
+      nwritten = -1;
       goto out;
     }
 
@@ -2046,10 +2054,13 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     goto out;
   }
 
+  /* TODO: this assumes that the `buf` and `len` we are called with
+   * is *all* HEADERs and no body. We have no way to determine here
+   * if that is indeed the case. */
   result = Curl_pseudo_headers(data, buf, len, NULL, &hreq);
   if(result) {
     *err = result;
-    len = -1;
+    nwritten = -1;
     goto out;
   }
   nheader = hreq->entries;
@@ -2058,7 +2069,7 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!nva) {
     Curl_pseudo_free(hreq);
     *err = CURLE_OUT_OF_MEMORY;
-    len = -1;
+    nwritten = -1;
     goto out;
   }
   else {
@@ -2105,25 +2116,28 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     DEBUGF(LOG_CF(data, cf, "send: nghttp2_submit_request error (%s)%u",
                   nghttp2_strerror(stream_id), stream_id));
     *err = CURLE_SEND_ERROR;
-    len = -1;
+    nwritten = -1;
     goto out;
   }
 
   infof(data, "Using Stream ID: %u (easy handle %p)",
         stream_id, (void *)data);
   stream->stream_id = stream_id;
+  /* See comment above. We assume that the whole buf was consumed by
+   * generating the request headers. */
+  nwritten = len;
 
   result = h2_session_send(cf, data);
   if(result) {
     *err = result;
-    len = -1;
+    nwritten = -1;
     goto out;
   }
 
   if(should_close_session(ctx)) {
     DEBUGF(LOG_CF(data, cf, "send: nothing to do in this session"));
     *err = CURLE_HTTP2;
-    len = -1;
+    nwritten = -1;
     goto out;
   }
 
@@ -2138,7 +2152,7 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
 out:
   CF_DATA_RESTORE(cf, save);
-  return len;
+  return nwritten;
 }
 
 static int cf_h2_get_select_socks(struct Curl_cfilter *cf,

--- a/tests/tests-httpd/test_07_upload.py
+++ b/tests/tests-httpd/test_07_upload.py
@@ -144,6 +144,9 @@ class TestUpload:
             assert respdata == [data]
 
     # upload large data parallel, check that this is what was echoed
+    # we seem to encounter errors on earlier httpd versions
+    @pytest.mark.skipif(condition=not Env.httpd_is_at_least('2.4.55'),
+                        reason=f"httpd version too old for this: {Env.httpd_version()}")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_21_upload_parallel_large(self, env: Env, httpd, nghttpx, repeat, proto):
         if proto == 'h3' and not env.have_h3():


### PR DESCRIPTION
- use explicit ssize_t return var instead of mis-using size_t len for -1 returns.

Refs #10449