### PR TITLE
scripts/contri*sh: no longer grep -v ' '

### DIFF
--- a/scripts/contributors.sh
+++ b/scripts/contributors.sh
@@ -78,18 +78,18 @@ sed 's/^ *//'
 
 )| \
 sed -f ./docs/THANKS-filter | \
-grep -a ' ' | \
 sort -fu | \
 awk '{
- num++;
- n = sprintf("%s%s%s,", n, length(n)?" ":"", $0);
- #print n;
- if(length(n) > 77) {
-   printf("  %s\n", p);
-   n=sprintf("%s,", $0);
+ if(length($0)) {
+   num++;
+   n = sprintf("%s%s%s,", n, length(n)?" ":"", $0);
+   #print n;
+   if(length(n) > 77) {
+     printf("  %s\n", p);
+     n=sprintf("%s,", $0);
+   }
+   p=n;
  }
- p=n;
-
 }
 
  END {

--- a/scripts/contrithanks.sh
+++ b/scripts/contrithanks.sh
@@ -73,6 +73,5 @@ sed 's/^ *//'
 
 )| \
 sed -f ./docs/THANKS-filter | \
-grep -a ' ' | \
 sort -fu | \
 grep -aixvf ./docs/THANKS


### PR DESCRIPTION
Originally these scripts filtered out names that have no space so that they better avoid nick names not intended for credits. Such names are not too commonly used, plus we now give credit even to those.

Additionally: non-latin names, like Asian, don't have spaces at all so they were also filtered out and had to be manually added which made it an error-prone operation where Asian names eventually easily fell off by mistake.