### PR TITLE
http2: send HEADER & DATA together if possible

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2667,11 +2667,7 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
 #ifndef USE_HYPER
     /* With Hyper the body is always passed on separately */
     if(data->set.postfields) {
-
-      /* In HTTP2, we send request body in DATA frame regardless of
-         its size. */
-      if(conn->httpversion < 20 &&
-         !data->state.expect100header &&
+      if(!data->state.expect100header &&
          (http->postsize < MAX_INITIAL_POST_SIZE)) {
         /* if we don't use expect: 100  AND
            postsize is less than MAX_INITIAL_POST_SIZE

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1893,7 +1893,8 @@ static ssize_t h2_submit(struct stream_ctx **pstream,
   struct h1_req_parser h1;
   struct dynhds h2_headers;
   nghttp2_nv *nva = NULL;
-  size_t nheader, i;
+  const void *body = NULL;
+  size_t nheader, bodylen, i;
   nghttp2_data_provider data_prd;
   int32_t stream_id;
   nghttp2_priority_spec pri_spec;
@@ -2011,6 +2012,20 @@ static ssize_t h2_submit(struct stream_ctx **pstream,
     }
   }
 
+  body = (const char *)buf + nwritten;
+  bodylen = len - nwritten;
+
+  if(bodylen > 0) {
+    /* We have request body to send in DATA frame */
+    ssize_t n = Curl_bufq_write(&stream->sendbuf, body, bodylen, err);
+    if(n < 0) {
+      *err = CURLE_SEND_ERROR;
+      nwritten = -1;
+      goto out;
+    }
+    nwritten += n;
+  }
+
 out:
   DEBUGF(LOG_CF(data, cf, "[h2sid=%d] submit -> %zd, %d",
          stream? stream->id : -1, nwritten, *err));
@@ -2060,8 +2075,9 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       stream->upload_blocked_len = 0;
     }
     else {
-      /* If stream_id != -1, we have dispatched request HEADERS, and now
-         are going to send or sending request body in DATA frame */
+      /* If stream_id != -1, we have dispatched request HEADERS and
+        * optionally request body, and now are going to send or sending
+        * more request body in DATA frame */
       nwritten = Curl_bufq_write(&stream->sendbuf, buf, len, err);
       if(nwritten < 0) {
         if(*err != CURLE_AGAIN)


### PR DESCRIPTION
This PR is based on the conversation [here](https://curl.se/mail/lib-2023-06/0040.html).

When sending an HTTP/2 POST request, curl will always defer request body to a different TLS record (if SSL/TLS is enabled) and TCP packet. This problem is previously addressed in https://github.com/curl/curl/issues/6363.

Belows are network packets captured by Wireshark by running `SSLKEYLOGFILE=/tmp/sslkeylog.log src/curl -k "https://nghttp2.org" -d "moo"`:

![image](https://github.com/curl/curl/assets/41262596/a1e1af32-d441-4717-a7d8-6f49a55f0800)

We can combine the TCP packet by disabling `TCP_NODELAY`. Belows is a TCP packet sent by running `SSLKEYLOGFILE=/tmp/sslkeylog.log src/curl -k "https://nghttp2.org" -d "moo" --no-tcp-nodelay`:

![image](https://github.com/curl/curl/assets/41262596/e0d1557f-8368-4ef5-b968-a78e9a8bd854)

As can be seen from the image above, curl still generates 2 TLS records for HEADER and DATA frames, respectively (ignore the first TLS record from MAGIC frame).

Therefore, this PR provides an optimization that allows request body to be sent together with request headers in a single TLS record and TCP packet if the body size is small enough. This is achieved by attaching request body to header data so that `h2_submit()` can write the body directly after it has created a stream.

Belows is a TCP packet sent by running `SSLKEYLOGFILE=/tmp/sslkeylog.log src/curl -k "https://nghttp2.org" -d "moo"` with this change:

![image](https://github.com/curl/curl/assets/41262596/da17bbb3-f4ff-4c3d-90c4-43649093c0ad)
