### PR TITLE
server/getpart: clear the buffer before load

### DIFF
--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -149,7 +149,7 @@ static int readline(char **buffer, size_t *bufsize, size_t *length,
   char *newptr;
 
   if(!*buffer) {
-    *buffer = malloc(128);
+    *buffer = calloc(128, 1);
     if(!*buffer)
       return GPE_OUT_OF_MEMORY;
     *bufsize = 128;
@@ -171,6 +171,7 @@ static int readline(char **buffer, size_t *bufsize, size_t *length,
     newptr = realloc(*buffer, *bufsize * 2);
     if(!newptr)
       return GPE_OUT_OF_MEMORY;
+    memset(&newptr[*bufsize], 0, *bufsize);
     *buffer = newptr;
     *bufsize *= 2;
   }


### PR DESCRIPTION
Fixes msan warnings:

==54195==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55ece35e57cb in line_length /home/runner/work/curl/curl/tests/server/getpart.c:111:25
    #1 0x55ece35e3b83 in readline /home/runner/work/curl/curl/tests/server/getpart.c:164:24
    #2 0x55ece35e0269 in getpart /home/runner/work/curl/curl/tests/server/getpart.c:347:18
    #3 0x55ece36180b6 in parse_servercmd /home/runner/work/curl/curl/tests/server/sws.c:283:13