### PR TITLE
lib: lower the default connect timeout from 300 to 30 seconds

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.3
@@ -35,8 +35,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CONNECTTIMEOUT, long timeout);
 Pass a long. It should contain the maximum time in seconds that you allow the
 connection phase to the server to take. This timeout only limits the
 connection phase, it has no impact once it has connected. Set to zero to
-switch to the default built-in connection timeout - 300 seconds. See also the
-\fICURLOPT_TIMEOUT(3)\fP option.
+switch to the built-in default. See also the \fICURLOPT_TIMEOUT(3)\fP option.
 
 \fICURLOPT_CONNECTTIMEOUT_MS(3)\fP is the same function but set in milliseconds.
 
@@ -61,7 +60,7 @@ This option may cause libcurl to use the SIGALRM signal to timeout system
 calls on builds not using asynch DNS. In unix-like systems, this might cause
 signals to be used unless \fICURLOPT_NOSIGNAL(3)\fP is set.
 .SH DEFAULT
-300
+30 seconds since 8.3.0, 300 before that.
 .SH PROTOCOLS
 All
 .SH EXAMPLE

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
@@ -38,7 +38,7 @@ the connection phase to the server to take.
 
 See \fICURLOPT_CONNECTTIMEOUT(3)\fP for details.
 .SH DEFAULT
-300000
+30 seconds (30000 milliseconds) since 8.3.0, 300000 millseconds before that.
 .SH PROTOCOLS
 All
 .SH EXAMPLE

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.3
@@ -38,7 +38,7 @@ the connection phase to the server to take.
 
 See \fICURLOPT_CONNECTTIMEOUT(3)\fP for details.
 .SH DEFAULT
-30 seconds (30000 milliseconds) since 8.3.0, 300000 millseconds before that.
+30 seconds (30000 milliseconds) since 8.3.0, 300000 milliseconds before that.
 .SH PROTOCOLS
 All
 .SH EXAMPLE

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -37,7 +37,7 @@ timediff_t Curl_timeleft(struct Curl_easy *data,
                          struct curltime *nowp,
                          bool duringconnect);
 
-#define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
+#define DEFAULT_CONNECT_TIMEOUT 30000 /* milliseconds == 30 seconds */
 
 /*
  * Used to extract socket and connectdata struct for the most recent

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -41,8 +41,8 @@
  */
 #define CURL_HOSTENT_SIZE 9000
 
-#define CURL_TIMEOUT_RESOLVE 300 /* when using asynch methods, we allow this
-                                    many seconds for a name resolve */
+#define CURL_TIMEOUT_RESOLVE 30 /* when using asynch methods, we allow this
+                                   many seconds for a name resolve */
 
 #define CURL_ASYNC_SUCCESS CURLE_OK
 

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -125,10 +125,10 @@ UNITTEST_START
   {BASE + 12, 0,     0, 0, FALSE, 0, "no timeout active"},
 
   /* no timeout set, connecting */
-  {BASE + 4, 0,      0, 0, TRUE, 296000, "no timeout active"},
-  {BASE + 4, 990000, 0, 0, TRUE, 295010, "no timeout active"},
-  {BASE + 10, 0,     0, 0, TRUE, 290000, "no timeout active"},
-  {BASE + 12, 0,     0, 0, TRUE, 288000, "no timeout active"},
+  {BASE + 4, 0,      0, 0, TRUE, 26000, "no timeout active"},
+  {BASE + 4, 990000, 0, 0, TRUE, 25010, "no timeout active"},
+  {BASE + 10, 0,     0, 0, TRUE, 20000, "no timeout active"},
+  {BASE + 12, 0,     0, 0, TRUE, 18000, "no timeout active"},
 
   /* both timeouts set, connecting, connect timeout the longer one */
   {BASE + 4, 0,      10000, 12000, TRUE, 6000, "6 seconds should be left"},
@@ -146,8 +146,11 @@ UNITTEST_START
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
     timeout =  Curl_timeleft(data, &now, run[i].connecting);
-    if(timeout != run[i].result)
+    if(timeout != run[i].result) {
+      fprintf(stderr, "Got %ld, expected %ld\n",
+              (long)timeout, (long)run[i].result);
       fail(run[i].comment);
+    }
   }
 }
 UNITTEST_STOP

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -125,10 +125,14 @@ UNITTEST_START
   {BASE + 12, 0,     0, 0, FALSE, 0, "no timeout active"},
 
   /* no timeout set, connecting */
-  {BASE + 4, 0,      0, 0, TRUE, 26000, "no timeout active"},
-  {BASE + 4, 990000, 0, 0, TRUE, 25010, "no timeout active"},
-  {BASE + 10, 0,     0, 0, TRUE, 20000, "no timeout active"},
-  {BASE + 12, 0,     0, 0, TRUE, 18000, "no timeout active"},
+  {BASE + 4, 0,      0, 0, TRUE, DEFAULT_CONNECT_TIMEOUT - 4*1000,
+   "no timeout active"},
+  {BASE + 4, 990000, 0, 0, TRUE, DEFAULT_CONNECT_TIMEOUT - 4990,
+   "no timeout active"},
+  {BASE + 10, 0,     0, 0, TRUE, DEFAULT_CONNECT_TIMEOUT - 10000,
+   "no timeout active"},
+  {BASE + 12, 0,     0, 0, TRUE, DEFAULT_CONNECT_TIMEOUT - 12000,
+   "no timeout active"},
 
   /* both timeouts set, connecting, connect timeout the longer one */
   {BASE + 4, 0,      10000, 12000, TRUE, 6000, "6 seconds should be left"},


### PR DESCRIPTION
It was always a very large value. 30 seconds is still a long time.