### PR TITLE
documentation: fix missing parameter names in examples

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.3
@@ -43,7 +43,7 @@ SFTP and SCP
 static int keycb(CURL *easy,
                  const struct curl_khkey *knownkey,
                  const struct curl_khkey *foundkey,
-                 enum curl_khmatch,
+                 enum curl_khmatch match,
                  void *clientp)
 {
   /* 'clientp' points to the callback_data struct */

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.3
@@ -56,7 +56,7 @@ struct curl_khkey {
 int ssh_keycallback(CURL *easy,
                     const struct curl_khkey *knownkey,
                     const struct curl_khkey *foundkey,
-                    enum curl_khmatch,
+                    enum curl_khmatch match,
                     void *clientp);
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_KEYFUNCTION,
@@ -108,7 +108,7 @@ SFTP and SCP
 static int keycb(CURL *easy,
                  const struct curl_khkey *knownkey,
                  const struct curl_khkey *foundkey,
-                 enum curl_khmatch,
+                 enum curl_khmatch match,
                  void *clientp)
 {
   /* 'clientp' points to the callback_data struct */


### PR DESCRIPTION
SSH key option documentation has example snippets but they seem to be missing function parameter names in enum parameters