### PR TITLE
ci: `-Wno-vla` no longer necessary

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -126,8 +126,7 @@ jobs:
     - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}  --enable-websockets
       name: 'configure'
       env:
-        # -Wvla is caused by brotli
-        CFLAGS: "-Wno-vla -mmacosx-version-min=${{ matrix.build.macosx-version-min }}"
+        CFLAGS: "-mmacosx-version-min=${{ matrix.build.macosx-version-min }}"
 
     - run: make V=1
       name: 'make'


### PR DESCRIPTION
We handle this issue in the source now.

Follow-up to b725fe1944b45406676ea3aff333ae3085a848d9

Closes #11048
