### PR TITLE
tool_operate: fix scanbuild compiler warning

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1301,15 +1301,16 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         my_setopt(curl, CURLOPT_SEEKDATA, input);
         my_setopt(curl, CURLOPT_SEEKFUNCTION, tool_seek_cb);
 
-#ifdef CURLDEBUG
-        if(getenv("CURL_BUFFERSIZE")) {
-          long size = strtol(getenv("CURL_BUFFERSIZE"), NULL, 10);
-          if(size)
-            my_setopt(curl, CURLOPT_BUFFERSIZE, size);
-        }
-        else
-#endif
         {
+#ifdef CURLDEBUG
+          char *env = getenv("CURL_BUFFERSIZE");
+          if(env) {
+            long size = strtol(env, NULL, 10);
+            if(size)
+              my_setopt(curl, CURLOPT_BUFFERSIZE, size);
+          }
+          else
+#endif
           if(config->recvpersecond &&
              (config->recvpersecond < BUFFER_SIZE))
             /* use a smaller sized buffer for better sleeps */


### PR DESCRIPTION
Prior to this change Azure CI scanbuild warned of a potential NULL pointer string passed to strtol when CURLDEBUG enabled, even though the way the code was written it wouldn't have happened.

Bug: https://github.com/curl/curl/commit/5479d991#r101159711
Reported-by: Marcel Raad

Closes #xxxx