### PR TITLE
Test and fix for forward proxy handling (non-tunneling).

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2122,6 +2122,22 @@ static bool subj_alt_hostcheck(struct Curl_easy *data,
   return FALSE;
 }
 
+static CURLcode
+ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
+                X509 *server_cert, const char *hostname,
+                const char *dispname);
+
+CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
+                              X509 *server_cert)
+{
+  const char *hostname, *dispname;
+  int port;
+
+  (void)conn;
+  Curl_conn_get_host(data, FIRSTSOCKET, &hostname, &dispname, &port);
+  return ossl_verifyhost(data, conn, server_cert, hostname, dispname);
+}
+
 /* Quote from RFC2818 section 3.1 "Server Identity"
 
    If a subjectAltName extension of type dNSName is present, that MUST
@@ -2144,8 +2160,10 @@ static bool subj_alt_hostcheck(struct Curl_easy *data,
 
    This function is now used from ngtcp2 (QUIC) as well.
 */
-CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
-                              X509 *server_cert)
+static CURLcode
+ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
+                X509 *server_cert, const char *hostname,
+                const char *dispname)
 {
   bool matched = FALSE;
   int target = GEN_DNS; /* target type, GEN_DNS or GEN_IPADD */
@@ -2159,12 +2177,9 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
   CURLcode result = CURLE_OK;
   bool dNSName = FALSE; /* if a dNSName field exists in the cert */
   bool iPAddress = FALSE; /* if a iPAddress field exists in the cert */
-  const char *hostname, *dispname;
-  int port;
   size_t hostlen;
 
   (void)conn;
-  Curl_conn_get_host(data, FIRSTSOCKET, &hostname, &dispname, &port);
   hostlen = strlen(hostname);
 
 #ifndef ENABLE_IPV6
@@ -4129,7 +4144,8 @@ static CURLcode servercert(struct Curl_cfilter *cf,
   BIO_free(mem);
 
   if(conn_config->verifyhost) {
-    result = Curl_ossl_verifyhost(data, conn, backend->server_cert);
+    result = ossl_verifyhost(data, conn, backend->server_cert,
+                             connssl->hostname, connssl->dispname);
     if(result) {
       X509_free(backend->server_cert);
       backend->server_cert = NULL;

--- a/tests/tests-httpd/test_10_proxy.py
+++ b/tests/tests-httpd/test_10_proxy.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2008 - 2022, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+import logging
+import os
+import pytest
+
+from testenv import Env, CurlClient
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(condition=Env.setup_incomplete(),
+                    reason=f"missing: {Env.incomplete_reason()}")
+class TestProxy:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, httpd):
+        push_dir = os.path.join(httpd.docs_dir, 'push')
+        if not os.path.exists(push_dir):
+            os.makedirs(push_dir)
+
+    # download via http: proxy (no tunnel)
+    def test_10_01_http_get(self, env: Env, httpd, repeat):
+        curl = CurlClient(env=env)
+        url = f'http://localhost:{env.http_port}/data.json'
+        r = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
+                               extra_args=[
+                                 '--proxy', f'http://{env.proxy_domain}:{env.http_port}/',
+                                 '--resolve', f'{env.proxy_domain}:{env.http_port}:127.0.0.1',
+                               ])
+        assert r.exit_code == 0
+        r.check_stats(count=1, exp_status=200)
+
+    # download via https: proxy (no tunnel)
+    def test_10_02_http_get(self, env: Env, httpd, repeat):
+        curl = CurlClient(env=env)
+        url = f'http://localhost:{env.http_port}/data.json'
+        r = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
+                               extra_args=[
+                                 '--proxy', f'https://{env.proxy_domain}:{env.https_port}/',
+                                 '--resolve', f'{env.proxy_domain}:{env.https_port}:127.0.0.1',
+                                 '--proxy-cacert', env.ca.cert_file,
+                               ])
+        assert r.exit_code == 0
+        r.check_stats(count=1, exp_status=200)

--- a/tests/tests-httpd/testenv/env.py
+++ b/tests/tests-httpd/testenv/env.py
@@ -113,9 +113,11 @@ class EnvConfig:
         self.tld = 'tests-httpd.curl.se'
         self.domain1 = f"one.{self.tld}"
         self.domain2 = f"two.{self.tld}"
+        self.proxy_domain = f"proxy.{self.tld}"
         self.cert_specs = [
             CertificateSpec(domains=[self.domain1], key_type='rsa2048'),
             CertificateSpec(domains=[self.domain2], key_type='rsa2048'),
+            CertificateSpec(domains=[self.proxy_domain], key_type='rsa2048'),
             CertificateSpec(name="clientsX", sub_specs=[
                CertificateSpec(name="user1", client=True),
             ]),
@@ -293,6 +295,11 @@ class Env:
     @property
     def domain2(self) -> str:
         return self.CONFIG.domain2
+
+    @property
+    def proxy_domain(self) -> str:
+        return self.CONFIG.proxy_domain
+
 
     @property
     def http_port(self) -> str:


### PR DESCRIPTION
- adding pytest test_10 cases for proxy httpd setup tests
- fixing openssl bug in https: proxy hostname verification that used the hostname of the request and not the proxy name.