### PR TITLE
fopen: fix conversion warning on 32-bit Android

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -85,7 +85,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
     if((fstat(fd, &nsb) != -1) &&
        (nsb.st_uid == sb.st_uid) && (nsb.st_gid == sb.st_gid)) {
       /* if the user and group are the same, clone the original mode */
-      if(fchmod(fd, sb.st_mode) == -1)
+      if(fchmod(fd, (mode_t)sb.st_mode) == -1)
         goto fail;
     }
   }


### PR DESCRIPTION
When building for 32-bit ARM or x86 Android, `st_mode` is defined as `unsigned int` instead of `mode_t`, resulting in a -Wimplicit-int-conversion clang warning because `mode_t` is `unsigned short`. Add a cast to silence the warning.

Ref: https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r25c/libc/include/sys/stat.h#86