### PR TITLE
tests: move server config files under the pid dir

### DIFF
--- a/tests/data/test1446
+++ b/tests/data/test1446
@@ -24,7 +24,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP with --remote-time
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/rofile.txt --insecure --remote-time
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/rofile.txt --insecure --remote-time
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir && \

--- a/tests/data/test2004
+++ b/tests/data/test2004
@@ -30,7 +30,7 @@ sftp
 TFTP RRQ followed by SFTP retrieval followed by FILE followed by SCP retrieval then again in reverse order
  </name>
 <command option="no-include">
---key curl_client_key --pubkey curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.txt file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.txt file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.txt file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.txt file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER --insecure
 </command>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
 This is test data

--- a/tests/data/test3021
+++ b/tests/data/test3021
@@ -28,7 +28,7 @@ sftp
 SFTP correct sha256 host key
  </name>
  <command>
---hostpubsha256 %SSHSRVSHA256 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
+--hostpubsha256 %SSHSRVSHA256 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
 </command>
 <setenv>
 # Needed for MSYS2 to not treat the argument as a POSIX path list

--- a/tests/data/test3022
+++ b/tests/data/test3022
@@ -28,7 +28,7 @@ scp
 SCP correct sha256 host key
  </name>
  <command>
---hostpubsha256 %SSHSRVSHA256 --key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
+--hostpubsha256 %SSHSRVSHA256 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
 </command>
 <setenv>
 # Needed for MSYS2 to not treat the argument as a POSIX path list

--- a/tests/data/test582
+++ b/tests/data/test582
@@ -24,7 +24,7 @@ lib%TESTNUMBER
 SFTP upload using multi interface
  </name>
  <command>
-Sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload%TESTNUMBER.txt %PWD/%LOGDIR/file%TESTNUMBER.txt %USER:
+Sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload%TESTNUMBER.txt %PWD/%LOGDIR/file%TESTNUMBER.txt %USER: %LOGDIR/server/curl_client_key.pub %LOGDIR/server/curl_client_key
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Moooooooooooo

--- a/tests/data/test583
+++ b/tests/data/test583
@@ -29,7 +29,7 @@ SFTP with multi interface, remove handle early
 # name resolve will cause it to return rather quickly and thus we could trigger
 # the problem we're looking to verify.
  <command>
-sftp://localhost:%SSHPORT%SSH_PWD/%LOGDIR/upload%TESTNUMBER.txt %USER:
+sftp://localhost:%SSHPORT%SSH_PWD/%LOGDIR/upload%TESTNUMBER.txt %USER: %LOGDIR/server/curl_client_key.pub %LOGDIR/server/curl_client_key
 </command>
 </client>
 

--- a/tests/data/test600
+++ b/tests/data/test600
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test601
+++ b/tests/data/test601
@@ -24,7 +24,7 @@ scp
 SCP retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test602
+++ b/tests/data/test602
@@ -21,7 +21,7 @@ sftp
 SFTP put
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test603
+++ b/tests/data/test603
@@ -21,7 +21,7 @@ scp
 SCP upload
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test604
+++ b/tests/data/test604
@@ -16,7 +16,7 @@ sftp
 SFTP retrieval of nonexistent file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test605
+++ b/tests/data/test605
@@ -16,7 +16,7 @@ scp
 SCP retrieval of nonexistent file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test606
+++ b/tests/data/test606
@@ -16,7 +16,7 @@ sftp
 SFTP invalid user login
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test607
+++ b/tests/data/test607
@@ -16,7 +16,7 @@ scp
 SCP invalid user login
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u not-a-valid-user: scp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u not-a-valid-user: scp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure
 </command>
 </client>
 

--- a/tests/data/test608
+++ b/tests/data/test608
@@ -24,7 +24,7 @@ sftp
 SFTP post-quote rename
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rename %PWD/%LOGDIR/file%TESTNUMBER.txt %PWD/%LOGDIR/file%TESTNUMBER-renamed.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "-rename %PWD/%LOGDIR/file%TESTNUMBER.txt %PWD/%LOGDIR/file%TESTNUMBER-renamed.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 # Verify that the file was renamed properly, then rename the file back to what
 # it was so the verify section works and the file can be cleaned up.

