### PR TITLE
docs: removing "pausing transfers" from HYPER.md.

### DIFF
--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -65,7 +65,6 @@ still need attention and verification include:
 
 - multiplexed HTTP/2
 - h2 Upgrade:
-- pausing transfers
 - receiving HTTP/1 trailers
 - sending HTTP/1 trailers
 


### PR DESCRIPTION
It's a reference to #8600, which was fixed by #9070.