### PR TITLE
checksrc: disallow spaces before labels

### DIFF
--- a/docs/examples/parseurl.c
+++ b/docs/examples/parseurl.c
@@ -74,7 +74,7 @@ int main(void)
     curl_free(path);
   }
 
-  fail:
+fail:
   curl_url_cleanup(h); /* free url handle */
   return 0;
 }

--- a/docs/examples/urlapi.c
+++ b/docs/examples/urlapi.c
@@ -67,7 +67,7 @@ int main(void)
     goto cleanup;
   }
 
-  cleanup:
+cleanup:
   curl_url_cleanup(urlp);
   curl_easy_cleanup(curl);
   return 0;

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -117,7 +117,7 @@ static struct altsvc *altsvc_createid(const char *srchost,
   as->dst.port = curlx_ultous(dstport);
 
   return as;
-  error:
+error:
   altsvc_free(as);
   return NULL;
 }
@@ -217,7 +217,7 @@ static CURLcode altsvc_load(struct altsvcinfo *asi, const char *file)
   }
   return result;
 
-  fail:
+fail:
   Curl_safefree(asi->filename);
   free(line);
   fclose(fp);

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -251,7 +251,7 @@ int init_thread_sync_data(struct thread_data *td,
 
   return 1;
 
- err_exit:
+err_exit:
 #ifndef CURL_DISABLE_SOCKETPAIR
   if(tsd->sock_pair[0] != CURL_SOCKET_BAD) {
     sclose(tsd->sock_pair[0]);
@@ -469,10 +469,10 @@ static bool init_resolve_thread(struct Curl_easy *data,
 
   return TRUE;
 
- err_exit:
+err_exit:
   destroy_async_data(asp);
 
- errno_exit:
+errno_exit:
   errno = err;
   return FALSE;
 }

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -178,7 +178,7 @@ CURLcode Curl_base64_decode(const char *src,
   *outlen = rawlen;
 
   return CURLE_OK;
-  bad:
+bad:
   free(newstr);
   return CURLE_BAD_CONTENT_ENCODING;
 }

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -1212,7 +1212,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   Curl_safefree(data->state.aptr.userpwd);
   Curl_safefree(data->state.aptr.proxyuserpwd);
   return CURLE_OK;
-  error:
+error:
   DEBUGASSERT(result);
   if(io)
     hyper_io_free(io);

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -246,7 +246,7 @@ CURLcode Curl_conncache_add_conn(struct Curl_easy *data)
                "The cache now contains %zu members",
                conn->connection_id, connc->num_conn));
 
-  unlock:
+unlock:
   CONNCACHE_UNLOCK(data);
 
   return result;

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1387,7 +1387,7 @@ static struct Cookie *dup_cookie(struct Cookie *src)
   }
   return d;
 
-  fail:
+fail:
   freecookie(d);
   return NULL;
 }

--- a/lib/curl_path.c
+++ b/lib/curl_path.c
@@ -191,7 +191,7 @@ CURLcode Curl_get_pathname(const char **cpp, char **path, char *homedir)
   }
   return CURLE_OK;
 
-  fail:
+fail:
   Curl_safefree(*path);
   return CURLE_QUOTE_ERROR;
 }

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -312,7 +312,7 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
     }
   }
 
-  error:
+error:
   free(eword);
   free(path);
   return result;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -347,7 +347,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
   free(nurl);
   return CURLE_OK;
 
-  error:
+error:
   free(nurl);
   Curl_close(&doh);
   return result;
@@ -409,7 +409,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
 #endif
   return NULL;
 
-  error:
+error:
   curl_slist_free_all(dohp->headers);
   data->req.doh->headers = NULL;
   for(slot = 0; slot < DOH_PROBE_SLOTS; slot++) {

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -209,7 +209,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 
   return CURLE_OK;
 
-  fail:
+fail:
   initialized--; /* undo the increase */
   return CURLE_FAILED_INIT;
 }
@@ -993,7 +993,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
 
   return outcurl;
 
-  fail:
+fail:
 
   if(outcurl) {
 #ifndef CURL_DISABLE_COOKIES

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3838,7 +3838,7 @@ static CURLcode init_wc_data(struct Curl_easy *data)
   infof(data, "Wildcard - Parsing started");
   return CURLE_OK;
 
-  fail:
+fail:
   if(ftpwc) {
     Curl_ftp_parselist_data_free(&ftpwc->parser);
     free(ftpwc);

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -325,7 +325,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
                          hs, &hs->node);
   data->state.prevhead = hs;
   return CURLE_OK;
-  fail:
+fail:
   free(hs);
   return result;
 }

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1238,7 +1238,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
         goto err;
 
       error = false;
