### PR TITLE
Update chkstrings.c

### DIFF
--- a/packages/OS400/chkstrings.c
+++ b/packages/OS400/chkstrings.c
@@ -37,8 +37,8 @@
  * made, the EXPECTED_STRING_LASTZEROTERMINATED/EXPECTED_STRING_LAST
  * values can be updated to match the latest enum values in urldata.h.
  */
-#define EXPECTED_STRING_LASTZEROTERMINATED  (STRING_SSL_EC_CURVES + 1)
-#define EXPECTED_STRING_LAST                (STRING_AWS_SIGV4 + 1)
+#define EXPECTED_STRING_LASTZEROTERMINATED  (STRING_AWS_SIGV4 + 1)
+#define EXPECTED_STRING_LAST                (STRING_COPYPOSTFIELDS + 1)
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Compensating changes for recent changes to urldata.h to reclassify STRING_AWS_SIGV4. Addresses https://github.com/curl/curl/issues/11132