### PR TITLE
misc: better random strings

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -64,7 +64,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   fclose(*fh);
   *fh = NULL;
 
-  result = Curl_rand_hex(data, randsuffix, sizeof(randsuffix));
+  result = Curl_rand_alnum(data, randsuffix, sizeof(randsuffix));
   if(result)
     goto fail;
 

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1289,9 +1289,9 @@ curl_mime *curl_mime_init(struct Curl_easy *easy)
     mime->lastpart = NULL;
 
     memset(mime->boundary, '-', MIME_BOUNDARY_DASHES);
-    if(Curl_rand_hex(easy,
-                     (unsigned char *) &mime->boundary[MIME_BOUNDARY_DASHES],
-                     MIME_RAND_BOUNDARY_CHARS + 1)) {
+    if(Curl_rand_alnum(easy,
+                       (unsigned char *) &mime->boundary[MIME_BOUNDARY_DASHES],
+                       MIME_RAND_BOUNDARY_CHARS + 1)) {
       /* failed to get random separator, bail out */
       free(mime);
       return NULL;

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -27,7 +27,7 @@
 #include "curl_setup.h"
 
 #define MIME_BOUNDARY_DASHES            24  /* leading boundary dashes */
-#define MIME_RAND_BOUNDARY_CHARS        16  /* Nb. of random boundary chars. */
+#define MIME_RAND_BOUNDARY_CHARS        22  /* Nb. of random boundary chars. */
 #define MAX_ENCODED_LINE_LENGTH         76  /* Maximum encoded line length. */
 #define ENCODING_BUFFER_SIZE            256 /* Encoding temp buffers size. */
 

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -295,8 +295,8 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   /* set initial values for the CONNECT packet */
   pos = init_connpack(packet, remain, remain_pos);
 
-  result = Curl_rand_hex(data, (unsigned char *)&client_id[clen],
-                         MQTT_CLIENTID_LEN - clen + 1);
+  result = Curl_rand_alnum(data, (unsigned char *)&client_id[clen],
+                           MQTT_CLIENTID_LEN - clen + 1);
   /* add client id */
   rc = add_client_id(client_id, strlen(client_id), packet, pos + 1);
   if(rc) {

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -24,6 +24,8 @@
 
 #include "curl_setup.h"
 
+#include <limits.h>
+
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -262,6 +264,39 @@ CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd,
     *rnd++ = hex[*bufp & 0x0F];
     bufp++;
     num -= 2;
+  }
+  *rnd = 0;
+
+  return result;
+}
+
+/*
+ * Curl_rand_alnum() fills the 'rnd' buffer with a given 'num' size with random
+ * alphanumerical chars PLUS a null-terminating byte.
+ */
+
+static const char alnum[26 + 26 + 10] =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+CURLcode Curl_rand_alnum(struct Curl_easy *data, unsigned char *rnd,
+                         size_t num)
+{
+  CURLcode result = CURLE_OK;
+  const int alnumspace = sizeof(alnum);
+  unsigned int r;
+  DEBUGASSERT(num > 1);
+
+  num--; /* save one for null-termination */
+
+  while(num) {
+    do {
+      result = randit(data, &r);
+      if(result)
+        return result;
+    } while(r >= (UINT_MAX - UINT_MAX % alnumspace));
+
+    *rnd++ = alnum[r % alnumspace];
+    num--;
   }
   *rnd = 0;
 

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -34,6 +34,13 @@ CURLcode Curl_rand(struct Curl_easy *data, unsigned char *rnd, size_t num);
 CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd,
                        size_t num);
 
+/*
+ * Curl_rand_alnum() fills the 'rnd' buffer with a given 'num' size with random
+ * alphanumerical chars PLUS a null-terminating byte.
+ */
+CURLcode Curl_rand_alnum(struct Curl_easy *data, unsigned char *rnd,
+                         size_t num);
+
 #ifdef WIN32
 /* Random generator shared between the Schannel vtls and Curl_rand*()
    functions */

--- a/tests/data/test1053
+++ b/tests/data/test1053
@@ -81,7 +81,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 410
+Content-Length: 434
 Content-Type: multipart/form-data; boundary=----------------------------9ef8d6205763
 
 ------------------------------9ef8d6205763
@@ -105,7 +105,7 @@ POST /we/want/data/%TESTNUMBER0002.txt?coolsite=yes HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 410
+Content-Length: 434
 Content-Type: multipart/form-data; boundary=----------------------------9ef8d6205763
 
 ------------------------------9ef8d6205763

--- a/tests/data/test1133
+++ b/tests/data/test1133
@@ -50,7 +50,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 1264
+Content-Length: 1324
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32

--- a/tests/data/test1158
+++ b/tests/data/test1158
@@ -53,7 +53,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 958
+Content-Length: 1006
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32

--- a/tests/data/test1186
+++ b/tests/data/test1186
@@ -53,7 +53,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 954
+Content-Length: 1002
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32

--- a/tests/data/test1187
+++ b/tests/data/test1187
@@ -38,8 +38,8 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt recipient@example.com --mail-fr
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test1189
+++ b/tests/data/test1189
@@ -50,7 +50,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 1186
+Content-Length: 1240
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32

--- a/tests/data/test1293
+++ b/tests/data/test1293
@@ -47,15 +47,15 @@ http://0 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -F=
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 126
+Content-Length: 138
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test1315
+++ b/tests/data/test1315
@@ -50,7 +50,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 797
+Content-Length: 845
 Content-Type: multipart/form-data; boundary=----------------------------9ef8d6205763
 
 ------------------------------9ef8d6205763

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -54,7 +54,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 882
+Content-Length: 930
 Content-Type: multipart/form-data; boundary=----------------------------9ef8d6205763
 
 ------------------------------9ef8d6205763

--- a/tests/data/test158
+++ b/tests/data/test158
@@ -42,7 +42,7 @@ POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 145
+Content-Length: 157
 Content-Type: multipart/form-data; boundary=----------------------------4f12fcdaa3bc
 
 ------------------------------4f12fcdaa3bc

--- a/tests/data/test163
+++ b/tests/data/test163
@@ -56,7 +56,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 304
+Content-Length: 322
 Content-Type: multipart/form-data; boundary=----------------------------c2d1767eb6ac
 
 ------------------------------c2d1767eb6ac

--- a/tests/data/test166
+++ b/tests/data/test166
@@ -48,7 +48,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 223
+Content-Length: 235
 Content-Type: multipart/form-data; boundary=----------------------------b0b3d6d23991
 
 ------------------------------b0b3d6d23991

--- a/tests/data/test173
+++ b/tests/data/test173
@@ -56,7 +56,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 360
+Content-Length: 378
 Content-Type: multipart/form-data; boundary=----------------------------5dbea401cd8c
 
 ------------------------------5dbea401cd8c

--- a/tests/data/test186
+++ b/tests/data/test186
@@ -46,7 +46,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 320
+Content-Length: 338
 Content-Type: multipart/form-data; boundary=----------------------------212d9006ceb5
 
 ------------------------------212d9006ceb5

--- a/tests/data/test1972
+++ b/tests/data/test1972
@@ -67,13 +67,13 @@ Host: exam.ple.com:9000
 Authorization: AWS4-HMAC-SHA256 Credential=xxx/19700101/us-east-1/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=eaee0f1c5984ad5d81c8bc7805f28c7b83b35322de654b2ace18cb8cf6d5a9cb
 X-Amz-Date: 19700101T000000Z
 x-amz-content-sha256: UNSIGNED-PAYLOAD
-Content-Length: 142
+Content-Length: 154
 
---------------------------3433323135333231
+--------------------------qrstuvwxyz0123456789AB
 Content-Disposition: attachment; name="foo"
 
 bar
---------------------------3433323135333231--
+--------------------------qrstuvwxyz0123456789AB--
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test2073
+++ b/tests/data/test2073
@@ -52,7 +52,7 @@ POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 189
+Content-Length: 201
 
 Content-Disposition: form-data; name="name"; filename="a.pdf"
 Content-Type: application/pdf
@@ -62,7 +62,7 @@ POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 184
+Content-Length: 196
 
 Content-Disposition: form-data; name="name"; filename="b.jpg"
 Content-Type: image/jpeg

--- a/tests/data/test258
+++ b/tests/data/test258
@@ -86,7 +86,7 @@ Host: remotehost:54321
 User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
-Content-Length: 409
+Content-Length: 433
 Content-Type: multipart/form-data; boundary=----------------------------7c633d5c27ce
 
 ------------------------------7c633d5c27ce
@@ -112,7 +112,7 @@ Proxy-Authorization: Digest username="uuuser", realm="many secrets", nonce="911"
 User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
-Content-Length: 409
+Content-Length: 433
 Content-Type: multipart/form-data; boundary=----------------------------7c633d5c27ce
 
 ------------------------------7c633d5c27ce

--- a/tests/data/test259
+++ b/tests/data/test259
@@ -83,7 +83,7 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Expect: 100-continue
-Content-Length: 409
+Content-Length: 433
 Content-Type: multipart/form-data; boundary=----------------------------7c633d5c27ce
 
 ------------------------------7c633d5c27ce
@@ -110,7 +110,7 @@ User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
 Expect: 100-continue
-Content-Length: 409
+Content-Length: 433
 Content-Type: multipart/form-data; boundary=----------------------------7c633d5c27ce
 
 ------------------------------7c633d5c27ce

--- a/tests/data/test277
+++ b/tests/data/test277
@@ -37,15 +37,15 @@ http://%HOSTIP:%HTTPPORT/want/%TESTNUMBER -F name=daniel -H "Content-Type: text/
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/--------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=------------------------/
+s/^--------------------------[A-Za-z0-9]*/--------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=------------------------/
 </strippart>
 <protocol>
 POST /want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 146
+Content-Length: 158
 Content-Type: text/info; boundary=------------------------
 
 --------------------------

--- a/tests/data/test304
+++ b/tests/data/test304
@@ -49,24 +49,24 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPSPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 1386
-Content-Type: multipart/form-data; boundary=----------------------------c3b2ef7f0bb8
+Content-Length: 1410
+Content-Type: multipart/form-data; boundary=----------------------------qrstuvwxyz0123456789AB
 
-------------------------------c3b2ef7f0bb8
+------------------------------qrstuvwxyz0123456789AB
 Content-Disposition: form-data; name="name"
 
 daniel
-------------------------------c3b2ef7f0bb8
+------------------------------qrstuvwxyz0123456789AB
 Content-Disposition: form-data; name="tool"
 
 curl
-------------------------------c3b2ef7f0bb8
+------------------------------qrstuvwxyz0123456789AB
 Content-Disposition: form-data; name="file"; filename="test%TESTNUMBER.txt"
 Content-Type: text/plain
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-------------------------------c3b2ef7f0bb8--
+------------------------------qrstuvwxyz0123456789AB--
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test39
+++ b/tests/data/test39
@@ -50,7 +50,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 1180
+Content-Length: 1234
 Content-Type: multipart/form-data; boundary=----------------------------24e78000bd32
 
 ------------------------------24e78000bd32

--- a/tests/data/test44
+++ b/tests/data/test44
@@ -50,7 +50,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 408
+Content-Length: 432
 Content-Type: multipart/form-data; boundary=----------------------------7c633d5c27ce
 
 ------------------------------7c633d5c27ce

--- a/tests/data/test554
+++ b/tests/data/test554
@@ -62,8 +62,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -72,7 +72,7 @@ s/boundary=------------------------[a-z0-9]*/boundary=--------------------------
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 744
+Content-Length: 780
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------
@@ -103,7 +103,7 @@ blah blah
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 758
+Content-Length: 794
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test584
+++ b/tests/data/test584
@@ -59,14 +59,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/--------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=------------------------/
+s/^--------------------------[A-Za-z0-9]*/--------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 144
+Content-Length: 156
 Content-Type: multipart/form-data; boundary=------------------------
 
 --------------------------

--- a/tests/data/test587
+++ b/tests/data/test587
@@ -40,14 +40,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 744
+Content-Length: 780
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test643
+++ b/tests/data/test643
@@ -62,8 +62,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -72,7 +72,7 @@ s/boundary=------------------------[a-z0-9]*/boundary=--------------------------
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 640
+Content-Length: 676
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------
@@ -102,7 +102,7 @@ blah blah
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 654
+Content-Length: 690
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test645
+++ b/tests/data/test645
@@ -62,8 +62,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -76,7 +76,11 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-76
+%if hyper
+7C
+%else
+7c
+%endif
 ------------------------------
 Content-Disposition: form-data; name="sendfile"; filename="postit2.c"
 
@@ -92,7 +96,11 @@ y
 1
 
 
-65
+%if hyper
+6B
+%else
+6b
+%endif
 
 ------------------------------
 Content-Disposition: form-data; name="callbackdata"
@@ -112,9 +120,9 @@ y
 
 
 %if hyper
-19A
+1B2
 %else
-19a
+1b2
 %endif
 
 ------------------------------
@@ -141,7 +149,11 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-84
+%if hyper
+8A
+%else
+8a
+%endif
 ------------------------------
 Content-Disposition: form-data; name="sendfile alternative"; filename="file name 2"
 
@@ -157,7 +169,11 @@ y
 1
 
 
-65
+%if hyper
+6B
+%else
+6b
+%endif
 
 ------------------------------
 Content-Disposition: form-data; name="callbackdata"
@@ -177,9 +193,9 @@ y
 
 
 %if hyper
-19A
+1B2
 %else
-19a
+1b2
 %endif
 
 ------------------------------

--- a/tests/data/test646
+++ b/tests/data/test646
@@ -51,8 +51,8 @@ X-fileheader2: This is #a
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test647
+++ b/tests/data/test647
@@ -38,13 +38,13 @@ It may contain any type of data.
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 A001 CAPABILITY
 A002 LOGIN user secret
-A003 APPEND %TESTNUMBER (\Seen) {892}
+A003 APPEND %TESTNUMBER (\Seen) {940}
 A004 LOGOUT
 </protocol>
 <upload>

--- a/tests/data/test648
+++ b/tests/data/test648
@@ -43,8 +43,8 @@ It may contain any type of data and will be encoded in base64 for transfer.
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test649
+++ b/tests/data/test649
@@ -43,8 +43,8 @@ It contains at least an 8-bit byte value.
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test650
+++ b/tests/data/test650
@@ -60,11 +60,11 @@ This is data from a file.
 </client>
 
 #
-# Verify data after the test has been "shot"
+# Verify data bbter the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -77,7 +77,7 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-361
+385
 ------------------------------
 Content-Disposition: form-data; name="fieldname"
 Content-Type: text/plain
@@ -105,9 +105,9 @@ Content-Type: text/whatever
 
 
 %if hyper
-A5
+AB
 %else
-a5
+ab
 %endif
 This is data from a file.
 
@@ -117,9 +117,9 @@ Content-Type: text/whatever
 
 
 %if hyper
-AF
+BB
 %else
-af
+bb
 %endif
 This is data from a file.
 
@@ -130,16 +130,16 @@ Content-Disposition: form-data; name="filecontents"
 
 
 %if hyper
-10F
+11B
 %else
-10f
+11b
 %endif
 This is data from a file.
 
 ------------------------------
 Content-Disposition: form-data; name="formlength"
 
-1367
+1433
 ------------------------------
 Content-Disposition: form-data; name="standardinput"
 Content-Type: application/octet-stream
@@ -148,7 +148,7 @@ Content-Type: application/octet-stream
 16
  Some data from stdin
 
-30
+36
 
 --------------------------------
 
@@ -161,7 +161,7 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-361
+385
 ------------------------------
 Content-Disposition: form-data; name="fieldname"
 Content-Type: text/plain
@@ -189,9 +189,9 @@ Content-Type: text/whatever
 
 
 %if hyper
-A5
+AB
 %else
-a5
+ab
 %endif
 This is data from a file.
 
@@ -201,9 +201,9 @@ Content-Type: text/whatever
 
 
 %if hyper
-AF
+BB
 %else
-af
+bb
 %endif
 This is data from a file.
 
@@ -214,16 +214,16 @@ Content-Disposition: form-data; name="filecontents"
 
 
 %if hyper
-10F
+11B
 %else
-10f
+11b
 %endif
 This is data from a file.
 
 ------------------------------
 Content-Disposition: form-data; name="formlength"
 
-1367
+1433
 ------------------------------
 Content-Disposition: form-data; name="standardinput"
 Content-Type: application/octet-stream
@@ -232,7 +232,7 @@ Content-Type: application/octet-stream
 16
  Some data from stdin
 
-30
+36
 
 --------------------------------
 

--- a/tests/data/test651
+++ b/tests/data/test651
@@ -52,8 +52,8 @@ This is data from a file.
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -62,7 +62,7 @@ s/boundary=------------------------[a-z0-9]*/boundary=--------------------------
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 17139
+Content-Length: 17151
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test652
+++ b/tests/data/test652
@@ -36,8 +36,8 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 EHLO %TESTNUMBER

--- a/tests/data/test653
+++ b/tests/data/test653
@@ -62,8 +62,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -72,7 +72,7 @@ s/boundary=------------------------[a-z0-9]*/boundary=--------------------------
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 150
+Content-Length: 162
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------
@@ -83,7 +83,7 @@ short value
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 167
+Content-Length: 179
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test654
+++ b/tests/data/test654
@@ -65,8 +65,8 @@ This is data from a file
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -85,9 +85,9 @@ Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
 %if hyper
-1AF
+1C1
 %else
-1af
+1c1
 %endif
 ------------------------------
 Content-Disposition: form-data; name="greeting"
@@ -119,7 +119,7 @@ y
 1
 
 
-30
+36
 
 --------------------------------
 

--- a/tests/data/test666
+++ b/tests/data/test666
@@ -54,14 +54,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 17225
+Content-Length: 17237
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test667
+++ b/tests/data/test667
@@ -55,8 +55,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -69,11 +69,7 @@ Transfer-Encoding: chunked
 Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
-%if hyper
-7F
-%else
-7f
-%endif
+85
 ------------------------------
 Content-Disposition: form-data; name="field"
 Content-Transfer-Encoding: base64
@@ -81,7 +77,11 @@ Content-Transfer-Encoding: base64
 
 4
 ZHVt
-34
+%if hyper
+3A
+%else
+3a
+%endif
 bXk=
 --------------------------------
 

--- a/tests/data/test668
+++ b/tests/data/test668
@@ -12,7 +12,7 @@ HTTP MIME POST
 <reply>
 <data>
 HTTP/1.1 200 OK
-Date: Tue, 09 Nov 2010 14:49:00 GMT
+Date: Tue, 09 Nov 2010 14:4f:00 GMT
 Server: test-server/fake swsclose
 Connection: close
 Content-Type: text/html
@@ -21,7 +21,7 @@ hello
 </data>
 <datacheck>
 HTTP/1.1 200 OK
-Date: Tue, 09 Nov 2010 14:49:00 GMT
+Date: Tue, 09 Nov 2010 14:4f:00 GMT
 Server: test-server/fake swsclose
 Connection: close
 Content-Type: text/html
@@ -58,8 +58,8 @@ This is data from a file
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 # Note that the stripping above removes 12 bytes from every occurrence of the
 # boundary string and since 5 of them are in the body contents, we see
@@ -73,9 +73,9 @@ Content-Type: multipart/form-data; boundary=----------------------------
 Expect: 100-continue
 
 %if hyper
-C1
+CD
 %else
-c1
+cd
 %endif
 ------------------------------
 Content-Disposition: form-data; name="field1"
@@ -87,14 +87,18 @@ Content-Disposition: form-data; name="field2"
 
 5
 dummy
-91
+97
 
 ------------------------------
 Content-Disposition: form-data; name="field3"; filename="file%TESTNUMBER.txt"
 Content-Type: text/plain
 
 
-49
+%if hyper
+4F
+%else
+4f
+%endif
 This is data from a file
 
 --------------------------------

--- a/tests/data/test669
+++ b/tests/data/test669
@@ -38,15 +38,15 @@ http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -H 'Content-type: multipart/form-da
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 242
+Content-Length: 260
 Content-Type: multipart/form-data; charset=utf-8; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test670
+++ b/tests/data/test670
@@ -55,14 +55,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 142
+Content-Length: 154
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test671
+++ b/tests/data/test671
@@ -55,14 +55,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 142
+Content-Length: 154
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test672
+++ b/tests/data/test672
@@ -55,14 +55,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 142
+Content-Length: 154
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test673
+++ b/tests/data/test673
@@ -55,14 +55,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <strippart>
-s/^--------------------------[a-z0-9]*/------------------------------/
-s/boundary=------------------------[a-z0-9]*/boundary=----------------------------/
+s/^--------------------------[A-Za-z0-9]*/------------------------------/
+s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
 </strippart>
 <protocol>
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 142
+Content-Length: 154
 Content-Type: multipart/form-data; boundary=----------------------------
 
 ------------------------------

--- a/tests/data/test71
+++ b/tests/data/test71
@@ -56,7 +56,7 @@ bar
 POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 Accept: */*
-Content-Length: 408
+Content-Length: 432
 Content-Type: multipart/form-data; boundary=----------------------------9ef8d6205763
 
 ------------------------------9ef8d6205763

--- a/tests/data/test9
+++ b/tests/data/test9
@@ -50,7 +50,7 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 407
+Content-Length: 431
 Content-Type: multipart/form-data; boundary=----------------------------9ef8d6205763
 
 ------------------------------9ef8d6205763

--- a/tests/unit/unit1308.c
+++ b/tests/unit/unit1308.c
@@ -74,7 +74,7 @@ UNITTEST_START
 
   fail_unless(rc == 0, "curl_formget returned error");
 
-  fail_unless(total_size == 488, "curl_formget got wrong size back");
+  fail_unless(total_size == 518, "curl_formget got wrong size back");
 
   curl_formfree(post);
 
@@ -91,7 +91,7 @@ UNITTEST_START
 
   rc = curl_formget(post, &total_size, print_httppost_callback);
   fail_unless(rc == 0, "curl_formget returned error");
-  fail_unless(total_size == 851, "curl_formget got wrong size back");
+  fail_unless(total_size == 899, "curl_formget got wrong size back");
 
   curl_formfree(post);
 


### PR DESCRIPTION
Generate alphanumerical random strings.

Prior this change curl used to create random hex strings. This was mostly okay, but having alphanumerical random strings is better: The strings have more entropy in the same space.

The MIME multipart boundary used to be mere 64-bits of randomness due to being 16 hex chars. With these changes the boundary is 22 alphanumerical chars, or little over 130 bits of randomness.