### PR TITLE
lib: silence clang/gcc -Wvla warnings in brotli headers

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -33,7 +33,15 @@
 #endif
 
 #ifdef HAVE_BROTLI
+#if defined(__GNUC__)
+/* Ignore -Wvla warnings in brotli headers */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
+#endif
 #include <brotli/decode.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #ifdef HAVE_ZSTD

--- a/lib/version.c
+++ b/lib/version.c
@@ -62,7 +62,15 @@
 #endif
 
 #ifdef HAVE_BROTLI
+#if defined(__GNUC__)
+/* Ignore -Wvla warnings in brotli headers */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
+#endif
 #include <brotli/decode.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #ifdef HAVE_ZSTD


### PR DESCRIPTION
brotli v1.0.0 throughout current latest v1.0.9 and latest master [^1] trigger this warning.

llvm/clang:
```
In file included from ./curl/lib/content_encoding.c:36:
./brotli/x64-ucrt/usr/include/brotli/decode.h:204:34: warning: variable length array used [-Wvla]
    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./brotli/x64-ucrt/usr/include/brotli/port.h:253:34: note: expanded from macro 'BROTLI_ARRAY_PARAM'
#define BROTLI_ARRAY_PARAM(name) (name)
                                 ^~~~~~
In file included from ./curl/lib/content_encoding.c:36:
./brotli/x64-ucrt/usr/include/brotli/decode.h:206:48: warning: variable length array used [-Wvla]
    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
                           ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
./brotli/x64-ucrt/usr/include/brotli/port.h:253:35: note: expanded from macro 'BROTLI_ARRAY_PARAM'
#define BROTLI_ARRAY_PARAM(name) (name)
                                 ~^~~~~
```

gcc:
```
In file included from ./curl/lib/content_encoding.c:36:
./brotli/x64-ucrt/usr/include/brotli/decode.h:204:5: warning: ISO C90 forbids variable length array 'encoded_buffer' [-Wvla]
  204 |     const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
      |     ^~~~~
./brotli/x64-ucrt/usr/include/brotli/decode.h:206:5: warning: ISO C90 forbids variable length array 'decoded_buffer' [-Wvla]
  206 |     uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
      |     ^~~~~~~
```

[^1]: https://github.com/google/brotli/commit/ed1995b6bda19244070ab5d331111f16f67c8054

Closes #10738