### PR TITLE
schannel: fix user-set older TLS ciphers in Windows 10 & 11

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -346,9 +346,12 @@ maps them to the following case-insensitive names.
 ## Schannel
 
 Schannel allows the enabling and disabling of encryption algorithms, but not
-specific cipher suites. They are
+specific cipher suites, prior to TLS 1.3. The algorithms are
 [defined](https://docs.microsoft.com/windows/desktop/SecCrypto/alg-id) by
 Microsoft.
+
+The algorithms below are for TLS 1.2 and earlier. TLS 1.3 is covered in the
+next section.
 
 There is also the case that the selected algorithm is not supported by the
 protocol or does not match the ciphers offered by the server during the SSL
@@ -412,13 +415,23 @@ are running an outdated OS you might still be supporting weak ciphers.
 
 ### TLS 1.3 cipher suites
 
-(Note these ciphers are set with `CURLOPT_TLS13_CIPHERS` and `--tls13-ciphers`)
+You can set TLS 1.3 ciphers for Schannel by using `CURLOPT_TLS13_CIPHERS` or
+`--tls13-ciphers` with the names below.
+
+If TLS 1.3 cipher suites are set then libcurl will add or restrict Schannel TLS
+1.3 algorithms automatically. Essentially, libcurl is emulating support for
+individual TLS 1.3 cipher suites since Schannel does not support it directly.
 
 `TLS_AES_256_GCM_SHA384`
 `TLS_AES_128_GCM_SHA256`
 `TLS_CHACHA20_POLY1305_SHA256`
 `TLS_AES_128_CCM_8_SHA256`
 `TLS_AES_128_CCM_SHA256`
+
+Note if you set TLS 1.3 ciphers without also setting the minimum TLS version to
+1.3 then it's possible Schannel may negotiate an earlier TLS version and cipher
+suite if your libcurl and OS settings allow it. You can set the minimum TLS
+version by using `CURLOPT_SSLVERSION` or `--tlsv1.3`.
 
 ## BearSSL
 

--- a/docs/cmdline-opts/tls13-ciphers.d
+++ b/docs/cmdline-opts/tls13-ciphers.d
@@ -17,5 +17,5 @@ cipher suite details on this URL:
 https://curl.se/docs/ssl-ciphers.html
 
 This option is currently used only when curl is built to use OpenSSL 1.1.1 or
-later or Schannel. If you are using a different SSL backend you can try
+later, or Schannel. If you are using a different SSL backend you can try
 setting TLS 1.3 cipher suites by using the --ciphers option.

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -52,7 +52,10 @@ etc.
 With BearSSL you do not add/remove ciphers. If one uses this option then all
 known ciphers are disabled and only those passed in are enabled.
 
-you will find more details about cipher lists on this URL:
+For Schannel, you can use this option to set algorithms but not specific cipher
+suites. Refer to the ciphers lists document for algorithms.
+
+You will find more details about cipher lists on this URL:
 
  https://curl.se/docs/ssl-ciphers.html
 

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
@@ -36,12 +36,12 @@ Pass a char *, pointing to a null-terminated string holding the list of cipher
 suites to use for the TLS 1.3 connection. The list must be syntactically
 correct, it consists of one or more cipher suite strings separated by colons.
 
-you will find more details about cipher lists on this URL:
+You will find more details about cipher lists on this URL:
 
  https://curl.se/docs/ssl-ciphers.html
 
 This option is currently used only when curl is built to use OpenSSL 1.1.1 or
-later or Schannel. If you are using a different SSL backend you can try
+later, or Schannel. If you are using a different SSL backend you can try
 setting TLS 1.3 cipher suites by using the \fICURLOPT_SSL_CIPHER_LIST(3)\fP
 option.
 


### PR DESCRIPTION
- If CURLOPT_TLS13_CIPHERS is not set then use CURLOPT_SSL_CIPHER_LIST ciphers instead.

Prior to this change libcurl would ignore older ciphers (TLS <= 1.2) in Windows 10 1809 and later. For example, if the user set anything via CURLOPT_SSL_CIPHER_LIST it was ignored in favor of CURLOPT_TLS13_CIPHERS even if the latter wasn't set.

Unresolved: CURLOPT_TLS13_CIPHERS and CURLOPT_SSL_CIPHER_LIST are still mutually exclusive for Schannel. I'm not sure how to solve this. Since this commit, if CURLOPT_TLS13_CIPHERS is set then SCH_CREDENTIALS is used to set banned ciphers based on what is missing from the user's TLS 1.3 cipher list; however if CURLOPT_TLS13_CIPHERS is not set then SCH_CREDENTIALS is used to set allowed TLS <= 1.2 ciphers, if any, set via CURLOPT_SSL_CIPHER_LIST. Can they be combined somehow into a single credentials struct?

Reported-by: zhihaoy@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/10741
Closes #xxxx

---

SCH_CREDENTIALS is what we use if CURLOPT_TLS13_CIPHERS is set.
https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials

SCHANNEL_CRED is what we use if CURLOPT_SSL_CIPHER_LIST is set, or if neither is set.
https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-schannel_cred
