### PR TITLE
websocket doc - typo fix

### DIFF
--- a/docs/WEBSOCKET.md
+++ b/docs/WEBSOCKET.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: curl
 ## URL
 
 WebSocket communication with libcurl is done by setting up a transfer to a URL
-using the `ws:/` or `wss://` URL schemes. The latter one being the secure
+using the `ws://` or `wss://` URL schemes. The latter one being the secure
 version done over HTTPS.
 
 When using `wss://` to do WebSocket over HTTPS, the standard TLS and HTTPS


### PR DESCRIPTION
Fixing missing slash for ws protocol scheme documentation.