### PR TITLE
cookie: clarify that init with data set to NULL reads no file

### DIFF
--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -61,7 +61,6 @@ struct Cookie {
 struct CookieInfo {
   /* linked list of cookies we know of */
   struct Cookie *cookies[COOKIE_HASH_SIZE];
-
   char *filename;  /* file we read from/write to */
   long numcookies; /* number of cookies in the "jar" */
   bool running;    /* state info, for cookie adding information */


### PR DESCRIPTION
... and make Curl_cookie_add() require 'data' being set proper with an assert.

The function has not worked with a NULL data for quite some time so this just corrects the code and comment.

This is a different take than the proposed fixed in #10927

Reported-by: Kvarec Lezki in #10929