### PR TITLE
curl-www: remove questionable text

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -323,8 +323,6 @@ of the letter's ASCII code.
 
 Example:
 
-(page located at `http://www.formpost.com/getthis/`)
-
 ```html
 <form action="post.cgi" method="post">
 <input name=user size=10>

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -323,21 +323,23 @@ of the letter's ASCII code.
 
 Example:
 
+(say a page has the following html)
+
 ```html
 <form action="post.cgi" method="post">
-<input name=user size=10>
-<input name=pass type=password size=10>
-<input name=id type=hidden value="blablabla">
-<input name=ding value="submit">
+  <input name=user size=10>
+  <input name=pass type=password size=10>
+  <input name=id type=hidden value="blablabla">
+  <input name=ding value="submit">
 </form>
 ```
 
 We want to enter user `foobar` with password `12345`.
 
-To post to this, you enter a curl command line like:
+To post to this, you would enter a curl command line like:
 
     curl -d "user=foobar&pass=12345&id=blablabla&ding=submit"
-      http://www.formpost.com/getthis/post.cgi
+      http://www.example.com/getthis/post.cgi
 
 While `-d` uses the application/x-www-form-urlencoded mime-type, generally
 understood by CGI's and similar, curl also supports the more capable

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -323,7 +323,7 @@ of the letter's ASCII code.
 
 Example:
 
-(say a page has the following html)
+(say if `http://example.com` had the following html)
 
 ```html
 <form action="post.cgi" method="post">
@@ -338,8 +338,7 @@ We want to enter user `foobar` with password `12345`.
 
 To post to this, you would enter a curl command line like:
 
-    curl -d "user=foobar&pass=12345&id=blablabla&ding=submit"
-      http://www.example.com/getthis/post.cgi
+    curl -d "user=foobar&pass=12345&id=blablabla&ding=submit" http://example.com/post.cgi
 
 While `-d` uses the application/x-www-form-urlencoded mime-type, generally
 understood by CGI's and similar, curl also supports the more capable


### PR DESCRIPTION
Removed (page located at `http://www.formpost.com/getthis/`). Was tinkering and got weird popups after copying and pasting into browser. Anyway the site isn't active anymore. It's listed for sale.