### PR TITLE
Remove `hyptransfer->endtask`.

### DIFF
--- a/lib/c-hyper.h
+++ b/lib/c-hyper.h
@@ -34,7 +34,6 @@ struct hyptransfer {
   hyper_waker *write_waker;
   hyper_waker *read_waker;
   const hyper_executor *exec;
-  hyper_task *endtask;
   hyper_waker *exp100_waker;
   hyper_waker *send_body_waker;
 };


### PR DESCRIPTION
`Curl_hyper_stream` needs to distinguish between two kinds of `HYPER_TASK_EMPTY` tasks: (a) the `foreach` tasks it creates itself, and (b) background tasks that hyper produces. It does this by recording the address of any `foreach` task in `hyptransfer->endtask` before pushing it into the executor, and then comparing that against the address of tasks later polled out of the executor.

This works right now, but there is no guarantee from hyper that the addresses are stable. `hyper_executor_push` says "The executor takes ownership of the task, which should not be accessed again unless returned back to the user with `hyper_executor_poll`". That wording is a bit ambiguous but with my Rust programmer's hat on I read it as meaning the task returned with `hyper_executor_poll` may be conceptually the same as a task that was pushed, but that there are no other guarantees and comparing addresses is a bad idea.

This commit instead uses `hyper_task_set_userdata` to mark the `foreach` task with a `USERDATA_RESP_BODY` value which can then be checked for, removing the need for `hyptransfer->endtask`. This makes the code look more like that hyper C API examples, which use userdata for every task and never look at task addresses.