### PR TITLE
Add test for socks proxy using unix sockets and connect to https

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -186,7 +186,7 @@ test1432 test1433 test1434 test1435 test1436 test1437 test1438 test1439 \
 test1440 test1441 test1442 test1443 test1444 test1445 test1446 test1447 \
 test1448 test1449 test1450 test1451 test1452 test1453 test1454 test1455 \
 test1456 test1457 test1458 test1459 test1460 test1461 test1462 test1463 \
-test1464 test1465 test1466 test1467 test1468 test1469 \
+test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1470
+++ b/tests/data/test1470
@@ -1,0 +1,64 @@
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP
+HTTP GET
+SOCKS5
+SOCKS5h
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+proxy
+unix-sockets
+</features>
+<server>
+https
+socks5unix
+</server>
+ <name>
+HTTPS GET with host name using SOCKS5h via unix sockets
+ </name>
+ <command>
+https://this.is.a.host.name:%HTTPSPORT/%TESTNUMBER -k --proxy socks5h://localhost%SOCKSUNIXPATH
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: this.is.a.host.name:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<socks>
+atyp 3 => this.is.a.host.name
+</socks>
+</verify>
+</testcase>


### PR DESCRIPTION
Similar to test1468 except using https instead of http

Connecting to http**s** via unix socks proxy was broken since [this](https://github.com/curl/curl/commit/671158242db32032a41e8da89da33d773b481ef8) commit (Feb 1 version 7.88) and was fixed [here](https://github.com/curl/curl/commit/a4d015e69f5ef4b6ab0e505257727c217801072e). Adding test to make sure it is not broken again.

