### PR TITLE
multi: remove PENDING + MSGSENT handles from the main linked list

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3977,8 +3977,10 @@ static CURLcode wc_statemach(struct Curl_easy *data)
     case CURLWC_DONE:
     case CURLWC_ERROR:
     case CURLWC_CLEAR:
-      if(wildcard->dtor)
+      if(wildcard->dtor) {
         wildcard->dtor(wildcard->ftpwc);
+        wildcard->ftpwc = NULL;
+      }
       return result;
     }
   }

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -101,6 +101,8 @@ struct Curl_multi {
 
   struct Curl_llist pending; /* Curl_easys that are in the
                                 MSTATE_PENDING state */
+  struct Curl_llist msgsent; /* Curl_easys that are in the
+                                MSTATE_MSGSENT state */
 
   /* callback function and user data pointer for the *socket() API */
   curl_socket_callback socket_cb;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1408,7 +1408,12 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
       }
       wc = data->wildcard;
-      if(wc->state < CURLWC_INIT) {
+      if((wc->state < CURLWC_INIT) ||
+         (wc->state >= CURLWC_CLEAN)) {
+        if(wc->ftpwc)
+          wc->dtor(wc->ftpwc);
+        Curl_safefree(wc->pattern);
+        Curl_safefree(wc->path);
         result = Curl_wildcard_init(wc); /* init wildcard structures */
         if(result)
           return CURLE_OUT_OF_MEMORY;

--- a/lib/url.c
+++ b/lib/url.c
@@ -346,7 +346,6 @@ static void up_free(struct Curl_easy *data)
 
 CURLcode Curl_close(struct Curl_easy **datap)
 {
-  struct Curl_multi *m;
   struct Curl_easy *data;
 
   if(!datap || !*datap)
@@ -360,8 +359,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
   /* Detach connection if any is left. This should not be normal, but can be
      the case for example with CONNECT_ONLY + recv/send (test 556) */
   Curl_detach_connection(data);
-  m = data->multi;
-  if(m)
+  if(data->multi)
     /* This handle is still part of a multi handle, take care of this first
        and detach this handle from there. */
     curl_multi_remove_handle(data->multi, data);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1903,7 +1903,8 @@ struct Curl_easy {
   struct Curl_easy *prev;
 
   struct connectdata *conn;
-  struct Curl_llist_element connect_queue;
+  struct Curl_llist_element connect_queue; /* for the pending and msgsent
+                                              lists */
   struct Curl_llist_element conn_queue; /* list per connectdata */
 
   CURLMstate mstate;  /* the handle's state */


### PR DESCRIPTION
As they are not driving transfers or any socket activity, the main loop does not need to iterate over these handles. A performance improvement.

They are instead only held in their own separate lists.

'data->multi' is kept a pointer to the multi handle as long as the easy handle is actually part of it even when the handle is moved to the pending/msgsent lists. ->multi gets cleared by curl_multi_cleanup() which "orphans" all previously attached easy handles.

This is take 2. The first version was reverted for the 8.0.1 release.

Assisted-by: Stefan Eissing