### PR TITLE
src: silence wmain() warning for all build methods

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,8 +80,6 @@ endif()
 
 if(ENABLE_UNICODE AND MINGW)
   target_link_libraries(${EXE_NAME} -municode)
-  # GCC doesn't know about wmain
-  set_source_files_properties(tool_main.c PROPERTIES COMPILE_FLAGS "-Wno-missing-prototypes -Wno-missing-declarations")
 endif()
 
 source_group("curlX source files" FILES ${CURLX_CFILES})

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -236,7 +236,18 @@ static void main_free(struct GlobalConfig *config)
 ** curl tool main function.
 */
 #ifdef _UNICODE
+
+#if defined(__GNUC__)
+/* GCC doesn't know about wmain() */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
 int wmain(int argc, wchar_t *argv[])
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #else
 int main(int argc, char *argv[])
 #endif

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -236,18 +236,12 @@ static void main_free(struct GlobalConfig *config)
 ** curl tool main function.
 */
 #ifdef _UNICODE
-
 #if defined(__GNUC__)
 /* GCC doesn't know about wmain() */
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #endif
 int wmain(int argc, wchar_t *argv[])
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
 #else
 int main(int argc, char *argv[])
 #endif


### PR DESCRIPTION
llvm/clang and gcc doesn't recognize the wmain() function in Unicode Windows builds:

llvm/clang:
```
../../src/tool_main.c:239:5: warning: no previous prototype for function 'wmain' [-Wmissing-prototypes]
int wmain(int argc, wchar_t *argv[])
    ^
1 warning generated.
```

gcc:
```
../../src/tool_main.c:239:5: warning: no previous prototype for 'wmain' [-Wmissing-prototypes]
  239 | int wmain(int argc, wchar_t *argv[])
      |     ^~~~~
```

Before this patch, we already silenced it with CMake. This patch moves the silencing to the source, so that it applies to all build tools.

Bug: https://github.com/curl/curl/issues/7229#issuecomment-1464806651

Closes #10744