### PR TITLE
include.d: explain headers not printed prior 7.75.0

### DIFF
--- a/docs/cmdline-opts/include.d
+++ b/docs/cmdline-opts/include.d
@@ -14,3 +14,6 @@ include things like server name, cookies, date of the document, HTTP version
 and more...
 
 To view the request headers, consider the --verbose option.
+
+Prior to 7.75.0 curl was not able to print headers if *fail* option was used and
+there was error reported by server.

--- a/docs/cmdline-opts/include.d
+++ b/docs/cmdline-opts/include.d
@@ -15,5 +15,5 @@ and more...
 
 To view the request headers, consider the --verbose option.
 
-Prior to 7.75.0 curl was not able to print headers if *fail* option was used and
+Prior to 7.75.0 curl did not print the headers if --fail was used in combination with this option and
 there was error reported by server.


### PR DESCRIPTION
Prior to `7.75.0` response headers were not printed if `-f`/`--fail` was used and an error was reported by server.

This is **NOK** example for curl `7.74.0`:
```shell
$ curl -q "http://httpbin.org/status/500" --include --fail
curl: (22) The requested URL returned error: 500 INTERNAL SERVER ERROR
```
This is **OK** example for curl `8.1.2`:

```shell
$ curl -q "http://httpbin.org/status/500" --include --fail
HTTP/1.1 500 INTERNAL SERVER ERROR
Server: gunicorn/19.9.0
Date: Fri, 08 Sep 2023 15:15:43 GMT
Connection: keep-alive
Content-Type: text/html; charset=utf-8
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Content-Length: 0

curl: (22) The requested URL returned error: 500
```

This behavior was fixed in ab525c0 (precedes 7.75.0).