### PR TITLE
docs: link to the website versions instead of markdowns

### DIFF
--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -11,8 +11,9 @@ HackerOne program](https://hackerone.com/curl).
 
 After you have reported a security issue, it has been deemed credible, and a
 patch and advisory has been made public, you may be eligible for a bounty from
-this program. See the [SECURITY-PROCESS](SECURITY-PROCESS.md) document for how
-we work with security issues.
+this program. See the [Security
+Process](http://curl.local/dev/secprocess.html) document for how we work with
+security issues.
 
 ## What are the reward amounts?
 

--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -11,9 +11,8 @@ HackerOne program](https://hackerone.com/curl).
 
 After you have reported a security issue, it has been deemed credible, and a
 patch and advisory has been made public, you may be eligible for a bounty from
-this program. See the [Security
-Process](http://curl.local/dev/secprocess.html) document for how we work with
-security issues.
+this program. See the [Security Process](https://curl.se/dev/secprocess.html)
+document for how we work with security issues.
 
 ## What are the reward amounts?
 

--- a/docs/SECURITY-ADVISORY.md
+++ b/docs/SECURITY-ADVISORY.md
@@ -1,10 +1,10 @@
 # Anatomy of a curl security advisory
 
-As described in the `SECURITY-PROCESS.md` document, when a security
-vulnerability has been reported to the project and confirmed, we author an
-advisory document for for the issue. It should ideally be written in
-cooperation with the reporter to make sure all the angles and details of the
-problem are gathered and described correctly and succinctly.
+As described in the [Security Process](http://curl.local/dev/secprocess.html)
+document, when a security vulnerability has been reported to the project and
+confirmed, we author an advisory document for for the issue. It should ideally
+be written in cooperation with the reporter to make sure all the angles and
+details of the problem are gathered and described correctly and succinctly.
 
 ## New document
 

--- a/docs/SECURITY-ADVISORY.md
+++ b/docs/SECURITY-ADVISORY.md
@@ -1,6 +1,6 @@
 # Anatomy of a curl security advisory
 
-As described in the [Security Process](http://curl.local/dev/secprocess.html)
+As described in the [Security Process](https://curl.se/dev/secprocess.html)
 document, when a security vulnerability has been reported to the project and
 confirmed, we author an advisory document for for the issue. It should ideally
 be written in cooperation with the reporter to make sure all the angles and

--- a/docs/SECURITY-PROCESS.md
+++ b/docs/SECURITY-PROCESS.md
@@ -56,7 +56,8 @@ announcement.
   problem is, its impact, which versions it affects, solutions or workarounds,
   when the release is out and make sure to credit all contributors properly.
   Figure out the CWE (Common Weakness Enumeration) number for the flaw. See
-  [SECURITY-ADVISORY](SECURITY-ADVISORY.md) for help on creating the advisory.
+  [SECURITY-ADVISORY](https://curl.se/dev/advisory.html) for help on creating
+  the advisory.
 
 - Request a CVE number from
   [HackerOne](https://docs.hackerone.com/programs/cve-requests.html)


### PR DESCRIPTION
... to make the links work when the markdown is converted to webpages on https://curl.se

Reported-by: Maurício Meneghini Fauth
Fixes https://github.com/curl/curl-www/issues/272