### PR TITLE
socketpair: allow EWOULDBLOCK when reading the pair check bytes

### DIFF
--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -144,8 +144,8 @@ int Curl_socketpair(int domain, int type, int protocol,
       nread = sread(socks[1], p, s);
       if(nread == -1) {
         int sockerr = SOCKERRNO;
-        /* Don't block more than 5 seconds */
-        if(Curl_timediff(Curl_now(), start) > 5000)
+        /* Don't block forever */
+        if(Curl_timediff(Curl_now(), start) > (60 * 1000))
           goto error;
         if(
 #ifdef WSAEWOULDBLOCK

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -85,9 +85,14 @@ int Curl_socketpair(int domain, int type, int protocol,
 
   socks[0] = socks[1] = CURL_SOCKET_BAD;
 
+#if defined(WIN32) || defined(__CYGWIN__)
+  /* don't set SO_REUSEADDR on Windows */
+  (void)reuse;
+#else
   if(setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
                 (char *)&reuse, (curl_socklen_t)sizeof(reuse)) == -1)
     goto error;
+#endif
   if(bind(listener, &a.addr, sizeof(a.inaddr)) == -1)
     goto error;
   if(getsockname(listener, &a.addr, &addrlen) == -1 ||

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -88,6 +88,14 @@ int Curl_socketpair(int domain, int type, int protocol,
 #if defined(WIN32) || defined(__CYGWIN__)
   /* don't set SO_REUSEADDR on Windows */
   (void)reuse;
+#ifdef SO_EXCLUSIVEADDRUSE
+  {
+    int exclusive = 1;
+    if(setsockopt(listener, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+                  (char *)&exclusive, (curl_socklen_t)sizeof(exclusive)) == -1)
+      goto error;
+  }
+#endif
 #else
   if(setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
                 (char *)&reuse, (curl_socklen_t)sizeof(reuse)) == -1)

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -121,7 +121,14 @@ int Curl_socketpair(int domain, int type, int protocol,
     swrite(socks[0], &now, sizeof(now));
     /* verify that we read the correct data */
     do {
-      ssize_t nread = sread(socks[1], p, s);
+      ssize_t nread;
+
+      pfd[0].fd = socks[1];
+      pfd[0].events = POLLIN;
+      pfd[0].revents = 0;
+      (void)Curl_poll(pfd, 1, 1000); /* one second */
+
+      nread = sread(socks[1], p, s);
       if(nread == -1) {
         int sockerr = SOCKERRNO;
         if(


### PR DESCRIPTION
Reported-by: Gunamoi Software
Debuggged-by: Jay Satiro
Fixes #10561