### PR TITLE
http: ignore content-range for 416 responses

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3477,7 +3477,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
           k->content_range = TRUE;
       }
     }
-    else
+    else if(416 != k->httpcode)
       data->state.resume_from = 0; /* get everything */
   }
 #if !defined(CURL_DISABLE_COOKIES)


### PR DESCRIPTION
- fix for #10521
- someone should add a test for this as well (not included here)