### PR TITLE
Use dynamic ports numbers in pytest suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,16 +22,30 @@
 #
 ###########################################################################
 #
-import logging
-import os
-import sys
-from typing import Optional
+import sys, os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'http'))
 
 import pytest
-
+from testenv import Env
 
 def pytest_report_header(config, startdir):
-    return f"curl tests"
+    # Env inits its base properties only once, we can report them here
+    env = Env()
+    report = [
+        f'Testing curl {env.curl_version()}',
+        f'  httpd: {env.httpd_version()}, http:{env.http_port} https:{env.https_port}',
+        f'  httpd-proxy: {env.httpd_version()}, http:{env.proxy_port} https:{env.proxys_port}'
+    ]
+    if env.have_h3_server():
+        report.extend([
+            f'  nghttpx: {env.nghttpx_version()}, h3:{env.https_port}'
+        ])
+    if env.has_caddy():
+        report.extend([
+            f'  Caddy: {env.caddy_version()}, http:{env.caddy_http_port} https:{env.caddy_https_port}'
+        ])
+    return '\n'.join(report)
 
 
 def pytest_addoption(parser):

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -34,10 +34,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
 from testenv import Env, Nghttpx, Httpd
 
 
-def pytest_report_header(config, startdir):
-    return f"curl http tests"
-
-
 @pytest.fixture(scope="package")
 def env(pytestconfig) -> Env:
     env = Env(pytestconfig=pytestconfig)
@@ -45,6 +41,10 @@ def env(pytestconfig) -> Env:
     logging.getLogger('').setLevel(level=level)
     env.setup()
     return env
+
+@pytest.fixture(scope="package", autouse=True)
+def log_global_env_facts(record_testsuite_property, env):
+    record_testsuite_property("http-port", env.http_port)
 
 
 @pytest.fixture(scope='package')

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -79,7 +79,7 @@ class TestErrors:
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
                f'/curltest/tweak?id=[0-{count - 1}]'\
-               '&chunks=3&chunk_size=16000&body_error=reset'
+               '&chunks=5&chunk_size=16000&body_error=reset'
         r = curl.http_download(urls=[urln], alpn_proto=proto, extra_args=[
             '--retry', '0', '--parallel',
         ])

--- a/tests/http/testenv/ports.py
+++ b/tests/http/testenv/ports.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #***************************************************************************
 #                                  _   _ ____  _
@@ -23,15 +24,26 @@
 #
 ###########################################################################
 #
-[global]
+import logging
+import socket
+from typing import Dict
 
-[httpd]
-apxs = @APXS@
-httpd = @HTTPD@
-apachectl = @APACHECTL@
+log = logging.getLogger(__name__)
 
-[nghttpx]
-nghttpx = @HTTPD_NGHTTPX@
 
-[caddy]
-caddy = @CADDY@
+def alloc_ports(port_specs: Dict[str, int]) -> Dict[str, int]:
+    ports = {}
+    socks = []
+    for name, ptype in port_specs.items():
+        try:
+            s = socket.socket(type=ptype)
+            s.bind(('', 0))
+            ports[name] = s.getsockname()[1]
+            socks.append(s)
+        except Exception as e:
+            raise e
+    for s in socks:
+        s.close()
+    return ports
+
+


### PR DESCRIPTION
- necessary ports are bound at start of test suite and then given to server fixtures for use.
- this make parallel use of pytest (in separate directories), practically safe for use as OS tend to not reuse such port numbers for a while