### PR TITLE
cmake: don't check CMake target during library detection

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -29,8 +29,19 @@
 # order of least-to-most-dependent.  Some libraries depend on others
 # to link correctly.
 macro(check_library_exists_concat LIBRARY SYMBOL VARIABLE)
-  check_library_exists("${LIBRARY};${CURL_LIBS}" ${SYMBOL} "${CMAKE_LIBRARY_PATH}"
+  # Enumerate CURL_LIBS and add each library to CMAKE_REQUIRED_LIBRARIES if it
+  # is not a CMake target. System libraries should not depend on CMake targets.
+  set(CMAKE_REQUIRED_LIBRARIES)
+  foreach(LIB ${CURL_LIBS})
+    if (NOT TARGET ${LIB})
+      set(CMAKE_REQUIRED_LIBRARIES ${LIB} ${CMAKE_REQUIRED_LIBRARIES})
+    endif()
+  endforeach()
+  # Using CMake targets in the call to check_library_exists() may cause it to fail
+  # unless the target is IMPORTED.
+  check_library_exists("${LIBRARY}" ${SYMBOL} "${CMAKE_LIBRARY_PATH}"
     ${VARIABLE})
+  set(CMAKE_REQUIRED_LIBRARIES)
   if(${VARIABLE})
     set(CURL_LIBS ${LIBRARY} ${CURL_LIBS})
   endif()


### PR DESCRIPTION
Keeps existing behavior which states that some system libraries may depend on others in order to do proper library detection. We remove CMake targets from required libraries test, because system libraries should not depend on CMake targets. Including them causes the library check to fail when using an ALIAS target.

See https://github.com/curl/curl/issues/11285#issuecomment-1629432834 for more details.