### PR TITLE
http: Do not use Negotiate if user and pw are provided

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -633,6 +633,10 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data)
   CURLcode result = CURLE_OK;
   unsigned long authmask = ~0ul;
 
+  /* We don't have to try to negotiate if we have a supplied user/password */
+  if(data->state.aptr.user && data->state.aptr.passwd)
+    authmask &= (unsigned long)~CURLAUTH_NEGOTIATE;
+
   if(!data->set.str[STRING_BEARER])
     authmask &= (unsigned long)~CURLAUTH_BEARER;
 


### PR DESCRIPTION
If we provide username and password to curl and the server supports authentication via Kerberos (WWW-Authenticate: Negotiate) and basic authentication libcurl tries to authenticate via Kerberos instead of using the provided username and password to authenticate via basic auth. With this patch libcurl does not use Negotiate authentication method if a username and password are provided.

I really would like to add a test which tests this behavior.
But i'm afraid, that i do not really understand how to add a test like that.