### PR TITLE
Correct Curl_os400_sendto()

### DIFF
--- a/lib/setup-os400.h
+++ b/lib/setup-os400.h
@@ -205,7 +205,7 @@ extern OM_uint32 Curl_gss_delete_sec_context_a(OM_uint32 * minor_status,
 extern int Curl_os400_connect(int sd, struct sockaddr *destaddr, int addrlen);
 extern int Curl_os400_bind(int sd, struct sockaddr *localaddr, int addrlen);
 extern int Curl_os400_sendto(int sd, char *buffer, int buflen, int flags,
-                             struct sockaddr *dstaddr, int addrlen);
+                             const struct sockaddr *dstaddr, int addrlen);
 extern int Curl_os400_recvfrom(int sd, char *buffer, int buflen, int flags,
                                struct sockaddr *fromaddr, int *addrlen);
 extern int Curl_os400_getpeername(int sd, struct sockaddr *addr, int *addrlen);

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -1265,7 +1265,7 @@ Curl_os400_bind(int sd, struct sockaddr *localaddr, int addrlen)
 
 int
 Curl_os400_sendto(int sd, char *buffer, int buflen, int flags,
-                  struct sockaddr *dstaddr, int addrlen)
+                  const struct sockaddr *dstaddr, int addrlen)
 {
   int i;
   struct sockaddr_storage laddr;


### PR DESCRIPTION
Add const qualifier to 5th argument of Curl_os400_sendto()

Make OS400 wrapper for sendto match the normal prototype of sendto() with a const qualifier.

Addresses https://github.com/curl/curl/issues/10539