### PR TITLE
Remove Lift's CI configuration

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,8 +1,0 @@
-# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
-#
-# SPDX-License-Identifier: curl
-
-ignoreRules = [ "DEAD_STORE", "subprocess_without_shell_equals_true" ]
-ignoreFiles = [ "tests/http/**" ]
-build = "make"
-setup = ".lift/setup.sh"

--- a/.lift/setup.sh
+++ b/.lift/setup.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
-#
-# SPDX-License-Identifier: curl
-autoreconf -fi
-./configure --with-openssl
-echo "Ran the setup script for Lift including autoconf and executing ./configure --with-openssl"


### PR DESCRIPTION
The Lift tool is being retired. Their [site](https://lift.sonatype.com) reads:

>  Sonatype Lift will be retiring on Sep 12, 2023, with its analysis stopping on Aug 12, 2023.

This PR removes the configuration but does not remove the GitHub App installation, which must be done by an administrator.

If you find value in continuing Infer then I can make a PR with a github action which uses the monthly builds at ghcr.io/foodforbrain/infer (i.e. builds by me). The action would just [upload the SARIF to github](https://github.com/foodforbrain/librdkafka/blob/master/.github/workflows/infer.yml) so potential issues are managed and sorted like any other finding in the security tab.