### PR TITLE
CMake config: version 8 is compatible with version 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1609,6 +1609,15 @@ write_basic_package_version_file(
     VERSION ${CURL_VERSION}
     COMPATIBILITY SameMajorVersion
 )
+file(READ "${version_config}" generated_version_config)
+file(WRITE "${version_config}"
+"if(NOT PACKAGE_FIND_VERSION_RANGE AND PACKAGE_FIND_VERSION_MAJOR STREQUAL \"7\")
+    # Version 8 satisfies version 7... requirements
+    set(PACKAGE_FIND_VERSION_MAJOR 8)
+    set(PACKAGE_FIND_VERSION_COUNT 1)
+endif()
+${generated_version_config}"
+)
 
 # Use:
 # * TARGETS_EXPORT_NAME


### PR DESCRIPTION
AFAIU curl version 8.0.0 does bring any breaking API changes. However, the change of the major version has the effect that the CMake config is not considered compatible for `find_package(CURL 7.123 CONFIG)`, breaking downstream usage, e.g.
azure-core-cpp
~~~
CMake Error at D:/installed/x64-windows-static/share/curl/vcpkg-cmake-wrapper.cmake:11 (_find_package):
  Could not find a configuration file for package "CURL" that is compatible
  with requested version "7.44".

  The following configuration files were considered but not accepted:

    D:/installed/x64-windows-static/share/curl/CURLConfig.cmake, version: 8.0.0-DEV
~~~

kubernetes:
~~~
CMake Error at D:/installed/x64-windows-static/share/curl/vcpkg-cmake-wrapper.cmake:11 (_find_package):
  Could not find a configuration file for package "CURL" that is compatible
  with requested version "7.58.0".

  The following configuration files were considered but not accepted:

    D:/installed/x64-windows-static/share/curl/CURLConfig.cmake, version: 8.0.0-DEV
~~~

This PR changes the default version check to accept version 8 as a compatible major version if version 7 is requested.