### PR TITLE
libssh2: fix crash in keyboard callback

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3274,7 +3274,7 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
                                               my_libssh2_free,
                                               my_libssh2_realloc, data);
 #else
-  sshc->ssh_session = libssh2_session_init();
+  sshc->ssh_session = libssh2_session_init_ex(NULL, NULL, NULL, data);
 #endif
   if(!sshc->ssh_session) {
     failf(data, "Failure initialising ssh session");


### PR DESCRIPTION
- Always set the libssh2 'abstract' user-pointer to the libcurl easy handle associated with the ssh session, so it is always passed to the ssh keyboard callback.

Prior to this change and since 8b5f100 (precedes curl 8.0.0), if libcurl was built without CURL_DEBUG then it could crash during the ssh auth phase due to a null dereference in the ssh keyboard callback.

Reported-by: Andreas Falkenhahn

Fixes https://github.com/curl/curl/pull/11024
Closes #xxxx