### PR TITLE
Disable asssertion blocking OSSFuzz testing

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2077,7 +2077,9 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     else if(stream->upload_blocked_len) {
       /* the data in `buf` has alread been submitted or added to the
        * buffers, but have been EAGAINed on the last invocation. */
-      DEBUGASSERT(len >= stream->upload_blocked_len);
+      /* TODO: this assertion triggers in OSSFuzz runs and it is not
+       * clear why. Disable for now to let OSSFuzz continue its tests.
+      DEBUGASSERT(len >= stream->upload_blocked_len); */
       if(len < stream->upload_blocked_len) {
         /* Did we get called again with a smaller `len`? This should not
          * happend. We are not prepared to handle that. */


### PR DESCRIPTION
- refs #11500
- not clear how this triggers and it blocks OSSFuzz testing other things. Since we handle the case with an error return, disabling the assertion for now seems the best way forward.