### PR TITLE
curl_multi_wait(3) formating: fix arg quoting to doc macro .BR

### DIFF
--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -123,4 +123,4 @@ This function was added in libcurl 7.28.0.
 CURLMcode type, general libcurl multi interface error code. See
 \fIlibcurl-errors(3)\fP
 .SH "SEE ALSO"
-.BR curl_multi_fdset "(3), " curl_multi_perform "(3)", curl_multi_poll "(3) ",
+.BR curl_multi_fdset "(3), " curl_multi_perform "(3), " curl_multi_poll "(3), "


### PR DESCRIPTION
fix quoting for .BR macro args in curl_multi_wait(3)