### PR TITLE
Test for HTTP/2 corruption as reported in #10525

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,7 +81,6 @@ jobs:
       name: 'install nghttp2'
 
     - run: |
-        sudo rm -rf mod_h2
         git clone --depth=1 -b master https://github.com/icing/mod_h2
         cd mod_h2
         autoreconf -fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -80,6 +80,14 @@ jobs:
         make install
       name: 'install nghttp2'
 
+    - run: |
+        git clone --depth=1 -b master https://github.com/icing/mod_h2
+        cd mod_h2
+        autoreconf -fi
+        ./configure
+        make install
+      name: 'install mod_h2'
+
     - uses: actions/checkout@v3
 
     - run: autoreconf -fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,6 +81,7 @@ jobs:
       name: 'install nghttp2'
 
     - run: |
+        sudo rm -rf mod_h2
         git clone --depth=1 -b master https://github.com/icing/mod_h2
         cd mod_h2
         autoreconf -fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -85,6 +85,7 @@ jobs:
         cd mod_h2
         autoreconf -fi
         ./configure PKG_CONFIG_PATH="$HOME/all/lib/pkgconfig"
+        make
         sudo make install
       name: 'install mod_h2'
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,8 +84,8 @@ jobs:
         git clone --depth=1 -b master https://github.com/icing/mod_h2
         cd mod_h2
         autoreconf -fi
-        ./configure
-        make install
+        ./configure PKG_CONFIG_PATH="$HOME/all/lib/pkgconfig"
+        sudo make install
       name: 'install mod_h2'
 
     - uses: actions/checkout@v3

--- a/tests/tests-httpd/testenv/curl.py
+++ b/tests/tests-httpd/testenv/curl.py
@@ -209,6 +209,13 @@ class CurlClient:
         self._rmrf(self._run_dir)
         self._mkpath(self._run_dir)
 
+    @property
+    def run_dir(self) -> str:
+        return self._run_dir
+
+    def download_file(self, i: int) -> str:
+        return os.path.join(self.run_dir, f'download_{i}.data')
+
     def _rmf(self, path):
         if os.path.exists(path):
             return os.remove(path)
@@ -232,8 +239,11 @@ class CurlClient:
         if extra_args is None:
             extra_args = []
         extra_args.extend([
-            '-o', 'download.data',
+            '-o', 'download_#1.data',
         ])
+        # remove any existing ones
+        for i in range(100):
+            self._rmf(self.download_file(i))
         if with_stats:
             extra_args.extend([
                 '-w', '%{json}\\n'

--- a/tests/tests-httpd/testenv/httpd.py
+++ b/tests/tests-httpd/testenv/httpd.py
@@ -307,12 +307,12 @@ class Httpd:
             ]))
 
     def _get_log_level(self):
-        if self.env.verbose > 3:
-            return 'trace2'
-        if self.env.verbose > 2:
-            return 'trace1'
-        if self.env.verbose > 1:
-            return 'debug'
+        #if self.env.verbose > 3:
+        #    return 'trace2'
+        #if self.env.verbose > 2:
+        #    return 'trace1'
+        #if self.env.verbose > 1:
+        #    return 'debug'
         return 'info'
 
     def _curltest_conf(self) -> List[str]:


### PR DESCRIPTION
- adding test_02_20 for reproducing the situation
- using recently released mod_h2 Apache module
- skipping test if an older version is installed
- adding installation of current mod_h2 to github pytest workflow

This reproduces the error reliable (for me) on the lib/http2.c version of curl 7.88.0. And passes with the recent curl master.