### PR TITLE
tool_setopt: remove unused function tool_setopt_flags

### DIFF
--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -300,49 +300,6 @@ nomem:
   return ret;
 }
 
-/* setopt wrapper for flags */
-CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
-                           const char *name, CURLoption tag,
-                           const struct NameValue *nvlist, long lval)
-{
-  CURLcode ret = CURLE_OK;
-  bool skip = FALSE;
-
-  ret = curl_easy_setopt(curl, tag, lval);
-  if(!lval)
-    skip = TRUE;
-
-  if(config->libcurl && !skip && !ret) {
-    /* we only use this for real if --libcurl was used */
-    char preamble[80];          /* should accommodate any symbol name */
-    long rest = lval;           /* bits not handled yet */
-    const struct NameValue *nv = NULL;
-    msnprintf(preamble, sizeof(preamble),
-              "curl_easy_setopt(hnd, %s, ", name);
-    for(nv = nvlist; nv->name; nv++) {
-      if((nv->value & ~ rest) == 0) {
-        /* all value flags contained in rest */
-        rest &= ~ nv->value;    /* remove bits handled here */
-        CODE3("%s(long)%s%s",
-              preamble, nv->name, rest ? " |" : ");");
-        if(!rest)
-          break;                /* handled them all */
-        /* replace with all spaces for continuation line */
-        msnprintf(preamble, sizeof(preamble), "%*s", (int)strlen(preamble),
-                  "");
-      }
-    }
-    /* If any bits have no definition, output an explicit value.
-     * This could happen if new bits are defined and used
-     * but the NameValue list is not updated. */
-    if(rest)
-      CODE2("%s%ldL);", preamble, rest);
-  }
-
-nomem:
-  return ret;
-}
-
 /* setopt wrapper for bitmasks */
 CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
                              const char *name, CURLoption tag,

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -106,9 +106,6 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
 #define my_setopt_enum(x,y,z) \
   SETOPT_CHECK(tool_setopt_enum(x, global, #y, y, setopt_nv_ ## y, z), y)
 
-#define my_setopt_flags(x,y,z) \
-  SETOPT_CHECK(tool_setopt_flags(x, global, #y, y, setopt_nv_ ## y, z), y)
-
 #define my_setopt_bitmask(x,y,z) \
   SETOPT_CHECK(tool_setopt_bitmask(x, global, #y, y, setopt_nv_ ## y, z), y)
 
@@ -133,9 +130,6 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
   SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_enum(x,y,z) \
-  SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
-
-#define my_setopt_flags(x,y,z) \
   SETOPT_CHECK(curl_easy_setopt(x, y, z), y)
 
 #define my_setopt_bitmask(x,y,z) \


### PR DESCRIPTION
This function is identical to tool_setopt_bitmask except that it treats
the argument as unsigned.

Closes #11943