### PR TITLE
getinfo: remove header_size from info struct

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -182,7 +182,6 @@ static int hyper_each_header(void *userdata,
     }
   }
 
-  data->info.header_size += (curl_off_t)len;
   data->req.headerbytecount += (curl_off_t)len;
   return HYPER_ITER_CONTINUE;
 }
@@ -313,7 +312,6 @@ static CURLcode status_line(struct Curl_easy *data,
     if(result)
       return result;
   }
-  data->info.header_size += (curl_off_t)len;
   data->req.headerbytecount += (curl_off_t)len;
   return CURLE_OK;
 }

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -587,7 +587,7 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
         return result;
     }
 
-    data->info.header_size += (long)perline;
+    data->req.headerbytecount += (long)perline;
 
     /* Newlines are CRLF, so the CR is ignored as the line isn't
        really terminated until the LF comes. Treat a following CR

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -64,7 +64,6 @@ CURLcode Curl_initinfo(struct Curl_easy *data)
   info->filetime = -1; /* -1 is an illegal time and thus means unknown */
   info->timecond = FALSE;
 
-  info->header_size = 0;
   info->request_size = 0;
   info->proxyauthavail = 0;
   info->httpauthavail = 0;
@@ -241,7 +240,7 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
       *param_longp = (long)data->info.filetime;
     break;
   case CURLINFO_HEADER_SIZE:
-    *param_longp = (long)data->info.header_size;
+    *param_longp = (long)data->req.headerbytecount;
     break;
   case CURLINFO_REQUEST_SIZE:
     *param_longp = (long)data->info.request_size;

--- a/lib/http.c
+++ b/lib/http.c
@@ -4173,7 +4173,6 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
       if(result)
         return result;
 
-      data->info.header_size += (long)headerlen;
       data->req.headerbytecount += (long)headerlen;
 
       /*
@@ -4496,7 +4495,6 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
     if(result)
       return result;
 
-    data->info.header_size += Curl_dyn_len(&data->state.headerb);
     data->req.headerbytecount += Curl_dyn_len(&data->state.headerb);
 
     Curl_dyn_reset(&data->state.headerb);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1089,7 +1089,6 @@ struct PureInfo {
   int httpversion; /* the http version number X.Y = X*10+Y */
   time_t filetime; /* If requested, this is might get set. Set to -1 if the
                       time was unretrievable. */
-  curl_off_t header_size;  /* size of read header(s) in bytes */
   curl_off_t request_size; /* the amount of bytes sent in the request(s) */
   unsigned long proxyauthavail; /* what proxy auth types were announced */
   unsigned long httpauthavail;  /* what host auth types were announced */


### PR DESCRIPTION
It is a duplicate of the size already kept in `req.headerbytecount`