### PR TITLE
man pages: simplify the .TH sections

### DIFF
--- a/docs/curl-config.1
+++ b/docs/curl-config.1
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl-config 1 "25 Oct 2007" "Curl 7.17.1" "curl-config manual"
+.TH curl-config 1 "25 Oct 2007" curl-config curl-config
 .SH NAME
 curl-config \- Get information about a libcurl installation
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_cleanup.3
+++ b/docs/libcurl/curl_easy_cleanup.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_cleanup 3 "22 Aug 2007" "libcurl 7.17.0" "libcurl Manual"
+.TH curl_easy_cleanup 3 "22 Aug 2007" "libcurl" "libcurl"
 .SH NAME
 curl_easy_cleanup - End a libcurl easy handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_duphandle.3
+++ b/docs/libcurl/curl_easy_duphandle.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_duphandle 3 "19 Sep 2014" "libcurl" "libcurl Manual"
+.TH curl_easy_duphandle 3 "19 Sep 2014" "libcurl" "libcurl"
 .SH NAME
 curl_easy_duphandle - Clone a libcurl session handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_escape.3
+++ b/docs/libcurl/curl_easy_escape.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_escape 3 "7 April 2006" "libcurl 7.15.4" "libcurl Manual"
+.TH curl_easy_escape 3 "7 April 2006" "libcurl" "libcurl"
 .SH NAME
 curl_easy_escape - URL encodes the given string
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_getinfo.3
+++ b/docs/libcurl/curl_easy_getinfo.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_getinfo 3 "11 Feb 2009" "libcurl 7.19.4" "libcurl Manual"
+.TH curl_easy_getinfo 3 "11 Feb 2009" "libcurl" "libcurl"
 .SH NAME
 curl_easy_getinfo - extract information from a curl handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_header.3
+++ b/docs/libcurl/curl_easy_header.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_header 3 "13 March 2022" "libcurl 7.83.0" "libcurl Manual"
+.TH curl_easy_header 3 "13 March 2022" "libcurl" "libcurl"
 .SH NAME
 curl_easy_header - get an HTTP header
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_init.3
+++ b/docs/libcurl/curl_easy_init.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_init 3 "4 March 2002" "libcurl 7.8.1" "libcurl Manual"
+.TH curl_easy_init 3 "4 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_easy_init - Start a libcurl easy session
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_nextheader.3
+++ b/docs/libcurl/curl_easy_nextheader.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_nextheader 3 "13 March 2022" "libcurl 7.83.0" "libcurl Manual"
+.TH curl_easy_nextheader 3 "13 March 2022" "libcurl" "libcurl"
 .SH NAME
 curl_easy_nextheader - get the next HTTP header
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_option_by_id.3
+++ b/docs/libcurl/curl_easy_option_by_id.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_option_by_id 3 "27 Aug 2020" "libcurl 7.73.0" "libcurl Manual"
+.TH curl_easy_option_by_id 3 "27 Aug 2020" "libcurl" "libcurl"
 .SH NAME
 curl_easy_option_by_id - find an easy setopt option by id
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_option_by_name.3
+++ b/docs/libcurl/curl_easy_option_by_name.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_option_by_name 3 "27 Aug 2020" "libcurl 7.73.0" "libcurl Manual"
+.TH curl_easy_option_by_name 3 "27 Aug 2020" "libcurl" "libcurl"
 .SH NAME
 curl_easy_option_by_name - find an easy setopt option by name
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_option_next.3
+++ b/docs/libcurl/curl_easy_option_next.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_option_next 3 "27 Aug 2020" "libcurl 7.73.0" "libcurl Manual"
+.TH curl_easy_option_next 3 "27 Aug 2020" "libcurl" "libcurl"
 .SH NAME
 curl_easy_option_next - iterate over easy setopt options
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_pause 3 "17 Dec 2007" "libcurl 7.18.0" "libcurl Manual"
+.TH curl_easy_pause 3 "17 Dec 2007" "libcurl" "libcurl"
 .SH NAME
 curl_easy_pause - pause and unpause a connection
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_perform.3
+++ b/docs/libcurl/curl_easy_perform.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_perform 3 "5 Mar 2001" "libcurl 7.7" "libcurl Manual"
+.TH curl_easy_perform 3 "5 Mar 2001" "libcurl" "libcurl"
 .SH NAME
 curl_easy_perform - perform a blocking file transfer
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_recv.3
+++ b/docs/libcurl/curl_easy_recv.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_recv 3 "29 April 2008" "libcurl 7.18.2" "libcurl Manual"
+.TH curl_easy_recv 3 "29 April 2008" "libcurl" "libcurl"
 .SH NAME
 curl_easy_recv - receives raw data on an "easy" connection
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_reset.3
+++ b/docs/libcurl/curl_easy_reset.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_reset 3 "31 July 2004" "libcurl 7.12.1" "libcurl Manual"
+.TH curl_easy_reset 3 "31 July 2004" "libcurl" "libcurl"
 .SH NAME
 curl_easy_reset - reset all options of a libcurl session handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_send.3
+++ b/docs/libcurl/curl_easy_send.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_send 3 "29 April 2008" "libcurl 7.18.2" "libcurl Manual"
+.TH curl_easy_send 3 "29 April 2008" "libcurl" "libcurl"
 .SH NAME
 curl_easy_send - sends raw data over an "easy" connection
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_setopt.3
+++ b/docs/libcurl/curl_easy_setopt.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_setopt 3 "25 Jun 2014" "libcurl 7.38.0" "libcurl Manual"
+.TH curl_easy_setopt 3 "25 Jun 2014" "libcurl" "libcurl"
 .SH NAME
 curl_easy_setopt \- set options for a curl easy handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_strerror.3
+++ b/docs/libcurl/curl_easy_strerror.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_easy_strerror 3 "26 Apr 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_easy_strerror 3 "26 Apr 2004" "libcurl" "libcurl"
 .SH NAME
 curl_easy_strerror - return string describing error code
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_unescape.3
+++ b/docs/libcurl/curl_easy_unescape.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_unescape 3 "7 April 2006" "libcurl 7.15.4" "libcurl Manual"
+.TH curl_easy_unescape 3 "7 April 2006" "libcurl" "libcurl"
 .SH NAME
 curl_easy_unescape - URL decodes the given string
 .SH SYNOPSIS

--- a/docs/libcurl/curl_easy_upkeep.3
+++ b/docs/libcurl/curl_easy_upkeep.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_easy_upkeep 3 "31 Oct 2018" "libcurl 7.62.0" "libcurl Manual"
+.TH curl_easy_upkeep 3 "31 Oct 2018" "libcurl" "libcurl"
 .SH NAME
 curl_easy_upkeep - Perform any connection upkeep checks.
 .SH SYNOPSIS

--- a/docs/libcurl/curl_escape.3
+++ b/docs/libcurl/curl_escape.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_escape 3 "6 March 2002" "libcurl 7.9" "libcurl Manual"
+.TH curl_escape 3 "6 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_escape - URL encodes the given string
 .SH SYNOPSIS

--- a/docs/libcurl/curl_formadd.3
+++ b/docs/libcurl/curl_formadd.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_formadd 3 "24 June 2002" "libcurl 7.9.8" "libcurl Manual"
+.TH curl_formadd 3 "24 June 2002" "libcurl" "libcurl"
 .SH NAME
 curl_formadd - add a section to a multipart form POST
 .SH SYNOPSIS

--- a/docs/libcurl/curl_formfree.3
+++ b/docs/libcurl/curl_formfree.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_formfree 3 "6 April 2001" "libcurl 7.7.1" "libcurl Manual"
+.TH curl_formfree 3 "6 April 2001" "libcurl" "libcurl"
 .SH NAME
 curl_formfree - free a previously build multipart form post chain
 .SH SYNOPSIS

--- a/docs/libcurl/curl_formget.3
+++ b/docs/libcurl/curl_formget.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_formget 3 "20 June 2006" "libcurl 7.15.5" "libcurl Manual"
+.TH curl_formget 3 "20 June 2006" "libcurl" "libcurl"
 .SH NAME
 curl_formget - serialize a previously built multipart form POST chain
 .SH SYNOPSIS

--- a/docs/libcurl/curl_free.3
+++ b/docs/libcurl/curl_free.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_free 3 "12 Aug 2003" "libcurl 7.10" "libcurl Manual"
+.TH curl_free 3 "12 Aug 2003" "libcurl" "libcurl"
 .SH NAME
 curl_free - reclaim memory that has been obtained through a libcurl call
 .SH SYNOPSIS

--- a/docs/libcurl/curl_getdate.3
+++ b/docs/libcurl/curl_getdate.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_getdate 3 "12 Aug 2005" "libcurl 7.0" "libcurl Manual"
+a.TH curl_getdate 3 "12 Aug 2005" "libcurl" "libcurl"
 .SH NAME
 curl_getdate - Convert a date string to number of seconds
 .SH SYNOPSIS

--- a/docs/libcurl/curl_getenv.3
+++ b/docs/libcurl/curl_getenv.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_getenv 3 "30 April 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_getenv 3 "30 April 2004" "libcurl" "libcurl"
 .SH NAME
 curl_getenv - return value for environment name
 .SH SYNOPSIS

--- a/docs/libcurl/curl_global_cleanup.3
+++ b/docs/libcurl/curl_global_cleanup.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_global_cleanup 3 "17 Feb 2006" "libcurl 7.8" "libcurl Manual"
+.TH curl_global_cleanup 3 "17 Feb 2006" "libcurl" "libcurl"
 .SH NAME
 curl_global_cleanup - global libcurl cleanup
 .SH SYNOPSIS

--- a/docs/libcurl/curl_global_init.3
+++ b/docs/libcurl/curl_global_init.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_global_init 3 "11 May 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_global_init 3 "11 May 2004" "libcurl" "libcurl"
 .SH NAME
 curl_global_init - Global libcurl initialization
 .SH SYNOPSIS

--- a/docs/libcurl/curl_global_init_mem.3
+++ b/docs/libcurl/curl_global_init_mem.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_global_init_mem 3 "10 May 2004" "libcurl 7.12.0" "libcurl Manual"
+.TH curl_global_init_mem 3 "10 May 2004" "libcurl" "libcurl"
 .SH NAME
 curl_global_init_mem - Global libcurl initialization with memory callbacks
 .SH SYNOPSIS

--- a/docs/libcurl/curl_global_sslset.3
+++ b/docs/libcurl/curl_global_sslset.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_global_sslset 3 "15 July 2017" "libcurl 7.56" "libcurl Manual"
+.TH curl_global_sslset 3 "15 July 2017" "libcurl" "libcurl"
 .SH NAME
 curl_global_sslset - Select SSL backend to use with libcurl
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_addpart.3
+++ b/docs/libcurl/curl_mime_addpart.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_addpart 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_addpart 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_addpart - append a new empty part to a mime structure
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_data.3
+++ b/docs/libcurl/curl_mime_data.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_data 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_data 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_data - set a mime part's body data from memory
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_data_cb.3
+++ b/docs/libcurl/curl_mime_data_cb.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_data_cb 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_data_cb 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_data_cb - set a callback-based data source for a mime part's body
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_encoder.3
+++ b/docs/libcurl/curl_mime_encoder.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_encoder 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_encoder 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_encoder - set a mime part's encoder and content transfer encoding
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_filedata.3
+++ b/docs/libcurl/curl_mime_filedata.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_filedata 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_filedata 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_filedata - set a mime part's body data from a file contents
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_filename.3
+++ b/docs/libcurl/curl_mime_filename.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_filename 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_filename 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_filename - set a mime part's remote file name
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_free.3
+++ b/docs/libcurl/curl_mime_free.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_free 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_free 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_free - free a previously built mime structure
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_headers.3
+++ b/docs/libcurl/curl_mime_headers.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_headers 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_headers 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_headers - set a mime part's custom headers
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_init.3
+++ b/docs/libcurl/curl_mime_init.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_init 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_init 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_init - create a mime handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_name.3
+++ b/docs/libcurl/curl_mime_name.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_name 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_name 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_name - set a mime part's name
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_subparts.3
+++ b/docs/libcurl/curl_mime_subparts.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_subparts 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_subparts 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_subparts - set sub-parts of a multipart mime part
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mime_type.3
+++ b/docs/libcurl/curl_mime_type.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_mime_type 3 "22 August 2017" "libcurl 7.56.0" "libcurl Manual"
+.TH curl_mime_type 3 "22 August 2017" "libcurl" "libcurl"
 .SH NAME
 curl_mime_type - set a mime part's content type
 .SH SYNOPSIS

--- a/docs/libcurl/curl_mprintf.3
+++ b/docs/libcurl/curl_mprintf.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_printf 3 "30 April 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_printf 3 "30 April 2004" "libcurl" "libcurl"
 .SH NAME
 curl_maprintf, curl_mfprintf, curl_mprintf, curl_msnprintf, curl_msprintf
 curl_mvaprintf, curl_mvfprintf, curl_mvprintf, curl_mvsnprintf,

