### PR TITLE
Adjust config and code defined checks for ngtcp2 without nghttp3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,7 @@ curl_headers_msg="enabled (--disable-headers-api)"
     ssl_backends=
      curl_h1_msg="enabled (internal)"
      curl_h2_msg="no      (--with-nghttp2, --with-hyper)"
-     curl_h3_msg="no      (--with-ngtcp2, --with-quiche --with-msh3)"
+     curl_h3_msg="no      (--with-ngtcp2 --with-nghttp3, --with-quiche, --with-msh3)"
 
 enable_altsvc="yes"
 hsts="yes"

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -833,7 +833,8 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define USE_HTTP2
 #endif
 
-#if defined(USE_NGTCP2) || defined(USE_QUICHE) || defined(USE_MSH3)
+#if (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || \
+    defined(USE_QUICHE) || defined(USE_MSH3)
 #define ENABLE_QUIC
 #define USE_HTTP3
 #endif

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifdef USE_NGTCP2
+#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
 #include <ngtcp2/ngtcp2.h>
 #include <nghttp3/nghttp3.h>
 

--- a/lib/vquic/curl_ngtcp2.h
+++ b/lib/vquic/curl_ngtcp2.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifdef USE_NGTCP2
+#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
 
 #ifdef HAVE_NETINET_UDP_H
 #include <netinet/udp.h>

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -53,7 +53,7 @@
 
 void Curl_quic_ver(char *p, size_t len)
 {
-#ifdef USE_NGTCP2
+#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
   Curl_ngtcp2_ver(p, len);
 #elif defined(USE_QUICHE)
   Curl_quiche_ver(p, len);
@@ -330,7 +330,7 @@ CURLcode Curl_cf_quic_create(struct Curl_cfilter **pcf,
 {
   (void)transport;
   DEBUGASSERT(transport == TRNSPRT_QUIC);
-#ifdef USE_NGTCP2
+#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
   return Curl_cf_ngtcp2_create(pcf, data, conn, ai);
 #elif defined(USE_QUICHE)
   return Curl_cf_quiche_create(pcf, data, conn, ai);
@@ -349,7 +349,7 @@ bool Curl_conn_is_http3(const struct Curl_easy *data,
                         const struct connectdata *conn,
                         int sockindex)
 {
-#ifdef USE_NGTCP2
+#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
   return Curl_conn_is_ngtcp2(data, conn, sockindex);
 #elif defined(USE_QUICHE)
   return Curl_conn_is_quiche(data, conn, sockindex);


### PR DESCRIPTION
- make configure show on HTTP3 feature that both ngtcp2 and nghttp3 are in play
- define ENABLE_QUIC only when USE_NGTCP2 and USE_NGHTTP3 are defined
- add USE_NGHTTP3 in the ngtcp2 implementation
- refs #10793