### PR TITLE
lib: fix compiler warnings in H3 and Schannel on Windows

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -64,6 +64,8 @@
 #include "vtls/vtls.h"
 #include "curl_ngtcp2.h"
 
+#include "warnless.h"
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"
@@ -1762,7 +1764,7 @@ static CURLcode cf_process_ingress(struct Curl_cfilter *cf,
   ssize_t recvd;
   int rv;
   uint8_t buf[65536];
-  size_t bufsize = sizeof(buf);
+  int bufsize = (int)sizeof(buf);
   size_t pktcount = 0, total_recvd = 0;
   struct sockaddr_storage remote_addr;
   socklen_t remote_addrlen;
@@ -2176,7 +2178,7 @@ static void cf_ngtcp2_close(struct Curl_cfilter *cf, struct Curl_easy *data)
                                             (uint8_t *)buffer, sizeof(buffer),
                                             &ctx->last_error, ts);
     if(rc > 0) {
-      while((send(ctx->q.sockfd, buffer, rc, 0) == -1) &&
+      while((send(ctx->q.sockfd, buffer, (SEND_TYPE_ARG3)rc, 0) == -1) &&
             SOCKERRNO == EINTR);
     }
 
@@ -2190,9 +2192,12 @@ static void cf_ngtcp2_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 static void cf_ngtcp2_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
+  /*
   struct cf_call_data save;
 
   CF_DATA_SAVE(save, cf, data);
+  */
+  (void)data;
   DEBUGF(LOG_CF(data, cf, "destroy"));
   if(ctx) {
     cf_ngtcp2_ctx_clear(ctx);

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2192,12 +2192,9 @@ static void cf_ngtcp2_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 static void cf_ngtcp2_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  /*
   struct cf_call_data save;
 
   CF_DATA_SAVE(save, cf, data);
-  */
-  (void)data;
   DEBUGF(LOG_CF(data, cf, "destroy"));
   if(ctx) {
     cf_ngtcp2_ctx_clear(ctx);
@@ -2205,6 +2202,7 @@ static void cf_ngtcp2_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
   cf->ctx = NULL;
   /* No CF_DATA_RESTORE(cf, save) possible */
+  (void)save;
 }
 
 /*

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -444,7 +444,7 @@ static CURLcode cf_process_ingress(struct Curl_cfilter *cf,
   struct cf_quiche_ctx *ctx = cf->ctx;
   int64_t stream3_id = data->req.p.http? data->req.p.http->stream3_id : -1;
   uint8_t buf[65536];
-  size_t bufsize = sizeof(buf);
+  int bufsize = (int)sizeof(buf);
   struct sockaddr_storage remote_addr;
   socklen_t remote_addrlen;
   quiche_recv_info recv_info;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -167,7 +167,8 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
 
   *psent = 0;
 
-  while((sent = send(qctx->sockfd, (const char *)pkt, pktlen, 0)) == -1 &&
+  while((sent = send(qctx->sockfd,
+                     (const char *)pkt, (SEND_TYPE_ARG3)pktlen, 0)) == -1 &&
         SOCKERRNO == EINTR)
     ;
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1201,18 +1201,18 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* The first four bytes will be an unsigned int indicating number
        of bytes of data in the rest of the buffer. */
     extension_len = (unsigned int *)(void *)(&alpn_buffer[cur]);
-    cur += sizeof(unsigned int);
+    cur += (int)sizeof(unsigned int);
 
     /* The next four bytes are an indicator that this buffer will contain
        ALPN data, as opposed to NPN, for example. */
     *(unsigned int *)(void *)&alpn_buffer[cur] =
       SecApplicationProtocolNegotiationExt_ALPN;
-    cur += sizeof(unsigned int);
+    cur += (int)sizeof(unsigned int);
 
     /* The next two bytes will be an unsigned short indicating the number
        of bytes used to list the preferred protocols. */
     list_len = (unsigned short*)(void *)(&alpn_buffer[cur]);
-    cur += sizeof(unsigned short);
+    cur += (int)sizeof(unsigned short);
 
     list_start_index = cur;
 
@@ -1225,7 +1225,9 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     cur += proto.len;
 
     *list_len = curlx_uitous(cur - list_start_index);
-    *extension_len = *list_len + sizeof(unsigned int) + sizeof(unsigned short);
+    *extension_len = *list_len +
+      (unsigned short)sizeof(unsigned int) +
+      (unsigned short)sizeof(unsigned short);
 
     InitSecBuffer(&inbuf, SECBUFFER_APPLICATION_PROTOCOLS, alpn_buffer, cur);
     InitSecBufferDesc(&inbuf_desc, &inbuf, 1);


### PR DESCRIPTION
Fix compiler warnings in

- ngtcp2 builds,

  Reported-by: Keitagit-kun on github

- quiche builds,

- Schannel code with gcc.

Also synced curl-for-win GNU Make build warnings with CMake's `PICKY_COMPILER` ones:
https://github.com/curl/curl-for-win/commit/f70d8a3b965f5406a9cd8ffa1921143eb8bb2253

Fixes #10603
Closes #10616
