### PR TITLE
Bump AWS-LC version to support OCSP

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -42,7 +42,7 @@ permissions: {}
 
 env:
   MAKEFLAGS: -j 3
-  awslc-version: 1.3.0
+  awslc-version: 1.13.0
 
 jobs:
   autoconf:

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -266,7 +266,7 @@
 #define HAVE_OPENSSL_VERSION
 #endif
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 typedef uint32_t sslerr_t;
 #else
 typedef unsigned long sslerr_t;
@@ -2320,7 +2320,11 @@ static CURLcode verifystatus(struct Curl_cfilter *cf,
 {
   struct ssl_connect_data *connssl = cf->ctx;
   int i, ocsp_status;
+#if defined(OPENSSL_IS_AWSLC)
+  const uint8_t *status;
+#else
   unsigned char *status;
+#endif
   const unsigned char *p;
   CURLcode result = CURLE_OK;
   OCSP_RESPONSE *rsp = NULL;
@@ -2418,7 +2422,7 @@ static CURLcode verifystatus(struct Curl_cfilter *cf,
     goto end;
   }
 
-  for(i = 0; i < sk_X509_num(ch); i++) {
+  for(i = 0; i < (int)sk_X509_num(ch); i++) {
     X509 *issuer = sk_X509_value(ch, i);
     if(X509_check_issued(issuer, cert) == X509_V_OK) {
       id = OCSP_cert_to_id(EVP_sha1(), cert, issuer);


### PR DESCRIPTION
AWS-LC has recently added missing symbols to support OCSP and removed the default `OPENSSL_NO_OCSP` flag from our headers. This unveiled some previously unseen errors/warnings behind the OCSP features. 

### Changes
* Bump AWS-LC version in GitHub Actions script 
* Minor tweaks to some variables

### Testing
CI