### PR TITLE
tests/sshserver.pl: Define AddressFamily earlier

### DIFF
--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -725,7 +725,7 @@ push @cfgarr, '#';
 #
 if(sshd_supports_opt('AddressFamily','any')) {
     # Address family must be specified before ListenAddress
-    splice @cfgarr, 14, 0, 'AddressFamily any';
+    splice @cfgarr, 11, 0, 'AddressFamily any';
 }
 if(sshd_supports_opt('Compression','no')) {
     push @cfgarr, 'Compression no';


### PR DESCRIPTION
As the comment states "Address family must be specified before ListenAddress", otherwise the tests fail to run `"failed starting SSH server" 52 times (582, 583, 600, 601, 602, 603, 604, 605, 606 and 43 more)`