### PR TITLE
Improve test and test harness reliability

### DIFF
--- a/tests/data/test1007
+++ b/tests/data/test1007
@@ -30,12 +30,14 @@ This data will not be sent
 <errorcode>
 69
 </errorcode>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 2
 mode = octet
 tsize = 27
 blksize = 512
-timeout = 6
 filename = /invalid-file
 </protocol>
 </verify>

--- a/tests/data/test1009
+++ b/tests/data/test1009
@@ -35,12 +35,14 @@ tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER --local-port 44444-45444
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/data/test1049
+++ b/tests/data/test1049
@@ -35,12 +35,14 @@ tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER --interface %CLIENTIP
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/data/test1093
+++ b/tests/data/test1093
@@ -35,12 +35,14 @@ TFTP retrieve with mode=i
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/data/test1094
+++ b/tests/data/test1094
@@ -41,12 +41,14 @@ TFTP retrieve with mode=netascii
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = netascii
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/data/test1099
+++ b/tests/data/test1099
@@ -30,18 +30,19 @@ tftp://%HOSTIP:%TFTPPORT/an/invalid-file tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = an/invalid-file
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 <stdout>

--- a/tests/data/test1238
+++ b/tests/data/test1238
@@ -47,12 +47,14 @@ tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER -Y1000 -y2
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 # 28 = CURLE_OPERATION_TIMEDOUT

--- a/tests/data/test2002
+++ b/tests/data/test2002
@@ -72,6 +72,9 @@ moo
 #
 # Verify data after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 GET /%TESTNUMBER0001 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
@@ -89,7 +92,6 @@ opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER0003
 QUIT
 </protocol>

--- a/tests/data/test2003
+++ b/tests/data/test2003
@@ -72,6 +72,9 @@ moo
 #
 # Verify data after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 GET /%TESTNUMBER0001 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
@@ -89,13 +92,11 @@ opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER0003
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER0003
 EPSV
 SIZE %TESTNUMBER0002

--- a/tests/data/test2004
+++ b/tests/data/test2004
@@ -41,18 +41,19 @@ for several protocols
 #
 # Verify data after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 <stdout>

--- a/tests/data/test271
+++ b/tests/data/test271
@@ -34,12 +34,14 @@ tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/data/test283
+++ b/tests/data/test283
@@ -27,12 +27,14 @@ tftp://%HOSTIP:%TFTPPORT//invalid-file --tftp-blksize 1024
 <errorcode>
 69
 </errorcode>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 1024
-timeout = 6
 filename = /invalid-file
 </protocol>
 </verify>

--- a/tests/data/test284
+++ b/tests/data/test284
@@ -58,12 +58,14 @@ tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 512
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/data/test285
+++ b/tests/data/test285
@@ -16,7 +16,7 @@ tftp
 TFTP send
  </name>
  <command>
--T %LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//
+-T %LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT// --connect-time 549
 </command>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
 a chunk of
@@ -40,7 +40,7 @@ opcode = 2
 mode = octet
 tsize = 32
 blksize = 512
-timeout = 6
+timeout = 10
 filename = /test%TESTNUMBER.txt
 </protocol>
 </verify>

--- a/tests/data/test286
+++ b/tests/data/test286
@@ -83,12 +83,14 @@ condition in the TFTP transmit code.
 123456789ABCDEF
 123456789ABCDEF
 </upload>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 2
 mode = octet
 tsize = 512
 blksize = 512
-timeout = 6
 filename = /test%TESTNUMBER.txt
 </protocol>
 </verify>

--- a/tests/data/test332
+++ b/tests/data/test332
@@ -33,12 +33,14 @@ tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER --tftp-blksize 400
 #
 # Verify pseudo protocol after the test has been "shot"
 <verify>
+<strip>
+^timeout = [5-6]$
+</strip>
 <protocol>
 opcode = 1
 mode = octet
 tsize = 0
 blksize = 400
-timeout = 6
 filename = /%TESTNUMBER
 </protocol>
 </verify>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -79,6 +79,7 @@ use pathhelp qw(
     );
 
 use globalconfig qw(
+    $SERVERCMD
     $LOCKDIR
     );
 
