### PR TITLE
aws_sigv4: the query canon code miscounted URL encoded input

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -445,6 +445,7 @@ static CURLcode canon_query(struct Curl_easy *data,
             tmp[2] = Curl_raw_toupper(q[2]);
             result = Curl_dyn_addn(dq, tmp, 3);
             q += 2;
+            len -= 2;
           }
           else
             /* '%' without a following two-digit hex, encode it */
@@ -666,6 +667,8 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
                   (int)payload_hash_len, payload_hash);
   if(!canonical_request)
     goto fail;
+
+  DEBUGF(infof(data, "Canonical request: %s", canonical_request));
 
   /* provider 0 lowercase */
   Curl_strntolower(provider0, provider0, strlen(provider0));

--- a/tests/data/test439
+++ b/tests/data/test439
@@ -38,7 +38,7 @@ debug
 aws-sigv4 with query
 </name>
 <command>
-"http://fake.fake.fake:8000/%TESTNUMBER/?name=me%&aim=b%aad&weirdo=*.//-" -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --connect-to fake.fake.fake:8000:%HOSTIP:%HTTPPORT
+"http://fake.fake.fake:8000/%TESTNUMBER/?name=me%&aim=b%aad&&&weirdo=*.//-" -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --connect-to fake.fake.fake:8000:%HOSTIP:%HTTPPORT
 </command>
 </client>
 
@@ -46,9 +46,9 @@ aws-sigv4 with query
 # Verify data after the test has been "shot"
 <verify>
 <protocol crlf="yes">
-GET /%TESTNUMBER/?name=me%&aim=b%aad&weirdo=*.//- HTTP/1.1
+GET /%TESTNUMBER/?name=me%&aim=b%aad&&&weirdo=*.//- HTTP/1.1
 Host: fake.fake.fake:8000
-Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=61376efa7adec25078f791a830dc3173d68e6c93799dd9a02046cf5092e2362a
+Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=88884e3b3142133685b2092d29d8b522b785b1a9ec9e4a90cbea83e882f8dcb6
 X-Amz-Date: 19700101T000000Z
 User-Agent: curl/%VERSION
 Accept: */*


### PR DESCRIPTION
Added some extra ampersands to test 439 to verify "blank" query parts

Follow-up to fc76a24c53b08cdf