### PR TITLE
urldata: CURLOPT_AWS_SIGV4 value is null-terminated

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1562,6 +1562,7 @@ enum dupstring {
   STRING_DNS_LOCAL_IP4,
   STRING_DNS_LOCAL_IP6,
   STRING_SSL_EC_CURVES,
+  STRING_AWS_SIGV4, /* Parameters for V4 signature */
 
   /* -- end of null-terminated strings -- */
 
@@ -1570,8 +1571,6 @@ enum dupstring {
   /* -- below this are pointers to binary data that cannot be strdup'ed. --- */
 
   STRING_COPYPOSTFIELDS,  /* if POST, set the fields' values here */
-
-  STRING_AWS_SIGV4, /* Parameters for V4 signature */
 
   STRING_LAST /* not used, just an end-of-list marker */
 };


### PR DESCRIPTION
Without this fix, this option's value is not copied upon calling curl_easy_duphandle().