### PR TITLE
http: don't send 100-continue for short PUT requests

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -990,11 +990,10 @@ FAQ
 
   4.16 My HTTP POST or PUT requests are slow
 
-  libcurl makes all POST and PUT requests (except for POST requests with a
-  tiny request body) use the "Expect: 100-continue" header. This header
-  allows the server to deny the operation early so that libcurl can bail out
-  before having to send any data. This is useful in authentication
-  cases and others.
+  libcurl makes all POST and PUT requests (except for requests with a small
+  request body) use the "Expect: 100-continue" header. This header allows the
+  server to deny the operation early so that libcurl can bail out before having
+  to send any data. This is useful in authentication cases and others.
 
   However, many servers do not implement the Expect: stuff properly and if the
   server does not respond (positively) within 1 second libcurl will continue

--- a/tests/data/test10
+++ b/tests/data/test10
@@ -49,7 +49,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 78
-Expect: 100-continue
 
 Weird
      file

--- a/tests/data/test1001
+++ b/tests/data/test1001
@@ -98,7 +98,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 3
-Expect: 100-continue
 
 st
 </protocol>

--- a/tests/data/test1002
+++ b/tests/data/test1002
@@ -97,7 +97,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 3
-Expect: 100-continue
 
 st
 GET http://%HOSTIP:%HTTPPORT/%TESTNUMBER.upload2 HTTP/1.1
@@ -116,7 +115,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 3
-Expect: 100-continue
 
 st
 </protocol>

--- a/tests/data/test1030
+++ b/tests/data/test1030
@@ -85,7 +85,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line
@@ -97,7 +96,6 @@ Authorization: Digest username="testuser", realm="gimme all yer s3cr3ts", nonce=
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test1041
+++ b/tests/data/test1041
@@ -59,7 +59,6 @@ Content-Range: bytes 0-99/100
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 100
-Expect: 100-continue
 
 012345678
 012345678

--- a/tests/data/test1051
+++ b/tests/data/test1051
@@ -85,7 +85,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 78
-Expect: 100-continue
 
 Weird
      file
@@ -101,7 +100,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 78
-Expect: 100-continue
 
 Weird
      file

--- a/tests/data/test1055
+++ b/tests/data/test1055
@@ -60,7 +60,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 78
-Expect: 100-continue
 
 Weird
      file

--- a/tests/data/test1071
+++ b/tests/data/test1071
@@ -91,7 +91,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test1074
+++ b/tests/data/test1074
@@ -4,6 +4,7 @@
 HTTP
 HTTP GET
 HTTP/1.0
+DELAY
 </keywords>
 </info>
 

--- a/tests/data/test1075
+++ b/tests/data/test1075
@@ -70,7 +70,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line
@@ -82,7 +81,6 @@ Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test1131
+++ b/tests/data/test1131
@@ -51,7 +51,7 @@ http
 HTTP PUT expect 100-continue with a 400
  </name>
  <command option="no-output">
--T log/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T log/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001
+-H "Expect: 100-continue" -T log/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T log/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001
 </command>
 </client>
 
@@ -79,15 +79,15 @@ PUT /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 100
 Expect: 100-continue
+Content-Length: 100
 
 PUT /%TESTNUMBER0001 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 100
 Expect: 100-continue
+Content-Length: 100
 
 </protocol>
 </verify>

--- a/tests/data/test1285
+++ b/tests/data/test1285
@@ -85,7 +85,6 @@ Authorization: Digest username="auser", realm="testrealm", nonce="1053604144", u
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test1513
+++ b/tests/data/test1513
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 PROGRESSFUNCTION
+DELAY
 </keywords>
 </info>
 

--- a/tests/data/test1524
+++ b/tests/data/test1524
@@ -61,7 +61,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 4
-Expect: 100-continue
 
 moo
 GET /blah/moo.html&testcase=/%TESTNUMBER0002 HTTP/1.1

--- a/tests/data/test1525
+++ b/tests/data/test1525
@@ -71,7 +71,6 @@ Host: the.old.moo.%TESTNUMBER:%HTTPPORT
 Accept: */*
 User-Agent: Http Agent
 Content-Length: 13
-Expect: 100-continue
 
 Hello Cloud!
 </protocol>

--- a/tests/data/test1526
+++ b/tests/data/test1526
@@ -73,7 +73,6 @@ Host: the.old.moo.%TESTNUMBER:%HTTPPORT
 Accept: */*
 User-Agent: Http Agent
 Content-Length: 13
-Expect: 100-continue
 
 Hello Cloud!
 </protocol>

--- a/tests/data/test154
+++ b/tests/data/test154
@@ -10,9 +10,6 @@ HTTP Digest auth
 
 # Server-side
 <reply>
-<servercmd>
-auth_required
-</servercmd>
 <data>
 HTTP/1.1 401 Authorization Required swsclose
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2

--- a/tests/data/test154
+++ b/tests/data/test154
@@ -88,15 +88,17 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
+This is data we upload with PUT
+a second line
+line three
+four is the number of lines
 PUT /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Authorization: Digest username="testuser", realm="gimme all yer s3cr3ts", nonce="11223344", uri="/%TESTNUMBER", response="b71551e12d1c456e47d8388ecb2edeca"
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test155
+++ b/tests/data/test155
@@ -10,9 +10,6 @@ NTLM
 
 # Server-side
 <reply>
-<servercmd>
-auth_required
-</servercmd>
 <data>
 HTTP/1.1 401 NTLM Authorization Required swsclose
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2

