### PR TITLE
docs: add more .IP after .RE to fix indentation of generate paragraphs

### DIFF
--- a/docs/cmdline-opts/data-urlencode.d
+++ b/docs/cmdline-opts/data-urlencode.d
@@ -39,3 +39,4 @@ URL-encode that data and pass it on in the POST. The name part gets an equal
 sign appended, resulting in *name=urlencoded-file-content*. Note that the
 name is expected to be URL-encoded already.
 .RE
+.IP

--- a/docs/cmdline-opts/delegation.d
+++ b/docs/cmdline-opts/delegation.d
@@ -21,3 +21,4 @@ service ticket, which is a matter of realm policy.
 .IP "always"
 Unconditionally allow the server to delegate.
 .RE
+.IP

--- a/docs/cmdline-opts/ftp-method.d
+++ b/docs/cmdline-opts/ftp-method.d
@@ -27,3 +27,4 @@ curl does one CWD with the full target directory and then operates on the file
 "normally" (like in the multicwd case). This is somewhat more standards
 compliant than 'nocwd' but without the full penalty of 'multicwd'.
 .RE
+.IP

--- a/docs/cmdline-opts/ftp-port.d
+++ b/docs/cmdline-opts/ftp-port.d
@@ -29,6 +29,7 @@ e.g. "my.host.domain" to specify the machine
 make curl pick the same IP address that is already used for the control
 connection
 .RE
+.IP
 
 Disable the use of PORT with --ftp-pasv. Disable the attempt to use the EPRT
 command instead of PORT by using --disable-eprt. EPRT is really PORT++.

--- a/docs/cmdline-opts/tls-max.d
+++ b/docs/cmdline-opts/tls-max.d
@@ -31,3 +31,4 @@ Use up to TLSv1.2.
 .IP "1.3"
 Use up to TLSv1.3.
 .RE
+.IP

--- a/docs/cmdline-opts/version.d
+++ b/docs/cmdline-opts/version.d
@@ -83,3 +83,4 @@ Unix sockets support is provided.
 .IP "zstd"
 Automatic decompression (via zstd) of compressed files over HTTP is supported.
 .RE
+.IP


### PR DESCRIPTION
follow-up from 099f41e097c030077b8ec078f2c2d4038d31353b

I just thought of checking all the other files with .RE, and I found 6 other files that were missing .IP at the end.