### PR TITLE
disable.d: explain --disable not implemented prior to 7.50.0

### DIFF
--- a/docs/cmdline-opts/disable.d
+++ b/docs/cmdline-opts/disable.d
@@ -9,6 +9,9 @@ Added: 5.0
 See-also: config
 Multi: boolean
 ---
-If used as the first parameter on the command line, the *curlrc* config
+If used as the **first** parameter on the command line, the *curlrc* config
 file will not be read and used. See the --config for details on the default
 config file search path.
+
+Prior to 7.50.0 curl supported the short option name *q* but not the long
+option name *disable*.


### PR DESCRIPTION
Option -q/--disable was added in 5.0 but only -q was actually implemented. Later --disable was implemented in e200034 (precedes 7.49.0), but incorrectly, and fixed in 6dbc23c (precedes 7.50.0).

Reported-by: pszlazak@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/11710
Closes #xxxx