--- a/tests/data/test609
+++ b/tests/data/test609
@@ -25,7 +25,7 @@ sftp
 SFTP post-quote mkdir failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-mkdir %PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "-mkdir %PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test file for mkdir test

--- a/tests/data/test610
+++ b/tests/data/test610
@@ -27,7 +27,7 @@ perl %SRCDIR/libtest/test%TESTNUMBER.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP post-quote rmdir
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "-rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test%TESTNUMBER.pl gone %PWD/%LOGDIR/test%TESTNUMBER.dir

--- a/tests/data/test611
+++ b/tests/data/test611
@@ -27,7 +27,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP post-quote rename
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-rename %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/test%TESTNUMBER.new" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "-rename %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/test%TESTNUMBER.new" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.new

--- a/tests/data/test612
+++ b/tests/data/test612
@@ -24,7 +24,7 @@ sftp
 SFTP post-quote remove file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt -Q "-rm %PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER  --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt -Q "-rm %PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER  --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt

--- a/tests/data/test613
+++ b/tests/data/test613
@@ -29,7 +29,7 @@ perl %SRCDIR/libtest/test%TESTNUMBER.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP directory retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test%TESTNUMBER.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -30,7 +30,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP pre-quote chmod
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "chmod 444 %PWD/%LOGDIR/test%TESTNUMBER.dir/plainfile.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "chmod 444 %PWD/%LOGDIR/test%TESTNUMBER.dir/plainfile.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out

--- a/tests/data/test615
+++ b/tests/data/test615
@@ -20,7 +20,7 @@ perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP put remote failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/rofile.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/rofile.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir

--- a/tests/data/test616
+++ b/tests/data/test616
@@ -23,7 +23,7 @@ sftp
 SFTP retrieval of empty file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 </file>

--- a/tests/data/test617
+++ b/tests/data/test617
@@ -23,7 +23,7 @@ scp
 SCP retrieval of empty file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 </file>

--- a/tests/data/test618
+++ b/tests/data/test618
@@ -15,7 +15,7 @@ sftp
 SFTP retrieval of two files
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test619
+++ b/tests/data/test619
@@ -15,7 +15,7 @@ scp
 SCP retrieval of two files
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test620
+++ b/tests/data/test620
@@ -16,7 +16,7 @@ sftp
 SFTP retrieval of missing file followed by good file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/not-a-valid-file-moooo sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/not-a-valid-file-moooo sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test621
+++ b/tests/data/test621
@@ -16,7 +16,7 @@ scp
 SCP retrieval of missing file followed by good file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/not-a-valid-file-moooo scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/not-a-valid-file-moooo scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test622
+++ b/tests/data/test622
@@ -22,7 +22,7 @@ sftp
 SFTP put failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/nonexistent-directory/nonexistent-file --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/nonexistent-directory/nonexistent-file --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test623
+++ b/tests/data/test623
@@ -22,7 +22,7 @@ scp
 SCP upload failure
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/nonexistent-directory/nonexistent-file --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/nonexistent-directory/nonexistent-file --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test624
+++ b/tests/data/test624
@@ -22,7 +22,7 @@ sftp
 SFTP put with --ftp-create-dirs
  </name>
  <command>
---ftp-create-dirs --key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.%TESTNUMBER --insecure
+--ftp-create-dirs --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.%TESTNUMBER --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl move %PWD/%LOGDIR/test%TESTNUMBER.dir/upload.%TESTNUMBER %PWD/%LOGDIR/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir

--- a/tests/data/test625
+++ b/tests/data/test625
@@ -22,7 +22,7 @@ sftp
 SFTP put with --ftp-create-dirs twice
  </name>
  <command>
