### PR TITLE
tests/servers: generate temp names in /tmp for unix domain sockets

### DIFF
--- a/tests/data/test1467
+++ b/tests/data/test1467
@@ -42,7 +42,7 @@ socks5unix
 HTTP GET via SOCKS5 proxy via unix sockets
  </name>
  <command>
---socks5 localhost%PWD/%SOCKSUNIXPATH http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+--socks5 localhost%SOCKSUNIXPATH http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test1468
+++ b/tests/data/test1468
@@ -43,7 +43,7 @@ socks5unix
 HTTP GET with host name using SOCKS5h via unix sockets
  </name>
  <command>
-http://this.is.a.host.name:%HTTPPORT/%TESTNUMBER --proxy socks5h://localhost%PWD/%SOCKSUNIXPATH
+http://this.is.a.host.name:%HTTPPORT/%TESTNUMBER --proxy socks5h://localhost%SOCKSUNIXPATH
 </command>
 </client>
 

--- a/tests/data/test1470
+++ b/tests/data/test1470
@@ -45,7 +45,7 @@ socks5unix
 HTTPS GET with host name using SOCKS5h via unix sockets
  </name>
  <command>
-https://this.is.a.host.name:%HTTPSPORT/%TESTNUMBER -k --proxy socks5h://localhost%PWD/%SOCKSUNIXPATH
+https://this.is.a.host.name:%HTTPSPORT/%TESTNUMBER -k --proxy socks5h://localhost%SOCKSUNIXPATH
 </command>
 </client>
 

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -180,11 +180,19 @@ sub getfreeport {
     return $server->sockport();
 }
 
+use File::Temp qw/ tempfile/;
+
 #######################################################################
 # Initialize configuration variables
 sub initserverconfig {
-    $SOCKSUNIXPATH = "$LOGDIR/$PIDDIR/socks.sock"; # SOCKS Unix domain socket
-    $HTTPUNIXPATH = "$LOGDIR/$PIDDIR/http.sock";   # HTTP Unix domain socket
+    my ($fh, $socks) = tempfile("/tmp/curl-socksd-XXXXXXXX");
+    close($fh);
+    unlink($socks);
+    my ($f2, $http) = tempfile("/tmp/curl-http-XXXXXXXX");
+    close($f2);
+    unlink($http);
+    $SOCKSUNIXPATH = $socks; # SOCKS Unix domain socket
+    $HTTPUNIXPATH = $http;   # HTTP Unix domain socket
     $stunnel = checkcmd("stunnel4") || checkcmd("tstunnel") || checkcmd("stunnel");
 
     # get the name of the current user


### PR DESCRIPTION
... instead of putting them in the regular pid directories. Simply because system generally have strict length requirements on that path name to be less than 107 bytes and we easily hit that boundary otherwise.

The new concept generates two random names: one for the socks daemon and one for http.

Reported-by: Andy Fiddaman
Fixes #11152