### PR TITLE
http: close the connection after a late 417 received

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -332,6 +332,7 @@ about to issue.
 
 - `auth_required` if this is set and a POST/PUT is made without auth, the
   server will NOT wait for the full request body to get sent
+- `delay: [msecs]` - delay this amount after connection
 - `idle` - do nothing after receiving the request, just "sit idle"
 - `stream` - continuously send data to the client, never-ending
 - `writedelay: [msecs]` delay this amount between reply packets

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -185,7 +185,7 @@ test1439 test1440 test1441 test1442 test1443 test1444 test1445 test1446 \
 test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
 test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
-test1471 test1472 test1473 \
+test1471 test1472 test1473 test1474 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1328
+++ b/tests/data/test1328
@@ -10,7 +10,7 @@ globbing
 
 <reply>
 <data>
-HTTP/1.1 404 OK
+HTTP/1.1 404 NOT OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Content-Length: 6
 Funny-head: yesyes

--- a/tests/data/test1474
+++ b/tests/data/test1474
@@ -1,0 +1,111 @@
+<testcase>
+# This test is quite timing dependent and tricky to set up. The time line of
+# test operations looks like this:
+#
+# 1. curl sends a PUT request with Expect: 100-continue and waits only 1 msec
+#    for a 100 response.
+# 2. The HTTP server accepts the connection but waits 500 msec before acting
+#    on the request.
+# 3. curl doesn't receive the expected 100 response before its timeout expires,
+#    so it starts sending the body. It is throttled by a --limit-rate, so it
+#    sends the first 64 KiB then stops for 1000 msec due to this
+#    throttling.
+# 4. The server sends its 417 response while curl is throttled.
+# 5. curl responds to this 417 response by closing the connection (because it
+#    has a half-completed response outstanding) and starting a new one. This
+#    new request does not have an Expect: header so it is sent without delay.
+#    It's still throttled, however, so it takes about 16 seconds to finish
+#    sending.
+# 6. The server receives the response and this time acks it with 200.
+#
+# Because of the timing sensitivity (scheduling delays of 500 msec can cause
+# the test to fail), this test is marked flaky to avoid it being run in the CI
+# builds which are often run on overloaded servers.
+# Increasing the --limit-rate would decrease the test time, but at the cost of
+# becoming even more sensitive to delays (going from 500 msec to 250 msec or
+# less of accepted delay before failure).
+<info>
+<keywords>
+HTTP
+HTTP PUT
+Expect
+flaky
+</keywords>
+</info>
+# Server-side
+<reply>
+# 417 means the server didn't like the Expect header
+<data>
+HTTP/1.1 417 BAD swsbounce
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 0
+
+</data>
+<data1>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 10
+
+blablabla
+</data1>
+<datacheck>
+HTTP/1.1 417 BAD swsbounce
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 0
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 10
+
+blablabla
+</datacheck>
+<servercmd>
+no-expect
+delay: 500
+connection-monitor
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+ <name>
+HTTP PUT with Expect: 100-continue and 417 response during upload
+ </name>
+ <command>
+http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt --limit-rate 64K --expect100-timeout 0.001
+</command>
+# Must be large enough to trigger curl's automatic 100-continue behaviour
+<file name="%LOGDIR/test%TESTNUMBER.txt">
+%repeat[132 x S]%%repeat[16462 x xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%0a]%
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+PUT /we/want/%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 1053701
+Expect: 100-continue
+
+%repeat[132 x S]%%repeat[1021 x xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%0a]%%repeat[60 x x]%[DISCONNECT]
+PUT /we/want/%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 1053701
+
+%repeat[132 x S]%%repeat[16462 x xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%0a]%
+[DISCONNECT]
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test197
+++ b/tests/data/test197
@@ -10,7 +10,7 @@ retry
 # Server-side
 <reply>
 <data nocheck="yes">
-HTTP/1.1 503 OK swsbounce
+HTTP/1.1 503 BAD swsbounce
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Content-Length: 21
 
@@ -58,7 +58,7 @@ Accept: */*
 </protocol>
 
 <stdout>
-HTTP/1.1 503 OK swsbounce
+HTTP/1.1 503 BAD swsbounce
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Content-Length: 21
 

--- a/tests/data/test357
+++ b/tests/data/test357
@@ -10,7 +10,7 @@ Expect
 <reply>
 # 417 means the server didn't like the Expect header
 <data>
-HTTP/1.1 417 OK swsbounce
+HTTP/1.1 417 BAD swsbounce
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
 Content-Length: 0
@@ -25,7 +25,7 @@ Content-Length: 10
 blablabla
 </data1>
 <datacheck>
-HTTP/1.1 417 OK swsbounce
+HTTP/1.1 417 BAD swsbounce
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
 Content-Length: 0

--- a/tests/data/test366
+++ b/tests/data/test366
@@ -10,7 +10,7 @@ retry
 # Server-side
 <reply>
 <data>
-HTTP/1.1 503 OK
+HTTP/1.1 503 BAD
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Content-Length: 21
 Retry-After: 200

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2672,7 +2672,7 @@ sub displaylogcontent {
                     logmsg " $line\n";
                 }
                 $linecount++;
-                $truncate = $linecount > 1000;
+                $truncate = $linecount > 1200;
             }
         }
         close($single);


### PR DESCRIPTION
In this situation, only part of the data has been sent before aborting
so the connection is no longer usable.

Fixes #11678
Closes #11679