### PR TITLE
build: streamline non-UWP wincrypt detections

### DIFF
--- a/CMake/Platforms/WindowsCache.cmake
+++ b/CMake/Platforms/WindowsCache.cmake
@@ -27,7 +27,6 @@ if(NOT UNIX)
     set(HAVE_WINDOWS_H 1)
     set(HAVE_WS2TCPIP_H 1)
     set(HAVE_WINSOCK2_H 1)
-    set(HAVE_WINCRYPT_H 1)
 
     if(MINGW)
       set(HAVE_SNPRINTF 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1332,11 +1332,8 @@ if(WIN32)
   # Use the manifest embedded in the Windows Resource
   set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} -DCURL_EMBED_MANIFEST")
 
-  # Check if crypto functions in wincrypt.h are actually available
-  if(HAVE_WINCRYPT_H)
-    check_symbol_exists(CryptAcquireContext "windows.h;wincrypt.h" USE_WINCRYPT)
-  endif()
-  if(USE_WINCRYPT)
+  # We use crypto functions that are not available for UWP apps
+  if(NOT WINDOWS_STORE)
     set(USE_WIN32_CRYPTO ON)
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,7 +997,6 @@ if(NOT UNIX)
   check_include_file_concat("windows.h"      HAVE_WINDOWS_H)
   check_include_file_concat("ws2tcpip.h"     HAVE_WS2TCPIP_H)
   check_include_file_concat("winsock2.h"     HAVE_WINSOCK2_H)
-  check_include_file_concat("wincrypt.h"     HAVE_WINCRYPT_H)
 endif()
 
 check_include_file_concat("inttypes.h"       HAVE_INTTYPES_H)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1664,6 +1664,7 @@ dnl -------------------------------------------------
 dnl Check if curl's WIN32 crypto lib can be used
 
 AC_DEFUN([CURL_CHECK_WIN32_CRYPTO], [
+  AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
   AC_MSG_CHECKING([whether build target supports WIN32 crypto API])
   curl_win32_crypto_api="no"
   AC_COMPILE_IFELSE([

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -312,39 +312,6 @@ AC_DEFUN([CURL_CHECK_HEADER_WS2TCPIP], [
 ])
 
 
-dnl CURL_CHECK_HEADER_WINCRYPT
-dnl -------------------------------------------------
-dnl Check for compilable and valid wincrypt.h header
-
-AC_DEFUN([CURL_CHECK_HEADER_WINCRYPT], [
-  AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
-  AC_CACHE_CHECK([for wincrypt.h], [curl_cv_header_wincrypt_h], [
-    AC_COMPILE_IFELSE([
-      AC_LANG_PROGRAM([[
-#undef inline
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#include <wincrypt.h>
-      ]],[[
-        int dummy=2*PROV_RSA_FULL;
-      ]])
-    ],[
-      curl_cv_header_wincrypt_h="yes"
-    ],[
-      curl_cv_header_wincrypt_h="no"
-    ])
-  ])
-  case "$curl_cv_header_wincrypt_h" in
-    yes)
-      AC_DEFINE_UNQUOTED(HAVE_WINCRYPT_H, 1,
-        [Define to 1 if you have the wincrypt.h header file.])
-      ;;
-  esac
-])
-
-
 dnl CURL_CHECK_HEADER_LBER
 dnl -------------------------------------------------
 dnl Check for compilable and valid lber.h header,
@@ -1697,29 +1664,26 @@ dnl -------------------------------------------------
 dnl Check if curl's WIN32 crypto lib can be used
 
 AC_DEFUN([CURL_CHECK_WIN32_CRYPTO], [
-  AC_REQUIRE([CURL_CHECK_HEADER_WINCRYPT])dnl
   AC_MSG_CHECKING([whether build target supports WIN32 crypto API])
   curl_win32_crypto_api="no"
-  if test "$curl_cv_header_wincrypt_h" = "yes"; then
-    AC_COMPILE_IFELSE([
-      AC_LANG_PROGRAM([[
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
 #undef inline
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
 #include <wincrypt.h>
-      ]],[[
-        HCRYPTPROV hCryptProv;
-        if(CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL,
-                               CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
-          CryptReleaseContext(hCryptProv, 0);
-        }
-      ]])
-    ],[
-      curl_win32_crypto_api="yes"
-    ])
-  fi
+    ]],[[
+      HCRYPTPROV hCryptProv;
+      if(CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL,
+                             CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
+        CryptReleaseContext(hCryptProv, 0);
+      }
+    ]])
+  ],[
+    curl_win32_crypto_api="yes"
+  ])
   case "$curl_win32_crypto_api" in
     yes)
       AC_MSG_RESULT([yes])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1667,24 +1667,26 @@ AC_DEFUN([CURL_CHECK_WIN32_CRYPTO], [
   AC_REQUIRE([CURL_CHECK_HEADER_WINDOWS])dnl
   AC_MSG_CHECKING([whether build target supports WIN32 crypto API])
   curl_win32_crypto_api="no"
-  AC_COMPILE_IFELSE([
-    AC_LANG_PROGRAM([[
+  if test "$curl_cv_header_windows_h" = "yes"; then
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
 #undef inline
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
 #include <wincrypt.h>
-    ]],[[
-      HCRYPTPROV hCryptProv;
-      if(CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL,
-                             CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
-        CryptReleaseContext(hCryptProv, 0);
-      }
-    ]])
-  ],[
-    curl_win32_crypto_api="yes"
-  ])
+      ]],[[
+        HCRYPTPROV hCryptProv;
+        if(CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL,
+                               CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
+          CryptReleaseContext(hCryptProv, 0);
+        }
+      ]])
+    ],[
+      curl_win32_crypto_api="yes"
+    ])
+  fi
   case "$curl_win32_crypto_api" in
     yes)
       AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -657,12 +657,10 @@ case X-"$curl_cv_native_windows" in
   X-yes)
     CURL_CHECK_HEADER_WINSOCK2
     CURL_CHECK_HEADER_WS2TCPIP
-    CURL_CHECK_HEADER_WINCRYPT
     ;;
   *)
     curl_cv_header_winsock2_h="no"
     curl_cv_header_ws2tcpip_h="no"
-    curl_cv_header_wincrypt_h="no"
     ;;
 esac
 CURL_CHECK_WIN32_LARGEFILE


### PR DESCRIPTION
- with CMake, use the variable `WINDOWS_STORE` to detect an UWP build
  and disable our non-UWP-compatible use the Windows crypto API. This
  allows to drop two dynamic feature checks.

  `WINDOWS_STORE` is true when invoking CMake with
  `CMAKE_SYSTEM_NAME` == `WindowsStore`. Introduced in CMake v3.1.

  Ref: https://cmake.org/cmake/help/latest/variable/WINDOWS_STORE.html

- with autotools, drop the separate feature check for `wincrypt.h`. On
  one hand this header has been present for long (even Borland C 5.5 had
  it from year 2000), on the other we used the check result solely to
  enable another check for certain crypto functions. This fails anyway
  with the header not present. We save one dynamic feature check at the
  configure stage.

Closes #11657
