### PR TITLE
vtls and h2 improvements

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -76,12 +76,19 @@ static size_t chunk_read(struct buf_chunk *chunk,
   unsigned char *p = &chunk->x.data[chunk->r_offset];
   size_t n = chunk->w_offset - chunk->r_offset;
   DEBUGASSERT(chunk->w_offset >= chunk->r_offset);
-  if(n) {
-    n = CURLMIN(n, len);
-    memcpy(buf, p, n);
-    chunk->r_offset += n;
+  if(!n) {
+    return 0;
   }
-  return n;
+  else if(n <= len) {
+    memcpy(buf, p, n);
+    chunk->r_offset = chunk->w_offset = 0;
+    return n;
+  }
+  else {
+    memcpy(buf, p, len);
+    chunk->r_offset += len;
+    return len;
+  }
 }
 
 static ssize_t chunk_slurpn(struct buf_chunk *chunk, size_t max_len,

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -68,6 +68,7 @@ class EnvConfig:
         self.curl_props = {
             'version': None,
             'os': None,
+            'fullname': None,
             'features': [],
             'protocols': [],
             'libs': [],
@@ -82,6 +83,7 @@ class EnvConfig:
             if l.startswith('curl '):
                 m = re.match(r'^curl (?P<version>\S+) (?P<os>\S+) (?P<libs>.*)$', l)
                 if m:
+                    self.curl_props['fullname'] = m.group(0)
                     self.curl_props['version'] = m.group('version')
                     self.curl_props['os'] = m.group('os')
                     self.curl_props['lib_versions'] = [
@@ -243,7 +245,6 @@ class Env:
     def curl_has_protocol(protocol: str) -> bool:
         return protocol.lower() in Env.CONFIG.curl_props['protocols']
 
-
     @staticmethod
     def curl_lib_version(libname: str) -> str:
         prefix = f'{libname.lower()}/'
@@ -255,6 +256,10 @@ class Env:
     @staticmethod
     def curl_os() -> str:
         return Env.CONFIG.curl_props['os']
+
+    @staticmethod
+    def curl_fullname() -> str:
+        return Env.CONFIG.curl_props['fullname']
 
     @staticmethod
     def curl_version() -> str:


### PR DESCRIPTION
- eliminate receive loop in vtls to fill buffer. This may lead to partial reads of data which is counter productive
- let http2 instead loop smarter to process pending network data without transfer switches

scorecard improvements
- do not start caddy when only httpd is requested
- allow curl -v to stderr file on --curl-verbose