### PR TITLE
md(4|5): don't use deprecated iOS functions

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -68,10 +68,12 @@
 #include <openssl/md4.h>
 #elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
               (__MAC_OS_X_VERSION_MAX_ALLOWED >= 1040) && \
-       defined(__MAC_OS_X_VERSION_MIN_ALLOWED) && \
-              (__MAC_OS_X_VERSION_MIN_ALLOWED < 101500)) || \
+       defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+              (__MAC_OS_X_VERSION_MIN_REQUIRED < 101500)) || \
       (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && \
-              (__IPHONE_OS_VERSION_MAX_ALLOWED >= 20000))
+              (__IPHONE_OS_VERSION_MAX_ALLOWED >= 20000) && \
+       defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && \
+              (__IPHONE_OS_VERSION_MIN_REQUIRED < 130000))
 #define AN_APPLE_OS
 #include <CommonCrypto/CommonDigest.h>
 #elif defined(USE_WIN32_CRYPTO)

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if !defined(CURL_DISABLE_CRYPTO_AUTH)
+#if defined(USE_CURL_NTLM_CORE)
 
 #include <string.h>
 
@@ -504,4 +504,4 @@ void Curl_md4it(unsigned char *output, const unsigned char *input,
   MD4_Final(output, &ctx);
 }
 
-#endif /* CURL_DISABLE_CRYPTO_AUTH */
+#endif /* USE_CURL_NTLM_CORE */

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -66,10 +66,12 @@
 #include <mbedtls/md5.h>
 #elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
               (__MAC_OS_X_VERSION_MAX_ALLOWED >= 1040) && \
-       defined(__MAC_OS_X_VERSION_MIN_ALLOWED) && \
-              (__MAC_OS_X_VERSION_MIN_ALLOWED < 101500)) || \
+       defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+              (__MAC_OS_X_VERSION_MIN_REQUIRED < 101500)) || \
       (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && \
-              (__IPHONE_OS_VERSION_MAX_ALLOWED >= 20000))
+              (__IPHONE_OS_VERSION_MAX_ALLOWED >= 20000) && \
+       defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && \
+              (__IPHONE_OS_VERSION_MIN_REQUIRED < 130000))
 #define AN_APPLE_OS
 #include <CommonCrypto/CommonDigest.h>
 #elif defined(USE_WIN32_CRYPTO)

--- a/tests/unit/unit1611.c
+++ b/tests/unit/unit1611.c
@@ -37,7 +37,7 @@ static void unit_stop(void)
 
 UNITTEST_START
 
-#ifndef CURL_DISABLE_CRYPTO_AUTH
+#ifdef USE_CURL_NTLM_CORE
   const char string1[] = "1";
   const char string2[] = "hello-you-fool";
   unsigned char output[MD4_DIGEST_LENGTH];


### PR DESCRIPTION
Also, use `*_MIN_REQUIRED` instead of `*_MIN_ALLOWED` to check for the minimum macOS and iOS versions. There are other open source projects checking for `__MAC_OS_X_VERSION_MIN_ALLOWED` too, but `__MAC_OS_X_VERSION_MIN_REQUIRED` and `__IPHONE_OS_VERSION_MIN_REQUIRED` seems to be what's currently defined in Apple's AvailabilityInternal.h.