### PR TITLE
drop linkcheck config file

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -49,10 +49,6 @@ Files: lib/libcurl.vers.in
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-Files: mlc_config.json
-Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
-License: curl
-
 Files: packages/OS400/README.OS400
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,8 +1,0 @@
-{
-  "_comment": "Config file for linkcheck: If urls have some issues we can not fix on our end past it in here. MLC will ignore this.",
-  "ignorePatterns": [
-    {
-      "pattern": ""
-    }
-  ]
-}


### PR DESCRIPTION
is no longer needed since links are always available over time.