### PR TITLE
docs: use consistent code style in manual pages

### DIFF
--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -39,7 +39,7 @@ that are URL encoded (%XX where XX is a two-digit hexadecimal number) are
 converted to their binary versions.
 
 If the \fBlength\fP argument is set to 0 (zero), \fIcurl_easy_unescape(3)\fP
-will use strlen() on the input \fIurl\fP string to find out the size.
+will use strlen() on the input \fBurl\fP string to find out the size.
 
 If \fBoutlength\fP is non-NULL, the function will write the length of the
 returned string in the integer it points to. This allows proper handling even

--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -33,13 +33,13 @@ char *curl_easy_unescape(CURL *curl, const char *input,
                          int inlength, int *outlength);
 .fi
 .SH DESCRIPTION
-This function converts the given URL encoded \fBinput\fP string to a "plain
-string" and returns that in an allocated memory area. All input characters
-that are URL encoded (%XX where XX is a two-digit hexadecimal number) are
-converted to their binary versions.
+This function converts the URL encoded string \fBinput\fP to a "plain string"
+and returns that in an allocated memory area. All input characters that are URL
+encoded (%XX where XX is a two-digit hexadecimal number) are converted to their
+binary versions.
 
 If the \fBlength\fP argument is set to 0 (zero), \fIcurl_easy_unescape(3)\fP
-will use strlen() on the input \fBurl\fP string to find out the size.
+will use strlen() on \fBinput\fP to find out the size.
 
 If \fBoutlength\fP is non-NULL, the function will write the length of the
 returned string in the integer it points to. This allows proper handling even

--- a/docs/libcurl/curl_escape.3
+++ b/docs/libcurl/curl_escape.3
@@ -28,18 +28,18 @@ curl_escape - URL encodes the given string
 .nf
 #include <curl/curl.h>
 
-char *curl_escape(const char *url, int length);
+char *curl_escape(const char *string, int length);
 .fi
 .SH DESCRIPTION
 Obsolete function. Use \fIcurl_easy_escape(3)\fP instead!
 
-This function will convert the given input string to a URL encoded string and
-return that as a new allocated string. All input characters that are not a-z,
-A-Z or 0-9 will be converted to their "URL escaped" version (\fB%NN\fP where
-\fBNN\fP is a two-digit hexadecimal number).
+This function will convert the given input \fBstring\fP to a URL encoded string
+and return that as a new allocated string. All input characters that are not
+a-z, A-Z or 0-9 will be converted to their "URL escaped" version (\fB%NN\fP
+where \fBNN\fP is a two-digit hexadecimal number).
 
 If the \fBlength\fP argument is set to 0, \fIcurl_escape(3)\fP will use
-strlen() on the input \fBurl\fP string to find out the size.
+strlen() on \fBstring\fP to find out the size.
 
 You must \fIcurl_free(3)\fP the returned string when you are done with it.
 .SH EXAMPLE

--- a/docs/libcurl/curl_formadd.3
+++ b/docs/libcurl/curl_formadd.3
@@ -176,8 +176,8 @@ for the curl handle.
 See example below.
 .SH EXAMPLE
 .nf
- struct curl_httppost* post = NULL;
- struct curl_httppost* last = NULL;
+ struct curl_httppost *post = NULL;
+ struct curl_httppost *last = NULL;
  char namebuffer[] = "name buffer";
  long namelength = strlen(namebuffer);
  char buffer[] = "test buffer";

--- a/docs/libcurl/curl_unescape.3
+++ b/docs/libcurl/curl_unescape.3
@@ -28,7 +28,7 @@ curl_unescape - URL decodes the given string
 .nf
 #include <curl/curl.h>
 
-char *curl_unescape( const char *url, int length);
+char *curl_unescape(const char *url, int length);
 .fi
 .SH DESCRIPTION
 Obsolete function. Use \fIcurl_easy_unescape(3)\fP instead!
@@ -38,8 +38,8 @@ string" and return that as a new allocated string. All input characters that
 are URL encoded (%XX where XX is a two-digit hexadecimal number) will be
 converted to their plain text versions.
 
-If the 'length' argument is set to 0, \fIcurl_unescape(3)\fP will use strlen()
-on the input \fBurl\fP string to find out the size.
+If the \fBlength\fP argument is set to 0, \fIcurl_unescape(3)\fP will use
+strlen() on the input \fBurl\fP string to find out the size.
 
 You must \fIcurl_free(3)\fP the returned string when you are done with it.
 .SH EXAMPLE

--- a/docs/libcurl/curl_unescape.3
+++ b/docs/libcurl/curl_unescape.3
@@ -28,18 +28,18 @@ curl_unescape - URL decodes the given string
 .nf
 #include <curl/curl.h>
 
-char *curl_unescape(const char *url, int length);
+char *curl_unescape(const char *input, int length);
 .fi
 .SH DESCRIPTION
 Obsolete function. Use \fIcurl_easy_unescape(3)\fP instead!
 
-This function will convert the given URL encoded input string to a "plain
+This function will convert the URL encoded string \fBinput\fP to a "plain
 string" and return that as a new allocated string. All input characters that
 are URL encoded (%XX where XX is a two-digit hexadecimal number) will be
 converted to their plain text versions.
 
 If the \fBlength\fP argument is set to 0, \fIcurl_unescape(3)\fP will use
-strlen() on the input \fBurl\fP string to find out the size.
+strlen() on \fBinput\fP to find out the size.
 
 You must \fIcurl_free(3)\fP the returned string when you are done with it.
 .SH EXAMPLE

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -29,7 +29,7 @@ curl_version_info - returns runtime libcurl version info
 .nf
 #include <curl/curl.h>
 
-curl_version_info_data *curl_version_info( CURLversion age);
+curl_version_info_data *curl_version_info(CURLversion age);
 .fi
 .SH DESCRIPTION
 Returns a pointer to a filled in static struct with information about various

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
@@ -32,7 +32,7 @@ CURLMOPT_SOCKETFUNCTION \- callback informed about what to wait for
 int socket_callback(CURL *easy,      /* easy handle */
                     curl_socket_t s, /* socket */
                     int what,        /* describes the socket */
-                    void *clientp,     /* private callback pointer */
+                    void *clientp,   /* private callback pointer */
                     void *socketp);  /* private socket pointer */
 
 CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_SOCKETFUNCTION, socket_callback);
@@ -87,8 +87,8 @@ All
 .nf
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
-  GlobalInfo *g = (GlobalInfo*) cbp;
-  SockInfo *fdp = (SockInfo*) sockp;
+  GlobalInfo *g = cbp;
+  SockInfo *fdp = sockp;
 
   if(what == CURL_POLL_REMOVE) {
     remsock(fdp);


### PR DESCRIPTION
I was reading curl_unescape(3) and I noticed that there was an extra space after the open parenthesis in the SYNOPSIS; I removed the extra space.

I also ran a few  grep -r  commands to find and remove extra spaces after '(' in other files, and to find and replace uses of `T*` instead of `T *`.

And I also fixed some formatting inconsistencies: in curl_unescape(3), all function parameter were mentioned with bold text except length, that was mentioned as 'length'; and, in curl_easy_unescape(3), all parameters were mentioned in bold text except url that was italicised. Now they are all mentioned in bold.
Documentation is not very consistent in how function parameter are formatted: many pages italicise them, and others display them in bold text; but I think it makes sense to at least be consistent with formatting within the same page.