### PR TITLE
Allocate the FTP wildcard struct on demand

### DIFF
--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -274,8 +274,8 @@ static CURLcode ftp_pl_insert_finfo(struct Curl_easy *data,
                                     struct fileinfo *infop)
 {
   curl_fnmatch_callback compare;
-  struct WildcardData *wc = &data->wildcard;
-  struct ftp_wc *ftpwc = wc->protdata;
+  struct WildcardData *wc = data->wildcard;
+  struct ftp_wc *ftpwc = wc->wc;
   struct Curl_llist *llist = &wc->filelist;
   struct ftp_parselist_data *parser = ftpwc->parser;
   bool add = TRUE;
@@ -330,7 +330,7 @@ size_t Curl_ftp_parselist(char *buffer, size_t size, size_t nmemb,
 {
   size_t bufflen = size*nmemb;
   struct Curl_easy *data = (struct Curl_easy *)connptr;
-  struct ftp_wc *ftpwc = data->wildcard.protdata;
+  struct ftp_wc *ftpwc = data->wildcard->wc;
   struct ftp_parselist_data *parser = ftpwc->parser;
   struct fileinfo *infop;
   struct curl_fileinfo *finfo;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2192,7 +2192,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 #ifndef CURL_DISABLE_FTP
             /* some steps needed for wildcard matching */
             if(data->state.wildcardmatch) {
-              struct WildcardData *wc = &data->wildcard;
+              struct WildcardData *wc = data->wildcard;
               if(wc->state == CURLWC_DONE || wc->state == CURLWC_SKIP) {
                 /* skip some states if it is important */
                 multi_done(data, CURLE_OK, FALSE);
@@ -2344,7 +2344,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 #ifndef CURL_DISABLE_FTP
         if(data->state.wildcardmatch &&
            ((data->conn->handler->flags & PROTOPT_WILDCARD) == 0)) {
-          data->wildcard.state = CURLWC_DONE;
+          data->wildcard->state = CURLWC_DONE;
         }
 #endif
         multistate(data, MSTATE_DONE);
@@ -2574,7 +2574,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
 #ifndef CURL_DISABLE_FTP
       if(data->state.wildcardmatch) {
-        if(data->wildcard.state != CURLWC_DONE) {
+        if(data->wildcard->state != CURLWC_DONE) {
           /* if a wildcard is set and we are not ending -> lets start again
              with MSTATE_INIT */
           multistate(data, MSTATE_INIT);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1394,7 +1394,13 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 #ifndef CURL_DISABLE_FTP
     data->state.wildcardmatch = data->set.wildcard_enabled;
     if(data->state.wildcardmatch) {
-      struct WildcardData *wc = &data->wildcard;
+      struct WildcardData *wc;
+      if(!data->wildcard) {
+        data->wildcard = calloc(1, sizeof(struct WildcardData));
+        if(!data->wildcard)
+          return CURLE_OUT_OF_MEMORY;
+      }
+      wc = data->wildcard;
       if(wc->state < CURLWC_INIT) {
         result = Curl_wildcard_init(wc); /* init wildcard structures */
         if(result)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1935,7 +1935,7 @@ struct Curl_easy {
   struct UrlState state;       /* struct for fields used for state info and
                                   other dynamic purposes */
 #ifndef CURL_DISABLE_FTP
-  struct WildcardData wildcard; /* wildcard download state info */
+  struct WildcardData *wildcard; /* wildcard download state info */
 #endif
   struct PureInfo info;        /* stats, reports and info data */
   struct curl_tlssessioninfo tsi; /* Information about the TLS session, only

--- a/lib/wildcard.c
+++ b/lib/wildcard.c
@@ -48,17 +48,18 @@ CURLcode Curl_wildcard_init(struct WildcardData *wc)
   return CURLE_OK;
 }
 
-void Curl_wildcard_dtor(struct WildcardData *wc)
+void Curl_wildcard_dtor(struct WildcardData **wcp)
 {
+  struct WildcardData *wc = *wcp;
   if(!wc)
     return;
 
   if(wc->dtor) {
-    wc->dtor(wc->protdata);
+    wc->dtor(wc->wc);
     wc->dtor = ZERO_NULL;
-    wc->protdata = NULL;
+    wc->wc = NULL;
   }
-  DEBUGASSERT(wc->protdata == NULL);
+  DEBUGASSERT(wc->wc == NULL);
 
   Curl_llist_destroy(&wc->filelist, NULL);
   free(wc->path);
@@ -66,6 +67,8 @@ void Curl_wildcard_dtor(struct WildcardData *wc)
   free(wc->pattern);
   wc->pattern = NULL;
   wc->state = CURLWC_INIT;
+  free(wc);
+  *wcp = NULL;
 }
 
 #endif /* if disabled */

--- a/lib/wildcard.h
+++ b/lib/wildcard.h
@@ -52,12 +52,12 @@ struct WildcardData {
   char *path; /* path to the directory, where we trying wildcard-match */
   char *pattern; /* wildcard pattern */
   struct Curl_llist filelist; /* llist with struct Curl_fileinfo */
-  void *protdata; /* pointer to protocol specific temporary data */
+  struct ftp_wc *wc; /* pointer to FTP data */
   wildcard_dtor dtor;
 };
 
 CURLcode Curl_wildcard_init(struct WildcardData *wc);
-void Curl_wildcard_dtor(struct WildcardData *wc);
+void Curl_wildcard_dtor(struct WildcardData **wcp);
 
 struct Curl_easy;
 


### PR DESCRIPTION
The feature is rarely used so this frees up data for the vast majority of easy handles that don't use it.