### PR TITLE
libssh2: use custom memory functions

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -100,11 +100,9 @@
 
 /* Local functions: */
 static const char *sftp_libssh2_strerror(unsigned long err);
-#ifdef CURL_LIBSSH2_DEBUG
 static LIBSSH2_ALLOC_FUNC(my_libssh2_malloc);
 static LIBSSH2_REALLOC_FUNC(my_libssh2_realloc);
 static LIBSSH2_FREE_FUNC(my_libssh2_free);
-#endif
 static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data);
 static CURLcode ssh_connect(struct Curl_easy *data, bool *done);
 static CURLcode ssh_multi_statemach(struct Curl_easy *data, bool *done);
@@ -284,8 +282,6 @@ static CURLcode libssh2_session_error_to_CURLE(int err)
   return CURLE_SSH;
 }
 
-#ifdef CURL_LIBSSH2_DEBUG
-
 static LIBSSH2_ALLOC_FUNC(my_libssh2_malloc)
 {
   (void)abstract; /* arg not used */
@@ -304,8 +300,6 @@ static LIBSSH2_FREE_FUNC(my_libssh2_free)
   if(ptr) /* ssh2 agent sometimes call free with null ptr */
     free(ptr);
 }
-
-#endif
 
 /*
  * SSH State machine related code
@@ -3268,13 +3262,12 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
   sock = conn->sock[FIRSTSOCKET];
 #endif /* CURL_LIBSSH2_DEBUG */
 
-#ifdef CURL_LIBSSH2_DEBUG
+  /* libcurl MUST to set custom memory functions so that the kbd_callback
+     funciton's memory allocations can be properled freed */
   sshc->ssh_session = libssh2_session_init_ex(my_libssh2_malloc,
                                               my_libssh2_free,
                                               my_libssh2_realloc, data);
-#else
-  sshc->ssh_session = libssh2_session_init_ex(NULL, NULL, NULL, data);
-#endif
+
   if(!sshc->ssh_session) {
     failf(data, "Failure initialising ssh session");
     return CURLE_FAILED_INIT;


### PR DESCRIPTION
Because of how libssh2_userauth_keyboard_interactive_ex() works: the libcurl callback allocates memory that is later free()d by libssh2, we must set the custom memory functions.

Reverts 8b5f100db388ee60118c08aa28

Ref: https://github.com/libssh2/libssh2/issues/1078