### PR TITLE
Fix clang uninitialized variable for `struct curltime`

### DIFF
--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -125,9 +125,9 @@ int Curl_socketpair(int domain, int type, int protocol,
   if(socks[1] == CURL_SOCKET_BAD)
     goto error;
   else {
-    // clang msan doesn't like memory reads from
-    // unaligned structures that haven't been fully
-    // initialized, so we use memset here
+    /* clang msan doesn't like memory reads from
+       unaligned structures that haven't been fully
+       initialized, so we use memset here */
     struct curltime check;
     memset(&check, 0, sizeof(check));
     struct curltime start;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -126,7 +126,8 @@ int Curl_socketpair(int domain, int type, int protocol,
     goto error;
   else {
     struct curltime check;
-    struct curltime start = Curl_now();
+    struct curltime start = {};
+    start = Curl_now();
     char *p = (char *)&check;
     size_t s = sizeof(check);
 

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -125,8 +125,13 @@ int Curl_socketpair(int domain, int type, int protocol,
   if(socks[1] == CURL_SOCKET_BAD)
     goto error;
   else {
+    // clang msan doesn't like memory reads from
+    // unaligned structures that haven't been fully
+    // initialized, so we use memset here
     struct curltime check;
-    struct curltime start = {};
+    memset(&check, 0, sizeof(check));
+    struct curltime start;
+    memset(&start, 0, sizeof(start));
     start = Curl_now();
     char *p = (char *)&check;
     size_t s = sizeof(check);


### PR DESCRIPTION
When compiling with clang-15 memory sanitizer:

```
Uninitialized value was created by an allocation of 'start' in the stack frame of function 'Curl_socketpair'
```

Maybe the special handling of returning a struct from a function uses the uninitialized reference to `curltime` as initializing it to zeros (by `{}`) prior to Curl_now() avoids the uninitialized value error.