### PR TITLE
vtls. Fix V220 for sizeof(buf->data)

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -2022,7 +2022,7 @@ CURLcode Curl_alpn_to_proto_str(struct alpn_proto_buf *buf,
     len = strlen(spec->entries[i]);
     if(len >= ALPN_NAME_MAX)
       return CURLE_FAILED_INIT;
-    if(off + len + 2 >= (int)sizeof(buf->data))
+    if(off + len + 2 >= sizeof(buf->data))
       return CURLE_FAILED_INIT;
     if(off)
       buf->data[off++] = ',';


### PR DESCRIPTION
V220 Suspicious sequence of types castings: memsize -> 32-bit integer -> memsize. The value being cast: 'sizeof (buf->data)'. curl\lib\vtls\vtls.c 2025

https://pvs-studio.com/en/docs/warnings/v220/