### PR TITLE
runtests: refactor the main test loop into two

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,7 +27,7 @@ PDFPAGES = testcurl.pdf runtests.pdf
 MANDISTPAGES = runtests.1.dist testcurl.1.dist
 
 EXTRA_DIST = appveyor.pm azure.pm badsymbols.pl check-deprecated.pl CMakeLists.txt \
- dictserver.py directories.pm disable-scan.pl error-codes.pl extern-scan.pl FILEFORMAT.md \
+ devtest.pl dictserver.py directories.pm disable-scan.pl error-codes.pl extern-scan.pl FILEFORMAT.md \
  processhelp.pm ftpserver.pl getpart.pm globalconfig.pm http-server.pl http2-server.pl \
  http3-server.pl manpage-scan.pl manpage-syntax.pl markdown-uppercase.pl mem-include-scan.pl \
  memanalyze.pl negtelnetserver.py nroff-scan.pl option-check.pl options-scan.pl \

--- a/tests/devtest.pl
+++ b/tests/devtest.pl
@@ -1,0 +1,193 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Fandrich, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# This script is intended for developers to test some internals of the
+# runtests.pl harneess. Don't try to use this unless you know what you're
+# doing!
+
+# An example command-line that starts a test http server for test 11 and waits
+# for the user before stopping it:
+#   ./devtest.pl --verbose serverfortest https echo "Started https" protoport https preprocess 11 pause echo Stopping stopservers echo Done
+# curl can connect to the server while it's running like this:
+#   curl -vkL https://localhost:<protoport>/11
+
+use strict;
+use warnings;
+use 5.006;
+
+BEGIN {
+    # Define srcdir to the location of the tests source directory. This is
+    # usually set by the Makefile, but for out-of-tree builds with direct
+    # invocation of runtests.pl, it may not be set.
+    if(!defined $ENV{'srcdir'}) {
+        use File::Basename;
+        $ENV{'srcdir'} = dirname(__FILE__);
+    }
+    push(@INC, $ENV{'srcdir'});
+}
+
+use globalconfig;
+use servers;
+use runner qw(
+    readtestkeywords
+    singletest_preprocess
+);
+use getpart;
+
+
+#######################################################################
+# logmsg is our general message logging subroutine.
+# This function is currently required to be here by servers.pm
+# This is copied from runtests.pl
+#
+my $uname_release = `uname -r`;
+my $is_wsl = $uname_release =~ /Microsoft$/;
+sub logmsg {
+    for(@_) {
+        my $line = $_;
+        if ($is_wsl) {
+            # use \r\n for WSL shell
+            $line =~ s/\r?\n$/\r\n/g;
+        }
+        print "$line";
+    }
+}
+
+#######################################################################
+# Parse and store the protocols in curl's Protocols: line
+# This is copied from runtests.pl
+#
+sub parseprotocols {
+    my ($line)=@_;
+
+    @protocols = split(' ', lc($line));
+
+    # Generate a "proto-ipv6" version of each protocol to match the
+    # IPv6 <server> name and a "proto-unix" to match the variant which
+    # uses Unix domain sockets. This works even if support isn't
+    # compiled in because the <features> test will fail.
+    push @protocols, map(("$_-ipv6", "$_-unix"), @protocols);
+
+    # 'http-proxy' is used in test cases to do CONNECT through
+    push @protocols, 'http-proxy';
+
+    # 'none' is used in test cases to mean no server
+    push @protocols, 'none';
+}
+
+
+#######################################################################
+# Initialize @protocols from the curl binary under test
+#
+sub init_protocols {
+    for (`$CURL -V 2>/dev/null`) {
+        if(m/^Protocols: (.*)$/) {
+            parseprotocols($1);
+        }
+    }
+}
+
+
+#######################################################################
+# Initialize the test harness to run tests
+#
+sub init_tests {
+    init_protocols();
+    initserverconfig();
+}
+
+#######################################################################
+# Main test loop
+
+init_tests();
+
+#***************************************************************************
+# Parse command-line options and commands
+#
+while(@ARGV) {
+    if($ARGV[0] eq "-h") {
+        print "Usage: devtest.pl [--verbose] [command [arg]...]\n";
+        print "command is one of:\n";
+        print "  echo X\n";
+        print "  pause\n";
+        print "  preprocess\n";
+        print "  protocols *|X[,Y...]\n";
+        print "  protoport X\n";
+        print "  serverfortest X[,Y...]\n";
+        print "  stopservers\n";
+        print "  sleep N\n";
+        exit 0;
+    }
+    elsif($ARGV[0] eq "--verbose") {
+        $verbose = 1;
+    }
+    elsif($ARGV[0] eq "sleep") {
+        shift @ARGV;
+        sleep $ARGV[0];
+    }
+    elsif($ARGV[0] eq "echo") {
+        shift @ARGV;
+        print $ARGV[0] . "\n";
+    }
+    elsif($ARGV[0] eq "pause") {
+        print "Press Enter to continue: ";
+        readline STDIN;
+    }
+    elsif($ARGV[0] eq "protocols") {
+        shift @ARGV;
+        if($ARGV[0] eq "*") {
+            init_protocols();
+        }
+        else {
+            @protocols = split(",", $ARGV[0]);
+        }
+        print "Set " . scalar @protocols . " protocols\n";
+    }
+    elsif($ARGV[0] eq "preprocess") {
+        shift @ARGV;
+        loadtest("${TESTDIR}/test${ARGV[0]}");
+        readtestkeywords();
+        singletest_preprocess($ARGV[0]);
+    }
+    elsif($ARGV[0] eq "protoport") {
+        shift @ARGV;
+        my $port = protoport($ARGV[0]);
+        print "protoport: $port\n";
+    }
+    elsif($ARGV[0] eq "serverfortest") {
+        shift @ARGV;
+        my ($why, $e) = serverfortest(split(/,/, $ARGV[0]));
+        print "serverfortest: $e $why\n";
+    }
+    elsif($ARGV[0] eq "stopservers") {
+        my $err = stopservers();
+        print "stopservers: $err\n";
+    }
+    else {
+        print "Error: Unknown command: $ARGV[0]\n";
+        print "Continuing anyway\n";
+    }
+    shift @ARGV;
+}

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -31,16 +31,15 @@ BEGIN {
     use base qw(Exporter);
 
     our @EXPORT = qw(
-        getpartattr
-        getpart
-        partexists
-        loadtest
-        fulltest
-        striparray
         compareparts
-        writearray
+        fulltest
+        getpart
+        getpartattr
         loadarray
-        showdiff
+        loadtest
+        partexists
+        striparray
+        writearray
     );
 }
 
