### PR TITLE
lib: fix some format specifiers

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -449,7 +449,7 @@ static CURLcode proxy_h2_progress_ingress(struct Curl_cfilter *cf,
 
   /* Process network input buffer fist */
   if(!Curl_bufq_is_empty(&ctx->inbufq)) {
-    DEBUGF(LOG_CF(data, cf, "Process %zd bytes in connection buffer",
+    DEBUGF(LOG_CF(data, cf, "Process %zu bytes in connection buffer",
                   Curl_bufq_len(&ctx->inbufq)));
     if(proxy_h2_process_pending_input(cf, data, &result) < 0)
       return result;
@@ -463,7 +463,7 @@ static CURLcode proxy_h2_progress_ingress(struct Curl_cfilter *cf,
         !Curl_bufq_is_full(&ctx->tunnel.recvbuf)) {
 
     nread = Curl_bufq_slurp(&ctx->inbufq, proxy_nw_in_reader, cf, &result);
-    DEBUGF(LOG_CF(data, cf, "read %zd bytes nw data -> %zd, %d",
+    DEBUGF(LOG_CF(data, cf, "read %zu bytes nw data -> %zd, %d",
                   Curl_bufq_len(&ctx->inbufq), nread, result));
     if(nread < 0) {
       if(result != CURLE_AGAIN) {

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1466,8 +1466,8 @@ static ssize_t req_body_read_callback(nghttp2_session *session,
   if(nread > 0 && stream->upload_left != -1)
     stream->upload_left -= nread;
 
-  DEBUGF(LOG_CF(data_s, cf, "[h2sid=%d] req_body_read(len=%zu) left=%zd"
-                " -> %zd, %d",
+  DEBUGF(LOG_CF(data_s, cf, "[h2sid=%d] req_body_read(len=%zu) left=%"
+                            CURL_FORMAT_CURL_OFF_T " -> %zd, %d",
                 stream_id, length, stream->upload_left, nread, result));
 
   if(stream->upload_left == 0)
@@ -1757,7 +1757,7 @@ static CURLcode h2_progress_ingress(struct Curl_cfilter *cf,
 
   /* Process network input buffer fist */
   if(!Curl_bufq_is_empty(&ctx->inbufq)) {
-    DEBUGF(LOG_CF(data, cf, "Process %zd bytes in connection buffer",
+    DEBUGF(LOG_CF(data, cf, "Process %zu bytes in connection buffer",
                   Curl_bufq_len(&ctx->inbufq)));
     if(h2_process_pending_input(cf, data, &result) < 0)
       return result;
@@ -1778,7 +1778,7 @@ static CURLcode h2_progress_ingress(struct Curl_cfilter *cf,
     }
 
     nread = Curl_bufq_slurp(&ctx->inbufq, nw_in_reader, cf, &result);
-    /* DEBUGF(LOG_CF(data, cf, "read %zd bytes nw data -> %zd, %d",
+    /* DEBUGF(LOG_CF(data, cf, "read %zu bytes nw data -> %zd, %d",
                   Curl_bufq_len(&ctx->inbufq), nread, result)); */
     if(nread < 0) {
       if(result != CURLE_AGAIN) {

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -636,7 +636,7 @@ MQTT_SUBACK_COMING:
 
     /* -- switched state -- */
     remlen = mq->remaining_length;
-    infof(data, "Remaining length: %zd bytes", remlen);
+    infof(data, "Remaining length: %zu bytes", remlen);
     if(data->set.max_filesize &&
        (curl_off_t)remlen > data->set.max_filesize) {
       failf(data, "Maximum file size exceeded");

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -769,8 +769,9 @@ static CURLcode multi_done(struct Curl_easy *data,
 #endif
      ) || conn->bits.close
        || (premature && !Curl_conn_is_multiplex(conn, FIRSTSOCKET))) {
-    DEBUGF(infof(data, "multi_done, not re-using connection=%zd, forbid=%d"
-                 ", close=%d, premature=%d, conn_multiplex=%d",
+    DEBUGF(infof(data, "multi_done, not re-using connection=%"
+                       CURL_FORMAT_CURL_OFF_T ", forbid=%d"
+                       ", close=%d, premature=%d, conn_multiplex=%d",
                  conn->connection_id,
                  data->set.reuse_forbid, conn->bits.close, premature,
                  Curl_conn_is_multiplex(conn, FIRSTSOCKET)));
@@ -792,7 +793,7 @@ static CURLcode multi_done(struct Curl_easy *data,
     /* create string before returning the connection */
     curl_off_t connection_id = conn->connection_id;
     msnprintf(buffer, sizeof(buffer),
-              "Connection #%zd to host %s left intact",
+              "Connection #%" CURL_FORMAT_CURL_OFF_T " to host %s left intact",
               connection_id, host);
     /* the connection is no longer in use by this transfer */
     CONNCACHE_UNLOCK(data);

--- a/lib/url.c
+++ b/lib/url.c
@@ -1152,8 +1152,8 @@ ConnectionExists(struct Curl_easy *data,
           /* primary_ip[0] is NUL only if the resolving of the name hasn't
              completed yet and until then we don't re-use this connection */
           if(!check->primary_ip[0]) {
-            infof(data,
-                  "Connection #%zd is still name resolving, can't reuse",
+            infof(data, "Connection #%" CURL_FORMAT_CURL_OFF_T " is still "
+                        "name resolving, can't reuse",
                   check->connection_id);
             continue;
           }

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -646,7 +646,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
   else {
     /* request is open */
-    DEBUGF(LOG_CF(data, cf, "req: send %zd body bytes", len));
+    DEBUGF(LOG_CF(data, cf, "req: send %zu body bytes", len));
     if(len > 0xFFFFFFFF) {
       len = 0xFFFFFFFF;
     }

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1558,8 +1558,10 @@ cb_h3_read_req_body(nghttp3_conn *conn, int64_t stream_id,
   }
 
   DEBUGF(LOG_CF(data, cf, "[h3sid=%" PRId64 "] read req body -> "
-                "%d vecs%s with %zu (buffered=%zu, left=%zd)", stream->id,
-                (int)nvecs, *pflags == NGHTTP3_DATA_FLAG_EOF?" EOF":"",
+                          "%d vecs%s with %zu (buffered=%zu, left=%"
+                          CURL_FORMAT_CURL_OFF_T ")",
+                stream->id, (int)nvecs,
+                *pflags == NGHTTP3_DATA_FLAG_EOF?" EOF":"",
                 nwritten, Curl_bufq_len(&stream->sendbuf),
                 stream->upload_left));
   return (nghttp3_ssize)nvecs;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -649,7 +649,7 @@ static CURLcode recv_pkt(const unsigned char *pkt, size_t pktlen,
     }
   }
   else if((size_t)nread < pktlen) {
-    DEBUGF(LOG_CF(r->data, r->cf, "ingress, quiche only read %zd/%zd bytes",
+    DEBUGF(LOG_CF(r->data, r->cf, "ingress, quiche only read %zd/%zu bytes",
                   nread, pktlen));
   }
 
@@ -883,7 +883,8 @@ out:
   }
   if(nread > 0)
     ctx->data_recvd += nread;
-  DEBUGF(LOG_CF(data, cf, "[h3sid=%"PRId64"] cf_recv(total=%zd) -> %zd, %d",
+  DEBUGF(LOG_CF(data, cf, "[h3sid=%"PRId64"] cf_recv(total=%"
+                          CURL_FORMAT_CURL_OFF_T ") -> %zd, %d",
                 stream->id, ctx->data_recvd, nread, *err));
   return nread;
 }
@@ -1067,7 +1068,7 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
         stream->send_closed = TRUE;
 
       DEBUGF(LOG_CF(data, cf, "[h3sid=%" PRId64 "] send body(len=%zu, "
-                    "left=%zd) -> %zd",
+                              "left=%" CURL_FORMAT_CURL_OFF_T ") -> %zd",
                     stream->id, len, stream->upload_left, nwritten));
       *err = CURLE_OK;
     }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -362,7 +362,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
   }
 
 out:
-  DEBUGF(LOG_CF(data, cf, "recvd %zu packets with %zd bytes -> %d",
+  DEBUGF(LOG_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
                 pkts, total_nread, result));
   return result;
 }
@@ -425,7 +425,7 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
   }
 
 out:
-  DEBUGF(LOG_CF(data, cf, "recvd %zu packets with %zd bytes -> %d",
+  DEBUGF(LOG_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
                 pkts, total_nread, result));
   return result;
 }
@@ -482,7 +482,7 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
   }
 
 out:
-  DEBUGF(LOG_CF(data, cf, "recvd %zu packets with %zd bytes -> %d",
+  DEBUGF(LOG_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
                 pkts, total_nread, result));
   return result;
 }

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -277,7 +277,7 @@ static ssize_t wsftp_send(struct Curl_easy *data, int sockindex,
     return -1;
   }
   DEBUGASSERT(rc == (int)len);
-  infof(data, "sent %zd bytes SFTP from offset %zd",
+  infof(data, "sent %zu bytes SFTP from offset %" CURL_FORMAT_CURL_OFF_T,
         len, sshc->offset);
   sshc->offset += len;
   return (ssize_t)rc;

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -126,8 +126,9 @@ static void ws_dec_info(struct ws_decoder *dec, struct Curl_easy *data,
             dec->head_len, dec->head_total);
     }
     else {
-      infof(data, "WS-DEC: %s [%s%s payload=%zd/%zd]", msg,
-            ws_frame_name_of_op(dec->head[0]),
+      infof(data, "WS-DEC: %s [%s%s payload=%" CURL_FORMAT_CURL_OFF_T
+                  "/%" CURL_FORMAT_CURL_OFF_T "]",
+            msg, ws_frame_name_of_op(dec->head[0]),
             (dec->head[0] & WSBIT_FIN)? "" : " NON-FINAL",
             dec->payload_offset, dec->payload_len);
     }
@@ -272,7 +273,8 @@ static CURLcode ws_dec_pass_payload(struct ws_decoder *dec,
     Curl_bufq_skip(inraw, (size_t)nwritten);
     dec->payload_offset += (curl_off_t)nwritten;
     remain = dec->payload_len - dec->payload_offset;
-    /* infof(data, "WS-DEC: passed  %zd bytes payload, %zd remain",
+    /* infof(data, "WS-DEC: passed  %zd bytes payload, %"
+                CURL_FORMAT_CURL_OFF_T " remain",
           nwritten, remain); */
   }
 
@@ -351,7 +353,8 @@ static void update_meta(struct websocket *ws,
 static void ws_enc_info(struct ws_encoder *enc, struct Curl_easy *data,
                         const char *msg)
 {
-  infof(data, "WS-ENC: %s [%s%s%s payload=%zd/%zd]", msg,
+  infof(data, "WS-ENC: %s [%s%s%s payload=%" CURL_FORMAT_CURL_OFF_T
+              "/%" CURL_FORMAT_CURL_OFF_T "]", msg,
         ws_frame_name_of_op(enc->firstbyte),
         (enc->firstbyte & WSBIT_OPCODE_MASK) == WSBIT_OPCODE_CONT ?
         " CONT" : "",
@@ -921,7 +924,8 @@ CURL_EXTERN CURLcode curl_ws_recv(struct Curl_easy *data, void *buffer,
               ctx.payload_len, ctx.bufidx);
   *metap = &ws->frame;
   *nread = ws->frame.len;
-  /* infof(data, "curl_ws_recv(len=%zu) -> %zu bytes (frame at %zd, %zd left)",
+  /* infof(data, "curl_ws_recv(len=%zu) -> %zu bytes (frame at %"
+              CURL_FORMAT_CURL_OFF_T ", %" CURL_FORMAT_CURL_OFF_T " left)",
         buflen, *nread, ws->frame.offset, ws->frame.bytesleft); */
   return CURLE_OK;
 }
@@ -1036,7 +1040,8 @@ CURL_EXTERN CURLcode curl_ws_send(struct Curl_easy *data, const void *buffer,
     }
     else {
       if((curl_off_t)buflen > ws->enc.payload_remain) {
-        infof(data, "WS: unaligned frame size (sending %zu instead of %zd)",
+        infof(data, "WS: unaligned frame size (sending %zu instead of %"
+                    CURL_FORMAT_CURL_OFF_T ")",
               buflen, ws->enc.payload_remain);
       }
     }


### PR DESCRIPTION
- Use CURL_FORMAT_CURL_OFF_T where %zd was erroneously used for some curl_off_t variables.

- Use %zu where %zd was erroneously used for some size_t variables.

Prior to this change some of the Windows CI tests were failing because in Windows 32-bit targets have a 32-bit size_t and a 64-bit curl_off_t. When %zd was used for some curl_off_t variables then only the lower 32-bits was read and the upper 32-bits would be read for part or all of the next specifier.

Closes #xxxx

---

The CI failures are since e024d566. [Example](https://cirrus-ci.com/task/5617442999762944?logs=test#L2503):

~~~diff
-* Connection #3 to host server4.example.com left intact[CR][LF]
+* Connection #3 to host (nil) left intact[CR][LF]
~~~

Although there were a bunch of others it's not noticeable because there are no additional specifiers that cause the upper 32-bits to be read.

I did all of them manually since I don't get any warnings in the CI or my VS compiler which makes it hard to figure out where they all are. There might be a switch that will do it but I couldn't find it.

/cc @icing