### PR TITLE
lib: silence compiler warning in inet_ntop6

### DIFF
--- a/lib/inet_ntop.c
+++ b/lib/inet_ntop.c
@@ -117,8 +117,9 @@ static char *inet_ntop6 (const unsigned char *src, char *dst, size_t size)
 
   for(i = 0; i < (IN6ADDRSZ / INT16SZ); i++) {
     if(words[i] == 0) {
-      if(cur.base == -1)
-        cur.base = i, cur.len = 1;
+      if(cur.base == -1) {
+        cur.base = i; cur.len = 1;
+      }
       else
         cur.len++;
     }


### PR DESCRIPTION
```
./curl/lib/inet_ntop.c:121:21: warning: possible misuse of comma operator here [-Wcomma]
        cur.base = i, cur.len = 1;
                    ^
./curl/lib/inet_ntop.c:121:9: note: cast expression to void to silence warning
        cur.base = i, cur.len = 1;
        ^~~~~~~~~~~~
        (void)(     )
```

Closes #11790