### PR TITLE
urlapi: parse IPv6 literals without ENABLE_IPV6

### DIFF
--- a/docs/libcurl/libcurl-url.3
+++ b/docs/libcurl/libcurl-url.3
@@ -137,6 +137,9 @@ Now the URL looks like
 .fi
 .SH AVAILABILITY
 The URL API was introduced in libcurl 7.62.0.
+
+A URL with a literal IPv6 address can be parsed even when IPv6 support is not
+enabled.
 .SH "SEE ALSO"
 .BR curl_url "(3), " curl_url_cleanup "(3), " curl_url_get "(3), "
 .BR curl_url_dup "(3), " curl_url_set "(3), " curl_url_strerror "(3), "

--- a/lib/inet_ntop.c
+++ b/lib/inet_ntop.c
@@ -42,6 +42,15 @@
 #define INT16SZ          2
 
 /*
+ * If ENABLE_IPV6 is disabled, we still want to parse IPv6 addresses, so make
+ * sure we have _some_ value for AF_INET6 without polluting our fake value
+ * everywhere.
+ */
+#if !defined(ENABLE_IPV6) && !defined(AF_INET6)
+#define AF_INET6 (AF_INET + 1)
+#endif
+
+/*
  * Format an IPv4 address, more or less like inet_ntop().
  *
  * Returns `dst' (as a const)
@@ -72,7 +81,6 @@ static char *inet_ntop4 (const unsigned char *src, char *dst, size_t size)
   return dst;
 }
 
-#ifdef ENABLE_IPV6
 /*
  * Convert IPv6 binary address into presentation (printable) format.
  */
@@ -168,7 +176,6 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
   strcpy(dst, tmp);
   return dst;
 }
-#endif  /* ENABLE_IPV6 */
 
 /*
  * Convert a network format address to presentation format.
@@ -187,10 +194,8 @@ char *Curl_inet_ntop(int af, const void *src, char *buf, size_t size)
   switch(af) {
   case AF_INET:
     return inet_ntop4((const unsigned char *)src, buf, size);
-#ifdef ENABLE_IPV6
   case AF_INET6:
     return inet_ntop6((const unsigned char *)src, buf, size);
-#endif
   default:
     errno = EAFNOSUPPORT;
     return NULL;

--- a/lib/inet_pton.c
+++ b/lib/inet_pton.c
@@ -39,14 +39,21 @@
 #define INT16SZ          2
 
 /*
+ * If ENABLE_IPV6 is disabled, we still want to parse IPv6 addresses, so make
+ * sure we have _some_ value for AF_INET6 without polluting our fake value
+ * everywhere.
+ */
+#if !defined(ENABLE_IPV6) && !defined(AF_INET6)
+#define AF_INET6 (AF_INET + 1)
+#endif
+
+/*
  * WARNING: Don't even consider trying to compile this on a system where
  * sizeof(int) < 4.  sizeof(int) > 4 is fine; all the world's not a VAX.
  */
 
 static int      inet_pton4(const char *src, unsigned char *dst);
-#ifdef ENABLE_IPV6
 static int      inet_pton6(const char *src, unsigned char *dst);
-#endif
 
 /* int
  * inet_pton(af, src, dst)
@@ -70,10 +77,8 @@ Curl_inet_pton(int af, const char *src, void *dst)
   switch(af) {
   case AF_INET:
     return (inet_pton4(src, (unsigned char *)dst));
-#ifdef ENABLE_IPV6
   case AF_INET6:
     return (inet_pton6(src, (unsigned char *)dst));
-#endif
   default:
     errno = EAFNOSUPPORT;
     return (-1);
@@ -135,7 +140,6 @@ inet_pton4(const char *src, unsigned char *dst)
   return (1);
 }
 
-#ifdef ENABLE_IPV6
 /* int
  * inet_pton6(src, dst)
  *      convert presentation level address to network order binary form.
@@ -234,6 +238,5 @@ inet_pton6(const char *src, unsigned char *dst)
   memcpy(dst, tmp, IN6ADDRSZ);
   return (1);
 }
-#endif /* ENABLE_IPV6 */
 
 #endif /* HAVE_INET_PTON */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -57,6 +57,15 @@
 /* scheme is not URL encoded, the longest libcurl supported ones are... */
 #define MAX_SCHEME_LEN 40
 
+/*
+ * If ENABLE_IPV6 is disabled, we still want to parse IPv6 addresses, so make
+ * sure we have _some_ value for AF_INET6 without polluting our fake value
+ * everywhere.
+ */
+#if !defined(ENABLE_IPV6) && !defined(AF_INET6)
+#define AF_INET6 (AF_INET + 1)
+#endif
+
 /* Internal representation of CURLU. Point to URL-encoded strings. */
 struct Curl_URL {
   char *scheme;
@@ -599,7 +608,8 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
         return CURLUE_BAD_IPV6;
       /* hostname is fine */
     }
-#ifdef ENABLE_IPV6
+
+    /* Check the IPv6 address. */
     {
       char dest[16]; /* fits a binary IPv6 address */
       char norm[MAX_IPADR_LEN];
@@ -616,7 +626,6 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
       }
       hostname[hlen] = ']'; /* restore ending bracket */
     }
-#endif
   }
   else {
     /* letters from the second string are not ok */

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -25,7 +25,6 @@ imap
 ldap
 dict
 ftp
-ipv6
 </features>
  <name>
 URL API


### PR DESCRIPTION
As per [the discussion on the curl-library mailing list](https://curl.se/mail/lib-2023-02/0043.html), here is a patch to allow URLs with IPv6 literals to be parsed correctly even when `ENABLE_IPV6` is not configured, including when the target lacks the `AF_INET6` constant (and other IPv6 definitions).

It simply enables the existing curl IPv6 literal parsing capabilities when `ENABLE_IPV6` is not defined, and creates a limited-scope definition of `AF_INET6` that the URL and IP parsing code (only) use to communicate.  It seemed safer to not define `AF_INET6` more widely, and it seemed unnecessarily complex to switch curl to define its own constant and use it, so I took a simple pragmatic approach.  Feedback on this detail, including the resulting redefinition of `AF_INET6` in a three spots, is welcome.

For tests, I simply relaxed the restrictions on the existing tests to now require IPv6 support.  I do not know if any CI runs the tests this way (but I did manually).

I don't have a machine that lacks `AF_INET6`, so I also simulated that case by undefining it.  

All tests passed for me on Linux x86_64.