### PR TITLE
checksrc: find bad indentation in conditions without open brace

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -241,7 +241,7 @@ void Curl_sock_assign_addr(struct Curl_sockaddr_ex *dest,
   dest->addrlen = ai->ai_addrlen;
 
   if(dest->addrlen > sizeof(struct Curl_sockaddr_storage))
-     dest->addrlen = sizeof(struct Curl_sockaddr_storage);
+    dest->addrlen = sizeof(struct Curl_sockaddr_storage);
   memcpy(&dest->sa_addr, ai->ai_addr, dest->addrlen);
 }
 
@@ -1222,7 +1222,7 @@ static bool cf_socket_data_pending(struct Curl_cfilter *cf,
 
   (void)data;
   if(!Curl_bufq_is_empty(&ctx->recvbuf))
-     return TRUE;
+    return TRUE;
 
   readable = SOCKET_READABLE(ctx->sock, 0);
   return (readable > 0 && (readable & CURL_CSELECT_IN));

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4134,7 +4134,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
     case FTPFILE_NOCWD: /* fastest, but less standard-compliant */
 
       if((pathLen > 0) && (rawPath[pathLen - 1] != '/'))
-          fileName = rawPath;  /* this is a full file path */
+        fileName = rawPath;  /* this is a full file path */
       /*
         else: ftpc->file is not used anywhere other than for operations on
               a file. In other words, never for directory operations.

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1931,7 +1931,7 @@ static CURLcode imap_parse_url_options(struct connectdata *conn)
     const char *value;
 
     while(*ptr && *ptr != '=')
-        ptr++;
+      ptr++;
 
     value = ptr + 1;
 

--- a/lib/inet_ntop.c
+++ b/lib/inet_ntop.c
@@ -164,7 +164,7 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
   /* Was it a trailing run of 0x00's?
    */
   if(best.base != -1 && (best.base + best.len) == (IN6ADDRSZ / INT16SZ))
-     *tp++ = ':';
+    *tp++ = ':';
   *tp++ = '\0';
 
   /* Check for overflow, copy, and we're done.

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -731,7 +731,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     }
 
     if(ber)
-       ber_free(ber, 0);
+      ber_free(ber, 0);
   }
 
 quit:
@@ -1069,7 +1069,7 @@ static int _ldap_url_parse(struct Curl_easy *data,
 
   *ludpp = NULL;
   if(!ludp)
-     return LDAP_NO_MEMORY;
+    return LDAP_NO_MEMORY;
 
   rc = _ldap_url_parse2(data, conn, ludp);
   if(rc != LDAP_SUCCESS) {

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1107,7 +1107,7 @@ static int mime_subparts_seek(void *instream, curl_off_t offset, int whence)
     return CURL_SEEKFUNC_CANTSEEK;    /* Only support full rewind. */
 
   if(mime->state.state == MIMESTATE_BEGIN)
-   return CURL_SEEKFUNC_OK;           /* Already rewound. */
+    return CURL_SEEKFUNC_OK;           /* Already rewound. */
 
   for(part = mime->firstpart; part; part = part->nextpart) {
     int res = mime_part_rewind(part);
@@ -1734,7 +1734,7 @@ const char *Curl_mime_contenttype(const char *filename)
       size_t len2 = strlen(ctts[i].extension);
 
       if(len1 >= len2 && strcasecompare(nameend - len2, ctts[i].extension))
-          return ctts[i].type;
+        return ctts[i].type;
     }
   }
   return NULL;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2021,7 +2021,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       else
 #endif
         if(conn->bits.conn_to_host)
-        hostname = conn->conn_to_host.name;
+          hostname = conn->conn_to_host.name;
       else
         hostname = conn->host.name;
 

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -295,7 +295,7 @@ static CURLcode oldap_parse_login_options(struct connectdata *conn)
     const char *value;
 
     while(*ptr && *ptr != '=')
