### PR TITLE
tool_progress: shut off progress meter for --silent in parallel

### DIFF
--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -173,7 +173,7 @@ bool progress_meter(struct GlobalConfig *global,
   struct timeval now;
   long diff;
 
-  if(global->noprogress)
+  if(global->noprogress || global->silent)
     return FALSE;
 
   now = tvnow();


### PR DESCRIPTION
Reported-by: finkjsc on github
Fixes #10573