### PR TITLE
CURLPROXY_HTTPS2: for HTTPS proxy that may speak HTTP/2

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.3
@@ -38,7 +38,9 @@ Pass one of the values below to set the type of the proxy.
 .IP CURLPROXY_HTTP
 HTTP Proxy. Default.
 .IP CURLPROXY_HTTPS
-HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and NSS)
+HTTPS Proxy using HTTP/1. (Added in 7.52.0 for OpenSSL, GnuTLS and NSS)
+.IP CURLPROXY_HTTPS2
+HTTPS Proxy and attempt to speak HTTP/2 over it. (Added in 8.1.0)
 .IP CURLPROXY_HTTP_1_0
 HTTP 1.0 Proxy. This is similar to CURLPROXY_HTTP except it uses HTTP/1.0 for
 any CONNECT tunneling. It does not change the HTTP version of the actual HTTP

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -954,6 +954,7 @@ CURLPROTO_TFTP                  7.19.4
 CURLPROXY_HTTP                  7.10
 CURLPROXY_HTTP_1_0              7.19.4
 CURLPROXY_HTTPS                 7.52.0
+CURLPROXY_HTTPS2                8.1.0
 CURLPROXY_SOCKS4                7.10
 CURLPROXY_SOCKS4A               7.18.0
 CURLPROXY_SOCKS5                7.10

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -780,7 +780,8 @@ typedef enum {
                            CONNECT HTTP/1.1 */
   CURLPROXY_HTTP_1_0 = 1,   /* added in 7.19.4, force to use CONNECT
                                HTTP/1.0  */
-  CURLPROXY_HTTPS = 2, /* added in 7.52.0 */
+  CURLPROXY_HTTPS = 2,  /* HTTPS but stick to HTTP/1 added in 7.52.0 */
+  CURLPROXY_HTTPS2 = 3, /* HTTPS and attempt HTTP/2 added in 8.1.0 */
   CURLPROXY_SOCKS4 = 4, /* support added in 7.15.2, enum existed already
                            in 7.10 */
   CURLPROXY_SOCKS5 = 5, /* added in 7.10 */

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1223,7 +1223,7 @@ connect_sub_chain:
 
   if(ctx->state < CF_SETUP_CNNCT_HTTP_PROXY && cf->conn->bits.httpproxy) {
 #ifdef USE_SSL
-    if(cf->conn->http_proxy.proxytype == CURLPROXY_HTTPS
+    if(IS_HTTPS_PROXY(cf->conn->http_proxy.proxytype)
        && !Curl_conn_is_ssl(cf->conn, cf->sockindex)) {
       result = Curl_cf_ssl_proxy_insert_after(cf, data);
       if(result)

--- a/lib/http.c
+++ b/lib/http.c
@@ -1305,7 +1305,7 @@ CURLcode Curl_buffer_send(struct dynbuf *in,
 
   if((conn->handler->flags & PROTOPT_SSL
 #ifndef CURL_DISABLE_PROXY
-      || conn->http_proxy.proxytype == CURLPROXY_HTTPS
+      || IS_HTTPS_PROXY(conn->http_proxy.proxytype)
 #endif
        )
      && conn->httpversion != 20) {

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -44,6 +44,9 @@ CURLcode Curl_cf_http_proxy_insert_after(struct Curl_cfilter *cf_at,
 
 extern struct Curl_cftype Curl_cft_http_proxy;
 
+#define IS_HTTPS_PROXY(t) (((t) == CURLPROXY_HTTPS) ||  \
+                           ((t) == CURLPROXY_HTTPS2))
+
 #endif /* !CURL_DISABLE_PROXY  && !CURL_DISABLE_HTTP */
 
 #endif /* HEADER_CURL_HTTP_PROXY_H */

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -44,9 +44,9 @@ CURLcode Curl_cf_http_proxy_insert_after(struct Curl_cfilter *cf_at,
 
 extern struct Curl_cftype Curl_cft_http_proxy;
 
+#endif /* !CURL_DISABLE_PROXY  && !CURL_DISABLE_HTTP */
+
 #define IS_HTTPS_PROXY(t) (((t) == CURLPROXY_HTTPS) ||  \
                            ((t) == CURLPROXY_HTTPS2))
-
-#endif /* !CURL_DISABLE_PROXY  && !CURL_DISABLE_HTTP */
 
 #endif /* HEADER_CURL_HTTP_PROXY_H */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1155,7 +1155,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_PROXYTYPE:
     /*
-     * Set proxy type. HTTP/HTTP_1_0/SOCKS4/SOCKS4a/SOCKS5/SOCKS5_HOSTNAME
+     * Set proxy type.
      */
     arg = va_arg(param, long);
     if((arg < CURLPROXY_HTTP) || (arg > CURLPROXY_SOCKS5_HOSTNAME))

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1813,8 +1813,14 @@ static CURLcode cf_ssl_proxy_create(struct Curl_cfilter **pcf,
   bool use_alpn = conn->bits.tls_enable_alpn;
   int httpwant = CURL_HTTP_VERSION_1_1;
 
-#if defined(USE_HTTP2) && defined(DEBUGBUILD)
-  if(conn->bits.tunnel_proxy && getenv("CURL_PROXY_TUNNEL_H2")) {
+#ifdef USE_HTTP2
+  if(conn->bits.tunnel_proxy &&
+     ((conn->http_proxy.proxytype == CURLPROXY_HTTPS2)
+#ifdef DEBUGBUILD
+      || getenv("CURL_PROXY_TUNNEL_H2")
+#endif
+       )
+    ) {
     use_alpn = TRUE;
     httpwant = CURL_HTTP_VERSION_2;
   }


### PR DESCRIPTION
Setting this proxy type allows curl to negotiate and use HTTP/2 with HTTPS proxies.

(There is no way for the curl tool to set this yet)