### PR TITLE
docs: improve curl man page references

### DIFF
--- a/docs/libcurl/curl_easy_getinfo.3
+++ b/docs/libcurl/curl_easy_getinfo.3
@@ -254,8 +254,8 @@ See \fICURLINFO_CONN_ID(3)\fP
 The ID of the transfer. (Added in 8.2.0)
 See \fICURLINFO_XFER_ID(3)\fP
 .SH TIMES
+An overview of the six time values available from \fIcurl_easy_getinfo(3)\fP
 .nf
-An overview of the six time values available from curl_easy_getinfo()
 
 curl_easy_perform()
     |
@@ -268,34 +268,34 @@ curl_easy_perform()
     |--|--|--|--|--|--REDIRECT
 .fi
 .IP NAMELOOKUP
-\fICURLINFO_NAMELOOKUP_TIME\fP and \fICURLINFO_NAMELOOKUP_TIME_T\fP.
+\fICURLINFO_NAMELOOKUP_TIME(3)\fP and \fICURLINFO_NAMELOOKUP_TIME_T(3)\fP.
 The time it took from the start until the name resolving was completed.
 .IP CONNECT
-\fICURLINFO_CONNECT_TIME\fP and \fICURLINFO_CONNECT_TIME_T\fP.
-The time it took from the start until the connect
-to the remote host (or proxy) was completed.
+\fICURLINFO_CONNECT_TIME(3)\fP and \fICURLINFO_CONNECT_TIME_T(3)\fP.  The time
+it took from the start until the connect to the remote host (or proxy) was
+completed.
 .IP APPCONNECT
-\fICURLINFO_APPCONNECT_TIME\fP and \fICURLINFO_APPCONNECT_TIME_T\fP.
-The time it took from the start until the SSL
-connect/handshake with the remote host was completed. (Added in 7.19.0)
-The latter is the integer version (measuring microseconds).  (Added in 7.60.0)
+\fICURLINFO_APPCONNECT_TIME(3)\fP and \fICURLINFO_APPCONNECT_TIME_T(3)\fP.
+The time it took from the start until the SSL connect/handshake with the
+remote host was completed. (Added in 7.19.0) The latter is the integer version
+(measuring microseconds). (Added in 7.60.0)
 .IP PRETRANSFER
-\fICURLINFO_PRETRANSFER_TIME\fP and \fICURLINFO_PRETRANSFER_TIME_T\fP.
-The time it took from the start until the
-file transfer is just about to begin. This includes all pre-transfer commands
-and negotiations that are specific to the particular protocol(s) involved.
+\fICURLINFO_PRETRANSFER_TIME(3)\fP and \fICURLINFO_PRETRANSFER_TIME_T(3)\fP.
+The time it took from the start until the file transfer is just about to
+begin. This includes all pre-transfer commands and negotiations that are
+specific to the particular protocol(s) involved.
 .IP STARTTRANSFER
-\fICURLINFO_STARTTRANSFER_TIME\fP and \fICURLINFO_STARTTRANSFER_TIME_T\fP.
-The time it took from the start until the
-first byte is received by libcurl.
+\fICURLINFO_STARTTRANSFER_TIME(3)\fP and
+\fICURLINFO_STARTTRANSFER_TIME_T(3)\fP. The time it took from the start until
+the first byte is received by libcurl.
 .IP TOTAL
-\fICURLINFO_TOTAL_TIME\fP and \fICURLINFO_TOTAL_TIME_T\fP.
-Total time of the previous request.
+\fICURLINFO_TOTAL_TIME(3)\fP and \fICURLINFO_TOTAL_TIME_T(3)\fP. Total time
+of the previous request.
 .IP REDIRECT
