### PR TITLE
tool_operate: propagate error codes better for missing URL after --next 

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2472,8 +2472,10 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
     else {
       /* setup the next one just before we delete this */
       result = create_transfer(global, share, &added);
-      if(result)
+      if(result) {
+        returncode = result;
         bailout = TRUE;
+      }
     }
 
     per = del_per_transfer(per);
@@ -2515,7 +2517,8 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
 
   /* Check we have a url */
   if(!config->url_list || !config->url_list->url) {
-    helpf(global->errors, "no URL specified!\n");
+    helpf(global->errors, "(%d) no URL specified!\n",
+          CURLE_FAILED_INIT);
     return CURLE_FAILED_INIT;
   }
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -96,7 +96,7 @@ test643 test644 test645 test646 test647 test648 test649 test650 test651 \
 test652 test653 test654 test655 test656 test658 test659 test660 test661 \
 test662 test663 test664 test665 test666 test667 test668 test669 \
 test670 test671 test672 test673 test674 test675 test676 test677 test678 \
-test679 test680 test681 test682 test683 test684 test685 \
+test679 test680 test681 test682 test683 test684 test685 test686 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test686
+++ b/tests/data/test686
@@ -1,0 +1,34 @@
+<testcase>
+<info>
+<keywords>
+errorcode
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+ <name>
+verify return code for missing URL after --next
+ </name>
+ <command>
+htdhdhdtp://localhost --next
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Fixes #10558