### PR TITLE
CI: don't run CI jobs if only another CI was changed

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,5 +1,4 @@
-#***************************************************************************
-#                                  _   _ ____  _
+#*************************************************************************** #                                  _   _ ____  _
 #  Project                     ___| | | |  _ \| |
 #                             / __| | | | |_) | |
 #                            | (__| |_| |  _ <| |___
@@ -21,9 +20,9 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
+# https://dev.azure.com/daniel0244/curl/_build?view=runs
+#
+# Azure Pipelines configuration:
 # https://aka.ms/yaml
 
 trigger:
@@ -31,6 +30,14 @@ trigger:
     include:
     - 'master'
     - '*/ci'
+  paths:
+    exclude:
+    - '.circleci/*'
+    - '.cirrus.yml'
+    - '.github/*'
+    - 'appveyor.yml'
+    - 'packages/*'
+    - 'plan9/*'
 
 pr:
   branches:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,10 +21,23 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-# Cirrus CI configuration
 # https://cirrus-ci.com/github/curl/curl
+#
+# Cirrus CI configuration:
+# https://cirrus-ci.org/guide/writing-tasks/
 
 freebsd_task:
+  skip: "changesIncludeOnly(
+    '.azure-pipelines.yml',
+    '.circleci/**',
+    '.github/**',
+    'appveyor.yml',
+    'packages/**',
+    'plan9/**',
+    'projects/**',
+    'winbuild/**'
+    )"
+
   name: FreeBSD
 
   matrix:
@@ -77,6 +90,15 @@ freebsd_task:
     - make V=1 install
 
 windows_task:
+  skip: "changesIncludeOnly(
+    '.azure-pipelines.yml',
+    '.circleci/**',
+    '.github/**',
+    'appveyor.yml',
+    'packages/**',
+    'plan9/**'
+    )"
+
   name: Windows
   timeout_in: 120m
   windows_container:
@@ -135,6 +157,17 @@ windows_task:
     %container_cmd% -l -c "cd $(echo '%cd%') && %make_cmd% TFLAGS='!IDN !SCP ~612 ~1056 %tests%' test-ci"
 
 macos_task:
+  skip: "changesIncludeOnly(
+    '.azure-pipelines.yml',
+    '.circleci/**',
+    '.github/**',
+    'appveyor.yml',
+    'packages/**',
+    'plan9/**',
+    'projects/**',
+    'winbuild/**'
+    )"
+
   name: macOS arm64
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   schedule:
     - cron: '0 0 * * 4'
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,9 +9,28 @@ on:
     branches:
     - master
     - '*/ci'
+    paths-ignore:
+    - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
+    paths-ignore:
+    - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   # Hardcoded workflow filename as workflow name above is just Linux again

--- a/.github/workflows/ngtcp2-quictls.yml
+++ b/.github/workflows/ngtcp2-quictls.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   # Hardcoded workflow filename as workflow name above is just Linux again

--- a/.github/workflows/ngtcp2-wolfssl.yml
+++ b/.github/workflows/ngtcp2-wolfssl.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   # Hardcoded workflow filename as workflow name above is just Linux again

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   # Hardcoded workflow filename as workflow name above is just Linux again

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   # Hardcoded workflow filename as workflow name above is just Linux again

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -11,11 +11,27 @@ on:
     - '*/ci'
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
   pull_request:
     branches:
     - master
     paths-ignore:
     - '**/*.md'
+    - '.azure-pipelines.yml'
+    - '.circleci/**'
+    - '.cirrus.yml'
+    - 'appveyor.yml'
+    - 'packages/**'
+    - 'plan9/**'
+    - 'projects/**'
+    - 'winbuild/**'
 
 concurrency:
   # Hardcoded workflow filename as workflow name above is just Linux again

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,9 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
+# https://ci.appveyor.com/project/curlorg/curl/history
+# Appveyor configuration
+# https://www.appveyor.com/docs/appveyor-yml/
 
 version: 7.50.0.{build}
 


### PR DESCRIPTION
Also skip builds on non-Windows platforms when only Windows build files
have changed.

This should reduce the number of useless builds and the associated
waiting time and chance of spurious failures, freeing resources for
new PRs.