### PR TITLE
Update CURLOPT_PROXY_SSL_VERIFYPEER.3

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.3
@@ -35,7 +35,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXY_SSL_VERIFYPEER,
 .SH DESCRIPTION
 Pass a long as parameter set to 1L to enable or 0L to disable.
 
-This option tells curl to verifies the authenticity of the HTTPS proxy's
+This option tells curl to verify the authenticity of the HTTPS proxy's
 certificate. A value of 1 means curl verifies; 0 (zero) means it does not.
 
 This is the proxy version of \fICURLOPT_SSL_VERIFYPEER(3)\fP that is used for


### PR DESCRIPTION
Fix minor grammar mistake in libcurl docs