### PR TITLE
cmake: fix duplicate symbols when linking tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,9 +61,10 @@ if(WIN32)
   list(APPEND CURL_CFILES curl.rc)
 endif()
 
-# CURL_CFILES, CURLX_CFILES, CURL_HFILES come from Makefile.inc
+# CURL_CFILES, CURLX_CFILES, CURL_HFILES, CURLTOOL_LIBCURL_CFILES
+# come from Makefile.inc
 if(BUILD_STATIC_CURL)
-  set(CURLX_CFILES ../lib/dynbuf.c ../lib/base64.c)
+  set(CURLX_CFILES ${CURLTOOL_LIBCURL_CFILES})
 endif()
 
 add_executable(
@@ -80,7 +81,7 @@ add_library(
   curltool # special libcurltool library just for unittests
   STATIC
   EXCLUDE_FROM_ALL
-  ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES}
+  ${CURL_CFILES} ${CURLTOOL_LIBCURL_CFILES} ${CURL_HFILES}
 )
 target_compile_definitions(curltool PUBLIC UNITTESTS CURL_STATICLIB)
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -29,6 +29,11 @@
 # CSRC2 = file4.c file5.c file6.c
 # CSOURCES = $(CSRC1) $(CSRC2)
 
+# libcurl sources to include in curltool lib we use for test binaries
+CURLTOOL_LIBCURL_CFILES = \
+  ../lib/base64.c \
+  ../lib/dynbuf.c
+
 # libcurl has sources that provide functions named curlx_* that aren't part of
 # the official API, but we reuse the code here to avoid duplication.
 CURLX_CFILES = \


### PR DESCRIPTION
The linker resolves this automatically in non-unity builds. In unity builds the linker cannot drop a single object with the duplicates, resulting in these errors. The root issue is that we started including certain objects both via both libcurlu and libcurltool libs.

Regression from 39e7c22bb459c2e818f079984989a26a09741860

Windows errors:
```
[  3%] Linking C executable unit1303.exe
[  3%] Building C object tests/server/CMakeFiles/rtspd.dir/__/__/lib/curl_multibyte.c.obj
../../lib/libcurlu-d.a(unity_0.c.obj): In function `curlx_convert_UTF8_to_wchar':
C:/projects/curl/lib/curl_multibyte.c:44: multiple definition of `curlx_convert_UTF8_to_wchar'
../../src/libcurltool-d.a(unity_0.c.obj):C:/projects/curl/lib/curl_multibyte.c:44: first defined here
../../lib/libcurlu-d.a(unity_0.c.obj): In function `curlx_convert_wchar_to_UTF8':
C:/projects/curl/lib/curl_multibyte.c:66: multiple definition of `curlx_convert_wchar_to_UTF8'
../../src/libcurltool-d.a(unity_0.c.obj):C:/projects/curl/lib/curl_multibyte.c:66: first defined here
../../lib/libcurlu-d.a(unity_0.c.obj): In function `curlx_win32_open':
C:/projects/curl/lib/curl_multibyte.c:92: multiple definition of `curlx_win32_open'
../../src/libcurltool-d.a(unity_0.c.obj):C:/projects/curl/lib/curl_multibyte.c:92: first defined here
../../lib/libcurlu-d.a(unity_0.c.obj): In function `curlx_win32_fopen':
C:/projects/curl/lib/curl_multibyte.c:120: multiple definition of `curlx_win32_fopen'
../../src/libcurltool-d.a(unity_0.c.obj):C:/projects/curl/lib/curl_multibyte.c:120: first defined here
../../lib/libcurlu-d.a(unity_0.c.obj): In function `curlx_win32_stat':
[...]
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/48110107/job/nvlhpt9aa4ehny5q#L247

macOS errors:
```
[ 56%] Linking C executable unit1302
duplicate symbol '_curlx_sotouz' in:
    ../../lib/libcurlu.a(unity_0_c.c.o)
    ../../src/libcurltool.a(unity_0_c.c.o)
duplicate symbol '_curlx_sitouz' in:
    ../../lib/libcurlu.a(unity_0_c.c.o)
    ../../src/libcurltool.a(unity_0_c.c.o)
duplicate symbol '_curlx_uztosz' in:
    ../../lib/libcurlu.a(unity_0_c.c.o)
    ../../src/libcurltool.a(unity_0_c.c.o)
[...]
```
with config:
```
  -DCMAKE_UNITY_BUILD=ON \
  -DENABLE_DEBUG=ON -DBUILD_TESTING=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
  -DBUILD_SHARED_LIBS=ON \
  -DBUILD_STATIC_LIBS=OFF
```

Closes #11926