### PR TITLE
curl: do NOT append file name to path for upload when there's a query

### DIFF
--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -95,6 +95,7 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
   CURLUcode uerr;
   CURLU *uh = curl_url();
   char *path = NULL;
+  char *query = NULL;
   if(uh) {
     char *ptr;
     uerr = curl_url_set(uh, CURLUPART_URL, *inurlp,
@@ -108,7 +109,13 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
       result = urlerr_cvt(uerr);
       goto fail;
     }
-
+    uerr = curl_url_get(uh, CURLUPART_QUERY, &query, 0);
+    if(query) {
+      curl_free(query);
+      curl_free(path);
+      curl_url_cleanup(uh);
+      return CURLE_OK;
+    }
     ptr = strrchr(path, '/');
     if(!ptr || !*++ptr) {
       /* The URL path has no file name part, add the local file name. In order

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -68,7 +68,7 @@ test380 test381 test383 test384 test385 test386 test387 test388 test389 \
 test390 test391 test392 test393 test394 test395 test396 test397 test398 \
 test399 test400 test401 test402 test403 test404 test405 test406 test407 \
 test408 test409 test410 test411 test412 test413 test414 test415 test416 \
-test417 test418 test419 test420 test421 test422 test423 test424 \
+test417 test418 test419 test420 test421 test422 test423 test424 test425 \
 \
 test430 test431 test432 test433 test434 test435 test436 \
 \

--- a/tests/data/test425
+++ b/tests/data/test425
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP PUT
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP PUT with path ending with slash + query
+ </name>
+ <command>
+-T log/up%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER/?fullpath
+</command>
+<file name="log/up%TESTNUMBER">
+content
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+PUT /%TESTNUMBER/?fullpath HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 8
+
+content
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Added test 425 to verify.

Reported-by: Dirk Rosenkranz
Bug: https://curl.se/mail/archive-2023-04/0008.html