### PR TITLE
Fixe unused variable ctx in cf-socker.c

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1360,8 +1360,8 @@ out:
 static void conn_set_primary_ip(struct Curl_cfilter *cf,
                                 struct Curl_easy *data)
 {
-  struct cf_socket_ctx *ctx = cf->ctx;
 #ifdef HAVE_GETPEERNAME
+  struct cf_socket_ctx *ctx = cf->ctx;
   if(!(data->conn->handler->protocol & CURLPROTO_TFTP)) {
     /* TFTP does not connect the endpoint: getpeername() failed with errno
        107: Transport endpoint is not connected */


### PR DESCRIPTION
This PR fixes compiler warning (gcc 8.3 with flag -Wunused-variable) "unused variable ‘ctx’".
The variable is used only if HAVE_GETPEERNAME is defined, but variable defined before directive.