### PR TITLE
lib: fix null ptr derefs and uninitialized vars (h2/h3)

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -244,12 +244,17 @@ static ssize_t proxy_nw_in_reader(void *reader_ctx,
                                   CURLcode *err)
 {
   struct Curl_cfilter *cf = reader_ctx;
-  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nread;
 
-  nread = Curl_conn_cf_recv(cf->next, data, (char *)buf, buflen, err);
-  CURL_TRC_CF(data, cf, "nw_in_reader(len=%zu) -> %zd, %d",
-              buflen, nread, *err);
+  if(cf) {
+    struct Curl_easy *data = CF_DATA_CURRENT(cf);
+    nread = Curl_conn_cf_recv(cf->next, data, (char *)buf, buflen, err);
+    CURL_TRC_CF(data, cf, "nw_in_reader(len=%zu) -> %zd, %d",
+                buflen, nread, *err);
+  }
+  else {
+    nread = 0;
+  }
   return nread;
 }
 
@@ -258,12 +263,18 @@ static ssize_t proxy_h2_nw_out_writer(void *writer_ctx,
                                       CURLcode *err)
 {
   struct Curl_cfilter *cf = writer_ctx;
-  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   ssize_t nwritten;
 
-  nwritten = Curl_conn_cf_send(cf->next, data, (const char *)buf, buflen, err);
-  CURL_TRC_CF(data, cf, "nw_out_writer(len=%zu) -> %zd, %d",
-              buflen, nwritten, *err);
+  if(cf) {
+    struct Curl_easy *data = CF_DATA_CURRENT(cf);
+    nwritten = Curl_conn_cf_send(cf->next, data, (const char *)buf, buflen,
+                                 err);
+    CURL_TRC_CF(data, cf, "nw_out_writer(len=%zu) -> %zd, %d",
+                buflen, nwritten, *err);
+  }
+  else {
+    nwritten = 0;
+  }
   return nwritten;
 }
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1820,6 +1820,9 @@ static ssize_t stream_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   struct stream_ctx *stream = H2_STREAM_CTX(data);
   ssize_t nread = -1;
 
