### PR TITLE
http: use the per-request header counter to check for too large headers

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -640,7 +640,9 @@ struct SingleRequest {
   curl_off_t pendingheader;      /* this many bytes left to send is actually
                                     header and not body */
   struct curltime start;         /* transfer started at this time */
-  unsigned int headerbytecount;  /* only count received headers */
+  unsigned int headerbytecount;  /* received server headers (not CONNECT
+                                    headers) */
+  unsigned int allheadercount;   /* all received headers (server + CONNECT) */
   unsigned int deductheadercount; /* this amount of bytes doesn't count when
                                      we check if anything has been transferred
                                      at the end of a connection. We use this

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -75,7 +75,7 @@ test435 test436 test437 test438 test439 \
 test440 test441 test442 test443 test444 test445 test446 test447 test448 \
 test449 test450 test451 test452 test453 test454 test455 test456 \
 \
-test490 test491 test492 test493 test494 test495 test496 test497 \
+test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 \
 test500 test501 test502 test503 test504 test505 test506 test507 test508 \
 test509 test510 test511 test512 test513 test514 test515 test516 test517 \

--- a/tests/data/test498
+++ b/tests/data/test498
@@ -1,0 +1,56 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 301 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Location: /
+Connection: close
+Content-Type: text/html
+%repeat[1700 x Repeat-this-Header-a-large-number-of-times: Dorothy lived in the midst of the great Kansas prairies, with Uncle Henry, who was a farmer, and Aunt Em, who was the farmer’s wife.%0a]%
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Reject too large HTTP response headers on endless redirects
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --max-redir 400 --location
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# curl: (56) Too large response headers: 6144086 > 6144000
+# hyper returns a generic error that libcurl converts to an even more
+# generic error
+<errorcode>
+%if hyper
+1
+%else
+56
+%endif
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Not the counter that accumulates all headers over all redirects.
    
Do a second check for 20 times the limit for the accumulated size for all headers.

Fixes #11871
Reported-by: Joshix-1 on github