### PR TITLE
awssiv4: avoid freeing the date pointer on error

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -220,8 +220,10 @@ static CURLcode make_headers(struct Curl_easy *data,
     char *value;
 
     value = strchr(*date_header, ':');
-    if(!value)
+    if(!value) {
+      *date_header = NULL;
       goto fail;
+    }
     ++value;
     while(ISBLANK(*value))
       ++value;


### PR DESCRIPTION
Since it was not allocated, don't free it even if it was wrong syntax

Follow-up to b137634ba3adb

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61908 (not public yet)