### PR TITLE
Fix run-compiler for old /bin/sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,11 +193,15 @@ dnl something different but only have that affect the execution of the results
 dnl of the compile, not change the libraries for the compiler itself.
 dnl
 compilersh="run-compiler"
-export "CURL_SAVED_CC=$CC"
-export "CURL_SAVED_LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+CURL_SAVED_CC="$CC"
+export CURL_SAVED_CC
+CURL_SAVED_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
+export CURL_SAVED_LD_LIBRARY_PATH
 cat <<\EOF > "$compilersh"
-export "CC=$CURL_SAVED_CC"
-export "LD_LIBRARY_PATH=$CURL_SAVED_LD_LIBRARY_PATH"
+CC="$CURL_SAVED_CC"
+export CC
+LD_LIBRARY_PATH="$CURL_SAVED_LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH
 exec $CC "$@"
 EOF
 


### PR DESCRIPTION
If you try to assign and export on the same line on some older /bin/sh implementations, it complains:

```
$ export "NAME=value"
NAME=value: is not an identifier
```

Also, as written, the name and value are quoted together. This also makes old /bin/sh sad:

```
$ "NAME=value"
NAME=value: not found
```

This commit rewrites run-compiler's assignments and exports to work with old /bin/sh, splitting assignment and export into two separate statements, and only quote the value. So now we have:

```
NAME="value"
export NAME
```

While we're here, make the same change to the two supporting assign+export lines preceeding the script to be consistent with how exports work throughout the rest of configure.ac.