### PR TITLE
multi: add multi-ignore logic to multi_socket_action

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3180,9 +3180,9 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   struct Curl_easy *data = NULL;
   struct Curl_tree *t;
   struct curltime now = Curl_now();
-  SIGPIPE_VARIABLE(pipe_st);
   bool first = FALSE;
   bool nosig = FALSE;
+  SIGPIPE_VARIABLE(pipe_st);
 
   if(checkall) {
     /* *perform() deals with running_handles on its own */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3260,7 +3260,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
       if(!first) {
         first = TRUE;
         nosig = data->set.no_signal;
-        sigpipe_restore(&pipe_st);
+        sigpipe_ignore(data, &pipe_st);
       }
       else if(data->set.no_signal != nosig) {
         sigpipe_restore(&pipe_st);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3259,12 +3259,13 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
     if(data) {
       if(!first) {
         first = TRUE;
-        nosig = data->set.no_signal;
+        nosig = data->set.no_signal; /* initial state */
         sigpipe_ignore(data, &pipe_st);
       }
       else if(data->set.no_signal != nosig) {
         sigpipe_restore(&pipe_st);
         sigpipe_ignore(data, &pipe_st);
+        nosig = data->set.no_signal; /* remember new state */
       }
       result = multi_runsingle(multi, &now, data);
 


### PR DESCRIPTION
The multi-ignore logic that was previously applied to curl_multi_perform() (#10750) is here applied to the loop within curl_multi_socket_action() to make it use the same optimization: most handles have the same signal-ignore option state so this drastically reduces the number of ignore/unignore calls per libcurl function invoke.

Follow-up to bc90308328afb8