### PR TITLE
transfer: limit Windows SO_SNDBUF updates to once a second

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -980,7 +980,15 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
     if(result)
       return result;
 
-    win_update_buffer_size(conn->writesockfd);
+#if defined(WIN32) && defined(USE_WINSOCK)
+    {
+      struct curltime n = Curl_now();
+      if(Curl_timediff(n, k->last_sndbuf_update) > 1000) {
+        win_update_buffer_size(conn->writesockfd);
+        k->last_sndbuf_update = n;
+      }
+    }
+#endif
 
     if(k->pendingheader) {
       /* parts of what was sent was header */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -689,6 +689,10 @@ struct SingleRequest {
 #endif
   unsigned char setcookies;
   unsigned char writer_stack_depth; /* Unencoding stack depth. */
+#if defined(WIN32) && defined(USE_WINSOCK)
+  struct curltime last_sndbuf_update;  /* last time readwrite_upload called
+                                          win_update_buffer_size */
+#endif
   BIT(header);        /* incoming data has HTTP header */
   BIT(content_range); /* set TRUE if Content-Range: was found */
   BIT(upload_done);   /* set to TRUE when doing chunked transfer-encoding


### PR DESCRIPTION
- Change readwrite_upload() to call win_update_buffer_size() no more than once a second to update SO_SNDBUF (send buffer limit).

Prior to this change during an upload readwrite_upload() could call win_update_buffer_size() anywhere from hundreds of times per second to an extreme test case of 100k per second (which is likely due to a bug, and that will be reported separately). In the latter case WPA profiler showed win_update_buffer_size was the highest capture count in readwrite_upload. In any case the calls were excessive and unnecessary.

Closes #xxxx