### PR TITLE
Fix build warning

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -646,7 +646,7 @@ evaluate:
   /* Nothing connected, check the time before we might
    * start new ballers or return ok. */
   if((ongoing || not_started) && Curl_timeleft(data, &now, TRUE) < 0) {
-    failf(data, "Connection timeout after %ld ms",
+    failf(data, "Connection timeout after %" CURL_FORMAT_CURL_OFF_T " ms",
           Curl_timediff(now, data->progress.t_startsingle));
     return CURLE_OPERATION_TIMEDOUT;
   }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2313,7 +2313,7 @@ out:
                 "h2 windows %d-%d (stream-conn), "
                 "buffers %zu-%zu (stream-conn)",
                 stream->id, len, nwritten, *err,
-                (ssize_t)stream->upload_left,
+                stream->upload_left,
                 nghttp2_session_get_stream_remote_window_size(
                   ctx->h2, stream->id),
                 nghttp2_session_get_remote_window_size(ctx->h2),

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -300,7 +300,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   /* add client id */
   rc = add_client_id(client_id, strlen(client_id), packet, pos + 1);
   if(rc) {
-    failf(data, "Client ID length mismatched: [%lu]", strlen(client_id));
+    failf(data, "Client ID length mismatched: [%zu]", strlen(client_id));
     result = CURLE_WEIRD_SERVER_REPLY;
     goto end;
   }
@@ -317,7 +317,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
     rc = add_user(username, ulen,
                   (unsigned char *)packet, start_user, remain_pos);
     if(rc) {
-      failf(data, "Username is too large: [%lu]", ulen);
+      failf(data, "Username is too large: [%zu]", ulen);
       result = CURLE_WEIRD_SERVER_REPLY;
       goto end;
     }
@@ -327,7 +327,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   if(plen) {
     rc = add_passwd(passwd, plen, packet, start_pwd, remain_pos);
     if(rc) {
-      failf(data, "Password is too large: [%lu]", plen);
+      failf(data, "Password is too large: [%zu]", plen);
       result = CURLE_WEIRD_SERVER_REPLY;
       goto end;
     }

--- a/lib/url.c
+++ b/lib/url.c
@@ -888,8 +888,8 @@ static bool conn_maxage(struct Curl_easy *data,
   idletime /= 1000; /* integer seconds is fine */
 
   if(idletime > data->set.maxage_conn) {
-    infof(data, "Too old connection (%ld seconds idle), disconnect it",
-          idletime);
+    infof(data, "Too old connection (%" CURL_FORMAT_TIMEDIFF_T
+          " seconds idle), disconnect it", idletime);
     return TRUE;
   }
 
@@ -898,8 +898,8 @@ static bool conn_maxage(struct Curl_easy *data,
 
   if(data->set.maxlifetime_conn && lifetime > data->set.maxlifetime_conn) {
     infof(data,
-          "Too old connection (%ld seconds since creation), disconnect it",
-          lifetime);
+          "Too old connection (%" CURL_FORMAT_TIMEDIFF_T
+          " seconds since creation), disconnect it", lifetime);
     return TRUE;
   }
 
@@ -3214,8 +3214,8 @@ static CURLcode resolve_host(struct Curl_easy *data,
   if(rc == CURLRESOLV_PENDING)
     *async = TRUE;
   else if(rc == CURLRESOLV_TIMEDOUT) {
-    failf(data, "Failed to resolve host '%s' with timeout after %ld ms",
-          connhost->dispname,
+    failf(data, "Failed to resolve host '%s' with timeout after %"
+          CURL_FORMAT_TIMEDIFF_T " ms", connhost->dispname,
           Curl_timediff(Curl_now(), data->progress.t_startsingle));
     return CURLE_OPERATION_TIMEDOUT;
   }


### PR DESCRIPTION
```
C/C++: [armeabi-v7a] Compile thumb  : curl_static <= connect.c
C/C++: curl-android/curl/src/main/native/curl/lib/connect.c:650:11: error: format specifies type 'long' but the argument has type 'timediff_t' (aka 'long long') [-Werror,-Wformat]
C/C++:           Curl_timediff(now, data->progress.t_startsingle));
C/C++:           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: 1 error generated.
```
```
C/C++: [armeabi-v7a] Compile thumb  : curl_static <= http2.c
C/C++: curl-android/curl/src/main/native/curl/lib/http2.c:2316:17: error: format specifies type 'long long' but the argument has type 'ssize_t' (aka 'int') [-Werror,-Wformat]
C/C++:                 (ssize_t)stream->upload_left,
C/C++:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: curl-android/curl/src/main/native/curl/lib/curl_trc.h:123:38: note: expanded from macro 'CURL_TRC_CF'
C/C++:          Curl_trc_cf_infof(data, cf, __VA_ARGS__); } while(0)
C/C++:                                      ^~~~~~~~~~~
C/C++: 1 error generated.
```
```
C/C++: [armeabi-v7a] Compile thumb  : curl_static <= mqtt.c
C/C++: curl-android/curl/src/main/native/curl/lib/mqtt.c:303:55: error: format specifies type 'unsigned long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
C/C++:     failf(data, "Client ID length mismatched: [%lu]", strlen(client_id));
C/C++:                                                ~~~    ^~~~~~~~~~~~~~~~~
C/C++:                                                %zu
C/C++: curl-android/curl/src/main/native/curl/lib/mqtt.c:320:51: error: format specifies type 'unsigned long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
C/C++:       failf(data, "Username is too large: [%lu]", ulen);
C/C++:                                            ~~~    ^~~~
C/C++:                                            %zu
C/C++: curl-android/curl/src/main/native/curl/lib/mqtt.c:330:51: error: format specifies type 'unsigned long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
C/C++:       failf(data, "Password is too large: [%lu]", plen);
C/C++:                                            ~~~    ^~~~
C/C++:                                            %zu
C/C++: 3 errors generated.
```
```
C/C++: [armeabi-v7a] Compile thumb  : curl_static <= url.c
C/C++: curl-android/curl/src/main/native/curl/lib/url.c:892:11: error: format specifies type 'long' but the argument has type 'timediff_t' (aka 'long long') [-Werror,-Wformat]
C/C++:           idletime);
C/C++:           ^~~~~~~~
C/C++: curl-android/curl/src/main/native/curl/lib/curl_trc.h:120:27: note: expanded from macro 'infof'
C/C++:          Curl_infof(data, __VA_ARGS__); } while(0)
C/C++:                           ^~~~~~~~~~~
C/C++: curl-android/curl/src/main/native/curl/lib/url.c:902:11: error: format specifies type 'long' but the argument has type 'timediff_t' (aka 'long long') [-Werror,-Wformat]
C/C++:           lifetime);
C/C++:           ^~~~~~~~
C/C++: curl-android/curl/src/main/native/curl/lib/curl_trc.h:120:27: note: expanded from macro 'infof'
C/C++:          Curl_infof(data, __VA_ARGS__); } while(0)
C/C++:                           ^~~~~~~~~~~
C/C++: curl-android/curl/src/main/native/curl/lib/url.c:3044:52: warning: use of logical '||' with constant operand [-Wconstant-logical-operand]
C/C++:      ((conn->handler->protocol == CURLPROTO_HTTPS) ||
C/C++:                                                    ^
C/C++: curl-android/curl/src/main/native/curl/lib/url.c:3044:52: note: use '|' for a bitwise operation
C/C++:      ((conn->handler->protocol == CURLPROTO_HTTPS) ||
C/C++:                                                    ^~
C/C++:                                                    |
C/C++: curl-android/curl/src/main/native/curl/lib/url.c:3219:11: error: format specifies type 'long' but the argument has type 'timediff_t' (aka 'long long') [-Werror,-Wformat]
C/C++:           Curl_timediff(Curl_now(), data->progress.t_startsingle));
C/C++:           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: 1 warning and 3 errors generated.
```