### PR TITLE
remove trailing 'dnl' that causes this to break autoconf etc

### DIFF
--- a/docs/libcurl/libcurl.m4
+++ b/docs/libcurl/libcurl.m4
@@ -272,4 +272,4 @@ if (x) {;}
   fi
 
   unset _libcurl_with
-])dnl
+])


### PR DESCRIPTION
This trailing `dnl` causes the following error when used as an automake extension
```
/usr/bin/m4:mk/m4ext/ax_libcurl.m4:275: Warning: end of file treated as newline
autom4te: error: /usr/bin/m4 failed with exit status: 1
aclocal: error: /usr/bin/autom4te failed with exit status: 1
autoreconf: error: aclocal failed with exit status: 1
```