### PR TITLE
spelling: use 'reuse' not 're-use' in code and elsewhere

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -1228,8 +1228,8 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
        the full request has been sent. */
     data->req.start100 = Curl_now();
 
-  /* clear userpwd and proxyuserpwd to avoid re-using old credentials
-   * from re-used connections */
+  /* clear userpwd and proxyuserpwd to avoid reusing old credentials
+   * from reused connections */
   Curl_safefree(data->state.aptr.userpwd);
   Curl_safefree(data->state.aptr.proxyuserpwd);
   return CURLE_OK;

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1045,7 +1045,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
   if(data->info.httpproxycode/100 != 2) {
     /* a non-2xx response and we have no next url to try. */
     Curl_safefree(data->req.newurl);
-    /* failure, close this connection to avoid re-use */
+    /* failure, close this connection to avoid reuse */
     streamclose(conn, "proxy CONNECT failure");
     h1_tunnel_go_state(cf, ts, H1_TUNNEL_FAILED, data);
     failf(data, "CONNECT tunnel failed, response %d", data->req.httpcode);

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -629,7 +629,7 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
       if(port == 0)
         break;
       infof(data, "Bind to local port %d failed, trying next", port - 1);
-      /* We re-use/clobber the port variable here below */
+      /* We reuse/clobber the port variable here below */
       if(sock->sa_family == AF_INET)
         si4->sin_port = ntohs(port);
 #ifdef ENABLE_IPV6

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -715,7 +715,7 @@ static CURLcode easy_transfer(struct Curl_multi *multi)
  *
  * REALITY: it can't just create and destroy the multi handle that easily. It
  * needs to keep it around since if this easy handle is used again by this
- * function, the same multi handle must be re-used so that the same pools and
+ * function, the same multi handle must be reused so that the same pools and
  * caches can be used.
  *
  * DEBUG: if 'events' is set TRUE, this function will use a replacement engine

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -862,7 +862,7 @@ static CURLcode ftp_state_cwd(struct Curl_easy *data,
     if(conn->bits.reuse && ftpc->entrypath &&
        /* no need to go to entrypath when we have an absolute path */
        !(ftpc->dirdepth && ftpc->dirs[0][0] == '/')) {
-      /* This is a re-used connection. Since we change directory to where the
+      /* This is a reused connection. Since we change directory to where the
          transfer is taking place, we must first get back to the original dir
          where we ended up after login: */
       ftpc->cwdcount = 0; /* we count this as the first path, then we add one
@@ -1897,7 +1897,7 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
     if(data->set.ftp_skip_ip) {
       /* told to ignore the remotely given IP but instead use the host we used
          for the control connection */
-      infof(data, "Skip %u.%u.%u.%u for data connection, re-use %s instead",
+      infof(data, "Skip %u.%u.%u.%u for data connection, reuse %s instead",
             ip[0], ip[1], ip[2], ip[3],
             conn->host.name);
       ftpc->newhost = strdup(control_address(conn));

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -601,7 +601,7 @@ bool Curl_ipv6works(struct Curl_easy *data)
   if(data) {
     /* the nature of most system is that IPv6 status doesn't come and go
        during a program's lifetime so we only probe the first time and then we
-       have the info kept for fast re-use */
+       have the info kept for fast reuse */
     DEBUGASSERT(data);
     DEBUGASSERT(data->multi);
     if(data->multi->ipv6_up == IPV6_UNKNOWN) {

--- a/lib/http.c
+++ b/lib/http.c
@@ -1531,7 +1531,7 @@ CURLcode Curl_http_connect(struct Curl_easy *data, bool *done)
   struct connectdata *conn = data->conn;
 
   /* We default to persistent connections. We set this already in this connect
-     function to make the re-use checks properly be able to check this bit. */
+     function to make the reuse checks properly be able to check this bit. */
   connkeep(conn, "HTTP default");
 
   return Curl_conn_connect(data, FIRSTSOCKET, FALSE, done);
@@ -3035,7 +3035,7 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
       *done = TRUE;
       return CURLE_OK;
     }
-    /* We have a new url to load, but since we want to be able to re-use this
+    /* We have a new url to load, but since we want to be able to reuse this
        connection properly, we read the full response in "ignore more" */
     k->ignorebody = TRUE;
     infof(data, "Ignoring the response-body");
@@ -3075,7 +3075,7 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
       data->info.httpcode = 304;
       infof(data, "Simulate an HTTP 304 response");
       /* we abort the transfer before it is completed == we ruin the
-         re-use ability. Close the connection */
+         reuse ability. Close the connection */
       streamclose(conn, "Simulated 304 handling");
       return CURLE_OK;
     }
@@ -3319,8 +3319,8 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
                   altused ? altused : ""
       );
 
-  /* clear userpwd and proxyuserpwd to avoid re-using old credentials
-   * from re-used connections */
+  /* clear userpwd and proxyuserpwd to avoid reusing old credentials
+   * from reused connections */
   Curl_safefree(data->state.aptr.userpwd);
   Curl_safefree(data->state.aptr.proxyuserpwd);
   free(altused);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -762,7 +762,7 @@ quit:
 
   /* no data to transfer */
   Curl_setup_transfer(data, -1, -1, FALSE, -1);
-  connclose(conn, "LDAP connection always disable re-use");
+  connclose(conn, "LDAP connection always disable reuse");
 
   return result;
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -752,7 +752,7 @@ static CURLcode multi_done(struct Curl_easy *data,
 
      if premature is TRUE, it means this connection was said to be DONE before
      the entire request operation is complete and thus we can't know in what
-     state it is for re-using, so we're forced to close it. In a perfect world
+     state it is for reusing, so we're forced to close it. In a perfect world
      we can add code that keep track of if we really must close it here or not,
      but currently we have no such detail knowledge.
   */
@@ -769,7 +769,7 @@ static CURLcode multi_done(struct Curl_easy *data,
 #endif
      ) || conn->bits.close
        || (premature && !Curl_conn_is_multiplex(conn, FIRSTSOCKET))) {
-    DEBUGF(infof(data, "multi_done, not re-using connection=%"
+    DEBUGF(infof(data, "multi_done, not reusing connection=%"
                        CURL_FORMAT_CURL_OFF_T ", forbid=%d"
                        ", close=%d, premature=%d, conn_multiplex=%d",
                  conn->connection_id,
@@ -2471,7 +2471,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
       if(done || (result == CURLE_RECV_ERROR)) {
         /* If CURLE_RECV_ERROR happens early enough, we assume it was a race
-         * condition and the server closed the re-used connection exactly when
+         * condition and the server closed the reused connection exactly when
          * we wanted to use it, so figure out if that is indeed the case.
          */
         CURLcode ret = Curl_retry_request(data, &newurl);
@@ -2513,7 +2513,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(result) {
         /*
          * The transfer phase returned error, we mark the connection to get
-         * closed to prevent being re-used. This is because we can't possibly
+         * closed to prevent being reused. This is because we can't possibly
          * know if the connection is in a good shape or not now.  Unless it is
          * a protocol which uses two "channels" like FTP, as then the error
          * happened in the data connection.

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1396,7 +1396,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     Curl_pgrsResetTransferSizes(data);
     Curl_pgrsStartNow(data);
 
-    /* In case the handle is re-used and an authentication method was picked
+    /* In case the handle is reused and an authentication method was picked
        in the session we need to make sure we only use the one(s) we now
        consider to be fine */
     data->state.authhost.picked &= data->state.authhost.want;
@@ -1786,7 +1786,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
      && (data->set.rtspreq != RTSPREQ_RECEIVE)
 #endif
     )
-    /* We got no data, we attempted to re-use a connection. For HTTP this
+    /* We got no data, we attempted to reuse a connection. For HTTP this
        can be a retry so we try again regardless if we expected a body.
        For other protocols we only try again only if we expected a body.
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -1103,7 +1103,7 @@ ConnectionExists(struct Curl_easy *data,
           infof(data, "Server doesn't support multiplex yet, wait");
           *waitpipe = TRUE;
           CONNCACHE_UNLOCK(data);
-          return FALSE; /* no re-use */
+          return FALSE; /* no reuse */
         }
 
         infof(data, "Server doesn't support multiplex (yet)");
@@ -1160,7 +1160,7 @@ ConnectionExists(struct Curl_easy *data,
 
         if(Curl_resolver_asynch() &&
            /* primary_ip[0] is NUL only if the resolving of the name hasn't
-              completed yet and until then we don't re-use this connection */
+              completed yet and until then we don't reuse this connection */
            !check->primary_ip[0])
           continue;
       }
@@ -1246,7 +1246,7 @@ ConnectionExists(struct Curl_easy *data,
           infof(data, "Server upgrade doesn't support multiplex yet, wait");
           *waitpipe = TRUE;
           CONNCACHE_UNLOCK(data);
-          return FALSE; /* no re-use */
+          return FALSE; /* no reuse */
         }
         infof(data, "Server upgrade cannot be used");
         continue; /* can't be used atm */
@@ -1268,14 +1268,14 @@ ConnectionExists(struct Curl_easy *data,
 
       if(needle->localdev || needle->localport) {
         /* If we are bound to a specific local end (IP+port), we must not
-           re-use a random other one, although if we didn't ask for a
+           reuse a random other one, although if we didn't ask for a
            particular one we can reuse one that was bound.
 
            This comparison is a bit rough and too strict. Since the input
            parameters can be specified in numerous ways and still end up the
            same it would take a lot of processing to make it really accurate.
-           Instead, this matching will assume that re-uses of bound connections
-           will most likely also re-use the exact same binding parameters and
+           Instead, this matching will assume that reuses of bound connections
+           will most likely also reuse the exact same binding parameters and
            missing out a few edge cases shouldn't hurt anyone very much.
         */
         if((check->localport != needle->localport) ||
@@ -2130,7 +2130,7 @@ static char *detect_proxy(struct Curl_easy *data,
 
 /*
  * If this is supposed to use a proxy, we need to figure out the proxy
- * host name, so that we can re-use an existing connection
+ * host name, so that we can reuse an existing connection
  * that may exist registered to the same proxy host.
  */
 static CURLcode parse_proxy(struct Curl_easy *data,
@@ -2451,7 +2451,7 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
 
   /***********************************************************************
    * If this is supposed to use a proxy, we need to figure out the proxy host
-   * name, proxy type and port number, so that we can re-use an existing
+   * name, proxy type and port number, so that we can reuse an existing
    * connection that may exist registered to the same proxy host.
    ***********************************************************************/
   if(proxy || socksproxy) {
@@ -3269,7 +3269,7 @@ static CURLcode resolve_server(struct Curl_easy *data,
   /* Resolve the name of the server or proxy */
   if(conn->bits.reuse) {
     /* We're reusing the connection - no need to resolve anything, and
-       idnconvert_hostname() was called already in create_conn() for the re-use
+       idnconvert_hostname() was called already in create_conn() for the reuse
        case. */
     *async = FALSE;
     return CURLE_OK;
@@ -3288,7 +3288,7 @@ static void reuse_conn(struct Curl_easy *data,
                        struct connectdata *existing)
 {
   /* get the user+password information from the temp struct since it may
-   * be new for this request even when we re-use an existing connection */
+   * be new for this request even when we reuse an existing connection */
   if(temp->user) {
     /* use the new user name and password though */
     Curl_safefree(existing->user);
@@ -3348,14 +3348,14 @@ static void reuse_conn(struct Curl_easy *data,
   existing->hostname_resolve = temp->hostname_resolve;
   temp->hostname_resolve = NULL;
 
-  /* re-use init */
-  existing->bits.reuse = TRUE; /* yes, we're re-using here */
+  /* reuse init */
+  existing->bits.reuse = TRUE; /* yes, we're reusing here */
 
   conn_free(data, temp);
 }
 
 /**
- * create_conn() sets up a new connectdata struct, or re-uses an already
+ * create_conn() sets up a new connectdata struct, or reuses an already
  * existing one, and resolves host name.
  *
  * if this function returns CURLE_OK and *async is set to TRUE, the resolve
@@ -3667,7 +3667,7 @@ static CURLcode create_conn(struct Curl_easy *data,
 
   /*************************************************************
    * Check the current list of connections to see if we can
-   * re-use an already existing one or if we have to create a
+   * reuse an already existing one or if we have to create a
    * new one.
    *************************************************************/
 
@@ -3675,7 +3675,7 @@ static CURLcode create_conn(struct Curl_easy *data,
   DEBUGASSERT(conn->passwd);
 
   /* reuse_fresh is TRUE if we are told to use a new connection by force, but
-     we only acknowledge this option if this is not a re-used connection
+     we only acknowledge this option if this is not a reused connection
      already (which happens due to follow-location or during an HTTP
      authentication phase). CONNECT_ONLY transfers also refuse reuse. */
   if((data->set.reuse_fresh && !data->state.followlocation) ||

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -495,7 +495,7 @@ struct ConnectBits {
 #endif
   /* always modify bits.close with the connclose() and connkeep() macros! */
   BIT(close); /* if set, we close the connection after this request */
-  BIT(reuse); /* if set, this is a re-used connection */
+  BIT(reuse); /* if set, this is a reused connection */
   BIT(altused); /* this is an alt-svc "redirect" */
   BIT(conn_to_host); /* if set, this connection has a "connect to host"
                         that overrides the host in the URL */
@@ -894,7 +894,7 @@ struct connectdata {
 
   /* 'dns_entry' is the particular host we use. This points to an entry in the
      DNS cache and it will not get pruned while locked. It gets unlocked in
-     multi_done(). This entry will be NULL if the connection is re-used as then
+     multi_done(). This entry will be NULL if the connection is reused as then
      there is no name resolve done. */
   struct Curl_dns_entry *dns_entry;
 
@@ -1057,7 +1057,7 @@ struct connectdata {
   /* When this connection is created, store the conditions for the local end
      bind. This is stored before the actual bind and before any connection is
      made and will serve the purpose of being used for comparison reasons so
-     that subsequent bound-requested connections aren't accidentally re-using
+     that subsequent bound-requested connections aren't accidentally reusing
      wrong connections. */
   char *localdev;
   unsigned short localportrange;
@@ -1878,7 +1878,7 @@ struct UserDefined {
   BIT(verbose);        /* output verbosity */
   BIT(krb);            /* Kerberos connection requested */
   BIT(reuse_forbid);   /* forbidden to be reused, close after use */
-  BIT(reuse_fresh);    /* do not re-use an existing connection  */
+  BIT(reuse_fresh);    /* do not reuse an existing connection  */
   BIT(no_signal);      /* do not use any signal/alarm handler */
   BIT(tcp_nodelay);    /* whether to enable TCP_NODELAY or not */
   BIT(ignorecl);       /* ignore content length */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2183,7 +2183,7 @@ static CURLcode myssh_connect(struct Curl_easy *data, bool *done)
     myssh_setup_connection(data, conn);
 
   /* We default to persistent connections. We set this already in this connect
-     function to make the re-use checks properly be able to check this bit. */
+     function to make the reuse checks properly be able to check this bit. */
   connkeep(conn, "SSH default");
 
   if(conn->handler->protocol & CURLPROTO_SCP) {

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3252,7 +3252,7 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
   }
 
   /* We default to persistent connections. We set this already in this connect
-     function to make the re-use checks properly be able to check this bit. */
+     function to make the reuse checks properly be able to check this bit. */
   connkeep(conn, "SSH default");
 
   sshc = &conn->proto.sshc;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -374,7 +374,7 @@ static CURLcode wssh_connect(struct Curl_easy *data, bool *done)
     wssh_setup_connection(data, conn);
 
   /* We default to persistent connections. We set this already in this connect
-     function to make the re-use checks properly be able to check this bit. */
+     function to make the reuse checks properly be able to check this bit. */
   connkeep(conn, "SSH default");
 
   if(conn->handler->protocol & CURLPROTO_SCP) {

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -688,7 +688,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
     if(!Curl_ssl_getsessionid(cf, data, &session, NULL)) {
       br_ssl_engine_set_session_parameters(&backend->ctx.eng, session);
       session_set = 1;
-      infof(data, "BearSSL: re-using session ID");
+      infof(data, "BearSSL: reusing session ID");
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -735,7 +735,7 @@ gtls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
                               ssl_sessionid, ssl_idsize);
 
       /* Informational message */
-      infof(data, "SSL re-using session ID");
+      infof(data, "SSL reusing session ID");
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -619,7 +619,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
         failf(data, "mbedtls_ssl_set_session returned -0x%x", -ret);
         return CURLE_SSL_CONNECT_ERROR;
       }
-      infof(data, "mbedTLS re-using session");
+      infof(data, "mbedTLS reusing session");
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3772,7 +3772,7 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
         return CURLE_SSL_CONNECT_ERROR;
       }
       /* Informational message */
-      infof(data, "SSL re-using session ID");
+      infof(data, "SSL reusing session ID");
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1174,7 +1174,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     Curl_ssl_sessionid_lock(data);
     if(!Curl_ssl_getsessionid(cf, data, (void **)&old_cred, NULL)) {
       backend->cred = old_cred;
-      DEBUGF(infof(data, "schannel: re-using existing credential handle"));
+      DEBUGF(infof(data, "schannel: reusing existing credential handle"));
 
       /* increment the reference counter of the credential/session handle */
       backend->cred->refcount++;
@@ -1776,7 +1776,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 #endif
 
-  /* save the current session data for possible re-use */
+  /* save the current session data for possible reuse */
   if(ssl_config->primary.sessionid) {
     bool incache;
     bool added = FALSE;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2070,7 +2070,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
         return CURLE_SSL_CONNECT_ERROR;
       }
       /* Informational message */
-      infof(data, "SSL re-using session ID");
+      infof(data, "SSL reusing session ID");
     }
     /* If there isn't one, then let's make one up! This has to be done prior
        to starting the handshake. */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -417,7 +417,7 @@ bool Curl_ssl_getsessionid(struct Curl_cfilter *cf,
   DEBUGASSERT(ssl_config->primary.sessionid);
 
   if(!ssl_config->primary.sessionid || !data->state.session)
-    /* session ID re-use is disabled or the session cache has not been
+    /* session ID reuse is disabled or the session cache has not been
        setup */
     return TRUE;
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -712,7 +712,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
         infof(data, "Can't use session ID, going on without");
       }
       else
-        infof(data, "SSL re-using session ID");
+        infof(data, "SSL reusing session ID");
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -30,7 +30,7 @@
 # CSOURCES = $(CSRC1) $(CSRC2)
 
 # libcurl has sources that provide functions named curlx_* that aren't part of
-# the official API, but we re-use the code here to avoid duplication.
+# the official API, but we reuse the code here to avoid duplication.
 CURLX_CFILES = \
   ../lib/base64.c \
   ../lib/curl_multibyte.c \

--- a/tests/data/test1096
+++ b/tests/data/test1096
@@ -21,7 +21,7 @@ REPLY SIZE 500 command not understood
 ftp
 </server>
  <name>
-Two FTP downloads, with failed RETR but re-used control connection
+Two FTP downloads, with failed RETR but reused control connection
  </name>
  <command>
 ftp://%HOSTIP:%FTPPORT/dir/%TESTNUMBER ftp://%HOSTIP:%FTPPORT/dir/%TESTNUMBER

--- a/tests/data/test1134
+++ b/tests/data/test1134
@@ -35,7 +35,7 @@ contents2
 http
 </server>
  <name>
-HTTP connection re-use with different credentials
+HTTP connection reuse with different credentials
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u user1:password1 --next http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 -u 2user:password2

--- a/tests/data/test1418
+++ b/tests/data/test1418
@@ -4,7 +4,7 @@
 HTTP
 HTTP GET
 HTTP NTLM auth
-connection re-use
+connection reuse
 </keywords>
 </info>
 # Server-side
@@ -84,7 +84,7 @@ http
 crypto
 </features>
  <name>
-HTTP with --anyauth and connection re-use
+HTTP with --anyauth and connection reuse
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u testuser:testpass --anyauth http://%HOSTIP:%HTTPPORT/%TESTNUMBER0003

--- a/tests/data/test1419
+++ b/tests/data/test1419
@@ -4,7 +4,7 @@
 HTTP
 HTTP GET
 HTTP NTLM auth
-connection re-use
+connection reuse
 </keywords>
 </info>
 # Server-side
@@ -42,7 +42,7 @@ Feel free to get it
 http
 </server>
  <name>
-HTTP with --anyauth (but no auth!) and connection re-use
+HTTP with --anyauth (but no auth!) and connection reuse
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER --anyauth http://%HOSTIP:%HTTPPORT/%TESTNUMBER0003

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -2,7 +2,7 @@
 <info>
 <keywords>
 HTTP
-connection re-use
+connection reuse
 persistent connection
 CURLOPT_MAXLIFETIME_CONN
 verbose logs

--- a/tests/data/test1632
+++ b/tests/data/test1632
@@ -49,7 +49,7 @@ ftp
 https-proxy
 </server>
  <name>
-FTP through HTTPS-proxy, with connection re-use
+FTP through HTTPS-proxy, with connection reuse
  </name>
  <command>
 -p -x https://%HOSTIP:%HTTPSPROXYPORT ftp://ftp.site.thru.https.proxy:%FTPPORT/%TESTNUMBER --proxy-insecure ftp://ftp.site.thru.https.proxy:%FTPPORT/%TESTNUMBER0002

--- a/tests/data/test2046
+++ b/tests/data/test2046
@@ -49,7 +49,7 @@ LC_CTYPE=en_US.UTF-8
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'
 </precheck>
  <name>
-Connection re-use with IDN host name
+Connection reuse with IDN host name
  </name>
 
  <command>

--- a/tests/data/test2047
+++ b/tests/data/test2047
@@ -50,7 +50,7 @@ LC_CTYPE=en_US.UTF-8
 perl -MI18N::Langinfo=langinfo,CODESET -e 'die "Needs a UTF-8 locale" if (lc(langinfo(CODESET())) ne "utf-8");'
 </precheck>
  <name>
-Connection re-use with IDN host name over HTTP proxy
+Connection reuse with IDN host name over HTTP proxy
  </name>
 
  <command>

--- a/tests/data/test2306
+++ b/tests/data/test2306
@@ -44,7 +44,7 @@ lib%TESTNUMBER
 </tool>
 
  <name>
-HTTP GET re-used handle with first header folded
+HTTP GET reused handle with first header folded
  </name>
  <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002

--- a/tests/data/test435
+++ b/tests/data/test435
@@ -23,7 +23,7 @@ Content-Length: 0
 http
 </server>
 <name>
-verify -w local/remote port+ip after connection re-use
+verify -w local/remote port+ip after connection reuse
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w 'local port == %{local_port}\nlocal ip == %{local_ip}\nremote_ip == %{remote_ip}\nremote_port == %{remote_port}\n'

--- a/tests/data/test675
+++ b/tests/data/test675
@@ -24,7 +24,7 @@ the content would go here
 http
 </server>
  <name>
-HTTP connection re-use and different credentials
+HTTP connection reuse and different credentials
  </name>
 
 <command>

--- a/tests/data/test836
+++ b/tests/data/test836
@@ -4,7 +4,7 @@
 IMAP
 Clear Text
 FETCH
-connection re-use
+connection reuse
 </keywords>
 </info>
 

--- a/tests/data/test882
+++ b/tests/data/test882
@@ -4,7 +4,7 @@
 POP3
 Clear Text
 RETR
-connection re-use
+connection reuse
 </keywords>
 </info>
 

--- a/tests/data/test938
+++ b/tests/data/test938
@@ -4,7 +4,7 @@
 SMTP
 SASL
 SASL AUTH PLAIN
-connection re-use
+connection reuse
 RFC4616
 RFC4954
 </keywords>


### PR DESCRIPTION
Unify the spelling