### PR TITLE
tests: add support for nested %if conditions

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -101,8 +101,7 @@ like:
     Accept-Encoding: nothing
     %endif
 
-**Note** that there can be no nested conditions. You can only do one
-conditional at a time and you can only check for a single feature in it.
+Nested conditions are supported.
 
 # Variables
 


### PR DESCRIPTION
Provides more flexiblity to test cases.

Also warn and bail out if there is an '%else' or %endif' without a preceeding '%if'.

Ref: #11610