### PR TITLE
CURLOPT_SSL_VERIFYPEER.3: does not load CA certs when disabled

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
@@ -49,7 +49,7 @@ specify alternate certificates with the \fICURLOPT_CAINFO(3)\fP option or the
 When \fICURLOPT_SSL_VERIFYPEER(3)\fP is enabled, and the verification fails to
 prove that the certificate is signed by a CA, the connection fails.
 
-When this option is disabled (set to zero), the CA certficates are not loaded
+When this option is disabled (set to zero), the CA certificates are not loaded
 and the peer certificate verification is simply skipped.
 
 Authenticating the certificate is not enough to be sure about the server. You

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.3
@@ -38,17 +38,19 @@ This option determines whether curl verifies the authenticity of the peer's
 certificate. A value of 1 means curl verifies; 0 (zero) means it does not.
 
 When negotiating a TLS or SSL connection, the server sends a certificate
-indicating its identity.  Curl verifies whether the certificate is authentic,
+indicating its identity. Curl verifies whether the certificate is authentic,
 i.e. that you can trust that the server is who the certificate says it is.
 This trust is based on a chain of digital signatures, rooted in certification
-authority (CA) certificates you supply.  curl uses a default bundle of CA
+authority (CA) certificates you supply. curl uses a default bundle of CA
 certificates (the path for that is determined at build time) and you can
 specify alternate certificates with the \fICURLOPT_CAINFO(3)\fP option or the
 \fICURLOPT_CAPATH(3)\fP option.
 
 When \fICURLOPT_SSL_VERIFYPEER(3)\fP is enabled, and the verification fails to
-prove that the certificate is authentic, the connection fails.  When the
-option is zero, the peer certificate verification succeeds regardless.
+prove that the certificate is signed by a CA, the connection fails.
+
+When this option is disabled (set to zero), the CA certficates are not loaded
+and the peer certificate verification is simply skipped.
 
 Authenticating the certificate is not enough to be sure about the server. You
 typically also want to ensure that the server is the server you mean to be
@@ -67,7 +69,7 @@ HSTS and Alt-Svc information to be stored and used subsequently. Disabling
 certificate verification can make libcurl trust and use such information from
 malicious servers.
 .SH DEFAULT
-By default, curl assumes a value of 1.
+1 - enabled
 .SH PROTOCOLS
 All TLS based protocols: HTTPS, FTPS, IMAPS, POP3S, SMTPS etc.
 .SH EXAMPLE


### PR DESCRIPTION
Ref: #11457