### PR TITLE
CI, ngtcp2-wolfssl, downgrade to wolfSSL v5.6.0

### DIFF
--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -51,7 +51,7 @@ env:
   ngtcp2-version: v0.18.0
   nghttp2-version: v1.55.1
   gnutls-version: 3.8.0
-  wolfssl-version: v5.6.3-stable
+  wolfssl-version: v5.6.2-stable
   mod_h2-version: v2.0.21
 
 jobs:

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -51,7 +51,7 @@ env:
   ngtcp2-version: v0.18.0
   nghttp2-version: v1.55.1
   gnutls-version: 3.8.0
-  wolfssl-version: v5.6.2-stable
+  wolfssl-version: v5.6.0-stable
   mod_h2-version: v2.0.21
 
 jobs:


### PR DESCRIPTION
- due to failures in test_02_07b with v5.6.3, tests with master seem to indicate that the issue with session reuse is fixed there