### PR TITLE
CI: Retry failed downloads to reduce spurious failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
     steps:
       - run:
           command: |
-            curl -LO https://github.com/wolfSSL/wolfssl/archive/v5.1.1-stable.tar.gz
+            curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v5.1.1-stable.tar.gz
             tar -xzf v5.1.1-stable.tar.gz
             cd wolfssl-5.1.1-stable
             ./autogen.sh
@@ -89,7 +89,7 @@ commands:
     steps:
       - run:
           command: |
-            curl -LO https://github.com/wolfSSL/wolfssh/archive/v1.4.8-stable.tar.gz
+            curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssh/archive/v1.4.8-stable.tar.gz
             tar -xzf v1.4.8-stable.tar.gz
             cd wolfssh-1.4.8-stable
             ./autogen.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,7 +142,7 @@ jobs:
 
     - if: ${{ contains(matrix.build.install_steps, 'bearssl') }}
       run: |
-        curl -LO https://bearssl.org/bearssl-0.6.tar.gz
+        curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://bearssl.org/bearssl-0.6.tar.gz
         tar -xzf bearssl-0.6.tar.gz
         cd bearssl-0.6
         make
@@ -216,7 +216,7 @@ jobs:
     - if: ${{ contains(matrix.build.install_steps, 'rust') }}
       run: |
         cd $HOME
-        curl https://sh.rustup.rs -sSf | sh -s -- -y
+        curl -sSf --compressed https://sh.rustup.rs/ | sh -s -- -y
         source $HOME/.cargo/env
         rustup toolchain install nightly
       name: 'install rust'
@@ -240,7 +240,7 @@ jobs:
     - if: ${{ contains(matrix.build.install_steps, 'intel') }}
       run: |
         cd /tmp
-        curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo apt-key add -
+        curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo apt-key add -
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt install --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -50,7 +50,7 @@ jobs:
       name: 'install prereqs and impacket'
 
     - run: |
-        curl -LO https://github.com/wolfSSL/wolfssl/archive/v5.5.4-stable.tar.gz
+        curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v5.5.4-stable.tar.gz
         tar -xzf v5.5.4-stable.tar.gz
         cd wolfssl-5.5.4-stable
         ./autogen.sh


### PR DESCRIPTION
A temporary error with a remote server shouldn't cause a CI run to fail.
Also, put a cap on the time to download to fail faster on a misbehaving
server or connection and use HTTP compression where possible to reduce
download times.