### PR TITLE
configure: quote the compiler command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ dnl something different but only have that affect the execution of the results
 dnl of the compile, not change the libraries for the compiler itself.
 dnl
 compilersh="run-compiler"
-echo "CC=$CC" > $compilersh
+echo "CC=\"$CC\"" > $compilersh
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $compilersh
 echo 'exec $CC $@' >> $compilersh
 

--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,7 @@ dnl of the compile, not change the libraries for the compiler itself.
 dnl
 compilersh="run-compiler"
 echo "CC=\"$CC\"" > $compilersh
-echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $compilersh
+echo "LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\"" >> $compilersh
 echo 'exec $CC $@' >> $compilersh
 
 dnl **********************************************************************


### PR DESCRIPTION
Building for multilib failed, as the compiler command contains an extra argument. That needs quoting.

Fixes #11179
Fixes b78ca50cb3dda361f9c1e7a83af7e2e0fa0edbf2