### PR TITLE
Refactor url_proto to tell why it failed.

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -327,6 +327,11 @@ struct GlobalConfig {
   struct OperationConfig *last;   /* Always last in the struct */
 };
 
+struct URLProtoResult {
+  const char *proto;              /* The protocol as discovered by url_proto */
+  CURLcode result;                /* The result of protocol parsing */
+};
+
 void config_init(struct OperationConfig *config);
 void config_free(struct OperationConfig *config);
 


### PR DESCRIPTION
https://github.com/curl/curl/pull/8805 will need to know why `url_proto` fails.
That is a very self-contained change so might be better as it's own PR.

I did put the `struct URLProtoResult` just somewhere that worked for me, i'm not sure if `tool_cfgtable.h` is the appropriate file.