### PR TITLE
multi.h: the 'revents' field of curl_waitfd is supported

### DIFF
--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -118,7 +118,7 @@ typedef struct CURLMsg CURLMsg;
 struct curl_waitfd {
   curl_socket_t fd;
   short events;
-  short revents; /* not supported yet */
+  short revents;
 };
 
 /*


### PR DESCRIPTION
Since 6d30f8ebed34e7276

Reported-by: Nicolás Ojeda Bär
Ref: #11748