### PR TITLE
setopt: move the CURLOPT_CHUNK_DATA pointer to the set struct

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3255,7 +3255,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
   if(data->state.wildcardmatch) {
     if(data->set.chunk_end && ftpc->file) {
       Curl_set_in_callback(data, true);
-      data->set.chunk_end(data->wildcard.customptr);
+      data->set.chunk_end(data->set.wildcardptr);
       Curl_set_in_callback(data, false);
     }
     ftpc->known_filesize = -1;
@@ -3909,7 +3909,7 @@ static CURLcode wc_statemach(struct Curl_easy *data)
         long userresponse;
         Curl_set_in_callback(data, true);
         userresponse = data->set.chunk_bgn(
-          finfo, wildcard->customptr, (int)wildcard->filelist.size);
+          finfo, data->set.wildcardptr, (int)wildcard->filelist.size);
         Curl_set_in_callback(data, false);
         switch(userresponse) {
         case CURL_CHUNK_BGN_FUNC_SKIP:
@@ -3949,7 +3949,7 @@ static CURLcode wc_statemach(struct Curl_easy *data)
     case CURLWC_SKIP: {
       if(data->set.chunk_end) {
         Curl_set_in_callback(data, true);
-        data->set.chunk_end(data->wildcard.customptr);
+        data->set.chunk_end(data->set.wildcardptr);
         Curl_set_in_callback(data, false);
       }
       Curl_llist_remove(&wildcard->filelist, wildcard->filelist.head, NULL);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2849,7 +2849,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.fnmatch = va_arg(param, curl_fnmatch_callback);
     break;
   case CURLOPT_CHUNK_DATA:
-    data->wildcard.customptr = va_arg(param, void *);
+    data->set.wildcardptr = va_arg(param, void *);
     break;
   case CURLOPT_FNMATCH_DATA:
     data->set.fnmatch_data = va_arg(param, void *);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1739,6 +1739,7 @@ struct UserDefined {
   curl_fnmatch_callback fnmatch; /* callback to decide which file corresponds
                                     to pattern (e.g. if WILDCARDMATCH is on) */
   void *fnmatch_data;
+  void *wildcardptr;
 #endif
  /* GSS-API credential delegation, see the documentation of
     CURLOPT_GSSAPI_DELEGATION */

--- a/lib/wildcard.c
+++ b/lib/wildcard.c
@@ -61,14 +61,10 @@ void Curl_wildcard_dtor(struct WildcardData *wc)
   DEBUGASSERT(wc->protdata == NULL);
 
   Curl_llist_destroy(&wc->filelist, NULL);
-
-
   free(wc->path);
   wc->path = NULL;
   free(wc->pattern);
   wc->pattern = NULL;
-
-  wc->customptr = NULL;
   wc->state = CURLWC_INIT;
 }
 

--- a/lib/wildcard.h
+++ b/lib/wildcard.h
@@ -54,7 +54,6 @@ struct WildcardData {
   struct Curl_llist filelist; /* llist with struct Curl_fileinfo */
   void *protdata; /* pointer to protocol specific temporary data */
   wildcard_dtor dtor;
-  void *customptr;  /* for CURLOPT_CHUNK_DATA pointer */
 };
 
 CURLcode Curl_wildcard_init(struct WildcardData *wc);


### PR DESCRIPTION
To make duphandle work etc