### PR TITLE
Clear OpenSSL error queue after SSL_shutdown

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1884,6 +1884,9 @@ static void ossl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
       (void)SSL_read(backend->handle, buf, (int)sizeof(buf));
 
       (void)SSL_shutdown(backend->handle);
+
+      ERR_clear_error();
+
       SSL_set_connect_state(backend->handle);
     }
 


### PR DESCRIPTION
In production we've observed from other libraries errors left in the OpenSSL error queue (specifically, "shutdown while in init"). By adding some logging to the errors being pushed it revealed that the source was this file.

Since we call `SSL_read` and `SSL_shutdown` here, but don't check the return code for an error, we should clear the OpenSSL error queue in case one was raised.

This didn't affect curl because we call ERR_clear_error before every write operation (a0dd9df9ab35528eb9eb669e741a5df4b1fb833c), but when libcurl is used in a process with other OpenSSL users, they may detect an OpenSSL error pushed by libcurl's `SSL_shutdown` as if it was their own.

Our use of libcurl is through `ethon`, a Ruby wrapper, so I'm not 100% sure the use of libcurl is correct, but this does seem like a place we must clear errors, since we don't handle them.