### PR TITLE
TLS session sharing test, BearSSL affection

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -587,6 +587,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
   const bool verifyhost = conn_config->verifyhost;
   CURLcode ret;
   unsigned version_min, version_max;
+  int session_set = 0;
 #ifdef ENABLE_IPV6
   struct in6_addr addr;
 #else
@@ -594,6 +595,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
 #endif
 
   DEBUGASSERT(backend);
+  CURL_TRC_CF(data, cf, "connect_step1");
 
   switch(conn_config->version) {
   case CURL_SSLVERSION_SSLv2:
@@ -631,6 +633,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
       source.data = ca_info_blob->data;
       source.len = ca_info_blob->len;
 
+      CURL_TRC_CF(data, cf, "connect_step1, load ca_info_blob");
       ret = load_cafile(&source, &backend->anchors, &backend->anchors_len);
       if(ret != CURLE_OK) {
         failf(data, "error importing CA certificate blob");
@@ -644,6 +647,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
       source.data = ssl_cafile;
       source.len = 0;
 
+      CURL_TRC_CF(data, cf, "connect_step1, load cafile");
       ret = load_cafile(&source, &backend->anchors, &backend->anchors_len);
       if(ret != CURLE_OK) {
         failf(data, "error setting certificate verify locations."
@@ -663,6 +667,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
   if(conn_config->cipher_list) {
     /* Override the ciphers as specified. For the default cipher list see the
        BearSSL source code of br_ssl_client_init_full() */
+    CURL_TRC_CF(data, cf, "connect_step1, set ciphers");
     ret = bearssl_set_selected_ciphers(data, &backend->ctx.eng,
                                        conn_config->cipher_list);
     if(ret)
@@ -678,9 +683,11 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
   if(ssl_config->primary.sessionid) {
     void *session;
 
+    CURL_TRC_CF(data, cf, "connect_step1, check session cache");
     Curl_ssl_sessionid_lock(data);
     if(!Curl_ssl_getsessionid(cf, data, &session, NULL)) {
       br_ssl_engine_set_session_parameters(&backend->ctx.eng, session);
+      session_set = 1;
       infof(data, "BearSSL: re-using session ID");
     }
     Curl_ssl_sessionid_unlock(data);
@@ -718,6 +725,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
       return CURLE_SSL_CONNECT_ERROR;
     }
     hostname = snihost;
+    CURL_TRC_CF(data, cf, "connect_step1, SNI set");
   }
 
   /* give application a chance to interfere with SSL set up. */
@@ -732,13 +740,35 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
     }
   }
 
-  if(!br_ssl_client_reset(&backend->ctx, hostname, 1))
+  if(!br_ssl_client_reset(&backend->ctx, hostname, session_set))
     return CURLE_FAILED_INIT;
   backend->active = TRUE;
 
   connssl->connecting_state = ssl_connect_2;
 
   return CURLE_OK;
+}
+
+static int bearssl_get_select_socks(struct Curl_cfilter *cf,
+                                    struct Curl_easy *data,
+                                    curl_socket_t *socks)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  curl_socket_t sock = Curl_conn_cf_get_socket(cf->next, data);
+
+  if(sock == CURL_SOCKET_BAD)
+    return GETSOCK_BLANK;
+  else {
+    struct bearssl_ssl_backend_data *backend =
+      (struct bearssl_ssl_backend_data *)connssl->backend;
+    unsigned state = br_ssl_engine_current_state(&backend->ctx.eng);
+    if(state & BR_SSL_SENDREC) {
+      socks[0] = sock;
+      return GETSOCK_WRITESOCK(0);
+    }
+  }
+  socks[0] = sock;
+  return GETSOCK_READSOCK(0);
 }
 
 static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
