### PR TITLE
Makefile.mk: fix -g option in debug mode [ci skip]

### DIFF
--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -103,8 +103,8 @@ endif
 ### Optional features
 
 ifneq ($(findstring -debug,$(CFG)),)
+  CFLAGS += -g
   CPPFLAGS += -DDEBUGBUILD
-  LDFLAGS += -g
 else
   CPPFLAGS += -DNDEBUG
 endif


### PR DESCRIPTION
Add it to `CFLAGS` (was: `LDFLAGS`).

Closes #10747
