### PR TITLE
tests: fix error handling around UNIX sockets

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2779,6 +2779,7 @@ while () {
     # a new one shortly. If all runners are busy, wait indefinitely for one to
     # finish.
     my $runnerwait = scalar(@runnersidle) && scalar(@runtests) ? 0 : undef;
+print STDERR "TESTING waiting indefinitely for test completion\n" if(!scalar(@runtests));
     my $ridready = runnerar_ready($runnerwait);
     if($ridready) {
         # This runner is ready to be serviced

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -771,7 +771,7 @@ static bool incoming(curl_socket_t listenfd)
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
         logmsg("accept(%d, NULL, NULL) failed with error: (%d) %s",
-               sockfd, error, strerror(error));
+               sockfd, error, sstrerror(error));
       }
       else {
         logmsg("====> Client connect, fd %d. Read config from %s",
@@ -810,7 +810,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
     if(rc) {
       error = SOCKERRNO;
       logmsg("setsockopt(SO_REUSEADDR) failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       if(maxretr) {
         rc = wait_ms(delay);
         if(rc) {
@@ -860,7 +860,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   if(rc) {
     error = SOCKERRNO;
     logmsg("Error binding socket on port %hu: (%d) %s",
-           *listenport, error, strerror(error));
+           *listenport, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -882,7 +882,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       sclose(sock);
       return CURL_SOCKET_BAD;
     }
@@ -914,7 +914,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   if(0 != rc) {
     error = SOCKERRNO;
     logmsg("listen(%d, 5) failed with error: (%d) %s",
-           sock, error, strerror(error));
+           sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -1041,8 +1041,7 @@ int main(int argc, char *argv[])
 
   if(CURL_SOCKET_BAD == sock) {
     error = SOCKERRNO;
-    logmsg("Error creating socket: (%d) %s",
-           error, strerror(error));
+    logmsg("Error creating socket: (%d) %s", error, sstrerror(error));
     goto mqttd_cleanup;
   }
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -717,7 +717,7 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
     }
     else if(got < 0) {
       error = SOCKERRNO;
-      logmsg("recv() returned error: (%d) %s", error, strerror(error));
+      logmsg("recv() returned error: (%d) %s", error, sstrerror(error));
       fail = 1;
     }
     if(fail) {
@@ -1170,8 +1170,7 @@ int main(int argc, char *argv[])
 
   if(CURL_SOCKET_BAD == sock) {
     error = SOCKERRNO;
-    logmsg("Error creating socket: (%d) %s",
-           error, strerror(error));
+    logmsg("Error creating socket: (%d) %s", error, sstrerror(error));
     goto server_cleanup;
   }
 
@@ -1180,7 +1179,7 @@ int main(int argc, char *argv[])
             (void *)&flag, sizeof(flag))) {
     error = SOCKERRNO;
     logmsg("setsockopt(SO_REUSEADDR) failed with error: (%d) %s",
-           error, strerror(error));
+           error, sstrerror(error));
     goto server_cleanup;
   }
 
@@ -1205,7 +1204,7 @@ int main(int argc, char *argv[])
   if(0 != rc) {
     error = SOCKERRNO;
     logmsg("Error binding socket on port %hu: (%d) %s",
-           port, error, strerror(error));
+           port, error, sstrerror(error));
     goto server_cleanup;
   }
 
@@ -1226,7 +1225,7 @@ int main(int argc, char *argv[])
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       sclose(sock);
       goto server_cleanup;
     }
@@ -1259,7 +1258,7 @@ int main(int argc, char *argv[])
   if(0 != rc) {
     error = SOCKERRNO;
     logmsg("listen() failed with error: (%d) %s",
-           error, strerror(error));
+           error, sstrerror(error));
     goto server_cleanup;
   }
 
