### PR TITLE
Remove "live" mod-h2 master from CI builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -289,13 +289,7 @@ jobs:
       run: |
         sudo apt-get install apache2 apache2-dev libnghttp2-dev
         sudo python3 -m pip install -r tests/http/requirements.txt
-        git clone --quiet --depth=1 -b master https://github.com/icing/mod_h2
-        cd mod_h2
-        autoreconf -fi
-        ./configure PKG_CONFIG_PATH="$HOME/all/lib/pkgconfig"
-        make
-        sudo make install
-      name: 'install pytest and apach2-dev mod-h2'
+      name: 'install pytest and apach2-dev'
 
     - run: autoreconf -fi
       name: 'autoreconf'


### PR DESCRIPTION
- this will skip test_02_20_h2_small_frames until the CI has an Apache that supports the option