### PR TITLE
tool_parsecfg: accept line lengths up to 10M

### DIFF
--- a/docs/cmdline-opts/config.d
+++ b/docs/cmdline-opts/config.d
@@ -29,7 +29,8 @@ preceding any other letter is ignored.
 If the first column of a config line is a '#' character, the rest of the line
 will be treated as a comment.
 
-Only write one option per physical line in the config file.
+Only write one option per physical line in the config file. A single line is
+required to be no more than 10 megabytes (since 8.2.0).
 
 Specify the filename to --config as '-' to make curl read the file from stdin.
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -43,7 +43,7 @@
 
 static const char *unslashquote(const char *line, char *param);
 
-#define MAX_CONFIG_LINE_LENGTH (100*1024)
+#define MAX_CONFIG_LINE_LENGTH (10*1024*1024)
 static bool my_get_line(FILE *fp, struct curlx_dynbuf *, bool *error);
 
 #ifdef WIN32


### PR DESCRIPTION
Bumped from 100K set in 47dd957daff9

Reported-by: Antoine du Hamel
Fixes #11431