### PR TITLE
Update rustls dependency to 0.9.2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -223,7 +223,7 @@ jobs:
 
     - if: ${{ contains(matrix.build.install_steps, 'rustls') }}
       run: |
-        git clone --depth=1 -b v0.9.1 --recursive https://github.com/rustls/rustls-ffi.git
+        git clone --depth=1 -b v0.9.2 --recursive https://github.com/rustls/rustls-ffi.git
         cd rustls-ffi
         make DESTDIR=$HOME/rustls install
       name: 'install rustls'

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -3,7 +3,7 @@
 [Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.8.2 of rustls-ffi.
+version of curl depends on version v0.9.2 of rustls-ffi.
 
 # Building with rustls
 
@@ -12,7 +12,7 @@ First, [install Rust](https://rustup.rs/).
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
     % cargo install cbindgen
-    % git clone https://github.com/rustls/rustls-ffi -b v0.8.2
+    % git clone https://github.com/rustls/rustls-ffi -b v0.9.2
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -80,9 +80,12 @@
 2305
 %endif
 2043
-# Tests that are disabled here for rustls are SUPPOSED to work
+# The CRL test (313) doesn't work with rustls because rustls doesn't support
+# CRLs.
+# Tests that rely on connecting to an IP address over TLS don't work because
+# rustls doesn't support IP address certificates yet. That's the 400 series of
+# tests listed here, plus 1112 and 1272
 %if rustls
-312
 313
 400
 401


### PR DESCRIPTION
This allows re-enabling test 312 for the rustls backend.