--- a/docs/libcurl/curl_multi_add_handle.3
+++ b/docs/libcurl/curl_multi_add_handle.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_add_handle 3 "4 March 2002" "libcurl 7.9.5" "libcurl Manual"
+.TH curl_multi_add_handle 3 "4 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_multi_add_handle - add an easy handle to a multi session
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_assign.3
+++ b/docs/libcurl/curl_multi_assign.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_assign 3 "9 Jul 2006" "libcurl 7.16.0" "libcurl Manual"
+.TH curl_multi_assign 3 "9 Jul 2006" "libcurl" "libcurl"
 .SH NAME
 curl_multi_assign \- set data to associate with an internal socket
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_cleanup.3
+++ b/docs/libcurl/curl_multi_cleanup.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_cleanup 3 "1 March 2002" "libcurl 7.9.5" "libcurl Manual"
+.TH curl_multi_cleanup 3 "1 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_multi_cleanup - close down a multi session
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_fdset.3
+++ b/docs/libcurl/curl_multi_fdset.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_fdset 3 "2 Jan 2006" "libcurl 7.16.0" "libcurl Manual"
+.TH curl_multi_fdset 3 "2 Jan 2006" "libcurl" "libcurl"
 .SH NAME
 curl_multi_fdset - extracts file descriptor information from a multi handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_info_read.3
+++ b/docs/libcurl/curl_multi_info_read.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_info_read 3 "18 Dec 2004" "libcurl 7.10.3" "libcurl Manual"
+.TH curl_multi_info_read 3 "18 Dec 2004" "libcurl" "libcurl"
 .SH NAME
 curl_multi_info_read - read multi stack information
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_init.3
+++ b/docs/libcurl/curl_multi_init.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_init 3 "1 March 2002" "libcurl 7.9.5" "libcurl Manual"
+.TH curl_multi_init 3 "1 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_multi_init - create a multi handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_perform.3
+++ b/docs/libcurl/curl_multi_perform.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_perform 3 "1 March 2002" "libcurl 7.9.5" "libcurl Manual"
+.TH curl_multi_perform 3 "1 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_multi_perform - reads/writes available data from easy handles
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_poll.3
+++ b/docs/libcurl/curl_multi_poll.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_poll 3 "29 Jul 2019" "libcurl 7.66.0" "libcurl Manual"
+.TH curl_multi_poll 3 "29 Jul 2019" "libcurl" "libcurl"
 .SH NAME
 curl_multi_poll - polls on all easy handles in a multi handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_remove_handle.3
+++ b/docs/libcurl/curl_multi_remove_handle.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_remove_handle 3 "6 March 2002" "libcurl 7.9.5" "libcurl Manual"
+.TH curl_multi_remove_handle 3 "6 March 2002" "libcurl" "libcurl"
 .SH NAME
 curl_multi_remove_handle - remove an easy handle from a multi session
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_setopt.3
+++ b/docs/libcurl/curl_multi_setopt.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_setopt 3 "4 Nov 2014" "libcurl 7.39.0" "libcurl Manual"
+.TH curl_multi_setopt 3 "4 Nov 2014" "libcurl" "libcurl"
 .SH NAME
 curl_multi_setopt \- set options for a curl multi handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_socket.3
+++ b/docs/libcurl/curl_multi_socket.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_socket 3 "9 Jul 2006" "libcurl 7.16.0" "libcurl Manual"
+.TH curl_multi_socket 3 "9 Jul 2006" "libcurl" "libcurl"
 .SH NAME
 curl_multi_socket \- reads/writes available data
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_socket_action.3
+++ b/docs/libcurl/curl_multi_socket_action.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_socket_action 3 "9 Jul 2006" "libcurl 7.16.0" "libcurl Manual"
+.TH curl_multi_socket_action 3 "9 Jul 2006" "libcurl" "libcurl"
 .SH NAME
 curl_multi_socket_action \- reads/writes available data given an action
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_strerror.3
+++ b/docs/libcurl/curl_multi_strerror.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_strerror 3 "26 Apr 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_multi_strerror 3 "26 Apr 2004" "libcurl" "libcurl"
 .SH NAME
 curl_multi_strerror - return string describing error code
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_timeout.3
+++ b/docs/libcurl/curl_multi_timeout.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_timeout 3 "2 Jan 2006" "libcurl 7.16.0" "libcurl Manual"
+.TH curl_multi_timeout 3 "2 Jan 2006" "libcurl" "libcurl"
 .SH NAME
 curl_multi_timeout \- how long to wait for action before proceeding
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_wait 3 "12 Jul 2012" "libcurl 7.28.0" "libcurl Manual"
+.TH curl_multi_wait 3 "12 Jul 2012" "libcurl" "libcurl"
 .SH NAME
 curl_multi_wait - polls on all easy handles in a multi handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_multi_wakeup.3
+++ b/docs/libcurl/curl_multi_wakeup.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_multi_wakeup 3 "17 Nov 2019" "libcurl 7.68.0" "libcurl Manual"
+.TH curl_multi_wakeup 3 "17 Nov 2019" "libcurl" "libcurl"
 .SH NAME
 curl_multi_wakeup - wakes up a sleeping curl_multi_poll call
 .SH SYNOPSIS

--- a/docs/libcurl/curl_share_cleanup.3
+++ b/docs/libcurl/curl_share_cleanup.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_share_cleanup 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH curl_share_cleanup 3 "8 Aug 2003" "libcurl" "libcurl"
 .SH NAME
 curl_share_cleanup - Clean up a shared object
 .SH SYNOPSIS

--- a/docs/libcurl/curl_share_init.3
+++ b/docs/libcurl/curl_share_init.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_share_init 3 "Aug 3, 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH curl_share_init 3 "Aug 3, 2003" "libcurl" "libcurl"
 .SH NAME
 curl_share_init - Create a shared object
 .SH SYNOPSIS

--- a/docs/libcurl/curl_share_setopt.3
+++ b/docs/libcurl/curl_share_setopt.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_share_setopt 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH curl_share_setopt 3 "8 Aug 2003" "libcurl" "libcurl"
 .SH NAME
 curl_share_setopt - Set options for a shared object
 .SH SYNOPSIS

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_share_strerror 3 "Apr 26, 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_share_strerror 3 "Apr 26, 2004" "libcurl" "libcurl"
 .SH NAME
 curl_share_strerror - return string describing error code
 .SH SYNOPSIS

--- a/docs/libcurl/curl_slist_append.3
+++ b/docs/libcurl/curl_slist_append.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_slist_append 3 "19 Jun 2003" "libcurl 7.10.4" "libcurl Manual"
+.TH curl_slist_append 3 "19 Jun 2003" "libcurl" "libcurl"
 .SH NAME
 curl_slist_append - add a string to an slist
 .SH SYNOPSIS

--- a/docs/libcurl/curl_slist_free_all.3
+++ b/docs/libcurl/curl_slist_free_all.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_slist_free_all 3 "5 March 2001" "libcurl 7.0" "libcurl Manual"
+.TH curl_slist_free_all 3 "5 March 2001" "libcurl" "libcurl"
 .SH NAME
 curl_slist_free_all - free an entire curl_slist list
 .SH SYNOPSIS

--- a/docs/libcurl/curl_strequal.3
+++ b/docs/libcurl/curl_strequal.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_strequal 3 "30 April 2004" "libcurl 7.12" "libcurl Manual"
+.TH curl_strequal 3 "30 April 2004" "libcurl" "libcurl"
 .SH NAME
 curl_strequal, curl_strnequal - case insensitive string comparisons
 .SH SYNOPSIS

--- a/docs/libcurl/curl_unescape.3
+++ b/docs/libcurl/curl_unescape.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_unescape 3 "22 March 2001" "libcurl 7.7" "libcurl Manual"
+.TH curl_unescape 3 "22 March 2001" "libcurl" "libcurl"
 .SH NAME
 curl_unescape - URL decodes the given string
 .SH SYNOPSIS

--- a/docs/libcurl/curl_url.3
+++ b/docs/libcurl/curl_url.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_url 3 "6 Aug 2018" "libcurl" "libcurl Manual"
+.TH curl_url 3 "6 Aug 2018" "libcurl" "libcurl"
 .SH NAME
 curl_url - returns a new URL handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_url_cleanup.3
+++ b/docs/libcurl/curl_url_cleanup.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_url_cleanup 3 "6 Aug 2018" "libcurl" "libcurl Manual"
+.TH curl_url_cleanup 3 "6 Aug 2018" "libcurl" "libcurl"
 .SH NAME
 curl_url_cleanup - free the URL handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_url_dup.3
+++ b/docs/libcurl/curl_url_dup.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_url_dup 3 "6 Aug 2018" "libcurl" "libcurl Manual"
+.TH curl_url_dup 3 "6 Aug 2018" "libcurl" "libcurl"
 .SH NAME
 curl_url_dup - duplicate a URL handle
 .SH SYNOPSIS

--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_url_get 3 "6 Aug 2018" "libcurl" "libcurl Manual"
+.TH curl_url_get 3 "6 Aug 2018" "libcurl" "libcurl"
 .SH NAME
 curl_url_get - extract a part from a URL
 .SH SYNOPSIS

--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_url_set 3 "6 Aug 2018" "libcurl" "libcurl Manual"
+.TH curl_url_set 3 "6 Aug 2018" "libcurl" "libcurl"
 .SH NAME
 curl_url_set - set a URL part
 .SH SYNOPSIS

--- a/docs/libcurl/curl_url_strerror.3
+++ b/docs/libcurl/curl_url_strerror.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_url_strerror 3 "21 Aug 2021" "libcurl 7.80.0" "libcurl Manual"
+.TH curl_url_strerror 3 "21 Aug 2021" "libcurl" "libcurl"
 .SH NAME
 curl_url_strerror - return string describing error code
 .SH SYNOPSIS

--- a/docs/libcurl/curl_version.3
+++ b/docs/libcurl/curl_version.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH curl_version 3 "5 March 2001" "libcurl 7.0" "libcurl Manual"
+.TH curl_version 3 "5 March 2001" "libcurl" "libcurl"
 .SH NAME
 curl_version - returns the libcurl version string
 .SH SYNOPSIS

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_version_info 3 "2 Nov 2014" "libcurl 7.40.0" "libcurl Manual"
+.TH curl_version_info 3 "2 Nov 2014" "libcurl" "libcurl"
 .SH NAME
 curl_version_info - returns runtime libcurl version info
 .SH SYNOPSIS

--- a/docs/libcurl/curl_ws_meta.3
+++ b/docs/libcurl/curl_ws_meta.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_ws_meta 3 "12 Jun 2022" "libcurl 7.85.0" "libcurl Manual"
+.TH curl_ws_meta 3 "12 Jun 2022" "libcurl" "libcurl"
 .SH NAME
 curl_ws_meta - meta data WebSocket information
 .SH SYNOPSIS

--- a/docs/libcurl/curl_ws_recv.3
+++ b/docs/libcurl/curl_ws_recv.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_ws_recv 3 "12 Jun 2022" "libcurl 7.85.0" "libcurl Manual"
+.TH curl_ws_recv 3 "12 Jun 2022" "libcurl" "libcurl"
 .SH NAME
 curl_ws_recv - receive WebSocket data
 .SH SYNOPSIS

--- a/docs/libcurl/curl_ws_send.3
+++ b/docs/libcurl/curl_ws_send.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH curl_ws_send 3 "12 Jun 2022" "libcurl 7.85.0" "libcurl Manual"
+.TH curl_ws_send 3 "12 Jun 2022" "libcurl" "libcurl"
 .SH NAME
 curl_ws_send - send WebSocket data
 .SH SYNOPSIS

--- a/docs/libcurl/libcurl-easy.3
+++ b/docs/libcurl/libcurl-easy.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH libcurl 3 "19 Sep 2014" "libcurl" "libcurl easy interface"
+.TH libcurl 3 "19 Sep 2014" "libcurl" "libcurl"
 .SH NAME
 libcurl-easy \- easy interface overview
 .SH DESCRIPTION

--- a/docs/libcurl/libcurl-env.3
+++ b/docs/libcurl/libcurl-env.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH libcurl-env 3 "20 January 2018" "libcurl 7.58.0" "libcurl environment variables"
+.TH libcurl-env 3 "20 January 2018" "libcurl" "libcurl"
 .SH NAME
 libcurl-env \- environment variables libcurl understands
 .SH DESCRIPTION

--- a/docs/libcurl/libcurl-errors.3
+++ b/docs/libcurl/libcurl-errors.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH libcurl-errors 3 "23 Nov 2021" "libcurl 7.81.0" "libcurl errors"
+.TH libcurl-errors 3 "23 Nov 2021" "libcurl" "libcurl"
 .SH NAME
 libcurl-errors \- error codes in libcurl
 .SH DESCRIPTION

