### PR TITLE
rtsp: Value stored to 'skip_size' is never read

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -703,7 +703,6 @@ static CURLcode rtsp_rtp_readwrite(struct Curl_easy *data,
           DEBUGF(infof(data, "Skip the malformed interleaved data %lu "
                        "bytes", skip_size));
         }
-        skip_size = 0;
         break; /* maybe is an RTSP message */
       }
       /* Skip incorrect data util the next RTP packet or RTSP message */


### PR DESCRIPTION
Pointed out by scan-build

Follow-up to 6c6306f3008f2c9b20a64