### PR TITLE
http_proxy: provide missing arg to infof() call

### DIFF
--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -106,7 +106,7 @@ connect_sub:
 #endif
     default:
       DEBUGF(LOG_CF(data, cf, "installing subfilter for default HTTP/1.1"));
-      infof(data, "CONNECT tunnel: unsupported ALPN(%d) negotiated");
+      infof(data, "CONNECT tunnel: unsupported ALPN(%d) negotiated", alpn);
       result = CURLE_COULDNT_CONNECT;
       goto out;
     }


### PR DESCRIPTION
Pointed out by Coverity