### PR TITLE
cf-socket: turn off IPV6_V6ONLY on Windows if it is supported

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -84,14 +84,16 @@
 /* It makes support for IPv4-mapped IPv6 addresses.
  * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
  * Windows Vista and later: default is on;
- * DragonFly BSD: off and dummy setting;
- * OpenBSD and previous Windows: unsupported.
+ * DragonFly BSD: acts like off, and dummy setting;
+ * OpenBSD and earlier Windows: unsupported.
  * Linux: controlled by /proc/sys/net/ipv6/bindv6only.
  */
 static void set_ipv6_v6only(curl_socket_t sockfd, int on)
 {
   (void)setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&on, sizeof(on));
 }
+#else
+#define set_ipv6_v6only(x,y)
 #endif
 
 static void tcpnodelay(struct Curl_easy *data, curl_socket_t sockfd)
@@ -959,9 +961,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
 
 #ifdef ENABLE_IPV6
   if(ctx->addr.family == AF_INET6) {
-#if defined(IPV6_V6ONLY) && defined(WIN32)
     set_ipv6_v6only(ctx->sock, 0);
-#endif
     ipmsg = "  Trying [%s]:%d...";
   }
   else

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -80,6 +80,20 @@
 #include "memdebug.h"
 
 
+#if defined(ENABLE_IPV6) && defined(IPV6_V6ONLY) && defined(WIN32)
+/* It makes support for IPv4-mapped IPv6 addresses.
+ * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
+ * Windows Vista and later: default is on;
+ * DragonFly BSD: off and dummy setting;
+ * OpenBSD and previous Windows: unsupported.
+ * Linux: controlled by /proc/sys/net/ipv6/bindv6only.
+ */
+static void set_ipv6_v6only(curl_socket_t sockfd, int on)
+{
+  (void)setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&on, sizeof(on));
+}
+#endif
+
 static void tcpnodelay(struct Curl_easy *data, curl_socket_t sockfd)
 {
 #if defined(TCP_NODELAY)
@@ -944,8 +958,12 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     goto out;
 
 #ifdef ENABLE_IPV6
-  if(ctx->addr.family == AF_INET6)
+  if(ctx->addr.family == AF_INET6) {
+#if defined(IPV6_V6ONLY) && defined(WIN32)
+    set_ipv6_v6only(ctx->sock, 0);
+#endif
     ipmsg = "  Trying [%s]:%d...";
+  }
   else
 #endif
     ipmsg = "  Trying %s:%d...";


### PR DESCRIPTION
It makes support for IPv4-mapped IPv6 addresses.

IPV6_V6ONLY refs:
https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses
https://github.com/golang/go/blob/master/src/net/ipsock_posix.go
https://en.wikipedia.org/wiki/Unix-like
off:
https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#proc-sys-net-ipv6-variables
https://man.netbsd.org/inet6.4
https://man.freebsd.org/cgi/man.cgi?query=inet6
https://github.com/apple-oss-distributions/xnu/blob/main/bsd/man/man4/inet6.4
on:
https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options
acts like off, but returns 1 and dummy setting:
https://man.dragonflybsd.org/?command=inet6
https://man.dragonflybsd.org/?command=ip6
unsupported and read-only returns 1:
https://man.openbsd.org/inet6.4

default value refs:
https://datatracker.ietf.org/doc/html/rfc3493#section-5.3
https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#proc-sys-net-ipv6-variables
