### PR TITLE
CI: run pytest with the -v option

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -404,7 +404,7 @@ jobs:
       # run for `tests` directory, so pytest does not pick up any other
       # packages we might have built here
       run:
-        pytest tests
+        pytest -v tests
       name: 'run pytest'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -263,13 +263,13 @@ jobs:
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
 
-    - run: pytest tests
+    - run: pytest -v tests
       name: 'run pytest'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
         CURL_CI: github
 
-    - run: pytest tests
+    - run: pytest -v tests
       name: 'run pytest with slowed network'
       env:
         # 33% of sends are EAGAINed

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -202,7 +202,7 @@ jobs:
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
 
-    - run: pytest tests
+    - run: pytest -v tests
       name: 'run pytest'
       env:
         TFLAGS: "${{ matrix.build.tflags }}"


### PR DESCRIPTION
This lists of the test cases being run so it can be tracked over time.

Closes #11824

This lack can be currently seen as "truncated" test runs on my test summary page.