### PR TITLE
cmake: add support for `CURL_DEFAULT_SSL_BACKEND`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1557,6 +1557,9 @@ if(_items)
 endif()
 string(REPLACE ";" " " SSL_BACKENDS "${_items}")
 message(STATUS "Enabled SSL backends: ${SSL_BACKENDS}")
+if(CURL_DEFAULT_SSL_BACKEND)
+  message(STATUS "Default SSL backend: ${CURL_DEFAULT_SSL_BACKEND}")
+endif()
 
 # curl-config needs the following options to be set.
 set(CC                      "${CMAKE_C_COMPILER}")

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -32,6 +32,9 @@
 /* Location of default ca path */
 #cmakedefine CURL_CA_PATH "${CURL_CA_PATH}"
 
+/* Default SSL backend */
+#cmakedefine CURL_DEFAULT_SSL_BACKEND "${CURL_DEFAULT_SSL_BACKEND}"
+
 /* disables alt-svc */
 #cmakedefine CURL_DISABLE_ALTSVC 1
 


### PR DESCRIPTION
Allow overriding the default TLS backend via a CMake setting.

E.g.:
`cmake [...] -DCURL_DEFAULT_SSL_BACKEND=mbedtls`

Accepted values: bearssl, gnutls, mbedtls, openssl, rustls,
schannel, secure-transport, wolfssl

The passed string is baked into the curl/libcurl binaries.
The value is case-insensitive.

We added a similar option to autotools in 2017 via
c7170e20d0a18ec8a514b4daa53bcdbb4dcb3a05.

TODO: Convert to lowercase to improve reproducibility.

Closes #11774