### PR TITLE
[WIP] cmake: fix libcurl export alias

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -33,6 +33,3 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
-
-# Alias for either shared or static library
-add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -219,6 +219,9 @@ endif()
 add_library(${LIB_NAME} ALIAS ${LIB_SELECTED})
 add_library(${PROJECT_NAME}::${LIB_NAME} ALIAS ${LIB_SELECTED})
 
+# export libcurl alias as target name
+set_property(TARGET ${LIB_SELECTED} PROPERTY EXPORT_NAME ${LIB_NAME})
+
 if(CURL_ENABLE_EXPORT_TARGET)
   if(BUILD_STATIC_LIBS)
     install(TARGETS ${LIB_STATIC}


### PR DESCRIPTION
Fixes:
```
[25/26] -- Found CURL: ***/build/parts/curl/install/lib64/cmake/CURL/CURLConfig.cmake (found version "8.3.0-DEV")
[25/26] CMake Error at ***/build/parts/curl/install/lib64/cmake/CURL/CURLConfig.cmake:62 (add_library):
[25/26]   add_library cannot create ALIAS target "CURL::libcurl" because target
[25/26]   "CURL::libcurl_static" is imported but not globally visible.
```

Follow-up to 1199308dbc902c52be67fc805c72dd2582520d30 #11505

Reported-by: balikalina on Github
Suggested-by: balikalina on Github
Ref: https://github.com/curl/curl/pull/11629#issuecomment-1671596059
Closes #11646
