### PR TITLE
libssh: Implement SFTP packet size limit

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2567,6 +2567,11 @@ static ssize_t sftp_send(struct Curl_easy *data, int sockindex,
   struct connectdata *conn = data->conn;
   (void)sockindex;
 
+  /* limit the writes to the maximum specified in Section 3 of
+   * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
+   */
+  len = len > 32768 ? 32768 : len;
+
   nwrite = sftp_write(conn->proto.sshc.sftp_file, mem, len);
 
   myssh_block2waitfor(conn, FALSE);


### PR DESCRIPTION
The curl does not do any chunking when writing SFTP packets (at least up to some size) and calls `sftp_write()`  directly with very large chunks. The `sftp_write()` is quite dummy and does not enforce any size limits. But SFTP specification is quite explicit that the clients should not try to write more than 32k or so:

https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-3

This might not be a problem for all implementations, but we got a report of a proprietary servers not accepting SFTP packets of size 65512 and larger.

The dummy fix I applied and verified it works is attached in this PR, but there might be better mechanisms to do this, please suggest.