-   err:
+err:
       if(error) {
         failf(data, "Couldn't parse CURLOPT_RESOLVE entry '%s'",
               hostp->data);

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -390,7 +390,7 @@ CURLcode Curl_hsts_save(struct Curl_easy *data, struct hsts *h,
       unlink(tempstore);
   }
   free(tempstore);
-  skipsave:
+skipsave:
   if(data->set.hsts_write) {
     /* if there's a write callback */
     struct curl_index i; /* count */
@@ -534,7 +534,7 @@ static CURLcode hsts_load(struct hsts *h, const char *file)
   }
   return result;
 
-  fail:
+fail:
   Curl_safefree(h->filename);
   fclose(fp);
   return CURLE_OUT_OF_MEMORY;

--- a/lib/http.c
+++ b/lib/http.c
@@ -398,7 +398,7 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
     goto fail;
   }
 
-  fail:
+fail:
   free(out);
   return result;
 }
@@ -424,7 +424,7 @@ static CURLcode http_output_bearer(struct Curl_easy *data)
     goto fail;
   }
 
-  fail:
+fail:
   return result;
 }
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -806,7 +806,7 @@ static int set_transfer_url(struct Curl_easy *data,
   uc = curl_url_get(u, CURLUPART_URL, &url, 0);
   if(uc)
     rc = 4;
-  fail:
+fail:
   curl_url_cleanup(u);
   if(rc)
     return rc;
@@ -930,7 +930,7 @@ static int push_promise(struct Curl_cfilter *cf,
     DEBUGF(LOG_CF(data, cf, "Got PUSH_PROMISE, ignore it"));
     rv = CURL_PUSH_DENY;
   }
-  fail:
+fail:
   return rv;
 }
 

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -743,11 +743,11 @@ static int dprintf_formatf(
 
       goto number;
 
-      unsigned_number:
+unsigned_number:
       /* Unsigned number of base BASE.  */
       is_neg = 0;
 
-      number:
+number:
       /* Number of base BASE.  */
 
       /* Supply a default precision if none was given.  */

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -605,7 +605,7 @@ static CURLcode mqtt_read_publish(struct Curl_easy *data, bool *done)
   unsigned char packet;
 
   switch(mqtt->state) {
-  MQTT_SUBACK_COMING:
+MQTT_SUBACK_COMING:
   case MQTT_SUBACK_COMING:
     result = mqtt_verify_suback(data);
     if(result)
@@ -688,7 +688,7 @@ static CURLcode mqtt_read_publish(struct Curl_easy *data, bool *done)
     result = CURLE_WEIRD_SERVER_REPLY;
     goto end;
   }
-  end:
+end:
   return result;
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -448,7 +448,7 @@ struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
 
   return multi;
 
-  error:
+error:
 
   sockhash_destroy(&multi->sockhash);
   Curl_hash_destroy(&multi->hostcache);
@@ -2625,7 +2625,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       multi_handle_timeout(data, nowp, &stream_error, &result, TRUE);
     }
 
-    statemachine_end:
+statemachine_end:
 
     if(data->mstate < MSTATE_COMPLETED) {
       if(result) {

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -244,7 +244,7 @@ static int parsenetrc(const char *host,
       }
     } /* while Curl_get_line() */
 
-    out:
+out:
     if(!retcode) {
       /* success */
       if(login_alloc) {

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -332,7 +332,7 @@ static bool match_time(const char *date,
     }
   }
   return FALSE; /* not a time string */
-  match:
+match:
   *h = hh;
   *m = mm;
   *s = ss;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -183,7 +183,7 @@ int Curl_socketpair(int domain, int type, int protocol,
   sclose(listener);
   return 0;
 
-  error:
+error:
   sclose(listener);
   sclose(socks[0]);
   sclose(socks[1]);

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -354,7 +354,7 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
       }
     }
     /* FALLTHROUGH */
-  CONNECT_RESOLVED:
+CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     struct Curl_addrinfo *hp = NULL;
     /*
@@ -394,7 +394,7 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
       return CURLPX_RESOLVE_HOST;
   }
     /* FALLTHROUGH */
-  CONNECT_REQ_INIT:
+CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
     /*
      * This is currently not supporting "Identification Protocol (RFC1413)".
@@ -638,7 +638,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
       return CURLPX_OK;
     }
     /* FALLTHROUGH */
-  CONNECT_SOCKS_READ_INIT:
+CONNECT_SOCKS_READ_INIT:
   case CONNECT_SOCKS_READ_INIT:
     sx->outstanding = 2; /* expect two bytes */
     sx->outp = socksreq; /* store it here */
@@ -700,7 +700,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
   default: /* do nothing! */
     break;
 
-  CONNECT_AUTH_INIT:
+CONNECT_AUTH_INIT:
   case CONNECT_AUTH_INIT: {
     /* Needs user name and password */
     size_t proxy_user_len, proxy_password_len;
@@ -779,7 +779,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
     /* Everything is good so far, user was authenticated! */
     sxstate(sx, data, CONNECT_REQ_INIT);
     /* FALLTHROUGH */
-  CONNECT_REQ_INIT:
+CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
     if(socks5_resolve_local) {
       enum resolve_t rc = Curl_resolv(data, sx->hostname, sx->remote_port,
@@ -818,7 +818,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
       }
     }
     /* FALLTHROUGH */
-  CONNECT_RESOLVED:
+CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     struct Curl_addrinfo *hp = NULL;
     size_t destlen;
@@ -873,7 +873,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
     Curl_resolv_unlock(data, dns); /* not used anymore from now on */
     goto CONNECT_REQ_SEND;
   }
-  CONNECT_RESOLVE_REMOTE:
+CONNECT_RESOLVE_REMOTE:
   case CONNECT_RESOLVE_REMOTE:
     /* Authentication is complete, now specify destination to the proxy */
     len = 0;
@@ -913,7 +913,7 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
     }
     /* FALLTHROUGH */
 
