### PR TITLE
http/2, workaround for stalled uploads

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -590,6 +590,7 @@ ssize_t Curl_bufq_write_pass(struct bufq *q,
     *err = CURLE_AGAIN;
     return -1;
   }
+  *err = CURLE_OK;
   return nwritten;
 }
 


### PR DESCRIPTION
- refs #11242 where CPU busy loop is reported. Removed drain setting
   that caused this
- discovered stalled uploads using the server from #11242 on my slow
   internet
- added workaround on flushing the last upload chunk that, if not
   written fully, makes the transfer stall. This is not the fix we
   are looking for.

## Problem description

There is unavoidable buffering with HTTP/2 uploads. Even if we remove all our own buffers, nghttp2
still buffers the DATA frame if sending it would block.

The problem with buffered upload data arises on the very last chunk. If that write reports success, the transfer loop stops monitoring the connection for output and waits for a server reply. This will not come until the server times out the upload and RSTs the stream.

## Update

This PR is not it. I will make a new attempt next week. With the current transfer handling in curl, filters HAVE TO make sure date gets written out to the network or EGAIN the send call.