+  if(!stream)
+    return nread;
+
   *err = CURLE_AGAIN;
   if(!Curl_bufq_is_empty(&stream->recvbuf)) {
     nread = Curl_bufq_read(&stream->recvbuf,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1814,14 +1814,11 @@ out:
 }
 
 static ssize_t stream_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
+                           struct stream_ctx *stream,
                            char *buf, size_t len, CURLcode *err)
 {
   struct cf_h2_ctx *ctx = cf->ctx;
-  struct stream_ctx *stream = H2_STREAM_CTX(data);
   ssize_t nread = -1;
-
-  if(!stream)
-    return nread;
 
   *err = CURLE_AGAIN;
   if(!Curl_bufq_is_empty(&stream->recvbuf)) {
@@ -1940,7 +1937,7 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   CF_DATA_SAVE(save, cf, data);
 
-  nread = stream_recv(cf, data, buf, len, err);
+  nread = stream_recv(cf, data, stream, buf, len, err);
   if(nread < 0 && *err != CURLE_AGAIN)
     goto out;
 
@@ -1949,7 +1946,7 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(*err)
       goto out;
 
-    nread = stream_recv(cf, data, buf, len, err);
+    nread = stream_recv(cf, data, stream, buf, len, err);
   }
 
   if(nread > 0) {

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2349,7 +2349,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   int rc;
   int rv;
   CURLcode result;
-  const struct Curl_sockaddr_ex *sockaddr;
+  const struct Curl_sockaddr_ex *sockaddr = NULL;
   int qfd;
 
   ctx->version = NGTCP2_PROTO_VER_MAX;
@@ -2395,6 +2395,8 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
 
   Curl_cf_socket_peek(cf->next, data, &ctx->q.sockfd,
                       &sockaddr, NULL, NULL, NULL, NULL);
+  if(!sockaddr)
+    return CURLE_QUIC_CONNECT_ERROR;
   ctx->q.local_addrlen = sizeof(ctx->q.local_addr);
   rv = getsockname(ctx->q.sockfd, (struct sockaddr *)&ctx->q.local_addr,
                    &ctx->q.local_addrlen);
@@ -2525,8 +2527,8 @@ out:
 
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
   if(result) {
-    const char *r_ip;
-    int r_port;
+    const char *r_ip = NULL;
+    int r_port = 0;
 
     Curl_cf_socket_peek(cf->next, data, NULL, NULL,
                         &r_ip, &r_port, NULL, NULL);

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -334,8 +334,8 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
         goto out;
       }
       if(!cf->connected && SOCKERRNO == ECONNREFUSED) {
-        const char *r_ip;
-        int r_port;
+        const char *r_ip = NULL;
+        int r_port = 0;
         Curl_cf_socket_peek(cf->next, data, NULL, NULL,
                             &r_ip, &r_port, NULL, NULL);
         failf(data, "QUIC: connection to %s port %u refused",
@@ -404,8 +404,8 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
         goto out;
       }
       if(!cf->connected && SOCKERRNO == ECONNREFUSED) {
-        const char *r_ip;
-        int r_port;
+        const char *r_ip = NULL;
+        int r_port = 0;
         Curl_cf_socket_peek(cf->next, data, NULL, NULL,
                             &r_ip, &r_port, NULL, NULL);
         failf(data, "QUIC: connection to %s port %u refused",
@@ -464,8 +464,8 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
         goto out;
       }
       if(!cf->connected && SOCKERRNO == ECONNREFUSED) {
-        const char *r_ip;
-        int r_port;
+        const char *r_ip = NULL;
+        int r_port = 0;
         Curl_cf_socket_peek(cf->next, data, NULL, NULL,
                             &r_ip, &r_port, NULL, NULL);
         failf(data, "QUIC: connection to %s port %u refused",


### PR DESCRIPTION
Closes #11739

---

~~FIXME~~, could not figure how to fix/silence this one [NOW FIXED]:
```
In function 'Curl_bufq_is_empty',
    inlined from 'stream_recv' at /test/curl/lib/http2.c:1824:7:
/test/curl/lib/bufq.c:308:12: warning: potential null pointer dereference [-Wnull-dereference]
  308 |   return !q->head || chunk_is_empty(q->head);
      |           ~^~~~~~
/test/curl/lib/bufq.c:308:12: warning: potential null pointer dereference [-Wnull-dereference]
```

Warnings from gcc 13.2.0, unity build:
```
In file included from /test/curl/bld-cmake-gcc-x64/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:31:
/test/curl/lib/cf-h2-proxy.c: In function 'proxy_nw_in_reader':
/test/curl/lib/cf-h2-proxy.c:250:11: warning: null pointer dereference [-Wnull-dereference]
  250 |   nread = Curl_conn_cf_recv(cf->next, data, (char *)buf, buflen, err);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/test/curl/lib/cf-h2-proxy.c: In function 'proxy_h2_nw_out_writer':
/test/curl/lib/cf-h2-proxy.c:264:14: warning: null pointer dereference [-Wnull-dereference]
  264 |   nwritten = Curl_conn_cf_send(cf->next, data, (const char *)buf, buflen, err);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'proxy_nw_in_reader',
    inlined from 'chunk_slurpn' at /test/curl/lib/bufq.c:109:11,
    inlined from 'Curl_bufq_sipn' at /test/curl/lib/bufq.c:616:11,
    inlined from 'bufq_slurpn.constprop' at /test/curl/lib/bufq.c:645:9:
/test/curl/lib/cf-h2-proxy.c:250:11: warning: null pointer dereference [-Wnull-dereference]
  250 |   nread = Curl_conn_cf_recv(cf->next, data, (char *)buf, buflen, err);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'Curl_bufq_is_empty',
    inlined from 'stream_recv' at /test/curl/lib/http2.c:1824:7:
/test/curl/lib/bufq.c:308:12: warning: potential null pointer dereference [-Wnull-dereference]
  308 |   return !q->head || chunk_is_empty(q->head);
      |           ~^~~~~~
/test/curl/lib/bufq.c:308:12: warning: potential null pointer dereference [-Wnull-dereference]
In file included from /test/curl/lib/sendf.h:29,
                 from /test/curl/lib/altsvc.c:37,
                 from /test/curl/bld-cmake-gcc-x64/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:4:
/test/curl/lib/vquic/vquic.c: In function 'recvfrom_packets.constprop':
/test/curl/lib/curl_trc.h:83:15: warning: 'r_ip' may be used uninitialized [-Wmaybe-uninitialized]
   83 | #define failf Curl_failf
/test/curl/lib/vquic/vquic.c:471:9: note: in expansion of macro 'failf'
  471 |         failf(data, "QUIC: connection to %s port %u refused",
      |         ^~~~~
In file included from /test/curl/bld-cmake-gcc-x64/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:484:
/test/curl/lib/vquic/vquic.c:467:21: note: 'r_ip' was declared here
  467 |         const char *r_ip;
      |                     ^~~~
/test/curl/lib/curl_trc.h:83:15: warning: 'r_port' may be used uninitialized [-Wmaybe-uninitialized]
   83 | #define failf Curl_failf
/test/curl/lib/vquic/vquic.c:471:9: note: in expansion of macro 'failf'
  471 |         failf(data, "QUIC: connection to %s port %u refused",
      |         ^~~~~
/test/curl/lib/vquic/vquic.c:468:13: note: 'r_port' was declared here
  468 |         int r_port;
      |             ^~~~~~
/test/curl/lib/vquic/vquic.c: In function 'recvfrom_packets':
/test/curl/lib/curl_trc.h:83:15: warning: 'r_ip' may be used uninitialized [-Wmaybe-uninitialized]
   83 | #define failf Curl_failf
/test/curl/lib/vquic/vquic.c:471:9: note: in expansion of macro 'failf'
  471 |         failf(data, "QUIC: connection to %s port %u refused",
      |         ^~~~~
/test/curl/lib/vquic/vquic.c:467:21: note: 'r_ip' was declared here
  467 |         const char *r_ip;
      |                     ^~~~
/test/curl/lib/curl_trc.h:83:15: warning: 'r_port' may be used uninitialized [-Wmaybe-uninitialized]
   83 | #define failf Curl_failf
/test/curl/lib/vquic/vquic.c:471:9: note: in expansion of macro 'failf'
  471 |         failf(data, "QUIC: connection to %s port %u refused",
      |         ^~~~~
/test/curl/lib/vquic/vquic.c:468:13: note: 'r_port' was declared here
  468 |         int r_port;
      |             ^~~~~~
In file included from /test/curl/bld-cmake-gcc-x64/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:478:
In function 'cf_connect_start',
    inlined from 'cf_ngtcp2_connect' at /test/curl/lib/vquic/curl_ngtcp2.c:2468:14:
/test/curl/lib/vquic/curl_ngtcp2.c:2408:20: warning: 'sockaddr' may be used uninitialized [-Wmaybe-uninitialized]
 2408 |                    &sockaddr->sa_addr, sockaddr->addrlen);
/test/curl/lib/vquic/curl_ngtcp2.c: In function 'cf_ngtcp2_connect':
/test/curl/lib/vquic/curl_ngtcp2.c:2352:34: note: 'sockaddr' was declared here
 2352 |   const struct Curl_sockaddr_ex *sockaddr;
      |                                  ^~~~~~~~
/test/curl/lib/curl_trc.h:120:10: warning: 'r_ip' may be used uninitialized [-Wmaybe-uninitialized]
  120 |          Curl_infof(data, __VA_ARGS__); } while(0)
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/test/curl/lib/vquic/curl_ngtcp2.c:2533:5: note: in expansion of macro 'infof'
 2533 |     infof(data, "QUIC connect to %s port %u failed: %s",
      |     ^~~~~
/test/curl/lib/vquic/curl_ngtcp2.c:2528:17: note: 'r_ip' was declared here
 2528 |     const char *r_ip;
      |                 ^~~~
/test/curl/lib/curl_trc.h:120:10: warning: 'r_port' may be used uninitialized [-Wmaybe-uninitialized]
  120 |          Curl_infof(data, __VA_ARGS__); } while(0)
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/test/curl/lib/vquic/curl_ngtcp2.c:2533:5: note: in expansion of macro 'infof'
 2533 |     infof(data, "QUIC connect to %s port %u failed: %s",
      |     ^~~~~
/test/curl/lib/vquic/curl_ngtcp2.c:2529:9: note: 'r_port' was declared here
 2529 |     int r_port;
      |         ^~~~~~
```
