### PR TITLE
Add --with-openssl to GIT-INFO

### DIFF
--- a/GIT-INFO
+++ b/GIT-INFO
@@ -14,7 +14,7 @@ To build in environments that support configure, after having extracted
 everything from git, do this:
 
 autoreconf -fi
-./configure
+./configure --with-openssl
 make
 
   Daniel uses a ./configure line similar to this for easier development:


### PR DESCRIPTION
When I ran `./configure` I received the following error:

```
configure: error: select TLS backend(s) or disable TLS with --without-ssl.

Select from these:

  --with-amissl
  --with-bearssl
  --with-gnutls
  --with-mbedtls
  --with-nss
  --with-openssl (also works for BoringSSL and libressl)
  --with-rustls
  --with-schannel
  --with-secure-transport
  --with-wolfssl
```

I suggested `--with-openssl` according to https://curl.se/docs/install.html 