-  CONNECT_REQ_SEND:
+CONNECT_REQ_SEND:
   case CONNECT_REQ_SEND:
     /* PORT MSB */
     socksreq[len++] = (unsigned char)((sx->remote_port >> 8) & 0xff);

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1110,7 +1110,7 @@ CURLcode telrcv(struct Curl_easy *data,
       break;
 
     case CURL_TS_IAC:
-    process_iac:
+process_iac:
       DEBUGASSERT(startwrite < 0);
       switch(c) {
       case CURL_WILL:

--- a/lib/url.c
+++ b/lib/url.c
@@ -1587,7 +1587,7 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
   conn->gssapi_delegation = data->set.gssapi_delegation;
 
   return conn;
-  error:
+error:
 
   free(conn->localdev);
   free(conn);
@@ -2301,7 +2301,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
   }
 #endif
 
-  error:
+error:
   free(proxyuser);
   free(proxypasswd);
   free(host);
@@ -2898,7 +2898,7 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
 
   *port_result = port;
 
-  error:
+error:
   free(host_dup);
   return result;
 }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -481,7 +481,7 @@ static CURLUcode parse_hostname_login(struct Curl_URL *u,
   *offset = ptr - login;
   return CURLUE_OK;
 
-  out:
+out:
 
   free(userp);
   free(passwdp);
@@ -1317,7 +1317,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   u->host = Curl_dyn_ptr(&host);
 
   return result;
-  fail:
+fail:
   Curl_dyn_free(&host);
   free_urlhandle(u);
   return result;
@@ -1380,7 +1380,7 @@ CURLU *curl_url_dup(const CURLU *in)
     u->portnum = in->portnum;
   }
   return u;
-  fail:
+fail:
   curl_url_cleanup(u);
   return NULL;
 }
@@ -1876,7 +1876,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
         free(*storep);
         *storep = Curl_dyn_ptr(&enc);
         return CURLUE_OK;
-        nomem:
+nomem:
         free((char *)newp);
         return CURLUE_OUT_OF_MEMORY;
       }

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1305,7 +1305,7 @@ static int init_ngh3_conn(struct Curl_cfilter *cf)
   }
 
   return CURLE_OK;
-  fail:
+fail:
 
   return result;
 }

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -425,7 +425,7 @@ static CURLcode wssh_connect(struct Curl_easy *data, bool *done)
     state(data, SSH_SFTP_INIT);
 
   return wssh_multi_statemach(data, done);
-  error:
+error:
   wolfSSH_free(sshc->ssh_session);
   wolfSSH_CTX_free(sshc->ctx);
   return CURLE_FAILED_INIT;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -831,7 +831,7 @@ mbed_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
     result = Curl_pin_peer_pubkey(data,
                                   pinnedpubkey,
                                   &pubkey[PUB_DER_MAX_BYTES - size], size);
-    pinnedpubkey_error:
+pinnedpubkey_error:
     mbedtls_x509_crt_free(p);
     free(p);
     free(pubkey);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1496,7 +1496,7 @@ int cert_stuff(struct Curl_easy *data,
       }
 
       cert_done = 1;
