### PR TITLE
doc: fix compiler warning in libcurl.m4

### DIFF
--- a/docs/libcurl/libcurl.m4
+++ b/docs/libcurl/libcurl.m4
@@ -199,9 +199,10 @@ if (x) {;}
            _libcurl_save_libs=$LIBS
            LIBS="$LIBS $LIBCURL"
 
-           AC_CHECK_FUNC(curl_free,,
-              AC_DEFINE(curl_free,free,
-                [Define curl_free() as free() if our version of curl lacks curl_free.]))
+           AC_CHECK_DECL([curl_free],[],
+              [AC_DEFINE([curl_free],[free],
+                [Define curl_free() as free() if our version of curl lacks curl_free.])],
+              [[#include <curl/curl.h>]])
 
            CPPFLAGS=$_libcurl_save_cppflags
            LIBS=$_libcurl_save_libs


### PR DESCRIPTION
Current test for `curl_free()` may produce warnings with strict compiler flags or even with default compiler flags with upcoming versions like this:
``` config.log
configure:38960: checking for curl_free
configure:38960: clang-17 -o conftest -fno-strict-aliasing -O0 -Wall -Wnull-dereference -Wdeclaration-after-statement -Wimplicit -Wnested-externs -Wredundant-decls -Wpoison-system-directories -ggdb3 -Wextra -Wdouble-promotion -Wformat=2 -Wno-format-nonliteral -Wformat-security -Wmissing-include-dirs -Wfloat-equal -Wshadow -Wpointer-arith -Wshadow-all -Wbad-function-cast -Wcast-qual -Wwrite-strings -Wconversion -Wcast-align -Waggregate-return -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations -Wmissing-prototypes -Wuninitialized -Winit-self -Wshift-negative-value -Wswitch-enum -Wstrict-overflow=4 -Walloca -Warray-bounds -Wpacked -Wvariadic-macros -Wundef -Wanon-enum-enum-conversion -Warray-bounds-pointer-arithmetic -Wassign-enum -Wbit-int-extension -Wbitfield-enum-conversion -Wparentheses -Wbool-operation -Wcast-function-type -Wcomma -Wcomment -Wcompound-token-split -Wconditional-uninitialized -Wdeprecated -Wdocumentation-pedantic -Wempty-init-stmt -Wenum-conversion -Wexpansion-to-defined -Wflexible-array-extensions -Wloop-analysis -Wformat-pedantic -Wformat-type-confusion -Wfour-char-constants -Wgcc-compat -Wgnu-anonymous-struct -Wgnu-compound-literal-initializer -Wgnu-conditional-omitted-operand -Wgnu-designator -Wgnu-empty-initializer -Wgnu-empty-struct -Wgnu-flexible-array-initializer -Wgnu-folding-constant -Wgnu-null-pointer-arithmetic -Wgnu-pointer-arith -Wgnu-redeclared-enum -Wgnu-union-cast -Wgnu-variable-sized-type-not-at-end -Widiomatic-parentheses -Wmissing-noreturn -Wmissing-variable-declarations -Wnested-anon-types -Wnewline-eof -Wover-aligned -Wredundant-parens -Wshift-sign-overflow -Wtautological-compare -Wunaligned-access -Wunused -Wzero-as-null-pointer-constant -Wzero-length-array -Wused-but-marked-unused   -D_GNU_SOURCE -D_XOPEN_SOURCE=700   -Wl,--warn-common  conftest.c  -lcurl >&5
conftest.c:127:16: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
char curl_free ();
               ^
                void
1 warning generated.
configure:38960: $? = 0
configure:38960: result: yes
```
These warning could turned into errors by `-Werror` or similar flags. 
Such warnings/errors are avoided by this patch.

With this patch the check is based on header, not libcurl binary, but having different versions of libcurl binary and libcurl header could easily lead to many various problems, so quick failure on build-time (if `curl_free()` is present in header, but absent in the library binary) could be a better option then hard-to-debug failures on run-time.