### PR TITLE
docs: mention critical files in same directories as curl saves

### DIFF
--- a/docs/SECURITY-PROCESS.md
+++ b/docs/SECURITY-PROCESS.md
@@ -269,3 +269,8 @@ timeout value or otherwise) are not considered security problems. Applications
 are supposed to already handle situations when the transfer loop legitimately
 consumes 100% CPU time, so while a prolonged such busy-loop is a nasty bug, we
 do not consider it a security problem.
+
+## Saving files
+
+curl cannot protect against attacks where an attacker has write access to the
+same directory where curl is directed to save files.

--- a/docs/libcurl/libcurl-security.3
+++ b/docs/libcurl/libcurl-security.3
@@ -417,6 +417,9 @@ core dump file, such data might be accessible.
 Further, when eventually closing a handle and the secrets are no longer
 needed, libcurl does not explicitly clear memory before freeing it, so
 credentials may be left in freed data.
+.SH "Saving files"
+libcurl cannot protect against attacks where an attacker has write access to
+the same directory where libcurl is directed to save files.
 .SH "Report Security Problems"
 Should you detect or just suspect a security problem in libcurl or curl,
 contact the project curl security team immediately. See


### PR DESCRIPTION
... cannot be fully protected. Don't do it.

Reported-by: Harry Sintonen
Fixes #11530