### PR TITLE
wolfssl: support loading system CA certificates

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -150,6 +150,7 @@ cyassl
 Cygwin
 daniel
 datatracker
+Debian
 decrypt
 deepcode
 DELE
@@ -216,6 +217,7 @@ Falkeborn
 Fandrich
 Fastly
 fcpp
+Fedora
 Feltzing
 ffi
 filesize
@@ -243,6 +245,7 @@ gcc
 GCM
 gdb
 Genode
+Gentoo
 Gergely
 getaddrinfo
 getenv
@@ -624,6 +627,7 @@ resending
 RETR
 retransmit
 retrigger
+RHEL
 RICS
 Rikard
 rmdir
@@ -785,6 +789,7 @@ tvOS
 txt
 typedef
 typedefed
+Ubuntu
 ucLinux
 UDP
 UI

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -62,9 +62,10 @@ library). If combined with \fICURLSSLOPT_NO_REVOKE\fP, the latter takes
 precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
-verification. Works only on Windows when built to use OpenSSL. If you set this
-option and also set a CA certificate file or directory then during verification
-those certificates are searched in addition to the native CA store.
+verification. Works only when built to use wolfSSL (since 8.2.0) or on
+Windows when built to use OpenSSL. If you set this option and also set a CA
+certificate file or directory then during verification those certificates are
+searched in addition to the native CA store.
 (Added in 7.71.0)
 .IP CURLSSLOPT_AUTO_CLIENT_CERT
 Tell libcurl to automatically locate and use a client certificate for

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -62,10 +62,11 @@ library). If combined with \fICURLSSLOPT_NO_REVOKE\fP, the latter takes
 precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
-verification. Works only when built to use wolfSSL (since 8.2.0) or on
+verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
+RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.2.0) or on
 Windows when built to use OpenSSL. If you set this option and also set a CA
-certificate file or directory then during verification those certificates are
-searched in addition to the native CA store.
+certificate file or directory then during verification those certificates
+are searched in addition to the native CA store.
 (Added in 7.71.0)
 .IP CURLSSLOPT_AUTO_CLIENT_CERT
 Tell libcurl to automatically locate and use a client certificate for

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -63,7 +63,7 @@ precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
 verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
-RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.2.0) or on
+RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.3.0) or on
 Windows when built to use OpenSSL. If you set this option and also set a CA
 certificate file or directory then during verification those certificates
 are searched in addition to the native CA store.

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -61,10 +61,11 @@ library). If combined with \fICURLSSLOPT_NO_REVOKE\fP, the latter takes
 precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
-verification. Works only when built to use wolfSSL (since 8.2.0) or on
-Windows when built to use OpenSSL. If you set this option and also set a CA
-certificate file or directory then during verification those certificates are
-searched in addition to the native CA store.
+verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
+RHEL), macOS, Android, macOS and iOS when built to use wolfSSL (since 8.2.0)
+or on Windows when built to use OpenSSL. If you set this option and also set
+a CA certificate file or directory then during verification those certificates
+are searched in addition to the native CA store.
 (Added in 7.71.0)
 .IP CURLSSLOPT_AUTO_CLIENT_CERT
 Tell libcurl to automatically locate and use a client certificate for

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -62,7 +62,7 @@ precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
 verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
-RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.2.0) or on
+RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.3.0) or on
 Windows when built to use OpenSSL. If you set this option and also set a CA
 certificate file or directory then during verification those certificates
 are searched in addition to the native CA store.

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -62,9 +62,9 @@ precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
 verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
-RHEL), macOS, Android, macOS and iOS when built to use wolfSSL (since 8.2.0)
-or on Windows when built to use OpenSSL. If you set this option and also set
-a CA certificate file or directory then during verification those certificates
+RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.2.0) or on
+Windows when built to use OpenSSL. If you set this option and also set a CA
+certificate file or directory then during verification those certificates
 are searched in addition to the native CA store.
 (Added in 7.71.0)
 .IP CURLSSLOPT_AUTO_CLIENT_CERT

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -61,9 +61,10 @@ library). If combined with \fICURLSSLOPT_NO_REVOKE\fP, the latter takes
 precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
-verification. Works only on Windows when built to use OpenSSL. If you set this
-option and also set a CA certificate file or directory then during verification
-those certificates are searched in addition to the native CA store.
+verification. Works only when built to use wolfSSL (since 8.2.0) or on
+Windows when built to use OpenSSL. If you set this option and also set a CA
+certificate file or directory then during verification those certificates are
+searched in addition to the native CA store.
 (Added in 7.71.0)
 .IP CURLSSLOPT_AUTO_CLIENT_CERT
 Tell libcurl to automatically locate and use a client certificate for


### PR DESCRIPTION
The wolfssl backend currently does not support loading the system CA certificates. However, wolfSSL has built-in support for this functionality.

This PR ensures that system CA certs are loaded when the CURLSSLOPT_NATIVE_CA bit is set.

In case the system CA store cannot be read, the program will continue. If the system CA store was read successfully, but certificates could not be read either from memory or from disk, the program will still continue. This is the same behaviour that the OpenSSL backend exhibits.