### PR TITLE
CMakeLists.txt: Fix typo for Haiku detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES AIX)
 endif()
 
 # If we are on Haiku, make sure that the network library is brought in.
-if(${CMAKE_SYSTE_NAME} MATCHES Haiku)
+if(${CMAKE_SYSTEM_NAME} MATCHES Haiku)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lnetwork")
 endif()
 


### PR DESCRIPTION
When I initially fixed the Haiku detection, I had to attempt to recreate my work inside of Git.

I misspelled SYSTEM. 😃 