### PR TITLE
checksrc: fix SPACEBEFOREPAREN for conditions starting with "*"

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1096,7 +1096,7 @@ static CURLcode cf_h1_proxy_connect(struct Curl_cfilter *cf,
 
 out:
   *done = (result == CURLE_OK) && tunnel_is_established(cf->ctx);
-  if (*done) {
+  if(*done) {
     cf->connected = TRUE;
     tunnel_free(cf, data);
   }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -293,8 +293,8 @@ bool Curl_conn_cf_discard_sub(struct Curl_cfilter *cf,
 
   /* remove from sub-chain and destroy */
   DEBUGASSERT(cf);
-  while (*pprev) {
-    if (*pprev == cf) {
+  while(*pprev) {
+    if(*pprev == cf) {
       *pprev = discard->next;
       discard->next = NULL;
       found = TRUE;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -548,7 +548,7 @@ static CURLcode baller_connect(struct Curl_cfilter *cf,
     baller->result = Curl_conn_cf_connect(baller->cf, data, 0, connected);
 
     if(!baller->result) {
-      if (*connected) {
+      if(*connected) {
         baller->connected = TRUE;
         baller->is_done = TRUE;
       }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4180,7 +4180,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
       size_t dirAlloc = 0;
       const char *str = rawPath;
       for(; *str != 0; ++str)
-        if (*str == '/')
+        if(*str == '/')
           ++dirAlloc;
 
       if(dirAlloc) {

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -204,7 +204,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
       p++;
     if(*p == ';')
       p++;
-  } while (*p);
+  } while(*p);
 
   if(!gotma)
     /* max-age is mandatory */

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -192,7 +192,7 @@ static CURLcode make_headers(struct Curl_easy *data,
   }
 
 
-  if (*content_sha256_header) {
+  if(*content_sha256_header) {
     tmp_head = curl_slist_append(head, content_sha256_header);
     if(!tmp_head)
       goto fail;

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -400,7 +400,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
         /* out of allowed range */
         return 1;
 
-      switch (*fmt) {
+      switch(*fmt) {
       case 'S':
         flags |= FLAGS_ALT;
         /* FALLTHROUGH */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -678,7 +678,7 @@ static int ipv4_normalize(struct dynbuf *host)
     parts[n] = l;
     c = endp;
 
-    switch (*c) {
+    switch(*c) {
     case '.' :
       if(n == 3)
         return HOST_BAD;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -897,7 +897,7 @@ static ssize_t bearssl_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   for(;;) {
     *err = bearssl_run_until(cf, data, BR_SSL_SENDAPP);
-    if (*err != CURLE_OK)
+    if(*err)
       return -1;
     app = br_ssl_engine_sendapp_buf(&backend->ctx.eng, &applen);
     if(!app) {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1554,7 +1554,7 @@ static CURLcode sectransp_set_selected_ciphers(struct Curl_easy *data,
     }
     /* Find last position of a cipher in the ciphers string */
     cipher_end = cipher_start;
-    while (*cipher_end != '\0' && !is_separator(*cipher_end)) {
+    while(*cipher_end != '\0' && !is_separator(*cipher_end)) {
       ++cipher_end;
     }
 

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -517,7 +517,8 @@ sub scanfile {
 
         my $nostr = nostrings($l);
         # check spaces after for/if/while/function call
-        if($nostr =~ /^(.*)(for|if|while| ([a-zA-Z0-9_]+)) \((.)/) {
+        if($nostr =~ /^(.*)(for|if|while|switch| ([a-zA-Z0-9_]+)) \((.)/) {
+            my ($leading, $word, $extra, $first)=($1,$2,$3,$4);
             if($1 =~ / *\#/) {
                 # this is a #if, treat it differently
             }
@@ -527,15 +528,16 @@ sub scanfile {
             elsif(defined $3 && $3 eq "case") {
                 # case must have a space
             }
-            elsif($4 eq "*") {
-                # (* beginning makes the space OK!
+            elsif(($first eq "*") && ($word !~ /(for|if|while|switch)/)) {
+                # A "(*" beginning makes the space OK because it wants to
+                # allow funcion pointer declared
             }
             elsif($1 =~ / *typedef/) {
                 # typedefs can use space-paren
             }
             else {
-                checkwarn("SPACEBEFOREPAREN", $line, length($1)+length($2), $file, $l,
-                          "$2 with space");
+                checkwarn("SPACEBEFOREPAREN", $line, length($leading)+length($word), $file, $l,
+                          "$word with space");
             }
         }
         # check for '== NULL' in if/while conditions but not if the thing on

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -369,7 +369,7 @@ ParameterError proto2num(struct OperationConfig *config,
 
     /* Process token modifiers */
     while(!ISALNUM(*token)) { /* may be NULL if token is all modifiers */
-      switch (*token++) {
+      switch(*token++) {
       case '=':
         action = set;
         break;

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -100,7 +100,7 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
   pat->globindex = globindex;
 
   while(!done) {
-    switch (*pattern) {
+    switch(*pattern) {
     case '\0':                  /* URL ended while set was still open */
       return GLOBERROR("unmatched brace", opos, CURLE_URL_MALFORMAT);
 
@@ -411,7 +411,7 @@ static CURLcode glob_parse(struct URLGlob *glob, char *pattern,
       res = glob_fixed(glob, glob->glob_buffer, sublen);
     }
     else {
-      switch (*pattern) {
+      switch(*pattern) {
       case '\0': /* done  */
         break;
 

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -61,7 +61,7 @@ void jsonWriteString(FILE *stream, const char *in, bool lowercase)
       fputs("\\t", stream);
       break;
     default:
-      if (*i < 32) {
+      if(*i < 32) {
         fprintf(stream, "u%04x", *i);
       }
       else {


### PR DESCRIPTION
The open paren check wants to warn for spaces before open parenthesis for if/while/for but also for any function call. In order to avoid catching function pointer declarations, the logic allows a space if the first character after the open parenthesis is an asterisk.

I also spotted what we did not include "switch" in the check but we should.

This check is a little lame, but we reduce this problem by not allowing that space for if/while/for/switch.

Reported-by: Emanuele Torre