### PR TITLE
hostip: include easy_lock.h before using GLOBAL_INIT_IS_THREADSAFE

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -70,6 +70,8 @@
 #include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
 #endif
 
+#include "easy_lock.h"
+
 #if defined(CURLRES_SYNCH) &&                   \
   defined(HAVE_ALARM) &&                        \
   defined(SIGALRM) &&                           \
@@ -77,10 +79,6 @@
   defined(GLOBAL_INIT_IS_THREADSAFE)
 /* alarm-based timeouts can only be used with all the dependencies satisfied */
 #define USE_ALARM_TIMEOUT
-#endif
-
-#ifdef USE_ALARM_TIMEOUT
-#include "easy_lock.h"
 #endif
 
 #define MAX_HOSTCACHE_LEN (255 + 7) /* max FQDN + colon + port number + zero */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -287,8 +287,8 @@ void Curl_hostcache_prune(struct Curl_easy *data)
 /* Beware this is a global and unique instance. This is used to store the
    return address that we can jump back to from inside a signal handler. This
    is not thread-safe stuff. */
-sigjmp_buf curl_jmpenv;
-curl_simple_lock curl_jmpenv_lock;
+static sigjmp_buf curl_jmpenv;
+static curl_simple_lock curl_jmpenv_lock;
 #endif
 
 /* lookup address, returns entry if found and not stale */

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -186,15 +186,6 @@ Curl_cache_addr(struct Curl_easy *data, struct Curl_addrinfo *addr,
 #define CURL_INADDR_NONE INADDR_NONE
 #endif
 
-#ifdef HAVE_SIGSETJMP
-/* Forward-declaration of variable defined in hostip.c. Beware this
- * is a global and unique instance. This is used to store the return
- * address that we can jump back to from inside a signal handler.
- * This is not thread-safe stuff.
- */
-extern sigjmp_buf curl_jmpenv;
-#endif
-
 /*
  * Function provided by the resolver backend to set DNS servers to use.
  */


### PR DESCRIPTION
Since that header file is the only place that define can be defined.

Reported-by: Marc Deslauriers

Follow-up to 13718030ad4b3209