### PR TITLE
cmake: fix stderr initialization in unity builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,11 @@ if(BUILD_STATIC_CURL)
   set(CURLX_CFILES ../lib/dynbuf.c ../lib/base64.c)
 endif()
 
+# Compile this source separately to avoid having `stderr` overridden in this
+# file. Necessary for successfully initializing stderr in unity builds.
+# (Not necessary for the libcurltool target.)
+set_source_files_properties(tool_stderr.c PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_executable(
   ${EXE_NAME}
   ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES}


### PR DESCRIPTION
Before this patch, in certain build configurations the curl tool may
not have displayed anything (debug, macOS), or crashed at startup
(debug, Windows).

Follow-up to 3f8fc25720900b14b7432f4bd93407ca15311719
Necessary after 2f17a9b654121dd1ecf4fc043c6d08a9da3522db

Closes #11929
