### PR TITLE
HTTP/2, error stream resets with code CURLE_HTTP2_STREAM

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1584,16 +1584,16 @@ static ssize_t http2_handle_stream_close(struct Curl_cfilter *cf,
     *err = CURLE_SEND_ERROR; /* trigger Curl_retry_request() later */
     return -1;
   }
-  else if(stream->reset) {
-    failf(data, "HTTP/2 stream %u was reset", stream->id);
-    *err = stream->bodystarted? CURLE_PARTIAL_FILE : CURLE_RECV_ERROR;
-    return -1;
-  }
   else if(stream->error != NGHTTP2_NO_ERROR) {
     failf(data, "HTTP/2 stream %u was not closed cleanly: %s (err %u)",
           stream->id, nghttp2_http2_strerror(stream->error),
           stream->error);
     *err = CURLE_HTTP2_STREAM;
+    return -1;
+  }
+  else if(stream->reset) {
+    failf(data, "HTTP/2 stream %u was reset", stream->id);
+    *err = stream->bodystarted? CURLE_PARTIAL_FILE : CURLE_RECV_ERROR;
     return -1;
   }
 

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -92,3 +92,20 @@ class TestErrors:
             if 'exitcode' not in s or s['exitcode'] not in [18, 55, 56, 92, 95]:
                 invalid_stats.append(f'request {idx} exit with {s["exitcode"]}\n{s}')
         assert len(invalid_stats) == 0, f'failed: {invalid_stats}'
+
+    # access a resource that, on h2, RST the stream with HTTP_1_1_REQUIRED
+    def test_05_03_required(self, env: Env, httpd, nghttpx, repeat):
+        curl = CurlClient(env=env)
+        proto = 'http/1.1'
+        urln = f'https://{env.authority_for(env.domain1, proto)}/curltest/1_1'
+        r = curl.http_download(urls=[urln], alpn_proto=proto)
+        r.check_exit_code(0)
+        r.check_response(http_status=200, count=1)
+        proto = 'h2'
+        urln = f'https://{env.authority_for(env.domain1, proto)}/curltest/1_1'
+        r = curl.http_download(urls=[urln], alpn_proto=proto)
+        r.check_exit_code(0)
+        r.check_response(http_status=200, count=1)
+        # check that we did a downgrade
+        assert r.stats[0]['http_version'] == '1.1', r.dump_logs()
+

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -376,6 +376,9 @@ class Httpd:
                 f'    <Location /curltest/tweak>',
                 f'      SetHandler curltest-tweak',
                 f'    </Location>',
+                f'    <Location /curltest/1_1>',
+                f'      SetHandler curltest-1_1-required',
+                f'    </Location>',
             ])
         if self._auth_digest:
             lines.extend([


### PR DESCRIPTION
- refs #11357, where it was reported that HTTP/1.1 downgrades no longer works
- fixed with suggested change
- added test_05_03 and a new handler in the curltest module to reproduce that downgrades work