### PR TITLE
Some work on the OS/400 port

### DIFF
--- a/lib/setup-os400.h
+++ b/lib/setup-os400.h
@@ -34,6 +34,9 @@
 /* No OS/400 header file defines u_int32_t. */
 typedef unsigned long   u_int32_t;
 
+/* OS/400 has no idea of a tty! */
+#define isatty(fd)      0
+
 
 /* System API wrapper prototypes & definitions to support ASCII parameters. */
 

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -32,6 +32,7 @@ EXTRA_DIST = README.md \
   OS400/curlmain.c \
   OS400/curl.inc.in \
   OS400/initscript.sh \
+  OS400/config400.default \
   OS400/make-include.sh \
   OS400/make-lib.sh \
   OS400/make-src.sh \

--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -28,6 +28,8 @@ EXTRA_DIST = README.md \
   OS400/rpg-examples \
   OS400/ccsidcurl.c \
   OS400/ccsidcurl.h \
+  OS400/curlcl.c \
+  OS400/curlmain.c \
   OS400/curl.inc.in \
   OS400/initscript.sh \
   OS400/make-include.sh \
@@ -36,7 +38,8 @@ EXTRA_DIST = README.md \
   OS400/make-tests.sh \
   OS400/makefile.sh \
   OS400/os400sys.c \
-  OS400/os400sys.h
+  OS400/os400sys.h \
+  OS400/curl.cmd
 
 CHECKSRC = $(CS_$(V))
 CS_0 = @echo "  RUN     " $@;

--- a/packages/OS400/README.OS400
+++ b/packages/OS400/README.OS400
@@ -374,3 +374,16 @@ _ Since V7R4M0, procedure overloading is used to emulate limited "vararg-like"
 is provided for that purpose: this allows storing a long value in the
 curl_forms array. Please note the form API is deprecated and the MIME API
 should be used instead.
+
+
+CLI tool:
+
+  The build system provides it as a bound program, an IFS link to it and a
+simple CL command. The latter however is not able to provide a different
+parameter for each option since there are too many of those; instead,
+parameters are entered in a single field subject to quoting and escaping, in
+the same form as expected by the standard CLI program.
+  Care must be taken about the program output encoding: by default, it is sent
+to the standard output and is thus subject to transcoding. It is therefore
+recommended to use option "--output" to redirect output to a specific IFS file.
+Similar problems may occur about the standard input encoding.

--- a/packages/OS400/README.OS400
+++ b/packages/OS400/README.OS400
@@ -275,9 +275,11 @@ _ Install the curl source directory in IFS. Do NOT install it in the
 _ Enter Qshell (QSH, not PASE)
 _ Change current directory to the curl installation directory
 _ Change current directory to ./packages/OS400
-_ Edit file iniscript.sh. You may want to change tunable configuration
-  parameters, like debug info generation, optimization level, listing option,
-  target library, ZLIB/LIBSSH2 availability and location, etc.
+- If you want to change the default configuration parameters like debug info
+  generation, optimization level, listing option, target library, ZLIB/LIBSSH2
+  availability and location, etc., copy file config400.default to
+  config400.override and edit the latter. Do not edit the original default file
+  as it might be overwritten by a subsequent source installation.
 _ Copy any file in the current directory to makelog (i.e.:
   cp initscript.sh makelog): this is intended to create the makelog file with
   an ASCII CCSID!
@@ -285,8 +287,8 @@ _ Enter the command "sh makefile.sh > makelog 2>&1"
 _ Examine the makelog file to check for compilation errors. CZM0383 warnings on
   C or system standard API come from QADRT inlining and can safely be ignored.
 
-  Leaving file initscript.sh unchanged, this will produce the following OS/400
-objects:
+  Without configuration parameters override, this will produce the following
+OS/400 objects:
 _ Library CURL. All other objects will be stored in this library.
 _ Modules for all libcurl units.
 _ Binding directory CURL_A, to be used at calling program link time for
@@ -297,6 +299,8 @@ _ Service program CURL.<soname>, where <soname> is extracted from the
   when this program has dynamically bound curl at link time.
 _ Binding directory CURL. To be used to dynamically bind libcurl when linking a
   calling program.
+- CLI tool bound program CURL.
+- CLI command CURL.
 _ Source file H. It contains all the include members needed to compile a C/C++
   module using libcurl, and an ILE/RPG /copy member for support in this
   language.
@@ -305,11 +309,9 @@ _ CCSIDCURL member in file H. This defines the non-standard EBCDIC wrappers for
   C and C++.
 _ CURL.INC member in file H. This defines everything needed by an ILE/RPG
   program using libcurl.
-_ LIBxxx modules and programs. Although the test environment is not supported
-  on OS/400, the libcurl test programs are compiled for manual tests.
 _ IFS directory /curl/include/curl containing the C header files for IFS source
   C/C++ compilation and curl.inc.rpgle for IFS source ILE/RPG compilation.
-
+- IFS link /curl/bin/curl to CLI tool program.
 
 
 Special programming consideration:

