### PR TITLE
CURLOPT_MIMEPOST.3: clarify what setting to NULL means

### DIFF
--- a/docs/libcurl/opts/CURLOPT_MIMEPOST.3
+++ b/docs/libcurl/opts/CURLOPT_MIMEPOST.3
@@ -40,6 +40,10 @@ SMTP and IMAP protocols to provide the email data to send/upload.
 
 This option is the preferred way of posting an HTTP form, replacing and
 extending the \fICURLOPT_HTTPPOST(3)\fP option.
+
+When setting \fICURLOPT_MIMEPOST(3)\fP to NULL, libcurl resets the request
+type for HTTP to the default to disable the POST. Typically that would mean it
+is reset to GET. Instead you should set a desired request method explicitly.
 .SH PROTOCOLS
 HTTP, SMTP, IMAP.
 .SH EXAMPLE


### PR DESCRIPTION
Follow-up to e08382a208d4e480