### PR TITLE
tool_operate: fix memory leak when SSL_CERT_DIR is used

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2599,6 +2599,7 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
             errorf(global, "out of memory");
             return CURLE_OUT_OF_MEMORY;
           }
+          curl_free(env);
           capath_from_env = true;
         }
         env = curlx_getenv("SSL_CERT_FILE");


### PR DESCRIPTION
Detected by Coverity

Follow-up to 29bce9857a12b6cfa726a5