### PR TITLE
sectransp: fix compiler warning c89 mixed code/declaration

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2429,6 +2429,7 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
     SecTrustRef trust;
     OSStatus ret;
     SecKeyRef keyRef;
+    OSStatus success;
 
     ret = SSLCopyPeerTrust(ctx, &trust);
     if(ret != noErr || !trust)
@@ -2448,8 +2449,8 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
 
 #elif SECTRANSP_PINNEDPUBKEY_V2
 
-    OSStatus success = SecItemExport(keyRef, kSecFormatOpenSSL, 0, NULL,
-                                     &publicKeyBits);
+    success = SecItemExport(keyRef, kSecFormatOpenSSL, 0, NULL,
+                            &publicKeyBits);
     CFRelease(keyRef);
     if(success != errSecSuccess || !publicKeyBits)
       break;


### PR DESCRIPTION
Since cbf57176 the Cirrus CI 'macOS arm64 SecureTransport http2' has been failing due to c89 warnings mixed code/declaration. That commit is not the cause so I assume something has changed in the CI outside of our configuration. Anyway, we don't mix code/declaration so this is the fix for that.

Closes #xxxx