### PR TITLE
Update to rustls-ffi 0.10.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -264,7 +264,7 @@ jobs:
 
     - if: ${{ contains(matrix.build.install_steps, 'rustls') }}
       run: |
-        git clone --quiet --depth=1 -b v0.9.2 --recursive https://github.com/rustls/rustls-ffi.git
+        git clone --quiet --depth=1 -b v0.10.0 --recursive https://github.com/rustls/rustls-ffi.git
         cd rustls-ffi
         make DESTDIR=$HOME/rustls install
       name: 'install rustls'

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -3,7 +3,7 @@
 [Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.9.2 of rustls-ffi.
+version of curl depends on version v0.10.0 of rustls-ffi.
 
 # Building with rustls
 
@@ -12,7 +12,7 @@ First, [install Rust](https://rustup.rs/).
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
     % cargo install cbindgen
-    % git clone https://github.com/rustls/rustls-ffi -b v0.9.2
+    % git clone https://github.com/rustls/rustls-ffi -b v0.10.0
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install


### PR DESCRIPTION
This brings in version 0.21.0 of the upstream rustls implementation, which notable includes support for IP address certificates. This allows enabling many of the unittests that relied on IP address certificates to communicate with localhost.