### PR TITLE
CI, cirrus, FreeBSD, disable testing since rust/crypto

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,7 +57,7 @@ freebsd_task:
 
   pkginstall_script:
     - pkg update -f
-    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel rust
+    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel
     - pkg delete -y curl
     - python -m ensurepip --default-pip
     - python -m pip install --upgrade pip

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,13 +57,15 @@ freebsd_task:
 
   pkginstall_script:
     - pkg update -f
-    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel
+    - pkg install -y autoconf automake libtool pkgconf brotli openldap24-client heimdal libpsl libssh2 openssh-portable libidn2 librtmp libnghttp2 nghttp2 stunnel rust
     - pkg delete -y curl
     - python -m ensurepip --default-pip
     - python -m pip install --upgrade pip
-    - pip install "cryptography<3.2"
-    - pip install "pyOpenSSL<20.0"
-    - pip install "impacket"
+    # PYTHON/RUST/CRYPTO FAIL
+    # this currently fails with "error" in building rust crypto for python
+    #- pip install "cryptography<3.2"
+    #- pip install "pyOpenSSL<20.0"
+    #- pip install "impacket"
   configure_script:
     - autoreconf -fi
     # Building with the address sanitizer is causing unexplainable test issues due to timeouts
@@ -87,7 +89,10 @@ freebsd_task:
     - find . -type d -exec chmod 777 {} \;
     # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
     # therefore the SFTP and SCP tests are disabled right away from the beginning.
-    - sudo -u nobody make V=1 TFLAGS="-n !SFTP !SCP" test-ci
+    #
+    # PYTHON/RUST/CRYPTO FAIL
+    # disable test run
+    #- sudo -u nobody make V=1 TFLAGS="-n !SFTP !SCP" test-ci
   install_script:
     - make V=1 install
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,9 +90,7 @@ freebsd_task:
     # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
     # therefore the SFTP and SCP tests are disabled right away from the beginning.
     #
-    # PYTHON/RUST/CRYPTO FAIL
-    # disable test run
-    #- sudo -u nobody make V=1 TFLAGS="-n !SFTP !SCP" test-ci
+    - sudo -u nobody make V=1 TFLAGS="-n !SFTP !SCP" test-ci
   install_script:
     - make V=1 install
 


### PR DESCRIPTION
- python cryptography package does not build build FreeBSD
- install just mentions "error"
- disabling test suite

- alternate approach to @bagder's PR - whatever suites the BDFL