### PR TITLE
docs/cmdline: remove repeated working for negotiate + ntlm

### DIFF
--- a/docs/cmdline-opts/negotiate.d
+++ b/docs/cmdline-opts/negotiate.d
@@ -17,5 +17,3 @@ This option requires a library built with GSS-API or SSPI support. Use
 When using this option, you must also provide a fake --user option to activate
 the authentication code properly. Sending a '-u :' is enough as the user name
 and password from the --user option are not actually used.
-
-If this option is used several times, only the first one is used.

--- a/docs/cmdline-opts/ntlm.d
+++ b/docs/cmdline-opts/ntlm.d
@@ -20,5 +20,3 @@ method instead, such as Digest.
 
 If you want to enable NTLM for your proxy authentication, then use
 --proxy-ntlm.
-
-If this option is used several times, only the first one is used.


### PR DESCRIPTION
The extra wording is added automatically by the gen.pl tool