### PR TITLE
winbuild: fix makefile clean

### DIFF
--- a/winbuild/Makefile.vc
+++ b/winbuild/Makefile.vc
@@ -265,6 +265,10 @@ CONFIG_NAME_LIB = $(CONFIG_NAME_LIB)-msh3
 
 !MESSAGE configuration name: $(CONFIG_NAME_LIB)
 
+# Note these directories are removed by this makefile's 'clean' so they should
+# not be changed to point to user-specified directories that may contain other
+# data. MakefileBuild.vc uses the same variable names but allows some user
+# changes and therefore does not remove the directories.
 BUILD_DIR=../builds/$(CONFIG_NAME_LIB)
 LIBCURL_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-lib
 CURL_DIROBJ = ..\builds\$(CONFIG_NAME_LIB)-obj-curl
@@ -300,4 +304,7 @@ copy_from_lib:
 	FOR %%i IN ($(CURLX_CFILES:/=\)) DO copy %%i ..\src\
 
 clean:
+	@if exist $(LIBCURL_DIROBJ) rd /s /q $(LIBCURL_DIROBJ)
+	@if exist $(CURL_DIROBJ) rd /s /q $(CURL_DIROBJ)
+	@if exist $(DIRDIST) rd /s /q $(DIRDIST)
 	$(MAKE) /NOLOGO /F MakefileBuild.vc $@

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -692,6 +692,12 @@ $(CURL_DIROBJ)\curl.res: $(CURL_SRC_DIR)\curl.rc
 
 !ENDIF  # End of case where a config was provided.
 
+# Makefile.vc's clean removes (LIB)CURL_DIROBJ and DIRDIST dirs then calls
+# this clean. Note those are the original directories we control and not the
+# directories possibly modified by this makefile to point to user-specified
+# directories.
+# For example, don't remove DIRDIST here since it may contain user files if it
+# has been changed by WITH_PREFIX to a different output dir (eg C:\usr\local).
 clean:
 	@-erase /s *.dll 2> NUL
 	@-erase /s *.exp 2> NUL
@@ -701,6 +707,3 @@ clean:
 	@-erase /s *.pch 2> NUL
 	@-erase /s *.pdb 2> NUL
 	@-erase /s *.res 2> NUL
-	@if exist $(LIB_DIROBJ) rd /s/q $(LIB_DIROBJ)
-	@if exist $(CURL_DIROBJ)rd /s/q $(CURL_DIROBJ)
-	@if exist $(DIRDIST) rd /s/q $(DIRDIST)


### PR DESCRIPTION
- Fix and move 'clean' code that removes the output and obj directories trees from MakefileBuild.vc to Makefile.vc.

Prior to this change the 'clean' code did not work right because the variables containing the directory names were not fully initialized and the rmdir syntax was sometimes incorrect (typos). DIRDIST for example was set to `..\builds\` and not `..\builds\$(CONFIG_NAME_LIB)\` so it would remove the former and not the latter. If WITH_PREFIX was set then that directory was removed instead.

Also, DIRDIST (the output directory) even if initialized should not be removed by MakefileBuild.vc because by that time it could be set to a user directory that may contain other files if WITH_PREFIX is set (eg we don't want rmdir /s /q C:\usr\local). Therefore we remove from Makefile.vc before any of that happens. I added a comment in both makefiles explaining this.

Closes #xxxx