### PR TITLE
trace: fix C89 build with CURL_DISABLE_VERBOSE_STRINGS

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -238,14 +238,4 @@ CURLcode Curl_trc_init(void)
   return CURLE_OK;
 }
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
-void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
-                       const char *fmt, ...)
-{
-  (void)data;
-  (void)cf;
-  (void)fmt;
-}
-#endif
-
 #endif /* !DEBUGBUILD */


### PR DESCRIPTION
gcc supports variadic macros even in C89 mode, so Curl_trc_cf_infof is both defined as Curl_nop_stmt and as a stub function.
Moreover, curl_trc.h errors without variadic macro support, so the stub is unnecessary.