### PR TITLE
lib: enable hmac for digest as well

### DIFF
--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -24,8 +24,8 @@
  *
  ***************************************************************************/
 
-#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) \
-    || !defined(CURL_DISABLE_AWS)
+#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI))         \
+  || !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH)
 
 #include <curl/curl.h>
 

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -26,8 +26,8 @@
 
 #include "curl_setup.h"
 
-#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) \
-    || !defined(CURL_DISABLE_AWS)
+#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI))         \
+  || !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH)
 
 #include <curl/curl.h>
 

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -35,7 +35,6 @@
 #include "urldata.h"
 
 #include "vauth/vauth.h"
-#include "curl_md5.h"
 #include "warnless.h"
 #include "strtok.h"
 #include "sendf.h"


### PR DESCRIPTION
Previously a build that disbled NTLM and aws-sigv4 would fail to build since the hmac was disabled, but it is also needed for digest auth.

Follow-up to e92edfbef64448ef

Fixes #11890
Reported-by: Aleksander Mazur