### PR TITLE
cookie cleanups

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -119,7 +119,6 @@ static void freecookie(struct Cookie *co)
   free(co->name);
   free(co->value);
   free(co->maxage);
-  free(co->version);
   free(co);
 }
 
@@ -718,11 +717,7 @@ Curl_cookie_add(struct Curl_easy *data,
           }
         }
         else if((nlen == 7) && strncasecompare("version", namep, 7)) {
-          strstore(&co->version, valuep, vlen);
-          if(!co->version) {
-            badcookie = TRUE;
-            break;
-          }
+          /* just ignore */
         }
         else if((nlen == 7) && strncasecompare("max-age", namep, 7)) {
           /*
@@ -1160,7 +1155,6 @@ Curl_cookie_add(struct Curl_easy *data,
     free(clist->path);
     free(clist->spath);
     free(clist->expirestr);
-    free(clist->version);
     free(clist->maxage);
 
     *clist = *co;  /* then store all the new data */
@@ -1224,9 +1218,6 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
     c = calloc(1, sizeof(struct CookieInfo));
     if(!c)
       return NULL; /* failed to get memory */
-    c->filename = strdup(file?file:"none"); /* copy the name just in case */
-    if(!c->filename)
-      goto fail; /* failed to get memory */
     /*
      * Initialize the next_expiration time to signal that we don't have enough
      * information yet.
@@ -1378,7 +1369,6 @@ static struct Cookie *dup_cookie(struct Cookie *src)
     CLONE(name);
     CLONE(value);
     CLONE(maxage);
-    CLONE(version);
     d->expires = src->expires;
     d->tailmatch = src->tailmatch;
     d->secure = src->secure;
@@ -1595,7 +1585,6 @@ void Curl_cookie_cleanup(struct CookieInfo *c)
 {
   if(c) {
     unsigned int i;
-    free(c->filename);
     for(i = 0; i < COOKIE_HASH_SIZE; i++)
       Curl_cookie_freelist(c->cookies[i]);
     free(c); /* free the base struct as well */

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -68,7 +68,6 @@ struct CookieInfo {
 
    - At least 4096 bytes per cookie (as measured by the sum of the length of
      the cookie's name, value, and attributes).
-
    In the 6265bis draft document section 5.4 it is phrased even stronger: "If
    the sum of the lengths of the name string and the value string is more than
    4096 octets, abort these steps and ignore the set-cookie-string entirely."
@@ -109,7 +108,7 @@ struct Curl_easy;
 
 struct Cookie *Curl_cookie_add(struct Curl_easy *data,
                                struct CookieInfo *c, bool header,
-                               bool noexpiry, char *lineptr,
+                               bool noexpiry, const char *lineptr,
                                const char *domain, const char *path,
                                bool secure);
 

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -35,8 +35,6 @@ struct Cookie {
   char *spath;        /* sanitized cookie path */
   char *domain;      /* domain = <this> */
   curl_off_t expires;  /* expires = <this> */
-  char *expirestr;   /* the plain text version */
-  char *maxage;      /* Max-Age = <value> */
   bool tailmatch;    /* whether we do tail-matching of the domain name */
   bool secure;       /* whether the 'secure' keyword was used */
   bool livecookie;   /* updated from a server, not a stored file */

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -36,11 +36,7 @@ struct Cookie {
   char *domain;      /* domain = <this> */
   curl_off_t expires;  /* expires = <this> */
   char *expirestr;   /* the plain text version */
-
-  /* RFC 2109 keywords. Version=1 means 2109-compliant cookie sending */
-  char *version;     /* Version = <value> */
   char *maxage;      /* Max-Age = <value> */
-
   bool tailmatch;    /* whether we do tail-matching of the domain name */
   bool secure;       /* whether the 'secure' keyword was used */
   bool livecookie;   /* updated from a server, not a stored file */
@@ -56,17 +52,16 @@ struct Cookie {
 #define COOKIE_PREFIX__SECURE (1<<0)
 #define COOKIE_PREFIX__HOST (1<<1)
 
-#define COOKIE_HASH_SIZE 256
+#define COOKIE_HASH_SIZE 63
 
 struct CookieInfo {
   /* linked list of cookies we know of */
   struct Cookie *cookies[COOKIE_HASH_SIZE];
-  char *filename;  /* file we read from/write to */
-  long numcookies; /* number of cookies in the "jar" */
+  curl_off_t next_expiration; /* the next time at which expiration happens */
+  int numcookies;  /* number of cookies in the "jar" */
+  int lastct;      /* last creation-time used in the jar */
   bool running;    /* state info, for cookie adding information */
   bool newsession; /* new session, discard session cookies on load */
-  int lastct;      /* last creation-time used in the jar */
-  curl_off_t next_expiration; /* the next time at which expiration happens */
 };
 
 /* The maximum sizes we accept for cookies. RFC 6265 section 6.1 says

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -925,9 +925,7 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   if(data->cookies) {
     /* If cookies are enabled in the parent handle, we enable them
        in the clone as well! */
-    outcurl->cookies = Curl_cookie_init(data,
-                                        data->cookies->filename,
-                                        outcurl->cookies,
+    outcurl->cookies = Curl_cookie_init(data, NULL, outcurl->cookies,
                                         data->set.cookiesession);
     if(!outcurl->cookies)
       goto fail;


### PR DESCRIPTION
- reduce variable scope, add const
- do not store the expire or max-age strings in memory
- remove unnecessary struct fields filename and version
- reduce the hash table size