### PR TITLE
configure: use the pkg-config --libs-only-l flag for libssh2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2242,7 +2242,7 @@ if test X"$OPT_LIBSSH2" != Xno; then
     CURL_CHECK_PKGCONFIG(libssh2)
 
     if test "$PKGCONFIG" != "no" ; then
-      LIB_SSH2=`$PKGCONFIG --libs libssh2`
+      LIB_SSH2=`$PKGCONFIG --libs-only-l libssh2`
       LD_SSH2=`$PKGCONFIG --libs-only-L libssh2`
       CPP_SSH2=`$PKGCONFIG --cflags-only-I libssh2`
       version=`$PKGCONFIG --modversion libssh2`


### PR DESCRIPTION
... instead of --libs, as that one also returns -L flags.

Reported-by: Wilhelm von Thiele
Fixes #11538