### PR TITLE
HTTP/3, quiche, fix lookup of transfer at multi

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -329,7 +329,7 @@ static struct Curl_easy *get_stream_easy(struct Curl_cfilter *cf,
   else {
     DEBUGASSERT(data->multi);
     for(sdata = data->multi->easyp; sdata; sdata = sdata->next) {
-      if(H3_STREAM_ID(sdata) == stream3_id) {
+      if((sdata->conn == data->conn) && H3_STREAM_ID(sdata) == stream3_id) {
         return sdata;
       }
     }


### PR DESCRIPTION
- refs #11449 where weirdness in quiche multi connection tranfers was observed
- fixes lookup of transfer for a quiche event to take the connection into account
- formerly, a transfer with the same stream_id, but on another connection could be found