@@ -1286,7 +1285,7 @@ int main(int argc, char *argv[])
     if(CURL_SOCKET_BAD == msgsock) {
       error = SOCKERRNO;
       logmsg("MAJOR ERROR: accept() failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       break;
     }
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1091,7 +1091,7 @@ static bool juggle(curl_socket_t *sockfdp,
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
         logmsg("accept(%d, NULL, NULL) failed with error: (%d) %s",
-               sockfd, error, strerror(error));
+               sockfd, error, sstrerror(error));
       }
       else {
         logmsg("====> Client connect");
@@ -1155,7 +1155,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
     if(rc) {
       error = SOCKERRNO;
       logmsg("setsockopt(SO_REUSEADDR) failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       if(maxretr) {
         rc = wait_ms(delay);
         if(rc) {
@@ -1207,7 +1207,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   if(rc) {
     error = SOCKERRNO;
     logmsg("Error binding socket on port %hu: (%d) %s",
-           *listenport, error, strerror(error));
+           *listenport, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -1229,7 +1229,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       sclose(sock);
       return CURL_SOCKET_BAD;
     }
@@ -1267,7 +1267,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   if(0 != rc) {
     error = SOCKERRNO;
     logmsg("listen(%d, 5) failed with error: (%d) %s",
-           sock, error, strerror(error));
+           sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -1414,8 +1414,7 @@ int main(int argc, char *argv[])
 
   if(CURL_SOCKET_BAD == sock) {
     error = SOCKERRNO;
-    logmsg("Error creating socket: (%d) %s",
-           error, strerror(error));
+    logmsg("Error creating socket: (%d) %s", error, sstrerror(error));
     write_stdout("FAIL\n", 5);
     goto sockfilt_cleanup;
   }
@@ -1451,7 +1450,7 @@ int main(int argc, char *argv[])
     if(rc) {
       error = SOCKERRNO;
       logmsg("Error connecting to port %hu: (%d) %s",
-             connectport, error, strerror(error));
+             connectport, error, sstrerror(error));
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -304,7 +304,7 @@ static curl_socket_t socksconnect(unsigned short connectport,
   if(rc) {
     int error = SOCKERRNO;
     logmsg("Error connecting to %s:%hu: (%d) %s",
-           connectaddr, connectport, error, strerror(error));
+           connectaddr, connectport, error, sstrerror(error));
     return CURL_SOCKET_BAD;
   }
   logmsg("Connected fine to %s:%d", connectaddr, connectport);
@@ -740,7 +740,7 @@ static bool incoming(curl_socket_t listenfd)
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
         logmsg("accept(%d, NULL, NULL) failed with error: (%d) %s",
-               sockfd, error, strerror(error));
+               sockfd, error, sstrerror(error));
       }
       else {
         curl_socket_t remotefd;
@@ -810,7 +810,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
     if(rc) {
       error = SOCKERRNO;
       logmsg("setsockopt(SO_REUSEADDR) failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       if(maxretr) {
         rc = wait_ms(delay);
         if(rc) {
@@ -866,8 +866,14 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
 
   if(rc) {
     error = SOCKERRNO;
-    logmsg("Error binding socket on port %hu: (%d) %s",
-           *listenport, error, strerror(error));
+#ifdef USE_UNIX_SOCKETS
+    if(socket_domain == AF_UNIX)
+      logmsg("Error binding socket on path %s: (%d) %s",
+             unix_socket, error, sstrerror(error));
+    else
+#endif
+      logmsg("Error binding socket on port %hu: (%d) %s",
+             *listenport, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -891,7 +897,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       sclose(sock);
       return CURL_SOCKET_BAD;
     }
@@ -923,7 +929,7 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   if(0 != rc) {
     error = SOCKERRNO;
     logmsg("listen(%d, 5) failed with error: (%d) %s",
-           sock, error, strerror(error));
+           sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -1071,7 +1077,7 @@ int main(int argc, char *argv[])
   if(CURL_SOCKET_BAD == sock) {
     error = SOCKERRNO;
     logmsg("Error creating socket: (%d) %s",
-           error, strerror(error));
+           error, sstrerror(error));
     goto socks5_cleanup;
   }
 

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -668,8 +668,7 @@ int main(int argc, char **argv)
 
   if(CURL_SOCKET_BAD == sock) {
     error = SOCKERRNO;
-    logmsg("Error creating socket: (%d) %s",
-           error, strerror(error));
+    logmsg("Error creating socket: (%d) %s", error, sstrerror(error));
     result = 1;
     goto tftpd_cleanup;
   }
@@ -679,7 +678,7 @@ int main(int argc, char **argv)
             (void *)&flag, sizeof(flag))) {
     error = SOCKERRNO;
     logmsg("setsockopt(SO_REUSEADDR) failed with error: (%d) %s",
-           error, strerror(error));
+           error, sstrerror(error));
     result = 1;
     goto tftpd_cleanup;
   }
@@ -704,8 +703,8 @@ int main(int argc, char **argv)
 #endif /* ENABLE_IPV6 */
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("Error binding socket on port %hu: (%d) %s",
-           port, error, strerror(error));
+    logmsg("Error binding socket on port %hu: (%d) %s", port, error,
+           sstrerror(error));
     result = 1;
     goto tftpd_cleanup;
   }
@@ -727,7 +726,7 @@ int main(int argc, char **argv)
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error: (%d) %s",
-             error, strerror(error));
+             error, sstrerror(error));
       sclose(sock);
       goto tftpd_cleanup;
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -147,16 +147,22 @@ void logmsg(const char *msg, ...)
 }
 
 #ifdef WIN32
+/* use instead of strerror() on generic Windows */
+const char *win32_strerror(int err, char *buf, size_t buflen)
+{
+  if(!FormatMessageA((FORMAT_MESSAGE_FROM_SYSTEM |
+                      FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
+                     LANG_NEUTRAL, buf, buflen, NULL))
+    msnprintf(buf, buflen, "Unknown error %lu (%#lx)", err, err);
+  return buf;
+}
+
 /* use instead of perror() on generic windows */
 void win32_perror(const char *msg)
 {
   char buf[512];
   DWORD err = SOCKERRNO;
-
-  if(!FormatMessageA((FORMAT_MESSAGE_FROM_SYSTEM |
-                      FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
-                     LANG_NEUTRAL, buf, sizeof(buf), NULL))
-    msnprintf(buf, sizeof(buf), "Unknown error %lu (%#lx)", err, err);
+  win32_strerror(err, buf, sizeof(buf));
   if(msg)
     fprintf(stderr, "%s: ", msg);
   fprintf(stderr, "%s\n", buf);
@@ -196,6 +202,13 @@ void win32_cleanup(void)
 
   /* flush buffers of all streams regardless of their mode */
   _flushall();
+}
+
+/* socket-safe strerror (works on WinSock errors, too */
+const char *sstrerror(int err)
+{
+  static char buf[512];
+  return win32_strerror(err, buf, sizeof(buf));
 }
 #endif  /* WIN32 */
 
@@ -819,23 +832,22 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     sau->sun_family = AF_UNIX;
     strncpy(sau->sun_path, unix_socket, sizeof(sau->sun_path) - 1);
     rc = bind(sock, (struct sockaddr*)sau, sizeof(struct sockaddr_un));
-    if(0 != rc && errno == EADDRINUSE) {
+    if(0 != rc && SOCKERRNO == EADDRINUSE) {
       struct_stat statbuf;
       /* socket already exists. Perhaps it is stale? */
       curl_socket_t unixfd = socket(AF_UNIX, SOCK_STREAM, 0);
       if(CURL_SOCKET_BAD == unixfd) {
-        error = SOCKERRNO;
-        logmsg("Error binding socket, failed to create socket at %s: (%d) %s",
-               unix_socket, error, strerror(error));
-        return rc;
+        logmsg("Failed to create socket at %s: (%d) %s",
+               unix_socket, SOCKERRNO, sstrerror(SOCKERRNO));
+        return -1;
       }
       /* check whether the server is alive */
       rc = connect(unixfd, (struct sockaddr*)sau, sizeof(struct sockaddr_un));
-      error = errno;
+      error = SOCKERRNO;
       sclose(unixfd);
-      if(ECONNREFUSED != error) {
-        logmsg("Error binding socket, failed to connect to %s: (%d) %s",
-               unix_socket, error, strerror(error));
+      if(0 != rc && ECONNREFUSED != error) {
+        logmsg("Failed to connect to %s: (%d) %s",
+               unix_socket, error, sstrerror(error));
         return rc;
       }
       /* socket server is not alive, now check if it was actually a socket. */
@@ -852,9 +864,8 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
       }
 #ifdef S_IFSOCK
       if((statbuf.st_mode & S_IFSOCK) != S_IFSOCK) {
-        logmsg("Error binding socket, failed to stat %s: (%d) %s",
-               unix_socket, error, strerror(error));
-        return rc;
+        logmsg("Error binding socket, failed to stat %s", unix_socket);
+        return -1;
       }
 #endif
       /* dead socket, cleanup and retry bind */

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -148,11 +148,11 @@ void logmsg(const char *msg, ...)
 
 #ifdef WIN32
 /* use instead of strerror() on generic Windows */
-const char *win32_strerror(int err, char *buf, size_t buflen)
+static const char *win32_strerror(int err, char *buf, size_t buflen)
 {
   if(!FormatMessageA((FORMAT_MESSAGE_FROM_SYSTEM |
                       FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
-                     LANG_NEUTRAL, buf, buflen, NULL))
+                     LANG_NEUTRAL, buf, (DWORD)buflen, NULL))
     msnprintf(buf, buflen, "Unknown error %lu (%#lx)", err, err);
   return buf;
 }

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -53,6 +53,10 @@ void win32_perror(const char *msg);
 
 void win32_init(void);
 void win32_cleanup(void);
+const char *sstrerror(int err);
+#else   /* WIN32 */
+
+#define sstrerror(e) strerror(e)
 #endif  /* WIN32 */
 
 /* fopens the test case file */


### PR DESCRIPTION
The wrong error code was checked on Windows, which may have caused all
UNIX sockets to be reported as error and the tests skipped.

Fixes #11258
Closes #11265