### PR TITLE
do not clear the credentials on redirect to absolute URL

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1558,10 +1558,6 @@ CURLcode Curl_follow(struct Curl_easy *data,
     /* If this is not redirect due to a 401 or 407 response and an absolute
        URL: don't allow a custom port number */
     disallowport = TRUE;
-    if(!data->set.allow_auth_to_other_hosts) {
-      Curl_safefree(data->state.aptr.user);
-      Curl_safefree(data->state.aptr.passwd);
-    }
   }
 
   DEBUGASSERT(data->state.uh);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -122,6 +122,7 @@ test943 test944 test945 test946 test947 test948 test949 test950 test951 \
 test952 test953 test954 test955 test956 test957 test958 test959 test960 \
 test961 test962 test963 test964 test965 test966 test967 test968 test969 \
 test970 test971 test972 test973 test974 test975 test976 test977 test978 \
+test979 \
 \
 test980 test981 test982 test983 test984 test985 test986 test987 test988 \
 test989 \

--- a/tests/data/test979
+++ b/tests/data/test979
@@ -1,0 +1,64 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+Basic
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes" nocheck="yes">
+HTTP/1.1 302 go go go
+Content-Length: 8
+Location: http://%HOSTIP:%HTTPPORT/user/%TESTNUMBER0002
+Content-Type: text/html
+Funny-head: yesyes
+
+notreal
+</data>
+<data2 crlf="yes">
+HTTP/1.1 200 OK
+Content-Length: 6
+Content-Type: text/html
+Funny-head: yesyes
+
+final
+</data2>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+-u with redirect to absolute URL using same origin and auth
+</name>
+<command>
+http://first:secret@%HOSTIP:%HTTPPORT/%TESTNUMBER -L -u smith:doggie
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic c21pdGg6ZG9nZ2ll
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /user/%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic c21pdGg6ZG9nZ2ll
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Regression shipped in 8.2.0 from commit  dd4d1a26959f63a2c

Add test 979 to verify.
    
Fixes #11486
