### PR TITLE
http tests using libcurl, urlparser addition, h2 push, pausing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -288,7 +288,6 @@ jobs:
     - if: ${{ contains(matrix.build.install_steps, 'pytest') }}
       run: |
         sudo apt-get install apache2 apache2-dev libnghttp2-dev
-        sudo python3 -m pip install impacket pytest cryptography multipart
         git clone --quiet --depth=1 -b master https://github.com/icing/mod_h2
         cd mod_h2
         autoreconf -fi
@@ -296,6 +295,10 @@ jobs:
         make
         sudo make install
       name: 'install pytest and apach2-dev mod-h2'
+
+    - run: |
+        sudo python3 -m pip install -r tests/requirements.txt -r tests/http/requirements.txt
+      name: 'install python test prereqs'
 
     - run: autoreconf -fi
       name: 'autoreconf'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -288,6 +288,7 @@ jobs:
     - if: ${{ contains(matrix.build.install_steps, 'pytest') }}
       run: |
         sudo apt-get install apache2 apache2-dev libnghttp2-dev
+        sudo python3 -m pip install -r tests/http/requirements.txt
         git clone --quiet --depth=1 -b master https://github.com/icing/mod_h2
         cd mod_h2
         autoreconf -fi
@@ -295,10 +296,6 @@ jobs:
         make
         sudo make install
       name: 'install pytest and apach2-dev mod-h2'
-
-    - run: |
-        sudo python3 -m pip install -r tests/requirements.txt -r tests/http/requirements.txt
-      name: 'install python test prereqs'
 
     - run: autoreconf -fi
       name: 'autoreconf'

--- a/.github/workflows/ngtcp2-gnutls.yml
+++ b/.github/workflows/ngtcp2-gnutls.yml
@@ -75,7 +75,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install }}
         sudo apt-get install apache2 apache2-dev
-        sudo python3 -m pip install impacket pytest cryptography multipart
       name: 'install prereqs and impacket, pytest, crypto'
 
     - run: |
@@ -135,6 +134,10 @@ jobs:
       name: 'install mod_h2'
 
     - uses: actions/checkout@v3
+
+    - run: |
+        sudo python3 -m pip install -r tests/requirements.txt -r tests/http/requirements.txt
+      name: 'install python test prereqs'
 
     - run: autoreconf -fi
       name: 'autoreconf'

--- a/.github/workflows/ngtcp2-quictls.yml
+++ b/.github/workflows/ngtcp2-quictls.yml
@@ -66,7 +66,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install }}
         sudo apt-get install apache2 apache2-dev
-        sudo python3 -m pip install impacket pytest cryptography multipart
       name: 'install prereqs and impacket, pytest, crypto'
 
     - run: |
@@ -110,6 +109,10 @@ jobs:
       name: 'install mod_h2'
 
     - uses: actions/checkout@v3
+
+    - run: |
+        sudo python3 -m pip install -r tests/requirements.txt -r tests/http/requirements.txt
+      name: 'install python test prereqs'
 
     - run: autoreconf -fi
       name: 'autoreconf'

--- a/.github/workflows/ngtcp2-wolfssl.yml
+++ b/.github/workflows/ngtcp2-wolfssl.yml
@@ -70,8 +70,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install }}
         sudo apt-get install apache2 apache2-dev
-        sudo python3 -m pip install impacket pytest cryptography multipart
-      name: 'install prereqs and impacket, pytest, crypto'
+      name: 'install prereqs'
 
     - run: |
         git clone --quiet --depth=1 https://github.com/wolfSSL/wolfssl.git
@@ -122,6 +121,10 @@ jobs:
       name: 'install mod_h2'
 
     - uses: actions/checkout@v3
+
+    - run: |
+        sudo python3 -m pip install -r tests/requirements.txt -r tests/http/requirements.txt
+      name: 'install python test prereqs'
 
     - run: autoreconf -fi
       name: 'autoreconf'

--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: curl
 
 ignoreRules = [ "DEAD_STORE", "subprocess_without_shell_equals_true" ]
+ignoreFiles = [ "tests/http/**" ]
 build = "make"
 setup = ".lift/setup.sh"

