### PR TITLE
test2600: remove special case handling for USE_ALARM_TIMEOUT

### DIFF
--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -53,14 +53,6 @@
 #include "multiif.h"
 #include "curl_trc.h"
 
-/* copied from hostip.c to switch using SIGALARM for timeouts.
- * SIGALARM has only seconds resolution, so our tests will not work
- * here. */
-#if defined(CURLRES_SYNCH) && \
-    defined(HAVE_ALARM) && defined(SIGALRM) && defined(HAVE_SIGSETJMP)
-#define USE_ALARM_TIMEOUT
-#endif
-
 
 static CURL *easy;
 
@@ -270,7 +262,6 @@ static void check_result(struct test_case *tc,
     fail(msg);
   }
 
-#ifndef USE_ALARM_TIMEOUT
   duration_ms = Curl_timediff(tr->ended, tr->started);
   if(duration_ms < tc->min_duration_ms) {
     curl_msprintf(msg, "%d: expected min duration of %dms, but took %dms",
@@ -282,7 +273,6 @@ static void check_result(struct test_case *tc,
                   tc->id, (int)tc->max_duration_ms, (int)duration_ms);
     fail(msg);
   }
-#endif
   if(tr->cf6.creations && tr->cf4.creations && tc->pref_family) {
     /* did ipv4 and ipv6 both, expect the preferred family to start right arway
      * with the other being delayed by the happy_eyeball_timeout */
@@ -297,11 +287,7 @@ static void check_result(struct test_case *tc,
                     tc->id, stats1->family, (int)stats1->first_created);
       fail(msg);
     }
-#ifndef USE_ALARM_TIMEOUT
     if(stats2->first_created < tc->he_timeout_ms) {
-#else
-    if(stats2->first_created < 1000) {
-#endif
       curl_msprintf(msg, "%d: expected ip%s to start delayed after %dms, "
                     "instead first attempt made after %dms",
                     tc->id, stats2->family, (int)tc->he_timeout_ms,
@@ -326,15 +312,8 @@ static void test_connect(struct test_case *tc)
   curl_easy_setopt(easy, CURLOPT_IPRESOLVE, (long)tc->ip_version);
   curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS,
                    (long)tc->connect_timeout_ms);
-#ifdef USE_ALARM_TIMEOUT
-  /* we only 1sec timer resolution here */
-  curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
-                   (tc->he_timeout_ms > tc->connect_timeout_ms)?
-                   3000L : 1000L);
-#else
   curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,
                    (long)tc->he_timeout_ms);
-#endif
 
   curl_easy_setopt(easy, CURLOPT_URL, tc->url);
   memset(&tr, 0, sizeof(tr));


### PR DESCRIPTION
This was originally added to handle platforms that supported only 1
second granularity in connect timeouts, but after some recent changes
the test currently permafails on several Windows platforms.

The need for this special-case was removed in commit 86274163, which
increased the connect timeout in all cases to well above 1 second.

Fixes #11767
Closes #11849