--- a/docs/libcurl/libcurl-multi.3
+++ b/docs/libcurl/libcurl-multi.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH libcurl-multi 3 "19 Sep 2014" "libcurl" "libcurl multi interface"
+.TH libcurl-multi 3 "19 Sep 2014" "libcurl" "libcurl"
 .SH NAME
 libcurl-multi \- how to use the multi interface
 .SH DESCRIPTION

--- a/docs/libcurl/libcurl-security.3
+++ b/docs/libcurl/libcurl-security.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH libcurl-security 3 "13 Feb 2018" "libcurl" "libcurl security"
+.TH libcurl-security 3 "13 Feb 2018" "libcurl" "libcurl"
 .SH NAME
 libcurl-security \- security considerations when using libcurl
 .SH "Security"

--- a/docs/libcurl/libcurl-share.3
+++ b/docs/libcurl/libcurl-share.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH libcurl-share 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl share interface"
+.TH libcurl-share 3 "8 Aug 2003" "libcurl" "libcurl"
 .SH NAME
 libcurl-share \- how to use the share interface
 .SH DESCRIPTION

--- a/docs/libcurl/libcurl-thread.3
+++ b/docs/libcurl/libcurl-thread.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH libcurl-thread 3 "13 Jul 2015" "libcurl" "libcurl thread safety"
+.TH libcurl-thread 3 "13 Jul 2015" "libcurl" "libcurl"
 .SH NAME
 libcurl-thread \- libcurl thread safety
 .SH "Multi-threading with libcurl"

--- a/docs/libcurl/libcurl-tutorial.3
+++ b/docs/libcurl/libcurl-tutorial.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH libcurl-tutorial 3 "19 Sep 2014" "libcurl" "libcurl programming"
+.TH libcurl-tutorial 3 "19 Sep 2014" "libcurl" "libcurl"
 .SH NAME
 libcurl-tutorial \- libcurl programming tutorial
 .SH "Objective"

--- a/docs/libcurl/libcurl-url.3
+++ b/docs/libcurl/libcurl-url.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH libcurl 3 "10 Sep 2018" "libcurl" "libcurl URL interface"
+.TH libcurl 3 "10 Sep 2018" "libcurl" "libcurl"
 .SH NAME
 libcurl-url \- URL interface overview
 .SH DESCRIPTION

--- a/docs/libcurl/libcurl.3
+++ b/docs/libcurl/libcurl.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH libcurl 3 "March 19, 2002" "libcurl 7.9.6" "libcurl overview"
+.TH libcurl 3 "March 19, 2002" "libcurl" "libcurl"
 .SH NAME
 libcurl \- client-side URL transfers
 .SH DESCRIPTION

--- a/docs/libcurl/mksymbolsmanpage.pl
+++ b/docs/libcurl/mksymbolsmanpage.pl
@@ -53,7 +53,7 @@ print <<HEADER
 .\\" * SPDX-License-Identifier: curl
 .\\" *
 .\\" **************************************************************************
-.TH libcurl-symbols 3 "$date" "libcurl $version" "libcurl symbols"
+.TH libcurl-symbols 3 "$date" "libcurl" "libcurl"
 .SH NAME
 libcurl-symbols \\- libcurl symbol version information
 .SH "libcurl symbols"

--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_ACTIVESOCKET 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_ACTIVESOCKET 3 "12 Sep 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_ACTIVESOCKET \- get the active socket
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_APPCONNECT_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_APPCONNECT_TIME 3 "28 Aug 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_APPCONNECT_TIME \- get the time until the SSL/SSH handshake is completed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.3
@@ -22,9 +22,9 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_APPCONNECT_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_APPCONNECT_TIME_T 3 "28 Apr 2018" "libcurl" "libcurl"
 .SH NAME
-CURLINFO_APPCONNECT_TIME_T \- get the time until the SSL/SSH handshake is completed
+CURLINFO_APPCONNECT_TIME_T \- time until the SSL/SSH handshake completed
 .SH SYNOPSIS
 .nf
 #include <curl/curl.h>

--- a/docs/libcurl/opts/CURLINFO_CAINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CAINFO 3 "20 May 2022" "libcurl 7.84.0" "curl_easy_getinfo options"
+.TH CURLINFO_CAINFO 3 "20 May 2022" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CAINFO \- get the default built-in CA certificate path
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CAPATH.3
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CAPATH 3 "20 May 2022" "libcurl 7.84.0" "curl_easy_getinfo options"
+.TH CURLINFO_CAPATH 3 "20 May 2022" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CAPATH \- get the default built-in CA path string
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.3
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CERTINFO 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_CERTINFO 3 "12 Sep 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CERTINFO \- get the TLS certificate chain
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONDITION_UNMET 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONDITION_UNMET 3 "1 Sep 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONDITION_UNMET \- get info on unmet time conditional or 304 HTTP response.
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONNECT_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONNECT_TIME 3 "28 Aug 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONNECT_TIME \- get the time until connect
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONNECT_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONNECT_TIME_T 3 "28 Apr 2018" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONNECT_TIME_T \- get the time until connect
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONTENT_LENGTH_DOWNLOAD 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONTENT_LENGTH_DOWNLOAD 3 "1 Sep 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONTENT_LENGTH_DOWNLOAD \- get content-length of download
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONTENT_LENGTH_DOWNLOAD_T 3 "25 May 2017" "libcurl 7.55.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONTENT_LENGTH_DOWNLOAD_T 3 "25 May 2017" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONTENT_LENGTH_DOWNLOAD_T \- get content-length of download
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONTENT_LENGTH_UPLOAD 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONTENT_LENGTH_UPLOAD 3 "1 Sep 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONTENT_LENGTH_UPLOAD \- get the specified size of the upload
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONTENT_LENGTH_UPLOAD_T 3 "25 May 2017" "libcurl 7.55.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONTENT_LENGTH_UPLOAD_T 3 "25 May 2017" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONTENT_LENGTH_UPLOAD_T \- get the specified size of the upload
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.3
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_CONTENT_TYPE 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_CONTENT_TYPE 3 "1 Sep 2015" "libcurl" "libcurl"
 .SH NAME
 CURLINFO_CONTENT_TYPE \- get Content-Type
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_COOKIELIST 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_COOKIELIST 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_COOKIELIST \- get all known cookies
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.3
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_EFFECTIVE_METHOD 3 "28 Aug 2015" "libcurl 7.72.0" "curl_easy_getinfo options"
+.TH CURLINFO_EFFECTIVE_METHOD 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_EFFECTIVE_METHOD \- get the last used HTTP method
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.3
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_EFFECTIVE_URL 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_EFFECTIVE_URL 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_EFFECTIVE_URL \- get the last used URL
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_FILETIME.3
+++ b/docs/libcurl/opts/CURLINFO_FILETIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_FILETIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_FILETIME 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_FILETIME \- get the remote time of the retrieved document
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_FILETIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_FILETIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_FILETIME 3 "25 Jan 2018" "libcurl 7.59.0" "curl_easy_getinfo options"
+.TH CURLINFO_FILETIME 3 "25 Jan 2018" libcurl libcurl
 .SH NAME
 CURLINFO_FILETIME_T \- get the remote time of the retrieved document
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.3
+++ b/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_FTP_ENTRY_PATH 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_FTP_ENTRY_PATH 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_FTP_ENTRY_PATH \- get entry path in FTP server
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.3
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_HEADER_SIZE 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_HEADER_SIZE 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_HEADER_SIZE \- get size of retrieved headers
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.3
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_HTTPAUTH_AVAIL 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_HTTPAUTH_AVAIL 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_HTTPAUTH_AVAIL \- get available HTTP authentication methods
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.3
+++ b/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_HTTP_CONNECTCODE 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_HTTP_CONNECTCODE 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_HTTP_CONNECTCODE \- get the CONNECT response code
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLINFO_HTTP_VERSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_HTTP_VERSION 3 "11 May 2016" "libcurl 7.50.0" "curl_easy_getinfo options"
+.TH CURLINFO_HTTP_VERSION 3 "11 May 2016" libcurl libcurl
 .SH NAME
 CURLINFO_HTTP_VERSION \- get the http version used in the connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_LASTSOCKET 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_LASTSOCKET 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_LASTSOCKET \- get the last socket used
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_LOCAL_IP 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_LOCAL_IP 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_LOCAL_IP \- get local IP address of last connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.3
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_LOCAL_PORT 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_LOCAL_PORT 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_LOCAL_PORT \- get the latest local port number
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_NAMELOOKUP_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_NAMELOOKUP_TIME 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_NAMELOOKUP_TIME \- get the name lookup time
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_NAMELOOKUP_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_NAMELOOKUP_TIME_T 3 "28 Apr 2018" libcurl libcurl
 .SH NAME
 CURLINFO_NAMELOOKUP_TIME_T \- get the name lookup time in microseconds
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.3
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_NUM_CONNECTS 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_NUM_CONNECTS 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_NUM_CONNECTS \- get number of created connections
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_OS_ERRNO 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_OS_ERRNO 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_OS_ERRNO \- get errno number from last connect failure
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PRETRANSFER_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_PRETRANSFER_TIME 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_PRETRANSFER_TIME \- get the time until the file transfer start
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PRETRANSFER_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_PRETRANSFER_TIME_T 3 "28 Apr 2018" libcurl libcurl
 .SH NAME
 CURLINFO_PRETRANSFER_TIME_T \- get the time until the file transfer start
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PRIMARY_IP 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_PRIMARY_IP 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_PRIMARY_IP \- get IP address of last connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.3
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PRIMARY_PORT 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_PRIMARY_PORT 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_PRIMARY_PORT \- get the latest destination port number
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.3
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PRIVATE 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_PRIVATE 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_PRIVATE \- get the private pointer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.3
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PROTOCOL 3 "23 November 2016" "libcurl 7.52.0" "curl_easy_getinfo options"
+.TH CURLINFO_PROTOCOL 3 "23 November 2016" libcurl libcurl
 .SH NAME
 CURLINFO_PROTOCOL \- get the protocol used in the connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.3
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PROXYAUTH_AVAIL 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_PROXYAUTH_AVAIL 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_PROXYAUTH_AVAIL \- get available HTTP proxy authentication methods
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PROXY_ERROR.3
+++ b/docs/libcurl/opts/CURLINFO_PROXY_ERROR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PROXY_ERROR 3 "3 Aug 2020" "libcurl 7.73.0" "curl_easy_getinfo options"
+.TH CURLINFO_PROXY_ERROR 3 "3 Aug 2020" libcurl libcurl
 .SH NAME
 CURLINFO_PROXY_ERROR \- get the detailed (SOCKS) proxy error
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.3
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_PROXY_SSL_VERIFYRESULT 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_getinfo options"
+.TH CURLINFO_PROXY_SSL_VERIFYRESULT 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLINFO_PROXY_SSL_VERIFYRESULT \- get the result of the proxy certificate verification
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_REDIRECT_COUNT 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_REDIRECT_COUNT 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_REDIRECT_COUNT \- get the number of redirects
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_REDIRECT_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_REDIRECT_TIME 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_REDIRECT_TIME \- get the time for all redirection steps
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_REDIRECT_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_REDIRECT_TIME_T 3 "28 Apr 2018" libcurl libcurl
 .SH NAME
 CURLINFO_REDIRECT_TIME_T \- get the time for all redirection steps
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_URL.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_URL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_REDIRECT_URL 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_REDIRECT_URL 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_REDIRECT_URL \- get the URL a redirect would go to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_REFERER.3
+++ b/docs/libcurl/opts/CURLINFO_REFERER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_REFERER 3 "11 Feb 2021" "libcurl 7.76.0" "curl_easy_getinfo options"
+.TH CURLINFO_REFERER 3 "11 Feb 2021" libcurl libcurl
 .SH NAME
 CURLINFO_REFERER \- get the referrer header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.3
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_REQUEST_SIZE 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_REQUEST_SIZE 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_REQUEST_SIZE \- get size of sent request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_RESPONSE_CODE 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_RESPONSE_CODE 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_RESPONSE_CODE \- get the last response code
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_RETRY_AFTER.3
+++ b/docs/libcurl/opts/CURLINFO_RETRY_AFTER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_RETRY_AFTER 3 "6 Aug 2019" "libcurl 7.66.0" "curl_easy_getinfo options"
+.TH CURLINFO_RETRY_AFTER 3 "6 Aug 2019" libcurl libcurl
 .SH NAME
 CURLINFO_RETRY_AFTER \- returns the Retry-After retry delay
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_RTSP_CLIENT_CSEQ 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_RTSP_CLIENT_CSEQ 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_RTSP_CLIENT_CSEQ \- get the next RTSP client CSeq
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_RTSP_CSEQ_RECV 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_RTSP_CSEQ_RECV 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_RTSP_CSEQ_RECV \- get the recently received CSeq
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_RTSP_SERVER_CSEQ 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_RTSP_SERVER_CSEQ 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_RTSP_SERVER_CSEQ \- get the next RTSP server CSeq
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.3
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_RTSP_SESSION_ID 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_RTSP_SESSION_ID 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_RTSP_SESSION_ID \- get RTSP session ID
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SCHEME.3
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SCHEME 3 "23 November 2016" "libcurl 7.52.0" "curl_easy_getinfo options"
+.TH CURLINFO_SCHEME 3 "23 November 2016" libcurl libcurl
 .SH NAME
 CURLINFO_SCHEME \- get the URL scheme (sometimes called protocol) used in the connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SIZE_DOWNLOAD 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SIZE_DOWNLOAD 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SIZE_DOWNLOAD \- get the number of downloaded bytes
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SIZE_DOWNLOAD_T 3 "25 May 2017" "libcurl 7.55.0" "curl_easy_getinfo options"
+.TH CURLINFO_SIZE_DOWNLOAD_T 3 "25 May 2017" libcurl libcurl
 .SH NAME
 CURLINFO_SIZE_DOWNLOAD_T \- get the number of downloaded bytes
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SIZE_UPLOAD 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SIZE_UPLOAD 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SIZE_UPLOAD \- get the number of uploaded bytes
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SIZE_UPLOAD_T 3 "25 May 2017" "libcurl 7.55.0" "curl_easy_getinfo options"
+.TH CURLINFO_SIZE_UPLOAD_T 3 "25 May 2017" libcurl libcurl
 .SH NAME
 CURLINFO_SIZE_UPLOAD_T \- get the number of uploaded bytes
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SPEED_DOWNLOAD 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SPEED_DOWNLOAD 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SPEED_DOWNLOAD \- get download speed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SPEED_DOWNLOAD_T 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SPEED_DOWNLOAD_T 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SPEED_DOWNLOAD_T \- get download speed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SPEED_UPLOAD 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SPEED_UPLOAD 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SPEED_UPLOAD \- get upload speed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.3
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SPEED_UPLOAD_T 3 "25 May 2017" "libcurl 7.55.0" "curl_easy_getinfo options"
+.TH CURLINFO_SPEED_UPLOAD_T 3 "25 May 2017" libcurl libcurl
 .SH NAME
 CURLINFO_SPEED_UPLOAD_T \- get upload speed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.3
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SSL_ENGINES 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SSL_ENGINES 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SSL_ENGINES \- get an slist of OpenSSL crypto-engines
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.3
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_SSL_VERIFYRESULT 3 "1 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_SSL_VERIFYRESULT 3 "1 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_SSL_VERIFYRESULT \- get the result of the certificate verification
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_STARTTRANSFER_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_STARTTRANSFER_TIME 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_STARTTRANSFER_TIME \- get the time until the first byte is received
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_STARTTRANSFER_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_STARTTRANSFER_TIME_T 3 "28 Apr 2018" libcurl libcurl
 .SH NAME
 CURLINFO_STARTTRANSFER_TIME_T \- get the time until the first byte is received
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_TLS_SESSION 3 "12 Sep 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_TLS_SESSION 3 "12 Sep 2015" libcurl libcurl
 .SH NAME
 CURLINFO_TLS_SESSION \- get TLS session info
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_TLS_SSL_PTR 3 "23 Feb 2016" "libcurl 7.48.0" "curl_easy_getinfo options"
+.TH CURLINFO_TLS_SSL_PTR 3 "23 Feb 2016" libcurl libcurl
 .SH NAME
 CURLINFO_TLS_SESSION, CURLINFO_TLS_SSL_PTR \- get TLS session info
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_TOTAL_TIME 3 "28 Aug 2015" "libcurl 7.44.0" "curl_easy_getinfo options"
+.TH CURLINFO_TOTAL_TIME 3 "28 Aug 2015" libcurl libcurl
 .SH NAME
 CURLINFO_TOTAL_TIME \- get total time of previous transfer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLINFO_TOTAL_TIME_T 3 "28 Apr 2018" "libcurl 7.61.0" "curl_easy_getinfo options"
