### PR TITLE
Update curl_ngtcp2.c and https://github.com/curl/curl/issues/11292

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -925,13 +925,13 @@ static int cb_get_new_connection_id(ngtcp2_conn *tconn, ngtcp2_cid *cid,
   return 0;
 }
 
-static int cb_recv_rx_key(ngtcp2_conn *tconn, ngtcp2_encryption_level level,
+static int cb_recv_rx_key(ngtcp2_conn *tconn, ngtcp2_crypto_level level,
                           void *user_data)
 {
   struct Curl_cfilter *cf = user_data;
   (void)tconn;
 
-  if(level != NGTCP2_ENCRYPTION_LEVEL_1RTT) {
+  if(level != NGTCP2_CRYPTO_LEVEL_EARLY) {
     return 0;
   }
 
@@ -2426,7 +2426,7 @@ static CURLcode cf_ngtcp2_connect(struct Curl_cfilter *cf,
 
 out:
   if(result == CURLE_RECV_ERROR && ctx->qconn &&
-     ngtcp2_conn_in_draining_period(ctx->qconn)) {
+     ngtcp2_conn_is_in_draining_period(ctx->qconn)) {
     /* When a QUIC server instance is shutting down, it may send us a
      * CONNECTION_CLOSE right away. Our connection then enters the DRAINING
      * state.


### PR DESCRIPTION
it didnt remove all errors,but removed some errors

please fix below error also

Making all in lib
make[1]: Entering directory '/src/curl/lib'
make  all-am
make[2]: Entering directory '/src/curl/lib'
  CC       vquic/libcurl_la-curl_ngtcp2.lo
vquic/curl_ngtcp2.c: In function ‘quic_settings’:
vquic/curl_ngtcp2.c:353:6: error: ‘ngtcp2_settings’ has no member named ‘qlog_write’
  353 |     s->qlog_write = qlog_callback;
      |      ^~
vquic/curl_ngtcp2.c: In function ‘cb_h3_stop_sending’:
vquic/curl_ngtcp2.c:1233:8: error: too many arguments to function ‘ngtcp2_conn_shutdown_stream_read’
 1233 |   rv = ngtcp2_conn_shutdown_stream_read(ctx->qconn, 0, stream_id,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from vquic/curl_ngtcp2.c:28:
/var/local/ngtcp2/include/ngtcp2/ngtcp2.h:4374:19: note: declared here
 4374 | NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_read(ngtcp2_conn *conn,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
vquic/curl_ngtcp2.c: In function ‘cb_h3_reset_stream’:
vquic/curl_ngtcp2.c:1252:8: error: too many arguments to function ‘ngtcp2_conn_shutdown_stream_write’
 1252 |   rv = ngtcp2_conn_shutdown_stream_write(ctx->qconn, 0, stream_id,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from vquic/curl_ngtcp2.c:28:
/var/local/ngtcp2/include/ngtcp2/ngtcp2.h:4353:19: note: declared here
 4353 | NGTCP2_EXTERN int ngtcp2_conn_shutdown_stream_write(ngtcp2_conn *conn,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
vquic/curl_ngtcp2.c: At top level:
vquic/curl_ngtcp2.c:1277:3: warning: excess elements in struct initializer
 1277 |   NULL /* recv_settings */
      |   ^~~~
vquic/curl_ngtcp2.c:1277:3: note: (near initialization for ‘ngh3_callbacks’)