### PR TITLE
Improved pollset control

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1065,9 +1065,9 @@ static int cf_h1_proxy_get_select_socks(struct Curl_cfilter *cf,
   return fds;
 }
 
-static void cf_h1_proxy_adjust_poll_set(struct Curl_cfilter *cf,
+static void cf_h1_proxy_adjust_pollset(struct Curl_cfilter *cf,
                                         struct Curl_easy *data,
-                                        struct easy_poll_set *ps)
+                                        struct easy_pollset *ps)
 {
   struct h1_tunnel_state *ts = cf->ctx;
 
@@ -1089,7 +1089,7 @@ static void cf_h1_proxy_adjust_poll_set(struct Curl_cfilter *cf,
       Curl_poll_set_change(data, ps, sock, CURL_POLL_OUT, CURL_POLL_IN);
   }
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static void cf_h1_proxy_destroy(struct Curl_cfilter *cf,
@@ -1121,7 +1121,7 @@ struct Curl_cftype Curl_cft_h1_proxy = {
   cf_h1_proxy_close,
   Curl_cf_http_proxy_get_host,
   cf_h1_proxy_get_select_socks,
-  cf_h1_proxy_adjust_poll_set,
+  cf_h1_proxy_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1071,7 +1071,7 @@ static void cf_h1_proxy_adjust_pollset(struct Curl_cfilter *cf,
 {
   struct h1_tunnel_state *ts = cf->ctx;
 
-  if(!cf->connected) {
+  if(!cf->connected && cf->next && cf->next->connected) {
     /* If we are not connected, but the filter "below" is
      * and not waiting on something, we are tunneling. */
     curl_socket_t sock = Curl_conn_cf_get_socket(cf, data);

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1081,12 +1081,12 @@ static void cf_h1_proxy_adjust_pollset(struct Curl_cfilter *cf,
          response headers or if we're still sending the request, wait
          for write. */
       if(ts->CONNECT.sending == HTTPSEND_REQUEST)
-        Curl_poll_set_change(data, ps, sock, CURL_POLL_OUT, CURL_POLL_IN);
+        Curl_pollset_set_out_only(data, ps, sock);
       else
-        Curl_poll_set_change(data, ps, sock, CURL_POLL_IN, CURL_POLL_OUT);
+        Curl_pollset_set_in_only(data, ps, sock);
     }
     else
-      Curl_poll_set_change(data, ps, sock, CURL_POLL_OUT, CURL_POLL_IN);
+      Curl_pollset_set_out_only(data, ps, sock);
   }
   if(cf->next)
     cf->next->cft->adjust_pollset(cf->next, data, ps);

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1209,10 +1209,10 @@ static void cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
 
   /* HTTP/2 layer wants to send data) AND there's a window to send data in */
   if(nghttp2_session_want_read(ctx->h2))
-    Curl_poll_set_change(data, ps, sock, CURL_POLL_IN, 0);
+    Curl_pollset_add_in(data, ps, sock);
   if(nghttp2_session_want_write(ctx->h2) &&
      nghttp2_session_get_remote_window_size(ctx->h2))
-    Curl_poll_set_change(data, ps, sock, CURL_POLL_OUT, 0);
+    Curl_pollset_add_out(data, ps, sock);
 
   CF_DATA_RESTORE(cf, save);
   if(cf->next)

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1173,11 +1173,11 @@ static void cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
                                        struct easy_pollset *ps)
 {
   struct cf_h2_proxy_ctx *ctx = cf->ctx;
-  bool want_recv = CURL_WANT_RECV(data);
-  bool want_send = CURL_WANT_SEND(data);
+  curl_socket_t sock = Curl_conn_cf_get_socket(cf, data);
+  bool want_recv, want_send;
 
+  Curl_pollset_check(data, ps, sock, &want_recv, &want_send);
   if(ctx->h2 && (want_recv || want_send)) {
-    curl_socket_t sock = Curl_conn_cf_get_socket(cf, data);
     struct cf_call_data save;
     bool c_exhaust, s_exhaust;
 

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1197,9 +1197,9 @@ static int cf_h2_proxy_get_select_socks(struct Curl_cfilter *cf,
   return bitmap;
 }
 
-static void cf_h2_proxy_adjust_poll_set(struct Curl_cfilter *cf,
+static void cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
                                         struct Curl_easy *data,
-                                        struct easy_poll_set *ps)
+                                        struct easy_pollset *ps)
 {
   struct cf_h2_proxy_ctx *ctx = cf->ctx;
   struct cf_call_data save;
@@ -1216,7 +1216,7 @@ static void cf_h2_proxy_adjust_poll_set(struct Curl_cfilter *cf,
 
   CF_DATA_RESTORE(cf, save);
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static ssize_t h2_handle_tunnel_close(struct Curl_cfilter *cf,
@@ -1554,7 +1554,7 @@ struct Curl_cftype Curl_cft_h2_proxy = {
   cf_h2_proxy_close,
   Curl_cf_http_proxy_get_host,
   cf_h2_proxy_get_select_socks,
-  cf_h2_proxy_adjust_poll_set,
+  cf_h2_proxy_adjust_pollset,
   cf_h2_proxy_data_pending,
   cf_h2_proxy_send,
   cf_h2_proxy_recv,

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -171,22 +171,6 @@ static void cf_haproxy_close(struct Curl_cfilter *cf,
     cf->next->cft->do_close(cf->next, data);
 }
 
-static int cf_haproxy_get_select_socks(struct Curl_cfilter *cf,
-                                       struct Curl_easy *data,
-                                       curl_socket_t *socks)
-{
-  int fds;
-
-  fds = cf->next->cft->get_select_socks(cf->next, data, socks);
-  if(!fds && cf->next->connected && !cf->connected) {
-    /* If we are not connected, but the filter "below" is
-     * and not waiting on something, we are sending. */
-    socks[0] = Curl_conn_cf_get_socket(cf, data);
-    return GETSOCK_WRITESOCK(0);
-  }
-  return fds;
-}
-
 static void cf_haproxy_adjust_pollset(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
                                       struct easy_pollset *ps)
@@ -196,8 +180,6 @@ static void cf_haproxy_adjust_pollset(struct Curl_cfilter *cf,
      * and not waiting on something, we are sending. */
     Curl_pollset_set_out_only(data, ps, Curl_conn_cf_get_socket(cf, data));
   }
-  if(cf->next)
-    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 struct Curl_cftype Curl_cft_haproxy = {
@@ -208,7 +190,6 @@ struct Curl_cftype Curl_cft_haproxy = {
   cf_haproxy_connect,
   cf_haproxy_close,
   Curl_cf_def_get_host,
-  cf_haproxy_get_select_socks,
   cf_haproxy_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -197,6 +197,7 @@ struct Curl_cftype Curl_cft_haproxy = {
   cf_haproxy_close,
   Curl_cf_def_get_host,
   cf_haproxy_get_select_socks,
+  Curl_cf_def_adjust_poll_set,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -197,7 +197,7 @@ struct Curl_cftype Curl_cft_haproxy = {
   cf_haproxy_close,
   Curl_cf_def_get_host,
   cf_haproxy_get_select_socks,
-  Curl_cf_def_adjust_poll_set,
+  Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -363,9 +363,9 @@ static int cf_hc_get_select_socks(struct Curl_cfilter *cf,
   return rc;
 }
 
-static void cf_hc_adjust_poll_set(struct Curl_cfilter *cf,
+static void cf_hc_adjust_pollset(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
-                                  struct easy_poll_set *ps)
+                                  struct easy_pollset *ps)
 {
   if(!cf->connected) {
     struct cf_hc_ctx *ctx = cf->ctx;
@@ -378,12 +378,12 @@ static void cf_hc_adjust_poll_set(struct Curl_cfilter *cf,
       struct cf_hc_baller *b = ballers[i];
       if(!cf_hc_baller_is_active(b))
         continue;
-      b->cf->cft->adjust_poll_set(b->cf, data, ps);
+      b->cf->cft->adjust_pollset(b->cf, data, ps);
     }
-    CURL_TRC_CF(data, cf, "adjust_poll_set -> %d socks", ps->num);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static bool cf_hc_data_pending(struct Curl_cfilter *cf,
@@ -479,7 +479,7 @@ struct Curl_cftype Curl_cft_http_connect = {
   cf_hc_close,
   Curl_cf_def_get_host,
   cf_hc_get_select_socks,
-  cf_hc_adjust_poll_set,
+  cf_hc_adjust_pollset,
   cf_hc_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -325,44 +325,6 @@ out:
   return result;
 }
 
-static int cf_hc_get_select_socks(struct Curl_cfilter *cf,
-                                  struct Curl_easy *data,
-                                  curl_socket_t *socks)
-{
-  struct cf_hc_ctx *ctx = cf->ctx;
-  size_t i, j, s;
-  int brc, rc = GETSOCK_BLANK;
-  curl_socket_t bsocks[MAX_SOCKSPEREASYHANDLE];
-  struct cf_hc_baller *ballers[2];
-
-  if(cf->connected)
-    return cf->next->cft->get_select_socks(cf->next, data, socks);
-
-  ballers[0] = &ctx->h3_baller;
-  ballers[1] = &ctx->h21_baller;
-  for(i = s = 0; i < sizeof(ballers)/sizeof(ballers[0]); i++) {
-    struct cf_hc_baller *b = ballers[i];
-    if(!cf_hc_baller_is_active(b))
-      continue;
-    brc = Curl_conn_cf_get_select_socks(b->cf, data, bsocks);
-    CURL_TRC_CF(data, cf, "get_selected_socks(%s) -> %x", b->name, brc);
-    if(!brc)
-      continue;
-    for(j = 0; j < MAX_SOCKSPEREASYHANDLE && s < MAX_SOCKSPEREASYHANDLE; ++j) {
-      if((brc & GETSOCK_WRITESOCK(j)) || (brc & GETSOCK_READSOCK(j))) {
-        socks[s] = bsocks[j];
-        if(brc & GETSOCK_WRITESOCK(j))
-          rc |= GETSOCK_WRITESOCK(s);
-        if(brc & GETSOCK_READSOCK(j))
-          rc |= GETSOCK_READSOCK(s);
-        s++;
-      }
-    }
-  }
-  CURL_TRC_CF(data, cf, "get_selected_socks -> %x", rc);
-  return rc;
-}
-
 static void cf_hc_adjust_pollset(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
                                   struct easy_pollset *ps)
@@ -378,12 +340,10 @@ static void cf_hc_adjust_pollset(struct Curl_cfilter *cf,
       struct cf_hc_baller *b = ballers[i];
       if(!cf_hc_baller_is_active(b))
         continue;
-      b->cf->cft->adjust_pollset(b->cf, data, ps);
+      Curl_conn_cf_adjust_pollset(b->cf, data, ps);
     }
     CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
-  if(cf->next)
-    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static bool cf_hc_data_pending(struct Curl_cfilter *cf,
@@ -478,7 +438,6 @@ struct Curl_cftype Curl_cft_http_connect = {
   cf_hc_connect,
   cf_hc_close,
   Curl_cf_def_get_host,
-  cf_hc_get_select_socks,
   cf_hc_adjust_pollset,
   cf_hc_data_pending,
   Curl_cf_def_send,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1252,22 +1252,6 @@ static void cf_socket_get_host(struct Curl_cfilter *cf,
   *pport = cf->conn->port;
 }
 
-static int cf_socket_get_select_socks(struct Curl_cfilter *cf,
-                                      struct Curl_easy *data,
-                                      curl_socket_t *socks)
-{
-  struct cf_socket_ctx *ctx = cf->ctx;
-  int rc = GETSOCK_BLANK;
-
-  (void)data;
-  if(!cf->connected && ctx->sock != CURL_SOCKET_BAD) {
-    socks[0] = ctx->sock;
-    rc |= GETSOCK_WRITESOCK(0);
-  }
-
-  return rc;
-}
-
 static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
                                       struct easy_pollset *ps)
@@ -1627,7 +1611,6 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_tcp_connect,
   cf_socket_close,
   cf_socket_get_host,
-  cf_socket_get_select_socks,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
@@ -1758,7 +1741,6 @@ struct Curl_cftype Curl_cft_udp = {
   cf_udp_connect,
   cf_socket_close,
   cf_socket_get_host,
-  cf_socket_get_select_socks,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
@@ -1810,7 +1792,6 @@ struct Curl_cftype Curl_cft_unix = {
   cf_tcp_connect,
   cf_socket_close,
   cf_socket_get_host,
-  cf_socket_get_select_socks,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
@@ -1875,7 +1856,6 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_tcp_accept_connect,
   cf_socket_close,
   cf_socket_get_host,              /* TODO: not accurate */
-  cf_socket_get_select_socks,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1276,9 +1276,9 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 
   if(ctx->sock != CURL_SOCKET_BAD) {
     if(!cf->connected)
-      Curl_poll_set_change(data, ps, ctx->sock, CURL_POLL_OUT, CURL_POLL_IN);
+      Curl_pollset_set_out_only(data, ps, ctx->sock);
     else
-      Curl_poll_set_change(data, ps, ctx->sock, CURL_POLL_IN, 0);
+      Curl_pollset_add_in(data, ps, ctx->sock);
     CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1268,6 +1268,21 @@ static int cf_socket_get_select_socks(struct Curl_cfilter *cf,
   return rc;
 }
 
+static void cf_socket_adjust_poll_set(struct Curl_cfilter *cf,
+                                      struct Curl_easy *data,
+                                      struct easy_poll_set *ps)
+{
+  struct cf_socket_ctx *ctx = cf->ctx;
+
+  if(ctx->sock != CURL_SOCKET_BAD) {
+    if(!cf->connected)
+      Curl_poll_set_change(data, ps, ctx->sock, CURL_POLL_OUT, CURL_POLL_IN);
+    else
+      Curl_poll_set_change(data, ps, ctx->sock, CURL_POLL_IN, 0);
+    CURL_TRC_CF(data, cf, "adjust_poll_set -> %d socks", ps->num);
+  }
+}
+
 static bool cf_socket_data_pending(struct Curl_cfilter *cf,
                                    const struct Curl_easy *data)
 {
@@ -1613,6 +1628,7 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_socket_close,
   cf_socket_get_host,
   cf_socket_get_select_socks,
+  cf_socket_adjust_poll_set,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
@@ -1743,6 +1759,7 @@ struct Curl_cftype Curl_cft_udp = {
   cf_socket_close,
   cf_socket_get_host,
   cf_socket_get_select_socks,
+  cf_socket_adjust_poll_set,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
@@ -1794,6 +1811,7 @@ struct Curl_cftype Curl_cft_unix = {
   cf_socket_close,
   cf_socket_get_host,
   cf_socket_get_select_socks,
+  cf_socket_adjust_poll_set,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
@@ -1858,6 +1876,7 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_socket_close,
   cf_socket_get_host,              /* TODO: not accurate */
   cf_socket_get_select_socks,
+  cf_socket_adjust_poll_set,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1268,9 +1268,9 @@ static int cf_socket_get_select_socks(struct Curl_cfilter *cf,
   return rc;
 }
 
-static void cf_socket_adjust_poll_set(struct Curl_cfilter *cf,
+static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
-                                      struct easy_poll_set *ps)
+                                      struct easy_pollset *ps)
 {
   struct cf_socket_ctx *ctx = cf->ctx;
 
@@ -1279,7 +1279,7 @@ static void cf_socket_adjust_poll_set(struct Curl_cfilter *cf,
       Curl_poll_set_change(data, ps, ctx->sock, CURL_POLL_OUT, CURL_POLL_IN);
     else
       Curl_poll_set_change(data, ps, ctx->sock, CURL_POLL_IN, 0);
-    CURL_TRC_CF(data, cf, "adjust_poll_set -> %d socks", ps->num);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
 }
 
@@ -1628,7 +1628,7 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_socket_close,
   cf_socket_get_host,
   cf_socket_get_select_socks,
-  cf_socket_adjust_poll_set,
+  cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
@@ -1759,7 +1759,7 @@ struct Curl_cftype Curl_cft_udp = {
   cf_socket_close,
   cf_socket_get_host,
   cf_socket_get_select_socks,
-  cf_socket_adjust_poll_set,
+  cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
@@ -1811,7 +1811,7 @@ struct Curl_cftype Curl_cft_unix = {
   cf_socket_close,
   cf_socket_get_host,
   cf_socket_get_select_socks,
-  cf_socket_adjust_poll_set,
+  cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
@@ -1876,7 +1876,7 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_socket_close,
   cf_socket_get_host,              /* TODO: not accurate */
   cf_socket_get_select_socks,
-  cf_socket_adjust_poll_set,
+  cf_socket_adjust_pollset,
   cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -78,12 +78,12 @@ int Curl_cf_def_get_select_socks(struct Curl_cfilter *cf,
     cf->next->cft->get_select_socks(cf->next, data, socks) : 0;
 }
 
-void Curl_cf_def_adjust_poll_set(struct Curl_cfilter *cf,
+void Curl_cf_def_adjust_pollset(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
-                                 struct easy_poll_set *ps)
+                                 struct easy_pollset *ps)
 {
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 bool Curl_cf_def_data_pending(struct Curl_cfilter *cf,
@@ -459,8 +459,8 @@ int Curl_conn_get_select_socks(struct Curl_easy *data, int sockindex,
   return GETSOCK_BLANK;
 }
 
-void Curl_conn_adjust_poll_set(struct Curl_easy *data,
-                               struct easy_poll_set *ps)
+void Curl_conn_adjust_pollset(struct Curl_easy *data,
+                               struct easy_pollset *ps)
 {
   struct Curl_cfilter *cf;
   int i;
@@ -470,7 +470,7 @@ void Curl_conn_adjust_poll_set(struct Curl_easy *data,
   for(i = 0; i < 2; ++i) {
     cf = data->conn->cfilter[i];
     if(cf) {
-      cf->cft->adjust_poll_set(cf, data, ps);
+      cf->cft->adjust_pollset(cf, data, ps);
     }
   }
 }
@@ -673,7 +673,7 @@ size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
 
 
 void Curl_poll_set_change(struct Curl_easy *data,
-                       struct easy_poll_set *ps, curl_socket_t sock,
+                       struct easy_pollset *ps, curl_socket_t sock,
                        unsigned char add_flags, unsigned char remove_flags)
 {
   unsigned int i;

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -660,7 +660,7 @@ void Curl_pollset_reset(struct Curl_easy *data,
 
 void Curl_pollset_change(struct Curl_easy *data,
                        struct easy_pollset *ps, curl_socket_t sock,
-                       unsigned char add_flags, unsigned char remove_flags)
+                       int add_flags, int remove_flags)
 {
   unsigned int i;
 
@@ -669,13 +669,15 @@ void Curl_pollset_change(struct Curl_easy *data,
   if(!VALID_SOCK(sock))
     return;
 
+  DEBUGASSERT(add_flags <= (CURL_POLL_IN|CURL_POLL_OUT));
+  DEBUGASSERT(remove_flags <= (CURL_POLL_IN|CURL_POLL_OUT));
   for(i = 0; i < ps->num; ++i) {
     if(ps->sockets[i] == sock) {
       if(remove_flags) {
         ps->actions[i] &= (unsigned char)(~remove_flags);
       }
       if(add_flags) {
-        ps->actions[i] |= add_flags;
+        ps->actions[i] |= (unsigned char)add_flags;
       }
       /* all gone? remove socket */
       if(!ps->actions[i]) {
@@ -693,7 +695,7 @@ void Curl_pollset_change(struct Curl_easy *data,
     DEBUGASSERT(i < MAX_SOCKSPEREASYHANDLE);
     if(i < MAX_SOCKSPEREASYHANDLE) {
       ps->sockets[i] = sock;
-      ps->actions[i] = add_flags;
+      ps->actions[i] = (unsigned char)add_flags;
       ps->num = i + 1;
     }
   }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -672,7 +672,7 @@ void Curl_pollset_change(struct Curl_easy *data,
   for(i = 0; i < ps->num; ++i) {
     if(ps->sockets[i] == sock) {
       if(remove_flags) {
-        ps->actions[i] &= ~remove_flags;
+        ps->actions[i] &= (unsigned char)(~remove_flags);
       }
       if(add_flags) {
         ps->actions[i] |= add_flags;

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -699,6 +699,15 @@ void Curl_pollset_change(struct Curl_easy *data,
   }
 }
 
+void Curl_pollset_set(struct Curl_easy *data,
+                      struct easy_pollset *ps, curl_socket_t sock,
+                      bool do_in, bool do_out)
+{
+  Curl_pollset_change(data, ps, sock,
+                      (do_in?CURL_POLL_IN:0)|(do_out?CURL_POLL_OUT:0),
+                      (!do_in?CURL_POLL_IN:0)|(!do_out?CURL_POLL_OUT:0));
+}
+
 static void ps_add(struct Curl_easy *data, struct easy_pollset *ps,
                    int bitmap, curl_socket_t *socks)
 {

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -672,7 +672,7 @@ size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
 }
 
 
-void Curl_poll_set_change(struct Curl_easy *data,
+void Curl_pollset_change(struct Curl_easy *data,
                        struct easy_pollset *ps, curl_socket_t sock,
                        unsigned char add_flags, unsigned char remove_flags)
 {
@@ -708,3 +708,4 @@ void Curl_poll_set_change(struct Curl_easy *data,
     }
   }
 }
+

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -532,6 +532,14 @@ void Curl_pollset_add_socks2(struct Curl_easy *data,
                                                  curl_socket_t *socks));
 
 /**
+ * Check if the pollset, as is, wants to read and/or write regarding
+ * the given socket.
+ */
+void Curl_pollset_check(struct Curl_easy *data,
+                        struct easy_pollset *ps, curl_socket_t sock,
+                        bool *pwant_read, bool *pwant_write);
+
+/**
  * Types and macros used to keep the current easy handle in filter calls,
  * allowing for nested invocations. See #10336.
  *

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -60,6 +60,8 @@ typedef void     Curl_cft_get_host(struct Curl_cfilter *cf,
                                   const char **pdisplay_host,
                                   int *pport);
 
+struct easy_pollset;
+
 /* Passing in an easy_pollset for monitoring of sockets, let
  * filters add or remove sockets actions (CURL_POLL_OUT, CURL_POLL_IN).
  * This may add a socket or, in case no actions remain, remove

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -501,7 +501,7 @@ void Curl_pollset_reset(struct Curl_easy *data,
  */
 void Curl_pollset_change(struct Curl_easy *data,
                          struct easy_pollset *ps, curl_socket_t sock,
-                         unsigned char add_flags, unsigned char remove_flags);
+                         int add_flags, int remove_flags);
 
 void Curl_pollset_set(struct Curl_easy *data,
                       struct easy_pollset *ps, curl_socket_t sock,

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -501,6 +501,10 @@ void Curl_pollset_change(struct Curl_easy *data,
                          struct easy_pollset *ps, curl_socket_t sock,
                          unsigned char add_flags, unsigned char remove_flags);
 
+void Curl_pollset_set(struct Curl_easy *data,
+                      struct easy_pollset *ps, curl_socket_t sock,
+                      bool do_in, bool do_out);
+
 #define Curl_pollset_add_in(data, ps, sock) \
           Curl_pollset_change((data), (ps), (sock), CURL_POLL_IN, 0)
 #define Curl_pollset_add_out(data, ps, sock) \

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -510,10 +510,23 @@ size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
  * will be added.
  * If the socket is present and all poll flags are cleared, it will be removed.
  */
-void Curl_poll_set_change(struct Curl_easy *data,
-                       struct easy_pollset *ps, curl_socket_t sock,
-                       unsigned char add_flags, unsigned char remove_flags);
+void Curl_pollset_change(struct Curl_easy *data,
+                         struct easy_pollset *ps, curl_socket_t sock,
+                         unsigned char add_flags, unsigned char remove_flags);
 
+#define Curl_pollset_add_in(data, ps, sock) \
+          Curl_pollset_change((data), (ps), (sock), CURL_POLL_IN, 0)
+#define Curl_pollset_add_out(data, ps, sock) \
+          Curl_pollset_change((data), (ps), (sock), CURL_POLL_OUT, 0)
+#define Curl_pollset_add_inout(data, ps, sock) \
+          Curl_pollset_change((data), (ps), (sock), \
+                               CURL_POLL_IN|CURL_POLL_OUT, 0)
+#define Curl_pollset_set_in_only(data, ps, sock) \
+          Curl_pollset_change((data), (ps), (sock), \
+                               CURL_POLL_IN, CURL_POLL_OUT)
+#define Curl_pollset_set_out_only(data, ps, sock) \
+          Curl_pollset_change((data), (ps), (sock), \
+                               CURL_POLL_OUT, CURL_POLL_IN)
 
 /**
  * Types and macros used to keep the current easy handle in filter calls,

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -69,7 +69,7 @@ typedef int      Curl_cft_get_select_socks(struct Curl_cfilter *cf,
                                            struct Curl_easy *data,
                                            curl_socket_t *socks);
 
-/* Passing in an easy_poll_set for monitoring of sockets, let
+/* Passing in an easy_pollset for monitoring of sockets, let
  * filters add or remove sockets actions (CURL_POLL_OUT, CURL_POLL_IN).
  * This may add a socket or, in case no actions remain, remove
  * a socket from the set.
@@ -92,9 +92,9 @@ typedef int      Curl_cft_get_select_socks(struct Curl_cfilter *cf,
  * @param data   the easy handle the pollset is about
  * @param ps     the pollset (inout) for the easy handle
  */
-typedef void     Curl_cft_adjust_poll_set(struct Curl_cfilter *cf,
+typedef void     Curl_cft_adjust_pollset(struct Curl_cfilter *cf,
                                           struct Curl_easy *data,
-                                          struct easy_poll_set *ps);
+                                          struct easy_pollset *ps);
 
 typedef bool     Curl_cft_data_pending(struct Curl_cfilter *cf,
                                        const struct Curl_easy *data);
@@ -199,7 +199,7 @@ struct Curl_cftype {
   Curl_cft_close *do_close;               /* close conn */
   Curl_cft_get_host *get_host;            /* host filter talks to */
   Curl_cft_get_select_socks *get_select_socks;/* sockets to select on */
-  Curl_cft_adjust_poll_set *adjust_poll_set; /* adjust transfer poll set */
+  Curl_cft_adjust_pollset *adjust_pollset; /* adjust transfer poll set */
   Curl_cft_data_pending *has_data_pending;/* conn has data pending */
   Curl_cft_send *do_send;                 /* send data */
   Curl_cft_recv *do_recv;                 /* receive data */
@@ -231,9 +231,9 @@ void     Curl_cf_def_get_host(struct Curl_cfilter *cf, struct Curl_easy *data,
 int      Curl_cf_def_get_select_socks(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
                                       curl_socket_t *socks);
-void     Curl_cf_def_adjust_poll_set(struct Curl_cfilter *cf,
+void     Curl_cf_def_adjust_pollset(struct Curl_cfilter *cf,
                                      struct Curl_easy *data,
-                                     struct easy_poll_set *ps);
+                                     struct easy_pollset *ps);
 bool     Curl_cf_def_data_pending(struct Curl_cfilter *cf,
                                   const struct Curl_easy *data);
 ssize_t  Curl_cf_def_send(struct Curl_cfilter *cf, struct Curl_easy *data,
@@ -404,8 +404,8 @@ int Curl_conn_get_select_socks(struct Curl_easy *data, int sockindex,
 /**
  * Adjust poll set from filters installed at transfer's connection.
  */
-void Curl_conn_adjust_poll_set(struct Curl_easy *data,
-                               struct easy_poll_set *ps);
+void Curl_conn_adjust_pollset(struct Curl_easy *data,
+                               struct easy_pollset *ps);
 
 /**
  * Receive data through the filter chain at `sockindex` for connection
@@ -511,7 +511,7 @@ size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
  * If the socket is present and all poll flags are cleared, it will be removed.
  */
 void Curl_poll_set_change(struct Curl_easy *data,
-                       struct easy_poll_set *ps, curl_socket_t sock,
+                       struct easy_pollset *ps, curl_socket_t sock,
                        unsigned char add_flags, unsigned char remove_flags);
 
 

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -395,13 +395,6 @@ bool Curl_conn_data_pending(struct Curl_easy *data,
 curl_socket_t Curl_conn_get_socket(struct Curl_easy *data, int sockindex);
 
 /**
- * Get any select fd flags and the socket filters at chain `sockindex`
- * at connection `conn` might be waiting for.
- */
-int Curl_conn_get_select_socks(struct Curl_easy *data, int sockindex,
-                               curl_socket_t *socks);
-
-/**
  * Adjust poll set from filters installed at transfer's connection.
  */
 void Curl_conn_adjust_pollset(struct Curl_easy *data,
@@ -505,6 +498,9 @@ size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
                                     int sockindex);
 
 
+void Curl_pollset_reset(struct Curl_easy *data,
+                        struct easy_pollset *ps);
+
 /* Change the poll flags (CURL_POLL_IN/CURL_POLL_OUT) to the poll set for
  * socket `sock`. If the socket is not already part of the poll set, it
  * will be added.
@@ -527,6 +523,16 @@ void Curl_pollset_change(struct Curl_easy *data,
 #define Curl_pollset_set_out_only(data, ps, sock) \
           Curl_pollset_change((data), (ps), (sock), \
                                CURL_POLL_OUT, CURL_POLL_IN)
+
+void Curl_pollset_add_socks(struct Curl_easy *data,
+                            struct easy_pollset *ps,
+                            int (*get_socks_cb)(struct Curl_easy *data,
+                                                struct connectdata *conn,
+                                                curl_socket_t *socks));
+void Curl_pollset_add_socks2(struct Curl_easy *data,
+                             struct easy_pollset *ps,
+                             int (*get_socks_cb)(struct Curl_easy *data,
+                                                 curl_socket_t *socks));
 
 /**
  * Types and macros used to keep the current easy handle in filter calls,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -877,9 +877,9 @@ static int cf_he_get_select_socks(struct Curl_cfilter *cf,
   return rc;
 }
 
-static void cf_he_adjust_poll_set(struct Curl_cfilter *cf,
+static void cf_he_adjust_pollset(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
-                                  struct easy_poll_set *ps)
+                                  struct easy_pollset *ps)
 {
   struct cf_he_ctx *ctx = cf->ctx;
   size_t i;
@@ -890,12 +890,12 @@ static void cf_he_adjust_poll_set(struct Curl_cfilter *cf,
       if(!baller || !baller->cf)
         continue;
 
-      baller->cf->cft->adjust_poll_set(baller->cf, data, ps);
+      baller->cf->cft->adjust_pollset(baller->cf, data, ps);
     }
-    CURL_TRC_CF(data, cf, "adjust_poll_set -> %d socks", ps->num);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static CURLcode cf_he_connect(struct Curl_cfilter *cf,
@@ -1077,7 +1077,7 @@ struct Curl_cftype Curl_cft_happy_eyeballs = {
   cf_he_close,
   Curl_cf_def_get_host,
   cf_he_get_select_socks,
-  cf_he_adjust_poll_set,
+  cf_he_adjust_pollset,
   cf_he_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,
@@ -1342,7 +1342,7 @@ struct Curl_cftype Curl_cft_setup = {
   cf_setup_close,
   Curl_cf_def_get_host,
   Curl_cf_def_get_select_socks,
-  Curl_cf_def_adjust_poll_set,
+  Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -84,6 +84,9 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#ifndef ARRAYSIZE
+#define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
+#endif
 
 /*
  * Curl_timeleft() returns the amount of milliseconds left allowed for the
@@ -595,7 +598,7 @@ evaluate:
   *connected = FALSE; /* a very negative world view is best */
   now = Curl_now();
   ongoing = not_started = 0;
-  for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+  for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
     struct eyeballer *baller = ctx->baller[i];
 
     if(!baller || baller->is_done)
@@ -656,7 +659,7 @@ evaluate:
   if(not_started > 0) {
     int added = 0;
 
-    for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+    for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
       struct eyeballer *baller = ctx->baller[i];
 
       if(!baller || baller->has_started)
@@ -691,7 +694,7 @@ evaluate:
   /* all ballers have failed to connect. */
   CURL_TRC_CF(data, cf, "all eyeballers failed");
   result = CURLE_COULDNT_CONNECT;
-  for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+  for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
     struct eyeballer *baller = ctx->baller[i];
     if(!baller)
       continue;
@@ -838,7 +841,7 @@ static void cf_he_ctx_clear(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGASSERT(ctx);
   DEBUGASSERT(data);
-  for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+  for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
     baller_free(ctx->baller[i], data);
     ctx->baller[i] = NULL;
   }
@@ -854,7 +857,7 @@ static void cf_he_adjust_pollset(struct Curl_cfilter *cf,
   size_t i;
 
   if(!cf->connected) {
-    for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+    for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
       struct eyeballer *baller = ctx->baller[i];
       if(!baller || !baller->cf)
         continue;
@@ -943,7 +946,7 @@ static bool cf_he_data_pending(struct Curl_cfilter *cf,
   if(cf->connected)
     return cf->next->cft->has_data_pending(cf->next, data);
 
-  for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+  for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
     struct eyeballer *baller = ctx->baller[i];
     if(!baller || !baller->cf)
       continue;
@@ -962,7 +965,7 @@ static struct curltime get_max_baller_time(struct Curl_cfilter *cf,
   size_t i;
 
   memset(&tmax, 0, sizeof(tmax));
-  for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+  for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
     struct eyeballer *baller = ctx->baller[i];
 
     memset(&t, 0, sizeof(t));
@@ -987,7 +990,7 @@ static CURLcode cf_he_query(struct Curl_cfilter *cf,
       int reply_ms = -1;
       size_t i;
 
-      for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
+      for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {
         struct eyeballer *baller = ctx->baller[i];
         int breply_ms;
 
@@ -1112,10 +1115,6 @@ struct transport_provider transport_providers[] = {
   { TRNSPRT_UDP, Curl_cf_udp_create },
   { TRNSPRT_UNIX, Curl_cf_unix_create },
 };
-
-#ifndef ARRAYSIZE
-#define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
-#endif
 
 static cf_ip_connect_create *get_cf_create(int transport)
 {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -819,7 +819,7 @@ static int ftp_domore_getsock(struct Curl_easy *data,
   DEBUGF(infof(data, "ftp_domore_getsock()"));
   if(conn->cfilter[SECONDARYSOCKET]
      && !Curl_conn_is_connected(conn, SECONDARYSOCKET))
-    return Curl_conn_get_select_socks(data, SECONDARYSOCKET, socks);
+    return 0;
 
   if(FTP_STOP == ftpc->state) {
     int bits = GETSOCK_READSOCK(0);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2602,6 +2602,7 @@ struct Curl_cftype Curl_cft_nghttp2 = {
   cf_h2_close,
   Curl_cf_def_get_host,
   cf_h2_get_select_socks,
+  Curl_cf_def_adjust_poll_set,
   cf_h2_data_pending,
   cf_h2_send,
   cf_h2_recv,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2602,7 +2602,7 @@ struct Curl_cftype Curl_cft_nghttp2 = {
   cf_h2_close,
   Curl_cf_def_get_host,
   cf_h2_get_select_socks,
-  Curl_cf_def_adjust_poll_set,
+  Curl_cf_def_adjust_pollset,
   cf_h2_data_pending,
   cf_h2_send,
   cf_h2_recv,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1081,16 +1081,11 @@ static CURLcode on_stream_frame(struct Curl_cfilter *cf,
       stream->reset = TRUE;
     }
     stream->send_closed = TRUE;
-    data->req.keepon &= ~KEEP_SEND_HOLD;
     drain_stream(cf, data, stream);
     break;
   case NGHTTP2_WINDOW_UPDATE:
-    if((data->req.keepon & KEEP_SEND_HOLD) &&
-       (data->req.keepon & KEEP_SEND)) {
-      data->req.keepon &= ~KEEP_SEND_HOLD;
+    if(CURL_WANT_SEND(data)) {
       drain_stream(cf, data, stream);
-      CURL_TRC_CF(data, cf, "[%d] un-holding after win update",
-                  stream_id);
     }
     break;
   default:
@@ -1235,15 +1230,10 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
          * window and *assume* that we treat this like a WINDOW_UPDATE. Some
          * servers send an explicit WINDOW_UPDATE, but not all seem to do that.
          * To be safe, we UNHOLD a stream in order not to stall. */
-        if((data->req.keepon & KEEP_SEND_HOLD) &&
-           (data->req.keepon & KEEP_SEND)) {
+        if(CURL_WANT_SEND(data)) {
           struct stream_ctx *stream = H2_STREAM_CTX(data);
-          data->req.keepon &= ~KEEP_SEND_HOLD;
-          if(stream) {
+          if(stream)
             drain_stream(cf, data, stream);
-            CURL_TRC_CF(data, cf, "[%d] un-holding after SETTINGS",
-                        stream_id);
-          }
         }
       }
       break;
@@ -1343,7 +1333,6 @@ static int on_stream_close(nghttp2_session *session, int32_t stream_id,
   stream->error = error_code;
   if(stream->error)
     stream->reset = TRUE;
-  data_s->req.keepon &= ~KEEP_SEND_HOLD;
 
   if(stream->error)
     CURL_TRC_CF(data_s, cf, "[%d] RESET: %s (err %d)",
@@ -2267,14 +2256,6 @@ static ssize_t cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
      * frame buffer or our network out buffer. */
     size_t rwin = nghttp2_session_get_stream_remote_window_size(ctx->h2,
                                                                 stream->id);
-    if(rwin == 0) {
-      /* H2 flow window exhaustion. We need to HOLD upload until we get
-       * a WINDOW_UPDATE from the server. */
-      data->req.keepon |= KEEP_SEND_HOLD;
-      CURL_TRC_CF(data, cf, "[%d] holding send as remote flow "
-                  "window is exhausted", stream->id);
-    }
-
     /* Whatever the cause, we need to return CURL_EAGAIN for this call.
      * We have unwritten state that needs us being invoked again and EAGAIN
      * is the only way to ensure that. */
@@ -2331,35 +2312,27 @@ static void cf_h2_adjust_pollset(struct Curl_cfilter *cf,
                                  struct easy_pollset *ps)
 {
   struct cf_h2_ctx *ctx = cf->ctx;
-  struct SingleRequest *k = &data->req;
-  struct stream_ctx *stream = H2_STREAM_CTX(data);
-  curl_socket_t sock = Curl_conn_cf_get_socket(cf, data);
-  struct cf_call_data save;
-  bool window_exhausted;
+  bool want_recv = CURL_WANT_RECV(data);
+  bool want_send = CURL_WANT_SEND(data);
 
-  CF_DATA_SAVE(save, cf, data);
+  if(ctx->h2 && (want_recv || want_send)) {
+    struct stream_ctx *stream = H2_STREAM_CTX(data);
+    curl_socket_t sock = Curl_conn_cf_get_socket(cf, data);
+    struct cf_call_data save;
+    bool c_exhaust, s_exhaust;
 
-  window_exhausted = !nghttp2_session_get_remote_window_size(ctx->h2) ||
-      (stream && stream->id >= 0 &&
-       !nghttp2_session_get_stream_remote_window_size(ctx->h2,
-                                                      stream->id));
+    CF_DATA_SAVE(save, cf, data);
+    c_exhaust = !nghttp2_session_get_remote_window_size(ctx->h2);
+    s_exhaust = stream && stream->id >= 0 &&
+                !nghttp2_session_get_stream_remote_window_size(ctx->h2,
+                                                               stream->id);
+    want_recv = (want_recv || c_exhaust || s_exhaust);
+    want_send = (!s_exhaust && want_send) ||
+                (!c_exhaust && nghttp2_session_want_write(ctx->h2));
 
-  if(!(k->keepon & (KEEP_RECV_PAUSE|KEEP_RECV_HOLD))) {
-    /* Unless paused - in an HTTP/2 connection we can basically always get a
-       frame so we should always be ready for one */
-    if(window_exhausted)
-      Curl_pollset_set_in_only(data, ps, sock);
-    else
-      Curl_pollset_add_in(data, ps, sock);
+    Curl_pollset_set(data, ps, sock, want_recv, want_send);
+    CF_DATA_RESTORE(cf, save);
   }
-
-  /* we're (still uploading OR the HTTP/2 layer wants to send data) AND
-     there's a window to send data in */
-  if(!window_exhausted && (((k->keepon & KEEP_SENDBITS) == KEEP_SEND) ||
-      nghttp2_session_want_write(ctx->h2)))
-    Curl_pollset_add_out(data, ps, sock);
-
-  CF_DATA_RESTORE(cf, save);
 }
 
 static CURLcode cf_h2_connect(struct Curl_cfilter *cf,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -299,7 +299,6 @@ struct Curl_cftype Curl_cft_http_proxy = {
   http_proxy_cf_connect,
   http_proxy_cf_close,
   Curl_cf_http_proxy_get_host,
-  Curl_cf_def_get_select_socks,
   Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -300,7 +300,7 @@ struct Curl_cftype Curl_cft_http_proxy = {
   http_proxy_cf_close,
   Curl_cf_http_proxy_get_host,
   Curl_cf_def_get_select_socks,
-  Curl_cf_def_adjust_poll_set,
+  Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -300,6 +300,7 @@ struct Curl_cftype Curl_cft_http_proxy = {
   http_proxy_cf_close,
   Curl_cf_http_proxy_get_host,
   Curl_cf_def_get_select_socks,
+  Curl_cf_def_adjust_poll_set,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2895,7 +2895,6 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
     unsigned char cur_action = cur_poll.actions[i];
     unsigned char last_action = 0;
     int comboaction;
-    bool sincebefore = FALSE;
 
     s = cur_poll.sockets[i];
 
@@ -2907,7 +2906,6 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
       for(j = 0; j< data->last_poll.num; j++) {
         if(s == data->last_poll.sockets[j]) {
           last_action = data->last_poll.actions[j];
-          sincebefore = TRUE;
           break;
         }
       }
@@ -2919,7 +2917,7 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
         /* fatal */
         return CURLM_OUT_OF_MEMORY;
     }
-    if(sincebefore && (last_action != cur_action)) {
+    if(last_action && (last_action != cur_action)) {
       /* Socket was used already, but different action now */
       if(last_action & CURL_POLL_IN)
         entry->readers--;
@@ -2930,7 +2928,7 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
       if(cur_action & CURL_POLL_OUT)
         entry->writers++;
     }
-    else if(!sincebefore) {
+    else if(!last_action) {
       /* a new transfer using this socket */
       entry->users++;
       if(cur_action & CURL_POLL_IN)
@@ -2950,7 +2948,7 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
                    (entry->readers ? CURL_POLL_IN : 0);
 
     /* socket existed before and has the same action set as before */
-    if(sincebefore && ((int)entry->action == comboaction))
+    if(last_action && ((int)entry->action == comboaction))
       /* same, continue */
       continue;
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1061,8 +1061,9 @@ static void multi_getsock(struct Curl_easy *data,
 
   case MSTATE_TUNNELING:
   case MSTATE_CONNECTING:
-    actions = Curl_conn_get_select_socks(data, FIRSTSOCKET, poll_set->sockets);
-    break;
+    Curl_conn_adjust_poll_set(data, poll_set);
+    infof(data, "multi_getsock() -> %d sockets", poll_set->num);
+    return;
 
   case MSTATE_DOING_MORE:
     actions = domore_getsock(data, conn, poll_set->sockets);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2868,7 +2868,6 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
 
   /* Fill in the 'current' struct with the state as it is now: what sockets to
      supervise and for what actions */
-  memset(&cur_poll, 0, sizeof(cur_poll));
   multi_getsock(data, &cur_poll);
 
   /* We have 0 .. N sockets already and we get to know about the 0 .. M

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1214,10 +1214,10 @@ static void socks_cf_adjust_pollset(struct Curl_cfilter *cf,
     case CONNECT_AUTH_READ:
     case CONNECT_REQ_READ:
     case CONNECT_REQ_READ_MORE:
-      Curl_poll_set_change(data, ps, sock, CURL_POLL_IN, CURL_POLL_OUT);
+      Curl_pollset_set_in_only(data, ps, sock);
       break;
     default:
-      Curl_poll_set_change(data, ps, sock, CURL_POLL_OUT, CURL_POLL_IN);
+      Curl_pollset_set_out_only(data, ps, sock);
       break;
     }
   }

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1198,9 +1198,9 @@ static int socks_cf_get_select_socks(struct Curl_cfilter *cf,
   return fds;
 }
 
-static void socks_cf_adjust_poll_set(struct Curl_cfilter *cf,
+static void socks_cf_adjust_pollset(struct Curl_cfilter *cf,
                                      struct Curl_easy *data,
-                                     struct easy_poll_set *ps)
+                                     struct easy_pollset *ps)
 {
   struct socks_state *sx = cf->ctx;
 
@@ -1222,7 +1222,7 @@ static void socks_cf_adjust_poll_set(struct Curl_cfilter *cf,
     }
   }
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static void socks_proxy_cf_close(struct Curl_cfilter *cf,
@@ -1268,7 +1268,7 @@ struct Curl_cftype Curl_cft_socks_proxy = {
   socks_proxy_cf_close,
   socks_cf_get_host,
   socks_cf_get_select_socks,
-  socks_cf_adjust_poll_set,
+  socks_cf_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -592,7 +592,7 @@ struct Curl_async {
 /* Polling requested by an easy handle.
  * `action` is CURL_POLL_IN, CURL_POLL_OUT or CURL_POLL_INOUT.
  */
-struct easy_poll_set {
+struct easy_pollset {
   curl_socket_t sockets[MAX_SOCKSPEREASYHANDLE];
   unsigned int num;
   unsigned char actions[MAX_SOCKSPEREASYHANDLE];
@@ -1983,7 +1983,7 @@ struct Curl_easy {
      particular order. Note that all sockets are added to the sockhash, where
      the state etc are also kept. This array is mostly used to detect when a
      socket is to be removed from the hash. See singlesocket(). */
-  struct easy_poll_set last_poll;
+  struct easy_pollset last_poll;
 
   struct Names dns;
   struct Curl_multi *multi;    /* if non-NULL, points to the multi handle

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -589,6 +589,15 @@ struct Curl_async {
 #define FIRSTSOCKET     0
 #define SECONDARYSOCKET 1
 
+/* Polling requested by an easy handle.
+ * `action` is CURL_POLL_IN, CURL_POLL_OUT or CURL_POLL_INOUT.
+ */
+struct easy_poll_set {
+  curl_socket_t sockets[MAX_SOCKSPEREASYHANDLE];
+  int num;
+  unsigned char actions[MAX_SOCKSPEREASYHANDLE];
+};
+
 enum expect100 {
   EXP100_SEND_DATA,           /* enough waiting, just send the body now */
   EXP100_AWAITING_CONTINUE,   /* waiting for the 100 Continue header */
@@ -1974,10 +1983,7 @@ struct Curl_easy {
      particular order. Note that all sockets are added to the sockhash, where
      the state etc are also kept. This array is mostly used to detect when a
      socket is to be removed from the hash. See singlesocket(). */
-  curl_socket_t sockets[MAX_SOCKSPEREASYHANDLE];
-  unsigned char actions[MAX_SOCKSPEREASYHANDLE]; /* action for each socket in
-                                                    sockets[] */
-  int numsocks;
+  struct easy_poll_set last_poll;
 
   struct Names dns;
   struct Curl_multi *multi;    /* if non-NULL, points to the multi handle

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -571,6 +571,13 @@ struct hostname {
 #define KEEP_RECVBITS (KEEP_RECV | KEEP_RECV_HOLD | KEEP_RECV_PAUSE)
 #define KEEP_SENDBITS (KEEP_SEND | KEEP_SEND_HOLD | KEEP_SEND_PAUSE)
 
+/* transfer wants to send is not PAUSE or HOLD */
+#define CURL_WANT_SEND(data) \
+  (((data)->req.keepon & KEEP_SENDBITS) == KEEP_SEND)
+/* transfer receive is not on PAUSE or HOLD */
+#define CURL_WANT_RECV(data) \
+  (!((data)->req.keepon & (KEEP_RECV_PAUSE|KEEP_RECV_HOLD)))
+
 #if defined(CURLRES_ASYNCH) || !defined(CURL_DISABLE_DOH)
 #define USE_CURL_ASYNC
 struct Curl_async {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -594,7 +594,7 @@ struct Curl_async {
  */
 struct easy_poll_set {
   curl_socket_t sockets[MAX_SOCKSPEREASYHANDLE];
-  int num;
+  unsigned int num;
   unsigned char actions[MAX_SOCKSPEREASYHANDLE];
 };
 

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -1026,6 +1026,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_msh3_close,
   Curl_cf_def_get_host,
   cf_msh3_get_select_socks,
+  Curl_cf_def_adjust_poll_set,
   cf_msh3_data_pending,
   cf_msh3_send,
   cf_msh3_recv,

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -1026,7 +1026,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_msh3_close,
   Curl_cf_def_get_host,
   cf_msh3_get_select_socks,
-  Curl_cf_def_adjust_poll_set,
+  Curl_cf_def_adjust_pollset,
   cf_msh3_data_pending,
   cf_msh3_send,
   cf_msh3_recv,

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -672,31 +672,25 @@ out:
   return nwritten;
 }
 
-static int cf_msh3_get_select_socks(struct Curl_cfilter *cf,
-                                    struct Curl_easy *data,
-                                    curl_socket_t *socks)
+static void cf_msh3_adjust_pollset(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   struct easy_pollset *ps)
 {
   struct cf_msh3_ctx *ctx = cf->ctx;
   struct stream_ctx *stream = H3_STREAM_CTX(data);
-  int bitmap = GETSOCK_BLANK;
   struct cf_call_data save;
 
   CF_DATA_SAVE(save, cf, data);
   if(stream && ctx->sock[SP_LOCAL] != CURL_SOCKET_BAD) {
-    socks[0] = ctx->sock[SP_LOCAL];
-
     if(stream->recv_error) {
-      bitmap |= GETSOCK_READSOCK(0);
+      Curl_pollset_add_in(data, ps, ctx->sock[SP_LOCAL]);
       drain_stream(cf, data);
     }
     else if(stream->req) {
-      bitmap |= GETSOCK_READSOCK(0);
+      Curl_pollset_add_out(data, ps, ctx->sock[SP_LOCAL]);
       drain_stream(cf, data);
     }
   }
-  CURL_TRC_CF(data, cf, "select_sock -> %d", bitmap);
-  CF_DATA_RESTORE(cf, save);
-  return bitmap;
 }
 
 static bool cf_msh3_data_pending(struct Curl_cfilter *cf,
@@ -1025,8 +1019,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_msh3_connect,
   cf_msh3_close,
   Curl_cf_def_get_host,
-  cf_msh3_get_select_socks,
-  Curl_cf_def_adjust_pollset,
+  cf_msh3_adjust_pollset,
   cf_msh3_data_pending,
   cf_msh3_send,
   cf_msh3_recv,

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1104,9 +1104,9 @@ static int cf_ngtcp2_get_select_socks(struct Curl_cfilter *cf,
   return rv;
 }
 
-static void cf_ngtcp2_adjust_poll_set(struct Curl_cfilter *cf,
+static void cf_ngtcp2_adjust_pollset(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
-                                      struct easy_poll_set *ps)
+                                      struct easy_pollset *ps)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
   struct SingleRequest *k = &data->req;
@@ -1127,7 +1127,7 @@ static void cf_ngtcp2_adjust_poll_set(struct Curl_cfilter *cf,
 
   CF_DATA_RESTORE(cf, save);
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 static void h3_drain_stream(struct Curl_cfilter *cf,
@@ -2741,7 +2741,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_ngtcp2_close,
   Curl_cf_def_get_host,
   cf_ngtcp2_get_select_socks,
-  cf_ngtcp2_adjust_poll_set,
+  cf_ngtcp2_adjust_pollset,
   cf_ngtcp2_data_pending,
   cf_ngtcp2_send,
   cf_ngtcp2_recv,

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1116,14 +1116,14 @@ static void cf_ngtcp2_adjust_pollset(struct Curl_cfilter *cf,
   CF_DATA_SAVE(save, cf, data);
 
   /* in HTTP/3 we can always get a frame, so check read */
-  Curl_poll_set_change(data, ps, ctx->q.sockfd, CURL_POLL_IN, 0);
+  Curl_pollset_add_in(data, ps, ctx->q.sockfd);
 
   /* we're still uploading or the HTTP/2 layer wants to send data */
   if((k->keepon & KEEP_SENDBITS) == KEEP_SEND &&
      ngtcp2_conn_get_cwnd_left(ctx->qconn) &&
      ngtcp2_conn_get_max_data_left(ctx->qconn) &&
      stream && nghttp3_conn_is_stream_writable(ctx->h3conn, stream->id))
-    Curl_poll_set_change(data, ps, ctx->q.sockfd, CURL_POLL_OUT, 0);
+    Curl_pollset_add_out(data, ps, ctx->q.sockfd);
 
   CF_DATA_RESTORE(cf, save);
   if(cf->next)

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1675,7 +1675,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_quiche_close,
   Curl_cf_def_get_host,
   cf_quiche_get_select_socks,
-  Curl_cf_def_adjust_poll_set,
+  Curl_cf_def_adjust_pollset,
   cf_quiche_data_pending,
   cf_quiche_send,
   cf_quiche_recv,

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1675,6 +1675,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_quiche_close,
   Curl_cf_def_get_host,
   cf_quiche_get_select_socks,
+  Curl_cf_def_adjust_poll_set,
   cf_quiche_data_pending,
   cf_quiche_send,
   cf_quiche_recv,

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1672,8 +1672,7 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   gtls_cert_status_request,      /* cert_status_request */
   gtls_connect,                  /* connect */
   gtls_connect_nonblocking,      /* connect_nonblocking */
-  Curl_ssl_get_select_socks,     /* getsock */
-  Curl_ssl_adjust_pollset,      /* adjust_pollset */
+  Curl_ssl_adjust_pollset,       /* adjust_pollset */
   gtls_get_internals,            /* get_internals */
   gtls_close,                    /* close_one */
   Curl_none_close_all,           /* close_all */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1672,7 +1672,8 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   gtls_cert_status_request,      /* cert_status_request */
   gtls_connect,                  /* connect */
   gtls_connect_nonblocking,      /* connect_nonblocking */
-  Curl_ssl_get_select_socks,              /* getsock */
+  Curl_ssl_get_select_socks,     /* getsock */
+  Curl_ssl_adjust_poll_set,      /* adjust_poll_set */
   gtls_get_internals,            /* get_internals */
   gtls_close,                    /* close_one */
   Curl_none_close_all,           /* close_all */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1673,7 +1673,7 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   gtls_connect,                  /* connect */
   gtls_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_get_select_socks,     /* getsock */
-  Curl_ssl_adjust_poll_set,      /* adjust_poll_set */
+  Curl_ssl_adjust_pollset,      /* adjust_pollset */
   gtls_get_internals,            /* get_internals */
   gtls_close,                    /* close_one */
   Curl_none_close_all,           /* close_all */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1274,8 +1274,7 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   Curl_none_cert_status_request,    /* cert_status_request */
   mbedtls_connect,                  /* connect */
   mbedtls_connect_nonblocking,      /* connect_nonblocking */
-  Curl_ssl_get_select_socks,        /* getsock */
-  Curl_ssl_adjust_pollset,         /* adjust_pollset */
+  Curl_ssl_adjust_pollset,          /* adjust_pollset */
   mbedtls_get_internals,            /* get_internals */
   mbedtls_close,                    /* close_one */
   mbedtls_close_all,                /* close_all */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1275,7 +1275,7 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   mbedtls_connect,                  /* connect */
   mbedtls_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_get_select_socks,        /* getsock */
-  Curl_ssl_adjust_poll_set,         /* adjust_poll_set */
+  Curl_ssl_adjust_pollset,         /* adjust_pollset */
   mbedtls_get_internals,            /* get_internals */
   mbedtls_close,                    /* close_one */
   mbedtls_close_all,                /* close_all */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1274,7 +1274,8 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   Curl_none_cert_status_request,    /* cert_status_request */
   mbedtls_connect,                  /* connect */
   mbedtls_connect_nonblocking,      /* connect_nonblocking */
-  Curl_ssl_get_select_socks,                 /* getsock */
+  Curl_ssl_get_select_socks,        /* getsock */
+  Curl_ssl_adjust_poll_set,         /* adjust_poll_set */
   mbedtls_get_internals,            /* get_internals */
   mbedtls_close,                    /* close_one */
   mbedtls_close_all,                /* close_all */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4842,8 +4842,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_cert_status_request, /* cert_status_request */
   ossl_connect,             /* connect */
   ossl_connect_nonblocking, /* connect_nonblocking */
-  Curl_ssl_get_select_socks,/* getsock */
-  Curl_ssl_adjust_pollset, /* adjust_pollset */
+  Curl_ssl_adjust_pollset,  /* adjust_pollset */
   ossl_get_internals,       /* get_internals */
   ossl_close,               /* close_one */
   ossl_close_all,           /* close_all */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4843,7 +4843,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_connect,             /* connect */
   ossl_connect_nonblocking, /* connect_nonblocking */
   Curl_ssl_get_select_socks,/* getsock */
-  Curl_ssl_adjust_poll_set, /* adjust_poll_set */
+  Curl_ssl_adjust_pollset, /* adjust_pollset */
   ossl_get_internals,       /* get_internals */
   ossl_close,               /* close_one */
   ossl_close_all,           /* close_all */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4843,6 +4843,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_connect,             /* connect */
   ossl_connect_nonblocking, /* connect_nonblocking */
   Curl_ssl_get_select_socks,/* getsock */
+  Curl_ssl_adjust_poll_set, /* adjust_poll_set */
   ossl_get_internals,       /* get_internals */
   ossl_close,               /* close_one */
   ossl_close_all,           /* close_all */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -678,6 +678,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
   cr_connect,                      /* connect */
   cr_connect_nonblocking,          /* connect_nonblocking */
   cr_get_select_socks,             /* get_select_socks */
+  Curl_ssl_adjust_poll_set,        /* adjust_poll_set */
   cr_get_internals,                /* get_internals */
   cr_close,                        /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -589,32 +589,28 @@ cr_connect_nonblocking(struct Curl_cfilter *cf,
   DEBUGASSERT(false);
 }
 
-/* returns a bitmap of flags for this connection's first socket indicating
-   whether we want to read or write */
-static int
-cr_get_select_socks(struct Curl_cfilter *cf, struct Curl_easy *data,
-                    curl_socket_t *socks)
+static void cr_adjust_pollset(struct Curl_cfilter *cf,
+                              struct Curl_easy *data,
+                              struct easy_pollset *ps)
 {
-  struct ssl_connect_data *const connssl = cf->ctx;
-  curl_socket_t sockfd = Curl_conn_cf_get_socket(cf, data);
-  struct rustls_ssl_backend_data *const backend =
-    (struct rustls_ssl_backend_data *)connssl->backend;
-  struct rustls_connection *rconn = NULL;
+  if(!cf->connected) {
+    curl_socket_t sock = Curl_conn_cf_get_socket(cf->next, data);
+    struct ssl_connect_data *const connssl = cf->ctx;
+    struct rustls_ssl_backend_data *const backend =
+      (struct rustls_ssl_backend_data *)connssl->backend;
+    struct rustls_connection *rconn = NULL;
 
-  (void)data;
-  DEBUGASSERT(backend);
-  rconn = backend->conn;
+    (void)data;
+    DEBUGASSERT(backend);
+    rconn = backend->conn;
 
-  if(rustls_connection_wants_write(rconn)) {
-    socks[0] = sockfd;
-    return GETSOCK_WRITESOCK(0);
+    if(rustls_connection_wants_write(rconn)) {
+      Curl_pollset_add_out(data, ps, sock);
+    }
+    if(rustls_connection_wants_read(rconn)) {
+      Curl_pollset_add_in(data, ps, sock);
+    }
   }
-  if(rustls_connection_wants_read(rconn)) {
-    socks[0] = sockfd;
-    return GETSOCK_READSOCK(0);
-  }
-
-  return GETSOCK_BLANK;
 }
 
 static void *
@@ -677,8 +673,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
   Curl_none_cert_status_request,   /* cert_status_request */
   cr_connect,                      /* connect */
   cr_connect_nonblocking,          /* connect_nonblocking */
-  cr_get_select_socks,             /* get_select_socks */
-  Curl_ssl_adjust_pollset,        /* adjust_pollset */
+  cr_adjust_pollset,               /* adjust_pollset */
   cr_get_internals,                /* get_internals */
   cr_close,                        /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -678,7 +678,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
   cr_connect,                      /* connect */
   cr_connect_nonblocking,          /* connect_nonblocking */
   cr_get_select_socks,             /* get_select_socks */
-  Curl_ssl_adjust_poll_set,        /* adjust_poll_set */
+  Curl_ssl_adjust_pollset,        /* adjust_pollset */
   cr_get_internals,                /* get_internals */
   cr_close,                        /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2778,7 +2778,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
   schannel_connect,                  /* connect */
   schannel_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_get_select_socks,         /* getsock */
-  Curl_ssl_adjust_poll_set,          /* adjust_poll_set */
+  Curl_ssl_adjust_pollset,          /* adjust_pollset */
   schannel_get_internals,            /* get_internals */
   schannel_close,                    /* close_one */
   Curl_none_close_all,               /* close_all */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2778,6 +2778,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
   schannel_connect,                  /* connect */
   schannel_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_get_select_socks,         /* getsock */
+  Curl_ssl_adjust_poll_set,          /* adjust_poll_set */
   schannel_get_internals,            /* get_internals */
   schannel_close,                    /* close_one */
   Curl_none_close_all,               /* close_all */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2777,8 +2777,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
   Curl_none_cert_status_request,     /* cert_status_request */
   schannel_connect,                  /* connect */
   schannel_connect_nonblocking,      /* connect_nonblocking */
-  Curl_ssl_get_select_socks,         /* getsock */
-  Curl_ssl_adjust_pollset,          /* adjust_pollset */
+  Curl_ssl_adjust_pollset,           /* adjust_pollset */
   schannel_get_internals,            /* get_internals */
   schannel_close,                    /* close_one */
   Curl_none_close_all,               /* close_all */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3484,7 +3484,7 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   sectransp_connect,                  /* connect */
   sectransp_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_get_select_socks,          /* getsock */
-  Curl_ssl_adjust_poll_set,           /* adjust_poll_set */
+  Curl_ssl_adjust_pollset,           /* adjust_pollset */
   sectransp_get_internals,            /* get_internals */
   sectransp_close,                    /* close_one */
   Curl_none_close_all,                /* close_all */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3484,6 +3484,7 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   sectransp_connect,                  /* connect */
   sectransp_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_get_select_socks,          /* getsock */
+  Curl_ssl_adjust_poll_set,           /* adjust_poll_set */
   sectransp_get_internals,            /* get_internals */
   sectransp_close,                    /* close_one */
   Curl_none_close_all,                /* close_all */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -3483,8 +3483,7 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   Curl_none_cert_status_request,      /* cert_status_request */
   sectransp_connect,                  /* connect */
   sectransp_connect_nonblocking,      /* connect_nonblocking */
-  Curl_ssl_get_select_socks,          /* getsock */
-  Curl_ssl_adjust_pollset,           /* adjust_pollset */
+  Curl_ssl_adjust_pollset,            /* adjust_pollset */
   sectransp_get_internals,            /* get_internals */
   sectransp_close,                    /* close_one */
   Curl_none_close_all,                /* close_all */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -655,10 +655,10 @@ void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
     curl_socket_t sock = Curl_conn_cf_get_socket(cf->next, data);
     if(sock != CURL_SOCKET_BAD) {
       if(connssl->connecting_state == ssl_connect_2_writing) {
-        Curl_poll_set_change(data, ps, sock, CURL_POLL_OUT, CURL_POLL_IN);
+        Curl_pollset_set_out_only(data, ps, sock);
       }
       else {
-        Curl_poll_set_change(data, ps, sock, CURL_POLL_IN, CURL_POLL_OUT);
+        Curl_pollset_set_in_only(data, ps, sock);
       }
     }
   }

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -647,8 +647,8 @@ int Curl_ssl_get_select_socks(struct Curl_cfilter *cf, struct Curl_easy *data,
   return GETSOCK_READSOCK(0);
 }
 
-void Curl_ssl_adjust_poll_set(struct Curl_cfilter *cf, struct Curl_easy *data,
-                              struct easy_poll_set *ps)
+void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
+                              struct easy_pollset *ps)
 {
   if(!cf->connected) {
     struct ssl_connect_data *connssl = cf->ctx;
@@ -663,7 +663,7 @@ void Curl_ssl_adjust_poll_set(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
   }
   if(cf->next)
-    cf->next->cft->adjust_poll_set(cf->next, data, ps);
+    cf->next->cft->adjust_pollset(cf->next, data, ps);
 }
 
 /* Selects an SSL crypto engine
@@ -1184,13 +1184,13 @@ static int multissl_get_select_socks(struct Curl_cfilter *cf,
   return Curl_ssl->get_select_socks(cf, data, socks);
 }
 
-static void multissl_adjust_poll_set(struct Curl_cfilter *cf,
+static void multissl_adjust_pollset(struct Curl_cfilter *cf,
                                      struct Curl_easy *data,
-                                     struct easy_poll_set *ps)
+                                     struct easy_pollset *ps)
 {
   if(multissl_setup(NULL))
     return;
-  Curl_ssl->adjust_poll_set(cf, data, ps);
+  Curl_ssl->adjust_pollset(cf, data, ps);
 }
 
 static void *multissl_get_internals(struct ssl_connect_data *connssl,
@@ -1243,7 +1243,7 @@ static const struct Curl_ssl Curl_ssl_multi = {
   multissl_connect,                  /* connect */
   multissl_connect_nonblocking,      /* connect_nonblocking */
   multissl_get_select_socks,         /* getsock */
-  multissl_adjust_poll_set,          /* adjust_poll_set */
+  multissl_adjust_pollset,          /* adjust_pollset */
   multissl_get_internals,            /* get_internals */
   multissl_close,                    /* close_one */
   Curl_none_close_all,               /* close_all */
@@ -1646,15 +1646,15 @@ static int ssl_cf_get_select_socks(struct Curl_cfilter *cf,
   return fds;
 }
 
-static void ssl_cf_adjust_poll_set(struct Curl_cfilter *cf,
+static void ssl_cf_adjust_pollset(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
-                                   struct easy_poll_set *ps)
+                                   struct easy_pollset *ps)
 {
   struct cf_call_data save;
 
   if(!cf->connected) {
     CF_DATA_SAVE(save, cf, data);
-    Curl_ssl->adjust_poll_set(cf, data, ps);
+    Curl_ssl->adjust_pollset(cf, data, ps);
     CF_DATA_RESTORE(cf, save);
   }
 }
@@ -1748,7 +1748,7 @@ struct Curl_cftype Curl_cft_ssl = {
   ssl_cf_close,
   Curl_cf_def_get_host,
   ssl_cf_get_select_socks,
-  ssl_cf_adjust_poll_set,
+  ssl_cf_adjust_pollset,
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
@@ -1767,7 +1767,7 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
   ssl_cf_close,
   Curl_cf_def_get_host,
   ssl_cf_get_select_socks,
-  ssl_cf_adjust_poll_set,
+  ssl_cf_adjust_pollset,
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -125,8 +125,8 @@ struct Curl_ssl {
      Mandatory. */
   int (*get_select_socks)(struct Curl_cfilter *cf, struct Curl_easy *data,
                           curl_socket_t *socks);
-  void (*adjust_poll_set)(struct Curl_cfilter *cf, struct Curl_easy *data,
-                          struct easy_poll_set *ps);
+  void (*adjust_pollset)(struct Curl_cfilter *cf, struct Curl_easy *data,
+                          struct easy_pollset *ps);
   void *(*get_internals)(struct ssl_connect_data *connssl, CURLINFO info);
   void (*close)(struct Curl_cfilter *cf, struct Curl_easy *data);
   void (*close_all)(struct Curl_easy *data);
@@ -172,8 +172,8 @@ struct curl_slist *Curl_none_engines_list(struct Curl_easy *data);
 bool Curl_none_false_start(void);
 int Curl_ssl_get_select_socks(struct Curl_cfilter *cf, struct Curl_easy *data,
                               curl_socket_t *socks);
-void Curl_ssl_adjust_poll_set(struct Curl_cfilter *cf, struct Curl_easy *data,
-                              struct easy_poll_set *ps);
+void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
+                              struct easy_pollset *ps);
 
 /**
  * Get the ssl_config_data in `data` that is relevant for cfilter `cf`.

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -125,7 +125,8 @@ struct Curl_ssl {
      Mandatory. */
   int (*get_select_socks)(struct Curl_cfilter *cf, struct Curl_easy *data,
                           curl_socket_t *socks);
-
+  void (*adjust_poll_set)(struct Curl_cfilter *cf, struct Curl_easy *data,
+                          struct easy_poll_set *ps);
   void *(*get_internals)(struct ssl_connect_data *connssl, CURLINFO info);
   void (*close)(struct Curl_cfilter *cf, struct Curl_easy *data);
   void (*close_all)(struct Curl_easy *data);
@@ -171,6 +172,8 @@ struct curl_slist *Curl_none_engines_list(struct Curl_easy *data);
 bool Curl_none_false_start(void);
 int Curl_ssl_get_select_socks(struct Curl_cfilter *cf, struct Curl_easy *data,
                               curl_socket_t *socks);
+void Curl_ssl_adjust_poll_set(struct Curl_cfilter *cf, struct Curl_easy *data,
+                              struct easy_poll_set *ps);
 
 /**
  * Get the ssl_config_data in `data` that is relevant for cfilter `cf`.

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -118,13 +118,9 @@ struct Curl_ssl {
                                   struct Curl_easy *data,
                                   bool *done);
 
-  /* If the SSL backend wants to read or write on this connection during a
-     handshake, set socks[0] to the connection's FIRSTSOCKET, and return
-     a bitmap indicating read or write with GETSOCK_WRITESOCK(0) or
-     GETSOCK_READSOCK(0). Otherwise return GETSOCK_BLANK.
-     Mandatory. */
-  int (*get_select_socks)(struct Curl_cfilter *cf, struct Curl_easy *data,
-                          curl_socket_t *socks);
+  /* During handshake, adjust the pollset to include the socket
+   * for POLLOUT or POLLIN as needed.
+   * Mandatory. */
   void (*adjust_pollset)(struct Curl_cfilter *cf, struct Curl_easy *data,
                           struct easy_pollset *ps);
   void *(*get_internals)(struct ssl_connect_data *connssl, CURLINFO info);
@@ -170,8 +166,6 @@ CURLcode Curl_none_set_engine(struct Curl_easy *data, const char *engine);
 CURLcode Curl_none_set_engine_default(struct Curl_easy *data);
 struct curl_slist *Curl_none_engines_list(struct Curl_easy *data);
 bool Curl_none_false_start(void);
-int Curl_ssl_get_select_socks(struct Curl_cfilter *cf, struct Curl_easy *data,
-                              curl_socket_t *socks);
 void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
                               struct easy_pollset *ps);
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1399,7 +1399,7 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   wolfssl_connect,                 /* connect */
   wolfssl_connect_nonblocking,     /* connect_nonblocking */
   Curl_ssl_get_select_socks,       /* getsock */
-  Curl_ssl_adjust_poll_set,        /* adjust_poll_set */
+  Curl_ssl_adjust_pollset,        /* adjust_pollset */
   wolfssl_get_internals,           /* get_internals */
   wolfssl_close,                   /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1398,7 +1398,8 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   Curl_none_cert_status_request,   /* cert_status_request */
   wolfssl_connect,                 /* connect */
   wolfssl_connect_nonblocking,     /* connect_nonblocking */
-  Curl_ssl_get_select_socks,                /* getsock */
+  Curl_ssl_get_select_socks,       /* getsock */
+  Curl_ssl_adjust_poll_set,        /* adjust_poll_set */
   wolfssl_get_internals,           /* get_internals */
   wolfssl_close,                   /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1398,8 +1398,7 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   Curl_none_cert_status_request,   /* cert_status_request */
   wolfssl_connect,                 /* connect */
   wolfssl_connect_nonblocking,     /* connect_nonblocking */
-  Curl_ssl_get_select_socks,       /* getsock */
-  Curl_ssl_adjust_pollset,        /* adjust_pollset */
+  Curl_ssl_adjust_pollset,         /* adjust_pollset */
   wolfssl_get_internals,           /* get_internals */
   wolfssl_close,                   /* close_one */
   Curl_none_close_all,             /* close_all */

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -504,8 +504,8 @@ class CurlClient:
         args = [self._curl, "-s", "--path-as-is"]
         if with_headers:
             args.extend(["-D", self._headerfile])
-        if def_tracing is not False:
-            args.extend(['-v', '--trace-config', 'ids,time'])
+        if def_tracing is not False and not self._silent:
+            args.extend(['-v', '--trace-ids', '--trace-time'])
             if self.env.verbose > 1:
                 args.extend(['--trace-config', 'http/2,http/3,h2-proxy,h1-proxy'])
                 pass

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -163,6 +163,7 @@ static struct Curl_cftype cft_test = {
   Curl_cf_def_close,
   Curl_cf_def_get_host,
   Curl_cf_def_get_select_socks,
+  Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -162,7 +162,6 @@ static struct Curl_cftype cft_test = {
   cf_test_connect,
   Curl_cf_def_close,
   Curl_cf_def_get_host,
-  Curl_cf_def_get_select_socks,
   Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,
   Curl_cf_def_send,


### PR DESCRIPTION
This PR introduces improved control of a transfer's pollset by connection filters.

### shortcomings of previous `get_select_socks`

Connection filter had a `get_select_socks()` method, inspired by the various `getsocks` functions involved during the lifetime of a transfer. These, depending on transfer state (CONNECT/DO/DONE/ etc.), return sockets to monitor and flag if this shall be done for POLLIN and/or POLLOUT.

Due to this design, sockets and flags could only be added, not removed. This led to problems in filters like HTTP/2 where flow control prohibits the sending of data until the peer increases the flow window. The general transfer loop wants to write, adds POLLOUT, the socket is writeable but no data can be written. 

This leads to cpu busy loops. To prevent that, HTTP/2 did set the `SEND_HOLD` flag of such a blocked transfer, so the transfer loop cedes further attempts. This works if only one such filter is involved. If a HTTP/2 transfer goes through a HTTP/2 proxy, two filters are setting/clearing this flag and may step on each other's toes.

### the new `adjust_pollset`

Connection filters `get_select_socks()` is replaced by `adjust_pollset()`. They get passed a `struct easy_pollset` that keeps up to `MAX_SOCKSPEREASYHANDLE` sockets and their `POLLIN|POLLOUT` flags. This struct is initialized in `multi_getsock()` by calling the various `getsocks()` implementations based on transfer state, as before.

After protocol handlers/transfer loop have set the sockets and flags they want, the `easy_pollset` is *always* passed to the filters. Filters "higher" in the chain are called first, starting at the first not-yet-connection one. Each filter may add sockets and/or change flags. When all flags are removed, the socket itself is removed from the pollset. 

Example:

 * transfer wants to send, adds POLLOUT
 * http/2 filter has a flow control block, removes POLLOUT and adds POLLIN (it is waiting on a WINDOW_UPDATE from the server)
 * TLS filter is connected and changes nothing
 * h2-proxy filter also has a flow control block on its tunnel stream, removes POLLOUT and adds POLLIN also.
 * socket filter is connected and changes nothing
 * The resulting pollset is then mixed together with all other transfers and their pollsets, just as before. 

Use of `SEND_HOLD` is no longer necessary in the filters.

### Impact

All filters are adapted for the changed method. The handling in `multi.c` has been adjusted, but its state handling the the protocol handlers' `getsocks` method are untouched. 

The most affected filters are http/2, ngtcp2, quiche and h2-proxy. TLS filters needed to be adjusted for the connecting handshake read/write handling.

No noticeable difference in performance was detected in local scorecard runs.