### PR TITLE
tool_urlglob: use the correct format specifier for curl_off_t in msnprintf

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -591,7 +591,7 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
       }
       break;
     case UPTNumRange:
-      msnprintf(buf, buflen, "%0*lu",
+      msnprintf(buf, buflen, "%0*" CURL_FORMAT_CURL_OFF_T,
                 pat->content.NumRange.padlength,
                 pat->content.NumRange.ptr_n);
       len = strlen(buf);
@@ -661,7 +661,7 @@ CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
           appendlen = 1;
           break;
         case UPTNumRange:
-          msnprintf(numbuf, sizeof(numbuf), "%0*lu",
+          msnprintf(numbuf, sizeof(numbuf), "%0*" CURL_FORMAT_CURL_OFF_T,
                     pat->content.NumRange.padlength,
                     pat->content.NumRange.ptr_n);
           appendthis = numbuf;


### PR DESCRIPTION
Hello.
I have encountered a problem with URL globbing functionality (incorrect output of values from number ranges).
On my system (BS2000/OSD) curl_off_t and unsigned long have different size, which leads to a problem when printing curl_off_t value using %lu format specifier.
My commit fixes the problem.