### PR TITLE
config-win32: define HAVE__FSEEKI64

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -564,6 +564,10 @@ Vista
 #  endif
 #endif
 
+#ifdef USE_WIN32_LARGE_FILES
+#define HAVE__FSEEKI64
+#endif
+
 /* Define to the size of `off_t', as computed by sizeof. */
 #if defined(__MINGW32__) && \
   defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)


### PR DESCRIPTION
Follow-up to 9c7165e9 which added an fseeko wrapper to the lib that calls _fseeki64 if it is available.

Closes #xxxx

---

Follow up to #11918. I'm not entirely sure about the logic here but I think we need to do something for builds that use the pre-generated win32 configuration file config-win32.h.

/cc @ncopa
