### PR TITLE
test978: mark file as text mode

### DIFF
--- a/tests/data/test978
+++ b/tests/data/test978
@@ -49,7 +49,7 @@ User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>
-<file name="log/redir">
+<file name="log/redir" mode="text">
 nonsense
 </file>
 </verify>


### PR DESCRIPTION
Follow-up to 4ea5702980cb

To fix test failures on Windows