### PR TITLE
docs: document that curl_url_cleanup(NULL) is a safe no-op 

### DIFF
--- a/docs/libcurl/curl_url_cleanup.3
+++ b/docs/libcurl/curl_url_cleanup.3
@@ -32,6 +32,9 @@ void curl_url_cleanup(CURLU *handle);
 .fi
 .SH DESCRIPTION
 Frees all the resources associated with the given \fICURLU\fP handle!
+
+Passing in a NULL pointer in \fIhandle\fP will make this function return
+immediately with no action.
 .SH EXAMPLE
 .nf
   CURLU *url = curl_url();


### PR DESCRIPTION
This has always been the case, but it was not documented.

The paragraph was copied verbatim from curl_easy_cleanup.3