### PR TITLE
Add CURL_OFF_T definitions on HP-UX with HP aCC

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -347,6 +347,24 @@
 #  define CURL_PULL_SYS_TYPES_H      1
 #  define CURL_PULL_SYS_SOCKET_H     1
 
+#elif defined(__hpux) /* HP aCC compiler */
+#  if !defined(_LP64)
+#    define CURL_TYPEOF_CURL_OFF_T     long long
+#    define CURL_FORMAT_CURL_OFF_T     "lld"
+#    define CURL_FORMAT_CURL_OFF_TU    "llu"
+#    define CURL_SUFFIX_CURL_OFF_T     LL
+#    define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  else
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
+#  endif
+#  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
+#  define CURL_PULL_SYS_TYPES_H      1
+#  define CURL_PULL_SYS_SOCKET_H     1
+
 /* ===================================== */
 /*    KEEP MSVC THE PENULTIMATE ENTRY    */
 /* ===================================== */


### PR DESCRIPTION
HP-UX on IA64 provides two modes: 32 and 64 bit while 32 bit being the default one. Use "long long" in 32 bit mode and just "long" in 64 bit mode.

====================
Determined with:
```
osipovmi@deblndw024v:~
$ cat sizeof.c
#include <stdio.h>
#include <sys/types.h>
#include <sys/socket.h>

int main(void) {
#ifdef _LP64
        printf("_LP64 defined\n");
#endif
        printf("size of int: %zd\n", sizeof(int));
        printf("size of long: %zd\n", sizeof(long));
        printf("size of long long: %zd\n", sizeof(long long));
        printf("size of off_t: %zd\n", sizeof(off_t));
        printf("size of socklen_t: %zd\n", sizeof(socklen_t));
    return 0;
}
osipovmi@deblndw024v:~
$ for opts in "+DD32" "+DD32 -D_FILE_OFFSET_BITS=64" "+DD64"; do aCC -AC99 $opts sizeof.c -o sizeof; echo $opts; ./sizeof; done
+DD32
size of int: 4
size of long: 4
size of long long: 8
size of off_t: 4
size of socklen_t: 4
+DD32 -D_FILE_OFFSET_BITS=64
size of int: 4
size of long: 4
size of long long: 8
size of off_t: 8
size of socklen_t: 4
+DD64
_LP64 defined
size of int: 4
size of long: 8
size of long long: 8
size of off_t: 8
size of socklen_t: 8
```

Objects in both modes:
```
root@deblndw002x:/var/tmp/ports/work/curl-8.2.1
# ldd ./src/.libs/curl

./src/.libs/curl:
        libcurl.so.12 =>        /opt/ports/lib/hpux32/libcurl.so.12
        libssl.so.1.1 =>        /usr/lib/hpux32/libssl.so.1.1
        libcrypto.so.1.1 =>     /usr/lib/hpux32/libcrypto.so.1.1
        libgssapi_krb5.2 =>     /opt/ports/lib/hpux32/libgssapi_krb5.2
        libkrb5.3 =>    /opt/ports/lib/hpux32/libkrb5.3
        libk5crypto.3 =>        /opt/ports/lib/hpux32/libk5crypto.3
        libcom_err.3 => /opt/ports/lib/hpux32/libcom_err.3
        libz.so =>      /opt/ports/lib/hpux32/libz.so
        libc.so.1 =>    /usr/lib/hpux32/libc.so.1
        libcrypto.so.1.1 =>     /usr/lib/hpux32/libcrypto.so.1.1
        libdl.so.1 =>   /usr/lib/hpux32/libdl.so.1
        libpthread.so.1 =>      /usr/lib/hpux32/libpthread.so.1
        libkrb5support.0 =>     /opt/ports/lib/hpux32/libkrb5support.0
        libintl.so.11 =>        /opt/ports/lib/hpux32/libintl.so.11
        libc.so.1 =>    /usr/lib/hpux32/libc.so.1
        libdl.so.1 =>   /usr/lib/hpux32/libdl.so.1
        libiconv.so.8 =>        /opt/ports/lib/hpux32/libiconv.so.8
        libc.so.1 =>    /usr/lib/hpux32/libc.so.1
        libc.so.1 =>    /usr/lib/hpux32/libc.so.1
root@deblndw002x:/var/tmp/ports/work/curl-8.2.1
# file ./src/.libs/curl
./src/.libs/curl:       ELF-32 executable object file - IA64


root@deblndw002x:/var/tmp/ports/work/curl-8.2.1
# LD_LIBRARY_PATH=./lib/.libs ldd ./src/.libs/curl

./src/.libs/curl:
        libcurl.so.12 =>        ./lib/.libs/libcurl.so.12
        libssl.so.1.1 =>        /usr/lib/hpux64/libssl.so.1.1
        libcrypto.so.1.1 =>     /usr/lib/hpux64/libcrypto.so.1.1
        libgssapi_krb5.so =>    /usr/lib/hpux64/libgssapi_krb5.so
        libkrb5.so =>   /usr/lib/hpux64/libkrb5.so
        libk5crypto.so =>       /usr/lib/hpux64/libk5crypto.so
        libcom_err.so =>        /usr/lib/hpux64/libcom_err.so
        libc.so.1 =>    /usr/lib/hpux64/libc.so.1
        libcrypto.so.1.1 =>     /usr/lib/hpux64/libcrypto.so.1.1
        libdl.so.1 =>   /usr/lib/hpux64/libdl.so.1
        libpthread.so.1 =>      /usr/lib/hpux64/libpthread.so.1
        libkrb5.so =>   /usr/lib/hpux64/libkrb5.so
        libk5crypto.so =>       /usr/lib/hpux64/libk5crypto.so
        libcom_err.so =>        /usr/lib/hpux64/libcom_err.so
        libkrb5support.so =>    /usr/lib/hpux64/libkrb5support.so
        libkrb5support.so =>    /usr/lib/hpux64/libkrb5support.so
        libkrb5support.so =>    /usr/lib/hpux64/libkrb5support.so
        libdl.so.1 =>   /usr/lib/hpux64/libdl.so.1
root@deblndw002x:/var/tmp/ports/work/curl-8.2.1
# file ./src/.libs/curl
./src/.libs/curl:       ELF-64 executable object file - IA64
```

Don't be surprisedt hat the linked libraries in 64 bit mode are different, I don't build our entire stack in 64 bit, but on 32 bit only because it is enough for us.