### PR TITLE
tests: add 'large-time' as a testable feature

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -428,6 +428,7 @@ Features testable here are:
 - `ipv6`
 - `Kerberos`
 - `large_file`
+- `large-time` (time_t is larger than 32 bit)
 - `ld_preload`
 - `libssh2`
 - `libssh`

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -793,6 +793,7 @@ sub checksystemfeatures {
     $feature{"wakeup"} = 1;
     $feature{"headers-api"} = 1;
     $feature{"xattr"} = 1;
+    $feature{"large-time"} = 1;
 
     # make each protocol an enabled "feature"
     for my $p (@protocols) {

--- a/tests/server/disabled.c
+++ b/tests/server/disabled.c
@@ -85,6 +85,9 @@ static const char *disabled[]={
 #ifdef CURL_DISABLE_FORM_API
   "form-api",
 #endif
+#if (SIZEOF_TIME_T < 5)
+  "large-time",
+#endif
   NULL
 };
 


### PR DESCRIPTION
This allows test cases to require this feature to run and to be used in %if conditions.

Large here means larger than 32 bits. Ie does not suffer from y2038.