### PR TITLE
curl-functions.m4: fix include line

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -273,7 +273,7 @@ curl_includes_stdlib="\
 #ifdef HAVE_SYS_TYPES_H
 #  include <sys/types.h>
 #endif
-include <stdlib.h>
+#include <stdlib.h>
 /* includes end */"
   AC_CHECK_HEADERS(
     sys/types.h,


### PR DESCRIPTION
This made the getaddrinfo detection fail, but we did not spot it in the CI because it graciously falled back to using legacy functions instead!

Follow-up to 96c29900bcec (#11940)