### PR TITLE
configure: make quiche require quiche_conn_send_ack_eliciting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3224,7 +3224,7 @@ if test X"$want_quiche" != Xno; then
     if test "x$cross_compiling" != "xyes"; then
       DIR_QUICHE=`echo $LD_QUICHE | $SED -e 's/^-L//'`
     fi
-    AC_CHECK_LIB(quiche, quiche_connect,
+    AC_CHECK_LIB(quiche, quiche_conn_send_ack_eliciting,
       [
        AC_CHECK_HEADERS(quiche.h,
           experimental="$experimental HTTP3"


### PR DESCRIPTION
curl now requires quiche version >= 1.17.1 to be used and this function was added in this version and makes a convenient check.

This requirement is because this is the lowest quiche version that supports peer-initiated key updates correctly.