### PR TITLE
rand: use arc4random as fallback when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3626,7 +3626,8 @@ AC_CHECK_FUNCS([fnmatch \
   setrlimit \
   snprintf \
   utime \
-  utimes
+  utimes \
+  arc4random
 ],[
 ],[
   func="$ac_func"

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -30,6 +30,10 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifdef HAVE_ARC4RANDOM
+/* Some platforms might have the prototype missing (ubuntu + libressl) */
+uint32_t arc4random(void);
+#endif
 
 #include <curl/curl.h>
 #include "vtls/vtls.h"
@@ -141,6 +145,11 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
     if(result != CURLE_NOT_BUILT_IN)
       return result;
   }
+#endif
+
+#ifdef HAVE_ARC4RANDOM
+  *rnd = (unsigned int)arc4random();
+  return CURLE_OK;
 #endif
 
 #if defined(RANDOM_FILE) && !defined(WIN32)


### PR DESCRIPTION
Normally curl uses cryptographically strong random provided by the selected SSL backend. If compiled without SSL support, a naive built-in function was used instead.

Generally this was okay, but it will result in some downsides for non- SSL builds, such as predictable temporary file names.

This change ensures that arc4random will be used instead, if available.