### PR TITLE
HTTP/2, raise header limitations above and beyond

### DIFF
--- a/lib/http1.h
+++ b/lib/http1.h
@@ -33,11 +33,11 @@
 #define H1_PARSE_OPT_NONE       (0)
 #define H1_PARSE_OPT_STRICT     (1 << 0)
 
-#define H1_PARSE_DEFAULT_MAX_LINE_LEN (8 * 1024)
+#define H1_PARSE_DEFAULT_MAX_LINE_LEN   DYN_HTTP_REQUEST
 
 struct h1_req_parser {
   struct httpreq *req;
-  struct bufq scratch;
+  struct dynbuf scratch;
   size_t scratch_skip;
   const char *line;
   size_t max_line_len;


### PR DESCRIPTION
- not quite to infinity
- refs #11405
- rewrote the implementation of our internal HTTP/1.x request parsing to work with very large lines using dynbufs.
- new default limit is `DYN_HTTP_REQUEST`, aka 1MB, which is also the limit of curl's general HTTP request processing.