--- a/configure.ac
+++ b/configure.ac
@@ -4693,6 +4693,7 @@ AC_CONFIG_FILES([Makefile \
            tests/unit/Makefile \
            tests/http/config.ini \
            tests/http/Makefile \
+           tests/http/clients/Makefile \
            packages/Makefile \
            packages/vms/Makefile \
            curl-config \

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -28,6 +28,9 @@
 size_t Curl_is_absolute_url(const char *url, char *buf, size_t buflen,
                             bool guess_scheme);
 
+CURLUcode curl_url_set_authority(CURLU *u, const char *authority,
+                                 unsigned int flags);
+
 #ifdef DEBUGBUILD
 CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
                           bool has_scheme);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -120,6 +120,7 @@ checksrc:
 	cd libtest && $(MAKE) checksrc
 	cd unit && $(MAKE) checksrc
 	cd server && $(MAKE) checksrc
+	cd http && $(MAKE) checksrc
 
 if CURLDEBUG
 # for debug builds, we scan the sources on all regular make invokes

--- a/tests/http/Makefile.am
+++ b/tests/http/Makefile.am
@@ -22,6 +22,16 @@
 #
 ###########################################################################
 
+SUBDIRS = clients
+
 clean-local:
 	rm -rf *.pyc __pycache__
 	rm -rf gen
+
+check: clients
+
+clients:
+	@(cd clients; $(MAKE) check)
+
+checksrc:
+	cd clients && $(MAKE) checksrc

--- a/tests/http/clients/.gitignore
+++ b/tests/http/clients/.gitignore
@@ -1,0 +1,8 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+h2-serverpush
+h2-download
+ws-data
+ws-pingpong

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -1,0 +1,71 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+AUTOMAKE_OPTIONS = foreign nostdinc
+
+
+# Specify our include paths here, and do it relative to $(top_srcdir) and
+# $(top_builddir), to ensure that these paths which belong to the library
+# being currently built and tested are searched before the library which
+# might possibly already be installed in the system.
+#
+# $(top_srcdir)/include is for libcurl's external include files
+
+AM_CPPFLAGS = -I$(top_srcdir)/include   \
+              -DCURL_DISABLE_DEPRECATION
+
+LIBDIR = $(top_builddir)/lib
+
+# Avoid libcurl obsolete stuff
+AM_CPPFLAGS += -DCURL_NO_OLDIES
+
+if USE_CPPFLAG_CURL_STATICLIB
+AM_CPPFLAGS += -DCURL_STATICLIB
+endif
+
+# Prevent LIBS from being used for all link targets
+LIBS = $(BLANK_AT_MAKETIME)
+
+# Dependencies
+if USE_EXPLICIT_LIB_DEPS
+LDADD = $(LIBDIR)/libcurl.la @LIBCURL_LIBS@
+else
+LDADD = $(LIBDIR)/libcurl.la
+endif
+
+# This might hold -Werror
+CFLAGS += @CURL_CFLAG_EXTRAS@
+
+# Makefile.inc provides the check_PROGRAMS and COMPLICATED_EXAMPLES defines
+include Makefile.inc
+
+all: $(check_PROGRAMS)
+
+CHECKSRC = $(CS_$(V))
+CS_0 = @echo "  RUN     " $@;
+CS_1 =
+CS_ = $(CS_0)
+
+checksrc:
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) $(srcdir)/*.c)

--- a/tests/http/clients/Makefile.inc
+++ b/tests/http/clients/Makefile.inc
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #***************************************************************************
 #                                  _   _ ____  _
 #  Project                     ___| | | |  _ \| |
@@ -23,16 +21,10 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-#
-import pytest
-pytest.register_assert_rewrite("testenv.env", "testenv.curl", "testenv.caddy",
-                               "testenv.httpd", "testenv.nghttpx")
 
-from .env import Env
-from .certs import TestCA, Credentials
-from .caddy import Caddy
-from .httpd import Httpd
-from .curl import CurlClient, ExecResult
-from .client import LocalClient
-from .nghttpx import Nghttpx
-from .nghttpx import Nghttpx, NghttpxQuic, NghttpxFwd
+# These are all libcurl example programs to be test compiled
+check_PROGRAMS = \
+  h2-serverpush \
+  h2-download \
+  ws-data \
+  ws-pingpong

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -1,0 +1,275 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* <DESC>
+ * HTTP/2 server push
+ * </DESC>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* somewhat unix-specific */
+#include <sys/time.h>
+#include <unistd.h>
+
+/* curl stuff */
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
+#ifndef CURLPIPE_MULTIPLEX
+#error "too old libcurl, cannot do HTTP/2 server push!"
+#endif
+
+static int verbose = 1;
+
+static
+int my_trace(CURL *handle, curl_infotype type,
+             char *data, size_t size,
+             void *userp)
+{
+  const char *text;
+  (void)handle; /* prevent compiler warning */
+  (void)userp;
+
+  switch(type) {
+  case CURLINFO_TEXT:
+    fprintf(stderr, "== Info: %s", data);
+    /* FALLTHROUGH */
+  default: /* in case a new one is introduced to shock us */
+    return 0;
+
+  case CURLINFO_HEADER_OUT:
+    text = "=> Send header";
+    break;
+  case CURLINFO_DATA_OUT:
+    if(verbose <= 1)
+      return 0;
+    text = "=> Send data";
+    break;
+  case CURLINFO_HEADER_IN:
+    text = "<= Recv header";
+    break;
+  case CURLINFO_DATA_IN:
+    if(verbose <= 1)
+      return 0;
+    text = "<= Recv data";
+    break;
+  }
+
+  fprintf(stderr, "%s, %lu bytes (0x%lx)\n",
+          text, (unsigned long)size, (unsigned long)size);
+  return 0;
+}
+
+struct transfer {
+  int idx;
+  CURL *easy;
+  char filename[128];
+  FILE *out;
+  curl_off_t recv_size;
+  curl_off_t pause_at;
+  int paused;
+  int resumed;
+  int done;
+};
+
+static size_t transfer_count;
+static struct transfer *transfers;
+
+static struct transfer *get_transfer_for_easy(CURL *easy)
+{
+  size_t i;
+  for(i = 0; i < transfer_count; ++i) {
+    if(easy == transfers[i].easy)
+      return &transfers[i];
+  }
+  return NULL;
+}
+
+static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
+                          void *userdata)
+{
+  struct transfer *t = userdata;
+  ssize_t nwritten;
+
+  if(!t->resumed &&
+     t->recv_size < t->pause_at &&
+     ((curl_off_t)(t->recv_size + (nitems * buflen)) >= t->pause_at)) {
+    fprintf(stderr, "transfer %d: PAUSE\n", t->idx);
+    t->paused = 1;
+    return CURL_WRITEFUNC_PAUSE;
+  }
+
+  if(!t->out) {
+    curl_msnprintf(t->filename, sizeof(t->filename)-1, "download_%u.data",
+                   t->idx);
+    t->out = fopen(t->filename, "wb");
+    if(!t->out)
+      return 0;
+  }
+
+  nwritten = fwrite(buf, nitems, buflen, t->out);
+  if(nwritten < 0) {
+    fprintf(stderr, "transfer %d: write failure\n", t->idx);
+    return 0;
+  }
+  t->recv_size += nwritten;
+  return (size_t)nwritten;
+}
+
+static int setup(CURL *hnd, const char *url, struct transfer *t)
+{
+  curl_easy_setopt(hnd, CURLOPT_URL, url);
+  curl_easy_setopt(hnd, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+  curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
+  curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYHOST, 0L);
+
+  curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, my_write_cb);
+  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, t);
+
+  /* please be verbose */
+  if(verbose) {
+    curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(hnd, CURLOPT_DEBUGFUNCTION, my_trace);
+  }
+
+#if (CURLPIPE_MULTIPLEX > 0)
+  /* wait for pipe connection to confirm */
+  curl_easy_setopt(hnd, CURLOPT_PIPEWAIT, 1L);
+#endif
+  return 0; /* all is good */
+}
+
+/*
+ * Download a file over HTTP/2, take care of server push.
+ */
+int main(int argc, char *argv[])
+{
+  CURLM *multi_handle;
+  int active_transfers;
+  struct CURLMsg *m;
+  const char *url;
+  size_t i;
+  long pause_offset;
+  struct transfer *t;
+
+  if(argc != 4) {
+    fprintf(stderr, "usage: h2-download count pause-offset url\n");
+    return 2;
+  }
+
+  transfer_count = (size_t)strtol(argv[1], NULL, 10);
+  pause_offset = strtol(argv[2], NULL, 10);
+  url = argv[3];
+
+  transfers = calloc(transfer_count, sizeof(*transfers));
+  if(!transfers) {
+    fprintf(stderr, "error allocating transfer structs\n");
+    return 1;
+  }
+
+  multi_handle = curl_multi_init();
+  curl_multi_setopt(multi_handle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
+
+  active_transfers = 0;
+  for(i = 0; i < transfer_count; ++i) {
+    t = &transfers[i];
+    t->idx = (int)i;
+    t->pause_at = (curl_off_t)pause_offset * i;
+    t->easy = curl_easy_init();
+    if(!t->easy || setup(t->easy, url, t)) {
+      fprintf(stderr, "setup of transfer #%d failed\n", (int)i);
+      return 1;
+    }
+    curl_multi_add_handle(multi_handle, t->easy);
+    ++active_transfers;
+  }
+
+  do {
+    int still_running; /* keep number of running handles */
+    CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
+
+    if(still_running) {
+      /* wait for activity, timeout or "nothing" */
+      mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+      fprintf(stderr, "curl_multi_poll() -> %d\n", mc);
+    }
+
+    if(mc)
+      break;
+
+    /*
+     * A little caution when doing server push is that libcurl itself has
+     * created and added one or more easy handles but we need to clean them up
+     * when we are done.
+     */
+    do {
+      int msgq = 0;
+      m = curl_multi_info_read(multi_handle, &msgq);
+      if(m && (m->msg == CURLMSG_DONE)) {
+        CURL *e = m->easy_handle;
+        active_transfers--;
+        curl_multi_remove_handle(multi_handle, e);
+        t = get_transfer_for_easy(e);
+        if(t) {
+          t->done = 1;
+        }
+        else
+          curl_easy_cleanup(e);
+      }
+      else {
+        /* nothing happending, resume one paused transfer if there is one */
+        for(i = 0; i < transfer_count; ++i) {
+          t = &transfers[i];
+          if(!t->done && t->paused) {
+            t->resumed = 1;
+            t->paused = 0;
+            curl_easy_pause(t->easy, CURLPAUSE_CONT);
+            fprintf(stderr, "transfer %d: RESUME\n", t->idx);
+            break;
+          }
+        }
+
+      }
+    } while(m);
+
+  } while(active_transfers); /* as long as we have transfers going */
+
+  for(i = 0; i < transfer_count; ++i) {
+    t = &transfers[i];
+    if(t->out) {
+      fclose(t->out);
+      t->out = NULL;
+    }
+    if(t->easy) {
+      curl_easy_cleanup(t->easy);
+      t->easy = NULL;
+    }
+  }
+  free(transfers);
+
+  curl_multi_cleanup(multi_handle);
+
+  return 0;
+}

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -126,8 +126,8 @@ static CURLcode recv_binary(CURL *curl, char *exp_data, size_t exp_len)
       return CURLE_RECV_ERROR;
     }
     if(frame->offset != (curl_off_t)r_offset) {
-      fprintf(stderr, "recv_data: frame offset, expected %ld, got %zu\n",
-              (long)r_offset, frame->offset);
+      fprintf(stderr, "recv_data: frame offset, expected %ld, got %ld\n",
+              (long)r_offset, (long)frame->offset);
       return CURLE_RECV_ERROR;
     }
     if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
