### PR TITLE
tests: move pidfiles and portfiles under the log directory

### DIFF
--- a/tests/ftp.pm
+++ b/tests/ftp.pm
@@ -322,7 +322,7 @@ sub killpid {
 # killsockfilters kills sockfilter processes for a given server.
 #
 sub killsockfilters {
-    my ($proto, $ipvnum, $idnum, $verbose, $which) = @_;
+    my ($piddir, $proto, $ipvnum, $idnum, $verbose, $which) = @_;
     my $server;
     my $pidfile;
     my $pid;
@@ -335,7 +335,7 @@ sub killsockfilters {
     $server = servername_id($proto, $ipvnum, $idnum) if($verbose);
 
     if(!$which || ($which eq 'main')) {
-        $pidfile = mainsockf_pidfilename($proto, $ipvnum, $idnum);
+        $pidfile = mainsockf_pidfilename($piddir, $proto, $ipvnum, $idnum);
         $pid = processexists($pidfile);
         if($pid > 0) {
             printf("* kill pid for %s-%s => %d\n", $server,
@@ -349,7 +349,7 @@ sub killsockfilters {
     return if($proto ne 'ftp');
 
     if(!$which || ($which eq 'data')) {
-        $pidfile = datasockf_pidfilename($proto, $ipvnum, $idnum);
+        $pidfile = datasockf_pidfilename($piddir, $proto, $ipvnum, $idnum);
         $pid = processexists($pidfile);
         if($pid > 0) {
             printf("* kill pid for %s-data => %d\n", $server,
@@ -365,12 +365,12 @@ sub killsockfilters {
 # killallsockfilters kills sockfilter processes for all servers.
 #
 sub killallsockfilters {
-    my $verbose = $_[0];
+    my ($piddir, $verbose) = @_;
 
     for my $proto (('ftp', 'imap', 'pop3', 'smtp')) {
         for my $ipvnum (('4', '6')) {
             for my $idnum (('1', '2')) {
-                killsockfilters($proto, $ipvnum, $idnum, $verbose);
+                killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
             }
         }
     }

--- a/tests/http-server.pl
+++ b/tests/http-server.pl
@@ -23,13 +23,15 @@
 #
 #***************************************************************************
 
+use strict;
+use warnings;
+
 BEGIN {
     push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
     push(@INC, ".");
 }
 
-use strict;
-use warnings;
+use File::Basename;
 
 use serverhelp qw(
     server_pidfilename
@@ -57,6 +59,7 @@ my $gopher = 0;
 my $flags  = "";
 my $path   = '.';
 my $logdir = $path .'/log';
+my $piddir;
 
 while(@ARGV) {
     if($ARGV[0] eq '--pidfile') {
@@ -138,14 +141,24 @@ while(@ARGV) {
     shift @ARGV;
 }
 
-if(!$srcdir) {
-    $srcdir = $ENV{'srcdir'} || '.';
+#***************************************************************************
+# Initialize command line option dependent variables
+#
+
+if($pidfile) {
+    # Use our pidfile directory to store the other pidfiles
+    $piddir = dirname($pidfile);
 }
-if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+else {
+    # Use the current directory to store all the pidfiles
+    $piddir = $path;
+    $pidfile = server_pidfilename($piddir, $proto, $ipvnum, $idnum);
 }
 if(!$portfile) {
-    $portfile = "$path/". server_portfilename($proto, $ipvnum, $idnum);
+    $portfile = server_portfilename($piddir, $proto, $ipvnum, $idnum);
+}
+if(!$srcdir) {
+    $srcdir = $ENV{'srcdir'} || '.';
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);

--- a/tests/rtspserver.pl
+++ b/tests/rtspserver.pl
@@ -23,13 +23,13 @@
 #
 #***************************************************************************
 
+use strict;
+use warnings;
+
 BEGIN {
     push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
     push(@INC, ".");
 }
-
-use strict;
-use warnings;
 
 use serverhelp qw(
     server_pidfilename
@@ -112,11 +112,15 @@ while(@ARGV) {
     shift @ARGV;
 }
 
+#***************************************************************************
+# Initialize command line option dependent variables
+#
+
+if(!$pidfile) {
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
+}
 if(!$srcdir) {
     $srcdir = $ENV{'srcdir'} || '.';
-}
-if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -152,18 +152,19 @@ my $VCURL=$CURL;   # what curl binary to use to verify the servers with
 my $ACURL=$VCURL;  # what curl binary to use to talk to APIs (relevant for CI)
                    # ACURL is handy to set to the system one for reliability
 my $DBGCURL=$CURL; #"../src/.libs/curl";  # alternative for debugging
-my $LOGDIR="log";
 my $TESTDIR="$srcdir/data";
 my $LIBDIR="./libtest";
 my $UNITDIR="./unit";
+my $LOGDIR="log";
 # TODO: $LOGDIR could eventually change later on, so must regenerate all the
 # paths depending on it after $LOGDIR itself changes.
+my $PIDDIR = "$LOGDIR/pids";
 # TODO: change this to use server_inputfilename()
 my $SERVERIN="$LOGDIR/server.input"; # what curl sent the server
 my $SERVER2IN="$LOGDIR/server2.input"; # what curl sent the second server
 my $PROXYIN="$LOGDIR/proxy.input"; # what curl sent the proxy
 my $SOCKSIN="$LOGDIR/socksd-request.log"; # what curl sent to the SOCKS proxy
-my $CURLLOG="commands.log"; # all command lines run
+my $CURLLOG="$LOGDIR/commands.log"; # all command lines run
 my $FTPDCMD="$LOGDIR/ftpserver.cmd"; # copy server instructions here
 my $SERVERLOGS_LOCK="$LOGDIR/serverlogs.lock"; # server logs advisor read lock
 my $CURLCONFIG="../curl-config"; # curl-config from current build
@@ -384,9 +385,9 @@ sub init_serverpidfile_hash {
       for my $ipvnum ((4, 6)) {
         for my $idnum ((1, 2, 3)) {
           my $serv = servername_id("$proto$ssl", $ipvnum, $idnum);
-          my $pidf = server_pidfilename("$proto$ssl", $ipvnum, $idnum);
+          my $pidf = server_pidfilename($PIDDIR, "$proto$ssl", $ipvnum, $idnum);
           $serverpidfile{$serv} = $pidf;
-          my $portf = server_portfilename("$proto$ssl", $ipvnum, $idnum);
+          my $portf = server_portfilename($PIDDIR, "$proto$ssl", $ipvnum, $idnum);
           $serverportfile{$serv} = $portf;
         }
       }
@@ -397,9 +398,9 @@ sub init_serverpidfile_hash {
     for my $ipvnum ((4, 6)) {
       for my $idnum ((1, 2)) {
         my $serv = servername_id($proto, $ipvnum, $idnum);
-        my $pidf = server_pidfilename($proto, $ipvnum, $idnum);
+        my $pidf = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
         $serverpidfile{$serv} = $pidf;
-        my $portf = server_portfilename($proto, $ipvnum, $idnum);
+        my $portf = server_portfilename($PIDDIR, $proto, $ipvnum, $idnum);
         $serverportfile{$serv} = $portf;
       }
     }
@@ -407,9 +408,9 @@ sub init_serverpidfile_hash {
   for my $proto (('http', 'imap', 'pop3', 'smtp', 'http/2', 'http/3')) {
     for my $ssl (('', 's')) {
       my $serv = servername_id("$proto$ssl", "unix", 1);
-      my $pidf = server_pidfilename("$proto$ssl", "unix", 1);
+      my $pidf = server_pidfilename($PIDDIR, "$proto$ssl", "unix", 1);
       $serverpidfile{$serv} = $pidf;
-      my $portf = server_portfilename("$proto$ssl", "unix", 1);
+      my $portf = server_portfilename($PIDDIR, "$proto$ssl", "unix", 1);
       $serverportfile{$serv} = $portf;
     }
   }
@@ -757,7 +758,7 @@ sub stopserver {
         my $proto  = $1;
         my $idnum  = ($2 && ($2 > 1)) ? $2 : 1;
         my $ipvnum = ($3 && ($3 =~ /6$/)) ? 6 : 4;
-        killsockfilters($proto, $ipvnum, $idnum, $verbose);
+        killsockfilters($PIDDIR, $proto, $ipvnum, $idnum, $verbose);
     }
     #
     # All servers relative to the given one must be stopped also
@@ -1065,7 +1066,7 @@ sub verifyrtsp {
 #
 sub verifyssh {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
-    my $pidfile = server_pidfilename($proto, $ipvnum, $idnum);
+    my $pidfile = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
     my $pid = processexists($pidfile);
     if($pid < 0) {
         logmsg "RUN: SSH server has died after starting up\n";
@@ -1119,7 +1120,7 @@ sub verifysftp {
 sub verifyhttptls {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
     my $server = servername_id($proto, $ipvnum, $idnum);
-    my $pidfile = server_pidfilename($proto, $ipvnum, $idnum);
+    my $pidfile = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
 
     my $verifyout = "$LOGDIR/".
         servername_canon($proto, $ipvnum, $idnum) .'_verify.out';
@@ -1196,7 +1197,7 @@ sub verifyhttptls {
 #
 sub verifysocks {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
-    my $pidfile = server_pidfilename($proto, $ipvnum, $idnum);
+    my $pidfile = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
     my $pid = processexists($pidfile);
     if($pid < 0) {
         logmsg "RUN: SOCKS server has died after starting up\n";
@@ -2725,7 +2726,9 @@ sub cleardir {
         return 0; # can't open dir
     while($file = readdir($dh)) {
         if(($file !~ /^(\.|\.\.)\z/)) {
-            if(-d "$dir/$file") {
+            if(-d "$dir/$file" &&
+            # Don't clear the $PIDDIR since those need to live beyond one test
+               Cwd::abs_path($PIDDIR) ne Cwd::abs_path("$dir/$file")) {
                 if(!cleardir("$dir/$file")) {
                     $done = 0;
                 }
@@ -4055,7 +4058,7 @@ sub singletest_run {
         logmsg "$CMDLINE\n";
     }
 
-    open(my $cmdlog, ">", "$LOGDIR/$CURLLOG") || die "Failure writing log file";
+    open(my $cmdlog, ">", $CURLLOG) || die "Failure writing log file";
     print $cmdlog "$CMDLINE\n";
     close($cmdlog) || die "Failure writing log file";
 
@@ -4860,7 +4863,7 @@ sub stopservers {
     #
     # kill sockfilter processes for all pingpong servers
     #
-    killallsockfilters($verb);
+    killallsockfilters($PIDDIR, $verb);
     #
     # kill all server pids from %run hash clearing them
     #
@@ -5991,6 +5994,7 @@ $SOCKSUNIXPATH    = $pwd."/socks$$.sock"; # HTTP server Unix domain socket path,
 
 cleardir($LOGDIR);
 mkdir($LOGDIR, 0777);
+mkdir($PIDDIR, 0777);
 
 #######################################################################
 # initialize some variables

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -27,13 +27,14 @@
 # harness. Actually just a layer that runs stunnel properly using the
 # non-secure test harness servers.
 
+use strict;
+use warnings;
+
 BEGIN {
     push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
     push(@INC, ".");
 }
 
-use strict;
-use warnings;
 use Cwd;
 use Cwd 'abs_path';
 
@@ -183,7 +184,7 @@ while(@ARGV) {
 # Initialize command line option dependent variables
 #
 if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -146,18 +146,18 @@ sub servername_canon {
 # Return file name for server pid file.
 #
 sub server_pidfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     my $trailer = '_server.pid';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 #***************************************************************************
 # Return file name for server port file.
 #
 sub server_portfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     my $trailer = '_server.port';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 
@@ -206,11 +206,11 @@ sub server_outputfilename {
 # Return file name for main or primary sockfilter pid file.
 #
 sub mainsockf_pidfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     die "unsupported protocol: '$proto'" unless($proto &&
         (lc($proto) =~ /^(ftp|imap|pop3|smtp)s?$/));
     my $trailer = (lc($proto) =~ /^ftps?$/) ? '_sockctrl.pid':'_sockfilt.pid';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 
@@ -230,11 +230,11 @@ sub mainsockf_logfilename {
 # Return file name for data or secondary sockfilter pid file.
 #
 sub datasockf_pidfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     die "unsupported protocol: '$proto'" unless($proto &&
         (lc($proto) =~ /^ftps?$/));
     my $trailer = '_sockdata.pid';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -177,14 +177,17 @@ while(@ARGV) {
     shift @ARGV;
 }
 
+#***************************************************************************
+# Initialize command line option dependent variables
+#
+
 
 #***************************************************************************
 # Default ssh daemon pid file name
 #
 if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
 }
-
 
 #***************************************************************************
 # ssh and sftp server log file names

--- a/tests/tftpserver.pl
+++ b/tests/tftpserver.pl
@@ -117,7 +117,7 @@ if(!$srcdir) {
     $srcdir = $ENV{'srcdir'} || '.';
 }
 if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);


### PR DESCRIPTION
This is to segregate all files written by a test process into a single root
to allow for future parallel testing.