### PR TITLE
spellcheck: adapt to backslashed minuses

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -853,6 +853,8 @@ Viktor
 VM
 VMS
 VMware
+VRF
+VRFY
 VSE
 vsprintf
 vt

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -54,7 +54,7 @@ jobs:
     - name: trim the curl.1 markdown file
       run: |
         perl -pi -e 's/^    .*//' docs/curl.md
-        perl -pi -e 's/--[a-z0-9-]*//ig' docs/curl.md
+        perl -pi -e 's/\-\-[a-z0-9\-]*//ig' docs/curl.md
         perl -pi -e 's!https://[a-z0-9%/.-]*!!ig' docs/curl.md
 
     - name: setup the custom wordlist

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -54,7 +54,7 @@ jobs:
     - name: trim the curl.1 markdown file
       run: |
         perl -pi -e 's/^    .*//' docs/curl.md
-        perl -pi -e 's/\-\-[a-z0-9\-]*//ig' docs/curl.md
+        perl -pi -e 's/\-\-[\a-z0-9-]*//ig' docs/curl.md
         perl -pi -e 's!https://[a-z0-9%/.-]*!!ig' docs/curl.md
 
     - name: setup the custom wordlist

--- a/docs/cmdline-opts/login-options.d
+++ b/docs/cmdline-opts/login-options.d
@@ -13,9 +13,10 @@ Multi: single
 Specify the login options to use during server authentication.
 
 You can use login options to specify protocol specific options that may be
-used during authentication. At present only IMAP, POP3 and SMTP support
-login options. For more information about login options please see RFC
-2384, RFC 5092 and the IETF draft **draft-earhart-url-smtp-00.txt**.
+used during authentication. At present only IMAP, POP3 and SMTP support login
+options. For more information about login options please see RFC 2384,
+RFC 5092 and the IETF draft
+https://datatracker.ietf.org/doc/html/draft-earhart-url-smtp-00.
 
 Since 8.2.0, IMAP supports the login option "AUTH=+LOGIN". With this option,
 curl uses the plain (not SASL) LOGIN IMAP command even if the server advertises

--- a/docs/cmdline-opts/mail-rcpt.d
+++ b/docs/cmdline-opts/mail-rcpt.d
@@ -13,7 +13,7 @@ Multi: append
 Specify a single email address, user name or mailing list name. Repeat this
 option several times to send to multiple recipients.
 
-When performing an address verification (*VRFY* command), the recipient should be
+When performing an address verification (**VRFY** command), the recipient should be
 specified as the user name or user name and domain (as per Section 3.5 of
 RFC 5321). (Added in 7.34.0)
 

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -44,6 +44,6 @@ To suppress response bodies, you can redirect output to /dev/null:
 
  curl example.com -o /dev/null
 
-Or for Windows use **nul**:
+Or for Windows:
 
  curl example.com -o nul

--- a/docs/cmdline-opts/output.d
+++ b/docs/cmdline-opts/output.d
@@ -28,13 +28,13 @@ You may use this option as many times as the number of URLs you have. For
 example, if you specify two URLs on the same command line, you can use it like
 this:
 
-  curl -o aa example.com -o bb example.net
+ curl -o aa example.com -o bb example.net
 
 and the order of the -o options and the URLs does not matter, just that the
 first -o is for the first URL and so on, so the above command line can also be
 written as
 
-  curl example.com example.net -o aa -o bb
+ curl example.com example.net -o aa -o bb
 
 See also the --create-dirs option to create the local directories
 dynamically. Specifying the output as '-' (a single dash) will force the
@@ -42,8 +42,8 @@ output to be done to stdout.
 
 To suppress response bodies, you can redirect output to /dev/null:
 
-  curl example.com -o /dev/null
+ curl example.com -o /dev/null
 
 Or for Windows use **nul**:
 
-  curl example.com -o nul
+ curl example.com -o nul

--- a/docs/cmdline-opts/request.d
+++ b/docs/cmdline-opts/request.d
@@ -46,6 +46,6 @@ Specifies a custom POP3 command to use instead of *LIST* or *RETR*.
 Specifies a custom IMAP command to use instead of *LIST*. (Added in 7.30.0)
 .TP
 **SMTP**
-Specifies a custom SMTP command to use instead of *HELP* or *VRFY*. (Added in 7.34.0)
+Specifies a custom SMTP command to use instead of *HELP* or **VRFY**. (Added in 7.34.0)
 .RE
 .IP


### PR DESCRIPTION
As the curl.1 has more backslashed minus, the cleanup sed lines xneed to adapt.