### PR TITLE
curl_url_set: enforce the max string length check for all parts

### DIFF
--- a/docs/libcurl/curl_url_set.3
+++ b/docs/libcurl/curl_url_set.3
@@ -188,9 +188,8 @@ Returns a \fICURLUcode\fP error value, which is CURLUE_OK (0) if everything
 went fine. See the \fIlibcurl-errors(3)\fP man page for the full list with
 descriptions.
 
-A URL string passed on to \fIcurl_url_set(3)\fP for the \fBCURLUPART_URL\fP
-part, must be shorter than 8000000 bytes otherwise it returns
-\fBCURLUE_MALFORMED_INPUT\fP (added in 7.65.0).
+The input string passed to \fIcurl_url_set(3)\fP must be shorter than eight
+million bytes. Otherwise this function returns \fBCURLUE_MALFORMED_INPUT\fP.
 
 If this function returns an error, no URL part is set.
 .SH "SEE ALSO"

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1642,6 +1642,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
   bool leadingslash = FALSE;
   bool appendquery = FALSE;
   bool equalsencode = FALSE;
+  size_t nalloc;
 
   if(!u)
     return CURLUE_BAD_HANDLE;
@@ -1693,6 +1694,11 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     }
     return CURLUE_OK;
   }
+
+  nalloc = strlen(part);
+  if(nalloc > CURL_MAX_INPUT_LENGTH)
+    /* excessive input length */
+    return CURLUE_MALFORMED_INPUT;
 
   switch(what) {
   case CURLUPART_SCHEME: {
@@ -1800,14 +1806,8 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
   }
   DEBUGASSERT(storep);
   {
-    const char *newp = part;
-    size_t nalloc = strlen(part);
+    const char *newp;
     struct dynbuf enc;
-
-    if(nalloc > CURL_MAX_INPUT_LENGTH)
-      /* excessive input length */
-      return CURLUE_MALFORMED_INPUT;
-
     Curl_dyn_init(&enc, nalloc * 3 + 1 + leadingslash);
 
     if(leadingslash && (part[0] != '/')) {

--- a/tests/data/test1559
+++ b/tests/data/test1559
@@ -37,7 +37,7 @@ Set excessive URL lengths
 CURLOPT_URL 10000000 bytes URL == 43
 CURLOPT_POSTFIELDS 10000000 bytes data == 0
 CURLUPART_URL 10000000 bytes URL == 3 (Malformed input to a URL function)
-CURLUPART_SCHEME 10000000 bytes scheme == 27 (Bad scheme)
+CURLUPART_SCHEME 10000000 bytes scheme == 3 (Malformed input to a URL function)
 CURLUPART_USER 10000000 bytes user == 3 (Malformed input to a URL function)
 </stdout>
 </verify>


### PR DESCRIPTION
Update the docs accordingly