### PR TITLE
docs: Can't typedef bool in c23

### DIFF
--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -36,7 +36,10 @@
 /* curl stuff */
 #include <curl/curl.h>
 
+#if defined __STDC_VERSION__ && __STDC_VERSION__ > 201710L
 typedef char bool;
+#endif
+
 #define TRUE 1
 
 static


### PR DESCRIPTION
bool is a reserved keyword in c23.
Reserved keywords must not be redefined or UB ocurrs.