-\fICURLINFO_REDIRECT_TIME\fP and \fICURLINFO_REDIRECT_TIME_T\fP.
-The time it took for all redirection steps
-include name lookup, connect, pretransfer and transfer before final
-transaction was started. So, this is zero if no redirection took place.
+\fICURLINFO_REDIRECT_TIME(3)\fP and \fICURLINFO_REDIRECT_TIME_T(3)\fP. The
+time it took for all redirection steps include name lookup, connect,
+pretransfer and transfer before final transaction was started. So, this is
+zero if no redirection took place.
 .SH EXAMPLE
 .nf
   curl = curl_easy_init();

--- a/docs/libcurl/curl_easy_perform.3
+++ b/docs/libcurl/curl_easy_perform.3
@@ -46,7 +46,7 @@ even encouraged to do so. libcurl attempts to reuse existing connections for
 the following transfers, thus making the operations faster, less CPU intense
 and using less network resources. You probably want to use
 \fIcurl_easy_setopt(3)\fP between the invokes to set options for the following
-curl_easy_perform call.
+\fIcurl_easy_perform(3)\fP call.
 
 You must never call this function simultaneously from two places using the
 same \fBeasy_handle\fP. Let the function return first before invoking it

--- a/docs/libcurl/curl_mime_encoder.3
+++ b/docs/libcurl/curl_mime_encoder.3
@@ -67,11 +67,11 @@ not be used with other types of data.
 
 If the original data is already encoded in such a scheme, a custom
 \fIContent-Transfer-Encoding\fP header should be added with
-\fIcurl_mime_headers\fP() instead of setting a part encoder.
+\fIcurl_mime_headers(3)\fP instead of setting a part encoder.
 
-Encoding should not be applied to multiparts, thus the use of this
-function on a part with content set with \fIcurl_mime_subparts\fP() is
-strongly discouraged.
+Encoding should not be applied to multiparts, thus the use of this function on
+a part with content set with \fIcurl_mime_subparts(3)\fP is strongly
+discouraged.
 .SH EXAMPLE
 .nf
  curl_mime *mime;

--- a/docs/libcurl/curl_mime_subparts.3
+++ b/docs/libcurl/curl_mime_subparts.3
@@ -37,7 +37,7 @@ structure.
 \fIpart\fP is a handle to the multipart part.
 
 \fIsubparts\fP is a mime structure handle holding the sub-parts. After
-\fIcurl_mime_subparts\fP succeeds, the mime structure handle belongs to the
+\fIcurl_mime_subparts(3)\fP succeeds, the mime structure handle belongs to the
 multipart part and must not be freed explicitly. It may however be updated by
 subsequent calls to mime API functions.
 

--- a/docs/libcurl/curl_multi_strerror.3
+++ b/docs/libcurl/curl_multi_strerror.3
@@ -29,8 +29,8 @@ curl_multi_strerror - return string describing error code
 .B #include <curl/curl.h>
 .BI "const char *curl_multi_strerror(CURLMcode " errornum ");"
 .SH DESCRIPTION
-The curl_multi_strerror() function returns a string describing the
-\fICURLMcode\fP error code passed in the argument \fIerrornum\fP.
+This function returns a string describing the \fICURLMcode\fP error code
+passed in the argument \fIerrornum\fP.
 .SH EXAMPLE
 .nf
 int still_running;

--- a/docs/libcurl/curl_multi_timeout.3
+++ b/docs/libcurl/curl_multi_timeout.3
@@ -51,7 +51,7 @@ and desired behavior.
 
 Note: if libcurl returns a -1 timeout here, it just means that libcurl
 currently has no stored timeout value. You must not wait too long (more than a
-few seconds perhaps) before you call curl_multi_perform() again.
+few seconds perhaps) before you call \fIcurl_multi_perform(3)\fP again.
 .SH EXAMPLE
 .nf
 struct timeval timeout;

--- a/docs/libcurl/curl_share_cleanup.3
+++ b/docs/libcurl/curl_share_cleanup.3
@@ -48,7 +48,7 @@ immediately with no action.
 Added in 7.10
 .SH RETURN VALUE
 CURLSHE_OK (zero) means that the option was set properly, non-zero means an
