### PR TITLE
tool_urlglob: use curl_off_t instead of longs

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -37,11 +37,11 @@ struct State {
   char *outfiles;
   char *httpgetfields;
   char *uploadfile;
-  unsigned long infilenum; /* number of files to upload */
-  unsigned long up;  /* upload file counter within a single upload glob */
-  unsigned long urlnum; /* how many iterations this single URL has with ranges
+  curl_off_t infilenum; /* number of files to upload */
+  curl_off_t up;        /* upload file counter within a single upload glob */
+  curl_off_t urlnum;    /* how many iterations this single URL has with ranges
                            etc */
-  unsigned long li;
+  curl_off_t li;
 };
 
 struct OperationConfig {
@@ -317,7 +317,7 @@ struct GlobalConfig {
   bool test_event_based;
 #endif
   bool parallel;
-  long parallel_max;
+  unsigned short parallel_max; /* MAX_PARALLEL is the maximum */
   bool parallel_connect;
   char *help_category;            /* The help category, if set */
   struct OperationConfig *first;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2408,15 +2408,19 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       case '\0':  /* --parallel */
         global->parallel = toggle;
         break;
-      case 'b':   /* --parallel-max */
-        err = str2unum(&global->parallel_max, nextarg);
+      case 'b': {  /* --parallel-max */
+        long val;
+        err = str2unum(&val, nextarg);
         if(err)
           return err;
-        if(global->parallel_max > MAX_PARALLEL)
+        if(val > MAX_PARALLEL)
           global->parallel_max = MAX_PARALLEL;
-        else if(global->parallel_max < 1)
+        else if(val < 1)
           global->parallel_max = PARALLEL_DEFAULT;
+        else
+          global->parallel_max = (unsigned short)val;
         break;
+      }
       case 'c':   /* --parallel-connect */
         global->parallel_connect = toggle;
         break;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -205,7 +205,7 @@ static curl_off_t VmsSpecialSize(const char *name,
 
 struct per_transfer *transfers; /* first node */
 static struct per_transfer *transfersl; /* last node */
-static long all_pers;
+static curl_off_t all_pers;
 
 /* add_per_transfer creates a new 'per_transfer' node in the linked
    list of transfers */
@@ -806,7 +806,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
     }
 
     {
-      unsigned long urlnum;
+      curl_off_t urlnum;
 
       if(!state->up && !infiles)
         Curl_nop_stmt;

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -64,9 +64,9 @@ static CURLcode glob_fixed(struct URLGlob *glob, char *fixed, size_t len)
  *
  * Multiplies and checks for overflow.
  */
-static int multiply(unsigned long *amount, long with)
+static int multiply(curl_off_t *amount, curl_off_t with)
 {
-  unsigned long sum = *amount * with;
+  curl_off_t sum = *amount * with;
   if(!with) {
     *amount = 0;
     return 0;
@@ -78,7 +78,7 @@ static int multiply(unsigned long *amount, long with)
 }
 
 static CURLcode glob_set(struct URLGlob *glob, char **patternp,
-                         size_t *posp, unsigned long *amount,
+                         size_t *posp, curl_off_t *amount,
                          int globindex)
 {
   /* processes a set expression with the point behind the opening '{'
@@ -123,7 +123,8 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
       *buf = '\0';
       if(pat->content.Set.elements) {
         char **new_arr = realloc(pat->content.Set.elements,
-                                 (pat->content.Set.size + 1) * sizeof(char *));
+                                 (size_t)(pat->content.Set.size + 1) *
+                                 sizeof(char *));
         if(!new_arr)
           return GLOBERROR("out of memory", 0, CURLE_OUT_OF_MEMORY);
 
@@ -172,7 +173,7 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
 }
 
 static CURLcode glob_range(struct URLGlob *glob, char **patternp,
-                           size_t *posp, unsigned long *amount,
+                           size_t *posp, curl_off_t *amount,
                            int globindex)
 {
   /* processes a range expression with the point behind the opening '['
@@ -360,7 +361,7 @@ static bool peek_ipv6(const char *str, size_t *skip)
 }
 
 static CURLcode glob_parse(struct URLGlob *glob, char *pattern,
-                           size_t pos, unsigned long *amount)
+                           size_t pos, curl_off_t *amount)
 {
   /* processes a literal string component of a URL
      special characters '{' and '[' branch to set/range processing functions
@@ -437,7 +438,7 @@ static CURLcode glob_parse(struct URLGlob *glob, char *pattern,
   return res;
 }
 
-CURLcode glob_url(struct URLGlob **glob, char *url, unsigned long *urlnum,
+CURLcode glob_url(struct URLGlob **glob, char *url, curl_off_t *urlnum,
                   FILE *error)
 {
   /*
@@ -445,7 +446,7 @@ CURLcode glob_url(struct URLGlob **glob, char *url, unsigned long *urlnum,
    * as the specified URL!
    */
   struct URLGlob *glob_expand;
-  unsigned long amount = 0;
+  curl_off_t amount = 0;
   char *glob_buffer;
   CURLcode res;
 
@@ -496,7 +497,7 @@ CURLcode glob_url(struct URLGlob **glob, char *url, unsigned long *urlnum,
 void glob_cleanup(struct URLGlob *glob)
 {
   size_t i;
-  int elem;
+  curl_off_t elem;
 
   if(!glob)
     return;

--- a/src/tool_urlglob.h
+++ b/src/tool_urlglob.h
@@ -38,7 +38,7 @@ struct URLPattern {
   union {
     struct {
       char **elements;
-      int size;
+      curl_off_t size;
       int ptr_s;
     } Set;
     struct {
@@ -48,11 +48,11 @@ struct URLPattern {
       int step;
     } CharRange;
     struct {
-      unsigned long min_n;
-      unsigned long max_n;
+      curl_off_t min_n;
+      curl_off_t max_n;
       int padlength;
-      unsigned long ptr_n;
-      unsigned long step;
+      curl_off_t ptr_n;
+      curl_off_t step;
     } NumRange;
   } content;
 };
@@ -70,7 +70,7 @@ struct URLGlob {
   size_t pos;        /* column position of error or 0 */
 };
 
-CURLcode glob_url(struct URLGlob**, char *, unsigned long *, FILE *);
+CURLcode glob_url(struct URLGlob**, char *, curl_off_t *, FILE *);
 CURLcode glob_next_url(char **, struct URLGlob *);
 CURLcode glob_match_url(char **, char *, struct URLGlob *);
 void glob_cleanup(struct URLGlob *glob);


### PR DESCRIPTION
To handle more globs better (especially on Windows)