### PR TITLE
quiche: avoid NULL deref in debug logging

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -884,8 +884,9 @@ out:
   if(nread > 0)
     ctx->data_recvd += nread;
   DEBUGF(LOG_CF(data, cf, "[h3sid=%"PRId64"] cf_recv(total=%"
-                          CURL_FORMAT_CURL_OFF_T ") -> %zd, %d",
-                stream->id, ctx->data_recvd, nread, *err));
+                CURL_FORMAT_CURL_OFF_T ") -> %zd, %d",
+                stream ? stream->id : NULL,
+                ctx->data_recvd, nread, *err));
   return nread;
 }
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -885,7 +885,7 @@ out:
     ctx->data_recvd += nread;
   DEBUGF(LOG_CF(data, cf, "[h3sid=%"PRId64"] cf_recv(total=%"
                 CURL_FORMAT_CURL_OFF_T ") -> %zd, %d",
-                stream ? stream->id : NULL,
+                stream ? stream->id : (int64_t)0,
                 ctx->data_recvd, nread, *err));
   return nread;
 }


### PR DESCRIPTION
Coverity reported "Dereference after null check"

If stream is NULL and the function exits, the logging must not deref it.