### PR TITLE
ngtcp2-gnutls.yml: use github tarball instead of git clone

### DIFF
--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -78,7 +78,6 @@ jobs:
         curl -Lo gnutls https://www.gnupg.org/ftp/gcrypt/gnutls/$GNUTLS_VER_TAG/gnutls-$GNUTLS_VER.tar.xz
         tar -xf gnutls
         cd gnutls-$GNUTLS_VER
-        ./bootstrap
         ./configure ${{ matrix.build.gnutls-configure }} --prefix=$HOME/all
         make install
       name: 'install gnutls'

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -75,8 +75,8 @@ jobs:
     - run: |
         GNUTLS_VER_TAG="v3.7"
         GNUTLS_VER="3.7.9"
-        curl -Lo gnutls https://www.gnupg.org/ftp/gcrypt/gnutls/$GNUTLS_VER_TAG/gnutls-$GNUTLS_VER.tar.xz
-        tar -xf gnutls
+        curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://www.gnupg.org/ftp/gcrypt/gnutls/$GNUTLS_VER_TAG/gnutls-$GNUTLS_VER.tar.xz
+        tar -xf gnutls-$GNUTLS_VER.tar.xz
         cd gnutls-$GNUTLS_VER
         ./configure ${{ matrix.build.gnutls-configure }} --prefix=$HOME/all
         make install

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -73,10 +73,9 @@ jobs:
       name: 'install nettle'
 
     - run: |
-        GNUTLS_VER_TAG="v3.7"
-        GNUTLS_VER="3.7.9"
-        curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://www.gnupg.org/ftp/gcrypt/gnutls/$GNUTLS_VER_TAG/gnutls-$GNUTLS_VER.tar.xz
-        tar -xf gnutls-$GNUTLS_VER.tar.xz
+        GNUTLS_VER=3.8.0
+        curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/gnutls/gnutls/archive/refs/tags/$GNUTLS_VER.tar.gz
+        tar -xf $GNUTLS_VER.tar.gz
         cd gnutls-$GNUTLS_VER
         ./configure ${{ matrix.build.gnutls-configure }} --prefix=$HOME/all
         make install

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -73,8 +73,11 @@ jobs:
       name: 'install nettle'
 
     - run: |
-        git clone --depth=1 -b 3.7.8 https://github.com/gnutls/gnutls.git
-        cd gnutls
+        GNUTLS_VER_TAG="v3.7"
+        GNUTLS_VER="3.7.9"
+        curl -Lo gnutls https://www.gnupg.org/ftp/gcrypt/gnutls/$GNUTLS_VER_TAG/gnutls-$GNUTLS_VER.tar.xz
+        tar -xf gnutls
+        cd gnutls-$GNUTLS_VER
         ./bootstrap
         ./configure ${{ matrix.build.gnutls-configure }} --prefix=$HOME/all
         make install

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -77,6 +77,7 @@ jobs:
         curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/gnutls/gnutls/archive/refs/tags/$GNUTLS_VER.tar.gz
         tar -xf $GNUTLS_VER.tar.gz
         cd gnutls-$GNUTLS_VER
+        ./bootstrap
         ./configure ${{ matrix.build.gnutls-configure }} --prefix=$HOME/all
         make install
       name: 'install gnutls'


### PR DESCRIPTION
better Version update control
bump gnutls to 3.8.0