### PR TITLE
connect: expire the timeout when trying next

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -634,6 +634,7 @@ evaluate:
         /* next attempt was started */
         CURL_TRC_CF(data, cf, "%s trying next", baller->name);
         ++ongoing;
+        Curl_expire(data, 0, EXPIRE_RUN_NOW);
       }
     }
   }


### PR DESCRIPTION
... so that it gets called again immediately and can continue trying addresses to connect to. Otherwise it might unnecessarily wait for a while there.

Fixes #11920
Reported-by: Loïc Yhuel