### PR TITLE
curl_path: bring back support for SFTP path ending in /~

### DIFF
--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -62,24 +62,27 @@ CURLcode Curl_getworkingpath(struct Curl_easy *data,
     }
   }
   else if((data->conn->handler->protocol & CURLPROTO_SFTP) &&
-          (working_path_len > 2) && !memcmp(working_path, "/~/", 3)) {
-    size_t len;
-    const char *p;
-    int copyfrom = 3;
+          (!strcmp("/~", working_path) ||
+           ((working_path_len > 2) && !memcmp(working_path, "/~/", 3)))) {
     if(Curl_dyn_add(&npath, homedir)) {
       free(working_path);
       return CURLE_OUT_OF_MEMORY;
     }
-    /* Copy a separating '/' if homedir does not end with one */
-    len = Curl_dyn_len(&npath);
-    p = Curl_dyn_ptr(&npath);
-    if(len && (p[len-1] != '/'))
-      copyfrom = 2;
+    if(working_path_len > 2) {
+      size_t len;
+      const char *p;
+      int copyfrom = 3;
+      /* Copy a separating '/' if homedir does not end with one */
+      len = Curl_dyn_len(&npath);
+      p = Curl_dyn_ptr(&npath);
+      if(len && (p[len-1] != '/'))
+        copyfrom = 2;
 
-    if(Curl_dyn_addn(&npath,
-                     &working_path[copyfrom], working_path_len - copyfrom)) {
-      free(working_path);
-      return CURLE_OUT_OF_MEMORY;
+      if(Curl_dyn_addn(&npath,
+                       &working_path[copyfrom], working_path_len - copyfrom)) {
+        free(working_path);
+        return CURLE_OUT_OF_MEMORY;
+      }
     }
   }
 


### PR DESCRIPTION
libcurl used to do a directory listing for this case (even though the documentation says a URL needs to end in a slash for this), but 4e2b52b5f7a3 modified the behavior.

This change brings back a directory listing for SFTP paths that are specified exactly as /~ in the URL.

Reported-by: Pavel Mayorov
Fixes #11001