### PR TITLE
Disable quiche pacing while is not actually performed by curl

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1258,6 +1258,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
     failf(data, "can't create quiche config");
     return CURLE_FAILED_INIT;
   }
+  quiche_config_enable_pacing(ctx->cfg, false);
   quiche_config_set_max_idle_timeout(ctx->cfg, QUIC_IDLE_TIMEOUT);
   quiche_config_set_initial_max_data(ctx->cfg, (1 * 1024 * 1024)
     /* (QUIC_MAX_STREAMS/2) * H3_STREAM_WINDOW_SIZE */);


### PR DESCRIPTION
Hi,

Just a one-line commit that disables pacing in the quiche library as currently curl does not
perform pacing when sending the QUIC packets.

When pacing is enabled, quiche assumes that packet are sent at the asked time,
see https://github.com/cloudflare/quiche/blob/6cef26b946695300b214cd837a92dc1774c0ba84/quiche/src/recovery/mod.rs#L376

If packets are sent earlier than the asked time, it can lead to wrong RTT estimations (undersestimations), as the RTT estimation will be based on the packet sent time. At its turn, this can have an impact on the hystart algorithm
afterwards that is currently enabled too, and quiche may exit the slow-start too early and underestimate the link bandwidth.
