### PR TITLE
libssh2: do not use custom alloc functions for kbd_callback

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -205,7 +205,11 @@ kbd_callback(const char *name, int name_len, const char *instruction,
 #endif  /* CURL_LIBSSH2_DEBUG */
   if(num_prompts == 1) {
     struct connectdata *conn = data->conn;
+#ifdef CURL_LIBSSH2_DEBUG
     responses[0].text = strdup(conn->passwd);
+#else
+    responses[0].text = (strdup)(conn->passwd);
+#endif
     responses[0].length = curlx_uztoui(strlen(conn->passwd));
   }
   (void)prompts;


### PR DESCRIPTION
When libssh2_userauth_keyboard_interactive_ex() calls the callback to libcurl code, it allocates memory that is then managed and ultimately free()ed by libssh2.

It is then important that we don't use the normal strdup() call in libcurl, since this method will use a special memory system for debug builds and cause libssh2 to do a bad free().

If CURL_LIBSSH2_DEBUG is defined, we tell libssh2 to use the curl memory function and then it *should* instead use the curl function for strdup()!