--- a/packages/OS400/config400.default
+++ b/packages/OS400/config400.default
@@ -1,0 +1,52 @@
+#!/bin/sh
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+#                       Tunable configuration parameters.
+
+setenv TARGETLIB        'CURL'                  # Target OS/400 program library.
+setenv STATBNDDIR       'CURL_A'                # Static binding directory.
+setenv DYNBNDDIR        'CURL'                  # Dynamic binding directory.
+setenv SRVPGM           "CURL.${SONAME}"        # Service program.
+setenv TGTCCSID         '500'                   # Target CCSID of objects.
+setenv DEBUG            '*ALL'                  # Debug level.
+setenv OPTIMIZE         '10'                    # Optimization level
+setenv OUTPUT           '*NONE'                 # Compilation output option.
+setenv TGTRLS           '*CURRENT'              # Target OS release.
+setenv IFSDIR           '/curl'                 # Installation IFS directory.
+setenv QADRTDIR         '/QIBM/ProdData/qadrt'  # QADRT IFS directory.
+
+#       Define ZLIB availability and locations.
+
+setenv WITH_ZLIB        0                       # Define to 1 to enable.
+setenv ZLIB_INCLUDE     '/zlib/include'         # ZLIB include IFS directory.
+setenv ZLIB_LIB         'ZLIB'                  # ZLIB library.
+setenv ZLIB_BNDDIR      'ZLIB_A'                # ZLIB binding directory.
+
+#       Define LIBSSH2 availability and locations.
+
+setenv WITH_LIBSSH2     0                       # Define to 1 to enable.
+setenv LIBSSH2_INCLUDE  '/libssh2/include'      # LIBSSH2 include IFS directory.
+setenv LIBSSH2_LIB      'LIBSSH2'               # LIBSSH2 library.
+setenv LIBSSH2_BNDDIR   'LIBSSH2_A'             # LIBSSH2 binding directory.

--- a/packages/OS400/config400.default
+++ b/packages/OS400/config400.default
@@ -29,6 +29,9 @@ setenv TARGETLIB        'CURL'                  # Target OS/400 program library.
 setenv STATBNDDIR       'CURL_A'                # Static binding directory.
 setenv DYNBNDDIR        'CURL'                  # Dynamic binding directory.
 setenv SRVPGM           "CURL.${SONAME}"        # Service program.
+setenv CURLPGM          'CURL'                  # CLI tool bound program.
+setenv CURLCMD          'CURL'                  # CL command name.
+setenv CURLCLI          'CURLCL'                # CL interface program.
 setenv TGTCCSID         '500'                   # Target CCSID of objects.
 setenv DEBUG            '*ALL'                  # Debug level.
 setenv OPTIMIZE         '10'                    # Optimization level

--- a/packages/OS400/curl.cmd
+++ b/packages/OS400/curl.cmd
@@ -1,0 +1,32 @@
+/*****************************************************************************/
+/*                                  _   _ ____  _                            */
+/*  Project                     ___| | | |  _ \| |                           */
+/*                             / __| | | | |_) | |                           */
+/*                            | (__| |_| |  _ <| |___                        */
+/*                             \___|\___/|_| \_\_____|                       */
+/*                                                                           */
+/* Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.                   */
+/*                                                                           */
+/* This software is licensed as described in the file COPYING, which         */
+/* you should have received as part of this distribution. The terms          */
+/* are also available at https://curl.se/docs/copyright.html.                */
+/*                                                                           */
+/* You may opt to use, copy, modify, merge, publish, distribute and/or sell  */
+/* copies of the Software, and permit persons to whom the Software is        */
+/* furnished to do so, under the terms of the COPYING file.                  */
+/*                                                                           */
+/* This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY */
+/* KIND, either express or implied.                                          */
+/*                                                                           */
+/* SPDX-License-Identifier: curl                                             */
+/*                                                                           */
+/*                                                                           */
+/*****************************************************************************/
+
+/*      Use program CURLCL as interface to the curl command line tool        */
+
+             CMD        PROMPT('File transfer utility')
+
+             PARM       KWD(CMDARGS) TYPE(*CHAR) LEN(5000) VARY(*YES *INT2)   +
+                          CASE(*MIXED) EXPR(*YES) MIN(1)                      +
+                          PROMPT('Curl command arguments')

