### PR TITLE
Adding mod_h2 directive `H2ProxyRequests` needed for new master

### DIFF
--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -303,6 +303,7 @@ class Httpd:
                 f'    ServerName {proxy_domain}',
                 f'    Protocols h2c http/1.1',
                 f'    ProxyRequests On',
+                f'    H2ProxyRequests On',
                 f'    ProxyVia On',
                 f'    AllowCONNECT {self.env.http_port} {self.env.https_port}',
             ])
@@ -319,6 +320,7 @@ class Httpd:
                 f'    SSLCertificateFile {proxy_creds.cert_file}',
                 f'    SSLCertificateKeyFile {proxy_creds.pkey_file}',
                 f'    ProxyRequests On',
+                f'    H2ProxyRequests On',
                 f'    ProxyVia On',
                 f'    AllowCONNECT {self.env.http_port} {self.env.https_port}',
             ])


### PR DESCRIPTION
Just updated master of mod_h2 which now requires `H2ProxyRequests` directives for forward proxying with HTTP/2 to work.