### PR TITLE
src/mkhelp: strip off escape sequences

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -51,6 +51,7 @@ while (<STDIN>) {
     # remove trailing CR from line. msysgit checks out files as line+CRLF
     $line =~ s/\r$//;
 
+    $line =~ s/\x1b\x5b[0-9]+m//g; # escape sequence
     if($line =~ /^([ \t]*\n|curl)/i) {
         # cut off headers and empty lines
         $wline++; # count number of cut off lines


### PR DESCRIPTION
At some point the nroff command stopped stripping off escape sequences, so then this script needs to do the job instead.

Reported-by: VictorVG on github
Fixes #11501