### PR TITLE
bufq: simplify since expression is always true

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -524,22 +524,20 @@ ssize_t Curl_bufq_write_pass(struct bufq *q,
       }
     }
 
-    if(len) {
-      /* Add whatever is remaining now to bufq */
-      n = Curl_bufq_write(q, buf, len, err);
-      if(n < 0) {
-        if(*err != CURLE_AGAIN) {
-          /* real error, fail */
-          return -1;
-        }
-        /* no room in bufq, bail out */
-        goto out;
+    /* Add whatever is remaining now to bufq */
+    n = Curl_bufq_write(q, buf, len, err);
+    if(n < 0) {
+      if(*err != CURLE_AGAIN) {
+        /* real error, fail */
+        return -1;
       }
-      /* Maybe only part of `data` has been added, continue to loop */
-      buf += (size_t)n;
-      len -= (size_t)n;
-      nwritten += (size_t)n;
+      /* no room in bufq, bail out */
+      goto out;
     }
+    /* Maybe only part of `data` has been added, continue to loop */
+    buf += (size_t)n;
+    len -= (size_t)n;
+    nwritten += (size_t)n;
   }
 
 out:


### PR DESCRIPTION
The check for 'len' is already done so it will remain true until updated. Pointed out by PVS.

Ref: #10929