### PR TITLE
transfer: don't set TIMER_STARTTRANSFER on first send

### DIFF
--- a/docs/cmdline-opts/write-out.d
+++ b/docs/cmdline-opts/write-out.d
@@ -207,9 +207,9 @@ started. time_redirect shows the complete execution time for multiple
 redirections. (Added in 7.12.3)
 .TP
 **time_starttransfer**
-The time, in seconds, it took from the start until the first byte was just
-about to be transferred. This includes time_pretransfer and also the time the
-server needed to calculate the result.
+The time, in seconds, it took from the start until the first byte is received.
+This includes time_pretransfer and also the time the server needed to calculate
+the result.
 .TP
 **time_total**
 The total time, in seconds, that the full operation lasted.

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -824,9 +824,6 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
   bool sending_http_headers = FALSE;
   struct SingleRequest *k = &data->req;
 
-  if((k->bytecount == 0) && (k->writebytecount == 0))
-    Curl_pgrsTime(data, TIMER_STARTTRANSFER);
-
   *didwhat |= KEEP_SEND;
 
   do {


### PR DESCRIPTION
The time stamp is for measuring the first *received* byte

Fixes #11669
Reported-by: JazJas on github