### PR TITLE
cmake: delete unused HAVE__STRTOI64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1055,7 +1055,6 @@ check_symbol_exists(gethostbyname_r "${CURL_INCLUDES}" HAVE_GETHOSTBYNAME_R)
 
 check_symbol_exists(signal         "${CURL_INCLUDES}" HAVE_SIGNAL)
 check_symbol_exists(strtoll        "${CURL_INCLUDES}" HAVE_STRTOLL)
-check_symbol_exists(_strtoi64      "${CURL_INCLUDES}" HAVE__STRTOI64)
 check_symbol_exists(strerror_r     "${CURL_INCLUDES}" HAVE_STRERROR_R)
 check_symbol_exists(siginterrupt   "${CURL_INCLUDES}" HAVE_SIGINTERRUPT)
 check_symbol_exists(getaddrinfo    "${CURL_INCLUDES}" HAVE_GETADDRINFO)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,21 +47,6 @@ if(WIN32 AND NOT CURL_STATICLIB)
   list(APPEND CSOURCES libcurl.rc)
 endif()
 
-# SET(CSOURCES
-# #  memdebug.c -not used
-# # nwlib.c - Not used
-# # strtok.c - specify later
-# )
-
-# #OPTION(CURL_MALLOC_DEBUG "Debug mallocs in Curl" OFF)
-# MARK_AS_ADVANCED(CURL_MALLOC_DEBUG)
-# IF(CURL_MALLOC_DEBUG)
-# SET(CSOURCES ${CSOURCES}
-# memdebug.c
-# )
-# ENDIF(CURL_MALLOC_DEBUG)
-
-
 # The rest of the build
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/../include)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,7 +51,6 @@ endif()
 # #  memdebug.c -not used
 # # nwlib.c - Not used
 # # strtok.c - specify later
-# # strtoofft.c - specify later
 # )
 
 # #OPTION(CURL_MALLOC_DEBUG "Debug mallocs in Curl" OFF)
@@ -61,13 +60,6 @@ endif()
 # memdebug.c
 # )
 # ENDIF(CURL_MALLOC_DEBUG)
-
-# # only build compat strtoofft if we need to
-# IF(NOT HAVE_STRTOLL AND NOT HAVE__STRTOI64)
-# SET(CSOURCES ${CSOURCES}
-# strtoofft.c
-# )
-# ENDIF(NOT HAVE_STRTOLL AND NOT HAVE__STRTOI64)
 
 
 # The rest of the build


### PR DESCRIPTION
Also delete obsolete comments nearby.

Closes #xxxxx
