### PR TITLE
sectransp: Limit realloc size in read_cert

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2179,6 +2179,11 @@ static int read_cert(const char *file, unsigned char **out, size_t *outlen)
     }
 
     if(len + n >= cap) {
+      if(cap > SSIZE_T_MAX/2) {
+        close(fd);
+        free(data);
+        return -1;
+      }
       cap *= 2;
       data = Curl_saferealloc(data, cap);
       if(!data) {


### PR DESCRIPTION
Ensure that allocation size for `Curl_saferealloc` cannot overflow. This should never trigger but let's be consistent and protect against it either way.