### PR TITLE
ci: set minimal permissions on workflow ngtcp2-quictls.yml

### DIFF
--- a/.github/workflows/ngtcp2-quictls.yml
+++ b/.github/workflows/ngtcp2-quictls.yml
@@ -42,11 +42,14 @@ concurrency:
   group: ngtcp2-openssl-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   autotools:
     name: ${{ matrix.build.name }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 60
+    permissions: read-all
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ngtcp2-quictls.yml
+++ b/.github/workflows/ngtcp2-quictls.yml
@@ -49,7 +49,6 @@ jobs:
     name: ${{ matrix.build.name }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 60
-    permissions: read-all
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Hi! This PR brings a small security adjustment to limit the permissions of the workflow ngtcp2-quictls.yml, so that it follows the principle of least privilege. Exact same idea of the merged PR #9928 