### PR TITLE
Update version.c to remove unneeded easy_lock.h include

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -35,7 +35,6 @@
 #include "vssh/ssh.h"
 #include "vquic/vquic.h"
 #include "curl_printf.h"
-#include "easy_lock.h"
 
 #ifdef USE_ARES
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \


### PR DESCRIPTION
Removed unneeded easy_lock.h include.
As far as I see, it is not needed.