### PR TITLE
lib2305: deal with CURLE_AGAIN

### DIFF
--- a/docs/libcurl/curl_ws_recv.3
+++ b/docs/libcurl/curl_ws_recv.3
@@ -59,6 +59,10 @@ Added in 7.86.0.
 Returns \fBCURLE_OK\fP if everything is okay, and a non-zero number for
 errors. Returns \fBCURLE_GOT_NOTHING\fP if the associated connection is
 closed.
+
+Instead of blocking, the function returns \fBCURLE_AGAIN\fP. The correct
+behavior is then to wait for the socket to signal readability before calling
+this function again.
 .SH "SEE ALSO"
 .BR curl_easy_setopt "(3), " curl_easy_perform "(3), "
 .BR curl_easy_getinfo "(3), "

--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -52,6 +52,9 @@ static void websocket(CURL *curl)
     CURLcode result =
       curl_ws_recv(curl, buffer, sizeof(buffer), &nread, &meta);
     if(result) {
+      if(result == CURLE_AGAIN)
+        /* crude busy-loop */
+        continue;
       printf("curl_ws_recv returned %d\n", (int)result);
       return;
     }


### PR DESCRIPTION
The test does a slightly ugly busy-loop for this case but should be managable due to it likely being a very short moment.

Mention CURLE_AGAIN in curl_ws_recv.3

Fixes #10760
Reported-by: Jay Satiro