### PR TITLE
use CURLSSLBACKEND_NONE

### DIFF
--- a/docs/examples/sslbackend.c
+++ b/docs/examples/sslbackend.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
     const curl_ssl_backend **list;
     int i;
 
-    result = curl_global_sslset((curl_sslbackend)-1, NULL, &list);
+    result = curl_global_sslset(CURLSSLBACKEND_NONE, NULL, &list);
     assert(result == CURLSSLSET_UNKNOWN_BACKEND);
 
     for(i = 0; list[i]; i++)
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     result = curl_global_sslset((curl_sslbackend)id, NULL, NULL);
   }
   else
-    result = curl_global_sslset((curl_sslbackend)-1, name, NULL);
+    result = curl_global_sslset(CURLSSLBACKEND_NONE, name, NULL);
 
   if(result == CURLSSLSET_UNKNOWN_BACKEND) {
     fprintf(stderr, "Unknown SSL backend id: %s\n", name);

--- a/docs/libcurl/curl_global_sslset.3
+++ b/docs/libcurl/curl_global_sslset.3
@@ -61,8 +61,9 @@ must be called \fBbefore\fP \fIcurl_global_init(3)\fP.
 
 The backend can be identified by the \fIid\fP
 (e.g. \fBCURLSSLBACKEND_OPENSSL\fP). The backend can also be specified via the
-\fIname\fP parameter for a case insensitive match (passing -1 as \fIid\fP). If
-both \fIid\fP and \fIname\fP are specified, the \fIname\fP is ignored.
+\fIname\fP parameter for a case insensitive match (passing
+\fBCURLSSLBACKEND_NONE\fP as \fIid\fP). If both \fIid\fP and \fIname\fP are
+specified, the \fIname\fP is ignored.
 
 If neither \fIid\fP nor \fPname\fP are specified, the function fails with
 \fBCURLSSLSET_UNKNOWN_BACKEND\fP and set the \fIavail\fP pointer to the
@@ -105,7 +106,7 @@ OpenSSL flavor and version number is use.
 
   /* list the available ones */
   const curl_ssl_backend **list;
-  curl_global_sslset((curl_sslbackend)-1, NULL, &list);
+  curl_global_sslset(CURLSSLBACKEND_NONE, NULL, &list);
 
   for(i = 0; list[i]; i++)
     printf("SSL backend #%d: '%s' (ID: %d)\\n",


### PR DESCRIPTION
[ssl] use CURLSSLBACKEND_NONE instead of (curl_sslbackend)-1 in documentation and examples.