### PR TITLE
lib: rename struct 'http_req' to 'httpreq'

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -777,7 +777,7 @@ static CURLcode h2_submit(int32_t *pstream_id,
                           struct Curl_cfilter *cf,
                           struct Curl_easy *data,
                           nghttp2_session *h2,
-                          struct http_req *req,
+                          struct httpreq *req,
                           const nghttp2_priority_spec *pri_spec,
                           void *stream_user_data,
                           nghttp2_data_source_read_callback read_callback,
@@ -846,7 +846,7 @@ static CURLcode submit_CONNECT(struct Curl_cfilter *cf,
 {
   struct cf_h2_proxy_ctx *ctx = cf->ctx;
   CURLcode result;
-  struct http_req *req = NULL;
+  struct httpreq *req = NULL;
 
   infof(data, "Establish HTTP/2 proxy tunnel to %s", ts->authority);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -4537,13 +4537,13 @@ static char *my_strndup(const char *ptr, size_t len)
   return copy;
 }
 
-CURLcode Curl_http_req_make(struct http_req **preq,
+CURLcode Curl_http_req_make(struct httpreq **preq,
                             const char *method, size_t m_len,
                             const char *scheme, size_t s_len,
                             const char *authority, size_t a_len,
                             const char *path, size_t p_len)
 {
-  struct http_req *req;
+  struct httpreq *req;
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   DEBUGASSERT(method);
@@ -4580,7 +4580,7 @@ out:
   return result;
 }
 
-static CURLcode req_assign_url_authority(struct http_req *req, CURLU *url)
+static CURLcode req_assign_url_authority(struct httpreq *req, CURLU *url)
 {
   char *user, *pass, *host, *port;
   struct dynbuf buf;
@@ -4646,7 +4646,7 @@ out:
   return result;
 }
 
-static CURLcode req_assign_url_path(struct http_req *req, CURLU *url)
+static CURLcode req_assign_url_path(struct httpreq *req, CURLU *url)
 {
   char *path, *query;
   struct dynbuf buf;
@@ -4694,11 +4694,11 @@ out:
   return result;
 }
 
-CURLcode Curl_http_req_make2(struct http_req **preq,
+CURLcode Curl_http_req_make2(struct httpreq **preq,
                              const char *method, size_t m_len,
                              CURLU *url, const char *scheme_default)
 {
-  struct http_req *req;
+  struct httpreq *req;
   CURLcode result = CURLE_OUT_OF_MEMORY;
   CURLUcode uc;
 
@@ -4738,7 +4738,7 @@ out:
   return result;
 }
 
-void Curl_http_req_free(struct http_req *req)
+void Curl_http_req_free(struct httpreq *req)
 {
   if(req) {
     free(req->scheme);
@@ -4778,7 +4778,7 @@ static bool h2_non_field(const char *name, size_t namelen)
 }
 
 CURLcode Curl_http_req_to_h2(struct dynhds *h2_headers,
-                             struct http_req *req, struct Curl_easy *data)
+                             struct httpreq *req, struct Curl_easy *data)
 {
   const char *scheme = NULL, *authority = NULL;
   struct dynhds_entry *e;

--- a/lib/http.h
+++ b/lib/http.h
@@ -260,7 +260,7 @@ CURLcode Curl_http_decode_status(int *pstatus, const char *s, size_t len);
 /**
  * All about a core HTTP request, excluding body and trailers
  */
-struct http_req {
+struct httpreq {
   char method[12];
   char *scheme;
   char *authority;
@@ -272,17 +272,17 @@ struct http_req {
 /**
  * Create a HTTP request struct.
  */
-CURLcode Curl_http_req_make(struct http_req **preq,
+CURLcode Curl_http_req_make(struct httpreq **preq,
                             const char *method, size_t m_len,
                             const char *scheme, size_t s_len,
                             const char *authority, size_t a_len,
                             const char *path, size_t p_len);
 
-CURLcode Curl_http_req_make2(struct http_req **preq,
+CURLcode Curl_http_req_make2(struct httpreq **preq,
                              const char *method, size_t m_len,
                              CURLU *url, const char *scheme_default);
 
-void Curl_http_req_free(struct http_req *req);
+void Curl_http_req_free(struct httpreq *req);
 
 #define HTTP_PSEUDO_METHOD ":method"
 #define HTTP_PSEUDO_SCHEME ":scheme"
@@ -306,7 +306,7 @@ void Curl_http_req_free(struct http_req *req);
  * @param data       the handle to lookup defaults like ' :scheme' from
  */
 CURLcode Curl_http_req_to_h2(struct dynhds *h2_headers,
-                             struct http_req *req, struct Curl_easy *data);
+                             struct httpreq *req, struct Curl_easy *data);
 
 /**
  * All about a core HTTP response, excluding body and trailers

--- a/lib/http1.h
+++ b/lib/http1.h
@@ -36,7 +36,7 @@
 #define H1_PARSE_DEFAULT_MAX_LINE_LEN (8 * 1024)
 
 struct h1_req_parser {
-  struct http_req *req;
+  struct httpreq *req;
   struct bufq scratch;
   size_t scratch_skip;
   const char *line;
@@ -53,7 +53,7 @@ ssize_t Curl_h1_req_parse_read(struct h1_req_parser *parser,
                                const char *scheme_default, int options,
                                CURLcode *err);
 
-CURLcode Curl_h1_req_dprint(const struct http_req *req,
+CURLcode Curl_h1_req_dprint(const struct httpreq *req,
                             struct dynbuf *dbuf);
 
 


### PR DESCRIPTION
Because FreeBSD 14 kidnapped the name.

Fixes #11163