### PR TITLE
PARALLEL-TRANSFERS.md: not "early days" for this anymore

### DIFF
--- a/docs/PARALLEL-TRANSFERS.md
+++ b/docs/PARALLEL-TRANSFERS.md
@@ -1,6 +1,6 @@
 # Parallel transfers
 
-curl 7.66.0 introduces support for doing multiple transfers simultaneously; in
+curl 7.66.0 introduced support for doing multiple transfers simultaneously; in
 parallel.
 
 ## -Z, --parallel
@@ -48,11 +48,3 @@ To fix this, the authorization state could be made possible to share with the
 share API as well, as a context per origin + path (realm?) basically.
 
 Visible in test 153, 1412 and more.
-
-## Feedback
-
-This is early days for parallel transfer support. Keep your eyes open for
-unintended side effects or downright bugs.
-
-Tell us what you think and how you think we could improve this feature!
-


### PR DESCRIPTION
Refresh the language as the support is now over three years old