### PR TITLE
CURLOPT_PROXY.3: curl+NSS does not handle HTTPS over unix domain socket

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -118,6 +118,9 @@ Since 7.21.7 the proxy string supports the socks protocols as "schemes".
 
 Since 7.50.2, unsupported schemes in proxy strings cause libcurl to return
 error.
+
+curl built to use NSS cannot connect to a HTTPS server over a unix domain
+socket.
 .SH RETURN VALUE
 Returns CURLE_OK if proxies are supported, CURLE_UNKNOWN_OPTION if not, or
 CURLE_OUT_OF_MEMORY if there was insufficient heap space.

--- a/tests/data/test1470
+++ b/tests/data/test1470
@@ -34,6 +34,7 @@ Funny-head: yesyes
 <features>
 proxy
 unix-sockets
+!NSS
 </features>
 <server>
 https


### PR DESCRIPTION
It results in error "NSS error -5985 (PR_ADDRESS_NOT_SUPPORTED_ERROR)"

Disabled test 1470 for NSS builds and documented the restriction.

Reported-by: Dan Fandrich
Fixes #10723