### PR TITLE
configure: fail when pkg-config and --with-nghttp2 path are both absent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2811,7 +2811,7 @@ if test X"$want_nghttp2" != Xno; then
     LD_H2=-L${want_nghttp2_path}/lib$libsuff
     CPP_H2=-I${want_nghttp2_path}/include
     DIR_H2=${want_nghttp2_path}/lib$libsuff
-  elif test X"$want_nghttp2" != Xdefault; then
+  else
     dnl no nghttp2 pkg-config found and no custom directory specified,
     dnl deal with it
     AC_MSG_ERROR([--with-nghttp2 was specified but could not find libnghttp2 pkg-config file.])


### PR DESCRIPTION
This prevents linking failures due to undefined nghttp2 references.

Follow-up to adc84710

----

#### Steps to reproduce the linking failures
* Save the following `Dockerfile`

```dockerfile
FROM archlinux:base-20230521.0.152478
USER root

# Note: pkg-config is *not* included
RUN pacman -Sy --noconfirm autoconf automake binutils gcc git libtool make

WORKDIR /root/
RUN git clone --depth 1 https://github.com/curl/curl.git

WORKDIR /root/curl
RUN autoreconf -fi && \
  ./configure --with-openssl && \
  make -j3
```

* Run `docker image build . -f Dockerfile -t curl:nghttp2-config-repro`

#### Previous results
```
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_consume'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_pack_settings_payload'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_http2_strerror'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_submit_request'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_submit_rst_stream'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_priority_spec_init'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_get_stream_user_data'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_strerror'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_client_new2'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_on_data_chunk_recv_callback'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_get_stream_remote_window_size'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_set_stream_user_data'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_send'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_del'
#0 81.52 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_submit_ping'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_send_callback'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_option_set_no_auto_window_update'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_on_frame_recv_callback'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_option_new'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_get_remote_window_size'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_new'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_want_read'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_check_request_allowed'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_is_fatal'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_mem_recv'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_submit_priority'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_want_write'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_upgrade2'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_option_del'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_submit_settings'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_on_begin_headers_callback'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_error_callback'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_on_stream_close_callback'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_callbacks_set_on_header_callback'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_resume_data'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_set_local_window_size'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_get_remote_settings'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_version'
#0 81.53 /usr/sbin/ld: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_del'
#0 81.53 collect2: error: ld returned 1 exit status
#0 81.54 make[2]: *** [Makefile:1018: curl] Error 1
#0 81.54 make[2]: Leaving directory '/root/curl/src'
#0 81.54 make[1]: *** [Makefile:1496: all-recursive] Error 1
#0 81.54 make[1]: Leaving directory '/root/curl/src'
#0 81.54 make: *** [Makefile:1267: all-recursive] Error 1
```

#### Results after this change
```
checking for pkg-config... no
configure: error: --with-nghttp2 was specified but could not find libnghttp2 pkg-config file.
```