-error occurred as \fI<curl/curl.h>\fP defines. See the \fIlibcurl-errors.3\fP
+error occurred as \fI<curl/curl.h>\fP defines. See the \fIlibcurl-errors(3)\fP
 man page for the full list with descriptions. If an error occurs, then the
 share object is not deleted.
 .SH "SEE ALSO"

--- a/docs/libcurl/curl_share_setopt.3
+++ b/docs/libcurl/curl_share_setopt.3
@@ -55,7 +55,7 @@ See \fICURLSHOPT_USERDATA(3)\fP.
 Added in 7.10
 .SH RETURN VALUE
 CURLSHE_OK (zero) means that the option was set properly, non-zero means an
-error occurred as \fI<curl/curl.h>\fP defines. See the \fIlibcurl-errors.3\fP
+error occurred as \fI<curl/curl.h>\fP defines. See the \fIlibcurl-errors(3)\fP
 man page for the full list with descriptions.
 .SH "SEE ALSO"
 .BR curl_share_cleanup (3),

--- a/docs/libcurl/curl_url_strerror.3
+++ b/docs/libcurl/curl_url_strerror.3
@@ -29,8 +29,8 @@ curl_url_strerror - return string describing error code
 .B #include <curl/curl.h>
 .BI "const char *curl_url_strerror(CURLUcode " errornum ");"
 .SH DESCRIPTION
-The curl_url_strerror() function returns a string describing the CURLUcode
-error code passed in the argument \fIerrornum\fP.
+This function returns a string describing the CURLUcode error code passed in
+the argument \fIerrornum\fP.
 .SH EXAMPLE
 .nf
   CURLUcode rc;

--- a/docs/libcurl/curl_version_info.3
+++ b/docs/libcurl/curl_version_info.3
@@ -46,7 +46,7 @@ or not, instead of using compile-time checks, as dynamic/DLL libraries can be
 changed independent of applications.
 
 This function can alter the returned static data as long as
-\fIcurl_global_init\fP has not been called. It is therefore not thread-safe
+\fIcurl_global_init(3)\fP has not been called. It is therefore not thread-safe
 before libcurl initialization occurs.
 
 The curl_version_info_data struct looks like this

--- a/docs/libcurl/libcurl-share.3
+++ b/docs/libcurl/libcurl-share.3
@@ -58,7 +58,7 @@ handle.
 
 To make an easy handle stop using that particular share, you set
 \fICURLOPT_SHARE(3)\fP to NULL for that easy handle. To make a handle stop
-sharing a particular data, you can \fICURLSHOPT_UNSHARE\fP it.
+sharing a particular data, you can \fICURLSHOPT_UNSHARE(3)\fP it.
 
 When you are done using the share, make sure that no easy handle is still using
 it, and call \fIcurl_share_cleanup(3)\fP on the handle.

--- a/docs/libcurl/libcurl-tutorial.3
+++ b/docs/libcurl/libcurl-tutorial.3
@@ -624,7 +624,7 @@ becomes:
  curl_mime_headers(part, headers, FALSE);
 .fi
 
-Setting the last \fIcurl_mime_headers\fP argument to TRUE would have caused
+Setting the last \fIcurl_mime_headers(3)\fP argument to TRUE would have caused
 the headers to be automatically released upon destroyed the multi-part, thus
 saving a clean-up call to \fIcurl_slist_free_all(3)\fP.
 
@@ -641,10 +641,10 @@ becomes:
  curl_mime_data_cb(part, (curl_off_t) -1, fread, fseek, NULL, stdin);
 .fi
 