@@ -177,7 +177,7 @@ static CURLcode data_echo(CURL *curl, size_t plen_min, size_t plen_max)
   if(!send_buf)
     return CURLE_OUT_OF_MEMORY;
   for(i = 0; i < plen_max; ++i) {
-    send_buf[i] = '0' + (i % 10);
+    send_buf[i] = '0' + (char)(i % 10);
   }
 
   for(len = plen_min; len <= plen_max; ++len) {

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -1,0 +1,263 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* <DESC>
+ * Websockets data echos
+ * </DESC>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* somewhat unix-specific */
+#include <sys/time.h>
+#include <unistd.h>
+
+
+/* curl stuff */
+#include <curl/curl.h>
+#include "../../../lib/curl_setup.h"
+
+#ifdef USE_WEBSOCKETS
+
+static
+void dump(const char *text, unsigned char *ptr, size_t size,
+          char nohex)
+{
+  size_t i;
+  size_t c;
+
+  unsigned int width = 0x10;
+
+  if(nohex)
+    /* without the hex output, we can fit more on screen */
+    width = 0x40;
+
+  fprintf(stderr, "%s, %lu bytes (0x%lx)\n",
+          text, (unsigned long)size, (unsigned long)size);
+
+  for(i = 0; i<size; i += width) {
+
+    fprintf(stderr, "%4.4lx: ", (unsigned long)i);
+
+    if(!nohex) {
+      /* hex not disabled, show it */
+      for(c = 0; c < width; c++)
+        if(i + c < size)
+          fprintf(stderr, "%02x ", ptr[i + c]);
+        else
+          fputs("   ", stderr);
+    }
+
+    for(c = 0; (c < width) && (i + c < size); c++) {
+      /* check for 0D0A; if found, skip past and start a new line of output */
+      if(nohex && (i + c + 1 < size) && ptr[i + c] == 0x0D &&
+         ptr[i + c + 1] == 0x0A) {
+        i += (c + 2 - width);
+        break;
+      }
+      fprintf(stderr, "%c",
+              (ptr[i + c] >= 0x20) && (ptr[i + c]<0x80)?ptr[i + c]:'.');
+      /* check again for 0D0A, to avoid an extra \n if it's at width */
+      if(nohex && (i + c + 2 < size) && ptr[i + c + 1] == 0x0D &&
+         ptr[i + c + 2] == 0x0A) {
+        i += (c + 3 - width);
+        break;
+      }
+    }
+    fputc('\n', stderr); /* newline */
+  }
+}
+
+static CURLcode send_binary(CURL *curl, char *buf, size_t buflen)
+{
+  size_t nwritten;
+  CURLcode result =
+    curl_ws_send(curl, buf, buflen, &nwritten, 0, CURLWS_BINARY);
+  fprintf(stderr, "ws: send_binary(len=%ld) -> %d, %ld\n",
+          (long)buflen, result, (long)nwritten);
+  return result;
+}
+
+static CURLcode recv_binary(CURL *curl, char *exp_data, size_t exp_len)
+{
+  struct curl_ws_frame *frame;
+  char recvbuf[256];
+  size_t r_offset, nread;
+  CURLcode result;
+
+  fprintf(stderr, "recv_binary: expected payload %ld bytes\n", (long)exp_len);
+  r_offset = 0;
+  while(1) {
+    result = curl_ws_recv(curl, recvbuf, sizeof(recvbuf), &nread, &frame);
+    if(result == CURLE_AGAIN) {
+      fprintf(stderr, "EAGAIN, sleep, try again\n");
+      usleep(100*1000);
+      continue;
+    }
+    fprintf(stderr, "ws: curl_ws_recv(offset=%ld, len=%ld) -> %d, %ld\n",
+            (long)r_offset, (long)sizeof(recvbuf), result, (long)nread);
+    if(result) {
+      return result;
+    }
+    if(!(frame->flags & CURLWS_BINARY)) {
+      fprintf(stderr, "recv_data: wrong frame, got %ld bytes rflags %x\n",
+              (long)nread, frame->flags);
+      return CURLE_RECV_ERROR;
+    }
+    if(frame->offset != (curl_off_t)r_offset) {
+      fprintf(stderr, "recv_data: frame offset, expected %ld, got %zu\n",
+              (long)r_offset, frame->offset);
+      return CURLE_RECV_ERROR;
+    }
+    if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
+      fprintf(stderr, "recv_data: frame bytesleft, expected %ld, got %ld\n",
+              (long)(exp_len - r_offset - nread), (long)frame->bytesleft);
+      return CURLE_RECV_ERROR;
+    }
+    if(r_offset + nread > exp_len) {
+      fprintf(stderr, "recv_data: data length, expected %ld, now at %ld\n",
+              (long)exp_len, (long)(r_offset + nread));
+      return CURLE_RECV_ERROR;
+    }
+    if(memcmp(exp_data + r_offset, recvbuf, nread)) {
+      fprintf(stderr, "recv_data: data differs, offset=%ld, len=%ld\n",
+              (long)r_offset, (long)nread);
+      dump("expected:", (unsigned char *)exp_data + r_offset, nread, 0);
+      dump("received:", (unsigned char *)recvbuf, nread, 0);
+      return CURLE_RECV_ERROR;
+    }
+    r_offset += nread;
+    if(r_offset >= exp_len) {
+      fprintf(stderr, "recv_data: frame complete\n");
+      break;
+    }
+  }
+  return CURLE_OK;
+}
+
+/* just close the connection */
+static void websocket_close(CURL *curl)
+{
+  size_t sent;
+  CURLcode result =
+    curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
+  fprintf(stderr,
+          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+}
+
+static CURLcode data_echo(CURL *curl, size_t plen_min, size_t plen_max)
+{
+  CURLcode res;
+  size_t len;
+  char *send_buf;
+  size_t i;
+
+  send_buf = calloc(1, plen_max);
+  if(!send_buf)
+    return CURLE_OUT_OF_MEMORY;
+  for(i = 0; i < plen_max; ++i) {
+    send_buf[i] = '0' + (i % 10);
+  }
+
+  for(len = plen_min; len <= plen_max; ++len) {
+    res = send_binary(curl, send_buf, len);
+    if(res)
+      goto out;
+    res = recv_binary(curl, send_buf, len);
+    if(res) {
+      fprintf(stderr, "recv_data(len=%ld) -> %d\n", (long)len, res);
+      goto out;
+    }
+  }
+
+out:
+  if(!res)
+    websocket_close(curl);
+  free(send_buf);
+  return res;
+}
+
+#endif
+
+int main(int argc, char *argv[])
+{
+#ifdef USE_WEBSOCKETS
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+  const char *url;
+  curl_off_t l1, l2;
+  size_t plen_min, plen_max;
+
+
+  if(argc != 4) {
+    fprintf(stderr, "usage: ws-data url minlen maxlen\n");
+    return 2;
+  }
+  url = argv[1];
+  l1 = strtol(argv[2], NULL, 10);
+  if(l1 < 0) {
+    fprintf(stderr, "minlen must be >= 0, got %ld\n", (long)l1);
+    return 2;
+  }
+  l2 = strtol(argv[3], NULL, 10);
+  if(l2 < 0) {
+    fprintf(stderr, "maxlen must be >= 0, got %ld\n", (long)l2);
+    return 2;
+  }
+  plen_min = l1;
+  plen_max = l2;
+  if(plen_max < plen_min) {
+    fprintf(stderr, "maxlen must be >= minlen, got %ld-%ld\n",
+            (long)plen_min, (long)plen_max);
+    return 2;
+  }
+
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+
+    /* use the callback style */
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "ws-data");
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
+    res = curl_easy_perform(curl);
+    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    if(res == CURLE_OK)
+      res = data_echo(curl, plen_min, plen_max);
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+  return (int)res;
+
+#else /* USE_WEBSOCKETS */
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "websockets not enabled in libcurl\n");
+  return 1;
+#endif /* !USE_WEBSOCKETS */
+}

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -177,7 +177,7 @@ static CURLcode data_echo(CURL *curl, size_t plen_min, size_t plen_max)
   if(!send_buf)
     return CURLE_OUT_OF_MEMORY;
   for(i = 0; i < plen_max; ++i) {
-    send_buf[i] = '0' + (char)(i % 10);
+    send_buf[i] = (char)('0' + ((int)i % 10));
   }
 
   for(len = plen_min; len <= plen_max; ++len) {

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -59,8 +59,8 @@ static CURLcode recv_pong(CURL *curl, const char *exected_payload)
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(result) {
-    fprintf(stderr, "ws: curl_ws_recv returned %u, received %zu\n",
-            (int)result, rlen);
+    fprintf(stderr, "ws: curl_ws_recv returned %u, received %ld\n",
+            (int)result, (long)rlen);
     return result;
   }
 

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -1,0 +1,158 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* <DESC>
+ * Websockets pingpong
+ * </DESC>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* somewhat unix-specific */
+#include <sys/time.h>
+#include <unistd.h>
+
+
+/* curl stuff */
+#include <curl/curl.h>
+#include "../../../lib/curl_setup.h"
+
+#ifdef USE_WEBSOCKETS
+
+static CURLcode ping(CURL *curl, const char *send_payload)
+{
+  size_t sent;
+  CURLcode result =
+    curl_ws_send(curl, send_payload, strlen(send_payload), &sent, 0,
+                 CURLWS_PING);
+  fprintf(stderr,
+          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+
+  return result;
+}
+
+static CURLcode recv_pong(CURL *curl, const char *exected_payload)
+{
+  size_t rlen;
+  struct curl_ws_frame *meta;
+  char buffer[256];
+  CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
+  if(result) {
+    fprintf(stderr, "ws: curl_ws_recv returned %u, received %zu\n",
+            (int)result, rlen);
+    return result;
+  }
+
+  if(!(meta->flags & CURLWS_PONG)) {
+    fprintf(stderr, "recv_pong: wrong frame, got %d bytes rflags %x\n",
+            (int)rlen, meta->flags);
+    return CURLE_RECV_ERROR;
+  }
+
+  fprintf(stderr, "ws: got PONG back\n");
+  if(rlen == strlen(exected_payload) &&
+     !memcmp(exected_payload, buffer, rlen)) {
+    fprintf(stderr, "ws: got the same payload back\n");
+    return CURLE_OK;
+  }
+  fprintf(stderr, "ws: did NOT get the same payload back\n");
+  return CURLE_RECV_ERROR;
+}
+
+/* just close the connection */
+static void websocket_close(CURL *curl)
+{
+  size_t sent;
+  CURLcode result =
+    curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
+  fprintf(stderr,
+          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+}
+
+static CURLcode pingpong(CURL *curl, const char *payload)
+{
+  CURLcode res;
+  int i;
+
+  res = ping(curl, payload);
+  if(res)
+    return res;
+  for(i = 0; i < 10; ++i) {
+    fprintf(stderr, "Receive pong\n");
+    res = recv_pong(curl, payload);
+    if(res == CURLE_AGAIN) {
+      usleep(100*1000);
+      continue;
+    }
+    websocket_close(curl);
+    return res;
+  }
+  websocket_close(curl);
+  return CURLE_RECV_ERROR;
+}
+
+#endif
+
+int main(int argc, char *argv[])
+{
+#ifdef USE_WEBSOCKETS
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+  const char *url, *payload;
+
+  if(argc != 3) {
+    fprintf(stderr, "usage: ws-pingpong url payload\n");
+    return 2;
+  }
+  url = argv[1];
+  payload = argv[2];
+
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+
+    /* use the callback style */
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "ws-pingpong");
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
+    res = curl_easy_perform(curl);
+    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    if(res == CURLE_OK)
+      res = pingpong(curl, payload);
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+  return (int)res;
+
+#else /* USE_WEBSOCKETS */
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "websockets not enabled in libcurl\n");
+  return 1;
+#endif /* !USE_WEBSOCKETS */
+}

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -46,6 +46,8 @@ def env(pytestconfig) -> Env:
         pytest.skip(env.incomplete_reason())
 
     env.setup()
+    if not env.make_clients():
+        pytest.exit(1)
     return env
 
 @pytest.fixture(scope="package", autouse=True)

--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #***************************************************************************
 #                                  _   _ ____  _
@@ -24,15 +23,7 @@
 #
 ###########################################################################
 #
-import pytest
-pytest.register_assert_rewrite("testenv.env", "testenv.curl", "testenv.caddy",
-                               "testenv.httpd", "testenv.nghttpx")
-
-from .env import Env
-from .certs import TestCA, Credentials
-from .caddy import Caddy
-from .httpd import Httpd
-from .curl import CurlClient, ExecResult
-from .client import LocalClient
-from .nghttpx import Nghttpx
-from .nghttpx import Nghttpx, NghttpxQuic, NghttpxFwd
+pytest
+cryptography
+multipart
+websockets

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -30,7 +30,7 @@ import logging
 import os
 import pytest
 
-from testenv import Env, CurlClient
+from testenv import Env, CurlClient, LocalClient
 
 
 log = logging.getLogger(__name__)
@@ -47,9 +47,12 @@ class TestDownload:
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env, httpd):
-        env.make_data_file(indir=httpd.docs_dir, fname="data-100k", fsize=100*1024)
-        env.make_data_file(indir=httpd.docs_dir, fname="data-1m", fsize=1024*1024)
-        env.make_data_file(indir=httpd.docs_dir, fname="data-10m", fsize=10*1024*1024)
+        indir = httpd.docs_dir
+        env.make_data_file(indir=indir, fname="data-10k", fsize=10*1024)
+        env.make_data_file(indir=indir, fname="data-100k", fsize=100*1024)
+        env.make_data_file(indir=indir, fname="data-1m", fsize=1024*1024)
+        env.make_data_file(indir=indir, fname="data-10m", fsize=10*1024*1024)
+        env.make_data_file(indir=indir, fname="data-50m", fsize=50*1024*1024)
 
     # download 1 file
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
@@ -272,8 +275,29 @@ class TestDownload:
         ])
         r.check_response(count=count, http_status=200)
         srcfile = os.path.join(httpd.docs_dir, 'data-1m')