-        ptr++;
+      ptr++;
 
     value = ptr + 1;
 

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1376,7 +1376,7 @@ static CURLcode pop3_parse_url_options(struct connectdata *conn)
     const char *value;
 
     while(*ptr && *ptr != '=')
-        ptr++;
+      ptr++;
 
     value = ptr + 1;
 

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -542,7 +542,7 @@ static ssize_t cf_msh3_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(nread < 0)
       goto out;
     if(stream->closed)
-       drain_stream(cf, data);
+      drain_stream(cf, data);
   }
   else if(stream->closed) {
     nread = recv_closed_stream(cf, data, err);

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1710,7 +1710,7 @@ static CURLcode qng_verify_peer(struct Curl_cfilter *cf,
   Curl_conn_get_host(data, cf->sockindex, &hostname, &disp_hostname, &port);
   snihost = Curl_ssl_snihost(data, hostname, NULL);
   if(!snihost)
-      return CURLE_PEER_FAILED_VERIFICATION;
+    return CURLE_PEER_FAILED_VERIFICATION;
 
   cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   cf->conn->httpversion = 30;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1548,7 +1548,7 @@ static CURLcode sectransp_set_selected_ciphers(struct Curl_easy *data,
 
     /* Skip separators */
     while(is_separator(*cipher_start))
-       cipher_start++;
+      cipher_start++;
     if(*cipher_start == '\0') {
       break;
     }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -884,7 +884,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         ParameterError pe = GetSizeParameter(global, nextarg, "rate", &value);
 
         if(pe != PARAM_OK)
-           return pe;
+          return pe;
         config->recvpersecond = value;
         config->sendpersecond = value;
       }
@@ -1060,7 +1060,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
             GetSizeParameter(global, nextarg, "max-filesize", &value);
 
           if(pe != PARAM_OK)
-             return pe;
+            return pe;
           config->max_filesize = value;
         }
         break;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1878,7 +1878,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->dns_ipv4_addr)
           my_setopt_str(curl, CURLOPT_DNS_LOCAL_IP4, config->dns_ipv4_addr);
         if(config->dns_ipv6_addr)
-        my_setopt_str(curl, CURLOPT_DNS_LOCAL_IP6, config->dns_ipv6_addr);
+          my_setopt_str(curl, CURLOPT_DNS_LOCAL_IP6, config->dns_ipv6_addr);
 
         /* new in libcurl 7.6.2: */
         my_setopt_slist(curl, CURLOPT_TELNETOPTIONS, config->telnet_options);

--- a/tests/libtest/lib678.c
+++ b/tests/libtest/lib678.c
@@ -44,12 +44,12 @@ static int loadfile(const char *filename, void **filedata, size_t *filesize)
       else
         datasize = (size_t)cert_tell;
       if(continue_reading)
-         continue_reading = fseek(fInCert, 0, SEEK_SET) == 0;
+        continue_reading = fseek(fInCert, 0, SEEK_SET) == 0;
       if(continue_reading)
-          data = malloc(datasize + 1);
+        data = malloc(datasize + 1);
       if((!data) ||
-          ((int)fread(data, datasize, 1, fInCert) != 1))
-          continue_reading = FALSE;
+         ((int)fread(data, datasize, 1, fInCert) != 1))
+        continue_reading = FALSE;
       fclose(fInCert);
       if(!continue_reading) {
         free(data);

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -1095,7 +1095,7 @@ int main(int argc, char *argv[])
 
 #ifdef USE_UNIX_SOCKETS
   if(socket_domain == AF_UNIX)
-      logmsg("Listening on unix socket %s", unix_socket);
+    logmsg("Listening on unix socket %s", unix_socket);
   else
 #endif
   logmsg("Listening on port %hu", port);


### PR DESCRIPTION
If the previous line starts with if/while/for AND ends with a closed parenthesis and there's an equal number of open and closed parentheses on that line, verify that this line is indented $indent more steps, if not a cpp line.

Also adjust the fall-out from this fix.