### PR TITLE
tests/http: fix out-of-tree builds

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -70,19 +70,23 @@ jobs:
     - run: autoreconf -fi
       name: 'autoreconf'
 
-    - run: ./configure --enable-warnings --enable-werror --with-openssl=$HOME/awslc
-      name: 'configure'
+    - run: |
+        mkdir build
+        cd build
+        ../configure --enable-warnings --enable-werror --with-openssl=$HOME/awslc
+        cd ..
+      name: 'configure out-of-tree'
 
-    - run: make -j 2 V=1
+    - run: make -C build -j 2 V=1
       name: 'make'
 
-    - run: make -j 2 V=1 examples
+    - run: make -C build -j 2 V=1 examples
       name: 'make examples'
 
-    - run: make -j 2 V=1 -C tests
+    - run: make -C build -j 2 V=1 -C tests
       name: 'make tests'
 
-    - run: make V=1 test-ci
+    - run: make -C build V=1 test-ci
       name: 'run tests'
 
   cmake:
@@ -113,7 +117,7 @@ jobs:
 
     # CMAKE_COMPILE_WARNING_AS_ERROR is available in cmake 3.24 or later
     - run: cmake -Bbuild -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON .
-      name: 'cmake generate'
+      name: 'cmake generate out-of-tree'
 
     - run: cmake --build build --parallel
       name: 'cmake build'

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -33,6 +33,8 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 
 AM_CPPFLAGS = -I$(top_srcdir)/include   \
+              -I$(top_builddir)/lib     \
+              -I$(top_srcdir)/lib       \
               -DCURL_DISABLE_DEPRECATION
 
 LIBDIR = $(top_builddir)/lib

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -36,7 +36,7 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include "../../../lib/curl_setup.h"
+#include "curl_setup.h"
 
 #ifdef USE_WEBSOCKETS
 

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -36,7 +36,7 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include "../../../lib/curl_setup.h"
+#include "curl_setup.h"
 
 #ifdef USE_WEBSOCKETS
 


### PR DESCRIPTION
Add both lib/ directories (src & build) to the search path so curl_setup.h
and its dependencies can be found.

Switch the awslc builds to build out-of-tree to test this config.