### PR TITLE
Corrected and Added Item in Simple Usage Section

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -18,9 +18,13 @@ Get a directory listing of an FTP site:
 
     curl ftp://ftp.funet.fi
 
-Get the definition of curl from a dictionary:
+Get the all terms matching curl from a dictionary:
 
     curl dict://dict.org/m:curl
+    
+Get the definition of curl from a dictionary:
+
+    curl dict://dict.org/d:curl    
 
 Fetch two documents at once:
 


### PR DESCRIPTION
Change Line Range - 21 to 27

PROPOSED CHANGE ONE:
****************************
Changed the description of an example in the "Simple Usage" section on line 21. The command original returned all matches for "curl" and did not return the definition.  

PROPOSED CHANGE TWO:
****************************
Added an example in the "Simple Usage" section that returns the definition of curl from a dictionary.