### PR TITLE
tests: fix compiler warnings

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -347,7 +347,7 @@ SANITIZEcode msdosify(char **const sanitized, const char *file_name,
   if(s[0] >= 'A' && s[0] <= 'z' && s[1] == ':') {
     *d++ = *s++;
     *d = ((flags & (SANITIZE_ALLOW_COLONS|SANITIZE_ALLOW_PATH))) ? ':' : '_';
-    ++d, ++s;
+    ++d; ++s;
   }
 
   for(idx = 0, dot_idx = -1; *s && d < dlimit; s++, d++) {

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -143,7 +143,13 @@ static int loop(int num, CURLM *cm, const char *url, const char *userpwd,
       /* At this point, L is guaranteed to be greater or equal than -1. */
 
       if(L != -1) {
-        int itimeout = (L > (long)INT_MAX) ? INT_MAX : (int)L;
+        int itimeout;
+#if LONG_MAX > INT_MAX
+        itimeout = (L > INT_MAX) ? INT_MAX : (int)L;
+#else
+        itimeout = (int)L;
+#endif
+
         T.tv_sec = itimeout/1000;
         T.tv_usec = (itimeout%1000)*1000;
       }

--- a/tests/libtest/lib591.c
+++ b/tests/libtest/lib591.c
@@ -114,7 +114,13 @@ int test(char *URL)
     /* At this point, timeout is guaranteed to be greater or equal than -1. */
 
     if(timeout != -1L) {
-      int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+      int itimeout;
+#if LONG_MAX > INT_MAX
+      itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+#else
+      itimeout = (int)timeout;
+#endif
+
       interval.tv_sec = itimeout/1000;
       interval.tv_usec = (itimeout%1000)*1000;
     }

--- a/tests/libtest/lib597.c
+++ b/tests/libtest/lib597.c
@@ -96,7 +96,12 @@ int test(char *URL)
        -1. */
 
     if(timeout != -1L) {
-      int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+      int itimeout;
+#if LONG_MAX > INT_MAX
+      itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+#else
+      itimeout = (int)timeout;
+#endif
       interval.tv_sec = itimeout/1000;
       interval.tv_usec = (itimeout%1000)*1000;
     }

--- a/tests/libtest/libntlmconnect.c
+++ b/tests/libtest/libntlmconnect.c
@@ -192,7 +192,12 @@ int test(char *url)
             __FILE__, __LINE__, num_handles, timeout, running);
 
     if(timeout != -1L) {
-      int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+      int itimeout;
+#if LONG_MAX > INT_MAX
+      itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+#else
+      itimeout = (int)timeout;
+#endif
       interval.tv_sec = itimeout/1000;
       interval.tv_usec = (itimeout%1000)*1000;
     }

--- a/tests/server/fake_ntlm.c
+++ b/tests/server/fake_ntlm.c
@@ -40,7 +40,7 @@
 #include "memdebug.h"
 
 #define LOGFILE "%s/fake_ntlm%ld.log"
-const char *logdir = "log";
+static const char *logdir = "log";
 
 const char *serverlogfile;
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -133,8 +133,8 @@ static void storerequest(char *reqbuf, size_t totalsize);
 #endif
 
 const char *serverlogfile = DEFAULT_LOGFILE;
-const char *logdir = "log";
-char loglockfile[256];
+static const char *logdir = "log";
+static char loglockfile[256];
 
 #define RTSPDVERSION "curl test suite RTSP server/0.1"
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -438,7 +438,7 @@ static int ProcessRequest(struct httprequest *req)
       if(*ptr == '/') {
         if((npath + strlen(request)) < 400)
           msnprintf(logbuf, sizeof(logbuf), "Got request: %s %.*s HTTP/%d.%d",
-                    request, npath, httppath, prot_major, prot_minor);
+                    request, (int)npath, httppath, prot_major, prot_minor);
         else
           msnprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request HTTP/%d.%d",
                     prot_major, prot_minor);


### PR DESCRIPTION
Seen with llvm 17 on Windows x64.

```
.../curl/tests/server/rtspd.c:136:13: warning: no previous extern declaration for non-static variable 'logdir' [-Wmissing-variable-declarations]
  136 | const char *logdir = "log";
      |             ^
.../curl/tests/server/rtspd.c:136:7: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  136 | const char *logdir = "log";
      |       ^
.../curl/tests/server/rtspd.c:137:6: warning: no previous extern declaration for non-static variable 'loglockfile' [-Wmissing-variable-declarations]
  137 | char loglockfile[256];
      |      ^
.../curl/tests/server/rtspd.c:137:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
  137 | char loglockfile[256];
      | ^
.../curl/tests/server/fake_ntlm.c:43:13: warning: no previous extern declaration for non-static variable 'logdir' [-Wmissing-variable-declarations]
   43 | const char *logdir = "log";
      |             ^
.../curl/tests/server/fake_ntlm.c:43:7: note: declare 'static' if the variable is not intended to be used outside of this translation unit
   43 | const char *logdir = "log";
      |       ^
.../curl/src/tool_doswin.c:350:8: warning: possible misuse of comma operator here [-Wcomma]
  350 |     ++d, ++s;
      |        ^
.../curl/src/tool_doswin.c:350:5: note: cast expression to void to silence warning
  350 |     ++d, ++s;
      |     ^~~
      |     (void)( )
```

```
.../curl/tests/libtest/lib540.c:146:27: warning: result of comparison 'long' > 2147483647 is always false [-Wtautological-type-limit-compare]
  146 |         int itimeout = (L > (long)INT_MAX) ? INT_MAX : (int)L;
      |                         ~ ^ ~~~~~~~~~~~~~
1 warning generated.

.../curl/tests/libtest/libntlmconnect.c:195:31: warning: result of comparison 'long' > 2147483647 is always false [-Wtautological-type-limit-compare]
  195 |       int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
      |                       ~~~~~~~ ^ ~~~~~~~~~~~~~
1 warning generated.

.../curl/tests/libtest/lib591.c:117:31: warning: result of comparison 'long' > 2147483647 is always false [-Wtautological-type-limit-compare]
  117 |       int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
      |                       ~~~~~~~ ^ ~~~~~~~~~~~~~
1 warning generated.
.../curl/tests/libtest/lib597.c:99:31: warning: result of comparison 'long' > 2147483647 is always false [-Wtautological-type-limit-compare]
   99 |       int itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
      |                       ~~~~~~~ ^ ~~~~~~~~~~~~~
1 warning generated.
```

Seen on macOS Intel:
```
.../curl/tests/server/sws.c:440:64: warning: field precision should have type 'int', but argument has type 'size_t' (aka 'unsigned long') [-Wformat]
          msnprintf(logbuf, sizeof(logbuf), "Got request: %s %.*s HTTP/%d.%d",
                                                             ~~^~
1 warning generated.
```

Closes #11925
