### PR TITLE
c-hyper: fix two memory leaks in `Curl_http`.

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -119,12 +119,6 @@ problems may have been fixed or changed somewhat since this was written.
 
 1. HTTP
 
-1.1 hyper memory-leaks
-
- Building curl with the hyper backend causes mysterious memory-leaks
-
- https://github.com/curl/curl/issues/10803
-
 1.2 hyper is slow
 
  When curl is built to use hyper for HTTP, it is unnecessary slow.

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -1217,6 +1217,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   }
 
   hyper_clientconn_free(client);
+  client = NULL;
 
   if((httpreq == HTTPREQ_GET) || (httpreq == HTTPREQ_HEAD)) {
     /* HTTP GET/HEAD download */
@@ -1244,6 +1245,9 @@ error:
 
   if(handshake)
     hyper_task_free(handshake);
+
+  if(client)
+    hyper_clientconn_free(client);
 
   if(req)
     hyper_request_free(req);

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -1208,6 +1208,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     result = CURLE_OUT_OF_MEMORY;
     goto error;
   }
+  req = NULL;
 
   if(HYPERE_OK != hyper_executor_push(h->exec, sendtask)) {
     failf(data, "Couldn't hyper_executor_push the send");
@@ -1243,6 +1244,9 @@ error:
 
   if(handshake)
     hyper_task_free(handshake);
+
+  if(req)
+    hyper_request_free(req);
 
   return result;
 }


### PR DESCRIPTION
These commits fix the memory leaks in #10803.