### PR TITLE
Fix typos

### DIFF
--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -129,7 +129,7 @@ function to a variable expansion, add them colon separated to the right side
 of the variable. Variable content holding null bytes that are not encoded when
 expanded, will cause error.
 
-Exmaple: get the contents of a file called $HOME/.secret into a variable
+Example: get the contents of a file called $HOME/.secret into a variable
 called "fix". Make sure that the content is trimmed and percent-encoded sent
 as POST data:
 

--- a/docs/examples/connect-to.c
+++ b/docs/examples/connect-to.c
@@ -55,7 +55,7 @@ int main(void)
        returns CURLE_PEER_FAILED_VERIFICATION */
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
-    /* Letting the wrong host name in the certficate be okay, the transfer
+    /* Letting the wrong host name in the certificate be okay, the transfer
        goes through but will (most likely) cause a 404 or similar because it
        sends an unknown name in the Host: header field */
     res = curl_easy_perform(curl);

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -532,7 +532,7 @@ sub scanfile {
             }
             elsif(($first eq "*") && ($word !~ /(for|if|while|switch)/)) {
                 # A "(*" beginning makes the space OK because it wants to
-                # allow funcion pointer declared
+                # allow function pointer declared
             }
             elsif($1 =~ / *typedef/) {
                 # typedefs can use space-paren

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1363,7 +1363,7 @@ sub ipcrecv {
     # Decode the function name and arguments
     my $argsarrayref = thaw $buf;
 
-    # The name of the function to call is the frist argument
+    # The name of the function to call is the first argument
     my $funcname = shift @$argsarrayref;
 
     # print "ipcrecv $funcname\n";

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -66,7 +66,7 @@ Provide a path to a custom curl binary to run the tests with. Default is the
 curl executable in the build tree.
 .IP "-d"
 Enable protocol debug: have the servers display protocol output.  If used in
-conjuction with parallel testing, it will be difficult to associate the logs
+conjunction with parallel testing, it will be difficult to associate the logs
 with the test being run.
 .IP "-E <exclude_file>"
 Load the \fBexclude_file\fP with additional reasons why certain tests
@@ -170,7 +170,7 @@ combination with \fI-g\fP.
 .IP "-u"
 Error instead of warning on server unexpectedly alive.
 .IP "-v"
-Enable verbose output. Speaks more than by default. If used in conjuction with
+Enable verbose output. Speaks more than by default. If used in conjunction with
 parallel testing, it will be difficult to associate the logs with the test
 being run.
 .IP "-vc <curl>"

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -1845,7 +1845,7 @@ sub runsshserver {
         stopserver($server, "$sshpid $pid2");
         $doesntrun{$pidfile} = 1;
         $sshpid = $pid2 = 0;
-        logmsg "RUN: failed to verifty the $srvrname server on $port\n";
+        logmsg "RUN: failed to verify the $srvrname server on $port\n";
         return (5, 0, 0, 0);
     }
     # we're happy, no need to loop anymore!


### PR DESCRIPTION
Fixing several smaller typos in the codebase, mostly documentation or comments.

Hope this is okay

I have read and ack https://github.com/curl/curl/blob/15c40a32b7a153138941584e5717772e4da7a17c/.github/CONTRIBUTING.md