### PR TITLE
curl: return error when asked to use an unsupported HTTP version

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1438,10 +1438,14 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case '2':
         /* HTTP version 2.0 */
+        if(!feature_http2)
+          return PARAM_LIBCURL_DOESNT_SUPPORT;
         sethttpver(global, config, CURL_HTTP_VERSION_2_0);
         break;
       case '3': /* --http2-prior-knowledge */
         /* HTTP version 2.0 over clean TCP */
+        if(!feature_http2)
+          return PARAM_LIBCURL_DOESNT_SUPPORT;
         sethttpver(global, config, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
         break;
       case '4': /* --http3 */
@@ -1462,6 +1466,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       case 'a':
         /* --proxy-http2 */
+        if(!feature_httpsproxy || !feature_http2)
+          return PARAM_LIBCURL_DOESNT_SUPPORT;
         config->proxyver = CURLPROXY_HTTPS2;
         break;
       }

--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -73,6 +73,7 @@ bool feature_brotli = FALSE;
 bool feature_hsts = FALSE;
 bool feature_http2 = FALSE;
 bool feature_http3 = FALSE;
+bool feature_httpsproxy = FALSE;
 bool feature_libz = FALSE;
 bool feature_ntlm = FALSE;
 bool feature_ntlm_wb = FALSE;
@@ -97,7 +98,7 @@ static struct feature_name_presentp {
   {"HSTS",           &feature_hsts,       CURL_VERSION_HSTS},
   {"HTTP2",          &feature_http2,      CURL_VERSION_HTTP2},
   {"HTTP3",          &feature_http3,      CURL_VERSION_HTTP3},
-  {"HTTPS-proxy",    NULL,                CURL_VERSION_HTTPS_PROXY},
+  {"HTTPS-proxy",    &feature_httpsproxy, CURL_VERSION_HTTPS_PROXY},
   {"IDN",            NULL,                CURL_VERSION_IDN},
   {"IPv6",           NULL,                CURL_VERSION_IPV6},
   {"Kerberos",       NULL,                CURL_VERSION_KERBEROS5},

--- a/src/tool_libinfo.h
+++ b/src/tool_libinfo.h
@@ -50,6 +50,7 @@ extern bool feature_brotli;
 extern bool feature_hsts;
 extern bool feature_http2;
 extern bool feature_http3;
+extern bool feature_httpsproxy;
 extern bool feature_libz;
 extern bool feature_ntlm;
 extern bool feature_ntlm_wb;


### PR DESCRIPTION
When one of the following options are used but the libcurl in use does not support it:

--http2
--http2-prior-knowledge
--proxy-http2