### PR TITLE
transfer: clear credentials when redirecting to absolute URL

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1554,10 +1554,15 @@ CURLcode Curl_follow(struct Curl_easy *data,
 
   if((type != FOLLOW_RETRY) &&
      (data->req.httpcode != 401) && (data->req.httpcode != 407) &&
-     Curl_is_absolute_url(newurl, NULL, 0, FALSE))
+     Curl_is_absolute_url(newurl, NULL, 0, FALSE)) {
     /* If this is not redirect due to a 401 or 407 response and an absolute
        URL: don't allow a custom port number */
     disallowport = TRUE;
+    if(!data->set.allow_auth_to_other_hosts) {
+      Curl_safefree(data->state.aptr.user);
+      Curl_safefree(data->state.aptr.passwd);
+    }
+  }
 
   DEBUGASSERT(data->state.uh);
   uc = curl_url_set(data->state.uh, CURLUPART_URL, newurl,

--- a/lib/url.c
+++ b/lib/url.c
@@ -1864,7 +1864,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
    * User name and password set with their own options override the
    * credentials possibly set in the URL.
    */
-  if(!data->state.aptr.passwd) {
+  if(!data->set.str[STRING_PASSWORD]) {
     uc = curl_url_get(uh, CURLUPART_PASSWORD, &data->state.up.password, 0);
     if(!uc) {
       char *decoded;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -102,28 +102,26 @@ test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \
 test718 test719 test720 test721 \
 \
-test799 \
-test800 test801 test802 test803 test804 test805 test806 test807 test808 \
-test809 test810 test811 test812 test813 test814 test815 test816 test817 \
-test818 test819 test820 test821 test822 test823 test824 test825 test826 \
-test827 test828 test829 test830 test831 test832 test833 test834 test835 \
-test836 test837 test838 test839 test840 test841 test842 test843 test844 \
-test845 test846 test847 test848 test849 test850 test851 test852 test853 \
-test854 test855 test856 test857 test858 test859 test860 test861 test862 \
-test863 test864 test865 test866 test867 test868 test869 test870 test871 \
-test872 test873 test874 test875 test876 test877 test878 test879 test880 \
-test881 test882 test883 test884 test885 test886 test887 test888 test889 \
-test890 test891 test892 test893 test894 test895 test896 test897 test898 \
-\
-test900 test901 test902 test903 test904 test905 test906 test907 test908 \
-test909 test910 test911 test912 test913 test914 test915 test916 test917 \
-test918 test919 test920 test921 test922 test923 test924 test925 test926 \
-test927 test928 test929 test930 test931 test932 test933 test934 test935 \
-test936 test937 test938 test939 test940 test941 test942 test943 test944 \
-test945 test946 test947 test948 test949 test950 test951 test952 test953 \
-test954 test955 test956 test957 test958 test959 test960 test961 test962 \
-test963 test964 test965 test966 test967 test968 test969 test970 test971 \
-test972 test973 test974 test975 test976 test977 test978 \
+test799 test800 test801 test802 test803 test804 test805 test806 test807 \
+test808 test809 test810 test811 test812 test813 test814 test815 test816 \
+test817 test818 test819 test820 test821 test822 test823 test824 test825 \
+test826 test827 test828 test829 test830 test831 test832 test833 test834 \
+test835 test836 test837 test838 test839 test840 test841 test842 test843 \
+test844 test845 test846 test847 test848 test849 test850 test851 test852 \
+test853 test854 test855 test856 test857 test858 test859 test860 test861 \
+test862 test863 test864 test865 test866 test867 test868 test869 test870 \
+test871 test872 test873 test874 test875 test876 test877 test878 test879 \
+test880 test881 test882 test883 test884 test885 test886 test887 test888 \
+test889 test890 test891 test892 test893 test894 test895 test896 test897 \
+test898 test899 test900 test901 test902 test903 test904 test905 test906 \
+test907 test908 test909 test910 test911 test912 test913 test914 test915 \
+test916 test917 test918 test919 test920 test921 test922 test923 test924 \
+test925 test926 test927 test928 test929 test930 test931 test932 test933 \
+test934 test935 test936 test937 test938 test939 test940 test941 test942 \
+test943 test944 test945 test946 test947 test948 test949 test950 test951 \
+test952 test953 test954 test955 test956 test957 test958 test959 test960 \
+test961 test962 test963 test964 test965 test966 test967 test968 test969 \
+test970 test971 test972 test973 test974 test975 test976 test977 test978 \
 \
 test980 test981 test982 test983 test984 test985 test986 test987 test988 \
 test989 \

--- a/tests/data/test899
+++ b/tests/data/test899
@@ -1,0 +1,64 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+Basic
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes" nocheck="yes">
+HTTP/1.1 302 go go go
+Content-Length: 8
+Location: http://user:pass@%HOSTIP:%HTTPPORT/basic-auth/user/%TESTNUMBER0002
+Content-Type: text/html
+Funny-head: yesyes
+
+notreal
+</data>
+<data2 crlf="yes">
+HTTP/1.1 200 OK
+Content-Length: 6
+Content-Type: text/html
+Funny-head: yesyes
+
+final
+</data2>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+URL with credentials redirects to URL with different credentials
+</name>
+<command>
+http://first:secret@%HOSTIP:%HTTPPORT/%TESTNUMBER -L
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic Zmlyc3Q6c2VjcmV0
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /basic-auth/user/%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic dXNlcjpwYXNz
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
To make sure the user and password for the second request is taken from the redirected-to URL.

The -u option only sets credentials for the specified URL, not the redirected-to if the redirect is absolute.

Add test case 899 to verify.

Adjusted test 234.

Reported-by: James Lucas
Fixes #11410