### PR TITLE
Clean command-line on Win32 to hide possible sensitive information fr…

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -763,6 +763,7 @@ static void init_terminal(void)
 }
 
 /* clean possible sensitive information from the win32 command-line */
+#ifdef NDEBUG
 #define _acmdln (*__p__acmdln())
 #define _wcmdln (*__p__wcmdln())
 _CRTIMP char    **__cdecl __p__acmdln(void);
@@ -772,6 +773,9 @@ static void clean_cmdln(void)
   memset(_acmdln, 'x', strlen(_acmdln));
   wmemset(_wcmdln, L'x', wcslen(_wcmdln));
 }
+#else
+#define clean_cmdln() ((void)0)
+#endif
 
 LARGE_INTEGER tool_freq;
 bool tool_isVistaOrGreater;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -768,7 +768,7 @@ _CRTIMP char    **__cdecl __p__acmdln(void);
 _CRTIMP wchar_t **__cdecl __p__wcmdln(void);
 static void clean_cmdln(void)
 {
-  memset (_acmdln,  'x', strlen(_acmdln));
+  memset(_acmdln, 'x', strlen(_acmdln));
   wmemset(_wcmdln, L'x', wcslen(_wcmdln));
 }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -32,6 +32,7 @@
 #ifdef WIN32
 #  include <stdlib.h>
 #  include <tlhelp32.h>
+#  include <wchar.h>
 #  include "tool_cfgable.h"
 #  include "tool_libinfo.h"
 #endif

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -761,6 +761,17 @@ static void init_terminal(void)
   }
 }
 
+/* clean possible sensitive information from the win32 command-line */
+#define _acmdln (*__p__acmdln())
+#define _wcmdln (*__p__wcmdln())
+_CRTIMP char    **__cdecl __p__acmdln(void);
+_CRTIMP wchar_t **__cdecl __p__wcmdln(void);
+static void clean_cmdln(void)
+{
+  memset (_acmdln,  'x', strlen(_acmdln));
+  wmemset(_wcmdln, L'x', wcslen(_wcmdln));
+}
+
 LARGE_INTEGER tool_freq;
 bool tool_isVistaOrGreater;
 
@@ -775,6 +786,8 @@ CURLcode win32_init(void)
     tool_isVistaOrGreater = false;
 
   QueryPerformanceFrequency(&tool_freq);
+
+  clean_cmdln();
 
   init_terminal();
 


### PR DESCRIPTION
 Clean command-line on Win32 to hide possible sensitive information from Task Manager et al., similar to what `cleanarg()` already does on other platforms. See #10888 for details.