### PR TITLE
curl: make --silent work stand-alone

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -298,11 +298,9 @@ struct OperationConfig {
 };
 
 struct GlobalConfig {
-  int showerror;                  /* -1 == unset, default => show errors
-                                      0 => -s is used to NOT show errors
-                                      1 => -S has been used to show errors */
-  bool mute;                      /* don't show messages, --silent given */
-  bool noprogress;                /* don't show progress bar --silent given */
+  bool showerror;                 /* show errors when silent */
+  bool silent;                    /* don't show messages, --silent given */
+  bool noprogress;                /* don't show progress bar */
   bool isatty;                    /* Updated internally if output is a tty */
   FILE *errors;                   /* Error stream, defaults to stderr */
   bool errors_fopened;            /* Whether error stream isn't stderr */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2268,21 +2268,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       /* use remote file's time */
       config->remote_time = toggle;
       break;
-    case 's':
-      /* don't show progress meter, don't show errors : */
-      if(toggle)
-        global->mute = global->noprogress = TRUE;
-      else
-        global->mute = global->noprogress = FALSE;
-      if(global->showerror < 0)
-        /* if still on the default value, set showerror to the reverse of
-           toggle. This is to allow -S and -s to be used in an independent
-           order but still have the same effect. */
-        global->showerror = (!toggle)?TRUE:FALSE; /* toggle off */
+    case 's': /* --silent */
+      global->silent = toggle;
       break;
-    case 'S':
-      /* show errors */
-      global->showerror = toggle?1:0; /* toggle on if used with -s */
+    case 'S': /* --show-error */
+      global->showerror = toggle;
       break;
     case 't':
       /* Telnet options */

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -155,7 +155,7 @@ static CURLcode main_init(struct GlobalConfig *config)
 #endif
 
   /* Initialise the global config */
-  config->showerror = -1;             /* Will show errors */
+  config->showerror = FALSE;          /* show errors when silent */
   config->errors = stderr;            /* Default errors to stderr */
   config->styled_output = TRUE;       /* enable detection */
   config->parallel_max = PARALLEL_DEFAULT;

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -42,7 +42,7 @@ static void voutf(struct GlobalConfig *config,
                   va_list ap)
 {
   size_t width = (79 - strlen(prefix));
-  if(!config->mute) {
+  if(!config->silent) {
     size_t len;
     char *ptr;
     char *print_buffer;
@@ -132,7 +132,7 @@ void helpf(FILE *errors, const char *fmt, ...)
  */
 void errorf(struct GlobalConfig *config, const char *fmt, ...)
 {
-  if(!config->mute) {
+  if(!config->silent) {
     va_list ap;
     va_start(ap, fmt);
     voutf(config, ERROR_PREFIX, fmt, ap);


### PR DESCRIPTION
- renamed the struct field to 'silent' to match the cmdline option
- make --show-error toggle independently of --silent
- make --silent independent of ->noprogress as well

By doing this, the three options --silent, --no-progress-meter and --show-error should work independently of each other and also work with and without '--no-' prefix as documented.

Reported-by: u20221022 on github
Fixes #10535