### PR TITLE
rtsp: skip the malformed RTSP interleaved frame data

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -866,12 +866,10 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
     char *start;
     char *end;
     start = header + 10;
-    while(*start) {
-      while(*start && *start != ';' && ISBLANK(*start) )
+    while(start && *start) {
+      while(*start && ISBLANK(*start) )
         start++;
-      end = start;
-      while(*end && *end != ';')
-        end++;
+      end = strchr(start, ';');
       if(checkprefix("interleaved=", start)) {
         long chan1, chan2, chan;
         char *endp;
@@ -901,7 +899,7 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
         }
       }
       /* skip to next parameter */
-      start = (!*end) ? end : (end + 1);
+      start = (!end) ? end : (end + 1);
     }
   }
   return CURLE_OK;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -688,10 +688,10 @@ static CURLcode rtsp_rtp_readwrite(struct Curl_easy *data,
         break; /* maybe is an RTSP message */
       }
       /* Skip incorrect data util the next RTP packet or RTSP message */
-      while(rtp_dataleft > 0 && rtp[0] != '$' && rtp[0] != 'R') {
+      do {
         rtp++;
         rtp_dataleft--;
-      }
+      } while(rtp_dataleft > 0 && rtp[0] != '$' && rtp[0] != 'R');
     }
   }
 

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -45,8 +45,6 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#define RTP_PKT_CHANNEL(p)   ((int)((unsigned char)((p)[1])))
-
 #define RTP_PKT_LENGTH(p)  ((((int)((unsigned char)((p)[2]))) << 8) | \
                              ((int)((unsigned char)((p)[3]))))
 
@@ -627,15 +625,16 @@ static CURLcode rtsp_rtp_readwrite(struct Curl_easy *data,
   while(rtp_dataleft > 0) {
     if(rtp[0] == '$') {
       if(rtp_dataleft > 4) {
+        unsigned char rtp_channel;
         int rtp_length;
         int idx;
         int off;
 
         /* Parse the header */
         /* The channel identifier immediately follows and is 1 byte */
-        rtspc->rtp_channel = RTP_PKT_CHANNEL(rtp);
-        idx = rtspc->rtp_channel / 8;
-        off = rtspc->rtp_channel % 8;
+        rtp_channel = (unsigned char)rtp[1];
+        idx = rtp_channel / 8;
+        off = rtp_channel % 8;
         if(!(rtp_channel_mask[idx] & (1 << off))) {
           /* invalid channel number, maybe not an RTP packet */
           rtp++;
@@ -648,6 +647,7 @@ static CURLcode rtsp_rtp_readwrite(struct Curl_easy *data,
                        "bytes", skip_size));
         }
         skip_size = 0;
+        rtspc->rtp_channel = rtp_channel;
 
         /* The length is two bytes */
         rtp_length = RTP_PKT_LENGTH(rtp);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1353,6 +1353,9 @@ struct UrlState {
   long rtsp_next_client_CSeq; /* the session's next client CSeq */
   long rtsp_next_server_CSeq; /* the session's next server CSeq */
   long rtsp_CSeq_recv; /* most recent CSeq received */
+
+  unsigned char rtp_channel_mask[32]; /* for the correctness checking of the
+                                         interleaved data */
 #endif
 
   curl_off_t infilesize; /* size of file to upload, -1 means unknown.

--- a/tests/data/test571
+++ b/tests/data/test571
@@ -19,6 +19,7 @@ RTSP/1.0 200 OK
 Server: RTSPD/libcurl-test
 Session: asdf
 CSeq: 1
+Transport: RTP/AVP/TCP;unicast;interleaved=0-1
 
 </data1>
 
@@ -54,6 +55,7 @@ rtp: part 2 channel 0 size 500
 rtp: part 2 channel 0 size 196
 rtp: part 2 channel 0 size 124
 rtp: part 2 channel 0 size 824
+rtp: part 2 channel 0 size 18 size_err -6
 rtp: part 3 channel 1 size 10
 rtp: part 3 channel 0 size 50
 rtp: part 4 channel 0 size 798
@@ -62,6 +64,12 @@ rtp: part 4 channel 1 size 30
 rtp: part 4 channel 0 size 2048
 rtp: part 4 channel 0 size 85
 rtp: part 4 channel 1 size 24
+rtp: part 4 channel 0 size 17 size_err -4
+rtp: part 4 channel 0 size 33
+rtp: part 4 channel 0 size 127
+rtp: part 4 channel 1 size 24 size_err 11
+rtp: part 4 channel 0 size 37
+rtp: part 4 channel 0 size 63
 </servercmd>
 </reply>
 
@@ -89,6 +97,7 @@ RTP: message size 500, channel 0
 RTP: message size 196, channel 0
 RTP: message size 124, channel 0
 RTP: message size 824, channel 0
+RTP: message size 12, channel 0
 RTP: message size 10, channel 1
 RTP: message size 50, channel 0
 RTP: message size 798, channel 0
@@ -97,6 +106,12 @@ RTP: message size 30, channel 1
 RTP: message size 2048, channel 0
 RTP: message size 85, channel 0
 RTP: message size 24, channel 1
+RTP: message size 13, channel 0
+RTP: message size 33, channel 0
+RTP: message size 127, channel 0
+RTP: message size 35, channel 1
+RTP PAYLOAD END CORRUPTED (11), [$]
+RTP: message size 63, channel 0
 </stdout>
 
 <file name="log/protofile%TESTNUMBER.txt">

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -76,14 +76,14 @@ static size_t rtp_write(void *ptr, size_t size, size_t nmemb, void *stream)
     if(message_size - i > RTP_DATA_SIZE) {
       if(memcmp(RTP_DATA, data + i, RTP_DATA_SIZE) != 0) {
         printf("RTP PAYLOAD CORRUPTED [%s]\n", data + i);
-        return failure;
+        /* return failure; */
       }
     }
     else {
       if(memcmp(RTP_DATA, data + i, message_size - i) != 0) {
         printf("RTP PAYLOAD END CORRUPTED (%d), [%s]\n",
                message_size - i, data + i);
-        return failure;
+        /* return failure; */
       }
     }
   }
@@ -196,7 +196,7 @@ int test(char *URL)
   fprintf(stderr, "PLAY COMPLETE\n");
 
   /* Use Receive to get the rest of the data */
-  while(!res && rtp_packet_count < 13) {
+  while(!res && rtp_packet_count < 19) {
     fprintf(stderr, "LOOPY LOOP!\n");
     test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_RECEIVE);
     res = curl_easy_perform(curl);

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -48,7 +48,7 @@
                              ((int)((unsigned char)((p)[3]))))
 
 #define RTP_DATA_SIZE 12
-static const char *RTP_DATA = "$_1234\n\0asdf";
+static const char *RTP_DATA = "$_1234\n\0Rsdf";
 
 static int rtp_packet_count = 0;
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -201,7 +201,7 @@ static const char *doc404_RTSP = "RTSP/1.0 404 Not Found\r\n"
 
 /* Default size to send away fake RTP data */
 #define RTP_DATA_SIZE 12
-static const char *RTP_DATA = "$_1234\n\0asdf";
+static const char *RTP_DATA = "$_1234\n\0Rsdf";
 
 static int ProcessRequest(struct httprequest *req)
 {


### PR DESCRIPTION
Some IP camera send malformed RTSP interleaved frames sometimes, which can cause curl_easy_perform return 1 (CURLE_UNSUPPORTED_PROTOCOL). 
This commit attempts to skip clearly incorrect RTSP interleaving frame data.