### PR TITLE
Makefile.mk: delete redundant `HAVE_LDAP_SSL` macro [ci skip]

### DIFF
--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -310,9 +310,6 @@ endif
 ifneq ($(findstring -ipv6,$(CFG)),)
   CPPFLAGS += -DENABLE_IPV6
 endif
-ifneq ($(findstring -ldaps,$(CFG)),)
-  CPPFLAGS += -DHAVE_LDAP_SSL
-endif
 
 ifneq ($(findstring -watt,$(CFG))$(MSDOS),)
   WATT_PATH ?= $(PROOT)/../watt


### PR DESCRIPTION
Since abebb2b8939c6b3e0f951eb2d9ec3729b569aa2c, we set this macro for all Windows `wldap32` builds using `Makefile.mk`.

For OpenLDAP builds this macro is not enough to enable LDAPS, and OpenLDAP is not an option in `Makefile.mk`. For Novell LDAP it might have helped, but it's also not an option anymore in `Makefile.mk`.

The future for LDAPS is that we should enable it by default without extra build knobs.

Closes #10681
