### PR TITLE
If socket is already connected, return CURLE_OK

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1075,7 +1075,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
       *done = TRUE;
       return CURLE_OK;
     }
-    
+
     /* Connect TCP socket */
     rc = do_connect(cf, data, cf->conn->bits.tcp_fastopen);
     if(-1 == rc) {

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1071,6 +1071,11 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
     if(result)
       goto out;
 
+    if(cf->connected) {
+      *done = TRUE;
+      return CURLE_OK;
+    }
+    
     /* Connect TCP socket */
     rc = do_connect(cf, data, cf->conn->bits.tcp_fastopen);
     if(-1 == rc) {


### PR DESCRIPTION
This will fix the issue mentioned at https://github.com/curl/curl/issues/10626

In 7.87.0, if callback method for CURLOPT_SOCKOPTFUNCTION returns CURL_SOCKOPT_ALREADY_CONNECTED then curl library used to return CURLE_OK. In 7.88.0, now even if callback returns CURL_SOCKOPT_ALREADY_CONNECTED, curl library still tries to connect to socket by invoking method do_connect().

This is regression caused by commit 
https://github.com/curl/curl/commit/71b7e0161032927cdfb4e75ea40f65b8898b3956#diff-96ac2b9e301765fa5e816e0c41282610e9c0193a5852cc9bb0ed053b1fc4ef7f

Fix: Check if we are already connected and return CURLE_OK.