### PR TITLE
docs: --aws-sigv4 region identifier fix

### DIFF
--- a/docs/cmdline-opts/aws-sigv4.d
+++ b/docs/cmdline-opts/aws-sigv4.d
@@ -6,7 +6,7 @@ Help: Use AWS V4 signature authentication
 Category: auth http
 Added: 7.75.0
 See-also: basic user
-Example: --aws-sigv4 "aws:amz:east-2:es" --user "key:secret" $URL
+Example: --aws-sigv4 "aws:amz:us-east-2:es" --user "key:secret" $URL
 Multi: single
 ---
 Use AWS V4 signature authentication in the transfer.


### PR DESCRIPTION
- Update `--aws-sigv4` command line option example to include explicit `us` in region identifier `aws:amz:east-2:es` -> `aws:amz:us-east-2:es`

List of supported regions:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions