### PR TITLE
runtests: work around a perl without SIGUSR1

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -189,7 +189,10 @@ sub runner_init {
             # TODO: set up better signal handlers
             $SIG{INT} = 'IGNORE';
             $SIG{TERM} = 'IGNORE';
-            $SIG{USR1} = 'IGNORE';
+            eval {
+                # some msys2 perls don't define SIGUSR1
+                $SIG{USR1} = 'IGNORE';
+            };
 
             $thisrunnerid = $$;
             print "Runner $thisrunnerid starting\n" if($verbose);

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -271,7 +271,10 @@ sub catch_usr1 {
     }
 }
 
-$SIG{USR1} = \&catch_usr1;
+eval {
+    # some msys2 perls don't define SIGUSR1
+    $SIG{USR1} = \&catch_usr1;
+};
 $SIG{PIPE} = 'IGNORE';  # these errors are captured in the read/write calls
 
 ##########################################################################


### PR DESCRIPTION
At least msys2 perl v5.32.1 doesn't seem to define this signal. Since
this signal is only used for debugging, just ignore if setting it fails.

Reported-by: Marcel Raad
Fixes #11350
Closes #11366