### PR TITLE
Disable socket receive buffer, unless USE_RECV_BEFORE_SEND_WORKAROUND…

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1390,8 +1390,15 @@ static void cf_socket_active(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* We buffer only for TCP transfers that do not install their own
      * read function. Those may still have expectations about socket
      * behaviours from the past. */
+#ifdef USE_RECV_BEFORE_SEND_WORKAROUND
     ctx->buffer_recv = (ctx->transport == TRNSPRT_TCP &&
                         (cf->conn->recv[cf->sockindex] == Curl_conn_recv));
+#else
+    /* While we would like to use this, we have stalls in parallel
+     * transfers where not all buffered data is consumed and no
+     * socket events happen. */
+    ctx->buffer_recv = FALSE;
+#endif
   }
   ctx->active = TRUE;
 }


### PR DESCRIPTION
… is in place

While we would like to use this, we have stalls in parallel transfers where not all buffered data is consumed and no socket events happen.