### PR TITLE
examples/multi-debugcallback.c: avoid the bool typedef

### DIFF
--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -36,13 +36,10 @@
 /* curl stuff */
 #include <curl/curl.h>
 
-typedef char bool;
 #define TRUE 1
 
-static
-void dump(const char *text,
-          FILE *stream, unsigned char *ptr, size_t size,
-          bool nohex)
+static void dump(const char *text, FILE *stream, unsigned char *ptr,
+                 size_t size, char nohex)
 {
   size_t i;
   size_t c;


### PR DESCRIPTION
Apparently this cannot be done in c23

Reported-by: Cristian Rodríguez
Fixes #11299