### PR TITLE
cf-haproxy: make CURLOPT_HAPROXY_CLIENT_IP set the *source* IP

### DIFF
--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -86,12 +86,12 @@ static CURLcode cf_haproxy_date_out_set(struct Curl_cfilter*cf,
   if(data->set.str[STRING_HAPROXY_CLIENT_IP])
     client_ip = data->set.str[STRING_HAPROXY_CLIENT_IP];
   else
-    client_ip = data->info.conn_primary_ip;
+    client_ip = data->info.conn_local_ip;
 
   result = Curl_dyn_addf(&ctx->data_out, "PROXY %s %s %s %i %i\r\n",
                          tcp_version,
-                         data->info.conn_local_ip,
                          client_ip,
+                         data->info.conn_primary_ip,
                          data->info.conn_local_port,
                          data->info.conn_primary_port);
 

--- a/tests/data/test3201
+++ b/tests/data/test3201
@@ -48,7 +48,7 @@ proxy
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^PROXY TCP4 %CLIENTIP 192.168.1.1 (\d*) %HTTPPORT/proxy-line/
+s/^PROXY TCP4 192.168.1.1 %HOSTIP (\d*) %HTTPPORT/proxy-line/
 </strippart>
 <protocol>
 proxy-line

--- a/tests/data/test3202
+++ b/tests/data/test3202
@@ -53,10 +53,10 @@ proxy
 # Strip off the (random) local port number. This test used to use a fixed
 # local port number that frequently causes the test to fail
 <strippart>
-s/PROXY TCP6 ::1 2001:db8:: (\d+) (\d+)/PROXY TCP6 ::1 2001:db8:: $2/
+s/^PROXY TCP6 2001:db8:: ::1 (\d*) %HTTP6PORT/proxy-line/
 </strippart>
 <protocol>
-PROXY TCP6 ::1 2001:db8:: %HTTP6PORT
+proxy-line
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOST6IP:%HTTP6PORT
 User-Agent: curl/%VERSION


### PR DESCRIPTION
... as documented.

Update test 3201 and 3202 accordingly.

Reported-by: Markus Sommer
Fixes #11619