### PR TITLE
tests/http: make curl_setup.h the first include

### DIFF
--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -25,6 +25,11 @@
  * HTTP/2 server push
  * </DESC>
  */
+
+/* curl stuff */
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,10 +37,6 @@
 /* somewhat unix-specific */
 #include <sys/time.h>
 #include <unistd.h>
-
-/* curl stuff */
-#include <curl/curl.h>
-#include <curl/mprintf.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -25,6 +25,11 @@
  * HTTP/2 server push
  * </DESC>
  */
+
+/* curl stuff */
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,10 +37,6 @@
 /* somewhat unix-specific */
 #include <sys/time.h>
 #include <unistd.h>
-
-/* curl stuff */
-#include <curl/curl.h>
-#include <curl/mprintf.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -25,6 +25,11 @@
  * Websockets data echos
  * </DESC>
  */
+
+/* curl stuff */
+#include "curl_setup.h"
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,11 +37,6 @@
 /* somewhat unix-specific */
 #include <sys/time.h>
 #include <unistd.h>
-
-
-/* curl stuff */
-#include <curl/curl.h>
-#include "curl_setup.h"
 
 #ifdef USE_WEBSOCKETS
 

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -25,6 +25,11 @@
  * Websockets pingpong
  * </DESC>
  */
+
+/* curl stuff */
+#include "curl_setup.h"
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,11 +37,6 @@
 /* somewhat unix-specific */
 #include <sys/time.h>
 #include <unistd.h>
-
-
-/* curl stuff */
-#include <curl/curl.h>
-#include "curl_setup.h"
 
 #ifdef USE_WEBSOCKETS
 


### PR DESCRIPTION
This is required for the macros there to take effect for system libraries. Specifically, including the system libraries first led to warnings about `_FILE_OFFSET_BITS` being redefined in curl_config.h on the Solaris autobuilds for ws-data.c and ws-pingpong.c. Also make the curl includes come first for the other source files here for consistency.

FYI @icing 