### PR TITLE
let the max filesize option stop too big transfers too

### DIFF
--- a/docs/cmdline-opts/max-filesize.d
+++ b/docs/cmdline-opts/max-filesize.d
@@ -18,6 +18,9 @@ A size modifier may be used. For example, Appending 'k' or 'K' counts the
 number as kilobytes, 'm' or 'M' makes it megabytes, while 'g' or 'G' makes it
 gigabytes. Examples: 200K, 3m and 1G. (Added in 7.58.0)
 
-**NOTE**: The file size is not always known prior to download, and for such
-files this option has no effect even if the file transfer ends up being larger
-than this given limit.
+**NOTE**: before curl 8.4.0, when the file size is not known prior to
+download, for such files this option has no effect even if the file transfer
+ends up being larger than this given limit.
+
+Starting with curl 8.4.0, this option aborts the transfer if it reaches the
+threshold during transfer.

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.3
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.3
@@ -41,6 +41,9 @@ transfers this option has no effect - even if the file transfer eventually
 ends up being larger than this given limit.
 
 If you want a limit above 2GB, use \fICURLOPT_MAXFILESIZE_LARGE(3)\fP.
+
+Since 8.4.0, this option also stops ongoing transfers if they reach this
+threshold.
 .SH DEFAULT
 None
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.3
@@ -40,6 +40,9 @@ returned.
 The file size is not always known prior to the download start, and for such
 transfers this option has no effect - even if the file transfer eventually
 ends up being larger than this given limit.
+
+Since 8.4.0, this option also stops ongoing transfers if they reach this
+threshold.
 .SH DEFAULT
 None
 .SH PROTOCOLS

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -258,7 +258,11 @@ static int hyper_body_chunk(void *userdata, const hyper_buf *chunk)
   }
 
   data->req.bytecount += len;
-  Curl_pgrsSetDownloadCounter(data, data->req.bytecount);
+  result = Curl_pgrsSetDownloadCounter(data, data->req.bytecount);
+  if(result) {
+    data->state.hresult = result;
+    return HYPER_ITER_BREAK;
+  }
   return HYPER_ITER_CONTINUE;
 }
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -571,7 +571,9 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
     if(result)
       return result;
 
-    Curl_pgrsSetDownloadCounter(data, bytecount);
+    result = Curl_pgrsSetDownloadCounter(data, bytecount);
+    if(result)
+      return result;
 
     if(Curl_pgrsUpdate(data))
       result = CURLE_ABORTED_BY_CALLBACK;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -735,7 +735,9 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       if(result)
         goto quit;
       dlsize++;
-      Curl_pgrsSetDownloadCounter(data, dlsize);
+      result = Curl_pgrsSetDownloadCounter(data, dlsize);
+      if(result)
+        goto quit;
     }
 
     if(ber)

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -668,7 +668,9 @@ MQTT_SUBACK_COMING:
 
     mq->npacket -= nread;
     k->bytecount += nread;
-    Curl_pgrsSetDownloadCounter(data, k->bytecount);
+    result = Curl_pgrsSetDownloadCounter(data, k->bytecount);
+    if(result)
+      goto end;
 
     /* if QoS is set, message contains packet id */
 

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -317,9 +317,16 @@ timediff_t Curl_pgrsLimitWaitTime(curl_off_t cursize,
 /*
  * Set the number of downloaded bytes so far.
  */
-void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
+CURLcode Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size)
 {
+  if(data->set.max_filesize && (size > data->set.max_filesize)) {
+    failf(data, "Exceeded the maximum allowed file size "
+          "(%" CURL_FORMAT_CURL_OFF_T ")",
+          data->set.max_filesize);
+    return CURLE_FILESIZE_EXCEEDED;
+  }
   data->progress.downloaded = size;
+  return CURLE_OK;
 }
 
 /*

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -46,7 +46,10 @@ int Curl_pgrsDone(struct Curl_easy *data);
 void Curl_pgrsStartNow(struct Curl_easy *data);
 void Curl_pgrsSetDownloadSize(struct Curl_easy *data, curl_off_t size);
 void Curl_pgrsSetUploadSize(struct Curl_easy *data, curl_off_t size);
-void Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size);
+
+/* It is fine to not check the return code if 'size' is set to 0 */
+CURLcode Curl_pgrsSetDownloadCounter(struct Curl_easy *data, curl_off_t size);
+
 void Curl_pgrsSetUploadCounter(struct Curl_easy *data, curl_off_t size);
 void Curl_ratelimit(struct Curl_easy *data, struct curltime now);
 int Curl_pgrsUpdate(struct Curl_easy *data);

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -1049,7 +1049,12 @@ static CURLcode smb_request_state(struct Curl_easy *data, bool *done)
     }
     data->req.bytecount += len;
     data->req.offset += len;
