### PR TITLE
lib: fix multi-link and ftp wildcard failures

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3977,8 +3977,10 @@ static CURLcode wc_statemach(struct Curl_easy *data)
     case CURLWC_DONE:
     case CURLWC_ERROR:
     case CURLWC_CLEAR:
-      if(wildcard->dtor)
+      if(wildcard->dtor) {
         wildcard->dtor(wildcard->ftpwc);
+        wildcard->ftpwc = NULL;
+      }
       return result;
     }
   }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -479,6 +479,7 @@ static void link_easy(struct Curl_multi *multi,
     data->prev = NULL;
     multi->easylp = multi->easyp = data; /* both first and last */
   }
+  data->multi = multi;
 }
 
 /* unlink the given easy handle from the linked list of easy handles */
@@ -498,6 +499,7 @@ static void unlink_easy(struct Curl_multi *multi,
     multi->easylp = data->prev; /* point to last node */
 
   data->prev = data->next = NULL;
+  data->multi = NULL;
 }
 
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1408,7 +1408,12 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
       }
       wc = data->wildcard;
-      if(wc->state < CURLWC_INIT) {
+      if((wc->state < CURLWC_INIT) ||
+         (wc->state >= CURLWC_CLEAN)) {
+        if(wc->ftpwc)
+          wc->dtor(wc->ftpwc);
+        Curl_safefree(wc->pattern);
+        Curl_safefree(wc->path);
         result = Curl_wildcard_init(wc); /* init wildcard structures */
         if(result)
           return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
Follow-up to f6d6f3c

As reported and "fixed" with the revert in #10795

This rather fixes the problems instead of reverting.