### PR TITLE
header-api, tests with h2/h3

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -244,9 +244,9 @@ test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test2300 test2301 test2302 test2303 test2304 test2305 \
 \
-test2400 test2401 test2402 \
+test2400 test2401 test2402 test2403 \
 \
-test2500 test2501 test2502 \
+test2500 test2501 test2502 test2503 \
 \
 test2600 \
 \

--- a/tests/data/test2403
+++ b/tests/data/test2403
@@ -1,0 +1,73 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP/2
+HTTPS
+-w
+%header
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes" crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+h2c
+SSL
+headers-api
+</features>
+<server>
+http
+http/2
+</server>
+ <name>
+HTTP/2 GET
+ </name>
+<setenv>
+</setenv>
+ <command>
+-k --http2 -w '%{header_json}\n' "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
+</command>
+
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stdout crlf="yes">
+HTTP/2 200 
+date: Tue, 09 Nov 2010 14:49:00 GMT
+content-length: 6
+content-type: text/html
+funny-head: yesyes
+server: nghttpx
+via: 1.1 nghttpx
+
+-foo-
+{"date":["Tue, 09 Nov 2010 14:49:00 GMT"],
+"content-length":["6"],
+"content-type":["text/html"],
+"funny-head":["yesyes"],
+"server":["nghttpx"],
+"via":["1.1 nghttpx"]
+}
+</stdout>
+</verify>
+</testcase>

--- a/tests/data/test2503
+++ b/tests/data/test2503
@@ -1,0 +1,70 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP/3
+HTTPS
+-w
+%header
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes" crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+http/3
+nghttpx-h3
+headers-api
+</features>
+<server>
+http
+http/3
+</server>
+ <name>
+HTTP/3 header-api
+ </name>
+<setenv>
+</setenv>
+ <command>
+-w '%{header_json}\n' --http3-only --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --resolve localhost:%HTTP3PORT:%HOSTIP https://localhost:%HTTP3PORT/%TESTNUMBER
+</command>
+
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stdout crlf="yes">
+HTTP/3 200 
+date: Tue, 09 Nov 2010 14:49:00 GMT
+content-length: 6
+content-type: text/html
+funny-head: yesyes
+via: 1.1 nghttpx
+
+-foo-
+{"date":["Tue, 09 Nov 2010 14:49:00 GMT"],
+"content-length":["6"],
+"content-type":["text/html"],
+"funny-head":["yesyes"],
+"via":["1.1 nghttpx"]
+}
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
Adding test cases for HTTP/2 and HTTP/3 that check "header_json" output and therefore use of header-api.