### PR TITLE
docs/cmdline-opts/gen.pl: hide "added in" before 7.50.0

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -169,8 +169,8 @@ sub too_old {
     elsif($version =~ /^(\d+)\.(\d+)/) {
         $a = $1 * 1000 + $2 * 10;
     }
-    if($a < 7300) {
-        # we consider everything before 7.30.0 to be too old to mention
+    if($a < 7500) {
+        # we consider everything before 7.50.0 to be too old to mention
         # specific changes for
         return 1;
     }


### PR DESCRIPTION
7.50.0 shipped on Jul 21 2016, over seven years ago. We no longer need to specify version changes for earlier releases in the generated output.

This ups the limit from the previous 7.30.0 (Apr 12 2013)

This hides roughly 35 "added in" mentions.