### PR TITLE
Remove unneeded `unit*_LDADD` overrides in unit test Makefile.inc

### DIFF
--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -104,7 +104,6 @@ unit1614_SOURCES = unit1614.c $(UNITFILES)
 unit1620_SOURCES = unit1620.c $(UNITFILES)
 
 unit1621_SOURCES = unit1621.c $(UNITFILES)
-unit1621_LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurl.la @NSS_LIBS@
 
 unit1650_SOURCES = unit1650.c $(UNITFILES)
 

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -62,9 +62,6 @@ unit1323_SOURCES = unit1323.c $(UNITFILES)
 unit1330_SOURCES = unit1330.c $(UNITFILES)
 
 unit1394_SOURCES = unit1394.c $(UNITFILES)
-unit1394_LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_LIBS@
-unit1394_LDFLAGS = $(top_builddir)/src/libcurltool.la
-unit1394_LIBS =
 
 unit1395_SOURCES = unit1395.c $(UNITFILES)
 


### PR DESCRIPTION
While I was making PR https://github.com/curl/curl/pull/11446 and trying to build all of the unit tests in CMake, I noticed that some of the unit tests seem to have unneeded `_LDADD` overrides in the `tests/unit/Makefile.inc` file.

For reference, the default `LDADD` for all unit tests is:

https://github.com/curl/curl/blob/db1203781cd703ab7975bb37b1673214946dd3c9/tests/unit/Makefile.am#L48-L50

## Changes

### Removing unit1394_LDADD

These custom `unit1394_LDADD` and similar automake overrides are no longer neded. They were originally added by added by  [https://github.com/curl/curl/commit/8dac7be438512a8725d3c71e9139bdfdcac1ed8c][] for metalink support, but are no longer after  [https://github.com/curl/curl/commit/265b14d6b37c4298bd5556fabcbc37d36f911693][] removed metalink.

[https://github.com/curl/curl/commit/8dac7be438512a8725d3c71e9139bdfdcac1ed8c]: https://github.com/curl/curl/commit/8dac7be438512a8725d3c71e9139bdfdcac1ed8c
[https://github.com/curl/curl/commit/265b14d6b37c4298bd5556fabcbc37d36f911693]: https://github.com/curl/curl/commit/265b14d6b37c4298bd5556fabcbc37d36f911693

### Removing unit1621_LDADD

The `unit1621_LDADD` variable has the exact same value as the `LDADD` flag in `Makefile.am`, except without `@LDFLAGS@ @LIBCURL_LIBS@`.

This was originally added by [https://github.com/curl/curl/commit/98e6629154044e4ab1ee7cff8351c7ebcb131e88][], but I can't see any reason why it exists, so we should remove it to clean things up.

[https://github.com/curl/curl/commit/98e6629154044e4ab1ee7cff8351c7ebcb131e88]: https://github.com/curl/curl/commit/98e6629154044e4ab1ee7cff8351c7ebcb131e88