### PR TITLE
ws: make the curl_ws_meta() return pointer a const

### DIFF
--- a/docs/examples/websocket-cb.c
+++ b/docs/examples/websocket-cb.c
@@ -32,7 +32,7 @@ static size_t writecb(char *b, size_t size, size_t nitems, void *p)
 {
   CURL *easy = p;
   size_t i;
-  struct curl_ws_frame *frame = curl_ws_meta(easy);
+  const struct curl_ws_frame *frame = curl_ws_meta(easy);
   fprintf(stderr, "Type: %s\n", frame->flags & CURLWS_BINARY ?
           "binary" : "text");
   fprintf(stderr, "Bytes: %u", (unsigned int)(nitems * size));

--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -42,7 +42,7 @@ static int ping(CURL *curl, const char *send_payload)
 static int recv_pong(CURL *curl, const char *exected_payload)
 {
   size_t rlen;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(!result) {
@@ -71,7 +71,7 @@ static int recv_pong(CURL *curl, const char *exected_payload)
 static int recv_any(CURL *curl)
 {
   size_t rlen;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(result)

--- a/docs/libcurl/curl_ws_meta.3
+++ b/docs/libcurl/curl_ws_meta.3
@@ -36,7 +36,7 @@ struct curl_ws_frame {
   curl_off_t bytesleft; /* number of pending bytes left of the payload */
 };
 
-struct curl_ws_frame *curl_ws_meta(CURL *curl);
+const struct curl_ws_frame *curl_ws_meta(CURL *curl);
 .fi
 .SH DESCRIPTION
 This function call is EXPERIMENTAL.
@@ -93,7 +93,7 @@ static size_t writecb(unsigned char *buffer,
                       size_t size, size_t nitems, void *p)
 {
   struct customdata *c = (struct customdata *)p;
-  struct curl_ws_frame *m = curl_ws_meta(c->easy);
+  const struct curl_ws_frame *m = curl_ws_meta(c->easy);
 
   /* m->flags tells us about the traffic */
 }

--- a/docs/libcurl/curl_ws_recv.3
+++ b/docs/libcurl/curl_ws_recv.3
@@ -30,7 +30,7 @@ curl_ws_recv - receive WebSocket data
 #include <curl/easy.h>
 
 CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
-                      size_t *recv, struct curl_ws_frame **meta);
+                      size_t *recv, const struct curl_ws_frame **meta);
 .fi
 .SH DESCRIPTION
 This function call is EXPERIMENTAL.
@@ -43,13 +43,13 @@ If there is more fragment data to deliver than what fits in the provided
 \fIbuffer\fP, libcurl returns a full buffer and the application needs to call
 this function again to continue draining the buffer.
 
-The \fImeta\fP pointer gets set to point to a \fIstruct curl_ws_frame\fP that
-contains information about the received data. See the \fIcurl_ws_meta(3)\fP
-for details on that struct.
+The \fImeta\fP pointer gets set to point to a \fIconst struct curl_ws_frame\fP
+that contains information about the received data. See the
+\fIcurl_ws_meta(3)\fP for details on that struct.
 .SH EXAMPLE
 .nf
   size_t rlen;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
 .fi

--- a/include/curl/websockets.h
+++ b/include/curl/websockets.h
@@ -54,7 +54,7 @@ struct curl_ws_frame {
  */
 CURL_EXTERN CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
                                   size_t *recv,
-                                  struct curl_ws_frame **metap);
+                                  const struct curl_ws_frame **metap);
 
 /* sendflags for curl_ws_send() */
 #define CURLWS_PONG       (1<<6)
@@ -75,7 +75,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *curl, const void *buffer,
 /* bits for the CURLOPT_WS_OPTIONS bitmask: */
 #define CURLWS_RAW_MODE (1<<0)
 
-CURL_EXTERN struct curl_ws_frame *curl_ws_meta(CURL *curl);
+CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(CURL *curl);
 
 #ifdef  __cplusplus
 }

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -839,7 +839,7 @@ static ssize_t nw_in_recv(void *reader_ctx,
 
 CURL_EXTERN CURLcode curl_ws_recv(struct Curl_easy *data, void *buffer,
                                   size_t buflen, size_t *nread,
-                                  struct curl_ws_frame **metap)
+                                  const struct curl_ws_frame **metap)
 {
   struct connectdata *conn = data->conn;
   struct websocket *ws;
@@ -1082,7 +1082,7 @@ CURLcode Curl_ws_disconnect(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-CURL_EXTERN struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
+CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
 {
   /* we only return something for websocket, called from within the callback
      when not using raw mode */
@@ -1096,7 +1096,7 @@ CURL_EXTERN struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
 
 CURL_EXTERN CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
                                   size_t *nread,
-                                  struct curl_ws_frame **metap)
+                                  const struct curl_ws_frame **metap)
 {
   (void)curl;
   (void)buffer;
@@ -1120,7 +1120,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *curl, const void *buffer,
   return CURLE_NOT_BUILT_IN;
 }
 
-CURL_EXTERN struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
+CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
 {
   (void)data;
   return NULL;

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -101,7 +101,7 @@ static CURLcode send_binary(CURL *curl, char *buf, size_t buflen)
 
 static CURLcode recv_binary(CURL *curl, char *exp_data, size_t exp_len)
 {
-  struct curl_ws_frame *frame;
+  const struct curl_ws_frame *frame;
   char recvbuf[256];
   size_t r_offset, nread;
   CURLcode result;

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -55,7 +55,7 @@ static CURLcode ping(CURL *curl, const char *send_payload)
 static CURLcode recv_pong(CURL *curl, const char *exected_payload)
 {
   size_t rlen;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(result) {

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -97,7 +97,7 @@ static size_t writecb(char *buffer, size_t size, size_t nitems, void *p)
   CURL *easy = p;
   size_t i;
   size_t incoming = nitems;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   (void)size;
   for(i = 0; i < nitems; i++)
     printf("%02x ", (unsigned char)buffer[i]);

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -41,7 +41,7 @@ static int ping(CURL *curl, const char *send_payload)
 static int recv_pong(CURL *curl, const char *exected_payload)
 {
   size_t rlen;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(!result) {
@@ -70,7 +70,7 @@ static int recv_pong(CURL *curl, const char *exected_payload)
 static int recv_any(CURL *curl)
 {
   size_t rlen;
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(result)

--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -40,7 +40,7 @@ static void websocket_close(CURL *curl)
 static void websocket(CURL *curl)
 {
   char buffer[256];
-  struct curl_ws_frame *meta;
+  const struct curl_ws_frame *meta;
   size_t nread;
   size_t i = 0;
   FILE *save = fopen(libtest_arg2, FOPEN_WRITETEXT);


### PR DESCRIPTION
The returned info is read-only for the user.