### PR TITLE
amigaos: fix connect() macro expansion clash

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1074,7 +1074,7 @@ static CURLcode cf_h1_proxy_connect(struct Curl_cfilter *cf,
   }
 
   DEBUGF(LOG_CF(data, cf, "connect"));
-  result = cf->next->cft->connect(cf->next, data, blocking, done);
+  result = (cf->next->cft->connect)(cf->next, data, blocking, done);
   if(result || !*done)
     return result;
 

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -115,7 +115,7 @@ static CURLcode cf_haproxy_connect(struct Curl_cfilter *cf,
     return CURLE_OK;
   }
 
-  result = cf->next->cft->connect(cf->next, data, blocking, done);
+  result = (cf->next->cft->connect)(cf->next, data, blocking, done);
   if(result || !*done)
     return result;
 

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -293,7 +293,7 @@ CURLcode Curl_conn_cf_connect(struct Curl_cfilter *cf,
                               bool blocking, bool *done)
 {
   if(cf)
-    return cf->cft->connect(cf, data, blocking, done);
+    return (cf->cft->connect)(cf, data, blocking, done);
   return CURLE_FAILED_INIT;
 }
 
@@ -348,7 +348,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
 
   *done = cf->connected;
   if(!*done) {
-    result = cf->cft->connect(cf, data, blocking, done);
+    result = (cf->cft->connect)(cf, data, blocking, done);
     if(!result && *done) {
       Curl_conn_ev_update_info(data, data->conn);
       conn_report_connect_stats(data, data->conn);

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -71,7 +71,7 @@ static CURLcode http_proxy_cf_connect(struct Curl_cfilter *cf,
 
   DEBUGF(LOG_CF(data, cf, "connect"));
 connect_sub:
-  result = cf->next->cft->connect(cf->next, data, blocking, done);
+  result = (cf->next->cft->connect)(cf->next, data, blocking, done);
   if(result || !*done)
     return result;
 

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1115,7 +1115,7 @@ static CURLcode socks_proxy_cf_connect(struct Curl_cfilter *cf,
     return CURLE_OK;
   }
 
-  result = cf->next->cft->connect(cf->next, data, blocking, done);
+  result = (cf->next->cft->connect)(cf->next, data, blocking, done);
   if(result || !*done)
     return result;
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1528,7 +1528,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
   DEBUGASSERT(connssl);
   DEBUGASSERT(cf->conn->host.name);
 
-  result = cf->next->cft->connect(cf->next, data, blocking, done);
+  result = (cf->next->cft->connect)(cf->next, data, blocking, done);
   if(result || !*done)
     goto out;
 


### PR DESCRIPTION
The new connection filter code contains a structure with an item called "connect". On AmigaOS the standard networking connect() function is implemented via a macro. Parentheses have been added to the ->connect() calls to prevent them triggering expansion of the connect() macro.