### PR TITLE
CURLINFO_TLS_SSL_PTR.3: clarify a recommendation

### DIFF
--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
@@ -111,11 +111,9 @@ and the certificate may change, and data may continue to be sent or received
 after renegotiation but before you are able to get the (possibly) changed SSL
 pointer, with the (possibly) changed certificate information.
 
-If you are using OpenSSL or wolfSSL then \fICURLOPT_SSL_CTX_FUNCTION(3)\fP can
-be used to set a certificate verification callback. That is safer than using
-this option to poll for certificate changes and does not suffer from any of
-the problems above. There is currently no way in libcurl to set a verification
-callback for the other SSL backends.
+Instead of using this option to poll for certificate changes use
+\fICURLOPT_SSL_CTX_FUNCTION(3)\fP to set a verification callback, if supported.
+That is safer and does not suffer from any of the problems above.
 
 How are you using this option? Are you affected by any of these limitations?
 Please let us know by making a comment at


### PR DESCRIPTION
- Remove the out-of-date SSL backend list supported by CURLOPT_SSL_CTX_FUNCTION.

It makes more sense to just refer to that document instead of having a separate list that has to be kept in sync.

Closes #xxxx