### PR TITLE
websockets: Expose WebSocket FIN and RSV bits in public API

### DIFF
--- a/include/curl/websockets.h
+++ b/include/curl/websockets.h
@@ -30,6 +30,7 @@ extern "C" {
 
 struct curl_ws_frame {
   int age;              /* zero */
+  int actual_flags;      /* See the CURLWS_FLAGS_* defines */
   int flags;            /* See the CURLWS_* defines */
   curl_off_t offset;    /* the offset of this data into the frame */
   curl_off_t bytesleft; /* number of pending bytes left of the payload */
@@ -37,6 +38,12 @@ struct curl_ws_frame {
 };
 
 /* flag bits */
+#define CURLWS_FLAGS_FIN   (1<<7)
+#define CURLWS_FLAGS_RSV1  (1<<6)
+#define CURLWS_FLAGS_RSV2  (1<<5)
+#define CURLWS_FLAGS_RSV3  (1<<4)
+
+/* flag bits - not actually flags, opcodes + CURLWS_OFFSET - TODO */
 #define CURLWS_TEXT       (1<<0)
 #define CURLWS_BINARY     (1<<1)
 #define CURLWS_CONT       (1<<2)

--- a/lib/ws.h
+++ b/lib/ws.h
@@ -43,6 +43,7 @@ enum ws_dec_state {
 
 struct ws_decoder {
   int frame_age;        /* zero */
+  int frame_actual_flags; /* See the CURLWS_FLAGS_* defines */
   int frame_flags;      /* See the CURLWS_* defines */
   curl_off_t payload_offset;   /* the offset parsing is at */
   curl_off_t payload_len;

--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -70,6 +70,10 @@ static int websocket(CURL *curl)
              && (meta->bytesleft == 0);
     fwrite(buffer, 1, nread, save);
   }
+  if(i != 12291) {
+    return 1;
+  }
+
   fclose(save);
 
   websocket_close(curl);


### PR DESCRIPTION
This commit is not intended to be merged yet as further work is required. I will add comments in the PR to some of the changes to explain what still needs to be done.

When receiving WebSocket data with curl_ws_recv there was no way to know when a fragmented message had been fully received. A fragmented message is one which is sent over multiple frames. The total size of such a message is not necessarily known a priori so the protocol provides a "FIN" header bit to mark the final frame of the message.

The existing libtest 2305 involved the test server sending a fragmented message over three frames but used the known message size to test for message completion. The test has been updated to test for the FIN bit. The test also did not fail if insufficient bytes were received so that has been fixed too.