### PR TITLE
Brew fix for openssl in default path

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -177,6 +177,12 @@ jobs:
     - run: "while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done"
       name: 'brew install'
 
+    - run: |
+        if test -d /usr/local/include/openssl; then
+          brew unlink openssl
+        fi
+      name: 'brew unlink openssl'
+
     - uses: actions/checkout@v3
 
     - run: cmake -S. -Bbuild -DCURL_WERROR=ON -DPICKY_COMPILER=ON ${{ matrix.build.generate }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -119,6 +119,17 @@ jobs:
     - run: "while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done"
       name: 'brew install'
 
+    - run: |
+        case "${{ matrix.build.install }}" in
+          *openssl*)
+            ;;
+          *)
+            if test -d /usr/local/include/openssl; then
+              brew unlink openssl
+            fi;;
+        esac
+      name: 'brew unlink openssl'
+
     - run: python3 -m pip install impacket
       name: 'pip3 install'
 
@@ -178,9 +189,14 @@ jobs:
       name: 'brew install'
 
     - run: |
-        if test -d /usr/local/include/openssl; then
-          brew unlink openssl
-        fi
+        case "${{ matrix.build.install }}" in
+          *openssl*)
+            ;;
+          *)
+            if test -d /usr/local/include/openssl; then
+              brew unlink openssl
+            fi;;
+        esac
       name: 'brew unlink openssl'
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
- refs #11413
- if brew install/update links openssl into /usr/local, it will be found before anything we add with `-isystem path` to CPP/LDLFAGS. Get rid of that by unlinking the keg.