### PR TITLE
crypto: ensure crypto initialization works

### DIFF
--- a/lib/curl_md4.h
+++ b/lib/curl_md4.h
@@ -25,13 +25,14 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
+#include <curl/curl.h>
 
 #if !defined(CURL_DISABLE_CRYPTO_AUTH)
 
 #define MD4_DIGEST_LENGTH 16
 
-void Curl_md4it(unsigned char *output, const unsigned char *input,
-                const size_t len);
+CURLcode Curl_md4it(unsigned char *output, const unsigned char *input,
+                    const size_t len);
 
 #endif /* !defined(CURL_DISABLE_CRYPTO_AUTH) */
 

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -419,6 +419,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(const char *password,
 {
   size_t len = strlen(password);
   unsigned char *pw;
+  CURLcode result;
   if(len > SIZE_T_MAX/2) /* avoid integer overflow */
     return CURLE_OUT_OF_MEMORY;
   pw = len ? malloc(len * 2) : (unsigned char *)strdup("");
@@ -428,12 +429,13 @@ CURLcode Curl_ntlm_core_mk_nt_hash(const char *password,
   ascii_to_unicode_le(pw, password, len);
 
   /* Create NT hashed password. */
-  Curl_md4it(ntbuffer, pw, 2 * len);
-  memset(ntbuffer + 16, 0, 21 - 16);
+  result = Curl_md4it(ntbuffer, pw, 2 * len);
+  if(!result)
+    memset(ntbuffer + 16, 0, 21 - 16);
 
   free(pw);
 
-  return CURLE_OK;
+  return result;
 }
 
 #if !defined(USE_WINDOWS_SSPI)

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -522,7 +522,6 @@ CURLcode Curl_md4it(unsigned char *output, const unsigned char *input,
   MD4_Update(&ctx, input, curlx_uztoui(len));
   MD4_Final(output, &ctx);
   return CURLE_OK;
-#endif
 }
 
 #endif /* USE_CURL_NTLM_CORE */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -42,6 +42,7 @@
 
 #ifdef USE_WOLFSSL
 #include <wolfssl/options.h>
+#define VOID_MD4_INIT
 #ifdef NO_MD4
 #define WOLFSSL_NO_MD4
 #endif
@@ -510,6 +511,12 @@ CURLcode Curl_md4it(unsigned char *output, const unsigned char *input,
                     const size_t len)
 {
   MD4_CTX ctx;
+#ifdef VOID_MD4_INIT
+  MD4_Init(&ctx);
+  MD4_Update(&ctx, input, curlx_uztoui(len));
+  MD4_Final(output, &ctx);
+  return CURLE_OK;
+#else
   CURLcode result;
 
   result = MD4_Init(&ctx);
@@ -518,6 +525,7 @@ CURLcode Curl_md4it(unsigned char *output, const unsigned char *input,
     MD4_Final(output, &ctx);
   }
   return result;
+#endif
 }
 
 #endif /* USE_CURL_NTLM_CORE */

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -213,6 +213,7 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
 
   if(!CryptCreateHash(ctx->hCryptProv, CALG_MD5, 0, 0, &ctx->hHash)) {
     CryptReleaseContext(ctx->hCryptProv, 0);
+    ctx->hCryptProv = 0;
     return CURLE_FAILED_INIT;
   }
 

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -213,7 +213,7 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
 
   if(!CryptCreateHash(ctx->hCryptProv, CALG_MD5, 0, 0, &ctx->hHash)) {
     CryptReleaseContext(ctx->hCryptProv, 0);
-    return CURLE_OUT_OF_MEMORY;
+    return CURLE_FAILED_INIT;
   }
 
   return CURLE_OK;

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -110,7 +110,10 @@ static CURLcode my_sha256_init(my_sha256_ctx *ctx)
   if(!ctx->openssl_ctx)
     return CURLE_OUT_OF_MEMORY;
 
-  EVP_DigestInit_ex(ctx->openssl_ctx, EVP_sha256(), NULL);
+  if(!EVP_DigestInit_ex(ctx->openssl_ctx, EVP_sha256(), NULL)) {
+    EVP_MD_CTX_destroy(ctx->openssl_ctx);
+    return CURLE_FAILED_INIT;
+  }
   return CURLE_OK;
 }
 
@@ -218,9 +221,13 @@ typedef struct sha256_ctx my_sha256_ctx;
 
 static CURLcode my_sha256_init(my_sha256_ctx *ctx)
 {
-  if(CryptAcquireContext(&ctx->hCryptProv, NULL, NULL, PROV_RSA_AES,
-                         CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
-    CryptCreateHash(ctx->hCryptProv, CALG_SHA_256, 0, 0, &ctx->hHash);
+  if(!CryptAcquireContext(&ctx->hCryptProv, NULL, NULL, PROV_RSA_AES,
+                         CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+    return CURLE_OUT_OF_MEMORY;
+
+  if(!CryptCreateHash(ctx->hCryptProv, CALG_SHA_256, 0, 0, &ctx->hHash)) {
+    CryptReleaseContext(ctx->hCryptProv, 0);
+    return CURLE_FAILED_INIT;
   }
 
   return CURLE_OK;

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -227,6 +227,7 @@ static CURLcode my_sha256_init(my_sha256_ctx *ctx)
 
   if(!CryptCreateHash(ctx->hCryptProv, CALG_SHA_256, 0, 0, &ctx->hHash)) {
     CryptReleaseContext(ctx->hCryptProv, 0);
+    ctx->hCryptProv = 0;
     return CURLE_FAILED_INIT;
   }
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4730,7 +4730,10 @@ static CURLcode ossl_sha256sum(const unsigned char *tmp, /* input */
   mdctx = EVP_MD_CTX_create();
   if(!mdctx)
     return CURLE_OUT_OF_MEMORY;
-  EVP_DigestInit(mdctx, EVP_sha256());
+  if(!EVP_DigestInit(mdctx, EVP_sha256())) {
+    EVP_MD_CTX_destroy(mdctx);
+    return CURLE_FAILED_INIT;
+  }
   EVP_DigestUpdate(mdctx, tmp, tmplen);
   EVP_DigestFinal_ex(mdctx, sha256sum, &len);
   EVP_MD_CTX_destroy(mdctx);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1352,7 +1352,8 @@ static CURLcode wolfssl_sha256sum(const unsigned char *tmp, /* input */
 {
   wc_Sha256 SHA256pw;
   (void)unused;
-  wc_InitSha256(&SHA256pw);
+  if(wc_InitSha256(&SHA256pw))
+    return CURLE_FAILED_INIT;
   wc_Sha256Update(&SHA256pw, tmp, (word32)tmplen);
   wc_Sha256Final(&SHA256pw, sha256sum);
   return CURLE_OK;


### PR DESCRIPTION
Make sure that context initialization during hash setup works to avoid going forward with the risk of a null pointer dereference.

Reported-by: Philippe Antoine on HackerOne

Replaces #10733