### PR TITLE
lib539.c: use curl_free() to free libcurl allocated data

### DIFF
--- a/tests/libtest/lib539.c
+++ b/tests/libtest/lib539.c
@@ -70,7 +70,7 @@ int test(char *URL)
 
    slist = curl_slist_append(NULL, "SYST");
    if(!slist) {
-     free(newURL);
+     curl_free(newURL);
      curl_easy_cleanup(curl);
      curl_global_cleanup();
      return TEST_ERR_MAJOR_BAD;
@@ -85,7 +85,7 @@ int test(char *URL)
 test_cleanup:
 
    curl_slist_free_all(slist);
-   free(newURL);
+   curl_free(newURL);
    curl_easy_cleanup(curl);
    curl_global_cleanup();
 

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -75,7 +75,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   sdp = open(libtest_arg2, O_RDONLY);
@@ -110,7 +110,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
@@ -126,7 +126,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   custom_headers = curl_slist_append(custom_headers,
@@ -156,7 +156,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
@@ -167,7 +167,7 @@ test_cleanup:
   if(sdpf)
     fclose(sdpf);
 
-  free(stream_uri);
+  curl_free(stream_uri);
 
   if(custom_headers)
     curl_slist_free_all(custom_headers);

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -85,7 +85,7 @@ int test(char *URL)
       goto test_cleanup;
     }
     test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-    free(stream_uri);
+    curl_free(stream_uri);
     stream_uri = NULL;
 
     test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
@@ -105,7 +105,7 @@ int test(char *URL)
       goto test_cleanup;
     }
     test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-    free(stream_uri);
+    curl_free(stream_uri);
     stream_uri = NULL;
 
     test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_TEARDOWN);
@@ -120,7 +120,7 @@ test_cleanup:
   if(idfile)
     fclose(idfile);
 
-  free(stream_uri);
+  curl_free(stream_uri);
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -63,7 +63,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   res = curl_easy_perform(curl);
@@ -84,7 +84,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   res = curl_easy_perform(curl);
@@ -99,7 +99,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   res = curl_easy_perform(curl);
@@ -112,7 +112,7 @@ int test(char *URL)
   }
 
 test_cleanup:
-  free(stream_uri);
+  curl_free(stream_uri);
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -134,7 +134,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, rtp_write);
@@ -156,7 +156,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
 
@@ -171,7 +171,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
 
@@ -185,7 +185,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
 
@@ -203,7 +203,7 @@ int test(char *URL)
   }
 
 test_cleanup:
-  free(stream_uri);
+  curl_free(stream_uri);
 
   if(protofile)
     fclose(protofile);

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -78,7 +78,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_RTSP_TRANSPORT, "Planes/Trains/Automobiles");
@@ -93,7 +93,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   /* PUT style GET_PARAMETERS */
@@ -128,7 +128,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   res = curl_easy_perform(curl);
@@ -143,7 +143,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_GET_PARAMETER);
@@ -162,7 +162,7 @@ int test(char *URL)
     goto test_cleanup;
   }
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
-  free(stream_uri);
+  curl_free(stream_uri);
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
@@ -173,7 +173,7 @@ test_cleanup:
   if(paramsf)
     fclose(paramsf);
 
-  free(stream_uri);
+  curl_free(stream_uri);
 
   if(custom_headers)
     curl_slist_free_all(custom_headers);

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -52,7 +52,7 @@ int test(char *URL)
    test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_SINGLECWD);
    res = curl_easy_perform(curl);
 
-   free(newURL);
+   curl_free(newURL);
    newURL = aprintf("%s/folderB/661", URL);
    test_setopt(curl, CURLOPT_URL, newURL);
    res = curl_easy_perform(curl);
@@ -67,7 +67,7 @@ int test(char *URL)
      goto test_cleanup;
    }
 
-   free(newURL);
+   curl_free(newURL);
    newURL = aprintf("%s/folderA/661", URL);
    test_setopt(curl, CURLOPT_URL, newURL);
    test_setopt(curl, CURLOPT_VERBOSE, 1L);
@@ -76,13 +76,13 @@ int test(char *URL)
    res = curl_easy_perform(curl);
 
    /* curve ball: CWD /folderB before reusing connection with _NOCWD */
-   free(newURL);
+   curl_free(newURL);
    newURL = aprintf("%s/folderB/661", URL);
    test_setopt(curl, CURLOPT_URL, newURL);
    test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_SINGLECWD);
    res = curl_easy_perform(curl);
 
-   free(newURL);
+   curl_free(newURL);
    newURL = aprintf("%s/folderA/661", URL);
    test_setopt(curl, CURLOPT_URL, newURL);
    test_setopt(curl, CURLOPT_FTP_FILEMETHOD, (long) CURLFTPMETHOD_NOCWD);
@@ -144,7 +144,7 @@ int test(char *URL)
 test_cleanup:
 
    curl_slist_free_all(slist);
-   free(newURL);
+   curl_free(newURL);
    curl_easy_cleanup(curl);
    curl_global_cleanup();
 


### PR DESCRIPTION
Reported-by: Nicholas Nethercote