### PR TITLE
configure: add check for ldap_init_fd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1718,7 +1718,7 @@ if test x$CURL_DISABLE_LDAP != x1 ; then
       AC_DEFINE(USE_OPENLDAP, 1, [Use OpenLDAP-specific code])
       AC_SUBST(USE_OPENLDAP, [1])
     else
-      AC_MSG_ERROR([too old OpenLDAP found, can't use])
+      curl_ldap_msg="enabled (ancient OpenLDAP)"
     fi
   fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1706,7 +1706,8 @@ if test x$CURL_DISABLE_LDAP != x1 ; then
 fi
 
 if test x$CURL_DISABLE_LDAP != x1 ; then
-  AC_CHECK_FUNCS([ldap_url_parse])
+  AC_CHECK_FUNCS([ldap_url_parse \
+                  ldap_init_fd])
 
   if test "$LDAPLIBNAME" = "wldap32"; then
     curl_ldap_msg="enabled (winldap)"

--- a/configure.ac
+++ b/configure.ac
@@ -1713,10 +1713,12 @@ if test x$CURL_DISABLE_LDAP != x1 ; then
     curl_ldap_msg="enabled (winldap)"
     AC_DEFINE(USE_WIN32_LDAP, 1, [Use Windows LDAP implementation])
   else
-    curl_ldap_msg="enabled (OpenLDAP)"
     if test "x$ac_cv_func_ldap_init_fd" = "xyes"; then
+      curl_ldap_msg="enabled (OpenLDAP)"
       AC_DEFINE(USE_OPENLDAP, 1, [Use OpenLDAP-specific code])
       AC_SUBST(USE_OPENLDAP, [1])
+    else
+      AC_MSG_ERROR([too old OpenLDAP found, can't use])
     fi
   fi
 fi


### PR DESCRIPTION
... as otherwise the configure script will say it is OpenLDAP in the summary, but not set the USE_OPENLDAP define, therefor not using the intended OpenLDAP code paths.

Regression since 4d7385446 (7.85.0)