### PR TITLE
Fixes handling of remote addr for accepted tcp sockets.

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1836,6 +1836,8 @@ static void set_accepted_remote_ip(struct Curl_cfilter *cf,
   struct Curl_sockaddr_storage ssrem;
   curl_socklen_t plen;
 
+  ctx->r_ip[0] = 0;
+  ctx->r_port = 0;
   plen = sizeof(ssrem);
   memset(&ssrem, 0, plen);
   if(getpeername(ctx->sock, (struct sockaddr*) &ssrem, &plen)) {


### PR DESCRIPTION
- refs #10622, do not try to determine the remote address of a listen socket. There is none.
- Update remote address of an accepted socket by getpeername() if available.