+        self.check_downloads(curl, srcfile, count)
+        # restore httpd defaults
+        httpd.set_extra_config(env.domain1, lines=None)
+        assert httpd.stop()
+        assert httpd.start()
+
+    # download via lib client, pause/resume at different offsets
+    @pytest.mark.parametrize("pause_offset", [0, 10*1024, 100*1023, 640000])
+    def test_02_21_h2_lib_download(self, env: Env, httpd, nghttpx, pause_offset, repeat):
+        count = 10
+        docname = 'data-10m'
+        url = f'https://localhost:{env.https_port}/{docname}'
+        client = LocalClient(name='h2-download', env=env)
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        r = client.run(args=[str(count), str(pause_offset), url])
+        r.check_exit_code(0)
+        srcfile = os.path.join(httpd.docs_dir, docname)
+        self.check_downloads(client, srcfile, count)
+
+    def check_downloads(self, client, srcfile: str, count: int):
         for i in range(count):
-            dfile = curl.download_file(i)
+            dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if not filecmp.cmp(srcfile, dfile, shallow=False):
                 diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
@@ -282,8 +306,3 @@ class TestDownload:
                                                     tofile=dfile,
                                                     n=1))
                 assert False, f'download {dfile} differs:\n{diff}'
-        # restore httpd defaults
-        httpd.set_extra_config(env.domain1, lines=None)
-        assert httpd.stop()
-        assert httpd.start()
-

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+import logging
+import os
+import shutil
+import subprocess
+import time
+from datetime import datetime, timedelta
+import pytest
+
+from testenv import Env, CurlClient, LocalClient
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(condition=not Env.curl_has_protocol('ws'),
+                    reason='curl lacks ws protocol support')
+class TestWebsockets:
+
+    def check_alive(self, env, timeout=5):
+        curl = CurlClient(env=env)
+        url = f'http://localhost:{env.ws_port}/'
+        end = datetime.now() + timedelta(seconds=timeout)
+        while datetime.now() < end:
+            r = curl.http_download(urls=[url])
+            if r.exit_code == 0:
+                return True
+            time.sleep(.1)
+        return False
+
+    def _mkpath(self, path):
+        if not os.path.exists(path):
+            return os.makedirs(path)
+
+    def _rmrf(self, path):
+        if os.path.exists(path):
+            return shutil.rmtree(path)
+
+    @pytest.fixture(autouse=True, scope='class')
+    def ws_echo(self, env):
+        run_dir = os.path.join(env.gen_dir, 'ws-echo-server')
+        err_file = os.path.join(run_dir, 'stderr')
+        self._rmrf(run_dir)
+        self._mkpath(run_dir)
+
+        with open(err_file, 'w') as cerr:
+            cmd = os.path.join(env.project_dir,
+                               'tests/http/testenv/ws_echo_server.py')
+            args = [cmd, '--port', str(env.ws_port)]
+            p = subprocess.Popen(args=args, cwd=run_dir, stderr=cerr,
+                                 stdout=cerr)
+            assert self.check_alive(env)
+            yield
+            p.terminate()
+
+    def test_20_01_basic(self, env: Env, ws_echo, repeat):
+        curl = CurlClient(env=env)
+        url = f'http://localhost:{env.ws_port}/'
+        r = curl.http_download(urls=[url])
+        r.check_response(http_status=426)
+
+    def test_20_02_pingpong_small(self, env: Env, ws_echo, repeat):
+        payload = 125 * "x"
+        client = LocalClient(env=env, name='ws-pingpong')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        r = client.run(args=[url, payload])
+        r.check_exit_code(0)
+
+    # the python websocket server does not like 'large' control frames
+    def test_20_03_pingpong_too_large(self, env: Env, ws_echo, repeat):
+        payload = 127 * "x"
+        client = LocalClient(env=env, name='ws-pingpong')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        r = client.run(args=[url, payload])
+        r.check_exit_code(56)
+
+    # the python websocket server does not like 'large' control frames
+    def test_20_04_data_small(self, env: Env, ws_echo, repeat):
+        client = LocalClient(env=env, name='ws-data')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        r = client.run(args=[url, str(0), str(10)])
+        r.check_exit_code(0)
+
+    # the python websocket server does not like 'large' control frames
+    def test_20_05_data_med(self, env: Env, ws_echo, repeat):
+        client = LocalClient(env=env, name='ws-data')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        r = client.run(args=[url, str(120), str(130)])
+        r.check_exit_code(0)
+
+    # the python websocket server does not like 'large' control frames
+    def test_20_06_data_large(self, env: Env, ws_echo, repeat):
+        client = LocalClient(env=env, name='ws-data')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        r = client.run(args=[url, str(65535 - 5), str(65535 + 5)])
+        r.check_exit_code(0)

