### PR TITLE
http_aws_sigv4: skip the op if the query pair is zero bytes

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -422,6 +422,8 @@ static CURLcode canon_query(struct Curl_easy *data,
   for(i = 0; !result && (i < entry); i++, ap++) {
     size_t len;
     const char *q = ap->p;
+    if(!ap->len)
+      continue;
     for(len = ap->len; len && !result; q++, len--) {
       if(ISALNUM(*q))
         result = Curl_dyn_addn(dq, q, 1);


### PR DESCRIPTION
Follow-up to fc76a24c53b08cdf

Spotted by OSS-Fuzz

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62175