### PR TITLE
cmake: fix unity with Windows Unicode + TrackMemory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,16 +144,6 @@ if(ENABLE_CURLDEBUG)
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS CURLDEBUG)
 endif()
 
-# This combination results in curl tool crashing on startup when run on native
-# Windows (it was seen to work when run under WINE though). We disable UNITY
-# mode as a workaround.
-if(ENABLE_UNICODE AND ENABLE_CURLDEBUG)
-  set(CMAKE_UNITY_BUILD OFF)
-  message(WARNING "Unity builds are not supported with Windows Unicode and "
-    "TrackMemory (-DCURLDEBUG) enabled at the same time. Unity mode has been "
-    "disabled.")
-endif()
-
 # For debug libs and exes, add "-d" postfix
 if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
   set(CMAKE_DEBUG_POSTFIX "-d")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,7 +121,7 @@ environment:
       DISABLED_TESTS: '!1139 !1501'
       ADD_PATH: 'C:\msys64\usr\bin'
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
-    - job_name: 'CMake, mingw-w64, gcc 8, Debug x64, Schannel, Static, Unicode'
+    - job_name: 'CMake, mingw-w64, gcc 8, Debug x64, Schannel, Static, Unicode, Unity'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
@@ -134,6 +134,7 @@ environment:
       ADD_PATH: 'C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
+      UNITY: 'ON'
     - job_name: 'CMake, mingw-w64, gcc 7, Debug x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -56,9 +56,9 @@ add_library(
 target_compile_definitions(curlu PUBLIC UNITTESTS CURL_STATICLIB)
 
 if(ENABLE_CURLDEBUG)
-  # We must compile memdebug.c separately to avoid memdebug.h redefinitions
-  # being applied to memdebug.c itself.
-  set_source_files_properties(memdebug.c PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+  # We must compile these sources separately to avoid memdebug.h redefinitions
+  # applying to them.
+  set_source_files_properties(memdebug.c curl_multibyte.c PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 endif()
 target_link_libraries(curlu PRIVATE ${CURL_LIBS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,12 @@ if(BUILD_STATIC_CURL)
   set(CURLX_CFILES ${CURLTOOL_LIBCURL_CFILES})
 endif()
 
+if(ENABLE_CURLDEBUG)
+  # We must compile this source separately to avoid memdebug.h redefinitions
+  # applying to them.
+  set_source_files_properties(../lib/curl_multibyte.c PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+endif()
+
 add_executable(
   ${EXE_NAME}
   ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES}


### PR DESCRIPTION
Found the root cause of the startup crash in unity builds with Unicode
and TrackMemory enabled at the same time.

We must make sure that the `memdebug.h` header doesn't apply to
`lib/curl_multibyte.c` (as even noted in a comment there.) In unity
builds all headers apply to all sources, including `curl_multibyte.c`.
This probably resulted in an infinite loop on startup.

Exclude this source from unity compilation with TrackMemory enabled,
in both libcurl and curl tool. Enable unity mode for a debug Unicode
CI job to keep it tested. Also delete the earlier workaround that
fully disabled unity for affected builds.

Follow-up to d82b080f6374433ce7c98241329189ad2d3976f8 #12005
Follow-up to 3f8fc25720900b14b7432f4bd93407ca15311719 #11095

Closes #11928

---

Crashing on startup example:
```
could not get curl version! at C:/projects/curl/tests/runtests.pl line 2439.
```
https://ci.appveyor.com/project/curlorg/curl/builds/48113110/job/3ou611asxeop6uvi#L2522