--- a/tests/data/test155
+++ b/tests/data/test155
@@ -105,8 +105,11 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
+This is data we upload with PUT
+a second line
+line three
+four is the number of lines
 PUT /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Authorization: NTLM TlRMTVNTUAABAAAABoIIAAAAAAAAAAAAAAAAAAAAAAA=
@@ -120,7 +123,6 @@ Authorization: NTLM TlRMTVNTUAADAAAAGAAYAEAAAAAYABgAWAAAAAAAAABwAAAACAAIAHAAAAAL
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test1555
+++ b/tests/data/test1555
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 RECURSIVE_API_CALL
+DELAY
 </keywords>
 </info>
 

--- a/tests/data/test156
+++ b/tests/data/test156
@@ -46,7 +46,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line

--- a/tests/data/test160
+++ b/tests/data/test160
@@ -3,6 +3,7 @@
 <keywords>
 HTTP
 HTTP GET
+DELAY
 </keywords>
 </info>
 

--- a/tests/data/test1948
+++ b/tests/data/test1948
@@ -58,7 +58,6 @@ PUT /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
 Content-Length: 22
-Expect: 100-continue
 
 This is test PUT data
 POST /1948 HTTP/1.1

--- a/tests/data/test2058
+++ b/tests/data/test2058
@@ -98,7 +98,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 3
-Expect: 100-continue
 
 st
 </protocol>

--- a/tests/data/test2059
+++ b/tests/data/test2059
@@ -98,7 +98,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 3
-Expect: 100-continue
 
 st
 </protocol>

--- a/tests/data/test2060
+++ b/tests/data/test2060
@@ -98,7 +98,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 3
-Expect: 100-continue
 
 st
 </protocol>

--- a/tests/data/test208
+++ b/tests/data/test208
@@ -58,7 +58,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 78
-Expect: 100-continue
 
 Weird
      file

--- a/tests/data/test218
+++ b/tests/data/test218
@@ -45,7 +45,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Transfer-Encoding: chunked
-Expect: 100-continue
 
 %if hyper
 1E

--- a/tests/data/test281
+++ b/tests/data/test281
@@ -49,7 +49,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 38
-Expect: 100-continue
 
 Weird
      file

--- a/tests/data/test33
+++ b/tests/data/test33
@@ -49,7 +49,6 @@ Content-Range: bytes 50-99/100
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 50
-Expect: 100-continue
 
 012345678
 012345678

--- a/tests/data/test357
+++ b/tests/data/test357
@@ -53,16 +53,9 @@ HTTP PUT with Expect: 100-continue and 417 response
  <command>
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -T log/test%TESTNUMBER.txt
 </command>
+# 1053700 x 'x', large enough to invoke the 100-continue behaviour
 <file name="log/test%TESTNUMBER.txt">
-Weird
-     file
-         to
-   upload
-for
-   testing
-the
-   PUT
-      feature
+%repeat[1053700 x x]%
 </file>
 </client>
 
@@ -73,24 +66,16 @@ PUT /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 78
+Content-Length: 1053701
 Expect: 100-continue
 
 PUT /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 78
+Content-Length: 1053701
 
-Weird
-     file
-         to
-   upload
-for
-   testing
-the
-   PUT
-      feature
+%repeat[1053700 x x]%
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test364
+++ b/tests/data/test364
@@ -43,7 +43,6 @@ Host: %HOSTIP:%HTTPSPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 1201
-Expect: 100-continue
 
 %repeat[200 x banana]%
 </protocol>

--- a/tests/data/test490
+++ b/tests/data/test490
@@ -51,7 +51,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 10
-Expect: 100-continue
 
 surprise!
 PUT /%TESTNUMBER HTTP/1.1
@@ -59,7 +58,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 10
-Expect: 100-continue
 
 surprise!
 </protocol>

--- a/tests/data/test491
+++ b/tests/data/test491
@@ -51,7 +51,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 10
-Expect: 100-continue
 
 surprise!
 </protocol>

--- a/tests/data/test492
+++ b/tests/data/test492
@@ -55,7 +55,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Testno: %TESTNUMBER
 Content-Length: 19
-Expect: 100-continue
 
 first %TESTNUMBER contents
 PUT /two/first%TESTNUMBER HTTP/1.1
@@ -64,7 +63,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Testno: %TESTNUMBER
 Content-Length: 19
-Expect: 100-continue
 
 first %TESTNUMBER contents
 PUT /one/second%TESTNUMBER HTTP/1.1
@@ -73,7 +71,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Testno: %TESTNUMBER
 Content-Length: 20
-Expect: 100-continue
 
 second %TESTNUMBER contents
 PUT /two/second%TESTNUMBER HTTP/1.1
@@ -82,7 +79,6 @@ User-Agent: curl/%VERSION
 Accept: */*
 Testno: %TESTNUMBER
 Content-Length: 20
-Expect: 100-continue
 
 second %TESTNUMBER contents
 </protocol>

--- a/tests/data/test58
+++ b/tests/data/test58
@@ -41,7 +41,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 12
-Expect: 100-continue
 
 a few bytes
 </protocol>

--- a/tests/data/test88
+++ b/tests/data/test88
@@ -88,7 +88,6 @@ Authorization: Digest username="testuser", realm="testrealm", nonce="1053604145"
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 85
-Expect: 100-continue
 
 This is data we upload with PUT
 a second line


### PR DESCRIPTION
This is already how curl is documented to behave in Everything curl, but in
actuality only short POSTs skip this. This should knock 30 seconds off a
full run of the test suite since the 100-continue timeout will no longer be
hit.