### PR TITLE
configure: check for nghttp2_session_get_stream_local_window_size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2835,9 +2835,9 @@ if test X"$want_nghttp2" != Xno; then
   CPPFLAGS="$CPPFLAGS $CPP_H2"
   LIBS="$LIB_H2 $LIBS"
 
-  # use nghttp2_session_set_local_window_size to require nghttp2
-  # >= 1.12.0
-  AC_CHECK_LIB(nghttp2, nghttp2_session_set_local_window_size,
+  # use nghttp2_session_get_stream_local_window_size to require nghttp2
+  # >= 1.15.0
+  AC_CHECK_LIB(nghttp2, nghttp2_session_get_stream_local_window_size,
     [
      AC_CHECK_HEADERS(nghttp2/nghttp2.h,
         curl_h2_msg="enabled (nghttp2)"

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -30,7 +30,7 @@ versions of libs and build tools.
  - GSKit        V5R3M0
  - NSS          3.14.x
  - Heimdal      ?
- - nghttp2      1.12.0
+ - nghttp2      1.15.0
  - WinSock      2.2 (on Windows 95+ and Windows CE .NET 4.1+)
 
 ## Build tools


### PR DESCRIPTION
The http2 code uses it now. Introduced in nghttp2 1.15.0 (Sep 2016)

Fixes #11470
Reported-by: Paul Howarth