### PR TITLE
Stop CMake from quietly ignoring missing Brotli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,7 +524,7 @@ endif()
 option(CURL_BROTLI "Set to ON to enable building curl with brotli support." OFF)
 set(HAVE_BROTLI OFF)
 if(CURL_BROTLI)
-  find_package(Brotli QUIET)
+  find_package(Brotli REQUIRED)
   if(BROTLI_FOUND)
     set(HAVE_BROTLI ON)
     set(CURL_LIBS "${BROTLI_LIBRARIES};${CURL_LIBS}")  # For 'ld' linker. Emulate `list(PREPEND ...)` to stay compatible with <v3.15 CMake.


### PR DESCRIPTION
For some reason the CMake project was set to `QUIET` for Brotli instead of `REQUIRED`. This makes builds unexpectedly ignore missing Brotli even when `CURL_BROTLI` is enabled.