### PR TITLE
url: change default value for CURLOPT_MAXREDIRS to 30

### DIFF
--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.3
@@ -41,7 +41,7 @@ Setting the limit to 0 will make libcurl refuse any redirect.
 
 Set it to -1 for an infinite number of redirects.
 .SH DEFAULT
--1, unlimited
+30 (since 8.3.0)
 .SH PROTOCOLS
 HTTP(S)
 .SH EXAMPLE

--- a/lib/url.c
+++ b/lib/url.c
@@ -490,7 +490,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   set->filesize = -1;        /* we don't know the size */
   set->postfieldsize = -1;   /* unknown size */
-  set->maxredirs = -1;       /* allow any amount by default */
+  set->maxredirs = 30;       /* sensible default */
 
   set->method = HTTPREQ_GET; /* Default HTTP request */
 #ifndef CURL_DISABLE_RTSP


### PR DESCRIPTION
It was previously unlimited by default, but that's not a sensible default. While changing this has a remote risk of breaking an existing use case, I figure it is more likely to actually save users from loops.

The curl tool already sets a limit on its own, so that will not be affected by this.