--- a/packages/OS400/curlcl.c
+++ b/packages/OS400/curlcl.c
@@ -1,0 +1,176 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ *
+ ***************************************************************************/
+
+/* CL interface program to curl cli tool. */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <milib.h>
+#include <miptrnam.h>
+#include <mih/callpgmv.h>
+
+
+/* Variable-length string, with 16-bit length. */
+typedef struct {
+  short len;
+  char  string[5000];
+}  vary2;
+
+
+/* Arguments from CL command. */
+typedef struct {
+  char *    pgm;            /* Program name. */
+  vary2 *   cmdargs;        /* Command line arguments. */
+}  arguments;
+
+
+static int
+is_ifs(char c)
+{
+  return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+static int
+parse_command_line(const char *cmdargs, size_t len,
+                   size_t *argc, char **argv,
+                   size_t *argsize, char *argbuf)
+{
+  const char *endline = cmdargs + len;
+  char quote = '\0';
+  int inarg = 0;
+
+  *argc = 0;
+  *argsize = 0;
+
+  while(cmdargs < endline) {
+    char c = *cmdargs++;
+
+    if(!inarg) {
+      /* Skip argument separator. */
+      if(is_ifs(c))
+        continue;
+
+      /* Start a new argument. */
+      ++*argc;
+      if(argv)
+        *argv++ = argbuf;
+      inarg = 1;
+    }
+
+    /* Check for quoting end. */
+    if(quote && quote == c) {
+      quote = '\0';
+      continue;
+    }
+
+    /* Check for backslash-escaping. */
+    if(quote != '\'' && c == '\\') {
+      if(cmdargs >= endline) {
+        fputs("Trailing backslash in command\n", stderr);
+        return -1;
+      }
+      c = *cmdargs++;
+    }
+    else if(!quote && is_ifs(c)) {      /* Check for end of argument. */
+      inarg = 0;
+      c = '\0';         /* Will store a string terminator. */
+    }
+
+    /* Store argument character and count it. */
+    if(argbuf)
+      *argbuf++ = c;
+    ++*argsize;
+  }
+
+  if(quote) {
+    fprintf(stderr, "Unterminated quote: %c\n", quote);
+    return -1;
+  }
+
+  /* Terminate last argument. */
+  if(inarg) {
+    if(argbuf)
+      *argbuf = '\0';
+    ++*argsize;
+  }
+
+  /* Terminate argument list. */
+  if(argv)
+    *argv = NULL;
+
+  return 0;
+}
+
+
+int
+main(int argsc, arguments *args)
+{
+  size_t argc;
+  char **argv;
+  size_t argsize;
+  int i;
+  int exitcode;
+  char library[11];
+
+  /* Extract current program library name. */
+  for(i = 0; i < 10; i++) {
+    char c = args->pgm[i];
+
+    if(!c || c == '/')
+      break;
+
+    library[i] = c;
+  }
+  library[i] = '\0';
+
+  /* Measure arguments size. */
+  exitcode = parse_command_line(args->cmdargs->string, args->cmdargs->len,
+                   &argc, NULL, &argsize, NULL);
+
+  if(!exitcode) {
+    /* Allocate space for parsed arguments. */
+    argv = (char **) malloc((argc + 1) * sizeof(*argv) + argsize);
+    if(!argv) {
+      fputs("Memory allocation error\n", stderr);
+      exitcode = -2;
+    }
+    else {
+      _SYSPTR pgmptr = rslvsp(WLI_PGM, (char *) "CURL", library, _AUTH_NONE);
+      _LU_Work_Area_T *luwrka = (_LU_Work_Area_T *) _LUWRKA();
+
+      parse_command_line(args->cmdargs->string, args->cmdargs->len,
+                   &argc, argv, &argsize, (char *) (argv + argc + 1));
+
+      /* Call program. */
+      _CALLPGMV((void *) &pgmptr, argv, argc);
+      exitcode = luwrka->LU_RC;
+
+      free(argv);
+    }
+  }
+
+  return exitcode;
+}

--- a/packages/OS400/curlcl.c
+++ b/packages/OS400/curlcl.c
@@ -32,6 +32,10 @@
 #include <miptrnam.h>
 #include <mih/callpgmv.h>
 
+#ifndef CURLPGM
+#define CURLPGM "CURL"
+#endif
+
 
 /* Variable-length string, with 16-bit length. */
 typedef struct {
@@ -158,7 +162,7 @@ main(int argsc, arguments *args)
       exitcode = -2;
     }
     else {
-      _SYSPTR pgmptr = rslvsp(WLI_PGM, (char *) "CURL", library, _AUTH_NONE);
+      _SYSPTR pgmptr = rslvsp(WLI_PGM, (char *) CURLPGM, library, _AUTH_NONE);
       _LU_Work_Area_T *luwrka = (_LU_Work_Area_T *) _LUWRKA();
 
       parse_command_line(args->cmdargs->string, args->cmdargs->len,

--- a/packages/OS400/curlmain.c
+++ b/packages/OS400/curlmain.c
@@ -1,0 +1,123 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ *
+ ***************************************************************************/
+
+/*
+ * QADRT/QADRTMAIN2 substitution program.
+ * This is needed because the IBM-provided QADRTMAIN2 does not
+ * properly translate arguments by default or if no locale is provided.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <iconv.h>
+#include <errno.h>
+#include <locale.h>
+
+/* Do not use qadrt.h since it defines unneeded static procedures. */
+extern void     QadrtInit(void);
+extern int      QadrtFreeConversionTable(void);
+extern int      QadrtFreeEnviron(void);
+extern char *   setlocale_a(int, const char *);
+
+
+/* The ASCII main program. */
+extern int      main_a(int argc, char * * argv);
+
+/* Global values of original EBCDIC arguments. */
+int             ebcdic_argc;
+char **         ebcdic_argv;
+
+
+int
+main(int argc, char **argv)
+
+{
+  int i;
+  int j;
+  iconv_t cd;
+  size_t bytecount = 0;
+  char * inbuf;
+  char * outbuf;
+  size_t inbytesleft;
+  size_t outbytesleft;
+  char dummybuf[128];
+  char tocode[32];
+  char fromcode[32];
+
+  ebcdic_argc = argc;
+  ebcdic_argv = argv;
+
+  /* Build the encoding converter. */
+  strncpy(tocode, "IBMCCSID01208", sizeof tocode);      /* Use UTF-8. */
+  strncpy(fromcode, "IBMCCSID000000000010", sizeof fromcode);
+  cd = iconv_open(tocode, fromcode);
+
+  /* Measure the arguments. */
+  for(i = 0; i < argc; i++) {
+    inbuf = argv[i];
+    do {
+      inbytesleft = 0;
+      outbuf = dummybuf;
+      outbytesleft = sizeof dummybuf;
+      j = iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+      bytecount += outbuf - dummybuf;
+    } while(j == -1 && errno == E2BIG);
+
+    /* Reset the shift state. */
+    iconv(cd, NULL, &inbytesleft, &outbuf, &outbytesleft);
+   }
+
+  /* Allocate memory for the ASCII arguments and vector. */
+  argv = (char **) malloc((argc + 1) * sizeof *argv + bytecount);
+
+  /* Build the vector and convert argument encoding. */
+  outbuf = (char *) (argv + argc + 1);
+  outbytesleft = bytecount;
+
+  for(i = 0; i < argc; i++) {
+    argv[i] = outbuf;
+    inbuf = ebcdic_argv[i];
+    inbytesleft = 0;
+    iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+    iconv(cd, NULL, &inbytesleft, &outbuf, &outbytesleft);
+  }
+
+  iconv_close(cd);
+  argv[argc] = NULL;
+
+  /* Try setting the locale regardless of QADRT_ENV_LOCALE. */
+  setlocale_a(LC_ALL, "");
+
+  /* Call the program. */
+  i = main_a(argc, argv);
+
+  /* Clean-up allocated items. */
+  free((char *) argv);
+  QadrtFreeConversionTable();
+  QadrtFreeEnviron();
+
+  /* Terminate. */
+  return i;
+}

--- a/packages/OS400/initscript.sh
+++ b/packages/OS400/initscript.sh
@@ -185,8 +185,9 @@ make_module()
         echo "#line 1" >> __tmpsrcf.c
         cat "${2}" >> __tmpsrcf.c
         CMD="CRTCMOD MODULE(${TARGETLIB}/${1}) SRCSTMF('__tmpsrcf.c')"
-#       CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST *SHOWINC *SHOWSYS)"
-        CMD="${CMD} SYSIFCOPT(*IFS64IO) OPTION(*INCDIRFIRST)"
+        CMD="${CMD} SYSIFCOPT(*IFS64IO *ASYNCSIGNAL)"
+#       CMD="${CMD} OPTION(*INCDIRFIRST *SHOWINC *SHOWSYS)"
+        CMD="${CMD} OPTION(*INCDIRFIRST)"
         CMD="${CMD} LOCALETYPE(*LOCALE) FLAG(10)"
         CMD="${CMD} INCDIR('${QADRTDIR}/include'"
         CMD="${CMD} '${TOPDIR}/include/curl' '${TOPDIR}/include' '${SRCDIR}'"
@@ -265,6 +266,7 @@ versioned_copy()
 #       The `sed' statement works as follows:
 #       - Join \nl-separated lines.
 #       - Retain only lines that begins with "identifier =".
+#       - Replace @...@ sustitutions by shell variable references.
 #       - Turn these lines into shell variable assignments.
 
 get_make_vars()
@@ -277,6 +279,7 @@ get_make_vars()
                 -e 'b begin'                                            \
                 -e '}'                                                  \
                 -e '/^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/!d'           \
+                -e 's/@\\([A-Za-z0-9_]*\\)@/${\\1}/g'                   \
                 -e 's/[[:space:]]*=[[:space:]]*/=/'                     \
                 -e 's/=\\(.*[^[:space:]]\\)[[:space:]]*$/=\\"\\1\\"/'   \
                 -e 's/\\\$(\\([^)]*\\))/\${\\1}/g'                      \

--- a/packages/OS400/initscript.sh
+++ b/packages/OS400/initscript.sh
@@ -62,41 +62,12 @@ SONAME=`sed -e '/^VERSIONCHANGE=/!d;s/^.*=\([0-9]*\).*/\1/'             \
                                         < "${TOPDIR}/lib/Makefile.soname"`
 export SONAME
 
+#	Get OS/400 configuration parameters.
 
-################################################################################
-#
-#                       Tunable configuration parameters.
-#
-################################################################################
-
-setenv TARGETLIB        'CURL'                  # Target OS/400 program library.
-setenv STATBNDDIR       'CURL_A'                # Static binding directory.
-setenv DYNBNDDIR        'CURL'                  # Dynamic binding directory.
-setenv SRVPGM           "CURL.${SONAME}"        # Service program.
-setenv TGTCCSID         '500'                   # Target CCSID of objects.
-setenv DEBUG            '*ALL'                  # Debug level.
-setenv OPTIMIZE         '10'                    # Optimization level
-setenv OUTPUT           '*NONE'                 # Compilation output option.
-setenv TGTRLS           '*CURRENT'              # Target OS release.
-setenv IFSDIR           '/curl'                 # Installation IFS directory.
-setenv QADRTDIR         '/QIBM/ProdData/qadrt'  # QADRT IFS directory.
-
-#       Define ZLIB availability and locations.
-
-setenv WITH_ZLIB        0                       # Define to 1 to enable.
-setenv ZLIB_INCLUDE     '/zlib/include'         # ZLIB include IFS directory.
-setenv ZLIB_LIB         'ZLIB'                  # ZLIB library.
-setenv ZLIB_BNDDIR      'ZLIB_A'                # ZLIB binding directory.
-
-#       Define LIBSSH2 availability and locations.
-
-setenv WITH_LIBSSH2     0                       # Define to 1 to enable.
-setenv LIBSSH2_INCLUDE  '/libssh2/include'      # LIBSSH2 include IFS directory.
-setenv LIBSSH2_LIB      'LIBSSH2'               # LIBSSH2 library.
-setenv LIBSSH2_BNDDIR   'LIBSSH2_A'             # LIBSSH2 binding directory.
-
-
-################################################################################
+. "${SCRIPTDIR}/config400.default"
+if [ -f "${SCRIPTDIR}/config400.override" ]
+then	. "${SCRIPTDIR}/config400.override"
+fi
 
 #       Need to get the version definitions.
 

--- a/packages/OS400/initscript.sh
+++ b/packages/OS400/initscript.sh
@@ -62,11 +62,11 @@ SONAME=`sed -e '/^VERSIONCHANGE=/!d;s/^.*=\([0-9]*\).*/\1/'             \
                                         < "${TOPDIR}/lib/Makefile.soname"`
 export SONAME
 
-#	Get OS/400 configuration parameters.
+#       Get OS/400 configuration parameters.
 
 . "${SCRIPTDIR}/config400.default"
 if [ -f "${SCRIPTDIR}/config400.override" ]
-then	. "${SCRIPTDIR}/config400.override"
+then    . "${SCRIPTDIR}/config400.override"
 fi
 
 #       Need to get the version definitions.

--- a/packages/OS400/initscript.sh
+++ b/packages/OS400/initscript.sh
@@ -80,7 +80,6 @@ setenv OUTPUT           '*NONE'                 # Compilation output option.
 setenv TGTRLS           '*CURRENT'              # Target OS release.
 setenv IFSDIR           '/curl'                 # Installation IFS directory.
 setenv QADRTDIR         '/QIBM/ProdData/qadrt'  # QADRT IFS directory.
-setenv QADRTLIB         'QADRT'                 # QADRT object library.
 
 #       Define ZLIB availability and locations.
 
@@ -236,7 +235,7 @@ make_module()
         CMD="${CMD} OPTIMIZE(${OPTIMIZE})"
         CMD="${CMD} DBGVIEW(${DEBUG})"
 
-        DEFINES="${3} BUILDING_LIBCURL 'qadrt_use_inline'"
+        DEFINES="${3} 'qadrt_use_inline'"
 
         if [ "${WITH_ZLIB}" != "0" ]
         then    DEFINES="${DEFINES} HAVE_LIBZ"
@@ -270,6 +269,7 @@ db2_name()
                 tr 'a-z-' 'A-Z_'                                        |
                 sed -e 's/\..*//'                                       \
                     -e 's/^CURL_*/C/'                                   \
+                    -e 's/^TOOL_*/T/'                                   \
                     -e 's/^\(.\).*\(.........\)$/\1\2/'
         fi
 }
@@ -287,4 +287,27 @@ versioned_copy()
             -e "s/@LIBCURL_VERSION_NUM@/${LIBCURL_VERSION_NUM}/g"       \
             -e "s/@LIBCURL_TIMESTAMP@/${LIBCURL_TIMESTAMP}/g"           \
                 < "${1}" > "${2}"
+}
+
+
+#       Get definitions from a make file.
+#       The `sed' statement works as follows:
+#       - Join \nl-separated lines.
+#       - Retain only lines that begins with "identifier =".
+#       - Turn these lines into shell variable assignments.
+
+get_make_vars()
+
+{
+        eval "`sed -e ': begin'                                         \
+                -e '/\\\\$/{'                                           \
+                -e 'N'                                                  \
+                -e 's/\\\\\\n/ /'                                       \
+                -e 'b begin'                                            \
+                -e '}'                                                  \
+                -e '/^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/!d'           \
+                -e 's/[[:space:]]*=[[:space:]]*/=/'                     \
+                -e 's/=\\(.*[^[:space:]]\\)[[:space:]]*$/=\\"\\1\\"/'   \
+                -e 's/\\\$(\\([^)]*\\))/\${\\1}/g'                      \
+                < \"${1}\"`"
 }

--- a/packages/OS400/make-lib.sh
+++ b/packages/OS400/make-lib.sh
@@ -100,13 +100,13 @@ fi
 #       Gather the list of symbols to export.
 #       First use awk to pull all CURL_EXTERN function prototypes from
 #       the header files, pass through to sed to strip CURL_DEPRECATED(..)
-#       then back to awk to pull the string immediately to the left of a
-#       bracket stripping any spaces or *'s.
+#       and CURL_TEMP_PRINTF(..) then back to awk to pull the string
+#       immediately to the left of a bracket stripping any spaces or *'s.
 
 EXPORTS=`awk '/^CURL_EXTERN/,/;/'                                       \
               "${TOPDIR}"/include/curl/*.h                              \
               "${SCRIPTDIR}/ccsidcurl.h"                                |
-         sed 's| CURL_DEPRECATED(.*)||g'                                |
+         sed 's/ CURL_DEPRECATED(.*)//g;s/ CURL_TEMP_PRINTF(.*)//g'     |
          awk '{br=index($0,"(");                                        \
               if (br) {                                                 \
                 for(c=br-1; ;c--) {                                     \

--- a/packages/OS400/make-lib.sh
+++ b/packages/OS400/make-lib.sh
@@ -44,37 +44,26 @@ echo '#pragma comment(user, "libcurl version '"${LIBCURL_VERSION}"'")' > os400.c
 echo '#pragma comment(user, __DATE__)' >> os400.c
 echo '#pragma comment(user, __TIME__)' >> os400.c
 echo '#pragma comment(copyright, "Copyright (C) Daniel Stenberg et al. OS/400 version by P. Monnerat")' >> os400.c
-make_module     OS400           os400.c
+make_module     OS400           os400.c         BUILDING_LIBCURL
 LINK=                           # No need to rebuild service program yet.
 MODULES=
 
 
-#       Get source list.
+#       Get source list (CSOURCES variable).
 
-sed -e ':begin'                                                         \
-    -e '/\\$/{'                                                         \
-    -e 's/\\$/ /'                                                       \
-    -e 'N'                                                              \
-    -e 'bbegin'                                                         \
-    -e '}'                                                              \
-    -e 's/\n//g'                                                        \
-    -e 's/[[:space:]]*$//'                                              \
-    -e 's/^\([A-Za-z][A-Za-z0-9_]*\)[[:space:]]*=[[:space:]]*\(.*\)/\1="\2"/' \
-    -e 's/\$(\([A-Za-z][A-Za-z0-9_]*\))/${\1}/g'                        \
-        < Makefile.inc > tmpscript.sh
-. ./tmpscript.sh
+get_make_vars Makefile.inc
 
 
 #       Compile the sources into modules.
 
 INCLUDES="'`pwd`'"
 
-make_module     OS400SYS        "${SCRIPTDIR}/os400sys.c"
-make_module     CCSIDCURL       "${SCRIPTDIR}/ccsidcurl.c"
+make_module     OS400SYS        "${SCRIPTDIR}/os400sys.c"       BUILDING_LIBCURL
+make_module     CCSIDCURL       "${SCRIPTDIR}/ccsidcurl.c"      BUILDING_LIBCURL
 
 for SRC in ${CSOURCES}
 do      MODULE=`db2_name "${SRC}"`
-        make_module "${MODULE}" "${SRC}"
+        make_module "${MODULE}" "${SRC}" BUILDING_LIBCURL
 done
 
 

--- a/packages/OS400/make-src.sh
+++ b/packages/OS400/make-src.sh
@@ -23,5 +23,76 @@
 #
 ###########################################################################
 #
-#
-#       Not implemented yet on OS/400.
+#       Command line interface tool compilation script for the OS/400.
+
+SCRIPTDIR=`dirname "${0}"`
+. "${SCRIPTDIR}/initscript.sh"
+cd "${TOPDIR}/src"
+
+
+#       Get source lists.
+#       CURL_CFILES are in the current directory.
+#       CURLX_CFILES are in the lib directory and need to be recompiled because
+#               some function names change using macros.
+
+get_make_vars Makefile.inc
+
+
+#       Compile the sources into modules.
+
+LINK=
+MODULES=
+INCLUDES="'${TOPDIR}/lib'"
+
+for SRC in ${CURLX_CFILES}
+do      MODULE=`db2_name "${SRC}"`
+        MODULE=`db2_name "X${MODULE}"`
+        make_module "${MODULE}" "${SRC}"
+done
+
+for SRC in ${CURL_CFILES}
+do      MODULE=`db2_name "${SRC}"`
+        make_module "${MODULE}" "${SRC}"
+done
+
+
+#       Link modules into program.
+
+MODULES="`echo \"${MODULES}\" | sed \"s/[^ ][^ ]*/${TARGETLIB}\/&/g\"`"
+CMD="CRTPGM PGM(${TARGETLIB}/CURL)"
+CMD="${CMD} ENTMOD(${TARGETLIB}/CURLMAIN)"
+CMD="${CMD} MODULE(${MODULES})"
+CMD="${CMD} BNDSRVPGM(${TARGETLIB}/${SRVPGM} QADRTTS)"
+CMD="${CMD} TGTRLS(${TGTRLS})"
+CLcommand "${CMD}"
+
+
+#       Create the IFS command.
+
+IFSBIN="${IFSDIR}/bin"
+
+if action_needed "${IFSBIN}"
+then    mkdir -p "${IFSBIN}"
+fi
+
+rm -f "${IFSBIN}/curl"
+ln -s "/QSYS.LIB/${TARGETLIB}.LIB/CURL.PGM" "${IFSBIN}/curl"
+
+
+#       Create the CL interface program.
+
+if action_needed "${LIBIFSNAME}/CURLCL.PGM" "${SCRIPTDIR}/curlcl.c"
+then    CMD="CRTBNDC PGM(${TARGETLIB}/CURLCL)"
+        CMD="${CMD} SRCSTMF('${SCRIPTDIR}/curlcl.c')"
+        CMD="${CMD} TGTCCSID(${TGTCCSID})"
+        CLcommand "${CMD}"
+fi
+
+
+#       Create the CL command.
+
+if action_needed "${LIBIFSNAME}/CURL.CMD" "${SCRIPTDIR}/curl.cmd"
+then    CMD="CRTCMD CMD(${TARGETLIB}/CURL) PGM(${TARGETLIB}/CURLCL)"
+        CMD="${CMD} SRCSTMF('${SCRIPTDIR}/curl.cmd')"
+        CLcommand "${CMD}"
+fi

--- a/packages/OS400/make-src.sh
+++ b/packages/OS400/make-src.sh
@@ -59,7 +59,7 @@ done
 #       Link modules into program.
 
 MODULES="`echo \"${MODULES}\" | sed \"s/[^ ][^ ]*/${TARGETLIB}\/&/g\"`"
-CMD="CRTPGM PGM(${TARGETLIB}/CURL)"
+CMD="CRTPGM PGM(${TARGETLIB}/${CURLPGM})"
 CMD="${CMD} ENTMOD(${TARGETLIB}/CURLMAIN)"
 CMD="${CMD} MODULE(${MODULES})"
 CMD="${CMD} BNDSRVPGM(${TARGETLIB}/${SRVPGM} QADRTTS)"
@@ -76,14 +76,15 @@ then    mkdir -p "${IFSBIN}"
 fi
 
 rm -f "${IFSBIN}/curl"
-ln -s "/QSYS.LIB/${TARGETLIB}.LIB/CURL.PGM" "${IFSBIN}/curl"
+ln -s "/QSYS.LIB/${TARGETLIB}.LIB/${CURLPGM}.PGM" "${IFSBIN}/curl"
 
 
 #       Create the CL interface program.
 
 if action_needed "${LIBIFSNAME}/CURLCL.PGM" "${SCRIPTDIR}/curlcl.c"
-then    CMD="CRTBNDC PGM(${TARGETLIB}/CURLCL)"
+then    CMD="CRTBNDC PGM(${TARGETLIB}/${CURLCLI})"
         CMD="${CMD} SRCSTMF('${SCRIPTDIR}/curlcl.c')"
+        CMD="${CMD} DEFINE('CURLPGM=\"${CURLPGM}\"')"
         CMD="${CMD} TGTCCSID(${TGTCCSID})"
         CLcommand "${CMD}"
 fi
@@ -91,8 +92,8 @@ fi
 
 #       Create the CL command.
 
-if action_needed "${LIBIFSNAME}/CURL.CMD" "${SCRIPTDIR}/curl.cmd"
-then    CMD="CRTCMD CMD(${TARGETLIB}/CURL) PGM(${TARGETLIB}/CURLCL)"
+if action_needed "${LIBIFSNAME}/${CURLCMD}.CMD" "${SCRIPTDIR}/curl.cmd"
+then    CMD="CRTCMD CMD(${TARGETLIB}/${CURLCMD}) PGM(${TARGETLIB}/${CURLCLI})"
         CMD="${CMD} SRCSTMF('${SCRIPTDIR}/curl.cmd')"
         CLcommand "${CMD}"
 fi

--- a/packages/OS400/make-tests.sh
+++ b/packages/OS400/make-tests.sh
@@ -32,90 +32,114 @@ SCRIPTDIR=`dirname "${0}"`
 cd "${TOPDIR}/tests"
 
 
-#       tests directory not implemented yet.
+#       Build programs in a directory.
 
+build_all_programs()
 
-#       Process the libtest subdirectory.
+{
+        #       Compile all programs.
+        #       The list is found in variable "noinst_PROGRAMS"
 
-cd libtest
+        INCLUDES="'`pwd`' '${TOPDIR}/lib' '${TOPDIR}/src'"
+        MODS="${1}"
+        SRVPGMS="${2}"
 
-#       Get definitions from the Makefile.inc file.
+        for PGM in ${noinst_PROGRAMS}
+        do      DB2PGM=`db2_name "${PGM}"`
+                PGMIFSNAME="${LIBIFSNAME}/${DB2PGM}.PGM"
 
-get_make_vars Makefile.inc
+                #       Extract preprocessor symbol definitions from
+                #               compilation options for the program.
 
-#       Special case: redefine chkhostname compilation parameters.
+                PGMCFLAGS="`eval echo \"\\${${PGM}_CFLAGS}\"`"
+                PGMDFNS=
 
-chkhostname_SOURCES=chkhostname.c
-chkhostname_LDADD=curl_gethostname.o
-
-#       Compile all programs.
-#       The list is found in variable "noinst_PROGRAMS"
-
-INCLUDES="'${TOPDIR}/tests/libtest' '${TOPDIR}/lib'"
-
-for PGM in ${noinst_PROGRAMS}
-do      DB2PGM=`db2_name "${PGM}"`
-        PGMIFSNAME="${LIBIFSNAME}/${DB2PGM}.PGM"
-
-        #       Extract preprocessor symbol definitions from compilation
-        #               options for the program.
-
-        PGMCFLAGS="`eval echo \"\\${${PGM}_CFLAGS}\"`"
-        PGMDEFINES=
-
-        for FLAG in ${PGMCFLAGS}
-        do      case "${FLAG}" in
-                -D?*)   DEFINE="`echo \"${FLAG}\" | sed 's/^..//'`"
-                        PGMDEFINES="${PGMDEFINES} '${DEFINE}'"
-                        ;;
-                esac
-        done
-
-        #        Compile all C sources for the program into modules.
-
-        PGMSOURCES="`eval echo \"\\${${PGM}_SOURCES}\"`"
-        LINK=
-        MODULES=
-
-        for SOURCE in ${PGMSOURCES}
-        do      case "${SOURCE}" in
-                *.c)    #       Special processing for libxxx.c files: their
-                        #               module name is determined by the target
-                        #               PROGRAM name.
-
-                        case "${SOURCE}" in
-                        lib*.c) MODULE="${DB2PGM}"
-                                ;;
-                        *)      MODULE=`db2_name "${SOURCE}"`
-                                ;;
-                        esac
-
-                        make_module "${MODULE}" "${SOURCE}" "${PGMDEFINES}"
-                        if action_needed "${PGMIFSNAME}" "${MODIFSNAME}"
-                        then    LINK=yes
-                        fi
-                        ;;
-                esac
-        done
-
-        #       Link program if needed.
-
-        if [ "${LINK}" ]
-        then    PGMLDADD="`eval echo \"\\${${PGM}_LDADD}\"`"
-                for LDARG in ${PGMLDADD}
-                do      case "${LDARG}" in
-                        -*)     ;;              # Ignore non-module.
-                        *)      MODULES="${MODULES} "`db2_name "${LDARG}"`
+                for FLAG in ${PGMCFLAGS}
+                do      case "${FLAG}" in
+                        -D?*)   DEFINE="`echo \"${FLAG}\" | sed 's/^..//'`"
+                                PGMDFNS="${PGMDFNS} '${DEFINE}'"
                                 ;;
                         esac
                 done
