### PR TITLE
secureserver.pl: fix stunnel version parsing

### DIFF
--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -223,7 +223,7 @@ foreach my $veropt (('-version', '-V')) {
     }
     last if($ver_major);
 }
-if((!$ver_major) || (!$ver_minor)) {
+if((!$ver_major) || !defined($ver_minor)) {
     if(-x "$stunnel" && ! -d "$stunnel") {
         print "$ssltext Unknown stunnel version\n";
     }


### PR DESCRIPTION
- Allow the stunnel minor-version version part to be zero.

Prior to this change with the stunnel version scheme of `<major>.<minor>` if either part was 0 then version parsing would fail, causing secureserver.pl to fail with error "No stunnel", causing tests that use the SSL protocol to be skipped. As a practical matter this bug can only be caused by a minor version part of 0, since the major version part is always greater than 0.

Closes #xxxx