@@ -792,6 +822,7 @@ static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
     if(state & BR_SSL_SENDREC) {
       buf = br_ssl_engine_sendrec_buf(&backend->ctx.eng, &len);
       ret = Curl_conn_cf_send(cf->next, data, (char *)buf, len, &result);
+      CURL_TRC_CF(data, cf, "ssl_send(len=%zu) -> %zd, %d", len, ret, result);
       if(ret <= 0) {
         return result;
       }
@@ -800,6 +831,7 @@ static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
     else if(state & BR_SSL_RECVREC) {
       buf = br_ssl_engine_recvrec_buf(&backend->ctx.eng, &len);
       ret = Curl_conn_cf_recv(cf->next, data, (char *)buf, len, &result);
+      CURL_TRC_CF(data, cf, "ssl_recv(len=%zu) -> %zd, %d", len, ret, result);
       if(ret == 0) {
         failf(data, "SSL: EOF without close notify");
         return CURLE_READ_ERROR;
@@ -821,16 +853,26 @@ static CURLcode bearssl_connect_step2(struct Curl_cfilter *cf,
   CURLcode ret;
 
   DEBUGASSERT(backend);
+  CURL_TRC_CF(data, cf, "connect_step2");
 
   ret = bearssl_run_until(cf, data, BR_SSL_SENDAPP | BR_SSL_RECVAPP);
   if(ret == CURLE_AGAIN)
     return CURLE_OK;
   if(ret == CURLE_OK) {
+    unsigned int tver;
     if(br_ssl_engine_current_state(&backend->ctx.eng) == BR_SSL_CLOSED) {
       failf(data, "SSL: connection closed during handshake");
       return CURLE_SSL_CONNECT_ERROR;
     }
     connssl->connecting_state = ssl_connect_3;
+    /* Informational message */
+    tver = br_ssl_engine_get_version(&backend->ctx.eng);
+    if(tver == 0x0303)
+      infof(data, "SSL connection using TLSv1.2");
+    else if(tver == 0x0304)
+      infof(data, "SSL connection using TLSv1.3");
+    else
+      infof(data, "SSL connection using TLS 0x%x", tver);
   }
   return ret;
 }
@@ -846,6 +888,7 @@ static CURLcode bearssl_connect_step3(struct Curl_cfilter *cf,
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
   DEBUGASSERT(backend);
+  CURL_TRC_CF(data, cf, "connect_step3");
 
   if(connssl->alpn) {
     const char *proto;
@@ -954,8 +997,10 @@ static CURLcode bearssl_connect_common(struct Curl_cfilter *cf,
   timediff_t timeout_ms;
   int what;
 
+  CURL_TRC_CF(data, cf, "connect_common(blocking=%d)", !nonblocking);
   /* check if the connection has already been established */
   if(ssl_connection_complete == connssl->state) {
+    CURL_TRC_CF(data, cf, "connect_common, connected");
     *done = TRUE;
     return CURLE_OK;
   }
@@ -987,8 +1032,10 @@ static CURLcode bearssl_connect_common(struct Curl_cfilter *cf,
       curl_socket_t readfd = ssl_connect_2_reading ==
         connssl->connecting_state?sockfd:CURL_SOCKET_BAD;
 
+      CURL_TRC_CF(data, cf, "connect_common, check socket");
       what = Curl_socket_check(readfd, CURL_SOCKET_BAD, writefd,
                                nonblocking?0:timeout_ms);
+      CURL_TRC_CF(data, cf, "connect_common, check socket -> %d", what);
       if(what < 0) {
         /* fatal error */
         failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
@@ -1163,7 +1210,7 @@ const struct Curl_ssl Curl_ssl_bearssl = {
   Curl_none_cert_status_request,   /* cert_status_request */
   bearssl_connect,                 /* connect */
   bearssl_connect_nonblocking,     /* connect_nonblocking */
-  Curl_ssl_get_select_socks,                /* getsock */
+  bearssl_get_select_socks,        /* getsock */
   bearssl_get_internals,           /* get_internals */
   bearssl_close,                   /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -635,19 +635,16 @@ int Curl_ssl_get_select_socks(struct Curl_cfilter *cf, struct Curl_easy *data,
   struct ssl_connect_data *connssl = cf->ctx;
   curl_socket_t sock = Curl_conn_cf_get_socket(cf->next, data);
 
-  if(sock != CURL_SOCKET_BAD) {
-    if(connssl->connecting_state == ssl_connect_2_writing) {
-      /* write mode */
-      socks[0] = sock;
-      return GETSOCK_WRITESOCK(0);
-    }
-    if(connssl->connecting_state == ssl_connect_2_reading) {
-      /* read mode */
-      socks[0] = sock;
-      return GETSOCK_READSOCK(0);
-    }
+  if(sock == CURL_SOCKET_BAD)
+    return GETSOCK_BLANK;
+
+  if(connssl->connecting_state == ssl_connect_2_writing) {
+    /* we are only interested in writing */
+    socks[0] = sock;
+    return GETSOCK_WRITESOCK(0);
   }
-  return GETSOCK_BLANK;
+  socks[0] = sock;
+  return GETSOCK_READSOCK(0);
 }
 
 /* Selects an SSL crypto engine
@@ -1512,6 +1509,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
   }
 
   CF_DATA_SAVE(save, cf, data);
+  CURL_TRC_CF(data, cf, "cf_connect()");
   (void)connssl;
   DEBUGASSERT(data->conn);
   DEBUGASSERT(data->conn == cf->conn);
@@ -1541,6 +1539,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
     DEBUGASSERT(connssl->state == ssl_connection_complete);
   }
 out:
+  CURL_TRC_CF(data, cf, "cf_connect() -> %d, done=%d", result, *done);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -1601,12 +1600,17 @@ static int ssl_cf_get_select_socks(struct Curl_cfilter *cf,
                                    curl_socket_t *socks)
 {
   struct cf_call_data save;
-  int result;
+  int fds = GETSOCK_BLANK;
 
-  CF_DATA_SAVE(save, cf, data);
-  result = Curl_ssl->get_select_socks(cf, data, socks);
-  CF_DATA_RESTORE(cf, save);
-  return result;
+  if(!cf->next->connected) {
+    fds = cf->next->cft->get_select_socks(cf->next, data, socks);
+  }
+  else if(!cf->connected) {
+    CF_DATA_SAVE(save, cf, data);
+    fds = Curl_ssl->get_select_socks(cf, data, socks);
+    CF_DATA_RESTORE(cf, save);
+  }
+  return fds;
 }
 
 static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf,

--- a/tests/http/clients/.gitignore
+++ b/tests/http/clients/.gitignore
@@ -7,3 +7,4 @@ h2-download
 ws-data
 ws-pingpong
 h2-upgrade-extreme
+tls-session-reuse

--- a/tests/http/clients/Makefile.inc
+++ b/tests/http/clients/Makefile.inc
@@ -28,4 +28,5 @@ check_PROGRAMS = \
   h2-download \
   ws-data \
   ws-pingpong \
-  h2-upgrade-extreme
+  h2-upgrade-extreme \
+  tls-session-reuse

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -1,0 +1,306 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* <DESC>
+ * TLS session reuse
+ * </DESC>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+/* #include <error.h> */
+#include <errno.h>
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
+
+static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
+{
+  /*
+   * This is the trace look that is similar to what libcurl makes on its
+   * own.
+   */
+  static const char * const s_infotype[] = {
+    "* ", "< ", "> ", "{ ", "} ", "{ ", "} "
+  };
+  if(idsbuf && *idsbuf)
+    fprintf(log, "%s%s", idsbuf, s_infotype[type]);
+  else
+    fputs(s_infotype[type], log);
+}
+
+#define TRC_IDS_FORMAT_IDS_1  "[%" CURL_FORMAT_CURL_OFF_T "-x] "
+#define TRC_IDS_FORMAT_IDS_2  "[%" CURL_FORMAT_CURL_OFF_T "-%" \
+                                   CURL_FORMAT_CURL_OFF_T "] "
+/*
+** callback for CURLOPT_DEBUGFUNCTION
+*/
+static int debug_cb(CURL *handle, curl_infotype type,
+                    char *data, size_t size,
+                    void *userdata)
+{
+  FILE *output = stderr;
+  static int newl = 0;
+  static int traced_data = 0;
+  char idsbuf[60];
+  curl_off_t xfer_id, conn_id;
+
+  (void)handle; /* not used */
+  (void)userdata;
+
+  if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
+    if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
+        conn_id >= 0) {
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
+                     xfer_id, conn_id);
+    }
+    else {
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+    }
+  }
+  else
+    idsbuf[0] = 0;
+
+  switch(type) {
+  case CURLINFO_HEADER_OUT:
+    if(size > 0) {
+      size_t st = 0;
+      size_t i;
+      for(i = 0; i < size - 1; i++) {
+        if(data[i] == '\n') { /* LF */
+          if(!newl) {
+            log_line_start(output, idsbuf, type);
+          }
+          (void)fwrite(data + st, i - st + 1, 1, output);
+          st = i + 1;
+          newl = 0;
+        }
+      }
+      if(!newl)
+        log_line_start(output, idsbuf, type);
+      (void)fwrite(data + st, i - st + 1, 1, output);
+    }
+    newl = (size && (data[size - 1] != '\n')) ? 1 : 0;
+    traced_data = 0;
+    break;
+  case CURLINFO_TEXT:
+  case CURLINFO_HEADER_IN:
+    if(!newl)
+      log_line_start(output, idsbuf, type);
+    (void)fwrite(data, size, 1, output);
+    newl = (size && (data[size - 1] != '\n')) ? 1 : 0;
+    traced_data = 0;
+    break;
+  case CURLINFO_DATA_OUT:
+  case CURLINFO_DATA_IN:
+  case CURLINFO_SSL_DATA_IN:
+  case CURLINFO_SSL_DATA_OUT:
+    if(!traced_data) {
+      if(!newl)
+        log_line_start(output, idsbuf, type);
+      fprintf(output, "[%ld bytes data]\n", (long)size);
+      newl = 0;
+      traced_data = 1;
+    }
+    break;
+  default: /* nada */
+    newl = 0;
+    traced_data = 1;
+    break;
+  }
+
+  return 0;
+}
+
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *opaque)
+{
+  (void)ptr;
+  (void)opaque;
+  return size * nmemb;
+}
+
+static void add_transfer(CURLM *multi, CURLSH *share,
+                         struct curl_slist *resolve, const char *url)
+{
+  CURL *easy;
+  CURLMcode mc;
+
+  easy = curl_easy_init();
+  if(!easy) {
+    fprintf(stderr, "curl_easy_init failed\n");
+    exit(1);
+  }
+  curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(easy, CURLOPT_DEBUGFUNCTION, debug_cb);
+  curl_easy_setopt(easy, CURLOPT_URL, url);
+  curl_easy_setopt(easy, CURLOPT_SHARE, share);
+  curl_easy_setopt(easy, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(easy, CURLOPT_AUTOREFERER, 1L);
+  curl_easy_setopt(easy, CURLOPT_FAILONERROR, 1L);
+  curl_easy_setopt(easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
+  curl_easy_setopt(easy, CURLOPT_WRITEDATA, NULL);
+  curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
+  curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 0L);
+  if(resolve)
+    curl_easy_setopt(easy, CURLOPT_RESOLVE, resolve);
+
+
+  mc = curl_multi_add_handle(multi, easy);
+  if(mc != CURLM_OK) {
+    fprintf(stderr, "curl_multi_add_handle: %s\n",
+           curl_multi_strerror(mc));
+    exit(1);
+  }
+}
+
+int main(int argc, char *argv[])
+{
+  const char *url;
+  CURLM *multi;
+  CURLMcode mc;
+  int running_handles = 0, numfds;
+  CURLMsg *msg;
+  CURLSH *share;
+  CURLU *cu;
+  struct curl_slist resolve;
+  char resolve_buf[1024];
+  int msgs_in_queue;
+  int add_more, waits, ongoing = 0;
+  char *host, *port;
+
+  if(argc != 2) {
+    fprintf(stderr, "%s URL\n", argv[0]);
+    exit(2);
+  }
+
+  url = argv[1];
+  cu = curl_url();
+  if(!cu) {
+    fprintf(stderr, "out of memory\n");
+    exit(1);
+  }
+  if(curl_url_set(cu, CURLUPART_URL, url, 0)) {
+    fprintf(stderr, "not a URL: '%s'\n", url);
+    exit(1);
+  }
+  if(curl_url_get(cu, CURLUPART_HOST, &host, 0)) {
+    fprintf(stderr, "could not get host of '%s'\n", url);
+    exit(1);
+  }
+  if(curl_url_get(cu, CURLUPART_PORT, &port, 0)) {
+    fprintf(stderr, "could not get port of '%s'\n", url);
+    exit(1);
+  }
+
+   memset(&resolve, 0, sizeof(resolve));
+   curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1,
+                  "%s:%s:127.0.0.1", host, port);
+  curl_slist_append(&resolve, resolve_buf);
+
+  multi = curl_multi_init();
+  if(!multi) {
+    fprintf(stderr, "curl_multi_init failed\n");
+    exit(1);
+  }
+
+  share = curl_share_init();
+  if(!share) {
+    fprintf(stderr, "curl_share_init failed\n");
+    exit(1);
+  }
+  curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+
+
+  add_transfer(multi, share, &resolve, url);
+  ++ongoing;
+  add_more = 6;
+  waits = 3;
+  do {
+    mc = curl_multi_perform(multi, &running_handles);
+    if(mc != CURLM_OK) {
+      fprintf(stderr, "curl_multi_perform: %s\n",
+             curl_multi_strerror(mc));
+      exit(1);
+    }
+
+    if(running_handles) {
+      mc = curl_multi_poll(multi, NULL, 0, 1000000, &numfds);
+      if(mc != CURLM_OK) {
+        fprintf(stderr, "curl_multi_poll: %s\n",
+               curl_multi_strerror(mc));
+        exit(1);
+      }
+    }
+
+    if(waits) {
+      --waits;
+    }
+    else {
+      while(add_more) {
+        add_transfer(multi, share, &resolve, url);
+        ++ongoing;
+        --add_more;
+      }
+    }
+
+    /* Check for finished handles and remove. */
+    while((msg = curl_multi_info_read(multi, &msgs_in_queue))) {
+      if(msg->msg == CURLMSG_DONE) {
+        long status = 0;
+        curl_off_t xfer_id;
+        curl_easy_getinfo(msg->easy_handle, CURLINFO_XFER_ID, &xfer_id);
+        curl_easy_getinfo(msg->easy_handle, CURLINFO_RESPONSE_CODE, &status);
+        if(msg->data.result == CURLE_SEND_ERROR ||
+            msg->data.result == CURLE_RECV_ERROR) {
+          /* We get these if the server had a GOAWAY in transit on
+           * re-using a connection */
+        }
+        else if(msg->data.result) {
+          fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
+                  ": failed with %d\n", xfer_id, msg->data.result);
+          exit(1);
+        }
+        else if(status != 200) {
+          fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
+                  ": wrong http status %ld (expected 200)\n", xfer_id, status);
+          exit(1);
+        }
+        curl_multi_remove_handle(multi, msg->easy_handle);
+        curl_easy_cleanup(msg->easy_handle);
+        --ongoing;
+        fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T" retiring "
+                "(%d now running)\n", xfer_id, running_handles);
+      }
+    }
+
+    fprintf(stderr, "running_handles=%d, yet_to_start=%d\n",
+            running_handles, add_more);
+
+  } while(ongoing || add_more);
+
+  fprintf(stderr, "exiting\n");
+  exit(EXIT_SUCCESS);
+}

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -48,6 +48,7 @@ class Httpd:
         'authz_user', 'authz_core', 'authz_host',
         'auth_basic', 'auth_digest',
         'env', 'filter', 'headers', 'mime',
+        'socache_shmcb',
         'rewrite', 'http2', 'ssl', 'proxy', 'proxy_http', 'proxy_connect',
         'mpm_event',
     ]
@@ -251,6 +252,7 @@ class Httpd:
                 f'Listen {self.env.proxy_port}',
                 f'Listen {self.env.proxys_port}',
                 f'TypesConfig "{self._conf_dir}/mime.types',
+                f'SSLSessionCache "shmcb:ssl_gcache_data(32000)"',
             ]
             if 'base' in self._extra_configs:
                 conf.extend(self._extra_configs['base'])


### PR DESCRIPTION
- test TLS session sharing with special test client
- expect failure with wolfSSL
- disable flaky wolfSSL test_02_07b
- test apache: add suitable session cache directive

Other improvements
- generic vtls `get_select_socks()` improved
- BearSSL now with own `get_select_socks()` which fixes the socket polling during handshake. This results in reducing handshake times down to what other TLS backens achieve.