@@ -93,7 +94,7 @@ my $proto = 'ftp';  # default server protocol
 my $srcdir;         # directory where ftpserver.pl is located
 my $srvrname;       # server name for presentation purposes
 my $cwd_testno;     # test case numbers extracted from CWD command
-my $testno = 0;     # test case number (read from ftpserver.cmd)
+my $testno = 0;     # test case number (read from server.cmd)
 my $path   = '.';
 my $logdir = $path .'/log';
 my $piddir;
@@ -2799,10 +2800,10 @@ sub customize {
     %customcount = ();  #
     %delayreply = ();   #
 
-    open(my $custom, "<", "$logdir/ftpserver.cmd") ||
+    open(my $custom, "<", "$logdir/$SERVERCMD") ||
         return 1;
 
-    logmsg "FTPD: Getting commands from $logdir/ftpserver.cmd\n";
+    logmsg "FTPD: Getting commands from $logdir/$SERVERCMD\n";
 
     while(<$custom>) {
         if($_ =~ /REPLY \"([A-Z]+ [A-Za-z0-9+-\/=\*. ]+)\" (.*)/) {

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -38,7 +38,6 @@ BEGIN {
         $automakestyle
         $CURL
         $CURLVERSION
-        $FTPDCMD
         $has_shared
         $LIBDIR
         $listonly
@@ -53,6 +52,7 @@ BEGIN {
         $pwd
         $randseed
         $run_event_based
+        $SERVERCMD
         $SERVERIN
         $srcdir
         $TESTDIR
@@ -106,7 +106,7 @@ our $PIDDIR = "server";         # root of the server directory with PID files
 our $SERVERIN="server.input";   # what curl sent the server
 our $PROXYIN="proxy.input";     # what curl sent the proxy
 our $MEMDUMP="memdump";         # file that the memory debugging creates
-our $FTPDCMD="ftpserver.cmd";   # copy server instructions here
+our $SERVERCMD="server.cmd";    # copy server instructions here
 
 # other config variables
 our @protocols;   # array of lowercase supported protocol servers

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -440,12 +440,14 @@ extern int unitfail;
   tv_test_start = tutil_tvnow(); \
 } while(0)
 
-#define exe_test_timedout(Y,Z) do {                                    \
-  if(tutil_tvdiff(tutil_tvnow(), tv_test_start) > TEST_HANG_TIMEOUT) { \
-    fprintf(stderr, "%s:%d ABORTING TEST, since it seems "             \
-                    "that it would have run forever.\n", (Y), (Z));    \
-    res = TEST_ERR_RUNS_FOREVER;                                       \
-  }                                                                    \
+#define exe_test_timedout(Y,Z) do {                                       \
+  long timediff = tutil_tvdiff(tutil_tvnow(), tv_test_start);             \
+  if(timediff > (TEST_HANG_TIMEOUT)) {                                    \
+    fprintf(stderr, "%s:%d ABORTING TEST, since it seems "                \
+            "that it would have run forever (%ld ms > %ld ms)\n",         \
+            (Y), (Z), timediff, (long) (TEST_HANG_TIMEOUT));              \
+    res = TEST_ERR_RUNS_FOREVER;                                          \
+  }                                                                       \
 } while(0)
 
 #define res_test_timedout() \

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -546,7 +546,7 @@ sub singletest_startservers {
     my ($testnum, $testtimings) = @_;
 
     # remove old test server files before servers are started/verified
-    unlink("$LOGDIR/$FTPDCMD");
+    unlink("$LOGDIR/$SERVERCMD");
     unlink("$LOGDIR/$SERVERIN");
     unlink("$LOGDIR/$PROXYIN");
 
@@ -697,7 +697,7 @@ sub singletest_prepare {
     my @ftpservercmd = getpart("reply", "servercmd");
     push @ftpservercmd, "Testnum $testnum\n";
     # write the instructions to file
-    writearray("$LOGDIR/$FTPDCMD", \@ftpservercmd);
+    writearray("$LOGDIR/$SERVERCMD", \@ftpservercmd);
 
     # create (possibly-empty) files before starting the test
     for my $partsuffix (('', '1', '2', '3', '4')) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2775,10 +2775,10 @@ while () {
     }
 
     # See if a test runner needs attention
-    # If we could be running more tests, wait just a moment so we can schedule
-    # a new one shortly. If all runners are busy, wait indefinitely for one to
-    # finish.
-    my $runnerwait = scalar(@runnersidle) && scalar(@runtests) ? 0 : undef;
+    # If we could be running more tests, don't wait so we can schedule a new
+    # one immediately. If all runners are busy, wait a fraction of a second
+    # for one to finish so we can still loop around to check the abort flag.
+    my $runnerwait = scalar(@runnersidle) && scalar(@runtests) ? 0 : 0.5;
     my $ridready = runnerar_ready($runnerwait);
     if($ridready) {
         # This runner is ready to be serviced

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -160,7 +160,7 @@ static char loglockfile[256];
 #define RESPONSE_PROXY_DUMP "proxy.response"
 
 /* file in which additional instructions may be found */
-#define DEFAULT_CMDFILE "log/ftpserver.cmd"
+#define DEFAULT_CMDFILE "log/server.cmd"
 const char *cmdfile = DEFAULT_CMDFILE;
 
 /* very-big-path support */

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -1150,7 +1150,7 @@ sub runhttpserver {
     $flags .= "--pidfile \"$pidfile\" --logfile \"$logfile\" ";
     $flags .= "--logdir \"$LOGDIR\" ";
     $flags .= "--portfile $portfile ";
-    $flags .= "--config $LOGDIR/$FTPDCMD ";
+    $flags .= "--config $LOGDIR/$SERVERCMD ";
     $flags .= "--id $idnum " if($idnum > 1);
     if($ipvnum eq "unix") {
         $flags .= "--unix-socket '$port_or_path' ";
@@ -1912,7 +1912,7 @@ sub runmqttserver {
         " --port 0 ".
         " --pidfile $pidfile".
         " --portfile $portfile".
-        " --config $LOGDIR/$FTPDCMD".
+        " --config $LOGDIR/$SERVERCMD".
         " --logfile $logfile".
         " --logdir $LOGDIR";
     my ($sockspid, $pid2) = startnew($cmd, $pidfile, 30, 0);
@@ -1973,7 +1973,7 @@ sub runsocksserver {
             " --logfile $logfile".
             " --unix-socket $SOCKSUNIXPATH".
             " --backend $HOSTIP".
-            " --config $LOGDIR/$FTPDCMD";
+            " --config $LOGDIR/$SERVERCMD";
     } else {
         $cmd="server/socksd".exe_ext('SRV').
             " --port 0 ".
@@ -1982,7 +1982,7 @@ sub runsocksserver {
             " --reqfile $LOGDIR/$SOCKSIN".
             " --logfile $logfile".
             " --backend $HOSTIP".
-            " --config $LOGDIR/$FTPDCMD";
+            " --config $LOGDIR/$SERVERCMD";
     }
     my ($sockspid, $pid2) = startnew($cmd, $pidfile, 30, 0);
 

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -364,7 +364,7 @@ static struct test_case TEST_CASES[] = {
   /* TIMEOUT_MS,        FAIL_MS      CREATED    DURATION     Result, HE_PREF */
   /* CNCT   HE          v4    v6     v4 v6      MIN   MAX */
   { 1, TURL, "test.com:123:192.0.2.1", CURL_IPRESOLVE_WHATEVER,
-    250,  150,        200,  200,    1,  0,      200,  500,  R_FAIL, NULL },
+    250,  150,        200,  200,    1,  0,      200,  600,  R_FAIL, NULL },
   /* 1 ipv4, fails after ~200ms, reports COULDNT_CONNECT   */
   { 2, TURL, "test.com:123:192.0.2.1,192.0.2.2", CURL_IPRESOLVE_WHATEVER,
     500,  150,        200,  200,    2,  0,      400,  800,  R_FAIL, NULL },


### PR DESCRIPTION
This is done by tweaking some tests and improving logging, and making the test
harness more careful about detecting problems with pipe operations. The latter
makes the test harness less likely to hang, especially on ^C.