### PR TITLE
cmake: fix to use variable for the curl namespace

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -35,4 +35,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
 
 # Alias for either shared or static library
-add_library(curl::libcurl ALIAS curl::@LIB_SELECTED@)
+add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)


### PR DESCRIPTION
Replace (wrong) literal with a variable to specify the curl
namespace.

Follow-up to 1199308dbc902c52be67fc805c72dd2582520d30 #11505

Reported-by: balikalina on Github
Fixes https://github.com/curl/curl/commit/1199308dbc902c52be67fc805c72dd2582520d30#r123923098
Closes #11629
