### PR TITLE
cf-socket: skip calling getpeername() for TFTP

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1370,8 +1370,7 @@ static void conn_set_primary_ip(struct Curl_cfilter *cf,
        107: Transport endpoint is not connected */
     if(getpeername(ctx->sock, (struct sockaddr*) &ssrem, &plen)) {
       int error = SOCKERRNO;
-      failf(data, "%x getpeername() failed with errno %d: %s",
-            data->conn->handler->protocol,
+      failf(data, "getpeername() failed with errno %d: %s",
             error, Curl_strerror(error, buffer, sizeof(buffer)));
       return;
     }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -901,22 +901,26 @@ static CURLcode set_local_ip(struct Curl_cfilter *cf,
   struct cf_socket_ctx *ctx = cf->ctx;
 
 #ifdef HAVE_GETSOCKNAME
-  char buffer[STRERROR_LEN];
-  struct Curl_sockaddr_storage ssloc;
-  curl_socklen_t slen = sizeof(struct Curl_sockaddr_storage);
+  if(!(data->conn->handler->protocol & CURLPROTO_TFTP)) {
+    /* TFTP does not connect, so it cannot get the IP like this */
 
-  memset(&ssloc, 0, sizeof(ssloc));
-  if(getsockname(ctx->sock, (struct sockaddr*) &ssloc, &slen)) {
-    int error = SOCKERRNO;
-    failf(data, "getsockname() failed with errno %d: %s",
-          error, Curl_strerror(error, buffer, sizeof(buffer)));
-    return CURLE_FAILED_INIT;
-  }
-  if(!Curl_addr2string((struct sockaddr*)&ssloc, slen,
-                       ctx->l_ip, &ctx->l_port)) {
-    failf(data, "ssloc inet_ntop() failed with errno %d: %s",
-          errno, Curl_strerror(errno, buffer, sizeof(buffer)));
-    return CURLE_FAILED_INIT;
+    char buffer[STRERROR_LEN];
+    struct Curl_sockaddr_storage ssloc;
+    curl_socklen_t slen = sizeof(struct Curl_sockaddr_storage);
+
+    memset(&ssloc, 0, sizeof(ssloc));
+    if(getsockname(ctx->sock, (struct sockaddr*) &ssloc, &slen)) {
+      int error = SOCKERRNO;
+      failf(data, "getsockname() failed with errno %d: %s",
+            error, Curl_strerror(error, buffer, sizeof(buffer)));
+      return CURLE_FAILED_INIT;
+    }
+    if(!Curl_addr2string((struct sockaddr*)&ssloc, slen,
+                         ctx->l_ip, &ctx->l_port)) {
+      failf(data, "ssloc inet_ntop() failed with errno %d: %s",
+            errno, Curl_strerror(errno, buffer, sizeof(buffer)));
+      return CURLE_FAILED_INIT;
+    }
   }
 #else
   (void)data;
@@ -1358,16 +1362,17 @@ static void conn_set_primary_ip(struct Curl_cfilter *cf,
 {
   struct cf_socket_ctx *ctx = cf->ctx;
 #ifdef HAVE_GETPEERNAME
-  char buffer[STRERROR_LEN];
-  struct Curl_sockaddr_storage ssrem;
-  curl_socklen_t plen;
-  int port;
-
-  plen = sizeof(ssrem);
-  memset(&ssrem, 0, plen);
   if(!(data->conn->handler->protocol & CURLPROTO_TFTP)) {
     /* TFTP does not connect the endpoint: getpeername() failed with errno
        107: Transport endpoint is not connected */
+
+    char buffer[STRERROR_LEN];
+    struct Curl_sockaddr_storage ssrem;
+    curl_socklen_t plen;
+    int port;
+
+    plen = sizeof(ssrem);
+    memset(&ssrem, 0, plen);
     if(getpeername(ctx->sock, (struct sockaddr*) &ssrem, &plen)) {
       int error = SOCKERRNO;
       failf(data, "getpeername() failed with errno %d: %s",

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1370,7 +1370,8 @@ static void conn_set_primary_ip(struct Curl_cfilter *cf,
        107: Transport endpoint is not connected */
     if(getpeername(ctx->sock, (struct sockaddr*) &ssrem, &plen)) {
       int error = SOCKERRNO;
-      failf(data, "getpeername() failed with errno %d: %s",
+      failf(data, "%x getpeername() failed with errno %d: %s",
+            data->conn->handler->protocol,
             error, Curl_strerror(error, buffer, sizeof(buffer)));
       return;
     }

--- a/tests/data/test1007
+++ b/tests/data/test1007
@@ -17,7 +17,7 @@ tftp
 TFTP send with invalid permission on server
  </name>
  <command>
--T %LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//invalid-file
+-T %LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//invalid-file -sS
 </command>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
 This data will not be sent
@@ -38,5 +38,8 @@ blksize = 512
 timeout = 6
 filename = /invalid-file
 </protocol>
+<stderr mode="text">
+curl: (69) TFTP: Access Violation
+</stderr>
 </verify>
 </testcase>


### PR DESCRIPTION
Since the socket is not connected then the call fails. When the call fails, failf() is called to write an error message that is then surviving and is returned when the *real* error occurs later. The earlier, incorrect, error therefore hides the actual error message.

This could be seen in stderr for test 1007

Test 1007 has now been extended to verify the stderr message.