### PR TITLE
tests: ignore the "flaky" and "timing-dependent" tests in CI

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,8 +71,9 @@ TEST_F = -a -p -r
 TEST_T = -a -t
 TEST_E = -a -e
 
-# !flaky means that it'll skip all tests using the flaky keyword
-TEST_NF = -a -p !flaky
+# ~<keyword> means that it will run all tests matching the keyword, but will
+# ignore their results (since these ones are likely to fail for no good reason)
+TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
 TEST_CI = $(TEST_NF) -rm

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -172,6 +172,7 @@ int main(int argc, char **argv)
   fprintf(stderr, "URL: %s\n", URL);
 
   result = test(URL);
+  fprintf(stderr, "Test ended with result %d\n", result);
 
 #ifdef WIN32
   /* flush buffers of all streams regardless of mode */

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -753,7 +753,8 @@ sub singletest_prepare {
             my $path = $filename;
             # cut off the file name part
             $path =~ s/^(.*)\/[^\/]*/$1/;
-            my $nparts = scalar(split(/\//, $LOGDIR));
+            my @ldparts = split(/\//, $LOGDIR);
+            my $nparts = @ldparts;
             my @parts = split(/\//, $path);
             if(join("/", @parts[0..$nparts-1]) eq $LOGDIR) {
                 # the file is in $LOGDIR/

--- a/tests/unit/curlcheck.h
+++ b/tests/unit/curlcheck.h
@@ -24,19 +24,19 @@
 #include "test.h"
 
 /* The fail macros mark the current test step as failed, and continue */
-#define fail_if(expr, msg)                                \
-  do {                                                    \
-    if(expr) {                                            \
-      fprintf(stderr, "%s:%d Assertion '%s' met: %s\n",   \
-              __FILE__, __LINE__, #expr, msg);            \
-      unitfail++;                                         \
-    }                                                     \
+#define fail_if(expr, msg)                                       \
+  do {                                                           \
+    if(expr) {                                                   \
+      fprintf(stderr, "%s:%d FAILED Assertion '%s' met: %s\n",   \
+              __FILE__, __LINE__, #expr, msg);                   \
+      unitfail++;                                                \
+    }                                                            \
   } while(0)
 
 #define fail_unless(expr, msg)                             \
   do {                                                     \
     if(!(expr)) {                                          \
-      fprintf(stderr, "%s:%d Assertion '%s' failed: %s\n", \
+      fprintf(stderr, "%s:%d Assertion '%s' FAILED: %s\n", \
               __FILE__, __LINE__, #expr, msg);             \
       unitfail++;                                          \
     }                                                      \
@@ -44,9 +44,9 @@
 
 #define verify_memory(dynamic, check, len)                              \
   do {                                                                  \
-    if(dynamic && memcmp(dynamic, check, len)) {                             \
-      fprintf(stderr, "%s:%d Memory buffer mismatch size %d. '%s' is not\n", \
-              __FILE__, __LINE__, len,                                  \
+    if(dynamic && memcmp(dynamic, check, len)) {                        \
+      fprintf(stderr, "%s:%d Memory buffer FAILED match size %d. "      \
+              "'%s' is not\n", __FILE__, __LINE__, len,                 \
               hexdump((const unsigned char *)check, len));              \
       fprintf(stderr, "%s:%d the same as '%s'\n", __FILE__, __LINE__,   \
               hexdump((const unsigned char *)dynamic, len));            \
@@ -57,7 +57,7 @@
 /* fail() is for when the test case figured out by itself that a check
    proved a failure */
 #define fail(msg) do {                                                 \
-    fprintf(stderr, "%s:%d test failed: '%s'\n",                       \
+    fprintf(stderr, "%s:%d test FAILED: '%s'\n",                       \
             __FILE__, __LINE__, msg);                                  \
     unitfail++;                                                        \
   } while(0)
@@ -67,7 +67,7 @@
 #define abort_if(expr, msg)                                     \
   do {                                                          \
     if(expr) {                                                  \
-      fprintf(stderr, "%s:%d Abort assertion '%s' met: %s\n",   \
+      fprintf(stderr, "%s:%d ABORT assertion '%s' met: %s\n",   \
               __FILE__, __LINE__, #expr, msg);                  \
       unitfail++;                                               \
       goto unit_test_abort;                                     \
@@ -77,7 +77,7 @@
 #define abort_unless(expr, msg)                                         \
   do {                                                                  \
     if(!(expr)) {                                                       \
-      fprintf(stderr, "%s:%d Abort assertion '%s' failed: %s\n",        \
+      fprintf(stderr, "%s:%d ABORT assertion '%s' failed: %s\n",        \
               __FILE__, __LINE__, #expr, msg);                          \
       unitfail++;                                                       \
       goto unit_test_abort;                                             \
@@ -86,7 +86,7 @@
 
 #define abort_test(msg)                                       \
   do {                                                        \
-    fprintf(stderr, "%s:%d test aborted: '%s'\n",             \
+    fprintf(stderr, "%s:%d test ABORTED: '%s'\n",             \
             __FILE__, __LINE__, msg);                         \
     unitfail++;                                               \
     goto unit_test_abort;                                     \
@@ -100,7 +100,7 @@ extern int unitfail;
   {                                             \
     (void)arg;                                  \
     if(unit_setup()) {                          \
-      fail("unit_setup() failure");             \
+      fail("unit_setup() FAILURE");             \
     }                                           \
     else {
 


### PR DESCRIPTION
Also, add additional test logging and a perl warning in tests.