### PR TITLE
test1960: verify CURL_SOCKOPT_ALREADY_CONNECTED

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -225,7 +225,7 @@ test1916 test1917 test1918 test1919 \
 \
 test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
 test1941 test1942 test1943 test1944 test1945 test1946 test1947 test1948 \
-test1955 test1956 test1957 test1958 test1959 \
+test1955 test1956 test1957 test1958 test1959 test1960 \
 \
 test2000 test2001 test2002 test2003 test2004 \
 \

--- a/tests/data/test1960
+++ b/tests/data/test1960
@@ -1,0 +1,49 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+CURLOPT_SOCKOPTFUNCTION
+CURL_SOCKOPT_ALREADY_CONNECTED
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Content-Length: 0
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+
+<name>
+application hands over already connected socket
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<command>
+http://%HOSTIP:%HTTPPORT/file %HOSTIP %HTTPPORT
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /file HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1960
+++ b/tests/data/test1960
@@ -21,6 +21,9 @@ Content-Length: 0
 
 # Client-side
 <client>
+<precheck>
+lib%TESTNUMBER check
+</precheck>
 <server>
 http
 </server>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -69,6 +69,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect                \
          lib1915 lib1916 lib1917 lib1918 lib1919 \
  lib1933 lib1934 lib1935 lib1936 lib1937 lib1938 lib1939 lib1940 \
  lib1945 lib1946 lib1947 lib1948 lib1955 lib1956 lib1957 lib1958 lib1959 \
+ lib1960 \
  lib2301 lib2302 lib2304 lib2305 \
  lib2402 \
  lib2502 \
@@ -790,6 +791,9 @@ lib1958_CPPFLAGS = $(AM_CPPFLAGS)
 lib1959_SOURCES = lib1959.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1959_LDADD = $(TESTUTIL_LIBS)
 lib1959_CPPFLAGS = $(AM_CPPFLAGS)
+
+lib1960_SOURCES = lib1960.c $(SUPPORTFILES)
+lib1960_LDADD = $(TESTUTIL_LIBS)
 
 lib2301_SOURCES = lib2301.c $(SUPPORTFILES)
 lib2301_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -24,12 +24,12 @@
 #include "test.h"
 
 #ifdef WIN32
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600 /* override mingw v1's value that prevents the
+                               inet_pton() handling */
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>
-
-/* because of mingw v1 */
-extern int inet_pton(int af, const char *src, void *dst);
 #endif
 
 #ifdef HAVE_NETINET_IN_H

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -1,0 +1,143 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.haxx.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#ifdef WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+/* because of mingw v1 */
+extern int inet_pton(int af, const char *src, void *dst);
+#endif
+
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
+
+#include "memdebug.h"
+
+/* to prevent libcurl from closing our socket */
+static int closesocket_cb(void *clientp, curl_socket_t item)
+{
+  (void)clientp;
+  (void)item;
+  return 0;
+}
+
+/* provide our own socket */
+static curl_socket_t socket_cb(void *clientp,
+                               curlsocktype purpose,
+                               struct curl_sockaddr *address)
+{
+  int s = *(int *)clientp;
+  (void)purpose;
+  (void)address;
+  return (curl_socket_t)s;
+}
+
+/* tell libcurl the socket is connected */
+static int sockopt_cb(void *clientp,
+                      curl_socket_t curlfd,
+                      curlsocktype purpose)
+{
+  (void)clientp;
+  (void)curlfd;
+  (void)purpose;
+  return CURL_SOCKOPT_ALREADY_CONNECTED;
+}
+
+/* Expected args: URL IP PORT */
+int test(char *URL)
+{
+  CURL *curl = NULL;
+  CURLcode res = TEST_ERR_MAJOR_BAD;
+  int status;
+  curl_socket_t client_fd = CURL_SOCKET_BAD;
+  struct sockaddr_in serv_addr;
+  unsigned short port = (unsigned short)atoi(libtest_arg3);
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    fprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  /*
+   * This code connects to the TCP port "manually" so that we then can hand
+   * over this socket as "already connected" to libcurl and make sure that
+   * this works.
+   */
+  client_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if(client_fd == CURL_SOCKET_BAD) {
+    fprintf(stderr, "socket creation error\n");
+    goto test_cleanup;
+  }
+
+  serv_addr.sin_family = AF_INET;
+  serv_addr.sin_port = htons(port);
+
+  if(inet_pton(AF_INET, libtest_arg2, &serv_addr.sin_addr) <= 0) {
+    fprintf(stderr, "inet_pton failed\n");
+    goto test_cleanup;
+  }
+
+  status = connect(client_fd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+  if(status < 0) {
+    fprintf(stderr, "connection failed\n");
+    goto test_cleanup;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    fprintf(stderr, "curl_easy_init() failed\n");
+    goto test_cleanup;
+  }
+
+  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  test_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, socket_cb);
+  test_setopt(curl, CURLOPT_OPENSOCKETDATA, &client_fd);
+  test_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_cb);
+  test_setopt(curl, CURLOPT_SOCKOPTDATA, NULL);
+  test_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket_cb);
+  test_setopt(curl, CURLOPT_CLOSESOCKETDATA, NULL);
+  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  test_setopt(curl, CURLOPT_HEADER, 1L);
+  test_setopt(curl, CURLOPT_URL, URL);
+
+  res = curl_easy_perform(curl);
+
+test_cleanup:
+  if(client_fd != CURL_SOCKET_BAD)
+    sclose(client_fd);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return res;
+}

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -23,10 +23,9 @@
  ***************************************************************************/
 #include "test.h"
 
+#ifdef HAVE_INET_PTON
+
 #ifdef WIN32
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600 /* override mingw v1's value that prevents the
-                               inet_pton() handling */
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>
@@ -82,7 +81,12 @@ int test(char *URL)
   int status;
   curl_socket_t client_fd = CURL_SOCKET_BAD;
   struct sockaddr_in serv_addr;
-  unsigned short port = (unsigned short)atoi(libtest_arg3);
+  unsigned short port;
+
+  if(!strcmp("check", URL))
+    return 0; /* no output makes it not skipped */
+
+  port = (unsigned short)atoi(libtest_arg3);
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");
@@ -141,3 +145,11 @@ test_cleanup:
 
   return res;
 }
+#else
+int test(char *URL)
+{
+  (void)URL;
+  printf("Skip\n");
+  return 0;
+}
+#endif


### PR DESCRIPTION
When returned from the CURLOPT_SOCKOPTFUNCTION, like when we have a custom socket connected in the app, passed in to libcurl.

Verifies the fix in #10648