### PR TITLE
ftp: fix 'portsock' variable was assigned the same value

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1085,8 +1085,6 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
   host = NULL;
 
   /* step 2, create a socket for the requested address */
-
-  portsock = CURL_SOCKET_BAD;
   error = 0;
   for(ai = res; ai; ai = ai->ai_next) {
     if(Curl_socket_open(data, ai, NULL, conn->transport, &portsock)) {


### PR DESCRIPTION
Pointed out by PVS

Ref: #10929