### PR TITLE
OS400 checkstrings add CURLOPT_HAPROXY_CLIENT_IP

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1164,6 +1164,7 @@ curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...)
   case CURLOPT_USERNAME:
   case CURLOPT_USERPWD:
   case CURLOPT_XOAUTH2_BEARER:
+  case CURLOPT_HAPROXY_CLIENT_IP:
     s = va_arg(arg, char *);
     ccsid = va_arg(arg, unsigned int);
 

--- a/packages/OS400/chkstrings.c
+++ b/packages/OS400/chkstrings.c
@@ -37,7 +37,7 @@
  * made, the EXPECTED_STRING_LASTZEROTERMINATED/EXPECTED_STRING_LAST
  * values can be updated to match the latest enum values in urldata.h.
  */
-#define EXPECTED_STRING_LASTZEROTERMINATED  (STRING_AWS_SIGV4 + 1)
+#define EXPECTED_STRING_LASTZEROTERMINATED  (STRING_HAPROXY_CLIENT_IP + 1)
 #define EXPECTED_STRING_LAST                (STRING_COPYPOSTFIELDS + 1)
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Correct EXPECTED_STRING_LASTZEROTERMINATED  to account for CURLOPT_HAPROXY_CLIENT_IP which requires EBCDIC to ASCII conversion when a character string is passed into curl_easy_setopt().

Addresses https://github.com/curl/curl/issues/11472