### PR TITLE
cmake: fix multiple include of CURL package

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -36,5 +36,5 @@ check_required_components("@PROJECT_NAME@")
 
 # Alias for either shared or static library
 if(NOT TARGET @PROJECT_NAME@::libcurl)
-    add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+  add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
 endif()

--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -35,4 +35,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
 
 # Alias for either shared or static library
-add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+if(NOT TARGET @PROJECT_NAME@::libcurl)
+    add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+endif()


### PR DESCRIPTION
Fixes errors on second `find_package(CURL)`. This is a frequent case with transitive dependencies.

```
CMake Error at ...:
  add_library cannot create ALIAS target "CURL::libcurl" because another
  target with the same name already exists.
```

Test to reproduce:
```cmake
cmake_minimum_required(VERSION 3.27)  # must be 3.18 or higher

project(curl)

set(CURL_DIR "example/lib/cmake/CURL/")
find_package(CURL CONFIG REQUIRED)
find_package(CURL CONFIG REQUIRED)  # fails

add_executable(main main.c)
target_link_libraries(main CURL::libcurl)
```

Ref: https://cmake.org/cmake/help/latest/release/3.18.html#other-changes
Ref: https://cmake.org/cmake/help/v3.18/policy/CMP0107.html
Ref: #12300
Assisted-by: Harry Mallon
Closes #11913
