### PR TITLE
Test2600, fix flakiness on low cpu

### DIFF
--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -50,6 +50,7 @@
 #include "urldata.h"
 #include "connect.h"
 #include "cfilters.h"
+#include "multiif.h"
 #include "curl_trc.h"
 
 /* copied from hostip.c to switch using SIGALARM for timeouts.
@@ -148,19 +149,19 @@ static CURLcode cf_test_connect(struct Curl_cfilter *cf,
                                 bool blocking, bool *done)
 {
   struct cf_test_ctx *ctx = cf->ctx;
-  struct curltime now;
+  timediff_t duration_ms;
 
   (void)data;
   (void)blocking;
   *done = FALSE;
-  now = Curl_now();
-  if(Curl_timediff(now, ctx->started) >= ctx->fail_delay_ms) {
+  duration_ms = Curl_timediff(Curl_now(), ctx->started);
+  if(duration_ms > ctx->fail_delay_ms) {
     infof(data, "%04dms: cf[%s] fail delay reached",
-         (int)Curl_timediff(Curl_now(), current_tr->started), ctx->id);
+         (int)duration_ms, ctx->id);
     return CURLE_COULDNT_CONNECT;
   }
-  infof(data, "%04dms: cf[%s] continuing",
-       (int)Curl_timediff(Curl_now(), current_tr->started), ctx->id);
+  infof(data, "%04dms: cf[%s] continuing", (int)duration_ms, ctx->id);
+  Curl_expire(data, ctx->fail_delay_ms - duration_ms, EXPIRE_RUN_NOW);
   return CURLE_OK;
 }
 
@@ -226,6 +227,10 @@ static CURLcode cf_test_create(struct Curl_cfilter **pcf,
   infof(data, "%04dms: cf[%s] created", (int)created_at, ctx->id);
 
   result = Curl_cf_create(&cf, &cft_test, ctx);
+  if(result)
+    goto out;
+
+  Curl_expire(data, ctx->fail_delay_ms, EXPIRE_RUN_NOW);
 
 out:
   *pcf = (!result)? cf : NULL;
@@ -240,7 +245,10 @@ static void check_result(struct test_case *tc,
                          struct test_result *tr)
 {
   char msg[256];
-  timediff_t duration_ms = 0;
+  timediff_t duration_ms;
+
+  duration_ms = Curl_timediff(tr->ended, tr->started);
+  fprintf(stderr, "%d: test case took %dms\n", tc->id, (int)duration_ms);
 
   if(tr->result != tc->exp_result
     && CURLE_OPERATION_TIMEDOUT != tr->result) {
@@ -261,7 +269,6 @@ static void check_result(struct test_case *tc,
     fail(msg);
   }
 
-  (void)duration_ms;
 #ifndef USE_ALARM_TIMEOUT
   duration_ms = Curl_timediff(tr->ended, tr->started);
   if(duration_ms < tc->min_duration_ms) {
@@ -316,14 +323,14 @@ static void test_connect(struct test_case *tc)
   fail_unless(list, "error allocating resolve list entry");
   curl_easy_setopt(easy, CURLOPT_RESOLVE, list);
   curl_easy_setopt(easy, CURLOPT_IPRESOLVE, (long)tc->ip_version);
+  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS,
+                   (long)tc->connect_timeout_ms);
 #ifdef USE_ALARM_TIMEOUT
-  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, 2000L);
+  /* we only 1sec timer resolution here */
   curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
                    (tc->he_timeout_ms > tc->connect_timeout_ms)?
                    3000L : 1000L);
 #else
-  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS,
-                   (long)tc->connect_timeout_ms);
   curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
                    (long)tc->he_timeout_ms);
 #endif
@@ -362,39 +369,42 @@ static void test_connect(struct test_case *tc)
 #define TURL "http://test.com:123"
 
 #define R_FAIL      CURLE_COULDNT_CONNECT
