### PR TITLE
cmake, configure: Also link with CoreServices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ if(ENABLE_IPV6 AND NOT WIN32)
   endif()
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT ENABLE_ARES)
-    set(use_core_foundation ON)
+    set(use_core_foundation_and_core_services ON)
 
     find_library(SYSTEMCONFIGURATION_FRAMEWORK "SystemConfiguration")
     if(NOT SYSTEMCONFIGURATION_FRAMEWORK)
@@ -445,7 +445,7 @@ if(CURL_WINDOWS_SSPI)
 endif()
 
 if(CURL_USE_SECTRANSP)
-  set(use_core_foundation ON)
+  set(use_core_foundation_and_core_services ON)
 
   find_library(SECURITY_FRAMEWORK "Security")
   if(NOT SECURITY_FRAMEWORK)
@@ -457,13 +457,18 @@ if(CURL_USE_SECTRANSP)
   list(APPEND CURL_LIBS "-framework Security")
 endif()
 
-if(use_core_foundation)
+if(use_core_foundation_and_core_services)
   find_library(COREFOUNDATION_FRAMEWORK "CoreFoundation")
+  find_library(CORESERVICES_FRAMEWORK "CoreServices")
+
   if(NOT COREFOUNDATION_FRAMEWORK)
       message(FATAL_ERROR "CoreFoundation framework not found")
   endif()
+  if(NOT CORESERVICES_FRAMEWORK)
+      message(FATAL_ERROR "CoreServices framework not found")
+  endif()
 
-  list(APPEND CURL_LIBS "-framework CoreFoundation")
+  list(APPEND CURL_LIBS "-framework CoreFoundation -framework CoreServices")
 endif()
 
 if(CURL_USE_OPENSSL)

--- a/m4/curl-sectransp.m4
+++ b/m4/curl-sectransp.m4
@@ -33,7 +33,7 @@ if test "x$OPT_SECURETRANSPORT" != xno; then
     ssl_msg="Secure Transport"
     test secure-transport != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
     SECURETRANSPORT_ENABLED=1
-    LDFLAGS="$LDFLAGS -framework CoreFoundation -framework Security"
+    LDFLAGS="$LDFLAGS -framework CoreFoundation -framework CoreServices -framework Security"
   else
     AC_MSG_RESULT(no)
   fi

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -23,7 +23,7 @@
 #***************************************************************************
 
 AC_DEFUN([CURL_DARWIN_SYSTEMCONFIGURATION], [
-AC_MSG_CHECKING([whether to link macOS CoreFoundation and SystemConfiguration framework])
+AC_MSG_CHECKING([whether to link macOS CoreFoundation, CoreServices, and SystemConfiguration frameworks])
 case $host_os in
   darwin*)
     AC_COMPILE_IFELSE([
@@ -43,7 +43,7 @@ case $host_os in
     ])
     if test "x$build_for_macos" != xno; then
       AC_MSG_RESULT(yes)
-      LDFLAGS="$LDFLAGS -framework CoreFoundation -framework SystemConfiguration"
+      LDFLAGS="$LDFLAGS -framework CoreFoundation -framework CoreServices -framework SystemConfiguration"
     else
       AC_MSG_RESULT(no)
     fi


### PR DESCRIPTION
When linking with CoreFoundation, also link with CoreServices which is apparently required to avoid an NSInvalidArgumentException in software linking with libcurl on macOS Sonoma 14 and later.

Fixes #11893

I am running macOS Monterey 12 so I have not verified that this fixes the crash, though others claim that it does, and I have verified that this does cause libcurl.dylib to link with CoreServices using either the autotools or cmake build systems.

CoreServices is available on every version of macOS and dynamically linked libraries aren't loaded in unless their functions are actually used at runtime, so linking with this framework even on earlier macOS versions where it wasn't needed shouldn't cause any problems.