-                MODULES="`echo \"${MODULES}\" |
-                    sed \"s/[^ ][^ ]*/${TARGETLIB}\/&/g\"`"
-                CMD="CRTPGM PGM(${TARGETLIB}/${DB2PGM})"
-                CMD="${CMD} ENTMOD(${TARGETLIB}/CURLMAIN)"
-                CMD="${CMD} MODULE(${MODULES})"
-                CMD="${CMD} BNDSRVPGM(${TARGETLIB}/${SRVPGM} QADRTTS)"
-                CMD="${CMD} TGTRLS(${TGTRLS})"
-                CLcommand "${CMD}"
-        fi
-done
+
+                #        Compile all C sources for the program into modules.
+
+                PGMSOURCES="`eval echo \"\\${${PGM}_SOURCES}\"`"
+                LINK=
+                MODULES=
+
+                for SOURCE in ${PGMSOURCES}
+                do      case "${SOURCE}" in
+                        *.c)    #       Special processing for libxxx.c files:
+                                #               their module name is determined
+                                #               by the target PROGRAM name.
+
+                                case "${SOURCE}" in
+                                lib*.c) MODULE="${DB2PGM}"
+                                        ;;
+                                *)      MODULE=`db2_name "${SOURCE}"`
+                                        ;;
+                                esac
+
+                                #       If source is in a sibling directory,
+                                #               prefix module name with 'X'.
+
+                                case "${SOURCE}" in
+                                ../*)   MODULE=`db2_name "X${MODULE}"`
+                                            ;;
+                                esac
+
+                                make_module "${MODULE}" "${SOURCE}" "${PGMDFNS}"
+                                if action_needed "${PGMIFSNAME}" "${MODIFSNAME}"
+                                then    LINK=yes
+                                fi
+                                ;;
+                        esac
+                done
+
+                #       Link program if needed.
+
+                if [ "${LINK}" ]
+                then    PGMLDADD="`eval echo \"\\${${PGM}_LDADD}\"`"
+                        for ARG in ${PGMLDADD}
+                        do      case "${ARG}" in
+                                -*)     ;;              # Ignore non-module.
+                                *)      MODULES="${MODULES} "`db2_name "${ARG}"`
+                                        ;;
+                                esac
+                        done
+                        MODULES="`echo \"${MODULES}\" |
+                            sed \"s/[^ ][^ ]*/${TARGETLIB}\/&/g\"`"
+                        CMD="CRTPGM PGM(${TARGETLIB}/${DB2PGM})"
+                        CMD="${CMD} ENTMOD(${TARGETLIB}/CURLMAIN)"
+                        CMD="${CMD} MODULE(${MODULES} ${MODS})"
+                        CMD="${CMD} BNDSRVPGM(${SRVPGMS} QADRTTS)"
+                        CMD="${CMD} TGTRLS(${TGTRLS})"
+                        CLcommand "${CMD}"
+                fi
+        done
+}
+
+
+#       Build programs in the server directory.
+
+(
+        cd server
+        get_make_vars Makefile.inc
+        build_all_programs "${TARGETLIB}/OS400SYS"
+)
+
+
+#       Build all programs in the libtest subdirectory.
+
+(
+        cd libtest
+        get_make_vars Makefile.inc
+
+        #       Special case: redefine chkhostname compilation parameters.
+
+        chkhostname_SOURCES=chkhostname.c
+        chkhostname_LDADD=curl_gethostname.o
+
+        build_all_programs "" "${TARGETLIB}/${SRVPGM}"
+)

