### PR TITLE
lib1560: fix enumerated type mixed with another type

### DIFF
--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1430,7 +1430,7 @@ static int huge(void)
   int i;
   CURLU *urlp = curl_url();
   CURLUcode rc;
-  char part[]= {
+  CURLUPart part[]= {
     CURLUPART_SCHEME,
     CURLUPART_USER,
     CURLUPART_PASSWORD,


### PR DESCRIPTION
Follow-up from c84c0f9aa3bb006