### PR TITLE
github/labeler: give the sync-labels config item a default value

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -24,3 +24,4 @@ jobs:
     - uses: actions/labeler@v5.0.0-beta.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: false


### PR DESCRIPTION
This shouldn't be necessary and is likely a bug with this beta version
of the labeller.

Follow-up to dd12b452a