### PR TITLE
http_aws_sigv4: fix sorting with empty parts

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -409,6 +409,11 @@ static int compare_func(const void *a, const void *b)
 {
   const struct pair *aa = a;
   const struct pair *bb = b;
+  /* If one element is empty, the other is always sorted higher */
+  if(aa->len == 0)
+    return -1;
+  if(bb->len == 0)
+    return 1;
   return strncmp(aa->p, bb->p, aa->len < bb->len ? aa->len : bb->len);
 }
 


### PR DESCRIPTION
When comparing with an empty part, the non-empty one is always
considered greater-than. Previously, the two would be considered equal
which would randomly place empty parts amongst non-empty ones.

Fixes #11855
Closes #11868