-    Curl_pgrsSetDownloadCounter(data, data->req.bytecount);
+    result = Curl_pgrsSetDownloadCounter(data, data->req.bytecount);
+    if(result) {
+      req->result = result;
+      next_state = SMB_CLOSE;
+      break;
+    }
     next_state = (len < MAX_PAYLOAD_SIZE) ? SMB_CLOSE : SMB_DOWNLOAD;
     break;
 

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1570,8 +1570,9 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
         }
 
         total_dl += nread;
-        Curl_pgrsSetDownloadCounter(data, total_dl);
-        result = telrcv(data, (unsigned char *)buf, nread);
+        result = Curl_pgrsSetDownloadCounter(data, total_dl);
+        if(!result)
+          result = telrcv(data, (unsigned char *)buf, nread);
         if(result) {
           keepon = FALSE;
           break;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1141,12 +1141,15 @@ static CURLcode tftp_receive_packet(struct Curl_easy *data)
         result = Curl_client_write(data, CLIENTWRITE_BODY,
                                    (char *)state->rpacket.data + 4,
                                    state->rbytes-4);
+        if(!result) {
+          k->bytecount += state->rbytes-4;
+          result = Curl_pgrsSetDownloadCounter(data,
+                                               (curl_off_t) k->bytecount);
+        }
         if(result) {
           tftp_state_machine(state, TFTP_EVENT_ERROR);
           return result;
         }
-        k->bytecount += state->rbytes-4;
-        Curl_pgrsSetDownloadCounter(data, (curl_off_t) k->bytecount);
       }
       break;
     case TFTP_EVENT_ERROR:

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -671,7 +671,9 @@ static CURLcode readwrite_data(struct Curl_easy *data,
       k->bytecount += nread;
       max_recv -= nread;
 
-      Curl_pgrsSetDownloadCounter(data, k->bytecount);
+      result = Curl_pgrsSetDownloadCounter(data, k->bytecount);
+      if(result)
+        goto out;
 
       if(!k->chunk && (nread || k->badheader || is_empty_data)) {
         /* If this is chunky transfer, it was already written */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -70,10 +70,9 @@ test399 test400 test401 test402 test403 test404 test405 test406 test407 \
 test408 test409 test410 test411 test412 test413 test414 test415 test416 \
 test417 test418 test419 test420 test421 test422 test423 test424 test425 \
 test426 test427 test428 test429 test430 test431 test432 test433 test434 \
-test435 test436 test437 test438 test439 \
-\
-test440 test441 test442 test443 test444 test445 test446 test447 test448 \
-test449 test450 test451 test452 test453 test454 test455 test456 \
+test435 test436 test437 test438 test439 test440 test441 test442 test443 \
+test444 test445 test446 test447 test448 test449 test450 test451 test452 \
+test453 test454 test455 test456 test457 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 \

--- a/tests/data/test457
+++ b/tests/data/test457
@@ -1,0 +1,68 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked Transfer-Encoding
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Connection: mooo
+
+40
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+30
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+21;heresatest=moooo
+cccccccccccccccccccccccccccccccc
+
+0
+
+</data>
+<datacheck>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Connection: mooo
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+chunked Transfer-Encoding with --max-filesize
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --max-filesize 143
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+# curl: (63) Exceeded the maximum allowed file size (143)
+<errorcode>
+63
+</errorcode>
+</verify>
+
+</testcase>


### PR DESCRIPTION
Fixes #11810

I believe the wording and functionality of the option allows us to do this minor tweak of functionality without causing users harm. I still mark it to get done in the feature window for extra precaution.