### PR TITLE
docs/HYPER.md: document a workaround for a link error

### DIFF
--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -29,12 +29,14 @@ Then build hyper and enable its C API like this:
      % cd hyper
      % RUSTFLAGS="--cfg hyper_unstable_ffi" cargo +nightly rustc --features client,http1,http2,ffi -Z unstable-options --crate-type cdylib
 
+Also, `--release` can be added for a release (optimized) build.
+
 Build curl to use hyper's C API:
 
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure --with-hyper=<hyper dir>
+     % ./configure LDFLAGS="-Wl,-rpath,<hyper-dir>/target/debug -Wl,-rpath,<hyper-dir>/target/release" --with-openssl --with-hyper=<hyper-dir>
      % make
 
 # using Hyper internally


### PR DESCRIPTION
I hit this problem when I tried to build curl+hyper and then run the tests.