### PR TITLE
runtests: make test file directories in log/N

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -701,8 +701,9 @@ sub singletest_prepare {
             my $path = $filename;
             # cut off the file name part
             $path =~ s/^(.*)\/[^\/]*/$1/;
+            my $nparts = scalar(split(/\//, $LOGDIR));
             my @parts = split(/\//, $path);
-            if($parts[0] eq $LOGDIR) {
+            if(join("/", @parts[0..$nparts-1]) eq $LOGDIR) {
                 # the file is in $LOGDIR/
                 my $d = shift @parts;
                 for(@parts) {


### PR DESCRIPTION
Test files in subdirectories were not created after parallel test log
directories were moved down a level due to a now-bad comparison.

Follow-up to 92d7dd39

Ref #11264
Closes #11267