### PR TITLE
hyper: fix ownership problems

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -808,15 +808,16 @@ static CURLcode bodysend(struct Curl_easy *data,
       hyper_body_set_data_func(body, uploadpostfields);
     else {
       result = Curl_get_upload_buffer(data);
-      if(result)
+      if(result) {
+        hyper_body_free(body);
         return result;
+      }
       /* init the "upload from here" pointer */
       data->req.upload_fromhere = data->state.ulbuf;
       hyper_body_set_data_func(body, uploadstreamed);
     }
     if(HYPERE_OK != hyper_request_set_body(hyperreq, body)) {
       /* fail */
-      hyper_body_free(body);
       result = CURLE_OUT_OF_MEMORY;
     }
   }
@@ -1215,6 +1216,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     result = CURLE_OUT_OF_MEMORY;
     goto error;
   }
+  sendtask = NULL; /* ownership passed on */
 
   hyper_clientconn_free(client);
   client = NULL;


### PR DESCRIPTION
Some of these changes come from comparing `Curl_http` and `start_CONNECT`, which are similar, and adding things to them that are present in one and missing in another.

The most important changes:
- In `start_CONNECT`, add a missing `hyper_clientconn_free` call on the happy path.
- In `start_CONNECT`, add a missing `hyper_request_free` on the error path.
- In `bodysend`, add a missing `hyper_body_free` on an early-exit path.
- In `bodysend`, remove an unnecessary `hyper_body_free` on a different error path that would cause a double-free. https://docs.rs/hyper/latest/hyper/ffi/fn.hyper_request_set_body.html says of `hyper_request_set_body`: "This takes ownership of the hyper_body *, you must not use it or free it after setting it on the request." This is true even if `hyper_request_set_body` returns an error; I confirmed this by looking at the hyper source code.

Other changes are minor but make things slightly nicer.