### PR TITLE
tool_cb_hdr: Fix 'Location:' formatting for early VTE terminals

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -344,6 +344,15 @@ void write_linked_location(CURL *curl, const char *location, size_t loclen,
   char *copyloc = NULL, *locurl = NULL, *scheme = NULL, *finalurl = NULL;
   const char *loc = location;
   size_t llen = loclen;
+  char *vver = getenv("VTE_VERSION");
+
+  if(vver) {
+    long vvn = strtol(vver, NULL, 10);
+    /* Skip formatting for old versions of VTE <= 0.48.1 (Mar 2017) since some
+       of those versions have formatting bugs. (#10428) */
+    if(0 < vvn && vvn <= 4801)
+      goto locout;
+  }
 
   /* Strip leading whitespace of the redirect URL */
   while(llen && *loc == ' ') {


### PR DESCRIPTION
- Disable hyperlink formatting for the 'Location:' header value in VTE 0.48.1 and earlier, since it is buggy in those versions.

Prior to this change those terminals may show the location header value as gibberish or show it twice.

Ref: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#backward-compatibility

Fixes https://github.com/curl/curl/issues/10428
Closes #xxxx