### PR TITLE
Fix Brotli name

### DIFF
--- a/CMake/FindBrotli.cmake
+++ b/CMake/FindBrotli.cmake
@@ -28,7 +28,7 @@ find_path(BROTLI_INCLUDE_DIR "brotli/decode.h")
 find_library(BROTLICOMMON_LIBRARY NAMES brotlicommon)
 find_library(BROTLIDEC_LIBRARY NAMES brotlidec)
 
-find_package_handle_standard_args(BROTLI
+find_package_handle_standard_args(Brotli
     FOUND_VAR
       BROTLI_FOUND
     REQUIRED_VARS
@@ -36,7 +36,7 @@ find_package_handle_standard_args(BROTLI
       BROTLICOMMON_LIBRARY
       BROTLI_INCLUDE_DIR
     FAIL_MESSAGE
-      "Could NOT find BROTLI"
+      "Could NOT find Brotli"
 )
 
 set(BROTLI_INCLUDE_DIRS ${BROTLI_INCLUDE_DIR})


### PR DESCRIPTION
For avoiding CMake's warning:
>CMake Warning (dev) at /usr/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (BROTLI)
  does not match the name of the calling package (Brotli).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  CMake/FindBrotli.cmake:31 (find_package_handle_standard_args)
  CMakeLists.txt:713 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.