### PR TITLE
HTTP/2 buffer/pausedata and outpu flush fix.

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1923,6 +1923,7 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       drained_transfer(cf, data);
     }
 
+    *err = CURLE_OK;
     nread = retlen;
     DEBUGF(LOG_CF(data, cf, "[h2sid=%u] cf_h2_recv -> %zd",
                   stream->stream_id, nread));


### PR DESCRIPTION
 * do not process pending input data when copying pausedata to the caller
 * return CURLE_AGAIN if the output buffer could not be completely written out.

Refs #10525.