### PR TITLE
cmdline-opts/docs: mentioned the negative option part

### DIFF
--- a/docs/cmdline-opts/no-alpn.d
+++ b/docs/cmdline-opts/no-alpn.d
@@ -14,3 +14,6 @@ Multi: boolean
 Disable the ALPN TLS extension. ALPN is enabled by default if libcurl was built
 with an SSL library that supports ALPN. ALPN is used by a libcurl that supports
 HTTP/2 to negotiate HTTP/2 support with the server during https sessions.
+
+Note that this is the negated option name documented. You can use --alpn to
+enable ALPN.

--- a/docs/cmdline-opts/no-buffer.d
+++ b/docs/cmdline-opts/no-buffer.d
@@ -13,3 +13,6 @@ Disables the buffering of the output stream. In normal work situations, curl
 will use a standard buffered output stream that will have the effect that it
 will output the data in chunks, not necessarily exactly when the data arrives.
 Using this option will disable that buffering.
+
+Note that this is the negated option name documented. You can use --buffer to
+enable buffering again.


### PR DESCRIPTION
... for --no-alpn and --no-buffer in the same style done for other --no- options:

"Note that this is the negated option name documented."