### PR TITLE
Single URLs make no sense in --rate example

### DIFF
--- a/docs/cmdline-opts/rate.d
+++ b/docs/cmdline-opts/rate.d
@@ -4,9 +4,9 @@ Long: rate
 Arg: <max request rate>
 Help: Request rate for serial transfers
 Category: connection
-Example: --rate 2/s $URL
-Example: --rate 3/h $URL
-Example: --rate 14/m $URL
+Example: --rate 2/s $URL ...
+Example: --rate 3/h $URL ...
+Example: --rate 14/m $URL ...
 Added: 7.84.0
 See-also: limit-rate retry-delay
 Multi: single


### PR DESCRIPTION
Here somehow you need to put more than one URL in these examples, else they will make no sense, as --rate only affects the  second and beyond URLs. The first URL will always (OK, usually) finish the same time no matter what --rate is given.