+.TH CURLINFO_TOTAL_TIME_T 3 "28 Apr 2018" libcurl libcurl
 .SH NAME
 CURLINFO_TOTAL_TIME_T \- get total time of previous transfer in microseconds
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.3
+++ b/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE 3 "4 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE 3 "4 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE \- chunk length threshold for pipelining
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.3
+++ b/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE 3 "4 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE 3 "4 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE \- size threshold for pipelining penalty
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_MAXCONNECTS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_multi_setopt options"
+.TH CURLMOPT_MAXCONNECTS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_MAXCONNECTS \- size of connection cache
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_MAX_CONCURRENT_STREAMS 3 "06 Nov 2019" "libcurl 7.67.0" "curl_multi_setopt options"
+.TH CURLMOPT_MAX_CONCURRENT_STREAMS 3 "06 Nov 2019" libcurl libcurl
 .SH NAME
 CURLMOPT_MAX_CONCURRENT_STREAMS \- max concurrent streams for http2
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_MAX_HOST_CONNECTIONS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_multi_setopt options"
+.TH CURLMOPT_MAX_HOST_CONNECTIONS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_MAX_HOST_CONNECTIONS \- max number of connections to a single host
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_MAX_PIPELINE_LENGTH 3 "4 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_MAX_PIPELINE_LENGTH 3 "4 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_MAX_PIPELINE_LENGTH \- maximum number of requests in a pipeline
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_MAX_TOTAL_CONNECTIONS 3 "4 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_MAX_TOTAL_CONNECTIONS 3 "4 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_MAX_TOTAL_CONNECTIONS \- max simultaneously open connections
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_PIPELINING 3 "17 Jun 2014" "libcurl 7.37.0" "curl_multi_setopt options"
+.TH CURLMOPT_PIPELINING 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_PIPELINING \- enable HTTP pipelining and multiplexing
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_PIPELINING_SERVER_BL 3 "4 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_PIPELINING_SERVER_BL 3 "4 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_PIPELINING_SERVER_BL \- pipelining server block list
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.3
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_PIPELINING_SITE_BL 3 "4 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_PIPELINING_SITE_BL 3 "4 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_PIPELINING_SITE_BL \- pipelining host block list
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_PUSHDATA.3
+++ b/docs/libcurl/opts/CURLMOPT_PUSHDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_PUSHDATA 3 "1 Jun 2015" "libcurl 7.44.0" "curl_multi_setopt options"
+.TH CURLMOPT_PUSHDATA 3 "1 Jun 2015" libcurl libcurl
 .SH NAME
 CURLMOPT_PUSHDATA \- pointer to pass to push callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_PUSHFUNCTION 3 "1 Jun 2015" "libcurl 7.44.0" "curl_multi_setopt options"
+.TH CURLMOPT_PUSHFUNCTION 3 "1 Jun 2015" libcurl libcurl
 .SH NAME
 CURLMOPT_PUSHFUNCTION \- callback that approves or denies server pushes
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_SOCKETDATA.3
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_SOCKETDATA 3 "3 Nov 2014" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_SOCKETDATA 3 "3 Nov 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_SOCKETDATA \- custom pointer passed to the socket callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_SOCKETFUNCTION 3 "3 Nov 2016" "libcurl 7.39.0" "curl_multi_setopt options"
+.TH CURLMOPT_SOCKETFUNCTION 3 "3 Nov 2016" libcurl libcurl
 .SH NAME
 CURLMOPT_SOCKETFUNCTION \- callback informed about what to wait for
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.3
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_TIMERDATA 3 "17 Jun 2014" "libcurl 7.37.0" "curl_multi_setopt options"
+.TH CURLMOPT_TIMERDATA 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_TIMERDATA \- custom pointer to pass to timer callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.3
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLMOPT_TIMERFUNCTION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_multi_setopt options"
+.TH CURLMOPT_TIMERFUNCTION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLMOPT_TIMERFUNCTION \- callback to receive timeout values
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ABSTRACT_UNIX_SOCKET 3 "08 Jan 2017" "libcurl 7.53.0" "curl_easy_setopt options"
+.TH CURLOPT_ABSTRACT_UNIX_SOCKET 3 "08 Jan 2017" libcurl libcurl
 .SH NAME
 CURLOPT_ABSTRACT_UNIX_SOCKET \- abstract Unix domain socket
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ACCEPTTIMEOUT_MS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_ACCEPTTIMEOUT_MS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_ACCEPTTIMEOUT_MS \- timeout waiting for FTP server to connect back
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ACCEPT_ENCODING 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_ACCEPT_ENCODING 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_ACCEPT_ENCODING \- automatic decompression of HTTP downloads
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.3
+++ b/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ADDRESS_SCOPE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_ADDRESS_SCOPE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_ADDRESS_SCOPE \- scope id for IPv6 addresses
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.3
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ALTSVC 3 "5 Feb 2019" "libcurl 7.64.1" "curl_easy_setopt options"
+.TH CURLOPT_ALTSVC 3 "5 Feb 2019" libcurl libcurl
 .SH NAME
 CURLOPT_ALTSVC \- alt-svc cache file name
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.3
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ALTSVC_CTRL 3 "5 Feb 2019" "libcurl 7.64.1" "curl_easy_setopt options"
+.TH CURLOPT_ALTSVC_CTRL 3 "5 Feb 2019" libcurl libcurl
 .SH NAME
 CURLOPT_ALTSVC_CTRL \- control alt-svc behavior
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_APPEND.3
+++ b/docs/libcurl/opts/CURLOPT_APPEND.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_APPEND 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_APPEND 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_APPEND \- append to the remote file
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_AUTOREFERER 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_AUTOREFERER 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_AUTOREFERER \- automatically update the referer header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_AWS_SIGV4.3
+++ b/docs/libcurl/opts/CURLOPT_AWS_SIGV4.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_AWS_SIGV4 3 "03 Jun 2020" "libcurl 7.75.0" "curl_easy_setopt options"
+.TH CURLOPT_AWS_SIGV4 3 "03 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_AWS_SIGV4 \- V4 signature
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_BUFFERSIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_BUFFERSIZE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_BUFFERSIZE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_BUFFERSIZE \- receive buffer size
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CAINFO 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CAINFO 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CAINFO \- path to Certificate Authority (CA) bundle
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CAINFO_BLOB 3 "31 March 2021" "libcurl 7.77.0" "curl_easy_setopt options"
+.TH CURLOPT_CAINFO_BLOB 3 "31 March 2021" libcurl libcurl
 .SH NAME
 CURLOPT_CAINFO_BLOB \- Certificate Authority (CA) bundle in PEM format
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_CAPATH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CAPATH 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CAPATH 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CAPATH \- directory holding CA certificates
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CA_CACHE_TIMEOUT 3 "21 Dec 2022" "libcurl 7.87.0" "curl_easy_setopt options"
+.TH CURLOPT_CA_CACHE_TIMEOUT 3 "21 Dec 2022" libcurl libcurl
 .SH NAME
 CURLOPT_CA_CACHE_TIMEOUT \- life-time for cached certificate stores
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.3
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CERTINFO 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CERTINFO 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CERTINFO \- request SSL certificate information
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CHUNK_BGN_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CHUNK_BGN_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CHUNK_BGN_FUNCTION \- callback before a transfer with FTP wildcard match
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CHUNK_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_DATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CHUNK_DATA 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CHUNK_DATA 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CHUNK_DATA \- pointer passed to the FTP chunk callbacks
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CHUNK_END_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CHUNK_END_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CHUNK_END_FUNCTION \- callback after a transfer with FTP wildcard match
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.3
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CLOSESOCKETDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CLOSESOCKETDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CLOSESOCKETDATA \- pointer passed to the socket close callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CLOSESOCKETFUNCTION 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CLOSESOCKETFUNCTION 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CLOSESOCKETFUNCTION \- callback to socket close replacement
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONNECTTIMEOUT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CONNECTTIMEOUT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CONNECTTIMEOUT \- timeout for the connect phase
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONNECTTIMEOUT_MS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CONNECTTIMEOUT_MS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CONNECTTIMEOUT_MS \- timeout for the connect phase
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONNECT_ONLY 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CONNECT_ONLY 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CONNECT_ONLY \- stop when connected to target server
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONNECT_TO 3 "10 April 2016" "libcurl 7.49.0" "curl_easy_setopt options"
+.TH CURLOPT_CONNECT_TO 3 "10 April 2016" libcurl libcurl
 .SH NAME
 CURLOPT_CONNECT_TO \- connect to a specific host and port instead of the URL's host and port
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONV_FROM_NETWORK_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CONV_FROM_NETWORK_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CONV_FROM_NETWORK_FUNCTION \- convert data from network to host encoding
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONV_FROM_UTF8_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CONV_FROM_UTF8_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CONV_FROM_UTF8_FUNCTION \- convert data from UTF8 to host encoding
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CONV_TO_NETWORK_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CONV_TO_NETWORK_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CONV_TO_NETWORK_FUNCTION \- convert data to network from host encoding
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_COOKIE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_COOKIE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_COOKIE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_COOKIE \- HTTP Cookie header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_COOKIEFILE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_COOKIEFILE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_COOKIEFILE \- file name to read cookies from
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_COOKIEJAR 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_COOKIEJAR 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_COOKIEJAR \- file name to store cookies to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_COOKIELIST 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_COOKIELIST 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_COOKIELIST \- add to or manipulate cookies held in memory
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_COOKIESESSION.3
+++ b/docs/libcurl/opts/CURLOPT_COOKIESESSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_COOKIESESSION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_COOKIESESSION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_COOKIESESSION \- start a new cookie session
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_COPYPOSTFIELDS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_COPYPOSTFIELDS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_COPYPOSTFIELDS \- have libcurl copy data to POST
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CRLF.3
+++ b/docs/libcurl/opts/CURLOPT_CRLF.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CRLF 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CRLF 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CRLF \- CRLF conversion
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CRLFILE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CRLFILE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CRLFILE \- Certificate Revocation List file
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CURLU.3
+++ b/docs/libcurl/opts/CURLOPT_CURLU.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CURLU 3 "28 Oct 2018" "libcurl 7.63.0" "curl_easy_setopt options"
+.TH CURLOPT_CURLU 3 "28 Oct 2018" libcurl libcurl
 .SH NAME
 CURLOPT_CURLU \- URL in URL handle format
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_CUSTOMREQUEST 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_CUSTOMREQUEST 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_CUSTOMREQUEST \- custom request method
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DEBUGDATA.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DEBUGDATA 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DEBUGDATA 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DEBUGDATA \- pointer passed to the debug callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DEBUGFUNCTION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DEBUGFUNCTION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DEBUGFUNCTION \- debug callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.3
+++ b/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DEFAULT_PROTOCOL 3 "18 Aug 2015" "libcurl 7.45.0" "curl_easy_setopt options"
+.TH CURLOPT_DEFAULT_PROTOCOL 3 "18 Aug 2015" libcurl libcurl
 .SH NAME
 CURLOPT_DEFAULT_PROTOCOL \- default protocol to use if the URL is missing a
 scheme name

