### PR TITLE
cirrus: disable the FreeBSD jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,12 +43,12 @@ freebsd_task:
   name: FreeBSD
 
   matrix:
-    - name: FreeBSD 13.2
-      freebsd_instance:
-        image_family: freebsd-13-2
-    - name: FreeBSD 12.4
-      freebsd_instance:
-        image_family: freebsd-12-4
+#    - name: FreeBSD 13.2
+#      freebsd_instance:
+#        image_family: freebsd-13-2
+#    - name: FreeBSD 12.4
+#      freebsd_instance:
+#        image_family: freebsd-12-4
 
   env:
     CIRRUS_CLONE_DEPTH: 10


### PR DESCRIPTION
They have been broken for a long time already.