### PR TITLE
tool: dump headers even if file is write-only

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -983,11 +983,11 @@ static CURLcode single_transfer(struct GlobalConfig *global,
              * for every transfer.
              */
             if(!per->prev || per->prev->config != config) {
-              newfile = fopen(config->headerfile, "wb+");
+              newfile = fopen(config->headerfile, "wb");
               if(newfile)
                 fclose(newfile);
             }
-            newfile = fopen(config->headerfile, "ab+");
+            newfile = fopen(config->headerfile, "ab");
 
             if(!newfile) {
               errorf(global, "Failed to open %s\n", config->headerfile);


### PR DESCRIPTION
The fixes in #10079 brought a (seemingly unrelated) change of open mode from `wb`/`ab` to `wb+`/`ab+` for the headerfile. This makes it no longer possible to write the header file to e.g. a pipe, like:

    curl -D >(grep ...) file:///dev/null

Which presently results in `Warning: Failed to open /dev/fd/63`

See #10079
Closes #10675