### PR TITLE
vquic.c: make recvfrom_packets static, avoid compiler warning

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -431,11 +431,11 @@ out:
 }
 
 #else /* HAVE_SENDMMSG || HAVE_SENDMSG */
-CURLcode recvfrom_packets(struct Curl_cfilter *cf,
-                          struct Curl_easy *data,
-                          struct cf_quic_ctx *qctx,
-                          size_t max_pkts,
-                          vquic_recv_pkt_cb *recv_cb, void *userp)
+static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
+                                 struct Curl_easy *data,
+                                 struct cf_quic_ctx *qctx,
+                                 size_t max_pkts,
+                                 vquic_recv_pkt_cb *recv_cb, void *userp)
 {
   uint8_t buf[64*1024];
   int bufsize = (int)sizeof(buf);


### PR DESCRIPTION
warning: no previous prototype for 'recvfrom_packets'

Reported-by: Keitagit-kun on github
Fixes #11146