### PR TITLE
ngtcp2 fix file descriptor confusion on macOS

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -253,19 +253,6 @@ static CURLcode socket_open(struct Curl_easy *data,
   else {
     /* opensocket callback not set, so simply create the socket now */
     *sockfd = socket(addr->family, addr->socktype, addr->protocol);
-    if(!*sockfd && addr->socktype == SOCK_DGRAM) {
-      /* This is icky and seems, at least, to happen on macOS:
-       * we get sockfd == 0 and if called again, we get a valid one > 0.
-       * If we close the 0, we sometimes get failures in multi poll, as
-       * 0 seems also be the fd for the sockpair used for WAKEUP polling.
-       * Very strange. Maybe this code should be ifdef'ed for macOS, but
-       * on "real" OS, fd 0 is stdin and we never see that. So...
-       */
-      fake_sclose(*sockfd);
-      *sockfd = socket(addr->family, addr->socktype, addr->protocol);
-      DEBUGF(infof(data, "QUIRK: UDP socket() gave handle 0, 2nd attempt %d",
-                   (int)*sockfd));
-    }
   }
 
   if(*sockfd == CURL_SOCKET_BAD)

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2126,7 +2126,8 @@ static void cf_ngtcp2_ctx_clear(struct cf_ngtcp2_ctx *ctx)
   struct cf_call_data save = ctx->call_data;
 
   if(ctx->qlogfd != -1) {
-    close(ctx->qlogfd);
+    if(ctx->qlogfd > 0)
+      close(ctx->qlogfd);
     ctx->qlogfd = -1;
   }
 #ifdef USE_OPENSSL

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2126,9 +2126,7 @@ static void cf_ngtcp2_ctx_clear(struct cf_ngtcp2_ctx *ctx)
   struct cf_call_data save = ctx->call_data;
 
   if(ctx->qlogfd != -1) {
-    if(ctx->qlogfd > 0)
-      close(ctx->qlogfd);
-    ctx->qlogfd = -1;
+    close(ctx->qlogfd);
   }
 #ifdef USE_OPENSSL
   if(ctx->ssl)
@@ -2156,6 +2154,7 @@ static void cf_ngtcp2_ctx_clear(struct cf_ngtcp2_ctx *ctx)
     ngtcp2_conn_del(ctx->qconn);
 
   memset(ctx, 0, sizeof(*ctx));
+  ctx->qlogfd = -1;
   ctx->call_data = save;
 }
 
@@ -2471,6 +2470,7 @@ CURLcode Curl_cf_ngtcp2_create(struct Curl_cfilter **pcf,
     result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
+  ctx->qlogfd = -1;
   cf_ngtcp2_ctx_clear(ctx);
 
   result = Curl_cf_create(&cf, &Curl_cft_http3, ctx);


### PR DESCRIPTION
The QUIC implementation using ngtcp2 faultily closed file descriptor 0 during initialisation.

On macOS, the next `socket()` call then handed out file descriptor 0, but that could not be used successfully in further OS calls. With the unwanted close fixed, proper file descriptors are returned by `socket()`.