### PR TITLE
cmake: assume `_fseeki64` and no `fseeko` on Windows

### DIFF
--- a/CMake/Platforms/WindowsCache.cmake
+++ b/CMake/Platforms/WindowsCache.cmake
@@ -86,6 +86,8 @@ if(NOT UNIX)
     set(HAVE_TIME_H 1)
     set(HAVE_UTIME_H 0)
 
+    set(HAVE_FSEEKO 0)
+    set(HAVE__FSEEKI64 1)
     set(HAVE_SOCKET 1)
     set(HAVE_SELECT 1)
     set(HAVE_STRDUP 1)


### PR DESCRIPTION
`_fseeki64` is present in mingw-w64 1.0 (2011-09-26) headers, and
at least Watcom C 1.9 (2010) headers and MSVS 2008 [1].

`fseeko` is not present in any of these.

(mingw-w64 1.0 also offers `fseeko64`.)

[1] https://github.com/curl/curl/pull/11944#issuecomment-1734995004

Follow-up to 9c7165e96a3a9a2d0b7059c87c699b5ca8cdae93 #11918

Closes #11950