### PR TITLE
http2: fix EOF handling on uploads with auth negotiation

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1527,10 +1527,8 @@ static CURLcode http2_data_done_send(struct Curl_cfilter *cf,
   if(!stream->send_closed) {
     stream->send_closed = TRUE;
     if(stream->upload_left) {
-      /* If we operated with unknown length, we now know that everything
-       * that is buffered is all we have to send. */
-      if(stream->upload_left == -1)
-        stream->upload_left = Curl_bufq_len(&stream->sendbuf);
+      /* we now know that everything that is buffered is all there is. */
+      stream->upload_left = Curl_bufq_len(&stream->sendbuf);
       /* resume sending here to trigger the callback to get called again so
          that it can signal EOF to nghttp2 */
       (void)nghttp2_session_resume_data(ctx->h2, stream->id);

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -285,6 +285,26 @@ class TestUpload:
         assert r.exit_code == 0, r.dump_logs()
         r.check_stats(1, 200)
 
+    def test_07_34_issue_11194(self, env: Env, httpd, nghttpx, repeat):
+        proto = 'h2'
+        fdata = os.path.join(env.gen_dir, 'data-10m')
+        # tell our test PUT handler to read the upload more slowly, so
+        # that the send buffering and transfer loop needs to wait
+        fdata = os.path.join(env.gen_dir, 'data-100k')
+        url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put'
+        curl = CurlClient(env=env)
+        r = curl.run_direct(with_stats=True, args=[
+            '--verbose',
+            '--resolve', f'{env.authority_for(env.domain1, proto)}:127.0.0.1',
+            '--cacert', env.ca.cert_file,
+            '--request', 'PUT',
+            '--digest', '--user', 'test:test',
+            '--data-binary', f'@{fdata}'
+            '--url', url,
+        ])
+        assert r.exit_code == 0, r.dump_logs()
+        r.check_stats(1, 200)
+
     def check_download(self, count, srcfile, curl):
         for i in range(count):
             dfile = curl.download_file(i)

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+import difflib
+import filecmp
+import logging
+import os
+import pytest
+
+from testenv import Env, CurlClient, LocalClient
+
+
+log = logging.getLogger(__name__)
+
+
+class TestAuth:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, httpd, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+        httpd.clear_extra_configs()
+        httpd.reload()
+
+    # download 1 file, not authenticated
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_14_01_digest_get_noauth(self, env: Env, httpd, nghttpx, repeat, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/restricted/digest/data.json'
+        r = curl.http_download(urls=[url], alpn_proto=proto)
+        r.check_response(http_status=401)
+
+    # download 1 file, authenticated
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_14_02_digest_get_auth(self, env: Env, httpd, nghttpx, repeat, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/restricted/digest/data.json'
+        r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
+            '--digest', '--user', 'test:test'
+        ])
+        r.check_response(http_status=200)
+
+    # PUT data, authenticated
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_14_03_digest_put_auth(self, env: Env, httpd, nghttpx, repeat, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
+        data='0123456789'
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/restricted/digest/data.json'
+        r = curl.http_upload(urls=[url], data=data, alpn_proto=proto, extra_args=[
+            '--digest', '--user', 'test:test'
+        ])
+        r.check_response(http_status=200)


### PR DESCRIPTION
- doing a POST with `--digest` does an override on the initial request with `Content-Length: 0`, but the http2 filter was unaware of that and expected the originally request body. It did therefore not send a final DATA frame with EOF flag to the server.
- The fix overrides any initial notion of post size when the `done_send` event is triggered by the transfer loop, leading to the EOF that is necessary.
- refs #11194. The fault did not happen in testing, as Apache httpd never tries to read the request body of the initial request, sends the 401 reply and closes the stream. The server used in the reported issue however tried to read the EOF and timed out on the request.