### PR TITLE
macOS: fix target detection

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -258,7 +258,7 @@
 #if defined(__APPLE__) && !defined(USE_ARES)
 #include <TargetConditionals.h>
 #define USE_RESOLVE_ON_IPS 1
-#  if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#  if !defined(TARGET_OS_OSX) || TARGET_OS_OSX
 #    define CURL_OSX_CALL_COPYPROXIES 1
 #  endif
 #endif

--- a/lib/macos.c
+++ b/lib/macos.c
@@ -26,7 +26,7 @@
 
 #if defined(__APPLE__)
 
-#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#if !defined(TARGET_OS_OSX) || TARGET_OS_OSX
 
 #include <curl/curl.h>
 

--- a/lib/macos.h
+++ b/lib/macos.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(__APPLE__) && defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#if defined(__APPLE__) && (!defined(TARGET_OS_OSX) || TARGET_OS_OSX)
 
 CURLcode Curl_macos_init(void);
 


### PR DESCRIPTION
- TARGET_OS_OSX is not always defined on macOS
- this leads to missing symbol Curl_macos_init()
- TargetConditionals.h seems to define these only when dynamic targets are enabled (somewhere?)
- this PR fixes that on my macOS 13.4.1
- I have no clue why CI builds worked without it