### PR TITLE
ftp active mode with SSL, add the [...] filter

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -436,7 +436,7 @@ static CURLcode InitiateTransfer(struct Curl_easy *data)
   bool connected;
 
   DEBUGF(infof(data, "ftp InitiateTransfer()"));
-  if(conn->bits.ftp_use_data_ssl &&
+  if(conn->bits.ftp_use_data_ssl && data->set.ftp_use_port &&
      !Curl_conn_is_ssl(conn, SECONDARYSOCKET)) {
     result = Curl_ssl_cfilter_add(data, conn, SECONDARYSOCKET);
     if(result)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -436,6 +436,12 @@ static CURLcode InitiateTransfer(struct Curl_easy *data)
   bool connected;
 
   DEBUGF(infof(data, "ftp InitiateTransfer()"));
+  if(conn->bits.ftp_use_data_ssl &&
+     !Curl_conn_is_ssl(conn, SECONDARYSOCKET)) {
+    result = Curl_ssl_cfilter_add(data, conn, SECONDARYSOCKET);
+    if(result)
+      return result;
+  }
   result = Curl_conn_connect(data, SECONDARYSOCKET, TRUE, &connected);
   if(result || !connected)
     return result;


### PR DESCRIPTION
- since 7.87.0 we lost adding the SSL filter for an active FTP connection that uses SSL. This leads to hangers and timeouts as reported in #10666.