### PR TITLE
http/2, unstuck uploads

### DIFF
--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -275,14 +275,14 @@ class TestUpload:
             '--resolve', f'{env.authority_for(env.domain1, proto)}:127.0.0.1',
             '--cacert', env.ca.cert_file,
             '--request', 'PUT',
-            '--max-time', '5', '-v',
+            '--max-time', '10', '-v',
             '--url', url,
             '--form', 'idList=12345678',
             '--form', 'pos=top',
             '--form', 'name=mr_test',
             '--form', f'fileSource=@{fdata};type=application/pdf',
         ])
-        assert r.exit_code == 0, f'{r}'
+        assert r.exit_code == 0, r.dump_logs()
         r.check_stats(1, 200)
 
     def check_download(self, count, srcfile, curl):


### PR DESCRIPTION
- refs #11157 and #11175 where uploads get stuck or lead to RST streams
- fixes our h2 send behaviour to continue sending in the nghttp2 session as long as it wants to. This will empty our send buffer as long as the remote stream/connection window allows.
- in case the window is exhausted, the data remaining in the send buffer will wait for a WINDOW_UPDATE from the server. Which is a socket event that engages our transfer loop again
- the problem in the issue was that we did not exhaust the window, but left data in the sendbuffer and no further socket events did happen. The server was just waiting for us to send more.
- relatedly, there was an issue fixed that closing a stream with KEEP_HOLD set kept the transfer from shutting down - as it should have - leading to a timeout.