### PR TITLE
Fix CURLOPT_WS_OPTIONS availability version

### DIFF
--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.3
@@ -62,7 +62,7 @@ if(curl) {
 }
 .fi
 .SH AVAILABILITY
-Added in 7.85.0
+Added in 7.86.0
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"


### PR DESCRIPTION
CURLOPT_WS_OPTIONS documentation says 
```
Availability
  Added in 7.85.0
```

Where `symbols-in-versions` says 7.86.0