-\fIcurl_mime_name\fP always copies the field name. The special file name "-"
-is not supported by \fIcurl_mime_file\fP: to read an open file, use a callback
-source using fread(). The transfer is be chunk-encoded since the data size is
-unknown.
+\fIcurl_mime_name(3)\fP always copies the field name. The special file name
+"-" is not supported by \fIcurl_mime_filename(3)\fP: to read an open file, use
+a callback source using fread(). The transfer is be chunk-encoded since the
+data size is unknown.
 
 .nf
  curl_formadd(&post, &last,
@@ -686,7 +686,7 @@ becomes:
  curl_mime_type(part, "application/zip");
 .fi
 
-\fICURLOPT_READFUNCTION\fP callback is not used: it is replace by directly
+\fICURLOPT_READFUNCTION(3)\fP callback is not used: it is replace by directly
 setting the part source data from the callback read function.
 
 .nf
@@ -705,7 +705,7 @@ becomes:
  curl_mime_filename(part, "memfile.bin");
 .fi
 
-\fIcurl_mime_data\fP always copies the initial data: data buffer is thus
+\fIcurl_mime_data(3)\fP always copies the initial data: data buffer is thus
 free for immediate reuse.
 
 .nf
@@ -722,8 +722,9 @@ becomes:
  curl_mime_filename(part, NULL);
 .fi
 
-Use of \fIcurl_mime_filedata\fP sets the remote file name as a side effect: it
-is therefore necessary to clear it for \fICURLFORM_FILECONTENT\fP emulation.
+Use of \fIcurl_mime_filedata(3)\fP sets the remote file name as a side effect:
+it is therefore necessary to clear it for \fICURLFORM_FILECONTENT\fP
+emulation.
 
 .SH "Showing Progress"
 

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.3
@@ -36,8 +36,8 @@ Deprecated since 7.45.0. Use \fICURLINFO_ACTIVESOCKET(3)\fP instead.
 
 Pass a pointer to a long to receive the last socket used by this curl
 session. If the socket is no longer valid, -1 is returned. When you finish
-working with the socket, you must call curl_easy_cleanup() as usual and let
-libcurl close the socket and cleanup other resources associated with the
+working with the socket, you must call \fIcurl_easy_cleanup(3)\fP as usual and
+let libcurl close the socket and cleanup other resources associated with the
 handle. This is typically used in combination with
 \fICURLOPT_CONNECT_ONLY(3)\fP.
 

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.3
@@ -33,11 +33,11 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REDIRECT_TIME_T,
                            curl_off_t *timep);
 .fi
 .SH DESCRIPTION
-Pass a pointer to a curl_off_t to receive the total time, in microseconds,
-it took for
-all redirection steps include name lookup, connect, pretransfer and transfer
-before final transaction was started. \fICURLINFO_REDIRECT_TIME_T\fP contains
-the complete execution time for multiple redirections.
+Pass a pointer to a curl_off_t to receive the total time, in microseconds, it
+took for all redirection steps include name lookup, connect, pretransfer and
+transfer before final transaction was started.
+\fICURLINFO_REDIRECT_TIME_T(3)\fP holds the complete execution time for
+multiple redirections.
 
 See also the TIMES overview in the \fIcurl_easy_getinfo(3)\fP man page.
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.3
@@ -88,7 +88,8 @@ as well:
 
 If the \fIinternals\fP pointer is NULL then either the SSL backend is not
 supported, an SSL session has not yet been established or the connection is no
-longer associated with the easy handle (e.g. curl_easy_perform has returned).
+longer associated with the easy handle (e.g. \fIcurl_easy_perform(3)\fP has
+returned).
 .SH LIMITATIONS
 This option has some limitations that could make it unsafe when it comes to
 the manual verification of certificates.

--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.3
@@ -37,7 +37,7 @@ time any cached certificate store it has in memory may be kept and reused for
 new connections. Once the timeout has expired, a subsequent fetch requiring a
 certificate has to reload it.
 
-Building a certificate store from a \fICURLOPT_CAINFO\fP file is a slow
+Building a certificate store from a \fICURLOPT_CAINFO(3)\fP file is a slow
 operation so curl may cache the generated certificate store internally to speed
 up future connections.
 

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.3
@@ -47,7 +47,7 @@ parameter. \fICURLE_OK\fP must be returned upon successful conversion.  A
 CURLcode return value defined by curl.h, such as \fICURLE_CONV_FAILED\fP,
 should be returned if an error was encountered.
 
