### PR TITLE
openssl: switch to modern init for LibreSSL 2.7.0+

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1691,7 +1691,7 @@ static int x509_name_oneline(X509_NAME *a, char *buf, size_t size)
 static int ossl_init(void)
 {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) &&  \
-  !defined(LIBRESSL_VERSION_NUMBER)
+  (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
   const uint64_t flags =
 #ifdef OPENSSL_INIT_ENGINE_ALL_BUILTIN
     /* not present in BoringSSL */


### PR DESCRIPTION
LibreSSL 2.7.0 (2018-03-21) introduced automatic initialization, `OPENSSL_init_ssl()` function and deprecated the old, manual init method, as seen in OpenSSL 1.1.0. Switch to the modern method when available.

Ref: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.7.0-relnotes.txt

Closes #11611
