### PR TITLE
Set drain and expire transfer in HTTP/2 that is unpaused

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2229,6 +2229,10 @@ static CURLcode http2_data_pause(struct Curl_cfilter *cf,
     if(result)
       return result;
 
+    if(!pause) {
+      drain_this(cf, data);
+      Curl_expire(data, 0, EXPIRE_RUN_NOW);
+    }
     DEBUGF(infof(data, "Set HTTP/2 window size to %u for stream %u",
                  window, stream->id));
 


### PR DESCRIPTION
- #10988 reports transfer stalling when pausing/unpausing
- if the servers send window is exhausted before the pause, it will not send more on unpausing until the transfer consumes its data.
- make sure unpaused transfers get drained and expire, so any data already buffered will be processed. Which triggers a WINDOW_UPDATE to the server and it will start sending again.