### PR TITLE
SSL, invoke shutdown implementation when closing a connection

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1199,6 +1199,8 @@ static void cf_h2_proxy_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     cf_h2_proxy_ctx_clear(ctx);
     CF_DATA_RESTORE(cf, save);
   }
+  if(cf->next)
+    cf->next->cft->do_close(cf->next, data);
 }
 
 static void cf_h2_proxy_destroy(struct Curl_cfilter *cf,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2425,6 +2425,8 @@ static void cf_h2_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     cf_h2_ctx_clear(ctx);
     CF_DATA_RESTORE(cf, save);
   }
+  if(cf->next)
+    cf->next->cft->do_close(cf->next, data);
 }
 
 static void cf_h2_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1494,7 +1494,8 @@ static void ssl_cf_close(struct Curl_cfilter *cf,
 
   CF_DATA_SAVE(save, cf, data);
   cf_close(cf, data);
-  cf->next->cft->do_close(cf->next, data);
+  if(cf->next)
+    cf->next->cft->do_close(cf->next, data);
   CF_DATA_RESTORE(cf, save);
 }
 


### PR DESCRIPTION
* fix http2 and h2-proxy filter to call the next filters on close
* make openssl's shutdown handle a one-time effort with added tracing for what it achieved