### PR TITLE
When CURLOPT_SSL_CTX_FUNCTION is registered, init x509 store before

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3712,6 +3712,15 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
 
   /* give application a chance to interfere with SSL set up. */
   if(data->set.ssl.fsslctx) {
+    /* When a user callback is installed to modify the SSL_CTX,
+     * we need to do the full initialization before calling it.
+     * See: #11800 */
+    if(!backend->x509_store_setup) {
+      result = Curl_ssl_setup_x509_store(cf, data, backend->ctx);
+      if(result)
+        return result;
+      backend->x509_store_setup = TRUE;
+    }
     Curl_set_in_callback(data, true);
     result = (*data->set.ssl.fsslctx)(data, backend->ctx,
                                       data->set.ssl.fsslctxp);


### PR DESCRIPTION
- refs #11800
- we delay loading the x509 store to shorten the handshake time. However an application callback installed via CURLOPT_SSL_CTX_FUNCTION may need to have the store loaded and try to manipulate it.
- load the x509 store before invoking the app callback

test improvements

- set CURL_CI for pytest runs in CI environments
- exclude timing sensitive tests from CI runs
- for failed results, list only the log and stat of  the failed transfer

- fix typo in http.c comment
