### PR TITLE
build error due to change in ngtcp2 variables

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -231,7 +231,7 @@ static void quic_settings(struct cf_ngtcp2_ctx *ctx,
 
   (void)data;
   s->initial_ts = timestamp();
-  s->handshake_timeout = NGTCP2_ERR_HANDSHAKE_TIMEOUT;
+  s->handshake_timeout = 10;
   s->max_window = 100 * stream_win_size;
   s->max_stream_window = stream_win_size;
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -231,7 +231,7 @@ static void quic_settings(struct cf_ngtcp2_ctx *ctx,
 
   (void)data;
   s->initial_ts = timestamp();
-  s->handshake_timeout = NGTCP2_DEFAULT_HANDSHAKE_TIMEOUT;
+  s->handshake_timeout = NGTCP2_ERR_HANDSHAKE_TIMEOUT;
   s->max_window = 100 * stream_win_size;
   s->max_stream_window = stream_win_size;
 


### PR DESCRIPTION
raised PR cause while build curl with ngtcp2 below error is noticed
https://github.com/curl/curl/issues/10468

hers is the PR to ngtcp2 which is causing issue
https://github.com/ngtcp2/ngtcp2/pull/665/