### PR TITLE
curl_easy_unescape.3: rename the argument

### DIFF
--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -29,14 +29,14 @@ curl_easy_unescape - URL decodes the given string
 .nf
 #include <curl/curl.h>
 
-char *curl_easy_unescape(CURL *curl, const char *url,
+char *curl_easy_unescape(CURL *curl, const char *input,
                          int inlength, int *outlength);
 .fi
 .SH DESCRIPTION
-This function converts the given URL encoded input string to a "plain string"
-and returns that in an allocated memory area. All input characters that are
-URL encoded (%XX where XX is a two-digit hexadecimal number) are converted to
-their binary versions.
+This function converts the given URL encoded \fBinput\fP string to a "plain
+string" and returns that in an allocated memory area. All input characters
+that are URL encoded (%XX where XX is a two-digit hexadecimal number) are
+converted to their binary versions.
 
 If the \fBlength\fP argument is set to 0 (zero), \fIcurl_easy_unescape(3)\fP
 will use strlen() on the input \fIurl\fP string to find out the size.


### PR DESCRIPTION
and highlight it appropriately in the text.