### PR TITLE
socks: print IPv6 address in square brackets

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -830,9 +830,25 @@ CONNECT_RESOLVED:
       return CURLPX_RESOLVE_HOST;
     }
 
-    Curl_printable_address(hp, dest, sizeof(dest));
-    destlen = strlen(dest);
-    msnprintf(dest + destlen, sizeof(dest) - destlen, ":%d", sx->remote_port);
+#ifdef ENABLE_IPV6
+    if(hp->ai_family == AF_INET6) {
+      dest[0] = '[';
+      Curl_printable_address(hp, dest + 1, sizeof(dest) - 1);
+      destlen = strlen(dest);
+      dest[destlen] = ']';
+      ++destlen;
+      msnprintf(dest + destlen, sizeof(dest) - destlen,
+                ":%d", sx->remote_port);
+    }
+    else
+#else
+    {
+      Curl_printable_address(hp, dest, sizeof(dest));
+      destlen = strlen(dest);
+      msnprintf(dest + destlen, sizeof(dest) - destlen,
+                ":%d", sx->remote_port);
+    }
+#endif
 
     len = 0;
     socksreq[len++] = 5; /* version (SOCKS5) */


### PR DESCRIPTION
IPv6 address with port number should be printed with square brackets.

> The [] style as expressed in [RFC3986] SHOULD be
> employed, and is the default unless otherwise specified.

refer: https://www.rfc-editor.org/rfc/rfc5952#section-6

with command line: `curl -v --proxy socks5://localhost:1083 -I http://localhost:12345`

previous: 
```
* SOCKS5 connect to IPv6 ::1:12345 (locally resolved)
* SOCKS5 request granted.
```

current:
```
* SOCKS5 connect to IPv6 [::1]:12345 (locally resolved)
* SOCKS5 request granted.
```