### PR TITLE
cf-socket: use port 80 when resolving name for local bind

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -495,7 +495,7 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
         conn->ip_version = CURL_IPRESOLVE_V6;
 #endif
 
-      rc = Curl_resolv(data, dev, 0, FALSE, &h);
+      rc = Curl_resolv(data, dev, 80, FALSE, &h);
       if(rc == CURLRESOLV_PENDING)
         (void)Curl_resolver_wait_resolv(data, &h);
       conn->ip_version = ipver;


### PR DESCRIPTION
It turns out c-ares returns an error when asked to resolve a host name with ares_getaddrinfo using port number 0.

Reported as a c-ares bug here: https://github.com/c-ares/c-ares/issues/517

The work-around is to simply use port 80 instead, as the number typically does not make a difference and a non-zero number works for c-ares.

Fixes #10759
Reported-by: Matt Jolly