### PR TITLE
amigaos: fix sys/mbuf.h m_len macro clash

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -298,6 +298,7 @@
 #  if defined(HAVE_PROTO_BSDSOCKET_H) && \
     (!defined(__amigaos4__) || defined(USE_AMISSL))
      /* use bsdsocket.library directly, instead of libc networking functions */
+#    define _SYS_MBUF_H /* m_len define clashes with curl */
 #    include <proto/bsdsocket.h>
 #    ifdef __amigaos4__
        int Curl_amiga_select(int nfds, fd_set *readfds, fd_set *writefds,


### PR DESCRIPTION
The updated Curl_http_req_make and Curl_http_req_make2 functions spawned a parameter called m_len. The AmigaOS networking headers, derived from NetBSD, contain "#define m_len m_hdr.mh_len" which clashes with this. Since we do not actually use mbuf, force the include file to be ignored, removing the clash.