--- a/docs/libcurl/opts/CURLOPT_DIRLISTONLY.3
+++ b/docs/libcurl/opts/CURLOPT_DIRLISTONLY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DIRLISTONLY 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DIRLISTONLY 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DIRLISTONLY \- ask for names only in a directory listing
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DISALLOW_USERNAME_IN_URL 3 "30 May 2018" "libcurl 7.61.0" "curl_easy_setopt options"
+.TH CURLOPT_DISALLOW_USERNAME_IN_URL 3 "30 May 2018" libcurl libcurl
 .SH NAME
 CURLOPT_DISALLOW_USERNAME_IN_URL \- disallow specifying username in the URL
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_CACHE_TIMEOUT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_CACHE_TIMEOUT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_CACHE_TIMEOUT \- life-time for DNS cache entries
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_INTERFACE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_INTERFACE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_INTERFACE \- interface to speak DNS over
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_LOCAL_IP4 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_LOCAL_IP4 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_LOCAL_IP4 \- IPv4 address to bind DNS resolves to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_LOCAL_IP6 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_LOCAL_IP6 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_LOCAL_IP6 \- IPv6 address to bind DNS resolves to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_SERVERS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_SERVERS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_SERVERS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_SERVERS \- DNS servers to use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_SHUFFLE_ADDRESSES.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_SHUFFLE_ADDRESSES.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_SHUFFLE_ADDRESSES 3 "3 March 2018" "libcurl 7.60.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_SHUFFLE_ADDRESSES 3 "3 March 2018" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_SHUFFLE_ADDRESSES \- shuffle IP addresses for hostname
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DNS_USE_GLOBAL_CACHE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_DNS_USE_GLOBAL_CACHE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_DNS_USE_GLOBAL_CACHE \- global DNS cache
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DOH_SSL_VERIFYHOST 3 "11 Feb 2021" "libcurl 7.76.0" "curl_easy_setopt options"
+.TH CURLOPT_DOH_SSL_VERIFYHOST 3 "11 Feb 2021" libcurl libcurl
 .SH NAME
 CURLOPT_DOH_SSL_VERIFYHOST \- verify the host name in the DoH SSL certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DOH_SSL_VERIFYPEER 3 "11 Feb 2021" "libcurl 7.76.0" "curl_easy_setopt options"
+.TH CURLOPT_DOH_SSL_VERIFYPEER 3 "11 Feb 2021" libcurl libcurl
 .SH NAME
 CURLOPT_DOH_SSL_VERIFYPEER \- verify the DoH SSL certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DOH_SSL_VERIFYSTATUS 3 "11 Feb 2021" "libcurl 7.76.0" "curl_easy_setopt options"
+.TH CURLOPT_DOH_SSL_VERIFYSTATUS 3 "11 Feb 2021" libcurl libcurl
 .SH NAME
 CURLOPT_DOH_SSL_VERIFYSTATUS \- verify the DoH SSL certificate's status
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_DOH_URL 3 "18 Jun 2018" "libcurl 7.62.0" "curl_easy_setopt options"
+.TH CURLOPT_DOH_URL 3 "18 Jun 2018" libcurl libcurl
 .SH NAME
 CURLOPT_DOH_URL \- provide the DNS-over-HTTPS URL
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_EGDSOCKET 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_EGDSOCKET 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_EGDSOCKET \- EGD socket path
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ERRORBUFFER 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_ERRORBUFFER 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_ERRORBUFFER \- error buffer for error messages
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_EXPECT_100_TIMEOUT_MS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_EXPECT_100_TIMEOUT_MS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_EXPECT_100_TIMEOUT_MS \- timeout for Expect: 100-continue response
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FAILONERROR.3
+++ b/docs/libcurl/opts/CURLOPT_FAILONERROR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FAILONERROR 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FAILONERROR 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FAILONERROR \- request failure on HTTP response >= 400
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FILETIME.3
+++ b/docs/libcurl/opts/CURLOPT_FILETIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FILETIME 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FILETIME 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FILETIME \- get the modification time of the remote resource
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FNMATCH_DATA 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FNMATCH_DATA 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FNMATCH_DATA \- pointer passed to the fnmatch callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FNMATCH_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FNMATCH_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FNMATCH_FUNCTION \- wildcard match callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FOLLOWLOCATION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FOLLOWLOCATION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FOLLOWLOCATION \- follow HTTP 3xx redirects
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.3
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FORBID_REUSE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FORBID_REUSE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FORBID_REUSE \- make connection get closed at once after use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.3
+++ b/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FRESH_CONNECT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FRESH_CONNECT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FRESH_CONNECT \- force a new connection to be used
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTPPORT.3
+++ b/docs/libcurl/opts/CURLOPT_FTPPORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTPPORT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTPPORT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTPPORT \- make FTP transfer active
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTPSSLAUTH 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTPSSLAUTH 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTPSSLAUTH \- order in which to attempt TLS vs SSL
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_ACCOUNT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_ACCOUNT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_ACCOUNT \- account info for FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_ALTERNATIVE_TO_USER 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_ALTERNATIVE_TO_USER 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_ALTERNATIVE_TO_USER \- command to use instead of USER with FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_CREATE_MISSING_DIRS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_CREATE_MISSING_DIRS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_CREATE_MISSING_DIRS \- create missing directories for FTP and SFTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_FILEMETHOD 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_FILEMETHOD 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_FILEMETHOD \- select directory traversing method for FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_SKIP_PASV_IP 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_SKIP_PASV_IP 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_SKIP_PASV_IP \- ignore the IP address in the PASV response
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_SSL_CCC 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_SSL_CCC 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_SSL_CCC \- switch off SSL again with FTP after auth
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_USE_EPRT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_USE_EPRT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_USE_EPRT \- use EPRT for FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_USE_EPSV 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_USE_EPSV 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_USE_EPSV \- use EPSV for FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.3
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_FTP_USE_PRET 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_FTP_USE_PRET 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_FTP_USE_PRET \- use PRET for FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.3
+++ b/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_GSSAPI_DELEGATION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_GSSAPI_DELEGATION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_GSSAPI_DELEGATION \- allowed GSS-API delegation
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS 3 "1 Feb 2018" "libcurl 7.59.0" "curl_easy_setopt options"
+.TH CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS 3 "1 Feb 2018" libcurl libcurl
 .SH NAME
 CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS \- head start for IPv6 for happy eyeballs
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.3
+++ b/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HAPROXYPROTOCOL 3 "5 Feb 2018" "libcurl 7.60.0" "curl_easy_setopt options"
+.TH CURLOPT_HAPROXYPROTOCOL 3 "5 Feb 2018" libcurl libcurl
 .SH NAME
 CURLOPT_HAPROXYPROTOCOL \- send HAProxy PROXY protocol v1 header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HEADER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HEADER 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HEADER 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HEADER \- pass headers to the data stream
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HEADERDATA 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HEADERDATA 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HEADERDATA \- pointer to pass to header callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HEADERFUNCTION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HEADERFUNCTION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HEADERFUNCTION \- callback that receives header data
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.3
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HEADEROPT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HEADEROPT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HEADEROPT \- send HTTP headers to both proxy and host or separately
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HSTS.3
+++ b/docs/libcurl/opts/CURLOPT_HSTS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HSTS 3 "5 Feb 2019" "libcurl 7.74.0" "curl_easy_setopt options"
+.TH CURLOPT_HSTS 3 "5 Feb 2019" libcurl libcurl
 .SH NAME
 CURLOPT_HSTS \- HSTS cache file name
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HSTSREADDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HSTSREADDATA 3 "14 Sep 2020" "libcurl 7.74.0" "curl_easy_setopt options"
+.TH CURLOPT_HSTSREADDATA 3 "14 Sep 2020" libcurl libcurl
 .SH NAME
 CURLOPT_HSTSREADDATA \- pointer passed to the HSTS read callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HSTSREADFUNCTION 3 "14 Sep 2020" "libcurl 7.74.0" "curl_easy_setopt options"
+.TH CURLOPT_HSTSREADFUNCTION 3 "14 Sep 2020" libcurl libcurl
 .SH NAME
 CURLOPT_HSTSREADFUNCTION \- read callback for HSTS hosts
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HSTSWRITEDATA 3 "14 Sep 2020" "libcurl 7.74.0" "curl_easy_setopt options"
+.TH CURLOPT_HSTSWRITEDATA 3 "14 Sep 2020" libcurl libcurl
 .SH NAME
 CURLOPT_HSTSWRITEDATA \- pointer passed to the HSTS write callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HSTSWRITEFUNCTION 3 "14 Sep 2020" "libcurl 7.74.0" "curl_easy_setopt options"
