### PR TITLE
url: fix null dispname for --connect-to option

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1816,11 +1816,6 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   result = Curl_idnconvert_hostname(&conn->host);
   if(result)
     return result;
-  if(conn->bits.conn_to_host) {
-    result = Curl_idnconvert_hostname(&conn->conn_to_host);
-    if(result)
-      return result;
-  }
 
 #ifndef CURL_DISABLE_HSTS
   /* HSTS upgrade */
@@ -3480,6 +3475,11 @@ static CURLcode create_conn(struct Curl_easy *data,
       return result;
   }
 #endif
+  if(conn->bits.conn_to_host) {
+    result = Curl_idnconvert_hostname(&conn->conn_to_host);
+    if(result)
+      return result;
+  }
 
   /*************************************************************
    * Check whether the host and the "connect to host" are equal.


### PR DESCRIPTION
`parseurlandfillconn()` runs before `parse_connect_to_slist()` (which is where `conn->bits.conn_to_host` is set), so checking `conn->bits.conn_to_host` in `parseurlandfillconn()` would always be `FALSE`, and hence curl is always reporting `(nil)` dispname in output:

```sh
$ curl -svo /dev/null 'https://vercel.com/' --connect-to vercel.com:443:cname.vercel-dns.com 2>&1 | grep -i '* Connec'
* Connecting to hostname: cname.vercel-dns.com
* Connected to (nil) (76.76.21.142) port 443 (#0)
* Connection #0 to host (nil) left intact
```