### PR TITLE
HTTP/2, regression on upload EOF handling

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3380,6 +3380,9 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     }
   }
 
+  if(data->req.upload_done)
+    Curl_conn_ev_data_done_send(data);
+
   if((conn->httpversion >= 20) && data->req.upload_chunky)
     /* upload_chunky was set above to set up the request in a chunky fashion,
        but is disabled here again to avoid that the chunked encoded version is


### PR DESCRIPTION
- refs #11485
- a regression introduced by c9ec85121110d7cbbbed2990024222c8f5b8afe5 where optimization of small POST bodies leads to a new code path for such uploads that did not trigger the "done sending" event
- add triggering this event for early "upload_done" situations