### PR TITLE
tool: correct `easysrc_perform` with `CURL_DISABLE_LIBCURL_OPTION`

### DIFF
--- a/src/tool_easysrc.h
+++ b/src/tool_easysrc.h
@@ -51,7 +51,7 @@ void dumpeasysrc(struct GlobalConfig *config);
 #define easysrc_init() CURLE_OK
 #define easysrc_cleanup()
 #define dumpeasysrc(x)
-#define easysrc_perform(x) CURLE_OK
+#define easysrc_perform() CURLE_OK
 
 #endif /* CURL_DISABLE_LIBCURL_OPTION */
 


### PR DESCRIPTION
Remove unneeded macro parameter to match function and avoid compiler warning