### PR TITLE
tool_operate: avoid fclose(NULL) on bad header dump file

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -984,12 +984,13 @@ static CURLcode single_transfer(struct GlobalConfig *global,
              */
             if(!per->prev || per->prev->config != config) {
               newfile = fopen(config->headerfile, "wb+");
-              fclose(newfile);
+              if(newfile)
+                fclose(newfile);
             }
             newfile = fopen(config->headerfile, "ab+");
 
             if(!newfile) {
-              warnf(global, "Failed to open %s\n", config->headerfile);
+              errorf(global, "Failed to open %s\n", config->headerfile);
               result = CURLE_WRITE_ERROR;
               break;
             }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -68,7 +68,7 @@ test380 test381 test383 test384 test385 test386 test387 test388 test389 \
 test390 test391 test392 test393 test394 test395 test396 test397 test398 \
 test399 test400 test401 test402 test403 test404 test405 test406 test407 \
 test408 test409 test410 test411 test412 test413 test414 test415 test416 \
-test417 test418 \
+test417 test418 test419 \
 \
 test430 test431 test432 test433 test434 test435 test436 \
 \

--- a/tests/data/test419
+++ b/tests/data/test419
@@ -1,0 +1,34 @@
+<testcase>
+<info>
+<keywords>
+--dump-header
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+--dump-header to file that cannot be created
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -D loggg/save-here/fails
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+23
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test419
+++ b/tests/data/test419
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 --dump-header
+failure
 </keywords>
 </info>
 


### PR DESCRIPTION
Fixes #10570
Reported-by: Jérémy Rabasco