### PR TITLE
runtests: abort test run after failure without -a

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2653,7 +2653,7 @@ foreach my $testnum (@runtests) {
             elsif(!$anyway) {
                 # a test failed, abort
                 logmsg "\n - abort tests\n";
-                last;
+                last nexttest;
             }
         }
         elsif(!$error) {


### PR DESCRIPTION
This was broken in a recent refactor and test runs would not stop.

Follow-up to d4a1b5b6

Reported-by: Daniel Stenberg
Fixes #11225
Closes #11227