### PR TITLE
no-clobber.d: only use long form options in man page text

### DIFF
--- a/docs/cmdline-opts/no-clobber.d
+++ b/docs/cmdline-opts/no-clobber.d
@@ -15,5 +15,5 @@ of the file that would be created, up to filename.100 after which it will not
 create any file.
 
 Note that this is the negated option name documented.  You can thus use
---clobber to enforce the clobbering, even if --remote-header-name or -J is
+--clobber to enforce the clobbering, even if --remote-header-name is
 specified.


### PR DESCRIPTION
... since they are expanded and the short-form gets mentioned automatically so if the short form is mention as well, it gets repeated.

Fixes #10461
Reported-by: Dan Fandrich