### PR TITLE
Fix HTTP/2 and H2-PROXY connection alive check

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -588,7 +588,6 @@ static bool http2_connisalive(struct Curl_cfilter *cf, struct Curl_easy *data,
     ssize_t nread = -1;
 
     *input_pending = FALSE;
-    Curl_attach_connection(data, cf->conn);
     nread = Curl_bufq_slurp(&ctx->inbufq, nw_in_reader, cf, &result);
     if(nread != -1) {
       DEBUGF(LOG_CF(data, cf, "%zd bytes stray data read before trying "
@@ -600,11 +599,10 @@ static bool http2_connisalive(struct Curl_cfilter *cf, struct Curl_easy *data,
         alive = !should_close_session(ctx);
       }
     }
-    else {
+    else if(result != CURLE_AGAIN) {
       /* the read failed so let's say this is dead anyway */
       alive = FALSE;
     }
-    Curl_detach_connection(data);
   }
 
   return alive;

--- a/lib/url.c
+++ b/lib/url.c
@@ -941,6 +941,7 @@ static bool extract_if_dead(struct connectdata *conn,
     else {
       bool input_pending;
 
+      Curl_attach_connection(data, conn);
       dead = !Curl_conn_is_alive(data, conn, &input_pending);
       if(input_pending) {
         /* For reuse, we want a "clean" connection state. The includes
@@ -953,6 +954,7 @@ static bool extract_if_dead(struct connectdata *conn,
          */
         dead = TRUE;
       }
+      Curl_detach_connection(data);
     }
 
     if(dead) {

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2535,13 +2535,11 @@ static bool cf_ngtcp2_conn_is_alive(struct Curl_cfilter *cf,
        not in use by any other transfer, there shouldn't be any data here,
        only "protocol frames" */
     *input_pending = FALSE;
-    Curl_attach_connection(data, cf->conn);
     if(cf_process_ingress(cf, data, NULL))
       alive = FALSE;
     else {
       alive = TRUE;
     }
-    Curl_detach_connection(data);
   }
 
   return alive;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1555,13 +1555,11 @@ static bool cf_quiche_conn_is_alive(struct Curl_cfilter *cf,
        not in use by any other transfer, there shouldn't be any data here,
        only "protocol frames" */
     *input_pending = FALSE;
-    Curl_attach_connection(data, cf->conn);
     if(cf_process_ingress(cf, data))
       alive = FALSE;
     else {
       alive = TRUE;
     }
-    Curl_detach_connection(data);
   }
 
   return alive;

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -194,6 +194,7 @@ class TestProxy:
         for i in range(count):
             dfile = curl.download_file(i)
             assert filecmp.cmp(srcfile, dfile, shallow=False)
+        assert r.total_connects == 1, r.dump_logs()
 
     # upload many https: with proto via https: proxytunnel
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason=f"curl without SSL")
@@ -223,6 +224,7 @@ class TestProxy:
         for i in range(count):
             respdata = open(curl.response_file(i)).readlines()
             assert respdata == indata
+        assert r.total_connects == 1, r.dump_logs()
 
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason=f"curl without SSL")
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -483,15 +483,15 @@ class CurlClient:
         if not isinstance(urls, list):
             urls = [urls]
 
-        args = [self._curl, "-s", "--path-as-is"]
+        args = [self._curl, "-s", "--path-as-is", '--trace-time', '--trace-ids']
         if with_headers:
             args.extend(["-D", self._headerfile])
         if with_trace or self.env.verbose > 2:
-            args.extend(['--trace', self._tracefile, '--trace-time'])
-        elif self.env.verbose > 1:
             args.extend(['--trace', self._tracefile])
+        elif self.env.verbose > 1:
+            args.extend(['--trace-ascii', self._tracefile])
         elif not self._silent:
-            args.extend(['-v', '--trace-time', '--trace-ids'])
+            args.extend(['-v'])
 
         for url in urls:
             u = urlparse(urls[0])


### PR DESCRIPTION
- fix HTTP/2 check to not declare a connection dead when the read attempt results in EAGAIN
- add H2-PROXY alive check as for HTTP/2 that was missing and is needed
- add attach/detach around Curl_conn_is_alive() and remove these in filter methods
- add checks for number of connections used in some test_10 proxy tunneling tests