### PR TITLE
cmake: don't include non-IMPORTED zlib target in check_library_exists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ endif()
 
 # initialize CURL_LIBS
 set(CURL_LIBS "")
+set(CURL_DEPS "")
 
 if(ENABLE_ARES)
   set(USE_ARES 1)
@@ -540,7 +541,12 @@ if(ZLIB_FOUND)
   # version of CMake.  This allows our dependents to get our dependencies
   # transitively.
   if(NOT CMAKE_VERSION VERSION_LESS 3.4)
-    list(APPEND CURL_LIBS ZLIB::ZLIB)
+    get_target_property(_imported ZLIB::ZLIB IMPORTED)
+    if(_imported)
+      list(APPEND CURL_LIBS ZLIB::ZLIB)
+    else()
+      list(APPEND CURL_DEPS ZLIB::ZLIB)
+    endif()
   else()
     list(APPEND CURL_LIBS ${ZLIB_LIBRARIES})
     include_directories(${ZLIB_INCLUDE_DIRS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,7 +60,7 @@ if(ENABLE_CURLDEBUG)
   # being applied to memdebug.c itself.
   set_source_files_properties(memdebug.c PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 endif()
-target_link_libraries(curlu PRIVATE ${CURL_LIBS})
+target_link_libraries(curlu PRIVATE ${CURL_LIBS} ${CURL_DEPS})
 
 transform_makefile_inc("Makefile.soname" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.soname.cmake")
 include(${CMAKE_CURRENT_BINARY_DIR}/Makefile.soname.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ include_directories(
   )
 
 #Build curl executable
-target_link_libraries(${EXE_NAME} ${LIB_SELECTED_FOR_EXE} ${CURL_LIBS})
+target_link_libraries(${EXE_NAME} ${LIB_SELECTED_FOR_EXE} ${CURL_LIBS} ${CURL_DEPS})
 
 ################################################################################
 

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -44,7 +44,7 @@ function(setup_test TEST_NAME)          # ARGN are the files in the test
     include_directories(${CARES_INCLUDE_DIR})
   endif()
 
-  target_link_libraries(${TEST_NAME} ${LIB_SELECTED} ${CURL_LIBS})
+  target_link_libraries(${TEST_NAME} ${LIB_SELECTED} ${CURL_LIBS} ${CURL_DEPS})
 
   set_target_properties(${TEST_NAME}
     PROPERTIES COMPILE_DEFINITIONS ${UPPER_TEST_NAME})

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -42,7 +42,7 @@ function(SETUP_EXECUTABLE TEST_NAME)    # ARGN are the files in the test
     include_directories(${CARES_INCLUDE_DIR})
   endif()
 
-  target_link_libraries(${TEST_NAME} ${CURL_LIBS})
+  target_link_libraries(${TEST_NAME} ${CURL_LIBS} ${CURL_DEPS})
 
   # Test servers simply are standalone programs that do not use libcurl
   # library.  For convenience and to ease portability of these servers,


### PR DESCRIPTION
`check_library_exists` does not work well with non-imported targets. ZLIB might not be an imported target if it is included in a parent cmake project before including curl. 

We use a separate variable `CURL_DEPS` to keep track of non-imported targets so they don't get caught up in the `check_library_exists_concat()` call.

Original issue: #11285.

Background info: https://github.com/curl/curl/issues/11285#issuecomment-1629432834 and https://github.com/curl/curl/pull/11537#discussion_r1286108596.