### PR TITLE
include/curl/mprintf.h: add __attribute__ for the prototypes

### DIFF
--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -32,18 +32,36 @@
 extern "C" {
 #endif
 
-CURL_EXTERN int curl_mprintf(const char *format, ...);
-CURL_EXTERN int curl_mfprintf(FILE *fd, const char *format, ...);
-CURL_EXTERN int curl_msprintf(char *buffer, const char *format, ...);
+#if (defined(__GNUC__) || defined(__clang__)) &&                        \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+  !defined(__MINGW32__) && !defined(CURL_NO_FMT_CHECKS)
+#define CURL_TEMP_PRINTF(a,b) __attribute__ ((format(printf, a, b)))
+#else
+#define CURL_TEMP_PRINTF(a,b)
+#endif
+
+CURL_EXTERN int curl_mprintf(const char *format, ...) CURL_TEMP_PRINTF(1, 2);
+CURL_EXTERN int curl_mfprintf(FILE *fd, const char *format, ...)
+  CURL_TEMP_PRINTF(2, 3);
+CURL_EXTERN int curl_msprintf(char *buffer, const char *format, ...)
+  CURL_TEMP_PRINTF(2, 3);
 CURL_EXTERN int curl_msnprintf(char *buffer, size_t maxlength,
-                               const char *format, ...);
-CURL_EXTERN int curl_mvprintf(const char *format, va_list args);
-CURL_EXTERN int curl_mvfprintf(FILE *fd, const char *format, va_list args);
-CURL_EXTERN int curl_mvsprintf(char *buffer, const char *format, va_list args);
+                               const char *format, ...) CURL_TEMP_PRINTF(3, 4);
+CURL_EXTERN int curl_mvprintf(const char *format, va_list args)
+  CURL_TEMP_PRINTF(1, 0);
+CURL_EXTERN int curl_mvfprintf(FILE *fd, const char *format, va_list args)
+  CURL_TEMP_PRINTF(2, 0);
+CURL_EXTERN int curl_mvsprintf(char *buffer, const char *format, va_list args)
+  CURL_TEMP_PRINTF(2, 0);
 CURL_EXTERN int curl_mvsnprintf(char *buffer, size_t maxlength,
-                                const char *format, va_list args);
-CURL_EXTERN char *curl_maprintf(const char *format, ...);
-CURL_EXTERN char *curl_mvaprintf(const char *format, va_list args);
+                                const char *format, va_list args)
+  CURL_TEMP_PRINTF(3, 0);
+CURL_EXTERN char *curl_maprintf(const char *format, ...)
+  CURL_TEMP_PRINTF(1, 2);
+CURL_EXTERN char *curl_mvaprintf(const char *format, va_list args)
+  CURL_TEMP_PRINTF(1, 0);
+
+#undef CURL_TEMP_PRINTF
 
 #ifdef  __cplusplus
 } /* end of extern "C" */

