### PR TITLE
vtls/openssl: Support async certificate verification by user callback

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3864,6 +3864,12 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
       return CURLE_OK;
     }
 #endif
+#ifdef SSL_ERROR_WANT_RETRY_VERIFY
+    if(SSL_ERROR_WANT_RETRY_VERIFY == detail) {
+      connssl->connecting_state = ssl_connect_2;
+      return CURLE_OK;
+    }
+#endif
     else if(backend->io_result == CURLE_AGAIN) {
       return CURLE_OK;
     }


### PR DESCRIPTION
# Overview
Update the OpenSSL connect state machine to handle `SSL_ERROR_WANT_RETRY_VERIFY`. This allows libcurl users to suspend processing while waiting for external I/O during certificate validation.

## Intended usage
Clients perform asynchronous certificate verification by installing a X.509 certificate verification function with `SSL_CTX_set_cert_verify_callback` from the SSL context callback (see `CURLOPT_SSL_CTX_FUNCTION`).

The verification function calls `SSL_set_retry_verify` before returning `0` to indicate that the outcome is still pending. Once verification completes, the client calls `curl_multi_wakeup` to re-enter the `SSL_connect` state machine and return the final verification outcome from the next call to the verification function.

This mechanism is useful for applications that use OpenSSL for TLS protocol handling and crypto while delegating certificate verification to the platform's native trust store.