### PR TITLE
openssl: noverify continue if CA_BLOB error

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
@@ -37,8 +37,9 @@ Pass a pointer to a curl_blob structure, which contains information (pointer
 and size) about a memory block with binary data of PEM encoded content holding
 one or more certificates to verify the HTTPS server with.
 
-If \fICURLOPT_SSL_VERIFYPEER(3)\fP is zero and you avoid verifying the
-server's certificate, \fICURLOPT_CAINFO_BLOB(3)\fP is not needed.
+If \fICURLOPT_SSL_VERIFYPEER(3)\fP is zero and you avoid verifying the server's
+certificate, any certificates provided by using \fICURLOPT_CAINFO_BLOB(3)\fP
+are not used.
 
 This option overrides \fICURLOPT_CAINFO(3)\fP.
 .SH DEFAULT


### PR DESCRIPTION
See detailed issue description in #11456. This PR preserves independence of the `CURLOPT_SSL_VERIFYPEER` and `CURLOPT_CAINFO_BLOB` when using OpenSSL. This ensures certificates will be added to OpenSSL's root certificate chain, even if the user of libcurl is doing something strange with certificates. This behavior was tested with the `ossl_custom_verify.c` and `test_verify.c` scripts from #11456.

The major change is the addition of this line which makes these settings interact in libcurl the same was as they did in 7.86.0.

```diff
diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
index c6a1dd218..efd0c1cab 100644
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3171,6 +3171,7 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
         return result;
       }
       /* Only warn if no certificate verification is required. */
+      result = CURLE_OK;
       infof(data, "error importing CA certificate blob, continuing anyway");
     }
     else {
```