### PR TITLE
Use openssl 3.0.10+quic, nghttp3 0.14.0, ngtcp2 0.18.0

### DIFF
--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -46,9 +46,9 @@ permissions: {}
 
 env:
   MAKEFLAGS: -j 3
-  openssl-version: 3.0.9+quic
-  nghttp3-version: v0.13.0
-  ngtcp2-version: v0.17.0
+  openssl-version: 3.0.10+quic
+  nghttp3-version: v0.14.0
+  ngtcp2-version: v0.18.0
   nghttp2-version: v1.55.1
   gnutls-version: 3.8.0
   wolfssl-version: v5.6.3-stable

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -46,9 +46,9 @@ permissions: {}
 
 env:
   MAKEFLAGS: -j 3
-  openssl-version: 3.0.9+quic
-  nghttp3-version: v0.13.0
-  ngtcp2-version: v0.17.0
+  openssl-version: 3.0.10+quic
+  nghttp3-version: v0.14.0
+  ngtcp2-version: v0.18.0
   nghttp2-version: v1.55.1
   quiche-version: 0.17.2
   mod_h2-version: v2.0.21

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -39,14 +39,14 @@ Building curl with ngtcp2 involves 3 components: `ngtcp2` itself, `nghttp3` and 
 
 For now, `ngtcp2` and `nghttp3` are still *experimental* which means their evolution bring breaking changes. Therefore, the proper version of both libraries need to be used when building curl. These are
 
- * `ngtcp2`: v0.17.0
- * `nghttp3`: v0.13.0
+ * `ngtcp2`: v0.18.0
+ * `nghttp3`: v0.14.0
 
 ## Build with OpenSSL
 
 Build (patched) OpenSSL
 
-     % git clone --depth 1 -b openssl-3.0.9+quic https://github.com/quictls/openssl
+     % git clone --depth 1 -b openssl-3.0.10+quic https://github.com/quictls/openssl
      % cd openssl
      % ./config enable-tls1_3 --prefix=<somewhere1>
      % make
@@ -55,7 +55,7 @@ Build (patched) OpenSSL
 Build nghttp3
 
      % cd ..
-     % git clone -b v0.13.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v0.14.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
@@ -65,7 +65,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v0.17.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v0.18.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only
@@ -98,7 +98,7 @@ Build GnuTLS
 Build nghttp3
 
      % cd ..
-     % git clone -b v0.13.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v0.14.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
@@ -108,7 +108,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v0.17.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v0.18.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-gnutls
@@ -139,7 +139,7 @@ Build wolfSSL
 Build nghttp3
 
      % cd ..
-     % git clone -b v0.13.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v0.14.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
@@ -149,7 +149,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v0.17.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v0.18.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-wolfssl


### PR DESCRIPTION
I'm not aware of any changes in these releases that would affect us. The CI in master is already failing, which makes things quite hard to check.