--- a/packages/OS400/make-tests.sh
+++ b/packages/OS400/make-tests.sh
@@ -40,24 +40,8 @@ cd "${TOPDIR}/tests"
 cd libtest
 
 #       Get definitions from the Makefile.inc file.
-#       The `sed' statement works as follows:
-#       _ Join \nl-separated lines.
-#       _ Retain only lines that begins with "identifier =".
-#       _ Turn these lines into shell variable assignments.
 
-eval "`sed -e ': begin'                                                 \
-        -e '/\\\\$/{'                                                   \
-        -e 'N'                                                          \
-        -e 's/\\\\\\n/ /'                                               \
-        -e 'b begin'                                                    \
-        -e '}'                                                          \
-        -e '/^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[=]/b keep'             \
-        -e 'd'                                                          \
-        -e ': keep'                                                     \
-        -e 's/[[:space:]]*=[[:space:]]*/=/'                             \
-        -e 's/=\\(.*[^[:space:]]\\)[[:space:]]*$/=\\"\\1\\"/'           \
-        -e 's/\\$(\\([^)]*\\))/${\\1}/g'                                \
-        < Makefile.inc`"
+get_make_vars Makefile.inc
 
 #       Special case: redefine chkhostname compilation parameters.
 
@@ -128,7 +112,7 @@ do      DB2PGM=`db2_name "${PGM}"`
                 MODULES="`echo \"${MODULES}\" |
                     sed \"s/[^ ][^ ]*/${TARGETLIB}\/&/g\"`"
                 CMD="CRTPGM PGM(${TARGETLIB}/${DB2PGM})"
