### PR TITLE
escape: replace Curl_isunreserved with ISUNRESERVED

### DIFF
--- a/lib/curl_ctype.h
+++ b/lib/curl_ctype.h
@@ -43,9 +43,9 @@
 #define ISDIGIT(x)  (((x) >= '0') && ((x) <= '9'))
 #define ISBLANK(x)  (((x) == ' ') || ((x) == '\t'))
 #define ISSPACE(x)  (ISBLANK(x) || (((x) >= 0xa) && ((x) <= 0x0d)))
-#define isurlpuntcs(x) (((x) == '-') || ((x) == '.') || ((x) == '_') || \
+#define ISURLPUNTCS(x) (((x) == '-') || ((x) == '.') || ((x) == '_') || \
                         ((x) == '~'))
-#define ISUNRESERVED(x) (ISALNUM(x) || isurlpuntcs(x))
+#define ISUNRESERVED(x) (ISALNUM(x) || ISURLPUNTCS(x))
 
 
 #endif /* HEADER_CURL_CTYPE_H */

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -72,7 +72,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   while(length--) {
     unsigned char in = *string++; /* treat the characters unsigned */
 
-    if(Curl_isunreserved(in)) {
+    if(ISUNRESERVED(in)) {
       /* append this */
       if(Curl_dyn_addn(&d, &in, 1))
         return NULL;

--- a/lib/escape.h
+++ b/lib/escape.h
@@ -28,8 +28,6 @@
 
 #include "curl_ctype.h"
 
-#define Curl_isunreserved(x) ISUNRESERVED(x)
-
 enum urlreject {
   REJECT_NADA = 2,
   REJECT_CTRL,

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1865,7 +1865,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
           if(result)
             return CURLUE_OUT_OF_MEMORY;
         }
-        else if(Curl_isunreserved(*i) ||
+        else if(ISUNRESERVED(*i) ||
                 ((*i == '/') && urlskipslash) ||
                 ((*i == '=') && equalsencode)) {
           if((*i == '=') && equalsencode)


### PR DESCRIPTION
- Use the ALLCAPS version of the macro so that it is clear a macro is being called that evaluates the variable multiple times.

- Also capitalize macro isurlpuntcs => ISURLPUNTCS since it evaluates a variable multiple times.

This is a follow-up to 291d225a which changed Curl_isunreserved into an alias macro for ISUNRESERVED. The problem is the former is not easily identified as a macro by the caller, which could lead to a bug.

For example, ISUNRESERVED(*foo++) is easily identifiable as wrong but Curl_isunreserved(*foo++) is not even though they both are the same.

Closes #xxxx