### PR TITLE
macOS: Really fix target detection

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -258,8 +258,9 @@
 #if defined(__APPLE__) && !defined(USE_ARES)
 #include <TargetConditionals.h>
 #define USE_RESOLVE_ON_IPS 1
-#  if !defined(TARGET_OS_OSX) || TARGET_OS_OSX
-#    define CURL_OSX_CALL_COPYPROXIES 1
+#  if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) && \
+     defined(ENABLE_IPV6)
+#    define CURL_MACOS_CALL_COPYPROXIES 1
 #  endif
 #endif
 

--- a/lib/macos.c
+++ b/lib/macos.c
@@ -24,21 +24,16 @@
 
 #include "curl_setup.h"
 
-#if defined(__APPLE__)
-
-#if !defined(TARGET_OS_OSX) || TARGET_OS_OSX
+#ifdef CURL_MACOS_CALL_COPYPROXIES
 
 #include <curl/curl.h>
 
 #include "macos.h"
 
-#if defined(ENABLE_IPV6) && defined(CURL_OSX_CALL_COPYPROXIES)
 #include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
-#endif
 
 CURLcode Curl_macos_init(void)
 {
-#if defined(ENABLE_IPV6) && defined(CURL_OSX_CALL_COPYPROXIES)
   {
     /*
      * The automagic conversion from IPv4 literals to IPv6 literals only
@@ -46,17 +41,15 @@ CURLcode Curl_macos_init(void)
      * first. As Curl currently doesn't support system-wide HTTP proxies, we
      * therefore don't use any value this function might return.
      *
-     * This function is only available on a macOS and is not needed for
-     * IPv4-only builds, hence the conditions above.
+     * This function is only available on macOS and is not needed for
+     * IPv4-only builds, hence the conditions for defining
+     * CURL_MACOS_CALL_COPYPROXIES in curl_setup.h.
      */
     CFDictionaryRef dict = SCDynamicStoreCopyProxies(NULL);
     if(dict)
       CFRelease(dict);
   }
-#endif
   return CURLE_OK;
 }
 
-#endif /* TARGET_OS_OSX */
-
-#endif /* __APPLE__ */
+#endif

--- a/lib/macos.h
+++ b/lib/macos.h
@@ -23,9 +23,10 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+
 #include "curl_setup.h"
 
-#if defined(__APPLE__) && (!defined(TARGET_OS_OSX) || TARGET_OS_OSX)
+#ifdef CURL_MACOS_CALL_COPYPROXIES
 
 CURLcode Curl_macos_init(void);
 

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -30,10 +30,10 @@ case $host_os in
       AC_LANG_PROGRAM([[
 #include <TargetConditionals.h>
       ]],[[
-#if (TARGET_OS_OSX)
+#if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
       return 0;
 #else
-#error Not a macOS
+#error Not macOS
 #endif
       ]])
     ],[


### PR DESCRIPTION
`TARGET_OS_OSX` is only defined in the macOS 10.12 SDK and later and is only defined when dynamic targets are enabled. `TARGET_OS_MAC` is always defined but means any Darwin OS, including macOS, iOS, tvOS, watchOS. `TARGET_OS_IPHONE` means any Darwin OS other than macOS.

Follow-up to c73b2f82

Closes #11502

-----

I tested on macOS 12 building for OS X 10.8 and then for iOS 11.

And I tested on OS X 10.8 building for OS X 10.8 and then for iOS 7.