### PR TITLE
configure: fix build with arbitrary CC and LD_LIBRARY_PATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,9 +193,13 @@ dnl something different but only have that affect the execution of the results
 dnl of the compile, not change the libraries for the compiler itself.
 dnl
 compilersh="run-compiler"
-echo "CC=\"$CC\"" > $compilersh
-echo "LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\"" >> $compilersh
-echo 'exec $CC $@' >> $compilersh
+export "CURL_SAVED_CC=$CC"
+export "CURL_SAVED_LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+cat <<\EOF > "$compilersh"
+export "CC=$CURL_SAVED_CC"
+export "LD_LIBRARY_PATH=$CURL_SAVED_LD_LIBRARY_PATH"
+exec $CC "$@"
+EOF
 
 dnl **********************************************************************
 dnl See which TLS backend(s) that are requested. Just do all the


### PR DESCRIPTION
Since ./configure and processes that inherit its environment variables are the only callers of the run-compiler script, we can just save the current value of the LD_LIBRARY_PATH and CC variables to another pair of environment variables, and make run-compiler a static script that simply restores CC and LD_LIBRARY_PATH to the saved value, and before running the compiler.

This avoids having to inject the values of the variables in the script, possibly causing problems if they contains spaces, quotes, and other special characters.

Also add exports in the script just in case LD_LIBRARY_PATH and CC are not already in the environment.

follow-up from 471dab2