### PR TITLE
openssl: auto-detect `SSL_R_TLSV13_ALERT_CERTIFICATE_REQUIRED`

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3900,11 +3900,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
              error_buffer */
           strcpy(error_buffer, "SSL certificate verification failed");
       }
-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L &&   \
-     !defined(LIBRESSL_VERSION_NUMBER) &&       \
-     !defined(OPENSSL_IS_BORINGSSL) &&          \
-     !defined(OPENSSL_IS_AWSLC))
-
+#if defined(SSL_R_TLSV13_ALERT_CERTIFICATE_REQUIRED)
       /* SSL_R_TLSV13_ALERT_CERTIFICATE_REQUIRED is only available on
          OpenSSL version above v1.1.1, not LibreSSL, BoringSSL, or AWS-LC */
       else if((lib == ERR_LIB_SSL) &&


### PR DESCRIPTION
OpenSSL 1.1.1 defines this macro, but no ealier version, or any of the popular forks (yet). Use the macro itself to detect its presence, replacing the hard-wired fork-specific conditions.

This way the feature will enable automatically when forks implement it, while also shorter and possibly requiring less future maintenance.

Follow-up to 94241a9e78397a2aaf89a213e6ada61e7de7ee02 #6721

Closes #11617