### PR TITLE
docs/cmdline-opts: document the dotless config path

### DIFF
--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -57,7 +57,7 @@ config file is checked for in the following places in this order:
 
 1) "$CURL_HOME/.curlrc"
 
-2) "$XDG_CONFIG_HOME/.curlrc" (Added in 7.73.0)
+2) "$XDG_CONFIG_HOME/curlrc" (Added in 7.73.0)
 
 3) "$HOME/.curlrc"
 


### PR DESCRIPTION
The real xdg config path is $XDG_CONFIG_HOME/curlrc, without the dot. The dotless name seems preferable, so let's match the documentation to the behavior.

---

curl 8.0.1 doesn't seem to care about `$XDG_CONFIG_HOME/.curlc` but I was happy to find it does find `$XDG_CONFIG_HOME/curlrc`. Let's document that.