### PR TITLE
cmake: add `libcurlu`/`libcurltool` for unit tests

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -65,6 +65,14 @@ add_library(
   )
 
 add_library(
+  curlu # special libcurlu library just for unittests
+  STATIC
+  EXCLUDE_FROM_ALL
+  ${HHEADERS} ${CSOURCES}
+)
+target_compile_definitions(curlu PUBLIC UNITTESTS CURL_STATICLIB)
+
+add_library(
   ${PROJECT_NAME}::${LIB_NAME}
   ALIAS ${LIB_NAME}
   )
@@ -80,6 +88,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 target_link_libraries(${LIB_NAME} PRIVATE ${CURL_LIBS})
+target_link_libraries(curlu PRIVATE ${CURL_LIBS})
 
 transform_makefile_inc("Makefile.soname" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.soname.cmake")
 include(${CMAKE_CURRENT_BINARY_DIR}/Makefile.soname.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,14 @@ add_executable(
   ALIAS ${EXE_NAME}
   )
 
+add_library(
+  curltool # special libcurltool library just for unittests
+  STATIC
+  EXCLUDE_FROM_ALL
+  ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES}
+)
+target_compile_definitions(curltool PUBLIC UNITTESTS CURL_STATICLIB)
+
 if(CURL_HAS_LTO)
   set_target_properties(${EXE_NAME} PROPERTIES
     INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,18 +33,10 @@ include_directories(
   ${CURL_BINARY_DIR}/include      # To be able to reach "curl/curl.h"
 )
 
-# TODO build a special libcurlu library for unittests.
-# Until that happens, only build the unit tests when creating a static libcurl
-# or else they will fail to link. Some of the tests require the special libcurlu
-# build, so filter those out until we get libcurlu.
-list(FILTER UNITPROGS EXCLUDE REGEX
-  "unit1394|unit1395|unit1604|unit1608|unit1621|unit1650|unit1653|unit1655|unit1660|unit2600|unit2601|unit2602|unit2603")
-if(NOT BUILD_SHARED_LIBS)
+if (ENABLE_CURLDEBUG) # running unittests require curl to compiled with CURLDEBUG
   foreach(_testfile ${UNITPROGS})
     add_executable(${_testfile} EXCLUDE_FROM_ALL ${_testfile}.c ${UNITFILES})
     add_dependencies(testdeps ${_testfile})
-    target_link_libraries(${_testfile} libcurl ${CURL_LIBS})
-    set_target_properties(${_testfile}
-        PROPERTIES COMPILE_DEFINITIONS "UNITTESTS")
+    target_link_libraries(${_testfile} curltool curlu)
   endforeach()
 endif()


### PR DESCRIPTION
Add a `libcurlu`/`libcurltool` static library to the CMake build that is compiled only for unit tests. We use `EXCLUDE_FROM_ALL` to make sure that they're not built by default, they're only built if unit tests are built.

These libraries allow us to compile every unit test with CMake, rather than skipping some of them.

---

To make reviewing easier:
  - `libcurltool` is defined in the `Makefile.am` at: https://github.com/curl/curl/blob/ebd83bfbae31809a4525e953c8512aad797c38ad/src/Makefile.am#L77-L82
  - `libcurlu` is defined in the `Makefile.am` at: https://github.com/curl/curl/blob/ebd83bfbae31809a4525e953c8512aad797c38ad/lib/Makefile.am#L116-L118

You can also easily configure, build, and test everything using:

```bash
# configure the build/ directory for unit tests
cmake -B build/ -S . -DENABLE_THREADED_RESOLVER=OFF -DCMAKE_BUILD_TYPE=Debug -DENABLE_DEBUG=ON
# run `make testdeps all -j12`
cmake --build build/ --target=testdeps --target=all -j12
# run `make test-ci` (aka run tests)
# You may wish to modify tests/CMakeLists.txt to run tests with multiple cores
cmake --build build/ --target=test-ci
```
