### PR TITLE
configure: generate a script to run the compiler ...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,17 @@ dnl
 INITIAL_LDFLAGS=$LDFLAGS
 INITIAL_LIBS=$LIBS
 
+dnl
+dnl Generates a shell script to run the compiler with LD_LIBRARY_PATH set to
+dnl the value used right now. This lets CURL_RUN_IFELSE set LD_LIBRARY_PATH to
+dnl something different but only have that affect the execution of the results
+dnl of the compile, not change the libraries for the compiler itself.
+dnl
+compilersh="run-compiler"
+echo "CC=$CC" > $compilersh
+echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $compilersh
+echo 'exec $CC $@' >> $compilersh
+
 dnl **********************************************************************
 dnl See which TLS backend(s) that are requested. Just do all the
 dnl TLS AC_ARG_WITH() invokes here and do the checks later
@@ -4395,6 +4406,8 @@ else
   LIBCURL_NO_SHARED=
 fi
 AC_SUBST(LIBCURL_NO_SHARED)
+
+rm $compilersh
 
 dnl
 dnl For keeping supported features and protocols also in pkg-config file

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -5866,11 +5866,14 @@ AC_DEFUN([CURL_RUN_IFELSE], [
       AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
      ;;
      *)
+      oldcc=$CC
       old=$LD_LIBRARY_PATH
+      CC="sh ./run-compiler"
       LD_LIBRARY_PATH=$CURL_LIBRARY_PATH:$old
       export LD_LIBRARY_PATH
       AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
       LD_LIBRARY_PATH=$old # restore
+      CC=$oldcc
      ;;
    esac
 ])


### PR DESCRIPTION
in the CURL_RUN_IFELSE macro, with LD_LIBRARY_PATH set to the value of the configure invoke, and not the value that might be used later, intended for the execution of the output the compiler ouputs.

For example when the compiler uses the same library (like libz) that configure checks for.

Reported-by: Jonas Bülow
Fixes #11114