### PR TITLE
ftp, make disconnect persevere more

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4076,7 +4076,7 @@ static CURLcode ftp_disconnect(struct Curl_easy *data,
    * If it is, we try sending a QUIT.
    * If that succeeds, we check if pingpong has data buffered
    * and retry flushing to for a certain amount of time. */
-  if(conn->proto.ftpc.ctl_valid && !ftp_quit(data, conn)) {
+  if(ftpc->ctl_valid && pp && !ftp_quit(data, conn)) {
     int i, max_ms = 1000, wait_ms = 10;
     for(i = 0; i < (max_ms/wait_ms); ++i) {
       if(Curl_pp_moredata(&conn->proto.ftpc.pp))


### PR DESCRIPTION
- we test if FTP transfers send the final QUIT, but this is unreliable when the network is blocking
- this leads to test failures in CI, test1387 for example
- this PR retries sending the QUIT data in a loop with waits.
- this is not a very good soluition, but lets see if out CI tests like it.