### PR TITLE
ftp: fix temp write of ipv6 address

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -972,7 +972,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
         if(ip_end) {
           /* either ipv6 or (ipv4|domain|interface):port(-range) */
 #ifdef ENABLE_IPV6
-          if(Curl_inet_pton(AF_INET6, string_ftpport, sa6) == 1) {
+          if(Curl_inet_pton(AF_INET6, string_ftpport, &sa6->sin6_addr) == 1) {
             /* ipv6 */
             port_min = port_max = 0;
             strcpy(addr, string_ftpport);


### PR DESCRIPTION
- During the check to differentiate between a port and IPv6 address without brackets, write the binary IPv6 address to an in6_addr.

Prior to this change the binary IPv6 address was erroneously written to a sockaddr_in6 'sa6' when it should have been written to its in6_addr member 'sin6_addr'. There's no fallout because no members of 'sa6' are accessed before it is later overwritten.

Closes #xxxx