### PR TITLE
curl_setup: Suppress OpenSSL 3 deprecation warnings

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -862,4 +862,10 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #  endif
 #endif
 
+/* OpenSSLv3 marks DES, MD5 and ENGINE functions deprecated but we have no
+   replacements (yet) so tell the compiler to not warn for them. */
+#ifdef USE_OPENSSL
+#define OPENSSL_SUPPRESS_DEPRECATED
+#endif
+
 #endif /* HEADER_CURL_SETUP_H */

--- a/m4/curl-amissl.m4
+++ b/m4/curl-amissl.m4
@@ -55,11 +55,6 @@ if test "$HAVE_PROTO_BSDSOCKET_H" = "1"; then
       AC_DEFINE_UNQUOTED(HAVE_OPENSSL3, 1, [Define to 1 if using OpenSSL 3 or later.])
       AC_CHECK_HEADERS(openssl/x509.h openssl/rsa.h openssl/crypto.h \
                        openssl/pem.h openssl/ssl.h openssl/err.h)
-      dnl OpenSSLv3 marks the DES functions deprecated but we have no
-      dnl replacements (yet) so tell the compiler to not warn for them
-      dnl
-      dnl Ask OpenSSL to suppress the warnings.
-      CPPFLAGS="$CPPFLAGS -DOPENSSL_SUPPRESS_DEPRECATED"
     ],[
       AC_MSG_RESULT([no])
     ])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -310,11 +310,6 @@ if test "x$OPT_OPENSSL" != xno; then
       AC_MSG_RESULT([yes])
       AC_DEFINE_UNQUOTED(HAVE_OPENSSL3, 1,
         [Define to 1 if using OpenSSL 3 or later.])
-      dnl OpenSSLv3 marks the DES functions deprecated but we have no
-      dnl replacements (yet) so tell the compiler to not warn for them
-      dnl
-      dnl Ask OpenSSL to suppress the warnings.
-      CPPFLAGS="$CPPFLAGS -DOPENSSL_SUPPRESS_DEPRECATED"
       ssl_msg="OpenSSL v3+"
     ],[
       AC_MSG_RESULT([no])


### PR DESCRIPTION
- Define OPENSSL_SUPPRESS_DEPRECATED.

OpenSSL 3 has deprecated some of the functions libcurl uses such as those with DES, MD5 and ENGINE prefix. We don't have replacements for those functions so the warnings were disabled in autotools builds, but still showed in other builds.

Closes #xxxx