### PR TITLE
curl_quiche: remove superfluous NULL check

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -908,8 +908,7 @@ out:
     ctx->data_recvd += nread;
   CURL_TRC_CF(data, cf, "[%"PRId64"] cf_recv(total=%"
               CURL_FORMAT_CURL_OFF_T ") -> %zd, %d",
-              stream ? stream->id : (int64_t)0,
-              ctx->data_recvd, nread, *err);
+              stream->id, ctx->data_recvd, nread, *err);
   return nread;
 }
 


### PR DESCRIPTION
'stream' is always non-NULL at this point

Pointed out by Coverity