### PR TITLE
page-footer: QLOGDIR works with ngtcp2 and quiche

### DIFF
--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -70,7 +70,7 @@ have preference.
 If curl was built with HTTP/3 support, setting this environment variable to a
 local directory will make curl produce **qlogs** in that directory, using file
 names named after the destination connection id (in hex). Do note that these
-files can become rather large. Works with both QUIC backends.
+files can become rather large. Works with the ngtcp2 and quiche QUIC backends.
 .IP SHELL
 Used on VMS when trying to detect if using a **DCL** or a **unix** shell.
 .IP "SSL_CERT_DIR <dir>"


### PR DESCRIPTION
It previously said "both" backends which is confusing as we currently have three...