### PR TITLE
urlapi: prevent setting invalid schemes with *url_set()

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1728,9 +1728,11 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
   }
 
   switch(what) {
-  case CURLUPART_SCHEME:
-    if(strlen(part) > MAX_SCHEME_LEN)
-      /* too long */
+  case CURLUPART_SCHEME: {
+    size_t plen = strlen(part);
+    const char *s = part;
+    if((plen > MAX_SCHEME_LEN) || (plen < 1))
+      /* too long or too short */
       return CURLUE_BAD_SCHEME;
     if(!(flags & CURLU_NON_SUPPORT_SCHEME) &&
        /* verify that it is a fine scheme */
@@ -1738,7 +1740,15 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
       return CURLUE_UNSUPPORTED_SCHEME;
     storep = &u->scheme;
     urlencode = FALSE; /* never */
+    /* ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) */
+    while(plen--) {
+      if(ISALNUM(*s) || (*s == '+') || (*s == '-') || (*s == '.'))
+        s++; /* fine */
+      else
+        return CURLUE_BAD_SCHEME;
+    }
     break;
+  }
   case CURLUPART_USER:
     storep = &u->user;
     break;

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -713,6 +713,11 @@ static const struct setcase set_parts_list[] = {
    CURLUE_OK, CURLUE_OK},
 
   {"https://example.com/",
+   /* Set a bad scheme *including* :// */
+   "scheme=https://,",
+   "https://example.com/",
+   0, CURLU_NON_SUPPORT_SCHEME, CURLUE_OK, CURLUE_BAD_SCHEME},
+  {"https://example.com/",
    /* Set a 41 bytes scheme. That's too long so the old scheme remains set. */
    "scheme=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbc,",
    "https://example.com/",


### PR DESCRIPTION
A typical mistake would be to try to set "https://" - including the separator - this is now rejected as that would then lead to url_get(... URL...) would get an invalid URL extracted.

Extended test 1560 to verify.