### PR TITLE
GSSAPI, align global `gss_OID_desc` vars 

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -34,10 +34,16 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-gss_OID_desc Curl_spnego_mech_oid = {
+#if defined(__GNUC__)
+#define CURL_ALIGN8   __attribute__ ((aligned(8)))
+#else
+#define CURL_ALIGN8
+#endif
+
+gss_OID_desc Curl_spnego_mech_oid CURL_ALIGN8 = {
   6, (char *)"\x2b\x06\x01\x05\x05\x02"
 };
-gss_OID_desc Curl_krb5_mech_oid = {
+gss_OID_desc Curl_krb5_mech_oid CURL_ALIGN8 = {
   9, (char *)"\x2a\x86\x48\x86\xf7\x12\x01\x02\x02"
 };
 


### PR DESCRIPTION
This silences ld warnings on macOS ventura.

Refs #9975 which first reported this.