### PR TITLE
CURLOPT_IPRESOLVE.3: clarify that this for host names, not IP addresses

### DIFF
--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.3
@@ -34,8 +34,13 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_IPRESOLVE, long resolve);
 .SH DESCRIPTION
 Allows an application to select what kind of IP addresses to use when
 establishing a connection or choosing one from the connection pool. This is
-interesting when using host names that resolve addresses using more than
-one version of IP. The allowed values are:
+interesting when using host names that resolve to more than one version of IP.
+
+If the URL provided for a transfer contains a numerical IP version as a host
+name, this option will not override or prohibit libcurl from using that IP
+version.
+
+Available values for this option are:
 .IP CURL_IPRESOLVE_WHATEVER
 Default, can use addresses of all IP versions that your system allows.
 .IP CURL_IPRESOLVE_V4


### PR DESCRIPTION
Reported-by: Harry Sintonen