### PR TITLE
tool_writeout_json: fix encoding of control characters

### DIFF
--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -62,7 +62,7 @@ void jsonWriteString(FILE *stream, const char *in, bool lowercase)
       break;
     default:
       if(*i < 32) {
-        fprintf(stream, "u%04x", *i);
+        fprintf(stream, "\\u%04x", *i);
       }
       else {
         char out = *i;


### PR DESCRIPTION
Control characters without a shorthand e.g. %06 were being encoded as "u0006" instead of "\u0006".

See https://github.com/curl/trurl/pull/214#discussion_r1257487858.

---

I tried to add a test for this that gets a response with `Foo: %hex[%06%07%08]hex%` in the headers, and checks that `header_json` also contains `"foo": "\u0006\u0007\b"`, but nghttpx doesn't seem to like that.

<s>Maybe I could use a test that checks the entire `-w %{json}` output, and tests `filename_effecitive`?</s> That actually doesn't seem to work because `curl -Ow '%{json}\n' example.org/file%06.html` downloads to `file%06.html`, and outputs `"filename_effective": "file%06.html"`; when using `-O` the path from the URL is not url decoded.

Testing this would be easier using the `--expand-foo '{{json:something}}'` introduced by #11346, so maybe that PR could add a test for this instead.
