### PR TITLE
socketpair: verify with a random value

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -183,7 +183,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 }
 
 /*
- * Curl_rand() stores 'num' number of random unsigned character in the buffer
+ * Curl_rand() stores 'num' number of random unsigned characters in the buffer
  * 'rnd' points to.
  *
  * If libcurl is built without TLS support or with a TLS backend that lacks a

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -183,8 +183,8 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 }
 
 /*
- * Curl_rand() stores 'num' number of random unsigned integers in the buffer
- * 'rndptr' points to.
+ * Curl_rand() stores 'num' number of random unsigned character in the buffer
+ * 'rnd' points to.
  *
  * If libcurl is built without TLS support or with a TLS backend that lacks a
  * proper random API (rustls, Gskit or mbedTLS), this function will use "weak"

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -133,7 +133,7 @@ int Curl_socketpair(int domain, int type, int protocol,
     char *p = &check[0];
     size_t s = sizeof(check);
 
-    if(Curl_rand(NULL, rnd, sizeof(rnd)))
+    if(Curl_rand(NULL, (unsigned char *)rnd, sizeof(rnd)))
       goto error;
 
     /* write data to the socket */

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -125,13 +125,17 @@ int Curl_socketpair(int domain, int type, int protocol,
   if(socks[1] == CURL_SOCKET_BAD)
     goto error;
   else {
-    struct curltime check;
     struct curltime start = Curl_now();
-    char *p = (char *)&check;
+    char rnd[9];
+    char check[sizeof(rnd)];
+    char *p = (char *)&check[0];
     size_t s = sizeof(check);
 
+    if(Curl_rand(data, rnd, sizeof(rnd)))
+      goto error;
+
     /* write data to the socket */
-    swrite(socks[0], &start, sizeof(start));
+    swrite(socks[0], rnd, sizeof(rnd));
     /* verify that we read the correct data */
     do {
       ssize_t nread;
@@ -168,7 +172,7 @@ int Curl_socketpair(int domain, int type, int protocol,
         p += nread;
         continue;
       }
-      if(memcmp(&start, &check, sizeof(check)))
+      if(memcmp(rnd, check, sizeof(check)))
         goto error;
       break;
     } while(1);

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -130,7 +130,7 @@ int Curl_socketpair(int domain, int type, int protocol,
     struct curltime start = Curl_now();
     char rnd[9];
     char check[sizeof(rnd)];
-    char *p = (char *)&check[0];
+    char *p = &check[0];
     size_t s = sizeof(check);
 
     if(Curl_rand(NULL, rnd, sizeof(rnd)))

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -24,6 +24,8 @@
 
 #include "curl_setup.h"
 #include "socketpair.h"
+#include "urldata.h"
+#include "rand.h"
 
 #if !defined(HAVE_SOCKETPAIR) && !defined(CURL_DISABLE_SOCKETPAIR)
 #ifdef WIN32
@@ -131,7 +133,7 @@ int Curl_socketpair(int domain, int type, int protocol,
     char *p = (char *)&check[0];
     size_t s = sizeof(check);
 
-    if(Curl_rand(data, rnd, sizeof(rnd)))
+    if(Curl_rand(NULL, rnd, sizeof(rnd)))
       goto error;
 
     /* write data to the socket */


### PR DESCRIPTION
... instead of using the curl time struct, since it would use a few uninitialized bytes and the sanitizers would complain. This is a neater approach I think.

Reported-by: Boris Kuschel
Fixes #10993