### PR TITLE
windows: always use curl's basename() implementation

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -838,6 +838,13 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define USE_HTTP3
 #endif
 
+/* Certain Windows implementations are not aligned with what curl expects,
+   so always use the local one on this platform. E.g. the mingw-w64
+   implementation can return wrong results for non-ASCII inputs. */
+#if defined(HAVE_BASENAME) && defined(WIN32)
+#undef HAVE_BASENAME
+#endif
+
 #if defined(USE_UNIX_SOCKETS) && defined(WIN32)
 #  if defined(__MINGW32__) && !defined(LUP_SECURE)
      typedef u_short ADDRESS_FAMILY; /* Classic mingw, 11y+ old mingw-w64 */


### PR DESCRIPTION
The `basename()` \[1\]\[2\] implementation provided by mingw-w64 \[3\] makes assumptions about input encoding and may break with non-ASCII strings.

`basename()` was auto-detected with CMake, autotools and since 68fa9bf3f5d7b4fcbb57619f70cb4aabb79a51f6 (2022-10-13), also in `Makefile.mk` after syncing its behaviour with the mainline build methods. A similar patch for curl-for-win broke official Windows builds earlier, in release 7.83.1_4 (2022-06-15).

This patch forces all Windows builds to use curl's internal `basename()` implementation to avoid such problems.

\[1\]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/basename.html
\[2\]: https://www.man7.org/linux/man-pages/man3/basename.3.html
\[3\]: https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/misc/basename.c

Reported-by: UnicornZhang on Github
Assisted-by: Cherish98 on Github

Fixes #10261
Closes #10475