### PR TITLE
HTTTP/3 all backends, check stream_ctx more thoroughly

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1055,12 +1055,13 @@ static bool stream_is_writeable(struct Curl_cfilter *cf,
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
   struct stream_ctx *stream = H3_STREAM_CTX(data);
+  quiche_stream_iter *qiter;
   bool is_writable = FALSE;
 
   if(!stream)
     return FALSE;
   /* surely, there must be a better way */
-  quiche_stream_iter *qiter = quiche_conn_writable(ctx->qconn);
+  qiter = quiche_conn_writable(ctx->qconn);
   if(qiter) {
     uint64_t stream_id;
     while(quiche_stream_iter_next(qiter, &stream_id)) {


### PR DESCRIPTION
- callbacks and filter methods might be invoked at unexpected times, e.g. when the transfer's stream_ctx has not been initialized yet or, more likely, has already been taken down.
- check for existance of stream_ctx in such places and return an error or silently succeed the call.