### PR TITLE
CI/azure: make `MAKEFLAGS` global to parallelize all jobs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -55,6 +55,9 @@ pr:
     - 'packages/*'
     - 'plan9/*'
 
+variables:
+  MAKEFLAGS: '-j 2'
+
 stages:
 
 ##########################################
@@ -106,8 +109,6 @@ stages:
 
     - script: make V=1 && make V=1 examples && cd tests && make V=1
       displayName: 'compile'
-      env:
-        MAKEFLAGS: "-j 2"
 
     - script: make V=1 test-ci
       displayName: 'test'
@@ -290,8 +291,6 @@ stages:
 
     - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 && make V=1 examples && cd tests && make V=1"
       displayName: 'compile'
-      env:
-        MAKEFLAGS: "-j 2"
 
     - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 install && PATH=/usr/bin:/bin find . -type f -path '*/.libs/*.exe' -print -execdir mv -t .. {} \;"
       displayName: 'install'


### PR DESCRIPTION
https://dev.azure.com/daniel0244/curl/_build/results?buildId=17528 (before) https://dev.azure.com/daniel0244/curl/_build/results?buildId=17545 (after, with -j3)

Closes #11952