### PR TITLE
urlapi: have *set() prepend a slash if one is missing

### DIFF
--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -101,8 +101,8 @@ Port cannot be URL encoded on set. The given port number is provided as a
 string and the decimal number must be between 1 and 65535. Anything else will
 return an error.
 .IP CURLUPART_PATH
-If a path is set in the URL without a leading slash, a slash will be inserted
-automatically when this URL is read from the handle.
+If a path is set in the URL without a leading slash, a slash will be prepended
+automatically.
 .IP CURLUPART_QUERY
 The query part will also get spaces converted to pluses when asked to URL
 encode on set with the \fICURLU_URLENCODE\fP bit.


### PR DESCRIPTION
Previously the code would just do that when extracting the full URL, which made a subsequent curl_url_get() of the path to (unexpectedly) still return it without the leading path.

Amended lib1560 to verify this. Clarified the curl_url_set() docs about it.

Bug: https://curl.se/mail/lib-2023-06/0015.html
Reported-by: Pedro Henrique