### PR TITLE
checksrc: check for spaces before colon of switch label

### DIFF
--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -181,13 +181,13 @@ curl_easy_strerror(CURLcode error)
   case CURLE_INTERFACE_FAILED:
     return "Failed binding local connection end";
 
-  case CURLE_TOO_MANY_REDIRECTS :
+  case CURLE_TOO_MANY_REDIRECTS:
     return "Number of redirects hit maximum amount";
 
   case CURLE_UNKNOWN_OPTION:
     return "An unknown option was passed in to libcurl";
 
-  case CURLE_SETOPT_OPTION_SYNTAX :
+  case CURLE_SETOPT_OPTION_SYNTAX:
     return "Malformed option provided in a setopt";
 
   case CURLE_GOT_NOTHING:

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -679,7 +679,7 @@ static int ipv4_normalize(struct dynbuf *host)
     c = endp;
 
     switch(*c) {
-    case '.' :
+    case '.':
       if(n == 3)
         return HOST_BAD;
       n++;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -90,6 +90,7 @@ my %warnings = (
     'SPACEBEFORECOMMA' => 'space before a comma',
     'SPACEBEFOREPAREN' => 'space before an open parenthesis',
     'SPACESEMICOLON'   => 'space before semicolon',
+    'SPACESWITCHCOLON' => 'space before colon of switch label',
     'TABS'             => 'TAB characters not allowed',
     'TRAILINGSPACE'    => 'Trailing whitespace on the line',
     'TYPEDEFSTRUCT'    => 'typedefed struct',
@@ -688,6 +689,12 @@ sub scanfile {
         if($l =~ /^(.*[^ ].*) ;$/) {
             checkwarn("SPACESEMICOLON",
                       $line, length($1), $file, $ol, "no space before semicolon");
+        }
+
+        # check for space before the colon in a switch label
+        if($l =~ /^( *(case .+|default)) :/) {
+            checkwarn("SPACESWITCHCOLON",
+                      $line, length($1), $file, $ol, "no space before colon of switch label");
         }
 
         # scan for use of banned functions

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -74,7 +74,7 @@ static void show_dir_errno(FILE *errors, const char *name)
             "exceeded your quota.\n", name);
     break;
 #endif
-  default :
+  default:
     fprintf(errors, "Error creating directory %s.\n", name);
     break;
   }


### PR DESCRIPTION
I spotted this when looking at the diff of d567cca
https://github.com/curl/curl/pull/11044/commits/601508ee816fc89910fc52ebfaedda5ccdef8303#diff-72e7d4123a3c69e8c31616bfea3a66f88afb86864cbaaeab76e455c0d4c19a72R682