### PR TITLE
http2: Remove unused Curl_http2_strerror function declaration

### DIFF
--- a/lib/http2.h
+++ b/lib/http2.h
@@ -38,8 +38,6 @@
  */
 void Curl_http2_ver(char *p, size_t len);
 
-const char *Curl_http2_strerror(uint32_t err);
-
 CURLcode Curl_http2_request_upgrade(struct dynbuf *req,
                                     struct Curl_easy *data);
 


### PR DESCRIPTION

    Curl_http2_strerror was renamed to http2_strerror in 05b100aee247bb9bec8e9a1b0166496aa4248d1c
    and then http2_strerror was removed in 5808a0d0f5ea0399d4a2a22285f78c66f302c173

    This also fixes the following compiler error

    lib/http2.h:41:33: error: unknown type name 'uint32_t'
    lib/http2.h:1:1: note: 'uint32_t' is defined in header '<stdint.h>'

