### PR TITLE
imap: remove the only sscanf() call in the IMAP code + add strdup() check

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1115,7 +1115,10 @@ static CURLcode imap_state_select_resp(struct Curl_easy *data, int imapcode,
     }
     else {
       /* Note the currently opened mailbox on this connection */
+      DEBUGASSERT(!imapc->mailbox);
       imapc->mailbox = strdup(imap->mailbox);
+      if(!imapc->mailbox)
+        return CURLE_OUT_OF_MEMORY;
 
       if(imap->custom)
         result = imap_perform_list(data);

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1091,10 +1091,19 @@ static CURLcode imap_state_select_resp(struct Curl_easy *data, int imapcode,
 
   if(imapcode == '*') {
     /* See if this is an UIDVALIDITY response */
-    char tmp[20];
-    if(sscanf(line + 2, "OK [UIDVALIDITY %19[0123456789]]", tmp) == 1) {
-      Curl_safefree(imapc->mailbox_uidvalidity);
-      imapc->mailbox_uidvalidity = strdup(tmp);
+    if(checkprefix("OK [UIDVALIDITY ", line + 2)) {
+      size_t len = 0;
+      const char *p = &line[2] + strlen("OK [UIDVALIDITY ");
+      while(p[len] && ISDIGIT(p[len]) && (len < 20))
+        len++;
+      if(len && (p[len] == ']')) {
+        struct dynbuf uid;
+        Curl_dyn_init(&uid, 20);
+        if(Curl_dyn_addn(&uid, p, len))
+          return CURLE_OUT_OF_MEMORY;
+        Curl_safefree(imapc->mailbox_uidvalidity);
+        imapc->mailbox_uidvalidity = Curl_dyn_ptr(&uid);
+      }
     }
   }
   else if(imapcode == IMAP_RESP_OK) {

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1094,7 +1094,7 @@ static CURLcode imap_state_select_resp(struct Curl_easy *data, int imapcode,
     if(checkprefix("OK [UIDVALIDITY ", line + 2)) {
       size_t len = 0;
       const char *p = &line[2] + strlen("OK [UIDVALIDITY ");
-      while(p[len] && ISDIGIT(p[len]) && (len < 20))
+      while((len < 20) && p[len] && ISDIGIT(p[len]))
         len++;
       if(len && (p[len] == ']')) {
         struct dynbuf uid;


### PR DESCRIPTION
- sscanf has generally been a source of past problems
- this improvement also verifies that the uid ends with `]` which it did not previously
- failing a `strdup()` should never be silently ignored.