### PR TITLE
Secure transport: fix busy loop on EOF read

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -860,6 +860,9 @@ static OSStatus bio_cf_in_read(SSLConnectionRef connection,
     }
     nread = 0;
   }
+  else if(nread == 0) {
+    rtn = errSSLClosedGraceful;
+  }
   else if((size_t)nread < *dataLength) {
     rtn = errSSLWouldBlock;
   }


### PR DESCRIPTION
if EOF happens, socket is readable, SSLHandshake calls bio_cf_in_read; which interprets nread == 0 as errSSLWouldBlock, which leads to busy loop until timeout occurs or possibly write fails.

I have tried to return success with nread being 0 but SSLHandshake returns errSecParam. Returning errSSLClosedGraceful (old return value from https://github.com/curl/curl/commit/55807e6c056f27846d70cec70ee6ac3f0e5b3bbe#diff-016d06b58b35fe28e30d7967febf3d90524f38baf4f4c5923482a3ebde438ccfL859) leads to SSLHandshake returning errSSLClosedAbort (at least on M2 mac on Ventura); I assume the errSSLClosedNoNotify from the old comment may be returned outside of handshake, but that was not tested.