### PR TITLE
headers: clear (possibly) lingering pointer in init

### DIFF
--- a/lib/headers.c
+++ b/lib/headers.c
@@ -336,6 +336,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
 static void headers_init(struct Curl_easy *data)
 {
   Curl_llist_init(&data->state.httphdrs, NULL);
+  data->state.prevhead = NULL;
 }
 
 /*

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -244,7 +244,7 @@ test2100 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \
 \
-test2300 test2301 test2302 test2303 test2304 test2305 \
+test2300 test2301 test2302 test2303 test2304 test2305 test2306 \
 \
 test2400 test2401 test2402 test2403 \
 \

--- a/tests/data/test2306
+++ b/tests/data/test2306
@@ -1,0 +1,69 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+#
+# This reproduces the #11101 issue, when the second response comes back
+# with the first header being "folded"
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+<data2 nocheck="yes">
+HTTP/1.1 200 OK
+	Access-Control-Allow-Origin: *
+	Connection: Keep-Alive
+	Content-Type: text/html; charset=utf-8
+Date: Wed, 10 May 2023 14:58:08 GMT
+
+-foo-
+</data2>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool to run
+<tool>
+lib%TESTNUMBER
+</tool>
+
+ <name>
+HTTP GET re-used handle but only folded headers
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -70,7 +70,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect libprereq      \
  lib1945 lib1946 lib1947 lib1948 lib1955 lib1956 lib1957 lib1958 lib1959 \
  lib1960 \
  lib1970 lib1971 lib1972 lib1973 lib1974 lib1975 \
- lib2301 lib2302 lib2304 lib2305 \
+ lib2301 lib2302 lib2304 lib2305 lib2306 \
  lib2402 \
  lib2502 \
  lib3010 lib3025 lib3026 lib3027 \
@@ -652,6 +652,9 @@ lib2304_LDADD = $(TESTUTIL_LIBS)
 
 lib2305_SOURCES = lib2305.c $(SUPPORTFILES) $(TESTUTIL) $(TSTTRACE) $(MULTIBYTE)
 lib2305_LDADD = $(TESTUTIL_LIBS)
+
+lib2306_SOURCES = lib2306.c $(SUPPORTFILES)
+lib2306_LDADD = $(TESTUTIL_LIBS)
 
 lib2402_SOURCES = lib2402.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib2402_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib2306.c
+++ b/tests/libtest/lib2306.c
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "test.h"
+#include "testtrace.h"
+
+#include <curl/curl.h>
+
+#define URL2 libtest_arg2
+
+int test(char *URL)
+{
+  /* first a fine GET response, then a bad one */
+  CURL *cl;
+  int res = 0;
+
+  global_init(CURL_GLOBAL_ALL);
+
+  cl = curl_easy_init();
+  curl_easy_setopt(cl, CURLOPT_URL, URL);
+  curl_easy_perform(cl);
+
+  /* re-use handle, do a second transfer */
+  curl_easy_setopt(cl, CURLOPT_URL, URL2);
+  curl_easy_perform(cl);
+  curl_easy_cleanup(cl);
+  curl_global_cleanup();
+  return res;
+}


### PR DESCRIPTION
The "prevhead" pointer is used for the headers storage but was not cleared correctly in init, which made it possible to act up when a handle is reused.

Reported-by: Steve Herrell
Fixes #11101