### PR TITLE
cmake: fix missing `zlib.h` when compiling `libcurltool`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(
   ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES}
 )
 target_compile_definitions(curltool PUBLIC UNITTESTS CURL_STATICLIB)
+target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 
 if(CURL_HAS_LTO)
   set_target_properties(${EXE_NAME} PROPERTIES


### PR DESCRIPTION
Came up while testing debug/testing build for Windows. I'm not sure why it didn't come up in earlier tests with similar config. `tool_hugehelp.c` might indeed require `zlib.h` and without linking `CURL_LIBS` to the `curltool` target, CMake doesn't seem to add detected dependency headers to the compiler command.

```
[ 25%] Building C object src/CMakeFiles/curltool.dir/tool_hugehelp.c.obj
cd .../curl/bld-cmake-llvm-x64/src && /usr/local/opt/llvm/bin/clang
  --target=x86_64-w64-mingw32 --sysroot=/usr/local/opt/mingw-w64/toolchain-x86_64
  -DCURLDEBUG -DCURL_STATICLIB -DHAVE_CONFIG_H -DUNICODE -DUNITTESTS -D_UNICODE
  -I.../curl/include -I.../curl/lib -I.../curl/bld-cmake-llvm-x64/lib
  -I.../curl/bld-cmake-llvm-x64/include -I.../curl/src -Wno-unused-command-line-argument
  -D_UCRT -DDEBUGBUILD -DHAS_ALPN -DUSE_MANUAL=1  -fuse-ld=lld -Wl,-s -static-libgcc
  -lucrt [...] -O3 -DNDEBUG -municode -MD
  -MT src/CMakeFiles/curltool.dir/tool_hugehelp.c.obj
  -MF CMakeFiles/curltool.dir/tool_hugehelp.c.obj.d
  -o CMakeFiles/curltool.dir/tool_hugehelp.c.obj -c .../curl/bld-cmake-llvm-x64/src/tool_hugehelp.c
.../curl/bld-cmake-llvm-x64/src/tool_hugehelp.c:6:10: fatal error: 'zlib.h' file not found
    6 | #include <zlib.h>
      |          ^~~~~~~~
```

Follow-up to 39e7c22bb459c2e818f079984989a26a09741860

Closes #11927