### PR TITLE
build fix: include stdint.h more readily

### DIFF
--- a/lib/http.h
+++ b/lib/http.h
@@ -42,7 +42,7 @@ typedef enum {
 
 #ifndef CURL_DISABLE_HTTP
 
-#if defined(_WIN32) && (defined(ENABLE_QUIC) || defined(USE_NGHTTP2))
+#if defined(ENABLE_QUIC) || defined(USE_NGHTTP2)
 #include <stdint.h>
 #endif
 


### PR DESCRIPTION
stdin.h is needed for uint<n>_t etc types, and stdint.h wasn't included when needed.