+.TH CURLOPT_HSTSWRITEFUNCTION 3 "14 Sep 2020" libcurl libcurl
 .SH NAME
 CURLOPT_HSTSWRITEFUNCTION \- write callback for HSTS hosts
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HSTS_CTRL.3
+++ b/docs/libcurl/opts/CURLOPT_HSTS_CTRL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HSTS_CTRL 3 "4 Sep 2020" "libcurl 7.74.0" "curl_easy_setopt options"
+.TH CURLOPT_HSTS_CTRL 3 "4 Sep 2020" libcurl libcurl
 .SH NAME
 CURLOPT_HSTS_CTRL \- control HSTS behavior
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTP09_ALLOWED 3 "17 Dec 2018" "libcurl 7.64.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTP09_ALLOWED 3 "17 Dec 2018" libcurl libcurl
 .SH NAME
 CURLOPT_HTTP09_ALLOWED \- allow HTTP/0.9 response
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTP200ALIASES 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTP200ALIASES 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTP200ALIASES \- alternative matches for HTTP 200 OK
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTPAUTH 3 "2 Aug 2014" "libcurl 7.38.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTPAUTH 3 "2 Aug 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTPAUTH \- HTTP server authentication methods to try
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTPGET.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPGET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTPGET 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTPGET 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTPGET \- ask for an HTTP GET request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTPHEADER 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTPHEADER 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTPHEADER \- set of HTTP headers
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTPPOST.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPPOST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTPPOST 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTPPOST 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTPPOST \- multipart formpost content
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.3
+++ b/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTPPROXYTUNNEL 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTPPROXYTUNNEL 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTPPROXYTUNNEL \- tunnel through HTTP proxy
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTP_CONTENT_DECODING.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_CONTENT_DECODING.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTP_CONTENT_DECODING 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTP_CONTENT_DECODING 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTP_CONTENT_DECODING \- HTTP content decoding control
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTP_TRANSFER_DECODING.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_TRANSFER_DECODING.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTP_TRANSFER_DECODING 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTP_TRANSFER_DECODING 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTP_TRANSFER_DECODING \- HTTP transfer decoding control
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_HTTP_VERSION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_HTTP_VERSION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_HTTP_VERSION \- HTTP protocol version to use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.3
+++ b/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_IGNORE_CONTENT_LENGTH 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_IGNORE_CONTENT_LENGTH 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_IGNORE_CONTENT_LENGTH \- ignore content length
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE.3
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_INFILESIZE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_INFILESIZE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_INFILESIZE \- size of the input file to send off
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_INFILESIZE_LARGE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_INFILESIZE_LARGE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_INFILESIZE_LARGE \- size of the input file to send off
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_INTERFACE.3
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_INTERFACE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_INTERFACE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_INTERFACE \- source interface for outgoing traffic
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_INTERLEAVEDATA 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_INTERLEAVEDATA 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_INTERLEAVEDATA \- pointer passed to RTSP interleave callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_INTERLEAVEFUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_INTERLEAVEFUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_INTERLEAVEFUNCTION \- callback for RTSP interleaved data
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_IOCTLDATA.3
+++ b/docs/libcurl/opts/CURLOPT_IOCTLDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_IOCTLDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_IOCTLDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_IOCTLDATA \- pointer passed to I/O callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_IOCTLFUNCTION 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_IOCTLFUNCTION 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_IOCTLFUNCTION \- callback for I/O operations
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_IPRESOLVE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_IPRESOLVE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_IPRESOLVE \- IP protocol version to use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ISSUERCERT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_ISSUERCERT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_ISSUERCERT \- issuer SSL certificate filename
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_ISSUERCERT_BLOB 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_ISSUERCERT_BLOB 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_ISSUERCERT_BLOB \- issuer SSL certificate from memory blob
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.3
+++ b/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_KEEP_SENDING_ON_ERROR 3 "22 Sep 2016" "libcurl 7.51.0" "curl_easy_setopt options"
+.TH CURLOPT_KEEP_SENDING_ON_ERROR 3 "22 Sep 2016" libcurl libcurl
 .SH NAME
 CURLOPT_KEEP_SENDING_ON_ERROR \- keep sending on early HTTP response >= 300
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_KEYPASSWD 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_KEYPASSWD 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_KEYPASSWD \- passphrase to private key
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_KRBLEVEL.3
+++ b/docs/libcurl/opts/CURLOPT_KRBLEVEL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_KRBLEVEL 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_KRBLEVEL 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_KRBLEVEL \- FTP kerberos security level
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_LOCALPORT.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_LOCALPORT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_LOCALPORT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_LOCALPORT \- local port number to use for socket
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_LOCALPORTRANGE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_LOCALPORTRANGE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_LOCALPORTRANGE \- number of additional local ports to try
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_LOGIN_OPTIONS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_LOGIN_OPTIONS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_LOGIN_OPTIONS \- login options
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.3
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_LOW_SPEED_LIMIT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_LOW_SPEED_LIMIT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_LOW_SPEED_LIMIT \- low speed limit in bytes per second
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.3
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_LOW_SPEED_TIME 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_LOW_SPEED_TIME 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_LOW_SPEED_TIME \- low speed limit time period
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_AUTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAIL_AUTH 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAIL_AUTH 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAIL_AUTH \- SMTP authentication address
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_FROM.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAIL_FROM 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAIL_FROM 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAIL_FROM \- SMTP sender address
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAIL_RCPT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAIL_RCPT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAIL_RCPT \- list of SMTP mail recipients
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT_ALLLOWFAILS.3
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT_ALLLOWFAILS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAIL_RCPT_ALLLOWFAILS 3 "16 Jan 2020" "libcurl 7.69.0" "curl_easy_setopt options"
+.TH CURLOPT_MAIL_RCPT_ALLLOWFAILS 3 "16 Jan 2020" libcurl libcurl
 .SH NAME
 CURLOPT_MAIL_RCPT_ALLLOWFAILS \- allow RCPT TO command to fail for some recipients
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.3
+++ b/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAXAGE_CONN 3 "18 Apr 2019" "libcurl 7.65.0" "curl_easy_setopt options"
+.TH CURLOPT_MAXAGE_CONN 3 "18 Apr 2019" libcurl libcurl
 .SH NAME
 CURLOPT_MAXAGE_CONN \- max idle time allowed for reusing a connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAXCONNECTS.3
+++ b/docs/libcurl/opts/CURLOPT_MAXCONNECTS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAXCONNECTS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAXCONNECTS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAXCONNECTS \- maximum connection cache size
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.3
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAXFILESIZE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAXFILESIZE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAXFILESIZE \- maximum file size allowed to download
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAXFILESIZE_LARGE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAXFILESIZE_LARGE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAXFILESIZE_LARGE \- maximum file size allowed to download
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.3
+++ b/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAXLIFETIME_CONN 3 "10 Nov 2021" "libcurl 7.80.0" "curl_easy_setopt options"
+.TH CURLOPT_MAXLIFETIME_CONN 3 "10 Nov 2021" libcurl libcurl
 .SH NAME
 CURLOPT_MAXLIFETIME_CONN \- max lifetime (since creation) allowed for reusing a connection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAXREDIRS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAXREDIRS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAXREDIRS \- maximum number of redirects allowed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAX_RECV_SPEED_LARGE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAX_RECV_SPEED_LARGE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAX_RECV_SPEED_LARGE \- rate limit data download speed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MAX_SEND_SPEED_LARGE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_MAX_SEND_SPEED_LARGE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_MAX_SEND_SPEED_LARGE \- rate limit data upload speed
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MIMEPOST.3
+++ b/docs/libcurl/opts/CURLOPT_MIMEPOST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MIMEPOST 3 "22 Aug 2017" "libcurl 7.56.0" "curl_easy_setopt options"
+.TH CURLOPT_MIMEPOST 3 "22 Aug 2017" libcurl libcurl
 .SH NAME
 CURLOPT_MIMEPOST \- send data from mime structure
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_MIME_OPTIONS 3 "2 Oct 2021" "libcurl 7.81.0" "curl_easy_setopt options"
+.TH CURLOPT_MIME_OPTIONS 3 "2 Oct 2021" libcurl libcurl
 .SH NAME
 CURLOPT_MIME_OPTIONS \- set MIME option flags
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NETRC.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NETRC 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NETRC 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NETRC \- enable use of .netrc
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NETRC_FILE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NETRC_FILE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NETRC_FILE \- file name to read .netrc info from
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NEW_DIRECTORY_PERMS.3
+++ b/docs/libcurl/opts/CURLOPT_NEW_DIRECTORY_PERMS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NEW_DIRECTORY_PERMS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NEW_DIRECTORY_PERMS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NEW_DIRECTORY_PERMS \- permissions for remotely created directories
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NEW_FILE_PERMS.3
+++ b/docs/libcurl/opts/CURLOPT_NEW_FILE_PERMS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NEW_FILE_PERMS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NEW_FILE_PERMS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NEW_FILE_PERMS \- permissions for remotely created files
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NOBODY.3
+++ b/docs/libcurl/opts/CURLOPT_NOBODY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NOBODY 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NOBODY 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NOBODY \- do the download request without getting the body
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NOPROGRESS.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROGRESS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NOPROGRESS 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NOPROGRESS 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NOPROGRESS \- switch off the progress meter
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.3
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NOPROXY 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NOPROXY 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NOPROXY \- disable proxy use for specific hosts
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
+++ b/docs/libcurl/opts/CURLOPT_NOSIGNAL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_NOSIGNAL 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_NOSIGNAL 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_NOSIGNAL \- skip all signal handling
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.3
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_OPENSOCKETDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_OPENSOCKETDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_OPENSOCKETDATA \- pointer passed to open socket callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_OPENSOCKETFUNCTION 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_OPENSOCKETFUNCTION 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_OPENSOCKETFUNCTION \- callback for opening socket
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PASSWORD 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PASSWORD 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PASSWORD \- password to use in authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.3
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PATH_AS_IS 3 "17 Jun 2014" "libcurl 7.42.0" "curl_easy_setopt options"
+.TH CURLOPT_PATH_AS_IS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PATH_AS_IS \- do not handle dot dot sequences
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PINNEDPUBLICKEY 3 "27 Aug 2014" "libcurl 7.38.0" "curl_easy_setopt options"
+.TH CURLOPT_PINNEDPUBLICKEY 3 "27 Aug 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PINNEDPUBLICKEY \- pinned public key
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PIPEWAIT.3
+++ b/docs/libcurl/opts/CURLOPT_PIPEWAIT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PIPEWAIT 3 "12 May 2015" "libcurl 7.43.0" "curl_easy_setopt options"
+.TH CURLOPT_PIPEWAIT 3 "12 May 2015" libcurl libcurl
 .SH NAME
 CURLOPT_PIPEWAIT \- wait for pipelining/multiplexing
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PORT.3
+++ b/docs/libcurl/opts/CURLOPT_PORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PORT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PORT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PORT \- remote port number to connect to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_POST.3
+++ b/docs/libcurl/opts/CURLOPT_POST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_POST 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_POST 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_POST \- make an HTTP POST
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_POSTFIELDS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_POSTFIELDS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_POSTFIELDS \- data to POST to server
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_POSTFIELDSIZE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_POSTFIELDSIZE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_POSTFIELDSIZE \- size of POST data pointed to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_POSTFIELDSIZE_LARGE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_POSTFIELDSIZE_LARGE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_POSTFIELDSIZE_LARGE \- size of POST data pointed to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_POSTQUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTQUOTE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_POSTQUOTE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_POSTQUOTE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_POSTQUOTE \- (S)FTP commands to run after the transfer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.3
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_POSTREDIR 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_POSTREDIR 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_POSTREDIR \- how to act on an HTTP POST redirect
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PREQUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_PREQUOTE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PREQUOTE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PREQUOTE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PREQUOTE \- commands to run before an FTP transfer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PREREQDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PREREQDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PREREQDATA 3 "2 Aug 2021" "libcurl 7.80.0" "curl_easy_setopt options"
+.TH CURLOPT_PREREQDATA 3 "2 Aug 2021" libcurl libcurl
 .SH NAME
 CURLOPT_PREREQDATA \- pointer passed to the pre-request callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PREREQFUNCTION 3 "2 Aug 2021" "libcurl 7.80.0" "curl_easy_setopt options"
