### PR TITLE
HTTP/2 and HTTP/2 upload handling fixes

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -590,6 +590,7 @@ ssize_t Curl_bufq_write_pass(struct bufq *q,
     *err = CURLE_AGAIN;
     return -1;
   }
+  *err = CURLE_OK;
   return nwritten;
 }
 


### PR DESCRIPTION
- fixes #11242 where 100% CPU on uploads was reported
- fixes possible stalls on last part of a request body when that information could not be fully send on the connection due to an EAGAIN
- applies the same EAGAIN handling to HTTP/2 proxying