### PR TITLE
smb: return error on upload without size

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -45,7 +45,6 @@ problems may have been fixed or changed somewhat since this was written.
  5.6 make distclean loops forever
  5.8 configure finding libs in wrong directory
  5.9 Utilize Requires.private directives in libcurl.pc
- 5.10 curl hangs on SMB upload over stdin
  5.11 configure --with-gssapi with Heimdal is ignored on macOS
  5.12 flaky Windows CI builds
  5.13 long paths are not fully supported on Windows
@@ -331,10 +330,6 @@ problems may have been fixed or changed somewhat since this was written.
 5.9 Utilize Requires.private directives in libcurl.pc
 
  https://github.com/curl/curl/issues/864
-
-5.10 curl hangs on SMB upload over stdin
-
- See https://github.com/curl/curl/issues/7896
 
 5.11 configure --with-gssapi with Heimdal is ignored on macOS
 

--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -360,6 +360,9 @@ share and directory or the share to upload to and as such, may not be omitted.
 If the user name is embedded in the URL then it must contain the domain name
 and as such, the backslash must be URL encoded as %2f.
 
+When uploading to SMB, the size of the file needs to be known ahead of time,
+meaning that you can upload a file passed to curl over a pipe like stdin.
+
 curl supports SMB version 1 (only)
 
 ## SMTP

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -763,6 +763,11 @@ static CURLcode smb_request_state(struct Curl_easy *data, bool *done)
   void *msg = NULL;
   const struct smb_nt_create_response *smb_m;
 
+  if(data->set.upload && (data->state.infilesize < 0)) {
+    failf(data, "SMB upload needs to know the size up front");
+    return CURLE_SEND_ERROR;
+  }
+
   /* Start the request */
   if(req->state == SMB_REQUESTING) {
     result = smb_send_tree_connect(data);
@@ -993,6 +998,7 @@ static CURLcode smb_parse_url_path(struct Curl_easy *data,
   /* The share must be present */
   if(!slash) {
     Curl_safefree(smbc->share);
+    failf(data, "missing share in URL path for SMB");
     return CURLE_URL_MALFORMAT;
   }
 


### PR DESCRIPTION
The protocol needs to know the size ahead of time, this is now a known restriction and not a bug.

Also output a clearer error if the URL path does not contain proper share.

Ref: #7896