### PR TITLE
tool: avoid including leading spaces in the Location hyperlink

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -349,6 +349,7 @@ void write_linked_location(CURL *curl, const char *location, size_t loclen,
   char *copyloc = NULL, *locurl = NULL, *scheme = NULL, *finalurl = NULL;
   const char *loc = location;
   size_t llen = loclen;
+  int space_skipped = 0;
   char *vver = getenv("VTE_VERSION");
 
   if(vver) {
@@ -360,9 +361,10 @@ void write_linked_location(CURL *curl, const char *location, size_t loclen,
   }
 
   /* Strip leading whitespace of the redirect URL */
-  while(llen && *loc == ' ') {
+  while(llen && (*loc == ' ' || *loc == '\t')) {
     ++loc;
     --llen;
+    ++space_skipped;
   }
 
   /* Strip the trailing end-of-line characters, normally "\r\n" */
@@ -401,8 +403,10 @@ void write_linked_location(CURL *curl, const char *location, size_t loclen,
      !strcmp("https", scheme) ||
      !strcmp("ftp", scheme) ||
      !strcmp("ftps", scheme)) {
-    fprintf(stream, LINK "%s" LINKST "%.*s" LINKOFF,
-            finalurl, (int)loclen, location);
+    fprintf(stream, "%.*s" LINK "%s" LINKST "%.*s" LINKOFF,
+            space_skipped, location,
+            finalurl,
+            (int)loclen - space_skipped, loc);
     goto locdone;
   }
 


### PR DESCRIPTION
This PR ensures that leading whitespaces are not marked as part of the Location URL.

Before:
![image](https://github.com/curl/curl/assets/18464329/6738286a-c25c-43f7-82c6-cf3cf346e99c)

After:
![image](https://github.com/curl/curl/assets/18464329/04aa3fd6-f654-42cf-8658-d38fb90e9fde)
