### PR TITLE
Linux CI: Bump rustls-ffi to v0.9.1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -223,7 +223,7 @@ jobs:
 
     - if: ${{ contains(matrix.build.install_steps, 'rustls') }}
       run: |
-        git clone --depth=1 -b v0.8.2 --recursive https://github.com/rustls/rustls-ffi.git
+        git clone --depth=1 -b v0.9.1 --recursive https://github.com/rustls/rustls-ffi.git
         cd rustls-ffi
         make DESTDIR=$HOME/rustls install
       name: 'install rustls'


### PR DESCRIPTION
Follow-up: https://github.com/curl/curl/pull/10458