### PR TITLE
http3: adjust a cast for ngtcp2 0.19.0

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1914,7 +1914,7 @@ static CURLcode recv_pkt(const unsigned char *pkt, size_t pktlen,
                    ctx->q.local_addrlen);
   ngtcp2_addr_init(&path.remote, (struct sockaddr *)remote_addr,
                    remote_addrlen);
-  pi.ecn = (uint32_t)ecn;
+  pi.ecn = (uint8_t)ecn;
 
   rv = ngtcp2_conn_read_pkt(ctx->qconn, &path, &pi, pkt, pktlen, pktx->ts);
   if(rv) {


### PR DESCRIPTION
ngtcp v0.19.0 made size of `ecn` member of `ngtcp2_pkt_info` an `uint8_t` (was: `uint32_t`). Adjust our local cast accordingly.

Fixes:
```
./curl/lib/vquic/curl_ngtcp2.c:1912:12: warning: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'uint8_t' (aka 'unsigned char') [-Wimplicit-int-conversion]
  pi.ecn = (uint32_t)ecn;
         ~ ^~~~~~~~~~~~~
```

Ref: https://github.com/ngtcp2/ngtcp2/commit/80447281bbc94af53f8aa7a4cfc19175782894a3 Ref: https://github.com/ngtcp2/ngtcp2/pull/877
Closes #xxxxx