### PR TITLE
Take const CURLU* arg in URL observers

### DIFF
--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -117,14 +117,14 @@ CURL_EXTERN void curl_url_cleanup(CURLU *handle);
  * curl_url_dup() duplicates a CURLU handle and returns a new copy. The new
  * handle must also be freed with curl_url_cleanup().
  */
-CURL_EXTERN CURLU *curl_url_dup(CURLU *in);
+CURL_EXTERN CURLU *curl_url_dup(const CURLU *in);
 
 /*
  * curl_url_get() extracts a specific part of the URL from a CURLU
  * handle. Returns error code. The returned pointer MUST be freed with
  * curl_free() afterwards.
  */
-CURL_EXTERN CURLUcode curl_url_get(CURLU *handle, CURLUPart what,
+CURL_EXTERN CURLUcode curl_url_get(const CURLU *handle, CURLUPart what,
                                    char **part, unsigned int flags);
 
 /*

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1441,11 +1441,8 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
     break;
   case CURLUPART_PATH:
     ptr = u->path;
-    if(!ptr) {
-      ptr = u->path = strdup("/");
-      if(!u->path)
-        return CURLUE_OUT_OF_MEMORY;
-    }
+    if(!ptr)
+      ptr = "/";
     break;
   case CURLUPART_QUERY:
     ptr = u->query;
@@ -1555,8 +1552,7 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
               return CURLUE_OUT_OF_MEMORY;
             host++;
           }
-          free(u->host);
-          u->host = Curl_dyn_ptr(&enc);
+          allochost = Curl_dyn_ptr(&enc);
         }
       }
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1374,7 +1374,7 @@ CURLU *curl_url_dup(CURLU *in)
 CURLUcode curl_url_get(CURLU *u, CURLUPart what,
                        char **part, unsigned int flags)
 {
-  char *ptr;
+  const char *ptr;
   CURLUcode ifmissing = CURLUE_UNKNOWN_PART;
   char portbuf[7];
   bool urldecode = (flags & CURLU_URLDECODE)?1:0;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1350,7 +1350,7 @@ void curl_url_cleanup(CURLU *u)
     }                                           \
   } while(0)
 
-CURLU *curl_url_dup(CURLU *in)
+CURLU *curl_url_dup(const CURLU *in)
 {
   struct Curl_URL *u = calloc(sizeof(struct Curl_URL), 1);
   if(u) {
@@ -1371,7 +1371,7 @@ CURLU *curl_url_dup(CURLU *in)
   return NULL;
 }
 
-CURLUcode curl_url_get(CURLU *u, CURLUPart what,
+CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
                        char **part, unsigned int flags)
 {
   const char *ptr;


### PR DESCRIPTION
Currently, `curl_url_dup` and `curl_url_get` each take a non-const `CURLU*` arg. In the case of `_dup`, there seems to be no reason for this; it never actually mutates the input. `curl_url_get`, though, actually _can_ mutate its input; this is unintuitive and undocumented. This PR ensures that `_get` never mutates its input (this is a fairly trivial set of changes), and changes the arg type for those two functions to `const CURLU*`.

This changes the signatures for two public functions, but the result is both API- and ABI-compatible with existing code, so it shouldn't require a major semver bump.

If this change is rejected for some reason, the documentation should be updated to clearly indicate that `curl_url_get` can mutate its input.