-    fail:
+fail:
       EVP_PKEY_free(pri);
       X509_free(x509);
       sk_X509_pop_free(ca, X509_free);
@@ -4501,7 +4501,7 @@ static ssize_t ossl_send(struct Curl_cfilter *cf,
   }
   *curlcode = CURLE_OK;
 
-  out:
+out:
   return (ssize_t)rc; /* number of bytes */
 }
 
@@ -4603,7 +4603,7 @@ static ssize_t ossl_recv(struct Curl_cfilter *cf,
     }
   }
 
-  out:
+out:
   return nread;
 }
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2358,7 +2358,7 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
                "schannel: decrypted data buffer: offset %zu length %zu",
                backend->decdata_offset, backend->decdata_length));
 
-  cleanup:
+cleanup:
   /* Warning- there is no guarantee the encdata state is valid at this point */
   DEBUGF(infof(data, "schannel: schannel_recv cleanup"));
 

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3376,7 +3376,7 @@ static ssize_t sectransp_recv(struct Curl_cfilter *cf,
 
   DEBUGASSERT(backend);
 
-  again:
+again:
   *curlcode = CURLE_OK;
   err = SSLRead(backend->ssl_ctx, buf, buffersize, &processed);
 

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -75,6 +75,7 @@ my %warnings = (
     'INCLUDEDUP',      => 'same file is included again',
     'INDENTATION'      => 'wrong start column for code',
     'LONGLINE'         => "Line longer than $max_column",
+    'SPACEBEFORELABEL' => 'labels not at the start of the line',
     'MULTISPACE'       => 'multiple spaces used when not suitable',
     'NOSPACEEQUALS'    => 'equals sign without preceding space',
     'NOTEQUALSZERO',   => 'if/while comparison with != 0',
@@ -695,6 +696,11 @@ sub scanfile {
         if($l =~ /^( *(case .+|default)) :/) {
             checkwarn("SPACESWITCHCOLON",
                       $line, length($1), $file, $ol, "no space before colon of switch label");
+        }
+
+        if($prevl !~ /\?\z/ && $l =~ /^ +([A-Za-z_][A-Za-z0-9_]*):$/ && $1 ne 'default') {
+            checkwarn("SPACEBEFORELABEL",
+                      $line, length($1), $file, $ol, "no space before label");
         }
 
         # scan for use of banned functions

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -900,7 +900,7 @@ int formparse(struct OperationConfig *config,
     goto fail;
   }
   err = 0;
-  fail:
+fail:
   Curl_safefree(contents);
   curl_slist_free_all(headers);
   return err;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -624,7 +624,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
       return CURLE_OK;
     }
   } /* if retry_numretries */
-  noretry:
+noretry:
 
   if((global->progressmode == CURL_PROGRESS_BAR) &&
      per->progressbar.calls)

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -170,7 +170,7 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
       /* nothing to do */
       result = CURLE_OK;
   }
-  fail:
+fail:
   curl_url_cleanup(uh);
   curl_free(path);
   return result;

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -296,7 +296,7 @@ CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
   if(ret)
     warnf(config, "option %s returned error (%d)\n", name, (int)ret);
 #endif
-  nomem:
+nomem:
   return ret;
 }
 
@@ -338,7 +338,7 @@ CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
       CODE2("%s%ldL);", preamble, rest);
   }
 
- nomem:
+nomem:
   return ret;
 }
 
@@ -381,7 +381,7 @@ CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
       CODE2("%s%luUL);", preamble, rest);
   }
 
- nomem:
+nomem:
   return ret;
 }
 
@@ -407,7 +407,7 @@ static CURLcode libcurl_generate_slist(struct curl_slist *slist, int *slistno)
                                        *slistno, *slistno, escaped);
   }
 
- nomem:
+nomem:
   Curl_safefree(escaped);
   return ret;
 }
@@ -590,7 +590,7 @@ CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *config,
       CODE2("curl_easy_setopt(hnd, %s, slist%d);", name, i);
   }
 
- nomem:
+nomem:
   return ret;
 }
 
@@ -704,7 +704,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
     }
   }
 
- nomem:
+nomem:
   Curl_safefree(escaped);
   return ret;
 }

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -295,7 +295,7 @@ static CURLcode glob_range(struct URLGlob *glob, char **patternp,
       }
     }
 
-    fail:
+fail:
     *posp += (pattern - *patternp);
 
     if(!endp || !step_n ||

--- a/src/tool_xattr.c
+++ b/src/tool_xattr.c
@@ -75,7 +75,7 @@ char *stripcredentials(const char *url)
 
     return nurl;
   }
