### PR TITLE
Replacing the `state.drain` counter with `state.dselect_bits`

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1319,6 +1319,8 @@ struct UrlState {
   char *scratch; /* huge buffer[set.buffer_size*2] for upload CRLF replacing */
   long followlocation; /* redirect counter */
   int requests; /* request counter: redirects + authentication retakes */
+  int dselect_bits; /* != 0 -> bitmask of socket events for this transfer
+                     * overriding anything the socket may report */
 #ifdef HAVE_SIGNAL
   /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
   void (*prev_signal)(int sig);
@@ -1374,9 +1376,6 @@ struct UrlState {
   curl_off_t infilesize; /* size of file to upload, -1 means unknown.
                             Copied from set.filesize at start of operation */
 #if defined(USE_HTTP2) || defined(USE_HTTP3)
-  size_t drain; /* Increased when this stream has data to read, even if its
-                   socket is not necessarily is readable. Decreased when
-                   checked. */
   struct Curl_data_priority priority; /* shallow copy of data->set */
 #endif
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -299,11 +299,18 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 }
 
-static void notify_drain(struct Curl_cfilter *cf, struct Curl_easy *data)
+static void drain_stream(struct Curl_cfilter *cf,
+                         struct Curl_easy *data)
 {
+  struct stream_ctx *stream = H3_STREAM_CTX(data);
+  int bits;
+
   (void)cf;
-  if(!data->state.drain) {
-    data->state.drain = 1;
+  bits = CURL_CSELECT_IN;
+  if(stream && !stream->upload_done)
+    bits |= CURL_CSELECT_OUT;
+  if(data->state.dselect_bits != bits) {
+    data->state.dselect_bits = bits;
     Curl_expire(data, 0, EXPIRE_RUN_NOW);
   }
 }
@@ -573,9 +580,7 @@ static CURLcode cf_poll_events(struct Curl_cfilter *cf,
     }
     else {
       result = h3_process_event(cf, sdata, stream3_id, ev);
-      if(sdata != data) {
-        notify_drain(cf, sdata);
-      }
+      drain_stream(cf, sdata);
       if(result) {
         DEBUGF(LOG_CF(data, cf, "[h3sid=%"PRId64"] error processing event %s "
                       "for [h3sid=%"PRId64"] -> %d",
@@ -842,13 +847,18 @@ static ssize_t cf_quiche_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
   if(nread > 0) {
-    data->state.drain = (!Curl_bufq_is_empty(&stream->recvbuf) ||
-                         stream->closed);
+    if(stream->closed)
+      drain_stream(cf, data);
   }
   else {
-    data->state.drain = FALSE;
     if(stream->closed) {
       nread = recv_closed_stream(cf, data, err);
+      goto out;
+    }
+    else if(quiche_conn_is_draining(ctx->qconn)) {
+      failf(data, "QUIC connection is draining");
+      *err = CURLE_HTTP3;
+      nread = -1;
       goto out;
     }
     *err = CURLE_AGAIN;
@@ -1059,24 +1069,9 @@ static bool stream_is_writeable(struct Curl_cfilter *cf,
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
   struct stream_ctx *stream = H3_STREAM_CTX(data);
-  quiche_stream_iter *qiter;
-  bool is_writable = FALSE;
 
-  if(!stream)
-    return FALSE;
-  /* surely, there must be a better way */
-  qiter = quiche_conn_writable(ctx->qconn);
-  if(qiter) {
-    uint64_t stream_id;
-    while(quiche_stream_iter_next(qiter, &stream_id)) {
-      if(stream_id == (uint64_t)stream->id) {
-        is_writable = TRUE;
-        break;
-      }
-    }
-    quiche_stream_iter_free(qiter);
-  }
-  return is_writable;
+  return stream &&
+         quiche_conn_stream_writable(ctx->qconn, (uint64_t)stream->id, 1);
 }
 
 static int cf_quiche_get_select_socks(struct Curl_cfilter *cf,
@@ -1146,7 +1141,8 @@ static CURLcode cf_quiche_data_event(struct Curl_cfilter *cf,
   }
   case CF_CTRL_DATA_IDLE:
     result = cf_flush_egress(cf, data);
-    DEBUGF(LOG_CF(data, cf, "data idle, flush egress -> %d", result));
+    if(result)
+      DEBUGF(LOG_CF(data, cf, "data idle, flush egress -> %d", result));
     break;
   default:
     break;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -398,7 +398,6 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
       ;
     if(nread == -1) {
       if(SOCKERRNO == EAGAIN || SOCKERRNO == EWOULDBLOCK) {
-        DEBUGF(LOG_CF(data, cf, "ingress, recvmsg -> EAGAIN"));
         goto out;
       }
       if(!cf->connected && SOCKERRNO == ECONNREFUSED) {

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -89,6 +89,6 @@ class TestErrors:
         assert len(r.stats) == count, f'did not get all stats: {r}'
         invalid_stats = []
         for idx, s in enumerate(r.stats):
-            if 'exitcode' not in s or s['exitcode'] not in [18, 56, 92, 95]:
+            if 'exitcode' not in s or s['exitcode'] not in [18, 55, 56, 92, 95]:
                 invalid_stats.append(f'request {idx} exit with {s["exitcode"]}\n{s}')
         assert len(invalid_stats) == 0, f'failed: {invalid_stats}'


### PR DESCRIPTION
- `drain` was used by http/2 and http/3 implementations to indicate that the transfer requires send/recv independant from its socket poll state. Intended as a counter, it was used as bool flag only.
- a similar mechanism exists on `connectdata->cselect_bits` where specific protocols can indicate something similar, only for the whole connection.
- `cselect_bits` are cleard in transfer.c on use and, importantly, also set when the transfer loop expended its `maxloops` tries. `drain` was not cleared by transfer and the http2/3 implementations had to take care of that.
- `dselect_bits` is cleared *and* set by the transfer loop. http2/3 does no longer clear it, only set when new events happen.

This PR unifies the handling of socket poll overrides, extending `cselect_bits` by a easy handle specific value and a common treatment in transfers.