### PR TITLE
cmake: Bring in the network library on Haiku.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES AIX)
   set(_ALL_SOURCE 1)
 endif()
 
+# If we are on Haiku, make sure that the network library is brought in.
+if(${CMAKE_SYSTE_NAME} MATCHES Haiku)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lnetwork")
+endif()
+
 # Include all the necessary files for macros
 include(CMakePushCheckState)
 include(CheckFunctionExists)


### PR DESCRIPTION
When cross-compiling for Haiku, the networking library needs to be brought in. Without this, an unknown type of "Error" is reported in lib/curl_setup_once.h.

This is also needed when using CMake natively on Haiku to build libcurl.

Fixes #10296