### PR TITLE
quiche: fix quiche being unable to handle timeout events properly

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -56,7 +56,7 @@
 /* #define DEBUG_QUICHE */
 
 #define QUIC_MAX_STREAMS              (100)
-#define QUIC_IDLE_TIMEOUT        (5 * 1000) /* milliseconds */
+#define QUIC_IDLE_TIMEOUT        (60 * 1000) /* milliseconds */
 
 #define H3_STREAM_WINDOW_SIZE  (128 * 1024)
 #define H3_STREAM_CHUNK_SIZE    (16 * 1024)

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -751,6 +751,12 @@ static CURLcode cf_flush_egress(struct Curl_cfilter *cf,
   struct read_ctx readx;
   size_t pkt_count, gsolen;
 
+  quiche_conn_on_timeout(ctx->qconn);
+  if(quiche_conn_is_closed(ctx->qconn)) {
+    failf(data, "quiche_conn_on_timeout closed the connection");
+    return CURLE_SEND_ERROR;
+  }
+
   result = vquic_flush(cf, data, &ctx->q);
   if(result) {
     if(result == CURLE_AGAIN) {

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -747,14 +747,18 @@ static CURLcode cf_flush_egress(struct Curl_cfilter *cf,
   struct cf_quiche_ctx *ctx = cf->ctx;
   ssize_t nread;
   CURLcode result;
+  int64_t expiry_ns;
   int64_t timeout_ns;
   struct read_ctx readx;
   size_t pkt_count, gsolen;
 
-  quiche_conn_on_timeout(ctx->qconn);
-  if(quiche_conn_is_closed(ctx->qconn)) {
-    failf(data, "quiche_conn_on_timeout closed the connection");
-    return CURLE_SEND_ERROR;
+  expiry_ns = quiche_conn_timeout_as_nanos(ctx->qconn);
+  if(!expiry_ns) {
+    quiche_conn_on_timeout(ctx->qconn);
+    if(quiche_conn_is_closed(ctx->qconn)) {
+      failf(data, "quiche_conn_on_timeout closed the connection");
+      return CURLE_SEND_ERROR;
+    }
   }
 
   result = vquic_flush(cf, data, &ctx->q);


### PR DESCRIPTION
According to [quiche's document](https://github.com/cloudflare/quiche/blob/master/README.md#generating-outgoing-packets), it is essential to invoke `quiche_conn_on_timeout` when a timer expires. Failing to call this function can result in quiche being unable to manage various timeout events, including scenarios like retransmitting lost packets and handling idle timeout events.

> When packets are sent, the application is responsible for maintaining a timer to react to time-based connection events. The timer expiration can be obtained using the connection's [timeout()](https://docs.quic.tech/quiche/struct.Connection.html#method.timeout) method.

> The application is responsible for providing a timer implementation, which can be specific to the operating system or networking framework used. When a timer expires, the connection's [on_timeout()](https://docs.quic.tech/quiche/struct.Connection.html#method.on_timeout) method should be called, after which additional packets might need to be sent on the network: