### PR TITLE
CI: macos: use older gcc version

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -153,8 +153,8 @@ jobs:
         - CC: clang
           CXX: clang++
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-deprecated-declarations"
-        - CC: gcc-10
-          CXX: g++-10
+        - CC: gcc-9
+          CXX: g++-9
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"
         build:
         - name: OpenSSL
@@ -167,7 +167,7 @@ jobs:
           install: nghttp2 openssl libssh2
           generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON
     steps:
-    - run: echo libtool autoconf automake pkg-config gcc@10 ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+    - run: echo libtool autoconf automake pkg-config gcc@9 ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 
     - run: "while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,9 +39,6 @@ concurrency:
 
 permissions: {}
 
-env:
-  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
-
 jobs:
   autotools:
     name: ${{ matrix.build.name }}
@@ -156,8 +153,8 @@ jobs:
         - CC: clang
           CXX: clang++
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-deprecated-declarations"
-        - CC: gcc-12
-          CXX: g++-12
+        - CC: gcc-10
+          CXX: g++-10
           CFLAGS: "-mmacosx-version-min=10.15 -Wno-error=undef -Wno-error=conversion"
         build:
         - name: OpenSSL
@@ -170,7 +167,7 @@ jobs:
           install: nghttp2 openssl libssh2
           generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON
     steps:
-    - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+    - run: echo libtool autoconf automake pkg-config gcc@10 ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
       name: 'brew bundle'
 
     - run: "while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done"


### PR DESCRIPTION
Apple has no main gcc support.

So find out which version works best with xcode.

> Hi Philip,
> 
> after reviewing the issue you reported, we found that it should be investigated and fixed by gcc - the third-party software you are using. Contact them and ask for support.
> 
> Apple does not supply or support gcc. We only support clang.
> 
> When the problem is fixed, you can close this feedback. To do so, select "Close feedback" from the action button above. Thank you very much.