### PR TITLE
tool_operate: silence unused parameter warning

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -323,6 +323,7 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
       struct OperationConfig *config = per->config; /* for the macro below */
 #ifdef CURL_DISABLE_LIBCURL_OPTION
       (void)config;
+      (void)global;
 #endif
       my_setopt(per->curl, CURLOPT_INFILESIZE_LARGE, uploadfilesize);
     }


### PR DESCRIPTION
`global` is only used in the `my_setopt` macro version without `CURL_DISABLE_LIBCURL_OPTION` since commit 4774decf10a.