+/* timeout values accounting for low cpu resources in CI */
+#define TC_TMOT     90000  /* 90 sec max test duration */
+#define CNCT_TMOT   60000  /* 60sec connect timeout */
 
 static struct test_case TEST_CASES[] = {
-  /* TIMEOUT_MS,        FAIL_MS      CREATED    DURATION     Result, HE_PREF */
-  /* CNCT   HE          v4    v6     v4 v6      MIN   MAX */
+  /* TIMEOUT_MS,    FAIL_MS      CREATED    DURATION     Result, HE_PREF */
+  /* CNCT   HE      v4    v6     v4 v6      MIN   MAX */
   { 1, TURL, "test.com:123:192.0.2.1", CURL_IPRESOLVE_WHATEVER,
-    250,  150,        200,  200,    1,  0,      200,  600,  R_FAIL, NULL },
+    CNCT_TMOT, 150, 200,  200,    1,  0,      200,  TC_TMOT,  R_FAIL, NULL },
   /* 1 ipv4, fails after ~200ms, reports COULDNT_CONNECT   */
   { 2, TURL, "test.com:123:192.0.2.1,192.0.2.2", CURL_IPRESOLVE_WHATEVER,
-    500,  150,        200,  200,    2,  0,      400,  800,  R_FAIL, NULL },
+    CNCT_TMOT, 150, 200,  200,    2,  0,      400,  TC_TMOT,  R_FAIL, NULL },
   /* 2 ipv4, fails after ~400ms, reports COULDNT_CONNECT   */
 #ifdef ENABLE_IPV6
   { 3, TURL, "test.com:123:::1", CURL_IPRESOLVE_WHATEVER,
-    250,  150,        200,  200,    0,  1,      200,  500,  R_FAIL, NULL },
+    CNCT_TMOT, 150, 200,  200,    0,  1,      200,  TC_TMOT,  R_FAIL, NULL },
   /* 1 ipv6, fails after ~200ms, reports COULDNT_CONNECT   */
   { 4, TURL, "test.com:123:::1,::2", CURL_IPRESOLVE_WHATEVER,
-    500,  150,        200,  200,    0,  2,      400,  800,  R_FAIL, NULL },
+    CNCT_TMOT, 150, 200,  200,    0,  2,      400,  TC_TMOT,  R_FAIL, NULL },
   /* 2 ipv6, fails after ~400ms, reports COULDNT_CONNECT   */
 
   { 5, TURL, "test.com:123:192.0.2.1,::1", CURL_IPRESOLVE_WHATEVER,
-    500,  150,        200, 200,     1,  1,      350,  800,  R_FAIL, "v4" },
+    CNCT_TMOT, 150, 200, 200,     1,  1,      350,  TC_TMOT,  R_FAIL, "v4" },
   /* mixed ip4+6, v4 starts, v6 kicks in on HE, fails after ~350ms */
   { 6, TURL, "test.com:123:::1,192.0.2.1", CURL_IPRESOLVE_WHATEVER,
-    500,  150,        200, 200,     1,  1,      350,  800,  R_FAIL, "v6" },
+    CNCT_TMOT, 150, 200, 200,     1,  1,      350,  TC_TMOT,  R_FAIL, "v6" },
   /* mixed ip6+4, v6 starts, v4 kicks in on HE, fails after ~350ms */
   { 7, TURL, "test.com:123:::1,192.0.2.1,::2,::3", CURL_IPRESOLVE_WHATEVER,
-    500,  600,        200, 200,     0,  3,      350,  800,  R_FAIL, "v6" },
+    CNCT_TMOT, 600, 200, 200,     0,  3,      350,  TC_TMOT,  R_FAIL, "v6" },
   /* mixed ip6+4, v6 starts, v4 never starts due to high HE, TIMEOUT */
   { 8, TURL, "test.com:123:192.0.2.1,::1", CURL_IPRESOLVE_V4,
-    400,  150,        500, 500,     1,  0,      400,  600,  R_FAIL, NULL },
+    CNCT_TMOT, 150, 500, 500,     1,  0,      400,  TC_TMOT,  R_FAIL, NULL },
   /* mixed ip4+6, but only use v4, check it uses full connect timeout,
      although another address of the 'wrong' family is available */
   { 9, TURL, "test.com:123:::1,192.0.2.1", CURL_IPRESOLVE_V6,
-    400,  150,        500, 500,     0,  1,      400,  600,  R_FAIL, NULL },
+    CNCT_TMOT, 150, 500, 500,     0,  1,      400,  TC_TMOT,  R_FAIL, NULL },
   /* mixed ip4+6, but only use v6, check it uses full connect timeout,
      although another address of the 'wrong' family is available */
 #endif

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -395,15 +395,12 @@ static struct test_case TEST_CASES[] = {
   /* mixed ip4+6, v4 starts, v6 kicks in on HE, fails after ~350ms */
   { 6, TURL, "test.com:123:::1,192.0.2.1", CURL_IPRESOLVE_WHATEVER,
     CNCT_TMOT, 150, 200, 200,     1,  1,      350,  TC_TMOT,  R_FAIL, "v6" },
-  /* mixed ip6+4, v6 starts, v4 kicks in on HE, fails after ~350ms */
-  { 7, TURL, "test.com:123:::1,192.0.2.1,::2,::3", CURL_IPRESOLVE_WHATEVER,
-    CNCT_TMOT, 600, 200, 200,     0,  3,      350,  TC_TMOT,  R_FAIL, "v6" },
   /* mixed ip6+4, v6 starts, v4 never starts due to high HE, TIMEOUT */
-  { 8, TURL, "test.com:123:192.0.2.1,::1", CURL_IPRESOLVE_V4,
+  { 7, TURL, "test.com:123:192.0.2.1,::1", CURL_IPRESOLVE_V4,
     CNCT_TMOT, 150, 500, 500,     1,  0,      400,  TC_TMOT,  R_FAIL, NULL },
   /* mixed ip4+6, but only use v4, check it uses full connect timeout,
      although another address of the 'wrong' family is available */
-  { 9, TURL, "test.com:123:::1,192.0.2.1", CURL_IPRESOLVE_V6,
+  { 8, TURL, "test.com:123:::1,192.0.2.1", CURL_IPRESOLVE_V6,
     CNCT_TMOT, 150, 500, 500,     0,  1,      400,  TC_TMOT,  R_FAIL, NULL },
   /* mixed ip4+6, but only use v6, check it uses full connect timeout,
      although another address of the 'wrong' family is available */

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -155,12 +155,13 @@ static CURLcode cf_test_connect(struct Curl_cfilter *cf,
   (void)blocking;
   *done = FALSE;
   duration_ms = Curl_timediff(Curl_now(), ctx->started);
-  if(duration_ms > ctx->fail_delay_ms) {
+  if(duration_ms >= ctx->fail_delay_ms) {
     infof(data, "%04dms: cf[%s] fail delay reached",
          (int)duration_ms, ctx->id);
     return CURLE_COULDNT_CONNECT;
   }
-  infof(data, "%04dms: cf[%s] continuing", (int)duration_ms, ctx->id);
+  if(duration_ms)
+    infof(data, "%04dms: cf[%s] continuing", (int)duration_ms, ctx->id);
   Curl_expire(data, ctx->fail_delay_ms - duration_ms, EXPIRE_RUN_NOW);
   return CURLE_OK;
 }


### PR DESCRIPTION
- refs #11355 where failures to to low cpu resources in CI are reported
- vastly extend CURLOPT_CONNECTTIMEOUT_MS and max durations to test cases
- trigger Curl_expire() in test filter to allow re-checks before the usual 1second interval