### PR TITLE
HTTP/3, ngtcp2, shorten handshake, trace cleanup

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -363,8 +363,9 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
   }
 
 out:
-  CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
-              pkts, total_nread, result);
+  if(total_nread || result)
+    CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
+                pkts, total_nread, result);
   return result;
 }
 
@@ -428,8 +429,9 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
   }
 
 out:
-  CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
-              pkts, total_nread, result);
+  if(total_nread || result)
+    CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
+                pkts, total_nread, result);
   return result;
 }
 
@@ -487,8 +489,9 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
   }
 
 out:
-  CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
-              pkts, total_nread, result);
+  if(total_nread || result)
+    CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
+                pkts, total_nread, result);
   return result;
 }
 #endif /* !HAVE_SENDMMSG && !HAVE_SENDMSG */

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -65,7 +65,7 @@ class TestErrors:
         r.check_exit_code(False)
         invalid_stats = []
         for idx, s in enumerate(r.stats):
-            if 'exitcode' not in s or s['exitcode'] not in [18, 56, 92]:
+            if 'exitcode' not in s or s['exitcode'] not in [18, 56, 92, 95]:
                 invalid_stats.append(f'request {idx} exit with {s["exitcode"]}')
         assert len(invalid_stats) == 0, f'failed: {invalid_stats}'
 


### PR DESCRIPTION
- shorten handshake timing by delayed x509 store load (OpenSSL) as we do for HTTP/2
- cleanup of trace output, align with HTTP/2 output

Sample handshake times on my machine

```
> python3 tests/http/scorecard.py -H h3

BEFORE
Handshakes               ipv4                      ipv6
  Host                   Connect    Handshake      Connect    Handshake
  curl.se                   0 ms        53 ms         0 ms       219 ms

AFTER
Handshakes               ipv4                      ipv6
  Host                   Connect    Handshake      Connect    Handshake
  curl.se                   0 ms        29 ms         0 ms       196 ms
```

**update**: my ipv6 unborked itself, now seeing 22ms/22ms on both ip version...*shrugs*
