### PR TITLE
Unslowing hyper

### DIFF
--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -491,7 +491,7 @@ class CurlClient:
         elif self.env.verbose > 1:
             args.extend(['--trace', self._tracefile])
         elif not self._silent:
-            args.extend(['-v'])
+            args.extend(['-v', '--trace-time', '--trace-ids'])
 
         for url in urls:
             u = urlparse(urls[0])


### PR DESCRIPTION
- refs #11203 where hyper was reported as being slow
- fixes hyper_executor_poll to loop until it is out of tasks as advised by @seanmonstar in https://github.com/hyperium/hyper/issues/3237
- added a fix in hyper io handling for detecting EAGAIN
- added some debug logs to see IO results
- pytest http/1.1 test cases pass
- pytest h2 test cases fail on connection reuse. HTTP/2 connection reuse does not seem to work. Hyper submits a request on a reused connection, curl's IO works and thereafter hyper declares `Hyper: [1] operation was canceled: connection closed` on stderr without any error being logged before.