### PR TITLE
bug_report: require reporters to specify curl and os versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
     validations: 
       required: false
   
-  - type: input
+  - type: textarea
     id: version
     attributes:
       label: curl/libcurl version
@@ -42,9 +42,9 @@ body:
         Please paste the output of `curl -V` here.
       placeholder: 'curl 8.2.0'
     validations:
-      required: false
+      required: true
 
-  - type: input
+  - type: textarea
     id: os
     attributes:
       label: operating system
@@ -52,4 +52,4 @@ body:
         On Unix please post the output of `uname -a` here.
       placeholder: 'Fedora Linux 38'
     validations:
-      required: false
+      required: true


### PR DESCRIPTION
- Change curl version and os sections from single-line input to multi-line textarea.

- Require curl version and os sections to be filled out before report can be submitted.

Closes #xxxx

---

Some reporters don't fill out the curl and os version fields, make it required so we don't have to follow up asking them. Also make the fields multi-line. Right now if you hit enter in the single-line fields it submits the issue. This just happened to me when what I was trying to do was to start a new line.