### PR TITLE
easy_cleanup: require a "good" handle to act

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -787,14 +787,12 @@ CURLcode curl_easy_perform_ev(struct Curl_easy *data)
  */
 void curl_easy_cleanup(struct Curl_easy *data)
 {
-  SIGPIPE_VARIABLE(pipe_st);
-
-  if(!data)
-    return;
-
-  sigpipe_ignore(data, &pipe_st);
-  Curl_close(&data);
-  sigpipe_restore(&pipe_st);
+  if(GOOD_EASY_HANDLE(data)) {
+    SIGPIPE_VARIABLE(pipe_st);
+    sigpipe_ignore(data, &pipe_st);
+    Curl_close(&data);
+    sigpipe_restore(&pipe_st);
+  }
 }
 
 /*


### PR DESCRIPTION
By insisting that the passed in handle is "good" (the magic number is intact), this can limit the potential damage if a bad pointer is passed in. Like when this function is called twice on the same handle pointer.

Ref: #10964