### PR TITLE
docs/cmdline: add small "warning" to verbose options

### DIFF
--- a/docs/cmdline-opts/trace-ascii.d
+++ b/docs/cmdline-opts/trace-ascii.d
@@ -18,3 +18,7 @@ the output sent to stdout.
 This is similar to --trace, but leaves out the hex part and only shows the
 ASCII part of the dump. It makes smaller output that might be easier to read
 for untrained humans.
+
+Note that verbose output of curl activities and network traffic might contain
+sensitive data, including user names, credentials or secret data content. Be
+aware and be careful when sharing trace logs with others.

--- a/docs/cmdline-opts/trace.d
+++ b/docs/cmdline-opts/trace.d
@@ -15,3 +15,7 @@ Enables a full trace dump of all incoming and outgoing data, including
 descriptive information, to the given output file. Use "-" as filename to have
 the output sent to stdout. Use "%" as filename to have the output sent to
 stderr.
+
+Note that verbose output of curl activities and network traffic might contain
+sensitive data, including user names, credentials or secret data content. Be
+aware and be careful when sharing trace logs with others.

--- a/docs/cmdline-opts/verbose.d
+++ b/docs/cmdline-opts/verbose.d
@@ -22,3 +22,7 @@ be more suitable options.
 
 If you think this option still does not give you enough details, consider using
 --trace or --trace-ascii instead.
+
+Note that verbose output of curl activities and network traffic might contain
+sensitive data, including user names, credentials or secret data content. Be
+aware and be careful when sharing trace logs with others.


### PR DESCRIPTION
"Note that verbose output of curl activities and network traffic might contain sensitive data, including user names, credentials or secret data content. Be aware and be careful when sharing trace logs with others."