### PR TITLE
url: fix netrc info message

### DIFF
--- a/docs/cmdline-opts/netrc.d
+++ b/docs/cmdline-opts/netrc.d
@@ -10,13 +10,16 @@ See-also: netrc-file config user
 Mutexed: netrc-file netrc-optional
 Multi: boolean
 ---
-Makes curl scan the *.netrc* (*_netrc* on Windows) file in the user's home
-directory for login name and password. This is typically used for FTP on
-Unix. If used with HTTP, curl enables user authentication. See *netrc(5)* and
-*ftp(1)* for details on the file format. Curl does not complain if that file
-does not have the right permissions (it should be neither world- nor
-group-readable). The environment variable "HOME" is used to find the home
-directory.
+Makes curl scan the *.netrc* file in the user's home directory for login name
+and password. This is typically used for FTP on Unix. If used with HTTP, curl
+enables user authentication. See *netrc(5)* and *ftp(1)* for details on the
+file format. Curl does not complain if that file does not have the right
+permissions (it should be neither world- nor group-readable). The environment
+variable "HOME" is used to find the home directory.
+
+On Windows two filenames in the home directory are checked: *.netrc* and
+*_netrc*, preferring the former. Older versions on Windows checked for *_netrc*
+only.
 
 A quick and simple example of how to setup a *.netrc* to allow curl to FTP to
 the machine host.domain.com with user name 'myself' and password 'secret'

--- a/lib/url.c
+++ b/lib/url.c
@@ -2719,7 +2719,9 @@ static CURLcode override_login(struct Curl_easy *data,
                           data->set.str[STRING_NETRC_FILE]);
     if(ret > 0) {
       infof(data, "Couldn't find host %s in the %s file; using defaults",
-            conn->host.name, data->set.str[STRING_NETRC_FILE]);
+            conn->host.name,
+            (data->set.str[STRING_NETRC_FILE] ?
+             data->set.str[STRING_NETRC_FILE] : ".netrc"));
     }
     else if(ret < 0) {
       failf(data, ".netrc parser error");


### PR DESCRIPTION
- Fix netrc info message to use the generic ".netrc" filename if the user did not specify a netrc location.

- Update --netrc doc to add that recent versions of curl on Windows prefer .netrc over _netrc.

Before:
`* Couldn't find host google.com in the (nil) file; using defaults`

After:
`* Couldn't find host google.com in the .netrc file; using defaults`

Closes #xxxx