### PR TITLE
tests, increase sws timeout for more robust testing

### DIFF
--- a/tests/http-server.pl
+++ b/tests/http-server.pl
@@ -53,6 +53,7 @@ my $portfile;        # port number file
 my $logfile;         # log file
 my $cmdfile;         # command file
 my $connect;         # IP to connect to on CONNECT
+my $keepalive_secs;  # number of seconds to keep idle connections
 my $srcdir;
 my $gopher = 0;
 
@@ -126,6 +127,12 @@ while(@ARGV) {
             shift @ARGV;
         }
     }
+    elsif($ARGV[0] eq '--keepalive') {
+        if($ARGV[1]) {
+            $keepalive_secs = $ARGV[1];
+            shift @ARGV;
+        }
+    }
     elsif($ARGV[0] eq '--id') {
         if($ARGV[1] =~ /^(\d+)$/) {
             $idnum = $1 if($1 > 0);
@@ -171,6 +178,7 @@ $flags .= "--pidfile \"$pidfile\" ".
     "--portfile \"$portfile\" ";
 $flags .= "--gopher " if($gopher);
 $flags .= "--connect $connect " if($connect);
+$flags .= "--keepalive $keepalive_secs " if($keepalive_secs);
 if($ipvnum eq 'unix') {
     $flags .= "--unix-socket '$unix_socket' ";
 } else {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1552,6 +1552,8 @@ sub runhttpserver {
     my $idnum = 1;
     my $exe = "$perl $srcdir/http-server.pl";
     my $verbose_flag = "--verbose ";
+    my $keepalive_secs = 30; # forwarded to sws, was 5 by default which
+                             # led to pukes in CI jobs
 
     if($alt eq "ipv6") {
         # if IPv6, use a different setup
@@ -1590,6 +1592,7 @@ sub runhttpserver {
     my $flags = "";
     $flags .= "--gopher " if($proto eq "gopher");
     $flags .= "--connect $HOSTIP " if($alt eq "proxy");
+    $flags .= "--keepalive $keepalive_secs ";
     $flags .= $verbose_flag if($debugprotocol);
     $flags .= "--pidfile \"$pidfile\" --logfile \"$logfile\" ";
     $flags .= "--logdir \"$LOGDIR\" ";


### PR DESCRIPTION
- for https CONNECT forwarding, this was fixed at 5 seconds which led to spurious CI test failures
- add --keepalive parameter to sws to control this
- let httpserver use 30 seconds