### PR TITLE
examples/http-options: show how to send "OPTIONS *"

### DIFF
--- a/docs/examples/Makefile.inc
+++ b/docs/examples/Makefile.inc
@@ -46,6 +46,7 @@ check_PROGRAMS = \
   getredirect \
   getreferrer \
   headerapi \
+  http-options \
   http-post \
   http2-download \
   http2-pushinmemory \

--- a/docs/examples/http-options.c
+++ b/docs/examples/http-options.c
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* <DESC>
+ * Issue an HTTP 'OPTIONS *' request
+ * </DESC>
+ */
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void)
+{
+  CURL *curl;
+  CURLcode res;
+
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
+
+    /* issue an OPTIONS * request (no leading slash) */
+    curl_easy_setopt(curl, CURLOPT_REQUEST_TARGET, "*");
+
+    /* if this operation fails, allow risking a memory leak and do quick exit
+       from libcurl as this will exit() anyway */
+    curl_easy_setopt(curl, CURLOPT_QUICK_EXIT, 1L);
+
+    /* Perform the request, res will get the return code */
+    res = curl_easy_perform(curl);
+    /* Check for errors */
+    if(res != CURLE_OK)
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  return 0;
+}


### PR DESCRIPTION
With CURLOPT_REQUEST_TARGET.

Also snuck in a use of CURLOPT_QUICK_EXIT just to show.