### PR TITLE
runtests: internal IPC fixes & test update

### DIFF
--- a/tests/data/test425
+++ b/tests/data/test425
@@ -30,9 +30,9 @@ http
 HTTP PUT with path ending with slash + query
  </name>
  <command>
--T log/up%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER/?fullpath
+-T %LOGDIR/up%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER/?fullpath
 </command>
-<file name="log/up%TESTNUMBER">
+<file name="%LOGDIR/up%TESTNUMBER">
 content
 </file>
 </client>

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1226,7 +1226,7 @@ sub runnerar {
 }
 
 ###################################################################
-# Returns runnder ID if a response from an async call is ready
+# Returns runner ID if a response from an async call is ready
 # argument is 0 for nonblocking, undef for blocking, anything else for timeout
 # Called by controller
 sub runnerar_ready {
@@ -1248,7 +1248,7 @@ sub runnerar_ready {
     # TODO: handle errors
     if(select(my $rout=$rin, undef, undef, $blocking)) {
         for my $fd (0..$maxfileno) {
-            if(vec($rin, $fd, 1)) {
+            if(vec($rout, $fd, 1)) {
                 return $idbyfileno{$fd};
             }
         }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1203,14 +1203,17 @@ sub controlleripccall {
 # Called by controller
 sub runnerar {
     my ($runnerid) = @_;
+    my $err;
     my $datalen;
-    if (sysread($controllerr{$runnerid}, $datalen, 4) <= 0) {
-        die "error in runnerar\n";
+    while(! defined ($err = sysread($controllerr{$runnerid}, $datalen, 4)) || $err <= 0) {
+        $!{EINTR} || die "error in runnerar: $!\n";
+        # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
     my $len=unpack("L", $datalen);
     my $buf;
-    if (sysread($controllerr{$runnerid}, $buf, $len) <= 0) {
-        die "error in runnerar\n";
+    while(! defined ($err = sysread($controllerr{$runnerid}, $buf, $len)) || $err <= 0) {
+        $!{EINTR} || die "error in runnerar: $!\n";
+        # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
 
     # Decode response values
@@ -1259,14 +1262,17 @@ sub runnerar_ready {
 # The IPC is read from the $runnerr pipe and the response is
 # written to the $runnerw pipe
 sub ipcrecv {
+    my $err;
     my $datalen;
-    if (sysread($runnerr, $datalen, 4) <= 0) {
-        die "error in ipcrecv\n";
+    while(! defined ($err = sysread($runnerr, $datalen, 4)) || $err <= 0) {
+        $!{EINTR} || die "error in ipcrecv: $!\n";
+        # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
     my $len=unpack("L", $datalen);
     my $buf;
-    if (sysread($runnerr, $buf, $len) <= 0) {
-        die "error in ipcrecv\n";
+    while(! defined ($err = sysread($runnerr, $buf, $len)) || $err <= 0) {
+        $!{EINTR} || die "error in ipcrecv: $!\n";
+        # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
 
     # Decode the function name and arguments


### PR DESCRIPTION
- use the correct fd after select
- handle interrupted reads from IPC pipes
- fix the log directory in test425