---ftp-create-dirs --key curl_client_key --pubkey curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.a/upload.%TESTNUMBER -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.b/upload.%TESTNUMBER --insecure
+--ftp-create-dirs --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.a/upload.%TESTNUMBER -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.b/upload.%TESTNUMBER --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl move %PWD/%LOGDIR/test%TESTNUMBER.a/upload.%TESTNUMBER %PWD/%LOGDIR/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.a rm %PWD/%LOGDIR/test%TESTNUMBER.b/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.b

--- a/tests/data/test626
+++ b/tests/data/test626
@@ -22,7 +22,7 @@ sftp
 SFTP invalid quote command
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "invalid-command foo bar" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "invalid-command foo bar" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test file for rename test

--- a/tests/data/test627
+++ b/tests/data/test627
@@ -24,7 +24,7 @@ sftp
 SFTP quote remove file with NOBODY
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -I -Q "rm %PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -I -Q "rm %PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt

--- a/tests/data/test630
+++ b/tests/data/test630
@@ -17,7 +17,7 @@ sftp
 SFTP incorrect host key
  </name>
  <command>
---hostpubmd5 00000000000000000000000000000000 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/irrelevant-file --insecure
+--hostpubmd5 00000000000000000000000000000000 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test631
+++ b/tests/data/test631
@@ -17,7 +17,7 @@ scp
 SCP incorrect host key
  </name>
  <command>
---hostpubmd5 00000000000000000000000000000000 --key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/irrelevant-file --insecure
+--hostpubmd5 00000000000000000000000000000000 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test632
+++ b/tests/data/test632
@@ -20,7 +20,7 @@ sftp
 SFTP syntactically invalid host key
  </name>
  <command>
---hostpubmd5 00 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%NOLISTENPORT%SSH_PWD/%LOGDIR/irrelevant-file --insecure
+--hostpubmd5 00 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%NOLISTENPORT%SSH_PWD/%LOGDIR/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test633
+++ b/tests/data/test633
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval with byte range
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 5-9 --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 5-9 --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test634
+++ b/tests/data/test634
@@ -25,7 +25,7 @@ sftp
 SFTP retrieval with byte range past end of file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 5-99 --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 5-99 --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test635
+++ b/tests/data/test635
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval with byte range relative to end of file
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r -9 --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r -9 --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test636
+++ b/tests/data/test636
@@ -25,7 +25,7 @@ sftp
 SFTP retrieval with X- byte range
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 5- --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 5- --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test637
+++ b/tests/data/test637
@@ -23,7 +23,7 @@ sftp
 SFTP retrieval with invalid X- range
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 99- --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt -r 99- --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test638
+++ b/tests/data/test638
@@ -29,7 +29,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP post-quote rename * asterisk accept-fail
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/test%TESTNUMBER.new" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "-*rename %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/test%TESTNUMBER.new" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.new

--- a/tests/data/test639
+++ b/tests/data/test639
@@ -29,7 +29,7 @@ perl %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 SFTP post-quote rename * asterisk accept-fail
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: -Q "-*rename %PWD/%LOGDIR/test%TESTNUMBER-not-exists-dir %PWD/%LOGDIR/test%TESTNUMBER.new" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "-*rename %PWD/%LOGDIR/test%TESTNUMBER-not-exists-dir %PWD/%LOGDIR/test%TESTNUMBER.new" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <postcheck>
 perl %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir

--- a/tests/data/test640
+++ b/tests/data/test640
@@ -23,7 +23,7 @@ sftp
 SFTP --head retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure --head
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure --head
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test641
+++ b/tests/data/test641
@@ -23,7 +23,7 @@ scp
 SCP --head retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure --head
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure --head
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test642
+++ b/tests/data/test642
@@ -24,7 +24,7 @@ sftp
 SFTP retrieval
  </name>
  <command>
---key curl_client_key --pubkey curl_client_key.pub -u %USER: --compressed-ssh sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: --compressed-ssh sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Test data

--- a/tests/data/test656
+++ b/tests/data/test656
@@ -16,7 +16,7 @@ sftp
 SFTP retrieval with nonexistent private key file
  </name>
  <command>
