### PR TITLE
pytest, skip test_03_goaway in CI runs

### DIFF
--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -36,6 +36,7 @@ from testenv import Env, CurlClient, ExecResult
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
 class TestGoAway:
 
     @pytest.fixture(autouse=True, scope='class')


### PR DESCRIPTION
The behaviour checked is timing sensitive, making these tests unsuitable for CI.