### PR TITLE
h2-proxy: remove left-over mistake in drain_tunnel()

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -233,7 +233,7 @@ static void drain_tunnel(struct Curl_cfilter *cf,
   bits = CURL_CSELECT_IN;
   if(!tunnel->closed && !tunnel->reset && tunnel->upload_blocked_len)
     bits |= CURL_CSELECT_OUT;
-  if(data->state.dselect_bits != bits || 1) {
+  if(data->state.dselect_bits != bits) {
     CURL_TRC_CF(data, cf, "[%d] DRAIN dselect_bits=%x",
                 tunnel->stream_id, bits);
     data->state.dselect_bits = bits;


### PR DESCRIPTION
Left-over from 331b89a319

Reported-by: 南宫雪珊