### PR TITLE
configure: fix `HAVE_TIME_T_UNSIGNED` check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3569,8 +3569,10 @@ CURL_RUN_IFELSE(
   [
   #include <time.h>
   #include <limits.h>
-  time_t t = -1;
-  return (t > 0);
+  int main(void) {
+    time_t t = -1;
+    return (t < 0);
+  }
   ],[
   AC_MSG_RESULT([yes])
   AC_DEFINE(HAVE_TIME_T_UNSIGNED, 1, [Define this if time_t is unsigned])


### PR DESCRIPTION
The syntax was incorrect (need a proper main body), and the test condition was wrong (resulting in a signed `time_t` detected as unsigned).