-\fBCURLOPT_CONV_FROM_NETWORK_FUNCTION\fP converts to host encoding from the
+\fICURLOPT_CONV_FROM_NETWORK_FUNCTION(3)\fP converts to host encoding from the
 network encoding.  It is used when commands or ASCII data are received over
 the network.
 

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.3
@@ -47,7 +47,7 @@ parameter. \fICURLE_OK\fP must be returned upon successful conversion.  A
 CURLcode return value defined by curl.h, such as \fICURLE_CONV_FAILED\fP,
 should be returned if an error was encountered.
 
-\fBCURLOPT_CONV_FROM_UTF8_FUNCTION\fP converts to host encoding from UTF8
+\fICURLOPT_CONV_FROM_UTF8_FUNCTION(3)\fP converts to host encoding from UTF8
 encoding. It is required only for SSL processing.
 
 If you set a callback pointer to NULL, or do not set it at all, the built-in

--- a/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.3
@@ -47,8 +47,8 @@ parameter. \fICURLE_OK\fP must be returned upon successful conversion.  A
 CURLcode return value defined by curl.h, such as \fICURLE_CONV_FAILED\fP,
 should be returned if an error was encountered.
 
-\fBCURLOPT_CONV_TO_NETWORK_FUNCTION\fP converts from host encoding to the
-network encoding.  It is used when commands or ASCII data are sent over the
+\fICURLOPT_CONV_TO_NETWORK_FUNCTION(3)\fP converts from host encoding to the
+network encoding. It is used when commands or ASCII data are sent over the
 network.
 
 If you set a callback pointer to NULL, or do not set it at all, the built-in

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.3
@@ -58,8 +58,8 @@ Added in 7.61.0
 .SH RETURN VALUE
 Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
 
-curl_easy_perform() returns CURLE_LOGIN_DENIED if this option is enabled and a
-URL containing a username is specified.
+\fIcurl_easy_perform(3)\fP returns CURLE_LOGIN_DENIED if this option is
+enabled and a URL containing a username is specified.
 .SH "SEE ALSO"
 .BR curl_url_set (3),
 .BR CURLOPT_PROTOCOLS (3),

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.3
@@ -36,7 +36,7 @@ If you want to post static data to the server without having libcurl do a
 strlen() to measure the data size, this option must be used. When this option
 is used you can post fully binary data, which otherwise is likely to fail. If
 this size is set to -1, libcurl uses strlen() to get the size or relies on the
-\fICURLOPT_READFUNCTION\fP (if used) to signal the end of data.
+\fICURLOPT_READFUNCTION(3)\fP (if used) to signal the end of data.
 
 If you post more than 2GB, use \fICURLOPT_POSTFIELDSIZE_LARGE(3)\fP.
 .SH DEFAULT

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.3
@@ -36,7 +36,7 @@ If you want to post static data to the server without having libcurl do a
 strlen() to measure the data size, this option must be used. When this option
 is used you can post fully binary data, which otherwise is likely to fail. If
 this size is set to -1, libcurl uses strlen() to get the size or relies on the
-\fICURLOPT_READFUNCTION\fP (if used) to signal the end of data.
+\fICURLOPT_READFUNCTION(3)\fP (if used) to signal the end of data.
 .SH DEFAULT
 -1
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.3
@@ -43,8 +43,8 @@ option \fICURLOPT_PROXYPORT(3)\fP. If not specified, libcurl defaults to using
 port 1080 for proxies.
 
 A pre proxy is a SOCKS proxy that curl connects to before it connects to the
