### PR TITLE
cmake: don't add previous libraries to library detection

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -26,10 +26,9 @@
 # This macro checks if the symbol exists in the library and if it
 # does, it prepends library to the list.  It is intended to be called
 # multiple times with a sequence of possibly dependent libraries in
-# order of least-to-most-dependent.  Some libraries depend on others
-# to link correctly.
+# order of least-to-most-dependent.
 macro(check_library_exists_concat LIBRARY SYMBOL VARIABLE)
-  check_library_exists("${LIBRARY};${CURL_LIBS}" ${SYMBOL} "${CMAKE_LIBRARY_PATH}"
+  check_library_exists("${LIBRARY}" ${SYMBOL} "${CMAKE_LIBRARY_PATH}"
     ${VARIABLE})
   if(${VARIABLE})
     set(CURL_LIBS ${LIBRARY} ${CURL_LIBS})


### PR DESCRIPTION
Don't rely on previously found libraries for system library detection. In some cases the library list may contain a CMake target in which case `check_library_exists` may fail if the target is an ALIAS.

See https://github.com/curl/curl/issues/11285#issuecomment-1629432834 for more details.