### PR TITLE
libssh2: fix error message on failed pubkey-from-file

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1178,8 +1178,16 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       }
       else {
         char *err_msg = NULL;
-        (void)libssh2_session_last_error(sshc->ssh_session,
-                                         &err_msg, NULL, 0);
+        char unknown[] = "Reason unknown (-1)";
+        if(rc == -1) {
+          /* No error message has been set and the last set error message, if
+             any, is from a previous error so ignore it. #11837 */
+          err_msg = unknown;
+        }
+        else {
+          (void)libssh2_session_last_error(sshc->ssh_session,
+                                           &err_msg, NULL, 0);
+        }
         infof(data, "SSH public key authentication failed: %s", err_msg);
         state(data, SSH_AUTH_PASS_INIT);
         rc = 0; /* clear rc and continue */


### PR DESCRIPTION
- If libssh2_userauth_publickey_fromfile_ex returns -1 then show error message "SSH public key authentication failed: Reason unknown (-1)".

When libssh2_userauth_publickey_fromfile_ex returns -1 it does so as a generic error and therefore doesn't set an error message. AFAICT that is not documented behavior.

Prior to this change libcurl retrieved the last set error message which would be from a previous function failing. That resulted in misleading auth failed error messages in verbose mode.

Bug: https://github.com/curl/curl/issues/11837#issue-1891827355
Reported-by: consulion@users.noreply.github.com

Closes #xxxx