### PR TITLE
Address undefined behaviour by checking for null before incrementing pointer at end of do/while loop.

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -174,7 +174,7 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
 
       *val |= h->protocol;
     }
-  } while(str++);
+  } while(str && str++);
 
   if(!*val)
     /* no protocol listed */


### PR DESCRIPTION
This address undefined behaviour found using clang's UBsan:

curl/lib/setopt.c:177:14: runtime error: applying non-zero offset 1 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior curl/lib/setopt.c:177:14 in
