### PR TITLE
tool_cb_wrt: error on max filesize exceeded

### DIFF
--- a/docs/cmdline-opts/max-filesize.d
+++ b/docs/cmdline-opts/max-filesize.d
@@ -18,6 +18,7 @@ A size modifier may be used. For example, Appending 'k' or 'K' will count the
 number as kilobytes, 'm' or 'M' makes it megabytes, while 'g' or 'G' makes it
 gigabytes. Examples: 200K, 3m and 1G. (Added in 7.58.0)
 
-**NOTE**: The file size is not always known prior to download, and for such
-files this option has no effect even if the file transfer ends up being larger
-than this given limit.
+**NOTE**: The file size is not always known prior to download. In this case,
+curl will start the download and if the received data exceeds the maximum size
+then curl will terminate the transfer prematurely and return error 63. Prior to
+curl 8.4.0 the option would have no effect in this case.

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -231,6 +231,9 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     }
   }
 
+  if(config->max_filesize && (outs->bytes + bytes > config->max_filesize))
+    return CURLE_FILESIZE_EXCEEDED;
+
 #ifdef WIN32
   fhnd = _get_osfhandle(fileno(outs->stream));
   /* if windows console then UTF-8 must be converted to UTF-16 */


### PR DESCRIPTION
- Return CURLE_FILESIZE_EXCEEDED when the received data exceeds the maximum file size.

This is to handle those cases where the filesize is not known in advance (eg chunked encoding) but the bytes received exceeds the max file size.

Prior to this change --max-filesize had no effect when the file size was not provided by the server.

Reported-by: Elliot Killick

Fixes https://github.com/curl/curl/issues/11810
Closes #xxxx

---

draft for how i think we should do it. if there are no objections i'll add a test and finalize
