### PR TITLE
haproxy-clientip.d: remove backticks

### DIFF
--- a/docs/cmdline-opts/haproxy-clientip.d
+++ b/docs/cmdline-opts/haproxy-clientip.d
@@ -23,7 +23,7 @@ of consecutive zeroes. The total number of decoded bits must exactly be 128.
 
 Otherwise, any string can be accepted for the client IP and will be sent.
 
-It replaces `--haproxy-protocol` if used, it is not necessary to specify both flags.
+It replaces --haproxy-protocol if used, it is not necessary to specify both flags.
 
 This option is primarily useful when sending test requests to
 verify a service is working as intended.


### PR DESCRIPTION
This is not markdown

Follow-up to 0a75964d0d94a4