-  error:
+error:
   curl_url_cleanup(u);
   return NULL;
 }

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -123,7 +123,7 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   }
   return 0;
 
-  test_cleanup:
+test_cleanup:
 
   return 1;
 }
@@ -164,7 +164,7 @@ int test(char *URL)
   printf("%d\n", status);
   return status;
 
-  test_cleanup:
+test_cleanup:
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -92,7 +92,7 @@ int test(char *URL)
   else {
     printf("curl_easy_perform() failed. e = %d\n", code);
   }
-  test_cleanup:
+test_cleanup:
   curl_slist_free_all(pHeaderList);
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib1597.c
+++ b/tests/libtest/lib1597.c
@@ -107,7 +107,7 @@ int test(char *URL)
   printf("Tested %u strings\n", i);
   res = (int)result;
 
-  test_cleanup:
+test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 

--- a/tests/libtest/lib1903.c
+++ b/tests/libtest/lib1903.c
@@ -47,7 +47,7 @@ int test(char *URL)
   curl_easy_setopt(ch, CURLOPT_COOKIEFILE, libtest_arg2);
   curl_easy_perform(ch);
 
-  cleanup:
+cleanup:
   curl_easy_cleanup(ch);
   curl_global_cleanup();
 

--- a/tests/libtest/lib1905.c
+++ b/tests/libtest/lib1905.c
@@ -90,7 +90,7 @@ int test(char *URL)
   curl_easy_setopt(ch, CURLOPT_SHARE, NULL);
 
   curl_multi_remove_handle(cm, ch);
-  cleanup:
+cleanup:
   curl_easy_cleanup(ch);
   curl_share_cleanup(sh);
   curl_multi_cleanup(cm);

--- a/tests/libtest/lib590.c
+++ b/tests/libtest/lib590.c
@@ -64,7 +64,7 @@ int test(char *URL)
 
   res = curl_easy_perform(curl);
 
-  test_cleanup:
+test_cleanup:
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib677.c
+++ b/tests/libtest/lib677.c
@@ -112,7 +112,7 @@ int test(char *URL)
   }
 
   curl_multi_remove_handle(mcurl, curl);
-  fail:
+fail:
   curl_easy_cleanup(curl);
   curl_multi_cleanup(mcurl);
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -702,7 +702,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
     }
   } while(1);
 
-  end:
+end:
   if(buffer)
     free(buffer);
   if(dump)

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1172,7 +1172,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
     if(num > 20)
       num = 20;
 
-    retry:
+retry:
     written = swrite(sock, buffer, num);
     if(written < 0) {
       if((EWOULDBLOCK == SOCKERRNO) || (EAGAIN == SOCKERRNO)) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -500,7 +500,7 @@ static ssize_t write_behind(struct testcase *test, int convert)
        putc(c, file); */
     if(1 != write(test->ofile, &c, 1))
       break;
-    skipit:
+skipit:
     prevchar = c;
   }
   return count;
@@ -1201,7 +1201,7 @@ static void sendtftp(struct testcase *test, const struct formats *pf)
       wait_ms(1000*test->writedelay);
     }
 
-    send_data:
+send_data:
     logmsg("write");
     if(swrite(peer, sdp, size + 4) != size + 4) {
       logmsg("write: fail");

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -227,7 +227,7 @@ UNITTEST_START
       continue;
     }
   }
-  error:
+error:
   curl_easy_cleanup(easy);
   curl_multi_cleanup(multi);
   curl_slist_free_all(list);

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -212,7 +212,7 @@ UNITTEST_START
     }
   }
   goto unit_test_abort;
-  error:
+error:
   curl_easy_cleanup(easy);
   curl_multi_cleanup(multi);
   curl_slist_free_all(list);

--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -224,7 +224,7 @@ UNITTEST_START
     goto fail;
   ret = parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_BAD_PORT_NUMBER, "parse_port did wrong");
-  fail:
+fail:
   free(ipv6port);
   curl_url_cleanup(u);
 

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -106,7 +106,7 @@ UNITTEST_START
   Curl_altsvc_save(curl, asi, outname);
 
   curl_easy_cleanup(curl);
-  fail:
+fail:
   Curl_altsvc_cleanup(&asi);
 }
 #endif


### PR DESCRIPTION
Out of 223 labels throughout the code base, 65 of those labels were not at the start of the line. Which means labels always at the start of the line is the favoured style overall with 158 instances.

Out of the 65 labels not at the start of the line:
* 58 were indented with the same indentation level of the following line
* 5 were indented with exactly one space
* 1 was indented with one less indentation level of the following line
* 1 was indented with the indentation level of the following line minus three space (probably unintentional)