### PR TITLE
runtests: fix quoting in Appveyor and Azure test integration

### DIFF
--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -39,7 +39,7 @@ BEGIN {
 }
 
 
-my %APPVEYOR_TEST_NAMES;
+my %APPVEYOR_TEST_NAMES;  # JSON and shell-quoted test names by test number
 
 sub appveyor_check_environment {
     if(defined $ENV{'APPVEYOR_API_URL'} && $ENV{'APPVEYOR_API_URL'}) {
@@ -51,20 +51,20 @@ sub appveyor_check_environment {
 sub appveyor_create_test_result {
     my ($curl, $testnum, $testname)=@_;
     $testname =~ s/\\/\\\\/g;
-    $testname =~ s/\'/\\\'/g;
     $testname =~ s/\"/\\\"/g;
+    $testname =~ s/\'/'"'"'/g;
     my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`$curl --silent --noproxy "*" \\
-    --header "Content-Type: application/json" \\
-    --data "
+    my $appveyor_result=`$curl --silent --noproxy '*' \\
+    --header 'Content-Type: application/json' \\
+    --data '
         {
-            'testName': '$testname',
-            'testFramework': 'runtests.pl',
-            'fileName': 'tests/data/test$testnum',
-            'outcome': 'Running'
+            "testName": "$testname",
+            "testFramework": "runtests.pl",
+            "fileName": "tests/data/test$testnum",
+            "outcome": "Running"
         }
-    " \\
-    "$appveyor_baseurl/api/tests"`;
+    ' \\
+    '$appveyor_baseurl/api/tests'`;
     print "AppVeyor API result: $appveyor_result\n" if ($appveyor_result);
     $APPVEYOR_TEST_NAMES{$testnum}=$testname;
 }
@@ -98,31 +98,31 @@ sub appveyor_update_test_result {
         $appveyor_category = 'Error';
     }
     my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`$curl --silent --noproxy "*" --request PUT \\
-    --header "Content-Type: application/json" \\
-    --data "
+    my $appveyor_result=`$curl --silent --noproxy '*' --request PUT \\
+    --header 'Content-Type: application/json' \\
+    --data '
         {
-            'testName': '$testname',
-            'testFramework': 'runtests.pl',
-            'fileName': 'tests/data/test$testnum',
-            'outcome': '$appveyor_outcome',
-            'durationMilliseconds': $appveyor_duration,
-            'ErrorMessage': 'Test $testnum $appveyor_outcome'
+            "testName": "$testname",
+            "testFramework": "runtests.pl",
+            "fileName": "tests/data/test$testnum",
+            "outcome": "$appveyor_outcome",
+            "durationMilliseconds": $appveyor_duration,
+            "ErrorMessage": "Test $testnum $appveyor_outcome"
         }
-    " \\
-    "$appveyor_baseurl/api/tests"`;
+    ' \\
+    '$appveyor_baseurl/api/tests'`;
     print "AppVeyor API result: $appveyor_result\n" if ($appveyor_result);
     if($appveyor_category eq 'Error') {
-        $appveyor_result=`$curl --silent --noproxy "*" \\
-        --header "Content-Type: application/json" \\
-        --data "
+        $appveyor_result=`$curl --silent --noproxy '*' \\
+        --header 'Content-Type: application/json' \\
+        --data '
             {
-                'message': '$appveyor_outcome: $testname',
-                'category': '$appveyor_category',
-                'details': 'Test $testnum $appveyor_outcome'
+                "message": "$appveyor_outcome: $testname",
+                "category": "$appveyor_category",
+                "details": "Test $testnum $appveyor_outcome"
             }
-        " \\
-        "$appveyor_baseurl/api/build/messages"`;
+        ' \\
+        '$appveyor_baseurl/api/build/messages'`;
         print "AppVeyor API result: $appveyor_result\n" if ($appveyor_result);
     }
 }

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -75,26 +75,26 @@ sub azure_create_test_run {
 sub azure_create_test_result {
     my ($curl, $azure_run_id, $testnum, $testname)=@_;
     $testname =~ s/\\/\\\\/g;
-    $testname =~ s/\'/\\\'/g;
     $testname =~ s/\"/\\\"/g;
+    $testname =~ s/\'/'"'"'/g;
     my $title_testnum=sprintf("%04d", $testnum);
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`$curl --silent --noproxy "*" \\
+    my $azure_result=`$curl --silent --noproxy '*' \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
-    --header "Content-Type: application/json" \\
-    --data "
+    --header 'Content-Type: application/json' \\
+    --data '
         [
             {
-                'build': {'id': '$ENV{'BUILD_BUILDID'}'},
-                'testCase': {'id': $testnum},
-                'testCaseTitle': '$title_testnum: $testname',
-                'testCaseRevision': 2,
-                'automatedTestName': 'curl.tests.$testnum',
-                'outcome': 'InProgress'
+                "build": {"id": "$ENV{'BUILD_BUILDID'}"},
+                "testCase": {"id": $testnum},
+                "testCaseTitle": "$title_testnum: $testname",
+                "testCaseRevision": 2,
+                "automatedTestName": "curl.tests.$testnum",
+                "outcome": "InProgress"
             }
         ]
-    " \\
-    "$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1"`;
+    ' \\
+    '$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1'`;
     if($azure_result =~ /\[\{"id":(\d+)/) {
         return $1;
     }
@@ -123,21 +123,21 @@ sub azure_update_test_result {
         $azure_outcome = 'Failed';
     }
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`$curl --silent --noproxy "*" --request PATCH \\
+    my $azure_result=`$curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
-    --data "
+    --data '
         [
             {
-                'id': $azure_result_id,
-                'outcome': '$azure_outcome',
-                'startedDate': '$azure_start',
-                'completedDate': '$azure_complete',
-                'durationInMs': $azure_duration
+                "id": $azure_result_id,
+                "outcome": "$azure_outcome",
+                "startedDate": "$azure_start",
+                "completedDate": "$azure_complete",
+                "durationInMs": $azure_duration
             }
         ]
-    " \\
-    "$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1"`;
+    ' \\
+    '$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1'`;
     if($azure_result =~ /\[\{"id":(\d+)/) {
         return $1;
     }
@@ -147,15 +147,15 @@ sub azure_update_test_result {
 sub azure_update_test_run {
     my ($curl, $azure_run_id)=@_;
     my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`$curl --silent --noproxy "*" --request PATCH \\
+    my $azure_run=`$curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
-    --header "Content-Type: application/json" \\
-    --data "
+    --header 'Content-Type: application/json' \\
+    --data '
         {
-            'state': 'Completed'
+            "state": "Completed"
         }
-    " \\
-    "$azure_baseurl/_apis/test/runs/$azure_run_id?api-version=5.1"`;
+    ' \\
+    '$azure_baseurl/_apis/test/runs/$azure_run_id?api-version=5.1'`;
     if($azure_run =~ /"id":(\d+)/) {
         return $1;
     }


### PR DESCRIPTION
Test 1442's name was not quoted correctly so wasn't registered in
Appveyor and it had the wrong name in Azure. The JSON string quotes were
also invalid, even though both servers happened to accept it regardless.

Closes #11010