### PR TITLE
cmake: set SIZEOF_LONG_LONG in curl_config.h

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -649,6 +649,9 @@ ${SIZEOF_INT_CODE}
 /* The size of `long', as computed by sizeof. */
 ${SIZEOF_LONG_CODE}
 
+/* The size of `long long', as computed by sizeof. */
+${SIZEOF_LONG_LONG_CODE}
+
 /* The size of `off_t', as computed by sizeof. */
 ${SIZEOF_OFF_T_CODE}
 


### PR DESCRIPTION
in order to support 32bit builds regarding wolfssl CTC_SETTINGS

Ref: https://github.com/wolfSSL/wolfssl/pull/3283