### PR TITLE
sectransp: fix compiler warnings

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2433,7 +2433,6 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
     SecTrustRef trust;
     OSStatus ret;
     SecKeyRef keyRef;
-    OSStatus success;
 
     ret = SSLCopyPeerTrust(ctx, &trust);
     if(ret != noErr || !trust)
@@ -2453,11 +2452,14 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
 
 #elif SECTRANSP_PINNEDPUBKEY_V2
 
-    success = SecItemExport(keyRef, kSecFormatOpenSSL, 0, NULL,
-                            &publicKeyBits);
-    CFRelease(keyRef);
-    if(success != errSecSuccess || !publicKeyBits)
-      break;
+    {
+        OSStatus success;
+        success = SecItemExport(keyRef, kSecFormatOpenSSL, 0, NULL,
+                                &publicKeyBits);
+        CFRelease(keyRef);
+        if(success != errSecSuccess || !publicKeyBits)
+          break;
+    }
 
 #endif /* SECTRANSP_PINNEDPUBKEY_V2 */
 
@@ -3300,6 +3302,7 @@ static CURLcode sectransp_sha256sum(const unsigned char *tmp, /* input */
                                     unsigned char *sha256sum, /* output */
                                     size_t sha256len)
 {
+  (void)sha256len;
   assert(sha256len >= CURL_SHA256_DIGEST_LENGTH);
   (void)CC_SHA256(tmp, (CC_LONG)tmplen, sha256sum);
   return CURLE_OK;


### PR DESCRIPTION
https://github.com/curl/curl-for-win/actions/runs/6037489221/job/16381860220#step:3:11046
```
./curl-for-win/curl/lib/vtls/sectransp.c:2435:14: warning: unused variable 'success' [-Wunused-variable]
    OSStatus success;
             ^
./curl-for-win/curl/lib/vtls/sectransp.c:3300:44: warning: unused parameter 'sha256len' [-Wunused-parameter]
                                    size_t sha256len)
                                           ^
```

Closes #11773