### PR TITLE
fix compilation for MS-DOS/DJGPP

### DIFF
--- a/lib/config-dos.h
+++ b/lib/config-dos.h
@@ -82,7 +82,7 @@
 #define SIZEOF_INT             4
 #define SIZEOF_LONG            4
 #define SIZEOF_SIZE_T          4
-#define SIZEOF_CURL_OFF_T      4
+#define SIZEOF_CURL_OFF_T      8
 #define STDC_HEADERS           1
 #define TIME_WITH_SYS_TIME     1
 


### PR DESCRIPTION
This change fixed #10905 for me.
curl is compiled with mbedTLS.
The change was briefly tested with https://github.com/SuperIlu/DOStodon and seems to work.
