### PR TITLE
lib1560: verify that more bad host names are rejected

### DIFF
--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -698,6 +698,24 @@ static int checkurl(const char *org, const char *url, const char *out)
 /* !checksrc! disable SPACEBEFORECOMMA 1 */
 static const struct setcase set_parts_list[] = {
   {"https://example.com/",
+   "host=http://fake,",
+   "",
+   0, /* get */
+   0, /* set */
+   CURLUE_OK, CURLUE_BAD_HOSTNAME},
+  {"https://example.com/",
+   "host=test%,",
+   "",
+   0, /* get */
+   0, /* set */
+   CURLUE_OK, CURLUE_BAD_HOSTNAME},
+  {"https://example.com/",
+   "host=te st,",
+   "",
+   0, /* get */
+   0, /* set */
+   CURLUE_OK, CURLUE_BAD_HOSTNAME},
+  {"https://example.com/",
    "host=0xff,", /* '++' there's no automatic URL decode when settin this
                   part */
    "https://0xff/",


### PR DESCRIPTION
when setting the hostname component of a URL