+.TH CURLOPT_PREREQFUNCTION 3 "2 Aug 2021" libcurl libcurl
 .SH NAME
 CURLOPT_PREREQFUNCTION \- user callback called when a connection has been
 established, but before a request has been made.

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PRE_PROXY 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PRE_PROXY 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PRE_PROXY \- pre-proxy host to use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PRIVATE.3
+++ b/docs/libcurl/opts/CURLOPT_PRIVATE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PRIVATE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PRIVATE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PRIVATE \- store a private pointer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROGRESSDATA 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROGRESSDATA 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROGRESSDATA \- pointer passed to the progress callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROGRESSFUNCTION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROGRESSFUNCTION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROGRESSFUNCTION \- progress meter callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.3
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROTOCOLS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROTOCOLS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROTOCOLS \- allowed protocols
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.3
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROTOCOLS_STR 3 "11 Jun 2022" "libcurl 7.85.0" "curl_easy_setopt options"
+.TH CURLOPT_PROTOCOLS_STR 3 "11 Jun 2022" libcurl libcurl
 .SH NAME
 CURLOPT_PROTOCOLS_STR \- allowed protocols
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY \- proxy to use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYAUTH 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYAUTH 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYAUTH \- HTTP proxy authentication methods
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYHEADER.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYHEADER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYHEADER 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYHEADER 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYHEADER \- set of HTTP headers to pass to proxy
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYPASSWORD 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYPASSWORD 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYPASSWORD \- password to use with proxy authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYPORT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYPORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYPORT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYPORT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYPORT \- port number the proxy listens on
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYTYPE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYTYPE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYTYPE \- proxy protocol type
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYUSERNAME 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYUSERNAME 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYUSERNAME \- user name to use for proxy authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXYUSERPWD 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXYUSERPWD 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXYUSERPWD \- user name and password to use for proxy authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_CAINFO 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_CAINFO 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_CAINFO \- path to proxy Certificate Authority (CA) bundle
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_CAINFO_BLOB 3 "31 March 2021" "libcurl 7.77.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_CAINFO_BLOB 3 "31 March 2021" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_CAINFO_BLOB \- proxy Certificate Authority (CA) bundle in PEM format
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_CAPATH 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_CAPATH 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_CAPATH \- directory holding HTTPS proxy CA certificates
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_CRLFILE 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_CRLFILE 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_CRLFILE \- HTTPS proxy Certificate Revocation List file
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_ISSUERCERT 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_ISSUERCERT 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_ISSUERCERT \- proxy issuer SSL certificate filename
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_ISSUERCERT_BLOB 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_ISSUERCERT_BLOB 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_ISSUERCERT_BLOB \- proxy issuer SSL certificate from memory blob
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_KEYPASSWD 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_KEYPASSWD 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_KEYPASSWD \- passphrase for the proxy private key
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_PINNEDPUBLICKEY 3 "24 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_PINNEDPUBLICKEY 3 "24 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_PINNEDPUBLICKEY \- pinned public key for https proxy
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SERVICE_NAME 3 "17 Jun 2015" "libcurl 7.43.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SERVICE_NAME 3 "17 Jun 2015" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SERVICE_NAME \- proxy authentication service name
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLCERT 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLCERT 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLCERT \- HTTPS proxy client certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLCERTTYPE 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLCERTTYPE 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLCERTTYPE \- type of the proxy client SSL certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLCERT_BLOB 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLCERT_BLOB 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLCERT_BLOB \- SSL proxy client certificate from memory blob
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLKEY 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLKEY 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLKEY \- private key file for HTTPS proxy client cert
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLKEYTYPE 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLKEYTYPE 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLKEYTYPE \- type of the proxy private key file
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLKEY_BLOB 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLKEY_BLOB 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLKEY_BLOB \- private key for proxy cert from memory blob
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSLVERSION 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSLVERSION 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSLVERSION \- preferred HTTPS proxy TLS version
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSL_CIPHER_LIST 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSL_CIPHER_LIST 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSL_CIPHER_LIST \- ciphers to use for HTTPS proxy
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSL_OPTIONS 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSL_OPTIONS 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSL_OPTIONS \- HTTPS proxy SSL behavior options
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSL_VERIFYHOST 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSL_VERIFYHOST 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSL_VERIFYHOST \- verify the proxy certificate's name against host
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_SSL_VERIFYPEER 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_SSL_VERIFYPEER 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_SSL_VERIFYPEER \- verify the proxy's SSL certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_TLS13_CIPHERS 3 "25 May 2018" "libcurl 7.61.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_TLS13_CIPHERS 3 "25 May 2018" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_TLS13_CIPHERS \- ciphers suites for proxy TLS 1.3
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_TLSAUTH_PASSWORD 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_TLSAUTH_PASSWORD 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_TLSAUTH_PASSWORD \- password to use for proxy TLS authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_TLSAUTH_TYPE 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_TLSAUTH_TYPE 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_TLSAUTH_TYPE \- HTTPS proxy TLS authentication methods
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_TLSAUTH_USERNAME 3 "16 Nov 2016" "libcurl 7.52.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_TLSAUTH_USERNAME 3 "16 Nov 2016" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_TLSAUTH_USERNAME \- user name to use for proxy TLS authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PROXY_TRANSFER_MODE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PROXY_TRANSFER_MODE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PROXY_TRANSFER_MODE \- append FTP transfer mode to URL for proxy
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_PUT.3
+++ b/docs/libcurl/opts/CURLOPT_PUT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_PUT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_PUT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_PUT \- make an HTTP PUT request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_QUICK_EXIT.3
+++ b/docs/libcurl/opts/CURLOPT_QUICK_EXIT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_QUICK_EXIT 3 "30 Sep 2022" "libcurl 7.87.0" "curl_easy_setopt options"
+.TH CURLOPT_QUICK_EXIT 3 "30 Sep 2022" libcurl libcurl
 .SH NAME
 CURLOPT_QUICK_EXIT \- allow to exit quickly
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_QUOTE.3
+++ b/docs/libcurl/opts/CURLOPT_QUOTE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_QUOTE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_QUOTE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_QUOTE \- (S)FTP commands to run before transfer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RANDOM_FILE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RANDOM_FILE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RANDOM_FILE \- file to read random data from
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RANGE.3
+++ b/docs/libcurl/opts/CURLOPT_RANGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RANGE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RANGE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RANGE \- byte range to request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_READDATA.3
+++ b/docs/libcurl/opts/CURLOPT_READDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_READDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_READDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_READDATA \- pointer passed to the read callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_READFUNCTION 3 "25 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_READFUNCTION 3 "25 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_READFUNCTION \- read callback for data uploads
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_REDIR_PROTOCOLS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_REDIR_PROTOCOLS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_REDIR_PROTOCOLS \- protocols allowed to redirect to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.3
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_REDIR_PROTOCOLS_STR 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_REDIR_PROTOCOLS_STR 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_REDIR_PROTOCOLS_STR \- protocols allowed to redirect to
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_REFERER.3
+++ b/docs/libcurl/opts/CURLOPT_REFERER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_REFERER 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_REFERER 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_REFERER \- the HTTP referer header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.3
+++ b/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_REQUEST_TARGET 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_REQUEST_TARGET 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_REQUEST_TARGET \- alternative target for this request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RESOLVE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RESOLVE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RESOLVE \- provide custom host name to IP address resolves
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RESOLVER_START_DATA 3 "14 Feb 2018" "libcurl 7.59.0" "curl_easy_setopt options"
+.TH CURLOPT_RESOLVER_START_DATA 3 "14 Feb 2018" libcurl libcurl
 .SH NAME
 CURLOPT_RESOLVER_START_DATA \- pointer passed to the resolver start callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RESOLVER_START_FUNCTION 3 "14 Feb 2018" "libcurl 7.59.0" "curl_easy_setopt options"
+.TH CURLOPT_RESOLVER_START_FUNCTION 3 "14 Feb 2018" libcurl libcurl
 .SH NAME
 CURLOPT_RESOLVER_START_FUNCTION \- callback called before a new name resolve is started
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM.3
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RESUME_FROM 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RESUME_FROM 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RESUME_FROM \- offset to resume transfer from
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RESUME_FROM_LARGE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RESUME_FROM_LARGE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RESUME_FROM_LARGE \- offset to resume transfer from
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RTSP_CLIENT_CSEQ 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RTSP_CLIENT_CSEQ 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RTSP_CLIENT_CSEQ \- RTSP client CSEQ number
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RTSP_REQUEST 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RTSP_REQUEST 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RTSP_REQUEST \- RTSP request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RTSP_SERVER_CSEQ 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RTSP_SERVER_CSEQ 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RTSP_SERVER_CSEQ \- RTSP server CSEQ number
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RTSP_SESSION_ID 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RTSP_SESSION_ID 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RTSP_SESSION_ID \- RTSP session ID
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RTSP_STREAM_URI 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RTSP_STREAM_URI 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RTSP_STREAM_URI \- RTSP stream URI
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.3
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_RTSP_TRANSPORT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_RTSP_TRANSPORT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_RTSP_TRANSPORT \- RTSP Transport: header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
+++ b/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SASL_AUTHZID 3 "11 Sep 2019" "libcurl 7.66.0" "curl_easy_setopt options"
+.TH CURLOPT_SASL_AUTHZID 3 "11 Sep 2019" libcurl libcurl
 .SH NAME
 CURLOPT_SASL_AUTHZID \- authorization identity (identity to act as)
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SASL_IR.3
+++ b/docs/libcurl/opts/CURLOPT_SASL_IR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SASL_IR 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SASL_IR 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SASL_IR \- send initial response in first packet
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SEEKDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SEEKDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SEEKDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SEEKDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SEEKDATA \- pointer passed to the seek callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SEEKFUNCTION 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SEEKFUNCTION 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SEEKFUNCTION \- user callback for seeking in input stream
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SERVER_RESPONSE_TIMEOUT 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SERVER_RESPONSE_TIMEOUT 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SERVER_RESPONSE_TIMEOUT \- time allowed to wait for server response
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
+++ b/docs/libcurl/opts/CURLOPT_SERVICE_NAME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SERVICE_NAME 3 "17 Jun 2015" "libcurl 7.43.0" "curl_easy_setopt options"
+.TH CURLOPT_SERVICE_NAME 3 "17 Jun 2015" libcurl libcurl
 .SH NAME
 CURLOPT_SERVICE_NAME \- authentication service name
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SHARE.3
+++ b/docs/libcurl/opts/CURLOPT_SHARE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SHARE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SHARE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SHARE \- share handle to use
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SOCKOPTDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SOCKOPTDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SOCKOPTDATA \- pointer to pass to sockopt callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SOCKOPTFUNCTION 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SOCKOPTFUNCTION 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SOCKOPTFUNCTION \- callback for setting socket options
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SOCKS5_AUTH 3 "27 April 2017" "libcurl 7.55.0" "curl_easy_setopt options"
+.TH CURLOPT_SOCKS5_AUTH 3 "27 April 2017" libcurl libcurl
 .SH NAME
 CURLOPT_SOCKS5_AUTH \- methods for SOCKS5 proxy authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SOCKS5_GSSAPI_NEC 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SOCKS5_GSSAPI_NEC 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SOCKS5_GSSAPI_NEC \- SOCKS proxy GSSAPI negotiation protection
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.3
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SOCKS5_GSSAPI_SERVICE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SOCKS5_GSSAPI_SERVICE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SOCKS5_GSSAPI_SERVICE \- SOCKS5 proxy authentication service name
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_AUTH_TYPES 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_AUTH_TYPES 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_AUTH_TYPES \- auth types for SFTP and SCP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_COMPRESSION 3 "05 Aug 2017" "libcurl 7.56.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_COMPRESSION 3 "05 Aug 2017" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_COMPRESSION \- enable SSH compression
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_KEYDATA 3 "4 Nov 2021" "libcurl 7.84.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_KEYDATA 3 "4 Nov 2021" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_HOSTKEYDATA \- pointer to pass to the SSH host key callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_HOSTKEYFUNCTION 3 "4 Nov 2021" "libcurl 7.84.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_HOSTKEYFUNCTION 3 "4 Nov 2021" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_HOSTKEYFUNCTION \- callback to check host key
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_HOST_PUBLIC_KEY_MD5 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_HOST_PUBLIC_KEY_MD5 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_HOST_PUBLIC_KEY_MD5 \- MD5 checksum of SSH server public key
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256 3 "27 Aug 2021" "libcurl 7.80.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256 3 "27 Aug 2021" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256 \- SHA256 hash of SSH server public key
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_KEYDATA 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_KEYDATA 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_KEYDATA \- pointer passed to the SSH key callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_KEYFUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_KEYFUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_KEYFUNCTION \- callback for known host matching logic
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_KNOWNHOSTS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_KNOWNHOSTS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_KNOWNHOSTS \- file name holding the SSH known hosts
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_PRIVATE_KEYFILE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_PRIVATE_KEYFILE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_PRIVATE_KEYFILE \- private key file for SSH auth
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSH_PUBLIC_KEYFILE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSH_PUBLIC_KEYFILE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSH_PUBLIC_KEYFILE \- public key file for SSH auth
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLCERT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLCERT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLCERT \- SSL client certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLCERTTYPE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLCERTTYPE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLCERTTYPE \- type of client SSL certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLCERT_BLOB 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLCERT_BLOB 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_SSLCERT_BLOB \- SSL client certificate from memory blob
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLENGINE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLENGINE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLENGINE \- SSL engine identifier
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.3
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLENGINE_DEFAULT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLENGINE_DEFAULT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLENGINE_DEFAULT \- make SSL engine default
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLKEY 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLKEY 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLKEY \- private key file for TLS and SSL client cert
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLKEYTYPE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLKEYTYPE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLKEYTYPE \- type of the private key file
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLKEY_BLOB 3 "24 Jun 2020" "libcurl 7.71.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLKEY_BLOB 3 "24 Jun 2020" libcurl libcurl
 .SH NAME
 CURLOPT_SSLKEY_BLOB \- private key for client cert from memory blob
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.3
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSLVERSION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSLVERSION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSLVERSION \- preferred TLS/SSL version
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_CIPHER_LIST 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_CIPHER_LIST 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_CIPHER_LIST \- ciphers to use for TLS
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_CTX_DATA 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_CTX_DATA 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_CTX_DATA \- pointer passed to SSL context callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_CTX_FUNCTION 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_CTX_FUNCTION 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_CTX_FUNCTION \- SSL context callback for OpenSSL, wolfSSL or mbedTLS
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_EC_CURVES 3 "29 Aug 2020" "libcurl 7.73.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_EC_CURVES 3 "29 Aug 2020" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_EC_CURVES \- key exchange curves
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_ENABLE_ALPN 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_ENABLE_ALPN 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_ENABLE_ALPN \- Application Layer Protocol Negotiation
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_ENABLE_NPN 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_ENABLE_NPN 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_ENABLE_NPN \- use NPN
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_FALSESTART 3 "14 Feb 2015" "libcurl 7.41.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_FALSESTART 3 "14 Feb 2015" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_FALSESTART \- TLS false start
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_OPTIONS 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_OPTIONS 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_OPTIONS \- SSL behavior options
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_SESSIONID_CACHE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_SESSIONID_CACHE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_SESSIONID_CACHE \- use the SSL session-ID cache
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_VERIFYHOST 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_VERIFYHOST 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_VERIFYHOST \- verify the certificate's name against host
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_VERIFYPEER 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_VERIFYPEER 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_VERIFYPEER \- verify the peer's SSL certificate
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SSL_VERIFYSTATUS 3 "04 Dec 2014" "libcurl 7.40.0" "curl_easy_setopt options"
+.TH CURLOPT_SSL_VERIFYSTATUS 3 "04 Dec 2014" libcurl libcurl
 .SH NAME
 CURLOPT_SSL_VERIFYSTATUS \- verify the certificate's status
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_STDERR.3
+++ b/docs/libcurl/opts/CURLOPT_STDERR.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_STDERR 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_STDERR 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_STDERR \- redirect stderr to another stream
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.3
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_STREAM_DEPENDS 3 "13 Sep 2015" "libcurl 7.46.0" "curl_easy_setopt options"
+.TH CURLOPT_STREAM_DEPENDS 3 "13 Sep 2015" libcurl libcurl
 .SH NAME
 CURLOPT_STREAM_DEPENDS \- stream this transfer depends on
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.3
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_STREAM_DEPENDS_E 3 "13 Sep 2015" "libcurl 7.46.0" "curl_easy_setopt options"
+.TH CURLOPT_STREAM_DEPENDS_E 3 "13 Sep 2015" libcurl libcurl
 .SH NAME
 CURLOPT_STREAM_DEPENDS_E \- stream this transfer depends on exclusively
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.3
+++ b/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_STREAM_WEIGHT 3 "13 Sep 2015" "libcurl 7.46.0" "curl_easy_setopt options"
+.TH CURLOPT_STREAM_WEIGHT 3 "13 Sep 2015" libcurl libcurl
 .SH NAME
 CURLOPT_STREAM_WEIGHT \- numerical stream weight
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_SUPPRESS_CONNECT_HEADERS.3
+++ b/docs/libcurl/opts/CURLOPT_SUPPRESS_CONNECT_HEADERS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_SUPPRESS_CONNECT_HEADERS 3 "13 February 2017" "libcurl 7.54.0" "curl_easy_setopt options"
+.TH CURLOPT_SUPPRESS_CONNECT_HEADERS 3 "13 February 2017" libcurl libcurl
 .SH NAME
 CURLOPT_SUPPRESS_CONNECT_HEADERS \- suppress proxy CONNECT response headers from user callbacks
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TCP_FASTOPEN 3 "16 Feb 2016" "libcurl 7.49.0" "curl_easy_setopt options"
+.TH CURLOPT_TCP_FASTOPEN 3 "16 Feb 2016" libcurl libcurl
 .SH NAME
 CURLOPT_TCP_FASTOPEN \- TCP Fast Open
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TCP_KEEPALIVE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TCP_KEEPALIVE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TCP_KEEPALIVE \- TCP keep-alive probing
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TCP_KEEPIDLE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TCP_KEEPIDLE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TCP_KEEPIDLE \- TCP keep-alive idle time wait
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TCP_KEEPINTVL 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TCP_KEEPINTVL 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TCP_KEEPINTVL \- TCP keep-alive interval
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.3
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TCP_NODELAY 3 "30 Jun 2016" "libcurl 7.50.0" "curl_easy_setopt options"
+.TH CURLOPT_TCP_NODELAY 3 "30 Jun 2016" libcurl libcurl
 .SH NAME
 CURLOPT_TCP_NODELAY \- the TCP_NODELAY option
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TELNETOPTIONS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TELNETOPTIONS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TELNETOPTIONS \- set of telnet options
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TFTP_BLKSIZE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TFTP_BLKSIZE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TFTP_BLKSIZE \- TFTP block size
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TFTP_NO_OPTIONS 3 "23 Feb 2016" "libcurl 7.48.0" "curl_easy_setopt options"
+.TH CURLOPT_TFTP_NO_OPTIONS 3 "23 Feb 2016" libcurl libcurl
 .SH NAME
 CURLOPT_TFTP_NO_OPTIONS \- send no TFTP options requests
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TIMECONDITION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TIMECONDITION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TIMECONDITION \- select condition for a time request
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TIMEOUT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TIMEOUT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TIMEOUT \- maximum time the transfer is allowed to complete
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TIMEOUT_MS 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TIMEOUT_MS 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TIMEOUT_MS \- maximum time the transfer is allowed to complete
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TIMEVALUE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TIMEVALUE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TIMEVALUE \- time value for conditional
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TIMEVALUE_LARGE 3 "25 Jan 2018" "libcurl 7.59.0" "curl_easy_setopt options"
+.TH CURLOPT_TIMEVALUE_LARGE 3 "25 Jan 2018" libcurl libcurl
 .SH NAME
 CURLOPT_TIMEVALUE_LARGE \- time value for conditional
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TLS13_CIPHERS 3 "25 May 2018" "libcurl 7.61.0" "curl_easy_setopt options"
+.TH CURLOPT_TLS13_CIPHERS 3 "25 May 2018" libcurl libcurl
 .SH NAME
 CURLOPT_TLS13_CIPHERS \- ciphers suites to use for TLS 1.3
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TLSAUTH_PASSWORD 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TLSAUTH_PASSWORD 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TLSAUTH_PASSWORD \- password to use for TLS authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TLSAUTH_TYPE 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TLSAUTH_TYPE 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TLSAUTH_TYPE \- TLS authentication methods
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TLSAUTH_USERNAME 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TLSAUTH_USERNAME 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TLSAUTH_USERNAME \- user name to use for TLS authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TRAILERDATA.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TRAILERDATA 3 "14 Aug 2018" "libcurl 7.64.0" "curl_easy_setopt options"
+.TH CURLOPT_TRAILERDATA 3 "14 Aug 2018" libcurl libcurl
 .SH NAME
 CURLOPT_TRAILERDATA \- pointer passed to trailing headers callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TRAILERFUNCTION 3 "14 Aug 2018" "libcurl 7.64.0" "curl_easy_setopt options"
