### PR TITLE
pingpong: don't use *bump_headersize

### DIFF
--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -341,9 +341,7 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
       ssize_t clipamount = 0;
       bool restart = FALSE;
 
-      result = Curl_bump_headersize(data, gotbytes, FALSE);
-      if(result)
-        return result;
+      data->req.headerbytecount += (unsigned int)gotbytes;
 
       pp->nread_resp += gotbytes;
       for(i = 0; i < gotbytes; ptr++, i++) {


### PR DESCRIPTION
We use that for HTTP(S) only.

Follow-up to 3ee79c1674fd6