### PR TITLE
http: fix CURL_DISABLE_BEARER_AUTH breakage

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1139,6 +1139,8 @@ CURLcode Curl_http_input_auth(struct Curl_easy *data, bool proxy,
                 data->state.authproblem = TRUE;
               }
             }
+#else
+           ;
 #endif
 
     /* there may be multiple methods on one line, so keep reading */


### PR DESCRIPTION
When bearer auth was disabled, the if/else logic got wrong and caused problems.

Follow-up to e92edfbef64448ef461
Fixes #11892
Reported-by: Aleksander Mazur