---key DOES_NOT_EXIST --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure --connect-timeout 8
+--key DOES_NOT_EXIST --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/not-a-valid-file-moooo --insecure --connect-timeout 8
 </command>
 </client>
 

--- a/tests/data/test664
+++ b/tests/data/test664
@@ -24,7 +24,7 @@ sftp
 SFTP correct host key
  </name>
  <command>
---hostpubmd5 %SSHSRVMD5 --key curl_client_key --pubkey curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
+--hostpubmd5 %SSHSRVMD5 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 test

--- a/tests/data/test665
+++ b/tests/data/test665
@@ -24,7 +24,7 @@ scp
 SCP correct host key
  </name>
  <command>
---hostpubmd5 %SSHSRVMD5 --key curl_client_key --pubkey curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
+--hostpubmd5 %SSHSRVMD5 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: scp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 test

--- a/tests/ftp.pm
+++ b/tests/ftp.pm
@@ -322,7 +322,7 @@ sub killpid {
 # killsockfilters kills sockfilter processes for a given server.
 #
 sub killsockfilters {
-    my ($proto, $ipvnum, $idnum, $verbose, $which) = @_;
+    my ($piddir, $proto, $ipvnum, $idnum, $verbose, $which) = @_;
     my $server;
     my $pidfile;
     my $pid;
@@ -335,7 +335,7 @@ sub killsockfilters {
     $server = servername_id($proto, $ipvnum, $idnum) if($verbose);
 
     if(!$which || ($which eq 'main')) {
-        $pidfile = mainsockf_pidfilename($proto, $ipvnum, $idnum);
+        $pidfile = mainsockf_pidfilename($piddir, $proto, $ipvnum, $idnum);
         $pid = processexists($pidfile);
         if($pid > 0) {
             printf("* kill pid for %s-%s => %d\n", $server,
@@ -349,7 +349,7 @@ sub killsockfilters {
     return if($proto ne 'ftp');
 
     if(!$which || ($which eq 'data')) {
-        $pidfile = datasockf_pidfilename($proto, $ipvnum, $idnum);
+        $pidfile = datasockf_pidfilename($piddir, $proto, $ipvnum, $idnum);
         $pid = processexists($pidfile);
         if($pid > 0) {
             printf("* kill pid for %s-data => %d\n", $server,
@@ -365,12 +365,12 @@ sub killsockfilters {
 # killallsockfilters kills sockfilter processes for all servers.
 #
 sub killallsockfilters {
-    my $verbose = $_[0];
+    my ($piddir, $verbose) = @_;
 
     for my $proto (('ftp', 'imap', 'pop3', 'smtp')) {
         for my $ipvnum (('4', '6')) {
             for my $idnum (('1', '2')) {
-                killsockfilters($proto, $ipvnum, $idnum, $verbose);
+                killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
             }
         }
     }

--- a/tests/http-server.pl
+++ b/tests/http-server.pl
@@ -23,13 +23,15 @@
 #
 #***************************************************************************
 
+use strict;
+use warnings;
+
 BEGIN {
     push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
     push(@INC, ".");
 }
 
-use strict;
-use warnings;
+use File::Basename;
 
 use serverhelp qw(
     server_pidfilename
@@ -57,6 +59,7 @@ my $gopher = 0;
 my $flags  = "";
 my $path   = '.';
 my $logdir = $path .'/log';
+my $piddir;
 
 while(@ARGV) {
     if($ARGV[0] eq '--pidfile') {
@@ -138,14 +141,24 @@ while(@ARGV) {
     shift @ARGV;
 }
 
-if(!$srcdir) {
-    $srcdir = $ENV{'srcdir'} || '.';
+#***************************************************************************
+# Initialize command line option dependent variables
+#
+
+if($pidfile) {
+    # Use our pidfile directory to store the other pidfiles
+    $piddir = dirname($pidfile);
 }
-if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+else {
+    # Use the current directory to store all the pidfiles
+    $piddir = $path;
+    $pidfile = server_pidfilename($piddir, $proto, $ipvnum, $idnum);
 }
 if(!$portfile) {
-    $portfile = "$path/". server_portfilename($proto, $ipvnum, $idnum);
+    $portfile = server_portfilename($piddir, $proto, $ipvnum, $idnum);
+}
+if(!$srcdir) {
+    $srcdir = $ENV{'srcdir'} || '.';
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -238,6 +238,8 @@ int test(char *URL)
   struct timeval timeout = {-1, 0};
   int success = 0;
 
+  assert(test_argc >= 5);
+
   start_test_timing();
 
   if(!libtest_arg3) {
@@ -286,8 +288,8 @@ int test(char *URL)
   easy_setopt(curl, CURLOPT_READDATA, hd_src);
 
   easy_setopt(curl, CURLOPT_USERPWD, libtest_arg3);
-  easy_setopt(curl, CURLOPT_SSH_PUBLIC_KEYFILE, "curl_client_key.pub");
-  easy_setopt(curl, CURLOPT_SSH_PRIVATE_KEYFILE, "curl_client_key");
+  easy_setopt(curl, CURLOPT_SSH_PUBLIC_KEYFILE, test_argv[4]);
+  easy_setopt(curl, CURLOPT_SSH_PRIVATE_KEYFILE, test_argv[5]);
   easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);

--- a/tests/libtest/lib583.c
+++ b/tests/libtest/lib583.c
@@ -40,6 +40,8 @@ int test(char *URL)
   CURLcode res = CURLE_OK;
   CURLMcode mres;
 
+  assert(test_argc >= 4);
+
   global_init(CURL_GLOBAL_ALL);
 
   multi_init(multiHandle);
@@ -47,8 +49,8 @@ int test(char *URL)
   easy_init(curl);
 
   easy_setopt(curl, CURLOPT_USERPWD, libtest_arg2);
-  easy_setopt(curl, CURLOPT_SSH_PUBLIC_KEYFILE, "curl_client_key.pub");
-  easy_setopt(curl, CURLOPT_SSH_PRIVATE_KEYFILE, "curl_client_key");
+  easy_setopt(curl, CURLOPT_SSH_PUBLIC_KEYFILE,  test_argv[3]);
+  easy_setopt(curl, CURLOPT_SSH_PRIVATE_KEYFILE, test_argv[4]);
 
   easy_setopt(curl, CURLOPT_UPLOAD, 1L);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/rtspserver.pl
+++ b/tests/rtspserver.pl
@@ -23,13 +23,13 @@
 #
 #***************************************************************************
 
+use strict;
+use warnings;
+
 BEGIN {
     push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
     push(@INC, ".");
 }
-
-use strict;
-use warnings;
 
 use serverhelp qw(
     server_pidfilename
@@ -112,11 +112,15 @@ while(@ARGV) {
     shift @ARGV;
 }
 
+#***************************************************************************
+# Initialize command line option dependent variables
+#
+
+if(!$pidfile) {
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
+}
 if(!$srcdir) {
     $srcdir = $ENV{'srcdir'} || '.';
-}
-if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -152,18 +152,19 @@ my $VCURL=$CURL;   # what curl binary to use to verify the servers with
 my $ACURL=$VCURL;  # what curl binary to use to talk to APIs (relevant for CI)
                    # ACURL is handy to set to the system one for reliability
 my $DBGCURL=$CURL; #"../src/.libs/curl";  # alternative for debugging
-my $LOGDIR="log";
 my $TESTDIR="$srcdir/data";
 my $LIBDIR="./libtest";
 my $UNITDIR="./unit";
+my $LOGDIR="log";
 # TODO: $LOGDIR could eventually change later on, so must regenerate all the
 # paths depending on it after $LOGDIR itself changes.
+my $PIDDIR = "$LOGDIR/server";
 # TODO: change this to use server_inputfilename()
 my $SERVERIN="$LOGDIR/server.input"; # what curl sent the server
 my $SERVER2IN="$LOGDIR/server2.input"; # what curl sent the second server
 my $PROXYIN="$LOGDIR/proxy.input"; # what curl sent the proxy
 my $SOCKSIN="$LOGDIR/socksd-request.log"; # what curl sent to the SOCKS proxy
-my $CURLLOG="commands.log"; # all command lines run
+my $CURLLOG="$LOGDIR/commands.log"; # all command lines run
 my $FTPDCMD="$LOGDIR/ftpserver.cmd"; # copy server instructions here
 my $SERVERLOGS_LOCK="$LOGDIR/serverlogs.lock"; # server logs advisor read lock
 my $CURLCONFIG="../curl-config"; # curl-config from current build
@@ -384,9 +385,9 @@ sub init_serverpidfile_hash {
       for my $ipvnum ((4, 6)) {
         for my $idnum ((1, 2, 3)) {
           my $serv = servername_id("$proto$ssl", $ipvnum, $idnum);
-          my $pidf = server_pidfilename("$proto$ssl", $ipvnum, $idnum);
+          my $pidf = server_pidfilename($PIDDIR, "$proto$ssl", $ipvnum, $idnum);
           $serverpidfile{$serv} = $pidf;
-          my $portf = server_portfilename("$proto$ssl", $ipvnum, $idnum);
+          my $portf = server_portfilename($PIDDIR, "$proto$ssl", $ipvnum, $idnum);
           $serverportfile{$serv} = $portf;
         }
       }
@@ -397,9 +398,9 @@ sub init_serverpidfile_hash {
     for my $ipvnum ((4, 6)) {
       for my $idnum ((1, 2)) {
         my $serv = servername_id($proto, $ipvnum, $idnum);
-        my $pidf = server_pidfilename($proto, $ipvnum, $idnum);
+        my $pidf = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
         $serverpidfile{$serv} = $pidf;
-        my $portf = server_portfilename($proto, $ipvnum, $idnum);
+        my $portf = server_portfilename($PIDDIR, $proto, $ipvnum, $idnum);
         $serverportfile{$serv} = $portf;
       }
     }
@@ -407,9 +408,9 @@ sub init_serverpidfile_hash {
   for my $proto (('http', 'imap', 'pop3', 'smtp', 'http/2', 'http/3')) {
     for my $ssl (('', 's')) {
       my $serv = servername_id("$proto$ssl", "unix", 1);
-      my $pidf = server_pidfilename("$proto$ssl", "unix", 1);
+      my $pidf = server_pidfilename($PIDDIR, "$proto$ssl", "unix", 1);
       $serverpidfile{$serv} = $pidf;
-      my $portf = server_portfilename("$proto$ssl", "unix", 1);
+      my $portf = server_portfilename($PIDDIR, "$proto$ssl", "unix", 1);
       $serverportfile{$serv} = $portf;
     }
   }
@@ -757,7 +758,7 @@ sub stopserver {
         my $proto  = $1;
         my $idnum  = ($2 && ($2 > 1)) ? $2 : 1;
         my $ipvnum = ($3 && ($3 =~ /6$/)) ? 6 : 4;
-        killsockfilters($proto, $ipvnum, $idnum, $verbose);
+        killsockfilters($PIDDIR, $proto, $ipvnum, $idnum, $verbose);
     }
     #
     # All servers relative to the given one must be stopped also
@@ -1065,7 +1066,7 @@ sub verifyrtsp {
 #
 sub verifyssh {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
-    my $pidfile = server_pidfilename($proto, $ipvnum, $idnum);
+    my $pidfile = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
     my $pid = processexists($pidfile);
     if($pid < 0) {
         logmsg "RUN: SSH server has died after starting up\n";
@@ -1119,7 +1120,7 @@ sub verifysftp {
 sub verifyhttptls {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
     my $server = servername_id($proto, $ipvnum, $idnum);
-    my $pidfile = server_pidfilename($proto, $ipvnum, $idnum);
+    my $pidfile = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
 
     my $verifyout = "$LOGDIR/".
         servername_canon($proto, $ipvnum, $idnum) .'_verify.out';
@@ -1196,7 +1197,7 @@ sub verifyhttptls {
 #
 sub verifysocks {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
-    my $pidfile = server_pidfilename($proto, $ipvnum, $idnum);
+    my $pidfile = server_pidfilename($PIDDIR, $proto, $ipvnum, $idnum);
     my $pid = processexists($pidfile);
     if($pid < 0) {
         logmsg "RUN: SOCKS server has died after starting up\n";
@@ -2725,7 +2726,9 @@ sub cleardir {
         return 0; # can't open dir
     while($file = readdir($dh)) {
         if(($file !~ /^(\.|\.\.)\z/)) {
-            if(-d "$dir/$file") {
+            if(-d "$dir/$file" &&
+            # Don't clear the $PIDDIR since those need to live beyond one test
+               Cwd::abs_path($PIDDIR) ne Cwd::abs_path("$dir/$file")) {
                 if(!cleardir("$dir/$file")) {
                     $done = 0;
                 }
@@ -4055,7 +4058,7 @@ sub singletest_run {
         logmsg "$CMDLINE\n";
     }
 
-    open(my $cmdlog, ">", "$LOGDIR/$CURLLOG") || die "Failure writing log file";
+    open(my $cmdlog, ">", $CURLLOG) || die "Failure writing log file";
     print $cmdlog "$CMDLINE\n";
     close($cmdlog) || die "Failure writing log file";
 
@@ -4860,7 +4863,7 @@ sub stopservers {
     #
     # kill sockfilter processes for all pingpong servers
     #
-    killallsockfilters($verb);
+    killallsockfilters($PIDDIR, $verb);
     #
     # kill all server pids from %run hash clearing them
     #
@@ -5991,6 +5994,7 @@ $SOCKSUNIXPATH    = $pwd."/socks$$.sock"; # HTTP server Unix domain socket path,
 
 cleardir($LOGDIR);
 mkdir($LOGDIR, 0777);
+mkdir($PIDDIR, 0777);
 
 #######################################################################
 # initialize some variables

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -96,6 +96,8 @@ use serverhelp qw(
 
 # Variables and subs imported from sshhelp module
 use sshhelp qw(
+    $hstpubmd5f
+    $hstpubsha256f
     $sshdexe
     $sshexe
     $sftpexe
@@ -2214,7 +2216,6 @@ sub runsshserver {
         return (0,0,0);
     }
 
-    my $hstpubmd5f = "curl_host_rsa_key.pub_md5";
     my $hostfile;
     if(!open($hostfile, "<", $hstpubmd5f) ||
        (read($hostfile, $SSHSRVMD5, 32) != 32) ||
@@ -2227,7 +2228,6 @@ sub runsshserver {
         die $msg;
     }
 
-    my $hstpubsha256f = "curl_host_rsa_key.pub_sha256";
     if(!open($hostfile, "<", $hstpubsha256f) ||
        (read($hostfile, $SSHSRVSHA256, 48) == 0) ||
        !close($hostfile))

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1098,7 +1098,7 @@ sub verifysftp {
     }
     # Connect to sftp server, authenticate and run a remote pwd
     # command using our generated configuration and key files
-    my $cmd = "\"$sftp\" -b $sftpcmds -F $sftpconfig -S \"$ssh\" $ip > $sftplog 2>&1";
+    my $cmd = "\"$sftp\" -b $PIDDIR/$sftpcmds -F $PIDDIR/$sftpconfig -S \"$ssh\" $ip > $sftplog 2>&1";
     my $res = runclient($cmd);
     # Search for pwd command response in log file
     if(open(my $sftplogfile, "<", "$sftplog")) {
@@ -2212,12 +2212,12 @@ sub runsshserver {
 
     if(!$wport) {
         logmsg "RUN: couldn't start $srvrname. Tried these ports:";
-        logmsg "RUN: ".join(", ", @tports);
+        logmsg "RUN: ".join(", ", @tports)."\n";
         return (0,0,0);
     }
 
     my $hostfile;
-    if(!open($hostfile, "<", $hstpubmd5f) ||
+    if(!open($hostfile, "<", $PIDDIR . "/" . $hstpubmd5f) ||
        (read($hostfile, $SSHSRVMD5, 32) != 32) ||
        !close($hostfile) ||
        ($SSHSRVMD5 !~ /^[a-f0-9]{32}$/i))
@@ -2228,7 +2228,7 @@ sub runsshserver {
         die $msg;
     }
 
-    if(!open($hostfile, "<", $hstpubsha256f) ||
+    if(!open($hostfile, "<", $PIDDIR . "/" . $hstpubsha256f) ||
        (read($hostfile, $SSHSRVSHA256, 48) == 0) ||
        !close($hostfile))
     {

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -27,13 +27,14 @@
 # harness. Actually just a layer that runs stunnel properly using the
 # non-secure test harness servers.
 
+use strict;
+use warnings;
+
 BEGIN {
     push(@INC, $ENV{'srcdir'}) if(defined $ENV{'srcdir'});
     push(@INC, ".");
 }
 
-use strict;
-use warnings;
 use Cwd;
 use Cwd 'abs_path';
 
@@ -183,7 +184,7 @@ while(@ARGV) {
 # Initialize command line option dependent variables
 #
 if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -146,18 +146,18 @@ sub servername_canon {
 # Return file name for server pid file.
 #
 sub server_pidfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     my $trailer = '_server.pid';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 #***************************************************************************
 # Return file name for server port file.
 #
 sub server_portfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     my $trailer = '_server.port';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 
@@ -206,11 +206,11 @@ sub server_outputfilename {
 # Return file name for main or primary sockfilter pid file.
 #
 sub mainsockf_pidfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     die "unsupported protocol: '$proto'" unless($proto &&
         (lc($proto) =~ /^(ftp|imap|pop3|smtp)s?$/));
     my $trailer = (lc($proto) =~ /^ftps?$/) ? '_sockctrl.pid':'_sockfilt.pid';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 
@@ -230,11 +230,11 @@ sub mainsockf_logfilename {
 # Return file name for data or secondary sockfilter pid file.
 #
 sub datasockf_pidfilename {
-    my ($proto, $ipver, $idnum) = @_;
+    my ($piddir, $proto, $ipver, $idnum) = @_;
     die "unsupported protocol: '$proto'" unless($proto &&
         (lc($proto) =~ /^ftps?$/));
     my $trailer = '_sockdata.pid';
-    return '.'. servername_canon($proto, $ipver, $idnum) ."$trailer";
+    return "${piddir}/". servername_canon($proto, $ipver, $idnum) ."$trailer";
 }
 
 

--- a/tests/sshhelp.pm
+++ b/tests/sshhelp.pm
@@ -210,7 +210,7 @@ sub dump_array {
     if(!$filename) {
         $error = 'Error: Missing argument 1 for dump_array()';
     }
-    elsif(open(my $textfh, ">", "$filename")) {
+    elsif(open(my $textfh, ">", $filename)) {
         foreach my $line (@arr) {
             $line .= "\n" if($line !~ /\n$/);
             print $textfh $line;

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -177,14 +177,17 @@ while(@ARGV) {
     shift @ARGV;
 }
 
+#***************************************************************************
+# Initialize command line option dependent variables
+#
+
 
 #***************************************************************************
 # Default ssh daemon pid file name
 #
 if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
 }
-
 
 #***************************************************************************
 # ssh and sftp server log file names

--- a/tests/tftpserver.pl
+++ b/tests/tftpserver.pl
@@ -117,7 +117,7 @@ if(!$srcdir) {
     $srcdir = $ENV{'srcdir'} || '.';
 }
 if(!$pidfile) {
-    $pidfile = "$path/". server_pidfilename($proto, $ipvnum, $idnum);
+    $pidfile = server_pidfilename($path, $proto, $ipvnum, $idnum);
 }
 if(!$logfile) {
     $logfile = server_logfilename($logdir, $proto, $ipvnum, $idnum);


### PR DESCRIPTION
This is to segregate all files written by a test process into a single root
to allow for future parallel testing.

This builds on PR #10874 so only the most recent 2 commits are new.