### PR TITLE
enforce a maximum DNS cache size independent of timeout value

### DIFF
--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.3
@@ -37,15 +37,23 @@ memory and used for this number of seconds. Set to zero to completely disable
 caching, or set to -1 to make the cached entries remain forever. By default,
 libcurl caches this info for 60 seconds.
 
+We recommend users not to tamper with this option unless strictly necessary.
+If you do, be careful of using large values that can make the cache size grow
+significantly if many different host names are used within that timeout
+period.
+
 The name resolve functions of various libc implementations do not re-read name
 server information unless explicitly told so (for example, by calling
 \fIres_init(3)\fP). This may cause libcurl to keep using the older server even
 if DHCP has updated the server info, and this may look like a DNS cache issue
 to the casual libcurl-app user.
 
-Note that DNS entries have a "TTL" property but libcurl does not use that. This
-DNS cache timeout is entirely speculative that a name will resolve to the same
+DNS entries have a "TTL" property but libcurl does not use that. This DNS
+cache timeout is entirely speculative that a name will resolve to the same
 address for a certain small amount of time into the future.
+
+Since version 8.1.0, libcurl makes sure the total amount of entries in the DNS
+cache is always below 30,000 no matter which timeout value is used.
 .SH DEFAULT
 60
 .SH PROTOCOLS

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -196,8 +196,8 @@ create_hostcache_id(const char *name,
 }
 
 struct hostcache_prune_data {
-  long cache_timeout;
   time_t now;
+  int cache_timeout;
 };
 
 /*
@@ -222,7 +222,7 @@ hostcache_timestamp_remove(void *datap, void *hc)
  * Prune the DNS cache. This assumes that a lock has already been taken.
  */
 static void
-hostcache_prune(struct Curl_hash *hostcache, long cache_timeout, time_t now)
+hostcache_prune(struct Curl_hash *hostcache, int cache_timeout, time_t now)
 {
   struct hostcache_prune_data user;
 


### PR DESCRIPTION
To prevent it from growing uncontrollably.