### PR TITLE
tool_paramhlp: improve str2num() by avoiding unnecessary call to strlen()

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -138,7 +138,7 @@ static ParameterError getnum(long *val, const char *str, int base)
     num = strtol(str, &endptr, base);
     if(errno == ERANGE)
       return PARAM_NUMBER_TOO_LARGE;
-    if((endptr != str) && (endptr == str + strlen(str))) {
+    if((endptr != str) && (*endptr == '\0')) {
       *val = num;
       return PARAM_OK;  /* Ok */
     }


### PR DESCRIPTION
After reading @bagder last blog entry regarding CVE-2020-19909, I had a look to str2num() function and realized that a small improvement might be applied to avoid an unnecessary call to strlen().