@@ -354,45 +353,6 @@ sub loadarray {
         close($temp);
     }
     return @array;
-}
-
-# Given two array references, this function will store them in two temporary
-# files, run 'diff' on them, store the result and return the diff output!
-
-sub showdiff {
-    my ($logdir, $firstref, $secondref)=@_;
-
-    my $file1="$logdir/check-generated";
-    my $file2="$logdir/check-expected";
-
-    open(my $temp, ">", "$file1") || die "Failure writing diff file";
-    for(@$firstref) {
-        my $l = $_;
-        $l =~ s/\r/[CR]/g;
-        $l =~ s/\n/[LF]/g;
-        $l =~ s/([^\x20-\x7f])/sprintf "%%%02x", ord $1/eg;
-        print $temp $l;
-        print $temp "\n";
-    }
-    close($temp) || die "Failure writing diff file";
-
-    open($temp, ">", "$file2") || die "Failure writing diff file";
-    for(@$secondref) {
-        my $l = $_;
-        $l =~ s/\r/[CR]/g;
-        $l =~ s/\n/[LF]/g;
-        $l =~ s/([^\x20-\x7f])/sprintf "%%%02x", ord $1/eg;
-        print $temp $l;
-        print $temp "\n";
-    }
-    close($temp) || die "Failure writing diff file";
-    my @out = `diff -u $file2 $file1 2>/dev/null`;
-
-    if(!$out[0]) {
-        @out = `diff -c $file2 $file1 2>/dev/null`;
-    }
-
-    return @out;
 }
 
 

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -232,6 +232,11 @@ sub partexists {
 sub loadtest {
     my ($file)=@_;
 
+    if(defined $xmlfile && $file eq $xmlfile) {
+        # This test is already loaded
+        return
+    }
+
     undef @xml;
     $xmlfile = "";
 

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -62,12 +62,6 @@ BEGIN {
         %feature
         %keywords
         @protocols
-        %timesrvrend
-        %timesrvrini
-        %timesrvrlog
-        %timetoolend
-        %timetoolini
-        %timevrfyend
     );
 }
 use pathhelp qw(exe_ext);
@@ -117,11 +111,5 @@ our @protocols;   # array of lowercase supported protocol servers
 our %feature;     # hash of enabled features
 our $has_shared;  # built as a shared library
 our %keywords;    # hash of keywords from the test spec
-our %timesrvrini; # timestamp for each test required servers verification start
-our %timesrvrend; # timestamp for each test required servers verification end
-our %timetoolini; # timestamp for each test command run starting
-our %timetoolend; # timestamp for each test command run stopping
-our %timesrvrlog; # timestamp for each test server logs lock removal
-our %timevrfyend; # timestamp for each test result verification end
 
 1;

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -37,7 +37,6 @@ BEGIN {
         restore_test_env
         runner_test_preprocess
         runner_test_run
-        use_valgrind
         checktestcmd
         $DBGCURL
         $gdbthis
@@ -762,7 +761,7 @@ sub singletest_run {
     # timestamp finishing of test command
     $timetoolend{$testnum} = Time::HiRes::time();
 
-    return (0, $cmdres, $dumped_core, $CURLOUT, $tool, $disablevalgrind);
+    return (0, $cmdres, $dumped_core, $CURLOUT, $tool, use_valgrind() && !$disablevalgrind);
 }
 
 
@@ -933,8 +932,8 @@ sub runner_test_run {
     my $dumped_core;
     my $CURLOUT;
     my $tool;
-    my $disablevalgrind;
-    ($error, $cmdres, $dumped_core, $CURLOUT, $tool, $disablevalgrind) = singletest_run($testnum);
+    my $usedvalgrind;
+    ($error, $cmdres, $dumped_core, $CURLOUT, $tool, $usedvalgrind) = singletest_run($testnum);
     if($error) {
         return -2;
     }
@@ -957,7 +956,7 @@ sub runner_test_run {
     # restore environment variables that were modified
     restore_test_env(0);
 
-    return (0, $cmdres, $CURLOUT, $tool, $disablevalgrind);
+    return (0, $cmdres, $CURLOUT, $tool, $usedvalgrind);
 }
 
 1;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1561,24 +1561,26 @@ sub singletest {
     # Verify that the test should be run
     my ($why, $errorreturncode) = singletest_shouldrun($testnum);
 
+    if(!$listonly) {
 
-    #######################################################################
-    # Restore environment variables that were modified in a previous run.
-    # Test definition may instruct to (un)set environment vars.
-    # This is done this early so that leftover variables don't affect starting
-    # servers or CI registration.
-    restore_test_env(1);
+        ###################################################################
+        # Restore environment variables that were modified in a previous run.
+        # Test definition may instruct to (un)set environment vars.
+        # This is done this early so that leftover variables don't affect
+        # starting servers or CI registration.
+        restore_test_env(1);
 
-    #######################################################################
-    # Register the test case with the CI environment
-    citest_starttest($testnum);
+        ###################################################################
+        # Register the test case with the CI environment
+        citest_starttest($testnum);
 
-    if(!$why) {
-        $why = runner_test_preprocess($testnum);
-    } else {
+        if(!$why) {
+            $why = runner_test_preprocess($testnum);
+        } else {
 
-        # set zero servers verification time when they aren't started
-        $timesrvrini{$testnum} = $timesrvrend{$testnum} = Time::HiRes::time();
+            # set zero servers verification time when they aren't started
+            $timesrvrini{$testnum} = $timesrvrend{$testnum} = Time::HiRes::time();
+        }
     }
 
     #######################################################################
@@ -2389,8 +2391,10 @@ foreach my $testnum (@at) {
     # execute one test case
     my $error = singletest($testnum, $count, scalar(@at));
 
-    # Submit the test case result with the CI environment
-    citest_finishtest($testnum, $error);
+    if(!$listonly) {
+        # Submit the test case result with the CI environment
+        citest_finishtest($testnum, $error);
+    }
 
     if($error < 0) {
         # not a test we can run

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -297,6 +297,47 @@ sub cleardir {
     return $done;
 }
 
+
+#######################################################################
+# Given two array references, this function will store them in two temporary
+# files, run 'diff' on them, store the result and return the diff output!
+sub showdiff {
+    my ($logdir, $firstref, $secondref)=@_;
+
+    my $file1="$logdir/check-generated";
+    my $file2="$logdir/check-expected";
+
+    open(my $temp, ">", "$file1") || die "Failure writing diff file";
+    for(@$firstref) {
+        my $l = $_;
+        $l =~ s/\r/[CR]/g;
+        $l =~ s/\n/[LF]/g;
+        $l =~ s/([^\x20-\x7f])/sprintf "%%%02x", ord $1/eg;
+        print $temp $l;
+        print $temp "\n";
+    }
+    close($temp) || die "Failure writing diff file";
+
+    open($temp, ">", "$file2") || die "Failure writing diff file";
+    for(@$secondref) {
+        my $l = $_;
+        $l =~ s/\r/[CR]/g;
+        $l =~ s/\n/[LF]/g;
+        $l =~ s/([^\x20-\x7f])/sprintf "%%%02x", ord $1/eg;
+        print $temp $l;
+        print $temp "\n";
+    }
+    close($temp) || die "Failure writing diff file";
+    my @out = `diff -u $file2 $file1 2>/dev/null`;
+
+    if(!$out[0]) {
+        @out = `diff -c $file2 $file1 2>/dev/null`;
+    }
+
+    return @out;
+}
+
+
 #######################################################################
 # compare test results with the expected output, we might filter off
 # some pattern that is allowed to differ, output test results

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1014,7 +1014,7 @@ sub singletest_count {
 #######################################################################
 # Verify test succeeded
 sub singletest_check {
-    my ($testnum, $cmdres, $CURLOUT, $tool, $disablevalgrind)=@_;
+    my ($testnum, $cmdres, $CURLOUT, $tool, $usedvalgrind)=@_;
 
     # Skip all the verification on torture tests
     if ($torture) {
@@ -1462,7 +1462,7 @@ sub singletest_check {
     }
 
     if($valgrind) {
-        if(use_valgrind() && !$disablevalgrind) {
+        if($usedvalgrind) {
             if(!opendir(DIR, "$LOGDIR")) {
                 logmsg "ERROR: unable to read $LOGDIR\n";
                 # timestamp test result verification end
@@ -1500,7 +1500,7 @@ sub singletest_check {
             $ok .= "v";
         }
         else {
-            if($verbose && !$disablevalgrind) {
+            if($verbose) {
                 logmsg " valgrind SKIPPED\n";
             }
             $ok .= "-"; # skipped
@@ -1594,8 +1594,8 @@ sub singletest {
     my $cmdres;
     my $CURLOUT;
     my $tool;
-    my $disablevalgrind;
-    ($error, $cmdres, $CURLOUT, $tool, $disablevalgrind) = runner_test_run($testnum);
+    my $usedvalgrind;
+    ($error, $cmdres, $CURLOUT, $tool, $usedvalgrind) = runner_test_run($testnum);
     if($error == -1) {
       # return a test failure, either to be reported or to be ignored
       return $errorreturncode;
@@ -1610,7 +1610,7 @@ sub singletest {
 
     #######################################################################
     # Verify that the test succeeded
-    $error = singletest_check($testnum, $cmdres, $CURLOUT, $tool, $disablevalgrind);
+    $error = singletest_check($testnum, $cmdres, $CURLOUT, $tool, $usedvalgrind);
     if($error == -1) {
       # return a test failure, either to be reported or to be ignored
       return $errorreturncode;


### PR DESCRIPTION
In support of parallel testing. Also added a script for developers to allow
manually manipulating the test harness.