### PR TITLE
runtests: create multiple test runners when requested

### DIFF
--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -50,6 +50,7 @@ BEGIN {
         $proxy_address
         $PROXYIN
         $pwd
+        $randseed
         $run_event_based
         $SERVERIN
         $srcdir
@@ -80,6 +81,7 @@ our $run_event_based; # run curl with --test-event to test the event API
 our $automakestyle;   # use automake-like test status output format
 our $anyway;          # continue anyway, even if a test fail
 our $CURLVERSION="";  # curl's reported version number
+our $randseed = 0;    # random number seed
 
 # paths
 our $pwd = getcwd();  # current working directory

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -89,6 +89,7 @@ use processhelp qw(
 use servers qw(
     checkcmd
     clearlocks
+    initserverconfig
     serverfortest
     stopserver
     stopservers
@@ -159,7 +160,7 @@ sub runner_init {
     $multiprocess = !!$jobs;
 
     # enable memory debugging if curl is compiled with it
-    $ENV{'CURL_MEMDEBUG'} = "$LOGDIR/$MEMDUMP";
+    $ENV{'CURL_MEMDEBUG'} = "$logdir/$MEMDUMP";
     $ENV{'CURL_ENTROPY'}="12345678";
     $ENV{'CURL_FORCETIME'}=1; # for debug NTLM magic
     $ENV{'CURL_GLOBAL_INIT'}=1; # debug curl_global_init/cleanup use
@@ -201,6 +202,9 @@ sub runner_init {
             # Set this directory as ours
             $LOGDIR = $logdir;
             mkdir("$LOGDIR/$PIDDIR", 0777);
+
+            # Initialize various server variables
+            initserverconfig();
 
             # handle IPC calls
             event_loop();

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -168,6 +168,13 @@ sub runner_init {
     $ENV{'XDG_CONFIG_HOME'}=$ENV{'HOME'};
     $ENV{'COLUMNS'}=79; # screen width!
 
+    # Incorporate the $logdir into the random seed and re-seed the PRNG.
+    # This gives each runner a unique yet consistent seed which provides
+    # more unique port number selection in each runner, yet is deterministic
+    # across runs.
+    $randseed += unpack('%16C*', $logdir);
+    srand $randseed;
+
     # create pipes for communication with runner
     my ($thisrunnerr, $thiscontrollerw, $thiscontrollerr, $thisrunnerw);
     pipe $thisrunnerr, $thiscontrollerw;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -177,7 +177,6 @@ my $clearlocks;   # force removal of files by killing locking processes
 my $postmortem;   # display detailed info about failed tests
 my $run_disabled; # run the specific tests even if listed in DISABLED
 my $scrambleorder;
-my $randseed = 0;
 my $jobs = 0;
 
 # Azure Pipelines specific variables

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2371,6 +2371,7 @@ if(!$listonly) {
 
 #######################################################################
 # initialize configuration needed to set up servers
+# TODO: rearrange things so this can be called only in runner_init()
 #
 initserverconfig();
 


### PR DESCRIPTION
This is the final (ahem) set of changes to implement parallel testing. Still to
come are improvements to reduce flaky tests (like bug #11231) which are
exacerbated by the load and timing differences of parallel testing, but the
necessary testing framework is now complete and usable.