### PR TITLE
ipv4.d/ipv6.d: they are "mutex", not "boolean"

### DIFF
--- a/docs/cmdline-opts/ipv4.d
+++ b/docs/cmdline-opts/ipv4.d
@@ -11,7 +11,7 @@ See-also: http1.1 http2
 Help: Resolve names to IPv4 addresses
 Category: connection dns
 Example: --ipv4 $URL
-Multi: boolean
+Multi: mutex
 ---
-This option tells curl to use IPv4 addresses only, and not for example try
-IPv6.
+This option tells curl to use IPv4 addresses only when resolving host names,
+and not for example try IPv6.

--- a/docs/cmdline-opts/ipv6.d
+++ b/docs/cmdline-opts/ipv6.d
@@ -11,7 +11,7 @@ See-also: http1.1 http2
 Help: Resolve names to IPv6 addresses
 Category: connection dns
 Example: --ipv6 $URL
-Multi: boolean
+Multi: mutex
 ---
-This option tells curl to use IPv6 addresses only, and not for example try
-IPv4.
+This option tells curl to use IPv6 addresses only when resolving host names,
+and not for example try IPv4.


### PR DESCRIPTION
... which for example means they do not have --no-* versions.

Reported-by: Harry Sintonen
Fixes #11085