### PR TITLE
cmake: allow `SHARE_LIB_OBJECT=ON` on all platforms

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -108,13 +108,18 @@ if(WIN32 AND
   set(IMPORT_LIB_SUFFIX "_imp")
 endif()
 
-# On supported platforms, do a single compilation pass for libcurl sources
-# and reuse these objects to generate both static and shared target.
+# On supported platforms, automatically do a single compilation pass for
+# libcurl sources and reuse these objects to generate both static and shared
+# target.
 # This is possible where PIC is the default for both shared and static and
 # there is a way to tell the linker which libcurl symbols it should export
 # (vs. marking these symbols exportable at compile-time).
-if(WIN32 AND NOT DEFINED SHARE_LIB_OBJECT)
-  set(SHARE_LIB_OBJECT ON)
+if(NOT DEFINED SHARE_LIB_OBJECT)
+  if(WIN32)
+    set(SHARE_LIB_OBJECT ON)
+  else()
+    set(SHARE_LIB_OBJECT OFF)
+  endif()
 endif()
 
 if(SHARE_LIB_OBJECT)
@@ -123,7 +128,8 @@ if(SHARE_LIB_OBJECT)
   target_link_libraries(${LIB_OBJECT} PRIVATE ${CURL_LIBS})
   set_target_properties(${LIB_OBJECT} PROPERTIES
     COMPILE_DEFINITIONS "BUILDING_LIBCURL"
-    INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")
+    INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB"
+    POSITION_INDEPENDENT_CODE ON)
   if(HIDES_CURL_PRIVATE_SYMBOLS)
     set_target_properties(${LIB_OBJECT} PROPERTIES
       COMPILE_DEFINITIONS "CURL_HIDDEN_SYMBOLS"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -108,16 +108,16 @@ if(WIN32 AND
   set(IMPORT_LIB_SUFFIX "_imp")
 endif()
 
-# On supported platforms, automatically do a single compilation pass for
-# libcurl sources and reuse these objects to generate both static and shared
-# target.
-# This is possible where PIC is the default for both shared and static and
-# there is a way to tell the linker which libcurl symbols it should export
-# (vs. marking these symbols exportable at compile-time).
+# Whether to do a single compilation pass for libcurl sources and reuse these
+# objects to generate both static and shared target.
 if(NOT DEFINED SHARE_LIB_OBJECT)
+  # Enable it by default on platforms where PIC is the default for both shared
+  # and static and there is a way to tell the linker which libcurl symbols it
+  # should export (vs. marking these symbols exportable at compile-time).
   if(WIN32)
     set(SHARE_LIB_OBJECT ON)
   else()
+    # On other platforms, make it an option disabled by default
     set(SHARE_LIB_OBJECT OFF)
   endif()
 endif()


### PR DESCRIPTION
2ebc74c36a19a1700af394c16855ce144d9878e3 #11546 introduced sharing
libcurl objects for shared and static targets.

The above automatically enabled for Windows builds, with an option to
disable with `SHARE_LIB_OBJECT=OFF`.

This patch extend this feature to all platforms as a manual option.
You can enable it by setting `SHARE_LIB_OBJECT=ON`. Then shared objects
are built in PIC mode, meaning the static lib will also have PIC code.

[EXPERIMENTAL]

Closes #11627
