### PR TITLE
x509asn1.c: use correct format specifier for infof() call

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1127,7 +1127,7 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data,
       return result;
   }
   if(!certnum)
-    infof(data, "   Version: %lu (0x%lx)", version + 1, version);
+    infof(data, "   Version: %u (0x%x)", version + 1, version);
 
   /* Serial number. */
   ccp = ASN1tostr(&cert.serialNumber, 0);


### PR DESCRIPTION
Detected by Coverity