### PR TITLE
cmake: drop `HAVE_LIBWINMM` and `HAVE_LIBWS2_32` feature checks

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -38,7 +38,7 @@ if(HAVE_WINDOWS_H)
   set(_source_epilogue
       "${_source_epilogue}\n#ifndef WIN32_LEAN_AND_MEAN\n#define WIN32_LEAN_AND_MEAN\n#endif")
   set(signature_call_conv "PASCAL")
-  if(HAVE_LIBWS2_32)
+  if(WIN32)
     set(CMAKE_REQUIRED_LIBRARIES ws2_32)
   endif()
 else()
@@ -133,4 +133,3 @@ if(NOT CMAKE_CROSSCOMPILING)
     }" HAVE_POLL_FINE)
   endif()
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,9 +371,6 @@ check_library_exists_concat("socket" connect      HAVE_LIBSOCKET)
 check_function_exists(gethostname HAVE_GETHOSTNAME)
 
 if(WIN32)
-  check_library_exists_concat("ws2_32" getch        HAVE_LIBWS2_32)
-  check_library_exists_concat("winmm"  getch        HAVE_LIBWINMM)
-
   # Matching logic used for Curl_win32_random()
   if(MINGW)
     check_c_source_compiles("
@@ -1075,7 +1072,7 @@ if(NOT CMAKE_CROSSCOMPILING)
 endif()
 
 # Check for some functions that are used
-if(HAVE_LIBWS2_32)
+if(WIN32)
   set(CMAKE_REQUIRED_LIBRARIES ws2_32)
 elseif(HAVE_LIBSOCKET)
   set(CMAKE_REQUIRED_LIBRARIES socket)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,11 @@ check_library_exists_concat("socket" connect      HAVE_LIBSOCKET)
 check_function_exists(gethostname HAVE_GETHOSTNAME)
 
 if(WIN32)
+  list(APPEND CURL_LIBS "ws2_32")
+  if(USE_LIBRTMP)
+    list(APPEND CURL_LIBS "winmm")
+  endif()
+
   # Matching logic used for Curl_win32_random()
   if(MINGW)
     check_c_source_compiles("


### PR DESCRIPTION
- `HAVE_LIBWINMM` was detected but unused. The `winmm` system library
  is not used by curl, but it is by its optional dependency `librtmp`. Change
  the logic to add `winmm` when `USE_LIBRTMP` is set. This library has been
  available since the early days of Windows.

- `HAVE_LIBWS2_32` detected `ws2_32` lib on Windows. This lib is present
  since Windows 95 OSR2 (AFAIR). Winsock1 already wasn't supported and
  other existing logic already assumed this lib being present, so delete the
  check and replace the detection variable with `WIN32` and always add
  `ws2_32` on Windows.

Closes #11612