--- a/tests/extern-scan.pl
+++ b/tests/extern-scan.pl
@@ -79,7 +79,7 @@ foreach my $f (@incs) {
     while(<H>) {
         s/CURL_DEPRECATED\(.*"\)//;
         s/  */ /g;
-        if (/^(^CURL_EXTERN .*)\(/) {
+        if (/^(^CURL_EXTERN .*?)\(/) {
             my $decl = $1;
             $decl =~ s/\r$//;
             $decl =~ /([a-z_]+)$/;

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -103,7 +103,7 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   hasbody = 0;
   res = curl_easy_perform(curl);
   if(res != p->result) {
-    printf("%d: bad error code (%d): resume=%s, fail=%s, http416=%s, "
+    printf("%zd: bad error code (%d): resume=%s, fail=%s, http416=%s, "
            "content-range=%s, expected=%d\n", num, res,
            (p->flags & F_RESUME)? "yes": "no",
            (p->flags & F_FAIL)? "yes": "no",

--- a/tests/libtest/lib1523.c
+++ b/tests/libtest/lib1523.c
@@ -68,7 +68,6 @@ int test(char *URL)
   curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 0L);
   curl_easy_setopt(hnd, CURLOPT_XFERINFOFUNCTION, dload_progress_cb);
 
-  printf("Start: %d\n", time(NULL));
   ret = run(hnd, 1, 2);
   if(ret)
     fprintf(stderr, "error %d: %s\n", ret, buffer);
@@ -79,7 +78,6 @@ int test(char *URL)
   else
     ret = CURLE_OK;
 
-  printf("End: %d\n", time(NULL));
   curl_easy_cleanup(hnd);
   curl_global_cleanup();
 

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -63,7 +63,7 @@ static int recv_pong(CURL *curl, const char *exected_payload)
     }
   }
   fprintf(stderr, "ws: curl_ws_recv returned %u, received %u\n", (int)result,
-         rlen);
+          (int)rlen);
   return (int)result;
 }
 

--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -58,7 +58,7 @@ static void websocket(CURL *curl)
       printf("curl_ws_recv returned %d\n", (int)result);
       return;
     }
-    printf("%u: nread %u Age %u Flags %x "
+    printf("%u: nread %zu Age %u Flags %x "
            "Offset %" CURL_FORMAT_CURL_OFF_T " "
            "Bytesleft %" CURL_FORMAT_CURL_OFF_T "\n",
            (int)i,

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -27,6 +27,8 @@
  * curl_m*printf formatting capabilities and handling of some data types.
  */
 
+#define CURL_NO_FMT_CHECKS /* disable compiler *printf format checks */
+
 #include "test.h"
 
 #include <limits.h>

--- a/tests/symbol-scan.pl
+++ b/tests/symbol-scan.pl
@@ -170,11 +170,13 @@ for my $e (sort @syms) {
     #
     # CURLINC_ - defines for header dual-include prevention, ignore those.
     #
+    # CURL_TEMP_ - are defined and *undefined* again within the file
+    #
     # *_LAST and *_LASTENTRY are just prefix for the placeholders used for the
     # last entry in many enum series.
     #
 
-    if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z)/) {
+    if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z|^CURL_TEMP_)/) {
         $ignored++;
         next;
     }

--- a/tests/unit/unit1323.c
+++ b/tests/unit/unit1323.c
@@ -54,13 +54,13 @@ UNITTEST_START
   for(i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
     timediff_t result = Curl_timediff(tests[i].first, tests[i].second);
     if(result != tests[i].result) {
-      printf("%d.%06u to %d.%06u got %d, but expected %d\n",
-             tests[i].first.tv_sec,
+      printf("%ld.%06u to %ld.%06u got %d, but expected %ld\n",
+             (long)tests[i].first.tv_sec,
              tests[i].first.tv_usec,
-             tests[i].second.tv_sec,
+             (long)tests[i].second.tv_sec,
              tests[i].second.tv_usec,
-             result,
-             tests[i].result);
+             (int)result,
+             (long)tests[i].result);
       fail("unexpected result!");
     }
   }

--- a/tests/unit/unit1398.c
+++ b/tests/unit/unit1398.c
@@ -21,6 +21,8 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+#define CURL_NO_FMT_CHECKS
+
 #include "curlcheck.h"
 
 #include "curl/mprintf.h"

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -190,7 +190,7 @@ UNITTEST_START
 
       if(port != tests[i].port) {
         fprintf(stderr, "%s:%d tests[%d] failed. the retrieved port "
-                "for tests[%d].address[%d] is %ld but tests[%d].port is %d.\n",
+                "for tests[%d].address[%d] is %d but tests[%d].port is %d.\n",
                 __FILE__, __LINE__, i, i, j, port, i, tests[i].port);
         problem = true;
         break;

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -189,7 +189,7 @@ UNITTEST_START
 
       if(port != tests[i].port) {
         fprintf(stderr, "%s:%d tests[%d] failed. the retrieved port "
-                "for tests[%d].address[%d] is %ld but tests[%d].port is %d.\n",
+                "for tests[%d].address[%d] is %d but tests[%d].port is %d.\n",
                 __FILE__, __LINE__, i, i, j, port, i, tests[i].port);
         problem = true;
         break;

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -94,7 +94,7 @@ UNITTEST_START
     fp = fopen(arg, "rb");
     abort_unless(fp != NULL, "Cannot open testfile");
 
-    fprintf(stderr, "Test %d...", i);
+    fprintf(stderr, "Test %zd...", i);
     switch(i) {
       case 0:
         line = Curl_get_line(buf, len, fp);


### PR DESCRIPTION
- if gcc or clang is used
- if `__STDC_VERSION__ >= 199901L`, which means greater than C90
- if not using mingw
- only if `CURL_NO_FMT_CHECKS` is not defined