-                CMD="${CMD} ENTMOD(${QADRTLIB}/QADRTMAIN2)"
+                CMD="${CMD} ENTMOD(${TARGETLIB}/CURLMAIN)"
                 CMD="${CMD} MODULE(${MODULES})"
                 CMD="${CMD} BNDSRVPGM(${TARGETLIB}/${SRVPGM} QADRTTS)"
                 CMD="${CMD} TGTRLS(${TGTRLS})"

--- a/packages/OS400/makefile.sh
+++ b/packages/OS400/makefile.sh
@@ -101,6 +101,20 @@ do      MEMBER="`basename \"${EXAMPLE}\"`"
 done
 
 
+#       Compile the QADRTMAIN2 replacement module.
+
+if action_needed "${LIBIFSNAME}/CURLMAIN.MODULE" "${SCRIPTDIR}/curlmain.c"
+then    CMD="CRTCMOD MODULE(${TARGETLIB}/CURLMAIN)"
+        CMD="${CMD} SRCSTMF('${SCRIPTDIR}/curlmain.c')"
+        CMD="${CMD} SYSIFCOPT(*IFS64IO) LOCALETYPE(*LOCALE) FLAG(10)"
+        CMD="${CMD} TGTCCSID(${TGTCCSID}) TGTRLS(${TGTRLS})"
+        CMD="${CMD} OUTPUT(${OUTPUT})"
+        CMD="${CMD} OPTIMIZE(${OPTIMIZE})"
+        CMD="${CMD} DBGVIEW(${DEBUG})"
+        CLcommand "${CMD}"
+fi
+
+
 #       Build in each directory.
 
 # for SUBDIR in include lib src tests

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -40,7 +40,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
   (void) clientp;
   (void) purpose;
   setsockopt(curlfd, SOL_SOCKET, SO_SNDBUF,
-             (const char *)&sndbufsize, sizeof(sndbufsize));
+             (char *)&sndbufsize, sizeof(sndbufsize));
 #else
   (void)clientp;
   (void)curlfd;

--- a/tests/server/disabled.c
+++ b/tests/server/disabled.c
@@ -91,9 +91,13 @@ static const char *disabled[]={
   NULL
 };
 
-int main(void)
+int main(int argc, char **argv)
 {
   int i;
+
+  (void) argc;
+  (void) argv;
+
   for(i = 0; disabled[i]; i++)
     printf("%s\n", disabled[i]);
 


### PR DESCRIPTION
The most important commit of this bunch implements the curl cli tool in the ILE environment.
This is an important step towards supporting the tests on OS/400.

There is also a libtests compilation error fix.

The OS/400 build parameters are now customized in a separate file.

Rest is minor fixes and specific doc update.

Compiles and runs (tested manually!).