### PR TITLE
write-out.d: Use response_code in example

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -5,7 +5,7 @@ Short: w
 Arg: <format>
 Help: Use output FORMAT after completion
 Category: verbose
-Example: -w '%{http_code}\\n' $URL
+Example: -w '%{response_code}\\n' $URL
 Added: 6.5
 See-also: verbose head
 Multi: single


### PR DESCRIPTION
The documentation for `response_code` in the manual states (emphasis mine):

> The numerical response code that was found in the last transfer (**formerly known as "http_code"**).

This suggests that `response_code` is preferred over `http_code`, yet the example uses the latter. Seeing as this code is likely to be one of the most common `write-out` options someone is looking for, using the newest/recommended name in the example should be more effective in getting people to use it.