+.TH CURLOPT_TRAILERFUNCTION 3 "14 Aug 2018" libcurl libcurl
 .SH NAME
 CURLOPT_TRAILERFUNCTION \- callback for sending trailing headers
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.3
+++ b/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TRANSFERTEXT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TRANSFERTEXT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TRANSFERTEXT \- request a text based transfer for FTP
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.3
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TRANSFER_ENCODING 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TRANSFER_ENCODING 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TRANSFER_ENCODING \- ask for HTTP Transfer Encoding
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_UNIX_SOCKET_PATH 3 "09 Oct 2014" "libcurl 7.40.0" "curl_easy_setopt options"
+.TH CURLOPT_UNIX_SOCKET_PATH 3 "09 Oct 2014" libcurl libcurl
 .SH NAME
 CURLOPT_UNIX_SOCKET_PATH \- Unix domain socket
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.3
+++ b/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_UNRESTRICTED_AUTH 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_UNRESTRICTED_AUTH 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_UNRESTRICTED_AUTH \- send credentials to other hosts too
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.3
+++ b/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_UPKEEP_INTERVAL_MS 3 "31 Oct 2018" "libcurl 7.62.0" "curl_easy_setopt options"
+.TH CURLOPT_UPKEEP_INTERVAL_MS 3 "31 Oct 2018" libcurl libcurl
 .SH NAME
 CURLOPT_UPKEEP_INTERVAL_MS \- connection upkeep interval
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_UPLOAD.3
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_UPLOAD 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_UPLOAD 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_UPLOAD \- data upload
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_UPLOAD_BUFFERSIZE 3 "18 Aug 2018" "libcurl 7.62.0" "curl_easy_setopt options"
+.TH CURLOPT_UPLOAD_BUFFERSIZE 3 "18 Aug 2018" libcurl libcurl
 .SH NAME
 CURLOPT_UPLOAD_BUFFERSIZE \- upload buffer size
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_URL.3
+++ b/docs/libcurl/opts/CURLOPT_URL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_URL 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_URL 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_URL \- URL for this transfer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.3
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_USERAGENT 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_USERAGENT 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_USERAGENT \- HTTP user-agent header
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_USERNAME.3
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_USERNAME 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_USERNAME 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_USERNAME \- user name to use in authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_USERPWD.3
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_USERPWD 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_USERPWD 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_USERPWD \- user name and password to use in authentication
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.3
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_USE_SSL 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_USE_SSL 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_USE_SSL \- request using SSL / TLS for the transfer
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.3
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_VERBOSE 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_VERBOSE 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_VERBOSE \- verbose mode
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_WILDCARDMATCH 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_WILDCARDMATCH 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_WILDCARDMATCH \- directory wildcard transfers
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_WRITEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEDATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_WRITEDATA 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_WRITEDATA 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_WRITEDATA \- pointer passed to the write callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_WRITEFUNCTION 3 "16 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_WRITEFUNCTION 3 "16 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_WRITEFUNCTION \- callback for writing received data
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_WS_OPTIONS 3 "10 Jun 2022" "libcurl 7.85.0" "curl_easy_setopt options"
+.TH CURLOPT_WS_OPTIONS 3 "10 Jun 2022" libcurl libcurl
 .SH NAME
 CURLOPT_WS_OPTIONS \- WebSocket behavior options
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_XFERINFODATA 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_XFERINFODATA 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_XFERINFODATA \- pointer passed to the progress callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_XFERINFOFUNCTION 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_XFERINFOFUNCTION 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_XFERINFOFUNCTION \- progress meter callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_XOAUTH2_BEARER 3 "19 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_XOAUTH2_BEARER 3 "19 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_XOAUTH2_BEARER \- OAuth 2.0 access token
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH CURLSHOPT_LOCKFUNC 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH CURLSHOPT_LOCKFUNC 3 "8 Aug 2003" libcurl libcurl
 .SH NAME
 CURLSHOPT_LOCKFUNC - mutex lock callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLSHOPT_SHARE.3
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH CURLSHOPT_SHARE 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH CURLSHOPT_SHARE 3 "8 Aug 2003" libcurl libcurl
 .SH NAME
 CURLSHOPT_SHARE - add data to share
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH CURLSHOPT_UNLOCKFUNC 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH CURLSHOPT_UNLOCKFUNC 3 "8 Aug 2003" libcurl libcurl
 .SH NAME
 CURLSHOPT_UNLOCKFUNC - mutex unlock callback
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLSHOPT_UNSHARE.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNSHARE.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH CURLSHOPT_UNSHARE 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH CURLSHOPT_UNSHARE 3 "8 Aug 2003" libcurl libcurl
 .SH NAME
 CURLSHOPT_UNSHARE - remove data to share
 .SH SYNOPSIS

--- a/docs/libcurl/opts/CURLSHOPT_USERDATA.3
+++ b/docs/libcurl/opts/CURLSHOPT_USERDATA.3
@@ -21,7 +21,7 @@
 .\" * SPDX-License-Identifier: curl
 .\" *
 .\" **************************************************************************
-.TH CURLSHOPT_USERDATA 3 "8 Aug 2003" "libcurl 7.10.7" "libcurl Manual"
+.TH CURLSHOPT_USERDATA 3 "8 Aug 2003" libcurl libcurl
 .SH NAME
 CURLSHOPT_USERDATA - pointer passed to the lock and unlock mutex callbacks
 .SH SYNOPSIS

--- a/docs/libcurl/opts/template.3
+++ b/docs/libcurl/opts/template.3
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH CURLOPT_TEMPLATE 3 "17 Jun 2014" "libcurl 7.37.0" "curl_easy_setopt options"
+.TH CURLOPT_TEMPLATE 3 "17 Jun 2014" libcurl libcurl
 .SH NAME
 CURLOPT_TEMPLATE \- [short description]
 .SH SYNOPSIS

--- a/docs/mk-ca-bundle.1
+++ b/docs/mk-ca-bundle.1
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH mk-ca-bundle 1 "24 Oct 2016" "version 1.27" "mk-ca-bundle manual"
+.TH mk-ca-bundle 1 "24 Oct 2016" mk-ca-bundle mk-ca-bundle
 .SH NAME
 mk-ca-bundle \- convert Mozilla's certificate bundle to PEM format
 .SH SYNOPSIS

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH runtests.pl 1 "19 Jan 2021" "Curl 7.75.0" "runtests"
+.TH runtests.pl 1 "19 Jan 2021" runtests runtests
 .SH NAME
 runtests.pl \- run one or more test cases
 .SH SYNOPSIS

--- a/tests/testcurl.1
+++ b/tests/testcurl.1
@@ -22,7 +22,7 @@
 .\" *
 .\" **************************************************************************
 .\"
-.TH testcurl.pl 1 "24 Mar 2010" "Curl 7.20.1" "testcurl"
+.TH testcurl.pl 1 "24 Mar 2010" testcurl testcurl
 .SH NAME
 testcurl.pl \- (automatically) test curl
 .SH SYNOPSIS


### PR DESCRIPTION
- remove the version numbers
- simplify the texts

The date and version number will be put there for releases when maketgz runs the updatemanpages.pl script.