### PR TITLE
urlapi: setting a blank URL ("") is not an ok URL

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1816,6 +1816,10 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     char *oldurl;
     char *redired_url;
 
+    if(!nalloc)
+      /* a blank URL is not a valid URL */
+      return CURLUE_MALFORMED_INPUT;
+
     /* if the new thing is absolute or the old one is not
      * (we could not get an absolute url in 'oldurl'),
      * then replace the existing with the new. */

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -151,6 +151,8 @@ struct clearurlcase {
 };
 
 static const struct testcase get_parts_list[] ={
+  {"", "", 0, 0, CURLUE_MALFORMED_INPUT},
+  {" ", "", 0, 0, CURLUE_MALFORMED_INPUT},
   {"1h://example.net", "", 0, 0, CURLUE_BAD_SCHEME},
   {"..://example.net", "", 0, 0, CURLUE_BAD_SCHEME},
   {"-ht://example.net", "", 0, 0, CURLUE_BAD_SCHEME},


### PR DESCRIPTION
Test it in 1560
Fixes #11714
Reported-by: ad0p on github