-HTTP(S) proxy specified in the \fICURLOPT_PROXY\fP option. The pre proxy can
-only be a SOCKS proxy.
+HTTP(S) proxy specified in the \fICURLOPT_PROXY(3)\fP option. The pre proxy
+can only be a SOCKS proxy.
 
 The pre proxy string should be prefixed with [scheme]:// to specify which kind
 of socks is used. Use socks4://, socks4a://, socks5:// or socks5h:// (the last

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.3
@@ -52,8 +52,8 @@ If \fIverify\fP value is set to 1:
 In 7.28.0 and earlier: treated as a debug option of some sorts, not supported
 anymore due to frequently leading to programmer mistakes.
 
-From 7.28.1 to 7.65.3: setting it to 1 made curl_easy_setopt() return an error
-and leaving the flag untouched.
+From 7.28.1 to 7.65.3: setting it to 1 made \fIcurl_easy_setopt(3)\fP return
+an error and leaving the flag untouched.
 
 From 7.66.0: treats 1 and 2 the same.
 

--- a/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.3
+++ b/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.3
@@ -41,7 +41,7 @@ recommended that if used in conjunction with \fICURLOPT_TIMEOUT(3)\fP, you set
 \fICURLOPT_SERVER_RESPONSE_TIMEOUT(3)\fP to a value smaller than
 \fICURLOPT_TIMEOUT(3)\fP.
 
-This option was formerly known as \fBCURLOPT_FTP_RESPONSE_TIMEOUT\fP.
+This option was formerly known as CURLOPT_FTP_RESPONSE_TIMEOUT.
 .SH DEFAULT
 None
 .SH PROTOCOLS

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.3
@@ -54,8 +54,8 @@ If \fIverify\fP value is set to 1:
 In 7.28.0 and earlier: treated as a debug option of some sorts, not supported
 anymore due to frequently leading to programmer mistakes.
 
-From 7.28.1 to 7.65.3: setting it to 1 made curl_easy_setopt() return an error
-and leaving the flag untouched.
+From 7.28.1 to 7.65.3: setting it to 1 made \fIcurl_easy_setopt(3)\fP return
+an error and leaving the flag untouched.
 
 From 7.66.0: treats 1 and 2 the same.
 

--- a/docs/libcurl/opts/CURLOPT_WRITEDATA.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEDATA.3
@@ -56,8 +56,7 @@ data in. Like in the getinmemory example:
 https://curl.se/libcurl/c/getinmemory.html
 .SH AVAILABILITY
 Available in all libcurl versions. This option was formerly known as
-\fICURLOPT_FILE\fP, the name \fICURLOPT_WRITEDATA(3)\fP was introduced in
-7.9.7.
+CURLOPT_FILE, the name \fICURLOPT_WRITEDATA(3)\fP was added in 7.9.7.
 .SH RETURN VALUE
 This returns CURLE_OK.
 .SH "SEE ALSO"

--- a/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.3
@@ -49,7 +49,7 @@ sure that the callback uses a different lock for each kind of data.
 
 \fIaccess\fP defines what access type libcurl wants, shared or single.
 
-\fIclientp\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
+\fIclientp\fP is the private pointer you set with \fICURLSHOPT_USERDATA(3)\fP.
 This pointer is not used by libcurl itself.
 .SH PROTOCOLS
 All

--- a/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
+++ b/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.3
@@ -45,7 +45,7 @@ is released.
 The \fIdata\fP argument tells what kind of data libcurl wants to unlock. Make
 sure that the callback uses a different lock for each kind of data.
 
-\fIclientp\fP is the private pointer you set with \fICURLSHOPT_USERDATA\fP.
+\fIclientp\fP is the private pointer you set with \fICURLSHOPT_USERDATA(3)\fP.
 This pointer is not used by libcurl itself.
 .SH PROTOCOLS
 All


### PR DESCRIPTION
1. References to curl symbols are now checked that they indeed exist as man pages. This for \f references as well as the names referenced in the SEE ALSO section. Allowlist curl.1 since it is not always built in builds
2. References to curl symbols that lack section now causes warning, since that will prevent them from getting linked properly
3. Check for "bare" references to curl functions and warn, they should be references
