### PR TITLE
tool/var: also error when expansion result starts with NUL

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -307,7 +307,7 @@ ParameterError varexpand(struct GlobalConfig *global,
             vlen = curlx_dyn_len(&buf);
           }
 
-          if(value && *value) {
+          if(value && vlen > 0) {
             /* A variable might contain null bytes. Such bytes cannot be shown
                using normal means, this is an error. */
             char *nb = memchr(value, '\0', vlen);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 \
 \
 test440 test441 test442 test443 test444 test445 test446 test447 test448 \
-test449 test450 test451 test452 test453 test454 test455 \
+test449 test450 test451 test452 test453 test454 test455 test456 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 \
 \

--- a/tests/data/test456
+++ b/tests/data/test456
@@ -1,0 +1,33 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+variables
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Variable output starting with null byte
+</name>
+<file name="%LOGDIR/junk">
+%hex[%00]hex%hello
+</file>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable what@%LOGDIR/junk --expand-data "{{what}}"
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Expansions whose output starts with NUL were being expanded to the empty string, and not being recognised as values that contain a NUL byte, and should error.