### PR TITLE
pytest improvements

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -404,7 +404,8 @@ jobs:
       # run for `tests` directory, so pytest does not pick up any other
       # packages we might have built here
       run:
-        pytest -v tests
+        pytest tests
       name: 'run pytest'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
+        CURL_CI: github

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -263,15 +263,17 @@ jobs:
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
 
-    - run: pytest -v
+    - run: pytest tests
       name: 'run pytest'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
+        CURL_CI: github
 
-    - run: pytest
+    - run: pytest tests
       name: 'run pytest with slowed network'
       env:
         # 33% of sends are EAGAINed
         CURL_DBG_SOCK_WBLOCK: 33
         # only 80% of data > 10 bytes is send
         CURL_DBG_SOCK_WPARTIAL: 80
+        CURL_CI: github

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -202,7 +202,8 @@ jobs:
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
 
-    - run: pytest -v tests/http
+    - run: pytest tests
       name: 'run pytest'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
+        CURL_CI: github

--- a/lib/http.c
+++ b/lib/http.c
@@ -2707,7 +2707,7 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
 
         if(!data->req.upload_chunky) {
           /* We're not sending it 'chunked', append it to the request
-             already now to reduce the number if send() calls */
+             already now to reduce the number of send() calls */
           result = Curl_dyn_addn(r, data->set.postfields,
                                  (size_t)http->postsize);
           included_body = http->postsize;

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -201,6 +201,7 @@ class TestDownload:
         r.check_response(count=count, http_status=200)
 
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
+    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_10_10MB_serial(self, env: Env,
                               httpd, nghttpx, repeat, proto):
@@ -213,6 +214,7 @@ class TestDownload:
         r.check_response(count=count, http_status=200)
 
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
+    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_11_10MB_parallel(self, env: Env,
                               httpd, nghttpx, repeat, proto):
@@ -255,6 +257,7 @@ class TestDownload:
         r.check_response(count=count, http_status=200)
 
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
+    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     def test_02_20_h2_small_frames(self, env: Env, httpd, repeat):
         # Test case to reproduce content corruption as observed in
         # https://github.com/curl/curl/issues/10525

--- a/tests/http/test_04_stuttered.py
+++ b/tests/http/test_04_stuttered.py
@@ -36,6 +36,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
+@pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
 class TestStuttered:
 
     @pytest.fixture(autouse=True, scope='class')

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -111,6 +111,7 @@ class TestCaddy:
 
     # download 5MB files sequentially
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
+    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_08_04a_download_10mb_sequential(self, env: Env, caddy: Caddy,
                                            repeat, proto):
@@ -126,6 +127,7 @@ class TestCaddy:
 
     # download 10MB files sequentially
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
+    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_08_04b_download_10mb_sequential(self, env: Env, caddy: Caddy,
                                            repeat, proto):
@@ -142,6 +144,7 @@ class TestCaddy:
     # download 10MB files parallel
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     def test_08_05_download_1mb_parallel(self, env: Env, caddy: Caddy,
                                          repeat, proto):
         if proto == 'h3' and not env.have_h3_curl():

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -444,6 +444,10 @@ class Env:
         return "CURL_DBG_SOCK_WBLOCK" in os.environ or \
                "CURL_DBG_SOCK_WPARTIAL" in os.environ
 
+    @property
+    def ci_run(self) -> bool:
+        return "CURL_CI" in os.environ
+
     def authority_for(self, domain: str, alpn_proto: Optional[str] = None):
         if alpn_proto is None or \
                 alpn_proto in ['h2', 'http/1.1', 'http/1.0', 'http/0.9']:


### PR DESCRIPTION
- set CURL_CI for pytest runs in CI environments
- exclude timing sensitive tests from CI runs
- for failed results, list only the log and stat of the failed transfer

- fix typo in http.c comment