### PR TITLE
build: output warning when selecting quiche for h3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,9 @@ if(USE_QUICHE)
     check_symbol_exists(quiche_conn_set_qlog_fd "quiche.h" HAVE_QUICHE_CONN_SET_QLOG_FD)
     cmake_pop_check_state()
   endif()
+  message(WARNING
+    "Due to known problems in quiche we discourage use of it for doing HTTP/3 "
+    "with curl. Details in https://github.com/curl/curl/issues/10811")
 endif()
 
 option(USE_MSH3 "Use msquic library for HTTP/3 support" OFF)

--- a/configure.ac
+++ b/configure.ac
@@ -3229,6 +3229,12 @@ if test X"$want_quiche" != Xno; then
        AC_CHECK_HEADERS(quiche.h,
           experimental="$experimental HTTP3"
           AC_MSG_NOTICE([HTTP3 support is experimental])
+
+          warning=$(cat <<EOM
+Due to known problems in quiche we discourage use of it for doing HTTP/3
+with curl. Details in https://github.com/curl/curl/issues/10811
+EOM
+)
           curl_h3_msg="enabled (quiche)"
           QUICHE_ENABLED=1
           AC_DEFINE(USE_QUICHE, 1, [if quiche is in use])
@@ -4730,5 +4736,13 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
 if test -n "$experimental"; then
  cat >&2 << _EOF
   WARNING: $experimental enabled but marked EXPERIMENTAL. Use with caution!
+_EOF
+fi
+if test -n "$warning"; then
+ if test -n "$experimental"; then
+   echo ""
+ fi
+ cat >&2 << _EOF
+  WARNING: $warning
 _EOF
 fi


### PR DESCRIPTION
Until quiche is fixed, we discourage use of it.

Ref: #10811