### PR TITLE
idn: if idn2_check_version returns NULL, return error

### DIFF
--- a/lib/idn.c
+++ b/lib/idn.c
@@ -174,6 +174,9 @@ static CURLcode idn_decode(const char *input, char **output)
     if(rc != IDN2_OK)
       result = CURLE_URL_MALFORMAT;
   }
+  else
+    /* a too old libidn2 version */
+    result = CURLE_NOT_BUILT_IN;
 #elif defined(USE_WIN32_IDN)
   result = win32_idn_to_ascii(input, &decoded);
 #endif


### PR DESCRIPTION
... this avoids a NULL dereference for this unusual case.

Reported-by: s0urc3_ on hackerone