### PR TITLE
cmdline-opts/page-header: clarify stronger that !opt == URL

### DIFF
--- a/docs/cmdline-opts/page-header
+++ b/docs/cmdline-opts/page-header
@@ -60,6 +60,9 @@ separate curl runs.
 Provide an IPv6 zone id in the URL with an escaped percentage sign. Like in
 
   "http://[fe80::3%25eth0]/"
+
+Everything provided on the command line that is not a command line option or
+its argument, curl assumes is a URL and treats it as such.
 .SH GLOBBING
 You can specify multiple URLs or parts of URLs by writing lists within braces
 or ranges within brackets. We call this "globbing".
@@ -230,7 +233,8 @@ The online version of this man page is always showing the latest incarnation:
 https://curl.se/docs/manpage.html
 .SH OPTIONS
 Options start with one or two dashes. Many of the options require an
-additional value next to them.
+additional value next to them. If provided text does not start with a dash, it
+is presumed to be and treated as a URL.
 
 The short "single-dash" form of the options, -d for example, may be used with
 or without a space between it and its value, although a space is a recommended


### PR DESCRIPTION
Everything provided on the command line that is not an option (or an argument to an option) is treated as a URL.