--- a/tests/http/testenv/client.py
+++ b/tests/http/testenv/client.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+import pytest
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from datetime import timedelta, datetime
+from typing import List, Optional, Dict, Union
+from urllib.parse import urlparse
+
+from . import ExecResult
+from .env import Env
+
+
+log = logging.getLogger(__name__)
+
+
+class LocalClient:
+
+    def __init__(self, name: str, env: Env, run_dir: Optional[str] = None,
+                 timeout: Optional[float] = None):
+        self.name = name
+        self.path = os.path.join(env.project_dir, f'tests/http/clients/{name}')
+        self.env = env
+        self._timeout = timeout if timeout else env.test_timeout
+        self._curl = os.environ['CURL'] if 'CURL' in os.environ else env.curl
+        self._run_dir = run_dir if run_dir else os.path.join(env.gen_dir, name)
+        self._stdoutfile = f'{self._run_dir}/stdout'
+        self._stderrfile = f'{self._run_dir}/stderr'
+        self._rmrf(self._run_dir)
+        self._mkpath(self._run_dir)
+
+    @property
+    def run_dir(self) -> str:
+        return self._run_dir
+
+    def exists(self) -> bool:
+        return os.path.exists(self.path)
+
+    def download_file(self, i: int) -> str:
+        return os.path.join(self._run_dir, f'download_{i}.data')
+
+    def _rmf(self, path):
+        if os.path.exists(path):
+            return os.remove(path)
+
+    def _rmrf(self, path):
+        if os.path.exists(path):
+            return shutil.rmtree(path)
+
+    def _mkpath(self, path):
+        if not os.path.exists(path):
+            return os.makedirs(path)
+
+    def run(self, args):
+        self._rmf(self._stdoutfile)
+        self._rmf(self._stderrfile)
+        start = datetime.now()
+        exception = None
+        myargs = [self.path]
+        myargs.extend(args)
+        try:
+            with open(self._stdoutfile, 'w') as cout:
+                with open(self._stderrfile, 'w') as cerr:
+                    p = subprocess.run(myargs, stderr=cerr, stdout=cout,
+                                       cwd=self._run_dir, shell=False,
+                                       input=None,
+                                       timeout=self._timeout)
+                    exitcode = p.returncode
+        except subprocess.TimeoutExpired:
+            log.warning(f'Timeout after {self._timeout}s: {args}')
+            exitcode = -1
+            exception = 'TimeoutExpired'
+        coutput = open(self._stdoutfile).readlines()
+        cerrput = open(self._stderrfile).readlines()
+        return ExecResult(args=myargs, exit_code=exitcode, exception=exception,
+                          stdout=coutput, stderr=cerrput,
+                          duration=datetime.now() - start)

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -260,6 +260,7 @@ class Httpd:
             conf.extend([  # https host for domain1, h1 + h2
                 f'<VirtualHost *:{self.env.https_port}>',
                 f'    ServerName {domain1}',
+                f'    ServerAlias localhost',
                 f'    Protocols h2 http/1.1',
                 f'    SSLEngine on',
                 f'    SSLCertificateFile {creds1.cert_file}',

--- a/tests/http/testenv/ws_echo_server.py
+++ b/tests/http/testenv/ws_echo_server.py
@@ -24,15 +24,43 @@
 #
 ###########################################################################
 #
-import pytest
-pytest.register_assert_rewrite("testenv.env", "testenv.curl", "testenv.caddy",
-                               "testenv.httpd", "testenv.nghttpx")
+import argparse
+import asyncio
+import logging
+from asyncio import IncompleteReadError
 
-from .env import Env
-from .certs import TestCA, Credentials
-from .caddy import Caddy
-from .httpd import Httpd
-from .curl import CurlClient, ExecResult
-from .client import LocalClient
-from .nghttpx import Nghttpx
-from .nghttpx import Nghttpx, NghttpxQuic, NghttpxFwd
+from websockets import server
+from websockets.exceptions import ConnectionClosedError
+
+
+async def echo(websocket):
+    try:
+        async for message in websocket:
+            await websocket.send(message)
+    except ConnectionClosedError:
+        pass
+
+
+async def run_server(port):
+    async with server.serve(echo, "localhost", port):
+        await asyncio.Future()  # run forever
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='scorecard', description="""
+        Run a websocket echo server.
+        """)
+    parser.add_argument("--port", type=int,
+                        default=9876, help="port to listen on")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s %(message)s",
+        level=logging.DEBUG,
+    )
+
+    asyncio.run(run_server(args.port))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #***************************************************************************
 #                                  _   _ ____  _
@@ -24,15 +23,4 @@
 #
 ###########################################################################
 #
-import pytest
-pytest.register_assert_rewrite("testenv.env", "testenv.curl", "testenv.caddy",
-                               "testenv.httpd", "testenv.nghttpx")
-
-from .env import Env
-from .certs import TestCA, Credentials
-from .caddy import Caddy
-from .httpd import Httpd
-from .curl import CurlClient, ExecResult
-from .client import LocalClient
-from .nghttpx import Nghttpx
-from .nghttpx import Nghttpx, NghttpxQuic, NghttpxFwd
+impacket


### PR DESCRIPTION
* adding `tests/http/clients` with specific clients using `libcurl`. these clients are built when you run `pytest`
* adding client `h2-serverpush` to test HTTP/2 PUSH feature
* adding internal method `curl_url_set_authority()` to process the `:authority` header of a PUSH_PROMISE
* adding `test_09_02` to verify PUSH handling
* adding client `h2-download` to verify parallel downloads via `libcurl` and with the possibility to pause/unpause transfers
* adding `test_02_21` to verify lib downloads and pausing behaviour 

Based on top of the #11005 changes.