### PR TITLE
secureserver.pl: fix stunnel path quoting

### DIFF
--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -123,12 +123,7 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq '--stunnel') {
         if($ARGV[1]) {
-            if($ARGV[1] =~ /^([\w\/]+)$/) {
-                $stunnel = $ARGV[1];
-            }
-            else {
-                $stunnel = "\"". $ARGV[1] ."\"";
-            }
+            $stunnel = $ARGV[1];
             shift @ARGV;
         }
     }
@@ -210,7 +205,7 @@ my $ssltext = uc($proto) ." SSL/TLS:";
 # Find out version info for the given stunnel binary
 #
 foreach my $veropt (('-version', '-V')) {
-    foreach my $verstr (qx($stunnel $veropt 2>&1)) {
+    foreach my $verstr (qx("$stunnel" $veropt 2>&1)) {
         if($verstr =~ /^stunnel (\d+)\.(\d+) on /) {
             $ver_major = $1;
             $ver_minor = $2;
@@ -245,7 +240,7 @@ if($stunnel_version < 310) {
 #***************************************************************************
 # Find out if we are running on Windows using the tstunnel binary
 #
-if($stunnel =~ /tstunnel(\.exe)?"?$/) {
+if($stunnel =~ /tstunnel(\.exe)?$/) {
     $tstunnel_windows = 1;
 
     # convert Cygwin/MinGW paths to Win32 format
@@ -260,7 +255,7 @@ if($stunnel_version < 400) {
     if($stunnel_version >= 319) {
         $socketopt = "-O a:SO_REUSEADDR=1";
     }
-    $cmd  = "$stunnel -p $certfile -P $pidfile ";
+    $cmd  = "\"$stunnel\" -p $certfile -P $pidfile ";
     $cmd .= "-d $accept_port -r $target_port -f -D $loglevel ";
     $cmd .= ($socketopt) ? "$socketopt " : "";
     $cmd .= ">$logfile 2>&1";
@@ -286,7 +281,7 @@ if($stunnel_version >= 400) {
         # but does not work together with SO_REUSEADDR being on.
         $socketopt .= "\nsocket = a:SO_EXCLUSIVEADDRUSE=0";
     }
-    $cmd  = "$stunnel $conffile ";
+    $cmd  = "\"$stunnel\" $conffile ";
     $cmd .= ">$logfile 2>&1";
     # setup signal handler
     $SIG{INT} = \&exit_signal_handler;


### PR DESCRIPTION
- Store the stunnel path in the private variable $stunnel unquoted and instead quote it in the command strings.

Prior to this change the quoted stunnel path was passed to perl's file operators which cannot handle quoted paths. For example:

~~~
$stunnel = "\"/C/Program Files (x86)/stunnel/bin/tstunnel\"";
if(-x $stunnel or -x "$stunnel")
# false even if path exists and is executable
~~~

Our other test scripts written in perl, unlike this one, use servers.pm which has a global $stunnel variable with the path stored unquoted and therefore those scripts don't have this problem.

Closes #xxxx