### PR TITLE
CI: macOS bump gcc12 to gcc13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -153,8 +153,8 @@ jobs:
         - CC: clang
           CXX: clang++
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-deprecated-declarations"
-        - CC: gcc-12
-          CXX: g++-12
+        - CC: gcc-13
+          CXX: g++-13
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"
         build:
         - name: OpenSSL


### PR DESCRIPTION
Wait until CI ship it by default.