### PR TITLE
Spawn a new process for the test runner

### DIFF
--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -44,14 +44,13 @@ BEGIN {
         $listonly
         $LOGDIR
         $memanalyze
-        $memdump
+        $MEMDUMP
         $perl
         $PIDDIR
         $proxy_address
         $PROXYIN
         $pwd
         $run_event_based
-        $SERVER2IN
         $SERVERIN
         $srcdir
         $TESTDIR
@@ -87,15 +86,6 @@ our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
 our $perl="perl -I$srcdir"; # invoke perl like this
 our $LOGDIR="log";  # root of the log directory
-# TODO: $LOGDIR could eventually change later on, so must regenerate all the
-# paths depending on it after $LOGDIR itself changes.
-our $PIDDIR = "$LOGDIR/server";  # root of the server directory with PID files
-# TODO: change this to use server_inputfilename()
-our $SERVERIN="$LOGDIR/server.input";    # what curl sent the server
-our $SERVER2IN="$LOGDIR/server2.input";  # what curl sent the second server
-our $PROXYIN="$LOGDIR/proxy.input";      # what curl sent the proxy
-our $memdump="$LOGDIR/memdump";  # file that the memory debugging creates
-our $FTPDCMD="$LOGDIR/ftpserver.cmd";    # copy server instructions here
 our $LIBDIR="./libtest";
 our $TESTDIR="$srcdir/data";
 our $CURL="../src/curl".exe_ext('TOOL'); # what curl binary to run on the tests
@@ -105,6 +95,13 @@ our $VCURL=$CURL;  # what curl binary to use to verify the servers with
 # the path to the script that analyzes the memory debug output file
 our $memanalyze="$perl $srcdir/memanalyze.pl";
 our $valgrind;     # path to valgrind, or empty if disabled
+
+# paths in $LOGDIR
+our $PIDDIR = "server";         # root of the server directory with PID files
+our $SERVERIN="server.input";   # what curl sent the server
+our $PROXYIN="proxy.input";     # what curl sent the proxy
+our $MEMDUMP="memdump";         # file that the memory debugging creates
+our $FTPDCMD="ftpserver.cmd";   # copy server instructions here
 
 # other config variables
 our @protocols;   # array of lowercase supported protocol servers

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -85,7 +85,8 @@ our $CURLVERSION="";  # curl's reported version number
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
 our $perl="perl -I$srcdir"; # invoke perl like this
-our $LOGDIR="log";  # root of the log directory
+our $LOGDIR="log";  # root of the log directory; this will be different for
+                    # each runner in multiprocess mode
 our $LIBDIR="./libtest";
 our $TESTDIR="$srcdir/data";
 our $CURL="../src/curl".exe_ext('TOOL'); # what curl binary to run on the tests

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -36,6 +36,7 @@ BEGIN {
         checktestcmd
         prepro
         restore_test_env
+        runner_init
         runner_clearlocks
         runner_stopservers
         runner_test_preprocess
@@ -115,6 +116,28 @@ sub stdoutfilename {
 sub stderrfilename {
     my ($logdir, $testnum)=@_;
     return "$logdir/stderr$testnum";
+}
+
+#######################################################################
+# Initialize the runner and prepare it to run tests
+#
+sub runner_init {
+    my ($logdir)=@_;
+
+    # Set this directory as ours
+    # TODO: This will need to be uncommented once there are multiple runners
+    #$LOGDIR = $logdir;
+    mkdir("$LOGDIR/$PIDDIR", 0777);
+
+    # enable memory debugging if curl is compiled with it
+    $ENV{'CURL_MEMDEBUG'} = "$LOGDIR/$MEMDUMP";
+    $ENV{'CURL_ENTROPY'}="12345678";
+    $ENV{'CURL_FORCETIME'}=1; # for debug NTLM magic
+    $ENV{'CURL_GLOBAL_INIT'}=1; # debug curl_global_init/cleanup use
+    $ENV{'HOME'}=$pwd;
+    $ENV{'CURL_HOME'}=$ENV{'HOME'};
+    $ENV{'XDG_CONFIG_HOME'}=$ENV{'HOME'};
+    $ENV{'COLUMNS'}=79; # screen width!
 }
 
 #######################################################################

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1146,12 +1146,13 @@ sub runnerar {
 
 ###################################################################
 # Returns nonzero if a response from an async call is ready
+# argument is 0 for nonblocking, undef for blocking, anything else for timeout
 # Called by controller
 sub runnerar_ready {
     my ($blocking) = @_;
     my $rin = "";
     vec($rin, fileno($controllerr), 1) = 1;
-    return select(my $rout=$rin, undef, my $eout=$rin, $blocking ? undef : 0);
+    return select(my $rout=$rin, undef, my $eout=$rin, $blocking);
 }
 
 ###################################################################
@@ -1184,7 +1185,7 @@ sub ipcrecv {
     elsif($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response
-        return;
+        return 1;
     }
     elsif($funcname eq "runner_stopservers") {
         @res = runner_stopservers(@$argsarrayref);
@@ -1203,6 +1204,8 @@ sub ipcrecv {
     $buf = freeze \@res;
 
     syswrite($runnerw, (pack "L", length($buf)) . $buf);
+
+    return 0;
 }
 
 ###################################################################

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -28,6 +28,7 @@ package runner;
 
 use strict;
 use warnings;
+use 5.006;
 
 BEGIN {
     use base qw(Exporter);
@@ -37,10 +38,13 @@ BEGIN {
         prepro
         restore_test_env
         runner_init
-        runner_clearlocks
-        runner_stopservers
-        runner_test_preprocess
-        runner_test_run
+        runnerac_clearlocks
+        runnerac_shutdown
+        runnerac_stopservers
+        runnerac_test_preprocess
+        runnerac_test_run
+        runnerar
+        runnerar_ready
         stderrfilename
         stdoutfilename
         $DBGCURL
@@ -59,6 +63,14 @@ BEGIN {
         singletest_preprocess
     );
 }
+
+use B qw(
+    svref_2object
+    );
+use Storable qw(
+    freeze
+    thaw
+    );
 
 use pathhelp qw(
     exe_ext
@@ -105,6 +117,10 @@ my $CURLLOG="$LOGDIR/commands.log"; # all command lines run
 my $SERVERLOGS_LOCK="$LOGDIR/serverlogs.lock"; # server logs advisor read lock
 my $defserverlogslocktimeout = 2; # timeout to await server logs lock removal
 my $defpostcommanddelay = 0; # delay between command and postcheck sections
+my $controllerw;    # pipe that controller writes to
+my $runnerr;        # pipe that runner reads from
+my $runnerw;        # pipe that runner writes to
+my $controllerr;    # pipe that controller reads from
 
 
 # redirected stdout/stderr to these files
@@ -120,7 +136,9 @@ sub stderrfilename {
 
 #######################################################################
 # Initialize the runner and prepare it to run tests
-#
+# The runner ID returned by this function must be passed into the other
+# runnerac_* functions
+# Called by controller
 sub runner_init {
     my ($logdir)=@_;
 
@@ -138,6 +156,13 @@ sub runner_init {
     $ENV{'CURL_HOME'}=$ENV{'HOME'};
     $ENV{'XDG_CONFIG_HOME'}=$ENV{'HOME'};
     $ENV{'COLUMNS'}=79; # screen width!
+
+    # create pipes for communication with runner
+    pipe $runnerr, $controllerw;
+    pipe $controllerr, $runnerw;
+
+    # There is only one runner right now
+    return "singleton";
 }
 
 #######################################################################
@@ -1034,6 +1059,151 @@ sub runner_test_run {
     return (0, clearlogs(), \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
 }
 
+# Async call runner_clearlocks
+# Called by controller
+sub runnerac_clearlocks {
+    controlleripccall(\&runner_clearlocks, @_);
+}
+
+# Async call runner_shutdown
+# This call does NOT generate an IPC response and must be the last IPC call
+# received.
+# Called by controller
+sub runnerac_shutdown {
+    controlleripccall(\&runner_shutdown, @_);
+
+    # These have no more use
+    close($controllerw);
+    undef $controllerw;
+    close($controllerr);
+    undef $controllerr;
+}
+
+# Async call of runner_stopservers
+# Called by controller
+sub runnerac_stopservers {
+    controlleripccall(\&runner_stopservers, @_);
+}
+
+# Async call of runner_test_preprocess
+# Called by controller
+sub runnerac_test_preprocess {
+    controlleripccall(\&runner_test_preprocess, @_);
+}
+
+# Async call of runner_test_run
+# Called by controller
+sub runnerac_test_run {
+    controlleripccall(\&runner_test_run, @_);
+}
+
+###################################################################
+# Call an arbitrary function via IPC
+# The first argument is the function reference, the second is the runner ID
+# Called by controller (indirectly, via a more specific function)
+sub controlleripccall {
+    my $funcref = shift @_;
+    my $runnerid = shift @_;
+    # Get the name of the function from the reference
+    my $cv = svref_2object($funcref);
+    my $gv = $cv->GV;
+    # Prepend the name to the function arguments so it's marshalled along with them
+    unshift @_, $gv->NAME;
+    # Marshall the arguments into a flat string
+    my $margs = freeze \@_;
+
+    # Send IPC call via pipe
+    syswrite($controllerw, (pack "L", length($margs)) . $margs);
+
+    # Call the remote function
+    # TODO: this will eventually be done in a separate runner process
+    # kicked off by runner_init()
+    ipcrecv();
+}
+
+###################################################################
+# Receive async response of a previous call via IPC
+# The first return value is the runner ID
+# Called by controller
+sub runnerar {
+    my $datalen;
+    if (sysread($controllerr, $datalen, 4) <= 0) {
+        die "error in runnerar\n";
+    }
+    my $len=unpack("L", $datalen);
+    my $buf;
+    if (sysread($controllerr, $buf, $len) <= 0) {
+        die "error in runnerar\n";
+    }
+
+    # Decode response values
+    my $resarrayref = thaw $buf;
+
+    # First argument is runner ID
+    unshift @$resarrayref, "singleton";
+    return @$resarrayref;
+}
+
+###################################################################
+# Returns nonzero if a response from an async call is ready
+# Called by controller
+sub runnerar_ready {
+    my ($blocking) = @_;
+    my $rin = "";
+    vec($rin, fileno($controllerr), 1) = 1;
+    return select(my $rout=$rin, undef, my $eout=$rin, $blocking ? undef : 0);
+}
+
+###################################################################
+# Receive an IPC call in the runner and execute it
+# The IPC is read from the $runnerr pipe and the response is
+# written to the $runnerw pipe
+sub ipcrecv {
+    my $datalen;
+    if (sysread($runnerr, $datalen, 4) <= 0) {
+        die "error in ipcrecv\n";
+    }
+    my $len=unpack("L", $datalen);
+    my $buf;
+    if (sysread($runnerr, $buf, $len) <= 0) {
+        die "error in ipcrecv\n";
+    }
+
+    # Decode the function name and arguments
+    my $argsarrayref = thaw $buf;
+
+    # The name of the function to call is the frist argument
+    my $funcname = shift @$argsarrayref;
+
+    # print "ipcrecv $funcname\n";
+    # Synchronously call the desired function
+    my @res;
+    if($funcname eq "runner_clearlocks") {
+        @res = runner_clearlocks(@$argsarrayref);
+    }
+    elsif($funcname eq "runner_shutdown") {
+        runner_shutdown(@$argsarrayref);
+        # Special case: no response
+        return;
+    }
+    elsif($funcname eq "runner_stopservers") {
+        @res = runner_stopservers(@$argsarrayref);
+    }
+    elsif($funcname eq "runner_test_preprocess") {
+        @res = runner_test_preprocess(@$argsarrayref);
+    }
+    elsif($funcname eq "runner_test_run") {
+        @res = runner_test_run(@$argsarrayref);
+    } else {
+        die "Unknown IPC function $funcname\n";
+    }
+    # print "ipcrecv results\n";
+
+    # Marshall the results to return
+    $buf = freeze \@res;
+
+    syswrite($runnerw, (pack "L", length($buf)) . $buf);
+}
 
 ###################################################################
 # Kill the server processes that still have lock files in a directory
@@ -1053,6 +1223,15 @@ sub runner_stopservers {
     my $error = stopservers($verbose);
     my $logs = clearlogs();
     return ($error, $logs);
+}
+
+###################################################################
+# Shut down this runner
+sub runner_shutdown {
+    close($runnerr);
+    undef $runnerr;
+    close($runnerw);
+    undef $runnerw;
 }
 
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -227,7 +227,7 @@ sub torture {
     my ($testcmd, $testnum, $gdbline) = @_;
 
     # remove memdump first to be sure we get a new nice and clean one
-    unlink($memdump);
+    unlink("$LOGDIR/$MEMDUMP");
 
     # First get URL from test server, ignore the output/result
     runclient($testcmd);
@@ -236,7 +236,7 @@ sub torture {
 
     # memanalyze -v is our friend, get the number of allocations made
     my $count=0;
-    my @out = `$memanalyze -v $memdump`;
+    my @out = `$memanalyze -v "$LOGDIR/$MEMDUMP"`;
     for(@out) {
         if(/^Operations: (\d+)/) {
             $count = $1;
@@ -291,7 +291,7 @@ sub torture {
         $ENV{'CURL_MEMLIMIT'} = $limit;
 
         # remove memdump first to be sure we get a new nice and clean one
-        unlink($memdump);
+        unlink("$LOGDIR/$MEMDUMP");
 
         my $cmd = $testcmd;
         if($valgrind && !$gdbthis) {
@@ -349,7 +349,7 @@ sub torture {
             $fail=1;
         }
         else {
-            my @memdata=`$memanalyze $memdump`;
+            my @memdata=`$memanalyze "$LOGDIR/$MEMDUMP"`;
             my $leak=0;
             for(@memdata) {
                 if($_ ne "") {
@@ -361,7 +361,7 @@ sub torture {
             if($leak) {
                 logmsg "** MEMORY FAILURE\n";
                 logmsg @memdata;
-                logmsg `$memanalyze -l $memdump`;
+                logmsg `$memanalyze -l "$LOGDIR/$MEMDUMP"`;
                 $fail = 1;
             }
         }
@@ -403,10 +403,9 @@ sub singletest_startservers {
     my ($testnum, $testtimings) = @_;
 
     # remove old test server files before servers are started/verified
-    unlink($FTPDCMD);
-    unlink($SERVERIN);
-    unlink($SERVER2IN);
-    unlink($PROXYIN);
+    unlink("$LOGDIR/$FTPDCMD");
+    unlink("$LOGDIR/$SERVERIN");
+    unlink("$LOGDIR/$PROXYIN");
 
     # timestamp required servers verification start
     $$testtimings{"timesrvrini"} = Time::HiRes::time();
@@ -543,20 +542,19 @@ sub singletest_prepare {
     my ($testnum) = @_;
 
     if($feature{"TrackMemory"}) {
-        unlink($memdump);
+        unlink("$LOGDIR/$MEMDUMP");
     }
     unlink("core");
 
     # remove server output logfiles after servers are started/verified
-    unlink($SERVERIN);
-    unlink($SERVER2IN);
-    unlink($PROXYIN);
+    unlink("$LOGDIR/$SERVERIN");
+    unlink("$LOGDIR/$PROXYIN");
 
     # if this section exists, it might be FTP server instructions:
     my @ftpservercmd = getpart("reply", "servercmd");
     push @ftpservercmd, "Testnum $testnum\n";
     # write the instructions to file
-    writearray($FTPDCMD, \@ftpservercmd);
+    writearray("$LOGDIR/$FTPDCMD", \@ftpservercmd);
 
     # create (possibly-empty) files before starting the test
     for my $partsuffix (('', '1', '2', '3', '4')) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -182,16 +182,6 @@ sub logmsg {
     }
 }
 
-# enable memory debugging if curl is compiled with it
-$ENV{'CURL_MEMDEBUG'} = "$LOGDIR/$MEMDUMP";
-$ENV{'CURL_ENTROPY'}="12345678";
-$ENV{'CURL_FORCETIME'}=1; # for debug NTLM magic
-$ENV{'CURL_GLOBAL_INIT'}=1; # debug curl_global_init/cleanup use
-$ENV{'HOME'}=$pwd;
-$ENV{'CURL_HOME'}=$ENV{'HOME'};
-$ENV{'XDG_CONFIG_HOME'}=$ENV{'HOME'};
-$ENV{'COLUMNS'}=79; # screen width!
-
 sub catch_zap {
     my $signame = shift;
     logmsg "runtests.pl received SIG$signame, exiting\n";
@@ -2231,7 +2221,6 @@ if ($gdbthis) {
 
 cleardir($LOGDIR);
 mkdir($LOGDIR, 0777);
-mkdir("$LOGDIR/$PIDDIR", 0777);
 
 #######################################################################
 # initialize some variables
@@ -2468,11 +2457,7 @@ sub displaylogs {
 }
 
 #######################################################################
-# Setup CI Test Run
-citest_starttestrun();
-
-#######################################################################
-# The main test-loop
+# Scan tests to find suitable candidates
 #
 
 my $failed;
@@ -2504,6 +2489,19 @@ if($listonly) {
     exit(0);
 }
 
+#######################################################################
+# Setup CI Test Run
+citest_starttestrun();
+
+#######################################################################
+# Initialize the runner to prepare to run tests
+cleardir($LOGDIR);
+mkdir($LOGDIR, 0777);
+runner_init($LOGDIR);
+
+#######################################################################
+# The main test-loop
+#
 # run through each candidate test and execute it
 foreach my $testnum (@runtests) {
     $count++;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -778,17 +778,6 @@ sub displayserverfeatures {
     logmsg sprintf("%s", $http_ipv6?"HTTP-IPv6 ":"");
     logmsg sprintf("%s", $http_unix?"HTTP-unix ":"");
     logmsg sprintf("%s\n", $ftp_ipv6?"FTP-IPv6 ":"");
-
-    if($verbose) {
-        if($feature{"unix-sockets"}) {
-            logmsg "* Unix socket paths:\n";
-            if($http_unix) {
-                logmsg sprintf("*   HTTP-Unix:%s\n", $HTTPUNIXPATH);
-                logmsg sprintf("*   Socks-Unix:%s\n", $SOCKSUNIXPATH);
-            }
-        }
-    }
-
     logmsg "***************************************** \n";
 }
 
@@ -1476,7 +1465,7 @@ sub singletest_check {
     my @socksprot = getpart("verify", "socks");
     if(@socksprot) {
         # Verify the sent SOCKS proxy details
-        my @out = loadarray($SOCKSIN);
+        my @out = loadarray("$logdir/$SOCKSIN");
         $res = compare($testnum, $testname, "socks", \@out, \@socksprot);
         if($res) {
             return -1;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -37,16 +37,7 @@ BEGIN {
     our @EXPORT = (
         # variables
         qw(
-            $HOSTIP
-            $HOST6IP
-            $HTTPUNIXPATH
-            $sshdid
-            $SSHSRVMD5
-            $SSHSRVSHA256
-            $SOCKSUNIXPATH
             $SOCKSIN
-            $USER
-            $ftpchecktime
             $err_unexpected
             $debugprotocol
             $stunnel
@@ -142,21 +133,21 @@ my $serverstartretries=10; # number of times to attempt to start server;
 my $portrange = 999;       # space from which to choose a random port
                            # don't increase without making sure generated port
                            # numbers will always be valid (<=65535)
+my $HOSTIP="127.0.0.1";    # address on which the test server listens
+my $HOST6IP="[::1]";       # address on which the test server listens
+my $HTTPUNIXPATH;          # HTTP server Unix domain socket path
+my $SOCKSUNIXPATH;         # socks server Unix domain socket path
+my $SSHSRVMD5 = "[uninitialized]";    # MD5 of ssh server public key
+my $SSHSRVSHA256 = "[uninitialized]"; # SHA256 of ssh server public key
+my $USER;                  # name of the current user
+my $sshdid;                # for socks server, ssh daemon version id
+my $ftpchecktime=1;        # time it took to verify our test FTP server
 
 # Variables shared with runtests.pl
-our $HOSTIP="127.0.0.1";   # address on which the test server listens
-our $HOST6IP="[::1]";      # address on which the test server listens
-our $HTTPUNIXPATH; # HTTP server Unix domain socket path
-our $sshdid;      # for socks server, ssh daemon version id
-our $SSHSRVMD5 = "[uninitialized]"; # MD5 of ssh server public key
-our $SSHSRVSHA256 = "[uninitialized]"; # SHA256 of ssh server public key
-our $SOCKSUNIXPATH;  # socks server Unix domain socket path
-our $SOCKSIN; # what curl sent to the SOCKS proxy
-our $USER; # name of the current user
-our $ftpchecktime=1; # time it took to verify our test FTP server
+our $SOCKSIN="socksd-request.log"; # what curl sent to the SOCKS proxy
 our $err_unexpected; # error instead of warning on server unexpectedly alive
-our $debugprotocol; # nonzero for verbose server logs
-our $stunnel; # path to stunnel command
+our $debugprotocol;  # nonzero for verbose server logs
+our $stunnel;        # path to stunnel command
 
 
 #######################################################################
@@ -179,7 +170,6 @@ sub checkcmd {
 #######################################################################
 # Initialize configuration variables
 sub initserverconfig {
-    $SOCKSIN="$LOGDIR/socksd-request.log"; # what curl sent to the SOCKS proxy
     $SOCKSUNIXPATH = "$PIDDIR/socks.sock"; # SOCKS server Unix domain socket path
     $HTTPUNIXPATH = "$PIDDIR/http.sock";   # HTTP server Unix domain socket path
     $stunnel = checkcmd("stunnel4") || checkcmd("tstunnel") || checkcmd("stunnel");
@@ -2014,7 +2004,7 @@ sub runsocksserver {
     if($is_unix) {
         $cmd="server/socksd".exe_ext('SRV').
             " --pidfile $pidfile".
-            " --reqfile $SOCKSIN".
+            " --reqfile $LOGDIR/$SOCKSIN".
             " --logfile $logfile".
             " --unix-socket $SOCKSUNIXPATH".
             " --backend $HOSTIP".
@@ -2024,7 +2014,7 @@ sub runsocksserver {
             " --port 0 ".
             " --pidfile $pidfile".
             " --portfile $portfile".
-            " --reqfile $SOCKSIN".
+            " --reqfile $LOGDIR/$SOCKSIN".
             " --logfile $logfile".
             " --backend $HOSTIP".
             " --config $FTPDCMD";


### PR DESCRIPTION
This is optional (default disabled) and is controlled by the -j flag. It
currently supports at most 1 runner which will fork() a new process that takes
care of running curl for the actual test. This proves the groundwork to handle
tests in multiple processes has been laid.