### PR TITLE
telnet: simplify the implementation of str_is_nonascii()

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -772,12 +772,11 @@ static void printsub(struct Curl_easy *data,
 
 static bool str_is_nonascii(const char *str)
 {
-  size_t len = strlen(str);
-  while(len--) {
-    if(*str & 0x80)
+  char c;
+  while((c = *str++))
+    if(c & 0x80)
       return TRUE;
-    str++;
-  }
+
   return FALSE;
 }
 


### PR DESCRIPTION
There is no need to traverse the string twice.