### PR TITLE
tool_getparam: make --get a true boolean

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -294,7 +294,7 @@ static const struct LongShort aliases[]= {
   {"F",  "form",                     ARG_STRING},
   {"Fs", "form-string",              ARG_STRING},
   {"g",  "globoff",                  ARG_BOOL},
-  {"G",  "get",                      ARG_NONE},
+  {"G",  "get",                      ARG_BOOL},
   {"Ga", "request-target",           ARG_STRING},
   {"h",  "help",                     ARG_BOOL},
   {"H",  "header",                   ARG_STRING},


### PR DESCRIPTION
To match how it is documented in the man page.

Fixes #10527
Reported-by: u20221022 on github