### PR TITLE
rand: fix 'alnum': array is too small to include a terminating null c…

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -275,14 +275,14 @@ CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd,
  * alphanumerical chars PLUS a null-terminating byte.
  */
 
-static const char alnum[26 + 26 + 10] =
+static const char alnum[] =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 CURLcode Curl_rand_alnum(struct Curl_easy *data, unsigned char *rnd,
                          size_t num)
 {
   CURLcode result = CURLE_OK;
-  const int alnumspace = sizeof(alnum);
+  const int alnumspace = sizeof(alnum) - 1;
   unsigned int r;
   DEBUGASSERT(num > 1);
 


### PR DESCRIPTION
…haracter

It was that small on purpose, but this change now adds the null byte to avoid the error.

Follow-up to 3aa3cc9b052353b1

Reported-by: Dan Fandrich
Ref: #11838