### PR TITLE
docs: explain how PINNEDPUBLICKEY is independent of VERIFYPEER

### DIFF
--- a/docs/cmdline-opts/pinnedpubkey.d
+++ b/docs/cmdline-opts/pinnedpubkey.d
@@ -21,12 +21,18 @@ indicating its identity. A public key is extracted from this certificate and
 if it does not exactly match the public key provided to this option, curl
 aborts the connection before sending or receiving any data.
 
+This option is independent of option --insecure. If you use both options
+together then the peer is still verified by public key.
+
 PEM/DER support:
 
-OpenSSL and GnuTLS (added in 7.39.0), wolfSSL (added in 7.43.0), mbedTLS (added in 7.47.0)
+OpenSSL and GnuTLS (added in 7.39.0), wolfSSL (added in 7.43.0), mbedTLS
+(added in 7.47.0), Secure Transport macOS 10.7+/iOS 10+ (7.54.1), Schannel
+(7.58.1)
 
 sha256 support:
 
-OpenSSL, GnuTLS and wolfSSL (added in 7.44.0), mbedTLS (added in 7.47.0)
+OpenSSL, GnuTLS and wolfSSL (added in 7.44.0), mbedTLS (added in 7.47.0),
+Secure Transport macOS 10.7+/iOS 10+ (7.54.1), Schannel (7.58.1)
 
 Other SSL backends not supported.

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.3
@@ -43,6 +43,9 @@ indicating its identity. A public key is extracted from this certificate and
 if it does not exactly match the public key provided to this option, curl
 aborts the connection before sending or receiving any data.
 
+This option is independent of option \fICURLOPT_SSL_VERIFYPEER(3)\fP. If you
+turn off that option then the peer is still verified by public key.
+
 On mismatch, \fICURLE_SSL_PINNEDPUBKEYNOTMATCH\fP is returned.
 
 The application does not have to keep the string around after setting this
@@ -118,7 +121,7 @@ sha256 support:
 
   7.54.1: Secure Transport on macOS 10.7+/iOS 10+
 
-  7.58.1: Schannel Windows XP SP3+
+  7.58.1: Schannel
 
 Other SSL backends not supported.
 .SH RETURN VALUE


### PR DESCRIPTION
- Explain that peer verification via CURLOPT_PINNEDPUBLICKEY takes place even if peer verification via CURLOPT_SSL_VERIFYPEER is turned off.

The behavior is verified by test2048.

Bug: https://github.com/curl/curl/issues/2935#issuecomment-418371872
Reported-by: claudiusaiz@users.noreply.github.com

Bug: https://github.com/curl/curl/discussions/11910
Reported-by: Hakan Sunay Halil

Closes #xxxx