### PR TITLE
vtls: clarify "ALPN: offers" message

### DIFF
--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -43,7 +43,7 @@ struct Curl_ssl_session;
 #define VTLS_INFOF_NO_ALPN                                      \
   "ALPN: server did not agree on a protocol. Uses default."
 #define VTLS_INFOF_ALPN_OFFER_1STR              \
-  "ALPN: offers %s"
+  "ALPN: curl offers %s"
 #define VTLS_INFOF_ALPN_ACCEPTED_1STR           \
   ALPN_ACCEPTED "%s"
 #define VTLS_INFOF_ALPN_ACCEPTED_LEN_1STR       \


### PR DESCRIPTION
Before:
`* ALPN: offers h2,http/1.1`

After:
`* ALPN: client offers h2,http/1.1`

Bug: https://curl.se/mail/lib-2023-07/0041.html
Reported-by: Richard W.M. Jones

Closes #xxxx